### PR TITLE
feat(lsp): implement kakehashi/node/children (ADR-0025 PR-3)

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -586,6 +586,10 @@ async fn run_lsp_server() {
     .custom_method("kakehashi/node", Kakehashi::kakehashi_node)
     .custom_method("kakehashi/node/text", Kakehashi::kakehashi_node_text)
     .custom_method("kakehashi/node/parent", Kakehashi::kakehashi_node_parent)
+    .custom_method(
+        "kakehashi/node/children",
+        Kakehashi::kakehashi_node_children,
+    )
     .finish();
 
     // Wrap service with RequestIdCapture to:

--- a/src/lsp/lsp_impl/kakehashi/node.rs
+++ b/src/lsp/lsp_impl/kakehashi/node.rs
@@ -6,9 +6,9 @@
 //! - [`entry`]: `kakehashi/node` — position → NodeInfo entry point
 //! - [`text`]: `kakehashi/node/text` — id → current node text
 //! - [`parent`]: `kakehashi/node/parent` — id → immediate-parent NodeInfo
-//!
-//! Future PRs will add a `children` handler alongside these.
+//! - [`children`]: `kakehashi/node/children` — id → immediate-children NodeInfo[]
 
+mod children;
 mod entry;
 mod lookup;
 mod parent;

--- a/src/lsp/lsp_impl/kakehashi/node.rs
+++ b/src/lsp/lsp_impl/kakehashi/node.rs
@@ -10,5 +10,6 @@
 //! Future PRs will add a `children` handler alongside these.
 
 mod entry;
+mod lookup;
 mod parent;
 mod text;

--- a/src/lsp/lsp_impl/kakehashi/node/children.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/children.rs
@@ -64,6 +64,14 @@ impl Kakehashi {
             return Ok(Value::Null);
         };
 
+        // Ensure the document is parsed before snapshotting — same race as in
+        // `kakehashi/node` and `kakehashi/node/parent`: didOpen schedules an
+        // async parse, and a `didChange` mid-flight can briefly leave
+        // `Document::tree()` populated with a stale tree while NodeTracker has
+        // already been adjusted. The helper waits on the parse-state watch
+        // channel and re-parses on demand so the snapshot below is consistent.
+        self.ensure_parsed_for_node_lookup(&uri).await;
+
         // Snapshot the document so we operate on a consistent (text, tree) pair.
         let Some(snapshot) = self.documents.get(&uri).and_then(|doc| doc.snapshot()) else {
             log::debug!(target: "kakehashi::node::children", "no parsed document for {}", uri);

--- a/src/lsp/lsp_impl/kakehashi/node/children.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/children.rs
@@ -82,7 +82,7 @@ impl Kakehashi {
         // Find the tree-sitter node matching the tracked (start, end, kind).
         // Defensive: the tracker stays in sync with didChange, so this should
         // always succeed for a non-null lookup.
-        let Some(node) = find_node_at(tree, start, end, &kind) else {
+        let Some(node) = find_node_at(tree, start, end, kind) else {
             log::warn!(
                 target: "kakehashi::node::children",
                 "tracker hit but no matching node in tree for ulid={} uri={} range=[{},{}) kind={}",
@@ -100,11 +100,15 @@ impl Kakehashi {
         let infos: Vec<Value> = node
             .children(&mut cursor)
             .map(|child| {
+                // Cache child.kind() — tree-sitter returns the same &'static
+                // str on every call, but the FFI hop is non-zero, and we
+                // both register and emit the kind below.
+                let kind = child.kind();
                 let child_ulid =
-                    tracker.get_or_create(&uri, child.start_byte(), child.end_byte(), child.kind());
+                    tracker.get_or_create(&uri, child.start_byte(), child.end_byte(), kind);
                 json!({
                     "id": child_ulid.to_string(),
-                    "type": child.kind(),
+                    "type": kind,
                 })
             })
             .collect();

--- a/src/lsp/lsp_impl/kakehashi/node/children.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/children.rs
@@ -88,7 +88,7 @@ impl Kakehashi {
         // requires for PR-3. A leaf node yields an empty iterator, which we
         // serialize as `[]` (NOT `null`).
         let tracker = self.bridge.node_tracker();
-        let mut cursor = tree.walk();
+        let mut cursor = node.walk();
         let infos: Vec<Value> = node
             .children(&mut cursor)
             .map(|child| {

--- a/src/lsp/lsp_impl/kakehashi/node/children.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/children.rs
@@ -1,0 +1,106 @@
+//! `kakehashi/node/children` — id → immediate-children NodeInfo array (ADR-0025).
+//!
+//! Resolves a previously-issued ULID to its tracked `(start_byte, end_byte, kind)`
+//! triple, locates the matching tree-sitter node in the current parse tree, and
+//! returns one [`NodeInfo`](../../../../../docs/adr/0025-node-reference-protocol.md#nodeinfo-type)
+//! per immediate child in **document order** (ascending `start_byte`).
+//!
+//! Per ADR-0025 §"Navigation Methods":
+//! - Children include **both named and anonymous** nodes. A future `namedOnly`
+//!   parameter may filter, but PR-3 returns the full child list.
+//! - The order is tree-sitter's native child iteration, which equals ascending
+//!   `start_byte` because direct siblings in a tree-sitter tree are
+//!   non-overlapping by construction.
+//! - Navigation stays within a single language tree: children of an
+//!   injection-host node return ONLY the host-tree children, NOT the root of
+//!   the injected tree. Crossing injection boundaries is PR-4 scope.
+//!
+//! Return-value distinction (ADR-0025 §"Empty children"):
+//! - `[]` — id resolves to an existing node that has no children
+//! - `null` — id is not currently resolvable (never issued / invalidated /
+//!   mismatched URI / unparsed document / drift)
+//!
+//! The two cases are deliberately distinct so clients can tell "leaf node"
+//! apart from "this reference is gone".
+
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tower_lsp_server::jsonrpc::Result;
+use tower_lsp_server::ls_types::TextDocumentIdentifier;
+use ulid::Ulid;
+
+use crate::lsp::lsp_impl::kakehashi::node::lookup::find_node_at;
+use crate::lsp::lsp_impl::{Kakehashi, uri_to_url};
+
+/// Request parameters for `kakehashi/node/children`.
+///
+/// `pub` because the handler is registered as a custom LSP method in the
+/// `kakehashi` binary (see `src/bin/main.rs`).
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeChildrenParams {
+    pub text_document: TextDocumentIdentifier,
+    pub id: String,
+}
+
+impl Kakehashi {
+    /// Handler for `kakehashi/node/children`.
+    pub async fn kakehashi_node_children(&self, params: NodeChildrenParams) -> Result<Value> {
+        let lsp_uri = params.text_document.uri;
+        let Ok(uri) = uri_to_url(&lsp_uri) else {
+            log::warn!(target: "kakehashi::node::children", "invalid URI: {}", lsp_uri.as_str());
+            return Ok(Value::Null);
+        };
+
+        // Malformed ULID collapses to null per ADR-0025 §"Invalidate vs Not-Found".
+        let Ok(ulid) = params.id.parse::<Ulid>() else {
+            return Ok(Value::Null);
+        };
+
+        // Look up the tracked node's byte range and kind. None means: never
+        // issued, invalidated by a prior edit, or this URI has no entries.
+        let Some((start, end, kind)) = self.bridge.node_tracker().lookup_position(&uri, &ulid)
+        else {
+            return Ok(Value::Null);
+        };
+
+        // Snapshot the document so we operate on a consistent (text, tree) pair.
+        let Some(snapshot) = self.documents.get(&uri).and_then(|doc| doc.snapshot()) else {
+            log::debug!(target: "kakehashi::node::children", "no parsed document for {}", uri);
+            return Ok(Value::Null);
+        };
+        let tree = snapshot.tree();
+
+        // Find the tree-sitter node matching the tracked (start, end, kind).
+        // Defensive: the tracker stays in sync with didChange, so this should
+        // always succeed for a non-null lookup.
+        let Some(node) = find_node_at(tree, start, end, &kind) else {
+            log::warn!(
+                target: "kakehashi::node::children",
+                "tracker hit but no matching node in tree for ulid={} uri={} range=[{},{}) kind={}",
+                ulid, uri, start, end, kind
+            );
+            return Ok(Value::Null);
+        };
+
+        // tree-sitter's `Node::children(&mut cursor)` iterates BOTH named and
+        // anonymous children in document order — exactly the contract ADR-0025
+        // requires for PR-3. A leaf node yields an empty iterator, which we
+        // serialize as `[]` (NOT `null`).
+        let tracker = self.bridge.node_tracker();
+        let mut cursor = tree.walk();
+        let infos: Vec<Value> = node
+            .children(&mut cursor)
+            .map(|child| {
+                let child_ulid =
+                    tracker.get_or_create(&uri, child.start_byte(), child.end_byte(), child.kind());
+                json!({
+                    "id": child_ulid.to_string(),
+                    "type": child.kind(),
+                })
+            })
+            .collect();
+
+        Ok(Value::Array(infos))
+    }
+}

--- a/src/lsp/lsp_impl/kakehashi/node/lookup.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/lookup.rs
@@ -1,0 +1,41 @@
+//! Shared helpers for resolving tracker entries back to tree-sitter nodes.
+//!
+//! Multiple ADR-0025 handlers (`parent`, `children`, …) need to recover a
+//! `tree_sitter::Node` from a tracked `(start_byte, end_byte, kind)` triple in
+//! the current parse tree. Tree-sitter exposes no direct "find by composite
+//! key" API, so this module centralises the upward-walk strategy used by all
+//! navigation handlers — keeping the lookup semantics consistent and avoiding
+//! drift across copies.
+
+/// Find a tree-sitter node in `tree` whose `(start_byte, end_byte, kind)`
+/// matches the tracked triple.
+///
+/// Starts from the smallest descendant covering `[start, end)` (which is the
+/// usual case for a tracked node) and walks up to the root looking for an
+/// exact match. The walk is bounded by tree depth and runs in `O(depth)` time.
+///
+/// Returns `None` when no node along that ancestry chain matches — typically a
+/// sign that the tracker entry has drifted relative to the current tree (which
+/// `didChange` should normally prevent).
+pub(super) fn find_node_at<'tree>(
+    tree: &'tree tree_sitter::Tree,
+    start: usize,
+    end: usize,
+    kind: &str,
+) -> Option<tree_sitter::Node<'tree>> {
+    // `descendant_for_byte_range(start, end)` returns the smallest node whose
+    // byte range contains `[start, end)`. For a tracked node, that's the node
+    // itself; for stale ranges it returns the containing node, in which case
+    // the upward walk below will fail to find a match (and we return None).
+    let mut current = tree.root_node().descendant_for_byte_range(start, end)?;
+
+    loop {
+        if current.start_byte() == start && current.end_byte() == end && current.kind() == kind {
+            return Some(current);
+        }
+        match current.parent() {
+            Some(parent) => current = parent,
+            None => return None,
+        }
+    }
+}

--- a/src/lsp/lsp_impl/kakehashi/node/lookup.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/lookup.rs
@@ -10,9 +10,14 @@
 /// Find a tree-sitter node in `tree` whose `(start_byte, end_byte, kind)`
 /// matches the tracked triple.
 ///
-/// Starts from the smallest descendant covering `[start, end)` (which is the
-/// usual case for a tracked node) and walks up to the root looking for an
-/// exact match. The walk is bounded by tree depth and runs in `O(depth)` time.
+/// `descendant_for_byte_range` returns the smallest node containing `[start,
+/// end)`. If that node's range is not exactly `(start, end)`, no ancestor can
+/// match either (ancestors only grow), so we bail immediately. When the range
+/// matches but the kind doesn't, we walk upward but stop as soon as the
+/// ancestor's range diverges from `(start, end)` — this handles the rare case
+/// where multiple nodes share a span (e.g., a `document` wrapping a `section`
+/// that wraps a `paragraph` all starting at byte 0) without doing useless work
+/// on truly larger ancestors. The walk runs in O(depth-of-same-span chain).
 ///
 /// Returns `None` when no node along that ancestry chain matches — typically a
 /// sign that the tracker entry has drifted relative to the current tree (which
@@ -34,26 +39,22 @@ pub(super) fn find_node_at<'tree>(
     }
 
     // `descendant_for_byte_range(start, end)` returns the smallest node whose
-    // byte range contains `[start, end)`. For a tracked node, that's the node
-    // itself; for stale ranges it returns the containing node, in which case
-    // the upward walk below will fail to find a match (and we return None).
+    // byte range contains `[start, end)`. If its range does not match exactly,
+    // no node in the tree has `(start, end)` and we can stop here.
     let mut current = root.descendant_for_byte_range(start, end)?;
+    if current.start_byte() != start || current.end_byte() != end {
+        return None;
+    }
 
     loop {
-        let c_start = current.start_byte();
-        let c_end = current.end_byte();
-        if c_start == start && c_end == end && current.kind() == kind {
+        if current.kind() == kind {
             return Some(current);
         }
-        // Parents can only have equal or larger ranges. Once `current` exceeds
-        // the target on either side, no ancestor can ever match exactly, so
-        // bail out instead of climbing all the way to the root.
-        if c_start < start || c_end > end {
-            return None;
-        }
         match current.parent() {
-            Some(parent) => current = parent,
-            None => return None,
+            Some(parent) if parent.start_byte() == start && parent.end_byte() == end => {
+                current = parent;
+            }
+            _ => return None,
         }
     }
 }

--- a/src/lsp/lsp_impl/kakehashi/node/lookup.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/lookup.rs
@@ -23,15 +23,33 @@ pub(super) fn find_node_at<'tree>(
     end: usize,
     kind: &str,
 ) -> Option<tree_sitter::Node<'tree>> {
+    // Defensive: reject obviously-invalid ranges before handing them to
+    // tree-sitter. A stale tracker entry (or future bug) could pass a range
+    // outside the parsed tree's bounds; the underlying C bindings have, at
+    // various tree-sitter versions, exhibited surprising behavior for such
+    // inputs. Returning None preserves the caller's null-collapse semantics.
+    let root = tree.root_node();
+    if start > end || end > root.end_byte() {
+        return None;
+    }
+
     // `descendant_for_byte_range(start, end)` returns the smallest node whose
     // byte range contains `[start, end)`. For a tracked node, that's the node
     // itself; for stale ranges it returns the containing node, in which case
     // the upward walk below will fail to find a match (and we return None).
-    let mut current = tree.root_node().descendant_for_byte_range(start, end)?;
+    let mut current = root.descendant_for_byte_range(start, end)?;
 
     loop {
-        if current.start_byte() == start && current.end_byte() == end && current.kind() == kind {
+        let c_start = current.start_byte();
+        let c_end = current.end_byte();
+        if c_start == start && c_end == end && current.kind() == kind {
             return Some(current);
+        }
+        // Parents can only have equal or larger ranges. Once `current` exceeds
+        // the target on either side, no ancestor can ever match exactly, so
+        // bail out instead of climbing all the way to the root.
+        if c_start < start || c_end > end {
+            return None;
         }
         match current.parent() {
             Some(parent) => current = parent,

--- a/src/lsp/lsp_impl/kakehashi/node/parent.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/parent.rs
@@ -25,6 +25,7 @@ use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::TextDocumentIdentifier;
 use ulid::Ulid;
 
+use crate::lsp::lsp_impl::kakehashi::node::lookup::find_node_at;
 use crate::lsp::lsp_impl::{Kakehashi, uri_to_url};
 
 /// Request parameters for `kakehashi/node/parent`.
@@ -103,53 +104,5 @@ impl Kakehashi {
             "id": parent_ulid.to_string(),
             "type": parent.kind(),
         }))
-    }
-}
-
-/// Find a tree-sitter node in `tree` whose `(start_byte, end_byte, kind)` matches
-/// the tracked triple.
-///
-/// `descendant_for_byte_range` returns the smallest node containing `[start,
-/// end)`. If that node's range is not exactly `(start, end)`, no ancestor can
-/// match either (ancestors only grow), so we bail immediately. When the range
-/// matches but the kind doesn't, we walk upward but stop as soon as the
-/// ancestor's range diverges from `(start, end)` — this handles the rare case
-/// where multiple nodes share a span (e.g., a `document` wrapping a `section`
-/// that wraps a `paragraph` all starting at byte 0) without doing useless work
-/// on truly larger ancestors. The walk runs in O(depth-of-same-span chain).
-fn find_node_at<'tree>(
-    tree: &'tree tree_sitter::Tree,
-    start: usize,
-    end: usize,
-    kind: &str,
-) -> Option<tree_sitter::Node<'tree>> {
-    // Defensive: reject obviously-invalid ranges before handing them to
-    // tree-sitter. A stale tracker entry (or future bug) could pass a range
-    // outside the parsed tree's bounds; the underlying C bindings have, at
-    // various tree-sitter versions, exhibited surprising behavior for such
-    // inputs. Returning None preserves the caller's null-collapse semantics.
-    let root = tree.root_node();
-    if start > end || end > root.end_byte() {
-        return None;
-    }
-
-    // `descendant_for_byte_range(start, end)` returns the smallest node whose
-    // byte range contains `[start, end)`. If its range does not match exactly,
-    // no node in the tree has `(start, end)` and we can stop here.
-    let mut current = root.descendant_for_byte_range(start, end)?;
-    if current.start_byte() != start || current.end_byte() != end {
-        return None;
-    }
-
-    loop {
-        if current.kind() == kind {
-            return Some(current);
-        }
-        match current.parent() {
-            Some(parent) if parent.start_byte() == start && parent.end_byte() == end => {
-                current = parent;
-            }
-            _ => return None,
-        }
     }
 }

--- a/tests/e2e_kakehashi_node.rs
+++ b/tests/e2e_kakehashi_node.rs
@@ -1,9 +1,10 @@
-//! End-to-end tests for `kakehashi/node`, `kakehashi/node/text`, and
-//! `kakehashi/node/parent` (ADR-0025 PR-1 + PR-2).
+//! End-to-end tests for `kakehashi/node`, `kakehashi/node/text`,
+//! `kakehashi/node/parent`, and `kakehashi/node/children` (ADR-0025 PR-1 + PR-2 + PR-3).
 //!
 //! Covers the entry-point method (position → NodeInfo), the text resolution
 //! method (id → current node text), the parent navigation method
-//! (child id → parent NodeInfo), and their interaction with `didChange`:
+//! (child id → parent NodeInfo), the children navigation method
+//! (parent id → NodeInfo[]), and their interaction with `didChange`:
 //!
 //! - smallest-at-cursor lookup for named-or-anonymous nodes (host language only)
 //! - end-of-document exception (`b == L && L > 0 && e == L`)
@@ -11,6 +12,9 @@
 //! - `kakehashi/node/text` returning the live slice for a tracked node
 //! - `kakehashi/node/parent` walking one step toward the root
 //! - parent returning null at the root and for unknown ids
+//! - `kakehashi/node/children` returning siblings in document order
+//! - children returning `[]` (NOT `null`) for a leaf node
+//! - children returning `null` for unknown ids
 //! - ULID survival across position-adjusting edits
 //! - ULID invalidation when the edit covers the node's START byte
 //!
@@ -84,6 +88,27 @@ fn request_node_parent(client: &mut LspClient, uri: &str, id: &str) -> Value {
     assert!(
         response.get("error").is_none(),
         "kakehashi/node/parent returned an error: {:?}",
+        response.get("error")
+    );
+    response
+        .get("result")
+        .cloned()
+        .expect("response must contain a result field")
+}
+
+/// Send `kakehashi/node/children` for an id and unwrap the `result` field
+/// (which may be `null`, an empty array, or a non-empty array).
+fn request_node_children(client: &mut LspClient, uri: &str, id: &str) -> Value {
+    let response = client.send_request(
+        "kakehashi/node/children",
+        json!({
+            "textDocument": { "uri": uri },
+            "id": id
+        }),
+    );
+    assert!(
+        response.get("error").is_none(),
+        "kakehashi/node/children returned an error: {:?}",
         response.get("error")
     );
     response
@@ -512,6 +537,204 @@ fn test_node_parent_returns_null_for_unknown_id() {
     assert!(
         result.is_null(),
         "unknown id must resolve to null, got {:?}",
+        result
+    );
+}
+
+/// `kakehashi/node/children` returns the immediate children of a tracked node
+/// in **document order** (ADR-0025 §"Navigation Methods" — Ordering). The
+/// response includes BOTH named and anonymous children. The order invariant is
+/// expressed as a non-decreasing `start_byte` across the returned sequence —
+/// tree-sitter siblings are non-overlapping so the invariant is in fact strict
+/// ascent, but we use `<=` here to avoid coupling the test to that detail.
+#[test]
+fn test_node_children_returns_siblings_in_document_order() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+
+    let uri = "file:///test_kakehashi_node_children_order.md";
+    // A paragraph with several inline children: plain text, emphasis, more text.
+    // tree-sitter-markdown will produce multiple inline children for the paragraph.
+    let text = "# Heading\n\nplain **bold** more text.\n";
+    open_markdown(&mut client, uri, text);
+
+    // Cursor on the paragraph's plain leading text — we then walk to the parent
+    // until we find a node with multiple children.
+    let leaf = request_node(&mut client, uri, 2, 0);
+    assert!(!leaf.is_null(), "expected NodeInfo at paragraph start");
+    let leaf_id = leaf
+        .get("id")
+        .and_then(Value::as_str)
+        .expect("leaf id must be a string")
+        .to_string();
+
+    // Walk up until we find a parent with more than one child so the ordering
+    // assertion has something to assert against.
+    let mut current_id = leaf_id;
+    let children: Vec<Value>;
+    let mut hops = 0;
+    let max_hops = 16;
+    loop {
+        let response = request_node_children(&mut client, uri, &current_id);
+        assert!(
+            !response.is_null(),
+            "kakehashi/node/children must return an array (possibly empty) for a known id, got null at hop {}",
+            hops
+        );
+        let arr = response
+            .as_array()
+            .expect("children response must be a JSON array")
+            .clone();
+        if arr.len() >= 2 {
+            children = arr;
+            break;
+        }
+        // Climb one level via /parent.
+        let parent = request_node_parent(&mut client, uri, &current_id);
+        assert!(
+            !parent.is_null(),
+            "ran out of ancestors before finding a multi-child parent"
+        );
+        current_id = parent
+            .get("id")
+            .and_then(Value::as_str)
+            .expect("parent id must be a string")
+            .to_string();
+        hops += 1;
+        assert!(
+            hops <= max_hops,
+            "walked {} ancestors without finding a multi-child node; tree is unexpectedly thin",
+            hops
+        );
+    }
+
+    // Each child must be a well-formed NodeInfo with id + type.
+    for (i, child) in children.iter().enumerate() {
+        let id = child
+            .get("id")
+            .unwrap_or_else(|| panic!("child {} missing id field: {:?}", i, child));
+        assert_ulid_shaped(id);
+        let ty = child
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| panic!("child {} missing string type field: {:?}", i, child));
+        assert!(
+            !ty.is_empty(),
+            "child {} has empty type field: {:?}",
+            i,
+            child
+        );
+    }
+
+    // Document-order invariant: walk each adjacent pair and confirm that each
+    // child's text appears no later in the document than the next child's text.
+    // We use `/text` lookups instead of byte ranges (the protocol does not expose
+    // ranges in NodeInfo) and locate each in the original document via `find`.
+    let mut last_pos: Option<usize> = None;
+    for (i, child) in children.iter().enumerate() {
+        let id = child
+            .get("id")
+            .and_then(Value::as_str)
+            .expect("child id must be a string");
+        let text_response = request_node_text(&mut client, uri, id);
+        // Text MAY be null for a child with zero-width range (rare but legal);
+        // skip those — they cannot violate order on their own.
+        let Some(slice) = text_response.get("text").and_then(Value::as_str) else {
+            continue;
+        };
+        if slice.is_empty() {
+            continue;
+        }
+        let Some(pos) = text.find(slice) else {
+            // Anonymous tokens may have text that recurs; if `find` fails the
+            // grammar emitted something we can't easily locate. Skip rather
+            // than fail the ordering check on a non-locatable child.
+            continue;
+        };
+        if let Some(prev) = last_pos {
+            assert!(
+                prev <= pos,
+                "children must be in document order: child {} found at byte {} but previous child ended at byte >= {}",
+                i,
+                pos,
+                prev
+            );
+        }
+        last_pos = Some(pos);
+    }
+}
+
+/// A leaf node (no children) must return `[]`, NOT `null`. ADR-0025 explicitly
+/// distinguishes "node exists but is empty" (`[]`) from "id not in tracker"
+/// (`null`).
+#[test]
+fn test_node_children_returns_empty_array_for_leaf_node() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+
+    let uri = "file:///test_kakehashi_node_children_leaf.md";
+    let text = "# Heading\n\nparagraph text.\n";
+    open_markdown(&mut client, uri, text);
+
+    // Walk down to a leaf by repeatedly fetching children[0] until the array
+    // comes back empty. Bounded by a small hop count to avoid infinite loops.
+    let root = request_node(&mut client, uri, 0, 0);
+    assert!(!root.is_null(), "expected NodeInfo at document start");
+    let mut current_id = root
+        .get("id")
+        .and_then(Value::as_str)
+        .expect("id must be a string")
+        .to_string();
+
+    let mut hops = 0;
+    let max_hops = 16;
+    loop {
+        let response = request_node_children(&mut client, uri, &current_id);
+        assert!(
+            !response.is_null(),
+            "children of a tracked id must never be null (got null at hop {})",
+            hops
+        );
+        let arr = response
+            .as_array()
+            .expect("children response must be a JSON array")
+            .clone();
+        if arr.is_empty() {
+            // Leaf node — empty-array case verified. Test passes.
+            return;
+        }
+        // Descend into the first child.
+        current_id = arr[0]
+            .get("id")
+            .and_then(Value::as_str)
+            .expect("child id must be a string")
+            .to_string();
+        hops += 1;
+        assert!(
+            hops <= max_hops,
+            "descended {} levels without finding a leaf; tree is unexpectedly deep",
+            hops
+        );
+    }
+}
+
+/// A ULID that was never issued by this server must resolve to null for
+/// `kakehashi/node/children` (ADR-0025 §"Navigation Methods" — `null` cases).
+#[test]
+fn test_node_children_returns_null_for_unknown_id() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+
+    let uri = "file:///test_kakehashi_node_children_unknown.md";
+    open_markdown(&mut client, uri, "# Hello\n");
+
+    // A syntactically valid ULID that we never asked the server to issue.
+    let stray_id = "01HXXXXXXXXXXXXXXXXXXXXXXX";
+
+    let result = request_node_children(&mut client, uri, stray_id);
+    assert!(
+        result.is_null(),
+        "unknown id must resolve to null (not []), got {:?}",
         result
     );
 }

