### PR TITLE
fix(bridge): short-circuit response transforms on JSON-RPC error

### DIFF
--- a/src/lsp/bridge/protocol.rs
+++ b/src/lsp/bridge/protocol.rs
@@ -20,7 +20,7 @@ mod translation;
 mod virtual_uri;
 
 // Re-export all public items for external use
-pub(crate) use jsonrpc::{JsonRpcNotification, JsonRpcRequest};
+pub(crate) use jsonrpc::{JsonRpcNotification, JsonRpcRequest, response_has_jsonrpc_error};
 pub(crate) use lifecycle::*;
 pub(crate) use request::*;
 pub(crate) use request_id::RequestId;

--- a/src/lsp/bridge/protocol/jsonrpc.rs
+++ b/src/lsp/bridge/protocol/jsonrpc.rs
@@ -3,7 +3,28 @@
 //! These structs replace raw `serde_json::Value` construction in protocol
 //! builders, enabling compile-time validation of message structure.
 
+use log::warn;
 use serde::Serialize;
+
+/// Detect a JSON-RPC error response so transformers can short-circuit.
+///
+/// Per JSON-RPC 2.0 a response object MUST NOT contain both `result` and
+/// `error`; when `error` is present the `result` is meaningless. Returns `true`
+/// (after logging a warning tagged with `method`) when the response carries a
+/// non-null `error`, signalling the caller to abandon `result` parsing and
+/// return its own "no result" value.
+///
+/// A literal `"error": null` is treated as *no error*: some servers include the
+/// null field alongside a valid `result`, and short-circuiting on it would drop
+/// good results.
+pub(crate) fn response_has_jsonrpc_error(response: &serde_json::Value, method: &str) -> bool {
+    if let Some(error) = response.get("error").filter(|e| !e.is_null()) {
+        warn!(target: "kakehashi::bridge", "Downstream server returned error for {method}: {error}");
+        true
+    } else {
+        false
+    }
+}
 
 /// A JSON-RPC 2.0 request message (expects a response).
 #[derive(Debug, Serialize)]
@@ -75,5 +96,38 @@ mod tests {
         let req = JsonRpcRequest::new(1, "shutdown", ());
         let json = serde_json::to_value(&req).unwrap();
         assert!(json["params"].is_null());
+    }
+
+    #[test]
+    fn response_with_error_is_detected() {
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {"code": -32601, "message": "Method not found"},
+        });
+        assert!(response_has_jsonrpc_error(&response, "textDocument/hover"));
+    }
+
+    #[test]
+    fn response_without_error_is_not_flagged() {
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"contents": "value"},
+        });
+        assert!(!response_has_jsonrpc_error(&response, "textDocument/hover"));
+    }
+
+    #[test]
+    fn response_with_null_error_alongside_result_is_not_flagged() {
+        // Some servers send `"error": null` next to a valid result; this MUST NOT
+        // be treated as an error, otherwise good results get dropped.
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"contents": "value"},
+            "error": null,
+        });
+        assert!(!response_has_jsonrpc_error(&response, "textDocument/hover"));
     }
 }

--- a/src/lsp/bridge/protocol/response.rs
+++ b/src/lsp/bridge/protocol/response.rs
@@ -6,8 +6,7 @@
 //! request-virtual-URI matches, drop other virtual URIs (cross-region offsets
 //! are unsafe). Used by goto definition/type_definition/implementation/declaration.
 
-use log::warn;
-
+use super::jsonrpc::response_has_jsonrpc_error;
 use super::translation::{RegionOffset, translate_virtual_range_to_host};
 use super::virtual_uri::VirtualDocumentUri;
 use tower_lsp_server::ls_types::{Location, LocationLink, Uri};
