### PR TITLE
feat(semantic): latest query pattern wins at same depth

### DIFF
--- a/src/analysis/semantic/finalize.rs
+++ b/src/analysis/semantic/finalize.rs
@@ -2,7 +2,7 @@
 //!
 //! This module handles the final steps of semantic token processing:
 //! - Filtering zero-length tokens
-//! - Sorting by position (line, column, depth)
+//! - Sorting by position (line, column, depth, pattern_index)
 //! - Deduplicating tokens at the same position
 //! - Converting to LSP SemanticToken format with delta-relative positions
 //!
@@ -27,12 +27,13 @@ pub(super) fn finalize_tokens(mut all_tokens: Vec<RawToken>) -> Option<SemanticT
     // Unknown captures are already filtered at collection time (apply_capture_mapping returns None).
     all_tokens.retain(|token| token.length > 0);
 
-    // Sort by position (line, column, then prefer deeper tokens)
+    // Sort by position (line, column, then prefer deeper tokens, then later patterns)
     all_tokens.sort_by(|a, b| {
         a.line
             .cmp(&b.line)
             .then(a.column.cmp(&b.column))
             .then(b.depth.cmp(&a.depth))
+            .then(b.pattern_index.cmp(&a.pattern_index))
     });
 
     // Deduplicate at same position
@@ -82,15 +83,24 @@ pub(super) fn finalize_tokens(mut all_tokens: Vec<RawToken>) -> Option<SemanticT
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     /// Helper to create a RawToken for testing
-    fn make_token(line: usize, column: usize, length: usize, name: &str, depth: usize) -> RawToken {
+    fn make_token(
+        line: usize,
+        column: usize,
+        length: usize,
+        name: &str,
+        depth: usize,
+        pattern_index: usize,
+    ) -> RawToken {
         RawToken {
             line,
             column,
             length,
             mapped_name: name.to_string(),
             depth,
+            pattern_index,
         }
     }
 
@@ -103,8 +113,8 @@ mod tests {
     #[test]
     fn finalize_tokens_filters_zero_length_tokens() {
         let tokens = vec![
-            make_token(0, 0, 0, "keyword", 0), // zero length - should be filtered
-            make_token(0, 5, 3, "variable", 0), // valid
+            make_token(0, 0, 0, "keyword", 0, 0), // zero length - should be filtered
+            make_token(0, 5, 3, "variable", 0, 0), // valid
         ];
         let result = finalize_tokens(tokens);
         assert!(result.is_some());
@@ -120,8 +130,8 @@ mod tests {
     #[test]
     fn finalize_tokens_returns_none_when_all_tokens_are_zero_length() {
         let tokens = vec![
-            make_token(0, 0, 0, "keyword", 0),
-            make_token(1, 5, 0, "variable", 0),
+            make_token(0, 0, 0, "keyword", 0, 0),
+            make_token(1, 5, 0, "variable", 0, 0),
         ];
         assert!(finalize_tokens(tokens).is_none());
     }
@@ -129,9 +139,9 @@ mod tests {
     #[test]
     fn finalize_tokens_sorts_by_position() {
         let tokens = vec![
-            make_token(1, 0, 3, "keyword", 0),  // line 1
-            make_token(0, 10, 3, "string", 0),  // line 0, col 10
-            make_token(0, 0, 3, "function", 0), // line 0, col 0
+            make_token(1, 0, 3, "keyword", 0, 0),  // line 1
+            make_token(0, 10, 3, "string", 0, 0),  // line 0, col 10
+            make_token(0, 0, 3, "function", 0, 0), // line 0, col 0
         ];
         let result = finalize_tokens(tokens);
         assert!(result.is_some());
@@ -153,30 +163,12 @@ mod tests {
     }
 
     #[test]
-    fn finalize_tokens_prefers_deeper_tokens_at_same_position() {
-        // At same position, deeper tokens (higher depth) should be preferred
-        let tokens = vec![
-            make_token(0, 0, 5, "string", 0),  // depth 0
-            make_token(0, 0, 5, "keyword", 1), // depth 1 - should win
-        ];
-        let result = finalize_tokens(tokens);
-        assert!(result.is_some());
-
-        if let Some(SemanticTokensResult::Tokens(semantic_tokens)) = result {
-            // After dedup, only one token should remain
-            assert_eq!(semantic_tokens.data.len(), 1);
-        } else {
-            panic!("Expected Tokens variant");
-        }
-    }
-
-    #[test]
     fn finalize_tokens_delta_encoding_same_line() {
         // Multiple tokens on the same line use delta_start relative to previous token
         let tokens = vec![
-            make_token(0, 0, 3, "keyword", 0),
-            make_token(0, 5, 4, "function", 0),
-            make_token(0, 12, 2, "variable", 0),
+            make_token(0, 0, 3, "keyword", 0, 0),
+            make_token(0, 5, 4, "function", 0, 0),
+            make_token(0, 12, 2, "variable", 0, 0),
         ];
         let result = finalize_tokens(tokens);
         assert!(result.is_some());
@@ -201,8 +193,8 @@ mod tests {
     fn finalize_tokens_delta_encoding_new_line_resets_column() {
         // When moving to a new line, delta_start is absolute column (not relative)
         let tokens = vec![
-            make_token(0, 5, 3, "keyword", 0),
-            make_token(1, 10, 4, "function", 0),
+            make_token(0, 5, 3, "keyword", 0, 0),
+            make_token(1, 10, 4, "function", 0, 0),
         ];
         let result = finalize_tokens(tokens);
         assert!(result.is_some());
@@ -218,5 +210,40 @@ mod tests {
         } else {
             panic!("Expected Tokens variant");
         }
+    }
+
+    // At same position, dedup keeps the winner after sorting by (depth DESC, pattern_index DESC).
+    #[rstest]
+    #[case::deeper_injection_wins(
+        ("string", 0, 0), ("keyword", 1, 0), "keyword"
+    )]
+    #[case::latest_pattern_wins(
+        ("variable", 0, 0), ("type.builtin", 0, 10), "type.builtin"
+    )]
+    #[case::latest_pattern_wins_reversed_insertion(
+        ("type.builtin", 0, 10), ("variable", 0, 0), "type.builtin"
+    )]
+    #[case::depth_beats_pattern_index(
+        ("variable", 0, 99), ("keyword", 1, 0), "keyword"
+    )]
+    fn finalize_tokens_dedup_priority(
+        #[case] token_a: (&str, usize, usize),
+        #[case] token_b: (&str, usize, usize),
+        #[case] expected_winner: &str,
+    ) {
+        let tokens = vec![
+            make_token(0, 0, 5, token_a.0, token_a.1, token_a.2),
+            make_token(0, 0, 5, token_b.0, token_b.1, token_b.2),
+        ];
+        let result = finalize_tokens(tokens);
+
+        let SemanticTokensResult::Tokens(semantic_tokens) = result.expect("should produce tokens")
+        else {
+            panic!("Expected Tokens variant");
+        };
+        assert_eq!(semantic_tokens.data.len(), 1);
+        let (expected_type, _) = map_capture_to_token_type_and_modifiers(expected_winner)
+            .expect("expected_winner should be a known capture");
+        assert_eq!(semantic_tokens.data[0].token_type, expected_type);
     }
 }

