### PR TITLE
feat: Server pool coordination with server-name-based keying

### DIFF
--- a/docs/adr/0016-ls-bridge-server-pool-coordination.md
+++ b/docs/adr/0016-ls-bridge-server-pool-coordination.md
@@ -50,7 +50,7 @@ Routing: `language` → `server_name` (via config) → connection.
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│                   kakehashi (Host LS)               │
+│                   kakehashi (Host LS)                   │
 │  ┌────────────────────────────────────────────────────┐ │
 │  │              LanguageServerPool                    │ │
 │  │                                                    │ │
@@ -179,70 +179,20 @@ Transitions:
 
 **Connection Termination**: When a connection enters `Closed` state (graceful shutdown, crash, or respawn), all document lifecycle entries for that downstream are discarded. A respawned connection starts with all documents in `Closed` (default) state, requiring fresh `didOpen` notifications.
 
-### Notification Forwarding
+### Server-to-Client Notification Forwarding
 
-Server-initiated notifications from downstream servers are forwarded to the upstream client with URI transformation.
-
-**Basic Flow:**
+Server-initiated notifications from downstream servers are forwarded to the upstream client with optional modifications.
 
 ```
 downstream ──notification──►  bridge  ──notification──►  upstream
                                │
-                               └─ Transform virtual URI → host URI
+                               ├─ Transform uri and positions (virtual -> host)
+                               ├─ Transform content for distinguishability
+                               │    (e.g., to prefix title with downstream server name)
+                               ├─ Aggregate for multi-injection regions
+                               │    (e.g., to show diagnostics for multiple code blocks in markdown)
+                               └─ ...
 ```
-
-The bridge:
-1. Receives notification from downstream
-2. Transforms URI (virtual → host document URI)
-3. Transforms positions if needed (add region offset)
-4. Forwards to upstream client
-
-**Pass-Through Notifications** (no transformation needed):
-- `$/progress` — Forwarded with server-name prefix on token (e.g., `lua-ls:token123`)
-- `window/logMessage` — Forwarded as-is
-- `window/showMessage` — Forwarded as-is
-
-**Diagnostics — Aggregation for Injection Regions:**
-
-For diagnostics from **different servers**, the client automatically aggregates per LSP standard:
-
-```
-pyright  ──publishDiagnostics──►  bridge  ──publishDiagnostics──►  upstream
-ruff     ──publishDiagnostics──►  bridge  ──publishDiagnostics──►  upstream
-                                  (pass-through, client aggregates)
-```
-
-However, kakehashi's injection model requires **bridge-level aggregation** for multiple injection regions within the same host document:
-
-```
-Host: README.md
-├── Lua block 1 (lines 5-10)  → virtual: region-0.lua → diagnostics A
-├── Lua block 2 (lines 20-25) → virtual: region-1.lua → diagnostics B
-└── Lua block 3 (lines 40-45) → virtual: region-2.lua → diagnostics C
-
-Problem: Each publishDiagnostics for README.md replaces the previous one.
-Solution: Bridge caches and aggregates → sends A + B + C together.
-```
-
-**Diagnostic Aggregation Rules:**
-
-| Scenario | Aggregation |
-|----------|-------------|
-| Same host, same server, multiple injection regions | Bridge aggregates |
-| Same host, different servers | Client aggregates (pass-through) |
-| Different hosts | No aggregation needed |
-
-**Diagnostic Cache Structure:**
-
-```rust
-// host_uri → (virtual_uri → diagnostics)
-diagnostic_cache: HashMap<Url, HashMap<String, Vec<Diagnostic>>>
-```
-
-**Cache Lifecycle:**
-- Virtual document closed → Remove entry, re-send aggregated diagnostics
-- Host document closed → Clear entire cache for host_uri
-- Server crash/respawn → Clear all cache entries for that server
 
 ### Cancellation Propagation
 


### PR DESCRIPTION
## Summary

- **Enable process sharing for related languages**: Pool is now keyed by `server_name` instead of `languageId`, allowing TypeScript and TSX to share a single `tsgo` process
- **Comprehensive notification forwarding**: ADR-0016 documents uri/position transformation, distinguishability, and diagnostic aggregation for multi-injection regions

## Test plan

- [ ] Verify existing tests pass (`cargo test`)
- [ ] Verify `cargo build --release` succeeds  
- [ ] Test process sharing with a configuration where ts/tsx map to same server_name
- [ ] Review ADR-0016 for documentation accuracy