### PR TITLE
docs(adr): define concatenated formatting as a sequential pipeline

### DIFF
--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -133,7 +133,11 @@ opt-in to a sequential formatter pipeline driven by `priorities`.
    strip those prefixes and corrupt blockquoted/indented injections — the existing
    single-edit limitation noted in `src/lsp/bridge/text_document/formatting.rs`
    ("multi-line edits drop host indentation"), which the pipeline's full-region
-   output must resolve.
+   output must resolve. Because a formatter may add or remove lines, the per-line
+   `RegionOffset` columns no longer map 1:1 to the output; for lines without a
+   prior-line counterpart the pipeline applies the region's **uniform prefix** —
+   the common host prefix/indentation shared by the region's lines (e.g. the
+   blockquote `> `), captured once for the region — to every output line.
 
 5. **Range formatting stays on `preferred`.** Although `textDocument/rangeFormatting`
    shares this aggregation config (it resolves `strategy`/`priorities` under the
@@ -191,9 +195,9 @@ opt-in to a sequential formatter pipeline driven by `priorities`.
    project config (`.prettierrc`, `pyproject.toml`, …) and select a parser from
    the URI's directory and extension. So the scratch URI must keep the canonical
    virtual document's directory and file extension (not a random or
-   different-scheme URI), or config discovery and language detection break. The
-   naming requirements and examples are described below. The flip side: a
-   real-looking scratch
+   different-scheme URI), or config discovery and language detection break (naming
+   requirements and an example follow inline). The flip side: a real-looking
+   scratch
    URI risks the downstream server indexing it as a workspace file (duplicate
    symbols, namespace collisions, stray diagnostics). The bridge therefore
    **must keep the scratch document ephemeral** (`didOpen`/`didClose` bracketing

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -94,10 +94,10 @@ opt-in to a sequential formatter pipeline driven by `priorities`.
    text from the host document **after parse completion** — never a half-parsed
    snapshot, since stale injection boundaries would corrupt the region — then, for
    each server in `priorities` order, against the **current** region text:
-   1. make the current accumulated text available to the server — the scratch
-      document's `didOpen` (point 7) carries it; a `didChange` is only needed when
-      a single scratch document is reused across steps rather than opened fresh per
-      server;
+   1. make the current accumulated text available to the server — since each
+      downstream server is an independent process, it receives a
+      **fresh `didOpen`** on its scratch document (point 7) carrying the latest
+      accumulated text, so intermediate `didChange` notifications are unnecessary;
    2. ask that server to format the whole region. The **pipeline** prefers
       `textDocument/formatting`; the fallback keys on **capability**, not on the
       response: only when the server does not advertise `documentFormattingProvider`
@@ -184,7 +184,7 @@ opt-in to a sequential formatter pipeline driven by `priorities`.
    failing step is logged so the misbehaving server is diagnosable.
 
 7. **Isolate speculative state in a scratch document (state-consistency invariant).**
-   The intermediate `didChange` notifications (step 3.1) push
+   The scratch `didOpen` notifications (step 3.1) push
    *speculative* formatted text — text the editor has **not** applied. The
    editor's truth only changes when it applies the final emitted edit (or stays at
    the original on a no-op / complete failure / cancellation). The **invariant**
@@ -217,17 +217,20 @@ opt-in to a sequential formatter pipeline driven by `priorities`.
    the single pipeline run) and
    **discard any server-initiated notifications targeting scratch URIs**
    (notably `textDocument/publishDiagnostics`) so they never reach the editor. The
