### PR TITLE
fix(test): isolate e2e_data_dir from user config

### DIFF
--- a/tests/e2e_data_dir.rs
+++ b/tests/e2e_data_dir.rs
@@ -10,8 +10,24 @@
 
 mod helpers;
 
-use helpers::lsp_client::LspClient;
+use helpers::lsp_client::{LspClient, LspClientBuilder};
 use serde_json::json;
+use tempfile::TempDir;
+
+/// Create an `LspClientBuilder` that ignores the developer's user config.
+///
+/// The two assertions in this file pin the *default* raw `searchPaths`
+/// (`["${KAKEHASHI_DATA_DIR}"]`), so any non-default user config at
+/// `~/.config/kakehashi/kakehashi.toml` would silently corrupt these tests.
+/// Passing `--config-file <empty-toml>` short-circuits user config discovery
+/// and pins the binary to its built-in defaults.
+fn isolated_builder(tmp: &TempDir) -> LspClientBuilder {
+    let path = tmp.path().join("empty.toml");
+    std::fs::write(&path, "").expect("write empty config");
+    LspClient::builder()
+        .arg("--config-file")
+        .arg(path.to_str().expect("temp path is utf-8"))
+}
 
 /// Helper: initialize the LSP client and return the effective searchPaths.
 fn get_effective_search_paths(client: &mut LspClient) -> Vec<String> {
@@ -54,7 +70,8 @@ fn get_effective_search_paths(client: &mut LspClient) -> Vec<String> {
 /// still contains the `${KAKEHASHI_DATA_DIR}` template.
 #[test]
 fn test_search_paths_returns_raw_template() {
-    let mut client = LspClient::builder()
+    let tmp = TempDir::new().unwrap();
+    let mut client = isolated_builder(&tmp)
         .env_remove("KAKEHASHI_DATA_DIR")
         .build();
 
@@ -71,7 +88,8 @@ fn test_search_paths_returns_raw_template() {
 /// the raw template — expansion happens internally, not in the raw config.
 #[test]
 fn test_env_var_does_not_affect_raw_search_paths() {
-    let mut client = LspClient::builder()
+    let tmp = TempDir::new().unwrap();
+    let mut client = isolated_builder(&tmp)
         .env("KAKEHASHI_DATA_DIR", "/tmp/kakehashi_test_data")
         .build();
 


### PR DESCRIPTION
## Summary
- `tests/e2e_data_dir.rs` asserts the *default* raw `searchPaths` value (`["${KAKEHASHI_DATA_DIR}"]`) but did not pass `--config-file`, so a developer's `~/.config/kakehashi/kakehashi.toml` would leak into the assertion and produce false failures locally.
- Pass an empty temp config file via `--config-file` to short-circuit user config discovery — the same isolation pattern already used by `tests/e2e_config_file.rs`.

## Test plan
- [x] `cargo test --features e2e --test e2e_data_dir` — 19 passed (previously 2 failed in environments with a non-default user `searchPaths`).
- [x] CI re-runs the suite in a clean environment so it should remain green.