### PR TITLE
feat(lsp): implement kakehashi/node/parent (ADR-0025 PR-2)

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -585,6 +585,7 @@ async fn run_lsp_server() {
     )
     .custom_method("kakehashi/node", Kakehashi::kakehashi_node)
     .custom_method("kakehashi/node/text", Kakehashi::kakehashi_node_text)
+    .custom_method("kakehashi/node/parent", Kakehashi::kakehashi_node_parent)
     .finish();
 
     // Wrap service with RequestIdCapture to:

--- a/src/lsp/lsp_impl/kakehashi/node.rs
+++ b/src/lsp/lsp_impl/kakehashi/node.rs
@@ -5,8 +5,10 @@
 //!
 //! - [`entry`]: `kakehashi/node` — position → NodeInfo entry point
 //! - [`text`]: `kakehashi/node/text` — id → current node text
+//! - [`parent`]: `kakehashi/node/parent` — id → immediate-parent NodeInfo
 //!
-//! Future PRs will add `parent` and `children` handlers alongside these.
+//! Future PRs will add a `children` handler alongside these.
 
 mod entry;
+mod parent;
 mod text;

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -119,7 +119,7 @@ impl Kakehashi {
     /// not a stale combination produced mid-parse. The timeout matches the
     /// `semantic_tokens` budget so this helper stays responsive even if the
     /// parser hangs on a pathological input.
-    async fn ensure_parsed_for_node_lookup(&self, uri: &Url) {
+    pub(super) async fn ensure_parsed_for_node_lookup(&self, uri: &Url) {
         self.documents
             .wait_for_parse_completion(uri, std::time::Duration::from_millis(200))
             .await;

--- a/src/lsp/lsp_impl/kakehashi/node/parent.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/parent.rs
@@ -109,10 +109,14 @@ impl Kakehashi {
 /// Find a tree-sitter node in `tree` whose `(start_byte, end_byte, kind)` matches
 /// the tracked triple.
 ///
-/// Tree-sitter does not expose a direct "find node by composite key" API, so we
-/// start from the smallest descendant covering `[start, end)` (which is the
-/// usual case for a tracked node) and walk up to the root looking for an exact
-/// match. The walk is bounded by tree depth and runs in O(depth) time.
+/// `descendant_for_byte_range` returns the smallest node containing `[start,
+/// end)`. If that node's range is not exactly `(start, end)`, no ancestor can
+/// match either (ancestors only grow), so we bail immediately. When the range
+/// matches but the kind doesn't, we walk upward but stop as soon as the
+/// ancestor's range diverges from `(start, end)` — this handles the rare case
+/// where multiple nodes share a span (e.g., a `document` wrapping a `section`
+/// that wraps a `paragraph` all starting at byte 0) without doing useless work
+/// on truly larger ancestors. The walk runs in O(depth-of-same-span chain).
 fn find_node_at<'tree>(
     tree: &'tree tree_sitter::Tree,
     start: usize,
@@ -130,18 +134,22 @@ fn find_node_at<'tree>(
     }
 
     // `descendant_for_byte_range(start, end)` returns the smallest node whose
-    // byte range contains `[start, end)`. For a tracked node, that's the node
-    // itself; for stale ranges it returns the containing node, in which case
-    // the upward walk below will fail to find a match (and we return None).
+    // byte range contains `[start, end)`. If its range does not match exactly,
+    // no node in the tree has `(start, end)` and we can stop here.
     let mut current = root.descendant_for_byte_range(start, end)?;
+    if current.start_byte() != start || current.end_byte() != end {
+        return None;
+    }
 
     loop {
-        if current.start_byte() == start && current.end_byte() == end && current.kind() == kind {
+        if current.kind() == kind {
             return Some(current);
         }
         match current.parent() {
-            Some(parent) => current = parent,
-            None => return None,
+            Some(parent) if parent.start_byte() == start && parent.end_byte() == end => {
+                current = parent;
+            }
+            _ => return None,
         }
     }
 }

--- a/src/lsp/lsp_impl/kakehashi/node/parent.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/parent.rs
@@ -1,0 +1,132 @@
+//! `kakehashi/node/parent` — id → immediate-parent NodeInfo (ADR-0025).
+//!
+//! Resolves a previously-issued ULID to its tracked `(start_byte, end_byte, kind)`
+//! triple, locates the matching tree-sitter node in the current parse tree, and
+//! returns a [`NodeInfo`](../../../../../docs/adr/0025-node-reference-protocol.md#nodeinfo-type)
+//! for its tree-sitter parent.
+//!
+//! Per ADR-0025 §"Navigation Methods", navigation stays within a single language
+//! tree: calling `parent` on the root of an injected tree must **not** cross
+//! into the host node that contains the injection. This handler currently only
+//! operates on the host tree (matching PR-1); PR-4 will extend the protocol with
+//! explicit injection-layer addressing.
+//!
+//! Returns `null` (serialized as JSON `null`) when:
+//! - the URI is unknown or invalid,
+//! - the ULID is malformed or was never issued / has been invalidated,
+//! - the document has not yet been parsed,
+//! - the tracked range cannot be matched against a node in the current tree
+//!   (defensive: should not happen while the tracker is in sync), or
+//! - the matched node is the root of the tree (no parent).
+
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tower_lsp_server::jsonrpc::Result;
+use tower_lsp_server::ls_types::TextDocumentIdentifier;
+use ulid::Ulid;
+
+use crate::lsp::lsp_impl::{Kakehashi, uri_to_url};
+
+/// Request parameters for `kakehashi/node/parent`.
+///
+/// `pub` because the handler is registered as a custom LSP method in the
+/// `kakehashi` binary (see `src/bin/main.rs`).
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeParentParams {
+    pub text_document: TextDocumentIdentifier,
+    pub id: String,
+}
+
+impl Kakehashi {
+    /// Handler for `kakehashi/node/parent`.
+    pub async fn kakehashi_node_parent(&self, params: NodeParentParams) -> Result<Value> {
+        let lsp_uri = params.text_document.uri;
+        let Ok(uri) = uri_to_url(&lsp_uri) else {
+            log::warn!(target: "kakehashi::node::parent", "invalid URI: {}", lsp_uri.as_str());
+            return Ok(Value::Null);
+        };
+
+        // Malformed ULID collapses to null per ADR-0025 §"Invalidate vs Not-Found".
+        let Ok(ulid) = params.id.parse::<Ulid>() else {
+            return Ok(Value::Null);
+        };
+
+        // Look up the tracked node's byte range and kind. None means: never
+        // issued, invalidated by a prior edit, or this URI has no entries.
+        let Some((start, end, kind)) = self.bridge.node_tracker().lookup_position(&uri, &ulid)
+        else {
+            return Ok(Value::Null);
+        };
+
+        // Snapshot the document so we operate on a consistent (text, tree) pair.
+        let Some(snapshot) = self.documents.get(&uri).and_then(|doc| doc.snapshot()) else {
+            log::debug!(target: "kakehashi::node::parent", "no parsed document for {}", uri);
+            return Ok(Value::Null);
+        };
+        let tree = snapshot.tree();
+
+        // Find the tree-sitter node matching the tracked (start, end, kind).
+        // Defensive: the tracker stays in sync with didChange, so this should
+        // always succeed for a non-null lookup.
+        let Some(node) = find_node_at(tree, start, end, &kind) else {
+            log::warn!(
+                target: "kakehashi::node::parent",
+                "tracker hit but no matching node in tree for ulid={} uri={} range=[{},{}) kind={}",
+                ulid, uri, start, end, kind
+            );
+            return Ok(Value::Null);
+        };
+
+        // ADR-0025 "Scope rule": parent navigation stays within a single tree.
+        // tree-sitter's `node.parent()` returns None for the tree root, which is
+        // the exact semantics we want — do NOT chase into an enclosing host
+        // injection node.
+        let Some(parent) = node.parent() else {
+            return Ok(Value::Null);
+        };
+
+        // Issue / reuse a stable ULID for the parent (ADR-0019 lazy assignment).
+        let parent_ulid = self.bridge.node_tracker().get_or_create(
+            &uri,
+            parent.start_byte(),
+            parent.end_byte(),
+            parent.kind(),
+        );
+
+        Ok(json!({
+            "id": parent_ulid.to_string(),
+            "type": parent.kind(),
+        }))
+    }
+}
+
+/// Find a tree-sitter node in `tree` whose `(start_byte, end_byte, kind)` matches
+/// the tracked triple.
+///
+/// Tree-sitter does not expose a direct "find node by composite key" API, so we
+/// start from the smallest descendant covering `[start, end)` (which is the
+/// usual case for a tracked node) and walk up to the root looking for an exact
+/// match. The walk is bounded by tree depth and runs in O(depth) time.
+fn find_node_at<'tree>(
+    tree: &'tree tree_sitter::Tree,
+    start: usize,
+    end: usize,
+    kind: &str,
+) -> Option<tree_sitter::Node<'tree>> {
+    // `descendant_for_byte_range(start, end)` returns the smallest node whose
+    // byte range contains `[start, end)`. For a tracked node, that's the node
+    // itself; for stale ranges it returns the containing node, in which case
+    // the upward walk below will fail to find a match (and we return None).
+    let mut current = tree.root_node().descendant_for_byte_range(start, end)?;
+
+    loop {
+        if current.start_byte() == start && current.end_byte() == end && current.kind() == kind {
+            return Some(current);
+        }
+        match current.parent() {
+            Some(parent) => current = parent,
+            None => return None,
+        }
+    }
+}

--- a/src/lsp/lsp_impl/kakehashi/node/parent.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/parent.rs
@@ -59,6 +59,11 @@ impl Kakehashi {
             return Ok(Value::Null);
         };
 
+        // Ensure the document is parsed before snapshotting — same race as in
+        // `kakehashi/node`: didOpen schedules an async parse, a client that
+        // immediately follows up with `parent` must not see `tree: None`.
+        self.ensure_parsed_for_node_lookup(&uri).await;
+
         // Snapshot the document so we operate on a consistent (text, tree) pair.
         let Some(snapshot) = self.documents.get(&uri).and_then(|doc| doc.snapshot()) else {
             log::debug!(target: "kakehashi::node::parent", "no parsed document for {}", uri);
@@ -114,11 +119,21 @@ fn find_node_at<'tree>(
     end: usize,
     kind: &str,
 ) -> Option<tree_sitter::Node<'tree>> {
+    // Defensive: reject obviously-invalid ranges before handing them to
+    // tree-sitter. A stale tracker entry (or future bug) could pass a range
+    // outside the parsed tree's bounds; the underlying C bindings have, at
+    // various tree-sitter versions, exhibited surprising behavior for such
+    // inputs. Returning None preserves the caller's null-collapse semantics.
+    let root = tree.root_node();
+    if start > end || end > root.end_byte() {
+        return None;
+    }
+
     // `descendant_for_byte_range(start, end)` returns the smallest node whose
     // byte range contains `[start, end)`. For a tracked node, that's the node
     // itself; for stale ranges it returns the containing node, in which case
     // the upward walk below will fail to find a match (and we return None).
-    let mut current = tree.root_node().descendant_for_byte_range(start, end)?;
+    let mut current = root.descendant_for_byte_range(start, end)?;
 
     loop {
         if current.start_byte() == start && current.end_byte() == end && current.kind() == kind {

--- a/src/lsp/lsp_impl/kakehashi/node/parent.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/parent.rs
@@ -74,7 +74,7 @@ impl Kakehashi {
         // Find the tree-sitter node matching the tracked (start, end, kind).
         // Defensive: the tracker stays in sync with didChange, so this should
         // always succeed for a non-null lookup.
-        let Some(node) = find_node_at(tree, start, end, &kind) else {
+        let Some(node) = find_node_at(tree, start, end, kind) else {
             log::warn!(
                 target: "kakehashi::node::parent",
                 "tracker hit but no matching node in tree for ulid={} uri={} range=[{},{}) kind={}",

--- a/tests/e2e_kakehashi_node.rs
+++ b/tests/e2e_kakehashi_node.rs
@@ -438,12 +438,16 @@ fn test_node_parent_returns_immediate_parent_for_nested_node() {
         "parent type field should be the tree-sitter parent kind, got empty string"
     );
 
-    // Sanity: a single parent hop should not loop back to the same kind for
-    // this fixture (paragraph text's parent is not itself "text"/"inline" at
-    // the same depth). We don't pin the exact grammar-derived name to keep the
-    // test resilient to upstream tree-sitter-markdown changes, but a same-type
-    // identity hop would indicate the handler is returning the input node.
-    let _ = child_type; // referenced for clarity; assertion is positional below.
+    // Sanity: the parent must be structurally distinct from the child. We
+    // don't pin the exact grammar-derived names (tree-sitter-markdown's tag
+    // names can change across versions), but if the parent's type equals the
+    // child's type at the same span the handler is suspiciously returning the
+    // input node rather than its parent.
+    assert_ne!(
+        parent_type, child_type,
+        "parent's type ({:?}) must differ from child's type ({:?}); same-type hop suggests the handler returned the input node",
+        parent_type, child_type
+    );
 }
 
 /// Walking `kakehashi/node/parent` repeatedly from any in-document node must

--- a/tests/e2e_kakehashi_node.rs
+++ b/tests/e2e_kakehashi_node.rs
@@ -1,12 +1,16 @@
-//! End-to-end tests for `kakehashi/node` and `kakehashi/node/text` (ADR-0025 PR-1).
+//! End-to-end tests for `kakehashi/node`, `kakehashi/node/text`, and
+//! `kakehashi/node/parent` (ADR-0025 PR-1 + PR-2).
 //!
-//! Covers the entry-point method (position → NodeInfo) plus the text resolution
-//! method (id → current node text) and their interaction with `didChange`:
+//! Covers the entry-point method (position → NodeInfo), the text resolution
+//! method (id → current node text), the parent navigation method
+//! (child id → parent NodeInfo), and their interaction with `didChange`:
 //!
 //! - smallest-at-cursor lookup for named-or-anonymous nodes (host language only)
 //! - end-of-document exception (`b == L && L > 0 && e == L`)
 //! - empty document and out-of-bounds returning `null`
 //! - `kakehashi/node/text` returning the live slice for a tracked node
+//! - `kakehashi/node/parent` walking one step toward the root
+//! - parent returning null at the root and for unknown ids
 //! - ULID survival across position-adjusting edits
 //! - ULID invalidation when the edit covers the node's START byte
 //!
@@ -59,6 +63,27 @@ fn request_node_text(client: &mut LspClient, uri: &str, id: &str) -> Value {
     assert!(
         response.get("error").is_none(),
         "kakehashi/node/text returned an error: {:?}",
+        response.get("error")
+    );
+    response
+        .get("result")
+        .cloned()
+        .expect("response must contain a result field")
+}
+
+/// Send `kakehashi/node/parent` for an id and unwrap the `result` field
+/// (which may be `null`).
+fn request_node_parent(client: &mut LspClient, uri: &str, id: &str) -> Value {
+    let response = client.send_request(
+        "kakehashi/node/parent",
+        json!({
+            "textDocument": { "uri": uri },
+            "id": id
+        }),
+    );
+    assert!(
+        response.get("error").is_none(),
+        "kakehashi/node/parent returned an error: {:?}",
         response.get("error")
     );
     response
@@ -355,5 +380,134 @@ fn test_node_at_heading_returns_node_info() {
     assert!(
         !ty.is_empty(),
         "type field should be the tree-sitter node kind, got empty string"
+    );
+}
+
+/// `kakehashi/node/parent` walks one step toward the root of the same language
+/// tree (ADR-0025 §"Navigation Methods"). Acquiring an id deep inside a nested
+/// markdown structure and asking for its parent must yield a NodeInfo whose id
+/// is distinct from the child's and whose type is the kind of the immediate
+/// tree-sitter parent.
+#[test]
+fn test_node_parent_returns_immediate_parent_for_nested_node() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+
+    let uri = "file:///test_kakehashi_node_parent_nested.md";
+    // Nested structure: document → section → paragraph → inline → text.
+    let text = "# Heading\n\nSome paragraph text.\n";
+    open_markdown(&mut client, uri, text);
+
+    // Cursor inside the paragraph text on the second non-empty line.
+    let child = request_node(&mut client, uri, 2, 5);
+    assert!(!child.is_null(), "expected NodeInfo for paragraph text");
+    let child_id = child
+        .get("id")
+        .and_then(Value::as_str)
+        .expect("child id must be a string")
+        .to_string();
+    let child_type = child
+        .get("type")
+        .and_then(Value::as_str)
+        .expect("child type must be a string")
+        .to_string();
+
+    let parent = request_node_parent(&mut client, uri, &child_id);
+    assert!(
+        !parent.is_null(),
+        "a non-root node must have a parent, got null"
+    );
+
+    let parent_id = parent.get("id").expect("parent must have id field");
+    assert_ulid_shaped(parent_id);
+    let parent_id_str = parent_id
+        .as_str()
+        .expect("parent id must be a string")
+        .to_string();
+    assert_ne!(
+        parent_id_str, child_id,
+        "parent id must differ from the child id"
+    );
+
+    let parent_type = parent
+        .get("type")
+        .and_then(Value::as_str)
+        .expect("parent type must be a non-empty string");
+    assert!(
+        !parent_type.is_empty(),
+        "parent type field should be the tree-sitter parent kind, got empty string"
+    );
+
+    // Sanity: a single parent hop should not loop back to the same kind for
+    // this fixture (paragraph text's parent is not itself "text"/"inline" at
+    // the same depth). We don't pin the exact grammar-derived name to keep the
+    // test resilient to upstream tree-sitter-markdown changes, but a same-type
+    // identity hop would indicate the handler is returning the input node.
+    let _ = child_type; // referenced for clarity; assertion is positional below.
+}
+
+/// Walking `kakehashi/node/parent` repeatedly from any in-document node must
+/// eventually surface the root, at which point one more `parent` call returns
+/// null (ADR-0025 §"Navigation Methods" — "id refers to a root node").
+#[test]
+fn test_node_parent_returns_null_at_root() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+
+    let uri = "file:///test_kakehashi_node_parent_root.md";
+    // A small document — chosen so the tree is shallow enough that we hit the
+    // root within a bounded number of hops.
+    let text = "# A\n";
+    open_markdown(&mut client, uri, text);
+
+    // Start at the document's first byte and walk up.
+    let mut current = request_node(&mut client, uri, 0, 0);
+    assert!(!current.is_null(), "expected NodeInfo for document start");
+
+    // Bounded walk. tree-sitter-markdown's depth at byte 0 of "# A\n" is on the
+    // order of a handful of nodes; 32 is comfortably above that ceiling.
+    let mut hops = 0;
+    let max_hops = 32;
+    loop {
+        let id = current
+            .get("id")
+            .and_then(Value::as_str)
+            .expect("id must be a string")
+            .to_string();
+
+        let next = request_node_parent(&mut client, uri, &id);
+        if next.is_null() {
+            // Reached the root — its parent must be null. Test passes.
+            return;
+        }
+        hops += 1;
+        assert!(
+            hops <= max_hops,
+            "walked {} parent hops without reaching root; tree depth seems pathological",
+            hops
+        );
+        current = next;
+    }
+}
+
+/// A ULID that was never issued by this server must resolve to null
+/// (ADR-0025 §"Invalidate vs Not-Found" — never-issued / invalidated /
+/// mismatched URI collapse to a single null).
+#[test]
+fn test_node_parent_returns_null_for_unknown_id() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+
+    let uri = "file:///test_kakehashi_node_parent_unknown.md";
+    open_markdown(&mut client, uri, "# Hello\n");
+
+    // A syntactically valid ULID that we never asked the server to issue.
+    let stray_id = "01HXXXXXXXXXXXXXXXXXXXXXXX";
+
+    let result = request_node_parent(&mut client, uri, stray_id);
+    assert!(
+        result.is_null(),
+        "unknown id must resolve to null, got {:?}",
+        result
     );
 }


### PR DESCRIPTION
## Summary

Implements PR-2 of [ADR-0025 Node Reference Protocol](docs/adr/0025-node-reference-protocol.md): the `kakehashi/node/parent` custom LSP method. Clients holding a ULID issued by `kakehashi/node` can now walk one step toward the root of the same language tree.

- New `parent.rs` handler reverse-looks up the tracked node via `NodeTracker::lookup_position`, finds the matching tree-sitter node in the current parse tree, and returns its parent as a fresh or cached ULID (lazy per ADR-0019).
- Scope rule honored: the ADR-0025 invariant "navigation stays within a single language tree" is enforced by relying on tree-sitter's own `node.parent() == None` at the tree root — no silent injection-boundary crossing. PR-4 will add explicit injection layer addressing.
- Null cases collapse together per ADR-0025 §"Invalidate vs Not-Found": invalid URI, malformed/never-issued/invalidated ULID, unparsed document, or root node all return JSON `null`.

## Commits

1. `chore: apply rustfmt drift in PR-1 leftovers` — preparatory whitespace/import cleanup so subsequent commits land cleanly through the fmt hook.
2. `test(e2e): add failing kakehashi/node/parent cases` — three RED tests in `tests/e2e_kakehashi_node.rs`:
   - nested node walks up to its immediate parent (distinct id, non-empty type),
   - repeatedly walking up from byte 0 of a small document reaches a root whose parent is null,
   - a syntactically valid but never-issued ULID resolves to null.
3. `feat(lsp): add kakehashi/node/parent handler` — GREEN: new handler module, module registration in `src/lsp/lsp_impl/kakehashi/node.rs`, and `custom_method` wiring in `src/bin/main.rs`.

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test --features e2e --test e2e_kakehashi_node` — all 27 tests pass (24 from PR-1 + 3 new)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Pre-existing unrelated failure (`did_open_parses_before_eager_opening_injected_virtual_documents`) is the only `make test` failure; see PR-1 thread for context

## Stacking note

Based on `feat/node-tracker-foundation` (PR-1, #307). Merge PR-1 first.