-   scratch URI should also carry a
-   **standardized, ignorable marker** in its name (e.g. a `.kakehashi-scratch` infix as in
-   `…/file.kakehashi-scratch.py`) while keeping the directory and extension, so
-   that anything which does observe paths — file watchers, build tools, test
-   runners, hot-reloaders — can recognize and ignore it. (Scratch documents are
+   scratch URI should also follow the existing virtual-document scheme
+   (`{scheme}:///{host_dir}/kakehashi-virtual-uri-{id}.{ext}`,
+   `src/lsp/bridge/protocol/virtual_uri.rs`) with a scratch-specific id — e.g.
+   `…/{host_dir}/kakehashi-virtual-uri-{id}-scratch.py` — so it keeps the host
+   directory and extension (config discovery, parser selection), stays unique per
+   region (no host-file collision), and carries the distinctive `kakehashi-virtual-uri-`
+   marker that anything observing paths — file watchers, build tools, test
+   runners, hot-reloaders — can recognize and ignore. (Scratch documents are
    virtual LSP documents whose content is delivered via `didOpen`; a recognizable
    name bounds the blast radius if a server resolves the path on disk.)
 
 The pipeline reuses the existing per-server virtual-document and
 position-translation machinery; the new parts are (a) strategy dispatch, (b) the
-intermediate `didChange` that feeds each server's output into the next,
+fresh scratch `didOpen` that feeds each server's output into the next,
 (c) collapsing the final text into one region-replacement edit, and (d) the
 scratch-document lifecycle that isolates the pipeline's speculative state.
 
@@ -260,8 +263,8 @@ priorities = ["black", "isort"]
 Deterministic (config order), trivially non-overlapping (one pass, one output
 edit), handles the mixed whole-document + complementary case, and matches how
 formatter chains (`black` then `isort`) actually work. Cost: fully serial
-(latency = sum of round-trips) and requires `didChange` choreography to feed each
-server.
+(latency = sum of round-trips) and requires scratch-document lifecycle
+choreography (a `didOpen`/`didClose` per step) to feed each server.
 
 ### B. Parallel diff-stacking with conflict re-request (rejected)
 
@@ -301,7 +304,7 @@ change without affecting the config surface.
 ### Negative
 
 - **Serial latency**: total time is the sum of per-server round-trips plus the
-  intermediate `didChange` processing; a per-pipeline timeout budget is required —
+  scratch `didOpen`/`didClose` handling; a per-pipeline timeout budget is required —
   reusing the existing per-request aggregation timeout (ls-bridge-timeout-hierarchy,
   ls-bridge-server-pool-coordination) as the whole-pipeline bound rather than
   introducing a formatting-specific timeout config.
@@ -311,16 +314,15 @@ change without affecting the config surface.
   pipeline until it returns. On abort the bridge should also send
   `$/cancelRequest` to the active downstream server so it stops the discarded
   formatting task and frees its resources.
-- **Downstream statefulness**: feeding each server requires a `didChange` and
-  waiting for it to take effect before re-requesting — more protocol
-  choreography than a stateless forward.
+- **Downstream statefulness**: feeding each server requires a `didOpen` carrying
+  the accumulated text and a matching `didClose` — more protocol choreography than
+  a stateless forward.
 - **Coarse output**: full-region replacement enlarges the edit payload, can
   coarsen editor undo granularity, and may disrupt the user's cursor position,
   active code folds, or bookmarks within the region until option D is taken.
 - **Scratch-document overhead**: isolating speculative state (Decision point 7)
-  costs a `didOpen`/`didClose` of a throwaway document per pipeline run, plus the
-  per-step `didChange`s — extra protocol traffic to keep the canonical document
-  untouched.
+  costs a `didOpen`/`didClose` of a throwaway document per pipeline step — extra
+  protocol traffic to keep the canonical document untouched.
 - **`priorities` semantics overload**: for formatting, `priorities` becomes an
   allowlist+order (servers not listed do not run), unlike `preferred` where it is
   only a tie-break ordering. Documented, but a behavioral nuance.

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -1,0 +1,212 @@
+# Concatenated Formatting Pipeline
+
+> Scoped to `textDocument/formatting` within a single injection region (see
+> [language-server-bridge-virtual-document-model](language-server-bridge-virtual-document-model.md)).
+> Per-method strategy selection and the cross-file/edit-filtering rules live in
+> [language-server-bridge-request-strategies](language-server-bridge-request-strategies.md);
+> the `AggregationStrategy` enum and fan-in mechanics live in
+> [ls-bridge-server-pool-coordination](ls-bridge-server-pool-coordination.md).
+
+## Context
+
+A single injection region may have **multiple downstream language servers**
+configured for the same language. For most methods, the `preferred` strategy
+(first non-empty response wins) is the right default, and for list-producing
+methods (`textDocument/diagnostic`, `references`) the `concatenated` strategy
+concatenates the **result lists** from all servers.
+
+Formatting is different. Real-world formatting setups routinely chain several
+tools over one document:
+
+- complementary, minimal-edit tools: `isort` (imports), `autoflake` (unused
+  removal), `eslint --fix` (lint fixes) — each touches a different span;
+- whole-document formatters: `black`, `prettier`, `gofmt` — each returns one
+  edit that replaces (nearly) the entire region.
+
+Users want to combine **both kinds** in one region (e.g. `black` then `isort`).
+The previously documented rule (server-pool-coordination) said formatting *must*
+use a single server, precisely because naively merging `TextEdit[]` from several
+formatters violates the LSP "edits must not overlap" rule — two whole-document
+formatters always overlap.
+
+The list-concatenation mechanics used by diagnostics/references do **not**
+transfer to formatting: concatenating two formatters' edit lists produces
+overlapping edits. So formatting needs its own meaning for "combine multiple
+servers".
+
+### Two-level structure
+
+Formatting over a host document has two nesting levels, and overlap-freedom holds
+at each level for a **different** reason:
+
+- **Across injection regions — parallel.** A host document resolves to several
+  injection regions, each a disjoint span of the host. They are formatted
+  concurrently (one task per region) and their resulting edits are concatenated;
+  disjointness means the concatenation can never overlap. This is existing
+  behavior, owned by request-strategies, and is unchanged by this decision.
+- **Within one region — sequential.** When a single region has multiple servers,
+  this decision runs them serially over the same text. Here overlap-freedom comes
+  from seriality (each server sees the prior server's output), not disjointness.
+
+The asymmetry is deliberate: regions are parallel because they are disjoint;
+servers within a region are serial because they are *not* — running them in
+parallel would reintroduce the overlapping-edit problem. Everything below
+concerns the within-region level only.
+
+### Why not parallel diff-stacking
+
+An earlier idea was to compute each server's edits against the **original**
+region text in parallel, then stack non-conflicting diffs like a git merge and
+serialize only the conflicting ones. This was rejected because:
+
+- whole-document formatters always overlap, so the non-conflicting fast path
+  almost never applies for the mixed case we are targeting;
+- stacking original-based diffs requires **re-basing** each later edit's ranges
+  after applying earlier ones (offset drift), reintroducing the overlap-math the
+  approach was meant to avoid;
+- arrival-order stacking makes the result depend on process/network timing —
+  **non-deterministic formatting**, which is unacceptable for a formatter;
+- conflict resolution by re-request risks **oscillation** (two formatters that
+  each undo the other) and needs cycle/fixpoint guards.
+
+## Decision
+
+**Treat `strategy: "concatenated"` on `textDocument/formatting` as an explicit
+opt-in to a sequential formatter pipeline driven by `priorities`.**
+
+1. **Explicit switch.** The pipeline activates only when the resolved
+   aggregation config for the method sets `strategy = "concatenated"`. With the
+   default `preferred` strategy (or no config), formatting keeps the existing
+   first-non-empty-wins behavior. There is no implicit activation.
+
+2. **`priorities` is the pipeline definition.** When the pipeline is active,
+   `priorities` is both the **membership list** and the **application order**.
+   Servers configured for the language but **absent from `priorities` do not run**
+   for formatting — `priorities` acts as an allowlist plus order. An active
+   `concatenated` strategy with an empty `priorities` is a misconfiguration and
+   falls back to `preferred` (with a warning), since order would otherwise be
+   undefined.
+
+3. **Sequential application (single pass).** For each server in `priorities`
+   order, against the **current** region text:
+   1. push the current region text to the downstream server via `didChange`;
+   2. send `textDocument/formatting`;
+   3. apply the returned edits to the region text (empty edits = already
+      formatted = no-op);
+   4. proceed to the next server with the updated text.
+   Because each server always sees the latest text, edits **cannot overlap**
+   across servers — there is nothing to merge. The pipeline runs **one pass**;
+   recursion / fixpoint re-formatting is explicitly out of scope.
+
+4. **Region full-replacement output.** After the last server, the pipeline emits
+   a **single `TextEdit` that replaces the entire region** with the final text
+   (range = whole virtual document, translated to host coordinates via the
+   region offset). It does **not** attempt to compute a minimal diff. This keeps
+   the LSP output trivially non-overlapping and avoids needing a
+   text-edit-composition or diff utility.
+
+The pipeline reuses the existing per-server virtual-document and
+position-translation machinery; the new parts are (a) strategy dispatch, (b) the
+intermediate `didChange` that feeds each server's output into the next, and
+(c) collapsing the final text into one region-replacement edit.
+
+### Keyword overload, made explicit
+
+`strategy: "concatenated"` means **different mechanics per method**:
+
+| Method family | `concatenated` mechanics | Direction |
+|---------------|--------------------------|-----------|
+| diagnostics, references | concatenate **result lists** from all servers | parallel fan-in |
+| formatting (this decision) | **sequential text pipeline**, each server's output feeds the next | serial |
+
+Same config keyword, deliberately, so users reach for one familiar switch; the
+per-method behavior is documented here and in request-strategies.
+
+### Example
+
+```toml
+# Format Python injections in Markdown by running black, then isort.
+[languages.markdown.bridge.python.aggregation."textDocument/formatting"]
+strategy = "concatenated"
+priorities = ["black", "isort"]
+```
+
+## Considered Options
+
+### A. Sequential pipeline over `priorities`, region full-replacement (chosen)
+
+Deterministic (config order), trivially non-overlapping (one pass, one output
+edit), handles the mixed whole-document + complementary case, and matches how
+formatter chains (`black` then `isort`) actually work. Cost: fully serial
+(latency = sum of round-trips) and requires `didChange` choreography to feed each
+server.
+
+### B. Parallel diff-stacking with conflict re-request (rejected)
+
+The git-merge-style approach. Rejected for the reasons in *Why not parallel
+diff-stacking*: ineffective for whole-document formatters, non-deterministic on
+arrival order, offset-rebasing complexity, and oscillation risk. May be revisited
+as a latency optimization only if profiling shows many complementary minimal-edit
+formatters dominate and serial latency hurts.
+
+### C. Keep `preferred`-only for formatting (status quo, rejected)
+
+Simple but cannot chain complementary formatters at all — the user must pick one
+tool per region. Insufficient for the mixed real-world setups motivating this
+decision.
+
+### D. Minimal-diff output instead of full replacement (deferred)
+
+Emitting a minimal `TextEdit` set (via a Myers-style diff of original vs final)
+would shrink the edit payload and play nicer with editor undo granularity. It
+requires a diff utility the codebase lacks. Deferred until there is evidence the
+full-replacement payload causes problems; the output form is internal and can
+change without affecting the config surface.
+
+## Consequences
+
+### Positive
+
+- **Chains complementary + whole-document formatters** in one region with a
+  single, deterministic config switch.
+- **Trivially LSP-compliant output**: one region-replacement edit per region can
+  never overlap, satisfying the no-overlapping-edits rule by construction.
+- **Deterministic & reproducible**: result depends only on `priorities` order,
+  not on response timing.
+- **No new diff/edit-composition machinery**: reuses existing virtual-document
+  and position-translation code.
+
+### Negative
+
+- **Serial latency**: total time is the sum of per-server round-trips plus the
+  intermediate `didChange` processing; a per-pipeline timeout budget and
+  per-step cancellation checks are required.
+- **Downstream statefulness**: feeding each server requires a `didChange` and
+  waiting for it to take effect before re-requesting — more protocol
+  choreography than a stateless forward.
+- **Coarse output**: full-region replacement enlarges the edit payload and can
+  coarsen editor undo granularity until option D is taken.
+- **`priorities` semantics overload**: for formatting, `priorities` becomes an
+  allowlist+order (servers not listed do not run), unlike `preferred` where it is
+  only a tie-break ordering. Documented, but a behavioral nuance.
+
+### Neutral
+
+- Ordering is the user's responsibility; a bad order (e.g. a formatter that
+  reverts a previous tool) produces a bad-but-deterministic result, not an error.
+- Recursion/fixpoint re-formatting and minimal-diff output are left as future
+  options without committing to them.
+
+## Decision–Implementation Gap
+
+Not yet implemented as of this decision. `textDocument/formatting` currently runs
+the `preferred` strategy per region regardless of config, and a misconfigured
+`concatenated` formatting pair only emits a warning rather than running a
+pipeline. This record defines the target behavior; the warning path is the
+placeholder to be replaced.
+
+## Related Decisions
+
+- [language-server-bridge-request-strategies](language-server-bridge-request-strategies.md): Per-method bridge strategies, including formatting's edit handling
+- [ls-bridge-server-pool-coordination](ls-bridge-server-pool-coordination.md): `AggregationStrategy` enum, fan-out/fan-in, and aggregation timeout rules
+- [language-server-bridge-virtual-document-model](language-server-bridge-virtual-document-model.md): How injection regions are represented as virtual documents

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -93,7 +93,12 @@ opt-in to a sequential formatter pipeline driven by `priorities`.**
 3. **Sequential application (single pass).** For each server in `priorities`
    order, against the **current** region text:
    1. push the current region text to the downstream server via `didChange`;
-   2. send `textDocument/formatting`;
+   2. ask that server to format the whole region via `textDocument/formatting`,
+      reusing the existing formatting path — which **falls back to
+      `textDocument/rangeFormatting` over the entire region when the server lacks
+      full-formatting support** (returns `Ok(None)`). A genuine error propagates
+      (handled by point 6); an empty edit list is **authoritative** ("already
+      formatted"), not a fallback trigger;
    3. apply the returned edits to the region text (empty edits = already
       formatted = no-op);
    4. proceed to the next server with the updated text.
@@ -112,7 +117,10 @@ opt-in to a sequential formatter pipeline driven by `priorities`.**
    shares this aggregation config (it resolves `strategy`/`priorities` under the
    `textDocument/formatting` key), the pipeline applies to **full formatting
    only**. Range formatting always uses `preferred`, even when
-   `strategy: "concatenated"` is configured. A sequential pipeline over a
+   `strategy: "concatenated"` is configured. (Note this is distinct from the
+   whole-region range *fallback* inside step 2: that shim lets a server lacking
+   `textDocument/formatting` still participate in **full** formatting; it is not a
+   user-issued `rangeFormatting` request, which is what stays on `preferred`.) A sequential pipeline over a
    sub-range would reintroduce the offset drift full formatting avoids — each
    server's edits shift the requested range, forcing per-step range re-mapping
    and clipping the output back to the selection — and that cost is not worth it
@@ -158,7 +166,7 @@ end-of-pipeline reconciliation that restores downstream document state.
 
 | Method family | `concatenated` mechanics | Direction |
 |---------------|--------------------------|-----------|
-| diagnostics, references, code actions | concatenate **result lists** from all servers | parallel fan-in |
+| diagnostics, references | concatenate **result lists** from all servers | parallel fan-in |
 | formatting (this decision) | **sequential text pipeline**, each server's output feeds the next | serial |
 
 Same config keyword, deliberately, so users reach for one familiar switch; the

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -296,7 +296,9 @@ change without affecting the config surface.
   Cancellation must be polled **concurrently during** each in-flight step (e.g.
   `tokio::select!` on the request future and the cancel signal), not only between
   steps, so a hung formatter can be aborted immediately rather than blocking the
-  pipeline until it returns.
+  pipeline until it returns. On abort the bridge should also send
+  `$/cancelRequest` to the active downstream server so it stops the discarded
+  formatting task and frees its resources.
 - **Downstream statefulness**: feeding each server requires a `didChange` and
   waiting for it to take effect before re-requesting — more protocol
   choreography than a stateless forward.

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -142,26 +142,32 @@ opt-in to a sequential formatter pipeline driven by `priorities`.**
    timeout budget, and a failing step is logged so the misbehaving server is
    diagnosable.
 
-7. **Speculative `didChange` must be reconciled (state-consistency invariant).**
-   The intermediate `didChange` notifications (step 3.1) push *speculative*
-   formatted text into each downstream server's document — text the editor has
-   **not** applied. The editor's truth only changes when it applies the final
-   emitted edit (or stays at the original on a no-op / complete failure /
-   cancellation). So when the pipeline ends — on success, total failure, **or
-   cancellation** — the bridge **must restore every participating downstream
-   server's document to the canonical region content** (the host-derived virtual
-   text), otherwise those servers diverge from the editor and corrupt later
-   edits, diagnostics, and completions. The reconciliation mechanism (a corrective
-   `didChange` back to the canonical text, or running the pipeline against a
-   throwaway scratch document so the shared one is never speculatively mutated) is
-   an implementation choice; the **invariant** — no downstream document is left
-   holding speculative text after the pipeline returns — is the decision.
+7. **Isolate speculative state in a scratch document (state-consistency
+   invariant).** The intermediate `didChange` notifications (step 3.1) push
+   *speculative* formatted text — text the editor has **not** applied. The
+   editor's truth only changes when it applies the final emitted edit (or stays at
+   the original on a no-op / complete failure / cancellation). The **invariant**
+   is that no downstream document the rest of the bridge relies on is ever left
+   holding speculative text. The **recommended** mechanism is to run the pipeline
+   against a **throwaway scratch document** (a unique virtual URI, `didOpen`/
+   `didClose` per run) so the canonical virtual document is never speculatively
+   mutated at all. This is preferred over mutating the shared document and
+   reconciling afterward with a corrective `didChange`, because the shared-mutation
+   approach has two hazards (per tower-lsp concurrency, see CLAUDE.md):
+   - **Concurrent reads see speculative state**: a `hover`/`completion`/diagnostic
+     request the downstream server handles *during* the pipeline would evaluate
+     against unapplied text — flashes and wrong results.
+   - **Reconciliation can fail when it matters most**: if a step times out or the
+     server is stuck (point 6), the corrective `didChange` may itself queue behind
+     the stuck request or time out, leaving the shared document **permanently**
+     desynced. A scratch document needs no corrective step — it is simply
+     discarded — so failure can never desync the canonical document.
 
 The pipeline reuses the existing per-server virtual-document and
 position-translation machinery; the new parts are (a) strategy dispatch, (b) the
 intermediate `didChange` that feeds each server's output into the next,
 (c) collapsing the final text into one region-replacement edit, and (d) the
-end-of-pipeline reconciliation that restores downstream document state.
+scratch-document lifecycle that isolates the pipeline's speculative state.
 
 ### Keyword overload, made explicit
 
@@ -241,9 +247,10 @@ change without affecting the config surface.
 - **Coarse output**: full-region replacement enlarges the edit payload, can
   coarsen editor undo granularity, and may disrupt the user's cursor position,
   active code folds, or bookmarks within the region until option D is taken.
-- **Reconciliation overhead**: keeping downstream state consistent (Decision
-  point 7) costs an extra corrective `didChange` (or a scratch-document setup)
-  per participating server at the end of each pipeline run.
+- **Scratch-document overhead**: isolating speculative state (Decision point 7)
+  costs a `didOpen`/`didClose` of a throwaway document per pipeline run, plus the
+  per-step `didChange`s — extra protocol traffic to keep the canonical document
+  untouched.
 - **`priorities` semantics overload**: for formatting, `priorities` becomes an
   allowlist+order (servers not listed do not run), unlike `preferred` where it is
   only a tie-break ordering. Documented, but a behavioral nuance.

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -90,8 +90,10 @@ opt-in to a sequential formatter pipeline driven by `priorities`.
    falls back to `preferred` (with a warning), since order would otherwise be
    undefined.
 
-3. **Sequential application (single pass).** For each server in `priorities`
-   order, against the **current** region text:
+3. **Sequential application (single pass).** The pipeline seeds its initial region
+   text from the host document **after parse completion** — never a half-parsed
+   snapshot, since stale injection boundaries would corrupt the region — then, for
+   each server in `priorities` order, against the **current** region text:
    1. make the current accumulated text available to the server — the scratch
       document's `didOpen` (point 7) carries it; a `didChange` is only needed when
       a single scratch document is reused across steps rather than opened fresh per
@@ -103,7 +105,10 @@ opt-in to a sequential formatter pipeline driven by `priorities`.
       **fall back to `textDocument/rangeFormatting` over the entire region** so
       range-only servers still participate — the same whole-region equivalence the
       existing `textDocument/rangeFormatting` handler relies on for covering
