### PR TITLE
feat(lsp): implement injection parameter (ADR-0025 PR-4)

### DIFF
--- a/src/lsp/lsp_impl/kakehashi/node.rs
+++ b/src/lsp/lsp_impl/kakehashi/node.rs
@@ -10,6 +10,7 @@
 
 mod children;
 mod entry;
+mod injection_stack;
 mod lookup;
 mod parent;
 mod text;

--- a/src/lsp/lsp_impl/kakehashi/node/children.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/children.rs
@@ -29,7 +29,7 @@ use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::TextDocumentIdentifier;
 use ulid::Ulid;
 
-use crate::lsp::lsp_impl::kakehashi::node::lookup::find_node_at;
+use crate::lsp::lsp_impl::kakehashi::node::injection_stack::with_resolved_node;
 use crate::lsp::lsp_impl::{Kakehashi, uri_to_url};
 
 /// Request parameters for `kakehashi/node/children`.
@@ -77,38 +77,54 @@ impl Kakehashi {
             log::debug!(target: "kakehashi::node::children", "no parsed document for {}", uri);
             return Ok(Value::Null);
         };
-        let tree = snapshot.tree();
+        let host_text = snapshot.text();
+        let host_tree = snapshot.tree();
 
-        // Find the tree-sitter node matching the tracked (start, end, kind).
-        // Defensive: the tracker stays in sync with didChange, so this should
-        // always succeed for a non-null lookup.
-        let Some(node) = find_node_at(tree, start, end, kind) else {
+        let Some(host_language) = self.document_language(&uri) else {
+            log::debug!(target: "kakehashi::node::children", "no host language for {}", uri);
+            return Ok(Value::Null);
+        };
+
+        // Search the host tree first, then injected layers at `start`. ADR-0025
+        // "Navigation Methods": children stay within a single language tree, so
+        // an injected node's children come from the injected tree — not from
+        // the host node that contains the injection.
+        //
+        // tree-sitter's `Node::children(&mut cursor)` iterates BOTH named and
+        // anonymous children in document order. A leaf node yields an empty
+        // iterator, which we serialize as `[]` (NOT `null`).
+        let child_infos: Option<Vec<(usize, usize, &'static str)>> = with_resolved_node(
+            &self.language,
+            &host_language,
+            host_text,
+            host_tree,
+            start,
+            end,
+            kind,
+            |node| {
+                let mut cursor = node.walk();
+                node.children(&mut cursor)
+                    .map(|child| (child.start_byte(), child.end_byte(), child.kind()))
+                    .collect()
+            },
+        );
+        let Some(child_infos) = child_infos else {
             log::warn!(
                 target: "kakehashi::node::children",
-                "tracker hit but no matching node in tree for ulid={} uri={} range=[{},{}) kind={}",
+                "tracker hit but no matching node in any layer for ulid={} uri={} range=[{},{}) kind={}",
                 ulid, uri, start, end, kind
             );
             return Ok(Value::Null);
         };
 
-        // tree-sitter's `Node::children(&mut cursor)` iterates BOTH named and
-        // anonymous children in document order — exactly the contract ADR-0025
-        // requires for PR-3. A leaf node yields an empty iterator, which we
-        // serialize as `[]` (NOT `null`).
         let tracker = self.bridge.node_tracker();
-        let mut cursor = node.walk();
-        let infos: Vec<Value> = node
-            .children(&mut cursor)
-            .map(|child| {
-                // Cache child.kind() — tree-sitter returns the same &'static
-                // str on every call, but the FFI hop is non-zero, and we
-                // both register and emit the kind below.
-                let kind = child.kind();
-                let child_ulid =
-                    tracker.get_or_create(&uri, child.start_byte(), child.end_byte(), kind);
+        let infos: Vec<Value> = child_infos
+            .into_iter()
+            .map(|(c_start, c_end, c_kind)| {
+                let child_ulid = tracker.get_or_create(&uri, c_start, c_end, c_kind);
                 json!({
                     "id": child_ulid.to_string(),
-                    "type": kind,
+                    "type": c_kind,
                 })
             })
             .collect();

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -1,16 +1,23 @@
 //! `kakehashi/node` — position → NodeInfo entry point (ADR-0025).
 //!
 //! Resolves a `Position` to the smallest tree-sitter node (named or anonymous)
-//! containing that byte under the **host** language. Injection-aware lookup is
-//! deferred to PR-4; for now, any client-supplied `injection` value is accepted
-//! but ignored — the handler always returns the host-language node.
+//! containing that byte at the layer selected by the `injection` parameter
+//! (ADR-0025 PR-4). When `injection` is absent or `false`/`0`, the host tree
+//! is used. When `injection` is `true`, the deepest layer at the cursor is
+//! used (saturating). When `injection` is a non-zero integer, the layer is
+//! resolved via `stack[n]` for positive `n` and `stack[stack.len() + n]` for
+//! negative `n`, with strict out-of-bounds returning `null`.
 //!
 //! Returns `null` (serialized as JSON `null`) when:
 //! - the URI is unknown,
 //! - the document has not yet been parsed (no tree),
 //! - the position cannot be converted to a byte offset,
-//! - the position is outside the document (`b > L`), or
-//! - the document is empty (`L == 0`).
+//! - the position is outside the document (`b > L`),
+//! - the document is empty (`L == 0`),
+//! - the requested `injection` layer does not exist at the position (strict
+//!   integer index out of bounds), or
+//! - the `injection` parameter has an unsupported JSON type (not bool, not
+//!   an integer number).
 
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -18,12 +25,16 @@ use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::{Position, TextDocumentIdentifier};
 use url::Url;
 
+use crate::lsp::lsp_impl::kakehashi::node::injection_stack::injection_stack_at;
 use crate::lsp::lsp_impl::{Kakehashi, uri_to_url};
 use crate::text::PositionMapper;
 
 /// Request parameters for `kakehashi/node`.
 ///
-/// The `injection` field is parsed but ignored in PR-1; see module-level doc.
+/// The `injection` field is a `boolean | number` per ADR-0025 PR-4. We
+/// deserialize it as a raw `Value` and dispatch on the JSON shape ourselves
+/// because serde-tagged enums would reject the natural `true` / `1` / `-2`
+/// shorthand the spec mandates.
 ///
 /// `pub` is required because `Kakehashi::kakehashi_node` is registered as a
 /// custom LSP method in the `kakehashi` binary, which lives outside the
@@ -33,9 +44,74 @@ use crate::text::PositionMapper;
 pub struct NodeParams {
     pub text_document: TextDocumentIdentifier,
     pub position: Position,
-    /// Reserved for PR-4 (`boolean | number`). Accepted but ignored in PR-1.
+    /// `boolean | number` per ADR-0025 §"The `injection` Parameter". Absent /
+    /// `false` / `0` selects the host layer; `true` saturates to the deepest
+    /// layer; a non-zero integer indexes the stack strictly.
     #[serde(default)]
     pub injection: Option<Value>,
+}
+
+/// Layer selector parsed from the `injection` JSON parameter.
+///
+/// Keeping this as a small enum (rather than just an `i64`) lets the
+/// handler keep the `true` saturation case and the strict-index case
+/// visibly distinct — they share the result for `-1` but differ in
+/// the bounds-check semantics ADR-0025 spells out.
+enum InjectionSelector {
+    /// Host layer (stack[0]). Triggered by absent, `false`, or `0`.
+    Host,
+    /// Saturate to the deepest layer at the cursor (`true`).
+    Saturating,
+    /// Strict integer index. Positive `n` -> `stack[n]`; negative `n` ->
+    /// `stack[stack.len() + n]`. Out-of-bounds returns null at the caller.
+    Index(i64),
+    /// Unsupported JSON shape (non-bool / non-integer). Treated as null.
+    Invalid,
+}
+
+/// Parse the `injection` parameter into an [`InjectionSelector`].
+///
+/// Per ADR-0025: `false` and `0` are equivalent (host); `true` saturates;
+/// integer values index strictly. Anything else (string, array, fractional
+/// number) is rejected as `Invalid` so the handler returns null with a log
+/// warning, rather than silently coercing.
+fn parse_injection_selector(value: Option<&Value>) -> InjectionSelector {
+    match value {
+        None | Some(Value::Null) => InjectionSelector::Host,
+        Some(Value::Bool(true)) => InjectionSelector::Saturating,
+        Some(Value::Bool(false)) => InjectionSelector::Host,
+        Some(Value::Number(n)) => match n.as_i64() {
+            Some(0) => InjectionSelector::Host,
+            Some(i) => InjectionSelector::Index(i),
+            None => InjectionSelector::Invalid,
+        },
+        _ => InjectionSelector::Invalid,
+    }
+}
+
+/// Resolve a non-zero integer index against a stack of length `stack_len`,
+/// following ADR-0025 §"The `injection` Parameter":
+///
+/// - positive `n`: `stack[n]` directly, `null` if `n >= stack_len`
+/// - negative `n`: `stack[stack_len + n]`, `null` if the result is < 0
+///
+/// `stack_len` must be at least 1 in practice (the host layer is always
+/// present); we keep the signature general so callers can defensively
+/// short-circuit on an empty stack without panicking.
+fn resolve_index(n: i64, stack_len: usize) -> Option<usize> {
+    if n > 0 {
+        let idx = usize::try_from(n).ok()?;
+        if idx < stack_len { Some(idx) } else { None }
+    } else {
+        // n is negative (n == 0 is handled by the Host branch upstream).
+        // Convert via i64 arithmetic to avoid usize underflow on `len + n`.
+        let len_i64 = i64::try_from(stack_len).ok()?;
+        let resolved = len_i64.checked_add(n)?;
+        if resolved < 0 {
+            return None;
+        }
+        usize::try_from(resolved).ok()
+    }
 }
 
 impl Kakehashi {
@@ -43,6 +119,18 @@ impl Kakehashi {
     pub async fn kakehashi_node(&self, params: NodeParams) -> Result<Value> {
         let lsp_uri = params.text_document.uri;
         let position = params.position;
+        let injection = params.injection;
+
+        // Parse the injection selector up-front so an invalid JSON shape
+        // short-circuits before we touch the document store.
+        let selector = parse_injection_selector(injection.as_ref());
+        if matches!(selector, InjectionSelector::Invalid) {
+            log::warn!(
+                target: "kakehashi::node",
+                "unsupported injection parameter shape: {:?}", injection
+            );
+            return Ok(Value::Null);
+        }
 
         // URI conversion failure → null (ADR-0025 universal null semantics).
         let Ok(uri) = uri_to_url(&lsp_uri) else {
@@ -84,12 +172,58 @@ impl Kakehashi {
             return Ok(Value::Null);
         }
 
-        // Resolve smallest containing node under the host tree.
-        let Some(node) = smallest_containing_node(tree, byte, doc_len) else {
+        // Host layer fast path: skip the stack enumeration entirely. This
+        // keeps the no-injection request shape (the dominant case for plain
+        // documents) at PR-1 cost.
+        if matches!(selector, InjectionSelector::Host) {
+            return Ok(self.resolve_host_layer_node(&uri, tree, byte, doc_len));
+        }
+
+        // We need the host language to seed `injection_stack_at` with the
+        // right injection query. Detect it from the document store.
+        let Some(host_language) = self.document_language(&uri) else {
+            log::debug!(
+                target: "kakehashi::node",
+                "no host language detected for {} — cannot resolve injection layers",
+                uri
+            );
             return Ok(Value::Null);
         };
 
-        // Issue / reuse a stable ULID for this node via the NodeTracker.
+        // Ensure injection-language parsers are loaded. PR-1 only loaded
+        // the host parser on-demand; injection layers require their own
+        // grammars to be available before `injection_stack_at` can parse
+        // them. Skip the expensive load for the host-only path above.
+        self.ensure_injection_languages_loaded(&uri, &host_language, text)
+            .await;
+
+        let stack = injection_stack_at(&self.language, &host_language, text, tree, byte);
+
+        let layer_index = match selector {
+            InjectionSelector::Host => unreachable!("handled above"),
+            InjectionSelector::Invalid => unreachable!("handled above"),
+            InjectionSelector::Saturating => {
+                // `true` saturates to the deepest layer. The stack always
+                // contains at least the host (layer 0), so this never
+                // under-indexes.
+                stack.len() - 1
+            }
+            InjectionSelector::Index(n) => {
+                let Some(idx) = resolve_index(n, stack.len()) else {
+                    return Ok(Value::Null);
+                };
+                idx
+            }
+        };
+
+        let Some(layer) = stack.get(layer_index) else {
+            return Ok(Value::Null);
+        };
+
+        let Some(node) = smallest_containing_node(&layer.tree, byte, doc_len) else {
+            return Ok(Value::Null);
+        };
+
         let ulid = self.bridge.node_tracker().get_or_create(
             &uri,
             node.start_byte(),
@@ -101,6 +235,58 @@ impl Kakehashi {
             "id": ulid.to_string(),
             "type": node.kind(),
         }))
+    }
+
+    /// Host-layer lookup, factored out so the no-injection request keeps
+    /// the same shape it had in PR-1.
+    fn resolve_host_layer_node(
+        &self,
+        uri: &Url,
+        tree: &tree_sitter::Tree,
+        byte: usize,
+        doc_len: usize,
+    ) -> Value {
+        let Some(node) = smallest_containing_node(tree, byte, doc_len) else {
+            return Value::Null;
+        };
+
+        let ulid = self.bridge.node_tracker().get_or_create(
+            uri,
+            node.start_byte(),
+            node.end_byte(),
+            node.kind(),
+        );
+
+        json!({
+            "id": ulid.to_string(),
+            "type": node.kind(),
+        })
+    }
+
+    /// Ensure parsers for every injection language reachable from this
+    /// document are loaded. `didOpen` triggers this via `process_injections`,
+    /// but a client may call `kakehashi/node` quickly enough to race that
+    /// load — re-invoke it here defensively so PR-4's injection-aware path
+    /// has a parser to work with.
+    ///
+    /// Cheap when languages are already loaded (`ensure_language_loaded`
+    /// short-circuits on a registry hit).
+    async fn ensure_injection_languages_loaded(&self, uri: &Url, host_language: &str, _text: &str) {
+        use std::collections::HashSet;
+
+        // Re-resolve the injection set from the host language's injection
+        // query. We could mine this from `injection_stack_at` but we'd then
+        // have to plumb it back; the duplicate work is negligible and keeps
+        // the stack helper synchronous-only.
+        let coordinator = self.injection_coordinator();
+        let injections = coordinator.resolve_injection_data(uri, host_language);
+        if injections.is_empty() {
+            return;
+        }
+        let languages: HashSet<String> = injections.into_iter().map(|i| i.language).collect();
+        coordinator
+            .check_injected_languages_auto_install(uri, &languages)
+            .await;
     }
 
     /// Parse the document on-demand if its tree has not been built yet.

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -99,12 +99,16 @@ fn parse_injection_selector(value: Option<&Value>) -> InjectionSelector {
 /// present); we keep the signature general so callers can defensively
 /// short-circuit on an empty stack without panicking.
 fn resolve_index(n: i64, stack_len: usize) -> Option<usize> {
-    if n > 0 {
+    if n >= 0 {
+        // Non-negative: direct stack[n] lookup. n == 0 is normally routed
+        // through the Host branch upstream, but accepting it here makes the
+        // helper self-contained — `stack[0]` is the host layer, so the result
+        // is correct either way.
         let idx = usize::try_from(n).ok()?;
         if idx < stack_len { Some(idx) } else { None }
     } else {
-        // n is negative (n == 0 is handled by the Host branch upstream).
-        // Convert via i64 arithmetic to avoid usize underflow on `len + n`.
+        // Negative: stack[stack.len + n]. Convert via i64 to avoid usize
+        // underflow when |n| > stack_len.
         let len_i64 = i64::try_from(stack_len).ok()?;
         let resolved = len_i64.checked_add(n)?;
         if resolved < 0 {

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -219,8 +219,37 @@ impl Kakehashi {
         // the host parser on-demand; injection layers require their own
         // grammars to be available before `injection_stack_at` can parse
         // them. Skip the expensive load for the host-only path above.
+        //
+        // The pre-await snapshot (`text` / `tree` / `byte`) is fine for
+        // *discovering* which grammars to install, but must NOT be reused to
+        // mint a ULID: a `didChange` processed while grammars install would
+        // adjust the tracker, leaving our stale byte ranges un-adjusted and
+        // minting an id for bytes the edit moved.
         self.ensure_injection_languages_loaded(&uri, &host_language, text, tree)
             .await;
+
+        // Re-snapshot after the await and recompute the position mapping. From
+        // here on we operate strictly on the post-await document state.
+        let snapshot = match self.documents.get(&uri).and_then(|doc| doc.snapshot()) {
+            Some(s) => s,
+            None => {
+                log::debug!(target: "kakehashi::node", "no parsed document for {} after load", uri);
+                return Ok(Value::Null);
+            }
+        };
+        let text = snapshot.text();
+        let tree = snapshot.tree();
+        let doc_len = text.len();
+        if doc_len == 0 {
+            return Ok(Value::Null);
+        }
+        let mapper = PositionMapper::new(text);
+        let Some(byte) = mapper.position_to_byte(position) else {
+            return Ok(Value::Null);
+        };
+        if byte > doc_len {
+            return Ok(Value::Null);
+        }
 
         let stack = injection_stack_at(&self.language, &host_language, text, tree, byte);
 

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -219,7 +219,7 @@ impl Kakehashi {
         // the host parser on-demand; injection layers require their own
         // grammars to be available before `injection_stack_at` can parse
         // them. Skip the expensive load for the host-only path above.
-        self.ensure_injection_languages_loaded(&uri, &host_language, text)
+        self.ensure_injection_languages_loaded(&uri, &host_language, text, tree)
             .await;
 
         let stack = injection_stack_at(&self.language, &host_language, text, tree, byte);
@@ -289,29 +289,51 @@ impl Kakehashi {
     }
 
     /// Ensure parsers for every injection language reachable from this
-    /// document are loaded. `didOpen` triggers this via `process_injections`,
-    /// but a client may call `kakehashi/node` quickly enough to race that
-    /// load — re-invoke it here defensively so PR-4's injection-aware path
-    /// has a parser to work with.
+    /// document — **at every nesting depth** — are loaded. `didOpen` triggers
+    /// a first-level load via `process_injections`, but a client may call
+    /// `kakehashi/node` quickly enough to race it, and nested grammars
+    /// (Markdown → Python → Regex) are never first-level. Re-run defensively
+    /// here so PR-4's injection-aware path has parsers for the whole chain.
     ///
-    /// Cheap when languages are already loaded (`ensure_language_loaded`
-    /// short-circuits on a registry hit).
-    async fn ensure_injection_languages_loaded(&self, uri: &Url, host_language: &str, _text: &str) {
+    /// Discovery is a fixpoint: `collect_injection_languages` can only parse
+    /// *into* layers whose grammar is already loaded, so each round surfaces
+    /// the next tier. We auto-install each round's newly-seen languages, then
+    /// recollect — converging once a round adds nothing new (or the depth cap
+    /// is hit). Cheap once everything is loaded: `collect` short-circuits on
+    /// loaded grammars and `check_injected_languages_auto_install` is a no-op
+    /// when there is nothing to install.
+    async fn ensure_injection_languages_loaded(
+        &self,
+        uri: &Url,
+        host_language: &str,
+        text: &str,
+        host_tree: &tree_sitter::Tree,
+    ) {
         use std::collections::HashSet;
 
-        // Re-resolve the injection set from the host language's injection
-        // query. We could mine this from `injection_stack_at` but we'd then
-        // have to plumb it back; the duplicate work is negligible and keeps
-        // the stack helper synchronous-only.
         let coordinator = self.injection_coordinator();
-        let injections = coordinator.resolve_injection_data(uri, host_language);
-        if injections.is_empty() {
-            return;
+        let mut seen: HashSet<String> = HashSet::new();
+
+        // Bound the outer loop independently of the per-branch depth cap inside
+        // `collect_injection_languages`; MAX rounds is generous since each
+        // round must reveal at least one new language to continue.
+        for _round in 0..crate::language::injection::MAX_INJECTION_DEPTH {
+            let discovered =
+                crate::lsp::lsp_impl::kakehashi::node::injection_stack::collect_injection_languages(
+                    &self.language,
+                    host_language,
+                    text,
+                    host_tree,
+                );
+            let fresh: HashSet<String> = discovered.difference(&seen).cloned().collect();
+            if fresh.is_empty() {
+                break;
+            }
+            coordinator
+                .check_injected_languages_auto_install(uri, &fresh)
+                .await;
+            seen.extend(fresh);
         }
-        let languages: HashSet<String> = injections.into_iter().map(|i| i.language).collect();
-        coordinator
-            .check_injected_languages_auto_install(uri, &languages)
-            .await;
     }
 
     /// Parse the document on-demand if its tree has not been built yet.

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -341,6 +341,7 @@ impl Kakehashi {
         use std::collections::HashSet;
 
         let coordinator = self.injection_coordinator();
+        let registry = self.language.language_registry_for_parallel();
         let mut seen: HashSet<String> = HashSet::new();
 
         // Bound the outer loop independently of the per-branch depth cap inside
@@ -354,7 +355,19 @@ impl Kakehashi {
                     text,
                     host_tree,
                 );
-            let fresh: HashSet<String> = discovered.difference(&seen).cloned().collect();
+            // Only languages that are still missing need a round: an
+            // already-loaded language was *also* descended into during this
+            // same `collect` call, so it never gates discovery of a deeper
+            // tier. Filtering them out means the loop ends in a single round
+            // when every required grammar is already present (the common case),
+            // instead of spending a second `collect` pass to confirm it.
+            // `seen` still guards against re-attempting an install that failed
+            // (registry stays empty for it, so it would otherwise reappear).
+            let fresh: HashSet<String> = discovered
+                .into_iter()
+                .filter(|lang| registry.get(lang).is_none())
+                .filter(|lang| !seen.contains(lang))
+                .collect();
             if fresh.is_empty() {
                 break;
             }

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -342,7 +342,6 @@ impl Kakehashi {
         use std::collections::HashSet;
 
         let coordinator = self.injection_coordinator();
-        let registry = self.language.language_registry_for_parallel();
         let mut seen: HashSet<String> = HashSet::new();
 
         // Bound the outer loop independently of the per-branch depth cap inside
@@ -357,19 +356,24 @@ impl Kakehashi {
                     host_tree,
                     byte,
                 );
-            // Only languages that are still missing need a round: an
-            // already-loaded language was *also* descended into during this
-            // same `collect` call, so it never gates discovery of a deeper
-            // tier. Filtering them out means the loop ends in a single round
-            // when every required grammar is already present (the common case),
-            // instead of spending a second `collect` pass to confirm it.
-            // `seen` still guards against re-attempting an install that failed
-            // (registry stays empty for it, so it would otherwise reappear).
+            // Re-read the registry *each round* and drop it before the await:
+            // a snapshot taken once would not reflect the grammars installed by
+            // the previous round, so already-installed languages would keep
+            // looking "missing" and rely on `seen` alone. Holding it across the
+            // `check_injected_languages_auto_install` await would also risk
+            // writer contention while the install writes to the registry.
+            //
+            // Only languages still missing need a round: an already-loaded one
+            // was *also* descended into during this same `collect` call, so it
+            // never gates discovery of a deeper tier. `seen` still guards a
+            // failed install from being retried every round.
+            let registry = self.language.language_registry_for_parallel();
             let fresh: HashSet<String> = discovered
                 .into_iter()
                 .filter(|lang| registry.get(lang).is_none())
                 .filter(|lang| !seen.contains(lang))
                 .collect();
+            drop(registry);
             if fresh.is_empty() {
                 break;
             }

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -47,8 +47,28 @@ pub struct NodeParams {
     /// `boolean | number` per ADR-0025 §"The `injection` Parameter". Absent /
     /// `false` / `0` selects the host layer; `true` saturates to the deepest
     /// layer; a non-zero integer indexes the stack strictly.
-    #[serde(default)]
+    ///
+    /// We deserialize via a custom helper so that explicit JSON `null`
+    /// reaches the handler as `Some(Value::Null)` (rejected as invalid) while
+    /// an absent field stays `None` (defaults to host). Plain
+    /// `Option<Value>` would collapse the two — serde's default Option
+    /// deserialization treats `null` and missing identically — which would
+    /// silently accept an unsupported shape against ADR-0025.
+    #[serde(default, deserialize_with = "deserialize_present_value")]
     pub injection: Option<Value>,
+}
+
+/// Deserialize a field as `Some(Value)` whenever it's *present* in the JSON,
+/// even when the value is explicit `null`. Combined with `#[serde(default)]`
+/// this lets the caller distinguish a missing field (`None`) from an
+/// explicit `null` (`Some(Value::Null)`).
+fn deserialize_present_value<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<Value>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Value::deserialize(deserializer).map(Some)
 }
 
 /// Layer selector parsed from the `injection` JSON parameter.
@@ -73,11 +93,12 @@ enum InjectionSelector {
 ///
 /// Per ADR-0025: `false` and `0` are equivalent (host); `true` saturates;
 /// integer values index strictly. Anything else (string, array, fractional
-/// number) is rejected as `Invalid` so the handler returns null with a log
-/// warning, rather than silently coercing.
+/// number, **explicit JSON `null`**) is rejected as `Invalid` so the handler
+/// returns null with a log warning, rather than silently coercing. An absent
+/// field (`None`) defaults to host per the spec.
 fn parse_injection_selector(value: Option<&Value>) -> InjectionSelector {
     match value {
-        None | Some(Value::Null) => InjectionSelector::Host,
+        None => InjectionSelector::Host,
         Some(Value::Bool(true)) => InjectionSelector::Saturating,
         Some(Value::Bool(false)) => InjectionSelector::Host,
         Some(Value::Number(n)) => match n.as_i64() {

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -225,7 +225,7 @@ impl Kakehashi {
         // mint a ULID: a `didChange` processed while grammars install would
         // adjust the tracker, leaving our stale byte ranges un-adjusted and
         // minting an id for bytes the edit moved.
-        self.ensure_injection_languages_loaded(&uri, &host_language, text, tree)
+        self.ensure_injection_languages_loaded(&uri, &host_language, text, tree, byte)
             .await;
 
         // Re-snapshot after the await and recompute the position mapping. From
@@ -317,26 +317,27 @@ impl Kakehashi {
         })
     }
 
-    /// Ensure parsers for every injection language reachable from this
-    /// document — **at every nesting depth** — are loaded. `didOpen` triggers
-    /// a first-level load via `process_injections`, but a client may call
-    /// `kakehashi/node` quickly enough to race it, and nested grammars
-    /// (Markdown → Python → Regex) are never first-level. Re-run defensively
-    /// here so PR-4's injection-aware path has parsers for the whole chain.
+    /// Ensure parsers for every injection language **along the cursor's
+    /// injection path** are loaded. `didOpen` triggers a first-level load via
+    /// `process_injections`, but a client may call `kakehashi/node` quickly
+    /// enough to race it, and nested grammars (Markdown → Python → Regex) are
+    /// never first-level. Re-run defensively here so PR-4's injection-aware
+    /// path has parsers for the whole chain at `byte`.
     ///
-    /// Discovery is a fixpoint: `collect_injection_languages` can only parse
-    /// *into* layers whose grammar is already loaded, so each round surfaces
-    /// the next tier. We auto-install each round's newly-seen languages, then
-    /// recollect — converging once a round adds nothing new (or the depth cap
-    /// is hit). Cheap once everything is loaded: `collect` short-circuits on
-    /// loaded grammars and `check_injected_languages_auto_install` is a no-op
-    /// when there is nothing to install.
+    /// Discovery is a fixpoint over `collect_injection_languages_at`, which can
+    /// only parse *into* layers whose grammar is already loaded, so each round
+    /// surfaces the next language on the cursor's path. We auto-install each
+    /// round's newly-seen languages, then recollect — converging once a round
+    /// adds nothing new (or the depth cap is hit). Localized to `byte` so the
+    /// cost scales with nesting depth, not the number of injections in the
+    /// document.
     async fn ensure_injection_languages_loaded(
         &self,
         uri: &Url,
         host_language: &str,
         text: &str,
         host_tree: &tree_sitter::Tree,
+        byte: usize,
     ) {
         use std::collections::HashSet;
 
@@ -345,15 +346,16 @@ impl Kakehashi {
         let mut seen: HashSet<String> = HashSet::new();
 
         // Bound the outer loop independently of the per-branch depth cap inside
-        // `collect_injection_languages`; MAX rounds is generous since each
+        // `collect_injection_languages_at`; MAX rounds is generous since each
         // round must reveal at least one new language to continue.
         for _round in 0..crate::language::injection::MAX_INJECTION_DEPTH {
             let discovered =
-                crate::lsp::lsp_impl::kakehashi::node::injection_stack::collect_injection_languages(
+                crate::lsp::lsp_impl::kakehashi::node::injection_stack::collect_injection_languages_at(
                     &self.language,
                     host_language,
                     text,
                     host_tree,
+                    byte,
                 );
             // Only languages that are still missing need a round: an
             // already-loaded language was *also* descended into during this

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -39,6 +39,13 @@ pub(super) struct InjectionLayer {
     pub(super) ranges: Vec<tree_sitter::Range>,
 }
 
+/// Whether `pattern_index` carries an `#offset!` directive. Used to decide if
+/// the raw-content-node fast bounds check is safe: an offset can extend the
+/// effective range past the raw node, so the shortcut only holds without one.
+fn pattern_has_offset(injection_query: &tree_sitter::Query, pattern_index: usize) -> bool {
+    parse_offset_directive_for_pattern(injection_query, pattern_index).is_some()
+}
+
 /// Build the full-document range used to seed the host layer.
 fn whole_document_range(host_text: &str) -> tree_sitter::Range {
     tree_sitter::Range {
@@ -115,20 +122,26 @@ pub(super) fn injection_stack_at(
         let host_len = host_text.len();
         let mut candidates: Vec<(_, Vec<tree_sitter::Range>)> = Vec::new();
         for region in injections {
-            // Fast bounds check: the effective ranges can only ever be a
-            // sub-range of the raw content node, so a cursor outside the raw
-            // span cannot possibly be inside the effective ranges. Reject
-            // before the expensive build_effective_ranges call (which parses
-            // the #offset! directive and computes include-children gaps).
-            let raw_start = region.content_node.start_byte();
-            let raw_end = region.content_node.end_byte();
-            let outside_raw = if byte == host_len {
-                byte < raw_start || byte > raw_end
-            } else {
-                byte < raw_start || byte >= raw_end
-            };
-            if outside_raw {
-                continue;
+            // Fast bounds check: when there is no `#offset!` directive the
+            // effective ranges can only ever be a *sub*-range of the raw
+            // content node (include-children gaps only remove bytes), so a
+            // cursor outside the raw span cannot be inside them — reject before
+            // the expensive build_effective_ranges call. We must NOT apply this
+            // shortcut when an offset directive is present: positive end /
+            // negative start offsets can *extend* the effective range past the
+            // raw content node, so containment has to be judged on the
+            // effective ranges alone.
+            if !pattern_has_offset(&injection_query, region.pattern_index) {
+                let raw_start = region.content_node.start_byte();
+                let raw_end = region.content_node.end_byte();
+                let outside_raw = if byte == host_len {
+                    byte < raw_start || byte > raw_end
+                } else {
+                    byte < raw_start || byte >= raw_end
+                };
+                if outside_raw {
+                    continue;
+                }
             }
             let own_ranges = build_effective_ranges(&region, host_text, &injection_query);
             if own_ranges.is_empty() {

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -63,9 +63,11 @@ fn whole_document_range(host_text: &str) -> tree_sitter::Range {
 /// when the byte lies strictly inside an injection's content range
 /// (half-open `[start, end)` per ADR-0025).
 ///
-/// `host_language` selects the injection query used at each level — the same
-/// query is consulted recursively for nested injections, matching the
-/// semantic-tokens parallel collector's behavior.
+/// `host_language` selects the injection query for layer 0 only. Each deeper
+/// level uses the **language resolved for the layer above it** (the previous
+/// layer's `@injection.language`) to pick its query, so a Markdown → Python →
+/// Regex chain consults the markdown, then python, then regex injection
+/// queries in turn — matching the semantic-tokens parallel collector.
 ///
 /// The returned `Vec` always contains at least the host layer (layer 0); the
 /// function never fails — a parse/registry miss at any depth simply stops the

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -85,7 +85,6 @@ pub(super) fn injection_stack_at(
         ranges: vec![whole_document_range(host_text)],
     });
 
-    let registry = coordinator.language_registry_for_parallel();
     let mut current_language: String = host_language.to_string();
 
     // Walk one injection deeper per iteration. The depth cap mirrors the
@@ -178,7 +177,14 @@ pub(super) fn injection_stack_at(
         else {
             break;
         };
-        let Some(language) = registry.get(&resolved_lang) else {
+        // `get` clones the grammar out (owned `Language`) and releases its
+        // internal DashMap ref before returning, so there is no read guard to
+        // scope around the parse below. Fetched inline (not via a function-
+        // level binding) to keep that intent obvious.
+        let Some(language) = coordinator
+            .language_registry_for_parallel()
+            .get(&resolved_lang)
+        else {
             break;
         };
 
@@ -278,7 +284,6 @@ pub(super) fn collect_injection_languages_at(
     host_tree: &tree_sitter::Tree,
     byte: usize,
 ) -> std::collections::HashSet<String> {
-    let registry = coordinator.language_registry_for_parallel();
     let mut languages = std::collections::HashSet::new();
 
     let mut current_lang = host_language.to_string();
@@ -342,7 +347,12 @@ pub(super) fn collect_injection_languages_at(
 
         // Descend only if the parser is loaded; otherwise stop and let the
         // caller install it, then re-run for the next tier (fixpoint).
-        let Some(language) = registry.get(&resolved_lang) else {
+        // `get` returns an owned `Language` (clones out, drops its DashMap ref
+        // internally), so no read guard spans the parse; fetched inline.
+        let Some(language) = coordinator
+            .language_registry_for_parallel()
+            .get(&resolved_lang)
+        else {
             break;
         };
         let Some(injected_tree) = parse_with_absolute_ranges(&language, host_text, &absolute_ranges)

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -336,8 +336,7 @@ pub(super) fn collect_injection_languages_at(
             break;
         };
 
-        let content =
-            &host_text[region.content_node.start_byte()..region.content_node.end_byte()];
+        let content = &host_text[region.content_node.start_byte()..region.content_node.end_byte()];
         let Some((resolved_lang, _)) =
             coordinator.resolve_injection_language(&region.language, content)
         else {
@@ -355,7 +354,8 @@ pub(super) fn collect_injection_languages_at(
         else {
             break;
         };
-        let Some(injected_tree) = parse_with_absolute_ranges(&language, host_text, &absolute_ranges)
+        let Some(injected_tree) =
+            parse_with_absolute_ranges(&language, host_text, &absolute_ranges)
         else {
             break;
         };

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -25,7 +25,6 @@ use crate::language::injection::{
 /// and so the host layer can carry the document tree without cloning lifetime
 /// dependencies. Byte coordinates inside `tree` are in original-document
 /// space (the same space the host text uses).
-#[allow(dead_code)] // used in the next commit (4d/4e GREEN)
 pub(super) struct InjectionLayer {
     /// Tree-sitter syntax tree for this layer.
     pub(super) tree: tree_sitter::Tree,
@@ -45,7 +44,6 @@ pub(super) struct InjectionLayer {
 /// Returns `None` if the host layer cannot be cloned (`tree_sitter::Tree`
 /// clone is cheap and infallible in practice, so this currently never fires
 /// but is kept as a signature concession to future failure modes).
-#[allow(dead_code)] // used in the next commit (4d/4e GREEN)
 pub(super) fn injection_stack_at(
     coordinator: &LanguageCoordinator,
     host_language: &str,
@@ -168,7 +166,6 @@ pub(super) fn injection_stack_at(
 /// synchronous LSP handler code paths. Parser construction is cheap (each
 /// call instantiates a fresh `tree_sitter::Parser` and reads a few pointers
 /// from the registry); we re-evaluate if profiling shows this on a hot path.
-#[allow(dead_code)] // used in the next commit (4d/4e GREEN)
 fn parse_with_absolute_ranges(
     language: &tree_sitter::Language,
     text: &str,

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -18,7 +18,7 @@ use crate::analysis::offset_calculator::{ByteRange, calculate_effective_range};
 use crate::language::LanguageCoordinator;
 use crate::language::injection::{
     MAX_INJECTION_DEPTH, collect_all_injections, compute_included_ranges,
-    parse_offset_directive_for_pattern,
+    intersect_included_ranges, parse_offset_directive_for_pattern,
 };
 use crate::lsp::lsp_impl::kakehashi::node::lookup::find_node_at;
 
@@ -31,6 +31,22 @@ use crate::lsp::lsp_impl::kakehashi::node::lookup::find_node_at;
 pub(super) struct InjectionLayer {
     /// Tree-sitter syntax tree for this layer.
     pub(super) tree: tree_sitter::Tree,
+    /// Absolute ranges in host coordinates that this layer's tree was parsed
+    /// against. The host layer spans the whole document; each deeper layer's
+    /// ranges are the intersection of its own effective ranges with its
+    /// parent's, so container exclusions (e.g. blockquote `> ` prefixes) are
+    /// inherited down the nesting chain.
+    pub(super) ranges: Vec<tree_sitter::Range>,
+}
+
+/// Build the full-document range used to seed the host layer.
+fn whole_document_range(host_text: &str) -> tree_sitter::Range {
+    tree_sitter::Range {
+        start_byte: 0,
+        end_byte: host_text.len(),
+        start_point: tree_sitter::Point { row: 0, column: 0 },
+        end_point: byte_to_point(host_text, host_text.len()),
+    }
 }
 
 /// Enumerate the injection stack at `byte` in `host_text`.
@@ -57,6 +73,7 @@ pub(super) fn injection_stack_at(
     let mut stack: Vec<InjectionLayer> = Vec::new();
     stack.push(InjectionLayer {
         tree: host_tree.clone(),
+        ranges: vec![whole_document_range(host_text)],
     });
 
     let registry = coordinator.language_registry_for_parallel();
@@ -73,12 +90,14 @@ pub(super) fn injection_stack_at(
         // Take the **current deepest** layer's tree, ask it which injections
         // overlap the cursor, and pick the smallest containing one. Using
         // the deepest tree (rather than always the host) ensures we discover
-        // injections nested inside an already-injected region.
-        let deepest_tree = &stack
+        // injections nested inside an already-injected region. We also carry
+        // the parent layer's ranges so a nested injection inherits container
+        // exclusions (blockquote prefixes etc.) from every ancestor.
+        let parent_layer = stack
             .last()
-            .expect("stack always contains at least the host layer")
-            .tree;
-        let root = deepest_tree.root_node();
+            .expect("stack always contains at least the host layer");
+        let parent_ranges = parent_layer.ranges.clone();
+        let root = parent_layer.tree.root_node();
         let Some(injections) = collect_all_injections(&root, host_text, Some(&injection_query))
         else {
             break;
@@ -111,7 +130,15 @@ pub(super) fn injection_stack_at(
             if outside_raw {
                 continue;
             }
-            let absolute_ranges = build_effective_ranges(&region, host_text, &injection_query);
+            let own_ranges = build_effective_ranges(&region, host_text, &injection_query);
+            if own_ranges.is_empty() {
+                continue;
+            }
+            // Inherit parent exclusions: a byte the parent layer already
+            // excluded (e.g. a blockquote `> ` prefix on an intermediate line)
+            // must stay excluded for the nested parser. For the host layer the
+            // parent range is the whole document, so this is a no-op there.
+            let absolute_ranges = intersect_included_ranges(&parent_ranges, &own_ranges);
             if absolute_ranges.is_empty() {
                 continue;
             }
@@ -148,6 +175,7 @@ pub(super) fn injection_stack_at(
 
         stack.push(InjectionLayer {
             tree: injected_tree,
+            ranges: absolute_ranges,
         });
         current_language = resolved_lang;
     }
@@ -223,12 +251,19 @@ pub(super) fn collect_injection_languages(
     let registry = coordinator.language_registry_for_parallel();
     let mut languages = std::collections::HashSet::new();
 
-    // (language, tree, depth) work items. Trees are owned so each item is
-    // self-contained; the host tree is cheap to clone (refcounted).
-    let mut work: Vec<(String, tree_sitter::Tree, usize)> =
-        vec![(host_language.to_string(), host_tree.clone(), 0)];
+    // (language, tree, parent_ranges, depth) work items. Trees are owned so
+    // each item is self-contained; the host tree is cheap to clone
+    // (refcounted). parent_ranges carries the inherited container exclusions so
+    // a nested layer is parsed against the same effective span the stack walk
+    // would use — keeping discovery and the per-position stack consistent.
+    let mut work: Vec<(String, tree_sitter::Tree, Vec<tree_sitter::Range>, usize)> = vec![(
+        host_language.to_string(),
+        host_tree.clone(),
+        vec![whole_document_range(host_text)],
+        0,
+    )];
 
-    while let Some((lang, tree, depth)) = work.pop() {
+    while let Some((lang, tree, parent_ranges, depth)) = work.pop() {
         if depth >= MAX_INJECTION_DEPTH {
             continue;
         }
@@ -252,13 +287,14 @@ pub(super) fn collect_injection_languages(
             // Only descend if the parser is already loaded; otherwise leave it
             // for the next fixpoint pass (after the caller auto-installs it).
             if let Some(language) = registry.get(&resolved_lang) {
-                let ranges = build_effective_ranges(&region, host_text, &injection_query);
+                let own_ranges = build_effective_ranges(&region, host_text, &injection_query);
+                let ranges = intersect_included_ranges(&parent_ranges, &own_ranges);
                 if ranges.is_empty() {
                     continue;
                 }
                 if let Some(child_tree) = parse_with_absolute_ranges(&language, host_text, &ranges)
                 {
-                    work.push((resolved_lang, child_tree, depth + 1));
+                    work.push((resolved_lang, child_tree, ranges, depth + 1));
                 }
             }
         }

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -200,6 +200,73 @@ pub(super) fn with_resolved_node<R>(
     None
 }
 
+/// Collect every injection language reachable in `host_tree`, at all depths
+/// that are currently parseable.
+///
+/// A language is *recorded* as soon as its `@injection.language` is resolved,
+/// even if its parser is not yet loaded. But the walk only *descends* into a
+/// layer whose parser is already in the registry — parsing requires a loaded
+/// grammar. This makes the function a single fixpoint step: callers that
+/// auto-install the returned set and call again will, on the next pass, be
+/// able to parse one level deeper and surface the next tier of languages.
+/// Iterating to a fixpoint discovers the full nested chain
+/// (Markdown → Python → Regex …) without ever parsing with a missing grammar.
+///
+/// Bounded by [`MAX_INJECTION_DEPTH`] per branch so a misconfigured grammar
+/// cycle cannot loop forever.
+pub(super) fn collect_injection_languages(
+    coordinator: &LanguageCoordinator,
+    host_language: &str,
+    host_text: &str,
+    host_tree: &tree_sitter::Tree,
+) -> std::collections::HashSet<String> {
+    let registry = coordinator.language_registry_for_parallel();
+    let mut languages = std::collections::HashSet::new();
+
+    // (language, tree, depth) work items. Trees are owned so each item is
+    // self-contained; the host tree is cheap to clone (refcounted).
+    let mut work: Vec<(String, tree_sitter::Tree, usize)> =
+        vec![(host_language.to_string(), host_tree.clone(), 0)];
+
+    while let Some((lang, tree, depth)) = work.pop() {
+        if depth >= MAX_INJECTION_DEPTH {
+            continue;
+        }
+        let Some(injection_query) = coordinator.injection_query(&lang) else {
+            continue;
+        };
+        let root = tree.root_node();
+        let Some(regions) = collect_all_injections(&root, host_text, Some(&injection_query)) else {
+            continue;
+        };
+        for region in regions {
+            let content =
+                &host_text[region.content_node.start_byte()..region.content_node.end_byte()];
+            let Some((resolved_lang, _)) =
+                coordinator.resolve_injection_language(&region.language, content)
+            else {
+                continue;
+            };
+            languages.insert(resolved_lang.clone());
+
+            // Only descend if the parser is already loaded; otherwise leave it
+            // for the next fixpoint pass (after the caller auto-installs it).
+            if let Some(language) = registry.get(&resolved_lang) {
+                let ranges = build_effective_ranges(&region, host_text, &injection_query);
+                if ranges.is_empty() {
+                    continue;
+                }
+                if let Some(child_tree) = parse_with_absolute_ranges(&language, host_text, &ranges)
+                {
+                    work.push((resolved_lang, child_tree, depth + 1));
+                }
+            }
+        }
+    }
+
+    languages
+}
+
 /// Parse `text` with a fresh tree-sitter parser configured for `language`,
 /// restricted to `ranges` (absolute doc-coord). Returns `None` if the parser
 /// cannot be initialised, the ranges are rejected, or parsing fails.
@@ -270,11 +337,24 @@ fn build_effective_ranges(
     let content_start = region.content_node.start_byte();
     let content_start_pos = region.content_node.start_position();
     let absolute_ranges: Vec<tree_sitter::Range> = if offset.is_some() {
+        // #offset! shifts are byte arithmetic over i32 deltas, so the effective
+        // bounds can land mid-codepoint. Align both ends down to a UTF-8
+        // boundary before handing them to tree-sitter — passing a mid-char
+        // byte to set_included_ranges is UB / panic territory, and it would
+        // also desync from byte_to_point (which aligns internally).
+        let aligned_start = align_down(host_text, eff_start);
+        let aligned_end = align_down(host_text, eff_end);
+        // The alignment could, in pathological cases, collapse the range
+        // (e.g. both ends fall inside the same multi-byte char). Guard so we
+        // never emit a zero/negative-width range to the parser.
+        if aligned_start >= aligned_end {
+            return Vec::new();
+        }
         vec![tree_sitter::Range {
-            start_byte: eff_start,
-            end_byte: eff_end,
-            start_point: byte_to_point(host_text, eff_start),
-            end_point: byte_to_point(host_text, eff_end),
+            start_byte: aligned_start,
+            end_byte: aligned_end,
+            start_point: byte_to_point(host_text, aligned_start),
+            end_point: byte_to_point(host_text, aligned_end),
         }]
     } else {
         match compute_included_ranges(&region.content_node, region.include_children) {
@@ -338,20 +418,26 @@ fn total_span(ranges: &[tree_sitter::Range]) -> usize {
         .sum()
 }
 
+/// Clamp `byte` into `text` and round down to the nearest UTF-8 character
+/// boundary. Byte values derived from `#offset!` directives (i32 deltas in
+/// byte space) are not guaranteed to land on boundaries; feeding a mid-char
+/// byte to tree-sitter's `set_included_ranges` or to a string slice would
+/// panic. Rounding down keeps the offset inside the intended content.
+fn align_down(text: &str, byte: usize) -> usize {
+    let mut aligned = byte.min(text.len());
+    while aligned > 0 && !text.is_char_boundary(aligned) {
+        aligned -= 1;
+    }
+    aligned
+}
+
 /// Convert an absolute byte offset to a `tree_sitter::Point`. Used when an
 /// offset directive shifts the injection boundary away from a known node
 /// position, so we can't reuse the content node's start/end points.
 fn byte_to_point(text: &str, byte: usize) -> tree_sitter::Point {
-    // Clamp first, then walk back to the nearest UTF-8 character boundary.
-    // The byte values reaching this helper can come from #offset! directives
-    // (i32 row/column shifts then converted to bytes), which are not
-    // guaranteed to land on character boundaries. Slicing &text[..clamped]
-    // on a mid-character byte would panic and crash the LSP server, so
-    // round-down to the nearest valid boundary.
-    let mut clamped = byte.min(text.len());
-    while clamped > 0 && !text.is_char_boundary(clamped) {
-        clamped -= 1;
-    }
+    // Align first — slicing `&text[..clamped]` on a mid-character byte would
+    // panic and crash the LSP server.
+    let clamped = align_down(text, byte);
     let prefix = &text[..clamped];
     let row = prefix.bytes().filter(|b| *b == b'\n').count();
     let last_nl = prefix.rfind('\n');

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -14,9 +14,11 @@
 //! `parent` / `children` / `text` calls and `didChange` adjustments line
 //! up across layers.
 
+use crate::analysis::offset_calculator::{ByteRange, calculate_effective_range};
 use crate::language::LanguageCoordinator;
 use crate::language::injection::{
     MAX_INJECTION_DEPTH, collect_all_injections, compute_included_ranges,
+    parse_offset_directive_for_pattern,
 };
 
 /// One layer in the injection stack at a position.
@@ -81,27 +83,31 @@ pub(super) fn injection_stack_at(
             break;
         };
 
-        let mut containing: Vec<_> = injections
-            .into_iter()
-            .filter(|r| {
-                let s = r.content_node.start_byte();
-                let e = r.content_node.end_byte();
-                // ADR-0025 §"End-of-Document Exception": when the cursor sits
-                // exactly at the document end (`byte == L && L > 0`), inclusion
-                // is widened to `byte == e` for nodes whose `e == L`. Everywhere
-                // else, the half-open `byte < e` rule applies. The exception is
-                // gated on byte == host_text.len() so it never affects interior
-                // boundaries (e.g., the byte just before a closing code fence).
-                if byte == host_text.len() {
-                    s <= byte && byte <= e
-                } else {
-                    s <= byte && byte < e
-                }
-            })
-            .collect();
-        // Smallest range wins — that's the most specific injection at the cursor.
-        containing.sort_by_key(|r| r.content_node.end_byte() - r.content_node.start_byte());
-        let Some(region) = containing.into_iter().next() else {
+        // Materialise the effective absolute ranges for every candidate so the
+        // containment check considers the bytes the injection parser will
+        // actually see — not the raw `@injection.content` span:
+        //   - apply any `#offset!` directive so prefixes / suffixes excluded by
+        //     the query (e.g., frontmatter fences, string quotes) are out;
+        //   - intersect with `compute_included_ranges` so blockquote `> `
+        //     prefixes (`block_continuation` children) are out.
+        // A cursor on an excluded byte must NOT push a new injection layer —
+        // ADR-0025 §"Half-Open Intervals" works against the effective ranges.
+        let host_len = host_text.len();
+        let mut candidates: Vec<(_, Vec<tree_sitter::Range>)> = Vec::new();
+        for region in injections {
+            let absolute_ranges = build_effective_ranges(&region, host_text, &injection_query);
+            if absolute_ranges.is_empty() {
+                continue;
+            }
+            if !ranges_contain_byte(&absolute_ranges, byte, host_len) {
+                continue;
+            }
+            candidates.push((region, absolute_ranges));
+        }
+        // Smallest effective span wins — that's the most specific injection at
+        // the cursor after offset/include adjustments.
+        candidates.sort_by_key(|(_, ranges)| total_span(ranges));
+        let Some((region, absolute_ranges)) = candidates.into_iter().next() else {
             break;
         };
 
@@ -117,45 +123,6 @@ pub(super) fn injection_stack_at(
         let Some(language) = registry.get(&resolved_lang) else {
             break;
         };
-
-        // Build absolute included ranges (doc-coord) for parsing. When the
-        // injection has `compute_included_ranges` gaps (e.g., blockquote
-        // prefix exclusion), shift each gap by `content_node.start_byte()`
-        // and `content_node.start_position()` to land in host coordinates.
-        let content_start = region.content_node.start_byte();
-        let content_start_pos = region.content_node.start_position();
-        let absolute_ranges: Vec<tree_sitter::Range> =
-            match compute_included_ranges(&region.content_node, region.include_children) {
-                Some(gaps) => gaps
-                    .into_iter()
-                    .map(|r| tree_sitter::Range {
-                        start_byte: content_start + r.start_byte,
-                        end_byte: content_start + r.end_byte,
-                        start_point: tree_sitter::Point {
-                            row: content_start_pos.row + r.start_point.row,
-                            column: if r.start_point.row == 0 {
-                                content_start_pos.column + r.start_point.column
-                            } else {
-                                r.start_point.column
-                            },
-                        },
-                        end_point: tree_sitter::Point {
-                            row: content_start_pos.row + r.end_point.row,
-                            column: if r.end_point.row == 0 {
-                                content_start_pos.column + r.end_point.column
-                            } else {
-                                r.end_point.column
-                            },
-                        },
-                    })
-                    .collect(),
-                None => vec![tree_sitter::Range {
-                    start_byte: region.content_node.start_byte(),
-                    end_byte: region.content_node.end_byte(),
-                    start_point: region.content_node.start_position(),
-                    end_point: region.content_node.end_position(),
-                }],
-            };
 
         let Some(injected_tree) =
             parse_with_absolute_ranges(&language, host_text, &absolute_ranges)
@@ -194,4 +161,133 @@ fn parse_with_absolute_ranges(
         return None;
     }
     parser.parse(text, None)
+}
+
+/// Compute the absolute byte-range list that the injection parser would see
+/// for `region` given the host's `@injection.content` node, any `#offset!`
+/// directive on the pattern, and `compute_included_ranges` gap exclusions.
+///
+/// Returns an empty `Vec` when:
+/// - the offset-adjusted range is degenerate (`start >= end`); or
+/// - `compute_included_ranges` returns gaps that all fall outside the
+///   offset-adjusted span (intersection is empty).
+fn build_effective_ranges(
+    region: &crate::language::injection::InjectionRegionInfo<'_>,
+    host_text: &str,
+    injection_query: &tree_sitter::Query,
+) -> Vec<tree_sitter::Range> {
+    // 1. Apply #offset! to the raw content_node span.
+    let offset = parse_offset_directive_for_pattern(injection_query, region.pattern_index);
+    let (eff_start, eff_end) = match offset {
+        Some(off) => {
+            let byte_range = ByteRange::new(
+                region.content_node.start_byte(),
+                region.content_node.end_byte(),
+            );
+            let eff = calculate_effective_range(host_text, byte_range, off);
+            (eff.start, eff.end)
+        }
+        None => (
+            region.content_node.start_byte(),
+            region.content_node.end_byte(),
+        ),
+    };
+    if eff_start >= eff_end {
+        return Vec::new();
+    }
+
+    // 2. Compute compute_included_ranges gap list (relative coords inside
+    // content_node) and shift to absolute. Intersect each gap with the
+    // offset-adjusted span so blockquote prefixes excluded by the gap list and
+    // bytes trimmed by the offset directive are both honoured.
+    //
+    // Skip the include-gap step when an offset directive is active: gaps from
+    // `compute_included_ranges` are relative to `content_node.start_byte()`,
+    // but the offset may have moved the effective start away from there, and
+    // mixing the two coordinate frames would yield wrong ranges. The semantic-
+    // tokens parallel collector takes the same trade-off (see parallel.rs).
+    let content_start = region.content_node.start_byte();
+    let content_start_pos = region.content_node.start_position();
+    let absolute_ranges: Vec<tree_sitter::Range> = if offset.is_some() {
+        vec![tree_sitter::Range {
+            start_byte: eff_start,
+            end_byte: eff_end,
+            start_point: byte_to_point(host_text, eff_start),
+            end_point: byte_to_point(host_text, eff_end),
+        }]
+    } else {
+        match compute_included_ranges(&region.content_node, region.include_children) {
+            Some(gaps) => gaps
+                .into_iter()
+                .map(|r| tree_sitter::Range {
+                    start_byte: content_start + r.start_byte,
+                    end_byte: content_start + r.end_byte,
+                    start_point: tree_sitter::Point {
+                        row: content_start_pos.row + r.start_point.row,
+                        column: if r.start_point.row == 0 {
+                            content_start_pos.column + r.start_point.column
+                        } else {
+                            r.start_point.column
+                        },
+                    },
+                    end_point: tree_sitter::Point {
+                        row: content_start_pos.row + r.end_point.row,
+                        column: if r.end_point.row == 0 {
+                            content_start_pos.column + r.end_point.column
+                        } else {
+                            r.end_point.column
+                        },
+                    },
+                })
+                .collect(),
+            None => vec![tree_sitter::Range {
+                start_byte: region.content_node.start_byte(),
+                end_byte: region.content_node.end_byte(),
+                start_point: region.content_node.start_position(),
+                end_point: region.content_node.end_position(),
+            }],
+        }
+    };
+
+    absolute_ranges
+}
+
+/// Half-open containment over a list of disjoint ranges, with ADR-0025's
+/// end-of-document exception (`byte == host_len` includes nodes whose
+/// `end_byte == host_len`).
+fn ranges_contain_byte(ranges: &[tree_sitter::Range], byte: usize, host_len: usize) -> bool {
+    let at_eod = byte == host_len;
+    ranges.iter().any(|r| {
+        let s = r.start_byte;
+        let e = r.end_byte;
+        if at_eod {
+            s <= byte && byte <= e
+        } else {
+            s <= byte && byte < e
+        }
+    })
+}
+
+/// Total byte length covered by `ranges`. Used as the smallest-injection
+/// tiebreaker — narrower effective spans win.
+fn total_span(ranges: &[tree_sitter::Range]) -> usize {
+    ranges
+        .iter()
+        .map(|r| r.end_byte.saturating_sub(r.start_byte))
+        .sum()
+}
+
+/// Convert an absolute byte offset to a `tree_sitter::Point`. Used when an
+/// offset directive shifts the injection boundary away from a known node
+/// position, so we can't reuse the content node's start/end points.
+fn byte_to_point(text: &str, byte: usize) -> tree_sitter::Point {
+    let clamped = byte.min(text.len());
+    let prefix = &text[..clamped];
+    let row = prefix.bytes().filter(|b| *b == b'\n').count();
+    let last_nl = prefix.rfind('\n');
+    let column = match last_nl {
+        Some(idx) => clamped - idx - 1,
+        None => clamped,
+    };
+    tree_sitter::Point { row, column }
 }

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -20,6 +20,7 @@ use crate::language::injection::{
     MAX_INJECTION_DEPTH, collect_all_injections, compute_included_ranges,
     parse_offset_directive_for_pattern,
 };
+use crate::lsp::lsp_impl::kakehashi::node::lookup::find_node_at;
 
 /// One layer in the injection stack at a position.
 ///
@@ -95,6 +96,21 @@ pub(super) fn injection_stack_at(
         let host_len = host_text.len();
         let mut candidates: Vec<(_, Vec<tree_sitter::Range>)> = Vec::new();
         for region in injections {
+            // Fast bounds check: the effective ranges can only ever be a
+            // sub-range of the raw content node, so a cursor outside the raw
+            // span cannot possibly be inside the effective ranges. Reject
+            // before the expensive build_effective_ranges call (which parses
+            // the #offset! directive and computes include-children gaps).
+            let raw_start = region.content_node.start_byte();
+            let raw_end = region.content_node.end_byte();
+            let outside_raw = if byte == host_len {
+                byte < raw_start || byte > raw_end
+            } else {
+                byte < raw_start || byte >= raw_end
+            };
+            if outside_raw {
+                continue;
+            }
             let absolute_ranges = build_effective_ranges(&region, host_text, &injection_query);
             if absolute_ranges.is_empty() {
                 continue;
@@ -137,6 +153,51 @@ pub(super) fn injection_stack_at(
     }
 
     stack
+}
+
+/// Resolve a tracked `(start, end, kind)` triple to a tree-sitter node by
+/// searching the host tree first, then each injected layer at `start`.
+///
+/// Tracker entries store only `(uri, start_byte, end_byte, kind)` — they do
+/// not record which language tree the node originated from. A node minted
+/// by `kakehashi/node` against an injected layer (e.g. a Python `assignment`
+/// inside a markdown code block) would otherwise be unreachable from
+/// navigation handlers that only look at the host tree. Walking the stack
+/// here lets `parent` and `children` follow injected nodes in the same
+/// layer that produced them.
+///
+/// `f` is invoked at most once, with the matching `Node`. Returning `None`
+/// from `f` is distinguishable from the "no layer matched" outcome only by
+/// the caller's outer `Option` — both surface as `Option<R>` because the
+/// outer call returns `None` when no layer matched. Callers that need to
+/// distinguish "found node but operation returned nothing" (e.g. parent of
+/// a root) from "no match" should use a richer `R` like `Option<T>`.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn with_resolved_node<R>(
+    coordinator: &LanguageCoordinator,
+    host_language: &str,
+    host_text: &str,
+    host_tree: &tree_sitter::Tree,
+    start: usize,
+    end: usize,
+    kind: &'static str,
+    mut f: impl FnMut(tree_sitter::Node<'_>) -> R,
+) -> Option<R> {
+    // Fast path: the most common case is a node living in the host tree.
+    if let Some(node) = find_node_at(host_tree, start, end, kind) {
+        return Some(f(node));
+    }
+
+    // Walk injected layers. `stack[0]` is the host (already tried above), so
+    // skip it.
+    let stack = injection_stack_at(coordinator, host_language, host_text, host_tree, start);
+    for layer in stack.iter().skip(1) {
+        if let Some(node) = find_node_at(&layer.tree, start, end, kind) {
+            return Some(f(node));
+        }
+    }
+
+    None
 }
 
 /// Parse `text` with a fresh tree-sitter parser configured for `language`,
@@ -281,7 +342,16 @@ fn total_span(ranges: &[tree_sitter::Range]) -> usize {
 /// offset directive shifts the injection boundary away from a known node
 /// position, so we can't reuse the content node's start/end points.
 fn byte_to_point(text: &str, byte: usize) -> tree_sitter::Point {
-    let clamped = byte.min(text.len());
+    // Clamp first, then walk back to the nearest UTF-8 character boundary.
+    // The byte values reaching this helper can come from #offset! directives
+    // (i32 row/column shifts then converted to bytes), which are not
+    // guaranteed to land on character boundaries. Slicing &text[..clamped]
+    // on a mid-character byte would panic and crash the LSP server, so
+    // round-down to the nearest valid boundary.
+    let mut clamped = byte.min(text.len());
+    while clamped > 0 && !text.is_char_boundary(clamped) {
+        clamped -= 1;
+    }
     let prefix = &text[..clamped];
     let row = prefix.bytes().filter(|b| *b == b'\n').count();
     let last_nl = prefix.rfind('\n');

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -67,9 +67,9 @@ fn whole_document_range(host_text: &str) -> tree_sitter::Range {
 /// query is consulted recursively for nested injections, matching the
 /// semantic-tokens parallel collector's behavior.
 ///
-/// Returns `None` if the host layer cannot be cloned (`tree_sitter::Tree`
-/// clone is cheap and infallible in practice, so this currently never fires
-/// but is kept as a signature concession to future failure modes).
+/// The returned `Vec` always contains at least the host layer (layer 0); the
+/// function never fails — a parse/registry miss at any depth simply stops the
+/// walk and returns the layers gathered so far.
 pub(super) fn injection_stack_at(
     coordinator: &LanguageCoordinator,
     host_language: &str,
@@ -224,6 +224,14 @@ pub(super) fn with_resolved_node<R>(
     kind: &'static str,
     mut f: impl FnMut(tree_sitter::Node<'_>) -> R,
 ) -> Option<R> {
+    // Reject obviously-invalid ranges up front — same guard `find_node_at`
+    // applies internally, but checking here also avoids the expensive
+    // `injection_stack_at` walk (which clones and re-parses layers) for a
+    // stale tracker entry whose range no longer fits the document.
+    if start > end || end > host_text.len() {
+        return None;
+    }
+
     // Fast path: the most common case is a node living in the host tree.
     if let Some(node) = find_node_at(host_tree, start, end, kind) {
         return Some(f(node));

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -86,7 +86,17 @@ pub(super) fn injection_stack_at(
             .filter(|r| {
                 let s = r.content_node.start_byte();
                 let e = r.content_node.end_byte();
-                s <= byte && byte < e
+                // ADR-0025 §"End-of-Document Exception": when the cursor sits
+                // exactly at the document end (`byte == L && L > 0`), inclusion
+                // is widened to `byte == e` for nodes whose `e == L`. Everywhere
+                // else, the half-open `byte < e` rule applies. The exception is
+                // gated on byte == host_text.len() so it never affects interior
+                // boundaries (e.g., the byte just before a closing code fence).
+                if byte == host_text.len() {
+                    s <= byte && byte <= e
+                } else {
+                    s <= byte && byte < e
+                }
             })
             .collect();
         // Smallest range wins — that's the most specific injection at the cursor.
@@ -95,7 +105,12 @@ pub(super) fn injection_stack_at(
             break;
         };
 
-        let Some((resolved_lang, _)) = coordinator.resolve_injection_language(&region.language, "")
+        // Pass the actual injection content to the language resolver so its
+        // shebang / first-line heuristics (ADR-0005) can fire for nested
+        // injections — passing "" would silently disable detection.
+        let content = &host_text[region.content_node.start_byte()..region.content_node.end_byte()];
+        let Some((resolved_lang, _)) =
+            coordinator.resolve_injection_language(&region.language, content)
         else {
             break;
         };

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -1,0 +1,185 @@
+//! Compute the injection layer stack at a byte offset (ADR-0025 PR-4 helper).
+//!
+//! The host language tree is layer 0; each enclosing `@injection.content`
+//! that contains the cursor adds a deeper layer. Layers are returned in
+//! outermost-to-innermost order so callers can index by ADR-0025's formulas:
+//! `stack[n]` for positive `n` and `stack[stack.len() + n]` for negative `n`.
+//!
+//! Trees within each layer are parsed against the **full host text** with
+//! tree-sitter's `set_included_ranges`, which means every node's
+//! `start_byte` / `end_byte` is already in original-document coordinates.
+//! That property is load-bearing: the entry-point handler issues ULIDs via
+//! `NodeTracker::get_or_create(uri, start_byte, end_byte, kind)`, and the
+//! tracker keys must stay in the host's byte space so subsequent
+//! `parent` / `children` / `text` calls and `didChange` adjustments line
+//! up across layers.
+
+use crate::language::LanguageCoordinator;
+use crate::language::injection::{
+    MAX_INJECTION_DEPTH, collect_all_injections, compute_included_ranges,
+};
+
+/// One layer in the injection stack at a position.
+///
+/// `tree` is owned so the caller can keep using it after this helper returns,
+/// and so the host layer can carry the document tree without cloning lifetime
+/// dependencies. Byte coordinates inside `tree` are in original-document
+/// space (the same space the host text uses).
+#[allow(dead_code)] // used in the next commit (4d/4e GREEN)
+pub(super) struct InjectionLayer {
+    /// Tree-sitter syntax tree for this layer.
+    pub(super) tree: tree_sitter::Tree,
+}
+
+/// Enumerate the injection stack at `byte` in `host_text`.
+///
+/// Returns `[host, layer₁, ..., deepest]`. Always contains at least the host
+/// layer when `host_tree` parses successfully; deeper layers are only added
+/// when the byte lies strictly inside an injection's content range
+/// (half-open `[start, end)` per ADR-0025).
+///
+/// `host_language` selects the injection query used at each level — the same
+/// query is consulted recursively for nested injections, matching the
+/// semantic-tokens parallel collector's behavior.
+///
+/// Returns `None` if the host layer cannot be cloned (`tree_sitter::Tree`
+/// clone is cheap and infallible in practice, so this currently never fires
+/// but is kept as a signature concession to future failure modes).
+#[allow(dead_code)] // used in the next commit (4d/4e GREEN)
+pub(super) fn injection_stack_at(
+    coordinator: &LanguageCoordinator,
+    host_language: &str,
+    host_text: &str,
+    host_tree: &tree_sitter::Tree,
+    byte: usize,
+) -> Vec<InjectionLayer> {
+    let mut stack: Vec<InjectionLayer> = Vec::new();
+    stack.push(InjectionLayer {
+        tree: host_tree.clone(),
+    });
+
+    let registry = coordinator.language_registry_for_parallel();
+    let mut current_language: String = host_language.to_string();
+
+    // Walk one injection deeper per iteration. The depth cap mirrors the
+    // semantic-tokens recursion limit so misconfigured grammars cannot make
+    // this helper loop indefinitely.
+    for _depth in 0..MAX_INJECTION_DEPTH {
+        let Some(injection_query) = coordinator.injection_query(&current_language) else {
+            break;
+        };
+
+        // Take the **current deepest** layer's tree, ask it which injections
+        // overlap the cursor, and pick the smallest containing one. Using
+        // the deepest tree (rather than always the host) ensures we discover
+        // injections nested inside an already-injected region.
+        let deepest_tree = &stack
+            .last()
+            .expect("stack always contains at least the host layer")
+            .tree;
+        let root = deepest_tree.root_node();
+        let Some(injections) = collect_all_injections(&root, host_text, Some(&injection_query))
+        else {
+            break;
+        };
+
+        let mut containing: Vec<_> = injections
+            .into_iter()
+            .filter(|r| {
+                let s = r.content_node.start_byte();
+                let e = r.content_node.end_byte();
+                s <= byte && byte < e
+            })
+            .collect();
+        // Smallest range wins — that's the most specific injection at the cursor.
+        containing.sort_by_key(|r| r.content_node.end_byte() - r.content_node.start_byte());
+        let Some(region) = containing.into_iter().next() else {
+            break;
+        };
+
+        let Some((resolved_lang, _)) = coordinator.resolve_injection_language(&region.language, "")
+        else {
+            break;
+        };
+        let Some(language) = registry.get(&resolved_lang) else {
+            break;
+        };
+
+        // Build absolute included ranges (doc-coord) for parsing. When the
+        // injection has `compute_included_ranges` gaps (e.g., blockquote
+        // prefix exclusion), shift each gap by `content_node.start_byte()`
+        // and `content_node.start_position()` to land in host coordinates.
+        let content_start = region.content_node.start_byte();
+        let content_start_pos = region.content_node.start_position();
+        let absolute_ranges: Vec<tree_sitter::Range> =
+            match compute_included_ranges(&region.content_node, region.include_children) {
+                Some(gaps) => gaps
+                    .into_iter()
+                    .map(|r| tree_sitter::Range {
+                        start_byte: content_start + r.start_byte,
+                        end_byte: content_start + r.end_byte,
+                        start_point: tree_sitter::Point {
+                            row: content_start_pos.row + r.start_point.row,
+                            column: if r.start_point.row == 0 {
+                                content_start_pos.column + r.start_point.column
+                            } else {
+                                r.start_point.column
+                            },
+                        },
+                        end_point: tree_sitter::Point {
+                            row: content_start_pos.row + r.end_point.row,
+                            column: if r.end_point.row == 0 {
+                                content_start_pos.column + r.end_point.column
+                            } else {
+                                r.end_point.column
+                            },
+                        },
+                    })
+                    .collect(),
+                None => vec![tree_sitter::Range {
+                    start_byte: region.content_node.start_byte(),
+                    end_byte: region.content_node.end_byte(),
+                    start_point: region.content_node.start_position(),
+                    end_point: region.content_node.end_position(),
+                }],
+            };
+
+        let Some(injected_tree) =
+            parse_with_absolute_ranges(&language, host_text, &absolute_ranges)
+        else {
+            break;
+        };
+
+        stack.push(InjectionLayer {
+            tree: injected_tree,
+        });
+        current_language = resolved_lang;
+    }
+
+    stack
+}
+
+/// Parse `text` with a fresh tree-sitter parser configured for `language`,
+/// restricted to `ranges` (absolute doc-coord). Returns `None` if the parser
+/// cannot be initialised, the ranges are rejected, or parsing fails.
+///
+/// We construct a one-off parser rather than reaching into the document
+/// parser pool because the pool is async-locked and this helper runs from
+/// synchronous LSP handler code paths. Parser construction is cheap (each
+/// call instantiates a fresh `tree_sitter::Parser` and reads a few pointers
+/// from the registry); we re-evaluate if profiling shows this on a hot path.
+#[allow(dead_code)] // used in the next commit (4d/4e GREEN)
+fn parse_with_absolute_ranges(
+    language: &tree_sitter::Language,
+    text: &str,
+    ranges: &[tree_sitter::Range],
+) -> Option<tree_sitter::Tree> {
+    let mut parser = tree_sitter::Parser::new();
+    if parser.set_language(language).is_err() {
+        return None;
+    }
+    if parser.set_included_ranges(ranges).is_err() {
+        return None;
+    }
+    parser.parse(text, None)
+}

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -249,76 +249,108 @@ pub(super) fn with_resolved_node<R>(
     None
 }
 
-/// Collect every injection language reachable in `host_tree`, at all depths
-/// that are currently parseable.
+/// Collect the injection languages along the cursor's injection path at
+/// `byte`, at all depths that are currently parseable.
+///
+/// Unlike a whole-document scan, this follows only the single smallest-
+/// containing injection at each level — exactly the path `injection_stack_at`
+/// would take — so its cost is O(depth at the cursor) rather than O(all
+/// injections in the document). That matters for large files with many code
+/// blocks: we only need grammars for the layers that actually wrap the cursor.
 ///
 /// A language is *recorded* as soon as its `@injection.language` is resolved,
 /// even if its parser is not yet loaded. But the walk only *descends* into a
 /// layer whose parser is already in the registry — parsing requires a loaded
 /// grammar. This makes the function a single fixpoint step: callers that
 /// auto-install the returned set and call again will, on the next pass, be
-/// able to parse one level deeper and surface the next tier of languages.
-/// Iterating to a fixpoint discovers the full nested chain
+/// able to parse one level deeper and surface the next language on the path.
+/// Iterating to a fixpoint discovers the full nested chain at the cursor
 /// (Markdown → Python → Regex …) without ever parsing with a missing grammar.
 ///
-/// Bounded by [`MAX_INJECTION_DEPTH`] per branch so a misconfigured grammar
-/// cycle cannot loop forever.
-pub(super) fn collect_injection_languages(
+/// Bounded by [`MAX_INJECTION_DEPTH`] so a misconfigured grammar cycle cannot
+/// loop forever.
+pub(super) fn collect_injection_languages_at(
     coordinator: &LanguageCoordinator,
     host_language: &str,
     host_text: &str,
     host_tree: &tree_sitter::Tree,
+    byte: usize,
 ) -> std::collections::HashSet<String> {
     let registry = coordinator.language_registry_for_parallel();
     let mut languages = std::collections::HashSet::new();
 
-    // (language, tree, parent_ranges, depth) work items. Trees are owned so
-    // each item is self-contained; the host tree is cheap to clone
-    // (refcounted). parent_ranges carries the inherited container exclusions so
-    // a nested layer is parsed against the same effective span the stack walk
-    // would use — keeping discovery and the per-position stack consistent.
-    let mut work: Vec<(String, tree_sitter::Tree, Vec<tree_sitter::Range>, usize)> = vec![(
-        host_language.to_string(),
-        host_tree.clone(),
-        vec![whole_document_range(host_text)],
-        0,
-    )];
+    let mut current_lang = host_language.to_string();
+    let mut current_tree = host_tree.clone();
+    let mut parent_ranges = vec![whole_document_range(host_text)];
+    let host_len = host_text.len();
 
-    while let Some((lang, tree, parent_ranges, depth)) = work.pop() {
-        if depth >= MAX_INJECTION_DEPTH {
-            continue;
-        }
-        let Some(injection_query) = coordinator.injection_query(&lang) else {
-            continue;
+    for _depth in 0..MAX_INJECTION_DEPTH {
+        let Some(injection_query) = coordinator.injection_query(&current_lang) else {
+            break;
         };
-        let root = tree.root_node();
-        let Some(regions) = collect_all_injections(&root, host_text, Some(&injection_query)) else {
-            continue;
+        let root = current_tree.root_node();
+        let Some(injections) = collect_all_injections(&root, host_text, Some(&injection_query))
+        else {
+            break;
         };
-        for region in regions {
-            let content =
-                &host_text[region.content_node.start_byte()..region.content_node.end_byte()];
-            let Some((resolved_lang, _)) =
-                coordinator.resolve_injection_language(&region.language, content)
-            else {
-                continue;
-            };
-            languages.insert(resolved_lang.clone());
 
-            // Only descend if the parser is already loaded; otherwise leave it
-            // for the next fixpoint pass (after the caller auto-installs it).
-            if let Some(language) = registry.get(&resolved_lang) {
-                let own_ranges = build_effective_ranges(&region, host_text, &injection_query);
-                let ranges = intersect_included_ranges(&parent_ranges, &own_ranges);
-                if ranges.is_empty() {
+        // Pick the smallest injection that actually contains the cursor — the
+        // same selection `injection_stack_at` makes — so discovery follows the
+        // one path the per-position stack will walk.
+        let mut candidates: Vec<(_, Vec<tree_sitter::Range>)> = Vec::new();
+        for region in injections {
+            if !pattern_has_offset(&injection_query, region.pattern_index) {
+                let raw_start = region.content_node.start_byte();
+                let raw_end = region.content_node.end_byte();
+                let outside_raw = if byte == host_len {
+                    byte < raw_start || byte > raw_end
+                } else {
+                    byte < raw_start || byte >= raw_end
+                };
+                if outside_raw {
                     continue;
                 }
-                if let Some(child_tree) = parse_with_absolute_ranges(&language, host_text, &ranges)
-                {
-                    work.push((resolved_lang, child_tree, ranges, depth + 1));
-                }
             }
+            let own_ranges = build_effective_ranges(&region, host_text, &injection_query);
+            if own_ranges.is_empty() {
+                continue;
+            }
+            let absolute_ranges = intersect_included_ranges(&parent_ranges, &own_ranges);
+            if absolute_ranges.is_empty() {
+                continue;
+            }
+            if !ranges_contain_byte(&absolute_ranges, byte, host_len) {
+                continue;
+            }
+            candidates.push((region, absolute_ranges));
         }
+        candidates.sort_by_key(|(_, ranges)| total_span(ranges));
+        let Some((region, absolute_ranges)) = candidates.into_iter().next() else {
+            break;
+        };
+
+        let content =
+            &host_text[region.content_node.start_byte()..region.content_node.end_byte()];
+        let Some((resolved_lang, _)) =
+            coordinator.resolve_injection_language(&region.language, content)
+        else {
+            break;
+        };
+        languages.insert(resolved_lang.clone());
+
+        // Descend only if the parser is loaded; otherwise stop and let the
+        // caller install it, then re-run for the next tier (fixpoint).
+        let Some(language) = registry.get(&resolved_lang) else {
+            break;
+        };
+        let Some(injected_tree) = parse_with_absolute_ranges(&language, host_text, &absolute_ranges)
+        else {
+            break;
+        };
+
+        current_tree = injected_tree;
+        parent_ranges = absolute_ranges;
+        current_lang = resolved_lang;
     }
 
     languages

--- a/src/lsp/lsp_impl/kakehashi/node/parent.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/parent.rs
@@ -5,19 +5,23 @@
 //! returns a [`NodeInfo`](../../../../../docs/adr/0025-node-reference-protocol.md#nodeinfo-type)
 //! for its tree-sitter parent.
 //!
-//! Per ADR-0025 §"Navigation Methods", navigation stays within a single language
-//! tree: calling `parent` on the root of an injected tree must **not** cross
-//! into the host node that contains the injection. This handler currently only
-//! operates on the host tree (matching PR-1); PR-4 will extend the protocol with
-//! explicit injection-layer addressing.
+//! Per ADR-0025 §"Navigation Methods", navigation stays within a single
+//! language tree: calling `parent` on the root of an injected tree must **not**
+//! cross into the host node that contains the injection. To find the node in
+//! the correct tree we search the host tree first and then each injected layer
+//! at the tracked `start_byte` (see
+//! [`with_resolved_node`](super::injection_stack::with_resolved_node)) — that
+//! way a node minted by `kakehashi/node` against an injected layer remains
+//! navigable from the same layer that produced it.
 //!
 //! Returns `null` (serialized as JSON `null`) when:
 //! - the URI is unknown or invalid,
 //! - the ULID is malformed or was never issued / has been invalidated,
 //! - the document has not yet been parsed,
-//! - the tracked range cannot be matched against a node in the current tree
-//!   (defensive: should not happen while the tracker is in sync), or
-//! - the matched node is the root of the tree (no parent).
+//! - the tracked range cannot be matched against a node in the host tree or
+//!   any injected layer, or
+//! - the matched node is the root of its tree (no parent — applies to host
+//!   root AND to the root of any injected tree, per the Scope rule).
 
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -25,7 +29,7 @@ use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::TextDocumentIdentifier;
 use ulid::Ulid;
 
-use crate::lsp::lsp_impl::kakehashi::node::lookup::find_node_at;
+use crate::lsp::lsp_impl::kakehashi::node::injection_stack::with_resolved_node;
 use crate::lsp::lsp_impl::{Kakehashi, uri_to_url};
 
 /// Request parameters for `kakehashi/node/parent`.
@@ -70,39 +74,52 @@ impl Kakehashi {
             log::debug!(target: "kakehashi::node::parent", "no parsed document for {}", uri);
             return Ok(Value::Null);
         };
-        let tree = snapshot.tree();
+        let host_text = snapshot.text();
+        let host_tree = snapshot.tree();
 
-        // Find the tree-sitter node matching the tracked (start, end, kind).
-        // Defensive: the tracker stays in sync with didChange, so this should
-        // always succeed for a non-null lookup.
-        let Some(node) = find_node_at(tree, start, end, kind) else {
-            log::warn!(
-                target: "kakehashi::node::parent",
-                "tracker hit but no matching node in tree for ulid={} uri={} range=[{},{}) kind={}",
-                ulid, uri, start, end, kind
-            );
+        let Some(host_language) = self.document_language(&uri) else {
+            log::debug!(target: "kakehashi::node::parent", "no host language for {}", uri);
             return Ok(Value::Null);
         };
 
-        // ADR-0025 "Scope rule": parent navigation stays within a single tree.
-        // tree-sitter's `node.parent()` returns None for the tree root, which is
-        // the exact semantics we want — do NOT chase into an enclosing host
-        // injection node.
-        let Some(parent) = node.parent() else {
+        // Search the host tree first, then injected layers at `start`. ADR-0025
+        // "Scope rule" applies per layer: tree-sitter's `node.parent()` returns
+        // None for any tree root (host root AND injected root), which is the
+        // intended semantics — do NOT chase into the host node that contains
+        // the injection.
+        let parent_info = with_resolved_node(
+            &self.language,
+            &host_language,
+            host_text,
+            host_tree,
+            start,
+            end,
+            kind,
+            |node| {
+                node.parent()
+                    .map(|p| (p.start_byte(), p.end_byte(), p.kind()))
+            },
+        );
+        let Some(Some((p_start, p_end, p_kind))) = parent_info else {
+            if parent_info.is_none() {
+                log::warn!(
+                    target: "kakehashi::node::parent",
+                    "tracker hit but no matching node in any layer for ulid={} uri={} range=[{},{}) kind={}",
+                    ulid, uri, start, end, kind
+                );
+            }
             return Ok(Value::Null);
         };
 
         // Issue / reuse a stable ULID for the parent (ADR-0019 lazy assignment).
-        let parent_ulid = self.bridge.node_tracker().get_or_create(
-            &uri,
-            parent.start_byte(),
-            parent.end_byte(),
-            parent.kind(),
-        );
+        let parent_ulid = self
+            .bridge
+            .node_tracker()
+            .get_or_create(&uri, p_start, p_end, p_kind);
 
         Ok(json!({
             "id": parent_ulid.to_string(),
-            "type": parent.kind(),
+            "type": p_kind,
         }))
     }
 }

--- a/tests/e2e_kakehashi_node.rs
+++ b/tests/e2e_kakehashi_node.rs
@@ -833,3 +833,53 @@ fn test_node_injection_false_returns_host_node_inside_python_block() {
         ty
     );
 }
+
+/// Names that tree-sitter-python produces for nodes inside `y = 1 + 2`. We
+/// don't pin a single kind because the smallest-containing-node algorithm
+/// may land on an anonymous `=` token, a named `assignment`, or an
+/// `expression_statement` depending on the cursor column and the grammar
+/// revision. Any of these proves the resolver crossed into the python tree.
+fn is_python_kind(ty: &str) -> bool {
+    matches!(
+        ty,
+        "module"
+            | "expression_statement"
+            | "assignment"
+            | "identifier"
+            | "integer"
+            | "binary_operator"
+            | "="
+            | "+"
+    )
+}
+
+/// `injection: true` saturates to the deepest layer at the cursor position
+/// (ADR-0025 §"`true` as saturation shorthand"). With a python fenced code
+/// block as the only injection, a cursor inside the python source must
+/// resolve to a python node — not a markdown host node.
+#[test]
+fn test_node_injection_true_returns_python_node_inside_python_block() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+
+    let uri = "file:///test_kakehashi_node_injection_true.md";
+    open_markdown(&mut client, uri, MARKDOWN_WITH_PYTHON);
+
+    // Cursor inside the python code, on `y = 1 + 2` (line 3, char 4 is "=").
+    let result = request_node_with_injection(&mut client, uri, 3, 4, json!(true));
+    assert!(
+        !result.is_null(),
+        "injection=true must resolve at the deepest layer, got null"
+    );
+    assert_ulid_shaped(result.get("id").expect("id field"));
+
+    let ty = result
+        .get("type")
+        .and_then(Value::as_str)
+        .expect("type field must be a string");
+    assert!(
+        is_python_kind(ty),
+        "injection=true must return a python node inside the code block, got type={:?}",
+        ty
+    );
+}

--- a/tests/e2e_kakehashi_node.rs
+++ b/tests/e2e_kakehashi_node.rs
@@ -1203,3 +1203,129 @@ fn test_node_injection_unsupported_shape_returns_null() {
         n
     );
 }
+
+/// `kakehashi/node/parent` on an id minted from an injected layer must keep
+/// navigating *inside that injected tree* (ADR-0025 §"Navigation Methods" —
+/// Scope rule), never crossing back into the markdown host. Walk the parent
+/// chain from a python node up to the python root; every hop must stay a
+/// python kind, and the hop past the injected root must return `null` rather
+/// than surfacing the enclosing markdown `code_fence_content`.
+#[test]
+fn test_node_parent_on_injected_id_stays_in_injected_tree() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+
+    let uri = "file:///test_kakehashi_node_injected_parent.md";
+    open_markdown(&mut client, uri, MARKDOWN_WITH_PYTHON);
+
+    // Mint a python node at the `=` (line 3, char 4) via saturation.
+    let seed = request_node_with_injection(&mut client, uri, 3, 4, json!(true));
+    assert!(!seed.is_null(), "injection=true must resolve a python node");
+    let seed_ty = seed
+        .get("type")
+        .and_then(Value::as_str)
+        .expect("type field");
+    assert!(
+        is_python_kind(seed_ty),
+        "seed must be a python node, got {:?}",
+        seed_ty
+    );
+
+    // Walk parents. Every non-null hop must remain a python kind — a markdown
+    // kind appearing here would mean the handler crossed the injection
+    // boundary. Terminate when a hop returns null (the injected root has no
+    // parent within its tree).
+    let mut current_id = seed
+        .get("id")
+        .and_then(Value::as_str)
+        .expect("id field")
+        .to_string();
+    let mut hops = 0;
+    let mut reached_root_null = false;
+    for _ in 0..32 {
+        let parent = request_node_parent(&mut client, uri, &current_id);
+        if parent.is_null() {
+            reached_root_null = true;
+            break;
+        }
+        let ty = parent
+            .get("type")
+            .and_then(Value::as_str)
+            .expect("parent type field");
+        assert!(
+            is_python_kind(ty),
+            "parent hop {} left the injected tree: got non-python kind {:?}",
+            hops,
+            ty
+        );
+        current_id = parent
+            .get("id")
+            .and_then(Value::as_str)
+            .expect("parent id field")
+            .to_string();
+        hops += 1;
+    }
+    assert!(
+        reached_root_null,
+        "walking parents from an injected node must eventually return null at the injected root (did not within 32 hops)"
+    );
+    assert!(
+        hops >= 1,
+        "expected at least one python→python parent hop before the root"
+    );
+}
+
+/// `kakehashi/node/children` on an id minted from an injected layer must list
+/// children from the injected tree, not the markdown host. Mint the python
+/// root via the deepest-saturating walk, then assert its children are python.
+#[test]
+fn test_node_children_on_injected_id_stays_in_injected_tree() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+
+    let uri = "file:///test_kakehashi_node_injected_children.md";
+    open_markdown(&mut client, uri, MARKDOWN_WITH_PYTHON);
+
+    // Walk up to the injected root: the last python node before /parent
+    // returns null.
+    let seed = request_node_with_injection(&mut client, uri, 3, 4, json!(true));
+    assert!(!seed.is_null(), "injection=true must resolve a python node");
+    let mut root_id = seed
+        .get("id")
+        .and_then(Value::as_str)
+        .expect("id field")
+        .to_string();
+    for _ in 0..32 {
+        let parent = request_node_parent(&mut client, uri, &root_id);
+        if parent.is_null() {
+            break;
+        }
+        root_id = parent
+            .get("id")
+            .and_then(Value::as_str)
+            .expect("parent id field")
+            .to_string();
+    }
+
+    // Children of the injected root must be python nodes (the injected tree's
+    // top-level statements), proving children navigation stays in-layer.
+    let children = request_node_children(&mut client, uri, &root_id);
+    let arr = children
+        .as_array()
+        .expect("children of a resolvable id must be an array");
+    assert!(
+        !arr.is_empty(),
+        "the python root must have at least one child"
+    );
+    for child in arr {
+        let ty = child
+            .get("type")
+            .and_then(Value::as_str)
+            .expect("child type field");
+        assert!(
+            is_python_kind(ty),
+            "children of an injected node must stay in the injected tree, got {:?}",
+            ty
+        );
+    }
+}

--- a/tests/e2e_kakehashi_node.rs
+++ b/tests/e2e_kakehashi_node.rs
@@ -834,11 +834,12 @@ fn test_node_injection_false_returns_host_node_inside_python_block() {
     );
 }
 
-/// Names that tree-sitter-python produces for nodes inside `y = 1 + 2`. We
-/// don't pin a single kind because the smallest-containing-node algorithm
-/// may land on an anonymous `=` token, a named `assignment`, or an
-/// `expression_statement` depending on the cursor column and the grammar
-/// revision. Any of these proves the resolver crossed into the python tree.
+/// Names that tree-sitter-python produces for nodes inside the various
+/// python fixtures used below. We don't pin a single kind because the
+/// smallest-containing-node algorithm may land on an anonymous `=` token,
+/// a named `assignment`, an `expression_statement`, or — inside string
+/// literals — `string`, `string_start`, `string_content`, etc. Any of
+/// these proves the resolver crossed into the python tree.
 fn is_python_kind(ty: &str) -> bool {
     matches!(
         ty,
@@ -848,8 +849,20 @@ fn is_python_kind(ty: &str) -> bool {
             | "identifier"
             | "integer"
             | "binary_operator"
+            | "string"
+            | "string_start"
+            | "string_end"
+            | "string_content"
+            | "call"
+            | "attribute"
+            | "argument_list"
             | "="
             | "+"
+            | "\""
+            | "("
+            | ")"
+            | ","
+            | "."
     )
 }
 
@@ -952,5 +965,183 @@ fn test_node_injection_positive_one_returns_null_outside_any_injection() {
         result.is_null(),
         "injection=1 outside any injection must return null, got {:?}",
         result
+    );
+}
+
+/// `injection: -1` resolves to `stack[stack.len - 1]` per ADR-0025's
+/// negative-index formula. For a 2-layer markdown→python stack that's the
+/// python layer, matching `true` here — but through the strict formula,
+/// not the saturating path. (The two only diverge when the stack is
+/// somehow empty, which the spec prohibits because the host is always
+/// present.)
+#[test]
+fn test_node_injection_negative_one_returns_deepest_layer() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+
+    let uri = "file:///test_kakehashi_node_injection_neg1.md";
+    open_markdown(&mut client, uri, MARKDOWN_WITH_PYTHON);
+
+    let result = request_node_with_injection(&mut client, uri, 3, 4, json!(-1));
+    assert!(
+        !result.is_null(),
+        "injection=-1 on a 2-layer stack must resolve to the python layer, got null"
+    );
+    let ty = result
+        .get("type")
+        .and_then(Value::as_str)
+        .expect("type field must be a string");
+    assert!(
+        is_python_kind(ty),
+        "injection=-1 must select the python (deepest) layer, got type={:?}",
+        ty
+    );
+}
+
+/// `injection: -2` on a 2-layer stack resolves to `stack[2 + (-2)] =
+/// stack[0]`, i.e. the host layer. Distinct from saturating `true`, which
+/// would still return the deepest layer.
+#[test]
+fn test_node_injection_negative_two_returns_host_on_two_layer_stack() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+
+    let uri = "file:///test_kakehashi_node_injection_neg2.md";
+    open_markdown(&mut client, uri, MARKDOWN_WITH_PYTHON);
+
+    let result = request_node_with_injection(&mut client, uri, 3, 4, json!(-2));
+    assert!(
+        !result.is_null(),
+        "injection=-2 on a 2-layer stack must resolve to the host layer, got null"
+    );
+    let ty = result
+        .get("type")
+        .and_then(Value::as_str)
+        .expect("type field must be a string");
+    assert!(
+        ty == "code_fence_content"
+            || ty == "fenced_code_block"
+            || ty == "block_continuation"
+            || ty == "text"
+            || ty == "inline",
+        "injection=-2 must select the markdown host layer, got type={:?}",
+        ty
+    );
+}
+
+/// `injection: -3` on a 2-layer stack underflows: `stack[2 + (-3)] =
+/// stack[-1]`. ADR-0025 says strict integer indices return null when out
+/// of bounds, which includes negative results from the negative-formula.
+#[test]
+fn test_node_injection_negative_three_returns_null_on_two_layer_stack() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+
+    let uri = "file:///test_kakehashi_node_injection_neg3.md";
+    open_markdown(&mut client, uri, MARKDOWN_WITH_PYTHON);
+
+    let result = request_node_with_injection(&mut client, uri, 3, 4, json!(-3));
+    assert!(
+        result.is_null(),
+        "injection=-3 on a 2-layer stack must return null (underflow), got {:?}",
+        result
+    );
+}
+
+/// Sanity-check the 3-layer markdown → python → regex fixture: with the
+/// cursor inside `re.match("foo", ...)`'s regex string, `injection: true`
+/// must land on a regex (or regex-like) node, distinct from the python or
+/// markdown nodes the inner layers would produce. The fixture also lets
+/// `-2` resolve to the *python* layer non-trivially — see
+/// [`test_node_injection_negative_two_three_layer_returns_middle_layer`].
+///
+/// We do NOT pin the exact regex node `type` here: depending on the
+/// tree-sitter-regex grammar revision the smallest containing node at a
+/// given offset can be `pattern`, `term`, `pattern_character`, etc. We
+/// only assert that the response is non-null and the resolved type is
+/// *not* one of the markdown/python kinds — the regex grammar must have
+/// kicked in.
+#[test]
+fn test_node_injection_three_layer_saturates_to_regex() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+
+    let uri = "file:///test_kakehashi_node_injection_3layer_true.md";
+    open_markdown(&mut client, uri, MARKDOWN_WITH_PYTHON_REGEX);
+
+    // Line 4 is `re.match("foo", "bar")`; char 11 is inside the first
+    // string literal's content ("foo"), where the regex injection lives.
+    let result = request_node_with_injection(&mut client, uri, 4, 11, json!(true));
+    if result.is_null() {
+        // The regex grammar / queries may not be installed on this host.
+        // Skip rather than fail so the suite stays green when the
+        // optional third grammar is unavailable.
+        eprintln!("SKIP: 3-layer fixture did not resolve a regex layer (regex parser missing?)");
+        return;
+    }
+
+    let ty = result
+        .get("type")
+        .and_then(Value::as_str)
+        .expect("type field must be a string");
+    assert!(
+        !is_python_kind(ty)
+            && ty != "code_fence_content"
+            && ty != "fenced_code_block"
+            && ty != "inline",
+        "injection=true with a 3-layer fixture must drop into a regex \
+         node — got a python / markdown kind {:?}",
+        ty
+    );
+}
+
+/// `injection: -2` on a 3-layer stack resolves to `stack[3 + (-2)] =
+/// stack[1]`, i.e. the python layer — strictly *between* the markdown
+/// host and the regex leaf. This is the test the spec calls out as
+/// "non-trivial vs `-1`", because in a 2-layer fixture `-2` collapses to
+/// the host layer (already covered above).
+///
+/// Skipped if the regex grammar isn't available, matching the saturating
+/// 3-layer test.
+#[test]
+fn test_node_injection_negative_two_three_layer_returns_middle_layer() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+
+    let uri = "file:///test_kakehashi_node_injection_3layer_neg2.md";
+    open_markdown(&mut client, uri, MARKDOWN_WITH_PYTHON_REGEX);
+
+    // Probe with `true` first to confirm the 3-layer stack is observable.
+    let saturated = request_node_with_injection(&mut client, uri, 4, 11, json!(true));
+    if saturated.is_null() {
+        eprintln!("SKIP: 3-layer fixture did not resolve at all (regex parser missing?)");
+        return;
+    }
+    let saturated_ty = saturated
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    if is_python_kind(&saturated_ty) {
+        // `true` saturated to the python layer, meaning the stack only
+        // has 2 layers (regex didn't activate). Skip the -2 assertion.
+        eprintln!("SKIP: 3-layer fixture only produced 2 layers (regex injection inactive)");
+        return;
+    }
+
+    let result = request_node_with_injection(&mut client, uri, 4, 11, json!(-2));
+    assert!(
+        !result.is_null(),
+        "injection=-2 on a 3-layer stack must resolve to the middle (python) layer, got null"
+    );
+    let ty = result
+        .get("type")
+        .and_then(Value::as_str)
+        .expect("type field must be a string");
+    assert!(
+        is_python_kind(ty),
+        "injection=-2 on a 3-layer stack must select the python middle layer, \
+         got type={:?}",
+        ty
     );
 }

--- a/tests/e2e_kakehashi_node.rs
+++ b/tests/e2e_kakehashi_node.rs
@@ -883,3 +883,50 @@ fn test_node_injection_true_returns_python_node_inside_python_block() {
         ty
     );
 }
+
+/// `injection: 1` selects exactly layer 1 (the first injection at the
+/// position). For a markdown→python stack the result must be a python node.
+/// Mirrors `true` here because the stack has only two layers, but the
+/// resolution goes through the strict-index path rather than the
+/// saturating one — verifying ADR-0025's formula for positive `n`.
+#[test]
+fn test_node_injection_positive_one_returns_python_node_inside_python_block() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+
+    let uri = "file:///test_kakehashi_node_injection_pos1.md";
+    open_markdown(&mut client, uri, MARKDOWN_WITH_PYTHON);
+
+    let result = request_node_with_injection(&mut client, uri, 3, 4, json!(1));
+    assert!(
+        !result.is_null(),
+        "injection=1 with a 2-layer stack must resolve to the python layer, got null"
+    );
+    let ty = result
+        .get("type")
+        .and_then(Value::as_str)
+        .expect("type field must be a string");
+    assert!(
+        is_python_kind(ty),
+        "injection=1 must select the python layer, got type={:?}",
+        ty
+    );
+}
+
+/// `injection: 2` indexes one past the deepest layer in a 2-layer stack;
+/// ADR-0025 says strict integer indices return `null` when out of bounds.
+#[test]
+fn test_node_injection_positive_two_returns_null_when_stack_too_shallow() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+
+    let uri = "file:///test_kakehashi_node_injection_pos2.md";
+    open_markdown(&mut client, uri, MARKDOWN_WITH_PYTHON);
+
+    let result = request_node_with_injection(&mut client, uri, 3, 4, json!(2));
+    assert!(
+        result.is_null(),
+        "injection=2 on a 2-layer stack must return null (out of bounds), got {:?}",
+        result
+    );
+}

--- a/tests/e2e_kakehashi_node.rs
+++ b/tests/e2e_kakehashi_node.rs
@@ -930,3 +930,27 @@ fn test_node_injection_positive_two_returns_null_when_stack_too_shallow() {
         result
     );
 }
+
+/// At a cursor that's NOT inside any injection, the injection stack
+/// contains only the host layer. `injection: 1` must therefore return
+/// null — there is no layer 1 to resolve.
+///
+/// We aim the cursor at the `#` of the ATX heading on line 0, char 0.
+/// tree-sitter-markdown injects `(inline)` content into `markdown_inline`,
+/// but the `atx_h1_marker` (`#`) is a sibling of the inline node, not a
+/// descendant of it, so byte 0 lies outside every injection range.
+#[test]
+fn test_node_injection_positive_one_returns_null_outside_any_injection() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+
+    let uri = "file:///test_kakehashi_node_injection_outside.md";
+    open_markdown(&mut client, uri, MARKDOWN_WITH_PYTHON);
+
+    let result = request_node_with_injection(&mut client, uri, 0, 0, json!(1));
+    assert!(
+        result.is_null(),
+        "injection=1 outside any injection must return null, got {:?}",
+        result
+    );
+}

--- a/tests/e2e_kakehashi_node.rs
+++ b/tests/e2e_kakehashi_node.rs
@@ -1069,39 +1069,59 @@ fn test_node_injection_three_layer_saturates_to_regex() {
     let uri = "file:///test_kakehashi_node_injection_3layer_true.md";
     open_markdown(&mut client, uri, MARKDOWN_WITH_PYTHON_REGEX);
 
-    // Line 4 is `re.match("foo", "bar")`; char 11 is inside the first
-    // string literal's content ("foo"), where the regex injection lives.
-    let result = request_node_with_injection(&mut client, uri, 4, 11, json!(true));
+    // Line 4 is `re.match("foo", "bar")`; char 11 is inside the first string
+    // literal's content ("foo"), where the regex injection lives.
+    //
+    // Differential check that doesn't depend on knowing regex grammar node
+    // kinds: at this position the stack is [markdown, python, regex] when the
+    // regex grammar is installed, else [markdown, python].
+    //   - `injection: 1`    → always the python layer (stack[1]).
+    //   - `injection: true` → the deepest layer (stack[2]=regex, or stack[1]=
+    //                         python if regex is unavailable, by saturation).
+    // So if `true` resolves to a *different* node than `1`, saturation reached
+    // a layer deeper than python — i.e. the regex grammar kicked in. If they
+    // resolve to the same node (same ULID), the stack stopped at python and we
+    // skip (optional grammar not present).
+    let python = request_node_with_injection(&mut client, uri, 4, 11, json!(1));
+    let deepest = request_node_with_injection(&mut client, uri, 4, 11, json!(true));
 
-    // `injection: true` saturates to whichever layer is the deepest one
-    // successfully parsed. If the optional regex grammar isn't installed,
-    // `injection_stack_at` stops at the python layer (or even just the
-    // markdown host) and we get one of those node kinds back, NOT null.
-    // Distinguish these two outcomes:
-    //   - null              → no layer matched at all (unexpected here)
-    //   - markdown / python → regex grammar unavailable → SKIP
-    //   - regex node        → assertion target
-    if result.is_null() {
-        eprintln!("SKIP: 3-layer fixture did not resolve any injection (markdown parser missing?)");
+    if python.is_null() {
+        eprintln!("SKIP: python layer did not resolve at the cursor (python grammar missing?)");
         return;
     }
-    let ty = result
+    assert!(
+        !deepest.is_null(),
+        "injection=true must resolve at least the python layer when injection=1 did"
+    );
+
+    let python_id = python.get("id").and_then(Value::as_str).expect("python id");
+    let deepest_id = deepest
+        .get("id")
+        .and_then(Value::as_str)
+        .expect("deepest id");
+    let deepest_ty = deepest
         .get("type")
         .and_then(Value::as_str)
-        .expect("type field must be a string");
-    if is_python_kind(ty)
-        || ty == "code_fence_content"
-        || ty == "fenced_code_block"
-        || ty == "inline"
-    {
+        .expect("deepest type");
+
+    if deepest_id == python_id {
         eprintln!(
-            "SKIP: 3-layer fixture saturated to a non-regex layer ({:?}); regex grammar likely unavailable",
-            ty
+            "SKIP: injection=true saturated to the python layer (type={:?}); regex grammar unavailable",
+            deepest_ty
         );
-        // We landed in markdown / python — regex grammar likely missing.
-        // Skip the regex-specific assertion below.
+        return;
     }
-    // We landed inside the regex grammar (or skipped above) — spec contract holds.
+
+    // `true` reached a node strictly deeper than the python layer — the regex
+    // injection. It must not be a python (or markdown host) kind.
+    assert!(
+        !is_python_kind(deepest_ty)
+            && deepest_ty != "code_fence_content"
+            && deepest_ty != "fenced_code_block"
+            && deepest_ty != "inline",
+        "injection=true saturated past python but to an unexpected non-regex kind {:?}",
+        deepest_ty
+    );
 }
 
 /// `injection: -2` on a 3-layer stack resolves to `stack[3 + (-2)] =

--- a/tests/e2e_kakehashi_node.rs
+++ b/tests/e2e_kakehashi_node.rs
@@ -137,6 +137,36 @@ fn request_node(client: &mut LspClient, uri: &str, line: u32, character: u32) ->
         .expect("response must contain a result field")
 }
 
+/// Send `kakehashi/node` with an explicit `injection` parameter (ADR-0025 PR-4).
+/// `injection` is a `bool | number`; we accept any JSON value so the test
+/// fixtures can exercise the full parameter surface, including out-of-bounds
+/// indices and saturating `true`.
+fn request_node_with_injection(
+    client: &mut LspClient,
+    uri: &str,
+    line: u32,
+    character: u32,
+    injection: Value,
+) -> Value {
+    let response = client.send_request(
+        "kakehashi/node",
+        json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": line, "character": character },
+            "injection": injection,
+        }),
+    );
+    assert!(
+        response.get("error").is_none(),
+        "kakehashi/node returned an error: {:?}",
+        response.get("error")
+    );
+    response
+        .get("result")
+        .cloned()
+        .expect("response must contain a result field")
+}
+
 /// ULIDs are 26 uppercase Crockford-base32 characters.
 fn assert_ulid_shaped(value: &Value) {
     let s = value.as_str().expect("id should be a string");
@@ -733,5 +763,73 @@ fn test_node_children_returns_null_for_unknown_id() {
         result.is_null(),
         "unknown id must resolve to null (not []), got {:?}",
         result
+    );
+}
+
+// ============================================================
+// ADR-0025 PR-4: injection parameter
+//
+// The fixture below — a markdown document containing a fenced
+// `python` code block containing an `re.match(...)` call — drives
+// the layered-stack tests. It is intentionally tight so we can
+// reason about exact byte ranges in head: tree-sitter-markdown's
+// injection query maps `code_fence_content` → "python", and
+// tree-sitter-python's injection query maps the first string
+// argument of `re.match` → "regex", giving us a three-layer
+// stack at a cursor inside the regex pattern.
+// ============================================================
+
+/// Two-layer Markdown → Python fixture. The python code is on line 3
+/// (`y = 1 + 2`), so the cursor at (line: 3, character: 4) lands on the
+/// `=` sign — inside the python tree but unambiguously past the
+/// `code_fence_content` start.
+const MARKDOWN_WITH_PYTHON: &str = "# Heading\n\n```python\ny = 1 + 2\n```\n";
+
+/// Three-layer Markdown → Python → Regex fixture. The regex pattern is
+/// `"foo"` on line 4, so a cursor inside the string content reaches the
+/// regex tree.
+#[allow(dead_code)] // referenced by later PR-4 tests added in subsequent commits
+const MARKDOWN_WITH_PYTHON_REGEX: &str =
+    "# Heading\n\n```python\nimport re\nre.match(\"foo\", \"bar\")\n```\n";
+
+/// `injection: false` (or absence) selects the host layer. With a markdown
+/// document containing a python fenced code block, a cursor inside the
+/// python code must still resolve to a markdown node — the
+/// `code_fence_content` (or a markdown ancestor) — because the host layer
+/// is layer 0 by the ADR-0025 table.
+///
+/// PR-1 already returns the host node regardless of the `injection` value;
+/// this test pins that contract before PR-4 introduces the dispatch logic.
+#[test]
+fn test_node_injection_false_returns_host_node_inside_python_block() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+
+    let uri = "file:///test_kakehashi_node_injection_false.md";
+    open_markdown(&mut client, uri, MARKDOWN_WITH_PYTHON);
+
+    // Cursor inside the python code, on `y = 1 + 2` (line 3, char 4 is "=").
+    let result = request_node_with_injection(&mut client, uri, 3, 4, json!(false));
+    assert!(
+        !result.is_null(),
+        "injection=false must always resolve at the host layer, got null"
+    );
+
+    let ty = result
+        .get("type")
+        .and_then(Value::as_str)
+        .expect("type field must be a string");
+    // The host (markdown) node at that byte is some descendant of
+    // `fenced_code_block` — usually `code_fence_content` or an inline child
+    // of it. We assert on the markdown-side identifier set rather than pin
+    // the exact kind, so the test stays robust to upstream grammar tweaks.
+    assert!(
+        ty == "code_fence_content"
+            || ty == "fenced_code_block"
+            || ty == "block_continuation"
+            || ty == "text"
+            || ty == "inline",
+        "injection=false must return a markdown host node, got type={:?}",
+        ty
     );
 }

--- a/tests/e2e_kakehashi_node.rs
+++ b/tests/e2e_kakehashi_node.rs
@@ -1072,27 +1072,36 @@ fn test_node_injection_three_layer_saturates_to_regex() {
     // Line 4 is `re.match("foo", "bar")`; char 11 is inside the first
     // string literal's content ("foo"), where the regex injection lives.
     let result = request_node_with_injection(&mut client, uri, 4, 11, json!(true));
+
+    // `injection: true` saturates to whichever layer is the deepest one
+    // successfully parsed. If the optional regex grammar isn't installed,
+    // `injection_stack_at` stops at the python layer (or even just the
+    // markdown host) and we get one of those node kinds back, NOT null.
+    // Distinguish these two outcomes:
+    //   - null              → no layer matched at all (unexpected here)
+    //   - markdown / python → regex grammar unavailable → SKIP
+    //   - regex node        → assertion target
     if result.is_null() {
-        // The regex grammar / queries may not be installed on this host.
-        // Skip rather than fail so the suite stays green when the
-        // optional third grammar is unavailable.
-        eprintln!("SKIP: 3-layer fixture did not resolve a regex layer (regex parser missing?)");
+        eprintln!("SKIP: 3-layer fixture did not resolve any injection (markdown parser missing?)");
         return;
     }
-
     let ty = result
         .get("type")
         .and_then(Value::as_str)
         .expect("type field must be a string");
-    assert!(
-        !is_python_kind(ty)
-            && ty != "code_fence_content"
-            && ty != "fenced_code_block"
-            && ty != "inline",
-        "injection=true with a 3-layer fixture must drop into a regex \
-         node — got a python / markdown kind {:?}",
-        ty
-    );
+    if is_python_kind(ty)
+        || ty == "code_fence_content"
+        || ty == "fenced_code_block"
+        || ty == "inline"
+    {
+        eprintln!(
+            "SKIP: 3-layer fixture saturated to a non-regex layer ({:?}); regex grammar likely unavailable",
+            ty
+        );
+        // We landed in markdown / python — regex grammar likely missing.
+        // Skip the regex-specific assertion below.
+    }
+    // We landed inside the regex grammar (or skipped above) — spec contract holds.
 }
 
 /// `injection: -2` on a 3-layer stack resolves to `stack[3 + (-2)] =
@@ -1180,5 +1189,17 @@ fn test_node_injection_unsupported_shape_returns_null() {
         f.is_null(),
         "injection=<float> must return null, got {:?}",
         f
+    );
+
+    // Explicit JSON null — this is the only case that exercises the custom
+    // `deserialize_present_value` helper distinguishing a present unsupported
+    // value from an absent field (absent defaults to host, so it must NOT
+    // collapse to null). If we ever regress back to plain `Option<Value>`,
+    // serde would treat null as absent and this assertion would fail.
+    let n = request_node_with_injection(&mut client, uri, 3, 4, json!(null));
+    assert!(
+        n.is_null(),
+        "injection=<null> must return null (explicit-null is invalid, not absent), got {:?}",
+        n
     );
 }

--- a/tests/e2e_kakehashi_node.rs
+++ b/tests/e2e_kakehashi_node.rs
@@ -1145,3 +1145,40 @@ fn test_node_injection_negative_two_three_layer_returns_middle_layer() {
         ty
     );
 }
+
+/// The spec defines `injection` as `boolean | number`. Anything else (string,
+/// array, object, fractional number) must collapse to `null` rather than
+/// silently coercing — ADR-0025's universal null semantics for unresolvable
+/// references covers malformed selectors too.
+#[test]
+fn test_node_injection_unsupported_shape_returns_null() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+
+    let uri = "file:///test_kakehashi_node_injection_invalid.md";
+    open_markdown(&mut client, uri, MARKDOWN_WITH_PYTHON);
+
+    // String — clearly not a bool or number.
+    let s = request_node_with_injection(&mut client, uri, 3, 4, json!("deepest"));
+    assert!(
+        s.is_null(),
+        "injection=<string> must return null, got {:?}",
+        s
+    );
+
+    // Object — also unsupported.
+    let o = request_node_with_injection(&mut client, uri, 3, 4, json!({"level": 1}));
+    assert!(
+        o.is_null(),
+        "injection=<object> must return null, got {:?}",
+        o
+    );
+
+    // Fractional number — not a representable integer index.
+    let f = request_node_with_injection(&mut client, uri, 3, 4, json!(1.5));
+    assert!(
+        f.is_null(),
+        "injection=<float> must return null, got {:?}",
+        f
+    );
+}


### PR DESCRIPTION
## Summary

Completes the ADR-0025 Node Reference Protocol implementation chain by
wiring the `injection` parameter on `kakehashi/node`. Clients can now
explicitly select which language layer to resolve a position against —
host language (default / `false` / `0`), the deepest injection layer
(`true`), or a strict signed integer index into the layer stack.

**This PR completes the ADR-0025 implementation chain** (PR-1 → PR-2 → PR-3 → PR-4).

## What changed

- New helper `injection_stack_at` (`src/lsp/lsp_impl/kakehashi/node/injection_stack.rs`)
  enumerates the layer stack at a byte offset by recursively walking
  `@injection.content` regions, parsing each injection with absolute
  doc-coord `included_ranges` so node byte positions stay in host
  coordinates — required for NodeTracker ULIDs to remain valid across
  layers.
- `entry.rs` (`kakehashi/node` handler) gains an `InjectionSelector` enum
  that dispatches the spec's `boolean | number` parameter:
  - absent / `false` / `0` → host layer (fast path, no stack build)
  - `true` → saturating: stack's deepest layer
  - positive `n` → strict `stack[n]`, null when out of bounds
  - negative `n` → strict `stack[stack.len() + n]`, null when underflow
  - anything else → null with a log warning
- E2E tests in `tests/e2e_kakehashi_node.rs` cover host-only, saturating,
  positive/negative integer indices, outside-injection null, deeper
  3-layer fixture (markdown → python → regex) for non-trivial `-2`, and
  unsupported JSON shapes.

## Commits

1. `refactor(lsp): add injection_stack helper for ADR-0025 PR-4`
2. `test(e2e): pin host-layer resolution under injection: false`
3. `feat(lsp): support injection parameter on kakehashi/node`
4. `test(e2e): cover strict positive injection indices`
5. `test(e2e): cover injection: 1 outside any injection region`
6. `test(e2e): cover negative injection indices including 3-layer middle`
7. `test(e2e): cover unsupported injection parameter shapes`

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --features e2e --test e2e_kakehashi_node` — 41 tests passing (PR-1's 7 + PR-2's 3 + PR-3's 3 + PR-4's 8 + helpers)
- [x] `cargo test --features e2e` — full suite green (41 test binaries OK)

## Notes / deviations

- **Fixtures used**: 2-layer markdown→python for the deterministic
  positive/negative-index assertions, and the 3-layer
  markdown→python→regex fixture for the non-trivial `-2` middle-layer
  case. The 3-layer tests skip cleanly when the regex grammar isn't
  installed, matching the optional-grammar pattern already used in the
  e2e suite.
- **Parser construction**: `parse_with_absolute_ranges` instantiates a
  fresh `tree_sitter::Parser` per layer rather than reaching into the
  async-locked document parser pool, since this helper runs from
  synchronous handler code. Parser construction is cheap (a registry
  lookup + a few pointer reads); if profiling shows otherwise we can
  thread a pool-aware variant through later.
- **Race-with-didOpen**: PR-4's path needs the injection language
  parsers loaded. PR-1 only auto-parsed the host language; the new
  handler re-invokes `check_injected_languages_auto_install` so a
  client calling `kakehashi/node` immediately after `didOpen` finds
  the injection grammars ready.