### PR TITLE
feat(node): add tree-sitter Node accessor methods to node-reference-protocol

### DIFF
--- a/docs/architecture-decisions/node-reference-protocol.md
+++ b/docs/architecture-decisions/node-reference-protocol.md
@@ -250,18 +250,6 @@ Out-of-range / negative `index` or `byte` values collapse to `null` rather than 
 
 For `fieldNameFor*`, top-level `null` means the *id* is unresolvable, while `{ "fieldName": null }` means the node resolved but that child carries no field — the two are deliberately distinguished.
 
-#### Deferred accessors
-
-The following tree-sitter methods are **intentionally not implemented yet** because each carries a design decision that should be settled before freezing it on the wire. Each is tracked as an issue:
-
-| Method(s) | Open question | Issue |
-|---|---|---|
-| `range`, `startPosition`, `endPosition`, `descendantForPointRange`, `namedDescendantForPointRange` | tree-sitter `Point.column` is a UTF-8 byte column; LSP `Position.character` is UTF-16. Whether to return / accept native byte points or convert to LSP positions is the `kakehashi/node/range` endpoint design (see Alternative C). | [#331](https://github.com/atusy/kakehashi/issues/331) |
-| `language` | tree-sitter's `LanguageRef` carries no registered name; what to return (registered name? abi version?) and how to thread the layer's resolved language out is unresolved. | [#332](https://github.com/atusy/kakehashi/issues/332) |
-| `hasChanges` | Reflects pending `Tree::edit` state before a reparse. Kakehashi always serves freshly-parsed trees, so this would always be `false` — meaningless until/unless incremental reparsing is wired in. | [#333](https://github.com/atusy/kakehashi/issues/333) |
-| `childrenByFieldId` | Field **ids** are opaque, grammar-version-specific `u16`s. Exposing them raw invites version-coupling; clients should likely use field *names*. | [#334](https://github.com/atusy/kakehashi/issues/334) |
-| `childWithDescendant` | Takes a second node (the descendant) as an argument, requiring a two-id request whose both ids must resolve in the same layer — a richer contract than the other accessors. | [#335](https://github.com/atusy/kakehashi/issues/335) |
-
 ### Text Resolution: `kakehashi/node/text`
 
 ```jsonc

--- a/docs/architecture-decisions/node-reference-protocol.md
+++ b/docs/architecture-decisions/node-reference-protocol.md
@@ -43,6 +43,8 @@ These reduce to a small set of primitives: **identify a node at a position**, **
 
 All methods carry a `TextDocumentIdentifier` even when an `id` (ULID) is provided. While ULIDs are globally unique by construction, the `textDocument` field keeps the protocol aligned with LSP conventions, allows the server to route directly to the correct per-URI tracker, and lets the server reject mismatched (`uri`, `id`) pairs as `null` instead of silently querying another document.
 
+Beyond these core methods, a family of **node accessor methods** mirrors tree-sitter's [`Node`](https://docs.rs/tree-sitter/latest/tree_sitter/struct.Node.html) API one-for-one (`kind`, `childCount`, `child`, `nextSibling`, `childByFieldName`, …) so clients can introspect and walk the tree without bundling tree-sitter — see [Node Accessor Methods](#node-accessor-methods).
+
 ### `NodeInfo` Type
 
 ```typescript
@@ -203,6 +205,63 @@ This holds even when a host node and an injected node share an identical span **
 
 **No `namedParent`**: `parent` has no named-only variant, because tree-sitter's `Node` has no `named_parent` — `parent()` is singular. A client wanting the nearest *named* ancestor walks `parent` and stops at the first named node. Knowing which nodes are named for that walk is the one case that would motivate a `named` field on `NodeInfo` (mirroring `is_named()`); it is deferred until such a consumer exists (see Alternatives).
 
+### Node Accessor Methods
+
+To let clients introspect and walk the tree without re-implementing tree-sitter, the protocol exposes an accessor family mirroring [`tree_sitter::Node`](https://docs.rs/tree-sitter/latest/tree_sitter/struct.Node.html) method-for-method. Every accessor takes `{ textDocument, id }` (plus, where the tree-sitter method does, an `index` / `name` / `byte` / `startByte` + `endByte`) and resolves the held ULID **in the layer that minted it**, so the per-layer Scope rule holds uniformly: results of a navigation accessor are re-minted in the same layer as the input node.
+
+**Scalar accessors** return a single-field object (matching `text`'s `{ "text": ... }` shape — self-describing and additively extensible), or top-level `null` for an unresolvable id:
+
+| Method | Response | tree-sitter |
+|---|---|---|
+| `kind` | `{ "kind": string }` | `kind()` |
+| `grammarName` | `{ "grammarName": string }` | `grammar_name()` |
+| `isNamed` / `isExtra` | `{ "isNamed": bool }` / `{ "isExtra": bool }` | `is_named()` / `is_extra()` |
+| `hasError` / `isError` / `isMissing` | `{ "hasError": bool }` … | `has_error()` / `is_error()` / `is_missing()` |
+| `startByte` / `endByte` | `{ "startByte": int }` / `{ "endByte": int }` | `start_byte()` / `end_byte()` |
+| `byteRange` | `{ "startByte": int, "endByte": int }` | `byte_range()` |
+| `childCount` / `namedChildCount` | `{ "childCount": int }` … | `child_count()` / `named_child_count()` |
+| `descendantCount` | `{ "descendantCount": int }` | `descendant_count()` |
+| `toSexp` | `{ "sexp": string }` | `to_sexp()` |
+
+**Byte offsets are UTF-8** in host-document coordinates — tree-sitter's native space, the same one `text` slices and the byte-input accessors consume. This deliberately differs from `Position.character` (UTF-16); line/column reporting is the deferred `range` design below.
+
+**Navigation accessors** return `NodeInfo | null` (single) or `NodeInfo[] | null` (list — `null` only for an unresolvable id; an empty relation yields `[]`):
+
+| Method | Response | tree-sitter |
+|---|---|---|
+| `child` / `namedChild` (`index`) | `NodeInfo \| null` | `child(i)` / `named_child(i)` |
+| `namedChildren` | `NodeInfo[] \| null` | `named_children()` |
+| `nextSibling` / `prevSibling` | `NodeInfo \| null` | `next_sibling()` / `prev_sibling()` |
+| `nextNamedSibling` / `prevNamedSibling` | `NodeInfo \| null` | `next_named_sibling()` / `prev_named_sibling()` |
+| `firstChildForByte` (`byte`) | `NodeInfo \| null` | `first_child_for_byte(b)` |
+| `descendantForByteRange` (`startByte`, `endByte`) | `NodeInfo \| null` | `descendant_for_byte_range(s, e)` |
+| `namedDescendantForByteRange` (`startByte`, `endByte`) | `NodeInfo \| null` | `named_descendant_for_byte_range(s, e)` |
+
+Out-of-range / negative `index` or `byte` values collapse to `null` rather than erroring, consistent with the universal null semantics.
+
+**Field accessors** expose the name-keyed half of tree-sitter's field API:
+
+| Method | Response | tree-sitter |
+|---|---|---|
+| `childByFieldName` (`name`) | `NodeInfo \| null` | `child_by_field_name(name)` |
+| `childrenByFieldName` (`name`) | `NodeInfo[] \| null` | `children_by_field_name(name)` |
+| `fieldNameForChild` (`index`) | `{ "fieldName": string \| null } \| null` | `field_name_for_child(i)` |
+| `fieldNameForNamedChild` (`index`) | `{ "fieldName": string \| null } \| null` | `field_name_for_named_child(i)` |
+
+For `fieldNameFor*`, top-level `null` means the *id* is unresolvable, while `{ "fieldName": null }` means the node resolved but that child carries no field — the two are deliberately distinguished.
+
+#### Deferred accessors
+
+The following tree-sitter methods are **intentionally not implemented yet** because each carries a design decision that should be settled before freezing it on the wire. Each is tracked as an issue:
+
+| Method(s) | Open question | Issue |
+|---|---|---|
+| `range`, `startPosition`, `endPosition`, `descendantForPointRange`, `namedDescendantForPointRange` | tree-sitter `Point.column` is a UTF-8 byte column; LSP `Position.character` is UTF-16. Whether to return / accept native byte points or convert to LSP positions is the `kakehashi/node/range` endpoint design (see Alternative C). | [#331](https://github.com/atusy/kakehashi/issues/331) |
+| `language` | tree-sitter's `LanguageRef` carries no registered name; what to return (registered name? abi version?) and how to thread the layer's resolved language out is unresolved. | [#332](https://github.com/atusy/kakehashi/issues/332) |
+| `hasChanges` | Reflects pending `Tree::edit` state before a reparse. Kakehashi always serves freshly-parsed trees, so this would always be `false` — meaningless until/unless incremental reparsing is wired in. | [#333](https://github.com/atusy/kakehashi/issues/333) |
+| `childrenByFieldId` | Field **ids** are opaque, grammar-version-specific `u16`s. Exposing them raw invites version-coupling; clients should likely use field *names*. | [#334](https://github.com/atusy/kakehashi/issues/334) |
+| `childWithDescendant` | Takes a second node (the descendant) as an argument, requiring a two-id request whose both ids must resolve in the same layer — a richer contract than the other accessors. | [#335](https://github.com/atusy/kakehashi/issues/335) |
+
 ### Text Resolution: `kakehashi/node/text`
 
 ```jsonc
@@ -333,7 +392,7 @@ Split the entry point into anonymous-inclusive and named-only methods instead of
 ## Implementation Notes
 
 - Methods are registered via `LspService::build().custom_method(...)` in `src/bin/main.rs`, following the existing `kakehashi/internal/effectiveConfiguration` pattern
-- Handlers live under `src/lsp/lsp_impl/kakehashi/node/` (one file per method) for symmetry with `kakehashi/internal/`
+- Handlers live under `src/lsp/lsp_impl/kakehashi/node/`. The core methods keep one file each (`entry`, `text`, `parent`, `children`); the accessor family is grouped by category (`metadata`, `navigation`, `field`) since each method shrinks to a few lines over the shared `common` prelude (`with_node_by_id` / `navigate_to_node` / `navigate_to_nodes`), which centralises URI/ULID resolution, parse-readiness, snapshotting, and per-layer node resolution
 - The entry point resolves `namedOnly` by switching `descendant_for_byte_range` → `named_descendant_for_byte_range` at the selected layer's tree; the end-of-document exception walks the right spine to the deepest node ending at `L`, restricted to named nodes when `namedOnly` is set
 - `namedChildren` reuses the `children` handler's tracker-minting path over `Node::named_children` instead of `Node::children`
 - `NodeTracker` (`src/language/node_tracker.rs`) backs all four id-based methods via a per-URI bidirectional index — forward (`PositionKey → Ulid`) for minting/dedup, reverse (`Ulid → PositionKey`) for resolving a held ULID back to a node range; see lazy-node-identity-tracking

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -658,6 +658,100 @@ async fn run_lsp_server() {
         "kakehashi/node/children",
         Kakehashi::kakehashi_node_children,
     )
+    // Scalar accessors (node-reference-protocol) — mirror tree-sitter `Node`.
+    .custom_method("kakehashi/node/kind", Kakehashi::kakehashi_node_kind)
+    .custom_method(
+        "kakehashi/node/grammarName",
+        Kakehashi::kakehashi_node_grammar_name,
+    )
+    .custom_method("kakehashi/node/isNamed", Kakehashi::kakehashi_node_is_named)
+    .custom_method("kakehashi/node/isExtra", Kakehashi::kakehashi_node_is_extra)
+    .custom_method(
+        "kakehashi/node/hasError",
+        Kakehashi::kakehashi_node_has_error,
+    )
+    .custom_method("kakehashi/node/isError", Kakehashi::kakehashi_node_is_error)
+    .custom_method(
+        "kakehashi/node/isMissing",
+        Kakehashi::kakehashi_node_is_missing,
+    )
+    .custom_method(
+        "kakehashi/node/startByte",
+        Kakehashi::kakehashi_node_start_byte,
+    )
+    .custom_method("kakehashi/node/endByte", Kakehashi::kakehashi_node_end_byte)
+    .custom_method(
+        "kakehashi/node/byteRange",
+        Kakehashi::kakehashi_node_byte_range,
+    )
+    .custom_method(
+        "kakehashi/node/childCount",
+        Kakehashi::kakehashi_node_child_count,
+    )
+    .custom_method(
+        "kakehashi/node/namedChildCount",
+        Kakehashi::kakehashi_node_named_child_count,
+    )
+    .custom_method(
+        "kakehashi/node/descendantCount",
+        Kakehashi::kakehashi_node_descendant_count,
+    )
+    .custom_method("kakehashi/node/toSexp", Kakehashi::kakehashi_node_to_sexp)
+    // Tree-walking accessors (node-reference-protocol).
+    .custom_method("kakehashi/node/child", Kakehashi::kakehashi_node_child)
+    .custom_method(
+        "kakehashi/node/namedChild",
+        Kakehashi::kakehashi_node_named_child,
+    )
+    .custom_method(
+        "kakehashi/node/namedChildren",
+        Kakehashi::kakehashi_node_named_children,
+    )
+    .custom_method(
+        "kakehashi/node/nextSibling",
+        Kakehashi::kakehashi_node_next_sibling,
+    )
+    .custom_method(
+        "kakehashi/node/prevSibling",
+        Kakehashi::kakehashi_node_prev_sibling,
+    )
+    .custom_method(
+        "kakehashi/node/nextNamedSibling",
+        Kakehashi::kakehashi_node_next_named_sibling,
+    )
+    .custom_method(
+        "kakehashi/node/prevNamedSibling",
+        Kakehashi::kakehashi_node_prev_named_sibling,
+    )
+    .custom_method(
+        "kakehashi/node/firstChildForByte",
+        Kakehashi::kakehashi_node_first_child_for_byte,
+    )
+    .custom_method(
+        "kakehashi/node/descendantForByteRange",
+        Kakehashi::kakehashi_node_descendant_for_byte_range,
+    )
+    .custom_method(
+        "kakehashi/node/namedDescendantForByteRange",
+        Kakehashi::kakehashi_node_named_descendant_for_byte_range,
+    )
+    // Field-aware accessors (node-reference-protocol).
+    .custom_method(
+        "kakehashi/node/childByFieldName",
+        Kakehashi::kakehashi_node_child_by_field_name,
+    )
+    .custom_method(
+        "kakehashi/node/childrenByFieldName",
+        Kakehashi::kakehashi_node_children_by_field_name,
+    )
+    .custom_method(
+        "kakehashi/node/fieldNameForChild",
+        Kakehashi::kakehashi_node_field_name_for_child,
+    )
+    .custom_method(
+        "kakehashi/node/fieldNameForNamedChild",
+        Kakehashi::kakehashi_node_field_name_for_named_child,
+    )
     .finish();
 
     // Wrap service with RequestIdCapture to:

--- a/src/lsp/lsp_impl/kakehashi/node.rs
+++ b/src/lsp/lsp_impl/kakehashi/node.rs
@@ -9,8 +9,12 @@
 //! - [`children`]: `kakehashi/node/children` — id → immediate-children NodeInfo[]
 
 mod children;
+mod common;
 mod entry;
+mod field;
 mod injection_stack;
 mod lookup;
+mod metadata;
+mod navigation;
 mod parent;
 mod text;

--- a/src/lsp/lsp_impl/kakehashi/node/common.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/common.rs
@@ -112,8 +112,14 @@ impl Kakehashi {
         lsp_uri: &Uri,
         id: &str,
         f: impl FnMut(tree_sitter::Node<'_>) -> R,
-    ) -> Option<(usize, R)> {
-        let uri = uri_to_url(lsp_uri).ok()?;
+    ) -> Option<(url::Url, usize, R)> {
+        // An unparseable URI signals a misbehaving client; warn for parity with
+        // `node` / `node/text` / `node/parent` / `node/children` while still
+        // collapsing to `null`.
+        let Ok(uri) = uri_to_url(lsp_uri) else {
+            log::warn!(target: "kakehashi::node", "invalid URI: {}", lsp_uri.as_str());
+            return None;
+        };
 
         // Malformed ULID collapses to null, like a never-issued id.
         let ulid = id.parse::<Ulid>().ok()?;
@@ -129,6 +135,15 @@ impl Kakehashi {
         // Snapshot so we operate on a consistent (text, tree) pair.
         let snapshot = self.documents.get(&uri).and_then(|doc| doc.snapshot())?;
         let host_text = snapshot.text();
+
+        // Defensively reject an invalid or out-of-bounds tracked range before any
+        // tree work: an inverted range or one extending past the current text
+        // can't name a real node (and could panic byte slicing downstream). This
+        // collapses to `null` like the other not-found cases.
+        if start > end || end > host_text.len() {
+            return None;
+        }
+
         let host_tree = snapshot.tree();
         let host_language = self.document_language(&uri)?;
 
@@ -156,7 +171,7 @@ impl Kakehashi {
             );
             return None;
         };
-        Some((layer, result))
+        Some((uri, layer, result))
     }
 
     /// Resolve `id`, run `f` to pick a single related node (child, sibling,
@@ -174,15 +189,10 @@ impl Kakehashi {
         id: &str,
         f: impl FnMut(tree_sitter::Node<'_>) -> Option<NodeTriple>,
     ) -> Value {
-        let Some((layer, picked)) = self.with_node_by_id(lsp_uri, id, f).await else {
+        let Some((uri, layer, picked)) = self.with_node_by_id(lsp_uri, id, f).await else {
             return Value::Null;
         };
         let Some((start, end, kind)) = picked else {
-            return Value::Null;
-        };
-        // `uri_to_url` already succeeded inside `with_node_by_id`; re-deriving is
-        // cheap and infallible here, avoiding threading the `Url` back out.
-        let Ok(uri) = uri_to_url(lsp_uri) else {
             return Value::Null;
         };
         let ulid = self
@@ -204,10 +214,7 @@ impl Kakehashi {
         id: &str,
         f: impl FnMut(tree_sitter::Node<'_>) -> Vec<NodeTriple>,
     ) -> Value {
-        let Some((layer, items)) = self.with_node_by_id(lsp_uri, id, f).await else {
-            return Value::Null;
-        };
-        let Ok(uri) = uri_to_url(lsp_uri) else {
+        let Some((uri, layer, items)) = self.with_node_by_id(lsp_uri, id, f).await else {
             return Value::Null;
         };
         let tracker = self.bridge.node_tracker();

--- a/src/lsp/lsp_impl/kakehashi/node/common.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/common.rs
@@ -1,0 +1,210 @@
+//! Shared request shapes and the id-resolution helper for the id-based
+//! `kakehashi/node/*` accessor methods (node-reference-protocol).
+//!
+//! Every accessor (`kind`, `childCount`, `child`, `nextSibling`, …) repeats the
+//! same prelude: convert the URI, parse the ULID, look the tracked
+//! `(start, end, kind, layer)` up, ensure the document is parsed, snapshot it,
+//! and resolve the node **in the layer that minted it** via
+//! [`with_resolved_node`]. [`Kakehashi::with_node_by_id`] centralises that
+//! prelude so each handler shrinks to "run a closure on the `Node`, shape the
+//! result". This keeps the per-layer Scope rule (node-reference-protocol
+//! §"Navigation Methods") enforced uniformly: a node minted in an injected
+//! layer is never re-resolved against a different layer's tree.
+
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tower_lsp_server::ls_types::{TextDocumentIdentifier, Uri};
+use ulid::Ulid;
+
+use crate::lsp::lsp_impl::kakehashi::node::injection_stack::with_resolved_node;
+use crate::lsp::lsp_impl::{Kakehashi, uri_to_url};
+
+/// A tracked node's `(start_byte, end_byte, kind)` triple, as produced by a
+/// navigation closure and consumed by the re-minting helpers below. `kind` is
+/// `&'static str` because tree-sitter interns node kinds in the grammar's
+/// static data, so it outlives the borrowed tree.
+type NodeTriple = (usize, usize, &'static str);
+
+/// Request parameters for the id-only accessors (`kind`, `byteRange`,
+/// `childCount`, `nextSibling`, `namedChildren`, …).
+///
+/// `pub` because the handlers are registered as custom LSP methods in the
+/// `kakehashi` binary (see `src/bin/main.rs`).
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeIdParams {
+    pub text_document: TextDocumentIdentifier,
+    pub id: String,
+}
+
+/// Request parameters for index-based accessors (`child`, `namedChild`,
+/// `fieldNameForChild`, `fieldNameForNamedChild`).
+///
+/// `index` is deserialized as a signed integer so an out-of-range or negative
+/// value collapses to `null` (node-reference-protocol universal null semantics)
+/// instead of producing a JSON-RPC deserialization error. tree-sitter's child
+/// indices are `u32`; a value outside `0..=u32::MAX` can never match a child
+/// and is treated as "no such child".
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeIndexParams {
+    pub text_document: TextDocumentIdentifier,
+    pub id: String,
+    pub index: i64,
+}
+
+/// Request parameters for field-name accessors (`childByFieldName`,
+/// `childrenByFieldName`).
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeFieldNameParams {
+    pub text_document: TextDocumentIdentifier,
+    pub id: String,
+    pub name: String,
+}
+
+/// Request parameters for `firstChildForByte`.
+///
+/// `byte` is a UTF-8 byte offset in host-document coordinates — the same space
+/// `startByte` / `endByte` report — deserialized as a signed integer so a
+/// negative value collapses to `null` rather than erroring.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeByteParams {
+    pub text_document: TextDocumentIdentifier,
+    pub id: String,
+    pub byte: i64,
+}
+
+/// Request parameters for byte-range descendant lookups
+/// (`descendantForByteRange`, `namedDescendantForByteRange`).
+///
+/// Both bounds are UTF-8 byte offsets in host-document coordinates, signed so
+/// negatives collapse to `null`.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeByteRangeParams {
+    pub text_document: TextDocumentIdentifier,
+    pub id: String,
+    pub start_byte: i64,
+    pub end_byte: i64,
+}
+
+impl Kakehashi {
+    /// Resolve `id` to its tree-sitter node and run `f` on it, returning the
+    /// minting `layer` alongside the closure's result.
+    ///
+    /// This is the shared prelude for every id-based accessor. It returns
+    /// `None` — which handlers serialize as JSON `null` — for any unresolvable
+    /// reference (node-reference-protocol §"Invalidate vs Not-Found"):
+    /// - the URI is invalid,
+    /// - the ULID is malformed / never issued / invalidated,
+    /// - the document has not been parsed,
+    /// - no host language is known, or
+    /// - the tracked range no longer matches a node in the minting layer's tree
+    ///   (e.g. an edit restructured the injection nesting).
+    ///
+    /// The `layer` is handed back so navigation handlers can re-mint result
+    /// nodes (children, siblings, descendants) in the **same** layer — they live
+    /// in the same tree as the resolved node.
+    pub(super) async fn with_node_by_id<R>(
+        &self,
+        lsp_uri: &Uri,
+        id: &str,
+        f: impl FnMut(tree_sitter::Node<'_>) -> R,
+    ) -> Option<(usize, R)> {
+        let uri = uri_to_url(lsp_uri).ok()?;
+
+        // Malformed ULID collapses to null, like a never-issued id.
+        let ulid = id.parse::<Ulid>().ok()?;
+
+        // Tracked `(start, end, kind, layer)`. `layer` pins resolution to the
+        // language tree that minted the node so navigation stays in-layer.
+        let (start, end, kind, layer) = self.bridge.node_tracker().lookup_node(&uri, &ulid)?;
+
+        // Same race as the other handlers: didOpen schedules an async parse, so
+        // a request issued immediately after must not see `tree: None`.
+        self.ensure_parsed_for_node_lookup(&uri).await;
+
+        // Snapshot so we operate on a consistent (text, tree) pair.
+        let snapshot = self.documents.get(&uri).and_then(|doc| doc.snapshot())?;
+        let host_text = snapshot.text();
+        let host_tree = snapshot.tree();
+        let host_language = self.document_language(&uri)?;
+
+        let result = with_resolved_node(
+            &self.language,
+            &host_language,
+            host_text,
+            host_tree,
+            start,
+            end,
+            kind,
+            layer,
+            f,
+        )?;
+        Some((layer, result))
+    }
+
+    /// Resolve `id`, run `f` to pick a single related node (child, sibling,
+    /// descendant, …), and return its `NodeInfo` — or JSON `null`.
+    ///
+    /// `f` returns `None` when there is no such node (e.g. `next_sibling` on the
+    /// last child), which is reported as `null` exactly like an unresolvable id:
+    /// the protocol's universal null covers both. The result node lives in the
+    /// same tree as the input, so it is re-minted in the **same** `layer`,
+    /// keeping host and injected identities distinct (node-reference-protocol
+    /// Scope rule, issue #313).
+    pub(super) async fn navigate_to_node(
+        &self,
+        lsp_uri: &Uri,
+        id: &str,
+        f: impl FnMut(tree_sitter::Node<'_>) -> Option<NodeTriple>,
+    ) -> Value {
+        let Some((layer, picked)) = self.with_node_by_id(lsp_uri, id, f).await else {
+            return Value::Null;
+        };
+        let Some((start, end, kind)) = picked else {
+            return Value::Null;
+        };
+        // `uri_to_url` already succeeded inside `with_node_by_id`; re-deriving is
+        // cheap and infallible here, avoiding threading the `Url` back out.
+        let Ok(uri) = uri_to_url(lsp_uri) else {
+            return Value::Null;
+        };
+        let ulid = self
+            .bridge
+            .node_tracker()
+            .get_or_create_in_layer(&uri, start, end, kind, layer);
+        json!({ "id": ulid.to_string(), "kind": kind })
+    }
+
+    /// Resolve `id`, run `f` to collect a list of related nodes (children,
+    /// named children, field children, …), and return them as a `NodeInfo[]`.
+    ///
+    /// Returns JSON `null` only when the id itself does not resolve; a resolved
+    /// node with no matching relatives yields `[]` (node-reference-protocol
+    /// §"Empty children"). All results are minted in the input node's `layer`.
+    pub(super) async fn navigate_to_nodes(
+        &self,
+        lsp_uri: &Uri,
+        id: &str,
+        f: impl FnMut(tree_sitter::Node<'_>) -> Vec<NodeTriple>,
+    ) -> Value {
+        let Some((layer, items)) = self.with_node_by_id(lsp_uri, id, f).await else {
+            return Value::Null;
+        };
+        let Ok(uri) = uri_to_url(lsp_uri) else {
+            return Value::Null;
+        };
+        let tracker = self.bridge.node_tracker();
+        let infos: Vec<Value> = items
+            .into_iter()
+            .map(|(start, end, kind)| {
+                let ulid = tracker.get_or_create_in_layer(&uri, start, end, kind, layer);
+                json!({ "id": ulid.to_string(), "kind": kind })
+            })
+            .collect();
+        Value::Array(infos)
+    }
+}

--- a/src/lsp/lsp_impl/kakehashi/node/common.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/common.rs
@@ -132,7 +132,13 @@ impl Kakehashi {
         let host_tree = snapshot.tree();
         let host_language = self.document_language(&uri)?;
 
-        let result = with_resolved_node(
+        // A tracker hit that fails to resolve in its minting layer means the
+        // tree drifted out from under the tracked range (e.g. an edit
+        // restructured the injection nesting). That is worth a warning for
+        // diagnosing drift — mirroring `node/parent` and `node/children` — and
+        // is distinct from the silent `None` cases above (never-issued ULID,
+        // unparsed document), which are expected and collapse to `null` quietly.
+        let Some(result) = with_resolved_node(
             &self.language,
             &host_language,
             host_text,
@@ -142,7 +148,14 @@ impl Kakehashi {
             kind,
             layer,
             f,
-        )?;
+        ) else {
+            log::warn!(
+                target: "kakehashi::node",
+                "tracker hit but no matching node in minting layer {} for ulid={} uri={} range=[{},{}) kind={}",
+                layer, ulid, uri, start, end, kind
+            );
+            return None;
+        };
         Some((layer, result))
     }
 

--- a/src/lsp/lsp_impl/kakehashi/node/field.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/field.rs
@@ -1,0 +1,93 @@
+//! Field-aware accessors for the Node Reference Protocol (node-reference-protocol).
+//!
+//! tree-sitter grammars label some children with *field names* (e.g. a
+//! `function_definition`'s `name` and `body`). These handlers expose the
+//! name-keyed half of that API — looking children up by field name, and
+//! reporting the field name of a child by index — mirroring
+//! [`Node::child_by_field_name`], [`Node::children_by_field_name`],
+//! [`Node::field_name_for_child`], and [`Node::field_name_for_named_child`].
+//!
+//! Field *ids* (the numeric, grammar-internal counterpart) are intentionally
+//! not exposed here: they are opaque and grammar-version-specific, a design
+//! question tracked separately rather than implemented blindly.
+
+use serde_json::{Value, json};
+use tower_lsp_server::jsonrpc::Result;
+
+use crate::lsp::lsp_impl::Kakehashi;
+use crate::lsp::lsp_impl::kakehashi::node::common::{NodeFieldNameParams, NodeIndexParams};
+
+impl Kakehashi {
+    /// `kakehashi/node/childByFieldName` — the child labelled `name`, per
+    /// `Node::child_by_field_name`. `null` when no child carries that field (or
+    /// the id is unresolvable).
+    pub async fn kakehashi_node_child_by_field_name(
+        &self,
+        params: NodeFieldNameParams,
+    ) -> Result<Value> {
+        let name = params.name.as_str();
+        Ok(self
+            .navigate_to_node(&params.text_document.uri, &params.id, |n| {
+                n.child_by_field_name(name)
+                    .map(|c| (c.start_byte(), c.end_byte(), c.kind()))
+            })
+            .await)
+    }
+
+    /// `kakehashi/node/childrenByFieldName` — all children labelled `name` in
+    /// document order, per `Node::children_by_field_name`. A resolvable node with
+    /// no such children yields `[]`; an unresolvable id yields `null`.
+    pub async fn kakehashi_node_children_by_field_name(
+        &self,
+        params: NodeFieldNameParams,
+    ) -> Result<Value> {
+        let name = params.name.as_str();
+        Ok(self
+            .navigate_to_nodes(&params.text_document.uri, &params.id, |n| {
+                let mut cursor = n.walk();
+                n.children_by_field_name(name, &mut cursor)
+                    .map(|c| (c.start_byte(), c.end_byte(), c.kind()))
+                    .collect()
+            })
+            .await)
+    }
+
+    /// `kakehashi/node/fieldNameForChild` — the field name of the child at
+    /// `index` (named + anonymous), per `Node::field_name_for_child`.
+    ///
+    /// Returns `{ "fieldName": string | null }` when the node resolves —
+    /// `fieldName` is `null` for a child with no field, or an out-of-range
+    /// index — and top-level `null` only when the id itself is unresolvable.
+    pub async fn kakehashi_node_field_name_for_child(
+        &self,
+        params: NodeIndexParams,
+    ) -> Result<Value> {
+        let index = u32::try_from(params.index).ok();
+        let value = self
+            .with_node_by_id(&params.text_document.uri, &params.id, |n| {
+                index.and_then(|i| n.field_name_for_child(i))
+            })
+            .await
+            .map(|(_layer, field)| json!({ "fieldName": field }))
+            .unwrap_or(Value::Null);
+        Ok(value)
+    }
+
+    /// `kakehashi/node/fieldNameForNamedChild` — the field name of the *named*
+    /// child at `index`, per `Node::field_name_for_named_child`. Same response
+    /// shape as `fieldNameForChild`.
+    pub async fn kakehashi_node_field_name_for_named_child(
+        &self,
+        params: NodeIndexParams,
+    ) -> Result<Value> {
+        let index = u32::try_from(params.index).ok();
+        let value = self
+            .with_node_by_id(&params.text_document.uri, &params.id, |n| {
+                index.and_then(|i| n.field_name_for_named_child(i))
+            })
+            .await
+            .map(|(_layer, field)| json!({ "fieldName": field }))
+            .unwrap_or(Value::Null);
+        Ok(value)
+    }
+}

--- a/src/lsp/lsp_impl/kakehashi/node/field.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/field.rs
@@ -68,7 +68,7 @@ impl Kakehashi {
                 index.and_then(|i| n.field_name_for_child(i))
             })
             .await
-            .map(|(_layer, field)| json!({ "fieldName": field }))
+            .map(|(_uri, _layer, field)| json!({ "fieldName": field }))
             .unwrap_or(Value::Null);
         Ok(value)
     }
@@ -86,7 +86,7 @@ impl Kakehashi {
                 index.and_then(|i| n.field_name_for_named_child(i))
             })
             .await
-            .map(|(_layer, field)| json!({ "fieldName": field }))
+            .map(|(_uri, _layer, field)| json!({ "fieldName": field }))
             .unwrap_or(Value::Null);
         Ok(value)
     }

--- a/src/lsp/lsp_impl/kakehashi/node/metadata.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/metadata.rs
@@ -32,7 +32,7 @@ macro_rules! scalar_accessor {
         let value = $self
             .with_node_by_id(&$params.text_document.uri, &$params.id, $f)
             .await
-            .map(|(_layer, v)| json!({ $field: v }))
+            .map(|(_uri, _layer, v)| json!({ $field: v }))
             .unwrap_or(Value::Null);
         Ok(value)
     }};
@@ -102,7 +102,7 @@ impl Kakehashi {
                 |n| json!({ "startByte": n.start_byte(), "endByte": n.end_byte() }),
             )
             .await
-            .map(|(_layer, v)| v)
+            .map(|(_uri, _layer, v)| v)
             .unwrap_or(Value::Null);
         Ok(value)
     }

--- a/src/lsp/lsp_impl/kakehashi/node/metadata.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/metadata.rs
@@ -1,0 +1,133 @@
+//! Scalar node accessors for the Node Reference Protocol (node-reference-protocol).
+//!
+//! These handlers resolve a held ULID to its tree-sitter node and report a
+//! single intrinsic property — kind, namedness, error flags, byte span, child
+//! counts, or the s-expression. They mirror the like-named methods on
+//! tree-sitter's [`Node`](https://docs.rs/tree-sitter/latest/tree_sitter/struct.Node.html)
+//! one-for-one.
+//!
+//! Each response wraps the value in a single-field object (e.g.
+//! `{ "kind": "fenced_code_block" }`), matching the shape `kakehashi/node/text`
+//! established (`{ "text": ... }`): self-describing on the wire and open to
+//! future additive fields without a breaking change. Any unresolvable
+//! reference collapses to JSON `null` (node-reference-protocol §"Invalidate vs
+//! Not-Found").
+//!
+//! **Byte offsets are UTF-8** in host-document coordinates — tree-sitter's
+//! native space, the same one `kakehashi/node/text` slices against. Line/column
+//! `Position` reporting is deliberately *not* here: it needs the UTF-16 vs
+//! byte-column encoding decision the protocol defers to a dedicated
+//! `kakehashi/node/range` endpoint.
+
+use serde_json::{Value, json};
+use tower_lsp_server::jsonrpc::Result;
+
+use crate::lsp::lsp_impl::Kakehashi;
+use crate::lsp::lsp_impl::kakehashi::node::common::NodeIdParams;
+
+/// Run `f` on the resolved node and wrap its result under `field`, or return
+/// JSON `null` if the id does not resolve.
+macro_rules! scalar_accessor {
+    ($self:ident, $params:ident, $field:literal, $f:expr) => {{
+        let value = $self
+            .with_node_by_id(&$params.text_document.uri, &$params.id, $f)
+            .await
+            .map(|(_layer, v)| json!({ $field: v }))
+            .unwrap_or(Value::Null);
+        Ok(value)
+    }};
+}
+
+impl Kakehashi {
+    /// `kakehashi/node/kind` — the node's grammar symbol name (`Node::kind`).
+    pub async fn kakehashi_node_kind(&self, params: NodeIdParams) -> Result<Value> {
+        scalar_accessor!(self, params, "kind", |n| n.kind())
+    }
+
+    /// `kakehashi/node/grammarName` — the node's grammar name, which differs
+    /// from `kind` for nodes aliased by the grammar (`Node::grammar_name`).
+    pub async fn kakehashi_node_grammar_name(&self, params: NodeIdParams) -> Result<Value> {
+        scalar_accessor!(self, params, "grammarName", |n| n.grammar_name())
+    }
+
+    /// `kakehashi/node/isNamed` — whether the node is *named* (vs an anonymous
+    /// token), per `Node::is_named`.
+    pub async fn kakehashi_node_is_named(&self, params: NodeIdParams) -> Result<Value> {
+        scalar_accessor!(self, params, "isNamed", |n| n.is_named())
+    }
+
+    /// `kakehashi/node/isExtra` — whether the node is an *extra* (e.g. a comment
+    /// the grammar permits anywhere), per `Node::is_extra`.
+    pub async fn kakehashi_node_is_extra(&self, params: NodeIdParams) -> Result<Value> {
+        scalar_accessor!(self, params, "isExtra", |n| n.is_extra())
+    }
+
+    /// `kakehashi/node/hasError` — whether the node's subtree contains a syntax
+    /// error, per `Node::has_error`.
+    pub async fn kakehashi_node_has_error(&self, params: NodeIdParams) -> Result<Value> {
+        scalar_accessor!(self, params, "hasError", |n| n.has_error())
+    }
+
+    /// `kakehashi/node/isError` — whether the node itself is an `ERROR` node,
+    /// per `Node::is_error`.
+    pub async fn kakehashi_node_is_error(&self, params: NodeIdParams) -> Result<Value> {
+        scalar_accessor!(self, params, "isError", |n| n.is_error())
+    }
+
+    /// `kakehashi/node/isMissing` — whether the node is a zero-width `MISSING`
+    /// node the parser inserted during error recovery, per `Node::is_missing`.
+    pub async fn kakehashi_node_is_missing(&self, params: NodeIdParams) -> Result<Value> {
+        scalar_accessor!(self, params, "isMissing", |n| n.is_missing())
+    }
+
+    /// `kakehashi/node/startByte` — the node's start byte (UTF-8, host coords),
+    /// per `Node::start_byte`.
+    pub async fn kakehashi_node_start_byte(&self, params: NodeIdParams) -> Result<Value> {
+        scalar_accessor!(self, params, "startByte", |n| n.start_byte())
+    }
+
+    /// `kakehashi/node/endByte` — the node's end byte (UTF-8, host coords),
+    /// per `Node::end_byte`.
+    pub async fn kakehashi_node_end_byte(&self, params: NodeIdParams) -> Result<Value> {
+        scalar_accessor!(self, params, "endByte", |n| n.end_byte())
+    }
+
+    /// `kakehashi/node/byteRange` — the node's `[startByte, endByte)` span
+    /// (UTF-8, host coords) in one call, per `Node::byte_range`.
+    pub async fn kakehashi_node_byte_range(&self, params: NodeIdParams) -> Result<Value> {
+        let value = self
+            .with_node_by_id(
+                &params.text_document.uri,
+                &params.id,
+                |n| json!({ "startByte": n.start_byte(), "endByte": n.end_byte() }),
+            )
+            .await
+            .map(|(_layer, v)| v)
+            .unwrap_or(Value::Null);
+        Ok(value)
+    }
+
+    /// `kakehashi/node/childCount` — number of children (named + anonymous),
+    /// per `Node::child_count`.
+    pub async fn kakehashi_node_child_count(&self, params: NodeIdParams) -> Result<Value> {
+        scalar_accessor!(self, params, "childCount", |n| n.child_count())
+    }
+
+    /// `kakehashi/node/namedChildCount` — number of *named* children, per
+    /// `Node::named_child_count`.
+    pub async fn kakehashi_node_named_child_count(&self, params: NodeIdParams) -> Result<Value> {
+        scalar_accessor!(self, params, "namedChildCount", |n| n.named_child_count())
+    }
+
+    /// `kakehashi/node/descendantCount` — number of descendants including the
+    /// node itself, per `Node::descendant_count`.
+    pub async fn kakehashi_node_descendant_count(&self, params: NodeIdParams) -> Result<Value> {
+        scalar_accessor!(self, params, "descendantCount", |n| n.descendant_count())
+    }
+
+    /// `kakehashi/node/toSexp` — the node's subtree as an s-expression string,
+    /// per `Node::to_sexp`. Useful for debugging and snapshot tests.
+    pub async fn kakehashi_node_to_sexp(&self, params: NodeIdParams) -> Result<Value> {
+        scalar_accessor!(self, params, "sexp", |n| n.to_sexp())
+    }
+}

--- a/src/lsp/lsp_impl/kakehashi/node/navigation.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/navigation.rs
@@ -1,0 +1,164 @@
+//! Tree-walking accessors for the Node Reference Protocol (node-reference-protocol).
+//!
+//! Each handler resolves a held ULID and returns a *related* node (or list of
+//! nodes) as `NodeInfo`, mirroring the like-named methods on tree-sitter's
+//! [`Node`](https://docs.rs/tree-sitter/latest/tree_sitter/struct.Node.html):
+//! indexed children, siblings, the first child past a byte, and byte-range
+//! descendants. All results are minted in the **same injection layer** as the
+//! input node (they live in the same tree), preserving the per-layer Scope rule
+//! (node-reference-protocol §"Navigation Methods").
+//!
+//! Single-node lookups return `NodeInfo | null` (`null` when there is no such
+//! node *or* the id is unresolvable — both collapse to the universal null).
+//! List lookups return `NodeInfo[] | null` (`null` only when the id itself is
+//! unresolvable; an empty relation yields `[]`).
+
+use serde_json::Value;
+use tower_lsp_server::jsonrpc::Result;
+
+use crate::lsp::lsp_impl::Kakehashi;
+use crate::lsp::lsp_impl::kakehashi::node::common::{
+    NodeByteParams, NodeByteRangeParams, NodeIdParams, NodeIndexParams,
+};
+
+/// Map a tree-sitter node to the `(start, end, kind)` triple the navigation
+/// helpers re-mint from.
+fn triple(node: tree_sitter::Node<'_>) -> (usize, usize, &'static str) {
+    (node.start_byte(), node.end_byte(), node.kind())
+}
+
+impl Kakehashi {
+    /// `kakehashi/node/child` — the child at `index` (named + anonymous), per
+    /// `Node::child`. Out-of-range / negative indices resolve to `null`.
+    pub async fn kakehashi_node_child(&self, params: NodeIndexParams) -> Result<Value> {
+        // tree-sitter child indices are u32; anything outside that range can
+        // never match and is treated as "no such child".
+        let index = u32::try_from(params.index).ok();
+        Ok(self
+            .navigate_to_node(&params.text_document.uri, &params.id, |n| {
+                index.and_then(|i| n.child(i)).map(triple)
+            })
+            .await)
+    }
+
+    /// `kakehashi/node/namedChild` — the *named* child at `index`, per
+    /// `Node::named_child`. Out-of-range / negative indices resolve to `null`.
+    pub async fn kakehashi_node_named_child(&self, params: NodeIndexParams) -> Result<Value> {
+        let index = u32::try_from(params.index).ok();
+        Ok(self
+            .navigate_to_node(&params.text_document.uri, &params.id, |n| {
+                index.and_then(|i| n.named_child(i)).map(triple)
+            })
+            .await)
+    }
+
+    /// `kakehashi/node/namedChildren` — all *named* children in document order,
+    /// per `Node::named_children`. Complements `kakehashi/node/children`
+    /// (named + anonymous) and mints IDs only for named nodes.
+    pub async fn kakehashi_node_named_children(&self, params: NodeIdParams) -> Result<Value> {
+        Ok(self
+            .navigate_to_nodes(&params.text_document.uri, &params.id, |n| {
+                let mut cursor = n.walk();
+                n.named_children(&mut cursor).map(triple).collect()
+            })
+            .await)
+    }
+
+    /// `kakehashi/node/nextSibling` — the next sibling (named + anonymous), per
+    /// `Node::next_sibling`. `null` for the last child or an unresolvable id.
+    pub async fn kakehashi_node_next_sibling(&self, params: NodeIdParams) -> Result<Value> {
+        Ok(self
+            .navigate_to_node(&params.text_document.uri, &params.id, |n| {
+                n.next_sibling().map(triple)
+            })
+            .await)
+    }
+
+    /// `kakehashi/node/prevSibling` — the previous sibling (named + anonymous),
+    /// per `Node::prev_sibling`. `null` for the first child or an unresolvable id.
+    pub async fn kakehashi_node_prev_sibling(&self, params: NodeIdParams) -> Result<Value> {
+        Ok(self
+            .navigate_to_node(&params.text_document.uri, &params.id, |n| {
+                n.prev_sibling().map(triple)
+            })
+            .await)
+    }
+
+    /// `kakehashi/node/nextNamedSibling` — the next *named* sibling, per
+    /// `Node::next_named_sibling`.
+    pub async fn kakehashi_node_next_named_sibling(&self, params: NodeIdParams) -> Result<Value> {
+        Ok(self
+            .navigate_to_node(&params.text_document.uri, &params.id, |n| {
+                n.next_named_sibling().map(triple)
+            })
+            .await)
+    }
+
+    /// `kakehashi/node/prevNamedSibling` — the previous *named* sibling, per
+    /// `Node::prev_named_sibling`.
+    pub async fn kakehashi_node_prev_named_sibling(&self, params: NodeIdParams) -> Result<Value> {
+        Ok(self
+            .navigate_to_node(&params.text_document.uri, &params.id, |n| {
+                n.prev_named_sibling().map(triple)
+            })
+            .await)
+    }
+
+    /// `kakehashi/node/firstChildForByte` — the node's first child extending
+    /// beyond `byte` (UTF-8, host coords), per `Node::first_child_for_byte`.
+    /// Negative bytes resolve to `null`.
+    pub async fn kakehashi_node_first_child_for_byte(
+        &self,
+        params: NodeByteParams,
+    ) -> Result<Value> {
+        let byte = usize::try_from(params.byte).ok();
+        Ok(self
+            .navigate_to_node(&params.text_document.uri, &params.id, |n| {
+                byte.and_then(|b| n.first_child_for_byte(b)).map(triple)
+            })
+            .await)
+    }
+
+    /// `kakehashi/node/descendantForByteRange` — the smallest descendant
+    /// (named + anonymous) spanning `[startByte, endByte]` within this node's
+    /// subtree, per `Node::descendant_for_byte_range`. Negative bytes resolve to
+    /// `null`.
+    pub async fn kakehashi_node_descendant_for_byte_range(
+        &self,
+        params: NodeByteRangeParams,
+    ) -> Result<Value> {
+        let range = byte_range(&params);
+        Ok(self
+            .navigate_to_node(&params.text_document.uri, &params.id, |n| {
+                range
+                    .and_then(|(s, e)| n.descendant_for_byte_range(s, e))
+                    .map(triple)
+            })
+            .await)
+    }
+
+    /// `kakehashi/node/namedDescendantForByteRange` — the smallest *named*
+    /// descendant spanning `[startByte, endByte]` within this node's subtree, per
+    /// `Node::named_descendant_for_byte_range`. Negative bytes resolve to `null`.
+    pub async fn kakehashi_node_named_descendant_for_byte_range(
+        &self,
+        params: NodeByteRangeParams,
+    ) -> Result<Value> {
+        let range = byte_range(&params);
+        Ok(self
+            .navigate_to_node(&params.text_document.uri, &params.id, |n| {
+                range
+                    .and_then(|(s, e)| n.named_descendant_for_byte_range(s, e))
+                    .map(triple)
+            })
+            .await)
+    }
+}
+
+/// Convert the signed byte bounds to `usize`, returning `None` (→ `null`) if
+/// either is negative.
+fn byte_range(params: &NodeByteRangeParams) -> Option<(usize, usize)> {
+    let start = usize::try_from(params.start_byte).ok()?;
+    let end = usize::try_from(params.end_byte).ok()?;
+    Some((start, end))
+}

--- a/src/lsp/lsp_impl/kakehashi/node/navigation.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/navigation.rs
@@ -120,9 +120,9 @@ impl Kakehashi {
     }
 
     /// `kakehashi/node/descendantForByteRange` — the smallest descendant
-    /// (named + anonymous) spanning `[startByte, endByte]` within this node's
-    /// subtree, per `Node::descendant_for_byte_range`. Negative bytes resolve to
-    /// `null`.
+    /// (named + anonymous) spanning `[startByte, endByte)` within this node's
+    /// subtree, per `Node::descendant_for_byte_range`. Negative or inverted
+    /// (`startByte > endByte`) ranges resolve to `null`.
     pub async fn kakehashi_node_descendant_for_byte_range(
         &self,
         params: NodeByteRangeParams,
@@ -138,8 +138,9 @@ impl Kakehashi {
     }
 
     /// `kakehashi/node/namedDescendantForByteRange` — the smallest *named*
-    /// descendant spanning `[startByte, endByte]` within this node's subtree, per
-    /// `Node::named_descendant_for_byte_range`. Negative bytes resolve to `null`.
+    /// descendant spanning `[startByte, endByte)` within this node's subtree, per
+    /// `Node::named_descendant_for_byte_range`. Negative or inverted
+    /// (`startByte > endByte`) ranges resolve to `null`.
     pub async fn kakehashi_node_named_descendant_for_byte_range(
         &self,
         params: NodeByteRangeParams,
@@ -156,9 +157,16 @@ impl Kakehashi {
 }
 
 /// Convert the signed byte bounds to `usize`, returning `None` (→ `null`) if
-/// either is negative.
+/// either is negative or the range is inverted (`start > end`).
+///
+/// The inversion guard mirrors `lookup::find_node_at`: tree-sitter's
+/// `descendant_for_byte_range` is not specified for `start > end`, so we reject
+/// it up front rather than relying on the C bindings' behaviour.
 fn byte_range(params: &NodeByteRangeParams) -> Option<(usize, usize)> {
     let start = usize::try_from(params.start_byte).ok()?;
     let end = usize::try_from(params.end_byte).ok()?;
+    if start > end {
+        return None;
+    }
     Some((start, end))
 }

--- a/tests/e2e_kakehashi_node_accessors.rs
+++ b/tests/e2e_kakehashi_node_accessors.rs
@@ -480,7 +480,8 @@ fn test_field_name_lookups_on_python_assignment() {
     let uri = "file:///accessors_field_python.md";
     open_markdown(&mut client, uri, MARKDOWN_WITH_PYTHON);
 
-    // Saturate into the python layer at the `=` on line 3.
+    // Saturate into the python layer inside `y = 1 + 2` on line 3 (character 4
+    // is the `1`, which is unambiguously within the python tree).
     let py = call(
         &mut client,
         "kakehashi/node",

--- a/tests/e2e_kakehashi_node_accessors.rs
+++ b/tests/e2e_kakehashi_node_accessors.rs
@@ -1,0 +1,578 @@
+//! End-to-end tests for the scalar / navigation / field accessor methods of the
+//! Node Reference Protocol (node-reference-protocol) — the tree-sitter `Node`
+//! API surface beyond the original entry / text / parent / children methods.
+//!
+//! Covered: `kind`, `grammarName`, `isNamed`, `isExtra`, `hasError`, `isError`,
+//! `isMissing`, `startByte`, `endByte`, `byteRange`, `childCount`,
+//! `namedChildCount`, `descendantCount`, `toSexp`, `child`, `namedChild`,
+//! `namedChildren`, `nextSibling`, `prevSibling`, `nextNamedSibling`,
+//! `prevNamedSibling`, `firstChildForByte`, `descendantForByteRange`,
+//! `namedDescendantForByteRange`, `childByFieldName`, `childrenByFieldName`,
+//! `fieldNameForChild`, `fieldNameForNamedChild`.
+//!
+//! Run with: `cargo test --test e2e_kakehashi_node_accessors --features e2e`
+
+#![cfg(feature = "e2e")]
+
+mod helpers;
+
+use helpers::lsp_client::LspClient;
+use serde_json::{Value, json};
+
+/// Initialize + `initialized` handshake.
+fn initialize(client: &mut LspClient) {
+    client.send_request(
+        "initialize",
+        json!({ "processId": std::process::id(), "rootUri": null, "capabilities": {} }),
+    );
+    client.send_notification("initialized", json!({}));
+}
+
+/// Open a markdown document via `textDocument/didOpen`.
+fn open_markdown(client: &mut LspClient, uri: &str, text: &str) {
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": { "uri": uri, "languageId": "markdown", "version": 1, "text": text }
+        }),
+    );
+}
+
+/// Send a custom `kakehashi/node*` request and unwrap its `result` field.
+fn call(client: &mut LspClient, method: &str, params: Value) -> Value {
+    let response = client.send_request(method, params);
+    assert!(
+        response.get("error").is_none(),
+        "{} returned an error: {:?}",
+        method,
+        response.get("error")
+    );
+    response
+        .get("result")
+        .cloned()
+        .unwrap_or_else(|| panic!("{} response must contain a result field", method))
+}
+
+/// `{ textDocument, id }` request body shared by the id-only accessors.
+fn id_params(uri: &str, id: &str) -> Value {
+    json!({ "textDocument": { "uri": uri }, "id": id })
+}
+
+/// Resolve a position to a node id via `kakehashi/node`.
+fn node_at(client: &mut LspClient, uri: &str, line: u32, character: u32) -> Value {
+    call(
+        client,
+        "kakehashi/node",
+        json!({ "textDocument": { "uri": uri }, "position": { "line": line, "character": character } }),
+    )
+}
+
+/// Read the `id` field of a NodeInfo as a string.
+fn id_of(node: &Value) -> String {
+    node.get("id")
+        .and_then(Value::as_str)
+        .expect("NodeInfo must have a string id")
+        .to_string()
+}
+
+/// Walk to the root of the host tree starting from any in-document node, so we
+/// have a node with a stable, non-trivial child set to exercise navigation.
+fn root_id(client: &mut LspClient, uri: &str) -> String {
+    let start = node_at(client, uri, 0, 0);
+    assert!(!start.is_null(), "expected a node at document start");
+    let mut current = id_of(&start);
+    for _ in 0..64 {
+        let parent = call(client, "kakehashi/node/parent", id_params(uri, &current));
+        if parent.is_null() {
+            return current;
+        }
+        current = id_of(&parent);
+    }
+    panic!("did not reach the tree root within 64 hops");
+}
+
+const DOC: &str = "# Heading\n\nplain **bold** more text.\n";
+
+/// Descend from the root until we reach a node with at least two children, and
+/// return that node's id. tree-sitter-md wraps the document in a single
+/// `section`, so the root itself has only one child — siblings need a deeper,
+/// genuinely multi-child node (e.g. the inline content of the paragraph).
+fn multi_child_node(client: &mut LspClient, uri: &str) -> String {
+    let mut current = root_id(client, uri);
+    for _ in 0..32 {
+        let children = call(client, "kakehashi/node/children", id_params(uri, &current));
+        let arr = children.as_array().expect("children must be an array");
+        if arr.len() >= 2 {
+            return current;
+        }
+        assert!(
+            !arr.is_empty(),
+            "ran out of descendants before a multi-child node"
+        );
+        current = id_of(&arr[0]);
+    }
+    panic!("did not find a multi-child node within 32 levels");
+}
+
+#[test]
+fn test_scalar_accessors_report_intrinsic_properties() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+    let uri = "file:///accessors_scalar.md";
+    open_markdown(&mut client, uri, DOC);
+
+    let root = root_id(&mut client, uri);
+
+    // kind / grammarName are non-empty strings.
+    let kind = call(&mut client, "kakehashi/node/kind", id_params(uri, &root));
+    assert!(
+        kind.get("kind")
+            .and_then(Value::as_str)
+            .is_some_and(|s| !s.is_empty()),
+        "kind must be a non-empty string, got {:?}",
+        kind
+    );
+    let grammar = call(
+        &mut client,
+        "kakehashi/node/grammarName",
+        id_params(uri, &root),
+    );
+    assert!(
+        grammar.get("grammarName").and_then(Value::as_str).is_some(),
+        "grammarName must be a string, got {:?}",
+        grammar
+    );
+
+    // The document root is a named node spanning the whole document.
+    let is_named = call(&mut client, "kakehashi/node/isNamed", id_params(uri, &root));
+    assert_eq!(is_named.get("isNamed"), Some(&Value::Bool(true)));
+
+    for (method, field) in [
+        ("kakehashi/node/isExtra", "isExtra"),
+        ("kakehashi/node/hasError", "hasError"),
+        ("kakehashi/node/isError", "isError"),
+        ("kakehashi/node/isMissing", "isMissing"),
+    ] {
+        let v = call(&mut client, method, id_params(uri, &root));
+        assert!(
+            v.get(field).and_then(Value::as_bool).is_some(),
+            "{} must report a boolean {}, got {:?}",
+            method,
+            field,
+            v
+        );
+    }
+
+    // Byte span: root starts at 0 and ends at the document length.
+    let start_byte = call(
+        &mut client,
+        "kakehashi/node/startByte",
+        id_params(uri, &root),
+    );
+    assert_eq!(start_byte.get("startByte"), Some(&json!(0)));
+    let end_byte = call(&mut client, "kakehashi/node/endByte", id_params(uri, &root));
+    assert_eq!(
+        end_byte.get("endByte").and_then(Value::as_u64),
+        Some(DOC.len() as u64),
+        "root endByte must equal the document length"
+    );
+    let byte_range = call(
+        &mut client,
+        "kakehashi/node/byteRange",
+        id_params(uri, &root),
+    );
+    assert_eq!(byte_range.get("startByte"), Some(&json!(0)));
+    assert_eq!(
+        byte_range.get("endByte").and_then(Value::as_u64),
+        Some(DOC.len() as u64)
+    );
+
+    // Counts: the root has children, and named ≤ total.
+    let child_count = call(
+        &mut client,
+        "kakehashi/node/childCount",
+        id_params(uri, &root),
+    )
+    .get("childCount")
+    .and_then(Value::as_u64)
+    .expect("childCount");
+    let named_count = call(
+        &mut client,
+        "kakehashi/node/namedChildCount",
+        id_params(uri, &root),
+    )
+    .get("namedChildCount")
+    .and_then(Value::as_u64)
+    .expect("namedChildCount");
+    assert!(child_count >= 1, "root must have children");
+    assert!(
+        named_count <= child_count,
+        "named children cannot exceed total"
+    );
+
+    let descendant_count = call(
+        &mut client,
+        "kakehashi/node/descendantCount",
+        id_params(uri, &root),
+    )
+    .get("descendantCount")
+    .and_then(Value::as_u64)
+    .expect("descendantCount");
+    assert!(
+        descendant_count > child_count,
+        "descendant count must exceed immediate child count for a non-trivial tree"
+    );
+
+    // s-expression is a non-empty parenthesized form.
+    let sexp = call(&mut client, "kakehashi/node/toSexp", id_params(uri, &root));
+    assert!(
+        sexp.get("sexp")
+            .and_then(Value::as_str)
+            .is_some_and(|s| s.starts_with('(')),
+        "toSexp must return a parenthesized s-expression, got {:?}",
+        sexp
+    );
+}
+
+#[test]
+fn test_child_and_named_child_indexing() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+    let uri = "file:///accessors_child.md";
+    open_markdown(&mut client, uri, DOC);
+    let root = root_id(&mut client, uri);
+
+    let child0 = call(
+        &mut client,
+        "kakehashi/node/child",
+        json!({ "textDocument": { "uri": uri }, "id": root, "index": 0 }),
+    );
+    assert!(!child0.is_null(), "child(0) of a non-leaf must resolve");
+    assert!(child0.get("id").and_then(Value::as_str).is_some());
+
+    // Out-of-range and negative indices collapse to null.
+    let out = call(
+        &mut client,
+        "kakehashi/node/child",
+        json!({ "textDocument": { "uri": uri }, "id": root, "index": 100000 }),
+    );
+    assert!(out.is_null(), "out-of-range child index must be null");
+    let neg = call(
+        &mut client,
+        "kakehashi/node/child",
+        json!({ "textDocument": { "uri": uri }, "id": root, "index": -1 }),
+    );
+    assert!(neg.is_null(), "negative child index must be null");
+
+    let named0 = call(
+        &mut client,
+        "kakehashi/node/namedChild",
+        json!({ "textDocument": { "uri": uri }, "id": root, "index": 0 }),
+    );
+    assert!(
+        !named0.is_null(),
+        "namedChild(0) of a non-leaf must resolve"
+    );
+}
+
+#[test]
+fn test_named_children_are_a_subset_in_order() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+    let uri = "file:///accessors_named_children.md";
+    open_markdown(&mut client, uri, DOC);
+    let root = root_id(&mut client, uri);
+
+    let all = call(
+        &mut client,
+        "kakehashi/node/children",
+        id_params(uri, &root),
+    );
+    let named = call(
+        &mut client,
+        "kakehashi/node/namedChildren",
+        id_params(uri, &root),
+    );
+
+    let all_arr = all.as_array().expect("children must be an array");
+    let named_arr = named.as_array().expect("namedChildren must be an array");
+    assert!(
+        named_arr.len() <= all_arr.len(),
+        "named children cannot outnumber all children"
+    );
+    assert!(
+        !named_arr.is_empty(),
+        "root must have at least one named child"
+    );
+}
+
+#[test]
+fn test_sibling_navigation_round_trips() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+    let uri = "file:///accessors_siblings.md";
+    open_markdown(&mut client, uri, DOC);
+    let container = multi_child_node(&mut client, uri);
+
+    // child(0) of a multi-child node is followed by at least one more sibling.
+    let first = call(
+        &mut client,
+        "kakehashi/node/child",
+        json!({ "textDocument": { "uri": uri }, "id": container, "index": 0 }),
+    );
+    assert!(!first.is_null());
+    let first_id = id_of(&first);
+
+    let next = call(
+        &mut client,
+        "kakehashi/node/nextSibling",
+        id_params(uri, &first_id),
+    );
+    assert!(!next.is_null(), "first child must have a next sibling");
+    let next_id = id_of(&next);
+    assert_ne!(next_id, first_id, "next sibling must differ from the node");
+
+    // Walking back must return to the original node.
+    let back = call(
+        &mut client,
+        "kakehashi/node/prevSibling",
+        id_params(uri, &next_id),
+    );
+    assert_eq!(
+        id_of(&back),
+        first_id,
+        "prevSibling of nextSibling must return the original node"
+    );
+
+    // The first child has no previous sibling.
+    let none = call(
+        &mut client,
+        "kakehashi/node/prevSibling",
+        id_params(uri, &first_id),
+    );
+    assert!(none.is_null(), "first child must have no previous sibling");
+
+    // Named-sibling variants resolve (value depends on grammar; just exercise).
+    let _ = call(
+        &mut client,
+        "kakehashi/node/nextNamedSibling",
+        id_params(uri, &first_id),
+    );
+    let _ = call(
+        &mut client,
+        "kakehashi/node/prevNamedSibling",
+        id_params(uri, &next_id),
+    );
+}
+
+#[test]
+fn test_byte_based_descendant_lookups() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+    let uri = "file:///accessors_byte.md";
+    open_markdown(&mut client, uri, DOC);
+    let root = root_id(&mut client, uri);
+
+    // descendantForByteRange at [0, 1) lands inside the first heading.
+    let desc = call(
+        &mut client,
+        "kakehashi/node/descendantForByteRange",
+        json!({ "textDocument": { "uri": uri }, "id": root, "startByte": 0, "endByte": 1 }),
+    );
+    assert!(
+        !desc.is_null(),
+        "descendantForByteRange must resolve a node"
+    );
+    assert!(desc.get("id").and_then(Value::as_str).is_some());
+
+    let named_desc = call(
+        &mut client,
+        "kakehashi/node/namedDescendantForByteRange",
+        json!({ "textDocument": { "uri": uri }, "id": root, "startByte": 0, "endByte": 1 }),
+    );
+    assert!(
+        !named_desc.is_null(),
+        "namedDescendantForByteRange must resolve"
+    );
+
+    // firstChildForByte(0) returns the root's first child past byte 0.
+    let first_child = call(
+        &mut client,
+        "kakehashi/node/firstChildForByte",
+        json!({ "textDocument": { "uri": uri }, "id": root, "byte": 0 }),
+    );
+    assert!(!first_child.is_null(), "firstChildForByte(0) must resolve");
+
+    // Negative byte → null.
+    let neg = call(
+        &mut client,
+        "kakehashi/node/firstChildForByte",
+        json!({ "textDocument": { "uri": uri }, "id": root, "byte": -5 }),
+    );
+    assert!(neg.is_null(), "negative byte must collapse to null");
+}
+
+#[test]
+fn test_field_name_for_child_reports_or_nulls() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+    let uri = "file:///accessors_field_index.md";
+    open_markdown(&mut client, uri, DOC);
+    let root = root_id(&mut client, uri);
+
+    // The node resolves, so the response is an object with a `fieldName` key —
+    // possibly null when the child carries no field (markdown rarely labels
+    // fields). The point is that a resolvable node never yields top-level null.
+    let resp = call(
+        &mut client,
+        "kakehashi/node/fieldNameForChild",
+        json!({ "textDocument": { "uri": uri }, "id": root, "index": 0 }),
+    );
+    assert!(
+        resp.is_object() && resp.as_object().unwrap().contains_key("fieldName"),
+        "fieldNameForChild on a resolvable node must return {{fieldName: ...}}, got {:?}",
+        resp
+    );
+
+    let named = call(
+        &mut client,
+        "kakehashi/node/fieldNameForNamedChild",
+        json!({ "textDocument": { "uri": uri }, "id": root, "index": 0 }),
+    );
+    assert!(
+        named.is_object() && named.as_object().unwrap().contains_key("fieldName"),
+        "fieldNameForNamedChild on a resolvable node must return {{fieldName: ...}}, got {:?}",
+        named
+    );
+}
+
+/// Markdown → Python fixture: the python `y = 1 + 2` assignment has named
+/// fields (`left`, `right`), letting us exercise the field-name lookups
+/// meaningfully. Skipped when the python grammar is unavailable.
+const MARKDOWN_WITH_PYTHON: &str = "# Heading\n\n```python\ny = 1 + 2\n```\n";
+
+#[test]
+fn test_field_name_lookups_on_python_assignment() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+    let uri = "file:///accessors_field_python.md";
+    open_markdown(&mut client, uri, MARKDOWN_WITH_PYTHON);
+
+    // Saturate into the python layer at the `=` on line 3.
+    let py = call(
+        &mut client,
+        "kakehashi/node",
+        json!({ "textDocument": { "uri": uri }, "position": { "line": 3, "character": 4 }, "injection": true }),
+    );
+    if py.is_null() {
+        eprintln!("SKIP: python layer did not resolve (python grammar missing?)");
+        return;
+    }
+
+    // Walk up to the `assignment` node (its children carry `left` / `right`).
+    let mut current = id_of(&py);
+    let mut assignment: Option<String> = None;
+    for _ in 0..16 {
+        let kind = call(&mut client, "kakehashi/node/kind", id_params(uri, &current));
+        if kind.get("kind").and_then(Value::as_str) == Some("assignment") {
+            assignment = Some(current.clone());
+            break;
+        }
+        let parent = call(
+            &mut client,
+            "kakehashi/node/parent",
+            id_params(uri, &current),
+        );
+        if parent.is_null() {
+            break;
+        }
+        current = id_of(&parent);
+    }
+    let Some(assignment) = assignment else {
+        eprintln!("SKIP: could not locate a python `assignment` node");
+        return;
+    };
+
+    // child_by_field_name("left") → the `y` identifier.
+    let left = call(
+        &mut client,
+        "kakehashi/node/childByFieldName",
+        json!({ "textDocument": { "uri": uri }, "id": assignment, "name": "left" }),
+    );
+    assert!(!left.is_null(), "assignment must have a `left` field");
+    assert_eq!(
+        left.get("kind").and_then(Value::as_str),
+        Some("identifier"),
+        "the `left` field of a python assignment is an identifier"
+    );
+
+    // childrenByFieldName("left") → exactly one node, same as the singular lookup.
+    let lefts = call(
+        &mut client,
+        "kakehashi/node/childrenByFieldName",
+        json!({ "textDocument": { "uri": uri }, "id": assignment, "name": "left" }),
+    );
+    let lefts_arr = lefts
+        .as_array()
+        .expect("childrenByFieldName must be an array");
+    assert_eq!(lefts_arr.len(), 1, "exactly one `left` child expected");
+
+    // An absent field name yields an empty array, not null.
+    let nope = call(
+        &mut client,
+        "kakehashi/node/childrenByFieldName",
+        json!({ "textDocument": { "uri": uri }, "id": assignment, "name": "no_such_field" }),
+    );
+    assert_eq!(
+        nope.as_array().map(|a| a.len()),
+        Some(0),
+        "an unknown field name must return [] for a resolvable node"
+    );
+}
+
+#[test]
+fn test_accessors_return_null_for_unknown_id() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+    let uri = "file:///accessors_unknown.md";
+    open_markdown(&mut client, uri, DOC);
+
+    // A syntactically valid ULID that was never issued.
+    let stray = "01HXXXXXXXXXXXXXXXXXXXXXXX";
+
+    for method in [
+        "kakehashi/node/kind",
+        "kakehashi/node/grammarName",
+        "kakehashi/node/isNamed",
+        "kakehashi/node/startByte",
+        "kakehashi/node/byteRange",
+        "kakehashi/node/childCount",
+        "kakehashi/node/descendantCount",
+        "kakehashi/node/toSexp",
+        "kakehashi/node/namedChildren",
+        "kakehashi/node/nextSibling",
+    ] {
+        let v = call(&mut client, method, id_params(uri, stray));
+        assert!(v.is_null(), "{} must return null for an unknown id", method);
+    }
+
+    // Index / byte / field variants likewise collapse to null.
+    let v = call(
+        &mut client,
+        "kakehashi/node/child",
+        json!({ "textDocument": { "uri": uri }, "id": stray, "index": 0 }),
+    );
+    assert!(v.is_null(), "child on unknown id must be null");
+    let v = call(
+        &mut client,
+        "kakehashi/node/fieldNameForChild",
+        json!({ "textDocument": { "uri": uri }, "id": stray, "index": 0 }),
+    );
+    assert!(v.is_null(), "fieldNameForChild on unknown id must be null");
+    let v = call(
+        &mut client,
+        "kakehashi/node/childByFieldName",
+        json!({ "textDocument": { "uri": uri }, "id": stray, "name": "left" }),
+    );
+    assert!(v.is_null(), "childByFieldName on unknown id must be null");
+}

--- a/tests/e2e_kakehashi_node_accessors.rs
+++ b/tests/e2e_kakehashi_node_accessors.rs
@@ -410,6 +410,28 @@ fn test_byte_based_descendant_lookups() {
         json!({ "textDocument": { "uri": uri }, "id": root, "byte": -5 }),
     );
     assert!(neg.is_null(), "negative byte must collapse to null");
+
+    // Inverted range (startByte > endByte) is invalid → null, mirroring the
+    // defensive guard in lookup::find_node_at rather than handing tree-sitter an
+    // unspecified range.
+    let inverted = call(
+        &mut client,
+        "kakehashi/node/descendantForByteRange",
+        json!({ "textDocument": { "uri": uri }, "id": root, "startByte": 5, "endByte": 1 }),
+    );
+    assert!(
+        inverted.is_null(),
+        "inverted byte range must collapse to null"
+    );
+    let inverted_named = call(
+        &mut client,
+        "kakehashi/node/namedDescendantForByteRange",
+        json!({ "textDocument": { "uri": uri }, "id": root, "startByte": 5, "endByte": 1 }),
+    );
+    assert!(
+        inverted_named.is_null(),
+        "inverted byte range must collapse to null for the named variant too"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Expands the [Node Reference Protocol](../blob/main/docs/architecture-decisions/node-reference-protocol.md) with **28 accessor methods** mirroring [`tree_sitter::Node`](https://docs.rs/tree-sitter/latest/tree_sitter/struct.Node.html) one-for-one. Previously the protocol exposed only `entry` / `text` / `parent` / `children` — clients could identify and walk a node but could not introspect it (beyond `kind`) or reach indexed children, siblings, field children, or byte-range descendants without bundling tree-sitter. This opens the full read surface.

Implements the [tracking goal](https://docs.rs/tree-sitter/latest/tree_sitter/struct.Node.html) list; methods needing a design decision are deferred to issues rather than frozen blindly on the wire.

## Implemented (28)

**Scalar** (`{ "<field>": value }` | `null`): `kind`, `grammarName`, `isNamed`, `isExtra`, `hasError`, `isError`, `isMissing`, `startByte`, `endByte`, `byteRange`, `childCount`, `namedChildCount`, `descendantCount`, `toSexp`

**Navigation** (`NodeInfo` | `NodeInfo[]` | `null`): `child`, `namedChild`, `namedChildren`, `nextSibling`, `prevSibling`, `nextNamedSibling`, `prevNamedSibling`, `firstChildForByte`, `descendantForByteRange`, `namedDescendantForByteRange`

**Field**: `childByFieldName`, `childrenByFieldName`, `fieldNameForChild`, `fieldNameForNamedChild`

## Design

- **Shared prelude** (`node/common.rs`): `with_node_by_id` / `navigate_to_node` / `navigate_to_nodes` centralise URI/ULID resolution, parse-readiness, snapshotting, and **per-layer** node resolution, so each handler is a few lines and the Scope rule (results minted in the input node's injection layer) is enforced uniformly. Handlers grouped by category (`metadata.rs`, `navigation.rs`, `field.rs`).
- **Byte offsets are UTF-8** host-document coordinates (tree-sitter native), matching the `text` endpoint. Out-of-range / negative `index` / `byte` collapse to `null` (universal null semantics).

## Deferred (9 methods → 5 issues)

Each carries a design decision that should be settled before freezing on the wire:

| Method(s) | Open question | Issue |
|---|---|---|
| `range`, `startPosition`, `endPosition`, `descendant*ForPointRange` | tree-sitter `Point.column` is a UTF-8 byte column vs LSP UTF-16 `Position` — the deferred `kakehashi/node/range` encoding decision | #331 |
| `language` | `LanguageRef` has no registered name to return | #332 |
| `hasChanges` | always `false` under the full-reparse model | #333 |
| `childrenByFieldId` | opaque, grammar-version-specific numeric ids | #334 |
| `childWithDescendant` | needs a two-id, same-layer contract | #335 |

## Verification

- `cargo fmt --check` ✅
- `cargo clippy --all-targets --features e2e -- -D warnings` ✅
- `cargo test --lib` → 1527 passed ✅
- `cargo test --features e2e --test e2e_kakehashi_node --test e2e_kakehashi_node_accessors` → 46 + 25 passed ✅ (new accessor tests cover scalar/navigation/field methods, sibling round-trips, byte-range lookups, python field lookups via injection, and null-on-unknown-id)

## Docs

ADR updated: new **Node Accessor Methods** section (response shapes + tree-sitter mapping), the deferred table with issue links, and implementation notes on the grouped-handler / shared-prelude structure.