### PR TITLE
feat(lsp): full-format injection region when rangeFormatting covers it

### DIFF
--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -10,6 +10,13 @@
 //!
 //! Regions whose byte range is disjoint from the request are skipped
 //! entirely; no downstream request is sent.
+//!
+//! When the request fully covers a region (its byte span encloses the whole
+//! `byte_range`), the handler dispatches a full `textDocument/formatting`
+//! request for that region instead of `rangeFormatting`: the two are
+//! equivalent when the entire injected document is selected, and full
+//! formatting is also honored by downstream servers that implement
+//! `formatting` but not `rangeFormatting`.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -136,6 +143,13 @@ impl Kakehashi {
                 continue;
             };
 
+            // When the request encloses the whole region, format the entire
+            // virtual document instead of range-formatting the clipped span:
+            // the two are equivalent here, and a full-format request is also
+            // honored by downstream servers that support `formatting` but not
+            // `rangeFormatting`.
+            let covers_region = request_covers_region(&request_bytes, &resolved.region.byte_range);
+
             let configs = self.bridge_configs_for_injection_language(
                 &language_name,
                 &resolved.injection_language,
@@ -178,20 +192,36 @@ impl Kakehashi {
                     move |t| {
                         let options = options.clone();
                         async move {
-                            t.pool
-                                .send_range_formatting_request(
-                                    &t.server_name,
-                                    &t.server_config,
-                                    &t.uri,
-                                    &t.injection_language,
-                                    &t.region_id,
-                                    t.offset,
-                                    &t.virtual_content,
-                                    clipped_host_range,
-                                    options,
-                                    t.upstream_id,
-                                )
-                                .await
+                            if covers_region {
+                                t.pool
+                                    .send_formatting_request(
+                                        &t.server_name,
+                                        &t.server_config,
+                                        &t.uri,
+                                        &t.injection_language,
+                                        &t.region_id,
+                                        t.offset,
+                                        &t.virtual_content,
+                                        options,
+                                        t.upstream_id,
+                                    )
+                                    .await
+                            } else {
+                                t.pool
+                                    .send_range_formatting_request(
+                                        &t.server_name,
+                                        &t.server_config,
+                                        &t.uri,
+                                        &t.injection_language,
+                                        &t.region_id,
+                                        t.offset,
+                                        &t.virtual_content,
+                                        clipped_host_range,
+                                        options,
+                                        t.upstream_id,
+                                    )
+                                    .await
+                            }
                         }
                     },
                     // Same semantics as full formatting: `Some(vec![])` is
@@ -268,6 +298,21 @@ fn clip_request_to_region(
     Some(Range { start, end })
 }
 
+/// Whether the request fully covers the injection region — i.e. the request's
+/// byte span encloses the region's entire `byte_range`.
+///
+/// When this holds, the user selected the whole injected document, so a full
+/// `textDocument/formatting` request is equivalent to range-formatting the
+/// clipped span — and is honored by downstream servers that implement
+/// `formatting` but not `rangeFormatting`. The handler dispatches full
+/// formatting in that case and range formatting otherwise.
+fn request_covers_region(
+    request_bytes: &std::ops::Range<usize>,
+    region_bytes: &std::ops::Range<usize>,
+) -> bool {
+    request_bytes.start <= region_bytes.start && request_bytes.end >= region_bytes.end
+}
+
 /// Clamp a clipped host range so neither endpoint sits inside an injection's
 /// stripped per-line prefix (e.g. the `> ` of a blockquoted code block).
 ///
@@ -332,6 +377,31 @@ mod tests {
     /// handler would use, so tests stay in sync with the helper's contract.
     fn bytes(mapper: &PositionMapper, range: Range) -> std::ops::Range<usize> {
         mapper.position_to_byte(range.start).unwrap()..mapper.position_to_byte(range.end).unwrap()
+    }
+
+    #[test]
+    fn covers_region_true_when_request_encloses_region() {
+        assert!(request_covers_region(&(0..100), &(10..20)));
+    }
+
+    #[test]
+    fn covers_region_true_when_request_equals_region() {
+        assert!(request_covers_region(&(10..20), &(10..20)));
+    }
+
+    #[test]
+    fn covers_region_false_when_request_starts_after_region_start() {
+        assert!(!request_covers_region(&(12..20), &(10..20)));
+    }
+
+    #[test]
+    fn covers_region_false_when_request_ends_before_region_end() {
+        assert!(!request_covers_region(&(10..18), &(10..20)));
+    }
+
+    #[test]
+    fn covers_region_false_for_partial_overlap() {
+        assert!(!request_covers_region(&(0..15), &(10..20)));
     }
 
     #[test]

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -127,28 +127,41 @@ impl Kakehashi {
         let mut outer_join_set: JoinSet<Option<Vec<TextEdit>>> = JoinSet::new();
 
         for resolved in all_regions {
-            let Some(clipped_host_range) =
-                clip_request_to_region(&request_bytes, &resolved.region.byte_range, &mapper)
-            else {
-                continue;
-            };
-            // The byte-range clip can still leave an endpoint inside a
-            // stripped per-line prefix (e.g. blockquoted code's `> `); pull
-            // both endpoints onto the actual injected content.
-            let Some(clipped_host_range) = clamp_range_to_content_columns(
-                clipped_host_range,
-                resolved.region.line_range.start,
-                &resolved.line_column_offsets,
-            ) else {
-                continue;
-            };
-
-            // When the request encloses the whole region, format the entire
-            // virtual document instead of range-formatting the clipped span:
-            // the two are equivalent here, and a full-format request is also
-            // honored by downstream servers that support `formatting` but not
-            // `rangeFormatting`.
-            let covers_region = request_covers_region(&request_bytes, &resolved.region.byte_range);
+            // Decide full-vs-range *before* any range-clipping work. When the
+            // request encloses the whole region we format the entire virtual
+            // document instead of range-formatting the clipped span: the two
+            // are equivalent here, and a full-format request is also honored by
+            // downstream servers that support `formatting` but not
+            // `rangeFormatting`. A covering request is always relevant to the
+            // region, so it must not be skipped by the clip/clamp guards (which
+            // only decide whether a *partial* selection has a sub-range to
+            // format).
+            let clipped_host_range =
+                if request_covers_region(&request_bytes, &resolved.region.byte_range) {
+                    // Full-formatting path: no sub-range needed.
+                    None
+                } else {
+                    let Some(clipped) = clip_request_to_region(
+                        &request_bytes,
+                        &resolved.region.byte_range,
+                        &mapper,
+                    ) else {
+                        continue;
+                    };
+                    // The byte-range clip can still leave an endpoint inside a
+                    // stripped per-line prefix (e.g. blockquoted code's `> `); pull
+                    // both endpoints onto the actual injected content. If the
+                    // selection lies entirely in prefix bytes the range collapses
+                    // and the region is skipped.
+                    let Some(clipped) = clamp_range_to_content_columns(
+                        clipped,
+                        resolved.region.line_range.start,
+                        &resolved.line_column_offsets,
+                    ) else {
+                        continue;
+                    };
+                    Some(clipped)
+                };
 
             let configs = self.bridge_configs_for_injection_language(
                 &language_name,
@@ -192,35 +205,40 @@ impl Kakehashi {
                     move |t| {
                         let options = options.clone();
                         async move {
-                            if covers_region {
-                                t.pool
-                                    .send_formatting_request(
-                                        &t.server_name,
-                                        &t.server_config,
-                                        &t.uri,
-                                        &t.injection_language,
-                                        &t.region_id,
-                                        t.offset,
-                                        &t.virtual_content,
-                                        options,
-                                        t.upstream_id,
-                                    )
-                                    .await
-                            } else {
-                                t.pool
-                                    .send_range_formatting_request(
-                                        &t.server_name,
-                                        &t.server_config,
-                                        &t.uri,
-                                        &t.injection_language,
-                                        &t.region_id,
-                                        t.offset,
-                                        &t.virtual_content,
-                                        clipped_host_range,
-                                        options,
-                                        t.upstream_id,
-                                    )
-                                    .await
+                            match clipped_host_range {
+                                // Partial selection: range-format the clipped span.
+                                Some(range) => {
+                                    t.pool
+                                        .send_range_formatting_request(
+                                            &t.server_name,
+                                            &t.server_config,
+                                            &t.uri,
+                                            &t.injection_language,
+                                            &t.region_id,
+                                            t.offset,
+                                            &t.virtual_content,
+                                            range,
+                                            options,
+                                            t.upstream_id,
+                                        )
+                                        .await
+                                }
+                                // Request covers the whole region: full-format it.
+                                None => {
+                                    t.pool
+                                        .send_formatting_request(
+                                            &t.server_name,
+                                            &t.server_config,
+                                            &t.uri,
+                                            &t.injection_language,
+                                            &t.region_id,
+                                            t.offset,
+                                            &t.virtual_content,
+                                            options,
+                                            t.upstream_id,
+                                        )
+                                        .await
+                                }
                             }
                         }
                     },

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -12,11 +12,13 @@
 //! entirely; no downstream request is sent.
 //!
 //! When the request fully covers a region (its byte span encloses the whole
-//! `byte_range`), the handler dispatches a full `textDocument/formatting`
-//! request for that region instead of `rangeFormatting`: the two are
-//! equivalent when the entire injected document is selected, and full
-//! formatting is also honored by downstream servers that implement
-//! `formatting` but not `rangeFormatting`.
+//! `byte_range`), the handler prefers a full `textDocument/formatting` request
+//! for that region: the two are equivalent when the entire injected document
+//! is selected, and full formatting is also honored by downstream servers that
+//! implement `formatting` but not `rangeFormatting`. If such a covering
+//! request finds the server has no `documentFormattingProvider` (full
+//! formatting returns no result), it falls back to `rangeFormatting` so
+//! range-only servers still format.
 
 use std::sync::Arc;
 use std::time::Duration;

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -129,41 +129,33 @@ impl Kakehashi {
         let mut outer_join_set: JoinSet<Option<Vec<TextEdit>>> = JoinSet::new();
 
         for resolved in all_regions {
-            // Decide full-vs-range *before* any range-clipping work. When the
-            // request encloses the whole region we format the entire virtual
-            // document instead of range-formatting the clipped span: the two
-            // are equivalent here, and a full-format request is also honored by
-            // downstream servers that support `formatting` but not
-            // `rangeFormatting`. A covering request is always relevant to the
-            // region, so it must not be skipped by the clip/clamp guards (which
-            // only decide whether a *partial* selection has a sub-range to
-            // format).
-            let clipped_host_range =
-                if request_covers_region(&request_bytes, &resolved.region.byte_range) {
-                    // Full-formatting path: no sub-range needed.
-                    None
-                } else {
-                    let Some(clipped) = clip_request_to_region(
-                        &request_bytes,
-                        &resolved.region.byte_range,
-                        &mapper,
-                    ) else {
-                        continue;
-                    };
-                    // The byte-range clip can still leave an endpoint inside a
-                    // stripped per-line prefix (e.g. blockquoted code's `> `); pull
-                    // both endpoints onto the actual injected content. If the
-                    // selection lies entirely in prefix bytes the range collapses
-                    // and the region is skipped.
-                    let Some(clipped) = clamp_range_to_content_columns(
-                        clipped,
-                        resolved.region.line_range.start,
-                        &resolved.line_column_offsets,
-                    ) else {
-                        continue;
-                    };
-                    Some(clipped)
-                };
+            // A covering request (its byte span encloses the whole region)
+            // prefers full formatting; a partial request range-formats the
+            // clipped span. Either way we compute the clipped+content-clamped
+            // host range: the partial path sends it, and the covering path
+            // keeps it as a fallback for servers that support `rangeFormatting`
+            // but not `formatting`. For a covering request, clipping against
+            // the region yields the whole region.
+            let is_covering = request_covers_region(&request_bytes, &resolved.region.byte_range);
+
+            let Some(clipped) =
+                clip_request_to_region(&request_bytes, &resolved.region.byte_range, &mapper)
+            else {
+                continue;
+            };
+            // The byte-range clip can still leave an endpoint inside a stripped
+            // per-line prefix (e.g. blockquoted code's `> `); pull both
+            // endpoints onto the actual injected content. A partial selection
+            // lying entirely in prefix bytes collapses and the region is
+            // skipped (a covering selection spans real content, so it never
+            // collapses).
+            let Some(clipped_host_range) = clamp_range_to_content_columns(
+                clipped,
+                resolved.region.line_range.start,
+                &resolved.line_column_offsets,
+            ) else {
+                continue;
+            };
 
             let configs = self.bridge_configs_for_injection_language(
                 &language_name,
@@ -207,41 +199,47 @@ impl Kakehashi {
                     move |t| {
                         let options = options.clone();
                         async move {
-                            match clipped_host_range {
-                                // Partial selection: range-format the clipped span.
-                                Some(range) => {
-                                    t.pool
-                                        .send_range_formatting_request(
-                                            &t.server_name,
-                                            &t.server_config,
-                                            &t.uri,
-                                            &t.injection_language,
-                                            &t.region_id,
-                                            t.offset,
-                                            &t.virtual_content,
-                                            range,
-                                            options,
-                                            t.upstream_id,
-                                        )
-                                        .await
-                                }
-                                // Request covers the whole region: full-format it.
-                                None => {
-                                    t.pool
-                                        .send_formatting_request(
-                                            &t.server_name,
-                                            &t.server_config,
-                                            &t.uri,
-                                            &t.injection_language,
-                                            &t.region_id,
-                                            t.offset,
-                                            &t.virtual_content,
-                                            options,
-                                            t.upstream_id,
-                                        )
-                                        .await
+                            // Covering request: prefer full formatting, but fall
+                            // back to rangeFormatting over the whole region when
+                            // the server has no `documentFormattingProvider`
+                            // (`Ok(None)`) — otherwise a range-only server would
+                            // format nothing. Errors propagate (no fallback);
+                            // `Ok(Some(_))` (incl. an empty edit list) is an
+                            // authoritative result.
+                            if is_covering {
+                                match t
+                                    .pool
+                                    .send_formatting_request(
+                                        &t.server_name,
+                                        &t.server_config,
+                                        &t.uri,
+                                        &t.injection_language,
+                                        &t.region_id,
+                                        t.offset.clone(),
+                                        &t.virtual_content,
+                                        options.clone(),
+                                        t.upstream_id.clone(),
+                                    )
+                                    .await
+                                {
+                                    Ok(None) => {} // fall through to rangeFormatting
+                                    other => return other,
                                 }
                             }
+                            t.pool
+                                .send_range_formatting_request(
+                                    &t.server_name,
+                                    &t.server_config,
+                                    &t.uri,
+                                    &t.injection_language,
+                                    &t.region_id,
+                                    t.offset,
+                                    &t.virtual_content,
+                                    clipped_host_range,
+                                    options,
+                                    t.upstream_id,
+                                )
+                                .await
                         }
                     },
                     // Same semantics as full formatting: `Some(vec![])` is


### PR DESCRIPTION
## Summary

Extends `textDocument/rangeFormatting`: when the requested range **fully covers** an injection region (its byte span encloses the region's entire `byte_range`), the handler now dispatches a full `textDocument/formatting` request for that region instead of `rangeFormatting`.

## Why

- When the whole injected document is selected, full formatting and range formatting are **equivalent**.
- A full-format request is additionally honored by downstream servers that implement `formatting` but **not** `rangeFormatting` — so selecting an entire code fence now formats even against range-formatting-less servers.
- Partial selections are unchanged: they keep using `rangeFormatting` with the clipped range.

## Implementation

- New pure predicate `request_covers_region(request_bytes, region_bytes)` — true when the request byte span encloses the region.
- The per-region dispatch closure branches on it: `send_formatting_request` when covered, `send_range_formatting_request` (clipped) otherwise.

## Tests

- 5 new unit tests for `request_covers_region` (enclosing / equal / starts-after / ends-before / partial-overlap).
- Existing e2e `e2e_lsp_lua_range_formatting` (whose selection covers the whole fence) now exercises the full-format path and **passes end-to-end against a real lua-language-server**.
- `make check` clean; full lib suite green.