@@ -30,8 +29,8 @@ pub(crate) fn transform_goto_response_to_host(
     host_uri: &Uri,
     offset: &RegionOffset,
 ) -> Option<Vec<LocationLink>> {
-    if let Some(error) = response.get("error") {
-        warn!(target: "kakehashi::bridge", "Downstream server returned error for goto request: {}", error);
+    if response_has_jsonrpc_error(&response, "goto request") {
+        return None;
     }
     let result = response.get_mut("result").map(serde_json::Value::take)?;
     if result.is_null() {

--- a/src/lsp/bridge/text_document/color_presentation.rs
+++ b/src/lsp/bridge/text_document/color_presentation.rs
@@ -5,8 +5,6 @@
 
 use std::io;
 
-use log::warn;
-
 use crate::config::settings::BridgeServerConfig;
 use tower_lsp_server::ls_types::{
     Color, ColorPresentation, ColorPresentationParams, Range, TextDocumentIdentifier,
@@ -15,8 +13,8 @@ use url::Url;
 
 use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::{
-    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, translate_host_range_to_virtual,
-    translate_virtual_range_to_host, virtual_uri_to_lsp_uri,
+    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, response_has_jsonrpc_error,
+    translate_host_range_to_virtual, translate_virtual_range_to_host, virtual_uri_to_lsp_uri,
 };
 
 impl LanguageServerPool {
@@ -106,8 +104,8 @@ fn transform_color_presentation_response_to_host(
     mut response: serde_json::Value,
     offset: &RegionOffset,
 ) -> Vec<ColorPresentation> {
-    if let Some(error) = response.get("error") {
-        warn!(target: "kakehashi::bridge", "Downstream server returned error for textDocument/colorPresentation: {}", error);
+    if response_has_jsonrpc_error(&response, "textDocument/colorPresentation") {
+        return vec![];
     }
     let Some(result) = response.get_mut("result").map(serde_json::Value::take) else {
         return vec![];

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -6,7 +6,6 @@
 
 use std::io;
 
-use log::warn;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -18,6 +17,7 @@ use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::translate_virtual_range_to_host;
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, build_position_based_request,
+    response_has_jsonrpc_error,
 };
 use tower_lsp_server::ls_types::TextDocumentPositionParams;
 
@@ -104,8 +104,8 @@ fn transform_completion_response_to_host(
     offset: &RegionOffset,
     envelope_ctx: Option<EnvelopeContext<'_>>,
 ) -> Option<CompletionList> {
-    if let Some(error) = response.get("error") {
-        warn!(target: "kakehashi::bridge", "Downstream server returned error for textDocument/completion: {}", error);
+    if response_has_jsonrpc_error(&response, "textDocument/completion") {
+        return None;
     }
     let result = response.get_mut("result").map(serde_json::Value::take)?;
     if result.is_null() {

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -14,7 +14,7 @@ use log::warn;
 use tower_lsp_server::ls_types::CompletionItem;
 
 use super::super::pool::{LanguageServerPool, UpstreamId};
-use super::super::protocol::{JsonRpcRequest, RegionOffset, RequestId};
+use super::super::protocol::{JsonRpcRequest, RegionOffset, RequestId, response_has_jsonrpc_error};
 use super::completion::{
     EnvelopeContext, KakehashiEnvelope, envelope_item_data, strip_envelope,
     transform_completion_item,
@@ -185,12 +185,8 @@ fn build_completion_resolve_request(
 ///
 /// Returns `None` for null results, missing results, and deserialization failures.
 fn parse_completion_resolve_response(mut response: serde_json::Value) -> Option<CompletionItem> {
-    if let Some(error) = response.get("error") {
-        warn!(
-            target: "kakehashi::bridge",
-            "Downstream server returned error for completionItem/resolve: {}",
-            error
-        );
+    if response_has_jsonrpc_error(&response, "completionItem/resolve") {
+        return None;
     }
     let result = response.get_mut("result").map(serde_json::Value::take)?;
     if result.is_null() {

--- a/src/lsp/bridge/text_document/diagnostic.rs
+++ b/src/lsp/bridge/text_document/diagnostic.rs
@@ -16,8 +16,6 @@
 use std::io;
 use std::time::Duration;
 
-use log::warn;
-
 use crate::config::settings::BridgeServerConfig;
 use tower_lsp_server::ls_types::Diagnostic;
 use url::Url;
@@ -27,7 +25,8 @@ use tower_lsp_server::ls_types::{DocumentDiagnosticParams, TextDocumentIdentifie
 
 use super::super::protocol::translate_virtual_range_to_host;
 use super::super::protocol::{
-    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, virtual_uri_to_lsp_uri,
+    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, response_has_jsonrpc_error,
+    virtual_uri_to_lsp_uri,
 };
 
 impl LanguageServerPool {
@@ -126,8 +125,8 @@ fn transform_diagnostic_response_to_host(
     offset: &RegionOffset,
     host_uri: &str,
 ) -> Vec<Diagnostic> {
-    if let Some(error) = response.get("error") {
-        warn!(target: "kakehashi::bridge", "Downstream server returned error for textDocument/diagnostic: {}", error);
+    if response_has_jsonrpc_error(&response, "textDocument/diagnostic") {
+        return Vec::new();
     }
     let Some(mut result) = response.get_mut("result").map(serde_json::Value::take) else {
         return Vec::new();

--- a/src/lsp/bridge/text_document/document_color.rs
+++ b/src/lsp/bridge/text_document/document_color.rs
@@ -9,8 +9,6 @@
 
 use std::io;
 
-use log::warn;
-
 use crate::config::settings::BridgeServerConfig;
 use tower_lsp_server::ls_types::ColorInformation;
 use url::Url;
@@ -19,7 +17,7 @@ use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::translate_virtual_range_to_host;
 use super::super::protocol::{
     DocumentParams, JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri,
-    build_whole_document_request,
+    build_whole_document_request, response_has_jsonrpc_error,
 };
 
 impl LanguageServerPool {
@@ -81,8 +79,8 @@ fn transform_document_color_response_to_host(
     mut response: serde_json::Value,
     offset: &RegionOffset,
 ) -> Vec<ColorInformation> {
-    if let Some(error) = response.get("error") {
-        warn!(target: "kakehashi::bridge", "Downstream server returned error for textDocument/documentColor: {}", error);
+    if response_has_jsonrpc_error(&response, "textDocument/documentColor") {
+        return vec![];
     }
     let Some(result) = response.get_mut("result").map(serde_json::Value::take) else {
         return vec![];

--- a/src/lsp/bridge/text_document/document_highlight.rs
+++ b/src/lsp/bridge/text_document/document_highlight.rs
@@ -10,8 +10,6 @@
 
 use std::io;
 
-use log::warn;
-
 use crate::config::settings::BridgeServerConfig;
 use tower_lsp_server::ls_types::{DocumentHighlight, Position};
 use url::Url;
@@ -20,6 +18,7 @@ use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::translate_virtual_range_to_host;
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, build_position_based_request,
+    response_has_jsonrpc_error,
 };
 use tower_lsp_server::ls_types::TextDocumentPositionParams;
 
@@ -93,8 +92,8 @@ fn transform_document_highlight_response_to_host(
     mut response: serde_json::Value,
     offset: &RegionOffset,
 ) -> Option<Vec<DocumentHighlight>> {
-    if let Some(error) = response.get("error") {
-        warn!(target: "kakehashi::bridge", "Downstream server returned error for textDocument/documentHighlight: {}", error);
+    if response_has_jsonrpc_error(&response, "textDocument/documentHighlight") {
+        return None;
     }
     let result = response.get_mut("result").map(serde_json::Value::take)?;
 

--- a/src/lsp/bridge/text_document/document_link.rs
+++ b/src/lsp/bridge/text_document/document_link.rs
@@ -9,8 +9,6 @@
 
 use std::io;
 
-use log::warn;
-
 use crate::config::settings::BridgeServerConfig;
 use tower_lsp_server::ls_types::DocumentLink;
 use url::Url;
@@ -19,7 +17,7 @@ use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::translate_virtual_range_to_host;
 use super::super::protocol::{
     DocumentParams, JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri,
-    build_whole_document_request,
+    build_whole_document_request, response_has_jsonrpc_error,
 };
 
 impl LanguageServerPool {
@@ -78,8 +76,8 @@ fn transform_document_link_response_to_host(
     mut response: serde_json::Value,
     offset: &RegionOffset,
 ) -> Option<Vec<DocumentLink>> {
-    if let Some(error) = response.get("error") {
-        warn!(target: "kakehashi::bridge", "Downstream server returned error for textDocument/documentLink: {}", error);
+    if response_has_jsonrpc_error(&response, "textDocument/documentLink") {
+        return None;
     }
     let result = response.get_mut("result").map(serde_json::Value::take)?;
 

--- a/src/lsp/bridge/text_document/document_symbol.rs
+++ b/src/lsp/bridge/text_document/document_symbol.rs
@@ -12,8 +12,6 @@
 
 use std::io;
 
-use log::warn;
-
 use crate::config::settings::BridgeServerConfig;
 use tower_lsp_server::ls_types::{DocumentSymbol, SymbolInformation};
 use url::Url;
@@ -22,7 +20,7 @@ use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::translate_virtual_range_to_host;
 use super::super::protocol::{
     DocumentParams, JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri,
-    build_whole_document_request,
+    build_whole_document_request, response_has_jsonrpc_error,
 };
 
 impl LanguageServerPool {
@@ -99,8 +97,8 @@ fn transform_document_symbol_response_to_host(
     request_virtual_uri: &str,
     offset: &RegionOffset,
 ) -> Option<Vec<DocumentSymbol>> {
-    if let Some(error) = response.get("error") {
-        warn!(target: "kakehashi::bridge", "Downstream server returned error for textDocument/documentSymbol: {}", error);
+    if response_has_jsonrpc_error(&response, "textDocument/documentSymbol") {
+        return None;
     }
     let result = response.get_mut("result").map(serde_json::Value::take)?;
 

--- a/src/lsp/bridge/text_document/formatting.rs
+++ b/src/lsp/bridge/text_document/formatting.rs
@@ -29,7 +29,9 @@ use url::Url;
 
 use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::translate_virtual_range_to_host;
-use super::super::protocol::{JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri};
+use super::super::protocol::{
+    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, response_has_jsonrpc_error,
+};
 
 impl LanguageServerPool {
     /// Send a formatting request and wait for the response.
@@ -148,8 +150,8 @@ pub(super) fn transform_formatting_response_to_host(
     offset: &RegionOffset,
     virtual_line_count: u32,
 ) -> Option<Vec<TextEdit>> {
-    if let Some(error) = response.get("error") {
-        warn!(target: "kakehashi::bridge", "Downstream server returned error for formatting-style request: {}", error);
+    if response_has_jsonrpc_error(&response, "formatting-style request") {
+        return None;
     }
     let result = response.get_mut("result").map(serde_json::Value::take)?;
 

--- a/src/lsp/bridge/text_document/hover.rs
+++ b/src/lsp/bridge/text_document/hover.rs
@@ -10,8 +10,6 @@
 
 use std::io;
 
-use log::warn;
-
 use crate::config::settings::BridgeServerConfig;
 use tower_lsp_server::ls_types::{Hover, Position};
 use url::Url;
@@ -20,6 +18,7 @@ use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::translate_virtual_range_to_host;
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, build_position_based_request,
+    response_has_jsonrpc_error,
 };
 use tower_lsp_server::ls_types::TextDocumentPositionParams;
 
@@ -91,8 +90,8 @@ fn transform_hover_response_to_host(
     mut response: serde_json::Value,
     offset: &RegionOffset,
 ) -> Option<Hover> {
-    if let Some(error) = response.get("error") {
-        warn!(target: "kakehashi::bridge", "Downstream server returned error for textDocument/hover: {}", error);
+    if response_has_jsonrpc_error(&response, "textDocument/hover") {
+        return None;
     }
     let result = response.get_mut("result").map(serde_json::Value::take)?;
     if result.is_null() {
@@ -251,6 +250,24 @@ mod tests {
     #[case::no_result_key(serde_json::json!({"jsonrpc": "2.0", "id": 42, "error": {"code": -32600, "message": "Invalid Request"}}))]
     #[case::malformed_result(serde_json::json!({"jsonrpc": "2.0", "id": 42, "result": "not_a_hover_object"}))]
     fn hover_response_returns_none_for_invalid_response(#[case] response: serde_json::Value) {
+        let transformed = transform_hover_response_to_host(response, &RegionOffset::new(5, 0));
+        assert!(transformed.is_none());
+    }
+
+    #[test]
+    fn hover_response_short_circuits_when_error_present_alongside_result() {
+        // JSON-RPC 2.0: a response MUST NOT carry both `result` and `error`.
+        // A misbehaving server that sends both must not have its (meaningless)
+        // `result` parsed — the error takes precedence and we return None.
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 42,
+            "error": {"code": -32603, "message": "Internal error"},
+            "result": {
+                "contents": "this result must be ignored"
+            }
+        });
+
         let transformed = transform_hover_response_to_host(response, &RegionOffset::new(5, 0));
         assert!(transformed.is_none());
     }

--- a/src/lsp/bridge/text_document/inlay_hint.rs
+++ b/src/lsp/bridge/text_document/inlay_hint.rs
@@ -14,8 +14,6 @@
 
 use std::io;
 
-use log::warn;
-
 use crate::config::settings::BridgeServerConfig;
 use tower_lsp_server::ls_types::{InlayHint, InlayHintLabel, Range, Uri};
 use url::Url;
@@ -24,8 +22,9 @@ use super::super::pool::{LanguageServerPool, UpstreamId};
 use tower_lsp_server::ls_types::{InlayHintParams, TextDocumentIdentifier};
 
 use super::super::protocol::{
-    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, translate_host_range_to_virtual,
-    translate_virtual_position_to_host, translate_virtual_range_to_host, virtual_uri_to_lsp_uri,
+    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, response_has_jsonrpc_error,
+    translate_host_range_to_virtual, translate_virtual_position_to_host,
+    translate_virtual_range_to_host, virtual_uri_to_lsp_uri,
 };
 
 impl LanguageServerPool {
@@ -115,8 +114,8 @@ fn transform_inlay_hint_response_to_host(
     host_uri: &Uri,
     offset: &RegionOffset,
 ) -> Option<Vec<InlayHint>> {
-    if let Some(error) = response.get("error") {
-        warn!(target: "kakehashi::bridge", "Downstream server returned error for textDocument/inlayHint: {}", error);
+    if response_has_jsonrpc_error(&response, "textDocument/inlayHint") {
+        return None;
     }
     let result = response.get_mut("result").map(serde_json::Value::take)?;
 

--- a/src/lsp/bridge/text_document/moniker.rs
+++ b/src/lsp/bridge/text_document/moniker.rs
@@ -10,8 +10,6 @@
 
 use std::io;
 
-use log::warn;
-
 use crate::config::settings::BridgeServerConfig;
 use tower_lsp_server::ls_types::{Moniker, Position};
 use url::Url;
@@ -19,6 +17,7 @@ use url::Url;
 use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, build_position_based_request,
+    response_has_jsonrpc_error,
 };
 use tower_lsp_server::ls_types::TextDocumentPositionParams;
 
@@ -86,8 +85,8 @@ fn build_moniker_request(
 /// Moniker fields (scheme, identifier, unique, kind) are non-coordinate data,
 /// so no line/range transformation is needed.
 fn transform_moniker_response_to_host(mut response: serde_json::Value) -> Option<Vec<Moniker>> {
-    if let Some(error) = response.get("error") {
-        warn!(target: "kakehashi::bridge", "Downstream server returned error for textDocument/moniker: {}", error);
+    if response_has_jsonrpc_error(&response, "textDocument/moniker") {
+        return None;
     }
     let result = response.get_mut("result").map(serde_json::Value::take)?;
 

--- a/src/lsp/bridge/text_document/prepare_rename.rs
+++ b/src/lsp/bridge/text_document/prepare_rename.rs
@@ -10,8 +10,6 @@
 
 use std::io;
 
-use log::warn;
-
 use crate::config::settings::BridgeServerConfig;
 use tower_lsp_server::ls_types::{Position, PrepareRenameResponse, TextDocumentPositionParams};
 use url::Url;
@@ -20,6 +18,7 @@ use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::translate_virtual_range_to_host;
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, build_position_based_request,
+    response_has_jsonrpc_error,
 };
 
 impl LanguageServerPool {
@@ -104,8 +103,8 @@ fn transform_prepare_rename_response_to_host(
     mut response: serde_json::Value,
     offset: &RegionOffset,
 ) -> Option<PrepareRenameResponse> {
-    if let Some(error) = response.get("error") {
-        warn!(target: "kakehashi::bridge", "Downstream server returned error for textDocument/prepareRename: {}", error);
+    if response_has_jsonrpc_error(&response, "textDocument/prepareRename") {
+        return None;
     }
     let result = response.get_mut("result").map(serde_json::Value::take)?;
     if result.is_null() {

--- a/src/lsp/bridge/text_document/references.rs
+++ b/src/lsp/bridge/text_document/references.rs
@@ -10,15 +10,14 @@
 
 use std::io;
 
-use log::warn;
-
 use crate::config::settings::BridgeServerConfig;
 use tower_lsp_server::ls_types::{Location, Position, Uri};
 use url::Url;
 
 use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::{
-    JsonRpcRequest, RegionOffset, build_text_document_position_params, transform_location_for_goto,
+    JsonRpcRequest, RegionOffset, build_text_document_position_params, response_has_jsonrpc_error,
+    transform_location_for_goto,
 };
 use tower_lsp_server::ls_types::{ReferenceContext, ReferenceParams};
 
@@ -96,8 +95,8 @@ fn transform_references_response_to_host(
     host_uri: &Uri,
     offset: &RegionOffset,
 ) -> Option<Vec<Location>> {
-    if let Some(error) = response.get("error") {
-        warn!(target: "kakehashi::bridge", "Downstream server returned error for textDocument/references: {}", error);
+    if response_has_jsonrpc_error(&response, "textDocument/references") {
+        return None;
     }
     let result = response.get_mut("result").map(serde_json::Value::take)?;
     if result.is_null() {

--- a/src/lsp/bridge/text_document/rename.rs
+++ b/src/lsp/bridge/text_document/rename.rs
@@ -10,7 +10,6 @@
 
 use std::io;
 
-use log::warn;
 use std::collections::HashMap;
 
 use crate::config::settings::BridgeServerConfig;
@@ -26,7 +25,7 @@ use tower_lsp_server::ls_types::RenameParams;
 use super::super::protocol::translate_virtual_range_to_host;
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri,
-    build_text_document_position_params,
+    build_text_document_position_params, response_has_jsonrpc_error,
 };
 
 impl LanguageServerPool {
@@ -114,8 +113,8 @@ fn transform_workspace_edit_response_to_host(
     host_uri: &Uri,
     offset: &RegionOffset,
 ) -> Option<WorkspaceEdit> {
-    if let Some(error) = response.get("error") {
-        warn!(target: "kakehashi::bridge", "Downstream server returned error for textDocument/rename: {}", error);
+    if response_has_jsonrpc_error(&response, "textDocument/rename") {
+        return None;
     }
     let result = response.get_mut("result").map(serde_json::Value::take)?;
 

--- a/src/lsp/bridge/text_document/signature_help.rs
+++ b/src/lsp/bridge/text_document/signature_help.rs
@@ -6,8 +6,6 @@
 
 use std::io;
 
-use log::warn;
-
 use crate::config::settings::BridgeServerConfig;
 use tower_lsp_server::ls_types::{Position, SignatureHelp};
 use url::Url;
@@ -15,6 +13,7 @@ use url::Url;
 use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, build_position_based_request,
+    response_has_jsonrpc_error,
 };
 use tower_lsp_server::ls_types::TextDocumentPositionParams;
 
@@ -45,8 +44,8 @@ fn transform_signature_help_response_to_host(
 ) -> Option<SignatureHelp> {
     // SignatureHelp doesn't have ranges that need transformation.
     // activeSignature and activeParameter are indices, not coordinates.
-    if let Some(error) = response.get("error") {
-        warn!(target: "kakehashi::bridge", "Downstream server returned error for textDocument/signatureHelp: {}", error);
+    if response_has_jsonrpc_error(&response, "textDocument/signatureHelp") {
+        return None;
     }
     let result = response.get_mut("result").map(serde_json::Value::take)?;
 


### PR DESCRIPTION
## Summary

Per JSON-RPC 2.0, a response object MUST NOT contain both `result` and `error`. The bridge's response transformers (17 sites) logged the `error` field but then **fell through to parse `result`** anyway.

This is benign for well-behaved servers (which never send both) but is technically incorrect per spec — a misbehaving server could have its meaningless `result` processed after an error was logged.

## Changes

- Add `response_has_jsonrpc_error(response, method)` in `protocol/jsonrpc.rs` — a single place that defines what counts as a JSON-RPC error and emits the warning.
- Each transformer now returns its own "no result" value (`None` / `vec![]` / `Vec::new()`) when the helper returns `true`, instead of falling through.
- Centralizing the check also closes a latent hazard the short-circuit would otherwise introduce: the helper ignores a literal `"error": null`, so a `{result, error: null}` response (sent by some servers) is **not** mistakenly dropped.

## Affected handlers

`goto` (response.rs), hover, references, rename, prepare_rename, completion, completion_item, signature_help, moniker, document_symbol, document_link, document_highlight, document_color, color_presentation, inlay_hint, formatting, diagnostic.

## Tests

- Unit tests for the helper: error present → `true`; no error → `false`; **`error: null` alongside result → `false`** (regression guard).
- Handler-level regression test in `hover.rs`: a spec-violating `{error, result}` response now returns `None` (result ignored).
- Full suite green (pre-commit runs `clippy -D warnings`, `fmt`, `cargo test --lib`).

Closes #189