### PR TITLE
docs(adr): standardize cross-refs on plain-text mentions

### DIFF
--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -25,7 +25,7 @@ Design challenges:
 ## Decision Drivers
 
 - **Minimal schema disruption**: no new types in `BridgeServerConfig`, `BridgeLanguageConfig`, or `AggregationConfig`.
-- **Reuse wildcard machinery**: [wildcard-config-inheritance](wildcard-config-inheritance.md)'s `resolve_with_wildcard` should apply uniformly across host and virt entries.
+- **Reuse wildcard machinery**: wildcard-config-inheritance's `resolve_with_wildcard` should apply uniformly across host and virt entries.
 - **Capability vs. policy separation**: `languageServers.*` declares *what* an LS can do; `languages.*.bridge.*` decides *whether and how* it is used.
 - **Opt-in for new behavior**: host bridging defaults *off* so existing configs are unchanged.
 - **Symmetric mental model**: host and virt are both "bridges" — only the LS-matching rule differs.
@@ -91,7 +91,7 @@ No new fields on `BridgeServerConfig`. An LS that should not act as host for a g
 
 ### Wildcard Merge Safety
 
-Concern: under [wildcard-config-inheritance](wildcard-config-inheritance.md), `resolve_with_wildcard(map, "_self", merge)` merges the `_` wildcard into the `_self` entry. If `_.enabled = true` and `_self.enabled` were absent, the wildcard would silently turn host bridging on.
+Concern: under wildcard-config-inheritance, `resolve_with_wildcard(map, "_self", merge)` merges the `_` wildcard into the `_self` entry. If `_.enabled = true` and `_self.enabled` were absent, the wildcard would silently turn host bridging on.
 
 Resolution: built-in defaults at `languages._.bridge._self.enabled = false` and `languages._.bridge._.enabled = true` mean that after the *outer* wildcard merge (language layer), every `bridge` map sees `_self` populated with `Some(false)`. During the *inner* wildcard merge (`_self ⊕ _`), key-specific fields win — `_self.enabled = Some(false)` beats `_.enabled = Some(true)`. No special case is needed.
 
@@ -122,7 +122,7 @@ The same reasoning extends to any future `_self`-meaningful field: as long as th
 
 ### URI and Coordinate Handling
 
-Host bridges use the **real URI** as sent by the client. This is the key distinction from virt bridges ([language-server-bridge-virtual-document-model](language-server-bridge-virtual-document-model.md)):
+Host bridges use the **real URI** as sent by the client. This is the key distinction from virt bridges (language-server-bridge-virtual-document-model):
 
 | Aspect | Virt bridge | Host bridge |
 |---|---|---|

--- a/docs/architecture-decisions/language-detection-fallback-chain.md
+++ b/docs/architecture-decisions/language-detection-fallback-chain.md
@@ -1,6 +1,6 @@
 # Language Detection Fallback Chain
 
-> The `aliases` field (`build_alias_map()`, `resolve_alias()`) is superseded by the `base` field (see [base-language-inheritance](base-language-inheritance.md)); the detection fallback chain (languageId → token → first-line) and syntect normalization remain unchanged.
+> The `aliases` field (`build_alias_map()`, `resolve_alias()`) is superseded by the `base` field (see base-language-inheritance); the detection fallback chain (languageId → token → first-line) and syntect normalization remain unchanged.
 
 ## Context
 

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -2,8 +2,8 @@
 
 > The single-LS, per-method strategies defined here remain in effect. Multi-LS
 > routing, aggregation, and initialization-window handling are covered by
-> [ls-bridge-message-ordering](ls-bridge-message-ordering.md) and
-> [ls-bridge-server-pool-coordination](ls-bridge-server-pool-coordination.md).
+> ls-bridge-message-ordering and
+> ls-bridge-server-pool-coordination.
 
 ## Decision–Implementation Gap
 
@@ -13,7 +13,7 @@ The remaining three are not yet implemented.
 
 ## Context
 
