### PR TITLE
docs: drop tracker references from code comments

### DIFF
--- a/src/analysis/selection.rs
+++ b/src/analysis/selection.rs
@@ -70,8 +70,7 @@ mod tests {
     /// - If the effective row is > 0, we've moved to a later row (e.g., after skipping
     ///   a fence line), so the column is absolute within the content.
     ///
-    /// Note: This function was used for Point-based calculation before Sprint 9.
-    /// It's now kept for test coverage but production code uses byte-based offsets.
+    /// Kept for test coverage; production code uses byte-based offsets instead.
     fn calculate_nested_start_position(
         parent_start: tree_sitter::Point,
         content_start: tree_sitter::Point,

--- a/src/analysis/selection/context.rs
+++ b/src/analysis/selection/context.rs
@@ -1,17 +1,7 @@
 //! Context structs for SelectionRange building.
 //!
-//! This module provides context structs that bundle related parameters together,
-//! reducing the number of arguments needed for injection-aware selection building.
-//!
-//! ## Design Rationale
-//!
-//! The selection building functions previously had 8-11 parameters, which indicated
-//! missing abstractions. By grouping related parameters into context structs, we:
-//!
-//! 1. **Reduce cognitive load**: Function signatures become clearer
-//! 2. **Make dependencies explicit**: Each context has a clear responsibility
-//! 3. **Enable easier testing**: Contexts can be mocked or stubbed
-//! 4. **Improve code reuse**: Contexts can be passed through call chains
+//! Bundles related parameters together to keep injection-aware selection
+//! building function signatures small and dependencies explicit.
 
 use crate::language::injection::MAX_INJECTION_DEPTH;
 use crate::language::{DocumentParserPool, LanguageCoordinator};

--- a/src/analysis/selection/injection_aware.rs
+++ b/src/analysis/selection/injection_aware.rs
@@ -72,7 +72,7 @@ pub fn calculate_effective_lsp_range(
     let byte_range = ByteRange::new(content_node.start_byte(), content_node.end_byte());
     let effective = calculate_effective_range(text, byte_range, offset);
 
-    // Convert byte positions to LSP positions (reusing cached mapper - Sprint 7 perf fix)
+    // Convert byte positions to LSP positions (reusing cached mapper)
     let start_pos = mapper
         .byte_to_position(effective.start)
         .unwrap_or_else(|| Position::new(0, 0));

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -187,10 +187,8 @@ mod tests {
         assert_eq!(all_tokens.data.len(), 4);
     }
 
-    /// Alias for acceptance criteria naming
     #[test]
     fn test_diff_tokens_no_change() {
-        // Same as test_semantic_tokens_delta_no_changes
         let tokens = SemanticTokens {
             result_id: Some("v1".to_string()),
             data: vec![SemanticToken {
@@ -321,10 +319,8 @@ mod tests {
         );
     }
 
-    /// Test that line insertion disables suffix optimization (PBI-077 safety).
-    ///
     /// When lines are inserted, tokens at the end have the same delta encoding
-    /// but are at different absolute positions. We must NOT match them as suffix.
+    /// but are at different absolute positions, so they must not match as suffix.
     #[test]
     fn test_diff_tokens_line_insertion_no_suffix() {
         // Before: 3 tokens on lines 0, 1, 2

--- a/src/analysis/semantic/delta.rs
+++ b/src/analysis/semantic/delta.rs
@@ -38,8 +38,8 @@ pub(super) fn tokens_equal(a: &SemanticToken, b: &SemanticToken) -> bool {
 /// 2. Finds the longest common suffix (from what remains), with safety check for line changes
 /// 3. Returns a single edit replacing the middle section
 ///
-/// The suffix matching is disabled when total line deltas differ, as tokens with
-/// identical delta encoding would be at different absolute positions (PBI-077 safety).
+/// Suffix matching is disabled when total line deltas differ, since tokens with
+/// identical delta encoding would be at different absolute positions.
 ///
 /// # Arguments
 /// * `previous` - The previous semantic tokens
@@ -71,9 +71,8 @@ pub(super) fn calculate_semantic_tokens_delta(
     let prev_suffix = &previous.data[common_prefix_len..];
     let curr_suffix = &current.data[common_prefix_len..];
 
-    // PBI-077 Safety: Check if total line count changed
-    // When lines are inserted/deleted, tokens with identical delta encoding
-    // are at different absolute positions - suffix matching would be incorrect
+    // When line count changes, identical delta encoding maps to different absolute
+    // positions, so suffix matching is unsafe.
     let prev_total_lines: u32 = previous.data.iter().map(|t| t.delta_line).sum();
     let curr_total_lines: u32 = current.data.iter().map(|t| t.delta_line).sum();
 

--- a/src/analysis/semantic/legend.rs
+++ b/src/analysis/semantic/legend.rs
@@ -179,8 +179,6 @@ mod tests {
         assert!(LEGEND_MODIFIERS.iter().any(|m| m.as_str() == "readonly"));
     }
 
-    // PBI-152: Wildcard Config Inheritance for captureMappings
-
     #[test]
     fn resolve_capture_uses_wildcard_merge() {
         // ADR-0011: When both wildcard and specific key exist, merge them

--- a/src/analysis/semantic_cache.rs
+++ b/src/analysis/semantic_cache.rs
@@ -8,8 +8,8 @@
 //! 2. **InjectionMap** - Tracks all injection regions per document URI.
 //!    Each `CacheableInjectionRegion` stores language, byte/line ranges, and a region_id (ULID).
 //!    Enables targeted invalidation: when an edit occurs, only regions overlapping
-//!    the edit need re-tokenization (see PBI-083).
-//!    Uses interval tree (rust_lapper) for O(log n) overlap queries (PBI-167).
+//!    the edit need re-tokenization.
+//!    Uses interval tree (rust_lapper) for O(log n) overlap queries.
 //!
 //! 3. **InjectionTokenCache** - Per-injection token caching by (URI, region_id).
 //!    Stores tokens for individual code blocks, allowing cache reuse when
@@ -106,7 +106,7 @@ impl Default for SemanticTokenCache {
 ///
 /// Tracks all `CacheableInjectionRegion`s for each document URI,
 /// enabling targeted cache invalidation when only specific injections change.
-/// Uses interval tree (rust_lapper) for O(log n) overlap queries (PBI-167).
+/// Uses interval tree (rust_lapper) for O(log n) overlap queries.
 pub struct InjectionMap {
     /// Stores interval trees per document URI
     /// Each Interval contains the byte range and the full CacheableInjectionRegion as data
@@ -173,8 +173,7 @@ impl InjectionMap {
 
     /// Find all injection regions that overlap with the given byte range.
     ///
-    /// This is the key optimization (PBI-167): uses O(log n) interval tree query
-    /// instead of O(n) iteration through all regions.
+    /// Uses O(log n) interval tree query instead of O(n) iteration through all regions.
     ///
     /// Returns `Some(Vec)` with overlapping regions (may be empty), or `None` if URI unknown.
     pub fn find_overlapping(
@@ -613,9 +612,8 @@ mod tests {
     fn test_injection_map_find_overlapping_efficiently() {
         use crate::language::injection::CacheableInjectionRegion;
 
-        // PBI-167: Test that overlap query is efficient (O(log n) instead of O(n))
-        // This test verifies the API exists and works correctly.
-        // Performance characteristics are validated by the interval tree implementation.
+        // Verifies the overlap query API. Performance (O(log n)) is guaranteed
+        // by the interval tree implementation.
 
         let map = InjectionMap::new();
         let uri = Url::parse("file:///test_large.md").unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -441,7 +441,7 @@ mod tests {
     #[case::explicit_true(Some(true), true)]
     #[case::explicit_false(Some(false), false)]
     fn test_auto_install(#[case] auto_install: Option<bool>, #[case] expected: bool) {
-        // PBI-019: autoInstall defaults to true for zero-config; explicit values honored
+        // autoInstall defaults to true for zero-config; explicit values honored
         let settings = RawWorkspaceSettings {
             search_paths: None,
             languages: HashMap::new(),
@@ -456,16 +456,8 @@ mod tests {
 
     #[test]
     fn test_default_search_paths_format() {
-        // PBI-028: default_search_paths() should return base directory only.
-        //
-        // resolve_library_path() appends "parser/" to each search path,
-        // so default_search_paths() should NOT include "parser" or "queries" subdirectories.
-        //
-        // WRONG: [".../kakehashi/parser", ".../kakehashi/queries"]
-        //   -> resolve_library_path looks for ".../kakehashi/parser/parser/lua.so" (FAILS)
-        //
-        // CORRECT: [".../kakehashi"]
-        //   -> resolve_library_path looks for ".../kakehashi/parser/lua.so" (WORKS)
+        // resolve_library_path() appends "parser/" itself, so default_search_paths()
+        // must return the base directory (not "/parser" or "/queries" subdirectories).
         let paths = default_search_paths();
 
         // Should have exactly one path (the base directory)
@@ -494,9 +486,7 @@ mod tests {
 
     #[test]
     fn test_bridge_router_respects_host_filter() {
-        // PBI-108 AC4: Bridge filtering is applied at request time before routing to language servers
-        // This test verifies that is_language_bridgeable is correctly integrated into
-        // the bridge routing logic.
+        // Bridge filtering is applied at request time before routing to language servers.
         use settings::BridgeLanguageConfig;
 
         // Host markdown with bridge filter: only python and r enabled

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -647,7 +647,7 @@ mod tests {
         assert!(bridge.contains_key("javascript"));
     }
 
-    // PBI-153: Languages Wildcard Inheritance (ADR-0011)
+    // Languages wildcard inheritance (ADR-0011)
 
     #[test]
     fn test_specific_values_override_wildcards_at_both_levels() {
@@ -937,7 +937,7 @@ mod tests {
         );
     }
 
-    // PBI-154: languageServers Wildcard Inheritance (ADR-0011)
+    // languageServers wildcard inheritance (ADR-0011)
 
     /// ADR-0011: resolve_with_wildcard covers all 4 match arms for language servers.
     ///
@@ -1010,7 +1010,7 @@ mod tests {
         );
     }
 
-    // PBI-157: Deep merge for initialization_options (ADR-0010)
+    // Deep merge for initialization_options (ADR-0010)
 
     /// ADR-0010: initialization_options deep merge covers three behaviors:
     /// - Disjoint keys: both preserved (feature1 from base, feature2 from overlay)
@@ -1048,14 +1048,9 @@ mod tests {
         });
     }
 
-    // ========================================================================
-    // Tests moved from lsp_impl.rs (Phase 6.1)
-    // These test wildcard config resolution functions
-    // ========================================================================
+    // Wildcard config resolution tests
 
-    /// PBI-155 Subtask 2: Test wildcard language config inheritance
-    ///
-    /// This test verifies that languages._ (wildcard) settings are inherited
+    /// Verifies that languages._ (wildcard) settings are inherited
     /// by specific languages when looking up language configs.
     ///
     /// The key behavior:
@@ -1129,10 +1124,9 @@ mod tests {
         );
     }
 
-    /// PBI-155 Subtask 2: Test that LanguageSettings lookup uses wildcard resolution
-    ///
-    /// This test verifies the wiring: when we look up host language settings
-    /// using WorkspaceSettings.languages (HashMap<String, LanguageSettings>),
+    /// Verifies that when we look up host language settings using
+    /// WorkspaceSettings.languages (HashMap<String, LanguageSettings>),
+    /// wildcard resolution is applied.
     /// we should use wildcard resolution so that undefined languages inherit
     /// from languages._ settings.
     #[test]
@@ -1165,11 +1159,9 @@ mod tests {
         );
     }
 
-    /// PBI-155 Subtask 3: Test that server lookup uses wildcard resolution
-    ///
-    /// This test verifies that when looking up a language server config by name,
-    /// the wildcard server settings (languageServers._) are merged with specific
-    /// server settings.
+    /// Verifies that when looking up a language server config by name,
+    /// the wildcard server settings (languageServers._) are merged with
+    /// specific server settings.
     ///
     /// Key behavior:
     /// - languageServers._ defines default initialization options

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -1126,8 +1126,7 @@ mod tests {
 
     /// Verifies that when we look up host language settings using
     /// WorkspaceSettings.languages (HashMap<String, LanguageSettings>),
-    /// wildcard resolution is applied.
-    /// we should use wildcard resolution so that undefined languages inherit
+    /// wildcard resolution is applied so that undefined languages inherit
     /// from languages._ settings.
     #[test]
     fn test_language_settings_wildcard_lookup_blocks_bridging_for_undefined_host() {

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -765,7 +765,7 @@ mod tests {
 
     #[test]
     fn should_create_language_settings_with_parser_and_queries() {
-        // PBI-156: LanguageSettings uses parser (not library) and unified queries
+        // LanguageSettings uses parser (not library) and unified queries
         let settings = LanguageSettings {
             parser: Some("/path/to/parser.so".to_string()),
             queries: Some(vec![QueryItem {
@@ -832,8 +832,8 @@ mod tests {
 
     #[test]
     fn should_parse_language_config_with_bridge_map_enabled() {
-        // PBI-120: LanguageSettings should parse bridge field as HashMap<String, BridgeLanguageConfig>
-        // Example: bridge = { python = { enabled = true }, r = { enabled = true } }
+        // bridge = { python = { enabled = true }, r = { enabled = true } } parses as
+        // HashMap<String, BridgeLanguageConfig>.
         let config_json = r#"{
             "parser": "/path/to/parser.so",
             "queries": [{"path": "/path/to/highlights.scm", "kind": "highlights"}],
@@ -854,8 +854,7 @@ mod tests {
 
     #[test]
     fn should_parse_language_config_with_empty_bridge_map() {
-        // PBI-120: Empty bridge map should disable all bridging
-        // bridge: {} disables all bridging for that host filetype
+        // Empty bridge map (`bridge: {}`) disables all bridging for that host filetype.
         let config_json = r#"{
             "parser": "/path/to/parser.so",
             "queries": [{"path": "/path/to/highlights.scm", "kind": "highlights"}],
@@ -874,8 +873,7 @@ mod tests {
 
     #[test]
     fn should_parse_language_config_without_bridge_field() {
-        // PBI-108: Omitted bridge field should be None (bridges all languages)
-        // AC3: bridge omitted or null bridges all configured languages
+        // Omitted bridge field should be None (bridges all configured languages).
         let config_json = r#"{
             "parser": "/path/to/parser.so",
             "queries": [{"path": "/path/to/highlights.scm", "kind": "highlights"}]
@@ -991,7 +989,7 @@ mod tests {
 
     #[test]
     fn should_parse_language_servers_empty() {
-        // PBI-119: Empty languageServers should be valid
+        // Empty languageServers map should be valid.
         let config_json = r#"{
             "languageServers": {}
         }"#;
@@ -1004,7 +1002,7 @@ mod tests {
 
     #[test]
     fn should_parse_without_language_servers() {
-        // PBI-119: Missing languageServers should be None (backward compatibility)
+        // Missing languageServers should deserialize as None.
         let config_json = r#"{
             "searchPaths": ["/usr/local/lib"]
         }"#;
@@ -1016,8 +1014,7 @@ mod tests {
 
     #[test]
     fn should_parse_bridge_language_config() {
-        // PBI-120: BridgeLanguageConfig should deserialize with enabled field
-        // Example: bridge = { python = { enabled = true } }
+        // BridgeLanguageConfig deserializes the `enabled` field.
         let config_json = r#"{
             "enabled": true
         }"#;
@@ -1035,8 +1032,7 @@ mod tests {
 
     #[test]
     fn should_parse_language_config_with_bridge_map() {
-        // PBI-120: LanguageSettings.bridge should be HashMap<String, BridgeLanguageConfig>
-        // Example: bridge = { python = { enabled = true }, r = { enabled = false } }
+        // LanguageSettings.bridge is a HashMap<String, BridgeLanguageConfig>.
         let config_json = r#"{
             "parser": "/path/to/parser.so",
             "queries": [{"path": "/path/to/highlights.scm", "kind": "highlights"}],
@@ -1055,7 +1051,6 @@ mod tests {
         assert_eq!(bridge.get("r").unwrap().enabled, Some(false));
     }
 
-    // PBI-151: Unified query configuration with QueryItem struct
     #[test]
     fn should_parse_query_item_with_path_and_kind() {
         // QueryItem should have path (required) and kind (optional) fields
@@ -1124,7 +1119,8 @@ kind = "injections""#;
         assert_eq!(queries[1].kind, Some(QueryKind::Locals));
     }
 
-    // PBI-151 Subtask 2: Type inference for query kinds
+    // Type inference for query kinds
+
     #[test]
     fn should_infer_highlights_from_filename_pattern() {
         // Only exact match "highlights.scm" -> Some(Highlights)

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -585,7 +585,7 @@ mod tests {
         );
     }
 
-    /// PBI-015: Test that clone_repo works with tag revisions (e.g., v0.25.0)
+    /// clone_repo works with tag revisions (e.g., v0.25.0).
     #[test]
     fn test_clone_repo_with_tag_revision() {
         let temp = tempdir().expect("Failed to create temp dir");

--- a/src/language/injection.rs
+++ b/src/language/injection.rs
@@ -944,10 +944,10 @@ pub struct ResolvedInjection {
 pub struct InjectionResolver;
 
 impl InjectionResolver {
-    /// Resolve injection region at the given byte offset
+    /// Resolve injection region at the given byte offset.
     ///
-    /// This function centralizes the injection resolution logic that was previously
-    /// duplicated across 9 LSP handlers (hover, completion, definition, etc.).
+    /// Shared by LSP handlers (hover, completion, definition, etc.) that resolve
+    /// injection language at a cursor position.
     ///
     /// # Lock Safety
     /// This function does not hold Document locks. All inputs (tree, text) must be

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -717,9 +717,7 @@ mod tests {
         assert!(parsed.used_inheritance, "Should detect inheritance");
     }
 
-    // ============================================================
-    // Tests for query inheritance (PBI-020)
-    // ============================================================
+    // Tests for query inheritance
 
     #[test]
     fn test_parse_inherits_directive_single() {

--- a/src/language/region_id_tracker.rs
+++ b/src/language/region_id_tracker.rs
@@ -1228,9 +1228,8 @@ mod tests {
 
     #[test]
     fn test_end_clamping_prevents_range_collapse() {
-        // With end clamping, range collapse is prevented for Node A/B cases.
-        // Previously large deletes could cause end <= start, but now end is
-        // clamped to edit.new_end_byte, keeping a valid range.
+        // End is clamped to edit.new_end_byte so large deletes cannot make
+        // end <= start, keeping the range valid for Node A/B cases.
         let tracker = RegionIdTracker::new();
         let uri = test_uri("collapse");
 
@@ -2690,25 +2689,13 @@ mod tests {
         );
     }
 
-    // =========================================================================
-    // Phase 5: Regression Guard Test (Phase A - RED)
-    // This test captures the core behavioral difference of Phase 5.
-    // It should FAIL under Phase 4 (merged behavior) and PASS after Phase 5.
-    // =========================================================================
-
     #[test]
-    fn test_phase5_regression_middle_node_not_invalidated() {
-        // This test FAILS under Phase 4 (merged) behavior
-        // and PASSES under Phase 5 (individual) behavior.
-        //
+    fn test_individual_edits_keep_untouched_middle_node() {
         // Setup: "AAABBBCCC" with nodes at [0,3), [3,6), [6,9)
         // Edit:  "XBBBYY" - changes "AAA" to "X" and "CCC" to "YY"
         //
-        // Phase 4 (merged): Single EditInfo [0, 9) → [0, 6)
-        //   Node BBB START (3) is in [0, 9) → INVALIDATED (wrong!)
-        //
-        // Phase 5 (individual): Two EditInfos [0,3) and [6,9)
-        //   Node BBB START (3) is NOT in [0,3) and NOT in [6,9) → KEPT (correct!)
+        // With merged EditInfo [0,9), BBB's START (3) would fall inside and be
+        // invalidated. With individual EditInfos [0,3) and [6,9), BBB stays untouched.
         let tracker = RegionIdTracker::new();
         let uri = test_uri("regression");
 

--- a/src/lsp/aggregation/server/fan_out.rs
+++ b/src/lsp/aggregation/server/fan_out.rs
@@ -91,12 +91,9 @@ pub(crate) fn select_servers(
 
 /// Spawn one task per matching server, returning a `JoinSet` for collection.
 ///
-/// Centralises the per-server clone boilerplate that was previously duplicated
-/// in every fan-out handler. The caller supplies a closure that receives a
-/// [`FanOutTask`] and returns the handler-specific future.
-///
-/// Each task result is wrapped in [`TaggedResult`] so fan-in strategies
-/// can identify which server produced each result.
+/// The caller supplies a closure that receives a [`FanOutTask`] and returns
+/// the handler-specific future. Each task result is wrapped in [`TaggedResult`]
+/// so fan-in strategies can identify which server produced it.
 #[must_use = "the JoinSet must be passed to a collection strategy"]
 pub(crate) fn fan_out<T, F, Fut>(
     ctx: &DocumentRequestContext,

--- a/src/lsp/bridge/connection.rs
+++ b/src/lsp/bridge/connection.rs
@@ -354,7 +354,7 @@ impl SplitConnectionWriter {
 
 impl Drop for SplitConnectionWriter {
     fn drop(&mut self) {
-        // Kill the child process to prevent orphans (AC3)
+        // Kill the child process to prevent orphans.
         if let Err(e) = self.child.start_kill() {
             log::warn!(
                 target: "kakehashi::bridge",
@@ -467,8 +467,7 @@ impl AsyncBridgeConnection {
 
 impl Drop for AsyncBridgeConnection {
     fn drop(&mut self) {
-        // Kill the child process to prevent orphans (AC3)
-        // Child may be None if split() was called
+        // Kill the child process to prevent orphans (None if split() was called).
         if let Some(ref mut child) = self.child {
             if let Err(e) = child.start_kill() {
                 log::warn!(

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -82,13 +82,11 @@ struct EagerOpenBatch {
 /// # Design Notes
 ///
 /// The coordinator exposes internals via accessor methods (`pool()`, `region_id_tracker()`)
-/// for handlers that need direct access. This is a pragmatic trade-off for Phase 5:
-/// - Keeps handler changes minimal (just path changes, not signature changes)
-/// - Allows future phases to encapsulate these internals further
+/// for handlers that need direct access.
 ///
 /// The pool is wrapped in `Arc` to enable sharing with the cancel forwarding middleware.
 ///
-/// # API Design Pattern (Sprint 15 Retrospective)
+/// # API Design Pattern
 ///
 /// Two access patterns coexist:
 ///

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -2764,12 +2764,9 @@ mod tests {
         );
     }
 
-    /// Test that response forwarding still works after cancel notification is sent.
-    ///
-    /// This is the key test for Subtask 6: Per LSP spec, a cancelled request should
-    /// still receive a response (either the normal result or an error with code -32800).
-    /// The cancel forwarding mechanism must preserve the pending entry so that when
-    /// the downstream server eventually responds, we can still deliver it.
+    /// Per LSP spec, a cancelled request still receives a response (either the normal
+    /// result or an error with code -32800). The cancel forwarding mechanism must
+    /// preserve the pending entry so the eventual downstream response can be delivered.
     #[tokio::test]
     async fn response_forwarding_works_after_cancel() {
         use std::sync::Arc;
@@ -3484,11 +3481,8 @@ mod tests {
     // forward_didchange multi-server tests
     // ============================================================
 
-    /// Test that forward_didchange_to_opened_docs sends to ALL servers.
-    ///
     /// When the same virtual doc is opened on two servers (e.g., emmylua and lua_ls),
-    /// didChange must be forwarded to both. Previously, only the first server found
-    /// by the old get_server_for_virtual_uri received the notification.
+    /// didChange must be forwarded to both.
     #[tokio::test]
     async fn forward_didchange_sends_to_all_servers() {
         let pool = Arc::new(LanguageServerPool::new());

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -97,10 +97,10 @@ impl CacheCoordinator {
     /// Invalidate injection caches for regions that overlap with edits.
     ///
     /// Called BEFORE parse_document to use pre-edit byte offsets against pre-edit
-    /// injection regions. This implements AC4/AC5 (PBI-083): edits outside injections
-    /// preserve caches, edits inside invalidate only affected regions.
+    /// injection regions: edits outside injections preserve caches, edits inside
+    /// invalidate only affected regions.
     ///
-    /// PBI-167: Uses O(log n) interval tree query instead of O(n) iteration.
+    /// Uses an O(log n) interval tree query.
     pub(crate) fn invalidate_for_edits(&self, uri: &Url, edits: &[InputEdit]) {
         if edits.is_empty() {
             return;
@@ -167,8 +167,8 @@ impl CacheCoordinator {
 
     /// Populate InjectionMap with injection regions from the parsed tree.
     ///
-    /// This enables targeted cache invalidation (PBI-083): when an edit occurs,
-    /// we can check which injection regions overlap and only invalidate those.
+    /// Enables targeted cache invalidation: when an edit occurs, we can check
+    /// which injection regions overlap and only invalidate those.
     ///
     /// Region IDs are generated using `RegionIdTracker` which provides position-based
     /// ULIDs. The same (uri, start_byte, end_byte, kind) always produces the same ULID,

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -1,7 +1,7 @@
 //! Pull diagnostics for Kakehashi (textDocument/diagnostic).
 //!
-//! Implements ADR-0020 Phase 1: Pull-first diagnostic forwarding.
-//! Sprint 17: Multi-region diagnostic aggregation with parallel fan-out.
+//! Implements ADR-0020 Phase 1: Pull-first diagnostic forwarding with
+//! multi-region aggregation via parallel fan-out.
 //!
 //! For synthetic push diagnostics (publishDiagnostics), see `publish_diagnostic.rs`.
 //!

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -52,8 +52,8 @@ impl Kakehashi {
             self.bridge.apply_input_edits(&uri, &edit_infos)
         };
 
-        // Invalidate injection caches for regions overlapping with edits (AC4/AC5)
-        // Must be called BEFORE parse_document which updates the injection_map
+        // Invalidate injection caches for regions overlapping with edits.
+        // Must be called BEFORE parse_document which updates the injection_map.
         self.cache.invalidate_for_edits(&uri, &edits);
 
         // Parse the updated document with edit information

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -1021,9 +1021,8 @@ mod tests {
             None, // tree will be None until next parse
         );
 
-        // The cache should STILL contain the previous tokens
-        // (This is the key assertion - previously this would fail because
-        // didChange invalidated the cache)
+        // The cache must retain previous tokens after didChange — the delta
+        // calculation on the next semanticTokens request depends on them.
         let still_cached = server.cache.get_tokens_if_valid(&uri, &result_id);
         assert!(
             still_cached.is_some(),

--- a/src/lsp/settings.rs
+++ b/src/lsp/settings.rs
@@ -269,11 +269,8 @@ mod tests {
     use serial_test::serial;
     use tempfile::TempDir;
 
-    /// PBI-155 Subtask 1: Verify load_settings() uses 4-layer merge
-    ///
-    /// This test verifies that load_settings():
-    /// 1. Loads user config from XDG_CONFIG_HOME
-    /// 2. Merges 4 layers via reduce(merge_workspace_settings): defaults < user < project < InitializationOptions
+    /// load_settings() merges 4 layers via reduce(merge_workspace_settings):
+    /// defaults < user (XDG_CONFIG_HOME) < project < InitializationOptions.
     #[test]
     #[serial(xdg_env)]
     fn test_load_settings_merges_user_config_with_project_and_override() {
@@ -355,7 +352,7 @@ mod tests {
         );
     }
 
-    /// PBI-155: Verify override_settings (InitializationOptions) has highest precedence
+    /// override_settings (InitializationOptions) has highest precedence.
     #[test]
     #[serial(xdg_env)]
     fn test_load_settings_override_has_highest_precedence() {
@@ -434,7 +431,7 @@ mod tests {
         );
     }
 
-    /// PBI-155: Verify user config loading logs appropriate events
+    /// User config loading logs appropriate events.
     #[test]
     #[serial(xdg_env)]
     fn test_load_settings_logs_user_config_events() {

--- a/tests/e2e_incremental_sync.rs
+++ b/tests/e2e_incremental_sync.rs
@@ -1,8 +1,7 @@
 //! End-to-end test for incremental sync (TextDocumentSyncKind::Incremental).
 //!
-//! This test verifies that when didChange uses incremental sync (with range),
-//! the apply_edits path (Phase 4) correctly processes the edit and updates
-//! region tracking without over-invalidating ULIDs.
+//! Verifies that range-based didChange goes through the apply_edits path,
+//! updating region tracking without over-invalidating ULIDs.
 //!
 //! Run with: `cargo test --test e2e_incremental_sync --features e2e`
 //!
@@ -18,16 +17,10 @@ use helpers::lua_bridge::{
 };
 use serde_json::json;
 
-/// E2E test: incremental sync (range-based didChange) works correctly
+/// E2E: range-based didChange preserves region tracking and ULIDs (apply_edits path).
 ///
-/// This test verifies Phase 4's apply_edits path:
-/// 1. Open a markdown document with a Lua block
-/// 2. Trigger hover to establish virtual document
-/// 3. Send incremental didChange (with range, not full text)
-/// 4. Verify hover still works (no error — region tracking correct, ULID preserved)
-///
-/// The key difference from e2e_didchange_forwarding is using incremental sync
-/// with `range` instead of full document replacement.
+/// Differs from `e2e_didchange_forwarding` by using incremental sync with `range`
+/// rather than full document replacement.
 #[test]
 fn e2e_incremental_sync_preserves_region_tracking() {
     if skip_if_lua_ls_unavailable() {

--- a/tests/e2e_lsp_lua_diagnostic.rs
+++ b/tests/e2e_lsp_lua_diagnostic.rs
@@ -237,16 +237,12 @@ More text.
     shutdown_client(&mut client);
 }
 
-/// E2E test: multi-region diagnostic aggregation with multiple Lua code blocks
-///
-/// Sprint 17: Verifies that diagnostics from multiple injection regions
-/// are aggregated into a single response.
+/// E2E: diagnostics from multiple injection regions aggregate into a single response.
 #[test]
 fn e2e_diagnostic_multi_region_aggregation() {
     let (mut client, _config_dir) = create_lua_configured_client();
 
-    // Open markdown document with MULTIPLE Lua code blocks
-    // This tests the Sprint 17 multi-region aggregation
+    // Open markdown document with multiple Lua code blocks to exercise multi-region aggregation.
     let markdown_content = r#"# Multi-Region Diagnostic Test
 
 First Lua block:

--- a/tests/e2e_lsp_lua_hover.rs
+++ b/tests/e2e_lsp_lua_hover.rs
@@ -21,7 +21,7 @@ use helpers::lua_bridge::{
 };
 use serde_json::json;
 
-/// E2E test: hover on Lua function shows signature (AC2)
+/// E2E: hover on a Lua function shows its signature.
 #[test]
 fn e2e_hover_on_lua_function_shows_signature() {
     if skip_if_lua_ls_unavailable() {
@@ -96,7 +96,7 @@ More text.
     shutdown_client(&mut client);
 }
 
-/// E2E test: hover on Lua local variable shows type (AC1)
+/// E2E: hover on a Lua local variable shows its type.
 #[test]
 fn e2e_hover_on_lua_local_variable_shows_type() {
     if skip_if_lua_ls_unavailable() {

--- a/tests/e2e_lsp_lua_signature_help.rs
+++ b/tests/e2e_lsp_lua_signature_help.rs
@@ -38,7 +38,7 @@ fn verify_signature_help_has_signatures(result: &serde_json::Value) -> bool {
     }
 }
 
-/// E2E test: signature help on string.format shows parameters (AC1)
+/// E2E: signature help on string.format shows parameters.
 #[test]
 fn e2e_signature_help_on_string_format_shows_parameters() {
     if skip_if_lua_ls_unavailable() {
@@ -123,7 +123,7 @@ More text.
     shutdown_client(&mut client);
 }
 
-/// E2E test: signature help on print function shows parameter (AC2)
+/// E2E: signature help on print shows its parameter.
 #[test]
 fn e2e_signature_help_on_print_shows_parameter() {
     if skip_if_lua_ls_unavailable() {
@@ -197,7 +197,7 @@ More text.
     shutdown_client(&mut client);
 }
 
-/// E2E test: signature help on custom function shows parameters (AC3)
+/// E2E: signature help on a user-defined function shows its parameters.
 #[test]
 fn e2e_signature_help_on_custom_function_shows_parameters() {
     if skip_if_lua_ls_unavailable() {

--- a/tests/e2e_nonblocking_init.rs
+++ b/tests/e2e_nonblocking_init.rs
@@ -1,13 +1,10 @@
-//! End-to-end tests for non-blocking initialization (PBI-304).
+//! End-to-end tests for non-blocking initialization.
 //!
-//! These tests verify that kakehashi responds quickly even when
-//! downstream language servers like lua-language-server are still initializing.
+//! kakehashi must respond quickly even while downstream language servers like
+//! lua-language-server are still initializing, and native features (selection
+//! range, etc.) must work throughout bridge init.
 //!
 //! Run with: `cargo test --test e2e_nonblocking_init --features e2e`
-//!
-//! **PBI-304 Acceptance Criteria**:
-//! - AC1: kakehashi responds without blocking during lua-ls startup
-//! - AC4: Native features (selection range, etc.) work during bridge init
 
 #![cfg(feature = "e2e")]
 
@@ -39,10 +36,7 @@ fn create_minimal_client() -> LspClient {
     client
 }
 
-/// E2E test: Native selection range works regardless of bridge state (AC4)
-///
-/// This test verifies that kakehashi native features like selection range
-/// work correctly even while bridge language servers might be initializing.
+/// E2E: native selection range works regardless of bridge state.
 #[test]
 fn e2e_native_selection_range_works_during_bridge_init() {
     let mut client = create_minimal_client();
@@ -104,16 +98,13 @@ end
         "Should have at least one selection range"
     );
 
-    println!("✓ E2E AC4: Native selection range works during bridge init");
+    println!("✓ Native selection range works during bridge init");
 
     // Clean shutdown
     shutdown_client(&mut client);
 }
 
-/// E2E test: Selection range in markdown with injection works (AC4 variant)
-///
-/// Tests that selection range works on markdown files with code blocks,
-/// even if those code blocks would trigger bridge initialization.
+/// E2E: selection range works on markdown with injected code blocks during bridge init.
 #[test]
 fn e2e_native_selection_range_works_in_markdown_with_injection() {
     if skip_if_lua_ls_unavailable() {
@@ -172,16 +163,13 @@ More text.
         "Result should be array of SelectionRange"
     );
 
-    println!("✓ E2E AC4: Selection range in markdown works during bridge init");
+    println!("✓ Selection range in markdown works during bridge init");
 
     // Clean shutdown
     shutdown_client(&mut client);
 }
 
-/// E2E test: Semantic tokens work during bridge initialization (AC4)
-///
-/// Tests that semantic token requests complete quickly without waiting
-/// for downstream language servers.
+/// E2E: semantic token requests complete without waiting for downstream language servers.
 #[test]
 fn e2e_native_semantic_tokens_work_during_bridge_init() {
     let mut client = create_minimal_client();
@@ -228,7 +216,7 @@ end
     let result = response.get("result").expect("Should have result");
     assert!(result.is_object(), "Result should be SemanticTokens object");
 
-    println!("✓ E2E AC4: Semantic tokens work during bridge init");
+    println!("✓ Semantic tokens work during bridge init");
 
     // Clean shutdown
     shutdown_client(&mut client);

--- a/tests/e2e_stable_region_id.rs
+++ b/tests/e2e_stable_region_id.rs
@@ -29,11 +29,8 @@ use helpers::lua_bridge::{
 };
 use serde_json::json;
 
-/// E2E test: hover then complete on same Lua block shares virtual document URI
-///
-/// This verifies PBI-STABLE-REGION-ID acceptance criteria:
-/// - Hover and completion use the same virtual URI for the same injection region
-/// - First access sends didOpen, subsequent access sends didChange (not didOpen again)
+/// E2E: hover then completion on the same Lua block shares one virtual document URI.
+/// First access sends didOpen; subsequent accesses send didChange.
 #[test]
 fn e2e_hover_then_completion_on_same_lua_block_shares_uri() {
     if skip_if_lua_ls_unavailable() {


### PR DESCRIPTION
## Summary
- Strips `PBI-XXX`, `Sprint XX`, `Subtask N`, and `(AC1)`/`(AC2)`/etc. markers from comments and docstrings across ~25 files in `src/` and `tests/`.
- Tightens historical-narrative comments (e.g. "this function previously had 8-11 parameters", "this was previously duplicated across N handlers") into present-tense descriptions of current behavior.
- Net change: **-99 lines** (200 removed, 101 added) — substance preserved, tracker noise gone.

## Why
Tracker IDs and sprint history point at issue-tracker context that decays as the tracker evolves. Per `CLAUDE.md`, commits already carry the *why* — comments should describe the *why not* of the current code. `ADR-XXXX` references are kept because the documents live under `docs/adr/` in this repo.

## Test plan
- [x] `cargo check --tests --features e2e` passes
- [x] Pre-commit hook (`cargo clippy --all-targets --all-features -- -D warnings` + unit/integration tests) passes
- [ ] No behavior change — comments only