-      requests. (The current full-formatting path does not itself fall back; this
+      requests. The fallback is itself gated on `documentRangeFormattingProvider`;
+      a server advertising **neither** provider contributes nothing and is simply
+      skipped (no unsupported request is sent). (The current full-formatting path
+      does not itself fall back; this
       is target pipeline behavior.) Crucially, a `null` response from a *capable*
       server is the LSP "no changes / already formatted" signal and is
       **authoritative** — it must **not** trigger the fallback. The implementation
@@ -133,15 +138,17 @@ opt-in to a sequential formatter pipeline driven by `priorities`.
    prefixes and corrupt blockquoted/indented injections — the single-edit
    limitation noted in `src/lsp/bridge/text_document/formatting.rs` ("multi-line
    edits drop host indentation"), which the pipeline's full-region output must
-   resolve. An injection region's host prefix is **uniform** — the same `> ` or
-   indentation on each line — so the pipeline applies that one prefix, captured
-   once for the region, to all lines of the formatted output. This needs no
-   line-by-line diff or alignment (consistent with emitting one full-region
-   replacement rather than a minimal diff), and a formatter freely adding or
-   removing lines is fine because every output line receives the same prefix.
-   On **empty** output lines the prefix's trailing whitespace is trimmed (emit
-   `>` not `> `, and leave a space-only prefix off entirely) so the pipeline
-   does not introduce trailing-whitespace violations.
+   resolve. The host prefix is tracked **per line** (`RegionOffset::columns`) and
+   can differ line to line (e.g. nested blockquote levels). When the formatter
+   preserves the line count, each output line takes its original per-line offset
+   (a 1:1 mapping). When the formatter changes the line count, new lines have no
+   original counterpart and — since the pipeline computes no diff/alignment — the
+   **region's common prefix** is applied to them: this is exact for the usual
+   uniform-prefix injection (single-level indentation, or a uniform `> `) and is a
+   documented limitation for the rare region whose per-line prefixes genuinely
+   differ across a line-count change. On **empty** output lines the prefix's
+   trailing whitespace is trimmed (emit `>` not `> `, and leave a space-only prefix
+   off entirely) so the pipeline does not introduce trailing-whitespace violations.
 
 5. **Range formatting stays on `preferred`.** Although `textDocument/rangeFormatting`
    shares this aggregation config (it resolves `strategy`/`priorities` under the

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -100,8 +100,9 @@ opt-in to a sequential formatter pipeline driven by `priorities`.**
       servers still participate — the same whole-region equivalence the existing
       `rangeFormatting` handler relies on for covering requests. (The current
       full-formatting path does not itself fall back; this is target pipeline
-      behavior.) A genuine error propagates (handled by point 6); an empty edit
-      list is **authoritative** ("already formatted"), not a fallback trigger;
+      behavior.) A genuine error is treated as a **failed step** — handled by
+      point 6 (skip-and-continue), not surfaced to the editor; an empty edit list
+      is **authoritative** ("already formatted"), not a fallback trigger;
    3. apply the returned edits to the region text (empty edits = already
       formatted = no-op);
    4. proceed to the next server with the updated text.
@@ -153,7 +154,7 @@ opt-in to a sequential formatter pipeline driven by `priorities`.**
    `didClose` per run) so the canonical virtual document is never speculatively
    mutated at all. This is preferred over mutating the shared document and
    reconciling afterward with a corrective `didChange`, because the shared-mutation
-   approach has two hazards (per tower-lsp concurrency, see CLAUDE.md):
+   approach has two hazards under tower-lsp's concurrent request processing:
    - **Concurrent reads see speculative state**: a `hover`/`completion`/diagnostic
      request the downstream server handles *during* the pipeline would evaluate
      against unapplied text — flashes and wrong results.
@@ -168,7 +169,13 @@ opt-in to a sequential formatter pipeline driven by `priorities`.**
    the URI's directory and extension. So the scratch URI must keep the canonical
    virtual document's directory and file extension — e.g. a `…/file.scratch.py`
    suffix beside the real path, not a random or different-scheme URI — or config
-   discovery and language detection break.
+   discovery and language detection break. The flip side: a real-looking scratch
+   URI risks the downstream server indexing it as a workspace file (duplicate
+   symbols, namespace collisions, stray diagnostics). The bridge therefore
+   **must keep the scratch document ephemeral** (`didOpen`/`didClose` bracketing
+   the single pipeline run) and **discard any server-initiated notifications
+   targeting scratch URIs** (notably `textDocument/publishDiagnostics`) so they
+   never reach the editor.
 
 The pipeline reuses the existing per-server virtual-document and
 position-translation machinery; the new parts are (a) strategy dispatch, (b) the

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -143,7 +143,9 @@ opt-in to a sequential formatter pipeline driven by `priorities`.
    preserves the line count, each output line takes its original per-line offset
    (a 1:1 mapping). When the formatter changes the line count, new lines have no
    original counterpart and — since the pipeline computes no diff/alignment — the
-   **region's common prefix** is applied to them: this is exact for the usual
+   **region's common prefix** is applied to them — the longest leading host
+   prefix shared by every line of the region (its lines' LCP, equivalently the
+   narrowest per-line `RegionOffset` column). This is exact for the usual
    uniform-prefix injection (single-level indentation, or a uniform `> `) and is a
    documented limitation for the rare region whose per-line prefixes genuinely
    differ across a line-count change. On **empty** output lines the prefix's
@@ -299,7 +301,10 @@ change without affecting the config surface.
 ### Negative
 
 - **Serial latency**: total time is the sum of per-server round-trips plus the
-  intermediate `didChange` processing; a per-pipeline timeout budget is required.
+  intermediate `didChange` processing; a per-pipeline timeout budget is required —
+  reusing the existing per-request aggregation timeout (ls-bridge-timeout-hierarchy,
+  ls-bridge-server-pool-coordination) as the whole-pipeline bound rather than
+  introducing a formatting-specific timeout config.
   Cancellation must be polled **concurrently during** each in-flight step (e.g.
   `tokio::select!` on the request future and the cancel signal), not only between
   steps, so a hung formatter can be aborted immediately rather than blocking the

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -139,6 +139,9 @@ opt-in to a sequential formatter pipeline driven by `priorities`.
    line-by-line diff or alignment (consistent with emitting one full-region
    replacement rather than a minimal diff), and a formatter freely adding or
    removing lines is fine because every output line receives the same prefix.
+   On **empty** output lines the prefix's trailing whitespace is trimmed (emit
+   `>` not `> `, and leave a space-only prefix off entirely) so the pipeline
+   does not introduce trailing-whitespace violations.
 
 5. **Range formatting stays on `preferred`.** Although `textDocument/rangeFormatting`
    shares this aggregation config (it resolves `strategy`/`priorities` under the
@@ -289,8 +292,11 @@ change without affecting the config surface.
 ### Negative
 
 - **Serial latency**: total time is the sum of per-server round-trips plus the
-  intermediate `didChange` processing; a per-pipeline timeout budget and
-  per-step cancellation checks are required.
+  intermediate `didChange` processing; a per-pipeline timeout budget is required.
+  Cancellation must be polled **concurrently during** each in-flight step (e.g.
+  `tokio::select!` on the request future and the cancel signal), not only between
+  steps, so a hung formatter can be aborted immediately rather than blocking the
+  pipeline until it returns.
 - **Downstream statefulness**: feeding each server requires a `didChange` and
   waiting for it to take effect before re-requesting — more protocol
   choreography than a stateless forward.

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -5,7 +5,9 @@
 > both `textDocument/formatting` and `textDocument/rangeFormatting`: range
 > formatting resolves aggregation under the `textDocument/formatting` key, so it
 > shares the same `strategy`/`priorities` and inherits this pipeline once
-> implemented (it runs the same servers over the requested sub-range). Per-method
+> implemented — it runs the same servers in the same order, but sends the
+> `rangeFormatting` method and confines its output to the requested range (see
+> the per-method differences under *Decision*). Per-method
 > strategy selection and the cross-file/edit-filtering rules live in
 > language-server-bridge-request-strategies; the `AggregationStrategy` enum and
 > fan-in mechanics live in ls-bridge-server-pool-coordination.
@@ -93,7 +95,11 @@ opt-in to a sequential formatter pipeline driven by `priorities`.**
 3. **Sequential application (single pass).** For each server in `priorities`
    order, against the **current** region text:
    1. push the current region text to the downstream server via `didChange`;
-   2. send `textDocument/formatting`;
+   2. send the **originating method** to that server — `textDocument/formatting`
+      for full formatting, or `textDocument/rangeFormatting` for range
+      formatting. For the range case the requested range must be **re-mapped onto
+      the current text** before each step, since earlier servers' edits shift its
+      coordinates (an implementation concern, not a config one);
    3. apply the returned edits to the region text (empty edits = already
       formatted = no-op);
    4. proceed to the next server with the updated text.
@@ -101,17 +107,23 @@ opt-in to a sequential formatter pipeline driven by `priorities`.**
    across servers — there is nothing to merge. The pipeline runs **one pass**;
    recursion / fixpoint re-formatting is explicitly out of scope.
 
-4. **Region full-replacement output.** After the last server, the pipeline emits
-   a **single `TextEdit` that replaces the entire region** with the final text
-   (range = whole virtual document, translated to host coordinates via the
-   region offset). It does **not** attempt to compute a minimal diff. This keeps
-   the LSP output trivially non-overlapping and avoids needing a
-   text-edit-composition or diff utility.
+4. **Replacement output, bounded by request type.** After the last server the
+   pipeline emits a replacement rather than a computed minimal diff — keeping the
+   LSP output trivially non-overlapping and avoiding any text-edit-composition or
+   diff utility. The replacement span depends on the method:
+   - **full formatting** → a **single `TextEdit` replacing the entire region**
+     with the final text (range = whole virtual document, translated to host
+     coordinates via the region offset);
+   - **range formatting** → the replacement is **confined to the originally
+     requested range**; text outside the user's selection must stay untouched, as
+     `rangeFormatting` semantics require. Replacing the whole region here would
+     over-reach. The exact range-bounded output (and the range re-mapping above)
+     is an implementation detail this decision flags rather than fully specifies.
 
 The pipeline reuses the existing per-server virtual-document and
 position-translation machinery; the new parts are (a) strategy dispatch, (b) the
 intermediate `didChange` that feeds each server's output into the next, and
-(c) collapsing the final text into one region-replacement edit.
+(c) collapsing the final text into the bounded replacement edit.
 
 ### Keyword overload, made explicit
 

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -97,15 +97,17 @@ opt-in to a sequential formatter pipeline driven by `priorities`.
       a single scratch document is reused across steps rather than opened fresh per
       server;
    2. ask that server to format the whole region. The **pipeline** prefers
-      `textDocument/formatting`; if the server has no `documentFormattingProvider`
-      (full formatting yields no result), the pipeline
-      **falls back to `textDocument/rangeFormatting` over the entire region** so range-only
-      servers still participate — the same whole-region equivalence the existing
-      `textDocument/rangeFormatting` handler relies on for covering requests. (The current
-      full-formatting path does not itself fall back; this is target pipeline
-      behavior.) A genuine error is treated as a **failed step** — handled by
-      point 6 (skip-and-continue), not surfaced to the editor; an empty edit list
-      is **authoritative** ("already formatted"), not a fallback trigger;
+      `textDocument/formatting`; if the server lacks full-formatting support —
+      either not advertising `documentFormattingProvider` or returning `null`
+      (`Ok(None)`) — the pipeline
+      **falls back to `textDocument/rangeFormatting` over the entire region** so
+      range-only servers still participate — the same whole-region equivalence the
+      existing `textDocument/rangeFormatting` handler relies on for covering
+      requests. (The current full-formatting path does not itself fall back; this
+      is target pipeline behavior.) A genuine error is treated as a
+      **failed step** — handled by point 6 (skip-and-continue), not surfaced to
+      the editor; an empty edit list (`[]` / `Ok(Some([]))`) is
+      **authoritative** ("already formatted"), not a fallback trigger;
    3. apply the returned edits to the region text (empty edits = already
       formatted = no-op);
    4. proceed to the next server with the updated text.
@@ -185,7 +187,8 @@ opt-in to a sequential formatter pipeline driven by `priorities`.
    the URI's directory and extension. So the scratch URI must keep the canonical
    virtual document's directory and file extension (not a random or
    different-scheme URI), or config discovery and language detection break. The