-When bridging LSP requests for injection regions (see [language-server-bridge](language-server-bridge.md)), different LSP methods have different characteristics:
+When bridging LSP requests for injection regions (see language-server-bridge), different LSP methods have different characteristics:
 
 | Method | Latency Sensitivity | kakehashi Capability | Language Server Value |
 |--------|---------------------|--------------------------|----------------------|

--- a/docs/architecture-decisions/language-server-bridge-virtual-document-model.md
+++ b/docs/architecture-decisions/language-server-bridge-virtual-document-model.md
@@ -8,7 +8,7 @@ document) is deferred and not implemented.
 
 ## Context
 
-When bridging LSP requests for injection regions (see [language-server-bridge](language-server-bridge.md)), we need to represent injection content to language servers. A host document may contain multiple injection regions of the same language (e.g., multiple Rust code blocks in Markdown).
+When bridging LSP requests for injection regions (see language-server-bridge), we need to represent injection content to language servers. A host document may contain multiple injection regions of the same language (e.g., multiple Rust code blocks in Markdown).
 
 The key question: **Should multiple injections of the same language be isolated (each in its own virtual document), or combined into a single virtual document?**
 
@@ -78,7 +78,7 @@ isolation = true
 isolation = false
 ```
 
-The `_` wildcard matches any host or injection language, enabling layered defaults (see [wildcard-config-inheritance](wildcard-config-inheritance.md)):
+The `_` wildcard matches any host or injection language, enabling layered defaults (see wildcard-config-inheritance):
 
 | Host | Bridge Config | Meaning |
 |------|---------------|---------|
@@ -145,7 +145,7 @@ Virtual documents may be **logical** (in-memory only) or **materialized** (writt
 **Why materialization is sometimes required**: Some language servers (notably rust-analyzer) index from the filesystem rather than relying solely on `didOpen` content. They return `null` for queries when files don't exist on disk or lack project context.
 
 For materialized documents:
-- Create temporary project structure (see [language-server-bridge](language-server-bridge.md#workspace-provisioning))
+- Create temporary project structure (see language-server-bridge § Workspace Provisioning)
 - Write injection content to real file
 - Use real file URI in LSP communication
 - Clean up on document close or server shutdown

--- a/docs/architecture-decisions/language-server-bridge.md
+++ b/docs/architecture-decisions/language-server-bridge.md
@@ -438,9 +438,9 @@ For a single injection region starting at host line `H` and column `C`:
 | Host → Virtual | `virtual_line = host_line - H`, `virtual_col = host_col - C` (first line only) |
 | Virtual → Host | `host_line = virtual_line + H`, `host_col = virtual_col + C` (first line only) |
 
-For multiple injections of the same language in one document, see [language-server-bridge-virtual-document-model](language-server-bridge-virtual-document-model.md) for virtual document strategies.
+For multiple injections of the same language in one document, see language-server-bridge-virtual-document-model for virtual document strategies.
 
-Translation is straightforward for positions within a single injection. See [language-server-bridge-request-strategies](language-server-bridge-request-strategies.md) for complex cases involving cross-file references.
+Translation is straightforward for positions within a single injection. See language-server-bridge-request-strategies for complex cases involving cross-file references.
 
 ## Consequences
 
@@ -464,7 +464,7 @@ Translation is straightforward for positions within a single injection. See [lan
 ### Neutral
 
 - **Configuration optional**: Some servers (pyright) work out-of-the-box; others (rust-analyzer) benefit from `initializationOptions` for full functionality
-- **Partial feature support**: Not all LSP methods will be bridged (see [language-server-bridge-request-strategies](language-server-bridge-request-strategies.md))
+- **Partial feature support**: Not all LSP methods will be bridged (see language-server-bridge-request-strategies)
 - **Server availability**: Graceful degradation when servers not installed
 
 ## Implementation Phases
@@ -497,7 +497,7 @@ Translation is straightforward for positions within a single injection. See [lan
 
 ### Phase 5+: Feature Expansion
 
-See [language-server-bridge-request-strategies](language-server-bridge-request-strategies.md) for per-method implementation details.
+See language-server-bridge-request-strategies for per-method implementation details.
 
 ## Related Decisions
 

--- a/docs/architecture-decisions/lazy-node-identity-tracking.md
+++ b/docs/architecture-decisions/lazy-node-identity-tracking.md
@@ -104,7 +104,7 @@ different injection layers — "a Markdown `code_fence_content` vs a Python
 injection**: a ```` ```markdown ```` block injected into a Markdown host produces
 a `paragraph` (or any node kind) at the **same span and kind** in both the host
 tree and the injected tree. Without `layer`, both collapse to one ULID, and
