### PR TITLE
fix(lsp): remove redundant semantic_tokens_refresh call to prevent deadlock

### DIFF
--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -1440,13 +1440,10 @@ impl LanguageServer for TreeSitterLs {
         // This must be called AFTER parse_document so we have access to the updated AST
         self.check_injected_languages_auto_install(&uri).await;
 
-        // Request the client to refresh semantic tokens
-        // This will trigger the client to request new semantic tokens
-        if self.client.semantic_tokens_refresh().await.is_ok() {
-            self.client
-                .log_message(MessageType::INFO, "Requested semantic tokens refresh")
-                .await;
-        }
+        // NOTE: We intentionally do NOT call semantic_tokens_refresh() here.
+        // LSP clients already request new tokens after didChange (via semanticTokens/full/delta).
+        // Calling refresh would be redundant and can cause deadlocks with synchronous clients
+        // like vim-lsp on Vim, which cannot respond to server requests while processing.
 
         self.client
             .log_message(MessageType::INFO, "file changed!")


### PR DESCRIPTION
## Summary

Fixes a deadlock issue that occurs when using synchronous LSP clients like vim-lsp on Vim. The server was calling `semantic_tokens_refresh()` during `didChange` notification handling, which caused the client to hang waiting for a response while simultaneously blocking on the server to finish processing the notification.

**Key changes:**
- Removed the redundant `semantic_tokens_refresh()` call from `didChange` handler
- Added detailed comment explaining why the refresh is unnecessary and problematic

## Root Cause

Synchronous LSP clients cannot respond to server requests while they are waiting for the server to finish processing a notification. When the server calls `semantic_tokens_refresh()` during `didChange` handling:
1. Client sends `didChange` notification and waits for server to finish
2. Server processes notification and sends `semantic_tokens_refresh` request
3. Client cannot respond because it's blocked waiting for step 1 to complete
4. Server waits for client response → **deadlock**

## Why This Fix Works

The `semantic_tokens_refresh()` call was redundant. According to the LSP specification, clients already proactively request semantic tokens after document changes via `semanticTokens/full` or `semanticTokens/delta`. The explicit server-initiated refresh added no functionality while introducing the deadlock risk.

## Test Plan

- [ ] Test with vim-lsp on Vim to verify no deadlock occurs on file changes
- [ ] Verify semantic token highlighting still updates correctly after edits
- [ ] Test with other LSP clients (VS Code, Neovim) to ensure no regression
- [ ] Confirm that semantic token updates still happen as expected