### PR TITLE
ci: add Renovate for automated dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,8 @@
       "matchManagers": ["cargo"],
       "matchUpdateTypes": ["patch", "minor"],
       "groupName": "rust dependencies (non-major)",
-      "groupSlug": "rust-minor"
+      "groupSlug": "rust-minor",
+      "stabilityDays": 3
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add Renovate configuration to automate Cargo dependency updates
- Groups non-major (patch/minor) updates to reduce PR noise
- Keeps major version updates separate for careful review

## Test plan
- [ ] Verify Renovate bot creates initial dependency dashboard issue
- [ ] Verify Renovate bot creates PRs for available updates