### PR TITLE
docs(node-identity): plain-text inline decision references (follow-up to #316)

### DIFF
--- a/docs/architecture-decisions/lazy-node-identity-tracking.md
+++ b/docs/architecture-decisions/lazy-node-identity-tracking.md
@@ -104,7 +104,7 @@ different injection layers — "a Markdown `code_fence_content` vs a Python
 injection**: a ```` ```markdown ```` block injected into a Markdown host produces
 a `paragraph` (or any node kind) at the **same span and kind** in both the host
 tree and the injected tree. Without `layer`, both collapse to one ULID, and
-navigation ([node-reference-protocol](node-reference-protocol.md)) can no longer
+navigation (node-reference-protocol) can no longer
 tell which language tree the ID belongs to — violating that protocol's per-layer
 Scope rule. Adding `layer` makes the host and injected nodes distinct ULIDs,
 eliminating this collision **within a single parse**. (It does not by itself make

--- a/docs/architecture-decisions/node-reference-protocol.md
+++ b/docs/architecture-decisions/node-reference-protocol.md
@@ -163,7 +163,7 @@ Edge cases:
 
 **Scope rule**: Navigation stays within a single language tree. Calling `parent` on the root of an injected tree returns `null`, **not** the host node that contains the injection. Crossing injection boundaries requires a fresh `kakehashi/node` call.
 
-This holds even when a host node and an injected node share an identical span **and** kind (e.g. recursive same-language injection such as markdown-in-markdown). The identity key carries an injection-`layer` discriminator ([lazy-node-identity-tracking](lazy-node-identity-tracking.md) §"Node Uniqueness Key"), so the two are distinct ULIDs and `parent`/`children` resolve each in the tree that minted it.
+This holds even when a host node and an injected node share an identical span **and** kind (e.g. recursive same-language injection such as markdown-in-markdown). The identity key carries an injection-`layer` discriminator (lazy-node-identity-tracking §"Node Uniqueness Key"), so the two are distinct ULIDs and `parent`/`children` resolve each in the tree that minted it.
 
 **`null` cases**:
 - `parent`: id not in tracker, **or** id refers to a root node
@@ -282,7 +282,7 @@ Include `range` in every `NodeInfo` returned.
 
 - Methods are registered via `LspService::build().custom_method(...)` in `src/bin/main.rs`, following the existing `kakehashi/internal/effectiveConfiguration` pattern
 - Handlers live under `src/lsp/lsp_impl/kakehashi/node/` (one file per method) for symmetry with `kakehashi/internal/`
-- `RegionIdTracker` is renamed to `NodeTracker` and extended with a reverse index (`Ulid → PositionKey`); see [lazy-node-identity-tracking](lazy-node-identity-tracking.md)
+- `RegionIdTracker` is renamed to `NodeTracker` and extended with a reverse index (`Ulid → PositionKey`); see lazy-node-identity-tracking
 - Injection layer enumeration reuses the existing injection processing in `src/lsp/lsp_impl/coordinator/injection.rs`
 
 ## Summary


### PR DESCRIPTION
Follow-up to #316 (already merged). The Gemini review comments on #316 arrived after it merged, so this lands them in `main`.

Per the architecture-decisions convention (cf. `base-language-inheritance.md`), inline cross-references to other decisions are **bare-slug plain text**; markdown links are reserved for the dedicated "Related Decisions" section. Converts the three inline links introduced/touched by #316:

- `lazy-node-identity-tracking.md`: `([node-reference-protocol](…))` → `(node-reference-protocol)`
- `node-reference-protocol.md` (Scope rule): `([lazy-node-identity-tracking](…) §"…")` → `(lazy-node-identity-tracking §"…")`
- `node-reference-protocol.md` (Implementation Notes): `see [lazy-node-identity-tracking](…)` → `see lazy-node-identity-tracking`

Pre-existing inline links elsewhere in `node-reference-protocol.md` are left as-is (out of scope; not touched by #316).

Addresses:
- https://github.com/atusy/kakehashi/pull/316#discussion_r3367565056
- https://github.com/atusy/kakehashi/pull/316#discussion_r3367565064
- https://github.com/atusy/kakehashi/pull/316#discussion_r3367565067