### PR TITLE
test(semantic): update snapshot for latest-wins and merge behavior

### DIFF
--- a/tests/snapshots/e2e_semantic__semantic_tokens_lua_decoded.snap
+++ b/tests/snapshots/e2e_semantic__semantic_tokens_lua_decoded.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/e2e_semantic.rs
+assertion_line: 365
 expression: snapshot_tokens
 ---
 [
@@ -13,7 +14,7 @@ expression: snapshot_tokens
   {
     "length": 1,
     "line": 0,
-    "modifiers": 0,
+    "modifiers": 4,
     "start": 6,
     "type": "variable"
   },
@@ -25,17 +26,10 @@ expression: snapshot_tokens
     "type": "operator"
   },
   {
-    "length": 1,
+    "length": 2,
     "line": 0,
     "modifiers": 0,
     "start": 10,
-    "type": "function"
-  },
-  {
-    "length": 1,
-    "line": 0,
-    "modifiers": 0,
-    "start": 11,
     "type": "function"
   },
   {
@@ -48,7 +42,7 @@ expression: snapshot_tokens
   {
     "length": 1,
     "line": 2,
-    "modifiers": 0,
+    "modifiers": 4,
     "start": 9,
     "type": "variable"
   },
@@ -83,7 +77,7 @@ expression: snapshot_tokens
   {
     "length": 1,
     "line": 6,
-    "modifiers": 0,
+    "modifiers": 4,
     "start": 7,
     "type": "variable"
   }


### PR DESCRIPTION
## Summary
- Update stale E2E semantic token snapshot to reflect correct output after PRs #156 and #157
- **PR #156** (latest-pattern-wins): Uppercase `M` now correctly gets `@constant` over `@variable`, mapping to `variable.readonly` (modifier 4)
- **PR #157** (sweep-line token merging): Adjacent `{` `}` constructor tokens merge into a single length-2 token

## Test plan
- [x] `cargo test --features e2e --test e2e_semantic` — all 22 tests pass
- [x] `make test_e2e` — full E2E suite passes