-   concrete naming is given below. The flip side: a real-looking scratch
+   naming requirements and examples are described below. The flip side: a
+   real-looking scratch
    URI risks the downstream server indexing it as a workspace file (duplicate
    symbols, namespace collisions, stray diagnostics). The bridge therefore
    **must keep the scratch document ephemeral** (`didOpen`/`didClose` bracketing

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -137,7 +137,7 @@ opt-in to a sequential formatter pipeline driven by `priorities`.
    `RegionOffset` columns no longer map 1:1 to the output; for lines without a
    prior-line counterpart the pipeline applies the region's **uniform prefix** —
    the common host prefix/indentation shared by the region's lines (e.g. the
-   blockquote `> `), captured once for the region — to every output line.
+   blockquote `> `), captured once for the region — to those new output lines.
 
 5. **Range formatting stays on `preferred`.** Although `textDocument/rangeFormatting`
    shares this aggregation config (it resolves `strategy`/`priorities` under the

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -74,8 +74,7 @@ serialize only the conflicting ones. This was rejected because:
 
 ## Decision
 
-**Treat `strategy: "concatenated"` on `textDocument/formatting` as an explicit
-opt-in to a sequential formatter pipeline driven by `priorities`.**
+**Treat `strategy: "concatenated"` on `textDocument/formatting` as an explicit opt-in to a sequential formatter pipeline driven by `priorities`.**
 
 1. **Explicit switch.** The pipeline activates only when the resolved
    aggregation config for the method sets `strategy = "concatenated"`. With the
@@ -95,8 +94,8 @@ opt-in to a sequential formatter pipeline driven by `priorities`.**
    1. push the current region text to the downstream server via `didChange`;
    2. ask that server to format the whole region. The **pipeline** prefers
       `textDocument/formatting`; if the server has no `documentFormattingProvider`
-      (full formatting yields no result), the pipeline **falls back to
-      `textDocument/rangeFormatting` over the entire region** so range-only
+      (full formatting yields no result), the pipeline
+      **falls back to `textDocument/rangeFormatting` over the entire region** so range-only
       servers still participate — the same whole-region equivalence the existing
       `rangeFormatting` handler relies on for covering requests. (The current
       full-formatting path does not itself fall back; this is target pipeline
@@ -112,15 +111,23 @@ opt-in to a sequential formatter pipeline driven by `priorities`.**
 
 4. **Region full-replacement output.** After the last server, the pipeline emits
    a **single `TextEdit` that replaces the entire region** with the final text
-   (range = whole virtual document, translated to host coordinates via the
-   region offset). It does **not** attempt to compute a minimal diff. This keeps
-   the LSP output trivially non-overlapping and avoids needing a
-   text-edit-composition or diff utility.
+   (range = whole virtual document, translated to host coordinates via the region
+   offset). It does **not** attempt to compute a minimal diff. This keeps the LSP
+   output trivially non-overlapping and avoids needing a text-edit-composition or
+   diff utility. Because the replacement spans multiple lines, the host
+   translation **must re-apply each line's host prefix/indentation** (the
+   `RegionOffset` per-line columns — e.g. a Markdown blockquote `> ` on every
+   continuation line), not just the first line's offset. The virtual `newText`
+   starts at column 0 of the embedded language, so emitting it verbatim would
+   strip those prefixes and corrupt blockquoted/indented injections — the existing
+   single-edit limitation noted in `src/lsp/bridge/text_document/formatting.rs`
+   ("multi-line edits drop host indentation"), which the pipeline's full-region
+   output must resolve.
 
 5. **Range formatting stays on `preferred`.** Although `textDocument/rangeFormatting`
    shares this aggregation config (it resolves `strategy`/`priorities` under the
-   `textDocument/formatting` key), the pipeline applies to **full formatting
-   only**. Range formatting always uses `preferred`, even when
+   `textDocument/formatting` key), the pipeline applies to
+   **full formatting only**. Range formatting always uses `preferred`, even when
    `strategy: "concatenated"` is configured. (Note this is distinct from the
    whole-region range *fallback* inside step 3.2: that shim lets a server lacking
    `textDocument/formatting` still participate in **full** formatting; it is not a
@@ -132,8 +139,8 @@ opt-in to a sequential formatter pipeline driven by `priorities`.**
    want multi-formatter chaining trigger full-document formatting instead.
 
 6. **Best-effort on failure (skip-and-continue).** If a server in the pipeline
-   fails — LSP error, crash, or per-step timeout — the pipeline **skips it and
-   proceeds to the next server with the current accumulated text**. It never
+   fails — LSP error, crash, or per-step timeout — the pipeline
+   **skips it and proceeds to the next server with the current accumulated text**. It never
    aborts the pipeline or discards earlier successful steps. The emitted edit
    therefore reflects whatever steps succeeded, degrading to a no-op edit only
    when every server failed or the text is unchanged; it never falls back to
@@ -145,8 +152,8 @@ opt-in to a sequential formatter pipeline driven by `priorities`.**
    client's request timeout — it just exhausts the budget and the rest are
    skipped. A failing step is logged so the misbehaving server is diagnosable.
 
-7. **Isolate speculative state in a scratch document (state-consistency
-   invariant).** The intermediate `didChange` notifications (step 3.1) push
+7. **Isolate speculative state in a scratch document (state-consistency invariant).**
+   The intermediate `didChange` notifications (step 3.1) push
    *speculative* formatted text — text the editor has **not** applied. The
    editor's truth only changes when it applies the final emitted edit (or stays at
    the original on a no-op / complete failure / cancellation). The **invariant**
@@ -175,10 +182,11 @@ opt-in to a sequential formatter pipeline driven by `priorities`.**
    URI risks the downstream server indexing it as a workspace file (duplicate
    symbols, namespace collisions, stray diagnostics). The bridge therefore
    **must keep the scratch document ephemeral** (`didOpen`/`didClose` bracketing
-   the single pipeline run) and **discard any server-initiated notifications
-   targeting scratch URIs** (notably `textDocument/publishDiagnostics`) so they
-   never reach the editor. The scratch URI should also carry a **standardized,
-   ignorable marker** in its name (e.g. a `.kakehashi-scratch` infix as in
+   the single pipeline run) and
+   **discard any server-initiated notifications targeting scratch URIs**
+   (notably `textDocument/publishDiagnostics`) so they never reach the editor. The
+   scratch URI should also carry a
+   **standardized, ignorable marker** in its name (e.g. a `.kakehashi-scratch` infix as in
    `…/file.kakehashi-scratch.py`) while keeping the directory and extension, so
    that anything which does observe paths — file watchers, build tools, test
    runners, hot-reloaders — can recognize and ignore it. (Scratch documents are

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -163,6 +163,13 @@ opt-in to a sequential formatter pipeline driven by `priorities`.**
      desynced. A scratch document needs no corrective step — it is simply
      discarded — so failure can never desync the canonical document.
 
+   The scratch URI is **not** an arbitrary path: downstream servers resolve
+   project config (`.prettierrc`, `pyproject.toml`, …) and select a parser from
+   the URI's directory and extension. So the scratch URI must keep the canonical
+   virtual document's directory and file extension — e.g. a `…/file.scratch.py`
+   suffix beside the real path, not a random or different-scheme URI — or config
+   discovery and language detection break.
+
 The pipeline reuses the existing per-server virtual-document and
 position-translation machinery; the new parts are (a) strategy dispatch, (b) the
 intermediate `didChange` that feeds each server's output into the next,

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -126,18 +126,18 @@ opt-in to a sequential formatter pipeline driven by `priorities`.
    offset). It does **not** attempt to compute a minimal diff. This keeps the LSP
    output trivially non-overlapping and avoids needing a text-edit-composition or
    diff utility. Because the replacement spans multiple lines, the host
