### PR TITLE
chore(make): scope dead_code check to src directory only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ test_all:
 # Check code formatting and linting
 .PHONY: check
 check:
-	if git grep --quiet -E '#\[allow\(dead_code\)\]'; then echo 'Do not leave dead_code. Codes must be wired' >&2 && exit 1; fi
+	if git grep --quiet -E '#\[allow\(dead_code\)\]' -- src; then echo 'Do not leave dead_code. Codes must be wired' >&2 && exit 1; fi
 	$(CARGO) check
 	$(CARGO) clippy -- -D warnings
 	$(CARGO) fmt --check


### PR DESCRIPTION
## Summary
- Scopes the `#[allow(dead_code)]` check in `make check` to only search in `src/` directory
- Allows legitimate `#[allow(dead_code)]` annotations in test files and examples while still enforcing the rule in production code

## Test plan
- [ ] Run `make check` with no dead_code annotations in src/ - should pass
- [ ] Verify dead_code annotations in test files are now allowed