--- a/tests/e2e_kakehashi_node.rs
+++ b/tests/e2e_kakehashi_node.rs
@@ -626,11 +626,14 @@ fn test_node_children_returns_siblings_in_document_order() {
         );
     }
 
-    // Document-order invariant: walk each adjacent pair and confirm that each
-    // child's text appears no later in the document than the next child's text.
-    // We use `/text` lookups instead of byte ranges (the protocol does not expose
-    // ranges in NodeInfo) and locate each in the original document via `find`.
-    let mut last_pos: Option<usize> = None;
+    // Document-order invariant: each child's text must appear in the document
+    // after the previous child's text. We use `/text` lookups instead of byte
+    // ranges (the protocol does not expose ranges in NodeInfo) and search
+    // forward from the end of the previous match. Searching from byte 0 every
+    // time (via `text.find`) would falsely succeed on duplicate substrings or
+    // falsely fail when a later child's text happens to appear earlier in the
+    // document.
+    let mut search_start: usize = 0;
     for (i, child) in children.iter().enumerate() {
         let id = child
             .get("id")
@@ -645,22 +648,16 @@ fn test_node_children_returns_siblings_in_document_order() {
         if slice.is_empty() {
             continue;
         }
-        let Some(pos) = text.find(slice) else {
-            // Anonymous tokens may have text that recurs; if `find` fails the
-            // grammar emitted something we can't easily locate. Skip rather
-            // than fail the ordering check on a non-locatable child.
-            continue;
-        };
-        if let Some(prev) = last_pos {
-            assert!(
-                prev <= pos,
-                "children must be in document order: child {} found at byte {} but previous child ended at byte >= {}",
-                i,
-                pos,
-                prev
+        let Some(offset) = text[search_start..].find(slice) else {
+            panic!(
+                "children must be in document order: child {} text {:?} not found in document after byte {}",
+                i, slice, search_start
             );
-        }
-        last_pos = Some(pos);
+        };
+        // Advance past this match so the next child must appear at or after the
+        // end of this one. Equal positions are tolerated (zero-width overlap is
+        // not possible here because empty slices are skipped above).
+        search_start += offset + slice.len();
     }
 }
 


### PR DESCRIPTION
## Summary

Implements `kakehashi/node/children` from [ADR-0025](docs/adr/0025-node-reference-protocol.md), the third method in the Node Reference Protocol stacked PR chain (PR-1 #307, PR-2 #308).

Given a tracked ULID, the handler resolves the corresponding tree-sitter node in the current parse tree and returns one `NodeInfo` per immediate child — both **named and anonymous** — in **document order** (ascending `start_byte`, falling out of tree-sitter's native child iterator since direct siblings are non-overlapping).

Honors the ADR-0025 empty-vs-null distinction:
- `[]` — id resolves to an existing node that has no children
- `null` — id is not currently resolvable (never issued / invalidated / mismatched URI / unparsed document / drift)

Navigation stays within a single language tree (children of an injection-host node return only host-tree children); cross-injection navigation is PR-4 scope.

## Commits

1. `test(e2e): add failing kakehashi/node/children cases` — RED. Covers document order, the empty-array leaf case, and the unknown-id null case.
2. `refactor(lsp): extract node-by-position lookup helper` — Structural. Moves PR-2's `find_node_at` into a new `lookup` module so `children` and `parent` share one source of truth. No behavior change; PR-2's tests stay green.
3. `feat(lsp): add kakehashi/node/children handler` — GREEN. New `children.rs` handler, registered in `node.rs` and `main.rs` as the `kakehashi/node/children` custom method.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --features e2e --test e2e_kakehashi_node` — 30 tests pass (PR-1's 7 + PR-2's 3 + this PR's 3 + 17 helper unit tests)
- [x] PR-2's parent tests remain green after the lookup-helper extraction