-   translation **must re-apply each line's host prefix/indentation** (the
-   `RegionOffset` per-line columns — e.g. a Markdown blockquote `> ` on every
-   continuation line), not just the first line's offset. The virtual `newText`
-   starts at column 0 of the embedded language, so emitting it verbatim would
-   strip those prefixes and corrupt blockquoted/indented injections — the existing
-   single-edit limitation noted in `src/lsp/bridge/text_document/formatting.rs`
-   ("multi-line edits drop host indentation"), which the pipeline's full-region
-   output must resolve. Because a formatter may add or remove lines, the per-line
-   `RegionOffset` columns no longer map 1:1 to the output; for lines without a
-   prior-line counterpart the pipeline applies the region's **uniform prefix** —
-   the common host prefix/indentation shared by the region's lines (e.g. the
-   blockquote `> `), captured once for the region — to those new output lines.
+   translation **must re-apply the region's host prefix/indentation to every
+   output line** — not just the first line's offset. The virtual `newText` starts
+   at column 0 of the embedded language, so emitting it verbatim would strip those
+   prefixes and corrupt blockquoted/indented injections — the single-edit
+   limitation noted in `src/lsp/bridge/text_document/formatting.rs` ("multi-line
+   edits drop host indentation"), which the pipeline's full-region output must
+   resolve. An injection region's host prefix is **uniform** — the same `> ` or
+   indentation on each line — so the pipeline applies that one prefix, captured
+   once for the region, to all lines of the formatted output. This needs no
+   line-by-line diff or alignment (consistent with emitting one full-region
+   replacement rather than a minimal diff), and a formatter freely adding or
+   removing lines is fine because every output line receives the same prefix.
 
 5. **Range formatting stays on `preferred`.** Although `textDocument/rangeFormatting`
    shares this aggregation config (it resolves `strategy`/`priorities` under the

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -1,14 +1,11 @@
 # Concatenated Formatting Pipeline
 
-> Scoped to formatting within a single injection region (see the virtual
-> document model in language-server-bridge-virtual-document-model). Applies to
-> both `textDocument/formatting` and `textDocument/rangeFormatting`: range
-> formatting resolves aggregation under the `textDocument/formatting` key, so it
-> shares the same `strategy`/`priorities` and inherits this pipeline once
-> implemented — it runs the same servers in the same order, but sends the
-> `rangeFormatting` method and confines its output to the requested range (see
-> the per-method differences under *Decision*). Per-method
-> strategy selection and the cross-file/edit-filtering rules live in
+> Scoped to `textDocument/formatting` within a single injection region (see the
+> virtual document model in language-server-bridge-virtual-document-model).
+> `textDocument/rangeFormatting` is **out of scope**: although it resolves
+> aggregation under the same `textDocument/formatting` key, it always uses the
+> `preferred` strategy and ignores `concatenated` (rationale under *Decision*).
+> Per-method strategy selection and the cross-file/edit-filtering rules live in
 > language-server-bridge-request-strategies; the `AggregationStrategy` enum and
 > fan-in mechanics live in ls-bridge-server-pool-coordination.
 
@@ -95,11 +92,7 @@ opt-in to a sequential formatter pipeline driven by `priorities`.**
 3. **Sequential application (single pass).** For each server in `priorities`
    order, against the **current** region text:
    1. push the current region text to the downstream server via `didChange`;
-   2. send the **originating method** to that server — `textDocument/formatting`
-      for full formatting, or `textDocument/rangeFormatting` for range
-      formatting. For the range case the requested range must be **re-mapped onto
-      the current text** before each step, since earlier servers' edits shift its
-      coordinates (an implementation concern, not a config one);
+   2. send `textDocument/formatting`;
    3. apply the returned edits to the region text (empty edits = already
       formatted = no-op);
    4. proceed to the next server with the updated text.
@@ -107,23 +100,28 @@ opt-in to a sequential formatter pipeline driven by `priorities`.**
    across servers — there is nothing to merge. The pipeline runs **one pass**;
    recursion / fixpoint re-formatting is explicitly out of scope.
 
-4. **Replacement output, bounded by request type.** After the last server the
-   pipeline emits a replacement rather than a computed minimal diff — keeping the
-   LSP output trivially non-overlapping and avoiding any text-edit-composition or
-   diff utility. The replacement span depends on the method:
-   - **full formatting** → a **single `TextEdit` replacing the entire region**
-     with the final text (range = whole virtual document, translated to host
-     coordinates via the region offset);
-   - **range formatting** → the replacement is **confined to the originally
-     requested range**; text outside the user's selection must stay untouched, as
-     `rangeFormatting` semantics require. Replacing the whole region here would
-     over-reach. The exact range-bounded output (and the range re-mapping above)
-     is an implementation detail this decision flags rather than fully specifies.
+4. **Region full-replacement output.** After the last server, the pipeline emits
+   a **single `TextEdit` that replaces the entire region** with the final text
+   (range = whole virtual document, translated to host coordinates via the
+   region offset). It does **not** attempt to compute a minimal diff. This keeps
+   the LSP output trivially non-overlapping and avoids needing a
+   text-edit-composition or diff utility.
+
+5. **Range formatting stays on `preferred`.** Although `textDocument/rangeFormatting`
+   shares this aggregation config (it resolves `strategy`/`priorities` under the
+   `textDocument/formatting` key), the pipeline applies to **full formatting
+   only**. Range formatting always uses `preferred`, even when
+   `strategy: "concatenated"` is configured. A sequential pipeline over a
+   sub-range would reintroduce the offset drift full formatting avoids — each
+   server's edits shift the requested range, forcing per-step range re-mapping
+   and clipping the output back to the selection — and that cost is not worth it
+   for partial, interactive formatting where chaining is a rare need. Users who
+   want multi-formatter chaining trigger full-document formatting instead.
 
 The pipeline reuses the existing per-server virtual-document and
 position-translation machinery; the new parts are (a) strategy dispatch, (b) the
 intermediate `didChange` that feeds each server's output into the next, and
-(c) collapsing the final text into the bounded replacement edit.
+(c) collapsing the final text into one region-replacement edit.
 
 ### Keyword overload, made explicit
 
@@ -211,15 +209,23 @@ change without affecting the config surface.
   reverts a previous tool) produces a bad-but-deterministic result, not an error.
 - Recursion/fixpoint re-formatting and minimal-diff output are left as future
   options without committing to them.
+- **Shared config, asymmetric effect**: `strategy: "concatenated"` set under the
+  `textDocument/formatting` key affects full formatting but is silently ignored
+  by `rangeFormatting` (which stays on `preferred`). This is a deliberate scope
+  cut, not an oversight — keeping range formatting simple — but it means one
+  config key drives two methods differently.
 
 ## Decision–Implementation Gap
 
-Not yet implemented as of this decision. `textDocument/formatting` (and
-`textDocument/rangeFormatting`, which resolves aggregation under the same
-`textDocument/formatting` key) currently runs the `preferred` strategy per region
-regardless of config, and a misconfigured `concatenated` formatting pair only
-emits a warning rather than running a pipeline. This record defines the target
-behavior; the warning path is the placeholder to be replaced.
+Not yet implemented as of this decision. `textDocument/formatting` currently runs
+the `preferred` strategy per region regardless of config, and a misconfigured
+`concatenated` formatting pair only emits a warning rather than running a
+pipeline. This record defines the target behavior for full formatting; the
+warning path is the placeholder to be replaced.
+
+`textDocument/rangeFormatting` keeps the `preferred` behavior **by design**, not
+just pending implementation — it is out of scope for the pipeline (see *Decision*
+point 5), so this decision leaves it unchanged.
 
 ## Related Decisions
 

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -14,7 +14,7 @@
 A single injection region may have **multiple downstream language servers**
 configured for the same language. For most methods, the `preferred` strategy
 (first non-empty response wins) is the right default, and for list-producing
-methods (`textDocument/diagnostic`, `references`) the `concatenated` strategy
+methods (`textDocument/diagnostic`, `textDocument/references`) the `concatenated` strategy
 concatenates the **result lists** from all servers.
 
 Formatting is different. Real-world formatting setups routinely chain several
@@ -91,13 +91,16 @@ serialize only the conflicting ones. This was rejected because:
 
 3. **Sequential application (single pass).** For each server in `priorities`
    order, against the **current** region text:
-   1. push the current region text to the downstream server via `didChange`;
+   1. make the current accumulated text available to the server — the scratch
+      document's `didOpen` (point 7) carries it; a `didChange` is only needed when
+      a single scratch document is reused across steps rather than opened fresh per
+      server;
    2. ask that server to format the whole region. The **pipeline** prefers
       `textDocument/formatting`; if the server has no `documentFormattingProvider`
       (full formatting yields no result), the pipeline
       **falls back to `textDocument/rangeFormatting` over the entire region** so range-only
       servers still participate — the same whole-region equivalence the existing
-      `rangeFormatting` handler relies on for covering requests. (The current
+      `textDocument/rangeFormatting` handler relies on for covering requests. (The current
       full-formatting path does not itself fall back; this is target pipeline
       behavior.) A genuine error is treated as a **failed step** — handled by
       point 6 (skip-and-continue), not surfaced to the editor; an empty edit list
@@ -131,7 +134,7 @@ serialize only the conflicting ones. This was rejected because:
    `strategy: "concatenated"` is configured. (Note this is distinct from the
    whole-region range *fallback* inside step 3.2: that shim lets a server lacking
    `textDocument/formatting` still participate in **full** formatting; it is not a
-   user-issued `rangeFormatting` request, which is what stays on `preferred`.) A sequential pipeline over a
+   user-issued `textDocument/rangeFormatting` request, which is what stays on `preferred`.) A sequential pipeline over a
    sub-range would reintroduce the offset drift full formatting avoids — each
    server's edits shift the requested range, forcing per-step range re-mapping
    and clipping the output back to the selection — and that cost is not worth it
@@ -150,7 +153,9 @@ serialize only the conflicting ones. This was rejected because:
    of the overall pipeline budget (`overall − elapsed`), not a fixed per-step
    timeout, so a slow early step cannot let the cumulative latency overrun the
    client's request timeout — it just exhausts the budget and the rest are
-   skipped. A failing step is logged so the misbehaving server is diagnosable.
+   skipped. Below a small floor (e.g. < 50 ms remaining) the pipeline skips the
+   rest outright rather than issuing requests almost certain to time out. A
+   failing step is logged so the misbehaving server is diagnosable.
 
 7. **Isolate speculative state in a scratch document (state-consistency invariant).**
    The intermediate `didChange` notifications (step 3.1) push
@@ -176,9 +181,9 @@ serialize only the conflicting ones. This was rejected because:
    The scratch URI is **not** an arbitrary path: downstream servers resolve
    project config (`.prettierrc`, `pyproject.toml`, …) and select a parser from
    the URI's directory and extension. So the scratch URI must keep the canonical
-   virtual document's directory and file extension — e.g. a `…/file.scratch.py`
-   suffix beside the real path, not a random or different-scheme URI — or config
-   discovery and language detection break. The flip side: a real-looking scratch
+   virtual document's directory and file extension (not a random or
+   different-scheme URI), or config discovery and language detection break. The
+   concrete naming is given below. The flip side: a real-looking scratch
    URI risks the downstream server indexing it as a workspace file (duplicate
    symbols, namespace collisions, stray diagnostics). The bridge therefore
    **must keep the scratch document ephemeral** (`didOpen`/`didClose` bracketing
@@ -293,7 +298,7 @@ change without affecting the config surface.
   options without committing to them.
 - **Shared config, asymmetric effect**: `strategy: "concatenated"` set under the
   `textDocument/formatting` key affects full formatting but is silently ignored
-  by `rangeFormatting` (which stays on `preferred`). This is a deliberate scope
+  by `textDocument/rangeFormatting` (which stays on `preferred`). This is a deliberate scope
   cut, not an oversight — keeping range formatting simple — but it means one
   config key drives two methods differently.
 - **Silently skipped formatters**: a failing pipeline step is skipped (and

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -74,7 +74,8 @@ serialize only the conflicting ones. This was rejected because:
 
 ## Decision
 
-**Treat `strategy: "concatenated"` on `textDocument/formatting` as an explicit opt-in to a sequential formatter pipeline driven by `priorities`.**
+Treat `strategy: "concatenated"` on `textDocument/formatting` as an explicit
+opt-in to a sequential formatter pipeline driven by `priorities`.
 
 1. **Explicit switch.** The pipeline activates only when the resolved
    aggregation config for the method sets `strategy = "concatenated"`. With the
@@ -134,8 +135,9 @@ serialize only the conflicting ones. This was rejected because:
    `strategy: "concatenated"` is configured. (Note this is distinct from the
    whole-region range *fallback* inside step 3.2: that shim lets a server lacking
    `textDocument/formatting` still participate in **full** formatting; it is not a
-   user-issued `textDocument/rangeFormatting` request, which is what stays on `preferred`.) A sequential pipeline over a
-   sub-range would reintroduce the offset drift full formatting avoids — each
+   user-issued `textDocument/rangeFormatting` request, which is what stays on
+   `preferred`.) A sequential pipeline over a sub-range would reintroduce the
+   offset drift full formatting avoids — each
    server's edits shift the requested range, forcing per-step range re-mapping
    and clipping the output back to the selection — and that cost is not worth it
    for partial, interactive formatting where chaining is a rare need. Users who

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -26,8 +26,8 @@ tools over one document:
   edit that replaces (nearly) the entire region.
 
 Users want to combine **both kinds** in one region (e.g. `black` then `isort`).
-The previously documented rule (server-pool-coordination) said formatting *must*
-use a single server, precisely because naively merging `TextEdit[]` from several
+The previously documented rule (ls-bridge-server-pool-coordination) said
+formatting *must* use a single server, precisely because naively merging `TextEdit[]` from several
 formatters violates the LSP "edits must not overlap" rule — two whole-document
 formatters always overlap.
 
@@ -118,6 +118,18 @@ opt-in to a sequential formatter pipeline driven by `priorities`.**
    for partial, interactive formatting where chaining is a rare need. Users who
    want multi-formatter chaining trigger full-document formatting instead.
 
+6. **Best-effort on failure (skip-and-continue).** If a server in the pipeline
+   fails — LSP error, crash, or per-step timeout — the pipeline **skips it and
+   proceeds to the next server with the current accumulated text**. It never
+   aborts the pipeline or discards earlier successful steps. The emitted edit
+   therefore reflects whatever steps succeeded, degrading to a no-op edit only
+   when every server failed or the text is unchanged; it never falls back to
+   throwing away formatting already produced. This mirrors the partial-results
+   philosophy of ls-bridge-server-pool-coordination (return what succeeded rather
+   than fail the whole request). Each step runs under the overall pipeline
+   timeout budget, and a failing step is logged so the misbehaving server is
+   diagnosable.
+
 The pipeline reuses the existing per-server virtual-document and
 position-translation machinery; the new parts are (a) strategy dispatch, (b) the
 intermediate `didChange` that feeds each server's output into the next, and
@@ -129,7 +141,7 @@ intermediate `didChange` that feeds each server's output into the next, and
 
 | Method family | `concatenated` mechanics | Direction |
 |---------------|--------------------------|-----------|
-| diagnostics, references | concatenate **result lists** from all servers | parallel fan-in |
+| diagnostics, references, code actions | concatenate **result lists** from all servers | parallel fan-in |
 | formatting (this decision) | **sequential text pipeline**, each server's output feeds the next | serial |
 
 Same config keyword, deliberately, so users reach for one familiar switch; the
@@ -214,13 +226,17 @@ change without affecting the config surface.
   by `rangeFormatting` (which stays on `preferred`). This is a deliberate scope
   cut, not an oversight — keeping range formatting simple — but it means one
   config key drives two methods differently.
+- **Silently skipped formatters**: a failing pipeline step is skipped (and
+  logged) rather than surfaced to the editor, so a user may not notice that a
+  configured formatter did not run. Best-effort robustness is the deliberate
+  trade for not failing the whole format request.
 
 ## Decision–Implementation Gap
 
 Not yet implemented as of this decision. `textDocument/formatting` currently runs
 the `preferred` strategy per region regardless of config, and a misconfigured
-`concatenated` formatting pair only emits a warning rather than running a
-pipeline. This record defines the target behavior for full formatting; the
+`concatenated` formatting configuration only emits a warning rather than running
+a pipeline. This record defines the target behavior for full formatting; the
 warning path is the placeholder to be replaced.
 
 `textDocument/rangeFormatting` keeps the `preferred` behavior **by design**, not

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -329,6 +329,12 @@ the `preferred` strategy per region regardless of config, and a misconfigured
 a pipeline. This record defines the target behavior for full formatting; the
 warning path is the placeholder to be replaced.
 
+The current code also collapses a `null` formatting result to "no result", so a
+capable server's `null` ("already formatted") is today indistinguishable from a
+missing provider and falls through to lower-priority servers. The pipeline's
+capability-based fallback (Decision point 3.2) depends on telling these apart, so
+that collapse is part of the gap to close.
+
 `textDocument/rangeFormatting` keeps the `preferred` behavior **by design**, not
 just pending implementation — it is out of scope for the pipeline (see *Decision*
 point 5), so this decision leaves it unchanged.

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -139,9 +139,11 @@ opt-in to a sequential formatter pipeline driven by `priorities`.**
    when every server failed or the text is unchanged; it never falls back to
    throwing away formatting already produced. This mirrors the partial-results
    philosophy of ls-bridge-server-pool-coordination (return what succeeded rather
-   than fail the whole request). Each step runs under the overall pipeline
-   timeout budget, and a failing step is logged so the misbehaving server is
-   diagnosable.
+   than fail the whole request). Each step's deadline is the **remaining** share
+   of the overall pipeline budget (`overall − elapsed`), not a fixed per-step
+   timeout, so a slow early step cannot let the cumulative latency overrun the
+   client's request timeout — it just exhausts the budget and the rest are
+   skipped. A failing step is logged so the misbehaving server is diagnosable.
 
 7. **Isolate speculative state in a scratch document (state-consistency
    invariant).** The intermediate `didChange` notifications (step 3.1) push