-navigation ([node-reference-protocol](node-reference-protocol.md)) can no longer
+navigation (node-reference-protocol) can no longer
 tell which language tree the ID belongs to — violating that protocol's per-layer
 Scope rule. Adding `layer` makes the host and injected nodes distinct ULIDs,
 eliminating this collision **within a single parse**. (It does not by itself make

--- a/docs/architecture-decisions/ls-bridge-async-connection.md
+++ b/docs/architecture-decisions/ls-bridge-async-connection.md
@@ -158,7 +158,7 @@ The system uses two distinct timeout mechanisms with different purposes:
 
 **Independence**: The two timeouts serve different purposes and never overlap (liveness disabled during Initializing; initialization timeout disabled once Ready).
 
-**Coordination with Other Timeouts**: See [ls-bridge-timeout-hierarchy](ls-bridge-timeout-hierarchy.md) for precedence rules when shutdown timeout is active.
+**Coordination with Other Timeouts**: See ls-bridge-timeout-hierarchy for precedence rules when shutdown timeout is active.
 
 ## Consequences
 

--- a/docs/architecture-decisions/ls-bridge-graceful-shutdown.md
+++ b/docs/architecture-decisions/ls-bridge-graceful-shutdown.md
@@ -25,7 +25,7 @@ ls-bridge-async-connection (Async Bridge Connection), ls-bridge-message-ordering
 
 ### Connection State for Shutdown
 
-This decision defines behavior for `Closing` and `Closed` states. See [ls-bridge-message-ordering § Connection State Tracking](ls-bridge-message-ordering.md#4-connection-state-tracking) for the complete ConnectionState enum.
+This decision defines behavior for `Closing` and `Closed` states. See ls-bridge-message-ordering § Connection State Tracking for the complete ConnectionState enum.
 
 **Shutdown-Specific Transitions:**
 ```

--- a/docs/architecture-decisions/ls-bridge-message-ordering.md
+++ b/docs/architecture-decisions/ls-bridge-message-ordering.md
@@ -1,6 +1,6 @@
 # LS Bridge Message Ordering
 
-**Phasing**: See [ls-bridge-implementation-phasing](ls-bridge-implementation-phasing.md) — This decision covers Phase 1; optional coalescing deferred to Phase 2.
+**Phasing**: See ls-bridge-implementation-phasing — This decision covers Phase 1; optional coalescing deferred to Phase 2.
 
 ## Scope
 

--- a/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
+++ b/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
@@ -4,7 +4,7 @@
 - [ls-bridge-async-connection](ls-bridge-async-connection.md): Single-connection async I/O
 - [ls-bridge-message-ordering](ls-bridge-message-ordering.md): Single-server message ordering
 
-**Phasing**: See [ls-bridge-implementation-phasing](ls-bridge-implementation-phasing.md) — Phase 1 (routing), Phase 2 (rate-limited respawn), Phase 3 (aggregation).
+**Phasing**: See ls-bridge-implementation-phasing — Phase 1 (routing), Phase 2 (rate-limited respawn), Phase 3 (aggregation).
 
 ## Scope
 
@@ -191,7 +191,7 @@ downstream ──notification──►  bridge  ──notification──►  ups
 
 ### Cancellation Propagation
 
-See [ls-bridge-message-ordering § Cancellation Forwarding](ls-bridge-message-ordering.md#5-cancellation-forwarding) for single-connection cancellation semantics.
+See ls-bridge-message-ordering § Cancellation Forwarding for single-connection cancellation semantics.
 
 **Multi-Connection Coordination (Phase 3)**: Router forwards `$/cancelRequest` to all connections that received the original fan-out request.
 

--- a/docs/architecture-decisions/ls-bridge-timeout-hierarchy.md
+++ b/docs/architecture-decisions/ls-bridge-timeout-hierarchy.md
@@ -5,7 +5,7 @@
 - [ls-bridge-server-pool-coordination](ls-bridge-server-pool-coordination.md) § Response Aggregation
 - [ls-bridge-graceful-shutdown](ls-bridge-graceful-shutdown.md) § Shutdown Timeout
 
-**Phasing**: See [ls-bridge-implementation-phasing](ls-bridge-implementation-phasing.md) — Phase 1 (Init, Liveness, Global Shutdown), Phase 3 (Per-Request).
+**Phasing**: See ls-bridge-implementation-phasing — Phase 1 (Init, Liveness, Global Shutdown), Phase 3 (Per-Request).
 
 ## Scope
 

--- a/docs/architecture-decisions/node-reference-protocol.md
+++ b/docs/architecture-decisions/node-reference-protocol.md
@@ -163,7 +163,7 @@ Edge cases:
 
 **Scope rule**: Navigation stays within a single language tree. Calling `parent` on the root of an injected tree returns `null`, **not** the host node that contains the injection. Crossing injection boundaries requires a fresh `kakehashi/node` call.
 
-This holds even when a host node and an injected node share an identical span **and** kind (e.g. recursive same-language injection such as markdown-in-markdown). The identity key carries an injection-`layer` discriminator (lazy-node-identity-tracking §"Node Uniqueness Key"), so the two are distinct ULIDs and `parent`/`children` resolve each in the tree that minted it.
+This holds even when a host node and an injected node share an identical span **and** kind (e.g. recursive same-language injection such as markdown-in-markdown). The identity key carries an injection-`layer` discriminator (lazy-node-identity-tracking § Node Uniqueness Key), so the two are distinct ULIDs and `parent`/`children` resolve each in the tree that minted it.
 
 **`null` cases**:
 - `parent`: id not in tracker, **or** id refers to a root node

--- a/docs/architecture-decisions/node-reference-protocol.md
+++ b/docs/architecture-decisions/node-reference-protocol.md
@@ -6,7 +6,7 @@
 
 ## Context and Problem Statement
 
-Kakehashi already parses every open document with tree-sitter and maintains stable node identities across edits via [lazy-node-identity-tracking](lazy-node-identity-tracking.md). The syntax tree carries information that editor users and plugin authors routinely want to act on — node boundaries, types, parent-child relations, injection structure — but **none of it is currently reachable from the client side**.
+Kakehashi already parses every open document with tree-sitter and maintains stable node identities across edits via lazy-node-identity-tracking. The syntax tree carries information that editor users and plugin authors routinely want to act on — node boundaries, types, parent-child relations, injection structure — but **none of it is currently reachable from the client side**.
 
 The goal of this protocol is to **open kakehashi as a platform for syntax-aware extensions**: any LSP client (editor command, plugin, REPL, scripting layer) should be able to ask kakehashi about nodes and build features on top, **without bundling tree-sitter on the client side** and without re-implementing the parser, queries, or injection logic that kakehashi already maintains.
 
@@ -22,7 +22,7 @@ These all reduce to four primitives: **identify a node at a position**, **naviga
 ## Decision Drivers
 
 * **Minimal API surface**: Each method returns exactly one kind of information, composing well
-* **Edit-resilient**: A held ID must continue to resolve after `didChange`, as long as the underlying node survives invalidation rules ([lazy-node-identity-tracking](lazy-node-identity-tracking.md))
+* **Edit-resilient**: A held ID must continue to resolve after `didChange`, as long as the underlying node survives invalidation rules (lazy-node-identity-tracking)
 * **LSP-spec aligned**: Custom methods, but parameter shapes follow LSP conventions (`TextDocumentIdentifier`, `Position`, `Range`)
 * **Predictable null semantics**: A single null response means "not currently valid", whether due to invalidation, prior unknown ID, or out-of-range position
 * **Injection-aware**: Multi-layer language nesting (e.g., Markdown → Python → regex) must be addressable explicitly
@@ -163,7 +163,7 @@ Edge cases:
 
 **Scope rule**: Navigation stays within a single language tree. Calling `parent` on the root of an injected tree returns `null`, **not** the host node that contains the injection. Crossing injection boundaries requires a fresh `kakehashi/node` call.
 
-This holds even when a host node and an injected node share an identical span **and** kind (e.g. recursive same-language injection such as markdown-in-markdown). The identity key carries an injection-`layer` discriminator ([lazy-node-identity-tracking](lazy-node-identity-tracking.md) §"Node Uniqueness Key"), so the two are distinct ULIDs and `parent`/`children` resolve each in the tree that minted it.
+This holds even when a host node and an injected node share an identical span **and** kind (e.g. recursive same-language injection such as markdown-in-markdown). The identity key carries an injection-`layer` discriminator (lazy-node-identity-tracking §"Node Uniqueness Key"), so the two are distinct ULIDs and `parent`/`children` resolve each in the tree that minted it.
 
 **`null` cases**:
 - `parent`: id not in tracker, **or** id refers to a root node
@@ -186,7 +186,7 @@ This holds even when a host node and an injected node share an identical span **
 null                                    // id is not currently valid for this document
 ```
 
-The returned text is sliced from the **current** document content using the node's adjusted byte range. Because [lazy-node-identity-tracking](lazy-node-identity-tracking.md)'s position adjustment runs synchronously inside `didChange`, the slice is always consistent with the document the client has observed.
+The returned text is sliced from the **current** document content using the node's adjusted byte range. Because lazy-node-identity-tracking's position adjustment runs synchronously inside `didChange`, the slice is always consistent with the document the client has observed.
 
 ### Invalidate vs Not-Found
 
@@ -196,12 +196,12 @@ Clients **cannot distinguish** between:
 - An ID that was never issued by this server for the supplied `textDocument`
 - A `textDocument` that has no tracker entries (e.g., never opened, already closed)
 
-All three collapse to `null`. This is a deliberate consequence of the no-tombstone, no-LRU design ([lazy-node-identity-tracking](lazy-node-identity-tracking.md)). Clients that need to refresh a node should treat `null` as "re-acquire via `kakehashi/node`".
+All three collapse to `null`. This is a deliberate consequence of the no-tombstone, no-LRU design (lazy-node-identity-tracking). Clients that need to refresh a node should treat `null` as "re-acquire via `kakehashi/node`".
 
 ### Lifecycle
 
 - `didOpen`: no eager work — IDs are issued lazily on first `kakehashi/node*` request
-- `didChange`: existing IDs are repositioned or invalidated per [lazy-node-identity-tracking](lazy-node-identity-tracking.md)
+- `didChange`: existing IDs are repositioned or invalidated per lazy-node-identity-tracking
 - `didClose`: all IDs for the URI are dropped
 
 ## Example Flow
@@ -239,7 +239,7 @@ All three collapse to `null`. This is a deliberate consequence of the no-tombsto
 - **No invalidate diagnostics**: Clients cannot tell why an ID failed; they must re-acquire blindly
 - **Cross-injection navigation is two-step**: `parent` does not transparently cross into a host tree
 - **`injection` mixed mode**: `true` saturates while integer indices are strict (resolve via a single formula, return `null` when out of bounds) — clients must remember which mode they want
-- **Unbounded tracker growth per URI**: Long editing sessions on large files accumulate IDs until `didClose` (no LRU per [lazy-node-identity-tracking](lazy-node-identity-tracking.md))
+- **Unbounded tracker growth per URI**: Long editing sessions on large files accumulate IDs until `didClose` (no LRU per lazy-node-identity-tracking)
 
 ### Neutral
 
@@ -282,7 +282,7 @@ Include `range` in every `NodeInfo` returned.
 
 - Methods are registered via `LspService::build().custom_method(...)` in `src/bin/main.rs`, following the existing `kakehashi/internal/effectiveConfiguration` pattern
 - Handlers live under `src/lsp/lsp_impl/kakehashi/node/` (one file per method) for symmetry with `kakehashi/internal/`
-- `RegionIdTracker` is renamed to `NodeTracker` and extended with a reverse index (`Ulid → PositionKey`); see [lazy-node-identity-tracking](lazy-node-identity-tracking.md)
+- `RegionIdTracker` is renamed to `NodeTracker` and extended with a reverse index (`Ulid → PositionKey`); see lazy-node-identity-tracking
 - Injection layer enumeration reuses the existing injection processing in `src/lsp/lsp_impl/coordinator/injection.rs`
 
 ## Summary

--- a/docs/architecture-decisions/template.md
+++ b/docs/architecture-decisions/template.md
@@ -12,8 +12,7 @@ Keep the alternatives that were genuinely considered: this directory records the
 Cross-references between ADRs:
 - In body prose, refer to another ADR by its **bare slug in plain text**
   (e.g. `see node-reference-protocol`), NOT as a markdown link. Add a section
-  reference inline when useful (e.g. `ls-bridge-message-ordering § Cancellation
-  Forwarding`).
+  reference inline when useful (e.g. `ls-bridge-message-ordering § Cancellation Forwarding`).
 - Reserve markdown links (`[slug](slug.md)`) for the curated **Related
   Decisions** block and footer link lists (e.g. `## Related Decisions`,
   `## More Information`).

--- a/docs/architecture-decisions/template.md
+++ b/docs/architecture-decisions/template.md
@@ -9,14 +9,16 @@ old record — its history stays in `git log` (use `git log --follow <file>`).
 Keep the alternatives that were genuinely considered: this directory records the
 *decisions*, including the options weighed and why the chosen one won.
 
-Cross-references between ADRs:
+Cross-references between ADRs (this rule covers ADR-to-ADR `[slug](slug.md)`
+links only; links to non-ADR targets — external URLs, source files, README —
+are unaffected and may appear anywhere):
 - In body prose, refer to another ADR by its **bare slug in plain text**
   (e.g. `see node-reference-protocol`), NOT as a markdown link. Add a section
   reference inline when useful (e.g. `ls-bridge-message-ordering § Cancellation Forwarding`).
-- Reserve markdown links (`[slug](slug.md)`) for the curated related-decisions
-  block — written as a top-of-file `**Related Decisions**:` / `**Related**:`
-  list or a footer `## Related Decisions` section — and for footer link lists
-  (e.g. `## More Information`).
+- Reserve ADR-slug markdown links (`[slug](slug.md)`) for the curated
+  related-decisions block — written as a top-of-file `**Related Decisions**:` /
+  `**Related**:` list or a footer `## Related Decisions` section — and for
+  footer link lists (e.g. `## More Information`).
 - Rationale: ADRs are deleted when superseded (delete-on-supersede), so inline
   links rot into clickable 404s. Plain-text mentions degrade gracefully to a
   stale-but-harmless proper noun, keeping the curated link block the single

--- a/docs/architecture-decisions/template.md
+++ b/docs/architecture-decisions/template.md
@@ -8,6 +8,19 @@ Supersession is NOT recorded here. When a decision replaces another, delete the
 old record — its history stays in `git log` (use `git log --follow <file>`).
 Keep the alternatives that were genuinely considered: this directory records the
 *decisions*, including the options weighed and why the chosen one won.
+
+Cross-references between ADRs:
+- In body prose, refer to another ADR by its **bare slug in plain text**
+  (e.g. `see node-reference-protocol`), NOT as a markdown link. Add a section
+  reference inline when useful (e.g. `ls-bridge-message-ordering § Cancellation
+  Forwarding`).
+- Reserve markdown links (`[slug](slug.md)`) for the curated **Related
+  Decisions** block and footer link lists (e.g. `## Related Decisions`,
+  `## More Information`).
+- Rationale: ADRs are deleted when superseded (delete-on-supersede), so inline
+  links rot into clickable 404s. Plain-text mentions degrade gracefully to a
+  stale-but-harmless proper noun, keeping the curated link block the single
+  place a link can rot.
 -->
 
 ## Context

--- a/docs/architecture-decisions/template.md
+++ b/docs/architecture-decisions/template.md
@@ -13,9 +13,10 @@ Cross-references between ADRs:
 - In body prose, refer to another ADR by its **bare slug in plain text**
   (e.g. `see node-reference-protocol`), NOT as a markdown link. Add a section
   reference inline when useful (e.g. `ls-bridge-message-ordering § Cancellation Forwarding`).
-- Reserve markdown links (`[slug](slug.md)`) for the curated **Related
-  Decisions** block and footer link lists (e.g. `## Related Decisions`,
-  `## More Information`).
+- Reserve markdown links (`[slug](slug.md)`) for the curated related-decisions
+  block — written as a top-of-file `**Related Decisions**:` / `**Related**:`
+  list or a footer `## Related Decisions` section — and for footer link lists
+  (e.g. `## More Information`).
 - Rationale: ADRs are deleted when superseded (delete-on-supersede), so inline
   links rot into clickable 404s. Plain-text mentions degrade gracefully to a
   stale-but-harmless proper noun, keeping the curated link block the single


### PR DESCRIPTION
## Summary

Standardizes ADR cross-references on **terse plain-text slug mentions** in body prose, reserving markdown links for the curated **Related Decisions** blocks and footer link lists. Closes #317.

## Why

ADRs here are deleted when superseded (delete-on-supersede), so inline `[slug](slug.md)` links in body prose rot into clickable 404s on GitHub — and a single ADR is often linked many times in one file, so one rename breaks them all. The repo was genuinely *mixed*: some files used inline links, some plain-text mentions, and a few (`host-document-bridge.md`) used both. PR #316 surfaced this when a review bot cited a "guideline" that was never actually documented.

Plain-text mentions degrade gracefully to a stale-but-harmless proper noun, keeping the curated link block the single surface where a link is allowed to rot.

## Changes

- **`template.md`**: adds an explicit "Cross-references between ADRs" rule so the convention is documented and enforceable.
- **12 ADR files**: converted ~24 inline body-prose links to plain-text slugs. The two allowed link zones are untouched:
  - top `**Related**:` / `**Related Decisions**:` header blocks
  - footer `## Related Decisions` / `## More Information` sections

Edge cases: anchored links keep their section reference as plain text (e.g. `ls-bridge-message-ordering § Connection State Tracking`); `...#workspace-provisioning` became `language-server-bridge § Workspace Provisioning`.

## Acceptance criteria

- [x] Body prose contains no inline `[slug](slug.md)` links (verified via grep)
- [x] No `.md#anchor` links remain in body prose
- [x] Markdown links remain only in Related Decisions / More Information zones (61 surviving links, all in-zone)
- [x] `template.md` documents the rule

## Verification

Pre-commit hook (clippy `-D warnings`, fmt, full `--lib` test suite) passed. Docs-only change — no behavior affected.