### PR TITLE
fix(cli): handle broken pipe gracefully for stdout output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,9 +56,10 @@ nix = { version = "0.31", features = ["signal", "process"] }
 e2e = []
 experimental = []
 
-# Unix-only dev dependencies (e.g. pipe() for deterministic broken-pipe tests)
+# Unix-only dev dependencies: pipe() for deterministic broken-pipe tests,
+# Signal::SIGPIPE for asserting the termination signal.
 [target.'cfg(unix)'.dev-dependencies]
-nix = { version = "0.31", features = ["fs"] }
+nix = { version = "0.31", features = ["fs", "signal"] }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,10 @@ nix = { version = "0.31", features = ["signal", "process"] }
 e2e = []
 experimental = []
 
+# Unix-only dev dependencies (e.g. pipe() for deterministic broken-pipe tests)
+[target.'cfg(unix)'.dev-dependencies]
+nix = { version = "0.31", features = ["fs"] }
+
 [dev-dependencies]
 tokio-test = "0.4"
 tempfile = "3"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -117,19 +117,18 @@ enum ConfigAction {
 /// Restore the default `SIGPIPE` disposition (Unix only).
 ///
 /// Rust ignores `SIGPIPE` at startup, which turns a broken pipe into a panic on
-/// the next `print!`/`println!` (e.g. `kakehashi config schema | head`). CLI
-/// subcommands write to stdout and are routinely piped, so for those we restore
-/// the conventional Unix behavior: the process terminates quietly with `SIGPIPE`
-/// when the reader goes away.
-///
-/// LSP server mode intentionally keeps the Rust default (ignored) so the bridge
-/// can observe `BrokenPipe` as a recoverable I/O error when a downstream
-/// language server dies, rather than being killed by the signal.
+/// the next `print!`/`println!` (e.g. `kakehashi config schema | head`, or even
+/// `kakehashi --help | head`). Restoring the conventional Unix behavior makes the
+/// process terminate quietly with `SIGPIPE` when the reader goes away. This is
+/// installed at the very start of `main` so it also covers clap's `--help` /
+/// `--version` output emitted during argument parsing; LSP server mode restores
+/// the ignored disposition afterwards via [`ignore_sigpipe`].
 #[cfg(unix)]
 fn reset_sigpipe() {
-    use nix::sys::signal::{SigHandler, Signal, signal};
-    // SAFETY: `SigDfl` is async-signal-safe and installed once, before any output.
-    let result = unsafe { signal(Signal::SIGPIPE, SigHandler::SigDfl) };
+    use nix::sys::signal::{SaFlags, SigAction, SigHandler, SigSet, Signal, sigaction};
+    let action = SigAction::new(SigHandler::SigDfl, SaFlags::empty(), SigSet::empty());
+    // SAFETY: `SigDfl` is async-signal-safe and installed before any output.
+    let result = unsafe { sigaction(Signal::SIGPIPE, &action) };
     // Restoring the default disposition for a valid signal cannot realistically
     // fail, but surface it on stderr rather than swallowing it: otherwise a
     // silent failure would regress to panicking on a broken pipe.
@@ -138,10 +137,31 @@ fn reset_sigpipe() {
     }
 }
 
+/// Ignore `SIGPIPE` (Unix only) — the disposition the Rust runtime installs by
+/// default.
+///
+/// LSP server mode uses this to undo [`reset_sigpipe`]: the bridge writes to
+/// downstream language-server stdin and must observe a closed peer as a
+/// recoverable `BrokenPipe` I/O error rather than being killed by the signal.
+#[cfg(unix)]
+fn ignore_sigpipe() {
+    use nix::sys::signal::{SaFlags, SigAction, SigHandler, SigSet, Signal, sigaction};
+    let action = SigAction::new(SigHandler::SigIgn, SaFlags::empty(), SigSet::empty());
+    // SAFETY: `SigIgn` is async-signal-safe and installed before bridge I/O.
+    let _ = unsafe { sigaction(Signal::SIGPIPE, &action) };
+}
+
 #[cfg(not(unix))]
 fn reset_sigpipe() {}
 
+#[cfg(not(unix))]
+fn ignore_sigpipe() {}
+
 fn main() -> ExitCode {
+    // Restore the default SIGPIPE disposition before clap may write `--help` /
+    // `--version` to a (possibly piped) stdout during `Cli::parse()`.
+    reset_sigpipe();
+
     let cli = Cli::parse();
 
     // Set data directory override so default_data_dir() and config expansion
@@ -154,9 +174,11 @@ fn main() -> ExitCode {
         kakehashi::config::set_config_file_override(cli.config_file);
     }
 
-    // Subcommands (not the LSP server) print to stdout and are commonly piped.
-    if cli.command.is_some() {
-        reset_sigpipe();
+    // LSP server mode keeps SIGPIPE ignored so the bridge sees a closed
+    // downstream peer as a recoverable BrokenPipe error; subcommands keep the
+    // default disposition restored above.
+    if cli.command.is_none() {
+        ignore_sigpipe();
     }
 
     let result = match cli.command {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -131,9 +131,15 @@ fn reset_sigpipe() {
     let result = unsafe { sigaction(Signal::SIGPIPE, &action) };
     // Restoring the default disposition for a valid signal cannot realistically
     // fail, but surface it on stderr rather than swallowing it: otherwise a
-    // silent failure would regress to panicking on a broken pipe.
+    // silent failure would regress to panicking on a broken pipe. Use `writeln!`
+    // (ignoring its result) instead of `eprintln!`, which would itself panic if
+    // stderr is a broken pipe.
     if let Err(e) = result {
-        eprintln!("warning: failed to restore default SIGPIPE handler: {e}");
+        use std::io::Write;
+        let _ = writeln!(
+            std::io::stderr(),
+            "warning: failed to restore default SIGPIPE handler: {e}"
+        );
     }
 }
 
@@ -151,9 +157,11 @@ fn ignore_sigpipe() {
     let result = unsafe { sigaction(Signal::SIGPIPE, &action) };
     // LSP server mode relies on the ignored disposition so the bridge sees a
     // closed downstream peer as a recoverable BrokenPipe; surface a failure
-    // rather than silently risking a SIGPIPE kill.
+    // rather than silently risking a SIGPIPE kill. Use `writeln!` (ignoring its
+    // result) instead of `eprintln!`, which would panic on a broken stderr.
     if let Err(e) = result {
-        eprintln!("warning: failed to ignore SIGPIPE: {e}");
+        use std::io::Write;
+        let _ = writeln!(std::io::stderr(), "warning: failed to ignore SIGPIPE: {e}");
     }
 }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -148,7 +148,13 @@ fn ignore_sigpipe() {
     use nix::sys::signal::{SaFlags, SigAction, SigHandler, SigSet, Signal, sigaction};
     let action = SigAction::new(SigHandler::SigIgn, SaFlags::empty(), SigSet::empty());
     // SAFETY: `SigIgn` is async-signal-safe and installed before bridge I/O.
-    let _ = unsafe { sigaction(Signal::SIGPIPE, &action) };
+    let result = unsafe { sigaction(Signal::SIGPIPE, &action) };
+    // LSP server mode relies on the ignored disposition so the bridge sees a
+    // closed downstream peer as a recoverable BrokenPipe; surface a failure
+    // rather than silently risking a SIGPIPE kill.
+    if let Err(e) = result {
+        eprintln!("warning: failed to ignore SIGPIPE: {e}");
+    }
 }
 
 #[cfg(not(unix))]

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -129,8 +129,12 @@ enum ConfigAction {
 fn reset_sigpipe() {
     use nix::sys::signal::{SigHandler, Signal, signal};
     // SAFETY: `SigDfl` is async-signal-safe and installed once, before any output.
-    unsafe {
-        let _ = signal(Signal::SIGPIPE, SigHandler::SigDfl);
+    let result = unsafe { signal(Signal::SIGPIPE, SigHandler::SigDfl) };
+    // Restoring the default disposition for a valid signal cannot realistically
+    // fail, but surface it on stderr rather than swallowing it: otherwise a
+    // silent failure would regress to panicking on a broken pipe.
+    if let Err(e) = result {
+        eprintln!("warning: failed to restore default SIGPIPE handler: {e}");
     }
 }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -114,6 +114,29 @@ enum ConfigAction {
     },
 }
 
+/// Restore the default `SIGPIPE` disposition (Unix only).
+///
+/// Rust ignores `SIGPIPE` at startup, which turns a broken pipe into a panic on
+/// the next `print!`/`println!` (e.g. `kakehashi config schema | head`). CLI
+/// subcommands write to stdout and are routinely piped, so for those we restore
+/// the conventional Unix behavior: the process terminates quietly with `SIGPIPE`
+/// when the reader goes away.
+///
+/// LSP server mode intentionally keeps the Rust default (ignored) so the bridge
+/// can observe `BrokenPipe` as a recoverable I/O error when a downstream
+/// language server dies, rather than being killed by the signal.
+#[cfg(unix)]
+fn reset_sigpipe() {
+    use nix::sys::signal::{SigHandler, Signal, signal};
+    // SAFETY: `SigDfl` is async-signal-safe and installed once, before any output.
+    unsafe {
+        let _ = signal(Signal::SIGPIPE, SigHandler::SigDfl);
+    }
+}
+
+#[cfg(not(unix))]
+fn reset_sigpipe() {}
+
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
@@ -125,6 +148,11 @@ fn main() -> ExitCode {
 
     if !cli.config_file.is_empty() {
         kakehashi::config::set_config_file_override(cli.config_file);
+    }
+
+    // Subcommands (not the LSP server) print to stdout and are commonly piped.
+    if cli.command.is_some() {
+        reset_sigpipe();
     }
 
     let result = match cli.command {

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1029,9 +1029,10 @@ fn run_with_broken_stdout_pipe(args: &[&str]) -> std::process::Output {
         .expect("Failed to wait for command")
 }
 
-/// SIGPIPE is signal 13 on Linux and macOS.
+/// The platform's `SIGPIPE` signal number (13 on Linux/macOS), taken from `nix`
+/// rather than hardcoded so it stays correct across architectures.
 #[cfg(unix)]
-const SIGPIPE: i32 = 13;
+const SIGPIPE: i32 = nix::sys::signal::Signal::SIGPIPE as i32;
 
 /// A CLI subcommand whose stdout reader is gone (e.g. `kakehashi config schema |
 /// head`) must not panic. Rust ignores SIGPIPE by default, turning a broken pipe

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -998,3 +998,43 @@ fn test_language_uninstall_cancel() {
         "Parser should still exist after cancellation"
     );
 }
+
+/// A CLI subcommand whose stdout reader closes early (e.g. `kakehashi config
+/// schema | head`) must not panic. Rust ignores SIGPIPE by default, which turns
+/// a broken pipe into a panic on the next `print!`; the fix restores the default
+/// SIGPIPE disposition for subcommands so the process terminates quietly instead.
+///
+/// The read end of the pipe is closed *before* the child writes, so the first
+/// write hits a pipe with no readers and fails with EPIPE regardless of the
+/// kernel pipe-buffer size — making the reproduction deterministic.
+#[test]
+fn config_schema_does_not_panic_on_broken_pipe() {
+    use std::process::Stdio;
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args(["config", "schema"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn command");
+
+    // Close the stdout read end immediately, before the child gets to write.
+    drop(child.stdout.take());
+
+    let output = child
+        .wait_with_output()
+        .expect("Failed to wait for command");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !stderr.contains("panicked"),
+        "Broken pipe must not cause a panic. stderr: {stderr}"
+    );
+    // Rust's default panic handler exits with code 101; the fix must avoid that.
+    assert_ne!(
+        output.status.code(),
+        Some(101),
+        "Subcommand should not exit via panic (101) on broken pipe; status: {:?}",
+        output.status
+    );
+}

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1004,9 +1004,15 @@ fn test_language_uninstall_cancel() {
 /// a broken pipe into a panic on the next `print!`; the fix restores the default
 /// SIGPIPE disposition for subcommands so the process terminates quietly instead.
 ///
-/// The read end of the pipe is closed *before* the child writes, so the first
-/// write hits a pipe with no readers and fails with EPIPE regardless of the
-/// kernel pipe-buffer size — making the reproduction deterministic.
+/// Unix-only: `reset_sigpipe` is a no-op on Windows (no SIGPIPE), where this
+/// scenario would still panic, so the test would not hold there.
+///
+/// The parent closes the stdout read end immediately after `spawn` returns —
+/// before the child, which must initialize, parse args, and serialize the schema,
+/// reaches its first write. The child's first write therefore hits a pipe with no
+/// readers and fails with EPIPE regardless of the kernel pipe-buffer size. (This
+/// was confirmed by running the pre-fix binary, which panics here every time.)
+#[cfg(unix)]
 #[test]
 fn config_schema_does_not_panic_on_broken_pipe() {
     use std::process::Stdio;

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -999,84 +999,89 @@ fn test_language_uninstall_cancel() {
     );
 }
 
-/// A CLI subcommand whose stdout reader closes early (e.g. `kakehashi config
-/// schema | head`) must not panic. Rust ignores SIGPIPE by default, which turns
-/// a broken pipe into a panic on the next `print!`; the fix restores the default
-/// SIGPIPE disposition for subcommands so the process terminates quietly instead.
+/// Run the kakehashi binary with `args`, giving it a stdout pipe whose read end
+/// is closed *before* the child is spawned, and return the finished output.
 ///
-/// Unix-only: `reset_sigpipe` is a no-op on Windows (no SIGPIPE), where this
-/// scenario would still panic, so the test would not hold there.
-///
-/// The parent closes the stdout read end immediately after `spawn` returns —
-/// before the child, which must initialize, parse args, and serialize the schema,
-/// reaches its first write. The child's first write therefore hits a pipe with no
-/// readers and fails with EPIPE regardless of the kernel pipe-buffer size. (This
-/// was confirmed by running the pre-fix binary, which panics here every time.)
+/// With no reader, the child inherits only the write end, so its first stdout
+/// write fails with EPIPE — and, once the default SIGPIPE disposition is
+/// restored, the process is killed by SIGPIPE. This reproduces a broken pipe
+/// deterministically, independent of the kernel pipe-buffer size and free of any
+/// spawn/write race.
 #[cfg(unix)]
-#[test]
-fn config_schema_does_not_panic_on_broken_pipe() {
+fn run_with_broken_stdout_pipe(args: &[&str]) -> std::process::Output {
+    use std::os::fd::OwnedFd;
     use std::process::Stdio;
 
-    let mut child = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
-        .args(["config", "schema"])
-        .stdout(Stdio::piped())
+    let (read_fd, write_fd): (OwnedFd, OwnedFd) = nix::unistd::pipe().expect("create pipe");
+    // Close the read end before spawning: the child gets only the write end, so
+    // there is no reader and the first write hits EPIPE.
+    drop(read_fd);
+
+    let child = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args(args)
+        .stdout(Stdio::from(write_fd))
         .stderr(Stdio::piped())
         .spawn()
         .expect("Failed to spawn command");
 
-    // Close the stdout read end immediately, before the child gets to write.
-    drop(child.stdout.take());
-
-    let output = child
+    child
         .wait_with_output()
-        .expect("Failed to wait for command");
+        .expect("Failed to wait for command")
+}
+
+/// SIGPIPE is signal 13 on Linux and macOS.
+#[cfg(unix)]
+const SIGPIPE: i32 = 13;
+
+/// A CLI subcommand whose stdout reader is gone (e.g. `kakehashi config schema |
+/// head`) must not panic. Rust ignores SIGPIPE by default, turning a broken pipe
+/// into a panic on the next `print!`; the fix restores the default SIGPIPE
+/// disposition so the process is terminated quietly by the signal instead.
+///
+/// Unix-only: `reset_sigpipe` is a no-op on Windows (no SIGPIPE).
+#[cfg(unix)]
+#[test]
+fn config_schema_does_not_panic_on_broken_pipe() {
+    use std::os::unix::process::ExitStatusExt;
+
+    let output = run_with_broken_stdout_pipe(&["config", "schema"]);
     let stderr = String::from_utf8_lossy(&output.stderr);
 
     assert!(
         !stderr.contains("panicked"),
         "Broken pipe must not cause a panic. stderr: {stderr}"
     );
-    // Rust's default panic handler exits with code 101; the fix must avoid that.
-    assert_ne!(
-        output.status.code(),
-        Some(101),
-        "Subcommand should not exit via panic (101) on broken pipe; status: {:?}",
+    // The process must be terminated by SIGPIPE — proving the default disposition
+    // was restored — rather than exiting via a panic (code 101) or normally.
+    assert_eq!(
+        output.status.signal(),
+        Some(SIGPIPE),
+        "config schema should be terminated by SIGPIPE; status: {:?}, stderr: {stderr}",
         output.status
     );
 }
 
 /// `--help` output is written by clap during argument parsing, before any
 /// subcommand dispatch. `reset_sigpipe` runs as the first line of `main`, so a
-/// closed reader (e.g. `kakehashi --help | head`) must not panic either.
+/// closed reader (e.g. `kakehashi --help | head`) must be handled the same way.
 ///
 /// Unix-only for the same reason as `config_schema_does_not_panic_on_broken_pipe`.
 #[cfg(unix)]
 #[test]
 fn help_does_not_panic_on_broken_pipe() {
-    use std::process::Stdio;
+    use std::os::unix::process::ExitStatusExt;
 
-    let mut child = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
-        .arg("--help")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("Failed to spawn command");
-
-    drop(child.stdout.take());
-
-    let output = child
-        .wait_with_output()
-        .expect("Failed to wait for command");
+    let output = run_with_broken_stdout_pipe(&["--help"]);
     let stderr = String::from_utf8_lossy(&output.stderr);
 
     assert!(
         !stderr.contains("panicked"),
         "Broken pipe on --help must not cause a panic. stderr: {stderr}"
     );
-    assert_ne!(
-        output.status.code(),
-        Some(101),
-        "--help should not exit via panic (101) on broken pipe; status: {:?}",
+    assert_eq!(
+        output.status.signal(),
+        Some(SIGPIPE),
+        "--help should be terminated by SIGPIPE; status: {:?}, stderr: {stderr}",
         output.status
     );
 }

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1044,3 +1044,39 @@ fn config_schema_does_not_panic_on_broken_pipe() {
         output.status
     );
 }
+
+/// `--help` output is written by clap during argument parsing, before any
+/// subcommand dispatch. `reset_sigpipe` runs as the first line of `main`, so a
+/// closed reader (e.g. `kakehashi --help | head`) must not panic either.
+///
+/// Unix-only for the same reason as `config_schema_does_not_panic_on_broken_pipe`.
+#[cfg(unix)]
+#[test]
+fn help_does_not_panic_on_broken_pipe() {
+    use std::process::Stdio;
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .arg("--help")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn command");
+
+    drop(child.stdout.take());
+
+    let output = child
+        .wait_with_output()
+        .expect("Failed to wait for command");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !stderr.contains("panicked"),
+        "Broken pipe on --help must not cause a panic. stderr: {stderr}"
+    );
+    assert_ne!(
+        output.status.code(),
+        Some(101),
+        "--help should not exit via panic (101) on broken pipe; status: {:?}",
+        output.status
+    );
+}


### PR DESCRIPTION
## Summary

`print!`/`println!` panic when stdout is a broken pipe (e.g. `kakehashi config schema | head`) because Rust ignores `SIGPIPE` by default. This affected every subcommand writing to stdout (`config init`, `config schema`, `language list`, `language status`) as well as clap's own `--help` / `--version` output.

```
thread 'main' panicked at library/std/src/io/stdio.rs:
failed printing to stdout: Broken pipe (os error 32)
```

## Fix

Restore the conventional Unix `SIGPIPE` disposition (`SigDfl`) via `sigaction` at the **very start of `main`**, before `Cli::parse()`. This covers subcommand output *and* clap's `--help`/`--version`/parse-error output when piped — a closed reader now terminates the process quietly with `SIGPIPE` instead of panicking.

**LSP server mode** (`cli.command.is_none()`) restores the ignored disposition afterwards via `ignore_sigpipe()`, so the bridge keeps treating a dead downstream language server's closed stdin as a recoverable `BrokenPipe` I/O error rather than being killed by the signal. Both helpers surface a `sigaction` failure on stderr. `nix` (already a dependency for SIGTERM/SIGKILL) provides the API.

## Test

`tests/test_cli.rs` reproduces a broken pipe **deterministically**: it creates a pipe, closes the read end *before* spawning, and hands the child only the write end, so the first write hits EPIPE regardless of pipe-buffer size. Both `config schema` and `--help` are asserted to be **terminated by SIGPIPE (signal 13)** — a stronger guarantee than a mere non-panic exit code. Unix-only (the fix is a no-op on Windows, which has no SIGPIPE).

- Verified RED on the unfixed binary (panics, exit 101).
- GREEN with the fix; full pre-commit suite (`clippy -D warnings`, `fmt`, tests) passes.

Closes #223