@@ -175,7 +177,13 @@ opt-in to a sequential formatter pipeline driven by `priorities`.**
    **must keep the scratch document ephemeral** (`didOpen`/`didClose` bracketing
    the single pipeline run) and **discard any server-initiated notifications
    targeting scratch URIs** (notably `textDocument/publishDiagnostics`) so they
-   never reach the editor.
+   never reach the editor. The scratch URI should also carry a **standardized,
+   ignorable marker** in its name (e.g. a `.kakehashi-scratch` infix as in
+   `…/file.kakehashi-scratch.py`) while keeping the directory and extension, so
+   that anything which does observe paths — file watchers, build tools, test
+   runners, hot-reloaders — can recognize and ignore it. (Scratch documents are
+   virtual LSP documents whose content is delivered via `didOpen`; a recognizable
+   name bounds the blast radius if a server resolves the path on disk.)
 
 The pipeline reuses the existing per-server virtual-document and
 position-translation machinery; the new parts are (a) strategy dispatch, (b) the

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -97,17 +97,22 @@ opt-in to a sequential formatter pipeline driven by `priorities`.
       a single scratch document is reused across steps rather than opened fresh per
       server;
    2. ask that server to format the whole region. The **pipeline** prefers
-      `textDocument/formatting`; if the server lacks full-formatting support —
-      either not advertising `documentFormattingProvider` or returning `null`
-      (`Ok(None)`) — the pipeline
-      **falls back to `textDocument/rangeFormatting` over the entire region** so
+      `textDocument/formatting`; the fallback keys on **capability**, not on the
+      response: only when the server does not advertise `documentFormattingProvider`
+      does the pipeline
+      **fall back to `textDocument/rangeFormatting` over the entire region** so
       range-only servers still participate — the same whole-region equivalence the
       existing `textDocument/rangeFormatting` handler relies on for covering
       requests. (The current full-formatting path does not itself fall back; this
-      is target pipeline behavior.) A genuine error is treated as a
+      is target pipeline behavior.) Crucially, a `null` response from a *capable*
+      server is the LSP "no changes / already formatted" signal and is
+      **authoritative** — it must **not** trigger the fallback. The implementation
+      must therefore distinguish "no capability" from "no changes" rather than
+      collapsing both to one no-result value: reserve the no-result path for a
+      missing provider, and treat a successful `null` as an empty edit list
+      (`[]` / `Ok(Some([]))`). A genuine error is treated as a
       **failed step** — handled by point 6 (skip-and-continue), not surfaced to
-      the editor; an empty edit list (`[]` / `Ok(Some([]))`) is
-      **authoritative** ("already formatted"), not a fallback trigger;
+      the editor;
    3. apply the returned edits to the region text (empty edits = already
       formatted = no-op);
    4. proceed to the next server with the updated text.

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -45,7 +45,8 @@ at each level for a **different** reason:
   injection regions, each a disjoint span of the host. They are formatted
   concurrently (one task per region) and their resulting edits are concatenated;
   disjointness means the concatenation can never overlap. This is existing
-  behavior, owned by request-strategies, and is unchanged by this decision.
+  behavior, owned by language-server-bridge-request-strategies, and is unchanged
+  by this decision.
 - **Within one region — sequential.** When a single region has multiple servers,
   this decision runs them serially over the same text. Here overlap-freedom comes
   from seriality (each server sees the prior server's output), not disjointness.
@@ -130,10 +131,26 @@ opt-in to a sequential formatter pipeline driven by `priorities`.**
    timeout budget, and a failing step is logged so the misbehaving server is
    diagnosable.
 
+7. **Speculative `didChange` must be reconciled (state-consistency invariant).**
+   The intermediate `didChange` notifications (step 3.1) push *speculative*
+   formatted text into each downstream server's document — text the editor has
+   **not** applied. The editor's truth only changes when it applies the final
+   emitted edit (or stays at the original on a no-op / complete failure /
+   cancellation). So when the pipeline ends — on success, total failure, **or
+   cancellation** — the bridge **must restore every participating downstream
+   server's document to the canonical region content** (the host-derived virtual
+   text), otherwise those servers diverge from the editor and corrupt later
+   edits, diagnostics, and completions. The reconciliation mechanism (a corrective
+   `didChange` back to the canonical text, or running the pipeline against a
+   throwaway scratch document so the shared one is never speculatively mutated) is
+   an implementation choice; the **invariant** — no downstream document is left
+   holding speculative text after the pipeline returns — is the decision.
+
 The pipeline reuses the existing per-server virtual-document and
 position-translation machinery; the new parts are (a) strategy dispatch, (b) the
-intermediate `didChange` that feeds each server's output into the next, and
-(c) collapsing the final text into one region-replacement edit.
+intermediate `didChange` that feeds each server's output into the next,
+(c) collapsing the final text into one region-replacement edit, and (d) the
+end-of-pipeline reconciliation that restores downstream document state.
 
 ### Keyword overload, made explicit
 
@@ -145,7 +162,8 @@ intermediate `didChange` that feeds each server's output into the next, and
 | formatting (this decision) | **sequential text pipeline**, each server's output feeds the next | serial |
 
 Same config keyword, deliberately, so users reach for one familiar switch; the
-per-method behavior is documented here and in request-strategies.
+per-method behavior is documented here and in
+language-server-bridge-request-strategies.
 
 ### Example
 
@@ -209,8 +227,12 @@ change without affecting the config surface.
 - **Downstream statefulness**: feeding each server requires a `didChange` and
   waiting for it to take effect before re-requesting — more protocol
   choreography than a stateless forward.
-- **Coarse output**: full-region replacement enlarges the edit payload and can
-  coarsen editor undo granularity until option D is taken.
+- **Coarse output**: full-region replacement enlarges the edit payload, can
+  coarsen editor undo granularity, and may disrupt the user's cursor position,
+  active code folds, or bookmarks within the region until option D is taken.
+- **Reconciliation overhead**: keeping downstream state consistent (Decision
+  point 7) costs an extra corrective `didChange` (or a scratch-document setup)
+  per participating server at the end of each pipeline run.
 - **`priorities` semantics overload**: for formatting, `priorities` becomes an
   allowlist+order (servers not listed do not run), unlike `preferred` where it is
   only a tie-break ordering. Documented, but a behavioral nuance.

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -1,11 +1,14 @@
 # Concatenated Formatting Pipeline
 
-> Scoped to `textDocument/formatting` within a single injection region (see
-> [language-server-bridge-virtual-document-model](language-server-bridge-virtual-document-model.md)).
-> Per-method strategy selection and the cross-file/edit-filtering rules live in
-> [language-server-bridge-request-strategies](language-server-bridge-request-strategies.md);
-> the `AggregationStrategy` enum and fan-in mechanics live in
-> [ls-bridge-server-pool-coordination](ls-bridge-server-pool-coordination.md).
+> Scoped to formatting within a single injection region (see the virtual
+> document model in language-server-bridge-virtual-document-model). Applies to
+> both `textDocument/formatting` and `textDocument/rangeFormatting`: range
+> formatting resolves aggregation under the `textDocument/formatting` key, so it
+> shares the same `strategy`/`priorities` and inherits this pipeline once
+> implemented (it runs the same servers over the requested sub-range). Per-method
+> strategy selection and the cross-file/edit-filtering rules live in
+> language-server-bridge-request-strategies; the `AggregationStrategy` enum and
+> fan-in mechanics live in ls-bridge-server-pool-coordination.
 
 ## Context
 
@@ -199,11 +202,12 @@ change without affecting the config surface.
 
 ## Decision–Implementation Gap
 
-Not yet implemented as of this decision. `textDocument/formatting` currently runs
-the `preferred` strategy per region regardless of config, and a misconfigured
-`concatenated` formatting pair only emits a warning rather than running a
-pipeline. This record defines the target behavior; the warning path is the
-placeholder to be replaced.
+Not yet implemented as of this decision. `textDocument/formatting` (and
+`textDocument/rangeFormatting`, which resolves aggregation under the same
+`textDocument/formatting` key) currently runs the `preferred` strategy per region
+regardless of config, and a misconfigured `concatenated` formatting pair only
+emits a warning rather than running a pipeline. This record defines the target
+behavior; the warning path is the placeholder to be replaced.
 
 ## Related Decisions
 

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -126,8 +126,9 @@ opt-in to a sequential formatter pipeline driven by `priorities`.
    offset). It does **not** attempt to compute a minimal diff. This keeps the LSP
    output trivially non-overlapping and avoids needing a text-edit-composition or
    diff utility. Because the replacement spans multiple lines, the host
