### PR TITLE
feat(bridge): resolve injection language before bridge server lookup

### DIFF
--- a/src/lsp/lsp_impl/text_document/color_presentation.rs
+++ b/src/lsp/lsp_impl/text_document/color_presentation.rs
@@ -68,6 +68,7 @@ impl Kakehashi {
         };
 
         let Some(resolved) = InjectionResolver::resolve_at_byte_offset(
+            &self.language,
             self.bridge.region_id_tracker(),
             &uri,
             snapshot.tree(),

--- a/src/lsp/lsp_impl/text_document/completion.rs
+++ b/src/lsp/lsp_impl/text_document/completion.rs
@@ -69,6 +69,7 @@ impl Kakehashi {
         };
 
         let Some(resolved) = InjectionResolver::resolve_at_byte_offset(
+            &self.language,
             self.bridge.region_id_tracker(),
             &uri,
             snapshot.tree(),

--- a/src/lsp/lsp_impl/text_document/declaration.rs
+++ b/src/lsp/lsp_impl/text_document/declaration.rs
@@ -68,6 +68,7 @@ impl Kakehashi {
         };
 
         let Some(resolved) = InjectionResolver::resolve_at_byte_offset(
+            &self.language,
             self.bridge.region_id_tracker(),
             &uri,
             snapshot.tree(),

--- a/src/lsp/lsp_impl/text_document/definition.rs
+++ b/src/lsp/lsp_impl/text_document/definition.rs
@@ -67,6 +67,7 @@ impl Kakehashi {
         };
 
         let Some(resolved) = InjectionResolver::resolve_at_byte_offset(
+            &self.language,
             self.bridge.region_id_tracker(),
             &uri,
             snapshot.tree(),

--- a/src/lsp/lsp_impl/text_document/document_color.rs
+++ b/src/lsp/lsp_impl/text_document/document_color.rs
@@ -57,6 +57,7 @@ impl Kakehashi {
 
         // Collect all injection regions
         let all_regions = InjectionResolver::resolve_all(
+            &self.language,
             self.bridge.region_id_tracker(),
             &uri,
             snapshot.tree(),

--- a/src/lsp/lsp_impl/text_document/document_highlight.rs
+++ b/src/lsp/lsp_impl/text_document/document_highlight.rs
@@ -67,6 +67,7 @@ impl Kakehashi {
         };
 
         let Some(resolved) = InjectionResolver::resolve_at_byte_offset(
+            &self.language,
             self.bridge.region_id_tracker(),
             &uri,
             snapshot.tree(),

--- a/src/lsp/lsp_impl/text_document/document_link.rs
+++ b/src/lsp/lsp_impl/text_document/document_link.rs
@@ -57,6 +57,7 @@ impl Kakehashi {
 
         // Collect all injection regions
         let all_regions = InjectionResolver::resolve_all(
+            &self.language,
             self.bridge.region_id_tracker(),
             &uri,
             snapshot.tree(),

--- a/src/lsp/lsp_impl/text_document/document_symbol.rs
+++ b/src/lsp/lsp_impl/text_document/document_symbol.rs
@@ -59,6 +59,7 @@ impl Kakehashi {
 
         // Collect all injection regions
         let all_regions = InjectionResolver::resolve_all(
+            &self.language,
             self.bridge.region_id_tracker(),
             &uri,
             snapshot.tree(),

--- a/src/lsp/lsp_impl/text_document/hover.rs
+++ b/src/lsp/lsp_impl/text_document/hover.rs
@@ -64,6 +64,7 @@ impl Kakehashi {
         };
 
         let Some(resolved) = InjectionResolver::resolve_at_byte_offset(
+            &self.language,
             self.bridge.region_id_tracker(),
             &uri,
             snapshot.tree(),

--- a/src/lsp/lsp_impl/text_document/implementation.rs
+++ b/src/lsp/lsp_impl/text_document/implementation.rs
@@ -68,6 +68,7 @@ impl Kakehashi {
         };
 
         let Some(resolved) = InjectionResolver::resolve_at_byte_offset(
+            &self.language,
             self.bridge.region_id_tracker(),
             &uri,
             snapshot.tree(),

--- a/src/lsp/lsp_impl/text_document/inlay_hint.rs
+++ b/src/lsp/lsp_impl/text_document/inlay_hint.rs
@@ -69,6 +69,7 @@ impl Kakehashi {
         };
 
         let Some(resolved) = InjectionResolver::resolve_at_byte_offset(
+            &self.language,
             self.bridge.region_id_tracker(),
             &uri,
             snapshot.tree(),

--- a/src/lsp/lsp_impl/text_document/moniker.rs
+++ b/src/lsp/lsp_impl/text_document/moniker.rs
@@ -64,6 +64,7 @@ impl Kakehashi {
         };
 
         let Some(resolved) = InjectionResolver::resolve_at_byte_offset(
+            &self.language,
             self.bridge.region_id_tracker(),
             &uri,
             snapshot.tree(),

--- a/src/lsp/lsp_impl/text_document/references.rs
+++ b/src/lsp/lsp_impl/text_document/references.rs
@@ -68,6 +68,7 @@ impl Kakehashi {
         };
 
         let Some(resolved) = InjectionResolver::resolve_at_byte_offset(
+            &self.language,
             self.bridge.region_id_tracker(),
             &uri,
             snapshot.tree(),

--- a/src/lsp/lsp_impl/text_document/rename.rs
+++ b/src/lsp/lsp_impl/text_document/rename.rs
@@ -65,6 +65,7 @@ impl Kakehashi {
         };
 
         let Some(resolved) = InjectionResolver::resolve_at_byte_offset(
+            &self.language,
             self.bridge.region_id_tracker(),
             &uri,
             snapshot.tree(),

--- a/src/lsp/lsp_impl/text_document/signature_help.rs
+++ b/src/lsp/lsp_impl/text_document/signature_help.rs
@@ -67,6 +67,7 @@ impl Kakehashi {
         };
 
         let Some(resolved) = InjectionResolver::resolve_at_byte_offset(
+            &self.language,
             self.bridge.region_id_tracker(),
             &uri,
             snapshot.tree(),

--- a/src/lsp/lsp_impl/text_document/type_definition.rs
+++ b/src/lsp/lsp_impl/text_document/type_definition.rs
@@ -68,6 +68,7 @@ impl Kakehashi {
         };
 
         let Some(resolved) = InjectionResolver::resolve_at_byte_offset(
+            &self.language,
             self.bridge.region_id_tracker(),
             &uri,
             snapshot.tree(),


### PR DESCRIPTION
## Summary
- Expand bridge support to handle shorthand fence identifiers (e.g., `py`) by resolving them to canonical language names (e.g., `python`) before looking up bridge server configurations
- Use the existing ADR-0005 detection chain with syntect token normalization for consistent behavior between semantic tokens and bridge routing

## Test plan
- [x] `cargo test language::injection` - all 23 tests pass
- [x] `cargo check` - compiles without errors
- [ ] Manual test: hover on ` ```py ` code block should now route to pyright