### PR TITLE
docs(node-tracker): align comments with NodeTracker rename

### DIFF
--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -146,7 +146,7 @@ impl PositionKey {
     }
 }
 
-/// Edit position information for region ID tracking.
+/// Edit position information for node tracking.
 ///
 /// Represents byte positions of a text edit. Used to decouple
 /// NodeTracker from tree_sitter::InputEdit.

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -7,7 +7,7 @@
 //!
 //! - `actor` - Actor components (ResponseRouter, Reader task) for async I/O (ls-bridge-message-ordering)
 //! - `connection` - AsyncBridgeConnection for process spawning and I/O
-//! - `coordinator` - BridgeCoordinator for unified pool + region ID tracking
+//! - `coordinator` - BridgeCoordinator for unified pool + node tracking
 //! - `protocol` - VirtualDocumentUri, request building, and response transformation
 //! - `pool` - LanguageServerPool for server pool coordination (ls-bridge-server-pool-coordination)
 

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -1,4 +1,4 @@
-//! Bridge coordinator unifying the language server pool and region ID tracker
+//! Bridge coordinator unifying the language server pool and node tracker
 //! into a single coherent API.
 
 use std::collections::BTreeMap;
@@ -132,7 +132,7 @@ impl BridgeCoordinator {
     // Accessor methods (leaky but pragmatic)
     // ========================================
 
-    /// Access the underlying region ID tracker.
+    /// Access the underlying node tracker.
     ///
     /// Used by handlers for `InjectionResolver::resolve_at_byte_offset()`.
     pub(crate) fn node_tracker(&self) -> &NodeTracker {
@@ -284,7 +284,7 @@ impl BridgeCoordinator {
     }
 
     // ========================================
-    // Region ID management (delegate to tracker)
+    // Node tracker management (delegate to tracker)
     // ========================================
 
     /// Apply input edits to update region positions using START-priority invalidation.

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -134,7 +134,7 @@ pub struct Kakehashi {
     settings_manager: std::sync::Arc<SettingsManager>,
     /// Isolated coordinator for parser auto-installation
     auto_install: AutoInstallManager,
-    /// Bridge coordinator for downstream LS pool and region ID tracking
+    /// Bridge coordinator for downstream LS pool and node tracking
     bridge: std::sync::Arc<BridgeCoordinator>,
     /// Manager for synthetic (background) diagnostic push tasks (pull-first-diagnostic-forwarding Phase 2).
     /// Wrapped in Arc for sharing with debounced diagnostics (Phase 3).

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -37,7 +37,7 @@ impl Kakehashi {
         // Apply content changes and build tree-sitter edits
         let (text, edits) = apply_content_changes_with_edits(&old_text, params.content_changes);
 
-        // lazy-node-identity-tracking: Apply START-priority invalidation to region ID tracker.
+        // lazy-node-identity-tracking: Apply START-priority invalidation to node tracker.
         // Use InputEdits directly for precise invalidation when available,
         // fall back to diff-based approach for full document sync.
         //


### PR DESCRIPTION
## Why

The `RegionIdTracker → NodeTracker` rename updated the type and its identifiers but left several doc-comments and inline comments still describing the tracker by its old **"region ID tracker/tracking"** identity. These framed the live `NodeTracker` (and `node_tracker()`, which literally returns `&NodeTracker`) in terms that no longer match the type — misleading readers into conflating it with the still-valid `region_id` ULID **value**.

## What

Reworded type/instance references from "region ID track…" → "node track…" in 7 spots across 5 files:

| File:line | Before → After |
|---|---|
| `src/lsp/bridge/coordinator.rs:1` | `region ID tracker` → `node tracker` |
| `src/lsp/bridge/coordinator.rs:135` | `region ID tracker` → `node tracker` (doc on `node_tracker()`) |
| `src/lsp/bridge/coordinator.rs:287` | `Region ID management` → `Node tracker management` |
| `src/lsp/bridge.rs:10` | `region ID tracking` → `node tracking` |
| `src/lsp/lsp_impl.rs:137` | `region ID tracking` → `node tracking` |
| `src/language/node_tracker.rs:149` | `region ID tracking` → `node tracking` |
| `src/lsp/lsp_impl/text_document/did_change.rs:40` | `region ID tracker` → `node tracker` |

## Deliberately NOT changed

- **`region_id` value usages** (the injection ULID concept) — e.g. `calculate_region_id`, "tracked regions", `tests/e2e_stable_region_id.rs`. These were never renamed and remain correct; touching them would be a regression.
- **`docs/architecture-decisions/node-reference-protocol.md:285`** — the one remaining literal `RegionIdTracker` is in a markdown file handled in a **separate docs PR**.

## Verification

Comment-only, no behavior change. Pre-commit gate: `clippy -D warnings` clean, `fmt` clean, `cargo test --lib` → **1526 passed / 0 failed**.