### PR TITLE
fix(bridge): abort position requests when host position falls outside injection region

### DIFF
--- a/src/lsp/bridge/pool/execute.rs
+++ b/src/lsp/bridge/pool/execute.rs
@@ -140,17 +140,23 @@ impl LanguageServerPool {
 
     /// Like [`execute_bridge_request_with_handle`](Self::execute_bridge_request_with_handle)
     /// but for position-based requests (hover, completion, definition, …): aborts
-    /// before contacting the downstream server when `host_position` falls *above*
-    /// the injection region.
+    /// before contacting the downstream server when `host_position` falls outside
+    /// the injection region — either *above* its start line, or on the start line
+    /// but *before* its start column (e.g. the cursor is on the markdown fence
+    /// backticks or inside a blockquote `> ` prefix). See
+    /// [`host_position_within_region`].
     ///
-    /// That condition means the captured region data is stale (e.g. a concurrent
-    /// host edit moved the region). Translating anyway would clamp the line to 0
-    /// via `saturating_sub` and forward wrong coordinates, yielding
-    /// plausible-but-wrong results. Per the LSP spec every position request may
-    /// return an empty/null result, so on abort we feed a synthetic
+    /// Translating an out-of-region position would silently mistranslate it
+    /// (clamping line and/or character via `saturating_sub`) and forward
+    /// plausible-but-wrong coordinates. Per the LSP spec every position request
+    /// may return an empty/null result, so on abort we feed a synthetic
     /// `{"result": null}` to `transform_response`, which produces the handler's
-    /// natural "no result" value (`None` / empty `Vec`) — and we log a warning,
-    /// since this state should be unreachable and signals a bug if it fires.
+    /// natural "no result" value (`None` / empty `Vec`).
+    ///
+    /// A line *above* the region almost certainly means stale region data (a
+    /// concurrent host edit) and is logged at `warn`; a position merely before
+    /// the start column is a normal cursor location outside the content and is
+    /// logged at `debug` to avoid flooding logs during ordinary editing.
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn execute_position_bridge_request_with_handle<T, P: serde::Serialize>(
         &self,
@@ -168,13 +174,30 @@ impl LanguageServerPool {
         transform_response: impl FnOnce(serde_json::Value, &BridgeResponseContext<'_>) -> T,
     ) -> io::Result<T> {
         if !host_position_within_region(host_position, offset) {
-            warn!(
-                target: "kakehashi::bridge",
-                "{method}: host position (line {}) is above injection region (start line {}); \
-                 aborting request — stale region data",
-                host_position.line,
-                offset.line(),
-            );
+            if host_position.line < offset.line() {
+                // Line above the region → almost certainly stale region data
+                // (a concurrent host edit shifted the region). Unexpected.
+                warn!(
+                    target: "kakehashi::bridge",
+                    "{method}: host position (line {}) is above injection region (start line {}); \
+                     aborting request — stale region data",
+                    host_position.line,
+                    offset.line(),
+                );
+            } else {
+                // On the start line but left of the start column (fence backticks,
+                // blockquote prefix). A normal cursor location just outside the
+                // injected content — debug, not warn.
+                let virtual_line = host_position.line - offset.line();
+                log::debug!(
+                    target: "kakehashi::bridge",
+                    "{method}: host position (line {}, char {}) is before injection start column {}; \
+                     aborting request",
+                    host_position.line,
+                    host_position.character,
+                    offset.column_for_line(virtual_line),
+                );
+            }
 
             let host_uri_lsp = crate::lsp::lsp_impl::url_to_uri(host_uri)
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
@@ -309,6 +332,56 @@ mod tests {
         assert!(
             result.unwrap().is_none(),
             "out-of-region host position must abort to None"
+        );
+    }
+
+    /// Test that a position-based request also aborts when the host position is on
+    /// the region's start line but *before* its start column (e.g. cursor on the
+    /// markdown fence backticks). Same sink-server reasoning as the line-above
+    /// case: a fast `Ok(None)` proves the abort fired before any request was sent.
+    #[tokio::test]
+    async fn position_request_aborts_when_host_position_before_start_column() {
+        use tower_lsp_server::ls_types::{HoverProviderCapability, Position, ServerCapabilities};
+
+        let pool = Arc::new(LanguageServerPool::new());
+        let config = devnull_config();
+
+        {
+            let handle = create_handle_with_state(ConnectionState::Ready).await;
+            handle.set_server_capabilities(ServerCapabilities {
+                hover_provider: Some(HoverProviderCapability::Simple(true)),
+                ..Default::default()
+            });
+            pool.connections
+                .lock()
+                .await
+                .insert("test-server".to_string(), handle);
+        }
+
+        let host_uri = test_host_uri("doc");
+        // Region starts at line 10, column 4. Cursor is on line 10 but at column 1
+        // — left of the start column, i.e. outside the injected content.
+        let result = pool
+            .send_hover_request(
+                "test-server",
+                &config,
+                &host_uri,
+                Position {
+                    line: 10,
+                    character: 1,
+                },
+                "lua",
+                TEST_ULID_LUA_0,
+                RegionOffset::new(10, 4),
+                "print('hello')",
+                None,
+            )
+            .await;
+
+        assert!(result.is_ok(), "abort should yield Ok, got {result:?}");
+        assert!(
+            result.unwrap().is_none(),
+            "position before start column must abort to None"
         );
     }
 

--- a/src/lsp/bridge/pool/execute.rs
+++ b/src/lsp/bridge/pool/execute.rs
@@ -8,12 +8,15 @@
 use std::io;
 use std::sync::Arc;
 
-use tower_lsp_server::ls_types::Uri;
+use log::warn;
+use tower_lsp_server::ls_types::{Position, Uri};
 use url::Url;
 
 use super::{ConnectionHandle, ConnectionHandleSender, LanguageServerPool, UpstreamId};
 use crate::lsp::bridge::actor::RouterCleanupGuard;
-use crate::lsp::bridge::protocol::{JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri};
+use crate::lsp::bridge::protocol::{
+    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, host_position_within_region,
+};
 
 /// Context provided to response transformers during bridge request execution.
 ///
@@ -134,6 +137,73 @@ impl LanguageServerPool {
 
         Ok(transform_response(response?, &context))
     }
+
+    /// Like [`execute_bridge_request_with_handle`](Self::execute_bridge_request_with_handle)
+    /// but for position-based requests (hover, completion, definition, …): aborts
+    /// before contacting the downstream server when `host_position` falls *above*
+    /// the injection region.
+    ///
+    /// That condition means the captured region data is stale (e.g. a concurrent
+    /// host edit moved the region). Translating anyway would clamp the line to 0
+    /// via `saturating_sub` and forward wrong coordinates, yielding
+    /// plausible-but-wrong results. Per the LSP spec every position request may
+    /// return an empty/null result, so on abort we feed a synthetic
+    /// `{"result": null}` to `transform_response`, which produces the handler's
+    /// natural "no result" value (`None` / empty `Vec`) — and we log a warning,
+    /// since this state should be unreachable and signals a bug if it fires.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn execute_position_bridge_request_with_handle<T, P: serde::Serialize>(
+        &self,
+        handle: Arc<ConnectionHandle>,
+        server_name: &str,
+        host_uri: &Url,
+        injection_language: &str,
+        region_id: &str,
+        offset: &RegionOffset,
+        virtual_content: &str,
+        upstream_request_id: Option<UpstreamId>,
+        host_position: Position,
+        method: &'static str,
+        build_request: impl FnOnce(&VirtualDocumentUri, RequestId) -> JsonRpcRequest<P>,
+        transform_response: impl FnOnce(serde_json::Value, &BridgeResponseContext<'_>) -> T,
+    ) -> io::Result<T> {
+        if !host_position_within_region(host_position, offset) {
+            warn!(
+                target: "kakehashi::bridge",
+                "{method}: host position (line {}) is above injection region (start line {}); \
+                 aborting request — stale region data",
+                host_position.line,
+                offset.line(),
+            );
+
+            let host_uri_lsp = crate::lsp::lsp_impl::url_to_uri(host_uri)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+            let virtual_uri = VirtualDocumentUri::new(&host_uri_lsp, injection_language, region_id);
+            let context = BridgeResponseContext {
+                virtual_uri_string: virtual_uri.to_uri_string(),
+                host_uri_lsp: &host_uri_lsp,
+                offset,
+            };
+            return Ok(transform_response(
+                serde_json::json!({ "result": null }),
+                &context,
+            ));
+        }
+
+        self.execute_bridge_request_with_handle(
+            handle,
+            server_name,
+            host_uri,
+            injection_language,
+            region_id,
+            offset,
+            virtual_content,
+            upstream_request_id,
+            build_request,
+            transform_response,
+        )
+        .await
+    }
 }
 
 #[cfg(test)]
@@ -185,6 +255,60 @@ mod tests {
         assert!(
             result.unwrap().is_none(),
             "Should return None when server lacks hover capability"
+        );
+    }
+
+    /// Test that a position-based request aborts (returns Ok(None)) when the host
+    /// position falls *above* the injection region — stale region data.
+    ///
+    /// The connection advertises hover support, so the capability guard passes and
+    /// execution reaches `execute_position_bridge_request_with_handle`. The backing
+    /// process is a sink that never replies, so if the request were actually sent
+    /// the call would block until timeout and return `Err`. A fast `Ok(None)`
+    /// therefore proves the request was aborted before contacting the server.
+    #[tokio::test]
+    async fn position_request_aborts_when_host_position_above_region() {
+        use tower_lsp_server::ls_types::{HoverProviderCapability, Position, ServerCapabilities};
+
+        let pool = Arc::new(LanguageServerPool::new());
+        let config = devnull_config();
+
+        {
+            let handle = create_handle_with_state(ConnectionState::Ready).await;
+            handle.set_server_capabilities(ServerCapabilities {
+                hover_provider: Some(HoverProviderCapability::Simple(true)),
+                ..Default::default()
+            });
+            pool.connections
+                .lock()
+                .await
+                .insert("test-server".to_string(), handle);
+        }
+
+        let host_uri = test_host_uri("doc");
+        // Region starts at line 10, but the host position is on line 2 — above the
+        // region. This is the stale-data condition the abort guards against.
+        let result = pool
+            .send_hover_request(
+                "test-server",
+                &config,
+                &host_uri,
+                Position {
+                    line: 2,
+                    character: 0,
+                },
+                "lua",
+                TEST_ULID_LUA_0,
+                RegionOffset::new(10, 0),
+                "print('hello')",
+                None,
+            )
+            .await;
+
+        assert!(result.is_ok(), "abort should yield Ok, got {result:?}");
+        assert!(
+            result.unwrap().is_none(),
+            "out-of-region host position must abort to None"
         );
     }
 

--- a/src/lsp/bridge/protocol/translation.rs
+++ b/src/lsp/bridge/protocol/translation.rs
@@ -90,6 +90,19 @@ pub(crate) fn translate_virtual_range_to_host(range: &mut Range, offset: &Region
 // Host -> Virtual (request direction)
 // =============================================================================
 
+/// Whether `host_position` lies on or after the region's start line, i.e. it can
+/// be translated into virtual coordinates without line underflow.
+///
+/// A position *above* the region (`line < region start line`) signals stale
+/// region data — typically an in-flight request whose region was shifted by a
+/// concurrent host edit. Forwarding it would clamp the line to 0 via
+/// `saturating_sub` and send wrong coordinates downstream, so callers should
+/// abort instead. Only the line is checked: once the line is in range, column
+/// underflow is handled by saturation and does not warrant aborting.
+pub(crate) fn host_position_within_region(host_position: Position, offset: &RegionOffset) -> bool {
+    host_position.line >= offset.line()
+}
+
 /// Translate a single host position to virtual coordinates.
 ///
 /// Subtracts the line offset, then applies the per-line column offset for the
@@ -413,5 +426,37 @@ mod tests {
         assert_eq!(range.start.character, 5); // 3 + 2
         assert_eq!(range.end.line, 11);
         assert_eq!(range.end.character, 9); // 7 + 2
+    }
+
+    // ======================================================================
+    // host_position_within_region
+    // ======================================================================
+
+    #[test]
+    fn position_within_region_when_on_start_line() {
+        let pos = Position {
+            line: 10,
+            character: 0,
+        };
+        assert!(host_position_within_region(pos, &RegionOffset::new(10, 4)));
+    }
+
+    #[test]
+    fn position_within_region_when_below_start_line() {
+        let pos = Position {
+            line: 15,
+            character: 0,
+        };
+        assert!(host_position_within_region(pos, &RegionOffset::new(10, 4)));
+    }
+
+    #[test]
+    fn position_outside_region_when_above_start_line() {
+        // Stale region data: host position is above where the region starts.
+        let pos = Position {
+            line: 9,
+            character: 0,
+        };
+        assert!(!host_position_within_region(pos, &RegionOffset::new(10, 4)));
     }
 }

--- a/src/lsp/bridge/protocol/translation.rs
+++ b/src/lsp/bridge/protocol/translation.rs
@@ -90,17 +90,27 @@ pub(crate) fn translate_virtual_range_to_host(range: &mut Range, offset: &Region
 // Host -> Virtual (request direction)
 // =============================================================================
 
-/// Whether `host_position` lies on or after the region's start line, i.e. it can
-/// be translated into virtual coordinates without line underflow.
+/// Whether `host_position` can be translated into virtual coordinates without
+/// underflow, i.e. it lies within the injection region's boundary.
 ///
 /// A position *above* the region (`line < region start line`) signals stale
 /// region data — typically an in-flight request whose region was shifted by a
-/// concurrent host edit. Forwarding it would clamp the line to 0 via
-/// `saturating_sub` and send wrong coordinates downstream, so callers should
-/// abort instead. Only the line is checked: once the line is in range, column
-/// underflow is handled by saturation and does not warrant aborting.
+/// concurrent host edit. A position *on* the start line but *before* the region's
+/// start column (e.g. the cursor is on the markdown fence backticks or inside a
+/// blockquote `> ` prefix rather than the injected content) is likewise outside.
+///
+/// Both cases would otherwise be clamped to `0` by the `saturating_sub` in
+/// [`translate_host_position_to_virtual`] and forwarded as virtual coordinate
+/// `(0, 0)` — a plausible-but-wrong location at the very start of the injection.
+/// The column boundary is checked against the same per-virtual-line offset used
+/// by translation, so non-blockquote lines past the first (offset 0) never
+/// trigger a false abort.
 pub(crate) fn host_position_within_region(host_position: Position, offset: &RegionOffset) -> bool {
-    host_position.line >= offset.line()
+    if host_position.line < offset.line() {
+        return false;
+    }
+    let virtual_line = host_position.line - offset.line();
+    host_position.character >= offset.column_for_line(virtual_line)
 }
 
 /// Translate a single host position to virtual coordinates.
@@ -433,16 +443,19 @@ mod tests {
     // ======================================================================
 
     #[test]
-    fn position_within_region_when_on_start_line() {
+    fn position_within_region_when_on_start_line_at_or_after_start_column() {
+        // On the start line, at the start column → inside.
         let pos = Position {
             line: 10,
-            character: 0,
+            character: 4,
         };
         assert!(host_position_within_region(pos, &RegionOffset::new(10, 4)));
     }
 
     #[test]
     fn position_within_region_when_below_start_line() {
+        // Non-blockquote: lines past the first have column offset 0, so any
+        // character is inside — no false abort.
         let pos = Position {
             line: 15,
             character: 0,
@@ -458,5 +471,34 @@ mod tests {
             character: 0,
         };
         assert!(!host_position_within_region(pos, &RegionOffset::new(10, 4)));
+    }
+
+    #[test]
+    fn position_outside_region_when_before_start_column_on_start_line() {
+        // On the start line but left of the start column (e.g. cursor on the
+        // fence backticks) → outside; translation would clamp to (0, 0).
+        let pos = Position {
+            line: 10,
+            character: 2,
+        };
+        assert!(!host_position_within_region(pos, &RegionOffset::new(10, 4)));
+    }
+
+    #[test]
+    fn position_outside_region_within_blockquote_prefix() {
+        // Blockquote: every virtual line carries a `> ` prefix width of 2.
+        // A cursor inside that prefix on line 1 (char 1) is outside the content.
+        let offset = RegionOffset::with_per_line_offsets(10, vec![2, 2]);
+        let inside_prefix = Position {
+            line: 11,
+            character: 1,
+        };
+        assert!(!host_position_within_region(inside_prefix, &offset));
+
+        let at_content = Position {
+            line: 11,
+            character: 2,
+        };
+        assert!(host_position_within_region(at_content, &offset));
     }
 }

--- a/src/lsp/bridge/protocol/translation.rs
+++ b/src/lsp/bridge/protocol/translation.rs
@@ -99,12 +99,14 @@ pub(crate) fn translate_virtual_range_to_host(range: &mut Range, offset: &Region
 /// start column (e.g. the cursor is on the markdown fence backticks or inside a
 /// blockquote `> ` prefix rather than the injected content) is likewise outside.
 ///
-/// Both cases would otherwise be clamped to `0` by the `saturating_sub` in
-/// [`translate_host_position_to_virtual`] and forwarded as virtual coordinate
-/// `(0, 0)` — a plausible-but-wrong location at the very start of the injection.
-/// The column boundary is checked against the same per-virtual-line offset used
-/// by translation, so non-blockquote lines past the first (offset 0) never
-/// trigger a false abort.
+/// Either case would otherwise be silently mistranslated by the `saturating_sub`
+/// in [`translate_host_position_to_virtual`] and forwarded as wrong coordinates:
+/// a line above the region clamps the line to 0 (the column is deliberately left
+/// unadjusted there, so the character is preserved → `(0, character)`), while a
+/// position before the start column on an in-range line clamps the character to 0
+/// (→ `(virtual_line, 0)`). The column boundary is checked against the same
+/// per-virtual-line offset used by translation, so non-blockquote lines past the
+/// first (offset 0) never trigger a false abort.
 pub(crate) fn host_position_within_region(host_position: Position, offset: &RegionOffset) -> bool {
     if host_position.line < offset.line() {
         return false;

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -50,7 +50,7 @@ impl LanguageServerPool {
         if !handle.has_capability("textDocument/completion") {
             return Ok(None);
         }
-        self.execute_bridge_request_with_handle(
+        self.execute_position_bridge_request_with_handle(
             handle,
             server_name,
             host_uri,
@@ -59,6 +59,8 @@ impl LanguageServerPool {
             &offset,
             virtual_content,
             upstream_request_id,
+            host_position,
+            "textDocument/completion",
             |virtual_uri, request_id| {
                 build_completion_request(virtual_uri, host_position, &offset, request_id)
             },

--- a/src/lsp/bridge/text_document/declaration.rs
+++ b/src/lsp/bridge/text_document/declaration.rs
@@ -46,7 +46,7 @@ impl LanguageServerPool {
         if !handle.has_capability("textDocument/declaration") {
             return Ok(None);
         }
-        self.execute_bridge_request_with_handle(
+        self.execute_position_bridge_request_with_handle(
             handle,
             server_name,
             host_uri,
@@ -55,6 +55,8 @@ impl LanguageServerPool {
             &offset,
             virtual_content,
             upstream_request_id,
+            host_position,
+            "textDocument/declaration",
             |virtual_uri, request_id| {
                 build_declaration_request(virtual_uri, host_position, &offset, request_id)
             },

--- a/src/lsp/bridge/text_document/definition.rs
+++ b/src/lsp/bridge/text_document/definition.rs
@@ -46,7 +46,7 @@ impl LanguageServerPool {
         if !handle.has_capability("textDocument/definition") {
             return Ok(None);
         }
-        self.execute_bridge_request_with_handle(
+        self.execute_position_bridge_request_with_handle(
             handle,
             server_name,
             host_uri,
@@ -55,6 +55,8 @@ impl LanguageServerPool {
             &offset,
             virtual_content,
             upstream_request_id,
+            host_position,
+            "textDocument/definition",
             |virtual_uri, request_id| {
                 build_definition_request(virtual_uri, host_position, &offset, request_id)
             },

--- a/src/lsp/bridge/text_document/document_highlight.rs
+++ b/src/lsp/bridge/text_document/document_highlight.rs
@@ -47,7 +47,7 @@ impl LanguageServerPool {
         if !handle.has_capability("textDocument/documentHighlight") {
             return Ok(None);
         }
-        self.execute_bridge_request_with_handle(
+        self.execute_position_bridge_request_with_handle(
             handle,
             server_name,
             host_uri,
@@ -56,6 +56,8 @@ impl LanguageServerPool {
             &offset,
             virtual_content,
             upstream_request_id,
+            host_position,
+            "textDocument/documentHighlight",
             |virtual_uri, request_id| {
                 build_document_highlight_request(virtual_uri, host_position, &offset, request_id)
             },

--- a/src/lsp/bridge/text_document/hover.rs
+++ b/src/lsp/bridge/text_document/hover.rs
@@ -47,7 +47,7 @@ impl LanguageServerPool {
         if !handle.has_capability("textDocument/hover") {
             return Ok(None);
         }
-        self.execute_bridge_request_with_handle(
+        self.execute_position_bridge_request_with_handle(
             handle,
             server_name,
             host_uri,
@@ -56,6 +56,8 @@ impl LanguageServerPool {
             &offset,
             virtual_content,
             upstream_request_id,
+            host_position,
+            "textDocument/hover",
             |virtual_uri, request_id| {
                 build_hover_request(virtual_uri, host_position, &offset, request_id)
             },

--- a/src/lsp/bridge/text_document/implementation.rs
+++ b/src/lsp/bridge/text_document/implementation.rs
@@ -46,7 +46,7 @@ impl LanguageServerPool {
         if !handle.has_capability("textDocument/implementation") {
             return Ok(None);
         }
-        self.execute_bridge_request_with_handle(
+        self.execute_position_bridge_request_with_handle(
             handle,
             server_name,
             host_uri,
@@ -55,6 +55,8 @@ impl LanguageServerPool {
             &offset,
             virtual_content,
             upstream_request_id,
+            host_position,
+            "textDocument/implementation",
             |virtual_uri, request_id| {
                 build_implementation_request(virtual_uri, host_position, &offset, request_id)
             },

--- a/src/lsp/bridge/text_document/moniker.rs
+++ b/src/lsp/bridge/text_document/moniker.rs
@@ -46,7 +46,7 @@ impl LanguageServerPool {
         if !handle.has_capability("textDocument/moniker") {
             return Ok(None);
         }
-        self.execute_bridge_request_with_handle(
+        self.execute_position_bridge_request_with_handle(
             handle,
             server_name,
             host_uri,
@@ -55,6 +55,8 @@ impl LanguageServerPool {
             &offset,
             virtual_content,
             upstream_request_id,
+            host_position,
+            "textDocument/moniker",
             |virtual_uri, request_id| {
                 build_moniker_request(virtual_uri, host_position, &offset, request_id)
             },

--- a/src/lsp/bridge/text_document/prepare_rename.rs
+++ b/src/lsp/bridge/text_document/prepare_rename.rs
@@ -53,7 +53,7 @@ impl LanguageServerPool {
             }
             return Ok(None);
         }
-        self.execute_bridge_request_with_handle(
+        self.execute_position_bridge_request_with_handle(
             handle,
             server_name,
             host_uri,
@@ -62,6 +62,8 @@ impl LanguageServerPool {
             &offset,
             virtual_content,
             upstream_request_id,
+            host_position,
+            "textDocument/prepareRename",
             |virtual_uri, request_id| {
                 build_prepare_rename_request(virtual_uri, host_position, &offset, request_id)
             },

--- a/src/lsp/bridge/text_document/references.rs
+++ b/src/lsp/bridge/text_document/references.rs
@@ -47,7 +47,7 @@ impl LanguageServerPool {
         if !handle.has_capability("textDocument/references") {
             return Ok(None);
         }
-        self.execute_bridge_request_with_handle(
+        self.execute_position_bridge_request_with_handle(
             handle,
             server_name,
             host_uri,
@@ -56,6 +56,8 @@ impl LanguageServerPool {
             &offset,
             virtual_content,
             upstream_request_id,
+            host_position,
+            "textDocument/references",
             |virtual_uri, request_id| {
                 let params = ReferenceParams {
                     text_document_position: build_text_document_position_params(

--- a/src/lsp/bridge/text_document/rename.rs
+++ b/src/lsp/bridge/text_document/rename.rs
@@ -54,7 +54,7 @@ impl LanguageServerPool {
         if !handle.has_capability("textDocument/rename") {
             return Ok(None);
         }
-        self.execute_bridge_request_with_handle(
+        self.execute_position_bridge_request_with_handle(
             handle,
             server_name,
             host_uri,
@@ -63,6 +63,8 @@ impl LanguageServerPool {
             &offset,
             virtual_content,
             upstream_request_id,
+            host_position,
+            "textDocument/rename",
             |virtual_uri, request_id| {
                 build_rename_request(virtual_uri, host_position, &offset, new_name, request_id)
             },

--- a/src/lsp/bridge/text_document/signature_help.rs
+++ b/src/lsp/bridge/text_document/signature_help.rs
@@ -82,7 +82,7 @@ impl LanguageServerPool {
         if !handle.has_capability("textDocument/signatureHelp") {
             return Ok(None);
         }
-        self.execute_bridge_request_with_handle(
+        self.execute_position_bridge_request_with_handle(
             handle,
             server_name,
             host_uri,
@@ -91,6 +91,8 @@ impl LanguageServerPool {
             &offset,
             virtual_content,
             upstream_request_id,
+            host_position,
+            "textDocument/signatureHelp",
             |virtual_uri, request_id| {
                 build_signature_help_request(virtual_uri, host_position, &offset, request_id)
             },

--- a/src/lsp/bridge/text_document/type_definition.rs
+++ b/src/lsp/bridge/text_document/type_definition.rs
@@ -46,7 +46,7 @@ impl LanguageServerPool {
         if !handle.has_capability("textDocument/typeDefinition") {
             return Ok(None);
         }
-        self.execute_bridge_request_with_handle(
+        self.execute_position_bridge_request_with_handle(
             handle,
             server_name,
             host_uri,
@@ -55,6 +55,8 @@ impl LanguageServerPool {
             &offset,
             virtual_content,
             upstream_request_id,
+            host_position,
+            "textDocument/typeDefinition",
             |virtual_uri, request_id| {
                 build_type_definition_request(virtual_uri, host_position, &offset, request_id)
             },


### PR DESCRIPTION
## Summary

When translating a host position to virtual coordinates, the bridge used `saturating_sub` for the line, silently clamping `pos.line` to 0 when `pos.line < region_start_line`. That forwards garbage coordinates to the downstream server, which can return plausible-but-wrong results (hover for the wrong symbol, completion at the wrong place).

Per the analysis in #184, this condition means the captured region data is stale (a concurrent host edit shifted the region after the request was captured). Both inputs come from the same snapshot today, so it should be unreachable — which is exactly why surfacing it matters: turn a silent "impossible" state into an observable warning and skip a wasted downstream round-trip.

## Changes

- `host_position_within_region()` in `protocol/translation.rs` — single source of truth for the rule (line-only check; column underflow stays saturated).
- `execute_position_bridge_request_with_handle()` in `pool/execute.rs` — a position-specific wrapper around the core executor. On out-of-region it logs a `warn!` and feeds a synthetic `{"result": null}` to the handler's own transform, so each handler returns its natural "no result" value (`None` / empty `Vec`). Per the LSP spec, every position request may return null/empty, which editors handle gracefully.
- All **12 position-based handlers** route through the wrapper: hover, completion, signature help, definition/declaration/typeDefinition/implementation, references, prepareRename, rename, documentHighlight, moniker.
- The response-direction translation (virtual→host) keeps `saturating_*` — downstream servers may legitimately return positions beyond the region.

## Scope note

Range-based builders (inlay hint, color presentation) keep saturating behavior for now; they're not exercised by this abort path and can be addressed separately (consistent with the issue's "apply same pattern" follow-up).

## Tests

- `translation`: predicate true on/after start line, false above it.
- `execute`: `position_request_aborts_when_host_position_above_region` — a Ready connection advertising hover but backed by a non-responding sink process; a fast `Ok(None)` proves the request was aborted before contacting the server (otherwise it would block to timeout and return `Err`).
- Full pre-commit suite (`clippy -D warnings`, `fmt`, `cargo test --lib`) green.

Closes #184