### PR TITLE
feat(node-identity): layer-aware node keys to disambiguate host vs injected nodes (#313)

### DIFF
--- a/docs/architecture-decisions/lazy-node-identity-tracking.md
+++ b/docs/architecture-decisions/lazy-node-identity-tracking.md
@@ -79,7 +79,7 @@ This matches AST semantics: a `fenced_code_block` remains the "same" block when 
 Multiple nodes can share the same START byte position (e.g., a `document` node, `section` node, and `paragraph` node all starting at byte 0). To ensure unique identification, the `NodeTracker` uses a composite key:
 
 ```
-Key = (start_byte, end_byte, kind)
+Key = (start_byte, end_byte, kind, layer)
 ```
 
 | Field | Purpose |
@@ -87,15 +87,55 @@ Key = (start_byte, end_byte, kind)
 | `start_byte` | Primary identity anchor (per START-priority rule) |
 | `end_byte` | Disambiguates nested nodes at same start position |
 | `kind` | Disambiguates nodes with identical spans but different types |
+| `layer` | Disambiguates host vs injected nodes that share an identical span **and** kind (injection depth; `0` = host) |
 
 **Example**: At position 0-100, three nodes might exist:
-- `(0, 100, "document")` → ULID_A
-- `(0, 100, "section")` → ULID_B
-- `(0, 50, "paragraph")` → ULID_C
+- `(0, 100, "document", 0)` → ULID_A
+- `(0, 100, "section", 0)` → ULID_B
+- `(0, 50, "paragraph", 0)` → ULID_C
 
 All three have distinct keys and receive separate ULIDs.
 
-**Invalidation with composite keys**: The START-priority rule applies to the `start_byte` component. When `start_byte ∈ [edit.start, edit.old_end)`, all entries with that `start_byte` are invalidated regardless of their `end_byte` or `kind`.
+#### Why `layer` is part of the key
+
+`kind` alone was originally assumed sufficient to separate co-located nodes from
+different injection layers — "a Markdown `code_fence_content` vs a Python
+`module` differ by kind". That assumption breaks under **recursive same-language
+injection**: a ` ```markdown ` block injected into a Markdown host produces a
+`paragraph` (or any node kind) at the **same span and kind** in both the host
+tree and the injected tree. Without `layer`, both collapse to one ULID, and
+navigation ([node-reference-protocol](node-reference-protocol.md)) can no longer
+tell which language tree the ID belongs to — violating that protocol's per-layer
+Scope rule. Adding `layer` makes the host and injected nodes distinct ULIDs,
+eliminating the collision at its root.
+
+`layer` is **internal**: it lives only inside `PositionKey`. Clients receive an
+opaque ULID and never see the layer, so its representation can change without any
+protocol-visible effect.
+
+##### Layer discriminator: considered options
+
+The discriminator must (a) separate host from injected nodes including the
+same-language case, and (b) stay stable across edits per the START-priority rule.
+
+1. **Language name** — rejected: cannot separate same-language recursion
+   (markdown-in-markdown share the name "markdown").
+2. **Containing injection region's ULID** (host = sentinel) — viable and the
+   most edit-stable: a region ULID is itself START-anchored, so it survives
+   edits that restructure outer nesting. Rejected **for now** as over-engineered:
+   the injection-stack walk does not currently carry region IDs, and
+   `calculate_region_id` is itself a `get_or_create` caller (a chicken-and-egg to
+   break), so it is materially more invasive than the bug requires.
+3. **Injection depth index** (`0` = host, `1+` = nesting depth) — **chosen**.
+   It is already in scope at every mint site (the stack index) and at resolve
+   time (`stack[layer]`), so it is nearly free to plumb. Its one weakness is
+   that an edit which *restructures* injection nesting (adds/removes an outer
+   layer) shifts a node's depth, so a held ULID stops resolving — but it
+   degrades to a safe `null` ("re-acquire" per node-reference-protocol), never to
+   wrong-tree navigation. If that churn ever proves painful in practice, switch
+   to option 2; because `layer` is internal, the swap is non-breaking.
+
+**Invalidation with composite keys**: The START-priority rule applies to the `start_byte` component. When `start_byte ∈ [edit.start, edit.old_end)`, all entries with that `start_byte` are invalidated regardless of their `end_byte`, `kind`, or `layer`. The `layer` value is edit-invariant (a depth index does not move with byte positions), so position adjustment carries it through unchanged.
 
 ### Bidirectional Indexing
 
@@ -148,7 +188,8 @@ More text
 ### Negative
 
 - **Lookup table rebuild**: After edit, reverse lookup must be rebuilt
-- **Nested nodes**: Multiple nodes at same position require `(start, end, kind)` tuple for uniqueness (see [Node Uniqueness Key](#node-uniqueness-key))
+- **Nested nodes**: Multiple nodes at same position require the `(start, end, kind, layer)` tuple for uniqueness (see [Node Uniqueness Key](#node-uniqueness-key))
+- **Injection restructuring churn**: Because `layer` is an injection depth index, an edit that adds or removes an *outer* injection layer shifts an inner node's depth, invalidating its held ULID (degrades to a safe `null`, never wrong-tree). See the layer-discriminator options above
 - **START edits invalidate**: Editing a code block's opening delimiter invalidates its ID
 - **START shifts outside range**: Nodes whose START shifts due to earlier edits are preserved
 - **Injection region reordering**: When code blocks are inserted or deleted above tracked injection regions, those regions' container nodes are preserved (START unchanged), but their ordinal position changes. Systems relying on positional region IDs (e.g., `region-0`, `region-1`) must handle URI changes via close/reopen cycles
@@ -195,7 +236,7 @@ Invalidate any node whose range overlaps with the edit range.
 |--------|----------|
 | **Assignment** | Lazy (on-demand) |
 | **Identifier** | ULID |
-| **Uniqueness key** | `(start_byte, end_byte, kind)` |
+| **Uniqueness key** | `(start_byte, end_byte, kind, layer)` |
 | **Invalidation** | START-priority boundary-based |
 | **Storage** | Per-document |
 | **Indexing** | Bidirectional (`PositionKey ↔ Ulid`) |

--- a/docs/architecture-decisions/lazy-node-identity-tracking.md
+++ b/docs/architecture-decisions/lazy-node-identity-tracking.md
@@ -101,17 +101,29 @@ All three have distinct keys and receive separate ULIDs.
 `kind` alone was originally assumed sufficient to separate co-located nodes from
 different injection layers — "a Markdown `code_fence_content` vs a Python
 `module` differ by kind". That assumption breaks under **recursive same-language
-injection**: a ` ```markdown ` block injected into a Markdown host produces a
-`paragraph` (or any node kind) at the **same span and kind** in both the host
+injection**: a ```` ```markdown ```` block injected into a Markdown host produces
+a `paragraph` (or any node kind) at the **same span and kind** in both the host
 tree and the injected tree. Without `layer`, both collapse to one ULID, and
 navigation ([node-reference-protocol](node-reference-protocol.md)) can no longer
 tell which language tree the ID belongs to — violating that protocol's per-layer
 Scope rule. Adding `layer` makes the host and injected nodes distinct ULIDs,
-eliminating the collision at its root.
+eliminating this collision **within a single parse**. (It does not by itself make
+a held ULID survive an edit that restructures the nesting — see the considered
+options below and the "Injection restructuring churn" consequence.)
 
 `layer` is **internal**: it lives only inside `PositionKey`. Clients receive an
 opaque ULID and never see the layer, so its representation can change without any
 protocol-visible effect.
+
+**Scope — region IDs stay at layer 0**: the injection-region tracking that
+predates this protocol (`calculate_region_id`) keeps minting through the
+host-layer `get_or_create` (`layer = 0`). This is correct, not a residual
+collision: a region's `content_node` is taken from the host document's injection
+query and is therefore a host-tree node. The discriminator only needs to split
+the host node from the *injected* node that overlays it, which navigation mints
+at `layer ≥ 1`. A host node and its region ID legitimately dedup to one ULID.
+The "at its root" framing above is thus scoped to a single parse's node
+identities; it does not retro-fit edit-stability onto region IDs.
 
 ##### Layer discriminator: considered options
 
@@ -128,14 +140,21 @@ same-language case, and (b) stay stable across edits per the START-priority rule
    break), so it is materially more invasive than the bug requires.
 3. **Injection depth index** (`0` = host, `1+` = nesting depth) — **chosen**.
    It is already in scope at every mint site (the stack index) and at resolve
-   time (`stack[layer]`), so it is nearly free to plumb. Its one weakness is
-   that an edit which *restructures* injection nesting (adds/removes an outer
-   layer) shifts a node's depth, so a held ULID stops resolving — but it
-   degrades to a safe `null` ("re-acquire" per node-reference-protocol), never to
-   wrong-tree navigation. If that churn ever proves painful in practice, switch
-   to option 2; because `layer` is internal, the swap is non-breaking.
+   time (`stack[layer]`), so it is nearly free to plumb. Its weakness is that a
+   depth index is not a tree identity: an edit which *restructures* injection
+   nesting (adds/removes an outer layer) shifts a node's true depth, so a held
+   ULID no longer points at the layer that minted it. When the stack becomes
+   *shallower* than the stored `layer`, resolution detects this (`stack[layer]`
+   is out of bounds) and returns a safe `null` ("re-acquire" per
+   node-reference-protocol). When restructuring keeps the same depth but puts a
+   *different* tree there, the index cannot detect it: resolution still returns
+   `null` unless that tree coincidentally holds a node at the identical
+   `(start, end, kind)`. So the guarantee is "re-acquire on `null`", **not**
+   "never wrong-tree". If that churn ever proves painful in practice, switch to
+   option 2 (region ULID), which *is* a tree identity and closes the gap;
+   because `layer` is internal, the swap is non-breaking.
 
-**Invalidation with composite keys**: The START-priority rule applies to the `start_byte` component. When `start_byte ∈ [edit.start, edit.old_end)`, all entries with that `start_byte` are invalidated regardless of their `end_byte`, `kind`, or `layer`. The `layer` value is edit-invariant (a depth index does not move with byte positions), so position adjustment carries it through unchanged.
+**Invalidation with composite keys**: The START-priority rule applies to the `start_byte` component. When `start_byte ∈ [edit.start, edit.old_end)`, all entries with that `start_byte` are invalidated regardless of their `end_byte`, `kind`, or `layer`. Position adjustment carries the stored `layer` through unchanged (a depth index does not move with byte positions). Note this preserves the *stored* layer, not an absolute identity: an edit that restructures injection nesting can leave that stored layer stale (see the considered options above and "Injection restructuring churn" below).
 
 ### Bidirectional Indexing
 
@@ -189,7 +208,7 @@ More text
 
 - **Lookup table rebuild**: After edit, reverse lookup must be rebuilt
 - **Nested nodes**: Multiple nodes at same position require the `(start, end, kind, layer)` tuple for uniqueness (see [Node Uniqueness Key](#node-uniqueness-key))
-- **Injection restructuring churn**: Because `layer` is an injection depth index, an edit that adds or removes an *outer* injection layer shifts an inner node's depth, invalidating its held ULID (degrades to a safe `null`, never wrong-tree). See the layer-discriminator options above
+- **Injection restructuring churn**: Because `layer` is an injection depth index (not a tree identity), an edit that adds or removes an *outer* injection layer shifts an inner node's depth, so its held ULID no longer points at the minting layer. A shallower stack is detected and degrades to a safe `null`; a same-depth-but-different-tree restructuring is not detectable and resolves to `null` unless the new tree coincidentally holds an identical `(start, end, kind)` node. Either way clients rely on the "re-acquire on `null`" contract. See the layer-discriminator options above
 - **START edits invalidate**: Editing a code block's opening delimiter invalidates its ID
 - **START shifts outside range**: Nodes whose START shifts due to earlier edits are preserved
 - **Injection region reordering**: When code blocks are inserted or deleted above tracked injection regions, those regions' container nodes are preserved (START unchanged), but their ordinal position changes. Systems relying on positional region IDs (e.g., `region-0`, `region-1`) must handle URI changes via close/reopen cycles

--- a/docs/architecture-decisions/node-reference-protocol.md
+++ b/docs/architecture-decisions/node-reference-protocol.md
@@ -163,6 +163,8 @@ Edge cases:
 
 **Scope rule**: Navigation stays within a single language tree. Calling `parent` on the root of an injected tree returns `null`, **not** the host node that contains the injection. Crossing injection boundaries requires a fresh `kakehashi/node` call.
 
+This holds even when a host node and an injected node share an identical span **and** kind (e.g. recursive same-language injection such as markdown-in-markdown). The identity key carries an injection-`layer` discriminator ([lazy-node-identity-tracking](lazy-node-identity-tracking.md) §"Node Uniqueness Key"), so the two are distinct ULIDs and `parent`/`children` resolve each in the tree that minted it.
+
 **`null` cases**:
 - `parent`: id not in tracker, **or** id refers to a root node
 - `children`: id not in tracker
@@ -280,7 +282,7 @@ Include `range` in every `NodeInfo` returned.
 
 - Methods are registered via `LspService::build().custom_method(...)` in `src/bin/main.rs`, following the existing `kakehashi/internal/effectiveConfiguration` pattern
 - Handlers live under `src/lsp/lsp_impl/kakehashi/node/` (one file per method) for symmetry with `kakehashi/internal/`
-- `RegionIdTracker` is renamed to `NodeTracker` and extended with a reverse index (`Ulid → PositionKey`); see [lazy-node-identity-tracking](lazy-node-identity-tracking.md) amendment
+- `RegionIdTracker` is renamed to `NodeTracker` and extended with a reverse index (`Ulid → PositionKey`); see [lazy-node-identity-tracking](lazy-node-identity-tracking.md)
 - Injection layer enumeration reuses the existing injection processing in `src/lsp/lsp_impl/coordinator/injection.rs`
 
 ## Summary

--- a/src/language/injection.rs
+++ b/src/language/injection.rs
@@ -915,6 +915,14 @@ impl InjectionResolver {
     ///
     /// Phase 2 (lazy-node-identity-tracking): keyed on position (start_byte, end_byte, kind), so the
     /// ULID stays constant for the same position key.
+    ///
+    /// Minted via the host-layer `get_or_create` (`layer = 0`) **by design**:
+    /// `content_node` comes from the host document's injection query, so it is a
+    /// host-tree node. The `layer` discriminator (lazy-node-identity-tracking
+    /// §"Node Uniqueness Key") only needs to separate host from injected nodes,
+    /// and a region's content node is always the host side. If a navigation
+    /// `kakehashi/node` call resolves that same host node it dedups to this same
+    /// ULID, which is correct.
     pub(crate) fn calculate_region_id(
         tracker: &NodeTracker,
         uri: &Url,

--- a/src/language/injection.rs
+++ b/src/language/injection.rs
@@ -913,8 +913,9 @@ impl InjectionResolver {
 
     /// Calculate a stable ULID-based region_id for an injection.
     ///
-    /// Phase 2 (lazy-node-identity-tracking): keyed on position (start_byte, end_byte, kind), so the
-    /// ULID stays constant for the same position key.
+    /// Phase 2 (lazy-node-identity-tracking): keyed on position (start_byte,
+    /// end_byte, kind, layer), so the ULID stays constant for the same position
+    /// key. Region IDs always use `layer = 0` (see below).
     ///
     /// Minted via the host-layer `get_or_create` (`layer = 0`) **by design**:
     /// `content_node` comes from the host document's injection query, so it is a

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -14,7 +14,7 @@ use url::Url;
 
 /// Tracks stable ULID-based identifiers for tree-sitter nodes.
 ///
-/// Uses position-based composite keys (start_byte, end_byte, kind) per lazy-node-identity-tracking
+/// Uses position-based composite keys (start_byte, end_byte, kind, layer) per lazy-node-identity-tracking
 /// and applies START-priority invalidation rules to maintain stable ULIDs across edits.
 /// Originally introduced for injection regions; generalized for the Node Reference
 /// Protocol ([node-reference-protocol](../../docs/architecture-decisions/node-reference-protocol.md)).
@@ -98,8 +98,8 @@ impl UriEntries {
 /// `kind` was originally assumed to separate co-located nodes from different
 /// injection layers ("a Markdown `fenced_code_block` vs a Python `module`
 /// differ by kind"). Recursive same-language injection breaks that: a
-/// ` ```markdown ` block injected into Markdown yields the same kind at the same
-/// span in both the host and injected tree. `layer` (injection depth, `0` =
+/// ```` ```markdown ```` block injected into Markdown yields the same kind at the
+/// same span in both the host and injected tree. `layer` (injection depth, `0` =
 /// host) restores uniqueness so the two get distinct ULIDs — see
 /// lazy-node-identity-tracking §"Node Uniqueness Key". `layer` is internal:
 /// clients only ever see the opaque ULID.
@@ -112,9 +112,13 @@ struct PositionKey {
     /// `&'static str`. Storing the static slice avoids an allocation per
     /// tracker entry without losing any genuinely owned data.
     kind: &'static str,
-    /// Injection depth that minted the node (`0` = host). Edit-invariant: a
-    /// depth index does not move with byte positions, so position adjustment
-    /// carries it through unchanged.
+    /// Injection depth that minted the node (`0` = host). Preserved by position
+    /// adjustment: a depth index does not move with byte positions, so it is
+    /// carried through edits unchanged. It is *not* an absolute identity — an
+    /// edit that restructures injection nesting (adds/removes an outer layer)
+    /// shifts a node's true depth, leaving the stored `layer` stale. The held
+    /// ULID then degrades to "re-acquire" (see `with_resolved_node`), rather
+    /// than guaranteeing the node still lives at this depth.
     layer: usize,
 }
 
@@ -131,14 +135,13 @@ impl PositionKey {
 
     /// Create a position key with adjusted positions (for edit operations).
     ///
-    /// `layer` is preserved verbatim from the pre-edit key — depth does not
-    /// shift with byte positions.
-    fn with_positions(start: usize, end: usize, kind: &'static str, layer: usize) -> Self {
+    /// `kind` and `layer` are carried over verbatim via struct-update syntax —
+    /// neither shifts with byte positions (`PositionKey` is `Copy`).
+    fn with_positions(self, start: usize, end: usize) -> Self {
         Self {
             start_byte: start,
             end_byte: end,
-            kind,
-            layer,
+            ..self
         }
     }
 }
@@ -210,11 +213,9 @@ fn apply_delta(position: usize, delta: i64) -> usize {
 fn adjust_position_for_edit(key: PositionKey, edit: &EditInfo, delta: i64) -> Option<PositionKey> {
     if key.start_byte >= edit.old_end_byte {
         // Node E: AFTER edit → shift both start and end
-        Some(PositionKey::with_positions(
+        Some(key.with_positions(
             apply_delta(key.start_byte, delta),
             apply_delta(key.end_byte, delta),
-            key.kind,
-            key.layer,
         ))
     } else if key.end_byte > edit.start_byte {
         // Node A/B: CONTAINS or OVERLAPS edit
@@ -248,12 +249,7 @@ fn adjust_position_for_edit(key: PositionKey, edit: &EditInfo, delta: i64) -> Op
         if new_end <= key.start_byte {
             None // Range collapsed to zero or negative
         } else {
-            Some(PositionKey::with_positions(
-                key.start_byte,
-                new_end,
-                key.kind,
-                key.layer,
-            ))
+            Some(key.with_positions(key.start_byte, new_end))
         }
     } else {
         // Node F: BEFORE edit → unchanged

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -93,11 +93,16 @@ impl UriEntries {
     }
 }
 
-/// Key for Phase 2 position-based tracking (lazy-node-identity-tracking composite key).
+/// Composite key for position-based tracking (lazy-node-identity-tracking).
 ///
-/// Note: Language is NOT part of the key per lazy-node-identity-tracking specification.
-/// Same position with different language gets different ULID because
-/// kind will differ in the AST (e.g., fenced_code_block vs code_block).
+/// `kind` was originally assumed to separate co-located nodes from different
+/// injection layers ("a Markdown `fenced_code_block` vs a Python `module`
+/// differ by kind"). Recursive same-language injection breaks that: a
+/// ` ```markdown ` block injected into Markdown yields the same kind at the same
+/// span in both the host and injected tree. `layer` (injection depth, `0` =
+/// host) restores uniqueness so the two get distinct ULIDs — see
+/// lazy-node-identity-tracking §"Node Uniqueness Key". `layer` is internal:
+/// clients only ever see the opaque ULID.
 #[derive(Hash, Eq, PartialEq, Clone, Copy, Debug)]
 struct PositionKey {
     start_byte: usize,
@@ -107,24 +112,33 @@ struct PositionKey {
     /// `&'static str`. Storing the static slice avoids an allocation per
     /// tracker entry without losing any genuinely owned data.
     kind: &'static str,
+    /// Injection depth that minted the node (`0` = host). Edit-invariant: a
+    /// depth index does not move with byte positions, so position adjustment
+    /// carries it through unchanged.
+    layer: usize,
 }
 
 impl PositionKey {
-    /// Create a new position key from byte range and node kind.
-    fn new(start: usize, end: usize, kind: &'static str) -> Self {
+    /// Create a new position key from byte range, node kind, and injection layer.
+    fn new(start: usize, end: usize, kind: &'static str, layer: usize) -> Self {
         Self {
             start_byte: start,
             end_byte: end,
             kind,
+            layer,
         }
     }
 
     /// Create a position key with adjusted positions (for edit operations).
-    fn with_positions(start: usize, end: usize, kind: &'static str) -> Self {
+    ///
+    /// `layer` is preserved verbatim from the pre-edit key — depth does not
+    /// shift with byte positions.
+    fn with_positions(start: usize, end: usize, kind: &'static str, layer: usize) -> Self {
         Self {
             start_byte: start,
             end_byte: end,
             kind,
+            layer,
         }
     }
 }
@@ -200,6 +214,7 @@ fn adjust_position_for_edit(key: PositionKey, edit: &EditInfo, delta: i64) -> Op
             apply_delta(key.start_byte, delta),
             apply_delta(key.end_byte, delta),
             key.kind,
+            key.layer,
         ))
     } else if key.end_byte > edit.start_byte {
         // Node A/B: CONTAINS or OVERLAPS edit
@@ -237,6 +252,7 @@ fn adjust_position_for_edit(key: PositionKey, edit: &EditInfo, delta: i64) -> Op
                 key.start_byte,
                 new_end,
                 key.kind,
+                key.layer,
             ))
         }
     } else {
@@ -253,15 +269,13 @@ impl NodeTracker {
         }
     }
 
-    /// Get or create a stable ULID for a tree-sitter node.
+    /// Get or create a stable ULID for a **host-layer** tree-sitter node.
     ///
-    /// Uses lazy-node-identity-tracking composite key `(start_byte, end_byte, kind)`: the same
-    /// (uri, start, end, kind) always returns the same ULID, while different
-    /// nodes at the same position (e.g. nested `document` / `section` / `paragraph`
-    /// at byte 0) receive distinct ULIDs.
-    ///
-    /// Updates both the forward and reverse index so the returned ULID can be
-    /// resolved back to its position via [`lookup_position`](Self::lookup_position).
+    /// Convenience for the common case (host tree, region content nodes): it
+    /// delegates to [`get_or_create_in_layer`](Self::get_or_create_in_layer)
+    /// with `layer = 0`. Injection-aware call sites that mint nodes from a
+    /// deeper layer MUST use `get_or_create_in_layer` so host and injected
+    /// nodes sharing `(start, end, kind)` receive distinct ULIDs.
     pub(crate) fn get_or_create(
         &self,
         uri: &Url,
@@ -269,7 +283,27 @@ impl NodeTracker {
         end: usize,
         kind: &'static str,
     ) -> Ulid {
-        let key = PositionKey::new(start, end, kind);
+        self.get_or_create_in_layer(uri, start, end, kind, 0)
+    }
+
+    /// Get or create a stable ULID for a tree-sitter node at injection `layer`.
+    ///
+    /// Uses lazy-node-identity-tracking composite key `(start_byte, end_byte,
+    /// kind, layer)`: the same key always returns the same ULID, while
+    /// different nodes — including a host vs injected node that share an
+    /// identical span and kind (`layer` differs) — receive distinct ULIDs.
+    ///
+    /// Updates both the forward and reverse index so the returned ULID can be
+    /// resolved back to its position via [`lookup_node`](Self::lookup_node).
+    pub(crate) fn get_or_create_in_layer(
+        &self,
+        uri: &Url,
+        start: usize,
+        end: usize,
+        kind: &'static str,
+        layer: usize,
+    ) -> Ulid {
+        let key = PositionKey::new(start, end, kind, layer);
 
         // NOTE: Explicit two-step pattern to avoid DashMap lifetime ambiguity.
         let mut entry = self.entries.entry(uri.clone()).or_default();
@@ -277,6 +311,10 @@ impl NodeTracker {
     }
 
     /// Resolve a ULID back to its tracked `(start_byte, end_byte, kind)` triple.
+    ///
+    /// Drops the layer discriminator — callers that need it (the navigation
+    /// handlers, to re-mint in the same layer) use
+    /// [`lookup_node`](Self::lookup_node) instead.
     ///
     /// Returns `None` if the ULID was never issued for this URI, if it was
     /// invalidated by an edit (START fell inside the edit range per lazy-node-identity-tracking),
@@ -287,9 +325,24 @@ impl NodeTracker {
         uri: &Url,
         ulid: &Ulid,
     ) -> Option<(usize, usize, &'static str)> {
+        let (start, end, kind, _layer) = self.lookup_node(uri, ulid)?;
+        Some((start, end, kind))
+    }
+
+    /// Resolve a ULID back to its tracked `(start_byte, end_byte, kind, layer)`.
+    ///
+    /// Like [`lookup_position`](Self::lookup_position) but also returns the
+    /// injection `layer` that minted the node, so navigation handlers can
+    /// resolve it in the correct language tree and re-mint parent/children in
+    /// the same layer.
+    pub(crate) fn lookup_node(
+        &self,
+        uri: &Url,
+        ulid: &Ulid,
+    ) -> Option<(usize, usize, &'static str, usize)> {
         let entries = self.entries.get(uri)?;
         let key = entries.lookup(ulid)?;
-        Some((key.start_byte, key.end_byte, key.kind))
+        Some((key.start_byte, key.end_byte, key.kind, key.layer))
     }
 
     /// Get the ULID for a position if it exists, without creating it.
@@ -298,7 +351,7 @@ impl NodeTracker {
     /// Used in tests to verify position adjustment without side effects.
     #[cfg(test)]
     fn get(&self, uri: &Url, start: usize, end: usize, kind: &'static str) -> Option<Ulid> {
-        let key = PositionKey::new(start, end, kind);
+        let key = PositionKey::new(start, end, kind, 0);
         self.entries.get(uri)?.forward.get(&key).copied()
     }
 
@@ -533,8 +586,8 @@ impl NodeTracker {
             if let Err(_existing) = new_entries.insert(new_key, ulid) {
                 warn!(
                     target: "kakehashi::node_tracker",
-                    "Position collision after edit - ULID mapping dropped: ulid={}, start={}, end={}, kind={}",
-                    ulid, new_key.start_byte, new_key.end_byte, new_key.kind
+                    "Position collision after edit - ULID mapping dropped: ulid={}, start={}, end={}, kind={}, layer={}",
+                    ulid, new_key.start_byte, new_key.end_byte, new_key.kind, new_key.layer
                 );
                 // Note: Collided ULID is also invalidated (both nodes can't coexist)
                 invalidated.push(ulid);
@@ -620,6 +673,70 @@ mod tests {
         assert_ne!(
             block_ulid, fence_ulid,
             "Different kinds should return different ULIDs"
+        );
+    }
+
+    #[test]
+    fn test_different_layer_returns_different_ulid() {
+        // Issue #313: recursive same-language injection can place a node with an
+        // identical (start, end, kind) in both the host and an injected layer.
+        // The `layer` discriminator must keep their ULIDs distinct so navigation
+        // can resolve each in the correct language tree.
+        let tracker = NodeTracker::new();
+        let uri = test_uri("layer");
+
+        let host_ulid = tracker.get_or_create_in_layer(&uri, 0, 10, "paragraph", 0);
+        let injected_ulid = tracker.get_or_create_in_layer(&uri, 0, 10, "paragraph", 1);
+
+        assert_ne!(
+            host_ulid, injected_ulid,
+            "Same (start, end, kind) at different layers should return different ULIDs"
+        );
+    }
+
+    #[test]
+    fn test_same_layer_returns_same_ulid() {
+        let tracker = NodeTracker::new();
+        let uri = test_uri("layer-stable");
+
+        let a = tracker.get_or_create_in_layer(&uri, 0, 10, "paragraph", 2);
+        let b = tracker.get_or_create_in_layer(&uri, 0, 10, "paragraph", 2);
+
+        assert_eq!(a, b, "Same key including layer should return the same ULID");
+    }
+
+    #[test]
+    fn test_get_or_create_defaults_to_host_layer() {
+        // The plain `get_or_create` convenience must mint at layer 0, matching a
+        // node explicitly created in the host layer.
+        let tracker = NodeTracker::new();
+        let uri = test_uri("layer-default");
+
+        let default_ulid = tracker.get_or_create(&uri, 0, 10, "paragraph");
+        let host_ulid = tracker.get_or_create_in_layer(&uri, 0, 10, "paragraph", 0);
+
+        assert_eq!(
+            default_ulid, host_ulid,
+            "get_or_create should be equivalent to layer 0"
+        );
+    }
+
+    #[test]
+    fn test_lookup_node_returns_layer() {
+        let tracker = NodeTracker::new();
+        let uri = test_uri("lookup-layer");
+
+        let ulid = tracker.get_or_create_in_layer(&uri, 5, 15, "block", 3);
+
+        assert_eq!(
+            tracker.lookup_node(&uri, &ulid),
+            Some((5, 15, "block", 3)),
+            "lookup_node should round-trip the layer discriminator"
+        );
+        assert_eq!(
+            tracker.lookup_position(&uri, &ulid),
+            Some((5, 15, "block")),
+            "lookup_position should drop the layer"
         );
     }
 

--- a/src/lsp/lsp_impl/kakehashi/node/children.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/children.rs
@@ -57,9 +57,11 @@ impl Kakehashi {
             return Ok(Value::Null);
         };
 
-        // Look up the tracked node's byte range and kind. None means: never
-        // issued, invalidated by a prior edit, or this URI has no entries.
-        let Some((start, end, kind)) = self.bridge.node_tracker().lookup_position(&uri, &ulid)
+        // Look up the tracked node's byte range, kind, and injection layer.
+        // None means: never issued, invalidated by a prior edit, or this URI
+        // has no entries. `layer` pins resolution and child minting to the
+        // language tree that minted the node (node-reference-protocol Scope rule).
+        let Some((start, end, kind, layer)) = self.bridge.node_tracker().lookup_node(&uri, &ulid)
         else {
             return Ok(Value::Null);
         };
@@ -101,6 +103,7 @@ impl Kakehashi {
             start,
             end,
             kind,
+            layer,
             |node| {
                 let mut cursor = node.walk();
                 node.children(&mut cursor)
@@ -121,7 +124,10 @@ impl Kakehashi {
         let infos: Vec<Value> = child_infos
             .into_iter()
             .map(|(c_start, c_end, c_kind)| {
-                let child_ulid = tracker.get_or_create(&uri, c_start, c_end, c_kind);
+                // Children live in the same tree as their parent, so they are
+                // minted in the same `layer`.
+                let child_ulid =
+                    tracker.get_or_create_in_layer(&uri, c_start, c_end, c_kind, layer);
                 json!({
                     "id": child_ulid.to_string(),
                     "type": c_kind,

--- a/src/lsp/lsp_impl/kakehashi/node/children.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/children.rs
@@ -1,7 +1,7 @@
 //! `kakehashi/node/children` — id → immediate-children NodeInfo array (node-reference-protocol).
 //!
-//! Resolves a previously-issued ULID to its tracked `(start_byte, end_byte, kind)`
-//! triple, locates the matching tree-sitter node in the current parse tree, and
+//! Resolves a previously-issued ULID to its tracked `(start_byte, end_byte, kind, layer)`
+//! key, locates the matching tree-sitter node in the current parse tree, and
 //! returns one [`NodeInfo`](../../../../../docs/architecture-decisions/node-reference-protocol.md#nodeinfo-type)
 //! per immediate child in **document order** (ascending `start_byte`).
 //!

--- a/src/lsp/lsp_impl/kakehashi/node/children.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/children.rs
@@ -87,10 +87,11 @@ impl Kakehashi {
             return Ok(Value::Null);
         };
 
-        // Search the host tree first, then injected layers at `start`. node-reference-protocol
-        // "Navigation Methods": children stay within a single language tree, so
-        // an injected node's children come from the injected tree — not from
-        // the host node that contains the injection.
+        // Resolve in the minting layer only (`stack[layer]`), never falling back
+        // to other layers. node-reference-protocol "Navigation Methods":
+        // children stay within a single language tree, so an injected node's
+        // children come from the injected tree — not from the host node that
+        // contains the injection.
         //
         // tree-sitter's `Node::children(&mut cursor)` iterates BOTH named and
         // anonymous children in document order. A leaf node yields an empty
@@ -114,8 +115,8 @@ impl Kakehashi {
         let Some(child_infos) = child_infos else {
             log::warn!(
                 target: "kakehashi::node::children",
-                "tracker hit but no matching node in any layer for ulid={} uri={} range=[{},{}) kind={}",
-                ulid, uri, start, end, kind
+                "tracker hit but no matching node in minting layer {} for ulid={} uri={} range=[{},{}) kind={}",
+                layer, ulid, uri, start, end, kind
             );
             return Ok(Value::Null);
         };

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -278,11 +278,15 @@ impl Kakehashi {
             return Ok(Value::Null);
         };
 
-        let ulid = self.bridge.node_tracker().get_or_create(
+        // Mint with the resolved layer index so a host and injected node sharing
+        // (start, end, kind) get distinct ULIDs and stay navigable in their own
+        // tree (lazy-node-identity-tracking §"Node Uniqueness Key", issue #313).
+        let ulid = self.bridge.node_tracker().get_or_create_in_layer(
             &uri,
             node.start_byte(),
             node.end_byte(),
             node.kind(),
+            layer_index,
         );
 
         Ok(json!({

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -214,11 +214,21 @@ pub(super) fn injection_stack_at(
 /// searches `stack[layer]` only. We deliberately do **not** fall back to other
 /// layers: a node carries the layer it was created in, and resolving it in a
 /// different layer would violate node-reference-protocol's per-layer Scope rule.
-/// This is exactly the host-vs-injected collision the `layer` key prevents — a
-/// host and injected node sharing `(start, end, kind)` would otherwise be
-/// indistinguishable here (issue #313). If the stack is now shallower than
-/// `layer` (an edit restructured the nesting), `stack.get(layer)` is `None` and
-/// we return `None` — a safe "re-acquire" signal, never a wrong-tree match.
+/// Within a single parse this is exactly the host-vs-injected collision the
+/// `layer` key prevents — a host and injected node sharing `(start, end, kind)`
+/// would otherwise be indistinguishable here (issue #313).
+///
+/// Across edits the depth index is a weaker guarantee. If an edit makes the
+/// stack shallower than `layer`, `stack.get(layer)` is `None` and we return
+/// `None` — a safe "re-acquire" signal. But `layer` is only a depth, not a tree
+/// identity: an edit that restructures the nesting while keeping
+/// `stack.len() > layer` can leave a *different* tree at that depth. Resolution
+/// then succeeds only if that tree happens to hold a node at the identical
+/// `(start, end, kind)`, and otherwise returns `None`. We do not (and with a
+/// depth index cannot) detect that case, so the "re-acquire on `null`" contract
+/// — not a wrong-tree guarantee — is what protects clients. See the
+/// layer-discriminator options in lazy-node-identity-tracking for the
+/// region-ULID alternative that would close this gap.
 ///
 /// `f` is invoked at most once, with the matching `Node`. Returning `None`
 /// from `f` is distinguishable from the "no match" outcome only by

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -9,10 +9,11 @@
 //! tree-sitter's `set_included_ranges`, which means every node's
 //! `start_byte` / `end_byte` is already in original-document coordinates.
 //! That property is load-bearing: the entry-point handler issues ULIDs via
-//! `NodeTracker::get_or_create(uri, start_byte, end_byte, kind)`, and the
-//! tracker keys must stay in the host's byte space so subsequent
+//! `NodeTracker::get_or_create_in_layer(uri, start_byte, end_byte, kind, layer)`,
+//! and the tracker keys must stay in the host's byte space so subsequent
 //! `parent` / `children` / `text` calls and `didChange` adjustments line
-//! up across layers.
+//! up across layers. The `layer` index distinguishes a host node from an
+//! injected node sharing the same span and kind (lazy-node-identity-tracking).
 
 use crate::analysis::offset_calculator::{ByteRange, calculate_effective_range};
 use crate::language::LanguageCoordinator;
@@ -204,21 +205,25 @@ pub(super) fn injection_stack_at(
     stack
 }
 
-/// Resolve a tracked `(start, end, kind)` triple to a tree-sitter node by
-/// searching the host tree first, then each injected layer at `start`.
+/// Resolve a tracked node to a tree-sitter node **in the exact layer that
+/// minted it**, identified by the `layer` discriminator recorded in its
+/// identity key (lazy-node-identity-tracking §"Node Uniqueness Key").
 ///
-/// Tracker entries store only `(uri, start_byte, end_byte, kind)` — they do
-/// not record which language tree the node originated from. A node minted
-/// by `kakehashi/node` against an injected layer (e.g. a Python `assignment`
-/// inside a markdown code block) would otherwise be unreachable from
-/// navigation handlers that only look at the host tree. Walking the stack
-/// here lets `parent` and `children` follow injected nodes in the same
-/// layer that produced them.
+/// `layer == 0` resolves against the host tree directly (the common case, no
+/// stack walk). A deeper `layer` rebuilds the injection stack at `start` and
+/// searches `stack[layer]` only. We deliberately do **not** fall back to other
+/// layers: a node carries the layer it was created in, and resolving it in a
+/// different layer would violate node-reference-protocol's per-layer Scope rule.
+/// This is exactly the host-vs-injected collision the `layer` key prevents — a
+/// host and injected node sharing `(start, end, kind)` would otherwise be
+/// indistinguishable here (issue #313). If the stack is now shallower than
+/// `layer` (an edit restructured the nesting), `stack.get(layer)` is `None` and
+/// we return `None` — a safe "re-acquire" signal, never a wrong-tree match.
 ///
 /// `f` is invoked at most once, with the matching `Node`. Returning `None`
-/// from `f` is distinguishable from the "no layer matched" outcome only by
+/// from `f` is distinguishable from the "no match" outcome only by
 /// the caller's outer `Option` — both surface as `Option<R>` because the
-/// outer call returns `None` when no layer matched. Callers that need to
+/// outer call returns `None` when nothing matched. Callers that need to
 /// distinguish "found node but operation returned nothing" (e.g. parent of
 /// a root) from "no match" should use a richer `R` like `Option<T>`.
 #[allow(clippy::too_many_arguments)]
@@ -230,6 +235,7 @@ pub(super) fn with_resolved_node<R>(
     start: usize,
     end: usize,
     kind: &'static str,
+    layer: usize,
     mut f: impl FnMut(tree_sitter::Node<'_>) -> R,
 ) -> Option<R> {
     // Reject obviously-invalid ranges up front — same guard `find_node_at`
@@ -240,21 +246,18 @@ pub(super) fn with_resolved_node<R>(
         return None;
     }
 
-    // Fast path: the most common case is a node living in the host tree.
-    if let Some(node) = find_node_at(host_tree, start, end, kind) {
+    // Host layer: resolve against the host tree without the stack walk.
+    if layer == 0 {
+        let node = find_node_at(host_tree, start, end, kind)?;
         return Some(f(node));
     }
 
-    // Walk injected layers. `stack[0]` is the host (already tried above), so
-    // skip it.
+    // Deeper layer: rebuild the stack at `start` and search the minting layer
+    // only. `stack.get(layer)` is None when the nesting is now shallower.
     let stack = injection_stack_at(coordinator, host_language, host_text, host_tree, start);
-    for layer in stack.iter().skip(1) {
-        if let Some(node) = find_node_at(&layer.tree, start, end, kind) {
-            return Some(f(node));
-        }
-    }
-
-    None
+    let layer_tree = &stack.get(layer)?.tree;
+    let node = find_node_at(layer_tree, start, end, kind)?;
+    Some(f(node))
 }
 
 /// Collect the injection languages along the cursor's injection path at

--- a/src/lsp/lsp_impl/kakehashi/node/parent.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/parent.rs
@@ -57,9 +57,12 @@ impl Kakehashi {
             return Ok(Value::Null);
         };
 
-        // Look up the tracked node's byte range and kind. None means: never
-        // issued, invalidated by a prior edit, or this URI has no entries.
-        let Some((start, end, kind)) = self.bridge.node_tracker().lookup_position(&uri, &ulid)
+        // Look up the tracked node's byte range, kind, and injection layer.
+        // None means: never issued, invalidated by a prior edit, or this URI
+        // has no entries. `layer` pins resolution to the language tree that
+        // minted the node so navigation stays in-layer (node-reference-protocol
+        // Scope rule).
+        let Some((start, end, kind, layer)) = self.bridge.node_tracker().lookup_node(&uri, &ulid)
         else {
             return Ok(Value::Null);
         };
@@ -95,6 +98,7 @@ impl Kakehashi {
             start,
             end,
             kind,
+            layer,
             |node| {
                 node.parent()
                     .map(|p| (p.start_byte(), p.end_byte(), p.kind()))
@@ -111,11 +115,13 @@ impl Kakehashi {
             return Ok(Value::Null);
         };
 
-        // Issue / reuse a stable ULID for the parent (lazy-node-identity-tracking lazy assignment).
+        // Issue / reuse a stable ULID for the parent (lazy-node-identity-tracking
+        // lazy assignment). The parent lives in the same tree as the child, so
+        // it is minted in the same `layer`.
         let parent_ulid = self
             .bridge
             .node_tracker()
-            .get_or_create(&uri, p_start, p_end, p_kind);
+            .get_or_create_in_layer(&uri, p_start, p_end, p_kind, layer);
 
         Ok(json!({
             "id": parent_ulid.to_string(),

--- a/src/lsp/lsp_impl/kakehashi/node/parent.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/parent.rs
@@ -1,25 +1,25 @@
 //! `kakehashi/node/parent` — id → immediate-parent NodeInfo (node-reference-protocol).
 //!
-//! Resolves a previously-issued ULID to its tracked `(start_byte, end_byte, kind)`
-//! triple, locates the matching tree-sitter node in the current parse tree, and
+//! Resolves a previously-issued ULID to its tracked `(start_byte, end_byte, kind, layer)`
+//! key, locates the matching tree-sitter node in the current parse tree, and
 //! returns a [`NodeInfo`](../../../../../docs/architecture-decisions/node-reference-protocol.md#nodeinfo-type)
 //! for its tree-sitter parent.
 //!
 //! Per node-reference-protocol §"Navigation Methods", navigation stays within a single
 //! language tree: calling `parent` on the root of an injected tree must **not**
 //! cross into the host node that contains the injection. To find the node in
-//! the correct tree we search the host tree first and then each injected layer
-//! at the tracked `start_byte` (see
-//! [`with_resolved_node`](super::injection_stack::with_resolved_node)) — that
-//! way a node minted by `kakehashi/node` against an injected layer remains
-//! navigable from the same layer that produced it.
+//! the correct tree we resolve it **only** in the layer that minted it —
+//! `stack[layer]` for the tracked `layer` (see
+//! [`with_resolved_node`](super::injection_stack::with_resolved_node)) — so a
+//! node minted by `kakehashi/node` against an injected layer is never re-matched
+//! against a different layer's tree.
 //!
 //! Returns `null` (serialized as JSON `null`) when:
 //! - the URI is unknown or invalid,
 //! - the ULID is malformed or was never issued / has been invalidated,
 //! - the document has not yet been parsed,
-//! - the tracked range cannot be matched against a node in the host tree or
-//!   any injected layer, or
+//! - the tracked range cannot be matched against a node in the minting layer's
+//!   tree (e.g. an edit restructured the injection nesting), or
 //! - the matched node is the root of its tree (no parent — applies to host
 //!   root AND to the root of any injected tree, per the Scope rule).
 

--- a/src/lsp/lsp_impl/kakehashi/node/parent.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/parent.rs
@@ -85,11 +85,11 @@ impl Kakehashi {
             return Ok(Value::Null);
         };
 
-        // Search the host tree first, then injected layers at `start`. node-reference-protocol
-        // "Scope rule" applies per layer: tree-sitter's `node.parent()` returns
-        // None for any tree root (host root AND injected root), which is the
-        // intended semantics — do NOT chase into the host node that contains
-        // the injection.
+        // Resolve in the minting layer only (`stack[layer]`), never falling back
+        // to other layers. node-reference-protocol "Scope rule" applies per
+        // layer: tree-sitter's `node.parent()` returns None for any tree root
+        // (host root AND injected root), which is the intended semantics — do
+        // NOT chase into the host node that contains the injection.
         let parent_info = with_resolved_node(
             &self.language,
             &host_language,
@@ -108,8 +108,8 @@ impl Kakehashi {
             if parent_info.is_none() {
                 log::warn!(
                     target: "kakehashi::node::parent",
-                    "tracker hit but no matching node in any layer for ulid={} uri={} range=[{},{}) kind={}",
-                    ulid, uri, start, end, kind
+                    "tracker hit but no matching node in minting layer {} for ulid={} uri={} range=[{},{}) kind={}",
+                    layer, ulid, uri, start, end, kind
                 );
             }
             return Ok(Value::Null);

--- a/tests/e2e_kakehashi_node.rs
+++ b/tests/e2e_kakehashi_node.rs
@@ -1349,3 +1349,113 @@ fn test_node_children_on_injected_id_stays_in_injected_tree() {
         );
     }
 }
+
+// ============================================================
+// Issue #313: layer-aware node identity — host vs injected
+// nodes that share an identical (start, end, kind).
+//
+// Markdown injects `markdown_inline` over every `(inline)` node, and
+// tree-sitter-markdown-inline's root node is itself an `inline`. So a host
+// `inline` and the injected layer's root `inline` occupy the SAME span AND
+// kind — a real (start, end, kind) collision. Before the layer discriminator
+// they collapsed to one ULID and navigation could cross language trees.
+// ============================================================
+
+/// A single markdown paragraph. The inline text spans line 0, so a cursor at
+/// (0, 2) lands inside the host `inline` node and, one layer deeper, inside
+/// the injected `markdown_inline` tree whose root is also an `inline`.
+const MARKDOWN_PARAGRAPH: &str = "hello world\n";
+
+/// Read the `type` field as a string, asserting it is present.
+fn node_type(node: &Value) -> &str {
+    node.get("type")
+        .and_then(Value::as_str)
+        .expect("type field must be a string")
+}
+
+/// Read the `id` field as a string, asserting it is present.
+fn node_id(node: &Value) -> &str {
+    node.get("id")
+        .and_then(Value::as_str)
+        .expect("id field must be a string")
+}
+
+/// The collapsed-identity case (#313): a host `inline` and the injected
+/// `markdown_inline` root `inline` share the SAME `(start, end, kind)`. The
+/// layer discriminator must give them DISTINCT ULIDs. Before the fix they
+/// collapsed to a single ULID.
+#[test]
+fn test_node_layer_collision_host_and_injected_inline_get_distinct_ids() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+
+    let uri = "file:///test_kakehashi_node_inline_collision.md";
+    open_markdown(&mut client, uri, MARKDOWN_PARAGRAPH);
+
+    // Cursor inside the inline text "hello world" (line 0, char 2 is "l").
+    let host = request_node_with_injection(&mut client, uri, 0, 2, json!(false));
+    let injected = request_node_with_injection(&mut client, uri, 0, 2, json!(true));
+    assert!(!host.is_null(), "host layer must resolve a node");
+    assert!(!injected.is_null(), "injected layer must resolve a node");
+
+    // The fixture is chosen so the collision genuinely occurs: both layers
+    // resolve an `inline` node at the same span. If this regresses (e.g. an
+    // upstream grammar change), the test below is no longer exercising #313.
+    assert_eq!(
+        node_type(&host),
+        "inline",
+        "expected the host node to be `inline` (the collision fixture)"
+    );
+    assert_eq!(
+        node_type(&injected),
+        "inline",
+        "expected the injected root to be `inline` (the collision fixture)"
+    );
+
+    assert_ne!(
+        node_id(&host),
+        node_id(&injected),
+        "host and injected nodes sharing (start, end, kind) must have distinct ULIDs (#313)"
+    );
+}
+
+/// With the collapsed identity disambiguated, navigation from each ULID must
+/// stay in its own language tree: the host `inline` walks up to the host
+/// `paragraph`, while the injected `inline` is its tree's root and so returns
+/// `null` (node-reference-protocol Scope rule) — it must NOT surface the host
+/// `paragraph`.
+#[test]
+fn test_node_layer_collision_navigation_stays_in_layer() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+
+    let uri = "file:///test_kakehashi_node_inline_collision_nav.md";
+    open_markdown(&mut client, uri, MARKDOWN_PARAGRAPH);
+
+    let host = request_node_with_injection(&mut client, uri, 0, 2, json!(false));
+    let injected = request_node_with_injection(&mut client, uri, 0, 2, json!(true));
+    assert!(!host.is_null() && !injected.is_null());
+
+    // Host inline → host parent (a block-level markdown node).
+    let host_parent = request_node_parent(&mut client, uri, node_id(&host));
+    assert!(
+        !host_parent.is_null(),
+        "host inline must have a parent in the host tree"
+    );
+    assert_eq!(
+        node_type(&host_parent),
+        "paragraph",
+        "host inline's parent must be the host `paragraph`, got {:?}",
+        node_type(&host_parent)
+    );
+
+    // Injected inline is the root of the markdown_inline tree → null parent.
+    // The pre-fix collapse would have made this resolve through the shared
+    // ULID into the host `paragraph`, leaking across the injection boundary.
+    let injected_parent = request_node_parent(&mut client, uri, node_id(&injected));
+    assert!(
+        injected_parent.is_null(),
+        "injected inline is its tree root; parent must be null, not the host paragraph (got {:?})",
+        injected_parent
+    );
+}

--- a/tests/e2e_kakehashi_node.rs
+++ b/tests/e2e_kakehashi_node.rs
@@ -1459,3 +1459,67 @@ fn test_node_layer_collision_navigation_stays_in_layer() {
         injected_parent
     );
 }
+
+/// Regression for the layer discriminator's edit behavior (lazy-node-identity-tracking
+/// §"Injection restructuring churn"). An edit that does NOT touch the injected
+/// node's START byte must preserve its ULID *and* its stored `layer`, so a later
+/// `parent` call still resolves in the injected tree (→ `null` at its root)
+/// rather than re-matching the same `(start, end, kind)` against the host tree
+/// and leaking the host `paragraph`. This locks in "navigation stays in-layer
+/// across surviving edits", the safe half of the depth-index contract — the half
+/// the implementation *can* guarantee (the unguaranteed half, nesting
+/// restructuring, degrades to a safe `null` and is covered by the protocol's
+/// re-acquire contract, not asserted here).
+#[test]
+fn test_node_layer_collision_survives_edit_and_stays_in_layer() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+
+    let uri = "file:///test_kakehashi_node_inline_collision_edit.md";
+    open_markdown(&mut client, uri, MARKDOWN_PARAGRAPH);
+
+    // Acquire the injected-layer `inline` (root of the markdown_inline tree).
+    let injected = request_node_with_injection(&mut client, uri, 0, 2, json!(true));
+    assert!(!injected.is_null(), "injected layer must resolve a node");
+    assert_eq!(
+        node_type(&injected),
+        "inline",
+        "expected the injected root to be `inline` (the collision fixture)"
+    );
+    let injected_id = node_id(&injected).to_string();
+
+    // Baseline: before any edit, the injected root has a null parent.
+    assert!(
+        request_node_parent(&mut client, uri, &injected_id).is_null(),
+        "baseline: injected inline is its tree root; parent must be null"
+    );
+
+    // Append a second paragraph BELOW. The first paragraph's inline starts at
+    // byte 0 and is untouched, so START-priority keeps the injected ULID alive
+    // and carries its stored `layer` through unchanged.
+    let edited = "hello world\n\nsecond paragraph\n";
+    full_text_change(&mut client, uri, 2, edited);
+
+    // The ULID survived: text still resolves to the (unchanged) inline content.
+    let text = request_node_text(&mut client, uri, &injected_id);
+    assert!(
+        !text.is_null(),
+        "injected id must survive an edit that does not touch its START byte"
+    );
+    assert_eq!(
+        text.get("text").and_then(Value::as_str),
+        Some("hello world"),
+        "surviving injected id must still slice its original inline text"
+    );
+
+    // The crux: navigation still resolves in the injected tree. If the stored
+    // layer were lost (or navigation fell back across layers), this would
+    // re-match `(start, end, kind)` in the host tree and surface the host
+    // `paragraph`. It must stay null.
+    let injected_parent = request_node_parent(&mut client, uri, &injected_id);
+    assert!(
+        injected_parent.is_null(),
+        "after a surviving edit, injected inline must still be its tree root (null parent), not the host paragraph (got {:?})",
+        injected_parent
+    );
+}


### PR DESCRIPTION
## Why

`NodeTracker` keyed nodes by `(start_byte, end_byte, kind)`, deliberately excluding layer on the assumption that "kind differs across AST layers". That breaks when a host node and an injected node share an identical `(start, end, kind)` — e.g. Markdown injects `markdown_inline` over every `(inline)` node, and the inline grammar's root is itself `inline`, so the host `inline` and the injected root `inline` occupy the same span and kind. They collapsed to one ULID, so `kakehashi/node/parent`/`/children` could navigate the **wrong** language tree (violating the node-reference-protocol Scope rule).

Fixes #313.

## What

Add an injection-depth `layer` discriminator (`0` = host) to the identity key.

- `PositionKey` gains a `layer` field. `get_or_create` stays a layer-0 convenience; new `get_or_create_in_layer` mints at an explicit depth (entry-point injection path, parent, children). `lookup_node` returns the layer; `lookup_position` kept as a layer-dropping delegate.
- `with_resolved_node` resolves in `stack[layer]` only (no host-first scan), keeping traversal in-layer and degrading to a **safe null** ("re-acquire") when an edit restructured the nesting — never wrong-tree.
- Region/host mints stay at layer 0, so injection-region tracking is unchanged.

`layer` is **internal** to `PositionKey`; clients still see only the opaque ULID, so the representation can later switch to a region ULID (recorded as the considered, more edit-stable alternative) without a protocol change.

## Design decision

Chose **depth index** over a region-ULID discriminator: it is nearly free to plumb (the stack index is already in scope) and sufficient for the bug, with region-ULID kept as a ready-to-pull alternative if injection-restructuring churn ever bites. Rationale and alternatives recorded in `docs/architecture-decisions/lazy-node-identity-tracking.md`.

## Commits

1. `docs(node-identity)` — layer-aware key decision + considered alternatives; tightened the node-reference-protocol Scope-rule guarantee.
2. `feat(node-identity)` — `PositionKey.layer`, `get_or_create_in_layer`/`lookup_node`, layer-precise resolution, consumer migration, 4 unit tests.
3. `test(e2e)` — host-vs-injected collision regression (distinct ULIDs + in-layer navigation).

## Testing

- Full lib suite (1515 tests) green via pre-commit hook.
- e2e: `e2e_kakehashi_node` (45), `e2e_semantic_blockquote` (33), `e2e_stable_region_id` (19), `e2e_semantic` (23), `e2e_selection_range` (22) — all green; confirms no regression in semantic tokens or injection-region tracking.
- The new e2e regression tests were verified to **fail** when the injected mint is forced back to layer 0, proving they guard the fix.

## Notes

- The "remove ADR-0025 known-limitation note" acceptance criterion was a no-op — no such note exists in the migrated `node-reference-protocol.md`; the Scope-rule wording was strengthened instead.
- The issue text predates the ADR → `docs/architecture-decisions/` rename, so its criteria reference `ADR-0019`/`ADR-0025` (now `lazy-node-identity-tracking.md` / `node-reference-protocol.md`).