### PR TITLE
feat(region_tracker): implement Phase 5 discrete diff processing

### DIFF
--- a/src/language/region_id_tracker.rs
+++ b/src/language/region_id_tracker.rs
@@ -325,21 +325,13 @@ impl RegionIdTracker {
                     }
                     old_byte += change.value().len();
                 }
-                ChangeTag::Delete => {
-                    if current_edit.is_none() {
-                        current_edit = Some((old_byte, old_byte, 0));
-                    }
-                    old_byte += change.value().len();
-                    if let Some((_, ref mut old_end, _)) = current_edit {
-                        *old_end = old_byte;
-                    }
-                }
-                ChangeTag::Insert => {
-                    if current_edit.is_none() {
-                        current_edit = Some((old_byte, old_byte, 0));
-                    }
-                    if let Some((_, _, ref mut inserted_len)) = current_edit {
-                        *inserted_len += change.value().len();
+                ChangeTag::Delete | ChangeTag::Insert => {
+                    let edit = current_edit.get_or_insert((old_byte, old_byte, 0));
+                    if change.tag() == ChangeTag::Delete {
+                        old_byte += change.value().len();
+                        edit.1 = old_byte;
+                    } else {
+                        edit.2 += change.value().len();
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Implements **Phase 5 of the VirtualDocumentUri ADR-0019 migration**: Discrete diff processing for Full Sync mode.

**Key improvement**: When processing full-sync document changes, instead of merging all diffs into a single edit (which over-invalidates), we now reconstruct individual edits from the `similar` crate's diff output. This preserves region identities for content that wasn't actually modified.

**Before**: Editing "AAABBBCCC" → "AXXBBBCYY" would invalidate ALL nodes (single merged edit)
**After**: Only nodes at actual edit positions (1-3 and 7-9) are invalidated; middle content "BBB" preserves its ULID

### Changes

- **Core implementation** (`apply_text_diff`):
  - Added `reconstruct_individual_edits()` to extract discrete edits from character-level diffs
  - Reverse-order processing for diff edits (ORIGINAL coordinates) vs forward-order for LSP edits (RUNNING coordinates)
  - Runtime validation for non-overlapping edits with conservative fallback

- **Comprehensive test coverage** (107 tests):
  - Position collision handling when nodes collapse to same position
  - Multi-byte UTF-8 boundary tracking (emoji 4-byte, CJK 3-byte)
  - Forward vs reverse order processing verification
  - Invalid edit rejection (debug_assert first line of defense)
  - Stress tests with large documents (10K+ characters)
  - Concurrency tests for thread safety

### Code Review Process

This PR underwent **3 iterations of multi-perspective subagent review**:

| Perspective | Iteration 1 | Final Status |
|------------|-------------|--------------|
| Algorithm Correctness | ✅ OK | ✅ Verified |
| Test Coverage | 3 CRITICAL + 6 MAJOR gaps | ✅ 7/9 resolved, 2/9 acceptable |
| Code Quality | ✅ OK | ✅ Idiomatic Rust |
| Architecture | ✅ Aligned with ADR-0019 | ✅ Verified |

The 2 "acceptable" gaps are defensive code paths for `similar` crate bugs that cannot be triggered through normal usage.

## Test plan

- [x] `cargo test --lib region_id_tracker` - 107 tests pass
- [x] `cargo test --lib` - All 623 lib tests pass
- [x] `make check` - No dead code, clippy clean, formatted
- [ ] Manual testing with real editor (incremental sync still works)
- [ ] Verify E2E tests still pass