### PR TITLE
release v0 0 9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-ls"
-version = "0.1.0"
+version = "0.0.9"
 edition = "2024"
 
 [[bin]]


### PR DESCRIPTION
- **fix(lsp): remove redundant semantic_tokens_refresh call to prevent deadlock**
- **chore(vim): more frequent semantic requests**
- **fix(lsp): remove semantic_tokens_refresh from didOpen to prevent deadlock**
- **fix(lsp): make semantic_tokens_refresh non-blocking via unified event system**
- **refactor(lsp): extract semantic tokens refresh timeout to named constant**
- **chore(cargo): v0.0.9**
