### PR TITLE
feat(formatting): sequential pipeline for concatenated strategy (slice 1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,6 @@
 name = "kakehashi"
 version = "0.5.0"
 edition = "2024"
-# MSRV: edition 2024 needs >= 1.85, and the code uses `str::floor_char_boundary`
-# (stable since 1.95). This declares the minimum supported Rust — Cargo fails
-# fast with a clear error on an older toolchain. It does not select a toolchain
-# (there's no rust-toolchain file); CI still runs whatever Rust is installed.
-rust-version = "1.95"
 
 [[bin]]
 name = "kakehashi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 name = "kakehashi"
 version = "0.5.0"
 edition = "2024"
+# MSRV: edition 2024 needs >= 1.85, and the code uses `str::floor_char_boundary`
+# (stable since 1.95). Pin it so the build doesn't silently depend on whatever
+# toolchain is on the CI runner.
+rust-version = "1.95"
 
 [[bin]]
 name = "kakehashi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,9 @@ name = "kakehashi"
 version = "0.5.0"
 edition = "2024"
 # MSRV: edition 2024 needs >= 1.85, and the code uses `str::floor_char_boundary`
-# (stable since 1.95). Pin it so the build doesn't silently depend on whatever
-# toolchain is on the CI runner.
+# (stable since 1.95). This declares the minimum supported Rust — Cargo fails
+# fast with a clear error on an older toolchain. It does not select a toolchain
+# (there's no rust-toolchain file); CI still runs whatever Rust is installed.
 rust-version = "1.95"
 
 [[bin]]

--- a/src/lsp/aggregation/server.rs
+++ b/src/lsp/aggregation/server.rs
@@ -4,6 +4,6 @@ mod fan_in;
 mod fan_out;
 
 pub(crate) use concatenated_pipeline::run_sequential_format_pipeline;
-pub(crate) use dispatch::{dispatch_concatenated, dispatch_preferred};
+pub(crate) use dispatch::{dispatch_concatenated, dispatch_preferred, effective_priorities};
 pub(crate) use fan_in::FanInResult;
 pub(crate) use fan_out::FanOutTask;

--- a/src/lsp/aggregation/server.rs
+++ b/src/lsp/aggregation/server.rs
@@ -1,7 +1,9 @@
+mod concatenated_pipeline;
 mod dispatch;
 mod fan_in;
 mod fan_out;
 
+pub(crate) use concatenated_pipeline::run_sequential_format_pipeline;
 pub(crate) use dispatch::{dispatch_concatenated, dispatch_preferred};
 pub(crate) use fan_in::FanInResult;
 pub(crate) use fan_out::FanOutTask;

--- a/src/lsp/aggregation/server.rs
+++ b/src/lsp/aggregation/server.rs
@@ -4,6 +4,6 @@ mod fan_in;
 mod fan_out;
 
 pub(crate) use concatenated_pipeline::run_sequential_format_pipeline;
-pub(crate) use dispatch::{dispatch_concatenated, dispatch_preferred, effective_priorities};
+pub(crate) use dispatch::{dispatch_concatenated, dispatch_preferred, effective_priorities_from};
 pub(crate) use fan_in::FanInResult;
 pub(crate) use fan_out::FanOutTask;

--- a/src/lsp/aggregation/server/concatenated_pipeline.rs
+++ b/src/lsp/aggregation/server/concatenated_pipeline.rs
@@ -53,23 +53,25 @@ where
     F: Fn(String, String) -> Fut,
     Fut: Future<Output = (String, Option<Vec<TextEdit>>)>,
 {
-    // Start from the moved-in `initial_text` and only ever allocate a new
-    // string when a step actually changes the text. `changed` tracks whether
-    // any step produced a real edit, so we avoid both the up-front clone of
-    // `initial_text` and the final whole-string `accumulated == initial_text`
-    // comparison (which would re-scan potentially large region text on every
-    // call). When nothing changed we return `None` so the caller emits no edit.
+    // Keep one copy of the original text for the final equality check. The
+    // working copy is moved through each step (no per-step clone); `applied`
+    // skips the comparison entirely in the common case where no step produced a
+    // non-empty edit. The comparison matters because a step can return non-empty
+    // edits that nonetheless round-trip to byte-identical text (a formatter
+    // reformatting already-conformant code); without it the caller would emit a
+    // pointless whole-region replacement with identical content.
+    let original = initial_text.clone();
     let mut accumulated = initial_text;
-    let mut changed = false;
+    let mut applied = false;
 
     for server_name in server_names {
         // Move the accumulated text into the step and take it back out — no
         // per-step clone, even when the step is a no-op or fails.
         let (text, result) = format_step(server_name.clone(), accumulated).await;
         accumulated = match result {
-            // A non-empty edit list is the only signal that the text changed.
+            // A non-empty edit list is the only thing that can change the text.
             Some(edits) if !edits.is_empty() => {
-                changed = true;
+                applied = true;
                 apply_text_edits(&text, &edits)
             }
             // Empty edits ("already formatted") or `None` (failed/unsupported
@@ -78,7 +80,12 @@ where
         };
     }
 
-    if changed { Some(accumulated) } else { None }
+    // Emit `Some` only when an edit was applied AND the bytes actually differ.
+    if applied && accumulated != original {
+        Some(accumulated)
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]
@@ -190,22 +197,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn returns_some_when_a_step_applies_a_real_edit() {
-        // A non-empty edit list means the step changed the text. Even if the
-        // edit happens to reproduce the original bytes, the pipeline reports a
-        // change: emptiness — not byte-equality — is the "no-op" signal, and
-        // skipping the whole-string comparison is the point of the `changed`
-        // flag. The previous byte-equality check would have returned `None`
-        // here; this test pins the new contract.
-        let servers = vec!["echo".to_string()];
+    async fn returns_some_when_a_step_changes_the_bytes() {
+        // A non-empty edit that actually changes the text yields Some(new_text).
+        let servers = vec!["upper".to_string()];
         let result = run_sequential_format_pipeline("abc".to_string(), &servers, |_name, text| {
-            // Replace the whole text with identical content via a real edit.
-            let value = Some(vec![replace_all(&text)]);
+            let value = Some(vec![replace_all(&text.to_uppercase())]);
             async move { (text, value) }
         })
         .await;
 
-        assert_eq!(result, Some("abc".to_string()));
+        assert_eq!(result, Some("ABC".to_string()));
+    }
+
+    #[tokio::test]
+    async fn non_empty_edits_that_round_trip_to_identical_text_emit_nothing() {
+        // A formatter may return a (non-empty) whole-document replacement whose
+        // content is byte-identical to the input — e.g. re-formatting code that
+        // already conforms. The pipeline must NOT report a change, so the caller
+        // never emits a pointless whole-region replacement with identical text.
+        let servers = vec!["noop_reformat".to_string()];
+        let result = run_sequential_format_pipeline("abc".to_string(), &servers, |_name, text| {
+            let value = Some(vec![replace_all(&text)]); // same bytes back
+            async move { (text, value) }
+        })
+        .await;
+
+        assert_eq!(result, None);
     }
 
     #[tokio::test]

--- a/src/lsp/aggregation/server/concatenated_pipeline.rs
+++ b/src/lsp/aggregation/server/concatenated_pipeline.rs
@@ -22,13 +22,16 @@ use crate::text::edit::apply_text_edits;
 /// Run the priority-ordered servers serially over `initial_text`.
 ///
 /// For each `server_name` in order, `format_step` is invoked with that server's
-/// name and the **current** accumulated text *by value* and must hand the text
-/// back (possibly unchanged) alongside its result. Handing the text in and out
-/// by move — rather than passing a borrowed `&str` plus a per-step
-/// `accumulated.clone()` — keeps the pipeline O(text_size) total instead of
+/// name and the **current** accumulated text *by value*, and must return that
+/// **same text moved straight back, unchanged**, alongside its result. The move
+/// in/out is purely to avoid cloning — rather than borrowing `&str` and cloning
+/// per step — and keeps the pipeline O(text_size) total instead of
 /// O(steps × text_size): no-op and failed steps no longer clone the whole
-/// accumulated text. The result is interpreted per
-/// concatenated-formatting-pipeline Decision points 3 and 6:
+/// accumulated text. `format_step` must **not** mutate the text it returns: all
+/// changes are conveyed via the returned edit list, and *this function* applies
+/// them (returning mutated text would double-apply on top of the edits). The
+/// result is interpreted per concatenated-formatting-pipeline Decision points 3
+/// and 6:
 ///
 /// - `Some(edits)` — apply `edits` (relative to the returned text) to produce
 ///   the next accumulated text. An empty list is the authoritative "already

--- a/src/lsp/aggregation/server/concatenated_pipeline.rs
+++ b/src/lsp/aggregation/server/concatenated_pipeline.rs
@@ -1,0 +1,190 @@
+//! Sequential formatter pipeline for the `concatenated` aggregation strategy
+//! on `textDocument/formatting` (concatenated-formatting-pipeline).
+//!
+//! Unlike the list-concatenation mechanics diagnostics/references use, two
+//! formatters over the same region produce *overlapping* `TextEdit`s. The
+//! pipeline instead runs the priority-listed servers **serially**: each server
+//! formats the previous server's output, so by construction there is nothing to
+//! merge and the eventual region-replacement edit can never overlap.
+//!
+//! This module owns only the **pure** sequential core — feed each server the
+//! accumulated text, apply its returned edits, carry the result forward — so it
+//! is unit-testable with a fake per-server step and no real bridge. The host
+//! wiring (scratch URIs, capability fallback, host-coordinate translation) lives
+//! in the formatting handler.
+
+use std::future::Future;
+
+use tower_lsp_server::ls_types::TextEdit;
+
+use crate::text::edit::apply_text_edits;
+
+/// Run the priority-ordered servers serially over `initial_text`.
+///
+/// For each `server_name` in order, `format_step` is invoked with that server's
+/// name and the **current** accumulated text. Its result is interpreted per
+/// concatenated-formatting-pipeline Decision points 3 and 6:
+///
+/// - `Some(edits)` — apply `edits` (relative to the current text) to produce the
+///   next accumulated text. An empty list is the authoritative "already
+///   formatted / no changes" signal and is a no-op that still advances the
+///   pipeline.
+/// - `None` — a failed or unsupported step: **skip and continue** with the
+///   current accumulated text, never aborting the pipeline or discarding earlier
+///   successful steps.
+///
+/// Returns `Some(final_text)` when the final accumulated text differs from
+/// `initial_text`, or `None` when nothing changed (every server was a no-op,
+/// was skipped, or all failed) so the caller can emit no edit.
+pub(crate) async fn run_sequential_format_pipeline<F, Fut>(
+    initial_text: String,
+    server_names: &[String],
+    format_step: F,
+) -> Option<String>
+where
+    F: Fn(String, String) -> Fut,
+    Fut: Future<Output = Option<Vec<TextEdit>>>,
+{
+    let mut accumulated = initial_text.clone();
+
+    for server_name in server_names {
+        match format_step(server_name.clone(), accumulated.clone()).await {
+            // Skip-and-continue: a failed or unsupported server contributes
+            // nothing but must not discard the text produced so far.
+            None => continue,
+            Some(edits) => {
+                // Empty edits = authoritative "already formatted" = no-op.
+                if edits.is_empty() {
+                    continue;
+                }
+                accumulated = apply_text_edits(&accumulated, &edits);
+            }
+        }
+    }
+
+    if accumulated == initial_text {
+        None
+    } else {
+        Some(accumulated)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower_lsp_server::ls_types::{Position, Range};
+
+    /// Whole-text replacement edit (range covers the entire input), the shape a
+    /// whole-document formatter emits.
+    fn replace_all(new_text: &str) -> TextEdit {
+        TextEdit {
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                // u32::MAX end is clamped by `apply_text_edits` to the real EOF.
+                end: Position {
+                    line: u32::MAX,
+                    character: u32::MAX,
+                },
+            },
+            new_text: new_text.to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn feeds_each_server_the_previous_servers_output_in_order() {
+        // black uppercases, then isort appends a marker. The second server must
+        // see the FIRST server's output, not the original text.
+        let servers = vec!["black".to_string(), "isort".to_string()];
+        let result = run_sequential_format_pipeline("abc".to_string(), &servers, |name, text| {
+            let value = match name.as_str() {
+                "black" => {
+                    assert_eq!(text, "abc", "black must see the original text");
+                    Some(vec![replace_all(&text.to_uppercase())])
+                }
+                "isort" => {
+                    assert_eq!(text, "ABC", "isort must see black's output");
+                    Some(vec![replace_all(&format!("{text}!"))])
+                }
+                other => panic!("unexpected server {other}"),
+            };
+            async move { value }
+        })
+        .await;
+
+        assert_eq!(result, Some("ABC!".to_string()));
+    }
+
+    #[tokio::test]
+    async fn skips_a_failing_server_and_continues_with_current_text() {
+        // The first server fails (None); the pipeline must hand the SECOND
+        // server the unchanged original text rather than aborting.
+        let servers = vec!["broken".to_string(), "isort".to_string()];
+        let result = run_sequential_format_pipeline("abc".to_string(), &servers, |name, text| {
+            let value = match name.as_str() {
+                "broken" => None,
+                "isort" => {
+                    assert_eq!(text, "abc", "skipped server must not change the text");
+                    Some(vec![replace_all("formatted")])
+                }
+                other => panic!("unexpected server {other}"),
+            };
+            async move { value }
+        })
+        .await;
+
+        assert_eq!(result, Some("formatted".to_string()));
+    }
+
+    #[tokio::test]
+    async fn empty_edit_list_is_a_no_op_and_advances_the_pipeline() {
+        // First server reports "already formatted" (empty edits); the text is
+        // unchanged but the pipeline still proceeds to the second server.
+        let servers = vec!["already_ok".to_string(), "isort".to_string()];
+        let result = run_sequential_format_pipeline("abc".to_string(), &servers, |name, text| {
+            let value = match name.as_str() {
+                "already_ok" => Some(vec![]),
+                "isort" => {
+                    assert_eq!(text, "abc", "empty edits must leave the text untouched");
+                    Some(vec![replace_all("done")])
+                }
+                other => panic!("unexpected server {other}"),
+            };
+            async move { value }
+        })
+        .await;
+
+        assert_eq!(result, Some("done".to_string()));
+    }
+
+    #[tokio::test]
+    async fn returns_none_when_text_is_unchanged() {
+        // Every server is a no-op (empty edits or skip) → final text equals the
+        // original → no edit to emit.
+        let servers = vec!["noop".to_string(), "broken".to_string()];
+        let result = run_sequential_format_pipeline("abc".to_string(), &servers, |name, _text| {
+            let value = match name.as_str() {
+                "noop" => Some(vec![]),
+                "broken" => None,
+                other => panic!("unexpected server {other}"),
+            };
+            async move { value }
+        })
+        .await;
+
+        assert_eq!(result, None, "unchanged text must contribute no edit");
+    }
+
+    #[tokio::test]
+    async fn empty_server_list_returns_none() {
+        let result = run_sequential_format_pipeline(
+            "abc".to_string(),
+            &[],
+            |_name, _text| async move { None },
+        )
+        .await;
+        assert_eq!(result, None);
+    }
+}

--- a/src/lsp/aggregation/server/concatenated_pipeline.rs
+++ b/src/lsp/aggregation/server/concatenated_pipeline.rs
@@ -22,16 +22,21 @@ use crate::text::edit::apply_text_edits;
 /// Run the priority-ordered servers serially over `initial_text`.
 ///
 /// For each `server_name` in order, `format_step` is invoked with that server's
-/// name and the **current** accumulated text. Its result is interpreted per
+/// name and the **current** accumulated text *by value* and must hand the text
+/// back (possibly unchanged) alongside its result. Handing the text in and out
+/// by move — rather than passing a borrowed `&str` plus a per-step
+/// `accumulated.clone()` — keeps the pipeline O(text_size) total instead of
+/// O(steps × text_size): no-op and failed steps no longer clone the whole
+/// accumulated text. The result is interpreted per
 /// concatenated-formatting-pipeline Decision points 3 and 6:
 ///
-/// - `Some(edits)` — apply `edits` (relative to the current text) to produce the
-///   next accumulated text. An empty list is the authoritative "already
+/// - `Some(edits)` — apply `edits` (relative to the returned text) to produce
+///   the next accumulated text. An empty list is the authoritative "already
 ///   formatted / no changes" signal and is a no-op that still advances the
 ///   pipeline.
 /// - `None` — a failed or unsupported step: **skip and continue** with the
-///   current accumulated text, never aborting the pipeline or discarding earlier
-///   successful steps.
+///   text the step handed back, never aborting the pipeline or discarding
+///   earlier successful steps.
 ///
 /// Returns `Some(final_text)` when at least one server applied a non-empty
 /// edit, or `None` when nothing changed (every server was a no-op via empty
@@ -46,7 +51,7 @@ pub(crate) async fn run_sequential_format_pipeline<F, Fut>(
 ) -> Option<String>
 where
     F: Fn(String, String) -> Fut,
-    Fut: Future<Output = Option<Vec<TextEdit>>>,
+    Fut: Future<Output = (String, Option<Vec<TextEdit>>)>,
 {
     // Start from the moved-in `initial_text` and only ever allocate a new
     // string when a step actually changes the text. `changed` tracks whether
@@ -58,19 +63,19 @@ where
     let mut changed = false;
 
     for server_name in server_names {
-        match format_step(server_name.clone(), accumulated.clone()).await {
-            // Skip-and-continue: a failed or unsupported server contributes
-            // nothing but must not discard the text produced so far.
-            None => continue,
-            Some(edits) => {
-                // Empty edits = authoritative "already formatted" = no-op.
-                if edits.is_empty() {
-                    continue;
-                }
-                accumulated = apply_text_edits(&accumulated, &edits);
+        // Move the accumulated text into the step and take it back out — no
+        // per-step clone, even when the step is a no-op or fails.
+        let (text, result) = format_step(server_name.clone(), accumulated).await;
+        accumulated = match result {
+            // A non-empty edit list is the only signal that the text changed.
+            Some(edits) if !edits.is_empty() => {
                 changed = true;
+                apply_text_edits(&text, &edits)
             }
-        }
+            // Empty edits ("already formatted") or `None` (failed/unsupported
+            // step): skip-and-continue carrying the text the step handed back.
+            _ => text,
+        };
     }
 
     if changed { Some(accumulated) } else { None }
@@ -117,7 +122,7 @@ mod tests {
                 }
                 other => panic!("unexpected server {other}"),
             };
-            async move { value }
+            async move { (text, value) }
         })
         .await;
 
@@ -138,7 +143,7 @@ mod tests {
                 }
                 other => panic!("unexpected server {other}"),
             };
-            async move { value }
+            async move { (text, value) }
         })
         .await;
 
@@ -159,7 +164,7 @@ mod tests {
                 }
                 other => panic!("unexpected server {other}"),
             };
-            async move { value }
+            async move { (text, value) }
         })
         .await;
 
