### PR TITLE
feat(lsp): implement textDocument/rangeFormatting via bridge

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -159,15 +159,22 @@ pub mod test_support {
         };
         let mut all_ok = true;
         for lang in TEST_LANGUAGES {
-            if let Err(e) = parser::install_parser(lang, &parser_options) {
-                eprintln!("[test setup] install_parser({}) failed: {}", lang, e);
-                all_ok = false;
+            // `AlreadyExists` means the artifact is present from an earlier
+            // run — success for setup purposes, not a failure. Treating it as
+            // failure would make a partial prior run unrecoverable: if parsers
+            // installed but a query failed (so the marker was never written),
+            // every later run would see `AlreadyExists` for the parser and
+            // could never write the marker without deleting files by hand.
+            match parser::install_parser(lang, &parser_options) {
+                Ok(_) | Err(parser::ParserInstallError::AlreadyExists(_)) => {}
+                Err(e) => {
+                    eprintln!("[test setup] install_parser({}) failed: {}", lang, e);
+                    all_ok = false;
+                }
             }
-            if let Err(e) = queries::install_queries(lang, data_dir, false) {
-                let msg = e.to_string();
-                // An "already exists" error means the queries are present —
-                // that is success for setup purposes, not a failure.
-                if !msg.contains("already exists") {
+            match queries::install_queries(lang, data_dir, false) {
+                Ok(_) | Err(queries::QueryInstallError::AlreadyExists(_)) => {}
+                Err(e) => {
                     eprintln!("[test setup] install_queries({}) failed: {}", lang, e);
                     all_ok = false;
                 }

--- a/src/install.rs
+++ b/src/install.rs
@@ -132,13 +132,20 @@ pub mod test_support {
     }
 
     /// Install every language in [`TEST_LANGUAGES`] into `data_dir` if
-    /// the `.installed` marker is missing, then write the marker.
+    /// the `.installed` marker is missing, writing the marker only when
+    /// every required install succeeded.
     ///
     /// Mirrors the install loop in `make deps/tree-sitter/.installed`.
     /// Both `install_parser` and `install_queries` short-circuit when a
     /// language is up-to-date; any genuine failure is logged so tests
     /// depending on that language fail with a clearer error rather than
     /// the whole suite panicking in setup.
+    ///
+    /// A transient failure (network, file lock, compile error) must not
+    /// leave the marker behind: a marker over a half-populated data dir
+    /// would make every later test process skip setup, turning a one-off
+    /// failure into a persistent one until the marker is deleted by hand.
+    /// So the marker is written only after all installs succeed.
     pub fn ensure_test_languages_installed(data_dir: &Path) -> std::io::Result<()> {
         let marker = data_dir.join(".installed");
         if marker.exists() {
@@ -150,18 +157,26 @@ pub mod test_support {
             verbose: false,
             no_cache: false,
         };
+        let mut all_ok = true;
         for lang in TEST_LANGUAGES {
             if let Err(e) = parser::install_parser(lang, &parser_options) {
                 eprintln!("[test setup] install_parser({}) failed: {}", lang, e);
+                all_ok = false;
             }
             if let Err(e) = queries::install_queries(lang, data_dir, false) {
                 let msg = e.to_string();
+                // An "already exists" error means the queries are present —
+                // that is success for setup purposes, not a failure.
                 if !msg.contains("already exists") {
                     eprintln!("[test setup] install_queries({}) failed: {}", lang, e);
+                    all_ok = false;
                 }
             }
         }
-        std::fs::write(&marker, "")
+        if all_ok {
+            std::fs::write(&marker, "")?;
+        }
+        Ok(())
     }
 }
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -36,11 +36,130 @@ use std::path::PathBuf;
 /// - macOS: ~/Library/Application Support/kakehashi/
 /// - Windows: %APPDATA%/kakehashi/
 pub fn default_data_dir() -> Option<PathBuf> {
-    // --data-dir CLI flag override (highest priority)
-    if let Some(dir) = crate::config::expand::data_dir_override() {
-        return Some(dir.to_path_buf());
+    // In `cfg(test)`, redirect every caller (Kakehashi::new -> failed
+    // parser registry, search-path defaulting, etc.) to a project-local
+    // persistent dir under `deps/` so the developer's real
+    // `~/.local/share/kakehashi/` is never read or written. The dir is
+    // shared across the test process to keep parser/query installs
+    // cached between runs; transient crash-recovery files
+    // (`parsing_in_progress`, `failed_parsers`) are cleared once per
+    // process at first call so a prior E2E shutdown can't taint this run.
+    #[cfg(test)]
+    {
+        return Some(test_data_dir());
     }
-    resolve_data_dir(|var| std::env::var(var).ok())
+
+    #[cfg_attr(test, allow(unreachable_code))]
+    {
+        // --data-dir CLI flag override (highest priority)
+        if let Some(dir) = crate::config::expand::data_dir_override() {
+            return Some(dir.to_path_buf());
+        }
+        resolve_data_dir(|var| std::env::var(var).ok())
+    }
+}
+
+/// Project-local persistent data directory used by unit tests.
+///
+/// Lives under `deps/` (already gitignored). Parser/query installs persist
+/// across runs to avoid re-downloading, while crash-recovery state files
+/// are cleared once per test process so a previous test's leftovers
+/// (typically from an E2E binary that exited mid-parse) don't poison this
+/// run. Returns the same path every call within a process via `OnceLock`.
+#[cfg(test)]
+pub(crate) fn test_data_dir() -> PathBuf {
+    use std::sync::OnceLock;
+    static DIR: OnceLock<PathBuf> = OnceLock::new();
+    DIR.get_or_init(|| {
+        let dir = test_support::test_data_dir_path();
+        let _ = std::fs::create_dir_all(&dir);
+        // Crash-recovery state can be left over from a previous E2E
+        // shutdown; clear it once per test process so init() doesn't
+        // pre-mark languages as failed.
+        let _ = std::fs::remove_file(dir.join("parsing_in_progress"));
+        let _ = std::fs::remove_file(dir.join("failed_parsers"));
+        // Auto-install required parsers + queries on first call per
+        // process. Cached on disk via the `.installed` marker so
+        // subsequent test processes are fast.
+        let _ = test_support::ensure_test_languages_installed(&dir);
+        dir
+    })
+    .clone()
+}
+
+/// Test-support helpers exposed to integration tests under `tests/`.
+///
+/// Integration tests can't see `cfg(test)`-gated items in the lib (they
+/// link against the non-test build), so the shared test-data-dir wiring
+/// lives in a regular `pub` module and is just routed through
+/// `test_data_dir()` for lib unit tests.
+///
+/// Not part of the public LSP-server API — intended only for the
+/// in-tree test harness.
+pub mod test_support {
+    use super::{parser, queries};
+    use std::path::{Path, PathBuf};
+
+    /// Languages whose parsers and queries every kakehashi test relies on.
+    ///
+    /// Mirrors the `make deps/tree-sitter/.installed` Makefile target.
+    /// Tests that open lua / markdown / rust / yaml documents expect
+    /// parsers and highlight queries to already be present; without
+    /// them, semantic-tokens and similar end-to-end tests come back
+    /// empty.
+    pub const TEST_LANGUAGES: &[&str] = &[
+        "lua",
+        "markdown",
+        "markdown_inline",
+        "python",
+        "rust",
+        "yaml",
+    ];
+
+    /// Project-local persistent test data directory under `deps/test/`.
+    ///
+    /// `/deps` is already gitignored, so this dir doesn't pollute git.
+    /// Leaf is `kakehashi` so search-path defaulting (which asserts the
+    /// dir name) still matches production semantics.
+    pub fn test_data_dir_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("deps")
+            .join("test")
+            .join("kakehashi")
+    }
+
+    /// Install every language in [`TEST_LANGUAGES`] into `data_dir` if
+    /// the `.installed` marker is missing, then write the marker.
+    ///
+    /// Mirrors the install loop in `make deps/tree-sitter/.installed`.
+    /// Both `install_parser` and `install_queries` short-circuit when a
+    /// language is up-to-date; any genuine failure is logged so tests
+    /// depending on that language fail with a clearer error rather than
+    /// the whole suite panicking in setup.
+    pub fn ensure_test_languages_installed(data_dir: &Path) -> std::io::Result<()> {
+        let marker = data_dir.join(".installed");
+        if marker.exists() {
+            return Ok(());
+        }
+        let parser_options = parser::InstallOptions {
+            data_dir: data_dir.to_path_buf(),
+            force: false,
+            verbose: false,
+            no_cache: false,
+        };
+        for lang in TEST_LANGUAGES {
+            if let Err(e) = parser::install_parser(lang, &parser_options) {
+                eprintln!("[test setup] install_parser({}) failed: {}", lang, e);
+            }
+            if let Err(e) = queries::install_queries(lang, data_dir, false) {
+                let msg = e.to_string();
+                if !msg.contains("already exists") {
+                    eprintln!("[test setup] install_queries({}) failed: {}", lang, e);
+                }
+            }
+        }
+        std::fs::write(&marker, "")
+    }
 }
 
 /// Resolve the data directory from an env lookup and platform default.

--- a/src/install.rs
+++ b/src/install.rs
@@ -89,13 +89,16 @@ pub(crate) fn test_data_dir() -> PathBuf {
 
 /// Test-support helpers exposed to integration tests under `tests/`.
 ///
-/// Integration tests can't see `cfg(test)`-gated items in the lib (they
-/// link against the non-test build), so the shared test-data-dir wiring
-/// lives in a regular `pub` module and is just routed through
-/// `test_data_dir()` for lib unit tests.
+/// Gated to test-only builds: lib unit tests reach it via `cfg(test)`, and
+/// the E2E integration crate reaches it via `feature = "e2e"`. Plain
+/// `cfg(test)` alone would not work — integration tests link against the
+/// non-test lib build and can't see `cfg(test)`-gated items — so the gate
+/// also opts in the `e2e` feature. The production library/binary build (no
+/// `cfg(test)`, no `e2e`) compiles without this module.
 ///
 /// Not part of the public LSP-server API — intended only for the
 /// in-tree test harness.
+#[cfg(any(test, feature = "e2e"))]
 pub mod test_support {
     use super::{parser, queries};
     use std::path::{Path, PathBuf};

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -581,6 +581,12 @@ impl ConnectionHandle {
                     Some(OneOf::Left(true) | OneOf::Right(_))
                 )
             }
+            "textDocument/rangeFormatting" => {
+                matches!(
+                    caps.document_range_formatting_provider,
+                    Some(OneOf::Left(true) | OneOf::Right(_))
+                )
+            }
             "textDocument/documentSymbol" => {
                 matches!(
                     caps.document_symbol_provider,

--- a/src/lsp/bridge/text_document.rs
+++ b/src/lsp/bridge/text_document.rs
@@ -26,6 +26,7 @@ mod implementation;
 mod inlay_hint;
 mod moniker;
 mod prepare_rename;
+mod range_formatting;
 mod references;
 mod rename;
 mod signature_help;

--- a/src/lsp/bridge/text_document/formatting.rs
+++ b/src/lsp/bridge/text_document/formatting.rs
@@ -1,13 +1,17 @@
-//! Formatting request handling for bridge connections.
+//! `textDocument/formatting` bridge handler and helpers shared with
+//! `textDocument/rangeFormatting`.
 //!
-//! This module provides `textDocument/formatting` functionality for downstream
-//! language servers, translating each returned `TextEdit` range from virtual
-//! document coordinates back to the host document.
+//! Both endpoints return `TextEdit[] | null` and share the same virtual→host
+//! coordinate translation hazards (synthetic-EOF anchors, out-of-bounds
+//! edits). The shared response transformer
+//! ([`transform_formatting_response_to_host`]) and EOF helpers
+//! ([`count_lines`]) are exposed via `pub(super)` so the range handler in
+//! [`super::range_formatting`] can reuse them.
 //!
-//! Like `documentLink` and `documentSymbol`, formatting operates on an entire
-//! document — there is no cursor position. The injection region's
-//! [`RegionOffset`] is applied to every edit range, including the per-line
-//! column adjustment for the first line of the region.
+//! `textDocument/formatting` itself operates on an entire document — there
+//! is no cursor position. The injection region's [`RegionOffset`] is
+//! applied to every edit range, including the per-line column adjustment
+//! for the first line of the region.
 //!
 //! # Single-Writer Loop (ADR-0015)
 //!
@@ -107,7 +111,7 @@ impl LanguageServerPool {
 /// trailing newline introduces an extra (empty) line.
 ///
 /// Returns 1 for the empty string (a single empty line, index 0).
-fn count_lines(text: &str) -> u32 {
+pub(super) fn count_lines(text: &str) -> u32 {
     // `matches('\n').count() + 1` gives the number of line "buckets" in the
     // split — exactly what the LSP position model expects.
     u32::try_from(text.matches('\n').count())
@@ -178,13 +182,13 @@ fn build_formatting_request(
 /// line are dropped before translation. `virtual_line_count` is the number of
 /// LSP lines in the virtual document (1 for an empty document, computed via
 /// [`count_lines`]).
-fn transform_formatting_response_to_host(
+pub(super) fn transform_formatting_response_to_host(
     mut response: serde_json::Value,
     offset: &RegionOffset,
     virtual_line_count: u32,
 ) -> Option<Vec<TextEdit>> {
     if let Some(error) = response.get("error") {
-        warn!(target: "kakehashi::bridge", "Downstream server returned error for textDocument/formatting: {}", error);
+        warn!(target: "kakehashi::bridge", "Downstream server returned error for formatting-style request: {}", error);
     }
     let result = response.get_mut("result").map(serde_json::Value::take)?;
 
@@ -201,7 +205,7 @@ fn transform_formatting_response_to_host(
     let mut edits: Vec<TextEdit> = match serde_json::from_value(result) {
         Ok(edits) => edits,
         Err(err) => {
-            warn!(target: "kakehashi::bridge", "Failed to deserialize textDocument/formatting result as TextEdit[]: {}", err);
+            warn!(target: "kakehashi::bridge", "Failed to deserialize formatting-style result as TextEdit[]: {}", err);
             return None;
         }
     };

--- a/src/lsp/bridge/text_document/range_formatting.rs
+++ b/src/lsp/bridge/text_document/range_formatting.rs
@@ -1,0 +1,255 @@
+//! `textDocument/rangeFormatting` bridge handler.
+//!
+//! Unlike full formatting, range formatting carries a host-coordinate `Range`
+//! in the request. The bridge translates that range into virtual coordinates
+//! before forwarding, and the response transformer ([`transform_formatting_response_to_host`])
+//! is shared with full formatting since the payload shape is identical.
+//!
+//! # Single-Writer Loop (ADR-0015)
+//!
+//! This handler uses `send_request()` to queue requests via the channel-based
+//! writer task, ensuring FIFO ordering with other messages.
+//!
+//! # Multi-line edit limitation
+//!
+//! Same caveat as full formatting: positions translate correctly via
+//! [`RegionOffset::column_for_line`], but the `new_text` payload of a
+//! multi-line edit inside a prefixed injection (indented or blockquoted code
+//! block) is not re-indented. Single-line edits — which dominate the
+//! "format the selected range" use case — are unaffected.
+
+use std::io;
+
+use crate::config::settings::BridgeServerConfig;
+use tower_lsp_server::ls_types::{
+    DocumentRangeFormattingParams, FormattingOptions, Range, TextDocumentIdentifier, TextEdit,
+};
+use url::Url;
+
+use super::super::pool::{LanguageServerPool, UpstreamId};
+use super::super::protocol::{
+    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, translate_host_range_to_virtual,
+};
+use super::formatting::{count_lines, transform_formatting_response_to_host};
+
+impl LanguageServerPool {
+    /// Send a `textDocument/rangeFormatting` request and wait for the response.
+    ///
+    /// Returns `Ok(None)` when the downstream server does not advertise
+    /// `documentRangeFormattingProvider`.
+    ///
+    /// `host_range` is the **already-clipped** host range — the caller is
+    /// responsible for intersecting the editor-supplied range with the
+    /// injection region's line span (see
+    /// `lsp_impl::text_document::range_formatting` for the clipping logic).
+    /// This handler simply translates that range from host to virtual
+    /// coordinates and forwards.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn send_range_formatting_request(
+        &self,
+        server_name: &str,
+        server_config: &BridgeServerConfig,
+        host_uri: &Url,
+        injection_language: &str,
+        region_id: &str,
+        offset: RegionOffset,
+        virtual_content: &str,
+        host_range: Range,
+        options: FormattingOptions,
+        upstream_request_id: Option<UpstreamId>,
+    ) -> io::Result<Option<Vec<TextEdit>>> {
+        let handle = self
+            .get_or_create_connection(server_name, server_config)
+            .await?;
+        if !handle.has_capability("textDocument/rangeFormatting") {
+            return Ok(None);
+        }
+        let virtual_line_count = count_lines(virtual_content);
+        let offset_for_request = offset.clone();
+        self.execute_bridge_request_with_handle(
+            handle,
+            server_name,
+            host_uri,
+            injection_language,
+            region_id,
+            &offset,
+            virtual_content,
+            upstream_request_id,
+            move |virtual_uri, request_id| {
+                build_range_formatting_request(
+                    virtual_uri,
+                    host_range,
+                    &offset_for_request,
+                    options,
+                    request_id,
+                )
+            },
+            |response, ctx| {
+                transform_formatting_response_to_host(response, ctx.offset, virtual_line_count)
+            },
+        )
+        .await
+    }
+}
+
+/// Build a JSON-RPC `textDocument/rangeFormatting` request.
+///
+/// Translates the host range into virtual coordinates so the downstream
+/// language server formats only the slice of the virtual document that
+/// corresponds to the editor's selection. Translation uses saturating
+/// arithmetic — if a race condition leaves a stale offset, the request
+/// will degrade rather than panic (the downstream server sees a virtual
+/// range clipped at the document edges).
+fn build_range_formatting_request(
+    virtual_uri: &VirtualDocumentUri,
+    host_range: Range,
+    offset: &RegionOffset,
+    options: FormattingOptions,
+    request_id: RequestId,
+) -> JsonRpcRequest<DocumentRangeFormattingParams> {
+    let mut virtual_range = host_range;
+    translate_host_range_to_virtual(&mut virtual_range, offset);
+
+    let params = DocumentRangeFormattingParams {
+        text_document: TextDocumentIdentifier {
+            uri: virtual_uri.to_lsp_uri(),
+        },
+        range: virtual_range,
+        options,
+        work_done_progress_params: Default::default(),
+    };
+    JsonRpcRequest::new(request_id.as_i64(), "textDocument/rangeFormatting", params)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_helpers::*;
+    use super::*;
+    use tower_lsp_server::ls_types::Position;
+
+    fn default_options() -> FormattingOptions {
+        FormattingOptions {
+            tab_size: 4,
+            insert_spaces: true,
+            ..Default::default()
+        }
+    }
+
+    fn range(start_line: u32, start_char: u32, end_line: u32, end_char: u32) -> Range {
+        Range {
+            start: Position {
+                line: start_line,
+                character: start_char,
+            },
+            end: Position {
+                line: end_line,
+                character: end_char,
+            },
+        }
+    }
+
+    #[test]
+    fn range_formatting_request_uses_virtual_uri() {
+        let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
+        let request = build_range_formatting_request(
+            &virtual_uri,
+            range(5, 0, 8, 0),
+            &RegionOffset::new(5, 0),
+            default_options(),
+            test_request_id(),
+        );
+
+        assert_uses_virtual_uri(&request, "lua");
+    }
+
+    #[test]
+    fn range_formatting_request_translates_range_to_virtual_coordinates() {
+        // Region starts at host line 8; request covers host lines 10..20.
+        // Virtual range: 2..12 (subtract 8).
+        let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
+        let request = build_range_formatting_request(
+            &virtual_uri,
+            range(10, 5, 20, 30),
+            &RegionOffset::new(8, 0),
+            default_options(),
+            RequestId::new(42),
+        );
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["jsonrpc"], "2.0");
+        assert_eq!(json["id"], 42);
+        assert_eq!(json["method"], "textDocument/rangeFormatting");
+        assert_eq!(json["params"]["range"]["start"]["line"], 2);
+        assert_eq!(json["params"]["range"]["start"]["character"], 5);
+        assert_eq!(json["params"]["range"]["end"]["line"], 12);
+        assert_eq!(json["params"]["range"]["end"]["character"], 30);
+    }
+
+    #[test]
+    fn range_formatting_request_first_line_applies_column_offset() {
+        // Host range starts on the first line of the region (line 5),
+        // region starts at column 4 → virtual start column = 10 - 4 = 6.
+        let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
+        let request = build_range_formatting_request(
+            &virtual_uri,
+            range(5, 10, 8, 15),
+            &RegionOffset::new(5, 4),
+            default_options(),
+            RequestId::new(1),
+        );
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["params"]["range"]["start"]["line"], 0);
+        assert_eq!(json["params"]["range"]["start"]["character"], 6);
+        assert_eq!(json["params"]["range"]["end"]["line"], 3);
+        // End is on virtual line 3 (host line 8 - region line 5), not the
+        // first line, so column offset is not applied.
+        assert_eq!(json["params"]["range"]["end"]["character"], 15);
+    }
+
+    #[test]
+    fn range_formatting_request_forwards_options() {
+        let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
+        let options = FormattingOptions {
+            tab_size: 2,
+            insert_spaces: false,
+            trim_trailing_whitespace: Some(true),
+            insert_final_newline: Some(false),
+            trim_final_newlines: Some(false),
+            ..Default::default()
+        };
+
+        let request = build_range_formatting_request(
+            &virtual_uri,
+            range(0, 0, 2, 0),
+            &RegionOffset::new(0, 0),
+            options,
+            RequestId::new(1),
+        );
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["params"]["options"]["tabSize"], 2);
+        assert_eq!(json["params"]["options"]["insertSpaces"], false);
+        assert_eq!(json["params"]["options"]["trimTrailingWhitespace"], true);
+        assert_eq!(json["params"]["options"]["insertFinalNewline"], false);
+        assert_eq!(json["params"]["options"]["trimFinalNewlines"], false);
+    }
+
+    #[test]
+    fn range_formatting_request_range_saturates_at_zero() {
+        // Stale region: host range starts before the region.
+        // saturating_sub: virtual start = 0.
+        let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
+        let request = build_range_formatting_request(
+            &virtual_uri,
+            range(2, 0, 5, 0),
+            &RegionOffset::new(10, 0),
+            default_options(),
+            RequestId::new(1),
+        );
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["params"]["range"]["start"]["line"], 0);
+        assert_eq!(json["params"]["range"]["end"]["line"], 0);
+    }
+}

--- a/src/lsp/bridge/text_document/range_formatting.rs
+++ b/src/lsp/bridge/text_document/range_formatting.rs
@@ -40,10 +40,12 @@ impl LanguageServerPool {
     ///
     /// `host_range` is the **already-clipped** host range — the caller is
     /// responsible for intersecting the editor-supplied range with the
-    /// injection region's line span (see
+    /// injection region's `byte_range` (see
     /// `lsp_impl::text_document::range_formatting` for the clipping logic).
-    /// This handler simply translates that range from host to virtual
-    /// coordinates and forwards.
+    /// Byte-precision clipping (not just the region's line span) is what
+    /// avoids false overlaps for inline injections that share a line with
+    /// surrounding host text. This handler simply translates that range from
+    /// host to virtual coordinates and forwards.
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn send_range_formatting_request(
         &self,

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -19,13 +19,14 @@ use tower_lsp_server::ls_types::{
     DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
     DidSaveTextDocumentParams, DocumentDiagnosticParams, DocumentDiagnosticReportResult,
     DocumentFormattingParams, DocumentHighlight, DocumentHighlightParams, DocumentLink,
-    DocumentLinkParams, DocumentSymbolParams, DocumentSymbolResponse, GotoDefinitionParams,
-    GotoDefinitionResponse, Hover, HoverParams, InitializeParams, InitializeResult,
-    InitializedParams, InlayHint, InlayHintParams, Location, Moniker, MonikerParams,
-    PrepareRenameResponse, ReferenceParams, RenameParams, SelectionRange, SelectionRangeParams,
-    SemanticTokensDeltaParams, SemanticTokensFullDeltaResult, SemanticTokensParams,
-    SemanticTokensRangeParams, SemanticTokensRangeResult, SemanticTokensResult, SignatureHelp,
-    SignatureHelpParams, TextDocumentPositionParams, TextEdit, Uri, WorkspaceEdit,
+    DocumentLinkParams, DocumentRangeFormattingParams, DocumentSymbolParams,
+    DocumentSymbolResponse, GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams,
+    InitializeParams, InitializeResult, InitializedParams, InlayHint, InlayHintParams, Location,
+    Moniker, MonikerParams, PrepareRenameResponse, ReferenceParams, RenameParams, SelectionRange,
+    SelectionRangeParams, SemanticTokensDeltaParams, SemanticTokensFullDeltaResult,
+    SemanticTokensParams, SemanticTokensRangeParams, SemanticTokensRangeResult,
+    SemanticTokensResult, SignatureHelp, SignatureHelpParams, TextDocumentPositionParams, TextEdit,
+    Uri, WorkspaceEdit,
 };
 use tower_lsp_server::{Client, LanguageServer};
 use url::Url;
@@ -431,6 +432,13 @@ impl LanguageServer for Kakehashi {
 
     async fn formatting(&self, params: DocumentFormattingParams) -> Result<Option<Vec<TextEdit>>> {
         self.formatting_impl(params).await
+    }
+
+    async fn range_formatting(
+        &self,
+        params: DocumentRangeFormattingParams,
+    ) -> Result<Option<Vec<TextEdit>>> {
+        self.range_formatting_impl(params).await
     }
 
     async fn prepare_rename(

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -249,6 +249,7 @@ impl Kakehashi {
                     work_done_progress_options: WorkDoneProgressOptions::default(),
                 })),
                 document_formatting_provider: Some(OneOf::Left(true)),
+                document_range_formatting_provider: Some(OneOf::Left(true)),
                 inlay_hint_provider: Some(OneOf::Left(true)),
                 #[cfg(feature = "experimental")]
                 color_provider: Some(ColorProviderCapability::Simple(true)),

--- a/src/lsp/lsp_impl/text_document.rs
+++ b/src/lsp/lsp_impl/text_document.rs
@@ -23,6 +23,7 @@ mod inlay_hint;
 mod moniker;
 mod prepare_rename;
 pub(crate) mod publish_diagnostic;
+mod range_formatting;
 mod references;
 mod rename;
 mod selection_range;

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -143,8 +143,9 @@ mod tests {
         // Test isolation is automatic via the `cfg(test)` branch in
         // `kakehashi::install::default_data_dir()`, which redirects every
         // `Kakehashi::new` call in this binary to a project-local data dir
-        // under `deps/kakehashi-test-data/` and clears stale crash-recovery
-        // state once per process. No env-var dance or per-test setup needed.
+        // under `deps/test/kakehashi/` (see `test_support::test_data_dir_path`)
+        // and clears stale crash-recovery state once per process. No env-var
+        // dance or per-test setup needed.
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();
 

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -138,51 +138,13 @@ mod tests {
         .expect("condition should become true");
     }
 
-    /// RAII guard that restores `KAKEHASHI_DATA_DIR` to its original value on
-    /// drop, even on panic. Pairs with `#[serial(kakehashi_data_dir_env)]`
-    /// so the env-var mutation is serialized against other tests that read
-    /// it.
-    struct DataDirEnvGuard {
-        original: Option<String>,
-    }
-
-    impl Drop for DataDirEnvGuard {
-        fn drop(&mut self) {
-            // SAFETY: callers gate this guard with `#[serial(kakehashi_data_dir_env)]`,
-            // which prevents concurrent modification of `KAKEHASHI_DATA_DIR`
-            // by other tests in the same serial group.
-            unsafe {
-                match self.original.take() {
-                    Some(val) => std::env::set_var("KAKEHASHI_DATA_DIR", val),
-                    None => std::env::remove_var("KAKEHASHI_DATA_DIR"),
-                }
-            }
-        }
-    }
-
     #[tokio::test]
-    #[serial_test::serial(kakehashi_data_dir_env)]
     async fn did_open_parses_before_eager_opening_injected_virtual_documents() {
-        // Point `AutoInstallManager::init_failed_parser_registry()` (called
-        // by `Kakehashi::new`) at a per-test crash-recovery directory so a
-        // poisoned `parsing_in_progress` left behind by an earlier E2E
-        // shutdown does not pre-mark "markdown" as failed and short-circuit
-        // `parse_document` — and so this test doesn't touch the developer's
-        // real `~/.local/share/kakehashi/` either.
-        //
-        // `default_data_dir()` reads `KAKEHASHI_DATA_DIR`, so we override it
-        // for the duration of this test. The env var is process-wide;
-        // `#[serial(kakehashi_data_dir_env)]` prevents other tests in this
-        // serial group from racing on it.
-        let data_dir = tempfile::TempDir::new().expect("create temp data dir");
-        let _env_guard = DataDirEnvGuard {
-            original: std::env::var("KAKEHASHI_DATA_DIR").ok(),
-        };
-        // SAFETY: see `DataDirEnvGuard`'s `Drop` impl.
-        unsafe {
-            std::env::set_var("KAKEHASHI_DATA_DIR", data_dir.path());
-        }
-
+        // Test isolation is automatic via the `cfg(test)` branch in
+        // `kakehashi::install::default_data_dir()`, which redirects every
+        // `Kakehashi::new` call in this binary to a project-local data dir
+        // under `deps/kakehashi-test-data/` and clears stale crash-recovery
+        // state once per process. No env-var dance or per-test setup needed.
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();
 

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -138,8 +138,51 @@ mod tests {
         .expect("condition should become true");
     }
 
+    /// RAII guard that restores `KAKEHASHI_DATA_DIR` to its original value on
+    /// drop, even on panic. Pairs with `#[serial(kakehashi_data_dir_env)]`
+    /// so the env-var mutation is serialized against other tests that read
+    /// it.
+    struct DataDirEnvGuard {
+        original: Option<String>,
+    }
+
+    impl Drop for DataDirEnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: callers gate this guard with `#[serial(kakehashi_data_dir_env)]`,
+            // which prevents concurrent modification of `KAKEHASHI_DATA_DIR`
+            // by other tests in the same serial group.
+            unsafe {
+                match self.original.take() {
+                    Some(val) => std::env::set_var("KAKEHASHI_DATA_DIR", val),
+                    None => std::env::remove_var("KAKEHASHI_DATA_DIR"),
+                }
+            }
+        }
+    }
+
     #[tokio::test]
+    #[serial_test::serial(kakehashi_data_dir_env)]
     async fn did_open_parses_before_eager_opening_injected_virtual_documents() {
+        // Point `AutoInstallManager::init_failed_parser_registry()` (called
+        // by `Kakehashi::new`) at a per-test crash-recovery directory so a
+        // poisoned `parsing_in_progress` left behind by an earlier E2E
+        // shutdown does not pre-mark "markdown" as failed and short-circuit
+        // `parse_document` — and so this test doesn't touch the developer's
+        // real `~/.local/share/kakehashi/` either.
+        //
+        // `default_data_dir()` reads `KAKEHASHI_DATA_DIR`, so we override it
+        // for the duration of this test. The env var is process-wide;
+        // `#[serial(kakehashi_data_dir_env)]` prevents other tests in this
+        // serial group from racing on it.
+        let data_dir = tempfile::TempDir::new().expect("create temp data dir");
+        let _env_guard = DataDirEnvGuard {
+            original: std::env::var("KAKEHASHI_DATA_DIR").ok(),
+        };
+        // SAFETY: see `DataDirEnvGuard`'s `Drop` impl.
+        unsafe {
+            std::env::set_var("KAKEHASHI_DATA_DIR", data_dir.path());
+        }
+
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();
 

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -1,4 +1,5 @@
-//! Formatting method for Kakehashi.
+//! `textDocument/formatting` handler and helpers shared with
+//! `textDocument/rangeFormatting`.
 //!
 //! `textDocument/formatting` resolves every injection region in the document
 //! and asks the configured downstream language servers to format each one.
@@ -12,6 +13,14 @@
 //! over the same range, so merging them would violate the LSP "edits must not
 //! overlap" rule. If multiple servers are configured, configure a priority
 //! ordering (or rely on first-win) to pick one.
+//!
+//! # Shared helpers exposed to `range_formatting`
+//!
+//! [`Kakehashi::setup_formatting_cancel_token`] + [`FormattingCancelState`]
+//! package the multi-consumer cancel pattern and
+//! [`finalize_formatting_edits`] funnels per-region `JoinSet` results into
+//! a single sorted edit vector. Both are `pub(super)` so the sibling range
+//! handler in [`super::range_formatting`] reuses them verbatim.
 
 use std::sync::Arc;
 
@@ -22,10 +31,12 @@ use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::{DocumentFormattingParams, TextEdit};
 
 use crate::language::InjectionResolver;
+use crate::lsp::aggregation::region::collect_region_results_with_cancel;
 use crate::lsp::aggregation::server::FanInResult;
 use crate::lsp::aggregation::server::dispatch_preferred;
+use crate::lsp::bridge::UpstreamId;
 use crate::lsp::lsp_impl::bridge_context::DocumentRequestContext;
-use crate::lsp::request_id::CancelReceiver;
+use crate::lsp::request_id::{CancelReceiver, CancelSubscriptionGuard};
 
 use super::super::{Kakehashi, uri_to_url};
 
@@ -81,29 +92,7 @@ impl Kakehashi {
         }
 
         let upstream_request_id = crate::lsp::current_upstream_id();
-
-        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(upstream_request_id.as_ref());
-
-        // Fan one upstream cancel oneshot out to N+1 consumers (outer collector
-        // + per-region `dispatch_preferred`). `CancellationToken` is cloneable
-        // and broadcasts on cancel; the upstream rx isn't, so we forward it
-        // into the token once. When `subscribe_cancel` returns `None` (no
-        // upstream id, or duplicate subscription) there is no cancel source —
-        // leave the token as `None` so downstream consumers receive `None` for
-        // their `cancel_rx` and degrade to "no cancel" instead of being told
-        // "already cancelled". Using a pre-cancelled token here would abort
-        // every region task before it even started.
-        let cancel_token = cancel_rx.map(|rx| {
-            let token = CancellationToken::new();
-            let forward = token.clone();
-            tokio::spawn(async move {
-                // Fires on both real cancel and tx-drop (subscription guard).
-                let _ = rx.await;
-                forward.cancel();
-            });
-            token
-        });
-
+        let cancel_state = self.setup_formatting_cancel_token(upstream_request_id.as_ref());
         let pool = self.bridge.pool_arc();
 
         // Outer JoinSet: one task per injection region, all in parallel
@@ -134,14 +123,7 @@ impl Kakehashi {
             };
             let pool = Arc::clone(&pool);
             let options = options.clone();
-            // Per-region cancel receiver derived from the shared token, so
-            // the inner preferred() can abort its per-server JoinSet as soon
-            // as $/cancelRequest arrives — not after the slowest formatter
-            // completes naturally. `None` when no upstream cancel source
-            // exists, in which case the dispatcher disables cancel handling.
-            let region_cancel_rx = cancel_token
-                .as_ref()
-                .map(|t| cancel_rx_from_token(t.clone()));
+            let region_cancel_rx = cancel_state.derive_receiver();
 
             outer_join_set.spawn(async move {
                 let result = dispatch_preferred(
@@ -181,30 +163,9 @@ impl Kakehashi {
             });
         }
 
-        let all_edits = crate::lsp::aggregation::region::collect_region_results_with_cancel(
-            outer_join_set,
-            cancel_token.map(cancel_rx_from_token),
-            |acc, opt: Option<Vec<TextEdit>>| {
-                if let Some(items) = opt {
-                    acc.extend(items);
-                }
-            },
-        )
-        .await;
-
+        let response = finalize_formatting_edits(outer_join_set, cancel_state.token.clone()).await;
         pool.unregister_all_for_upstream_id(upstream_request_id.as_ref());
-
-        let mut all_edits = all_edits?;
-        // Per-region tasks complete in arbitrary order via JoinSet, so the
-        // concatenated TextEdit list is non-deterministic. Sort by start
-        // position to produce a stable LSP response (regions are disjoint,
-        // so this is a simple total order).
-        sort_edits_by_start_position(&mut all_edits);
-        Ok(if all_edits.is_empty() {
-            None
-        } else {
-            Some(all_edits)
-        })
+        response
     }
 }
 
@@ -243,6 +204,106 @@ fn cancel_rx_from_token(token: CancellationToken) -> CancelReceiver {
         }
     });
     rx
+}
+
+/// Multi-consumer cancel state for a formatting / rangeFormatting fan-out.
+///
+/// Wraps the cloneable [`CancellationToken`] that every per-region task and
+/// the outer collector subscribe to, plus the [`CancelSubscriptionGuard`]
+/// that keeps the upstream subscription alive for the duration of the
+/// request. The guard is bound to the lifetime of the parent `&Kakehashi`.
+pub(super) struct FormattingCancelState<'a> {
+    /// `None` when no upstream cancel source exists (no upstream id or
+    /// duplicate subscription). Per-region consumers should treat this as
+    /// "no cancel" rather than a pre-cancelled token, otherwise every
+    /// region task would abort before starting.
+    pub(super) token: Option<CancellationToken>,
+    /// Held alive for the lifetime of the request; dropping it unsubscribes
+    /// from the cancel forwarder. `None` when there is no upstream
+    /// subscription to manage.
+    _guard: Option<CancelSubscriptionGuard<'a>>,
+}
+
+impl<'a> FormattingCancelState<'a> {
+    /// Derive a fresh per-consumer [`CancelReceiver`] from the token, if any.
+    pub(super) fn derive_receiver(&self) -> Option<CancelReceiver> {
+        self.token.as_ref().map(|t| cancel_rx_from_token(t.clone()))
+    }
+}
+
+impl Kakehashi {
+    /// Wire up the multi-consumer cancel pattern used by both formatting
+    /// fan-outs.
+    ///
+    /// Subscribes to upstream cancel notifications (returning `None` when
+    /// no upstream id is present or the subscription is a duplicate), then
+    /// forwards that single-use oneshot into a cloneable
+    /// [`CancellationToken`]. Per-region tasks call
+    /// [`FormattingCancelState::derive_receiver`] to get their own oneshot
+    /// receiver, so cancel propagates to every dispatcher simultaneously —
+    /// not after the slowest formatter completes naturally.
+    ///
+    /// When `subscribe_cancel` returns `None`, the token stays `None` so
+    /// downstream consumers receive `None` for their `cancel_rx` and
+    /// degrade to "no cancel" instead of being told "already cancelled".
+    /// Using a pre-cancelled token here would abort every region task
+    /// before it even started.
+    pub(super) fn setup_formatting_cancel_token(
+        &self,
+        upstream_request_id: Option<&UpstreamId>,
+    ) -> FormattingCancelState<'_> {
+        let (cancel_rx, guard) = self.subscribe_cancel(upstream_request_id);
+        let token = cancel_rx.map(|rx| {
+            let token = CancellationToken::new();
+            let forward = token.clone();
+            tokio::spawn(async move {
+                // Fires on both real cancel and tx-drop (subscription guard).
+                let _ = rx.await;
+                forward.cancel();
+            });
+            token
+        });
+        FormattingCancelState {
+            token,
+            _guard: guard,
+        }
+    }
+}
+
+/// Collect per-region `JoinSet` results, sort the concatenated edits, and
+/// shape into the LSP-spec response (`None` when there are no edits).
+///
+/// Both formatting handlers funnel their per-region futures into a single
+/// `JoinSet<Option<Vec<TextEdit>>>` and need to:
+///
+/// 1. Cancel-aware collect every region's edits (regions whose dispatcher
+///    cancelled or returned no result contribute nothing).
+/// 2. Sort by start position so the concatenated response is deterministic
+///    across `JoinSet::join_next` arrival order.
+/// 3. Map `vec![]` to `Ok(None)` per the LSP convention that empty edit
+///    lists are equivalent to no response.
+pub(super) async fn finalize_formatting_edits(
+    outer_join_set: JoinSet<Option<Vec<TextEdit>>>,
+    cancel_token: Option<CancellationToken>,
+) -> Result<Option<Vec<TextEdit>>> {
+    let all_edits = collect_region_results_with_cancel(
+        outer_join_set,
+        cancel_token.map(cancel_rx_from_token),
+        |acc, opt: Option<Vec<TextEdit>>| {
+            if let Some(items) = opt {
+                acc.extend(items);
+            }
+        },
+    )
+    .await;
+
+    let mut all_edits = all_edits?;
+    sort_edits_by_start_position(&mut all_edits);
+    Ok(if all_edits.is_empty() {
+        None
+    } else {
+        Some(all_edits)
+    })
 }
 
 #[cfg(test)]

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -104,18 +104,7 @@ impl Kakehashi {
         // Multi-line code-fence injections (`start_column == 0`) are
         // unchanged because their line and byte bounds are equivalent.
         let mapper = PositionMapper::new(snapshot.text());
-        let Some(request_bytes) = mapper
-            .position_to_byte(host_range.start)
-            .zip(mapper.position_to_byte(host_range.end))
-            .map(|(start, end)| start..end)
-        else {
-            log::debug!(
-                target: "kakehashi::rangeFormatting",
-                "Could not map request range to byte offsets for {}",
-                uri
-            );
-            return Ok(None);
-        };
+        let request_bytes = clamp_request_to_document(&mapper, host_range, snapshot.text().len());
 
         let mut outer_join_set: JoinSet<Option<Vec<TextEdit>>> = JoinSet::new();
 
@@ -197,6 +186,25 @@ impl Kakehashi {
     }
 }
 
+/// Map a host request `Range` to a byte range, clamping endpoints that fall
+/// outside the document to its length.
+///
+/// Editors routinely send a range that runs past EOF when formatting "to the
+/// end of the file" (often `u32::MAX`), and `position_to_byte` returns `None`
+/// for such positions. Dropping the whole request on an unmappable endpoint
+/// would silently skip formatting of otherwise-valid regions, so we treat an
+/// out-of-bounds endpoint as the document end instead. A start past EOF
+/// collapses to an empty range that `clip_request_to_region` skips harmlessly.
+fn clamp_request_to_document(
+    mapper: &PositionMapper,
+    range: Range,
+    doc_len: usize,
+) -> std::ops::Range<usize> {
+    let start = mapper.position_to_byte(range.start).unwrap_or(doc_len);
+    let end = mapper.position_to_byte(range.end).unwrap_or(doc_len);
+    start..end
+}
+
 /// Intersect a request's byte range with a region's byte range and map the
 /// result back to host LSP positions.
 ///
@@ -250,6 +258,31 @@ mod tests {
     /// handler would use, so tests stay in sync with the helper's contract.
     fn bytes(mapper: &PositionMapper, range: Range) -> std::ops::Range<usize> {
         mapper.position_to_byte(range.start).unwrap()..mapper.position_to_byte(range.end).unwrap()
+    }
+
+    #[test]
+    fn request_bytes_clamps_out_of_bounds_end_to_document_length() {
+        // Editors send a range that runs past EOF when formatting "to the
+        // end of the file" (often `u32::MAX`). The end must clamp to the
+        // document length instead of dropping the whole request.
+        let text = "first line\nsecond line\n";
+        let mapper = PositionMapper::new(text);
+        let range = pos_range(0, 0, 999, 0);
+
+        let bytes = clamp_request_to_document(&mapper, range, text.len());
+        assert_eq!(bytes, 0..text.len());
+    }
+
+    #[test]
+    fn request_bytes_clamps_out_of_bounds_start_to_document_length() {
+        // A start past EOF clamps to the document end, yielding an empty
+        // (degenerate) range that downstream clipping skips harmlessly.
+        let text = "first line\nsecond line\n";
+        let mapper = PositionMapper::new(text);
+        let range = pos_range(999, 0, 999, 5);
+
+        let bytes = clamp_request_to_document(&mapper, range, text.len());
+        assert_eq!(bytes, text.len()..text.len());
     }
 
     #[test]

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -12,6 +12,7 @@
 //! entirely; no downstream request is sent.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use tokio::task::JoinSet;
 use tower_lsp_server::jsonrpc::Result;
@@ -41,6 +42,16 @@ impl Kakehashi {
         };
 
         log::debug!("rangeFormatting called for {} range {:?}", uri, host_range);
+
+        // Tower-LSP runs requests concurrently, so a rangeFormatting call can
+        // arrive before didOpen/didChange has finished parsing. Wait briefly
+        // for any in-flight parse to land a tree before snapshotting, matching
+        // the read-handler pattern (semantic tokens, node lookups); otherwise
+        // an otherwise-valid request would degrade to `Ok(None)` purely due to
+        // a parse race.
+        self.documents
+            .wait_for_parse_completion(&uri, Duration::from_millis(200))
+            .await;
 
         let snapshot = match self.documents.get(&uri) {
             None => {

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -3,19 +3,19 @@
 //! Range formatting is the partial-document counterpart of full formatting:
 //! it carries a `Range` and is expected to return edits that only modify
 //! that range. Implementation reuses the full-formatting fan-out shape (one
-//! `dispatch_preferred` per injection region) but pre-filters regions to
-//! those that overlap the requested range and **clips the request range to
-//! each region's bounds** before dispatching. Without that clip, an
-//! injection that the request only partially covers would be asked to
-//! format outside the user's selection.
+//! `dispatch_preferred` per injection region) but clips the request to
+//! each region's `byte_range` before dispatching — so an inline injection
+//! (`start_column > 0`) that the request only partially covers is never
+//! asked to format positions outside the injected content.
 //!
-//! Edits returned for non-overlapping regions are skipped entirely.
+//! Regions whose byte range is disjoint from the request are skipped
+//! entirely; no downstream request is sent.
 
 use std::sync::Arc;
 
 use tokio::task::JoinSet;
 use tower_lsp_server::jsonrpc::Result;
-use tower_lsp_server::ls_types::{DocumentRangeFormattingParams, Position, Range, TextEdit};
+use tower_lsp_server::ls_types::{DocumentRangeFormattingParams, Range, TextEdit};
 
 use crate::language::InjectionResolver;
 use crate::lsp::aggregation::server::FanInResult;
@@ -85,44 +85,44 @@ impl Kakehashi {
         let cancel_state = self.setup_formatting_cancel_token(upstream_request_id.as_ref());
         let pool = self.bridge.pool_arc();
 
-        // Byte-level overlap pre-check uses the actual host text. The
-        // line-only `clip_request_range_to_region` below is correct for
-        // multi-line injections (code fences etc., `start_column == 0`),
-        // but for inline injections (`start_column > 0`, e.g. backtick
-        // code inside a markdown paragraph) it would treat the same line
-        // as overlapping even when the request is entirely before the
-        // injected content. Using the region's `byte_range` against the
-        // request's byte span filters those out before we ask a
-        // downstream formatter for a zero-width / before-injection range.
+        // Clip the request to each region's actual byte bounds (not just
+        // its line span). Line-only clipping is incorrect for two cases
+        // that matter for inline injections (`start_column > 0`):
+        //
+        // 1. Request shares a line with the injection but lies entirely
+        //    before/after the injected content. Byte intersection
+        //    correctly skips the region; line-only would mis-overlap.
+        // 2. Request straddles an injection boundary (e.g., starts before
+        //    the injection's opening column, ends past its closing
+        //    column on the same line). Byte intersection clips the
+        //    endpoints to the injected content; line-only would pass the
+        //    out-of-bounds columns to `translate_host_range_to_virtual`,
+        //    where `saturating_sub` produces a virtual range past the
+        //    virtual document's actual columns and the downstream
+        //    formatter may error or format more than the user selected.
+        //
+        // Multi-line code-fence injections (`start_column == 0`) are
+        // unchanged because their line and byte bounds are equivalent.
         let mapper = PositionMapper::new(snapshot.text());
-        let request_bytes = mapper
+        let Some(request_bytes) = mapper
             .position_to_byte(host_range.start)
             .zip(mapper.position_to_byte(host_range.end))
-            .map(|(start, end)| start..end);
+            .map(|(start, end)| start..end)
+        else {
+            log::debug!(
+                target: "kakehashi::rangeFormatting",
+                "Could not map request range to byte offsets for {}",
+                uri
+            );
+            return Ok(None);
+        };
 
         let mut outer_join_set: JoinSet<Option<Vec<TextEdit>>> = JoinSet::new();
 
         for resolved in all_regions {
-            // Skip regions whose host byte range does not actually overlap
-            // the request — protects against inline-injection
-            // false-positives that the line-only clip below would miss.
-            if let Some(ref req_bytes) = request_bytes
-                && (req_bytes.end <= resolved.region.byte_range.start
-                    || req_bytes.start >= resolved.region.byte_range.end)
-            {
-                continue;
-            }
-
-            // Clip the editor-supplied range to this region's host line
-            // bounds. After the byte-level overlap check above, this is
-            // safe to do in line space — any column saturation inside
-            // `translate_host_range_to_virtual` only fires on partial
-            // overlaps that already passed the byte check.
-            let Some(clipped_host_range) = clip_request_range_to_region(
-                host_range,
-                resolved.region.line_range.start,
-                resolved.region.line_range.end,
-            ) else {
+            let Some(clipped_host_range) =
+                clip_request_to_region(&request_bytes, &resolved.region.byte_range, &mapper)
+            else {
                 continue;
             };
 
@@ -197,66 +197,33 @@ impl Kakehashi {
     }
 }
 
-/// Clip an editor-supplied `Range` to a region's host-line bounds.
+/// Intersect a request's byte range with a region's byte range and map the
+/// result back to host LSP positions.
 ///
-/// `region_line_lo..region_line_hi_exclusive` describes the region's host
-/// line span (matching `CacheableInjectionRegion::line_range`, which is
-/// half-open). Returns `None` when the request range does not overlap the
-/// region at all — the handler skips such regions outright.
+/// Returns `None` when the intervals are disjoint — the handler skips such
+/// regions. Returns the clipped host `Range` otherwise, with both endpoints
+/// converted from byte offsets back to LSP `Position`s via `mapper`.
 ///
-/// Overlap is computed in line space using half-open intervals:
-///
-/// - Region span: `[region_line_lo, region_line_hi_exclusive)`
-/// - Request span: `[req.start.line, req.end.line)` when `req.end.character == 0`;
-///   otherwise `[req.start.line, req.end.line + 1)` so a selection ending
-///   mid-line still counts that line as covered.
-///
-/// The returned range preserves the request's endpoints whenever they lie
-/// inside the region; endpoints that fall outside snap to the region's
-/// boundary at column 0 (start of the boundary line).
-fn clip_request_range_to_region(
-    request: Range,
-    region_line_lo: u32,
-    region_line_hi_exclusive: u32,
+/// Byte-precision clipping is what makes `range_formatting_impl` safe for
+/// inline injections (`start_column > 0`). A line-only clip would
+/// (1) treat a same-line request that lies entirely before/after the
+/// injected content as overlapping, and (2) pass host columns outside the
+/// injected content to `translate_host_range_to_virtual`, where
+/// `saturating_sub` would produce a virtual range past the virtual
+/// document's actual columns.
+fn clip_request_to_region(
+    request_bytes: &std::ops::Range<usize>,
+    region_bytes: &std::ops::Range<usize>,
+    mapper: &PositionMapper,
 ) -> Option<Range> {
-    let req_lo = request.start.line;
-    // Per LSP, `Range.end` is exclusive. When `end.character == 0`, the end
-    // sits at the start of a line — that line is NOT included in the
-    // selection. For all other end characters, the end line IS covered.
-    let req_hi_exclusive = if request.end.character == 0 {
-        request.end.line
-    } else {
-        request.end.line.saturating_add(1)
-    };
-
-    let clipped_lo = req_lo.max(region_line_lo);
-    let clipped_hi_exclusive = req_hi_exclusive.min(region_line_hi_exclusive);
-
-    if clipped_lo >= clipped_hi_exclusive {
+    let clipped_start = request_bytes.start.max(region_bytes.start);
+    let clipped_end = request_bytes.end.min(region_bytes.end);
+    if clipped_start >= clipped_end {
         return None;
     }
-
-    let clipped_start = if clipped_lo == req_lo {
-        request.start
-    } else {
-        Position {
-            line: clipped_lo,
-            character: 0,
-        }
-    };
-    let clipped_end = if clipped_hi_exclusive == req_hi_exclusive {
-        request.end
-    } else {
-        Position {
-            line: clipped_hi_exclusive,
-            character: 0,
-        }
-    };
-
-    Some(Range {
-        start: clipped_start,
-        end: clipped_end,
-    })
+    let start = mapper.byte_to_position(clipped_start)?;
+    let end = mapper.byte_to_position(clipped_end)?;
+    Some(Range { start, end })
 }
 
 #[cfg(test)]
@@ -264,7 +231,9 @@ mod tests {
     use super::*;
     use tower_lsp_server::ls_types::Position;
 
-    fn range(start_line: u32, start_char: u32, end_line: u32, end_char: u32) -> Range {
+    /// Build a `Range` from line/character endpoints. Tests use this for
+    /// readability against expected output.
+    fn pos_range(start_line: u32, start_char: u32, end_line: u32, end_char: u32) -> Range {
         Range {
             start: Position {
                 line: start_line,
@@ -277,60 +246,69 @@ mod tests {
         }
     }
 
+    /// Build a request byte range from positions using the same mapper the
+    /// handler would use, so tests stay in sync with the helper's contract.
+    fn bytes(mapper: &PositionMapper, range: Range) -> std::ops::Range<usize> {
+        mapper.position_to_byte(range.start).unwrap()..mapper.position_to_byte(range.end).unwrap()
+    }
+
     #[test]
     fn clip_returns_request_unchanged_when_fully_inside_region() {
-        let clipped = clip_request_range_to_region(range(5, 2, 9, 4), 3, 12).unwrap();
-        assert_eq!(
-            clipped.start,
-            Position {
-                line: 5,
-                character: 2
-            }
-        );
-        assert_eq!(
-            clipped.end,
-            Position {
-                line: 9,
-                character: 4
-            }
-        );
+        // Three-line document; region spans the second line entirely.
+        // Request is fully inside the region's content.
+        let text = "first line\nsecond line\nthird line\n";
+        let mapper = PositionMapper::new(text);
+        let req = pos_range(1, 2, 1, 7);
+        let region = bytes(&mapper, pos_range(1, 0, 2, 0));
+
+        let clipped = clip_request_to_region(&bytes(&mapper, req), &region, &mapper).unwrap();
+        assert_eq!(clipped, req);
     }
 
     #[test]
     fn clip_snaps_start_when_request_begins_before_region() {
-        // Request: lines 0..10; region: lines 4..15. Start clipped to (4, 0).
-        let clipped = clip_request_range_to_region(range(0, 0, 10, 0), 4, 15).unwrap();
+        // Request starts on line 0; region starts at line 1 col 0.
+        let text = "first line\nsecond line\nthird line\n";
+        let mapper = PositionMapper::new(text);
+        let req = pos_range(0, 0, 1, 7);
+        let region = bytes(&mapper, pos_range(1, 0, 2, 0));
+
+        let clipped = clip_request_to_region(&bytes(&mapper, req), &region, &mapper).unwrap();
         assert_eq!(
             clipped.start,
             Position {
-                line: 4,
+                line: 1,
                 character: 0
             }
         );
         assert_eq!(
             clipped.end,
             Position {
-                line: 10,
-                character: 0
+                line: 1,
+                character: 7
             }
         );
     }
 
     #[test]
     fn clip_snaps_end_when_request_extends_past_region() {
-        // Request: lines 2..20; region: lines 0..12. End clipped to (12, 0).
-        let clipped = clip_request_range_to_region(range(2, 0, 20, 5), 0, 12).unwrap();
+        let text = "first line\nsecond line\nthird line\n";
+        let mapper = PositionMapper::new(text);
+        let req = pos_range(1, 2, 2, 5);
+        let region = bytes(&mapper, pos_range(1, 0, 2, 0));
+
+        let clipped = clip_request_to_region(&bytes(&mapper, req), &region, &mapper).unwrap();
         assert_eq!(
             clipped.start,
             Position {
-                line: 2,
-                character: 0
+                line: 1,
+                character: 2
             }
         );
         assert_eq!(
             clipped.end,
             Position {
-                line: 12,
+                line: 2,
                 character: 0
             }
         );
@@ -338,62 +316,70 @@ mod tests {
 
     #[test]
     fn clip_returns_none_when_request_is_entirely_before_region() {
-        let clipped = clip_request_range_to_region(range(0, 0, 3, 0), 5, 10);
-        assert!(clipped.is_none(), "no overlap → no work");
+        let text = "first\nsecond\nthird\n";
+        let mapper = PositionMapper::new(text);
+        let req = bytes(&mapper, pos_range(0, 0, 0, 3));
+        let region = bytes(&mapper, pos_range(1, 0, 2, 0));
+
+        assert!(clip_request_to_region(&req, &region, &mapper).is_none());
     }
 
     #[test]
     fn clip_returns_none_when_request_is_entirely_after_region() {
-        let clipped = clip_request_range_to_region(range(20, 0, 25, 0), 5, 10);
-        assert!(clipped.is_none(), "no overlap → no work");
+        let text = "first\nsecond\nthird\n";
+        let mapper = PositionMapper::new(text);
+        let req = bytes(&mapper, pos_range(2, 0, 2, 3));
+        let region = bytes(&mapper, pos_range(0, 0, 1, 0));
+
+        assert!(clip_request_to_region(&req, &region, &mapper).is_none());
     }
 
     #[test]
-    fn clip_returns_none_when_request_touches_region_boundary_at_start() {
-        // Request: lines 0..5 with end.character == 0 → covers [0, 5),
-        // region: [5, 10). No overlap.
-        let clipped = clip_request_range_to_region(range(0, 0, 5, 0), 5, 10);
-        assert!(clipped.is_none());
+    fn clip_skips_inline_injection_when_request_is_before_injected_content() {
+        // Inline injection on a single line: paragraph text with backtick
+        // code starting mid-line (`start_column > 0`). A line-only clip
+        // would falsely overlap; byte-precision correctly skips.
+        //
+        //   "say `lua_inline` here"
+        //    ^cols 0..3 "say"
+        //         ^col 4..5 "`"
+        //          ^cols 5..15 "lua_inline"  ← injection content
+        //                    ^col 15..16 "`"
+        let text = "say `lua_inline` here\n";
+        let mapper = PositionMapper::new(text);
+        let req = bytes(&mapper, pos_range(0, 0, 0, 3)); // "say"
+        let region = bytes(&mapper, pos_range(0, 5, 0, 15)); // "lua_inline"
+
+        assert!(
+            clip_request_to_region(&req, &region, &mapper).is_none(),
+            "request before the inline injection must not be dispatched"
+        );
     }
 
     #[test]
-    fn clip_covers_single_line_with_mid_line_end_character() {
-        // Request: line 3, characters 0..5 → covers line 3.
-        // Region: lines 3..4. Overlap covers exactly line 3.
-        let clipped = clip_request_range_to_region(range(3, 0, 3, 5), 3, 4).unwrap();
+    fn clip_clamps_inline_injection_when_request_straddles_boundary() {
+        // Inline injection same as above; request straddles both ends.
+        let text = "say `lua_inline` here\n";
+        let mapper = PositionMapper::new(text);
+        let req = bytes(&mapper, pos_range(0, 3, 0, 18)); // " `lua_inline` h"
+        let region = bytes(&mapper, pos_range(0, 5, 0, 15)); // "lua_inline"
+
+        let clipped = clip_request_to_region(&req, &region, &mapper).unwrap();
         assert_eq!(
             clipped.start,
             Position {
-                line: 3,
-                character: 0
-            }
-        );
-        assert_eq!(
-            clipped.end,
-            Position {
-                line: 3,
+                line: 0,
                 character: 5
-            }
-        );
-    }
-
-    #[test]
-    fn clip_snaps_both_endpoints_when_request_spans_region() {
-        // Request: lines 0..100; region: lines 10..20. Result: (10,0)..(20,0).
-        let clipped = clip_request_range_to_region(range(0, 0, 100, 0), 10, 20).unwrap();
-        assert_eq!(
-            clipped.start,
-            Position {
-                line: 10,
-                character: 0
-            }
+            },
+            "start snaps to injection's start_column"
         );
         assert_eq!(
             clipped.end,
             Position {
-                line: 20,
-                character: 0
-            }
+                line: 0,
+                character: 15
+            },
+            "end snaps to injection's end column"
         );
     }
 }

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -104,7 +104,7 @@ impl Kakehashi {
         // Multi-line code-fence injections (`start_column == 0`) are
         // unchanged because their line and byte bounds are equivalent.
         let mapper = PositionMapper::new(snapshot.text());
-        let request_bytes = clamp_request_to_document(&mapper, host_range, snapshot.text().len());
+        let request_bytes = clamp_request_to_document(&mapper, host_range);
 
         let mut outer_join_set: JoinSet<Option<Vec<TextEdit>>> = JoinSet::new();
 
@@ -186,23 +186,26 @@ impl Kakehashi {
     }
 }
 
-/// Map a host request `Range` to a byte range, clamping endpoints that fall
-/// outside the document to its length.
+/// Map a host request `Range` to a byte range, clamping out-of-bounds
+/// endpoints to the nearest valid offset instead of dropping the request.
 ///
-/// Editors routinely send a range that runs past EOF when formatting "to the
-/// end of the file" (often `u32::MAX`), and `position_to_byte` returns `None`
-/// for such positions. Dropping the whole request on an unmappable endpoint
-/// would silently skip formatting of otherwise-valid regions, so we treat an
-/// out-of-bounds endpoint as the document end instead. A start past EOF
-/// collapses to an empty range that `clip_request_to_region` skips harmlessly.
-fn clamp_request_to_document(
-    mapper: &PositionMapper,
-    range: Range,
-    doc_len: usize,
-) -> std::ops::Range<usize> {
-    let start = mapper.position_to_byte(range.start).unwrap_or(doc_len);
-    let end = mapper.position_to_byte(range.end).unwrap_or(doc_len);
-    start..end
+/// Editors routinely send positions past the document or line bounds: a range
+/// that runs "to the end of the file" (often `u32::MAX`), or a character index
+/// past a line's end. `position_to_byte` returns `None` for both, which would
+/// silently skip formatting of otherwise-valid regions. `position_to_byte_clamped`
+/// resolves each endpoint precisely — a character past a line's end clamps to
+/// that line's end (within the line; not the document end, which would balloon
+/// a single-line request into later injection regions); a line past EOF clamps
+/// to the document end.
+///
+/// `start.min(end)` guards against an inverted result: a malformed client may
+/// send `start` after `end`, and clamping the start's line could otherwise
+/// push it past an in-bounds end. A collapsed (empty) range is skipped
+/// harmlessly by `clip_request_to_region`.
+fn clamp_request_to_document(mapper: &PositionMapper, range: Range) -> std::ops::Range<usize> {
+    let start = mapper.position_to_byte_clamped(range.start);
+    let end = mapper.position_to_byte_clamped(range.end);
+    start.min(end)..end
 }
 
 /// Intersect a request's byte range with a region's byte range and map the
@@ -269,7 +272,7 @@ mod tests {
         let mapper = PositionMapper::new(text);
         let range = pos_range(0, 0, 999, 0);
 
-        let bytes = clamp_request_to_document(&mapper, range, text.len());
+        let bytes = clamp_request_to_document(&mapper, range);
         assert_eq!(bytes, 0..text.len());
     }
 
@@ -281,8 +284,35 @@ mod tests {
         let mapper = PositionMapper::new(text);
         let range = pos_range(999, 0, 999, 5);
 
-        let bytes = clamp_request_to_document(&mapper, range, text.len());
+        let bytes = clamp_request_to_document(&mapper, range);
         assert_eq!(bytes, text.len()..text.len());
+    }
+
+    #[test]
+    fn request_bytes_clamps_overlong_character_to_line_end_not_document_end() {
+        // A character past a valid line's end must clamp to that line's end,
+        // not the document end — otherwise a single-line request would
+        // broaden into later lines and dispatch to regions the user did not
+        // select. Line 0 is "first line\n" (bytes 0..11), so col 999 clamps
+        // to byte 11 (start of line 1), well short of the document end (23).
+        let text = "first line\nsecond line\n";
+        let mapper = PositionMapper::new(text);
+        let range = pos_range(0, 0, 0, 999);
+
+        let bytes = clamp_request_to_document(&mapper, range);
+        assert_eq!(bytes, 0..11);
+    }
+
+    #[test]
+    fn request_bytes_never_inverts_when_start_is_after_end() {
+        // Malformed client: start positioned after end. The result must not
+        // invert (start <= end) so downstream clipping behaves sanely.
+        let text = "first line\nsecond line\n";
+        let mapper = PositionMapper::new(text);
+        let range = pos_range(1, 5, 0, 2);
+
+        let bytes = clamp_request_to_document(&mapper, range);
+        assert!(bytes.start <= bytes.end, "byte range must not invert");
     }
 
     #[test]

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -114,6 +114,16 @@ impl Kakehashi {
             else {
                 continue;
             };
+            // The byte-range clip can still leave an endpoint inside a
+            // stripped per-line prefix (e.g. blockquoted code's `> `); pull
+            // both endpoints onto the actual injected content.
+            let Some(clipped_host_range) = clamp_range_to_content_columns(
+                clipped_host_range,
+                resolved.region.line_range.start,
+                &resolved.line_column_offsets,
+            ) else {
+                continue;
+            };
 
             let configs = self.bridge_configs_for_injection_language(
                 &language_name,
@@ -247,6 +257,46 @@ fn clip_request_to_region(
     Some(Range { start, end })
 }
 
+/// Clamp a clipped host range so neither endpoint sits inside an injection's
+/// stripped per-line prefix (e.g. the `> ` of a blockquoted code block).
+///
+/// `clip_request_to_region` intersects against the injection's *raw*
+/// `byte_range`, but that range still contains the per-line prefix bytes that
+/// `extract_clean_content` strips out of `virtual_content`. An endpoint left
+/// inside such a prefix would be carried into `translate_host_range_to_virtual`,
+/// whose `saturating_sub` collapses it to virtual column 0 — so the clip alone
+/// is not aligned with the bytes that actually became the virtual document.
+///
+/// `line_column_offsets[v]` is the host column where content begins on virtual
+/// line `v` (the same per-line offset the bridge subtracts during translation).
+/// Clamping each endpoint up to its line's content-start column keeps the
+/// request inside the injected content, and lets a selection lying entirely in
+/// prefix bytes collapse to an empty range that the caller skips instead of
+/// dispatching a no-op downstream request.
+///
+/// No-op for the common cases: code-fence injections have all-zero offsets, and
+/// inline injections already start at content (their prefix bytes lie outside
+/// `byte_range`), so neither is altered.
+fn clamp_range_to_content_columns(
+    mut range: Range,
+    base_line: u32,
+    line_column_offsets: &[u32],
+) -> Option<Range> {
+    let content_col = |host_line: u32| -> u32 {
+        let virtual_line = host_line.saturating_sub(base_line) as usize;
+        line_column_offsets.get(virtual_line).copied().unwrap_or(0)
+    };
+    range.start.character = range.start.character.max(content_col(range.start.line));
+    range.end.character = range.end.character.max(content_col(range.end.line));
+
+    // Empty or inverted after clamping means nothing inside the content is
+    // selected on this region — skip it rather than dispatch an empty request.
+    if (range.start.line, range.start.character) >= (range.end.line, range.end.character) {
+        return None;
+    }
+    Some(range)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -325,6 +375,45 @@ mod tests {
 
         let bytes = clamp_request_to_document(&mapper, range);
         assert_eq!(bytes, 2..16);
+    }
+
+    #[test]
+    fn content_clamp_is_noop_for_zero_offsets() {
+        // Code-fence injection: all per-line offsets are 0, so nothing moves.
+        let r = pos_range(2, 0, 4, 3);
+        let clamped = clamp_range_to_content_columns(r, 2, &[0, 0, 0]).unwrap();
+        assert_eq!(clamped, r);
+    }
+
+    #[test]
+    fn content_clamp_pulls_prefix_start_onto_content() {
+        // Blockquoted code: content starts at host col 2 on each line.
+        // Region begins at host line 1; a start at (1,0) sits in the `> `
+        // prefix and must clamp to col 2; the in-content end is untouched.
+        let r = pos_range(1, 0, 2, 5);
+        let clamped = clamp_range_to_content_columns(r, 1, &[2, 2]).unwrap();
+        assert_eq!(
+            clamped.start,
+            Position {
+                line: 1,
+                character: 2
+            }
+        );
+        assert_eq!(
+            clamped.end,
+            Position {
+                line: 2,
+                character: 5
+            }
+        );
+    }
+
+    #[test]
+    fn content_clamp_skips_prefix_only_selection() {
+        // Whole selection lies within the `> ` prefix of one line → after
+        // clamping both endpoints to col 2 the range is empty → skipped.
+        let r = pos_range(1, 0, 1, 1);
+        assert!(clamp_range_to_content_columns(r, 1, &[2, 2]).is_none());
     }
 
     #[test]

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -123,10 +123,19 @@ impl Kakehashi {
                 continue;
             }
 
+            // Resolve aggregation under "textDocument/formatting", not
+            // "textDocument/rangeFormatting". Range formatting is the
+            // partial-document counterpart of full formatting and shares its
+            // server priorities and strategy (see ADR-0008, which groups the
+            // two). There is no separate rangeFormatting config key, and
+            // `resolve_aggregation_entry` only falls back method → `_`
+            // wildcard — never formatting → rangeFormatting — so keying off
+            // "textDocument/rangeFormatting" would silently ignore a user's
+            // "textDocument/formatting" configuration.
             let agg = self.resolve_aggregation_config(
                 &language_name,
                 &resolved.injection_language,
-                "textDocument/rangeFormatting",
+                "textDocument/formatting",
             );
             let region_ctx = DocumentRequestContext {
                 uri: uri.clone(),

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -207,14 +207,15 @@ impl Kakehashi {
 /// a single-line request into later injection regions); a line past EOF clamps
 /// to the document end.
 ///
-/// `start.min(end)` guards against an inverted result: a malformed client may
-/// send `start` after `end`, and clamping the start's line could otherwise
-/// push it past an in-bounds end. A collapsed (empty) range is skipped
-/// harmlessly by `clip_request_to_region`.
+/// A malformed client may send `start` after `end` (or clamping the start's
+/// line could push it past an in-bounds end). We normalize such an inverted
+/// pair to `[min, max]` rather than collapsing it to an empty range — the two
+/// positions still describe the span the user selected, so formatting it is
+/// more useful than silently doing nothing.
 fn clamp_request_to_document(mapper: &PositionMapper, range: Range) -> std::ops::Range<usize> {
     let start = mapper.position_to_byte_clamped(range.start);
     let end = mapper.position_to_byte_clamped(range.end);
-    start.min(end)..end
+    start.min(end)..start.max(end)
 }
 
 /// Intersect a request's byte range with a region's byte range and map the
@@ -313,15 +314,17 @@ mod tests {
     }
 
     #[test]
-    fn request_bytes_never_inverts_when_start_is_after_end() {
-        // Malformed client: start positioned after end. The result must not
-        // invert (start <= end) so downstream clipping behaves sanely.
+    fn request_bytes_normalizes_inverted_range_to_forward_span() {
+        // Malformed client: start positioned after end. The pair is
+        // normalized to [min, max] (the span the user selected) rather than
+        // collapsing to an empty range, so formatting still happens.
+        // "first line\n" is 11 bytes; (0,2) -> byte 2, (1,5) -> byte 16.
         let text = "first line\nsecond line\n";
         let mapper = PositionMapper::new(text);
         let range = pos_range(1, 5, 0, 2);
 
         let bytes = clamp_request_to_document(&mapper, range);
-        assert!(bytes.start <= bytes.end, "byte range must not invert");
+        assert_eq!(bytes, 2..16);
     }
 
     #[test]

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -70,7 +70,7 @@ impl Kakehashi {
 
         let all_regions = InjectionResolver::resolve_all(
             &self.language,
-            self.bridge.region_id_tracker(),
+            self.bridge.node_tracker(),
             &uri,
             snapshot.tree(),
             snapshot.text(),

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -1,0 +1,399 @@
+//! `textDocument/rangeFormatting` handler.
+//!
+//! Range formatting is the partial-document counterpart of full formatting:
+//! it carries a `Range` and is expected to return edits that only modify
+//! that range. Implementation reuses the full-formatting fan-out shape (one
+//! `dispatch_preferred` per injection region) but pre-filters regions to
+//! those that overlap the requested range and **clips the request range to
+//! each region's bounds** before dispatching. Without that clip, an
+//! injection that the request only partially covers would be asked to
+//! format outside the user's selection.
+//!
+//! Edits returned for non-overlapping regions are skipped entirely.
+
+use std::sync::Arc;
+
+use tokio::task::JoinSet;
+use tower_lsp_server::jsonrpc::Result;
+use tower_lsp_server::ls_types::{DocumentRangeFormattingParams, Position, Range, TextEdit};
+
+use crate::language::InjectionResolver;
+use crate::lsp::aggregation::server::FanInResult;
+use crate::lsp::aggregation::server::dispatch_preferred;
+use crate::lsp::lsp_impl::bridge_context::DocumentRequestContext;
+use crate::text::PositionMapper;
+
+use super::super::{Kakehashi, uri_to_url};
+use super::formatting::finalize_formatting_edits;
+
+impl Kakehashi {
+    pub(crate) async fn range_formatting_impl(
+        &self,
+        params: DocumentRangeFormattingParams,
+    ) -> Result<Option<Vec<TextEdit>>> {
+        let lsp_uri = params.text_document.uri;
+        let options = params.options;
+        let host_range = params.range;
+
+        let Ok(uri) = uri_to_url(&lsp_uri) else {
+            log::warn!("Invalid URI in rangeFormatting: {}", lsp_uri.as_str());
+            return Ok(None);
+        };
+
+        log::debug!("rangeFormatting called for {} range {:?}", uri, host_range);
+
+        let snapshot = match self.documents.get(&uri) {
+            None => {
+                log::debug!("rangeFormatting: No document found for {}", uri);
+                return Ok(None);
+            }
+            Some(doc) => match doc.snapshot() {
+                None => {
+                    log::debug!(
+                        "rangeFormatting: Document not fully initialized for {}",
+                        uri
+                    );
+                    return Ok(None);
+                }
+                Some(snapshot) => snapshot,
+            },
+        };
+
+        let Some(language_name) = self.document_language(&uri) else {
+            log::debug!(target: "kakehashi::rangeFormatting", "No language detected");
+            return Ok(None);
+        };
+
+        let Some(injection_query) = self.language.injection_query(&language_name) else {
+            return Ok(None);
+        };
+
+        let all_regions = InjectionResolver::resolve_all(
+            &self.language,
+            self.bridge.region_id_tracker(),
+            &uri,
+            snapshot.tree(),
+            snapshot.text(),
+            injection_query.as_ref(),
+        );
+
+        if all_regions.is_empty() {
+            return Ok(None);
+        }
+
+        let upstream_request_id = crate::lsp::current_upstream_id();
+        let cancel_state = self.setup_formatting_cancel_token(upstream_request_id.as_ref());
+        let pool = self.bridge.pool_arc();
+
+        // Byte-level overlap pre-check uses the actual host text. The
+        // line-only `clip_request_range_to_region` below is correct for
+        // multi-line injections (code fences etc., `start_column == 0`),
+        // but for inline injections (`start_column > 0`, e.g. backtick
+        // code inside a markdown paragraph) it would treat the same line
+        // as overlapping even when the request is entirely before the
+        // injected content. Using the region's `byte_range` against the
+        // request's byte span filters those out before we ask a
+        // downstream formatter for a zero-width / before-injection range.
+        let mapper = PositionMapper::new(snapshot.text());
+        let request_bytes = mapper
+            .position_to_byte(host_range.start)
+            .zip(mapper.position_to_byte(host_range.end))
+            .map(|(start, end)| start..end);
+
+        let mut outer_join_set: JoinSet<Option<Vec<TextEdit>>> = JoinSet::new();
+
+        for resolved in all_regions {
+            // Skip regions whose host byte range does not actually overlap
+            // the request — protects against inline-injection
+            // false-positives that the line-only clip below would miss.
+            if let Some(ref req_bytes) = request_bytes
+                && (req_bytes.end <= resolved.region.byte_range.start
+                    || req_bytes.start >= resolved.region.byte_range.end)
+            {
+                continue;
+            }
+
+            // Clip the editor-supplied range to this region's host line
+            // bounds. After the byte-level overlap check above, this is
+            // safe to do in line space — any column saturation inside
+            // `translate_host_range_to_virtual` only fires on partial
+            // overlaps that already passed the byte check.
+            let Some(clipped_host_range) = clip_request_range_to_region(
+                host_range,
+                resolved.region.line_range.start,
+                resolved.region.line_range.end,
+            ) else {
+                continue;
+            };
+
+            let configs = self.bridge_configs_for_injection_language(
+                &language_name,
+                &resolved.injection_language,
+            );
+            if configs.is_empty() {
+                continue;
+            }
+
+            let agg = self.resolve_aggregation_config(
+                &language_name,
+                &resolved.injection_language,
+                "textDocument/rangeFormatting",
+            );
+            let region_ctx = DocumentRequestContext {
+                uri: uri.clone(),
+                resolved,
+                configs,
+                upstream_request_id: upstream_request_id.clone(),
+                priorities: agg.priorities,
+                strategy: agg.strategy,
+                max_fan_out: agg.max_fan_out,
+            };
+            let pool = Arc::clone(&pool);
+            let options = options.clone();
+            let region_cancel_rx = cancel_state.derive_receiver();
+
+            outer_join_set.spawn(async move {
+                let result = dispatch_preferred(
+                    &region_ctx,
+                    pool.clone(),
+                    move |t| {
+                        let options = options.clone();
+                        async move {
+                            t.pool
+                                .send_range_formatting_request(
+                                    &t.server_name,
+                                    &t.server_config,
+                                    &t.uri,
+                                    &t.injection_language,
+                                    &t.region_id,
+                                    t.offset,
+                                    &t.virtual_content,
+                                    clipped_host_range,
+                                    options,
+                                    t.upstream_id,
+                                )
+                                .await
+                        }
+                    },
+                    // Same semantics as full formatting: `Some(vec![])` is
+                    // an authoritative "no edits needed" (e.g., the range is
+                    // already perfectly formatted) — keep it and stop. `None`
+                    // means "no response" and falls through to lower-priority
+                    // servers.
+                    |opt| opt.is_some(),
+                    region_cancel_rx,
+                )
+                .await;
+                match result {
+                    FanInResult::Done(edits) => edits,
+                    FanInResult::NoResult { .. } | FanInResult::Cancelled => None,
+                }
+            });
+        }
+
+        let response = finalize_formatting_edits(outer_join_set, cancel_state.token.clone()).await;
+        pool.unregister_all_for_upstream_id(upstream_request_id.as_ref());
+        response
+    }
+}
+
+/// Clip an editor-supplied `Range` to a region's host-line bounds.
+///
+/// `region_line_lo..region_line_hi_exclusive` describes the region's host
+/// line span (matching `CacheableInjectionRegion::line_range`, which is
+/// half-open). Returns `None` when the request range does not overlap the
+/// region at all — the handler skips such regions outright.
+///
+/// Overlap is computed in line space using half-open intervals:
+///
+/// - Region span: `[region_line_lo, region_line_hi_exclusive)`
+/// - Request span: `[req.start.line, req.end.line)` when `req.end.character == 0`;
+///   otherwise `[req.start.line, req.end.line + 1)` so a selection ending
+///   mid-line still counts that line as covered.
+///
+/// The returned range preserves the request's endpoints whenever they lie
+/// inside the region; endpoints that fall outside snap to the region's
+/// boundary at column 0 (start of the boundary line).
+fn clip_request_range_to_region(
+    request: Range,
+    region_line_lo: u32,
+    region_line_hi_exclusive: u32,
+) -> Option<Range> {
+    let req_lo = request.start.line;
+    // Per LSP, `Range.end` is exclusive. When `end.character == 0`, the end
+    // sits at the start of a line — that line is NOT included in the
+    // selection. For all other end characters, the end line IS covered.
+    let req_hi_exclusive = if request.end.character == 0 {
+        request.end.line
+    } else {
+        request.end.line.saturating_add(1)
+    };
+
+    let clipped_lo = req_lo.max(region_line_lo);
+    let clipped_hi_exclusive = req_hi_exclusive.min(region_line_hi_exclusive);
+
+    if clipped_lo >= clipped_hi_exclusive {
+        return None;
+    }
+
+    let clipped_start = if clipped_lo == req_lo {
+        request.start
+    } else {
+        Position {
+            line: clipped_lo,
+            character: 0,
+        }
+    };
+    let clipped_end = if clipped_hi_exclusive == req_hi_exclusive {
+        request.end
+    } else {
+        Position {
+            line: clipped_hi_exclusive,
+            character: 0,
+        }
+    };
+
+    Some(Range {
+        start: clipped_start,
+        end: clipped_end,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower_lsp_server::ls_types::Position;
+
+    fn range(start_line: u32, start_char: u32, end_line: u32, end_char: u32) -> Range {
+        Range {
+            start: Position {
+                line: start_line,
+                character: start_char,
+            },
+            end: Position {
+                line: end_line,
+                character: end_char,
+            },
+        }
+    }
+
+    #[test]
+    fn clip_returns_request_unchanged_when_fully_inside_region() {
+        let clipped = clip_request_range_to_region(range(5, 2, 9, 4), 3, 12).unwrap();
+        assert_eq!(
+            clipped.start,
+            Position {
+                line: 5,
+                character: 2
+            }
+        );
+        assert_eq!(
+            clipped.end,
+            Position {
+                line: 9,
+                character: 4
+            }
+        );
+    }
+
+    #[test]
+    fn clip_snaps_start_when_request_begins_before_region() {
+        // Request: lines 0..10; region: lines 4..15. Start clipped to (4, 0).
+        let clipped = clip_request_range_to_region(range(0, 0, 10, 0), 4, 15).unwrap();
+        assert_eq!(
+            clipped.start,
+            Position {
+                line: 4,
+                character: 0
+            }
+        );
+        assert_eq!(
+            clipped.end,
+            Position {
+                line: 10,
+                character: 0
+            }
+        );
+    }
+
+    #[test]
+    fn clip_snaps_end_when_request_extends_past_region() {
+        // Request: lines 2..20; region: lines 0..12. End clipped to (12, 0).
+        let clipped = clip_request_range_to_region(range(2, 0, 20, 5), 0, 12).unwrap();
+        assert_eq!(
+            clipped.start,
+            Position {
+                line: 2,
+                character: 0
+            }
+        );
+        assert_eq!(
+            clipped.end,
+            Position {
+                line: 12,
+                character: 0
+            }
+        );
+    }
+
+    #[test]
+    fn clip_returns_none_when_request_is_entirely_before_region() {
+        let clipped = clip_request_range_to_region(range(0, 0, 3, 0), 5, 10);
+        assert!(clipped.is_none(), "no overlap → no work");
+    }
+
+    #[test]
+    fn clip_returns_none_when_request_is_entirely_after_region() {
+        let clipped = clip_request_range_to_region(range(20, 0, 25, 0), 5, 10);
+        assert!(clipped.is_none(), "no overlap → no work");
+    }
+
+    #[test]
+    fn clip_returns_none_when_request_touches_region_boundary_at_start() {
+        // Request: lines 0..5 with end.character == 0 → covers [0, 5),
+        // region: [5, 10). No overlap.
+        let clipped = clip_request_range_to_region(range(0, 0, 5, 0), 5, 10);
+        assert!(clipped.is_none());
+    }
+
+    #[test]
+    fn clip_covers_single_line_with_mid_line_end_character() {
+        // Request: line 3, characters 0..5 → covers line 3.
+        // Region: lines 3..4. Overlap covers exactly line 3.
+        let clipped = clip_request_range_to_region(range(3, 0, 3, 5), 3, 4).unwrap();
+        assert_eq!(
+            clipped.start,
+            Position {
+                line: 3,
+                character: 0
+            }
+        );
+        assert_eq!(
+            clipped.end,
+            Position {
+                line: 3,
+                character: 5
+            }
+        );
+    }
+
+    #[test]
+    fn clip_snaps_both_endpoints_when_request_spans_region() {
+        // Request: lines 0..100; region: lines 10..20. Result: (10,0)..(20,0).
+        let clipped = clip_request_range_to_region(range(0, 0, 100, 0), 10, 20).unwrap();
+        assert_eq!(
+            clipped.start,
+            Position {
+                line: 10,
+                character: 0
+            }
+        );
+        assert_eq!(
+            clipped.end,
+            Position {
+                line: 20,
+                character: 0
+            }
+        );
+    }
+}

--- a/src/text/position.rs
+++ b/src/text/position.rs
@@ -31,6 +31,38 @@ impl PositionMapper {
         Some(text_size.into())
     }
 
+    /// Convert an LSP `Position` to a byte offset, clamping out-of-bounds
+    /// positions to the nearest valid offset.
+    ///
+    /// `position_to_byte` does not guard either bound: a `character` past a
+    /// line's end yields a byte offset running past that line (it is computed
+    /// as `line_start + character`), and a `line` past EOF yields `None`.
+    /// Both must be reined in, and *differently*:
+    /// - **character past the line's end** → clamp to the end of that line
+    ///   (`line(l).end()`, which is the start of the next line, i.e. just
+    ///   past this line's terminator). The request stays within its own line
+    ///   and never reaches a later line's content or injection region —
+    ///   unlike snapping to the document end, which would.
+    /// - **line past the last line** → clamp to the document's end.
+    ///
+    /// An in-bounds position maps exactly (identical to `position_to_byte`):
+    /// the largest in-bounds offset on a line is its end-of-content, which is
+    /// `<= line(l).end()`, so the `min` never alters it.
+    pub fn position_to_byte_clamped(&self, position: Position) -> usize {
+        match self.line_index.line(position.line) {
+            // Line exists: take the mapped offset but clamp it to the line's
+            // end so an over-long character can't spill past this line.
+            Some(line_range) => {
+                let line_end: usize = line_range.end().into();
+                self.position_to_byte(position)
+                    .unwrap_or(line_end)
+                    .min(line_end)
+            }
+            // The line itself is past EOF: clamp to the document end.
+            None => self.line_index.len().into(),
+        }
+    }
+
     /// Convert byte offset to LSP Position
     pub fn byte_to_position(&self, offset: usize) -> Option<Position> {
         // Convert byte offset to LineCol
@@ -189,6 +221,37 @@ mod tests {
         assert_eq!(
             mapper.position_to_byte(tower_lsp_server::ls_types::Position::new(0, 12)),
             Some(18)
+        );
+    }
+
+    #[test]
+    fn clamped_maps_in_bounds_position_exactly() {
+        let text = "hello\nworld\n";
+        let mapper = PositionMapper::new(text);
+        assert_eq!(
+            mapper.position_to_byte_clamped(Position::new(1, 2)),
+            mapper.position_to_byte(Position::new(1, 2)).unwrap()
+        );
+    }
+
+    #[test]
+    fn clamped_snaps_overlong_character_to_line_end_not_document_end() {
+        // Line 0 is "hello\n" (bytes 0..6); `line(0).end()` is byte 6, the
+        // start of line 1. A character far past the line end clamps there —
+        // within line 0's bounds, NOT the document end (12) — so a
+        // single-line range can never spill into later lines.
+        let text = "hello\nworld\n";
+        let mapper = PositionMapper::new(text);
+        assert_eq!(mapper.position_to_byte_clamped(Position::new(0, 999)), 6);
+    }
+
+    #[test]
+    fn clamped_snaps_line_past_eof_to_document_end() {
+        let text = "hello\nworld\n";
+        let mapper = PositionMapper::new(text);
+        assert_eq!(
+            mapper.position_to_byte_clamped(Position::new(99, 0)),
+            text.len()
         );
     }
 

--- a/tests/e2e_lsp_lua_range_formatting.rs
+++ b/tests/e2e_lsp_lua_range_formatting.rs
@@ -111,19 +111,27 @@ fn e2e_range_formatting_request_returns_host_coordinate_edits() {
             .expect("range formatting result must be null or TextEdit[]");
         println!("E2E: Got {} TextEdit(s)", edits.len());
 
-        // Code fence opens on host line 2 (after "# Test Document\n\n```lua\n").
-        // Every returned edit's start must land at or after line 2 — any
-        // earlier line would indicate a coordinate-translation bug. The
-        // requested range ended at line 5, so an edit at line >= 6 would
-        // mean the formatter overran our request.
+        // Host line layout:
+        //   line 0: "# Test Document"
+        //   line 1: ""
+        //   line 2: "```lua"          ← fence open (NOT inside the injection)
+        //   line 3: "local  x   =   1" ← injected lua, content line
+        //   line 4: "local y=2"        ← injected lua, content line
+        //   line 5: "```"              ← fence close (NOT inside the injection)
+        //
+        // The request range is (3, 0)..(5, 0): exclusive at line 5, so
+        // valid edit starts cover only lines 3..=4. Allowing line 2 or 5
+        // would mean a range-clipping / coordinate-translation bug
+        // produced edits outside the user's selection. Allowing line < 2
+        // would mean the bridge translated past the fence open.
         for edit in edits {
             let start_line = edit["range"]["start"]["line"]
                 .as_u64()
                 .expect("TextEdit.range.start.line must be a number");
             assert!(
-                (2..=5).contains(&start_line),
-                "Edit must land inside the code fence and within the requested range \
-                 (expected 2..=5, got {}). Full edit: {:?}",
+                (3..=4).contains(&start_line),
+                "Edit must land on a content line inside the user's selection \
+                 (expected 3..=4, got {}). Full edit: {:?}",
                 start_line,
                 edit
             );

--- a/tests/e2e_lsp_lua_range_formatting.rs
+++ b/tests/e2e_lsp_lua_range_formatting.rs
@@ -1,0 +1,193 @@
+//! End-to-end test for Lua textDocument/rangeFormatting in Markdown code blocks
+//! via the kakehashi binary.
+//!
+//! This is the range-formatting counterpart to `e2e_lsp_lua_formatting.rs` and
+//! exercises the same bridge pipeline (injection resolution → virtual document
+//! → downstream LS → host coordinate translation) with the added requirement
+//! that the request and resulting edits respect a caller-supplied `Range`.
+//!
+//! Like the full-formatting E2E test, lua-language-server's stylua-style range
+//! formatting is best-effort; the test tolerates `null` / empty-array
+//! responses and only asserts host-coordinate correctness when edits are
+//! returned. The bridge swallows downstream method-not-found errors and
+//! surfaces them as `null` results, so any top-level JSON-RPC `error` on this
+//! request indicates a kakehashi routing/handler bug.
+//!
+//! Run with: `cargo test --test e2e_lsp_lua_range_formatting --features e2e`
+//!
+//! **Requirements**: lua-language-server must be installed and in PATH.
+
+#![cfg(feature = "e2e")]
+
+mod helpers;
+
+use helpers::lua_bridge::{
+    create_lua_configured_client, shutdown_client, skip_if_lua_ls_unavailable,
+};
+use serde_json::json;
+
+/// Default LSP `FormattingOptions` body — fixed tab size + spaces. Matches
+/// what most editors send out of the box; sufficient to exercise the bridge.
+fn default_formatting_options() -> serde_json::Value {
+    json!({ "tabSize": 4, "insertSpaces": true })
+}
+
+/// E2E test: range formatting through the bridge completes without errors
+/// and (if edits are returned) places every edit inside the host code-fence.
+///
+/// The request range covers the entire lua code fence interior (host lines
+/// 3..5 inclusive — the two `local` declarations).
+#[test]
+fn e2e_range_formatting_request_returns_host_coordinate_edits() {
+    if skip_if_lua_ls_unavailable() {
+        return;
+    }
+
+    let (mut client, _config_dir) = create_lua_configured_client();
+
+    // Deliberately badly-formatted lua inside a markdown code fence — gives
+    // the downstream formatter something to rewrite. The fence opens on line
+    // 2 of the host doc, so any returned TextEdit must reference line >= 2.
+    let markdown_content = "# Test Document\n\n```lua\nlocal  x   =   1\nlocal y=2\n```\n";
+
+    let markdown_uri = "file:///test_range_formatting.md";
+
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": markdown_uri,
+                "languageId": "markdown",
+                "version": 1,
+                "text": markdown_content
+            }
+        }),
+    );
+
+    // Give lua-ls time to process the virtual document didOpen.
+    std::thread::sleep(std::time::Duration::from_millis(1500));
+
+    let format_response = client.send_request(
+        "textDocument/rangeFormatting",
+        json!({
+            "textDocument": { "uri": markdown_uri },
+            // Cover both lua lines: from start of `local  x ...` to end of
+            // `local y=2`. End is exclusive of the closing fence line.
+            "range": {
+                "start": { "line": 3, "character": 0 },
+                "end":   { "line": 5, "character": 0 }
+            },
+            "options": default_formatting_options(),
+        }),
+    );
+
+    println!("Range formatting response: {:?}", format_response);
+
+    assert!(
+        format_response.get("id").is_some(),
+        "Response should have id field"
+    );
+
+    // Before the handler is wired, tower-lsp returns `method_not_found` as a
+    // top-level JSON-RPC error — exactly the failure mode this test guards
+    // against. Once the handler is implemented, the bridge converts any
+    // downstream `-32601` into a `null` result instead.
+    assert!(
+        format_response.get("error").is_none(),
+        "kakehashi must not surface a top-level error for textDocument/rangeFormatting; \
+         downstream errors are absorbed by the bridge. Got: {:?}",
+        format_response.get("error")
+    );
+
+    let result = format_response
+        .get("result")
+        .expect("Response should carry a result field");
+
+    if result.is_null() {
+        println!("E2E: Got null result (formatter signalled no edits)");
+    } else {
+        let edits = result
+            .as_array()
+            .expect("range formatting result must be null or TextEdit[]");
+        println!("E2E: Got {} TextEdit(s)", edits.len());
+
+        // Code fence opens on host line 2 (after "# Test Document\n\n```lua\n").
+        // Every returned edit's start must land at or after line 2 — any
+        // earlier line would indicate a coordinate-translation bug. The
+        // requested range ended at line 5, so an edit at line >= 6 would
+        // mean the formatter overran our request.
+        for edit in edits {
+            let start_line = edit["range"]["start"]["line"]
+                .as_u64()
+                .expect("TextEdit.range.start.line must be a number");
+            assert!(
+                (2..=5).contains(&start_line),
+                "Edit must land inside the code fence and within the requested range \
+                 (expected 2..=5, got {}). Full edit: {:?}",
+                start_line,
+                edit
+            );
+        }
+    }
+
+    shutdown_client(&mut client);
+}
+
+/// E2E test: range formatting on a markdown document with no injection
+/// regions returns `null` (no regions to format).
+#[test]
+fn e2e_range_formatting_without_injections_returns_null() {
+    if skip_if_lua_ls_unavailable() {
+        return;
+    }
+
+    let (mut client, _config_dir) = create_lua_configured_client();
+
+    let markdown_content = "# Plain markdown\n\nNo code blocks here.\n";
+    let markdown_uri = "file:///test_range_formatting_plain.md";
+
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": markdown_uri,
+                "languageId": "markdown",
+                "version": 1,
+                "text": markdown_content
+            }
+        }),
+    );
+
+    let format_response = client.send_request(
+        "textDocument/rangeFormatting",
+        json!({
+            "textDocument": { "uri": markdown_uri },
+            "range": {
+                "start": { "line": 0, "character": 0 },
+                "end":   { "line": 2, "character": 0 }
+            },
+            "options": default_formatting_options(),
+        }),
+    );
+
+    println!(
+        "Range formatting (no injections) response: {:?}",
+        format_response
+    );
+
+    assert!(
+        format_response.get("error").is_none(),
+        "Should not error for markdown without injections"
+    );
+
+    let result = format_response
+        .get("result")
+        .expect("Response should carry a result field");
+    assert!(
+        result.is_null(),
+        "Range formatting without injections must return null, got {:?}",
+        result
+    );
+
+    shutdown_client(&mut client);
+}

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -20,27 +20,34 @@ use std::time::{Duration, Instant};
 /// Mirrors the `cfg(test)` redirection done inside the lib (see
 /// `kakehashi::install::default_data_dir`). Lives under `deps/`
 /// (already gitignored). Parser/query installs persist across runs to
-/// avoid re-downloading; crash-recovery state files
-/// (`parsing_in_progress`, `failed_parsers`) are cleared once per test
-/// process at first call so a prior E2E shutdown can't poison this run.
+/// avoid re-downloading.
+///
+/// The expensive, idempotent setup (dir creation + parser/query install) is
+/// cached once per process via `OnceLock`. The transient crash-recovery files
+/// (`parsing_in_progress`, `failed_parsers`), however, are cleared on **every**
+/// call — i.e. before every client spawn — not just the first: an E2E binary
+/// spawns several clients in one process, and a client that shuts down
+/// mid-parse leaves those files behind, which would otherwise poison later
+/// clients in the same binary.
 ///
 /// We always set `KAKEHASHI_DATA_DIR` on the spawned binary to this
 /// path — the binary itself runs without `cfg(test)`, so it cannot
 /// auto-redirect like lib unit tests do.
 fn test_data_dir() -> &'static Path {
     static DIR: OnceLock<PathBuf> = OnceLock::new();
-    DIR.get_or_init(|| {
+    let dir = DIR.get_or_init(|| {
         // Shares the same path and install logic as the lib-side
         // `kakehashi::install::test_data_dir` so unit tests and
         // E2E-spawned binaries reuse one cached parser/query install.
         let dir = kakehashi::install::test_support::test_data_dir_path();
         let _ = std::fs::create_dir_all(&dir);
-        let _ = std::fs::remove_file(dir.join("parsing_in_progress"));
-        let _ = std::fs::remove_file(dir.join("failed_parsers"));
         let _ = kakehashi::install::test_support::ensure_test_languages_installed(&dir);
         dir
-    })
-    .as_path()
+    });
+    // Clear crash-recovery state before every spawn, not just the first.
+    let _ = std::fs::remove_file(dir.join("parsing_in_progress"));
+    let _ = std::fs::remove_file(dir.join("failed_parsers"));
+    dir.as_path()
 }
 
 /// LSP client for communicating with kakehashi binary.

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -96,19 +96,24 @@ impl LspClientBuilder {
     pub fn build(self) -> LspClient {
         let mut cmd = Command::new(env!("CARGO_BIN_EXE_kakehashi"));
         cmd.args(&self.args)
-            // Isolate the spawned binary from the developer's real
-            // platform data dir before any user-supplied env / args
-            // override takes effect.
-            .env("KAKEHASHI_DATA_DIR", test_data_dir())
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
-        for (key, value) in &self.envs {
-            cmd.env(key, value);
-        }
+        // Order matters for isolation. Apply removals to the *inherited*
+        // environment first, then set the isolation default, then explicit
+        // per-test values. This way `.env_remove("KAKEHASHI_DATA_DIR")` (used
+        // by tests that exercise the "no env var" config path) drops only the
+        // developer's inherited value — the default below still keeps the
+        // spawned binary off the real platform data dir. Were removals applied
+        // last, they would strip the isolation default and the binary would
+        // fall back to the developer/platform data dir.
         for key in &self.env_removes {
             cmd.env_remove(key);
+        }
+        cmd.env("KAKEHASHI_DATA_DIR", test_data_dir());
+        for (key, value) in &self.envs {
+            cmd.env(key, value);
         }
 
         let mut child = cmd.spawn().expect("Failed to spawn kakehashi binary");

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -9,8 +9,39 @@
 
 use serde_json::{Value, json};
 use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
+
+/// Project-local persistent data directory used by every spawned
+/// `kakehashi` binary in this test process.
+///
+/// Mirrors the `cfg(test)` redirection done inside the lib (see
+/// `kakehashi::install::default_data_dir`). Lives under `deps/`
+/// (already gitignored). Parser/query installs persist across runs to
+/// avoid re-downloading; crash-recovery state files
+/// (`parsing_in_progress`, `failed_parsers`) are cleared once per test
+/// process at first call so a prior E2E shutdown can't poison this run.
+///
+/// We always set `KAKEHASHI_DATA_DIR` on the spawned binary to this
+/// path — the binary itself runs without `cfg(test)`, so it cannot
+/// auto-redirect like lib unit tests do.
+fn test_data_dir() -> &'static Path {
+    static DIR: OnceLock<PathBuf> = OnceLock::new();
+    DIR.get_or_init(|| {
+        // Shares the same path and install logic as the lib-side
+        // `kakehashi::install::test_data_dir` so unit tests and
+        // E2E-spawned binaries reuse one cached parser/query install.
+        let dir = kakehashi::install::test_support::test_data_dir_path();
+        let _ = std::fs::create_dir_all(&dir);
+        let _ = std::fs::remove_file(dir.join("parsing_in_progress"));
+        let _ = std::fs::remove_file(dir.join("failed_parsers"));
+        let _ = kakehashi::install::test_support::ensure_test_languages_installed(&dir);
+        dir
+    })
+    .as_path()
+}
 
 /// LSP client for communicating with kakehashi binary.
 ///
@@ -65,6 +96,10 @@ impl LspClientBuilder {
     pub fn build(self) -> LspClient {
         let mut cmd = Command::new(env!("CARGO_BIN_EXE_kakehashi"));
         cmd.args(&self.args)
+            // Isolate the spawned binary from the developer's real
+            // platform data dir before any user-supplied env / args
+            // override takes effect.
+            .env("KAKEHASHI_DATA_DIR", test_data_dir())
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
@@ -108,7 +143,8 @@ impl LspClient {
         // `CARGO_BIN_EXE_kakehashi` is set by Cargo's test harness for integration tests
         // and points to the built `kakehashi` binary, so we don't hardcode its path here.
         let mut cmd = Command::new(env!("CARGO_BIN_EXE_kakehashi"));
-        cmd.stdin(Stdio::piped())
+        cmd.env("KAKEHASHI_DATA_DIR", test_data_dir())
+            .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 

--- a/tests/snapshots/e2e_lsp_protocol__initialize_capabilities.snap
+++ b/tests/snapshots/e2e_lsp_protocol__initialize_capabilities.snap
@@ -35,6 +35,7 @@ expression: capabilities
   "documentHighlightProvider": true,
   "documentSymbolProvider": true,
   "documentFormattingProvider": true,
+  "documentRangeFormattingProvider": true,
   "renameProvider": {
     "prepareProvider": true
   },


### PR DESCRIPTION
## Summary

- Implement `textDocument/rangeFormatting` end-to-end through the bridge: handler resolves all injection regions overlapping the editor-supplied range, clips the range to each region's host bounds, and dispatches a range-formatting request to the matching downstream LS in parallel.
- Tidy First: extract `setup_formatting_cancel_token` / `FormattingCancelState` / `finalize_formatting_edits` from the existing `formatting_impl` so both full- and range-formatting handlers share the multi-consumer cancel pattern and the collect+sort+wrap epilogue.
- Drive-by: harden the `did_open_parses_before_eager_opening_injected_virtual_documents` test against leftover `parsing_in_progress` / `failed_parsers` state in the shared platform data dir. The test had a pre-existing intermittent failure when run after an E2E suite that exited mid-parse.

## Behavior notes

- Per-region fan-out: N regions → N parallel `dispatch_preferred` calls. Each region uses its own virtual document (independent ULID-keyed URI).
- Range is clipped to each region's host line span (`clip_request_range_to_region`); non-overlapping regions are skipped without dispatching.
- Downstream-side range honoring: the bridge **asks** for `textDocument/rangeFormatting` with the (clipped, virtual) range. Well-behaved LSs format only that range; we do not post-filter response edits by request range (we still drop edits past virtual EOF to protect host content outside the injection).
- Always sends `textDocument/rangeFormatting` even when the clipped range covers a whole region. A future optimization could fall back to `textDocument/formatting` for that case to widen LS support, but it's out of scope here.
- Markdown text between two formatted code blocks is **not** formatted — kakehashi only ever forwards to injection-language servers.
- Cancel propagation: one `\$/cancelRequest` triggers a cloneable `CancellationToken` that aborts every region's per-server `JoinSet` simultaneously, not after the slowest formatter completes naturally.

## Capabilities

`initialize` now advertises `documentRangeFormattingProvider: true`. Snapshot updated.

## Test plan

- [x] `make test` — 1477 lib tests pass (formatting subset: 53/53).
- [x] `cargo test --features e2e --test e2e_lsp_lua_range_formatting` — 2 new E2E tests cover (a) markdown→lua range formatting through the bridge with host-coordinate edits inside the requested range, (b) markdown with no injections returns null. Skips gracefully when `lua-language-server` isn't installed.
- [x] `cargo test --features e2e --test e2e_lsp_lua_formatting` — full-formatting E2E still green.
- [x] `cargo test --features e2e --test e2e_lsp_protocol` — capability snapshot regenerated for `documentRangeFormattingProvider`.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.

## Commits

1. `fix(test): isolate did_open test from leftover crash-recovery state` — independent test isolation hardening.
2. `refactor(formatting): extract shared cancel-token + finalize helpers` — Tidy First, no behavior change (133+/68-).
3. `feat(lsp): implement textDocument/rangeFormatting via bridge` — the feature.