-   translation **must re-apply the region's host prefix/indentation to every
-   output line** — not just the first line's offset. The virtual `newText` starts
+   translation
+   **must re-apply the region's host prefix/indentation to every output line** —
+   not just the first line's offset. The virtual `newText` starts
    at column 0 of the embedded language, so emitting it verbatim would strip those
    prefixes and corrupt blockquoted/indented injections — the single-edit
    limitation noted in `src/lsp/bridge/text_document/formatting.rs` ("multi-line

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -93,12 +93,15 @@ opt-in to a sequential formatter pipeline driven by `priorities`.**
 3. **Sequential application (single pass).** For each server in `priorities`
    order, against the **current** region text:
    1. push the current region text to the downstream server via `didChange`;
-   2. ask that server to format the whole region via `textDocument/formatting`,
-      reusing the existing formatting path — which **falls back to
-      `textDocument/rangeFormatting` over the entire region when the server lacks
-      full-formatting support** (returns `Ok(None)`). A genuine error propagates
-      (handled by point 6); an empty edit list is **authoritative** ("already
-      formatted"), not a fallback trigger;
+   2. ask that server to format the whole region. The **pipeline** prefers
+      `textDocument/formatting`; if the server has no `documentFormattingProvider`
+      (full formatting yields no result), the pipeline **falls back to
+      `textDocument/rangeFormatting` over the entire region** so range-only
+      servers still participate — the same whole-region equivalence the existing
+      `rangeFormatting` handler relies on for covering requests. (The current
+      full-formatting path does not itself fall back; this is target pipeline
+      behavior.) A genuine error propagates (handled by point 6); an empty edit
+      list is **authoritative** ("already formatted"), not a fallback trigger;
    3. apply the returned edits to the region text (empty edits = already
       formatted = no-op);
    4. proceed to the next server with the updated text.
@@ -118,7 +121,7 @@ opt-in to a sequential formatter pipeline driven by `priorities`.**
    `textDocument/formatting` key), the pipeline applies to **full formatting
    only**. Range formatting always uses `preferred`, even when
    `strategy: "concatenated"` is configured. (Note this is distinct from the
-   whole-region range *fallback* inside step 2: that shim lets a server lacking
+   whole-region range *fallback* inside step 3.2: that shim lets a server lacking
    `textDocument/formatting` still participate in **full** formatting; it is not a
    user-issued `rangeFormatting` request, which is what stays on `preferred`.) A sequential pipeline over a
    sub-range would reintroduce the offset drift full formatting avoids — each

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -221,12 +221,14 @@ Rename can affect multiple files. For injections, only same-document renames are
 | Output | TextEdit[] |
 | Cross-file | N/A (single document) |
 | Position mapping | All edit ranges |
-| Multi-server | `preferred` by default; `concatenated` opts into a sequential pipeline |
+| Multi-server | full formatting: `preferred` by default, `concatenated` opts into a sequential pipeline. rangeFormatting: `preferred` only |
 
 Single-server formatting is simple—all edits are within the virtual document.
 For multiple servers, the **planned** (not yet implemented) `concatenated`
 behavior does **not** concatenate edit lists (that would overlap); it runs a
-sequential formatter pipeline ordered by `priorities`. See
+sequential formatter pipeline ordered by `priorities`. This applies to **full
+formatting only** — `rangeFormatting` always uses `preferred`, even though it
+shares the `textDocument/formatting` config key. See
 concatenated-formatting-pipeline.
 
 ### Strategy 4: Background Collection
@@ -286,7 +288,7 @@ When multiple servers are configured for a language:
 | Completion | Merge completion lists from all servers |
 | Hover | Concatenate hover content with separator |
 | Diagnostics | Merge all, dedupe by range + message |
-| Formatting | `preferred` (first non-empty) by default; `concatenated` runs a sequential pipeline over `priorities` — planned, not yet implemented (concatenated-formatting-pipeline) |
+| Formatting | `preferred` (first non-empty) by default; `concatenated` runs a sequential pipeline over `priorities` — planned, full formatting only, not yet implemented. rangeFormatting stays on `preferred` (concatenated-formatting-pipeline) |
 
 ## Consequences
 

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -221,7 +221,7 @@ Rename can affect multiple files. For injections, only same-document renames are
 | Output | TextEdit[] |
 | Cross-file | N/A (single document) |
 | Position mapping | All edit ranges |
-| Multi-server | full formatting: `preferred` by default, `concatenated` opts into a sequential pipeline (planned, not yet implemented). `textDocument/rangeFormatting`: `preferred` only |
+| Multi-server | full formatting: `preferred` by default, `concatenated` opts into a sequential pipeline over `priorities` (also the membership allowlist — unlisted servers do not run; planned, not yet implemented). `textDocument/rangeFormatting`: `preferred` only |
 
 Single-server formatting is simple—all edits are within the virtual document.
 For multiple servers, the **planned** (not yet implemented) `concatenated`

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -221,7 +221,7 @@ Rename can affect multiple files. For injections, only same-document renames are
 | Output | TextEdit[] |
 | Cross-file | N/A (single document) |
 | Position mapping | All edit ranges |
-| Multi-server | full formatting: `preferred` by default, `concatenated` opts into a sequential pipeline. rangeFormatting: `preferred` only |
+| Multi-server | full formatting: `preferred` by default, `concatenated` opts into a sequential pipeline (planned, not yet implemented). rangeFormatting: `preferred` only |
 
 Single-server formatting is simple—all edits are within the virtual document.
 For multiple servers, the **planned** (not yet implemented) `concatenated`
@@ -288,6 +288,7 @@ When multiple servers are configured for a language:
 | Completion | Merge completion lists from all servers |
 | Hover | Concatenate hover content with separator |
 | Diagnostics | Merge all, dedupe by range + message |
+| Code Actions | Concatenate code action lists from all servers |
 | Formatting | `preferred` (first non-empty) by default; `concatenated` runs a sequential pipeline over `priorities` — planned, full formatting only, not yet implemented. rangeFormatting stays on `preferred` (concatenated-formatting-pipeline) |
 
 ## Consequences

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -226,8 +226,8 @@ Rename can affect multiple files. For injections, only same-document renames are
 Single-server formatting is simple—all edits are within the virtual document.
 For multiple servers, the **planned** (not yet implemented) `concatenated`
 behavior does **not** concatenate edit lists (that would overlap); it runs a
-sequential formatter pipeline over `priorities`, which is both the **membership
-allowlist** (servers not listed do not run) and the application order. This
+sequential formatter pipeline over `priorities`, which is both the
+**membership allowlist** (servers not listed do not run) and the application order. This
 applies to **full formatting only** — `textDocument/rangeFormatting` always uses `preferred`, even though it
 shares the `textDocument/formatting` config key. See
 concatenated-formatting-pipeline.

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -288,7 +288,6 @@ When multiple servers are configured for a language:
 | Completion | Merge completion lists from all servers |
 | Hover | Concatenate hover content with separator |
 | Diagnostics | Merge all, dedupe by range + message |
-| Code Actions | Concatenate code action lists from all servers |
 | Formatting | `preferred` (first non-empty) by default; `concatenated` runs a sequential pipeline over `priorities` — planned, full formatting only, not yet implemented. rangeFormatting stays on `preferred` (concatenated-formatting-pipeline) |
 
 ## Consequences

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -224,9 +224,10 @@ Rename can affect multiple files. For injections, only same-document renames are
 | Multi-server | `preferred` by default; `concatenated` opts into a sequential pipeline |
 
 Single-server formatting is simple—all edits are within the virtual document.
-For multiple servers, `concatenated` does **not** concatenate edit lists (that
-would overlap); it runs a sequential formatter pipeline ordered by `priorities`.
-See concatenated-formatting-pipeline.
+For multiple servers, the **planned** (not yet implemented) `concatenated`
+behavior does **not** concatenate edit lists (that would overlap); it runs a
+sequential formatter pipeline ordered by `priorities`. See
+concatenated-formatting-pipeline.
 
 ### Strategy 4: Background Collection
 
@@ -285,7 +286,7 @@ When multiple servers are configured for a language:
 | Completion | Merge completion lists from all servers |
 | Hover | Concatenate hover content with separator |
 | Diagnostics | Merge all, dedupe by range + message |
-| Formatting | `preferred` (first non-empty) by default; `concatenated` runs a sequential pipeline over `priorities` (concatenated-formatting-pipeline) |
+| Formatting | `preferred` (first non-empty) by default; `concatenated` runs a sequential pipeline over `priorities` — planned, not yet implemented (concatenated-formatting-pipeline) |
 
 ## Consequences
 

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -226,8 +226,9 @@ Rename can affect multiple files. For injections, only same-document renames are
 Single-server formatting is simple—all edits are within the virtual document.
 For multiple servers, the **planned** (not yet implemented) `concatenated`
 behavior does **not** concatenate edit lists (that would overlap); it runs a
-sequential formatter pipeline ordered by `priorities`. This applies to **full
-formatting only** — `textDocument/rangeFormatting` always uses `preferred`, even though it
+sequential formatter pipeline over `priorities`, which is both the **membership
+allowlist** (servers not listed do not run) and the application order. This
+applies to **full formatting only** — `textDocument/rangeFormatting` always uses `preferred`, even though it
 shares the `textDocument/formatting` config key. See
 concatenated-formatting-pipeline.
 
@@ -288,7 +289,7 @@ When multiple servers are configured for a language:
 | Completion | Merge completion lists from all servers |
 | Hover | Concatenate hover content with separator |
 | Diagnostics | Merge all, dedupe by range + message |
-| Formatting | `preferred` (first non-empty) by default; `concatenated` runs a sequential pipeline over `priorities` — planned, full formatting only, not yet implemented. `textDocument/rangeFormatting` stays on `preferred` (concatenated-formatting-pipeline) |
+| Formatting | `preferred` (first non-empty) by default; `concatenated` runs a sequential pipeline over `priorities` (which is also the membership allowlist — servers not listed do not run) — planned, full formatting only, not yet implemented. `textDocument/rangeFormatting` stays on `preferred` (concatenated-formatting-pipeline) |
 
 ## Consequences
 

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -61,7 +61,7 @@ A single bridge strategy doesn't fit all methods. We need per-method strategies 
 
 ```
                     ┌─────────────────────────────┐
- Request ──────────▶│      kakehashi              │
+ Request ──────────▶│      kakehashi          │
                     │  ┌─────────────────────┐    │
                     │  │ Tree-sitter tokens  │────│───▶ Immediate response
                     │  │ (local, fast)       │    │     (use if bridge slow)

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -221,13 +221,13 @@ Rename can affect multiple files. For injections, only same-document renames are
 | Output | TextEdit[] |
 | Cross-file | N/A (single document) |
 | Position mapping | All edit ranges |
-| Multi-server | full formatting: `preferred` by default, `concatenated` opts into a sequential pipeline (planned, not yet implemented). rangeFormatting: `preferred` only |
+| Multi-server | full formatting: `preferred` by default, `concatenated` opts into a sequential pipeline (planned, not yet implemented). `textDocument/rangeFormatting`: `preferred` only |
 
 Single-server formatting is simple—all edits are within the virtual document.
 For multiple servers, the **planned** (not yet implemented) `concatenated`
 behavior does **not** concatenate edit lists (that would overlap); it runs a
 sequential formatter pipeline ordered by `priorities`. This applies to **full
-formatting only** — `rangeFormatting` always uses `preferred`, even though it
+formatting only** — `textDocument/rangeFormatting` always uses `preferred`, even though it
 shares the `textDocument/formatting` config key. See
 concatenated-formatting-pipeline.
 
@@ -288,7 +288,7 @@ When multiple servers are configured for a language:
 | Completion | Merge completion lists from all servers |
 | Hover | Concatenate hover content with separator |
 | Diagnostics | Merge all, dedupe by range + message |
-| Formatting | `preferred` (first non-empty) by default; `concatenated` runs a sequential pipeline over `priorities` — planned, full formatting only, not yet implemented. rangeFormatting stays on `preferred` (concatenated-formatting-pipeline) |
+| Formatting | `preferred` (first non-empty) by default; `concatenated` runs a sequential pipeline over `priorities` — planned, full formatting only, not yet implemented. `textDocument/rangeFormatting` stays on `preferred` (concatenated-formatting-pipeline) |
 
 ## Consequences
 

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -61,7 +61,7 @@ A single bridge strategy doesn't fit all methods. We need per-method strategies 
 
 ```
                     ┌─────────────────────────────┐
- Request ──────────▶│      kakehashi          │
+ Request ──────────▶│      kakehashi              │
                     │  ┌─────────────────────┐    │
                     │  │ Tree-sitter tokens  │────│───▶ Immediate response
                     │  │ (local, fast)       │    │     (use if bridge slow)
@@ -221,8 +221,12 @@ Rename can affect multiple files. For injections, only same-document renames are
 | Output | TextEdit[] |
 | Cross-file | N/A (single document) |
 | Position mapping | All edit ranges |
+| Multi-server | `preferred` by default; `concatenated` opts into a sequential pipeline |
 
-Relatively simple—all edits are within the virtual document.
+Single-server formatting is simple—all edits are within the virtual document.
+For multiple servers, `concatenated` does **not** concatenate edit lists (that
+would overlap); it runs a sequential formatter pipeline ordered by `priorities`.
+See concatenated-formatting-pipeline.
 
 ### Strategy 4: Background Collection
 
@@ -281,6 +285,7 @@ When multiple servers are configured for a language:
 | Completion | Merge completion lists from all servers |
 | Hover | Concatenate hover content with separator |
 | Diagnostics | Merge all, dedupe by range + message |
+| Formatting | `preferred` (first non-empty) by default; `concatenated` runs a sequential pipeline over `priorities` (concatenated-formatting-pipeline) |
 
 ## Consequences
 
@@ -342,3 +347,4 @@ The original priority order (for reference):
 
 - [language-server-bridge](language-server-bridge.md): Core LSP bridge architecture
 - [language-server-bridge-virtual-document-model](language-server-bridge-virtual-document-model.md): How injections are represented as virtual documents
+- [concatenated-formatting-pipeline](concatenated-formatting-pipeline.md): Multi-server formatting via a sequential pipeline (`strategy: "concatenated"`)

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -213,11 +213,11 @@ Rename can affect multiple files. For injections, only same-document renames are
 | Cross-file | Filter out actions with cross-file edits |
 | Position mapping | All ranges in remaining actions |
 
-#### textDocument/formatting / rangeFormatting
+#### textDocument/formatting / textDocument/rangeFormatting
 
 | Aspect | Handling |
 |--------|----------|
-| Input | Options (or range for rangeFormatting) |
+| Input | Options (or range for `textDocument/rangeFormatting`) |
 | Output | TextEdit[] |
 | Cross-file | N/A (single document) |
 | Position mapping | All edit ranges |

--- a/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
+++ b/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
@@ -280,7 +280,7 @@ languages:
           # hover, definition: use default (single_by_capability)
           # rename: MUST use single_by_capability (overlapping WorkspaceEdits)
           # formatting: see concatenated-formatting-pipeline (planned sequential
-          #   pipeline; textDocument/rangeFormatting unaffected)
+          #   pipeline; user-issued textDocument/rangeFormatting requests unaffected)
 
 languageServers:
   pyright:

--- a/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
+++ b/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
@@ -282,8 +282,8 @@ languages:
           # formatting: concatenated is PLANNED to run a sequential pipeline,
           #   NOT list concatenation (not yet implemented) — see
           #   concatenated-formatting-pipeline
-          # rangeFormatting: preferred only — shares the formatting config key
-          #   but ignores concatenated (range pipeline is out of scope)
+          # textDocument/rangeFormatting: preferred only — shares the formatting
+          #   config key but ignores concatenated (range pipeline is out of scope)
 
 languageServers:
   pyright:

--- a/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
+++ b/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
@@ -279,8 +279,9 @@ languages:
             strategy: concatenated   # Safe: proposals, user executes one
           # hover, definition: use default (single_by_capability)
           # rename: MUST use single_by_capability (overlapping WorkspaceEdits)
-          # formatting: concatenated runs a sequential pipeline, NOT list
-          #   concatenation — see concatenated-formatting-pipeline
+          # formatting: concatenated is PLANNED to run a sequential pipeline,
+          #   NOT list concatenation (not yet implemented) — see
+          #   concatenated-formatting-pipeline
 
 languageServers:
   pyright:

--- a/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
+++ b/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
@@ -385,10 +385,10 @@ Silently discard notifications instead of explicit DROP with state tracking.
 ## Configuration Example (Phase 1)
 
 ```yaml
-# Phase 1: Server-name-based routing with process sharing
+# Phase 1: Server-name-based routing with process sharing (illustrative)
 languages:
   markdown:
-    bridges:
+    bridge:
       python:
         server: pyright          # Single server for Python
       lua:

--- a/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
+++ b/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
@@ -282,6 +282,8 @@ languages:
           # formatting: concatenated is PLANNED to run a sequential pipeline,
           #   NOT list concatenation (not yet implemented) — see
           #   concatenated-formatting-pipeline
+          # rangeFormatting: preferred only — shares the formatting config key
+          #   but ignores concatenated (range pipeline is out of scope)
 
 languageServers:
   pyright:

--- a/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
+++ b/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
@@ -278,7 +278,9 @@ languages:
           textDocument/codeAction:
             strategy: concatenated   # Safe: proposals, user executes one
           # hover, definition: use default (single_by_capability)
-          # formatting, rename: MUST use single_by_capability
+          # rename: MUST use single_by_capability (overlapping WorkspaceEdits)
+          # formatting: concatenated runs a sequential pipeline, NOT list
+          #   concatenation — see concatenated-formatting-pipeline
 
 languageServers:
   pyright:

--- a/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
+++ b/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
@@ -261,47 +261,43 @@ enum AggregationStrategy {
 
 ### Phase 3: Configuration Example
 
-> **Illustrative pseudo-config, not the literal schema.** The keys below
-> (`bridges`, `aggregations`, top-level `priorities`, `dedup_key`,
-> `single_by_capability`) sketch the *intent* of Phase-3 aggregation and predate
-> the implemented format. The real schema uses a singular `bridge` map with
-> per-method `aggregation` entries holding `priorities`/`strategy` — see
-> language-server-bridge-virtual-document-model and `src/config/settings.rs`.
-> Do not copy this block verbatim. (Aligning it with the current schema is
-> tracked as follow-up, out of scope for this ADR.)
+Multi-server aggregation is configured per host-language → injection-language →
+method, under `languages.<host>.bridge.<inj>.aggregation."<method>"` (with `_` as
+the wildcard/default); each entry carries `priorities`, `strategy`, and
+`maxFanOut`. Servers are declared under top-level `languageServers`. The
+authoritative schema and worked examples live in `docs/README.md` and
+host-document-bridge; a minimal shape:
 
-```yaml
-# Phase 3: Multiple servers per language with aggregation (ILLUSTRATIVE — see note above)
-languages:
-  markdown:
-    bridges:
-      python:
-        # Multiple servers for Python
-        priorities: ["ruff", "pyright"]  # Prioritize ruff when capability overlaps
-
-        # Per-method aggregation config:
-        aggregations:
-          textDocument/completion:
-            strategy: concatenated   # Safe: candidates, user selects one
-            dedup_key: label
-          textDocument/codeAction:
-            strategy: concatenated   # Safe: proposals, user executes one
-          # hover, definition: use default (single_by_capability)
-          # rename: MUST use single_by_capability (overlapping WorkspaceEdits)
-          # formatting: concatenated is PLANNED to run a sequential pipeline,
-          #   NOT list concatenation (not yet implemented) — see
-          #   concatenated-formatting-pipeline
-          # textDocument/rangeFormatting: preferred only — shares the formatting
-          #   config key but ignores concatenated (range pipeline is out of scope)
-
-languageServers:
-  pyright:
-    cmd: [pyright-langserver, --stdio]
-    languages: [python]
-  ruff:
-    cmd: [ruff, server]
-    languages: [python]  # Same language as pyright
+```json
+{
+  "languages": {
+    "markdown": {
+      "bridge": {
+        "python": {
+          "aggregation": {
+            "_": { "priorities": ["ruff", "pyright"] },
+            "textDocument/completion": { "strategy": "concatenated" }
+          }
+        }
+      }
+    }
+  },
+  "languageServers": {
+    "pyright": { "cmd": ["pyright-langserver", "--stdio"], "languages": ["python"] },
+    "ruff": { "cmd": ["ruff", "server"], "languages": ["python"] }
+  }
+}
 ```
+
+Per-method intent for that Python injection:
+
+- **completion** — `concatenated` (merge candidate lists; the user picks one).
+- **hover / definition** — default `preferred` (first non-empty response).
+- **rename** — single server only (overlapping `WorkspaceEdit`s cannot merge).
+- **formatting** — `concatenated` is PLANNED to run a sequential pipeline (not
+  list concatenation; not yet implemented) — see concatenated-formatting-pipeline.
+- **`textDocument/rangeFormatting`** — `preferred` only (shares the formatting
+  config key but ignores `concatenated`; the range pipeline is out of scope).
 
 ## Consequences
 

--- a/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
+++ b/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
@@ -261,8 +261,17 @@ enum AggregationStrategy {
 
 ### Phase 3: Configuration Example
 
+> **Illustrative pseudo-config, not the literal schema.** The keys below
+> (`bridges`, `aggregations`, top-level `priorities`, `dedup_key`,
+> `single_by_capability`) sketch the *intent* of Phase-3 aggregation and predate
+> the implemented format. The real schema uses a singular `bridge` map with
+> per-method `aggregation` entries holding `priorities`/`strategy` — see
+> language-server-bridge-virtual-document-model and `src/config/settings.rs`.
+> Do not copy this block verbatim. (Aligning it with the current schema is
+> tracked as follow-up, out of scope for this ADR.)
+
 ```yaml
-# Phase 3: Multiple servers per language with aggregation
+# Phase 3: Multiple servers per language with aggregation (ILLUSTRATIVE — see note above)
 languages:
   markdown:
     bridges:

--- a/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
+++ b/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
@@ -261,43 +261,35 @@ enum AggregationStrategy {
 
 ### Phase 3: Configuration Example
 
-Multi-server aggregation is configured per host-language → injection-language →
-method, under `languages.<host>.bridge.<inj>.aggregation."<method>"` (with `_` as
-the wildcard/default); each entry carries `priorities`, `strategy`, and
-`maxFanOut`. Servers are declared under top-level `languageServers`. The
-authoritative schema and worked examples live in `docs/README.md` and
-host-document-bridge; a minimal shape:
+```yaml
+# Phase 3: Multiple servers per language with aggregation
+languages:
+  markdown:
+    bridges:
+      python:
+        # Multiple servers for Python
+        priority: ["ruff", "pyright"]  # Prioritize ruff when capability overlaps
 
-```json
-{
-  "languages": {
-    "markdown": {
-      "bridge": {
-        "python": {
-          "aggregation": {
-            "_": { "priorities": ["ruff", "pyright"] },
-            "textDocument/completion": { "strategy": "concatenated" }
-          }
-        }
-      }
-    }
-  },
-  "languageServers": {
-    "pyright": { "cmd": ["pyright-langserver", "--stdio"], "languages": ["python"] },
-    "ruff": { "cmd": ["ruff", "server"], "languages": ["python"] }
-  }
-}
+        # Per-method aggregation config:
+        aggregations:
+          textDocument/completion:
+            strategy: concatenated   # Safe: candidates, user selects one
+            dedup_key: label
+          textDocument/codeAction:
+            strategy: concatenated   # Safe: proposals, user executes one
+          # hover, definition: use default (single_by_capability)
+          # rename: MUST use single_by_capability (overlapping WorkspaceEdits)
+          # formatting: see concatenated-formatting-pipeline (planned sequential
+          #   pipeline; textDocument/rangeFormatting stays preferred)
+
+languageServers:
+  pyright:
+    cmd: [pyright-langserver, --stdio]
+    languages: [python]
+  ruff:
+    cmd: [ruff, server]
+    languages: [python]  # Same language as pyright
 ```
-
-Per-method intent for that Python injection:
-
-- **completion** — `concatenated` (merge candidate lists; the user picks one).
-- **hover / definition** — default `preferred` (first non-empty response).
-- **rename** — single server only (overlapping `WorkspaceEdit`s cannot merge).
-- **formatting** — `concatenated` is PLANNED to run a sequential pipeline (not
-  list concatenation; not yet implemented) — see concatenated-formatting-pipeline.
-- **`textDocument/rangeFormatting`** — `preferred` only (shares the formatting
-  config key but ignores `concatenated`; the range pipeline is out of scope).
 
 ## Consequences
 
@@ -385,10 +377,10 @@ Silently discard notifications instead of explicit DROP with state tracking.
 ## Configuration Example (Phase 1)
 
 ```yaml
-# Phase 1: Server-name-based routing with process sharing (illustrative)
+# Phase 1: Server-name-based routing with process sharing
 languages:
   markdown:
-    bridge:
+    bridges:
       python:
         server: pyright          # Single server for Python
       lua:

--- a/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
+++ b/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
@@ -280,7 +280,7 @@ languages:
           # hover, definition: use default (single_by_capability)
           # rename: MUST use single_by_capability (overlapping WorkspaceEdits)
           # formatting: see concatenated-formatting-pipeline (planned sequential
-          #   pipeline; textDocument/rangeFormatting stays preferred)
+          #   pipeline; textDocument/rangeFormatting unaffected)
 
 languageServers:
   pyright:

--- a/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
+++ b/docs/architecture-decisions/ls-bridge-server-pool-coordination.md
@@ -268,7 +268,7 @@ languages:
     bridges:
       python:
         # Multiple servers for Python
-        priority: ["ruff", "pyright"]  # Prioritize ruff when capability overlaps
+        priorities: ["ruff", "pyright"]  # Prioritize ruff when capability overlaps
 
         # Per-method aggregation config:
         aggregations:


### PR DESCRIPTION
## Why

Multi-server `textDocument/formatting` had no defined behavior beyond "use a single server" — the previously documented rule in `ls-bridge-server-pool-coordination` said formatting *must* use one server, because naively concatenating `TextEdit[]` from several formatters overlaps and violates the LSP no-overlapping-edits rule.

But real setups want to chain **complementary + whole-document** formatters over one region (e.g. `black` then `isort`). This needs a defined semantics.

## Decision

Records a new decision: **`strategy: "concatenated"` on `textDocument/formatting` is an explicit opt-in to a sequential formatter pipeline ordered by `priorities`.**

- **Explicit switch** — default stays `preferred` (first non-empty wins); no implicit activation.
- **`priorities` = pipeline definition** — membership (allowlist) + application order. Servers not listed don't run for formatting.
- **Sequential, single pass** — each server formats the *previous* server's output (fed via a fresh scratch `didOpen`). Seriality makes the result overlap-free and deterministic, with no diff/merge machinery. Recursion/fixpoint is out of scope.
- **Region full-replacement output** — emit one `TextEdit` replacing the whole region; sidesteps needing a text-diff utility (minimal-diff output deferred).

### Two nesting levels (overlap-free for different reasons)
- **Across injection regions** → parallel; regions are disjoint spans, so concatenated edits never overlap (existing behavior, unchanged).
- **Within one region** → sequential; overlap-freedom comes from seriality, not disjointness.

### Keyword overload, made explicit
`strategy: "concatenated"` means different mechanics per method: **result-list concatenation** for diagnostics/references vs. a **sequential text pipeline** for formatting.

## Changes
- **New:** `concatenated-formatting-pipeline.md` — the decision, with Considered Options (parallel diff-stacking rejected: whole-document formatters always conflict, offset rebasing, arrival-order nondeterminism, oscillation; `preferred`-only insufficient; minimal-diff deferred) and a Decision–Implementation Gap (not yet implemented).
- **Updated:** `ls-bridge-server-pool-coordination.md` — retire the "formatting MUST use single_by_capability" constraint (rename still must); point to the new decision.
- **Updated:** `language-server-bridge-request-strategies.md` — add formatting to the multi-server merging rules and a per-method note; link from Related Decisions.

Docs-only. Defines target behavior ahead of implementation; next step is the first TDD test for the within-region pipeline.