### PR TITLE
feat: gate ColorProviderCapability behind experimental feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ percent-encoding = "2"
 
 [features]
 e2e = []
+experimental = []
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/src/lsp/bridge/protocol/request.rs
+++ b/src/lsp/bridge/protocol/request.rs
@@ -458,6 +458,7 @@ pub(crate) fn build_bridge_inlay_hint_request(
 /// **`host_range.start.line >= region_start_line`** - The host range must be within or after
 /// the injection region. This is guaranteed by callers which only invoke bridge requests
 /// when the range falls within a detected injection region's line range.
+#[cfg(feature = "experimental")]
 pub(crate) fn build_bridge_color_presentation_request(
     host_uri: &tower_lsp::lsp_types::Url,
     host_range: tower_lsp::lsp_types::Range,
@@ -535,6 +536,7 @@ pub(crate) fn build_bridge_moniker_request(
 /// * `injection_language` - The injection language (e.g., "lua")
 /// * `region_id` - The unique region ID for this injection
 /// * `request_id` - The JSON-RPC request ID
+#[cfg(feature = "experimental")]
 pub(crate) fn build_bridge_document_color_request(
     host_uri: &tower_lsp::lsp_types::Url,
     injection_language: &str,
@@ -1374,6 +1376,7 @@ mod tests {
     // ==========================================================================
 
     #[test]
+    #[cfg(feature = "experimental")]
     fn document_color_request_uses_virtual_uri() {
         let request = build_bridge_document_color_request(
             &test_host_uri(),
@@ -1386,6 +1389,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "experimental")]
     fn document_color_request_has_correct_method_and_structure() {
         let request = build_bridge_document_color_request(
             &test_host_uri(),
@@ -1409,6 +1413,7 @@ mod tests {
     // ==========================================================================
 
     #[test]
+    #[cfg(feature = "experimental")]
     fn color_presentation_request_uses_virtual_uri() {
         use tower_lsp::lsp_types::Range;
 
@@ -1442,6 +1447,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "experimental")]
     fn color_presentation_request_transforms_range_to_virtual_coordinates() {
         use tower_lsp::lsp_types::Range;
 
@@ -1493,6 +1499,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "experimental")]
     fn color_presentation_request_includes_color() {
         use tower_lsp::lsp_types::Range;
 

--- a/src/lsp/bridge/protocol/response.rs
+++ b/src/lsp/bridge/protocol/response.rs
@@ -475,6 +475,7 @@ fn transform_position(position: &mut serde_json::Value, region_start_line: u32) 
 /// # Arguments
 /// * `response` - The JSON-RPC response from the downstream language server
 /// * `region_start_line` - The starting line of the injection region in the host document
+#[cfg(feature = "experimental")]
 pub(crate) fn transform_document_color_response_to_host(
     mut response: serde_json::Value,
     region_start_line: u32,
@@ -515,6 +516,7 @@ pub(crate) fn transform_document_color_response_to_host(
 /// # Arguments
 /// * `response` - The JSON-RPC response from the downstream language server
 /// * `region_start_line` - The starting line of the injection region in the host document
+#[cfg(feature = "experimental")]
 pub(crate) fn transform_color_presentation_response_to_host(
     mut response: serde_json::Value,
     region_start_line: u32,
@@ -2743,6 +2745,7 @@ mod tests {
     // ==========================================================================
 
     #[test]
+    #[cfg(feature = "experimental")]
     fn document_color_response_transforms_ranges_to_host_coordinates() {
         // ColorInformation[] contains range + color for each color found
         let response = json!({
@@ -2793,6 +2796,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "experimental")]
     fn document_color_response_with_null_result_passes_through() {
         let response = json!({ "jsonrpc": "2.0", "id": 42, "result": null });
 
@@ -2801,6 +2805,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "experimental")]
     fn document_color_response_with_empty_array_passes_through() {
         let response = json!({ "jsonrpc": "2.0", "id": 42, "result": [] });
 
@@ -2810,6 +2815,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "experimental")]
     fn document_color_response_preserves_color_values() {
         let response = json!({
             "jsonrpc": "2.0",
@@ -2844,6 +2850,7 @@ mod tests {
     // ==========================================================================
 
     #[test]
+    #[cfg(feature = "experimental")]
     fn color_presentation_response_transforms_text_edit_range_to_host_coordinates() {
         // ColorPresentation[] contains label + optional textEdit + optional additionalTextEdits
         let response = json!({
@@ -2878,6 +2885,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "experimental")]
     fn color_presentation_response_transforms_additional_text_edits_to_host_coordinates() {
         // ColorPresentation with additionalTextEdits (multiple edits beyond the main one)
         let response = json!({
@@ -2932,6 +2940,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "experimental")]
     fn color_presentation_response_without_text_edit_passes_through() {
         // ColorPresentation with only label (no textEdit or additionalTextEdits)
         let response = json!({
@@ -2956,6 +2965,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "experimental")]
     fn color_presentation_response_with_null_result_passes_through() {
         let response = json!({ "jsonrpc": "2.0", "id": 42, "result": null });
 
@@ -2964,6 +2974,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "experimental")]
     fn color_presentation_response_with_empty_array_passes_through() {
         let response = json!({ "jsonrpc": "2.0", "id": 42, "result": [] });
 

--- a/src/lsp/bridge/text_document.rs
+++ b/src/lsp/bridge/text_document.rs
@@ -5,12 +5,14 @@
 //!
 //! The structure mirrors `lsp_impl/text_document/` for consistency.
 
+#[cfg(feature = "experimental")]
 mod color_presentation;
 mod completion;
 mod declaration;
 mod definition;
 mod did_change;
 mod did_close;
+#[cfg(feature = "experimental")]
 mod document_color;
 mod document_highlight;
 mod document_link;

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -1194,7 +1194,10 @@ impl LanguageServer for TreeSitterLs {
                 document_symbol_provider: Some(OneOf::Left(true)),
                 rename_provider: Some(OneOf::Left(true)),
                 inlay_hint_provider: Some(OneOf::Left(true)),
+                #[cfg(feature = "experimental")]
                 color_provider: Some(ColorProviderCapability::Simple(true)),
+                #[cfg(not(feature = "experimental"))]
+                color_provider: None,
                 moniker_provider: Some(OneOf::Left(true)),
                 ..ServerCapabilities::default()
             },
@@ -1564,10 +1567,12 @@ impl LanguageServer for TreeSitterLs {
         self.inlay_hint_impl(params).await
     }
 
+    #[cfg(feature = "experimental")]
     async fn document_color(&self, params: DocumentColorParams) -> Result<Vec<ColorInformation>> {
         self.document_color_impl(params).await
     }
 
+    #[cfg(feature = "experimental")]
     async fn color_presentation(
         &self,
         params: ColorPresentationParams,

--- a/src/lsp/lsp_impl/text_document.rs
+++ b/src/lsp/lsp_impl/text_document.rs
@@ -1,9 +1,11 @@
 //! Text document related LSP methods.
 
+#[cfg(feature = "experimental")]
 mod color_presentation;
 mod completion;
 mod declaration;
 mod definition;
+#[cfg(feature = "experimental")]
 mod document_color;
 mod document_highlight;
 mod document_link;

--- a/tests/e2e_lsp_lua_color_presentation.rs
+++ b/tests/e2e_lsp_lua_color_presentation.rs
@@ -13,7 +13,7 @@
 //! **Note**: colorPresentation is typically called after documentColor returns colors.
 //! Since lua-ls doesn't return colors, we use mock values to test the infrastructure.
 
-#![cfg(feature = "e2e")]
+#![cfg(all(feature = "e2e", feature = "experimental"))]
 
 mod helpers;
 

--- a/tests/e2e_lsp_lua_document_color.rs
+++ b/tests/e2e_lsp_lua_document_color.rs
@@ -13,7 +13,7 @@
 //! **Note**: lua-language-server typically doesn't return color information for Lua code,
 //! so this test verifies the bridge infrastructure works correctly by accepting empty results.
 
-#![cfg(feature = "e2e")]
+#![cfg(all(feature = "e2e", feature = "experimental"))]
 
 mod helpers;
 


### PR DESCRIPTION
## Summary

- Gate `ColorProviderCapability` behind the `experimental` Cargo feature flag
- Release builds exclude color provider by default to avoid performance issues from frequent invocations

## Changes

| File | Change |
|------|--------|
| `Cargo.toml` | Added `experimental = []` feature |
| `src/lsp/lsp_impl.rs` | Capability returns `None` by default, `Some(...)` with feature |
| `src/lsp/lsp_impl/text_document.rs` | Module includes gated |
| `src/lsp/bridge/text_document.rs` | Module includes gated |
| `src/lsp/bridge/protocol/request.rs` | Functions + tests gated |
| `src/lsp/bridge/protocol/response.rs` | Functions + tests gated |
| `tests/e2e_lsp_lua_document_color.rs` | Requires both `e2e` and `experimental` |
| `tests/e2e_lsp_lua_color_presentation.rs` | Requires both `e2e` and `experimental` |

## Usage

```bash
# Release build (no color provider - default)
cargo build --release

# Development with color provider
cargo build --features experimental

# Run e2e color tests
cargo test --features "e2e,experimental" --test e2e_lsp_lua_document_color
```

## Test plan

- [x] `cargo check` passes without `experimental` feature
- [x] `cargo check --features experimental` passes
- [x] `cargo test --lib` passes (689 tests)
- [x] `cargo test --lib --features experimental` passes (703 tests, +14 color tests)