@@ -171,13 +176,13 @@ mod tests {
         // Every server is a no-op (empty edits or skip) → final text equals the
         // original → no edit to emit.
         let servers = vec!["noop".to_string(), "broken".to_string()];
-        let result = run_sequential_format_pipeline("abc".to_string(), &servers, |name, _text| {
+        let result = run_sequential_format_pipeline("abc".to_string(), &servers, |name, text| {
             let value = match name.as_str() {
                 "noop" => Some(vec![]),
                 "broken" => None,
                 other => panic!("unexpected server {other}"),
             };
-            async move { value }
+            async move { (text, value) }
         })
         .await;
 
@@ -196,7 +201,7 @@ mod tests {
         let result = run_sequential_format_pipeline("abc".to_string(), &servers, |_name, text| {
             // Replace the whole text with identical content via a real edit.
             let value = Some(vec![replace_all(&text)]);
-            async move { value }
+            async move { (text, value) }
         })
         .await;
 
@@ -205,12 +210,11 @@ mod tests {
 
     #[tokio::test]
     async fn empty_server_list_returns_none() {
-        let result = run_sequential_format_pipeline(
-            "abc".to_string(),
-            &[],
-            |_name, _text| async move { None },
-        )
-        .await;
+        let result =
+            run_sequential_format_pipeline("abc".to_string(), &[], |_name, text| async move {
+                (text, None)
+            })
+            .await;
         assert_eq!(result, None);
     }
 }

--- a/src/lsp/aggregation/server/concatenated_pipeline.rs
+++ b/src/lsp/aggregation/server/concatenated_pipeline.rs
@@ -42,11 +42,17 @@ use crate::text::edit::apply_text_edits;
 ///   earlier successful steps.
 ///
 /// Returns `Some(final_text)` only when at least one server applied a non-empty
-/// edit **and** the resulting text is not byte-identical to `initial_text`;
+/// edit **and** the resulting text is not byte-identical to the original;
 /// otherwise `None`, so the caller emits no edit. Byte-equality with the
 /// original — not merely "some step returned edits" — is the "no change" signal,
 /// so a formatter that returns edits which round-trip to identical content does
 /// not produce a pointless whole-region replacement.
+///
+/// The original text is captured **lazily**: it is only cloned right before the
+/// first non-empty edit is applied (at which point `accumulated` still equals the
+/// original, since every prior step was a no-op that returned the text
+/// unchanged). The common "already formatted" case — where no step ever applies a
+/// non-empty edit — therefore never clones the text at all.
 pub(crate) async fn run_sequential_format_pipeline<F, Fut>(
     initial_text: String,
     server_names: &[String],
@@ -56,16 +62,18 @@ where
     F: Fn(String, String) -> Fut,
     Fut: Future<Output = (String, Option<Vec<TextEdit>>)>,
 {
-    // Keep one copy of the original text for the final equality check. The
-    // working copy is moved through each step (no per-step clone); `applied`
-    // skips the comparison entirely in the common case where no step produced a
-    // non-empty edit. The comparison matters because a step can return non-empty
-    // edits that nonetheless round-trip to byte-identical text (a formatter
-    // reformatting already-conformant code); without it the caller would emit a
-    // pointless whole-region replacement with identical content.
-    let original = initial_text.clone();
+    // The working copy is moved through each step (no per-step clone). The
+    // original is captured lazily into `original` only when the first non-empty
+    // edit is about to be applied — at that moment `accumulated` still equals the
+    // original (every prior step was a no-op that returned the text unchanged), so
+    // cloning it then is equivalent to cloning `initial_text` up front but avoids
+    // the clone entirely in the common "already formatted" case (no step ever
+    // applies a non-empty edit). The comparison matters because a step can return
+    // non-empty edits that nonetheless round-trip to byte-identical text (a
+    // formatter reformatting already-conformant code); without it the caller would
+    // emit a pointless whole-region replacement with identical content.
     let mut accumulated = initial_text;
-    let mut applied = false;
+    let mut original: Option<String> = None;
 
     for server_name in server_names {
         // Move the accumulated text into the step and take it back out — no
@@ -74,7 +82,11 @@ where
         accumulated = match result {
             // A non-empty edit list is the only thing that can change the text.
             Some(edits) if !edits.is_empty() => {
-                applied = true;
+                // Capture the original just before the first applied edit, while
+                // `text` still equals the original text.
+                if original.is_none() {
+                    original = Some(text.clone());
+                }
                 apply_text_edits(&text, &edits)
             }
             // Empty edits ("already formatted") or `None` (failed/unsupported
@@ -83,11 +95,11 @@ where
         };
     }
 
-    // Emit `Some` only when an edit was applied AND the bytes actually differ.
-    if applied && accumulated != original {
-        Some(accumulated)
-    } else {
-        None
+    // Emit `Some` only when an edit was captured-and-applied AND the bytes
+    // actually differ from the captured original.
+    match original {
+        Some(original) if accumulated != original => Some(accumulated),
+        _ => None,
     }
 }
 

--- a/src/lsp/aggregation/server/concatenated_pipeline.rs
+++ b/src/lsp/aggregation/server/concatenated_pipeline.rs
@@ -38,12 +38,12 @@ use crate::text::edit::apply_text_edits;
 ///   text the step handed back, never aborting the pipeline or discarding
 ///   earlier successful steps.
 ///
-/// Returns `Some(final_text)` when at least one server applied a non-empty
-/// edit, or `None` when nothing changed (every server was a no-op via empty
-/// edits, was skipped, or all failed) so the caller can emit no edit. An empty
-/// edit list — not byte-equality with `initial_text` — is the "no change"
-/// signal, which lets the pipeline avoid cloning `initial_text` up front and
-/// re-scanning the whole accumulated text at the end.
+/// Returns `Some(final_text)` only when at least one server applied a non-empty
+/// edit **and** the resulting text is not byte-identical to `initial_text`;
+/// otherwise `None`, so the caller emits no edit. Byte-equality with the
+/// original — not merely "some step returned edits" — is the "no change" signal,
+/// so a formatter that returns edits which round-trip to identical content does
+/// not produce a pointless whole-region replacement.
 pub(crate) async fn run_sequential_format_pipeline<F, Fut>(
     initial_text: String,
     server_names: &[String],

--- a/src/lsp/aggregation/server/concatenated_pipeline.rs
+++ b/src/lsp/aggregation/server/concatenated_pipeline.rs
@@ -33,9 +33,12 @@ use crate::text::edit::apply_text_edits;
 ///   current accumulated text, never aborting the pipeline or discarding earlier
 ///   successful steps.
 ///
-/// Returns `Some(final_text)` when the final accumulated text differs from
-/// `initial_text`, or `None` when nothing changed (every server was a no-op,
-/// was skipped, or all failed) so the caller can emit no edit.
+/// Returns `Some(final_text)` when at least one server applied a non-empty
+/// edit, or `None` when nothing changed (every server was a no-op via empty
+/// edits, was skipped, or all failed) so the caller can emit no edit. An empty
+/// edit list — not byte-equality with `initial_text` — is the "no change"
+/// signal, which lets the pipeline avoid cloning `initial_text` up front and
+/// re-scanning the whole accumulated text at the end.
 pub(crate) async fn run_sequential_format_pipeline<F, Fut>(
     initial_text: String,
     server_names: &[String],
@@ -45,7 +48,14 @@ where
     F: Fn(String, String) -> Fut,
     Fut: Future<Output = Option<Vec<TextEdit>>>,
 {
-    let mut accumulated = initial_text.clone();
+    // Start from the moved-in `initial_text` and only ever allocate a new
+    // string when a step actually changes the text. `changed` tracks whether
+    // any step produced a real edit, so we avoid both the up-front clone of
+    // `initial_text` and the final whole-string `accumulated == initial_text`
+    // comparison (which would re-scan potentially large region text on every
+    // call). When nothing changed we return `None` so the caller emits no edit.
+    let mut accumulated = initial_text;
+    let mut changed = false;
 
     for server_name in server_names {
         match format_step(server_name.clone(), accumulated.clone()).await {
@@ -58,15 +68,12 @@ where
                     continue;
                 }
                 accumulated = apply_text_edits(&accumulated, &edits);
+                changed = true;
             }
         }
     }
 
-    if accumulated == initial_text {
-        None
-    } else {
-        Some(accumulated)
-    }
+    if changed { Some(accumulated) } else { None }
 }
 
 #[cfg(test)]
@@ -175,6 +182,25 @@ mod tests {
         .await;
 
         assert_eq!(result, None, "unchanged text must contribute no edit");
+    }
+
+    #[tokio::test]
+    async fn returns_some_when_a_step_applies_a_real_edit() {
+        // A non-empty edit list means the step changed the text. Even if the
+        // edit happens to reproduce the original bytes, the pipeline reports a
+        // change: emptiness — not byte-equality — is the "no-op" signal, and
+        // skipping the whole-string comparison is the point of the `changed`
+        // flag. The previous byte-equality check would have returned `None`
+        // here; this test pins the new contract.
+        let servers = vec!["echo".to_string()];
+        let result = run_sequential_format_pipeline("abc".to_string(), &servers, |_name, text| {
+            // Replace the whole text with identical content via a real edit.
+            let value = Some(vec![replace_all(&text)]);
+            async move { value }
+        })
+        .await;
+
+        assert_eq!(result, Some("abc".to_string()));
     }
 
     #[tokio::test]

--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -21,7 +21,10 @@ use super::fan_in::{concatenated, preferred};
 use super::fan_out::{FanOutTask, fan_out};
 
 /// Pre-filter `ctx.priorities` to keep only server names present in `ctx.configs`.
-fn effective_priorities(ctx: &DocumentRequestContext) -> Vec<String> {
+///
+/// Shared by the preferred fan-out and the concatenated formatting pipeline so
+/// the "priorities is a membership allowlist + order" rule has a single source.
+pub(crate) fn effective_priorities(ctx: &DocumentRequestContext) -> Vec<String> {
     let configured: HashSet<&str> = ctx.configs.iter().map(|c| c.server_name.as_str()).collect();
     ctx.priorities
         .iter()

--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -20,15 +20,20 @@ use super::fan_in::FanInResult;
 use super::fan_in::{concatenated, preferred};
 use super::fan_out::{FanOutTask, fan_out};
 
-/// Pre-filter `ctx.priorities` to keep only server names present in `ctx.configs`.
+/// Pre-filter `ctx.priorities` to keep only server names present in `ctx.configs`,
+/// dropping duplicates (first occurrence wins, order preserved).
 ///
 /// Shared by the preferred fan-out and the concatenated formatting pipeline so
 /// the "priorities is a membership allowlist + order" rule has a single source.
+/// Deduping matters for the sequential pipeline: a misconfigured
+/// `priorities: ["black", "black"]` would otherwise format with the same server
+/// twice; it also avoids fanning out twice to one server in the preferred path.
 pub(crate) fn effective_priorities(ctx: &DocumentRequestContext) -> Vec<String> {
     let configured: HashSet<&str> = ctx.configs.iter().map(|c| c.server_name.as_str()).collect();
+    let mut seen: HashSet<&str> = HashSet::new();
     ctx.priorities
         .iter()
-        .filter(|name| configured.contains(name.as_str()))
+        .filter(|name| configured.contains(name.as_str()) && seen.insert(name.as_str()))
         .cloned()
         .collect()
 }

--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -12,7 +12,7 @@ use std::future::Future;
 use std::io;
 use std::sync::Arc;
 
-use crate::lsp::bridge::LanguageServerPool;
+use crate::lsp::bridge::{LanguageServerPool, ResolvedServerConfig};
 use crate::lsp::lsp_impl::bridge_context::DocumentRequestContext;
 use crate::lsp::request_id::CancelReceiver;
 
@@ -28,10 +28,25 @@ use super::fan_out::{FanOutTask, fan_out};
 /// Deduping matters for the sequential pipeline: a misconfigured
 /// `priorities: ["black", "black"]` would otherwise format with the same server
 /// twice; it also avoids fanning out twice to one server in the preferred path.
-pub(crate) fn effective_priorities(ctx: &DocumentRequestContext) -> Vec<String> {
-    let configured: HashSet<&str> = ctx.configs.iter().map(|c| c.server_name.as_str()).collect();
+fn effective_priorities(ctx: &DocumentRequestContext) -> Vec<String> {
+    effective_priorities_from(&ctx.priorities, &ctx.configs)
+}
+
+/// Slice-based core of [`effective_priorities`]: keep only `priorities` names
+/// present in `configs`, dropping duplicates (first occurrence wins, order
+/// preserved).
+///
+/// Split out from the [`DocumentRequestContext`] wrapper so callers that only
+/// have the two relevant fields — notably the formatting gating decision
+/// ([`crate::lsp::lsp_impl::text_document::formatting`]) and its unit tests —
+/// can reuse the exact allowlist rule without building a full context.
+pub(crate) fn effective_priorities_from(
+    priorities: &[String],
+    configs: &[ResolvedServerConfig],
+) -> Vec<String> {
+    let configured: HashSet<&str> = configs.iter().map(|c| c.server_name.as_str()).collect();
     let mut seen: HashSet<&str> = HashSet::new();
-    ctx.priorities
+    priorities
         .iter()
         .filter(|name| configured.contains(name.as_str()) && seen.insert(name.as_str()))
         .cloned()

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -28,6 +28,7 @@ pub(crate) use protocol::RegionOffset;
 #[cfg(test)]
 pub(crate) use protocol::VirtualDocumentUri;
 pub(crate) use protocol::location_link_to_location;
+pub(crate) use protocol::translate_virtual_range_to_host;
 
 /// Integration tests for the bridge module.
 ///

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -25,7 +25,6 @@ pub(crate) use coordinator::ResolvedServerConfig;
 pub use pool::LanguageServerPool;
 pub(crate) use pool::UpstreamId;
 pub(crate) use protocol::RegionOffset;
-#[cfg(test)]
 pub(crate) use protocol::VirtualDocumentUri;
 pub(crate) use protocol::location_link_to_location;
 pub(crate) use protocol::translate_virtual_range_to_host;

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -364,6 +364,23 @@ impl LanguageServerPool {
             .await
     }
 
+    /// Remove a virtual document's `host_to_virtual` registration.
+    ///
+    /// `untrack_document` clears `document_versions`, `opened_documents`, and
+    /// the reverse index but deliberately leaves `host_to_virtual` for the
+    /// host-close flow. Scratch documents (concatenated formatting pipeline) are
+    /// addressed directly and never go through that flow, so they must remove
+    /// their own `host_to_virtual` entry here to avoid lingering / double-close.
+    pub(crate) async fn unregister_virtual_doc(
+        &self,
+        host_uri: &Url,
+        virtual_uri: &VirtualDocumentUri,
+    ) {
+        self.document_tracker
+            .unregister_virtual_doc(host_uri, virtual_uri)
+            .await
+    }
+
     /// Whether a document has been claimed or opened on a downstream server (ls-bridge-message-ordering).
     ///
     /// Fast synchronous check used to gate operations on documents not yet known

--- a/src/lsp/bridge/text_document/did_close.rs
+++ b/src/lsp/bridge/text_document/did_close.rs
@@ -65,6 +65,38 @@ impl LanguageServerPool {
         }
     }
 
+    /// Close a single scratch virtual document by URI: send didClose and remove
+    /// it from tracking.
+    ///
+    /// Used by the concatenated formatting pipeline, which opens a throwaway
+    /// scratch virtual document per step (a unique URI carrying the accumulated
+    /// text) and must close it immediately afterward so it never orphans
+    /// tracking state, accumulates downstream documents, or leaks diagnostics
+    /// for the throwaway URI (concatenated-formatting-pipeline Decision point 7).
+    /// Unlike [`close_host_document`](Self::close_host_document) /
+    /// [`close_invalidated_docs`](Self::close_invalidated_docs), the scratch URI
+    /// is not registered under any host document, so it is addressed directly
+    /// rather than looked up via `host_to_virtual`. Best-effort: a didClose
+    /// failure is logged inside [`send_didclose_notification`] callers but never
+    /// surfaced, since the pipeline must not fail on cleanup.
+    pub(crate) async fn close_scratch_document(
+        &self,
+        scratch_uri: &VirtualDocumentUri,
+        server_name: &str,
+    ) {
+        if let Err(e) = self
+            .send_didclose_notification(scratch_uri, server_name)
+            .await
+        {
+            log::warn!(
+                target: "kakehashi::bridge",
+                "Failed to send didClose for scratch document {}: {}",
+                scratch_uri.to_uri_string(), e
+            );
+        }
+        self.untrack_document(scratch_uri, server_name).await;
+    }
+
     /// Close a single virtual document: send didClose and remove from tracking.
     ///
     /// This is the core cleanup operation used by both `close_host_document`
@@ -126,5 +158,77 @@ impl LanguageServerPool {
         for doc in &to_close {
             self.close_single_virtual_doc(doc).await;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lsp::bridge::pool::test_helpers::url_to_uri;
+
+    /// `close_scratch_document` untracks a directly-addressed scratch virtual
+    /// document.
+    ///
+    /// The concatenated formatting pipeline opens a throwaway scratch document
+    /// per step (a unique URI not registered under any host document) and must
+    /// be able to close + untrack it by URI alone — without going through the
+    /// `host_to_virtual` lookup that `close_host_document` uses. This guards the
+    /// scratch lifecycle that isolates the pipeline's speculative state
+    /// (concatenated-formatting-pipeline Decision point 7).
+    #[tokio::test]
+    async fn close_scratch_document_untracks_directly_addressed_doc() {
+        let pool = LanguageServerPool::new();
+        let host_uri = Url::parse("file:///project/doc.md").unwrap();
+        // A scratch URI uses a step-suffixed region_id, distinct from the
+        // canonical region's virtual document.
+        let scratch_uri =
+            VirtualDocumentUri::new(&url_to_uri(&host_uri), "python", "REGION-scratch-0");
+
+        // Simulate the per-step didOpen having registered the scratch doc.
+        pool.register_opened_document(&host_uri, &scratch_uri, "black")
+            .await;
+        assert!(
+            pool.is_document_opened(&scratch_uri),
+            "scratch doc should be tracked after register"
+        );
+
+        // No connection exists for "black", so the didClose send is a no-op,
+        // but the untrack must still happen so the scratch doc never lingers.
+        pool.close_scratch_document(&scratch_uri, "black").await;
+
+        assert!(
+            !pool.is_document_opened(&scratch_uri),
+            "scratch doc must be untracked after close_scratch_document"
+        );
+    }
+
+    /// A scratch URI is distinct from the canonical region URI, so an
+    /// already-open canonical document does NOT suppress the scratch `didOpen`.
+    ///
+    /// This is the crux of the stale-content fix: when the canonical region
+    /// document is already open for a server (e.g. after a prior hover), the
+    /// formatting step targets a *different* URI, so `ensure_document_opened`
+    /// (gated on `is_document_opened`) still sends a fresh `didOpen` carrying the
+    /// current accumulated text rather than reusing the stale open document.
+    #[tokio::test]
+    async fn scratch_uri_is_not_suppressed_by_open_canonical_document() {
+        let pool = LanguageServerPool::new();
+        let host_uri = Url::parse("file:///project/doc.md").unwrap();
+        let canonical_uri = VirtualDocumentUri::new(&url_to_uri(&host_uri), "python", "REGION");
+        let scratch_uri =
+            VirtualDocumentUri::new(&url_to_uri(&host_uri), "python", "REGION-scratch-0");
+
+        // Canonical region document already open downstream (the bug trigger).
+        pool.register_opened_document(&host_uri, &canonical_uri, "black")
+            .await;
+
+        assert!(
+            pool.is_document_opened(&canonical_uri),
+            "canonical doc is open"
+        );
+        assert!(
+            !pool.is_document_opened(&scratch_uri),
+            "scratch doc must be seen as NOT open so a fresh didOpen carries the current text"
+        );
     }
 }

--- a/src/lsp/bridge/text_document/did_close.rs
+++ b/src/lsp/bridge/text_document/did_close.rs
@@ -92,6 +92,13 @@ impl LanguageServerPool {
         scratch_uri: &VirtualDocumentUri,
         server_name: &str,
     ) {
+        // Idempotent close: if the scratch document is no longer open, a
+        // concurrent cleanup (e.g. `close_host_document`) already closed and
+        // untracked it, so another `didClose` would be a redundant notification
+        // the downstream server may warn about. Nothing left to do.
+        if !self.is_document_opened(scratch_uri) {
+            return;
+        }
         if let Err(e) = self
             .send_didclose_notification(scratch_uri, server_name)
             .await
@@ -211,6 +218,16 @@ mod tests {
         assert!(
             !pool.is_document_opened(&scratch_uri),
             "scratch doc must be untracked after close_scratch_document"
+        );
+
+        // Idempotent: a second close (the scratch doc is already gone, e.g. a
+        // concurrent close_host_document beat the per-step/sweep cleanup) is a
+        // safe no-op rather than a redundant didClose.
+        pool.close_scratch_document(&host_uri, &scratch_uri, "black")
+            .await;
+        assert!(
+            !pool.is_document_opened(&scratch_uri),
+            "second close must remain a no-op"
         );
     }
 

--- a/src/lsp/bridge/text_document/did_close.rs
+++ b/src/lsp/bridge/text_document/did_close.rs
@@ -73,9 +73,11 @@ impl LanguageServerPool {
     ///
     /// Used by the concatenated formatting pipeline, which opens a throwaway
     /// scratch virtual document per step (a unique URI carrying the accumulated
-    /// text) and must close it immediately afterward so it never orphans
-    /// tracking state, accumulates downstream documents, or leaks diagnostics
-    /// for the throwaway URI (concatenated-formatting-pipeline Decision point 7).
+    /// text). The handler closes these via an end-of-run sweep (and an abort-time
+    /// Drop guard) rather than per step — deferring keeps cancellation leak-free —
+    /// so they never orphan tracking state, accumulate downstream documents, or
+    /// leak diagnostics for the throwaway URI (concatenated-formatting-pipeline
+    /// Decision point 7).
     ///
     /// The scratch URI is addressed directly (by URI + host) rather than looked
     /// up via the `host_to_virtual` ULID scan that

--- a/src/lsp/bridge/text_document/did_close.rs
+++ b/src/lsp/bridge/text_document/did_close.rs
@@ -66,7 +66,10 @@ impl LanguageServerPool {
     }
 
     /// Close a single scratch virtual document by URI: send didClose and remove
-    /// it from ALL tracking state.
+    /// it from all tracking state for `server_name` (the `host_to_virtual`
+    /// registration, plus the version/opened/reverse-index entries that
+    /// `untrack_document` clears). A scratch URI is only ever opened against the
+    /// one server formatting that step, so per-server untracking is complete.
     ///
     /// Used by the concatenated formatting pipeline, which opens a throwaway
     /// scratch virtual document per step (a unique URI carrying the accumulated

--- a/src/lsp/bridge/text_document/did_close.rs
+++ b/src/lsp/bridge/text_document/did_close.rs
@@ -99,6 +99,13 @@ impl LanguageServerPool {
         if !self.is_document_opened(scratch_uri) {
             return;
         }
+        // Remove from ALL tracking BEFORE awaiting the didClose send. Otherwise a
+        // concurrent `close_host_document` could still find this scratch URI in
+        // `host_to_virtual` while our didClose is in flight and issue a redundant
+        // double-close. `untrack_document` does not touch `host_to_virtual`, so we
+        // remove that registration (added by `ensure_document_opened`) explicitly.
+        self.unregister_virtual_doc(host_uri, scratch_uri).await;
+        self.untrack_document(scratch_uri, server_name).await;
         if let Err(e) = self
             .send_didclose_notification(scratch_uri, server_name)
             .await
@@ -109,10 +116,6 @@ impl LanguageServerPool {
                 scratch_uri.to_uri_string(), e
             );
         }
-        self.untrack_document(scratch_uri, server_name).await;
-        // Remove the host_to_virtual registration that ensure_document_opened
-        // added; untrack_document does not touch it.
-        self.unregister_virtual_doc(host_uri, scratch_uri).await;
     }
 
     /// Close a single virtual document: send didClose and remove from tracking.

--- a/src/lsp/bridge/text_document/did_close.rs
+++ b/src/lsp/bridge/text_document/did_close.rs
@@ -66,21 +66,29 @@ impl LanguageServerPool {
     }
 
     /// Close a single scratch virtual document by URI: send didClose and remove
-    /// it from tracking.
+    /// it from ALL tracking state.
     ///
     /// Used by the concatenated formatting pipeline, which opens a throwaway
     /// scratch virtual document per step (a unique URI carrying the accumulated
     /// text) and must close it immediately afterward so it never orphans
     /// tracking state, accumulates downstream documents, or leaks diagnostics
     /// for the throwaway URI (concatenated-formatting-pipeline Decision point 7).
-    /// Unlike [`close_host_document`](Self::close_host_document) /
-    /// [`close_invalidated_docs`](Self::close_invalidated_docs), the scratch URI
-    /// is not registered under any host document, so it is addressed directly
-    /// rather than looked up via `host_to_virtual`. Best-effort: a didClose
-    /// failure is logged inside [`send_didclose_notification`] callers but never
-    /// surfaced, since the pipeline must not fail on cleanup.
+    ///
+    /// The scratch URI is addressed directly (by URI + host) rather than looked
+    /// up via the `host_to_virtual` ULID scan that
+    /// [`close_invalidated_docs`](Self::close_invalidated_docs) uses. But it IS
+    /// registered under its host document: `ensure_document_opened` calls
+    /// `register_opened_document`, which inserts the scratch URI into
+    /// `host_to_virtual` (alongside `document_versions`, `opened_documents`, and
+    /// the reverse index). `untrack_document` alone does NOT remove the
+    /// `host_to_virtual` entry, so we must also call `unregister_virtual_doc` —
+    /// otherwise the scratch URI lingers in `host_to_virtual` until the host doc
+    /// closes and gets a redundant second didClose then. Best-effort: a didClose
+    /// failure is logged but never surfaced, since the pipeline must not fail on
+    /// cleanup.
     pub(crate) async fn close_scratch_document(
         &self,
+        host_uri: &Url,
         scratch_uri: &VirtualDocumentUri,
         server_name: &str,
     ) {
@@ -95,6 +103,9 @@ impl LanguageServerPool {
             );
         }
         self.untrack_document(scratch_uri, server_name).await;
+        // Remove the host_to_virtual registration that ensure_document_opened
+        // added; untrack_document does not touch it.
+        self.unregister_virtual_doc(host_uri, scratch_uri).await;
     }
 
     /// Close a single virtual document: send didClose and remove from tracking.
@@ -194,11 +205,50 @@ mod tests {
 
         // No connection exists for "black", so the didClose send is a no-op,
         // but the untrack must still happen so the scratch doc never lingers.
-        pool.close_scratch_document(&scratch_uri, "black").await;
+        pool.close_scratch_document(&host_uri, &scratch_uri, "black")
+            .await;
 
         assert!(
             !pool.is_document_opened(&scratch_uri),
             "scratch doc must be untracked after close_scratch_document"
+        );
+    }
+
+    /// `close_scratch_document` removes the scratch URI from `host_to_virtual`.
+    ///
+    /// `ensure_document_opened` registers every virtual URI (scratch included)
+    /// in `host_to_virtual` via `register_opened_document`. `untrack_document`
+    /// alone does not clear that map, so without the extra `unregister_virtual_doc`
+    /// the scratch URI would linger under its host until the host doc closes —
+    /// where it would receive a redundant second didClose. This guards that the
+    /// scratch lifecycle leaves no `host_to_virtual` residue.
+    #[tokio::test]
+    async fn close_scratch_document_removes_host_to_virtual_registration() {
+        let pool = LanguageServerPool::new();
+        let host_uri = Url::parse("file:///project/doc.md").unwrap();
+        let scratch_uri =
+            VirtualDocumentUri::new(&url_to_uri(&host_uri), "python", "REGION-scratch-0");
+
+        // Same path ensure_document_opened takes: register under the host.
+        pool.register_opened_document(&host_uri, &scratch_uri, "black")
+            .await;
+        assert_eq!(
+            pool.get_all_servers_for_virtual_uri(&scratch_uri),
+            vec!["black".to_string()],
+            "scratch doc should be reachable via host_to_virtual after register"
+        );
+
+        pool.close_scratch_document(&host_uri, &scratch_uri, "black")
+            .await;
+
+        // After close, the host_to_virtual registration is gone: closing the
+        // host document must NOT surface the scratch doc again (no double-close).
+        let remaining = pool.close_host_document(&host_uri).await;
+        assert!(
+            remaining
+                .iter()
+                .all(|d| d.virtual_uri.to_uri_string() != scratch_uri.to_uri_string()),
+            "scratch doc must not linger in host_to_virtual after close_scratch_document"
         );
     }
 

--- a/src/lsp/bridge/text_document/did_close.rs
+++ b/src/lsp/bridge/text_document/did_close.rs
@@ -99,11 +99,15 @@ impl LanguageServerPool {
         if !self.is_document_opened(scratch_uri) {
             return;
         }
-        // Remove from ALL tracking BEFORE awaiting the didClose send. Otherwise a
-        // concurrent `close_host_document` could still find this scratch URI in
-        // `host_to_virtual` while our didClose is in flight and issue a redundant
-        // double-close. `untrack_document` does not touch `host_to_virtual`, so we
-        // remove that registration (added by `ensure_document_opened`) explicitly.
+        // Remove from ALL tracking BEFORE awaiting the didClose send, to narrow
+        // the window in which a concurrent `close_host_document` finds this
+        // scratch URI in `host_to_virtual` and issues a redundant double-close.
+        // (It only narrows, not eliminates: if `close_host_document` already
+        // snapshotted the host's virtual-doc list before this removal, it can
+        // still send a second didClose — a harmless, best-effort redundancy the
+        // `is_document_opened` guard above also helps avoid.) `untrack_document`
+        // does not touch `host_to_virtual`, so we remove that registration (added
+        // by `ensure_document_opened`) explicitly.
         self.unregister_virtual_doc(host_uri, scratch_uri).await;
         self.untrack_document(scratch_uri, server_name).await;
         if let Err(e) = self

--- a/src/lsp/bridge/text_document/did_close.rs
+++ b/src/lsp/bridge/text_document/did_close.rs
@@ -188,9 +188,10 @@ mod tests {
     /// document.
     ///
     /// The concatenated formatting pipeline opens a throwaway scratch document
-    /// per step (a unique URI not registered under any host document) and must
-    /// be able to close + untrack it by URI alone — without going through the
-    /// `host_to_virtual` lookup that `close_host_document` uses. This guards the
+    /// per step (a unique URI registered in `host_to_virtual` under its host,
+    /// like any virtual doc) and must be able to close + untrack it by URI alone
+    /// — without going through the `host_to_virtual` ULID scan that
+    /// `close_host_document` uses. This guards the
     /// scratch lifecycle that isolates the pipeline's speculative state
     /// (concatenated-formatting-pipeline Decision point 7).
     #[tokio::test]

--- a/src/lsp/bridge/text_document/did_close.rs
+++ b/src/lsp/bridge/text_document/did_close.rs
@@ -73,10 +73,11 @@ impl LanguageServerPool {
     ///
     /// Used by the concatenated formatting pipeline, which opens a throwaway
     /// scratch virtual document per step (a unique URI carrying the accumulated
-    /// text). The handler closes these via an end-of-run sweep (and an abort-time
-    /// Drop guard) rather than per step — deferring keeps cancellation leak-free —
-    /// so they never orphan tracking state, accumulate downstream documents, or
-    /// leak diagnostics for the throwaway URI (concatenated-formatting-pipeline
+    /// text). The handler closes these from a single cancel-safe cleanup guard
+    /// (a `Drop` that runs on a detached task) rather than per step — deferring
+    /// keeps cancellation leak-free — so they never orphan tracking state,
+    /// accumulate downstream documents, or leak diagnostics for the throwaway URI
+    /// (concatenated-formatting-pipeline
     /// Decision point 7).
     ///
     /// The scratch URI is addressed directly (by URI + host) rather than looked

--- a/src/lsp/bridge/text_document/did_close.rs
+++ b/src/lsp/bridge/text_document/did_close.rs
@@ -111,6 +111,14 @@ impl LanguageServerPool {
         // `is_document_opened` guard above also helps avoid.) `untrack_document`
         // does not touch `host_to_virtual`, so we remove that registration (added
         // by `ensure_document_opened`) explicitly.
+        //
+        // Untrack-first (rather than didClose-first) is safe against cancel-drop
+        // because the concatenated pipeline's `ScratchCleanupGuard` runs this on a
+        // DETACHED task that is not a child of the aborted dispatch future — so the
+        // didClose await below always completes even when the caller is cancelled
+        // mid-flight. The ordering is therefore kept to preserve the
+        // double-close-race fix without reintroducing an orphaned-downstream-doc
+        // leak on cancel.
         self.unregister_virtual_doc(host_uri, scratch_uri).await;
         self.untrack_document(scratch_uri, server_name).await;
         if let Err(e) = self

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -221,7 +221,8 @@ async fn dispatch_preferred_formatting(
 /// Runs the region's priority-listed servers serially over the region's virtual
 /// content — each server formats the previous server's output — then collapses
 /// the final text into a single host-coordinate region-replacement edit. When
-/// nothing changed, contributes no edit.
+/// the final text is byte-identical to the region's original content (no step
+/// changed anything, or the changes round-tripped), contributes no edit.
 ///
 /// Each step targets a unique scratch virtual document
 /// ([`scratch_region_id`]), so the bridge always sends a fresh `didOpen`
@@ -406,17 +407,14 @@ async fn dispatch_concatenated_formatting(
                     }
                 };
 
-                // Close the scratch document promptly on the happy path so it
-                // does not orphan tracking state or leak downstream diagnostics
-                // for the throwaway URI (concatenated-formatting-pipeline
-                // Decision point 7). Remove it from the tracker first so the
-                // post-`select!` sweep never closes it a second time.
-                if let Some(scratch_uri) = scratch_uri.as_ref()
-                    && remove_open_scratch(&open_scratch, scratch_uri)
-                {
-                    pool.close_scratch_document(&uri, scratch_uri, &server_name)
-                        .await;
-                }
+                // Scratch-document cleanup is deferred to the post-`select!`
+                // sweep (`close_remaining_scratch_docs`), NOT closed here per
+                // step. The sweep always runs to completion, so a cancel that
+                // drops this step's future mid-flight can never leak a scratch
+                // doc; closing per-step inside the (cancellable) pipeline future
+                // could be interrupted after the tracker entry was already
+                // removed, leaking it. The scratch doc stays tracked in
+                // `open_scratch` (registered above) for the sweep to close.
 
                 // Hand the (unchanged) virtual text back to the pipeline along
                 // with the result so the pipeline can move it forward without a
@@ -444,10 +442,12 @@ async fn dispatch_concatenated_formatting(
         }
     };
 
-    // ALWAYS sweep up any scratch documents the run left open — on both the
-    // completed and cancelled paths. On the happy path this is normally empty
-    // (each step removed its own entry before closing); on cancel it closes the
-    // in-flight step's scratch document that was dropped before its own close.
+    // Close every scratch document the run opened — on both the completed and
+    // cancelled paths. This sweep is the single cleanup point (steps only
+    // register their scratch docs, never close them), so it runs to completion
+    // regardless of cancellation and can never leak. `close_scratch_document` is
+    // idempotent, so a doc already gone (e.g. via a concurrent host close) is a
+    // no-op.
     close_remaining_scratch_docs(&pool, &host_uri_for_sweep, &open_scratch).await;
 
     // On cancel, contribute no edit (matches the prior early-return behavior).
@@ -475,22 +475,6 @@ struct OpenScratchDoc {
 /// lock-recovery convention.
 fn push_open_scratch(open: &std::sync::Mutex<Vec<OpenScratchDoc>>, doc: OpenScratchDoc) {
     lock_open_scratch(open).push(doc);
-}
-
-/// Remove a scratch document from the open set by URI, returning `true` if it
-/// was present (i.e. this caller now owns closing it). Prevents the happy-path
-/// per-step close and the post-`select!` sweep from both closing the same doc.
-fn remove_open_scratch(
-    open: &std::sync::Mutex<Vec<OpenScratchDoc>>,
-    uri: &VirtualDocumentUri,
-) -> bool {
-    let mut guard = lock_open_scratch(open);
-    if let Some(pos) = guard.iter().position(|d| &d.uri == uri) {
-        guard.remove(pos);
-        true
-    } else {
-        false
-    }
 }
 
 /// Drain and return all still-open scratch documents.
@@ -854,45 +838,18 @@ mod tests {
     }
 
     #[test]
-    fn open_scratch_remove_prevents_double_close() {
-        // Happy path: a step removes its own scratch doc before closing it, so
-        // the post-select sweep must NOT see it again.
+    fn open_scratch_tracker_accumulates_every_step_for_the_sweep() {
+        // Steps only register their scratch docs; the post-select sweep is the
+        // single close point, so every pushed doc must still be present to drain.
         let open = std::sync::Mutex::new(Vec::new());
-        let doc = scratch_doc("file:///d.md", "R-scratch-0", "black");
-        let uri = doc.uri.clone();
-        push_open_scratch(&open, doc);
-
-        assert!(
-            remove_open_scratch(&open, &uri),
-            "first remove owns the close and returns true"
+        push_open_scratch(&open, scratch_doc("file:///d.md", "R-scratch-0", "black"));
+        push_open_scratch(&open, scratch_doc("file:///d.md", "R-scratch-1", "isort"));
+        let drained = drain_open_scratch(&open);
+        assert_eq!(
+            drained.len(),
+            2,
+            "the sweep must see every step's scratch doc"
         );
-        assert!(
-            !remove_open_scratch(&open, &uri),
-            "second remove must return false (already owned) to avoid double-close"
-        );
-        assert!(
-            drain_open_scratch(&open).is_empty(),
-            "removed doc must not be swept again"
-        );
-    }
-
-    #[test]
-    fn open_scratch_remove_keeps_other_entries() {
-        // Removing one in-flight step's scratch doc must not disturb others
-        // still tracked open (e.g. a concurrent step in a different run shape).
-        let open = std::sync::Mutex::new(Vec::new());
-        let keep = scratch_doc("file:///d.md", "R-scratch-0", "black");
-        let keep_uri = keep.uri.clone();
-        let remove = scratch_doc("file:///d.md", "R-scratch-1", "isort");
-        let remove_uri = remove.uri.clone();
-        push_open_scratch(&open, keep);
-        push_open_scratch(&open, remove);
-
-        assert!(remove_open_scratch(&open, &remove_uri));
-
-        let remaining = drain_open_scratch(&open);
-        assert_eq!(remaining.len(), 1);
-        assert_eq!(remaining[0].uri, keep_uri, "the other doc must survive");
     }
 
     #[test]

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -318,7 +318,11 @@ async fn dispatch_concatenated_formatting(
             let host_uri_lsp = host_uri_lsp.clone();
             let open_scratch = Arc::clone(&open_scratch);
             async move {
-                let server_config = server_config?;
+                // No config for this server name: skip-and-continue, handing the
+                // unchanged text back to the pipeline (ADR Decision point 6).
+                let Some(server_config) = server_config else {
+                    return (current_text, None);
+                };
                 let step = step_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 let scratch_id = scratch_region_id(&region_id, step);
 
@@ -346,7 +350,21 @@ async fn dispatch_concatenated_formatting(
                 // result by passing the zero offset for the response transform.
                 // The region offset is only re-applied once, when the final
                 // text is collapsed into the host replacement edit below.
-                let result = pool
+                //
+                // Per-step host-transform interaction: `send_formatting_request`
+                // runs `transform_formatting_response_to_host`, which clamps
+                // edits to a synthetic EOF and drops any past `virtual_line_count`
+                // for *this step's* `current_text`. Because we pass
+                // `RegionOffset::new(0, 0)` (an identity translation) and the
+                // step's own current text, those edits come back already
+                // EOF-clamped and host-translated by a zero offset — i.e. still
+                // in virtual coordinates relative to `current_text` — so applying
+                // them to the virtual accumulated text is correct. The single
+                // real region-offset translation happens once at the final
+                // collapse in `build_region_replacement_edit`.
+                // (`apply_text_edits` does its own clamping as a general safety
+                // net, independent of this transform.)
+                let send_result = pool
                     .send_formatting_request(
                         &server_name,
                         &server_config,
@@ -358,9 +376,25 @@ async fn dispatch_concatenated_formatting(
                         options,
                         upstream_id,
                     )
-                    .await
-                    .ok()
-                    .flatten();
+                    .await;
+
+                // ADR Decision point 6 (best-effort, skip-and-continue): a
+                // failed step is skipped — never surfaced to the editor — but is
+                // logged so the misbehaving server stays diagnosable. We log the
+                // downstream error here (before mapping to `None`) instead of
+                // silently dropping it with `.ok().flatten()`.
+                let result = match send_result {
+                    Ok(edits) => edits,
+                    Err(e) => {
+                        log::warn!(
+                            target: "kakehashi::formatting",
+                            "concatenated formatting step for server {} failed; skipping (ADR point 6): {}",
+                            server_name,
+                            e
+                        );
+                        None
+                    }
+                };
 
                 // Close the scratch document promptly on the happy path so it
                 // does not orphan tracking state or leak downstream diagnostics
@@ -374,7 +408,10 @@ async fn dispatch_concatenated_formatting(
                         .await;
                 }
 
-                result
+                // Hand the (unchanged) virtual text back to the pipeline along
+                // with the result so the pipeline can move it forward without a
+                // per-step clone.
+                (current_text, result)
             }
         }
     });

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -627,9 +627,11 @@ async fn close_remaining_scratch_docs(
 /// time (concurrent LSP requests, or a cancel+restart race) would otherwise both
 /// start at step 0 and collide on the same scratch virtual URI. Mixing in this
 /// run sequence makes scratch ids unique across concurrent runs in the process.
-static SCRATCH_RUN_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+// `AtomicUsize` (not `AtomicU64`) so the build stays portable to targets without
+// native 64-bit atomics; a pointer-width counter is more than enough for run ids.
+static SCRATCH_RUN_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
-fn scratch_region_id(region_id: &str, run: u64, step: usize) -> String {
+fn scratch_region_id(region_id: &str, run: usize, step: usize) -> String {
     format!("{region_id}-kakehashi-scratch-{run}-{step}")
 }
 

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -254,6 +254,11 @@ async fn dispatch_concatenated_formatting(
         region_ctx.resolved.line_column_offsets.clone(),
     );
     let original_virtual = region_ctx.resolved.virtual_content.clone();
+    // Precompute the host replacement range now, while we still hold
+    // `original_virtual`, so it can be moved into the pipeline below without a
+    // second clone. An unresolvable end position means we emit no edit (bounded
+    // -range safety) — so bail before doing any downstream work.
+    let replacement_range = region_replacement_range(&original_virtual, &offset)?;
     let injection_language = region_ctx.resolved.injection_language.clone();
     let region_id = region_ctx.resolved.region.region_id.clone();
     let uri = region_ctx.uri.clone();
@@ -304,7 +309,7 @@ async fn dispatch_concatenated_formatting(
     // the per-step closure below.
     let host_uri_for_sweep = uri.clone();
 
-    let pipeline_fut = run_sequential_format_pipeline(original_virtual.clone(), &server_names, {
+    let pipeline_fut = run_sequential_format_pipeline(original_virtual, &server_names, {
         let pool = Arc::clone(&pool);
         let open_scratch = Arc::clone(&open_scratch);
         move |server_name, current_text| {
@@ -361,8 +366,8 @@ async fn dispatch_concatenated_formatting(
                 // EOF-clamped and host-translated by a zero offset — i.e. still
                 // in virtual coordinates relative to `current_text` — so applying
                 // them to the virtual accumulated text is correct. The single
-                // real region-offset translation happens once at the final
-                // collapse in `build_region_replacement_edit`.
+                // real region-offset translation happens once in the precomputed
+                // `region_replacement_range`.
                 // (`apply_text_edits` does its own clamping as a general safety
                 // net, independent of this transform.)
                 let send_result = pool
@@ -447,7 +452,10 @@ async fn dispatch_concatenated_formatting(
     }
 
     let final_text = final_text?;
-    build_region_replacement_edit(&original_virtual, final_text, &offset).map(|edit| vec![edit])
+    Some(vec![TextEdit {
+        range: replacement_range,
+        new_text: final_text,
+    }])
 }
 
 /// A scratch virtual document opened during a concatenated-formatting run that
@@ -523,24 +531,25 @@ async fn close_remaining_scratch_docs(
 /// always performs a fresh `didOpen` carrying the current accumulated text.
 ///
 /// The id keeps the canonical `region_id` as a prefix (so it stays unique per
-/// region — no host-file collision) and appends a `-scratch-{step}` suffix so it
-/// is unique per pipeline step. It still flows through
-/// [`VirtualDocumentUri::new`], which wraps it in the distinctive
-/// `kakehashi-virtual-uri-` filename marker (Decision point 7) and preserves the
+/// region — no host-file collision) and appends a `-kakehashi-scratch-{step}`
+/// suffix: unique per pipeline step, and carrying the standardized
+/// `kakehashi-scratch` marker (Decision point 7) so external tools (file
+/// watchers, build tools, test runners) can recognize and ignore these throwaway
+/// documents. It still flows through [`VirtualDocumentUri::new`], which also
+/// wraps it in the `kakehashi-virtual-uri-` filename marker and preserves the
 /// host directory and language extension required for downstream config and
 /// parser discovery.
 fn scratch_region_id(region_id: &str, step: usize) -> String {
-    format!("{region_id}-scratch-{step}")
+    format!("{region_id}-kakehashi-scratch-{step}")
 }
 
-/// Build a single host-coordinate `TextEdit` that replaces the entire injection
-/// region with `final_text`.
+/// Compute the host-coordinate `Range` that the concatenated pipeline's single
+/// whole-region replacement edit spans.
 ///
-/// The replacement range spans the whole *original* virtual document (`(0,0)`
-/// through the end of `original_virtual`), translated to host coordinates via
-/// the region [`RegionOffset`]. Emitting one whole-region edit keeps the LSP
-/// output trivially non-overlapping (concatenated-formatting-pipeline Decision
-/// point 4).
+/// The range covers the whole *original* virtual document (`(0,0)` through the
+/// end of `original_virtual`), translated to host coordinates via the region
+/// [`RegionOffset`]. Emitting one whole-region edit keeps the LSP output
+/// trivially non-overlapping (concatenated-formatting-pipeline Decision point 4).
 ///
 /// Returns `None` when the virtual end position cannot be resolved, rather than
 /// fabricating an unbounded range. `byte_to_position` should always succeed for
@@ -556,14 +565,12 @@ fn scratch_region_id(region_id: &str, step: usize) -> String {
 /// verbatim and relies on the existing range translation only, so multi-line /
 /// blockquoted regions still drop host indentation on replacement lines — the
 /// same limitation documented in `src/lsp/bridge/text_document/formatting.rs`.
-fn build_region_replacement_edit(
-    original_virtual: &str,
-    final_text: String,
-    offset: &RegionOffset,
-) -> Option<TextEdit> {
+fn region_replacement_range(original_virtual: &str, offset: &RegionOffset) -> Option<Range> {
     // Virtual end position = the position of the very last byte, derived via the
     // shared PositionMapper so line-ending handling (incl. `\r\n`) and UTF-16
-    // column math stay consistent with the rest of the codebase.
+    // column math stay consistent with the rest of the codebase. Computed from
+    // the original virtual text *before* it is moved into the pipeline, so the
+    // pipeline takes ownership without a second clone.
     let end = crate::text::PositionMapper::new(original_virtual)
         .byte_to_position(original_virtual.len())?;
 
@@ -575,11 +582,7 @@ fn build_region_replacement_edit(
         end,
     };
     translate_virtual_range_to_host(&mut range, offset);
-
-    Some(TextEdit {
-        range,
-        new_text: final_text,
-    })
+    Some(range)
 }
 
 /// Sort `edits` in place by `range.start` (line, then character).
@@ -895,33 +898,31 @@ mod tests {
     }
 
     // ==========================================================================
-    // build_region_replacement_edit (review: unbounded-range fallback)
+    // region_replacement_range (review: unbounded-range fallback)
     // ==========================================================================
 
     #[test]
-    fn build_region_replacement_edit_resolves_end_for_valid_text() {
+    fn region_replacement_range_resolves_end_for_valid_text() {
         // For any valid UTF-8 region the end position is resolvable, so we get a
-        // bounded replacement edit — never the old u32::MAX/u32::MAX fallback.
+        // bounded replacement range — never the old u32::MAX/u32::MAX fallback.
         let offset = RegionOffset::new(0, 0);
-        let edit = build_region_replacement_edit("line1\nline2", "formatted".to_string(), &offset)
+        let range = region_replacement_range("line1\nline2", &offset)
             .expect("end position must resolve for valid text");
-        assert_eq!(edit.new_text, "formatted");
         // End is the position just past the last byte: line 1, char 5 ("line2").
-        assert_eq!(edit.range.end.line, 1);
-        assert_eq!(edit.range.end.character, 5);
+        assert_eq!(range.end.line, 1);
+        assert_eq!(range.end.character, 5);
         // Crucially, the range is bounded (no fabricated u32::MAX).
-        assert_ne!(edit.range.end.line, u32::MAX);
-        assert_ne!(edit.range.end.character, u32::MAX);
+        assert_ne!(range.end.line, u32::MAX);
+        assert_ne!(range.end.character, u32::MAX);
     }
 
     #[test]
-    fn build_region_replacement_edit_handles_empty_region() {
-        // Empty region → end at (0,0), still a bounded Some(edit).
+    fn region_replacement_range_handles_empty_region() {
+        // Empty region → end at (0,0), still a bounded Some(range).
         let offset = RegionOffset::new(0, 0);
-        let edit = build_region_replacement_edit("", "new".to_string(), &offset)
-            .expect("empty region must still resolve to a bounded edit");
-        assert_eq!(edit.range.end.line, 0);
-        assert_eq!(edit.range.end.character, 0);
+        let range = region_replacement_range("", &offset).expect("empty region must still resolve");
+        assert_eq!(range.end.line, 0);
+        assert_eq!(range.end.character, 0);
     }
 
     #[test]

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -478,6 +478,7 @@ async fn dispatch_concatenated_formatting(
 /// A scratch virtual document opened during a concatenated-formatting run that
 /// has not yet been closed. Paired with its `server_name` so the `didClose`
 /// targets the connection the matching `didOpen` was sent on.
+#[derive(Clone)]
 struct OpenScratchDoc {
     uri: VirtualDocumentUri,
     server_name: String,
@@ -592,20 +593,22 @@ async fn close_remaining_scratch_docs(
     host_uri: &url::Url,
     open: &std::sync::Mutex<Vec<OpenScratchDoc>>,
 ) {
-    // Pop one at a time rather than draining the whole vector up front, so any
-    // docs not yet popped stay tracked in the mutex: if this sweep is itself
-    // cancelled mid-`.await`, the still-tracked docs remain visible to
-    // `ScratchCleanupGuard` (which drains on drop) instead of being lost — closing
-    // the leak window a drain-all-then-loop would open.
-    //
-    // NB: the `pop` is its own statement, not a `while let` scrutinee, so the
-    // non-`Send` `MutexGuard` is dropped at the `;` before the `.await` (otherwise
-    // the spawned region task's future would not be `Send`).
+    // Peek-close-remove, one doc at a time: clone the last tracked doc WITHOUT
+    // removing it, close it, then remove it only after the close completes. If
+    // this sweep is itself cancelled mid-`.await`, the in-flight doc is still
+    // tracked, so `ScratchCleanupGuard` (which drains on drop) still catches it —
+    // zero leak, not even the single in-flight doc that a pop-then-close would
+    // drop. The lock guards are scoped to their `let`/block so the non-`Send`
+    // `MutexGuard` never crosses the `.await` (keeping the region task `Send`).
     loop {
-        let next = lock_open_scratch(open).pop();
+        let next = {
+            let guard = lock_open_scratch(open);
+            guard.last().cloned()
+        };
         let Some(doc) = next else { break };
         pool.close_scratch_document(host_uri, &doc.uri, &doc.server_name)
             .await;
+        lock_open_scratch(open).retain(|d| d.uri != doc.uri);
     }
 }
 

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -302,13 +302,13 @@ async fn dispatch_concatenated_formatting(
     // close. The scratch doc is also swept on the host document's own close.
     let host_uri_lsp = crate::lsp::lsp_impl::url_to_uri(&uri).ok();
 
-    // Track every scratch document opened during this run that has NOT yet been
-    // closed, so we can guarantee cleanup even when a `tokio::select!` cancel
-    // drops the in-flight step future BEFORE its own `close_scratch_document`
-    // runs. Two reviewers flagged that drop-on-cancel as a scratch-document
-    // leak. The happy per-step path still closes immediately and removes its
-    // entry here, so the post-`select!` sweep only closes whatever a cancel
-    // left behind — no double-close.
+    // Track every scratch document opened during this run. Steps only register
+    // their scratch docs here; they never close them per step. All closing
+    // happens in the post-`select!` sweep (`close_remaining_scratch_docs`, which
+    // pops one at a time) and, if the task is aborted before the sweep runs, in
+    // `ScratchCleanupGuard`'s drop (which drains and closes on a detached task).
+    // Deferring all cleanup to those two cancel-safe points is what guarantees a
+    // cancel can never leak a scratch document downstream.
     let open_scratch: Arc<std::sync::Mutex<Vec<OpenScratchDoc>>> =
         Arc::new(std::sync::Mutex::new(Vec::new()));
 

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -39,7 +39,9 @@ use crate::lsp::aggregation::region::collect_region_results_with_cancel;
 use crate::lsp::aggregation::server::FanInResult;
 use crate::lsp::aggregation::server::dispatch_preferred;
 use crate::lsp::aggregation::server::run_sequential_format_pipeline;
-use crate::lsp::bridge::{RegionOffset, UpstreamId, translate_virtual_range_to_host};
+use crate::lsp::bridge::{
+    RegionOffset, UpstreamId, VirtualDocumentUri, translate_virtual_range_to_host,
+};
 use crate::lsp::lsp_impl::bridge_context::DocumentRequestContext;
 use crate::lsp::request_id::{CancelReceiver, CancelSubscriptionGuard};
 
@@ -219,14 +221,20 @@ async fn dispatch_preferred_formatting(
 /// the final text into a single host-coordinate region-replacement edit. When
 /// nothing changed, contributes no edit.
 ///
-/// TODO(concatenated-formatting-pipeline): this first slice reuses the existing
-/// `send_formatting_request` path for each step. Still to build (see the ADR):
-///   - scratch-document isolation (per-step didOpen/didClose with a unique
-///     scratch URI) so the canonical virtual document is never mutated;
+/// Each step targets a unique scratch virtual document
+/// ([`scratch_region_id`]), so the bridge always sends a fresh `didOpen`
+/// carrying the current accumulated text — fixing the stale-content bug where a
+/// step reused an already-open canonical document and formatted the *original*
+/// region text. The scratch document is `didClose`d after the step
+/// (concatenated-formatting-pipeline Decision point 7).
+///
+/// TODO(concatenated-formatting-pipeline): still to build (see the ADR):
 ///   - capability-based full -> rangeFormatting fallback for range-only servers,
 ///     distinguishing "no capability" from a `null` "already formatted";
 ///   - per-step remaining-budget timeout and concurrent $/cancelRequest
-///     propagation (Decision points 6 and the Consequences cancellation note).
+///     propagation (Decision points 6 and the Consequences cancellation note);
+///   - discarding downstream `publishDiagnostics` targeting scratch URIs;
+///     prompt didClose currently minimizes (but does not eliminate) the window.
 async fn dispatch_concatenated_formatting(
     region_ctx: &DocumentRequestContext,
     pool: Arc<crate::lsp::bridge::LanguageServerPool>,
@@ -265,6 +273,23 @@ async fn dispatch_concatenated_formatting(
             .map(|c| Arc::clone(&c.config))
     };
 
+    // Each pipeline step targets a *fresh* scratch virtual document so the
+    // bridge always performs a new `didOpen` carrying the current accumulated
+    // text. Reusing the canonical region virtual document would make a step
+    // format STALE text whenever that document is already open downstream (e.g.
+    // after a prior hover/diagnostic), because `send_formatting_request` only
+    // pushes content on the first `didOpen` (concatenated-formatting-pipeline
+    // Decision point 7, stale-content bug). The per-step counter makes the
+    // scratch id unique; the scratch document is `didClose`d after the step so
+    // it never orphans tracking state or leaks diagnostics.
+    let step_counter = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    // Convert the host URL to the bridge protocol's `Uri` once. On the
+    // unreachable conversion failure the per-step didClose is skipped (the
+    // scratch document is still cleaned up when the host document closes), but
+    // the unique-URI didOpen — the correctness core — still happens because the
+    // scratch id is passed to `send_formatting_request` directly.
+    let host_uri_lsp = crate::lsp::lsp_impl::url_to_uri(&uri).ok();
+
     let pipeline_fut = run_sequential_format_pipeline(original_virtual.clone(), &server_names, {
         let pool = Arc::clone(&pool);
         move |server_name, current_text| {
@@ -275,28 +300,47 @@ async fn dispatch_concatenated_formatting(
             let uri = uri.clone();
             let upstream_id = upstream_id.clone();
             let server_config = server_config_for(&server_name);
+            let step_counter = Arc::clone(&step_counter);
+            let host_uri_lsp = host_uri_lsp.clone();
             async move {
                 let server_config = server_config?;
+                let step = step_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                let scratch_id = scratch_region_id(&region_id, step);
                 // The bridge translates the returned edits back to host
                 // coordinates, but the pipeline applies them to the *virtual*
                 // accumulated text, so request a fresh virtual-coordinate
                 // result by passing the zero offset for the response transform.
                 // The region offset is only re-applied once, when the final
                 // text is collapsed into the host replacement edit below.
-                pool.send_formatting_request(
-                    &server_name,
-                    &server_config,
-                    &uri,
-                    &injection_language,
-                    &region_id,
-                    RegionOffset::new(0, 0),
-                    &current_text,
-                    options,
-                    upstream_id,
-                )
-                .await
-                .ok()
-                .flatten()
+                let result = pool
+                    .send_formatting_request(
+                        &server_name,
+                        &server_config,
+                        &uri,
+                        &injection_language,
+                        &scratch_id,
+                        RegionOffset::new(0, 0),
+                        &current_text,
+                        options,
+                        upstream_id,
+                    )
+                    .await
+                    .ok()
+                    .flatten();
+
+                // Close the scratch document promptly so it does not orphan
+                // tracking state or leak downstream diagnostics for the
+                // throwaway URI (concatenated-formatting-pipeline Decision
+                // point 7). Best-effort: a close failure must not abort the
+                // pipeline step.
+                if let Some(host_uri_lsp) = host_uri_lsp.as_ref() {
+                    let scratch_uri =
+                        VirtualDocumentUri::new(host_uri_lsp, &injection_language, &scratch_id);
+                    pool.close_scratch_document(&scratch_uri, &server_name)
+                        .await;
+                }
+
+                result
             }
         }
     });
@@ -320,6 +364,31 @@ async fn dispatch_concatenated_formatting(
         final_text,
         &offset,
     )])
+}
+
+/// Derive a unique scratch `region_id` for one step of the concatenated
+/// formatting pipeline.
+///
+/// The pipeline feeds each server the *previous* server's output by passing the
+/// accumulated text to `send_formatting_request`. But the bridge only pushes
+/// that content downstream via `didOpen` when the virtual document is not yet
+/// open (`ensure_document_opened`); if the canonical region virtual document is
+/// already open for that server (common after a prior hover/diagnostic), the
+/// formatting request reuses the stale open document and the server formats the
+/// *original* region text, breaking the serial semantics
+/// (concatenated-formatting-pipeline, the stale-content bug). Giving each step a
+/// distinct `region_id` yields a distinct [`VirtualDocumentUri`], so the bridge
+/// always performs a fresh `didOpen` carrying the current accumulated text.
+///
+/// The id keeps the canonical `region_id` as a prefix (so it stays unique per
+/// region — no host-file collision) and appends a `-scratch-{step}` suffix so it
+/// is unique per pipeline step. It still flows through
+/// [`VirtualDocumentUri::new`], which wraps it in the distinctive
+/// `kakehashi-virtual-uri-` filename marker (Decision point 7) and preserves the
+/// host directory and language extension required for downstream config and
+/// parser discovery.
+fn scratch_region_id(region_id: &str, step: usize) -> String {
+    format!("{region_id}-scratch-{step}")
 }
 
 /// Build a single host-coordinate `TextEdit` that replaces the entire injection
@@ -524,6 +593,66 @@ mod tests {
             },
             new_text: new_text.to_string(),
         }
+    }
+
+    // ==========================================================================
+    // scratch_region_id (concatenated-formatting-pipeline: stale-content fix)
+    // ==========================================================================
+
+    #[test]
+    fn scratch_region_id_is_unique_per_step() {
+        // Each pipeline step must get a distinct scratch id so the bridge builds
+        // a distinct virtual URI and re-sends a fresh didOpen with the current
+        // accumulated text (rather than reusing the prior step's stale document).
+        let a = scratch_region_id("REGION", 0);
+        let b = scratch_region_id("REGION", 1);
+        let c = scratch_region_id("REGION", 2);
+        assert_ne!(a, b);
+        assert_ne!(b, c);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn scratch_region_id_differs_from_canonical_region_id() {
+        // The scratch document must never collide with the region's canonical
+        // virtual document (which other requests like hover keep open).
+        let region_id = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+        assert_ne!(scratch_region_id(region_id, 0), region_id);
+    }
+
+    #[test]
+    fn scratch_region_id_keeps_region_id_as_prefix() {
+        // Preserving the region_id prefix keeps the scratch id unique per region
+        // (no host-file collision across regions).
+        let id = scratch_region_id("REGION", 3);
+        assert!(
+            id.starts_with("REGION"),
+            "scratch id should keep the region_id prefix: {id}"
+        );
+    }
+
+    #[test]
+    fn scratch_region_id_produces_virtual_uri_with_marker_and_extension() {
+        // The scratch id must flow through VirtualDocumentUri to keep the host
+        // directory + language extension (config/parser discovery) and the
+        // distinctive kakehashi-virtual-uri- marker (Decision point 7).
+        use crate::lsp::bridge::VirtualDocumentUri;
+        let host_uri: tower_lsp_server::ls_types::Uri = "file:///project/doc.md".parse().unwrap();
+        let id = scratch_region_id("REGION", 1);
+        let virtual_uri = VirtualDocumentUri::new(&host_uri, "python", &id);
+        let uri_string = virtual_uri.to_uri_string();
+        assert!(
+            uri_string.starts_with("file:///project/kakehashi-virtual-uri-"),
+            "scratch URI must keep host dir + marker: {uri_string}"
+        );
+        assert!(
+            uri_string.ends_with(".py"),
+            "scratch URI must keep the language extension: {uri_string}"
+        );
+        assert!(
+            VirtualDocumentUri::is_virtual_uri(&uri_string),
+            "scratch URI must be recognized as virtual: {uri_string}"
+        );
     }
 
     #[test]

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -34,6 +34,7 @@ use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::{DocumentFormattingParams, Position, Range, TextEdit};
 
 use crate::config::settings::AggregationStrategy;
+use crate::error::LockResultExt;
 use crate::language::InjectionResolver;
 use crate::lsp::aggregation::region::collect_region_results_with_cancel;
 use crate::lsp::aggregation::server::FanInResult;
@@ -452,16 +453,7 @@ fn drain_open_scratch(open: &std::sync::Mutex<Vec<OpenScratchDoc>>) -> Vec<OpenS
 fn lock_open_scratch(
     open: &std::sync::Mutex<Vec<OpenScratchDoc>>,
 ) -> std::sync::MutexGuard<'_, Vec<OpenScratchDoc>> {
-    match open.lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => {
-            log::warn!(
-                target: "kakehashi::lock_recovery",
-                "Recovered from poisoned scratch-document tracker lock"
-            );
-            poisoned.into_inner()
-        }
-    }
+    open.lock().recover_poison("scratch-document tracker")
 }
 
 /// Close every scratch document still tracked as open. Used on both the

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -3,16 +3,19 @@
 //!
 //! `textDocument/formatting` resolves every injection region in the document
 //! and asks the configured downstream language servers to format each one.
-//! Within a region, [`dispatch_preferred`] picks the highest-priority
-//! non-empty response (the `preferred` aggregation strategy). Across regions
-//! the resulting [`TextEdit`] lists are concatenated, since each region edits
-//! a disjoint span of the host document.
+//! Across regions the resulting [`TextEdit`] lists are concatenated, since each
+//! region edits a disjoint span of the host document.
 //!
-//! The `concatenated` aggregation strategy is intentionally not implemented
-//! here: formatters from different servers tend to produce conflicting edits
-//! over the same range, so merging them would violate the LSP "edits must not
-//! overlap" rule. If multiple servers are configured, configure a priority
-//! ordering (or rely on first-win) to pick one.
+//! Within a region, the aggregation strategy decides how multiple servers
+//! combine:
+//! - `preferred` (default) — [`dispatch_preferred_formatting`] picks the
+//!   highest-priority non-empty response.
+//! - `concatenated` (with a non-empty `priorities` allowlist) —
+//!   [`dispatch_concatenated_formatting`] runs the listed servers **serially**
+//!   (each formats the previous server's output) and collapses the result into
+//!   one region-replacement edit. Serial application keeps the output
+//!   overlap-free without merging conflicting edits. See
+//!   concatenated-formatting-pipeline.
 //!
 //! # Shared helpers exposed to `range_formatting`
 //!

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -134,15 +134,19 @@ impl Kakehashi {
             let options = options.clone();
             let region_cancel_rx = cancel_state.derive_receiver();
 
-            // `strategy: "concatenated"` with a non-empty priorities list opts
-            // this region into the sequential formatter pipeline
-            // (concatenated-formatting-pipeline): run the priority-listed
-            // servers serially, each formatting the prior server's output, then
-            // emit one region-replacement edit. Everything else (default
-            // `preferred`, or `concatenated` with no priorities — a
-            // misconfiguration) keeps the existing first-non-empty-wins path.
+            // `strategy: "concatenated"` with a non-empty *effective* priorities
+            // list opts this region into the sequential formatter pipeline
+            // (concatenated-formatting-pipeline): run the priority-listed servers
+            // serially, each formatting the prior server's output, then emit one
+            // region-replacement edit. Gating on `effective_priorities` (not the
+            // raw `priorities`) means a list of only unknown/typo'd server names
+            // falls through to the `preferred` path — which still uses the
+            // region's configured servers — rather than entering the pipeline and
+            // formatting nothing. Default `preferred`, or `concatenated` with no
+            // effective priorities, keeps the first-non-empty-wins path.
+            let pipeline_servers = effective_priorities(&region_ctx);
             let use_concatenated = region_ctx.strategy == AggregationStrategy::Concatenated
-                && !region_ctx.priorities.is_empty();
+                && !pipeline_servers.is_empty();
 
             outer_join_set.spawn(async move {
                 if use_concatenated {
@@ -150,6 +154,7 @@ impl Kakehashi {
                         &region_ctx,
                         pool.clone(),
                         options,
+                        pipeline_servers,
                         region_cancel_rx,
                     )
                     .await
@@ -253,6 +258,9 @@ async fn dispatch_concatenated_formatting(
     region_ctx: &DocumentRequestContext,
     pool: Arc<crate::lsp::bridge::LanguageServerPool>,
     options: tower_lsp_server::ls_types::FormattingOptions,
+    // The effective (configured, deduped, order-preserving) priority list,
+    // computed by the caller — which also gates entry on it being non-empty.
+    server_names: Vec<String>,
     cancel_rx: Option<CancelReceiver>,
 ) -> Option<Vec<TextEdit>> {
     let offset = RegionOffset::with_per_line_offsets(
@@ -269,11 +277,6 @@ async fn dispatch_concatenated_formatting(
     let region_id = region_ctx.resolved.region.region_id.clone();
     let uri = region_ctx.uri.clone();
     let upstream_id = region_ctx.upstream_request_id.clone();
-
-    // `priorities` is both the membership allowlist and the application order;
-    // `effective_priorities` keeps only entries configured for this region —
-    // shared with the preferred fan-out so the rule has one source of truth.
-    let server_names = effective_priorities(region_ctx);
 
     let server_config_for = |name: &str| {
         region_ctx

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -229,6 +229,12 @@ async fn dispatch_preferred_formatting(
 /// region text. The scratch document is `didClose`d after the step
 /// (concatenated-formatting-pipeline Decision point 7).
 ///
+/// Cleanup is guaranteed even on cancel: every opened-but-not-yet-closed scratch
+/// document is tracked, and a sweep after the cancel-aware `select!` closes any
+/// the per-step path did not. Without this, a `$/cancelRequest` that drops the
+/// in-flight step future before its own `close_scratch_document` ran would leak
+/// that scratch virtual document downstream (review HIGH).
+///
 /// TODO(concatenated-formatting-pipeline): still to build (see the ADR):
 ///   - capability-based full -> rangeFormatting fallback for range-only servers,
 ///     distinguishing "no capability" from a `null` "already formatted";
@@ -282,8 +288,23 @@ async fn dispatch_concatenated_formatting(
     // scratch id is passed to `send_formatting_request` directly.
     let host_uri_lsp = crate::lsp::lsp_impl::url_to_uri(&uri).ok();
 
+    // Track every scratch document opened during this run that has NOT yet been
+    // closed, so we can guarantee cleanup even when a `tokio::select!` cancel
+    // drops the in-flight step future BEFORE its own `close_scratch_document`
+    // runs. Two reviewers flagged that drop-on-cancel as a scratch-document
+    // leak. The happy per-step path still closes immediately and removes its
+    // entry here, so the post-`select!` sweep only closes whatever a cancel
+    // left behind — no double-close.
+    let open_scratch: Arc<std::sync::Mutex<Vec<OpenScratchDoc>>> =
+        Arc::new(std::sync::Mutex::new(Vec::new()));
+
+    // Retained for the post-`select!` cleanup sweep, since `uri` is moved into
+    // the per-step closure below.
+    let host_uri_for_sweep = uri.clone();
+
     let pipeline_fut = run_sequential_format_pipeline(original_virtual.clone(), &server_names, {
         let pool = Arc::clone(&pool);
+        let open_scratch = Arc::clone(&open_scratch);
         move |server_name, current_text| {
             let pool = Arc::clone(&pool);
             let options = options.clone();
@@ -294,10 +315,30 @@ async fn dispatch_concatenated_formatting(
             let server_config = server_config_for(&server_name);
             let step_counter = Arc::clone(&step_counter);
             let host_uri_lsp = host_uri_lsp.clone();
+            let open_scratch = Arc::clone(&open_scratch);
             async move {
                 let server_config = server_config?;
                 let step = step_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 let scratch_id = scratch_region_id(&region_id, step);
+
+                // Build the scratch URI up front and register it as "open" in the
+                // shared tracker BEFORE the request, so that if this future is
+                // dropped mid-send by a cancel, the post-`select!` sweep still
+                // closes it. Skipped only when the host URL could not be
+                // converted (then no didClose is possible anyway).
+                let scratch_uri = host_uri_lsp
+                    .as_ref()
+                    .map(|h| VirtualDocumentUri::new(h, &injection_language, &scratch_id));
+                if let Some(scratch_uri) = scratch_uri.as_ref() {
+                    push_open_scratch(
+                        &open_scratch,
+                        OpenScratchDoc {
+                            uri: scratch_uri.clone(),
+                            server_name: server_name.clone(),
+                        },
+                    );
+                }
+
                 // The bridge translates the returned edits back to host
                 // coordinates, but the pipeline applies them to the *virtual*
                 // accumulated text, so request a fresh virtual-coordinate
@@ -320,15 +361,15 @@ async fn dispatch_concatenated_formatting(
                     .ok()
                     .flatten();
 
-                // Close the scratch document promptly so it does not orphan
-                // tracking state or leak downstream diagnostics for the
-                // throwaway URI (concatenated-formatting-pipeline Decision
-                // point 7). Best-effort: a close failure must not abort the
-                // pipeline step.
-                if let Some(host_uri_lsp) = host_uri_lsp.as_ref() {
-                    let scratch_uri =
-                        VirtualDocumentUri::new(host_uri_lsp, &injection_language, &scratch_id);
-                    pool.close_scratch_document(&scratch_uri, &server_name)
+                // Close the scratch document promptly on the happy path so it
+                // does not orphan tracking state or leak downstream diagnostics
+                // for the throwaway URI (concatenated-formatting-pipeline
+                // Decision point 7). Remove it from the tracker first so the
+                // post-`select!` sweep never closes it a second time.
+                if let Some(scratch_uri) = scratch_uri.as_ref()
+                    && remove_open_scratch(&open_scratch, scratch_uri)
+                {
+                    pool.close_scratch_document(&uri, scratch_uri, &server_name)
                         .await;
                 }
 
@@ -341,21 +382,100 @@ async fn dispatch_concatenated_formatting(
     // $/cancelRequest aborts the region promptly rather than only between steps.
     // (Per-step $/cancelRequest propagation to the downstream server is a
     // follow-up — TODO(concatenated-formatting-pipeline).)
+    let cancelled;
     let final_text = match cancel_rx {
         Some(mut rx) => {
             tokio::select! {
-                res = pipeline_fut => res?,
-                _ = &mut rx => return None,
+                res = pipeline_fut => { cancelled = false; res }
+                _ = &mut rx => { cancelled = true; None }
             }
         }
-        None => pipeline_fut.await?,
+        None => {
+            cancelled = false;
+            pipeline_fut.await
+        }
     };
 
-    Some(vec![build_region_replacement_edit(
-        &original_virtual,
-        final_text,
-        &offset,
-    )])
+    // ALWAYS sweep up any scratch documents the run left open — on both the
+    // completed and cancelled paths. On the happy path this is normally empty
+    // (each step removed its own entry before closing); on cancel it closes the
+    // in-flight step's scratch document that was dropped before its own close.
+    close_remaining_scratch_docs(&pool, &host_uri_for_sweep, &open_scratch).await;
+
+    // On cancel, contribute no edit (matches the prior early-return behavior).
+    if cancelled {
+        return None;
+    }
+
+    let final_text = final_text?;
+    build_region_replacement_edit(&original_virtual, final_text, &offset).map(|edit| vec![edit])
+}
+
+/// A scratch virtual document opened during a concatenated-formatting run that
+/// has not yet been closed. Paired with its `server_name` so the `didClose`
+/// targets the connection the matching `didOpen` was sent on.
+struct OpenScratchDoc {
+    uri: VirtualDocumentUri,
+    server_name: String,
+}
+
+/// Record a scratch document as open. Poison-safe: a poisoned mutex is recovered
+/// (the tracked data is plain values, not invariants), logged per the project
+/// lock-recovery convention.
+fn push_open_scratch(open: &std::sync::Mutex<Vec<OpenScratchDoc>>, doc: OpenScratchDoc) {
+    lock_open_scratch(open).push(doc);
+}
+
+/// Remove a scratch document from the open set by URI, returning `true` if it
+/// was present (i.e. this caller now owns closing it). Prevents the happy-path
+/// per-step close and the post-`select!` sweep from both closing the same doc.
+fn remove_open_scratch(
+    open: &std::sync::Mutex<Vec<OpenScratchDoc>>,
+    uri: &VirtualDocumentUri,
+) -> bool {
+    let mut guard = lock_open_scratch(open);
+    if let Some(pos) = guard.iter().position(|d| &d.uri == uri) {
+        guard.remove(pos);
+        true
+    } else {
+        false
+    }
+}
+
+/// Drain and return all still-open scratch documents.
+fn drain_open_scratch(open: &std::sync::Mutex<Vec<OpenScratchDoc>>) -> Vec<OpenScratchDoc> {
+    std::mem::take(&mut *lock_open_scratch(open))
+}
+
+/// Lock the open-scratch tracker, recovering from poisoning per the project
+/// convention (no `unwrap()` on locks).
+fn lock_open_scratch(
+    open: &std::sync::Mutex<Vec<OpenScratchDoc>>,
+) -> std::sync::MutexGuard<'_, Vec<OpenScratchDoc>> {
+    match open.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => {
+            log::warn!(
+                target: "kakehashi::lock_recovery",
+                "Recovered from poisoned scratch-document tracker lock"
+            );
+            poisoned.into_inner()
+        }
+    }
+}
+
+/// Close every scratch document still tracked as open. Used on both the
+/// completed and cancelled paths so a cancel that drops an in-flight step never
+/// leaves its scratch virtual document open downstream.
+async fn close_remaining_scratch_docs(
+    pool: &crate::lsp::bridge::LanguageServerPool,
+    host_uri: &url::Url,
+    open: &std::sync::Mutex<Vec<OpenScratchDoc>>,
+) {
+    for doc in drain_open_scratch(open) {
+        pool.close_scratch_document(host_uri, &doc.uri, &doc.server_name)
+            .await;
+    }
 }
 
 /// Derive a unique scratch `region_id` for one step of the concatenated
@@ -392,6 +512,13 @@ fn scratch_region_id(region_id: &str, step: usize) -> String {
 /// output trivially non-overlapping (concatenated-formatting-pipeline Decision
 /// point 4).
 ///
+/// Returns `None` when the virtual end position cannot be resolved, rather than
+/// fabricating an unbounded range. `byte_to_position` should always succeed for
+/// the document's own length, but if it ever returns `None` (a mapper bug or
+/// corrupt content), emitting a `u32::MAX`/`u32::MAX` range would translate into
+/// a host edit spanning essentially the whole file — silently corrupting it. We
+/// emit no edit for that region instead, which is the safe degradation.
+///
 /// TODO(concatenated-formatting-pipeline): Decision point 4 also requires
 /// re-applying the region's per-line host prefix/indentation to every line of
 /// `final_text` (and the region LCP for new lines on a line-count change), plus
@@ -403,16 +530,12 @@ fn build_region_replacement_edit(
     original_virtual: &str,
     final_text: String,
     offset: &RegionOffset,
-) -> TextEdit {
+) -> Option<TextEdit> {
     // Virtual end position = the position of the very last byte, derived via the
     // shared PositionMapper so line-ending handling (incl. `\r\n`) and UTF-16
     // column math stay consistent with the rest of the codebase.
     let end = crate::text::PositionMapper::new(original_virtual)
-        .byte_to_position(original_virtual.len())
-        .unwrap_or(Position {
-            line: u32::MAX,
-            character: u32::MAX,
-        });
+        .byte_to_position(original_virtual.len())?;
 
     let mut range = Range {
         start: Position {
@@ -423,10 +546,10 @@ fn build_region_replacement_edit(
     };
     translate_virtual_range_to_host(&mut range, offset);
 
-    TextEdit {
+    Some(TextEdit {
         range,
         new_text: final_text,
-    }
+    })
 }
 
 /// Sort `edits` in place by `range.start` (line, then character).
@@ -645,6 +768,130 @@ mod tests {
             VirtualDocumentUri::is_virtual_uri(&uri_string),
             "scratch URI must be recognized as virtual: {uri_string}"
         );
+    }
+
+    // ==========================================================================
+    // Scratch-document tracking/cleanup (review HIGH: leak-on-cancel)
+    // ==========================================================================
+
+    fn scratch_doc(host: &str, id: &str, server: &str) -> OpenScratchDoc {
+        let host_uri: tower_lsp_server::ls_types::Uri = host.parse().unwrap();
+        OpenScratchDoc {
+            uri: VirtualDocumentUri::new(&host_uri, "python", id),
+            server_name: server.to_string(),
+        }
+    }
+
+    #[test]
+    fn open_scratch_tracker_drains_what_was_pushed() {
+        // The cancel-path sweep relies on draining everything that was recorded
+        // open but never removed by a per-step close.
+        let open = std::sync::Mutex::new(Vec::new());
+        push_open_scratch(&open, scratch_doc("file:///d.md", "R-scratch-0", "black"));
+        push_open_scratch(&open, scratch_doc("file:///d.md", "R-scratch-1", "isort"));
+
+        let drained = drain_open_scratch(&open);
+        assert_eq!(drained.len(), 2, "both opened scratch docs must be drained");
+        assert!(
+            drain_open_scratch(&open).is_empty(),
+            "drain must leave the tracker empty (no double-close)"
+        );
+    }
+
+    #[test]
+    fn open_scratch_remove_prevents_double_close() {
+        // Happy path: a step removes its own scratch doc before closing it, so
+        // the post-select sweep must NOT see it again.
+        let open = std::sync::Mutex::new(Vec::new());
+        let doc = scratch_doc("file:///d.md", "R-scratch-0", "black");
+        let uri = doc.uri.clone();
+        push_open_scratch(&open, doc);
+
+        assert!(
+            remove_open_scratch(&open, &uri),
+            "first remove owns the close and returns true"
+        );
+        assert!(
+            !remove_open_scratch(&open, &uri),
+            "second remove must return false (already owned) to avoid double-close"
+        );
+        assert!(
+            drain_open_scratch(&open).is_empty(),
+            "removed doc must not be swept again"
+        );
+    }
+
+    #[test]
+    fn open_scratch_remove_keeps_other_entries() {
+        // Removing one in-flight step's scratch doc must not disturb others
+        // still tracked open (e.g. a concurrent step in a different run shape).
+        let open = std::sync::Mutex::new(Vec::new());
+        let keep = scratch_doc("file:///d.md", "R-scratch-0", "black");
+        let keep_uri = keep.uri.clone();
+        let remove = scratch_doc("file:///d.md", "R-scratch-1", "isort");
+        let remove_uri = remove.uri.clone();
+        push_open_scratch(&open, keep);
+        push_open_scratch(&open, remove);
+
+        assert!(remove_open_scratch(&open, &remove_uri));
+
+        let remaining = drain_open_scratch(&open);
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].uri, keep_uri, "the other doc must survive");
+    }
+
+    #[test]
+    fn lock_open_scratch_recovers_from_poison() {
+        // Per the project convention, lock helpers must recover from poisoning
+        // rather than unwrap()-panic.
+        let open = Arc::new(std::sync::Mutex::new(Vec::new()));
+        push_open_scratch(&open, scratch_doc("file:///d.md", "R-scratch-0", "black"));
+
+        // Poison the mutex by panicking while holding the guard.
+        let open_clone = Arc::clone(&open);
+        let _ = std::thread::spawn(move || {
+            let _guard = open_clone.lock().unwrap();
+            panic!("poison the lock");
+        })
+        .join();
+
+        // Recovery path must still observe the previously-tracked doc.
+        let drained = drain_open_scratch(&open);
+        assert_eq!(
+            drained.len(),
+            1,
+            "poison recovery must preserve tracked scratch docs"
+        );
+    }
+
+    // ==========================================================================
+    // build_region_replacement_edit (review: unbounded-range fallback)
+    // ==========================================================================
+
+    #[test]
+    fn build_region_replacement_edit_resolves_end_for_valid_text() {
+        // For any valid UTF-8 region the end position is resolvable, so we get a
+        // bounded replacement edit — never the old u32::MAX/u32::MAX fallback.
+        let offset = RegionOffset::new(0, 0);
+        let edit = build_region_replacement_edit("line1\nline2", "formatted".to_string(), &offset)
+            .expect("end position must resolve for valid text");
+        assert_eq!(edit.new_text, "formatted");
+        // End is the position just past the last byte: line 1, char 5 ("line2").
+        assert_eq!(edit.range.end.line, 1);
+        assert_eq!(edit.range.end.character, 5);
+        // Crucially, the range is bounded (no fabricated u32::MAX).
+        assert_ne!(edit.range.end.line, u32::MAX);
+        assert_ne!(edit.range.end.character, u32::MAX);
+    }
+
+    #[test]
+    fn build_region_replacement_edit_handles_empty_region() {
+        // Empty region → end at (0,0), still a bounded Some(edit).
+        let offset = RegionOffset::new(0, 0);
+        let edit = build_region_replacement_edit("", "new".to_string(), &offset)
+            .expect("empty region must still resolve to a bounded edit");
+        assert_eq!(edit.range.end.line, 0);
+        assert_eq!(edit.range.end.character, 0);
     }
 
     #[test]

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -643,11 +643,12 @@ fn scratch_region_id(region_id: &str, run: usize, step: usize) -> String {
 /// blockquoted regions still drop host indentation on replacement lines — the
 /// same limitation documented in `src/lsp/bridge/text_document/formatting.rs`.
 fn region_replacement_range(original_virtual: &str, offset: &RegionOffset) -> Option<Range> {
-    // Virtual end position = the position of the very last byte, derived via the
-    // shared PositionMapper so line-ending handling (incl. `\r\n`) and UTF-16
-    // column math stay consistent with the rest of the codebase. Computed from
-    // the original virtual text *before* it is moved into the pipeline, so the
-    // pipeline takes ownership without a second clone.
+    // Virtual end position = the position one past the last byte (EOF), derived
+    // via the shared PositionMapper from `original_virtual.len()` so line-ending
+    // handling (incl. `\r\n`) and UTF-16 column math stay consistent with the rest
+    // of the codebase. Computed from the original virtual text *before* it is
+    // moved into the pipeline, so the pipeline takes ownership without a second
+    // clone.
     let end = crate::text::PositionMapper::new(original_virtual)
         .byte_to_position(original_virtual.len())?;
 

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -592,7 +592,18 @@ async fn close_remaining_scratch_docs(
     host_uri: &url::Url,
     open: &std::sync::Mutex<Vec<OpenScratchDoc>>,
 ) {
-    for doc in drain_open_scratch(open) {
+    // Pop one at a time rather than draining the whole vector up front, so any
+    // docs not yet popped stay tracked in the mutex: if this sweep is itself
+    // cancelled mid-`.await`, the still-tracked docs remain visible to
+    // `ScratchCleanupGuard` (which drains on drop) instead of being lost — closing
+    // the leak window a drain-all-then-loop would open.
+    //
+    // NB: the `pop` is its own statement, not a `while let` scrutinee, so the
+    // non-`Send` `MutexGuard` is dropped at the `;` before the `.await` (otherwise
+    // the spawned region task's future would not be `Send`).
+    loop {
+        let next = lock_open_scratch(open).pop();
+        let Some(doc) = next else { break };
         pool.close_scratch_document(host_uri, &doc.uri, &doc.server_name)
             .await;
     }

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -39,10 +39,11 @@ use crate::language::InjectionResolver;
 use crate::lsp::aggregation::region::collect_region_results_with_cancel;
 use crate::lsp::aggregation::server::FanInResult;
 use crate::lsp::aggregation::server::dispatch_preferred;
-use crate::lsp::aggregation::server::effective_priorities;
+use crate::lsp::aggregation::server::effective_priorities_from;
 use crate::lsp::aggregation::server::run_sequential_format_pipeline;
 use crate::lsp::bridge::{
-    RegionOffset, UpstreamId, VirtualDocumentUri, translate_virtual_range_to_host,
+    RegionOffset, ResolvedServerConfig, UpstreamId, VirtualDocumentUri,
+    translate_virtual_range_to_host,
 };
 use crate::lsp::lsp_impl::bridge_context::DocumentRequestContext;
 use crate::lsp::request_id::{CancelReceiver, CancelSubscriptionGuard};
@@ -134,27 +135,26 @@ impl Kakehashi {
             let options = options.clone();
             let region_cancel_rx = cancel_state.derive_receiver();
 
-            // `strategy: "concatenated"` with a non-empty *effective* priorities
-            // list opts this region into the sequential formatter pipeline
-            // (concatenated-formatting-pipeline): run the priority-listed servers
-            // serially, each formatting the prior server's output, then emit one
-            // region-replacement edit. Gating on `effective_priorities` (not the
-            // raw `priorities`) means a list of only unknown/typo'd server names
-            // falls through to the `preferred` path — which still uses the
-            // region's configured servers — rather than entering the pipeline and
-            // formatting nothing. Default `preferred`, or `concatenated` with no
-            // effective priorities, keeps the first-non-empty-wins path.
-            let pipeline_servers = effective_priorities(&region_ctx);
-            let use_concatenated = region_ctx.strategy == AggregationStrategy::Concatenated
-                && !pipeline_servers.is_empty();
+            // Decide how this region formats — concatenated pipeline, preferred
+            // fan-out, or skip — from its resolved aggregation config. See
+            // [`plan_region_format`] for the allowlist rule
+            // (concatenated-formatting-pipeline Decision point 2).
+            let pipeline_servers = match plan_region_format(
+                region_ctx.strategy,
+                &region_ctx.priorities,
+                &region_ctx.configs,
+            ) {
+                RegionFormatPlan::Concatenated(servers) => Some(servers),
+                RegionFormatPlan::Preferred => None,
+            };
 
             outer_join_set.spawn(async move {
-                if use_concatenated {
+                if let Some(servers) = pipeline_servers {
                     dispatch_concatenated_formatting(
                         &region_ctx,
                         pool.clone(),
                         options,
-                        pipeline_servers,
+                        servers,
                         region_cancel_rx,
                     )
                     .await
@@ -173,6 +173,40 @@ impl Kakehashi {
         let response = finalize_formatting_edits(outer_join_set, cancel_state.token.clone()).await;
         pool.unregister_all_for_upstream_id(upstream_request_id.as_ref());
         response
+    }
+}
+
+/// How a single injection region should be formatted, derived from its resolved
+/// aggregation config. Extracted so the gating rule lives in one testable place.
+#[derive(Debug, PartialEq, Eq)]
+enum RegionFormatPlan {
+    /// Run the sequential concatenated pipeline over these effective servers
+    /// (`priorities` filtered to configured servers, deduped, order preserved).
+    Concatenated(Vec<String>),
+    /// Use the `preferred` first-non-empty-wins fan-out over the region's servers.
+    Preferred,
+}
+
+/// Decide the [`RegionFormatPlan`] for a region from its aggregation `strategy`,
+/// `priorities`, and configured server `configs`.
+///
+/// `concatenated` opts the region into the sequential formatter pipeline
+/// (concatenated-formatting-pipeline) over `effective_priorities_from`; any other
+/// strategy uses `preferred`. An empty effective list falls through to
+/// `preferred`.
+fn plan_region_format(
+    strategy: AggregationStrategy,
+    priorities: &[String],
+    configs: &[ResolvedServerConfig],
+) -> RegionFormatPlan {
+    if strategy != AggregationStrategy::Concatenated {
+        return RegionFormatPlan::Preferred;
+    }
+    let effective = effective_priorities_from(priorities, configs);
+    if effective.is_empty() {
+        RegionFormatPlan::Preferred
+    } else {
+        RegionFormatPlan::Concatenated(effective)
     }
 }
 
@@ -819,6 +853,46 @@ mod tests {
             },
             new_text: new_text.to_string(),
         }
+    }
+
+    // ==========================================================================
+    // plan_region_format (concatenated-formatting-pipeline Decision point 2:
+    // `priorities` is an allowlist + order)
+    // ==========================================================================
+
+    fn config(name: &str) -> ResolvedServerConfig {
+        ResolvedServerConfig {
+            server_name: name.to_string(),
+            config: Arc::new(crate::config::settings::BridgeServerConfig {
+                cmd: vec![name.to_string()],
+                languages: vec![],
+                initialization_options: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn plan_non_concatenated_strategy_uses_preferred() {
+        // Default `preferred` keeps the first-non-empty-wins fan-out regardless
+        // of priorities.
+        let configs = vec![config("black"), config("isort")];
+        let priorities = vec!["black".to_string()];
+        assert_eq!(
+            plan_region_format(AggregationStrategy::Preferred, &priorities, &configs),
+            RegionFormatPlan::Preferred
+        );
+    }
+
+    #[test]
+    fn plan_concatenated_with_configured_priorities_runs_pipeline() {
+        // `concatenated` + priorities that resolve to configured servers opts
+        // into the sequential pipeline over exactly those servers, in order.
+        let configs = vec![config("black"), config("isort")];
+        let priorities = vec!["isort".to_string(), "black".to_string()];
+        assert_eq!(
+            plan_region_format(AggregationStrategy::Concatenated, &priorities, &configs),
+            RegionFormatPlan::Concatenated(vec!["isort".to_string(), "black".to_string()])
+        );
     }
 
     // ==========================================================================

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -287,6 +287,10 @@ async fn dispatch_concatenated_formatting(
     // scratch id unique; the scratch document is `didClose`d after the step so
     // it never orphans tracking state or leaks diagnostics.
     let step_counter = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    // Per-run sequence so scratch ids don't collide with a concurrent
+    // concatenated-formatting request for the same region (which would also start
+    // at step 0).
+    let run_seq = SCRATCH_RUN_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     // Convert the host URL to the bridge protocol's `Uri` once, for the per-step
     // didClose. This conversion is effectively infallible for a valid host URL;
     // if it ever failed, `send_formatting_request` (which performs the same
@@ -330,7 +334,7 @@ async fn dispatch_concatenated_formatting(
                     return (current_text, None);
                 };
                 let step = step_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                let scratch_id = scratch_region_id(&region_id, step);
+                let scratch_id = scratch_region_id(&region_id, run_seq, step);
 
                 // Build the scratch URI up front and register it as "open" in the
                 // shared tracker BEFORE the request, so that if this future is
@@ -539,8 +543,16 @@ async fn close_remaining_scratch_docs(
 /// wraps it in the `kakehashi-virtual-uri-` filename marker and preserves the
 /// host directory and language extension required for downstream config and
 /// parser discovery.
-fn scratch_region_id(region_id: &str, step: usize) -> String {
-    format!("{region_id}-kakehashi-scratch-{step}")
+/// Process-global, monotonically increasing pipeline-run sequence. The per-step
+/// counter alone only makes scratch ids unique *within* a single pipeline run;
+/// two concatenated-formatting requests for the same host region overlapping in
+/// time (concurrent LSP requests, or a cancel+restart race) would otherwise both
+/// start at step 0 and collide on the same scratch virtual URI. Mixing in this
+/// run sequence makes scratch ids unique across concurrent runs in the process.
+static SCRATCH_RUN_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+fn scratch_region_id(region_id: &str, run: u64, step: usize) -> String {
+    format!("{region_id}-kakehashi-scratch-{run}-{step}")
 }
 
 /// Compute the host-coordinate `Range` that the concatenated pipeline's single
@@ -752,12 +764,22 @@ mod tests {
         // Each pipeline step must get a distinct scratch id so the bridge builds
         // a distinct virtual URI and re-sends a fresh didOpen with the current
         // accumulated text (rather than reusing the prior step's stale document).
-        let a = scratch_region_id("REGION", 0);
-        let b = scratch_region_id("REGION", 1);
-        let c = scratch_region_id("REGION", 2);
+        let a = scratch_region_id("REGION", 0, 0);
+        let b = scratch_region_id("REGION", 0, 1);
+        let c = scratch_region_id("REGION", 0, 2);
         assert_ne!(a, b);
         assert_ne!(b, c);
         assert_ne!(a, c);
+    }
+
+    #[test]
+    fn scratch_region_id_is_unique_across_runs_for_the_same_step() {
+        // Two concurrent format requests for the same region both start at step 0;
+        // the per-run sequence must still make their scratch ids distinct.
+        assert_ne!(
+            scratch_region_id("REGION", 7, 0),
+            scratch_region_id("REGION", 8, 0)
+        );
     }
 
     #[test]
@@ -765,14 +787,14 @@ mod tests {
         // The scratch document must never collide with the region's canonical
         // virtual document (which other requests like hover keep open).
         let region_id = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
-        assert_ne!(scratch_region_id(region_id, 0), region_id);
+        assert_ne!(scratch_region_id(region_id, 0, 0), region_id);
     }
 
     #[test]
     fn scratch_region_id_keeps_region_id_as_prefix() {
         // Preserving the region_id prefix keeps the scratch id unique per region
         // (no host-file collision across regions).
-        let id = scratch_region_id("REGION", 3);
+        let id = scratch_region_id("REGION", 0, 3);
         assert!(
             id.starts_with("REGION"),
             "scratch id should keep the region_id prefix: {id}"
@@ -786,7 +808,7 @@ mod tests {
         // distinctive kakehashi-virtual-uri- marker (Decision point 7).
         use crate::lsp::bridge::VirtualDocumentUri;
         let host_uri: tower_lsp_server::ls_types::Uri = "file:///project/doc.md".parse().unwrap();
-        let id = scratch_region_id("REGION", 1);
+        let id = scratch_region_id("REGION", 0, 1);
         let virtual_uri = VirtualDocumentUri::new(&host_uri, "python", &id);
         let uri_string = virtual_uri.to_uri_string();
         assert!(

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -314,6 +314,17 @@ async fn dispatch_concatenated_formatting(
     // the per-step closure below.
     let host_uri_for_sweep = uri.clone();
 
+    // Safety net for the abort-before-sweep case: if this whole future is aborted
+    // (outer `JoinSet` dropped / tower-lsp task cancelled) before the explicit
+    // sweep below runs, the sweep never executes and the tracked scratch docs
+    // would leak. The guard's Drop drains the tracker and detaches the didCloses
+    // onto a task that outlives the aborted parent. On the normal/select-cancel
+    // paths the sweep drains the tracker first, so the guard's Drop is a no-op
+    // (drain-under-lock ⇒ no double-close). Kept alive across the whole pipeline
+    // + sweep below.
+    let _scratch_guard =
+        ScratchCleanupGuard::new(Arc::clone(&pool), uri.clone(), Arc::clone(&open_scratch));
+
     let pipeline_fut = run_sequential_format_pipeline(original_virtual, &server_names, {
         let pool = Arc::clone(&pool);
         let open_scratch = Arc::clone(&open_scratch);
@@ -468,6 +479,69 @@ async fn dispatch_concatenated_formatting(
 struct OpenScratchDoc {
     uri: VirtualDocumentUri,
     server_name: String,
+}
+
+/// Drop-based safety net that closes any scratch documents still tracked open
+/// when the concatenated-formatting future is **aborted** (its outer `JoinSet`
+/// dropped or the tower-lsp task cancelled) BEFORE the explicit post-`select!`
+/// sweep runs.
+///
+/// The explicit awaited sweep ([`close_remaining_scratch_docs`]) handles the
+/// normal-completion and `select!`-cancel paths deterministically and drains the
+/// tracker; by the time this guard's `Drop` runs on those paths the tracker is
+/// already empty, so its Drop is a no-op (the drain-under-lock makes the sweep
+/// and the guard mutually exclusive — they can never double-close).
+///
+/// The hard case this guard exists for: a `future`-level abort drops the whole
+/// dispatch future at an `.await` point before the sweep is reached. `Drop`
+/// cannot `.await`, so it drains the tracker and, if anything remains, **spawns a
+/// detached `tokio::task`** to run the `didClose`s. A detached task is NOT a
+/// child of the aborted future, so it survives the parent's cancellation and runs
+/// the `close_scratch_document` calls to completion — which is also why
+/// `close_scratch_document` can keep its untrack-before-didClose ordering (the
+/// detached task guarantees the didClose await still completes).
+struct ScratchCleanupGuard {
+    pool: Arc<crate::lsp::bridge::LanguageServerPool>,
+    host_uri: url::Url,
+    open: Arc<std::sync::Mutex<Vec<OpenScratchDoc>>>,
+}
+
+impl ScratchCleanupGuard {
+    fn new(
+        pool: Arc<crate::lsp::bridge::LanguageServerPool>,
+        host_uri: url::Url,
+        open: Arc<std::sync::Mutex<Vec<OpenScratchDoc>>>,
+    ) -> Self {
+        Self {
+            pool,
+            host_uri,
+            open,
+        }
+    }
+}
+
+impl Drop for ScratchCleanupGuard {
+    fn drop(&mut self) {
+        // Drain under the lock. On the normal/select-cancel paths the explicit
+        // sweep already drained, so this is empty and we return without spawning
+        // — no double-close. On an abort-before-sweep, this is the leftover set.
+        let remaining = drain_open_scratch(&self.open);
+        if remaining.is_empty() {
+            return;
+        }
+
+        // Drop can't await, and the parent future is (in the case that matters)
+        // being aborted — so finish the didCloses on a DETACHED task that is not a
+        // child of the aborted future and therefore runs to completion.
+        let pool = Arc::clone(&self.pool);
+        let host_uri = self.host_uri.clone();
+        tokio::spawn(async move {
+            for doc in remaining {
+                pool.close_scratch_document(&host_uri, &doc.uri, &doc.server_name)
+                    .await;
+            }
+        });
+    }
 }
 
 /// Record a scratch document as open. Poison-safe: a poisoned mutex is recovered
@@ -849,6 +923,56 @@ mod tests {
             drained.len(),
             2,
             "the sweep must see every step's scratch doc"
+        );
+    }
+
+    #[tokio::test]
+    async fn scratch_cleanup_guard_drains_tracker_on_drop() {
+        // The guard is the safety net for the abort-before-sweep case: if the
+        // dispatch future is aborted before the explicit sweep runs, the guard's
+        // Drop must drain the tracker (and detach the didClose), so no scratch
+        // doc leaks. Here we assert the drain-on-drop: the tracker is emptied.
+        let open = Arc::new(std::sync::Mutex::new(Vec::new()));
+        push_open_scratch(&open, scratch_doc("file:///d.md", "R-scratch-0", "black"));
+        push_open_scratch(&open, scratch_doc("file:///d.md", "R-scratch-1", "isort"));
+
+        let pool = Arc::new(crate::lsp::bridge::LanguageServerPool::new());
+        let host = url::Url::parse("file:///d.md").unwrap();
+        let guard = ScratchCleanupGuard::new(Arc::clone(&pool), host, Arc::clone(&open));
+
+        drop(guard);
+
+        assert!(
+            lock_open_scratch(&open).is_empty(),
+            "guard Drop must drain the tracker so nothing leaks on abort-before-sweep"
+        );
+    }
+
+    #[tokio::test]
+    async fn scratch_cleanup_guard_drop_is_noop_after_explicit_sweep() {
+        // Normal path: the explicit awaited sweep drains the tracker first, so the
+        // guard's Drop sees an empty tracker and does nothing — the sweep and the
+        // guard can never double-close.
+        let open = Arc::new(std::sync::Mutex::new(Vec::new()));
+        push_open_scratch(&open, scratch_doc("file:///d.md", "R-scratch-0", "black"));
+
+        let pool = Arc::new(crate::lsp::bridge::LanguageServerPool::new());
+        let host = url::Url::parse("file:///d.md").unwrap();
+        let guard = ScratchCleanupGuard::new(Arc::clone(&pool), host.clone(), Arc::clone(&open));
+
+        // Explicit sweep (the deterministic cleanup the normal/select-cancel paths
+        // run) drains the tracker.
+        close_remaining_scratch_docs(&pool, &host, &open).await;
+        assert!(
+            lock_open_scratch(&open).is_empty(),
+            "explicit sweep must drain the tracker"
+        );
+
+        // Guard Drop now sees an empty tracker → no-op, so no double-close.
+        drop(guard);
+        assert!(
+            lock_open_scratch(&open).is_empty(),
+            "guard Drop after sweep must remain a no-op"
         );
     }
 

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -28,13 +28,15 @@ use tokio::sync::oneshot;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tower_lsp_server::jsonrpc::Result;
-use tower_lsp_server::ls_types::{DocumentFormattingParams, TextEdit};
+use tower_lsp_server::ls_types::{DocumentFormattingParams, Position, Range, TextEdit};
 
+use crate::config::settings::AggregationStrategy;
 use crate::language::InjectionResolver;
 use crate::lsp::aggregation::region::collect_region_results_with_cancel;
 use crate::lsp::aggregation::server::FanInResult;
 use crate::lsp::aggregation::server::dispatch_preferred;
-use crate::lsp::bridge::UpstreamId;
+use crate::lsp::aggregation::server::run_sequential_format_pipeline;
+use crate::lsp::bridge::{RegionOffset, UpstreamId, translate_virtual_range_to_host};
 use crate::lsp::lsp_impl::bridge_context::DocumentRequestContext;
 use crate::lsp::request_id::{CancelReceiver, CancelSubscriptionGuard};
 
@@ -125,40 +127,27 @@ impl Kakehashi {
             let options = options.clone();
             let region_cancel_rx = cancel_state.derive_receiver();
 
+            // `strategy: "concatenated"` with a non-empty priorities list opts
+            // this region into the sequential formatter pipeline
+            // (concatenated-formatting-pipeline): run the priority-listed
+            // servers serially, each formatting the prior server's output, then
+            // emit one region-replacement edit. Everything else (default
+            // `preferred`, or `concatenated` with no priorities — a
+            // misconfiguration) keeps the existing first-non-empty-wins path.
+            let use_concatenated = region_ctx.strategy == AggregationStrategy::Concatenated
+                && !region_ctx.priorities.is_empty();
+
             outer_join_set.spawn(async move {
-                let result = dispatch_preferred(
-                    &region_ctx,
-                    pool.clone(),
-                    move |t| {
-                        let options = options.clone();
-                        async move {
-                            t.pool
-                                .send_formatting_request(
-                                    &t.server_name,
-                                    &t.server_config,
-                                    &t.uri,
-                                    &t.injection_language,
-                                    &t.region_id,
-                                    t.offset,
-                                    &t.virtual_content,
-                                    options,
-                                    t.upstream_id,
-                                )
-                                .await
-                        }
-                    },
-                    // `Some(vec![])` is an authoritative "no edits needed" from
-                    // the formatter (e.g., ruff signaling the code is already
-                    // formatted) — accept it instead of falling through to a
-                    // lower-priority server that might re-format the same code.
-                    // `None` still means "no response" and triggers fallback.
-                    |opt| opt.is_some(),
-                    region_cancel_rx,
-                )
-                .await;
-                match result {
-                    FanInResult::Done(edits) => edits,
-                    FanInResult::NoResult { .. } | FanInResult::Cancelled => None,
+                if use_concatenated {
+                    dispatch_concatenated_formatting(&region_ctx, pool.clone(), options).await
+                } else {
+                    dispatch_preferred_formatting(
+                        &region_ctx,
+                        pool.clone(),
+                        options,
+                        region_cancel_rx,
+                    )
+                    .await
                 }
             });
         }
@@ -166,6 +155,192 @@ impl Kakehashi {
         let response = finalize_formatting_edits(outer_join_set, cancel_state.token.clone()).await;
         pool.unregister_all_for_upstream_id(upstream_request_id.as_ref());
         response
+    }
+}
+
+/// `preferred`-strategy formatting for one region: the existing
+/// first-non-empty-wins fan-out, factored out of the per-region task body.
+async fn dispatch_preferred_formatting(
+    region_ctx: &DocumentRequestContext,
+    pool: Arc<crate::lsp::bridge::LanguageServerPool>,
+    options: tower_lsp_server::ls_types::FormattingOptions,
+    region_cancel_rx: Option<CancelReceiver>,
+) -> Option<Vec<TextEdit>> {
+    let result = dispatch_preferred(
+        region_ctx,
+        pool,
+        move |t| {
+            let options = options.clone();
+            async move {
+                t.pool
+                    .send_formatting_request(
+                        &t.server_name,
+                        &t.server_config,
+                        &t.uri,
+                        &t.injection_language,
+                        &t.region_id,
+                        t.offset,
+                        &t.virtual_content,
+                        options,
+                        t.upstream_id,
+                    )
+                    .await
+            }
+        },
+        // `Some(vec![])` is an authoritative "no edits needed" from the
+        // formatter (e.g., ruff signaling the code is already formatted) —
+        // accept it instead of falling through to a lower-priority server that
+        // might re-format the same code. `None` still means "no response" and
+        // triggers fallback.
+        |opt| opt.is_some(),
+        region_cancel_rx,
+    )
+    .await;
+    match result {
+        FanInResult::Done(edits) => edits,
+        FanInResult::NoResult { .. } | FanInResult::Cancelled => None,
+    }
+}
+
+/// `concatenated`-strategy formatting for one region: the sequential formatter
+/// pipeline (concatenated-formatting-pipeline).
+///
+/// Runs the region's priority-listed servers serially over the region's virtual
+/// content — each server formats the previous server's output — then collapses
+/// the final text into a single host-coordinate region-replacement edit. When
+/// nothing changed, contributes no edit.
+///
+/// TODO(concatenated-formatting-pipeline): this first slice reuses the existing
+/// `send_formatting_request` path for each step. Still to build (see the ADR):
+///   - scratch-document isolation (per-step didOpen/didClose with a unique
+///     scratch URI) so the canonical virtual document is never mutated;
+///   - capability-based full -> rangeFormatting fallback for range-only servers,
+///     distinguishing "no capability" from a `null` "already formatted";
+///   - per-step remaining-budget timeout and concurrent $/cancelRequest
+///     propagation (Decision points 6 and the Consequences cancellation note).
+async fn dispatch_concatenated_formatting(
+    region_ctx: &DocumentRequestContext,
+    pool: Arc<crate::lsp::bridge::LanguageServerPool>,
+    options: tower_lsp_server::ls_types::FormattingOptions,
+) -> Option<Vec<TextEdit>> {
+    let offset = RegionOffset::with_per_line_offsets(
+        region_ctx.resolved.region.line_range.start,
+        region_ctx.resolved.line_column_offsets.clone(),
+    );
+    let original_virtual = region_ctx.resolved.virtual_content.clone();
+    let injection_language = region_ctx.resolved.injection_language.clone();
+    let region_id = region_ctx.resolved.region.region_id.clone();
+    let uri = region_ctx.uri.clone();
+    let upstream_id = region_ctx.upstream_request_id.clone();
+
+    // `priorities` is both the membership allowlist and the application order;
+    // keep only entries that are actually configured for this region.
+    let configured: std::collections::HashSet<&str> = region_ctx
+        .configs
+        .iter()
+        .map(|c| c.server_name.as_str())
+        .collect();
+    let server_names: Vec<String> = region_ctx
+        .priorities
+        .iter()
+        .filter(|name| configured.contains(name.as_str()))
+        .cloned()
+        .collect();
+
+    let server_config_for = |name: &str| {
+        region_ctx
+            .configs
+            .iter()
+            .find(|c| c.server_name == name)
+            .map(|c| Arc::clone(&c.config))
+    };
+
+    let final_text = run_sequential_format_pipeline(original_virtual.clone(), &server_names, {
+        let pool = Arc::clone(&pool);
+        move |server_name, current_text| {
+            let pool = Arc::clone(&pool);
+            let options = options.clone();
+            let injection_language = injection_language.clone();
+            let region_id = region_id.clone();
+            let uri = uri.clone();
+            let upstream_id = upstream_id.clone();
+            let server_config = server_config_for(&server_name);
+            async move {
+                let server_config = server_config?;
+                // The bridge translates the returned edits back to host
+                // coordinates, but the pipeline applies them to the *virtual*
+                // accumulated text, so request a fresh virtual-coordinate
+                // result by passing the zero offset for the response transform.
+                // The region offset is only re-applied once, when the final
+                // text is collapsed into the host replacement edit below.
+                pool.send_formatting_request(
+                    &server_name,
+                    &server_config,
+                    &uri,
+                    &injection_language,
+                    &region_id,
+                    RegionOffset::new(0, 0),
+                    &current_text,
+                    options,
+                    upstream_id,
+                )
+                .await
+                .ok()
+                .flatten()
+            }
+        }
+    })
+    .await?;
+
+    Some(vec![build_region_replacement_edit(
+        &original_virtual,
+        final_text,
+        &offset,
+    )])
+}
+
+/// Build a single host-coordinate `TextEdit` that replaces the entire injection
+/// region with `final_text`.
+///
+/// The replacement range spans the whole *original* virtual document (`(0,0)`
+/// through the end of `original_virtual`), translated to host coordinates via
+/// the region [`RegionOffset`]. Emitting one whole-region edit keeps the LSP
+/// output trivially non-overlapping (concatenated-formatting-pipeline Decision
+/// point 4).
+///
+/// TODO(concatenated-formatting-pipeline): Decision point 4 also requires
+/// re-applying the region's per-line host prefix/indentation to every line of
+/// `final_text` (and the region LCP for new lines on a line-count change), plus
+/// trimming trailing whitespace on empty lines. This slice emits `final_text`
+/// verbatim and relies on the existing range translation only, so multi-line /
+/// blockquoted regions still drop host indentation on replacement lines — the
+/// same limitation documented in `src/lsp/bridge/text_document/formatting.rs`.
+fn build_region_replacement_edit(
+    original_virtual: &str,
+    final_text: String,
+    offset: &RegionOffset,
+) -> TextEdit {
+    // Virtual end position = last line index + its length, in the LSP line
+    // model (a trailing newline adds a final empty line).
+    let last_line = original_virtual.split('\n').next_back().unwrap_or("");
+    let end_line = u32::try_from(original_virtual.matches('\n').count()).unwrap_or(u32::MAX);
+    let end_char = u32::try_from(last_line.encode_utf16().count()).unwrap_or(u32::MAX);
+
+    let mut range = Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: end_line,
+            character: end_char,
+        },
+    };
+    translate_virtual_range_to_host(&mut range, offset);
+
+    TextEdit {
+        range,
+        new_text: final_text,
     }
 }
 

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -228,16 +228,19 @@ async fn dispatch_preferred_formatting(
 /// ([`scratch_region_id`]), so the bridge always sends a fresh `didOpen`
 /// carrying the current accumulated text — fixing the stale-content bug where a
 /// step reused an already-open canonical document and formatted the *original*
-/// region text. Scratch documents are `didClose`d by the post-`select!` sweep at
-/// the end of the run — and by [`ScratchCleanupGuard`] if the task is aborted
-/// first — rather than per step, so cancellation can never leak one
-/// (concatenated-formatting-pipeline Decision point 7).
+/// region text. Scratch documents are `didClose`d solely by
+/// [`ScratchCleanupGuard`]'s Drop rather than per step, so cancellation can never
+/// leak one (concatenated-formatting-pipeline Decision point 7).
 ///
 /// Cleanup is guaranteed even on cancel: every opened-but-not-yet-closed scratch
-/// document is tracked, and a sweep after the cancel-aware `select!` closes any
-/// the per-step path did not. Without this, a `$/cancelRequest` that drops the
-/// in-flight step future before its own `close_scratch_document` ran would leak
-/// that scratch virtual document downstream (review HIGH).
+/// document is tracked, and the guard's Drop — which fires on the normal return,
+/// the `select!` cancel return, and a future-level abort alike — drains the
+/// tracker and detaches the didCloses onto a task that always runs to completion.
+/// Without this, a `$/cancelRequest` that drops the in-flight step future before
+/// its own `close_scratch_document` ran would leak that scratch virtual document
+/// downstream (review HIGH). Routing every cleanup through the detached task also
+/// removes the cancel-during-cleanup edge cases the old awaited sweep had: a
+/// cancel mid-`didClose` can no longer orphan a downstream doc.
 ///
 /// TODO(concatenated-formatting-pipeline): still to build (see the ADR):
 ///   - capability-based full -> rangeFormatting fallback for range-only servers,
@@ -287,8 +290,8 @@ async fn dispatch_concatenated_formatting(
     // after a prior hover/diagnostic), because `send_formatting_request` only
     // pushes content on the first `didOpen` (concatenated-formatting-pipeline
     // Decision point 7, stale-content bug). The per-step counter makes the
-    // scratch id unique; scratch documents are `didClose`d by the end-of-run
-    // sweep (and the abort-time guard), not per step, so a cancel can't leak one.
+    // scratch id unique; scratch documents are `didClose`d solely by
+    // `ScratchCleanupGuard`'s Drop, not per step, so a cancel can't leak one.
     let step_counter = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     // Per-run sequence so scratch ids don't collide with a concurrent
     // concatenated-formatting request for the same region (which would also start
@@ -304,26 +307,23 @@ async fn dispatch_concatenated_formatting(
 
     // Track every scratch document opened during this run. Steps only register
     // their scratch docs here; they never close them per step. All closing
-    // happens in the post-`select!` sweep (`close_remaining_scratch_docs`, which
-    // pops one at a time) and, if the task is aborted before the sweep runs, in
-    // `ScratchCleanupGuard`'s drop (which drains and closes on a detached task).
-    // Deferring all cleanup to those two cancel-safe points is what guarantees a
-    // cancel can never leak a scratch document downstream.
+    // happens in `ScratchCleanupGuard`'s Drop, which drains the tracker and
+    // closes each doc on a detached task. Deferring all cleanup to that single
+    // cancel-safe point is what guarantees a cancel can never leak a scratch
+    // document downstream.
     let open_scratch: Arc<std::sync::Mutex<Vec<OpenScratchDoc>>> =
         Arc::new(std::sync::Mutex::new(Vec::new()));
 
-    // Retained for the post-`select!` cleanup sweep, since `uri` is moved into
-    // the per-step closure below.
-    let host_uri_for_sweep = uri.clone();
-
-    // Safety net for the abort-before-sweep case: if this whole future is aborted
-    // (outer `JoinSet` dropped / tower-lsp task cancelled) before the explicit
-    // sweep below runs, the sweep never executes and the tracked scratch docs
-    // would leak. The guard's Drop drains the tracker and detaches the didCloses
-    // onto a task that outlives the aborted parent. On the normal/select-cancel
-    // paths the sweep drains the tracker first, so the guard's Drop is a no-op
-    // (drain-under-lock ⇒ no double-close). Kept alive across the whole pipeline
-    // + sweep below.
+    // Sole scratch-document cleanup path: the guard's Drop runs on every exit
+    // from this function — normal return, the `select!` cancel return below, and
+    // a future-level abort (outer `JoinSet` dropped / tower-lsp task cancelled) at
+    // any `.await` point. Its Drop drains the tracker and, if anything remains,
+    // detaches the didCloses onto a task that outlives this (possibly aborted)
+    // future and runs them to completion. Because the close runs on a detached
+    // task that always completes, `close_scratch_document`'s untrack-before-didClose
+    // ordering is safe — there is no cancellable awaited sweep that could be
+    // interrupted mid-didClose and orphan a downstream doc. Kept alive across the
+    // whole pipeline below.
     let _scratch_guard =
         ScratchCleanupGuard::new(Arc::clone(&pool), uri.clone(), Arc::clone(&open_scratch));
 
@@ -352,7 +352,7 @@ async fn dispatch_concatenated_formatting(
 
                 // Build the scratch URI up front and register it as "open" in the
                 // shared tracker BEFORE the request, so that if this future is
-                // dropped mid-send by a cancel, the post-`select!` sweep still
+                // dropped mid-send by a cancel, `ScratchCleanupGuard`'s Drop still
                 // closes it. Skipped only when the host URL could not be
                 // converted (then no didClose is possible anyway).
                 let scratch_uri = host_uri_lsp
@@ -420,14 +420,14 @@ async fn dispatch_concatenated_formatting(
                     }
                 };
 
-                // Scratch-document cleanup is deferred to the post-`select!`
-                // sweep (`close_remaining_scratch_docs`), NOT closed here per
-                // step. The sweep always runs to completion, so a cancel that
-                // drops this step's future mid-flight can never leak a scratch
-                // doc; closing per-step inside the (cancellable) pipeline future
-                // could be interrupted after the tracker entry was already
+                // Scratch-document cleanup is deferred to `ScratchCleanupGuard`'s
+                // Drop, NOT closed here per step. The guard's Drop detaches the
+                // didCloses onto a task that always runs to completion, so a
+                // cancel that drops this step's future mid-flight can never leak a
+                // scratch doc; closing per-step inside the (cancellable) pipeline
+                // future could be interrupted after the tracker entry was already
                 // removed, leaking it. The scratch doc stays tracked in
-                // `open_scratch` (registered above) for the sweep to close.
+                // `open_scratch` (registered above) for the guard to close.
 
                 // Hand the (unchanged) virtual text back to the pipeline along
                 // with the result so the pipeline can move it forward without a
@@ -439,8 +439,11 @@ async fn dispatch_concatenated_formatting(
 
     // Poll cancellation concurrently with the in-flight pipeline so an upstream
     // $/cancelRequest aborts the region promptly rather than only between steps.
-    // (Per-step $/cancelRequest propagation to the downstream server is a
-    // follow-up — TODO(concatenated-formatting-pipeline).)
+    // On cancel we just stop polling the pipeline and return None; the scratch
+    // documents the run opened are closed by `_scratch_guard`'s Drop (which fires
+    // on this return as well as on a future-level abort), so there is no explicit
+    // sweep to interrupt. (Per-step $/cancelRequest propagation to the downstream
+    // server is a follow-up — TODO(concatenated-formatting-pipeline).)
     let cancelled;
     let final_text = match cancel_rx {
         Some(mut rx) => {
@@ -455,15 +458,8 @@ async fn dispatch_concatenated_formatting(
         }
     };
 
-    // Close every scratch document the run opened — on both the completed and
-    // cancelled paths. This sweep is the single cleanup point (steps only
-    // register their scratch docs, never close them), so it runs to completion
-    // regardless of cancellation and can never leak. `close_scratch_document` is
-    // idempotent, so a doc already gone (e.g. via a concurrent host close) is a
-    // no-op.
-    close_remaining_scratch_docs(&pool, &host_uri_for_sweep, &open_scratch).await;
-
     // On cancel, contribute no edit (matches the prior early-return behavior).
+    // Scratch cleanup is handled entirely by `_scratch_guard`'s Drop below.
     if cancelled {
         return None;
     }
@@ -484,25 +480,21 @@ struct OpenScratchDoc {
     server_name: String,
 }
 
-/// Drop-based safety net that closes any scratch documents still tracked open
-/// when the concatenated-formatting future is **aborted** (its outer `JoinSet`
-/// dropped or the tower-lsp task cancelled) BEFORE the explicit post-`select!`
-/// sweep runs.
+/// Drop-based cleanup that closes every scratch document still tracked open when
+/// the concatenated-formatting future exits — the **sole** scratch cleanup path.
 ///
-/// The explicit awaited sweep ([`close_remaining_scratch_docs`]) handles the
-/// normal-completion and `select!`-cancel paths deterministically and drains the
-/// tracker; by the time this guard's `Drop` runs on those paths the tracker is
-/// already empty, so its Drop is a no-op (the drain-under-lock makes the sweep
-/// and the guard mutually exclusive — they can never double-close).
+/// Its `Drop` runs on every exit from `dispatch_concatenated_formatting`: the
+/// normal return, the `select!` cancel return, and a future-level abort (its
+/// outer `JoinSet` dropped or the tower-lsp task cancelled) at any `.await`
+/// point.
 ///
-/// The hard case this guard exists for: a `future`-level abort drops the whole
-/// dispatch future at an `.await` point before the sweep is reached. `Drop`
-/// cannot `.await`, so it drains the tracker and, if anything remains, **spawns a
-/// detached `tokio::task`** to run the `didClose`s. A detached task is NOT a
-/// child of the aborted future, so it survives the parent's cancellation and runs
-/// the `close_scratch_document` calls to completion — which is also why
-/// `close_scratch_document` can keep its untrack-before-didClose ordering (the
-/// detached task guarantees the didClose await still completes).
+/// `Drop` cannot `.await`, so it drains the tracker and, if anything remains,
+/// **spawns a detached `tokio::task`** to run the `didClose`s. A detached task is
+/// NOT a child of the (possibly aborted) future, so it survives the parent's
+/// cancellation and runs the `close_scratch_document` calls to completion — which
+/// is also why `close_scratch_document` can keep its untrack-before-didClose
+/// ordering (the detached task guarantees the didClose await still completes,
+/// even on the abort path, so it can never orphan a downstream doc).
 struct ScratchCleanupGuard {
     pool: Arc<crate::lsp::bridge::LanguageServerPool>,
     host_uri: url::Url,
@@ -583,33 +575,6 @@ fn lock_open_scratch(
     open: &std::sync::Mutex<Vec<OpenScratchDoc>>,
 ) -> std::sync::MutexGuard<'_, Vec<OpenScratchDoc>> {
     open.lock().recover_poison("scratch-document tracker")
-}
-
-/// Close every scratch document still tracked as open. Used on both the
-/// completed and cancelled paths so a cancel that drops an in-flight step never
-/// leaves its scratch virtual document open downstream.
-async fn close_remaining_scratch_docs(
-    pool: &crate::lsp::bridge::LanguageServerPool,
-    host_uri: &url::Url,
-    open: &std::sync::Mutex<Vec<OpenScratchDoc>>,
-) {
-    // Peek-close-remove, one doc at a time: clone the last tracked doc WITHOUT
-    // removing it, close it, then remove it only after the close completes. If
-    // this sweep is itself cancelled mid-`.await`, the in-flight doc is still
-    // tracked, so `ScratchCleanupGuard` (which drains on drop) still catches it —
-    // zero leak, not even the single in-flight doc that a pop-then-close would
-    // drop. The lock guards are scoped to their `let`/block so the non-`Send`
-    // `MutexGuard` never crosses the `.await` (keeping the region task `Send`).
-    loop {
-        let next = {
-            let guard = lock_open_scratch(open);
-            guard.last().cloned()
-        };
-        let Some(doc) = next else { break };
-        pool.close_scratch_document(host_uri, &doc.uri, &doc.server_name)
-            .await;
-        lock_open_scratch(open).retain(|d| d.uri != doc.uri);
-    }
 }
 
 /// Derive a unique scratch `region_id` for one step of the concatenated
@@ -933,8 +898,8 @@ mod tests {
 
     #[test]
     fn open_scratch_tracker_drains_what_was_pushed() {
-        // The cancel-path sweep relies on draining everything that was recorded
-        // open but never removed by a per-step close.
+        // The guard's Drop relies on draining everything that was recorded open
+        // but never removed by a per-step close.
         let open = std::sync::Mutex::new(Vec::new());
         push_open_scratch(&open, scratch_doc("file:///d.md", "R-scratch-0", "black"));
         push_open_scratch(&open, scratch_doc("file:///d.md", "R-scratch-1", "isort"));
@@ -948,9 +913,9 @@ mod tests {
     }
 
     #[test]
-    fn open_scratch_tracker_accumulates_every_step_for_the_sweep() {
-        // Steps only register their scratch docs; the post-select sweep is the
-        // single close point, so every pushed doc must still be present to drain.
+    fn open_scratch_tracker_accumulates_every_step_for_the_guard() {
+        // Steps only register their scratch docs; the guard's Drop is the single
+        // close point, so every pushed doc must still be present to drain.
         let open = std::sync::Mutex::new(Vec::new());
         push_open_scratch(&open, scratch_doc("file:///d.md", "R-scratch-0", "black"));
         push_open_scratch(&open, scratch_doc("file:///d.md", "R-scratch-1", "isort"));
@@ -958,15 +923,15 @@ mod tests {
         assert_eq!(
             drained.len(),
             2,
-            "the sweep must see every step's scratch doc"
+            "the guard must see every step's scratch doc"
         );
     }
 
     #[tokio::test]
     async fn scratch_cleanup_guard_drains_tracker_on_drop() {
-        // The guard is the safety net for the abort-before-sweep case: if the
-        // dispatch future is aborted before the explicit sweep runs, the guard's
-        // Drop must drain the tracker (and detach the didClose), so no scratch
+        // The guard is the sole scratch cleanup path: on every exit from the
+        // dispatch future (normal return, select! cancel, or future-level abort)
+        // its Drop must drain the tracker (and detach the didClose), so no scratch
         // doc leaks. Here we assert the drain-on-drop: the tracker is emptied.
         let open = Arc::new(std::sync::Mutex::new(Vec::new()));
         push_open_scratch(&open, scratch_doc("file:///d.md", "R-scratch-0", "black"));
@@ -980,35 +945,7 @@ mod tests {
 
         assert!(
             lock_open_scratch(&open).is_empty(),
-            "guard Drop must drain the tracker so nothing leaks on abort-before-sweep"
-        );
-    }
-
-    #[tokio::test]
-    async fn scratch_cleanup_guard_drop_is_noop_after_explicit_sweep() {
-        // Normal path: the explicit awaited sweep drains the tracker first, so the
-        // guard's Drop sees an empty tracker and does nothing — the sweep and the
-        // guard can never double-close.
-        let open = Arc::new(std::sync::Mutex::new(Vec::new()));
-        push_open_scratch(&open, scratch_doc("file:///d.md", "R-scratch-0", "black"));
-
-        let pool = Arc::new(crate::lsp::bridge::LanguageServerPool::new());
-        let host = url::Url::parse("file:///d.md").unwrap();
-        let guard = ScratchCleanupGuard::new(Arc::clone(&pool), host.clone(), Arc::clone(&open));
-
-        // Explicit sweep (the deterministic cleanup the normal/select-cancel paths
-        // run) drains the tracker.
-        close_remaining_scratch_docs(&pool, &host, &open).await;
-        assert!(
-            lock_open_scratch(&open).is_empty(),
-            "explicit sweep must drain the tracker"
-        );
-
-        // Guard Drop now sees an empty tracker → no-op, so no double-close.
-        drop(guard);
-        assert!(
-            lock_open_scratch(&open).is_empty(),
-            "guard Drop after sweep must remain a no-op"
+            "guard Drop must drain the tracker so nothing leaks"
         );
     }
 

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -282,11 +282,12 @@ async fn dispatch_concatenated_formatting(
     // scratch id unique; the scratch document is `didClose`d after the step so
     // it never orphans tracking state or leaks diagnostics.
     let step_counter = Arc::new(std::sync::atomic::AtomicUsize::new(0));
-    // Convert the host URL to the bridge protocol's `Uri` once. On the
-    // unreachable conversion failure the per-step didClose is skipped (the
-    // scratch document is still cleaned up when the host document closes), but
-    // the unique-URI didOpen — the correctness core — still happens because the
-    // scratch id is passed to `send_formatting_request` directly.
+    // Convert the host URL to the bridge protocol's `Uri` once, for the per-step
+    // didClose. This conversion is effectively infallible for a valid host URL;
+    // if it ever failed, `send_formatting_request` (which performs the same
+    // conversion internally) would also fail, so the step would simply contribute
+    // no edit — there is no path where a step opens a scratch doc we then can't
+    // close. The scratch doc is also swept on the host document's own close.
     let host_uri_lsp = crate::lsp::lsp_impl::url_to_uri(&uri).ok();
 
     // Track every scratch document opened during this run that has NOT yet been

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -228,7 +228,9 @@ async fn dispatch_preferred_formatting(
 /// ([`scratch_region_id`]), so the bridge always sends a fresh `didOpen`
 /// carrying the current accumulated text — fixing the stale-content bug where a
 /// step reused an already-open canonical document and formatted the *original*
-/// region text. The scratch document is `didClose`d after the step
+/// region text. Scratch documents are `didClose`d by the post-`select!` sweep at
+/// the end of the run — and by [`ScratchCleanupGuard`] if the task is aborted
+/// first — rather than per step, so cancellation can never leak one
 /// (concatenated-formatting-pipeline Decision point 7).
 ///
 /// Cleanup is guaranteed even on cancel: every opened-but-not-yet-closed scratch
@@ -285,8 +287,8 @@ async fn dispatch_concatenated_formatting(
     // after a prior hover/diagnostic), because `send_formatting_request` only
     // pushes content on the first `didOpen` (concatenated-formatting-pipeline
     // Decision point 7, stale-content bug). The per-step counter makes the
-    // scratch id unique; the scratch document is `didClose`d after the step so
-    // it never orphans tracking state or leaks diagnostics.
+    // scratch id unique; scratch documents are `didClose`d by the end-of-run
+    // sweep (and the abort-time guard), not per step, so a cancel can't leak one.
     let step_counter = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     // Per-run sequence so scratch ids don't collide with a concurrent
     // concatenated-formatting request for the same region (which would also start
@@ -533,14 +535,32 @@ impl Drop for ScratchCleanupGuard {
         // Drop can't await, and the parent future is (in the case that matters)
         // being aborted — so finish the didCloses on a DETACHED task that is not a
         // child of the aborted future and therefore runs to completion.
+        //
+        // `tokio::spawn` panics outside a runtime, so spawn via a `Handle` from
+        // `try_current`. In practice this guard always drops inside the request's
+        // task (a runtime is present); the `Err` arm only guards pathological
+        // drops (shutdown / a synchronous context), where we log and rely on the
+        // host document's own close to reap the scratch docs rather than panicking.
+        let count = remaining.len();
         let pool = Arc::clone(&self.pool);
         let host_uri = self.host_uri.clone();
-        tokio::spawn(async move {
+        let cleanup = async move {
             for doc in remaining {
                 pool.close_scratch_document(&host_uri, &doc.uri, &doc.server_name)
                     .await;
             }
-        });
+        };
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                handle.spawn(cleanup);
+            }
+            Err(_) => {
+                log::warn!(
+                    target: "kakehashi::formatting",
+                    "ScratchCleanupGuard dropped outside a Tokio runtime; {count} scratch document(s) left for host-close cleanup"
+                );
+            }
+        }
     }
 }
 

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -131,10 +131,6 @@ impl Kakehashi {
                 strategy: agg.strategy,
                 max_fan_out: agg.max_fan_out,
             };
-            let pool = Arc::clone(&pool);
-            let options = options.clone();
-            let region_cancel_rx = cancel_state.derive_receiver();
-
             // Decide how this region formats — concatenated pipeline, preferred
             // fan-out, or skip — from its resolved aggregation config. See
             // [`plan_region_format`] for the allowlist rule
@@ -146,7 +142,30 @@ impl Kakehashi {
             ) {
                 RegionFormatPlan::Concatenated(servers) => Some(servers),
                 RegionFormatPlan::Preferred => None,
+                RegionFormatPlan::Skip => {
+                    // `concatenated` with a non-empty `priorities` that names only
+                    // unconfigured servers: the allowlist resolved to nothing, so
+                    // running the region's other servers would violate it. Leave
+                    // the region unformatted and warn so the typo'd/missing name
+                    // surfaces instead of silently formatting with the wrong
+                    // server.
+                    log::warn!(
+                        target: "kakehashi::formatting",
+                        "concatenated formatting for {}->{} lists only unconfigured \
+                         server(s) {:?}; none are configured for this region, so it \
+                         is left unformatted (priorities is an allowlist — \
+                         non-listed servers are not run)",
+                        language_name,
+                        region_ctx.resolved.injection_language,
+                        region_ctx.priorities,
+                    );
+                    continue;
+                }
             };
+
+            let pool = Arc::clone(&pool);
+            let options = options.clone();
+            let region_cancel_rx = cancel_state.derive_receiver();
 
             outer_join_set.spawn(async move {
                 if let Some(servers) = pipeline_servers {
@@ -185,15 +204,27 @@ enum RegionFormatPlan {
     Concatenated(Vec<String>),
     /// Use the `preferred` first-non-empty-wins fan-out over the region's servers.
     Preferred,
+    /// Run nothing for this region. Reached only when `concatenated` is active
+    /// with a NON-empty `priorities` whose names are all unconfigured/typo'd, so
+    /// the effective list is empty: every configured server is *absent from the
+    /// allowlist*, and the allowlist (concatenated-formatting-pipeline Decision
+    /// point 2) forbids running any of them. Falling through to `preferred` here
+    /// would wrongly run exactly the servers the user's `priorities` excluded.
+    Skip,
 }
 
 /// Decide the [`RegionFormatPlan`] for a region from its aggregation `strategy`,
 /// `priorities`, and configured server `configs`.
 ///
-/// `concatenated` opts the region into the sequential formatter pipeline
-/// (concatenated-formatting-pipeline) over `effective_priorities_from`; any other
-/// strategy uses `preferred`. An empty effective list falls through to
-/// `preferred`.
+/// Mirrors concatenated-formatting-pipeline Decision points 1–2:
+/// - any non-`concatenated` strategy → `Preferred` (first-non-empty-wins);
+/// - `concatenated` with an **empty** `priorities` is a misconfiguration (order
+///   would be undefined) → `Preferred` (a once-per-config warning is emitted at
+///   settings-apply time, see `format_concatenated_formatting_warning`);
+/// - `concatenated` with a **non-empty** `priorities` puts the allowlist in
+///   force: run the effective (configured ∩ `priorities`) servers as a pipeline,
+///   or — when none of the listed names are configured — `Skip`, since the
+///   allowlist forbids running the non-listed servers `preferred` would pick.
 fn plan_region_format(
     strategy: AggregationStrategy,
     priorities: &[String],
@@ -202,9 +233,12 @@ fn plan_region_format(
     if strategy != AggregationStrategy::Concatenated {
         return RegionFormatPlan::Preferred;
     }
+    if priorities.is_empty() {
+        return RegionFormatPlan::Preferred;
+    }
     let effective = effective_priorities_from(priorities, configs);
     if effective.is_empty() {
-        RegionFormatPlan::Preferred
+        RegionFormatPlan::Skip
     } else {
         RegionFormatPlan::Concatenated(effective)
     }
@@ -892,6 +926,44 @@ mod tests {
         assert_eq!(
             plan_region_format(AggregationStrategy::Concatenated, &priorities, &configs),
             RegionFormatPlan::Concatenated(vec!["isort".to_string(), "black".to_string()])
+        );
+    }
+
+    #[test]
+    fn plan_concatenated_with_empty_priorities_falls_back_to_preferred() {
+        // ADR point 2: `concatenated` with an EMPTY `priorities` is a
+        // misconfiguration (order is undefined) and falls back to `preferred`.
+        let configs = vec![config("black")];
+        assert_eq!(
+            plan_region_format(AggregationStrategy::Concatenated, &[], &configs),
+            RegionFormatPlan::Preferred
+        );
+    }
+
+    #[test]
+    fn plan_concatenated_with_only_unconfigured_priorities_skips() {
+        // ADR point 2 (allowlist): a NON-empty `priorities` naming only
+        // servers that aren't configured for the region resolves to an empty
+        // effective list. Every configured server is absent from the allowlist,
+        // so the region must run NOTHING — not fall through to `preferred`,
+        // which would run the very servers the allowlist excluded.
+        let configs = vec![config("black"), config("isort")];
+        let priorities = vec!["blackk".to_string(), "ruff".to_string()];
+        assert_eq!(
+            plan_region_format(AggregationStrategy::Concatenated, &priorities, &configs),
+            RegionFormatPlan::Skip
+        );
+    }
+
+    #[test]
+    fn plan_concatenated_drops_unconfigured_names_but_keeps_configured_ones() {
+        // A partially-typo'd list still runs the configured subset (allowlist
+        // membership), not a skip: only an all-unconfigured list skips.
+        let configs = vec![config("black"), config("isort")];
+        let priorities = vec!["ruff".to_string(), "black".to_string()];
+        assert_eq!(
+            plan_region_format(AggregationStrategy::Concatenated, &priorities, &configs),
+            RegionFormatPlan::Concatenated(vec!["black".to_string()])
         );
     }
 

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -38,6 +38,7 @@ use crate::language::InjectionResolver;
 use crate::lsp::aggregation::region::collect_region_results_with_cancel;
 use crate::lsp::aggregation::server::FanInResult;
 use crate::lsp::aggregation::server::dispatch_preferred;
+use crate::lsp::aggregation::server::effective_priorities;
 use crate::lsp::aggregation::server::run_sequential_format_pipeline;
 use crate::lsp::bridge::{
     RegionOffset, UpstreamId, VirtualDocumentUri, translate_virtual_range_to_host,
@@ -252,18 +253,9 @@ async fn dispatch_concatenated_formatting(
     let upstream_id = region_ctx.upstream_request_id.clone();
 
     // `priorities` is both the membership allowlist and the application order;
-    // keep only entries that are actually configured for this region.
-    let configured: std::collections::HashSet<&str> = region_ctx
-        .configs
-        .iter()
-        .map(|c| c.server_name.as_str())
-        .collect();
-    let server_names: Vec<String> = region_ctx
-        .priorities
-        .iter()
-        .filter(|name| configured.contains(name.as_str()))
-        .cloned()
-        .collect();
+    // `effective_priorities` keeps only entries configured for this region —
+    // shared with the preferred fan-out so the rule has one source of truth.
+    let server_names = effective_priorities(region_ctx);
 
     let server_config_for = |name: &str| {
         region_ctx

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -142,7 +142,13 @@ impl Kakehashi {
 
             outer_join_set.spawn(async move {
                 if use_concatenated {
-                    dispatch_concatenated_formatting(&region_ctx, pool.clone(), options).await
+                    dispatch_concatenated_formatting(
+                        &region_ctx,
+                        pool.clone(),
+                        options,
+                        region_cancel_rx,
+                    )
+                    .await
                 } else {
                     dispatch_preferred_formatting(
                         &region_ctx,
@@ -225,6 +231,7 @@ async fn dispatch_concatenated_formatting(
     region_ctx: &DocumentRequestContext,
     pool: Arc<crate::lsp::bridge::LanguageServerPool>,
     options: tower_lsp_server::ls_types::FormattingOptions,
+    cancel_rx: Option<CancelReceiver>,
 ) -> Option<Vec<TextEdit>> {
     let offset = RegionOffset::with_per_line_offsets(
         region_ctx.resolved.region.line_range.start,
@@ -258,7 +265,7 @@ async fn dispatch_concatenated_formatting(
             .map(|c| Arc::clone(&c.config))
     };
 
-    let final_text = run_sequential_format_pipeline(original_virtual.clone(), &server_names, {
+    let pipeline_fut = run_sequential_format_pipeline(original_virtual.clone(), &server_names, {
         let pool = Arc::clone(&pool);
         move |server_name, current_text| {
             let pool = Arc::clone(&pool);
@@ -292,8 +299,21 @@ async fn dispatch_concatenated_formatting(
                 .flatten()
             }
         }
-    })
-    .await?;
+    });
+
+    // Poll cancellation concurrently with the in-flight pipeline so an upstream
+    // $/cancelRequest aborts the region promptly rather than only between steps.
+    // (Per-step $/cancelRequest propagation to the downstream server is a
+    // follow-up — TODO(concatenated-formatting-pipeline).)
+    let final_text = match cancel_rx {
+        Some(mut rx) => {
+            tokio::select! {
+                res = pipeline_fut => res?,
+                _ = &mut rx => return None,
+            }
+        }
+        None => pipeline_fut.await?,
+    };
 
     Some(vec![build_region_replacement_edit(
         &original_virtual,
@@ -323,21 +343,22 @@ fn build_region_replacement_edit(
     final_text: String,
     offset: &RegionOffset,
 ) -> TextEdit {
-    // Virtual end position = last line index + its length, in the LSP line
-    // model (a trailing newline adds a final empty line).
-    let last_line = original_virtual.split('\n').next_back().unwrap_or("");
-    let end_line = u32::try_from(original_virtual.matches('\n').count()).unwrap_or(u32::MAX);
-    let end_char = u32::try_from(last_line.encode_utf16().count()).unwrap_or(u32::MAX);
+    // Virtual end position = the position of the very last byte, derived via the
+    // shared PositionMapper so line-ending handling (incl. `\r\n`) and UTF-16
+    // column math stay consistent with the rest of the codebase.
+    let end = crate::text::PositionMapper::new(original_virtual)
+        .byte_to_position(original_virtual.len())
+        .unwrap_or(Position {
+            line: u32::MAX,
+            character: u32::MAX,
+        });
 
     let mut range = Range {
         start: Position {
             line: 0,
             character: 0,
         },
-        end: Position {
-            line: end_line,
-            character: end_char,
-        },
+        end,
     };
     translate_virtual_range_to_host(&mut range, offset);
 

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -517,9 +517,11 @@ impl ScratchCleanupGuard {
 
 impl Drop for ScratchCleanupGuard {
     fn drop(&mut self) {
-        // Drain under the lock. On the normal/select-cancel paths the explicit
-        // sweep already drained, so this is empty and we return without spawning
-        // — no double-close. On an abort-before-sweep, this is the leftover set.
+        // This guard is the sole scratch-document cleanup path: on every exit of
+        // `dispatch_concatenated_formatting` (normal return, select!-cancel
+        // return, or future-level abort) the guard drops and drains the tracker
+        // here. Nothing else drains it, so there is no double-close to guard
+        // against.
         let remaining = drain_open_scratch(&self.open);
         if remaining.is_empty() {
             return;
@@ -592,10 +594,11 @@ fn lock_open_scratch(
 /// always performs a fresh `didOpen` carrying the current accumulated text.
 ///
 /// The id keeps the canonical `region_id` as a prefix (so it stays unique per
-/// region — no host-file collision) and appends a `-kakehashi-scratch-{step}`
-/// suffix: unique per pipeline step, and carrying the standardized
-/// `kakehashi-scratch` marker (Decision point 7) so external tools (file
-/// watchers, build tools, test runners) can recognize and ignore these throwaway
+/// region — no host-file collision) and appends a `-kakehashi-scratch-{run}-{step}`
+/// suffix: the `run` (a process-global sequence) keeps concurrent runs for the
+/// same region distinct, and `step` keeps each step within a run distinct. The
+/// `kakehashi-scratch` marker (Decision point 7) lets external tools (file
+/// watchers, build tools, test runners) recognize and ignore these throwaway
 /// documents. It still flows through [`VirtualDocumentUri::new`], which also
 /// wraps it in the `kakehashi-virtual-uri-` filename marker and preserves the
 /// host directory and language extension required for downstream config and

--- a/src/text.rs
+++ b/src/text.rs
@@ -4,6 +4,7 @@
 //! - Position mapping between LSP (UTF-16) and byte offsets
 //! - Content hashing for caching
 
+pub(crate) mod edit;
 mod hash;
 pub(crate) mod position;
 

--- a/src/text/edit.rs
+++ b/src/text/edit.rs
@@ -46,9 +46,16 @@ pub(crate) fn apply_text_edits(text: &str, edits: &[TextEdit]) -> String {
     byte_edits.sort_by_key(|&(start, end, _)| (start, end));
 
     // Upper-bound the result capacity (original text + all inserted text) so the
-    // forward copy never reallocates, even with many insertions.
-    let extra: usize = byte_edits.iter().map(|&(_, _, t)| t.len()).sum();
-    let mut result = String::with_capacity(text.len() + extra);
+    // forward copy never reallocates, even with many insertions. Saturating
+    // arithmetic keeps a pathological edit list (whose `new_text` lengths sum past
+    // `usize::MAX`) from panicking here in debug or wrapping to an undersized
+    // capacity in release — consistent with this module's "a buggy server must
+    // never make us panic" contract. Capacity is only a hint, so a saturated
+    // value at most costs one reallocation.
+    let extra: usize = byte_edits
+        .iter()
+        .fold(0usize, |acc, &(_, _, t)| acc.saturating_add(t.len()));
+    let mut result = String::with_capacity(text.len().saturating_add(extra));
     let mut cursor = 0usize;
     for (start, end, new_text) in byte_edits {
         // Drop an edit that starts before the cursor — it overlaps one already

--- a/src/text/edit.rs
+++ b/src/text/edit.rs
@@ -97,10 +97,11 @@ mod tests {
 
     #[test]
     fn applies_multiple_disjoint_edits_regardless_of_order() {
-        // Two edits given in ascending order; applying the later one first must
-        // not shift the earlier one. Replace "a"->"AAAA" and "c"->"C".
+        // Edits supplied OUT OF ORDER (later span first) to actually exercise the
+        // sort: applying the later one must not shift the earlier one. Replace
+        // "a"->"AAAA" and "c"->"C".
         let text = "a b c";
-        let edits = vec![edit(0, 0, 0, 1, "AAAA"), edit(0, 4, 0, 5, "C")];
+        let edits = vec![edit(0, 4, 0, 5, "C"), edit(0, 0, 0, 1, "AAAA")];
         assert_eq!(apply_text_edits(text, &edits), "AAAA b C");
     }
 

--- a/src/text/edit.rs
+++ b/src/text/edit.rs
@@ -35,11 +35,32 @@ pub(crate) fn apply_text_edits(text: &str, edits: &[TextEdit]) -> String {
 
     // Apply from the end of the document backwards so that replacing an earlier
     // span never invalidates the byte offsets of a later (non-overlapping) edit.
-    byte_edits.sort_by_key(|(start, _, _)| *start);
+    // Sort by `(start, end)`: when several edits share a start (e.g. a zero-width
+    // insertion and a replacement), the wider span must be applied first under
+    // the reversed iteration, so the insertion is not swallowed by the
+    // replacement's range.
+    byte_edits.sort_by_key(|&(start, end, _)| (start, end));
 
     let mut result = text.to_string();
-    for (start, end, new_text) in byte_edits.into_iter().rev() {
+    // Defensive against buggy downstream servers: clamp offsets to UTF-8 char
+    // boundaries (`replace_range` panics otherwise) and skip an edit that
+    // overlaps one already applied (LSP forbids overlap, but we never trust the
+    // server enough to panic). `last_start` is the start of the most recently
+    // applied edit; since we go highest-first, a later edit whose `end` reaches
+    // past it overlaps and is dropped.
+    let mut last_start = result.len();
+    for (mut start, mut end, new_text) in byte_edits.into_iter().rev() {
+        while start > 0 && !result.is_char_boundary(start) {
+            start -= 1;
+        }
+        while end > start && !result.is_char_boundary(end) {
+            end -= 1;
+        }
+        if end > last_start {
+            continue;
+        }
         result.replace_range(start..end, new_text);
+        last_start = start;
     }
     result
 }
@@ -107,5 +128,37 @@ mod tests {
         let text = "old\ncontent";
         let edits = vec![edit(0, 0, 1, 7, "new")];
         assert_eq!(apply_text_edits(text, &edits), "new");
+    }
+
+    #[test]
+    fn insertion_and_replacement_at_same_start_both_apply() {
+        // A zero-width insertion of "X" at col 0 and a replacement of "ab"
+        // (0..2) with "Y", both starting at col 0. The insertion must survive
+        // rather than being swallowed by the replacement's range.
+        let text = "ab";
+        let edits = vec![edit(0, 0, 0, 0, "X"), edit(0, 0, 0, 2, "Y")];
+        assert_eq!(apply_text_edits(text, &edits), "XY");
+    }
+
+    #[test]
+    fn overlapping_edits_are_dropped_rather_than_panicking() {
+        // Two edits whose original ranges overlap (0..3 and 2..5). Applying both
+        // verbatim would corrupt or panic; the second (lower-priority by
+        // position) overlapping edit is skipped defensively.
+        let text = "abcdef";
+        let edits = vec![edit(0, 0, 0, 3, "A"), edit(0, 2, 0, 5, "B")];
+        // Highest-start first: (2..5)->"B" applied, then (0..3) overlaps and is
+        // dropped, leaving the tail intact.
+        let out = apply_text_edits(text, &edits);
+        assert_eq!(out, "abBf");
+    }
+
+    #[test]
+    fn multibyte_text_is_not_corrupted() {
+        // "café" — 'é' is two bytes. Replace "café" (cols 0..4 in UTF-16) with
+        // "tea" and confirm no panic / clean result.
+        let text = "café";
+        let edits = vec![edit(0, 0, 0, 4, "tea")];
+        assert_eq!(apply_text_edits(text, &edits), "tea");
     }
 }

--- a/src/text/edit.rs
+++ b/src/text/edit.rs
@@ -154,6 +154,24 @@ mod tests {
     }
 
     #[test]
+    fn out_of_bounds_position_is_clamped_to_eof() {
+        // A downstream server may return an end past EOF (the canonical
+        // "insert final newline" shape). The position is clamped, not dropped.
+        let text = "abc";
+        let edits = vec![edit(0, 0, u32::MAX, u32::MAX, "X")];
+        assert_eq!(apply_text_edits(text, &edits), "X");
+    }
+
+    #[test]
+    fn inverted_range_is_normalized_not_panicking() {
+        // start after end: normalize to [end, start) rather than panicking.
+        // Here start=(0,3), end=(0,1) over "abcd" → replace "bc" with "Z".
+        let text = "abcd";
+        let edits = vec![edit(0, 3, 0, 1, "Z")];
+        assert_eq!(apply_text_edits(text, &edits), "aZd");
+    }
+
+    #[test]
     fn multibyte_text_is_not_corrupted() {
         // "café" — 'é' is two bytes. Replace "café" (cols 0..4 in UTF-16) with
         // "tea" and confirm no panic / clean result.

--- a/src/text/edit.rs
+++ b/src/text/edit.rs
@@ -12,11 +12,15 @@ use super::position::PositionMapper;
 
 /// Apply `edits` to `text`, returning the resulting string.
 ///
-/// All edit ranges are interpreted against the original `text` (LSP semantics),
-/// so edits are applied highest-position-first; that way an earlier edit never
-/// shifts the byte offsets a later edit still refers to. Out-of-bounds
-/// positions are clamped, and an inverted range (`start` after `end`) is
-/// normalized rather than panicking.
+/// All edit ranges are interpreted against the original `text` (LSP semantics).
+/// Edits are sorted by `(start, end)` and applied in a single **forward copy**
+/// (O(n + total edit length)) rather than repeated `String::replace_range`
+/// (which is O(n²)): the result is built by copying the gap before each edit,
+/// then its `new_text`. Out-of-bounds positions are clamped, an inverted range
+/// (`start` after `end`) is normalized, byte offsets are floored to UTF-8 char
+/// boundaries, and an edit overlapping one already applied is dropped (LSP
+/// forbids overlap, but a buggy server must never make us panic or corrupt) —
+/// the earlier, higher-priority edit wins.
 pub(crate) fn apply_text_edits(text: &str, edits: &[TextEdit]) -> String {
     if edits.is_empty() {
         return text.to_string();
@@ -26,43 +30,40 @@ pub(crate) fn apply_text_edits(text: &str, edits: &[TextEdit]) -> String {
     let mut byte_edits: Vec<(usize, usize, &str)> = edits
         .iter()
         .map(|e| {
-            let a = mapper.position_to_byte_clamped(e.range.start);
-            let b = mapper.position_to_byte_clamped(e.range.end);
+            let a = floor_char_boundary(text, mapper.position_to_byte_clamped(e.range.start));
+            let b = floor_char_boundary(text, mapper.position_to_byte_clamped(e.range.end));
             let (start, end) = if a <= b { (a, b) } else { (b, a) };
             (start, end, e.new_text.as_str())
         })
         .collect();
 
-    // Apply from the end of the document backwards so that replacing an earlier
-    // span never invalidates the byte offsets of a later (non-overlapping) edit.
-    // Sort by `(start, end)`: when several edits share a start (e.g. a zero-width
-    // insertion and a replacement), the wider span must be applied first under
-    // the reversed iteration, so the insertion is not swallowed by the
-    // replacement's range.
     byte_edits.sort_by_key(|&(start, end, _)| (start, end));
 
-    let mut result = text.to_string();
-    // Defensive against buggy downstream servers: clamp offsets to UTF-8 char
-    // boundaries (`replace_range` panics otherwise) and skip an edit that
-    // overlaps one already applied (LSP forbids overlap, but we never trust the
-    // server enough to panic). `last_start` is the start of the most recently
-    // applied edit; since we go highest-first, a later edit whose `end` reaches
-    // past it overlaps and is dropped.
-    let mut last_start = result.len();
-    for (mut start, mut end, new_text) in byte_edits.into_iter().rev() {
-        while start > 0 && !result.is_char_boundary(start) {
-            start -= 1;
-        }
-        while end > start && !result.is_char_boundary(end) {
-            end -= 1;
-        }
-        if end > last_start {
+    let mut result = String::with_capacity(text.len());
+    let mut cursor = 0usize;
+    for (start, end, new_text) in byte_edits {
+        // Drop an edit that starts before the cursor — it overlaps one already
+        // applied; keep the earlier (lower-start) edit.
+        if start < cursor {
             continue;
         }
-        result.replace_range(start..end, new_text);
-        last_start = start;
+        result.push_str(&text[cursor..start]);
+        result.push_str(new_text);
+        cursor = end;
     }
+    result.push_str(&text[cursor..]);
     result
+}
+
+/// Floor `offset` down to the nearest UTF-8 char boundary of `text` (or its
+/// length), so slicing never panics on a mid-codepoint offset from a buggy
+/// downstream server.
+fn floor_char_boundary(text: &str, offset: usize) -> usize {
+    let mut offset = offset.min(text.len());
+    while offset > 0 && !text.is_char_boundary(offset) {
+        offset -= 1;
+    }
+    offset
 }
 
 #[cfg(test)]
@@ -143,14 +144,14 @@ mod tests {
     #[test]
     fn overlapping_edits_are_dropped_rather_than_panicking() {
         // Two edits whose original ranges overlap (0..3 and 2..5). Applying both
-        // verbatim would corrupt or panic; the second (lower-priority by
-        // position) overlapping edit is skipped defensively.
+        // verbatim would corrupt or panic; the forward copy keeps the earlier
+        // (lower-start) edit and drops the later overlapping one.
         let text = "abcdef";
         let edits = vec![edit(0, 0, 0, 3, "A"), edit(0, 2, 0, 5, "B")];
-        // Highest-start first: (2..5)->"B" applied, then (0..3) overlaps and is
-        // dropped, leaving the tail intact.
+        // (0..3)->"A" applied (cursor=3), then (2..5) starts before the cursor
+        // and is dropped, leaving the tail "def".
         let out = apply_text_edits(text, &edits);
-        assert_eq!(out, "abBf");
+        assert_eq!(out, "Adef");
     }
 
     #[test]

--- a/src/text/edit.rs
+++ b/src/text/edit.rs
@@ -20,7 +20,7 @@ use super::position::PositionMapper;
 /// (`start` after `end`) is normalized, byte offsets are floored to UTF-8 char
 /// boundaries, and an edit overlapping one already applied is dropped (LSP
 /// forbids overlap, but a buggy server must never make us panic or corrupt) —
-/// the earlier, higher-priority edit wins.
+/// resolved purely by sort order, so the lower-start edit wins.
 pub(crate) fn apply_text_edits(text: &str, edits: &[TextEdit]) -> String {
     if edits.is_empty() {
         return text.to_string();

--- a/src/text/edit.rs
+++ b/src/text/edit.rs
@@ -31,11 +31,13 @@ pub(crate) fn apply_text_edits(text: &str, edits: &[TextEdit]) -> String {
     let mut byte_edits: Vec<(usize, usize, &str)> = edits
         .iter()
         .map(|e| {
-            // `floor_char_boundary` (stable since Rust 1.95) also clamps an
-            // index past the end down to `text.len()`, so a buggy mid-codepoint
-            // or out-of-range offset can never make the slices below panic.
-            let a = text.floor_char_boundary(mapper.position_to_byte_clamped(e.range.start));
-            let b = text.floor_char_boundary(mapper.position_to_byte_clamped(e.range.end));
+            // `floor_char_boundary` clamps an index past the end down to
+            // `text.len()` and floors a mid-codepoint offset to a char boundary,
+            // so a buggy out-of-range/mid-codepoint offset can't make the slices
+            // below panic. (Hand-rolled rather than `str::floor_char_boundary` to
+            // avoid raising the crate's MSRV — see the helper below.)
+            let a = floor_char_boundary(text, mapper.position_to_byte_clamped(e.range.start));
+            let b = floor_char_boundary(text, mapper.position_to_byte_clamped(e.range.end));
             let (start, end) = if a <= b { (a, b) } else { (b, a) };
             (start, end, e.new_text.as_str())
         })
@@ -60,6 +62,20 @@ pub(crate) fn apply_text_edits(text: &str, edits: &[TextEdit]) -> String {
     }
     result.push_str(&text[cursor..]);
     result
+}
+
+/// Floor `offset` to the nearest UTF-8 char boundary of `text` (clamping past the
+/// end to `text.len()`), so slicing at it never panics on a mid-codepoint or
+/// out-of-range offset from a buggy downstream server.
+///
+/// Hand-rolled rather than `str::floor_char_boundary` (stable only since Rust
+/// 1.95) to keep the crate's MSRV from being raised.
+fn floor_char_boundary(text: &str, offset: usize) -> usize {
+    let mut offset = offset.min(text.len());
+    while offset > 0 && !text.is_char_boundary(offset) {
+        offset -= 1;
+    }
+    offset
 }
 
 #[cfg(test)]

--- a/src/text/edit.rs
+++ b/src/text/edit.rs
@@ -1,0 +1,111 @@
+//! Apply LSP `TextEdit`s to a text buffer.
+//!
+//! Formatting and rangeFormatting responses are `TextEdit[]` whose ranges are
+//! all relative to the *original* document and which, per the LSP spec, must
+//! not overlap. The concatenated formatting pipeline
+//! (concatenated-formatting-pipeline) feeds each server's output into the next,
+//! which requires materializing the post-edit text — this module does that.
+
+use tower_lsp_server::ls_types::TextEdit;
+
+use super::position::PositionMapper;
+
+/// Apply `edits` to `text`, returning the resulting string.
+///
+/// All edit ranges are interpreted against the original `text` (LSP semantics),
+/// so edits are applied highest-position-first; that way an earlier edit never
+/// shifts the byte offsets a later edit still refers to. Out-of-bounds
+/// positions are clamped, and an inverted range (`start` after `end`) is
+/// normalized rather than panicking.
+pub(crate) fn apply_text_edits(text: &str, edits: &[TextEdit]) -> String {
+    if edits.is_empty() {
+        return text.to_string();
+    }
+
+    let mapper = PositionMapper::new(text);
+    let mut byte_edits: Vec<(usize, usize, &str)> = edits
+        .iter()
+        .map(|e| {
+            let a = mapper.position_to_byte_clamped(e.range.start);
+            let b = mapper.position_to_byte_clamped(e.range.end);
+            let (start, end) = if a <= b { (a, b) } else { (b, a) };
+            (start, end, e.new_text.as_str())
+        })
+        .collect();
+
+    // Apply from the end of the document backwards so that replacing an earlier
+    // span never invalidates the byte offsets of a later (non-overlapping) edit.
+    byte_edits.sort_by_key(|(start, _, _)| *start);
+
+    let mut result = text.to_string();
+    for (start, end, new_text) in byte_edits.into_iter().rev() {
+        result.replace_range(start..end, new_text);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower_lsp_server::ls_types::{Position, Range};
+
+    fn edit(sl: u32, sc: u32, el: u32, ec: u32, new_text: &str) -> TextEdit {
+        TextEdit {
+            range: Range {
+                start: Position {
+                    line: sl,
+                    character: sc,
+                },
+                end: Position {
+                    line: el,
+                    character: ec,
+                },
+            },
+            new_text: new_text.to_string(),
+        }
+    }
+
+    #[test]
+    fn applies_single_edit_replacing_a_span() {
+        let text = "hello world";
+        let edits = vec![edit(0, 6, 0, 11, "rust")];
+        assert_eq!(apply_text_edits(text, &edits), "hello rust");
+    }
+
+    #[test]
+    fn empty_edits_return_text_unchanged() {
+        assert_eq!(apply_text_edits("unchanged", &[]), "unchanged");
+    }
+
+    #[test]
+    fn applies_multiple_disjoint_edits_regardless_of_order() {
+        // Two edits given in ascending order; applying the later one first must
+        // not shift the earlier one. Replace "a"->"AAAA" and "c"->"C".
+        let text = "a b c";
+        let edits = vec![edit(0, 0, 0, 1, "AAAA"), edit(0, 4, 0, 5, "C")];
+        assert_eq!(apply_text_edits(text, &edits), "AAAA b C");
+    }
+
+    #[test]
+    fn applies_a_pure_insertion_at_a_zero_width_range() {
+        let text = "ab";
+        // Insert "X" between a and b (zero-width range at col 1).
+        let edits = vec![edit(0, 1, 0, 1, "X")];
+        assert_eq!(apply_text_edits(text, &edits), "aXb");
+    }
+
+    #[test]
+    fn applies_a_multi_line_replacement() {
+        let text = "line1\nline2\nline3";
+        // Replace from (0,0) through (1,5) — i.e. "line1\nline2" — with "L".
+        let edits = vec![edit(0, 0, 1, 5, "L")];
+        assert_eq!(apply_text_edits(text, &edits), "L\nline3");
+    }
+
+    #[test]
+    fn full_document_replacement_replaces_everything() {
+        let text = "old\ncontent";
+        let edits = vec![edit(0, 0, 1, 7, "new")];
+        assert_eq!(apply_text_edits(text, &edits), "new");
+    }
+}

--- a/src/text/edit.rs
+++ b/src/text/edit.rs
@@ -13,14 +13,15 @@ use super::position::PositionMapper;
 /// Apply `edits` to `text`, returning the resulting string.
 ///
 /// All edit ranges are interpreted against the original `text` (LSP semantics).
-/// Edits are sorted by `(start, end)` and applied in a single **forward copy**
-/// (O(n + total edit length)) rather than repeated `String::replace_range`
-/// (which is O(n²)): the result is built by copying the gap before each edit,
-/// then its `new_text`. Out-of-bounds positions are clamped, an inverted range
-/// (`start` after `end`) is normalized, byte offsets are floored to UTF-8 char
-/// boundaries, and an edit overlapping one already applied is dropped (LSP
-/// forbids overlap, but a buggy server must never make us panic or corrupt) —
-/// resolved purely by sort order, so the lower-start edit wins.
+/// For `m` edits over a `text` of length `n`, the cost is `O(m log m)` to sort by
+/// `(start, end)` plus `O(n + total new_text length)` for a single **forward
+/// copy** — the result is built by copying the gap before each edit, then its
+/// `new_text`, rather than repeated `String::replace_range` (which is O(n²)).
+/// Out-of-bounds positions are clamped, an inverted range (`start` after `end`)
+/// is normalized, byte offsets are floored to UTF-8 char boundaries, and an edit
+/// overlapping one already applied is dropped (LSP forbids overlap, but a buggy
+/// server must never make us panic or corrupt) — resolved purely by sort order,
+/// so the lower-start edit wins.
 pub(crate) fn apply_text_edits(text: &str, edits: &[TextEdit]) -> String {
     if edits.is_empty() {
         return text.to_string();
@@ -30,8 +31,11 @@ pub(crate) fn apply_text_edits(text: &str, edits: &[TextEdit]) -> String {
     let mut byte_edits: Vec<(usize, usize, &str)> = edits
         .iter()
         .map(|e| {
-            let a = floor_char_boundary(text, mapper.position_to_byte_clamped(e.range.start));
-            let b = floor_char_boundary(text, mapper.position_to_byte_clamped(e.range.end));
+            // `floor_char_boundary` (stable since Rust 1.95) also clamps an
+            // index past the end down to `text.len()`, so a buggy mid-codepoint
+            // or out-of-range offset can never make the slices below panic.
+            let a = text.floor_char_boundary(mapper.position_to_byte_clamped(e.range.start));
+            let b = text.floor_char_boundary(mapper.position_to_byte_clamped(e.range.end));
             let (start, end) = if a <= b { (a, b) } else { (b, a) };
             (start, end, e.new_text.as_str())
         })
@@ -39,7 +43,10 @@ pub(crate) fn apply_text_edits(text: &str, edits: &[TextEdit]) -> String {
 
     byte_edits.sort_by_key(|&(start, end, _)| (start, end));
 
-    let mut result = String::with_capacity(text.len());
+    // Upper-bound the result capacity (original text + all inserted text) so the
+    // forward copy never reallocates, even with many insertions.
+    let extra: usize = byte_edits.iter().map(|&(_, _, t)| t.len()).sum();
+    let mut result = String::with_capacity(text.len() + extra);
     let mut cursor = 0usize;
     for (start, end, new_text) in byte_edits {
         // Drop an edit that starts before the cursor — it overlaps one already
@@ -53,17 +60,6 @@ pub(crate) fn apply_text_edits(text: &str, edits: &[TextEdit]) -> String {
     }
     result.push_str(&text[cursor..]);
     result
-}
-
-/// Floor `offset` down to the nearest UTF-8 char boundary of `text` (or its
-/// length), so slicing never panics on a mid-codepoint offset from a buggy
-/// downstream server.
-fn floor_char_boundary(text: &str, offset: usize) -> usize {
-    let mut offset = offset.min(text.len());
-    while offset > 0 && !text.is_char_boundary(offset) {
-        offset -= 1;
-    }
-    offset
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Implements the **first vertical slice** of the concatenated formatting pipeline decided in [`concatenated-formatting-pipeline`](docs/architecture-decisions/concatenated-formatting-pipeline.md) (ADR merged in #320).

## What this does

When `strategy: "concatenated"` is configured for `textDocument/formatting` on an injection region **with a non-empty `priorities` list**, the region is formatted by running the priority-listed servers **serially** — each formats the previous server's output — then collapsed into a single region-replacement edit. Default / empty-priorities behavior is unchanged (`preferred`, first non-empty wins).

Serial application is what makes this safe: each server always sees the latest text, so edits never overlap and there is nothing to merge (unlike the list-concatenation used for diagnostics/references, which would produce overlapping `TextEdit`s for formatters).

## Changes
- **`src/text/edit.rs`** — new `apply_text_edits(text, &[TextEdit]) -> String`: applies edits in a single O(n) forward-copy pass (sorted by (start, end)), clamps out-of-bounds, normalizes inverted ranges, drops overlaps.
- **`src/lsp/aggregation/server/concatenated_pipeline.rs`** — `run_sequential_format_pipeline`: the pure async core, generic over an injected per-server format step (mirrors `dispatch_preferred`'s closure shape) so it's unit-testable without the bridge. Sequential feed; skip-on-failure (best-effort, never discards prior output); empty edits = authoritative "already formatted" no-op; unchanged text → no edit.
- **`formatting.rs`** — per-region task branches on `strategy == Concatenated && !priorities.is_empty()`; `preferred` extracted verbatim into `dispatch_preferred_formatting` (unchanged); new `dispatch_concatenated_formatting` runs the pipeline (priorities filtered to configured servers = allowlist+order) and translates the final text into one host-coordinate replacement edit.

## Tests (unit, all green; full `make check` passes)
- `text::edit` — 6 tests (single/multi/insertion/multi-line/full-replace/empty).
- `concatenated_pipeline` — 5 tests: feeds each server the prior output in order, skips a failing server, empty-edits no-op advances, unchanged → none, empty server list → none.

## Deliberately out of scope (TODO comments + ADR refs in code) — follow-up slices
1. ~~Scratch-document isolation~~ — **now implemented in this PR** (per-step unique scratch URIs + `didOpen`/`didClose`); review found the region-virtual-doc reuse formatted stale content, so it was pulled forward.
2. Capability-based full→`rangeFormatting` fallback; distinguish `null` "already formatted" from a missing provider.
3. Per-line/LCP host-prefix re-application on multi-line / line-count-changing output (currently emits final text verbatim — same limitation already documented in the bridge formatting handler).
4. Per-step remaining-budget timeout + concurrent `$/cancelRequest` propagation.
5. Retire the now-partially-stale `concatenated_formatting_pairs` misconfiguration warning for the non-empty-priorities case.
6. E2E test exercising a real multi-server chain.

Per the ADR's Decision–Implementation Gap, the feature is being built incrementally; this slice delivers the core sequential behavior.