--- a/src/analysis/semantic/token_collector.rs
+++ b/src/analysis/semantic/token_collector.rs
@@ -22,6 +22,10 @@ pub(crate) struct RawToken {
     pub mapped_name: String,
     /// Injection depth (0 = host document)
     pub depth: usize,
+    /// Index of the query pattern that produced this token.
+    /// Within a single query, later patterns (higher index) are more specific
+    /// and should override earlier ones at the same position and depth.
+    pub pattern_index: usize,
 }
 
 /// Convert byte column position to UTF-16 column position within a line
@@ -204,6 +208,7 @@ pub(super) fn collect_host_tokens(
                     length: end_utf16 - start_utf16,
                     mapped_name,
                     depth,
+                    pattern_index: m.pattern_index,
                 });
             } else if supports_multiline {
                 // Multiline token with client support: emit a single token spanning multiple lines.
@@ -263,6 +268,7 @@ pub(super) fn collect_host_tokens(
                     length: total_length_utf16,
                     mapped_name,
                     depth,
+                    pattern_index: m.pattern_index,
                 });
             } else {
                 // Multiline token without client support: split into per-line tokens
@@ -290,6 +296,7 @@ pub(super) fn collect_host_tokens(
                             length: end_utf16 - start_utf16,
                             mapped_name: mapped_name.clone(),
                             depth,
+                            pattern_index: m.pattern_index,
                         });
                     }
                 }


### PR DESCRIPTION
## Summary

- Implements "latest match wins" for tree-sitter query captures at the same position and injection depth, matching nvim-treesitter behavior
- Adds `pattern_index` field to `RawToken` from `QueryMatch::pattern_index`
- Extends finalize sort key to `(line ASC, column ASC, depth DESC, pattern_index DESC)` so `dedup_by` keeps the most-specific pattern

## Motivation

Tree-sitter query files (e.g., `highlights.scm`) use a convention where broad patterns appear early and specific overrides appear later:
- Line 4: `(identifier) @variable` — matches ALL identifiers
- Line 266: `((identifier) @type.builtin ...)` — matches specific builtins

LSP semantic tokens require exactly **one** type per token. Previously, when multiple patterns matched the same position at the same depth, the winner was undefined (happened to be the earliest due to stable sort + dedup-keeps-first). Now, later patterns correctly override earlier ones.

## Design

- **Depth still takes priority** — injection depth resolves before `pattern_index`, preserving existing semantics
- **Safe across queries** — within the same depth, all tokens come from the same query, so `pattern_index` values are directly comparable
- **Backward compatible** — existing behavior unchanged where `pattern_index` values are equal

## Test plan

- [x] `finalize_tokens_latest_pattern_wins_at_same_depth` — higher pattern_index wins
- [x] `finalize_tokens_latest_pattern_wins_regardless_of_insertion_order` — order independence
- [x] `finalize_tokens_depth_beats_pattern_index` — depth still overrides pattern_index
- [x] All 976 existing unit tests pass
- [x] `cargo clippy` clean