### PR TITLE
perf(semantic): speed up the semantic-tokens hot path (1.06×–1.72×)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,3 +73,11 @@ insta = { version = "1", features = ["json", "redactions"] }
 serial_test = "3"
 rstest = "0.26"
 
+# A/B performance comparison of the semantic-tokens hot path across two server
+# binaries (e.g. HEAD vs origin/main). Custom harness (no criterion): it drives
+# the compiled `kakehashi` binary over LSP, so it benchmarks the real process
+# without needing access to pub(crate) internals. See benches/semantic_tokens.rs.
+[[bench]]
+name = "semantic_tokens"
+harness = false
+

--- a/benches/compare_head_vs_main.sh
+++ b/benches/compare_head_vs_main.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# A/B-benchmark the semantic-tokens hot path of HEAD against a baseline ref
+# (default: origin/main).
+#
+# How it works: it builds the `kakehashi` *binary* from both revisions, then runs
+# the single benchmark harness (benches/semantic_tokens.rs, always from HEAD)
+# against both binaries. Because the harness drives the server over LSP as a
+# separate process, the same harness can benchmark any binary — so the baseline
+# revision never needs to contain this benchmark.
+#
+# Usage:
+#   benches/compare_head_vs_main.sh [BASELINE_REF]
+#
+# Env:
+#   KAKEHASHI_BENCH_ITERS / KAKEHASHI_BENCH_WARMUP  forwarded to the harness.
+set -euo pipefail
+
+BASELINE_REF="${1:-origin/main}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+WORK="$(mktemp -d)"
+WORKTREE="$WORK/baseline-src"
+HEAD_BIN="$WORK/kakehashi-head"
+BASE_BIN="$WORK/kakehashi-baseline"
+
+cleanup() {
+  git worktree remove --force "$WORKTREE" 2>/dev/null || true
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+echo "==> Building HEAD binary"
+cargo build --release --bin kakehashi
+cp target/release/kakehashi "$HEAD_BIN"
+
+echo "==> Building ${BASELINE_REF} binary in a detached worktree"
+git worktree add --detach "$WORKTREE" "$BASELINE_REF"
+# Separate target dir so the baseline build can't clash with HEAD's artifacts.
+( cd "$WORKTREE" && CARGO_TARGET_DIR="$WORK/baseline-target" cargo build --release --bin kakehashi )
+cp "$WORK/baseline-target/release/kakehashi" "$BASE_BIN"
+
+echo "==> Running A/B benchmark (A=${BASELINE_REF}, B=HEAD)"
+# A = baseline, B = HEAD, so the reported Δ (B vs A) is HEAD relative to baseline:
+# a negative Δ means HEAD is faster.
+# The harness needs --features e2e to reach install::test_support for parser
+# setup. The benchmarked binaries were built separately above without it.
+KAKEHASHI_BENCH_BIN_A="$BASE_BIN" KAKEHASHI_BENCH_LABEL_A="baseline" \
+KAKEHASHI_BENCH_BIN_B="$HEAD_BIN" KAKEHASHI_BENCH_LABEL_B="HEAD" \
+  cargo bench --bench semantic_tokens --features e2e

--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -1,0 +1,574 @@
+//! Semantic-tokens A/B performance benchmark.
+//!
+//! Compares the semantic-tokens hot path of two `kakehashi` server binaries —
+//! typically the current `HEAD` against `origin/main` — across several
+//! scenarios, each chosen to exercise a specific performance improvement made
+//! on this branch.
+//!
+//! ## Why drive the binary over LSP
+//!
+//! The semantic-tokens code is `pub(crate)`, so a `benches/` crate cannot call
+//! it directly. Driving the compiled binary over the LSP protocol instead means
+//! ONE harness (compiled from HEAD) can benchmark ANY binary, selected at
+//! runtime via an env var — so we never need this file to exist on `origin/main`.
+//! Both binaries read the same parser/query data dir, so only their code differs.
+//!
+//! ## Usage
+//!
+//! The harness must be built with `--features e2e` so it can reach
+//! `install::test_support` for parser/query setup. The benchmarked server
+//! binaries are built separately and do NOT need that feature.
+//!
+//! Single binary (absolute timings):
+//! ```sh
+//! cargo build --release --bin kakehashi
+//! KAKEHASHI_BENCH_BIN=target/release/kakehashi \
+//!   cargo bench --bench semantic_tokens --features e2e
+//! ```
+//!
+//! A/B comparison (the common case — see benches/compare_head_vs_main.sh):
+//! ```sh
+//! KAKEHASHI_BENCH_BIN_A=/tmp/kakehashi-main KAKEHASHI_BENCH_LABEL_A=main \
+//! KAKEHASHI_BENCH_BIN_B=/tmp/kakehashi-head KAKEHASHI_BENCH_LABEL_B=head \
+//!   cargo bench --bench semantic_tokens --features e2e
+//! ```
+//!
+//! Tunables (env): `KAKEHASHI_BENCH_ITERS` (default 80),
+//! `KAKEHASHI_BENCH_WARMUP` (default 10).
+
+use serde_json::{Value, json};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::path::PathBuf;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::time::{Duration, Instant};
+
+// ───────────────────────────── Minimal LSP client ─────────────────────────────
+
+/// A spawned `kakehashi` server process plus the JSON-RPC plumbing needed to
+/// initialize it and request semantic tokens. Intentionally minimal — just the
+/// subset of `tests/helpers/lsp_client.rs` the benchmark needs (benches cannot
+/// import test helpers).
+struct Server {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: i64,
+}
+
+impl Server {
+    /// Spawn `bin`, run the LSP handshake, and return a ready server.
+    fn start(bin: &str, data_dir: &str) -> Server {
+        let mut child = Command::new(bin)
+            .env("KAKEHASHI_DATA_DIR", data_dir)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap_or_else(|e| panic!("failed to spawn server binary {bin:?}: {e}"));
+
+        let stdin = child.stdin.take().expect("stdin");
+        let stdout = BufReader::new(child.stdout.take().expect("stdout"));
+        let mut server = Server {
+            child,
+            stdin,
+            stdout,
+            next_id: 0,
+        };
+
+        server.request(
+            "initialize",
+            json!({
+                "processId": std::process::id(),
+                "rootUri": null,
+                "capabilities": {
+                    "textDocument": {
+                        "semanticTokens": {
+                            "dynamicRegistration": false,
+                            "requests": { "full": { "delta": true } },
+                            "tokenTypes": [],
+                            "tokenModifiers": [],
+                            "formats": ["relative"]
+                        }
+                    }
+                }
+            }),
+        );
+        server.notify("initialized", json!({}));
+        server
+    }
+
+    fn did_open(&mut self, uri: &str, language_id: &str, text: &str) {
+        self.notify(
+            "textDocument/didOpen",
+            json!({
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": language_id,
+                    "version": 1,
+                    "text": text,
+                }
+            }),
+        );
+    }
+
+    /// `semanticTokens/full`; returns the response's `result` object.
+    fn semantic_full(&mut self, uri: &str) -> Value {
+        self.request(
+            "textDocument/semanticTokens/full",
+            json!({ "textDocument": { "uri": uri } }),
+        )
+    }
+
+    /// `semanticTokens/full/delta` against `previous_result_id`.
+    fn semantic_delta(&mut self, uri: &str, previous_result_id: &str) -> Value {
+        self.request(
+            "textDocument/semanticTokens/full/delta",
+            json!({
+                "textDocument": { "uri": uri },
+                "previousResultId": previous_result_id,
+            }),
+        )
+    }
+
+    fn request(&mut self, method: &str, params: Value) -> Value {
+        self.next_id += 1;
+        let id = self.next_id;
+        self.send(&json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        }));
+        self.recv_response(id)
+    }
+
+    fn notify(&mut self, method: &str, params: Value) {
+        self.send(&json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        }));
+    }
+
+    fn send(&mut self, msg: &Value) {
+        let body = serde_json::to_string(msg).unwrap();
+        write!(self.stdin, "Content-Length: {}\r\n\r\n{}", body.len(), body).unwrap();
+        self.stdin.flush().unwrap();
+    }
+
+    /// Read messages until the response for `id` arrives, skipping
+    /// notifications and server-to-client requests.
+    fn recv_response(&mut self, id: i64) -> Value {
+        let deadline = Instant::now() + Duration::from_secs(60);
+        loop {
+            if Instant::now() > deadline {
+                panic!("timed out waiting for response id={id}");
+            }
+            let msg = self.recv_message();
+            // Server-to-client requests carry a "method"; skip them.
+            if msg.get("method").is_some() {
+                continue;
+            }
+            if msg.get("id").and_then(Value::as_i64) == Some(id) {
+                return msg.get("result").cloned().unwrap_or(Value::Null);
+            }
+        }
+    }
+
+    fn recv_message(&mut self) -> Value {
+        // Parse Content-Length framing.
+        let mut content_length = None;
+        loop {
+            let mut line = String::new();
+            if self.stdout.read_line(&mut line).unwrap() == 0 {
+                panic!("server closed stdout unexpectedly");
+            }
+            let trimmed = line.trim_end();
+            if trimmed.is_empty() {
+                break; // end of headers
+            }
+            if let Some(v) = trimmed.strip_prefix("Content-Length:") {
+                content_length = Some(v.trim().parse::<usize>().expect("content-length"));
+            }
+        }
+        let len = content_length.expect("missing Content-Length");
+        let mut buf = vec![0u8; len];
+        self.stdout.read_exact(&mut buf).unwrap();
+        serde_json::from_slice(&buf).expect("valid json body")
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        // Best-effort shutdown; kill if it doesn't exit promptly.
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+// ───────────────────────────── Document generators ────────────────────────────
+
+/// Dense, all-ASCII Rust source: keywords, types, strings, numbers, comments,
+/// functions, and locals. Exercises the host-only token path.
+fn gen_rust(funcs: usize) -> String {
+    let mut s = String::with_capacity(funcs * 400);
+    s.push_str("use std::collections::HashMap;\nuse std::fmt;\n\n");
+    for i in 0..funcs {
+        s.push_str(&format!(
+            "/// Documentation comment for function number {i}.\n\
+             pub fn function_{i}(arg_a: i32, arg_b: &str, items: &[u64]) -> Result<String, String> {{\n\
+            \x20   let local_total: i64 = arg_a as i64 * 2 + {i};\n\
+            \x20   let mut lookup: HashMap<String, u64> = HashMap::new();\n\
+            \x20   for (index, value) in items.iter().enumerate() {{\n\
+            \x20       lookup.insert(format!(\"key_{{}}\", index), *value);\n\
+            \x20   }}\n\
+            \x20   let message = format!(\"total is {{}} for {{}}\", local_total, arg_b);\n\
+            \x20   if local_total > 100 && !items.is_empty() {{\n\
+            \x20       return Err(String::from(\"value too large\"));\n\
+            \x20   }}\n\
+            \x20   match arg_b {{\n\
+            \x20       \"alpha\" => Ok(message),\n\
+            \x20       \"beta\" => Ok(String::from(\"the beta branch\")),\n\
+            \x20       _ => Ok(message.clone()),\n\
+            \x20   }}\n\
+             }}\n\n"
+        ));
+    }
+    s
+}
+
+/// Markdown with many fenced code blocks in rust/lua/python — each block is a
+/// separate injection region. Exercises the injection pipeline: included-range
+/// computation, active-region detection, and host/injection coordinate mapping.
+fn gen_markdown_injections(blocks: usize) -> String {
+    let mut s = String::with_capacity(blocks * 300);
+    s.push_str("# Benchmark Document\n\nAn introductory paragraph with some **bold** and `inline code`.\n\n");
+    for i in 0..blocks {
+        s.push_str(&format!(
+            "## Section {i}\n\nProse describing the code in section {i} before the fence.\n\n"
+        ));
+        match i % 3 {
+            0 => s.push_str(&format!(
+                "```rust\n\
+                 fn rust_block_{i}(x: i32) -> i32 {{\n\
+                \x20   let doubled = x * 2; // a comment\n\
+                \x20   let label = \"section {i}\";\n\
+                \x20   println!(\"{{}} {{}}\", label, doubled);\n\
+                \x20   doubled + {i}\n\
+                 }}\n```\n\n"
+            )),
+            1 => s.push_str(&format!(
+                "```lua\n\
+                 local function lua_block_{i}(x)\n\
+                \x20   local doubled = x * 2 -- a comment\n\
+                \x20   local label = \"section {i}\"\n\
+                \x20   print(label, doubled)\n\
+                \x20   return doubled + {i}\n\
+                 end\n```\n\n"
+            )),
+            _ => s.push_str(&format!(
+                "```python\n\
+                 def python_block_{i}(x):\n\
+                \x20   doubled = x * 2  # a comment\n\
+                \x20   label = \"section {i}\"\n\
+                \x20   print(label, doubled)\n\
+                \x20   return doubled + {i}\n```\n\n"
+            )),
+        }
+    }
+    s
+}
+
+/// Rust source whose comments and string literals are full of multi-byte UTF-8,
+/// forcing the non-ASCII branch of byte→UTF-16 column conversion on most lines.
+fn gen_unicode_rust(funcs: usize) -> String {
+    let mut s = String::with_capacity(funcs * 300);
+    for i in 0..funcs {
+        s.push_str(&format!(
+            "/// 関数番号 {i} のドキュメントコメント — 日本語の説明文です。\n\
+             pub fn 関数_{i}(引数: i32) -> String {{\n\
+            \x20   let メッセージ = \"こんにちは世界、ベンチマーク {i} 番\";\n\
+            \x20   let emoji = \"🚀✨🎯 milestone {i}\";\n\
+            \x20   format!(\"{{}} {{}} {{}}\", メッセージ, emoji, 引数)\n\
+             }}\n\n"
+        ));
+    }
+    s
+}
+
+// ─────────────────────────────── Statistics ───────────────────────────────────
+
+struct Stats {
+    median: Duration,
+    p25: Duration,
+    p75: Duration,
+}
+
+fn summarize(mut samples: Vec<Duration>) -> Stats {
+    samples.sort_unstable();
+    let pick = |q: f64| samples[((samples.len() as f64 * q) as usize).min(samples.len() - 1)];
+    Stats {
+        median: pick(0.50),
+        p25: pick(0.25),
+        p75: pick(0.75),
+    }
+}
+
+fn ms(d: Duration) -> f64 {
+    d.as_secs_f64() * 1000.0
+}
+
+// ───────────────────────────── Scenario harness ───────────────────────────────
+
+#[derive(Clone, Copy)]
+enum Kind {
+    Full,
+    DeltaNoop,
+}
+
+struct Scenario {
+    name: &'static str,
+    language_id: &'static str,
+    uri: &'static str,
+    content: String,
+    kind: Kind,
+    /// Which branch commits this scenario is designed to exercise.
+    targets: &'static str,
+}
+
+struct Binary {
+    label: String,
+    path: String,
+}
+
+/// Run one scenario against one binary and return per-request timing samples.
+/// `iters` requests are measured after `warmup` unmeasured ones.
+fn measure(
+    bin: &Binary,
+    scn: &Scenario,
+    data_dir: &str,
+    iters: usize,
+    warmup: usize,
+) -> Vec<Duration> {
+    let mut server = Server::start(&bin.path, data_dir);
+    server.did_open(scn.uri, scn.language_id, &scn.content);
+    // Let the initial parse settle (didOpen parse may be async).
+    std::thread::sleep(Duration::from_millis(300));
+
+    // For delta scenarios we need a valid previous result_id; seed it from a
+    // full request, then keep it current (a no-op delta may or may not rotate).
+    let mut prev_result_id = seed_result_id(&mut server, scn);
+
+    for _ in 0..warmup {
+        run_once(&mut server, scn, &mut prev_result_id);
+    }
+
+    let mut samples = Vec::with_capacity(iters);
+    for _ in 0..iters {
+        let start = Instant::now();
+        run_once(&mut server, scn, &mut prev_result_id);
+        samples.push(start.elapsed());
+    }
+    samples
+}
+
+fn seed_result_id(server: &mut Server, scn: &Scenario) -> String {
+    match scn.kind {
+        Kind::Full => String::new(),
+        Kind::DeltaNoop => result_id_of(&server.semantic_full(scn.uri)).unwrap_or_default(),
+    }
+}
+
+fn run_once(server: &mut Server, scn: &Scenario, prev_result_id: &mut String) {
+    match scn.kind {
+        Kind::Full => {
+            let _ = server.semantic_full(scn.uri);
+        }
+        Kind::DeltaNoop => {
+            let result = server.semantic_delta(scn.uri, prev_result_id);
+            // Keep the id valid for the next request whether or not it rotated.
+            if let Some(id) = result_id_of(&result) {
+                *prev_result_id = id;
+            }
+        }
+    }
+}
+
+fn result_id_of(result: &Value) -> Option<String> {
+    result
+        .get("resultId")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+fn main() {
+    // Ensure parsers/queries exist, and reuse the test data dir both binaries read.
+    let data_dir: PathBuf = kakehashi::install::test_support::test_data_dir_path();
+    std::fs::create_dir_all(&data_dir).expect("create data dir");
+    kakehashi::install::test_support::ensure_test_languages_installed(&data_dir)
+        .expect("install test languages");
+    let data_dir = data_dir.to_string_lossy().to_string();
+
+    let iters = env_usize("KAKEHASHI_BENCH_ITERS", 80);
+    let warmup = env_usize("KAKEHASHI_BENCH_WARMUP", 10);
+
+    let binaries = resolve_binaries();
+
+    let scenarios = vec![
+        Scenario {
+            name: "rust_small/full",
+            language_id: "rust",
+            uri: "file:///bench/small.rs",
+            content: gen_rust(15),
+            kind: Kind::Full,
+            targets: "token-index resolution, Arc mappings, lazy filter_captures",
+        },
+        Scenario {
+            name: "rust_large/full",
+            language_id: "rust",
+            uri: "file:///bench/large.rs",
+            content: gen_rust(150),
+            kind: Kind::Full,
+            targets: "per-token String removal, ASCII fast-path, Arc mappings (amplified)",
+        },
+        Scenario {
+            name: "markdown_injections/full",
+            language_id: "markdown",
+            uri: "file:///bench/injections.md",
+            content: gen_markdown_injections(60),
+            kind: Kind::Full,
+            targets: "active-region binary search, line/col index, host_lines sharing",
+        },
+        Scenario {
+            name: "markdown_injections_large/full",
+            language_id: "markdown",
+            uri: "file:///bench/injections_large.md",
+            content: gen_markdown_injections(150),
+            kind: Kind::Full,
+            targets: "injection pipeline at scale (amplifies region/coord work)",
+        },
+        Scenario {
+            name: "unicode_rust/full",
+            language_id: "rust",
+            uri: "file:///bench/unicode.rs",
+            content: gen_unicode_rust(150),
+            kind: Kind::Full,
+            targets: "byte→UTF-16 conversion (non-ASCII fallback) + token path",
+        },
+        Scenario {
+            name: "rust_large/delta_noop",
+            language_id: "rust",
+            uri: "file:///bench/large_delta.rs",
+            content: gen_rust(150),
+            kind: Kind::DeltaNoop,
+            targets: "no-op delta result_id reuse",
+        },
+    ];
+
+    println!();
+    println!("semantic-tokens benchmark  (iters={iters}, warmup={warmup}, lower is better)");
+    for b in &binaries {
+        println!("  {} = {}", b.label, b.path);
+    }
+    println!();
+
+    if binaries.len() == 2 {
+        print_ab_header(&binaries[0].label, &binaries[1].label);
+        for scn in &scenarios {
+            // Interleave A and B at the scenario level (separate processes); the
+            // two runs are back-to-back to minimize machine drift between them.
+            let a = summarize(measure(&binaries[0], scn, &data_dir, iters, warmup));
+            let b = summarize(measure(&binaries[1], scn, &data_dir, iters, warmup));
+            print_ab_row(scn, &a, &b);
+        }
+    } else {
+        print_single_header();
+        for scn in &scenarios {
+            let s = summarize(measure(&binaries[0], scn, &data_dir, iters, warmup));
+            print_single_row(scn, &s);
+        }
+    }
+    println!();
+}
+
+// ───────────────────────────── Output formatting ──────────────────────────────
+
+fn print_single_header() {
+    println!(
+        "{:<34} {:>10} {:>10} {:>10}",
+        "scenario", "median", "p25", "p75"
+    );
+    println!("{}", "-".repeat(68));
+}
+
+fn print_single_row(scn: &Scenario, s: &Stats) {
+    println!(
+        "{:<34} {:>9.3}ms {:>9.3}ms {:>9.3}ms",
+        scn.name,
+        ms(s.median),
+        ms(s.p25),
+        ms(s.p75)
+    );
+    println!("    └ targets: {}", scn.targets);
+}
+
+fn print_ab_header(label_a: &str, label_b: &str) {
+    println!(
+        "{:<34} {:>12} {:>12} {:>10}",
+        "scenario",
+        format!("{label_a} (med)"),
+        format!("{label_b} (med)"),
+        "Δ (B vs A)"
+    );
+    println!("{}", "-".repeat(72));
+}
+
+fn print_ab_row(scn: &Scenario, a: &Stats, b: &Stats) {
+    let am = ms(a.median);
+    let bm = ms(b.median);
+    let delta_pct = if am > 0.0 {
+        (bm - am) / am * 100.0
+    } else {
+        0.0
+    };
+    let sign = if delta_pct <= 0.0 { "" } else { "+" };
+    println!(
+        "{:<34} {:>10.3}ms {:>10.3}ms {:>8}{:.1}%",
+        scn.name, am, bm, sign, delta_pct
+    );
+    println!("    └ targets: {}", scn.targets);
+}
+
+// ──────────────────────────────── Env helpers ─────────────────────────────────
+
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+/// Resolve which binaries to benchmark from the environment.
+/// A/B mode if both `_A` and `_B` are set; otherwise single-binary mode.
+fn resolve_binaries() -> Vec<Binary> {
+    let a = std::env::var("KAKEHASHI_BENCH_BIN_A").ok();
+    let b = std::env::var("KAKEHASHI_BENCH_BIN_B").ok();
+    if let (Some(a), Some(b)) = (a, b) {
+        return vec![
+            Binary {
+                label: std::env::var("KAKEHASHI_BENCH_LABEL_A").unwrap_or_else(|_| "A".into()),
+                path: a,
+            },
+            Binary {
+                label: std::env::var("KAKEHASHI_BENCH_LABEL_B").unwrap_or_else(|_| "B".into()),
+                path: b,
+            },
+        ];
+    }
+    let single = std::env::var("KAKEHASHI_BENCH_BIN")
+        .unwrap_or_else(|_| "target/release/kakehashi".to_string());
+    vec![Binary {
+        label: "binary".into(),
+        path: single,
+    }]
+}

--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -202,6 +202,12 @@ impl Server {
                 continue;
             }
             if msg.get("id").and_then(Value::as_i64) == Some(id) {
+                // Fail fast on a JSON-RPC error: a misconfigured server (missing
+                // parser/query, bad setup) must not silently produce Null and
+                // bogus timings.
+                if let Some(error) = msg.get("error") {
+                    panic!("server returned a JSON-RPC error for request id={id}: {error}");
+                }
                 return msg.get("result").cloned().unwrap_or(Value::Null);
             }
         }

--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -365,10 +365,11 @@ enum Kind {
 }
 
 /// Mutable per-run state for [`Kind::EditDelta`]: the next `didChange` version,
-/// an edit counter (parity selects insert vs delete), and the line edited.
+/// whether the next edit inserts (vs deletes) — flips each iteration to toggle —
+/// and the line edited.
 struct EditState {
     version: i64,
-    count: u64,
+    insert_next: bool,
     line: u32,
 }
 
@@ -409,7 +410,8 @@ fn measure(
     // middle of the document (representative of typical cursor position).
     let mut edit = EditState {
         version: 1,
-        count: 0,
+        // First edit must insert (the document opens with no extra space).
+        insert_next: true,
         line: (scn.content.lines().count() / 2) as u32,
     };
 
@@ -455,8 +457,8 @@ fn run_once(
         }
         Kind::EditDelta => {
             // Apply one toggle edit, then request a delta against the prior id.
-            let insert = edit.count.is_multiple_of(2);
-            edit.count += 1;
+            let insert = edit.insert_next;
+            edit.insert_next = !edit.insert_next;
             edit.version += 1;
             server.did_change_toggle(scn.uri, edit.version, edit.line, insert);
             // Fall back to a full request if we don't yet have a valid id

--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -130,6 +130,38 @@ impl Server {
         )
     }
 
+    /// Incremental `didChange` that toggles a single space at the start of
+    /// `line`: `insert` adds it, `!insert` removes it. Because the char at
+    /// column 0 after an insert is always that space, the delete restores the
+    /// document to its exact original bytes — so a type/untype pair round-trips
+    /// and keeps token count stable across iterations.
+    fn did_change_toggle(&mut self, uri: &str, version: i64, line: u32, insert: bool) {
+        let change = if insert {
+            json!({
+                "range": {
+                    "start": { "line": line, "character": 0 },
+                    "end": { "line": line, "character": 0 },
+                },
+                "text": " ",
+            })
+        } else {
+            json!({
+                "range": {
+                    "start": { "line": line, "character": 0 },
+                    "end": { "line": line, "character": 1 },
+                },
+                "text": "",
+            })
+        };
+        self.notify(
+            "textDocument/didChange",
+            json!({
+                "textDocument": { "uri": uri, "version": version },
+                "contentChanges": [change],
+            }),
+        );
+    }
+
     fn request(&mut self, method: &str, params: Value) -> Value {
         self.next_id += 1;
         let id = self.next_id;
@@ -322,8 +354,22 @@ fn ms(d: Duration) -> f64 {
 
 #[derive(Clone, Copy)]
 enum Kind {
+    /// `semanticTokens/full` on an unchanging document.
     Full,
+    /// `semanticTokens/full/delta` with no edit between requests.
     DeltaNoop,
+    /// Realistic editing: a toggle `didChange` then `semanticTokens/full/delta`,
+    /// so each measured request pays incremental reparse + cache invalidation +
+    /// delta diff on top of the (full) token recompute.
+    EditDelta,
+}
+
+/// Mutable per-run state for [`Kind::EditDelta`]: the next `didChange` version,
+/// an edit counter (parity selects insert vs delete), and the line edited.
+struct EditState {
+    version: i64,
+    count: u64,
+    line: u32,
 }
 
 struct Scenario {
@@ -355,18 +401,26 @@ fn measure(
     // Let the initial parse settle (didOpen parse may be async).
     std::thread::sleep(Duration::from_millis(300));
 
-    // For delta scenarios we need a valid previous result_id; seed it from a
+    // For delta/edit scenarios we need a valid previous result_id; seed it from a
     // full request, then keep it current (a no-op delta may or may not rotate).
     let mut prev_result_id = seed_result_id(&mut server, scn);
 
+    // did_open used version 1; edits continue from there. Edit a line in the
+    // middle of the document (representative of typical cursor position).
+    let mut edit = EditState {
+        version: 1,
+        count: 0,
+        line: (scn.content.lines().count() / 2) as u32,
+    };
+
     for _ in 0..warmup {
-        run_once(&mut server, scn, &mut prev_result_id);
+        run_once(&mut server, scn, &mut prev_result_id, &mut edit);
     }
 
     let mut samples = Vec::with_capacity(iters);
     for _ in 0..iters {
         let start = Instant::now();
-        run_once(&mut server, scn, &mut prev_result_id);
+        run_once(&mut server, scn, &mut prev_result_id, &mut edit);
         samples.push(start.elapsed());
     }
     samples
@@ -375,11 +429,19 @@ fn measure(
 fn seed_result_id(server: &mut Server, scn: &Scenario) -> String {
     match scn.kind {
         Kind::Full => String::new(),
-        Kind::DeltaNoop => result_id_of(&server.semantic_full(scn.uri)).unwrap_or_default(),
+        // Both delta-based scenarios need an initial result_id to diff against.
+        Kind::DeltaNoop | Kind::EditDelta => {
+            result_id_of(&server.semantic_full(scn.uri)).unwrap_or_default()
+        }
     }
 }
 
-fn run_once(server: &mut Server, scn: &Scenario, prev_result_id: &mut String) {
+fn run_once(
+    server: &mut Server,
+    scn: &Scenario,
+    prev_result_id: &mut String,
+    edit: &mut EditState,
+) {
     match scn.kind {
         Kind::Full => {
             let _ = server.semantic_full(scn.uri);
@@ -387,6 +449,23 @@ fn run_once(server: &mut Server, scn: &Scenario, prev_result_id: &mut String) {
         Kind::DeltaNoop => {
             let result = server.semantic_delta(scn.uri, prev_result_id);
             // Keep the id valid for the next request whether or not it rotated.
+            if let Some(id) = result_id_of(&result) {
+                *prev_result_id = id;
+            }
+        }
+        Kind::EditDelta => {
+            // Apply one toggle edit, then request a delta against the prior id.
+            let insert = edit.count.is_multiple_of(2);
+            edit.count += 1;
+            edit.version += 1;
+            server.did_change_toggle(scn.uri, edit.version, edit.line, insert);
+            // Fall back to a full request if we don't yet have a valid id
+            // (e.g. a prior delta was cancelled and returned no result).
+            let result = if prev_result_id.is_empty() {
+                server.semantic_full(scn.uri)
+            } else {
+                server.semantic_delta(scn.uri, prev_result_id)
+            };
             if let Some(id) = result_id_of(&result) {
                 *prev_result_id = id;
             }
@@ -462,6 +541,22 @@ fn main() {
             content: gen_rust(150),
             kind: Kind::DeltaNoop,
             targets: "no-op delta result_id reuse",
+        },
+        Scenario {
+            name: "rust_large/edit_delta",
+            language_id: "rust",
+            uri: "file:///bench/large_edit.rs",
+            content: gen_rust(150),
+            kind: Kind::EditDelta,
+            targets: "edit→reparse→retokenize→delta diff (host path under typing)",
+        },
+        Scenario {
+            name: "markdown_injections/edit_delta",
+            language_id: "markdown",
+            uri: "file:///bench/injections_edit.md",
+            content: gen_markdown_injections(60),
+            kind: Kind::EditDelta,
+            targets: "edit→reparse→injection re-detect→cache invalidation→delta (typing)",
         },
     ];
 

--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -1,0 +1,140 @@
+# Injection Token Cache Reuse
+
+<!--
+Status: Proposed (aspirational). The invalidation half described here is
+implemented; the reuse half is not. See "Decision–Implementation Gap".
+-->
+
+**Related Decisions**: [semantic-token-overlap-resolution](semantic-token-overlap-resolution.md), [lazy-node-identity-tracking](lazy-node-identity-tracking.md)
+
+## Context
+
+Semantic tokens for a document with code injections (e.g. a Markdown file with
+many fenced code blocks) are recomputed *in full* on every `semanticTokens/full`
+and `semanticTokens/full/delta` request. The delta request additionally diffs
+the freshly computed token vector against the previous one — saving wire size
+but not CPU. Editing a single character inside one Python block re-parses and
+re-queries the host plus *every* injection region in the document.
+
+The codebase already contains most of the machinery to avoid this, but only its
+*invalidation* half is wired up:
+
+- `InjectionMap` (`src/analysis/semantic_cache.rs`): a per-URI `rust_lapper`
+  interval tree of `CacheableInjectionRegion`s. Populated on parse
+  (`src/lsp/cache.rs` `insert`) and queried via `find_overlapping(uri, start,
+  end)` to find which regions an edit touches. Fully wired and tested.
+- `CacheableInjectionRegion` carries `region_id` (ULID), `byte_range`,
+  `line_range`, `start_column`, and `content_hash` — enough to detect whether a
+  region's *content* changed and to re-anchor it after edits elsewhere.
+- `InjectionTokenCache`: a per-`(uri, region_id)` token store. On edit,
+  `src/lsp/cache.rs` calls `find_overlapping` and `injection_token_cache.remove`
+  for each touched region, and `clear_document` on close/reparse — so stale
+  entries are evicted correctly.
+
+The gap: `InjectionTokenCache::store` and `::get` are `#[cfg(test)]`-only. In
+production nothing ever writes to or reads from the cache, so the eviction logic
+guards an always-empty cache. The hot path (`handle_semantic_tokens_full` in
+`src/analysis/semantic.rs`) unconditionally calls `collect_host_tokens` +
+`collect_injection_tokens_parallel` over the whole document.
+
+This is the single highest-impact remaining performance lever for the feature.
+The reason it has not been wired in is a genuine design question, not an
+oversight: what to cache, and how to keep coordinates correct when an edit above
+a region shifts that region's position in the host document.
+
+## Decision
+
+Wire the injection token cache into the hot path with **region-local
+`RawToken`s** as the cached representation, re-anchored to host coordinates at
+reuse time, and re-entering the pipeline *before* `finalize_tokens`.
+
+Per request, in `collect_injection_tokens_parallel`:
+
+1. For each injection region (identified by `region_id` via `InjectionMap`),
+   check `InjectionTokenCache` for an entry whose `content_hash` matches the
+   region's current content.
+2. **Hit**: translate the cached region-local `RawToken`s into host coordinates
+   using the region's *current* `line_range.start` / `start_column` (which the
+   freshly parsed `InjectionMap` already provides), and skip re-parsing /
+   re-querying that region.
+3. **Miss**: compute the region's tokens as today, then store them back in
+   region-local coordinates keyed by `(uri, region_id)` + `content_hash`.
+4. Merge cached-and-recomputed injection tokens with freshly computed host
+   tokens and run the existing `finalize_tokens` sweep line over the union.
+
+Caching **region-local pre-finalize `RawToken`s** (not post-finalize
+`SemanticTokens`) is the load-bearing choice: it keeps the priority / depth /
+`node_byte_len` / `pattern_index` metadata the sweep line needs, and makes
+re-anchoring a pure `line += region_line_offset` translation rather than a
+delta-decode-then-re-encode.
+
+## Considered Options
+
+### A. Cache region-local `RawToken`s, re-enter before finalize (chosen)
+
+Re-anchoring is a single additive line/column offset. The sweep line still sees
+the full token set, so host-vs-injection exclusion and transparent-token
+breakpoints at region boundaries keep working unchanged. Cost: change
+`InjectionTokenCache`'s value type from `SemanticTokens` to `Vec<RawToken>` (or a
+region-local newtype), and make `RawToken` storable across requests (it already
+holds only owned/`Copy` fields after `perf(semantic): pre-resolve token type to
+legend indices` removed the `String`).
+
+### B. Cache post-finalize `SemanticTokens`, splice into output (today's type)
+
+Matches the current `InjectionTokenCache` value type, so no representation
+change. Rejected: finalized tokens have lost the sweep-line metadata, so cached
+region tokens cannot correctly interact with host tokens or transparent
+breakpoints at their boundaries — splicing them in risks wrong winners exactly
+at region edges (the subtlety `semantic-token-overlap-resolution` exists to get
+right). It also forces a delta-decode + re-encode to re-anchor coordinates.
+
+### C. Whole-document memoization keyed by content hash
+
+Cache the entire finalized result per `(uri, content_hash)`. Trivial to wire,
+but only helps when the *whole* document is unchanged — which the existing
+`result_id` no-op short-circuit already covers. Provides nothing for the actual
+hot case (one region edited, the rest reused). Rejected as redundant.
+
+### D. Leave as-is, optimize allocation/algorithm only
+
+The route taken so far (Arc-shared mappings, binary-search coordinate
+conversion, pre-resolved token indices). Real wins, but all O(work) constant-
+factor reductions — none removes the *recompute-everything* structure. Kept as
+complementary, not a substitute.
+
+## Consequences
+
+### Positive
+
+- Editing one region recomputes one region; the rest are O(token-count) copies
+  with an offset. Turns per-edit cost from "reparse whole document" into
+  "reparse the edited region", which is the dominant cost for large injected
+  documents.
+- Reuses infrastructure already built, maintained, and tested (`InjectionMap`,
+  `content_hash`, eviction in `src/lsp/cache.rs`).
+
+### Negative
+
+- `RawToken` becomes a cross-request persisted type, so its memory layout and
+  any future field changes now affect cache validity, not just one request.
+- Re-anchoring logic is a new correctness surface: an off-by-one in the line/
+  column offset would mis-place every token in a reused region. Needs targeted
+  tests (edit-above-shifts-region, same-line-edit-before-region, region added/
+  removed) plus the existing e2e snapshot coverage as a backstop.
+- Column re-anchoring is only trivial for the region's *first* line; multi-line
+  regions whose `start_column` changes need care (only line-0 columns shift).
+
+### Neutral
+
+- Memory grows by one token vector per live injection region per open document,
+  bounded by `clear_document` on close and `remove` on region change.
+
+## Decision–Implementation Gap
+
+Only the invalidation half is implemented today: `InjectionMap` population +
+`find_overlapping` + `InjectionTokenCache::{remove, clear_document}` are wired in
+`src/lsp/cache.rs`; `InjectionTokenCache::{store, get}` are `#[cfg(test)]`-only
+and never called from production. This ADR records the intended design for the
+reuse half; until it lands, the cache is maintained-but-unread and the hot path
+recomputes in full.

--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -44,9 +44,9 @@ a region shifts that region's position in the host document.
 
 ## Decision
 
-Wire the injection token cache into the hot path with **region-local
-`RawToken`s** as the cached representation, re-anchored to host coordinates at
-reuse time, and re-entering the pipeline *before* `finalize_tokens`.
+Wire the injection token cache into the hot path with **region-local `RawToken`s**
+as the cached representation, re-anchored to host coordinates at reuse time, and
+re-entering the pipeline *before* `finalize_tokens`.
 
 Per request, in `collect_injection_tokens_parallel`:
 

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -36,7 +36,7 @@ pub(crate) async fn handle_semantic_tokens_full(
     tree: Tree,
     query: std::sync::Arc<Query>,
     filetype: Option<String>,
-    capture_mappings: Option<CaptureMappings>,
+    capture_mappings: Option<std::sync::Arc<CaptureMappings>>,
     coordinator: std::sync::Arc<crate::language::LanguageCoordinator>,
     supports_multiline: bool,
 ) -> Option<SemanticTokensResult> {
@@ -50,7 +50,7 @@ pub(crate) async fn handle_semantic_tokens_full(
             &tree,
             &query,
             filetype.as_deref(),
-            capture_mappings.as_ref(),
+            capture_mappings.as_deref(),
             &text,
             &lines,
             0,
@@ -69,7 +69,7 @@ pub(crate) async fn handle_semantic_tokens_full(
             &tree,
             filetype.as_deref(),
             &coordinator,
-            capture_mappings.as_ref(),
+            capture_mappings.as_deref(),
             supports_multiline,
         );
 
@@ -685,7 +685,7 @@ local x = 42
 
         // Use default capture mappings so markdown captures like @markup.raw.block
         // are translated to `string` (token_type 2).
-        let capture_mappings = default_capture_mappings();
+        let capture_mappings = std::sync::Arc::new(default_capture_mappings());
 
         // Use the full pipeline — exclusion now happens in finalize_tokens
         let result = handle_semantic_tokens_full(
@@ -798,7 +798,7 @@ local x = 42
         parser_pool.release("markdown".to_string(), parser);
 
         // Use default capture mappings so @markup.raw.block → `string`
-        let capture_mappings = default_capture_mappings();
+        let capture_mappings = std::sync::Arc::new(default_capture_mappings());
 
         let result = handle_semantic_tokens_full(
             text,
@@ -910,7 +910,7 @@ local x = 42
         };
         parser_pool.release("markdown".to_string(), parser);
 
-        let capture_mappings = default_capture_mappings();
+        let capture_mappings = std::sync::Arc::new(default_capture_mappings());
         let result = handle_semantic_tokens_full(
             text,
             tree,
@@ -1019,7 +1019,7 @@ local x = 42
         };
         parser_pool.release("markdown".to_string(), parser);
 
-        let capture_mappings = default_capture_mappings();
+        let capture_mappings = std::sync::Arc::new(default_capture_mappings());
 
         // KEY: supports_multiline = true
         let result = handle_semantic_tokens_full(
@@ -1151,7 +1151,7 @@ foo
         };
         parser_pool.release("markdown".to_string(), parser);
 
-        let capture_mappings = default_capture_mappings();
+        let capture_mappings = std::sync::Arc::new(default_capture_mappings());
         let result = handle_semantic_tokens_full(
             text,
             tree,
@@ -1259,7 +1259,7 @@ foo
         };
         parser_pool.release("markdown".to_string(), parser);
 
-        let capture_mappings = default_capture_mappings();
+        let capture_mappings = std::sync::Arc::new(default_capture_mappings());
 
         let result = handle_semantic_tokens_full(
             text,

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -65,6 +65,7 @@ pub(crate) async fn handle_semantic_tokens_full(
         // Also returns active injection regions for finalize-time exclusion.
         let (injection_tokens, active_injection_regions) = collect_injection_tokens_parallel(
             &text,
+            &lines,
             &tree,
             filetype.as_deref(),
             &coordinator,

--- a/src/analysis/semantic/finalize.rs
+++ b/src/analysis/semantic/finalize.rs
@@ -13,7 +13,6 @@ use std::collections::HashMap;
 
 use tower_lsp_server::ls_types::{SemanticToken, SemanticTokens, SemanticTokensResult};
 
-use super::legend::map_capture_to_token_type_and_modifiers;
 use super::token_collector::{ActiveInjectionBounds, RawToken, TokenKind};
 
 /// Priority key for token comparison. Higher values win.
@@ -499,20 +498,22 @@ pub(super) fn finalize_tokens(
     let mut last_start = 0usize;
 
     for token in all_tokens {
-        let TokenKind::Mapped(ref type_name) = token.kind else {
+        let (token_type, token_modifiers_bitset) = match token.kind {
+            // Token type/modifiers were resolved to legend indices at collection
+            // time, so encoding is just a copy here (no per-token re-parse).
+            TokenKind::Mapped(token_type, modifiers) => (token_type, modifiers),
+            // Invalid user mapping: competed in the sweep line but emits nothing.
+            TokenKind::MappedUnknown(ref type_name) => {
+                log::warn!(
+                    target: "kakehashi::semantic",
+                    "Skipping token with unknown type '{}' at line {} col {}",
+                    type_name, token.line, token.column
+                );
+                continue;
+            }
             // Transparent or NoneCapture tokens should not reach delta encoding,
             // but if they do, skip silently.
-            continue;
-        };
-        let Some((token_type, token_modifiers_bitset)) =
-            map_capture_to_token_type_and_modifiers(type_name)
-        else {
-            log::warn!(
-                target: "kakehashi::semantic",
-                "Skipping token with unknown type '{}' at line {} col {}",
-                type_name, token.line, token.column
-            );
-            continue;
+            TokenKind::Transparent | TokenKind::NoneCapture => continue,
         };
 
         let delta_line = token.line.saturating_sub(last_line);
@@ -542,12 +543,20 @@ pub(super) fn finalize_tokens(
 
 #[cfg(test)]
 mod tests {
+    use super::super::legend::map_capture_to_token_type_and_modifiers;
     use super::*;
     use rstest::rstest;
 
-    /// Shorthand for `TokenKind::Mapped(name.to_string())`.
+    /// Shorthand for a token kind from a name, so tests read in terms of names.
+    ///
+    /// Legend names resolve to `Mapped(token_type, modifiers)`; non-legend names
+    /// (e.g., "markup.raw.block") map to `MappedUnknown` — the kind that, like a
+    /// misconfigured user mapping, competes in the sweep line but emits nothing.
     fn mapped(name: &str) -> TokenKind {
-        TokenKind::Mapped(name.to_string())
+        match map_capture_to_token_type_and_modifiers(name) {
+            Some((token_type, modifiers)) => TokenKind::Mapped(token_type, modifiers),
+            None => TokenKind::MappedUnknown(name.to_string()),
+        }
     }
 
     /// Helper to create a RawToken with explicit priority (node_byte_len defaults to 0)

--- a/src/analysis/semantic/finalize.rs
+++ b/src/analysis/semantic/finalize.rs
@@ -555,7 +555,7 @@ mod tests {
     fn mapped(name: &str) -> TokenKind {
         match map_capture_to_token_type_and_modifiers(name) {
             Some((token_type, modifiers)) => TokenKind::Mapped(token_type, modifiers),
-            None => TokenKind::MappedUnknown(name.to_string()),
+            None => TokenKind::MappedUnknown(name.into()),
         }
     }
 

--- a/src/analysis/semantic/legend.rs
+++ b/src/analysis/semantic/legend.rs
@@ -50,8 +50,14 @@ pub const LEGEND_MODIFIERS: &[SemanticTokenModifier] = &[
 /// Result of mapping a tree-sitter capture name to a semantic token role.
 #[derive(Debug, PartialEq)]
 pub(super) enum CaptureResult {
-    /// Matched or user-mapped token type — emitted as a semantic token.
-    Mapped(String),
+    /// Matched or user-mapped token type, pre-resolved to its legend
+    /// `(token_type, modifiers)` indices — emitted as a semantic token.
+    Mapped(u32, u32),
+    /// User-config mapping to a value whose base type is not in the legend.
+    /// Carries the offending name so the encode stage can log it. Competes in
+    /// the sweep line like a mapped token but emits nothing (historical
+    /// behavior); kept off the hot path since it only occurs on misconfig.
+    MappedUnknown(String),
     /// Unknown base type — transparent breakpoint-only token (not emitted).
     Transparent,
     /// `@none` capture — pre-processed to punch holes in parent tokens.
@@ -75,24 +81,14 @@ pub(super) fn resolve_capture(
             && let Some(lang_mappings) = mappings.get(ft)
             && let Some(mapped) = lang_mappings.highlights.get(capture_name)
         {
-            // Explicit mapping to empty string means "filter this capture"
-            return if mapped.is_empty() {
-                CaptureResult::Suppressed
-            } else {
-                CaptureResult::Mapped(mapped.clone())
-            };
+            return resolve_user_mapping(mapped);
         }
 
         // Try wildcard mapping
         if let Some(wildcard_mappings) = mappings.get(WILDCARD_KEY)
             && let Some(mapped) = wildcard_mappings.highlights.get(capture_name)
         {
-            // Explicit mapping to empty string means "filter this capture"
-            return if mapped.is_empty() {
-                CaptureResult::Suppressed
-            } else {
-                CaptureResult::Mapped(mapped.clone())
-            };
+            return resolve_user_mapping(mapped);
         }
     }
 
@@ -105,20 +101,29 @@ pub(super) fn resolve_capture(
         return CaptureResult::NoneCapture;
     }
 
-    // No mapping found - check if the base type is in SemanticTokensLegend.
-    // Known types are returned as-is; unknown types return Transparent to create
-    // tokens that generate sweep-line breakpoints without competing for winner selection.
-    // split('.') on a non-empty string always yields at least one element
-    let base_type = capture_name
-        .split('.')
-        .next()
-        .expect("split always yields at least one element");
-    if LEGEND_TYPES.iter().any(|t| t.as_str() == base_type) {
-        CaptureResult::Mapped(capture_name.to_string())
-    } else {
-        // Transparent token: participates in sweep line as a breakpoint
-        // generator but is excluded from winner selection (no token emitted).
-        CaptureResult::Transparent
+    // No user mapping - resolve the capture name against the built-in legend.
+    // Known base types resolve to their indices; unknown ones become Transparent
+    // tokens that generate sweep-line breakpoints without competing for winner
+    // selection. Resolving here (instead of at encode time) drops the per-token
+    // String that previously rode through the whole pipeline.
+    match map_capture_to_token_type_and_modifiers(capture_name) {
+        Some((token_type, modifiers)) => CaptureResult::Mapped(token_type, modifiers),
+        None => CaptureResult::Transparent,
+    }
+}
+
+/// Resolve a non-empty user-config mapping value to a [`CaptureResult`].
+///
+/// An empty value means "suppress"; a value whose base type isn't in the legend
+/// becomes [`CaptureResult::MappedUnknown`] (preserving the historical
+/// compete-then-skip behavior) rather than being silently dropped.
+fn resolve_user_mapping(mapped: &str) -> CaptureResult {
+    if mapped.is_empty() {
+        return CaptureResult::Suppressed;
+    }
+    match map_capture_to_token_type_and_modifiers(mapped) {
+        Some((token_type, modifiers)) => CaptureResult::Mapped(token_type, modifiers),
+        None => CaptureResult::MappedUnknown(mapped.to_string()),
     }
 }
 
@@ -153,6 +158,14 @@ mod tests {
     use crate::config::QueryTypeMappings;
     use rstest::rstest;
     use std::collections::HashMap;
+
+    /// Shorthand for the pre-resolved `CaptureResult::Mapped(type, modifiers)`
+    /// of a legend capture name, so tests read in terms of names not indices.
+    fn mapped(name: &str) -> CaptureResult {
+        let (token_type, modifiers) = map_capture_to_token_type_and_modifiers(name)
+            .expect("name must be a valid legend type");
+        CaptureResult::Mapped(token_type, modifiers)
+    }
 
     #[test]
     fn test_legend_types_includes_keyword() {
@@ -205,7 +218,7 @@ mod tests {
         let result = resolve_capture("variable", Some("rust"), Some(&mappings));
         assert_eq!(
             result,
-            CaptureResult::Mapped("variable".to_string()),
+            mapped("variable"),
             "Should inherit 'variable' mapping from wildcard for 'rust'"
         );
 
@@ -213,7 +226,7 @@ mod tests {
         let result = resolve_capture("type.builtin", Some("rust"), Some(&mappings));
         assert_eq!(
             result,
-            CaptureResult::Mapped("type.defaultLibrary".to_string()),
+            mapped("type.defaultLibrary"),
             "Should use rust-specific 'type.builtin' mapping"
         );
 
@@ -221,7 +234,7 @@ mod tests {
         let result = resolve_capture("function", Some("rust"), Some(&mappings));
         assert_eq!(
             result,
-            CaptureResult::Mapped("function".to_string()),
+            mapped("function"),
             "Should inherit 'function' mapping from wildcard for 'rust'"
         );
     }
@@ -252,9 +265,9 @@ mod tests {
     #[case::unknown_conceal("conceal", CaptureResult::Transparent)]
     #[case::unknown_markup("markup", CaptureResult::Transparent)]
     #[case::unknown_other("unknown", CaptureResult::Transparent)]
-    #[case::known_comment("comment", CaptureResult::Mapped("comment".to_string()))]
-    #[case::known_keyword("keyword", CaptureResult::Mapped("keyword".to_string()))]
-    #[case::known_variable_with_modifier("variable.readonly", CaptureResult::Mapped("variable.readonly".to_string()))]
+    #[case::known_comment("comment", mapped("comment"))]
+    #[case::known_keyword("keyword", mapped("keyword"))]
+    #[case::known_variable_with_modifier("variable.readonly", mapped("variable.readonly"))]
     #[case::none_is_recognized("none", CaptureResult::NoneCapture)]
     fn resolve_capture_known_and_unknown_types(
         #[case] capture_name: &str,

--- a/src/analysis/semantic/legend.rs
+++ b/src/analysis/semantic/legend.rs
@@ -57,7 +57,8 @@ pub(super) enum CaptureResult {
     /// Carries the offending name so the encode stage can log it. Competes in
     /// the sweep line like a mapped token but emits nothing (historical
     /// behavior); kept off the hot path since it only occurs on misconfig.
-    MappedUnknown(String),
+    /// `Box<str>` (not `String`) to keep the downstream `TokenKind` small.
+    MappedUnknown(Box<str>),
     /// Unknown base type — transparent breakpoint-only token (not emitted).
     Transparent,
     /// `@none` capture — pre-processed to punch holes in parent tokens.
@@ -123,7 +124,7 @@ fn resolve_user_mapping(mapped: &str) -> CaptureResult {
     }
     match map_capture_to_token_type_and_modifiers(mapped) {
         Some((token_type, modifiers)) => CaptureResult::Mapped(token_type, modifiers),
-        None => CaptureResult::MappedUnknown(mapped.to_string()),
+        None => CaptureResult::MappedUnknown(mapped.into()),
     }
 }
 

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -498,6 +498,12 @@ pub(crate) fn collect_injection_tokens_parallel(
 
 /// Convert byte-based exclusion ranges to line/column `ActiveInjectionBounds`s,
 /// keeping only those regions that contain at least one injection token.
+///
+/// `tokens` MUST be sorted ascending by `(line, column)` (the caller sorts
+/// before invoking). That ordering lets each region binary-search its start
+/// position and scan only the tokens inside the region, rather than the whole
+/// token list — turning the cost from O(regions × tokens) into
+/// O(regions × log n + tokens-in-regions).
 fn compute_active_injection_regions(
     host_text: &str,
     host_lines: &[&str],
@@ -511,12 +517,15 @@ fn compute_active_injection_regions(
             let (start_line, start_col) = byte_to_line_col(host_text, host_lines, start_byte);
             let (end_line, end_col) = byte_to_line_col(host_text, host_lines, end_byte);
 
-            // Check if any token (depth ≥ 1) falls within this region
-            let has_injection_tokens = tokens.iter().any(|t| {
-                t.depth >= 1
-                    && ((t.line > start_line || (t.line == start_line && t.column >= start_col))
-                        && (t.line < end_line || (t.line == end_line && t.column < end_col)))
+            // Binary-search the first token at or after the region start, then
+            // scan forward only while tokens remain inside the region.
+            let start_idx = tokens.partition_point(|t| {
+                t.line < start_line || (t.line == start_line && t.column < start_col)
             });
+            let has_injection_tokens = tokens[start_idx..]
+                .iter()
+                .take_while(|t| t.line < end_line || (t.line == end_line && t.column < end_col))
+                .any(|t| t.depth >= 1);
 
             if has_injection_tokens {
                 Some(ActiveInjectionBounds {

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -1019,12 +1019,16 @@ local x = 42
         );
 
         // Look for the "local" keyword token (should be at line 3, col 0)
+        let (keyword_type, keyword_mods) =
+            crate::analysis::semantic::legend::map_capture_to_token_type_and_modifiers("keyword")
+                .unwrap();
         let has_local_keyword = tokens.iter().any(|t| {
             t.line == 3
                 && t.column == 0
                 && t.kind
                     == crate::analysis::semantic::token_collector::TokenKind::Mapped(
-                        "keyword".to_string(),
+                        keyword_type,
+                        keyword_mods,
                     )
         });
 

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -421,6 +421,7 @@ fn collect_injection_contexts_sync<'a>(
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn collect_injection_tokens_parallel(
     host_text: &str,
+    host_lines: &[&str],
     host_tree: &Tree,
     host_filetype: Option<&str>,
     coordinator: &LanguageCoordinator,
@@ -428,9 +429,6 @@ pub(crate) fn collect_injection_tokens_parallel(
     supports_multiline: bool,
 ) -> (Vec<RawToken>, Vec<ActiveInjectionBounds>) {
     use rayon::prelude::*;
-
-    // Pre-compute host lines for position calculations
-    let host_lines: Vec<&str> = host_text.lines().collect();
 
     // Collect top-level injection contexts and their byte ranges
     let (contexts, exclusion_byte_ranges) =
@@ -458,7 +456,7 @@ pub(crate) fn collect_injection_tokens_parallel(
                     coordinator,
                     capture_mappings,
                     host_text,
-                    &host_lines,
+                    host_lines,
                     1, // depth 1 (first level of injection, host is 0)
                     supports_multiline,
                 )
@@ -475,7 +473,7 @@ pub(crate) fn collect_injection_tokens_parallel(
                     coordinator,
                     capture_mappings,
                     host_text,
-                    &host_lines,
+                    host_lines,
                     1,
                     supports_multiline,
                 )
@@ -490,7 +488,7 @@ pub(crate) fn collect_injection_tokens_parallel(
     // regions that actually produced tokens (= "active" injection regions).
     let active_regions = compute_active_injection_regions(
         host_text,
-        &host_lines,
+        host_lines,
         &exclusion_byte_ranges,
         &all_tokens,
     );
@@ -891,8 +889,10 @@ mod tests {
         parser_pool.release("markdown".to_string(), parser);
 
         // Collect tokens - should be empty for empty document
+        let host_lines: Vec<&str> = text.lines().collect();
         let (tokens, _regions) = collect_injection_tokens_parallel(
             text,
+            &host_lines,
             &tree,
             Some("markdown"),
             &coordinator,
@@ -943,8 +943,10 @@ local x = 42
         parser_pool.release("markdown".to_string(), parser);
 
         // Collect tokens in parallel
+        let host_lines: Vec<&str> = text.lines().collect();
         let (tokens, _regions) = collect_injection_tokens_parallel(
             text,
+            &host_lines,
             &tree,
             Some("markdown"),
             &coordinator,
@@ -1019,8 +1021,10 @@ local b = 2
         };
         parser_pool.release("markdown".to_string(), parser);
 
+        let host_lines: Vec<&str> = text.lines().collect();
         let (tokens, _regions) = collect_injection_tokens_parallel(
             text,
+            &host_lines,
             &tree,
             Some("markdown"),
             &coordinator,

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -510,12 +510,17 @@ fn compute_active_injection_regions(
     byte_ranges: &[(usize, usize)],
     tokens: &[RawToken],
 ) -> Vec<ActiveInjectionBounds> {
+    // Precompute line-start offsets once so each conversion below is a binary
+    // search rather than an O(offset) scan (was O(regions × offset)).
+    let line_starts = build_line_start_bytes(host_text);
     byte_ranges
         .iter()
         .filter_map(|&(start_byte, end_byte)| {
             // Convert byte range to line/col
-            let (start_line, start_col) = byte_to_line_col(host_text, host_lines, start_byte);
-            let (end_line, end_col) = byte_to_line_col(host_text, host_lines, end_byte);
+            let (start_line, start_col) =
+                byte_to_line_col(host_text, host_lines, &line_starts, start_byte);
+            let (end_line, end_col) =
+                byte_to_line_col(host_text, host_lines, &line_starts, end_byte);
 
             // Binary-search the first token at or after the region start, then
             // scan forward only while tokens remain inside the region.
@@ -541,8 +546,32 @@ fn compute_active_injection_regions(
         .collect()
 }
 
+/// Build an ascending index of the byte offset at which each line starts.
+///
+/// `line_starts[0]` is always 0; every subsequent entry is the byte just after
+/// a `\n`. Built once per request so each `byte_to_line_col` lookup is a binary
+/// search instead of an O(offset) scan of the host text. Scanning raw bytes for
+/// `\n` is safe because UTF-8 never places `0x0A` inside a multi-byte sequence.
+fn build_line_start_bytes(host_text: &str) -> Vec<usize> {
+    let mut starts = Vec::with_capacity(host_text.len() / 32 + 1);
+    starts.push(0);
+    for (i, b) in host_text.bytes().enumerate() {
+        if b == b'\n' {
+            starts.push(i + 1);
+        }
+    }
+    starts
+}
+
 /// Convert a byte offset in host_text to a (line, utf16_col) pair.
-fn byte_to_line_col(host_text: &str, host_lines: &[&str], byte_offset: usize) -> (usize, usize) {
+///
+/// `line_starts` must come from [`build_line_start_bytes`] for the same text.
+fn byte_to_line_col(
+    host_text: &str,
+    host_lines: &[&str],
+    line_starts: &[usize],
+    byte_offset: usize,
+) -> (usize, usize) {
     let byte_offset = byte_offset.min(host_text.len());
     // Snap to valid UTF-8 char boundary (tree-sitter always provides valid offsets,
     // but guard defensively against unexpected inputs).
@@ -553,15 +582,10 @@ fn byte_to_line_col(host_text: &str, host_lines: &[&str], byte_offset: usize) ->
         }
         b
     };
-    let line = host_text[..byte_offset]
-        .chars()
-        .filter(|c| *c == '\n')
-        .count();
-    let line_start_byte = if line == 0 {
-        0
-    } else {
-        host_text[..byte_offset].rfind('\n').map_or(0, |p| p + 1)
-    };
+    // Largest line whose start byte is <= byte_offset. line_starts[0] == 0, so
+    // the predicate holds for at least one element and the subtraction is safe.
+    let line = line_starts.partition_point(|&s| s <= byte_offset) - 1;
+    let line_start_byte = line_starts[line];
     let col_byte = byte_offset - line_start_byte;
     let line_text = host_lines.get(line).unwrap_or(&"");
     let col_utf16 = byte_to_utf16_col(line_text, col_byte);
@@ -717,31 +741,55 @@ mod tests {
         // by snapping to the nearest valid char boundary.
         let text = "あいう"; // Three 3-byte UTF-8 characters (9 bytes total)
         let lines: Vec<&str> = text.lines().collect();
+        let line_starts = build_line_start_bytes(text);
 
         // Offset 0 is valid (start of first char)
-        let (line, col) = byte_to_line_col(text, &lines, 0);
+        let (line, col) = byte_to_line_col(text, &lines, &line_starts, 0);
         assert_eq!(line, 0);
         assert_eq!(col, 0);
 
         // Offset 1 is mid-character (should snap to 0)
-        let (line, col) = byte_to_line_col(text, &lines, 1);
+        let (line, col) = byte_to_line_col(text, &lines, &line_starts, 1);
         assert_eq!(line, 0, "Mid-character offset should snap to line 0");
         assert_eq!(col, 0, "Mid-character offset should snap to col 0");
 
         // Offset 2 is mid-character (should snap to 0)
-        let (line, col) = byte_to_line_col(text, &lines, 2);
+        let (line, col) = byte_to_line_col(text, &lines, &line_starts, 2);
         assert_eq!(line, 0);
         assert_eq!(col, 0);
 
         // Offset 3 is valid (start of second char)
-        let (line, col) = byte_to_line_col(text, &lines, 3);
+        let (line, col) = byte_to_line_col(text, &lines, &line_starts, 3);
         assert_eq!(line, 0);
         assert_eq!(col, 1); // One UTF-16 code unit (Japanese chars are in BMP)
 
         // Offset 4 is mid-character (should snap to 3)
-        let (line, col) = byte_to_line_col(text, &lines, 4);
+        let (line, col) = byte_to_line_col(text, &lines, &line_starts, 4);
         assert_eq!(line, 0);
         assert_eq!(col, 1); // Should snap to start of second char
+    }
+
+    #[test]
+    fn test_byte_to_line_col_multiline() {
+        // Exercises the binary-search line lookup across multiple lines, plus a
+        // multibyte char so byte offset != utf16 column.
+        let text = "ab\ncö\n\nde"; // ö is 2 bytes (U+00F6), 1 utf16 unit
+        let lines: Vec<&str> = text.lines().collect();
+        let line_starts = build_line_start_bytes(text);
+        // line_starts: [0, 3, 7, 8] -> starts of "ab", "cö", "", "de"
+        assert_eq!(line_starts, vec![0, 3, 7, 8]);
+
+        // 'a' at byte 0 -> line 0 col 0
+        assert_eq!(byte_to_line_col(text, &lines, &line_starts, 0), (0, 0));
+        // start of line 1 ("cö") at byte 3 -> line 1 col 0
+        assert_eq!(byte_to_line_col(text, &lines, &line_starts, 3), (1, 0));
+        // byte 5 is the start of the byte after 'ö' begins... 'c'=3, 'ö'=4..6,
+        // so byte 6 is end-of-line on line 1 -> col is utf16 width of "cö" = 2
+        assert_eq!(byte_to_line_col(text, &lines, &line_starts, 6), (1, 2));
+        // empty line 2 at byte 7 -> line 2 col 0
+        assert_eq!(byte_to_line_col(text, &lines, &line_starts, 7), (2, 0));
+        // 'e' on line 3: 'd'=8, 'e'=9 -> line 3 col 1
+        assert_eq!(byte_to_line_col(text, &lines, &line_starts, 9), (3, 1));
     }
 
     #[test]

--- a/src/analysis/semantic/range.rs
+++ b/src/analysis/semantic/range.rs
@@ -25,7 +25,7 @@ pub(crate) async fn handle_semantic_tokens_range_parallel_async(
     query: std::sync::Arc<Query>,
     range: Range,
     filetype: Option<String>,
-    capture_mappings: Option<crate::config::CaptureMappings>,
+    capture_mappings: Option<std::sync::Arc<crate::config::CaptureMappings>>,
     coordinator: std::sync::Arc<crate::language::LanguageCoordinator>,
     supports_multiline: bool,
 ) -> Option<SemanticTokensResult> {

--- a/src/analysis/semantic/token_collector.rs
+++ b/src/analysis/semantic/token_collector.rs
@@ -65,7 +65,9 @@ pub(crate) enum TokenKind {
     /// User-config mapping to a value not in the legend. Competes in the sweep
     /// line like a mapped token but emits nothing at encode time (where the
     /// carried name is logged). Off the hot path — only occurs on misconfig.
-    MappedUnknown(String),
+    /// Stored as `Box<str>` (not `String`) to keep `TokenKind`/`RawToken` small,
+    /// since this variant is the largest and never needs to grow.
+    MappedUnknown(Box<str>),
     /// Transparent breakpoint-only token — not emitted as a semantic token.
     Transparent,
     /// `@none` capture — punches holes in parent tokens during pre-processing.
@@ -508,7 +510,7 @@ mod tests {
     fn is_emitted_returns_true_for_mapped_unknown() {
         // MappedUnknown competes in the sweep line (then dropped at encode),
         // matching the historical behavior of an invalid user mapping.
-        assert!(TokenKind::MappedUnknown("bogus".to_string()).is_emitted());
+        assert!(TokenKind::MappedUnknown("bogus".into()).is_emitted());
     }
 
     #[test]

--- a/src/analysis/semantic/token_collector.rs
+++ b/src/analysis/semantic/token_collector.rs
@@ -59,8 +59,13 @@ fn parse_priority_for_pattern(query: &Query, pattern_index: usize) -> u32 {
 /// magic-string conventions.
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) enum TokenKind {
-    /// Normal semantic token with a mapped type name (e.g., "keyword", "variable.readonly").
-    Mapped(String),
+    /// Normal semantic token, pre-resolved to its legend `(token_type, modifiers)`
+    /// indices (e.g., keyword → `(1, 0)`, variable.readonly → `(17, 1 << 2)`).
+    Mapped(u32, u32),
+    /// User-config mapping to a value not in the legend. Competes in the sweep
+    /// line like a mapped token but emits nothing at encode time (where the
+    /// carried name is logged). Off the hot path — only occurs on misconfig.
+    MappedUnknown(String),
     /// Transparent breakpoint-only token — not emitted as a semantic token.
     Transparent,
     /// `@none` capture — punches holes in parent tokens during pre-processing.
@@ -68,9 +73,11 @@ pub(crate) enum TokenKind {
 }
 
 impl TokenKind {
-    /// Returns `true` for tokens that will be emitted as semantic tokens in the LSP response.
+    /// Returns `true` for tokens that compete for winner selection in the sweep
+    /// line. `MappedUnknown` competes (historical behavior) but is dropped at
+    /// encode time, so it is included here.
     pub(crate) fn is_emitted(&self) -> bool {
-        matches!(self, TokenKind::Mapped(_))
+        matches!(self, TokenKind::Mapped(..) | TokenKind::MappedUnknown(_))
     }
 }
 
@@ -341,7 +348,10 @@ pub(super) fn collect_host_tokens(
             let capture_name = &query.capture_names()[c.index as usize];
             let kind = match resolve_capture(capture_name, filetype, capture_mappings) {
                 CaptureResult::Suppressed => continue,
-                CaptureResult::Mapped(s) => TokenKind::Mapped(s),
+                CaptureResult::Mapped(token_type, modifiers) => {
+                    TokenKind::Mapped(token_type, modifiers)
+                }
+                CaptureResult::MappedUnknown(name) => TokenKind::MappedUnknown(name),
                 CaptureResult::Transparent => TokenKind::Transparent,
                 CaptureResult::NoneCapture => TokenKind::NoneCapture,
             };
@@ -491,7 +501,14 @@ mod tests {
 
     #[test]
     fn is_emitted_returns_true_for_mapped() {
-        assert!(TokenKind::Mapped("keyword".to_string()).is_emitted());
+        assert!(TokenKind::Mapped(1, 0).is_emitted());
+    }
+
+    #[test]
+    fn is_emitted_returns_true_for_mapped_unknown() {
+        // MappedUnknown competes in the sweep line (then dropped at encode),
+        // matching the historical behavior of an invalid user mapping.
+        assert!(TokenKind::MappedUnknown("bogus".to_string()).is_emitted());
     }
 
     #[test]
@@ -794,12 +811,15 @@ mod tests {
             &mut tokens2,
         );
 
+        use super::super::legend::map_capture_to_token_type_and_modifiers as resolve;
+        let keyword = resolve("keyword").unwrap();
+        let variable = resolve("variable").unwrap();
         let has_keyword = tokens2
             .iter()
-            .any(|t| t.kind == TokenKind::Mapped("keyword".to_string()));
+            .any(|t| t.kind == TokenKind::Mapped(keyword.0, keyword.1));
         let has_variable = tokens2
             .iter()
-            .any(|t| t.kind == TokenKind::Mapped("variable".to_string()));
+            .any(|t| t.kind == TokenKind::Mapped(variable.0, variable.1));
         assert!(has_keyword, "fn keyword outside exclusion should be kept");
         assert!(
             !has_variable,

--- a/src/language/config_store.rs
+++ b/src/language/config_store.rs
@@ -2,20 +2,20 @@ use crate::config::{CaptureMappings, WorkspaceSettings};
 use crate::error::LockResultExt;
 use path_clean::PathClean;
 use std::path::PathBuf;
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 
 /// Thread-safe cache of workspace settings for the language subsystem.
 ///
 /// Search paths are cleaned/normalized (e.g. `..` resolved) on write.
 pub(crate) struct ConfigStore {
-    capture_mappings: RwLock<CaptureMappings>,
+    capture_mappings: RwLock<Arc<CaptureMappings>>,
     search_paths: RwLock<Vec<PathBuf>>,
 }
 
 impl ConfigStore {
     pub(crate) fn new() -> Self {
         Self {
-            capture_mappings: RwLock::new(CaptureMappings::default()),
+            capture_mappings: RwLock::new(Arc::new(CaptureMappings::default())),
             search_paths: RwLock::new(Vec::new()),
         }
     }
@@ -29,14 +29,20 @@ impl ConfigStore {
         *self
             .capture_mappings
             .write()
-            .recover_poison("ConfigStore::set_capture_mappings") = mappings;
+            .recover_poison("ConfigStore::set_capture_mappings") = Arc::new(mappings);
     }
 
-    pub(crate) fn capture_mappings(&self) -> CaptureMappings {
-        self.capture_mappings
-            .read()
-            .recover_poison("ConfigStore::capture_mappings")
-            .clone()
+    /// Returns a cheap `Arc` handle to the shared capture mappings.
+    ///
+    /// Cloning the `Arc` is a refcount bump, not a deep copy of the nested
+    /// maps — this is called once per semantic-tokens request on the hot path.
+    pub(crate) fn capture_mappings(&self) -> Arc<CaptureMappings> {
+        Arc::clone(
+            &self
+                .capture_mappings
+                .read()
+                .recover_poison("ConfigStore::capture_mappings"),
+        )
     }
 
     fn set_search_paths(&self, paths: Vec<String>) {
@@ -77,7 +83,7 @@ mod tests {
         store.update_from_settings(&settings);
 
         assert_eq!(store.search_paths(), vec![PathBuf::from("/search/path")]);
-        assert_eq!(store.capture_mappings(), settings.capture_mappings);
+        assert_eq!(*store.capture_mappings(), settings.capture_mappings);
     }
 
     #[test]

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1010,7 +1010,7 @@ impl LanguageCoordinator {
     ///
     /// Visibility: pub(crate) - called by LSP layer (semantic_tokens) and analysis
     /// layer (refactor) for custom capture-to-token-type mapping.
-    pub(crate) fn capture_mappings(&self) -> CaptureMappings {
+    pub(crate) fn capture_mappings(&self) -> Arc<CaptureMappings> {
         self.config_store.capture_mappings()
     }
 

--- a/src/language/query_predicates.rs
+++ b/src/language/query_predicates.rs
@@ -210,17 +210,22 @@ fn check_has_ancestor(args: &[tree_sitter::QueryPredicateArg], node: tree_sitter
     false
 }
 
-pub fn filter_captures<'a>(
-    query: &Query,
+/// Yield the captures of `match_` that pass all general predicates, lazily.
+///
+/// Returns an iterator rather than a `Vec` so the hot token-collection loop
+/// (one call per query match on every semantic-tokens request) avoids a
+/// per-match heap allocation. `QueryCapture` is `Copy`, so yielding owned
+/// values is free.
+pub(crate) fn filter_captures<'a>(
+    query: &'a Query,
     match_: &'a QueryMatch<'a, 'a>,
-    text: &str,
-) -> Vec<QueryCapture<'a>> {
+    text: &'a str,
+) -> impl Iterator<Item = QueryCapture<'a>> + 'a {
     match_
         .captures
         .iter()
-        .filter(|capture| check_predicate(query, match_, capture, text))
-        .cloned()
-        .collect()
+        .filter(move |capture| check_predicate(query, match_, capture, text))
+        .copied()
 }
 
 #[cfg(test)]

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -599,6 +599,15 @@ impl Kakehashi {
                 self.cache.store_tokens(uri.clone(), tokens.clone());
                 SemanticTokensFullDeltaResult::Tokens(tokens)
             }
+            SemanticTokensFullDeltaResult::TokensDelta(mut delta) if delta.edits.is_empty() => {
+                // No-op delta: recomputed tokens are byte-identical to the cached
+                // tokens, which already carry `previous_result_id`. Reuse that id
+                // and skip re-storing — the version token shouldn't advance when
+                // nothing changed, and the cache entry stays valid for the next
+                // request. Saves a clone + cache store + id rotation.
+                delta.result_id = Some(previous_result_id.clone());
+                SemanticTokensFullDeltaResult::TokensDelta(delta)
+            }
             SemanticTokensFullDeltaResult::TokensDelta(mut delta) => {
                 // For delta, we still need to store the current tokens with new result_id
                 let mut stored_tokens = current_tokens;
@@ -955,6 +964,106 @@ mod tests {
         assert!(
             follow_up_result.is_ok(),
             "follow-up delta request should succeed"
+        );
+    }
+
+    /// Test that a no-op delta (no document change) reuses the previous
+    /// result_id instead of rotating it and re-storing identical tokens.
+    ///
+    /// When the document is unchanged, recomputed tokens are byte-identical to
+    /// the cached tokens, so the delta has zero edits. The LSP result_id is a
+    /// version token the client echoes back; keeping it stable avoids a wasted
+    /// clone + cache store + id increment, and the cache entry under the
+    /// previous id stays valid for the next request.
+    #[tokio::test]
+    async fn semantic_tokens_noop_delta_reuses_previous_result_id() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let uri = Url::parse("file:///noop_delta.lua").expect("should construct test uri");
+
+        server.documents.insert(
+            uri.clone(),
+            "local x = 1".to_string(),
+            Some("lua".to_string()),
+            None,
+        );
+
+        // Configure the grammar search path so the language actually loads
+        // (grammars live under deps/tree-sitter, or TREE_SITTER_GRAMMARS in Nix).
+        let settings = crate::config::WorkspaceSettings {
+            search_paths: vec![
+                std::env::var("TREE_SITTER_GRAMMARS")
+                    .unwrap_or_else(|_| "deps/tree-sitter".to_string()),
+            ],
+            ..Default::default()
+        };
+        let _ = server.language.load_settings(&settings);
+
+        let load_result = server.language.ensure_language_loaded("lua");
+        if !load_result.success || server.language.highlight_query("lua").is_none() {
+            eprintln!("Skipping: lua language parser or highlight query not available");
+            return;
+        }
+
+        // First request: semanticTokens/full to get the initial result_id.
+        let full_params = SemanticTokensParams {
+            text_document: TextDocumentIdentifier {
+                uri: crate::lsp::lsp_impl::url_to_uri(&uri).expect("test URI should convert"),
+            },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        };
+        let full_result = server
+            .semantic_tokens_full_impl(full_params)
+            .await
+            .expect("full request should succeed")
+            .expect("should return tokens");
+        let initial_result_id = match full_result {
+            SemanticTokensResult::Tokens(t) => t.result_id.expect("should have result_id"),
+            _ => panic!("expected Tokens variant"),
+        };
+
+        // Second request: delta WITHOUT changing the document → no edits.
+        let delta_params = SemanticTokensDeltaParams {
+            text_document: TextDocumentIdentifier {
+                uri: crate::lsp::lsp_impl::url_to_uri(&uri).expect("test URI should convert"),
+            },
+            previous_result_id: initial_result_id.clone(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        };
+        let delta_result = server
+            .semantic_tokens_full_delta_impl(delta_params)
+            .await
+            .expect("delta request should succeed")
+            .expect("should return delta");
+
+        let delta = match delta_result {
+            SemanticTokensFullDeltaResult::TokensDelta(d) => d,
+            other => panic!("expected TokensDelta for unchanged document, got {other:?}"),
+        };
+
+        // No edits, since nothing changed.
+        assert!(
+            delta.edits.is_empty(),
+            "unchanged document should produce a delta with no edits, got {:?}",
+            delta.edits
+        );
+
+        // The result_id must be reused, not rotated.
+        assert_eq!(
+            delta.result_id.as_deref(),
+            Some(initial_result_id.as_str()),
+            "no-op delta should reuse the previous result_id"
+        );
+
+        // The cache entry under the initial result_id must still be valid.
+        assert!(
+            server
+                .cache
+                .get_tokens_if_valid(&uri, &initial_result_id)
+                .is_some(),
+            "cache should still hold tokens under the reused result_id"
         );
     }
 

--- a/src/text/position.rs
+++ b/src/text/position.rs
@@ -117,6 +117,15 @@ pub(crate) fn byte_to_utf16_col(line: &str, byte_col: usize) -> usize {
 /// Returns None if the byte position is invalid (e.g., in the middle of a multi-byte character)
 #[inline(always)]
 pub fn convert_byte_to_utf16_in_line(line_text: &str, byte_pos: usize) -> Option<usize> {
+    // Fast path: when the prefix up to `byte_pos` is pure ASCII, every byte is a
+    // single-byte UTF-8 char and a single UTF-16 code unit, so the UTF-16 column
+    // equals `byte_pos`. `<[u8]>::is_ascii` is vectorized by the standard library,
+    // which beats the per-`char` decode loop on the common all-ASCII source line.
+    // Multi-byte prefixes fall through to the exact loop below.
+    if byte_pos <= line_text.len() && line_text.as_bytes()[..byte_pos].is_ascii() {
+        return Some(byte_pos);
+    }
+
     let mut utf16_offset = 0;
     let mut byte_count = 0;
 


### PR DESCRIPTION
## Summary

Reduces the cost of the semantic-tokens hot path (`semanticTokens/full` and
`/full/delta`) through a series of behavior-preserving optimizations, plus a
benchmark to quantify them and an ADR recording the one remaining architectural
lever.

Every change is behavior-preserving: the full `--features e2e` suite (lib +
integration + e2e, incl. the semantic snapshot tests) stays green.

## Performance changes

**Allocation / constant-factor reductions**
- `perf(semantic): pre-resolve token type to legend indices, drop per-token String`
  — `TokenKind::Mapped(u32, u32)` resolved once at collection instead of a heap
  `String` per emitted token that was re-parsed again at encode time. A new
  explicit `MappedUnknown` variant preserves the exact behavior of invalid
  *user-config* mappings (competes in the sweep line, dropped-with-warning at
  encode). `RawToken` shrinks to all-`Copy` fields.
- `perf(semantic): share capture mappings via Arc instead of per-request deep clone`
  — `ConfigStore` hands out `Arc<CaptureMappings>` (refcount bump) rather than
  deep-cloning three nested `HashMap`s on every request.
- `perf(semantic): make filter_captures lazy to drop per-match allocation`
- `perf(semantic): share host_lines vector with injection collection`

**Algorithmic**
- `perf(semantic): binary-search line/col conversion via precomputed index`
  — a per-document line-start index replaces two O(offset) scans per injection
  region; each conversion becomes O(log lines).
- `perf(semantic): binary-search active injection region detection`

**Text / delta**
- `perf(text): ASCII fast-path in byte-to-UTF16 column conversion`
- `perf(semantic): reuse result_id on no-op delta instead of rotating`

## Benchmark

`benches/semantic_tokens.rs` (+ `benches/compare_head_vs_main.sh`) A/B-benchmarks
the hot path by driving the compiled server binary over LSP, so one harness can
compare any two revisions (HEAD vs a baseline ref) without the baseline needing
to contain the benchmark. Scenarios cover static `full`, no-op delta, and
**edit-driven** (`didChange` → reparse → re-tokenize → delta) workloads, plus
host-only / injection-heavy / unicode variants.

Measured HEAD vs `origin/main` (median, 80 iters, lower is better):

| scenario | origin/main | HEAD | Δ |
|---|---:|---:|---:|
| rust_small/full | 4.64ms | 4.38ms | −5.6% |
| rust_large/full | 74.12ms | 48.55ms | −34.5% |
| markdown_injections/full | 5.38ms | 3.99ms | −25.8% |
| markdown_injections_large/full | 19.28ms | 11.24ms | −41.7% |
| unicode_rust/full | 15.61ms | 10.53ms | −32.5% |
| rust_large/delta_noop | 71.82ms | 46.75ms | −34.9% |
| rust_large/edit_delta | 82.54ms | 57.02ms | −30.9% |
| markdown_injections/edit_delta | 7.62ms | 6.35ms | −16.6% |

Biggest relative win on injection-dense documents (algorithmic), biggest absolute
saving on large dense source (allocation). Improvements hold under real editing.
Tiny files show the least gain because process IPC dominates their few-hundred-µs
compute — expected for a process-level benchmark.

Run: `benches/compare_head_vs_main.sh [BASELINE_REF]`.

## Not in scope (recorded as ADR)

`docs/architecture-decisions/injection-token-cache-reuse.md` documents the
highest-impact remaining lever: the per-injection token cache is built and
invalidated on every edit but never *read* on the hot path, so every request
recomputes the whole document. Wiring it in is a genuine design decision
(cached-token representation + coordinate re-anchoring) that risks the
overlap-resolution correctness this PR preserves, so it's proposed separately
rather than rushed in here.