### PR TITLE
fix(nix): skip sandbox-incompatible tests in nix build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -155,6 +155,16 @@
               pkgs.libiconv
             ];
 
+          # Skip tests that require network access or debug-only assertions
+          checkFlags = [
+            "--skip"
+            "test_clone_repo"
+            "--skip"
+            "test_edit_info_new_rejects_invalid_in_debug"
+            "--skip"
+            "test_dynamic_lua_load"
+          ];
+
           meta = with pkgs.lib; {
             description = "kakehashi - A Tree-sitter Language Server";
             homepage = "https://github.com/atusy/kakehashi";


### PR DESCRIPTION
## Summary

- Add `checkFlags` to `buildRustPackage` in `flake.nix` to skip 4 tests that cannot pass in the Nix sandbox environment
- No Rust source code changes — Nix-side configuration only

## Changes
- `flake.nix`: Add `checkFlags` with `--skip` patterns for:
  - `test_clone_repo` — requires network access and git binary
  - `test_edit_info_new_rejects_invalid_in_debug` — `#[should_panic]` test for `debug_assert!` which is stripped in the release profile used by `nix build`
  - `test_dynamic_lua_load` — requires `deps/tree-sitter` populated by `make deps`

## Test plan

- [x] `nix build .` completes successfully
- [x] All 936 tests pass locally with `cargo test --lib` (0 ignored, 0 failed)
- [x] Skipped tests verified to still run in local `cargo test` (debug mode)
