### PR TITLE
perf(query): eliminate per-call regex cache rebuild in lua-match predicates (flamegraph-guided)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2024"
 name = "kakehashi"
 path = "src/bin/main.rs"
 
-# Profiling build: optimized like release but with debug symbols and frame
-# pointers so flamegraph/samply can symbolicate the semantic-tokens hot path.
-# Build with `cargo build --profile profiling --bin kakehashi`.
+# Profiling build: optimized like release but with debug symbols retained (not
+# stripped) so flamegraph/samply + atos can symbolicate the semantic-tokens hot
+# path. Build with `cargo build --profile profiling --bin kakehashi`.
 [profile.profiling]
 inherits = "release"
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,13 @@ edition = "2024"
 name = "kakehashi"
 path = "src/bin/main.rs"
 
+# Profiling build: optimized like release but with debug symbols and frame
+# pointers so flamegraph/samply can symbolicate the semantic-tokens hot path.
+# Build with `cargo build --profile profiling --bin kakehashi`.
+[profile.profiling]
+inherits = "release"
+debug = true
+strip = false
 
 [dependencies]
 arc-swap = "1"

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -4,6 +4,11 @@ Flamegraph profiling of the `semanticTokens/full` hot path, used to find and
 verify bottlenecks that the A/B benchmark (`benches/semantic_tokens.rs`) then
 quantifies.
 
+> **macOS only.** Offline symbolication relies on `.dSYM` + `dsymutil`/`atos`,
+> and `analyze.py` assumes the macOS `__TEXT` base. `profile.sh` checks for this
+> and fails early elsewhere. (The benchmark in `benches/semantic_tokens.rs` is
+> cross-platform; only this profiling harness is macOS-specific.)
+
 ## Quick start
 
 ```sh

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -13,9 +13,16 @@ quantifies.
 
 ```sh
 cargo install samply inferno          # one-time
+cargo test --features e2e             # one-time: populate deps/test/kakehashi with parsers
 benches/profile/profile.sh --lang rust --size 150 --requests 150
-# -> /tmp/kakehashi-profile/flamegraph.svg  (+ a top-functions report on stdout)
+# -> $TMPDIR/kakehashi-profile/flamegraph.svg  (+ a top-functions report on stdout)
 ```
+
+The harness drives the server against `deps/test/kakehashi` for parsers/queries.
+If that dir has no installed parsers, the server auto-installs on the first
+request (slow, needs network) and the profile is dominated by install work —
+`profile.sh` warns when the `.installed` marker is missing. Running the test
+suite (or `make deps/tree-sitter`) once populates it.
 
 ## Why it's shaped this way
 

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -1,0 +1,43 @@
+# Semantic-tokens profiling harness
+
+Flamegraph profiling of the `semanticTokens/full` hot path, used to find and
+verify bottlenecks that the A/B benchmark (`benches/semantic_tokens.rs`) then
+quantifies.
+
+## Quick start
+
+```sh
+cargo install samply inferno          # one-time
+benches/profile/profile.sh --lang rust --size 150 --requests 150
+# -> /tmp/kakehashi-profile/flamegraph.svg  (+ a top-functions report on stdout)
+```
+
+## Why it's shaped this way
+
+- **Drive synchronously, don't pipe a static session.** The server coalesces
+  superseded requests: if many `semanticTokens/full` calls are queued at once it
+  answers all but the last with `-32800 Canceled` and does no real work. `drive.py`
+  waits for each response before sending the next, so every request actually
+  computes. (`gen_session.py` can still emit a framed session for other uses.)
+- **Profile the server, driven by Python.** The semantic-tokens code is
+  `pub(crate)`, so it can't be called from a bench/example. samply launches the
+  driver and follows its child (the server), capturing the server's stacks.
+- **Symbolicate offline.** samply only symbolicates when serving a profile in the
+  browser; the saved JSON keeps raw module-relative addresses. `analyze.py`
+  resolves the kakehashi frames with `atos` against the `.dSYM` (built by the
+  `profiling` cargo profile + `dsymutil`), so the flow is headless.
+
+## Reading the result
+
+samply samples wall-clock, so blocked syscalls (the synchronous request/response
+IO) show up as `[libsystem_kernel.dylib]` — that's IO wait, not compute. Focus on
+the kakehashi/tree-sitter/regex frames for the actual CPU cost.
+
+## Files
+
+| file | role |
+| ---- | ---- |
+| `profile.sh` | end-to-end: build → dSYM → samply record → analyze → SVG |
+| `drive.py` | synchronous LSP driver (no request coalescing) |
+| `gen_session.py` | document generators + a framed-session emitter |
+| `analyze.py` | atos symbolication, self/inclusive report, collapsed stacks |

--- a/benches/profile/analyze.py
+++ b/benches/profile/analyze.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Symbolicate and summarize a samply (Firefox-profiler-format) profile of the
+kakehashi server, and emit collapsed stacks for flamegraph rendering.
+
+samply on macOS symbolicates only when *serving* the profile in a browser; the
+saved JSON keeps raw module-relative addresses. This script resolves the
+kakehashi frames offline with `atos` against the binary's dSYM, so it works
+headlessly and feeds inferno-flamegraph.
+
+Usage:
+    analyze.py PROFILE.json.gz \
+        --dsym target/profiling/kakehashi.dSYM/Contents/Resources/DWARF/kakehashi \
+        [--pid-name kakehashi] [--folded OUT.folded] [--top N]
+
+Pipe the folded output to a flamegraph:
+    analyze.py ... --folded /tmp/p.folded && inferno-flamegraph /tmp/p.folded > p.svg
+"""
+import argparse
+import gzip
+import json
+import re
+import subprocess
+from collections import Counter
+
+TEXT_BASE = 0x100000000  # __TEXT vmaddr for a macOS arm64/x86_64 executable
+
+
+def load(path):
+    return json.loads(gzip.open(path).read() if path.endswith(".gz") else open(path).read())
+
+
+def lib_name(libs, thread, func_idx):
+    res = thread["resourceTable"]
+    r = thread["funcTable"]["resource"][func_idx]
+    if r is None or r < 0:
+        return "?"
+    rl = res.get("lib")
+    if rl and r < len(rl) and rl[r] is not None and rl[r] >= 0:
+        return libs[rl[r]].get("name", "?")
+    return "?"
+
+
+def symbolicate(dsym, arch, addrs):
+    """Map kakehashi module-relative addresses -> 'func (file:line)' via atos."""
+    if not addrs:
+        return {}
+    runtime = [hex(TEXT_BASE + a) for a in addrs]
+    out = subprocess.run(
+        ["atos", "-o", dsym, "-arch", arch, "-l", hex(TEXT_BASE)] + runtime,
+        capture_output=True, text=True).stdout.splitlines()
+    clean = {}
+    for a, line in zip(addrs, out):
+        s = re.sub(r"::h[0-9a-f]{16}", "", line)
+        s = re.sub(r"\s*\(in kakehashi\)", "", s)
+        clean[a] = s.strip()
+    return clean
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("profile")
+    ap.add_argument("--dsym", required=True)
+    ap.add_argument("--arch", default="arm64")
+    ap.add_argument("--pid-name", default="kakehashi")
+    ap.add_argument("--folded")
+    ap.add_argument("--top", type=int, default=25)
+    args = ap.parse_args()
+
+    d = load(args.profile)
+    libs = d["libs"]
+    pids = {t["pid"] for t in d["threads"] if t.get("name") == args.pid_name} \
+        or {t.get("pid") for t in d["threads"]}
+
+    # Collect kakehashi addresses to symbolicate.
+    kaddrs = set()
+    for t in d["threads"]:
+        if t["pid"] not in pids:
+            continue
+        ft = t["frameTable"]
+        for fr in range(ft["length"]):
+            if lib_name(libs, t, ft["func"][fr]) == "kakehashi":
+                kaddrs.add(ft["address"][fr])
+    sym = symbolicate(args.dsym, args.arch, sorted(kaddrs))
+
+    def frame_label(t, fr):
+        ft = t["frameTable"]
+        lib = lib_name(libs, t, ft["func"][fr])
+        if lib == "kakehashi":
+            return sym.get(ft["address"][fr], hex(ft["address"][fr]))
+        # Non-kakehashi: label by library so kernel/malloc/parser are visible.
+        return f"[{lib}]"
+
+    self_t, incl, folded = Counter(), Counter(), Counter()
+    total = 0
+    for t in d["threads"]:
+        if t["pid"] not in pids:
+            continue
+        st = t["stackTable"]
+        frame, prefix = st["frame"], st["prefix"]
+        for s in t["samples"]["stack"]:
+            if s is None:
+                continue
+            total += 1
+            stack = []
+            cur = s
+            while cur is not None:
+                stack.append(frame_label(t, frame[cur]))
+                cur = prefix[cur]
+            stack.reverse()
+            leaf = stack[-1].split(" (")[0]
+            self_t[leaf] += 1
+            for f in set(x.split(" (")[0] for x in stack):
+                incl[f] += 1
+            folded[";".join(x.split(" (")[0] for x in stack)] += 1
+
+    if total == 0:
+        raise SystemExit("no samples for server pid")
+
+    def line(n):
+        return f"  {100.0 * n / total:5.1f}%  {n:6}"
+
+    print(f"\n=== self-time (leaf) — {total} samples ===")
+    for nm, n in self_t.most_common(args.top):
+        print(f"{line(n)}  {nm}")
+    print(f"\n=== inclusive (kakehashi semantic/query frames) — top {args.top} ===")
+    rel = [(k, v) for k, v in incl.most_common()
+           if k.startswith("kakehashi") or "regex" in k or "ts_query" in k
+           or "ts_parser" in k]
+    for nm, n in rel[:args.top]:
+        print(f"{line(n)}  {nm}")
+
+    if args.folded:
+        with open(args.folded, "w") as f:
+            for stack, n in folded.items():
+                f.write(f"{stack} {n}\n")
+        print(f"\ncollapsed stacks -> {args.folded} ({len(folded)} unique)")
+
+
+if __name__ == "__main__":
+    main()

--- a/benches/profile/analyze.py
+++ b/benches/profile/analyze.py
@@ -49,9 +49,11 @@ def symbolicate(dsym, arch, addrs):
     if not addrs:
         return {}
     runtime = [hex(TEXT_BASE + a) for a in addrs]
+    # Feed addresses on stdin (atos reads them when none are given as args) so a
+    # large profile with thousands of unique addresses can't exceed ARG_MAX.
     out = subprocess.run(
-        ["atos", "-o", dsym, "-arch", arch, "-l", hex(TEXT_BASE)] + runtime,
-        capture_output=True, text=True, check=True).stdout.splitlines()
+        ["atos", "-o", dsym, "-arch", arch, "-l", hex(TEXT_BASE)],
+        input="\n".join(runtime), capture_output=True, text=True, check=True).stdout.splitlines()
     clean = {}
     for a, line in zip(addrs, out):
         s = re.sub(r"::h[0-9a-f]{16}", "", line)

--- a/benches/profile/analyze.py
+++ b/benches/profile/analyze.py
@@ -39,7 +39,7 @@ def lib_name(libs, thread, func_idx):
     if r is None or r < 0:
         return "?"
     rl = res.get("lib")
-    if rl and r < len(rl) and rl[r] is not None and rl[r] >= 0:
+    if rl and r < len(rl) and rl[r] is not None and 0 <= rl[r] < len(libs):
         return libs[rl[r]].get("name", "?")
     return "?"
 

--- a/benches/profile/analyze.py
+++ b/benches/profile/analyze.py
@@ -26,7 +26,11 @@ TEXT_BASE = 0x100000000  # __TEXT vmaddr for a macOS arm64/x86_64 executable
 
 
 def load(path):
-    return json.loads(gzip.open(path).read() if path.endswith(".gz") else open(path).read())
+    if path.endswith(".gz"):
+        with gzip.open(path) as f:
+            return json.loads(f.read())
+    with open(path, encoding="utf-8") as f:
+        return json.loads(f.read())
 
 
 def lib_name(libs, thread, func_idx):
@@ -47,7 +51,7 @@ def symbolicate(dsym, arch, addrs):
     runtime = [hex(TEXT_BASE + a) for a in addrs]
     out = subprocess.run(
         ["atos", "-o", dsym, "-arch", arch, "-l", hex(TEXT_BASE)] + runtime,
-        capture_output=True, text=True).stdout.splitlines()
+        capture_output=True, text=True, check=True).stdout.splitlines()
     clean = {}
     for a, line in zip(addrs, out):
         s = re.sub(r"::h[0-9a-f]{16}", "", line)
@@ -130,7 +134,7 @@ def main():
         print(f"{line(n)}  {nm}")
 
     if args.folded:
-        with open(args.folded, "w") as f:
+        with open(args.folded, "w", encoding="utf-8") as f:
             for stack, n in folded.items():
                 f.write(f"{stack} {n}\n")
         print(f"\ncollapsed stacks -> {args.folded} ({len(folded)} unique)")

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -33,6 +33,8 @@ def main() -> None:
              "(populated by `cargo test --features e2e` or `make deps/tree-sitter`), "
              "else the server auto-installs on first request")
     args = ap.parse_args()
+    if args.requests <= 0:
+        ap.error("--requests must be positive")  # avoids divide-by-zero in the summary
 
     if args.lang == "rust":
         uri, lang, text = "file:///profile/large.rs", "rust", gen_rust(args.size)

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -85,41 +85,47 @@ def main() -> None:
             if m.get("id") == want_id:
                 return m
 
-    request("initialize", {"processId": None, "rootUri": None, "capabilities": {
-        "textDocument": {"semanticTokens": {"requests": {"full": {"delta": True}},
-                                            "tokenTypes": [], "tokenModifiers": [],
-                                            "formats": ["relative"]}}}})
-    notify("initialized", {})
-    notify("textDocument/didOpen", {"textDocument": {
-        "uri": uri, "languageId": lang, "version": 1, "text": text}})
-    time.sleep(0.3)  # let the initial parse settle
-
-    ok, canceled, tokens = 0, 0, 0
-    t0 = time.time()
-    for _ in range(args.requests):
-        resp = request("textDocument/semanticTokens/full", {"textDocument": {"uri": uri}})
-        if "error" in resp:
-            # Only -32800 (request cancelled) is expected here; any other error
-            # means a broken setup that would make the profile meaningless, so
-            # surface it instead of silently counting it as a cancellation.
-            if resp["error"].get("code") == -32800:
-                canceled += 1
-            else:
-                raise RuntimeError(f"server error (not a cancellation): {resp['error']}")
-        else:
-            ok += 1
-            # `result` may be null (the server can answer Ok(None)); `or {}`
-            # guards against `None.get`, which a `{}` default would not.
-            tokens = len((resp.get("result") or {}).get("data", [])) // 5
-    elapsed = time.time() - t0
-
-    request("shutdown", None)
-    notify("exit", {})
+    # Drive inside try/finally so any error (e.g. a server error raised in the
+    # loop, or a shutdown timeout) still reaps the server instead of leaving a
+    # stray process behind.
     try:
+        request("initialize", {"processId": None, "rootUri": None, "capabilities": {
+            "textDocument": {"semanticTokens": {"requests": {"full": {"delta": True}},
+                                                "tokenTypes": [], "tokenModifiers": [],
+                                                "formats": ["relative"]}}}})
+        notify("initialized", {})
+        notify("textDocument/didOpen", {"textDocument": {
+            "uri": uri, "languageId": lang, "version": 1, "text": text}})
+        time.sleep(0.3)  # let the initial parse settle
+
+        ok, canceled, tokens = 0, 0, 0
+        t0 = time.time()
+        for _ in range(args.requests):
+            resp = request("textDocument/semanticTokens/full", {"textDocument": {"uri": uri}})
+            if "error" in resp:
+                # Only -32800 (request cancelled) is expected here; any other
+                # error means a broken setup that would make the profile
+                # meaningless, so surface it instead of counting it as cancelled.
+                if resp["error"].get("code") == -32800:
+                    canceled += 1
+                else:
+                    raise RuntimeError(f"server error (not a cancellation): {resp['error']}")
+            else:
+                ok += 1
+                # `result` may be null (the server can answer Ok(None)); `or {}`
+                # guards against `None.get`, which a `{}` default would not.
+                tokens = len((resp.get("result") or {}).get("data", [])) // 5
+        elapsed = time.time() - t0
+
+        request("shutdown", None)
+        notify("exit", {})
         srv.wait(timeout=5)
     except subprocess.TimeoutExpired:
-        srv.kill()  # don't leave a hung server behind
-        srv.wait()
+        pass  # graceful shutdown didn't land in time; the finally kills it
+    finally:
+        if srv.poll() is None:
+            srv.kill()
+            srv.wait()
 
     sys.stderr.write(
         f"[drive] lang={args.lang} size={args.size} requests={args.requests} "

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -27,7 +27,11 @@ def main() -> None:
     ap.add_argument("--lang", choices=["rust", "markdown"], default="rust")
     ap.add_argument("--size", type=int, default=150)
     ap.add_argument("--requests", type=int, default=300)
-    ap.add_argument("--data-dir", default=os.path.join(os.getcwd(), "deps/test/kakehashi"))
+    ap.add_argument(
+        "--data-dir", default=os.path.join(os.getcwd(), "deps/test/kakehashi"),
+        help="parser/query data dir; must already contain installed parsers "
+             "(populated by `cargo test --features e2e` or `make deps/tree-sitter`), "
+             "else the server auto-installs on first request")
     args = ap.parse_args()
 
     if args.lang == "rust":
@@ -95,7 +99,13 @@ def main() -> None:
     for _ in range(args.requests):
         resp = request("textDocument/semanticTokens/full", {"textDocument": {"uri": uri}})
         if "error" in resp:
-            canceled += 1
+            # Only -32800 (request cancelled) is expected here; any other error
+            # means a broken setup that would make the profile meaningless, so
+            # surface it instead of silently counting it as a cancellation.
+            if resp["error"].get("code") == -32800:
+                canceled += 1
+            else:
+                raise RuntimeError(f"server error (not a cancellation): {resp['error']}")
         else:
             ok += 1
             # `result` may be null (the server can answer Ok(None)); `or {}`

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -65,6 +65,10 @@ def main() -> None:
                 break
             if line.lower().startswith(b"content-length:"):
                 length = int(line.split(b":")[1])
+        if length is None:
+            # Without a length, read(None) would block until EOF on the
+            # persistent server — fail fast instead.
+            raise RuntimeError("missing Content-Length header from server")
         return json.loads(srv.stdout.read(length))
 
     def read_until(want_id):

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -36,8 +36,10 @@ def main() -> None:
         uri, lang, text = "file:///profile/inj.md", "markdown", gen_markdown_injections(args.size)
 
     env = dict(os.environ, KAKEHASHI_DATA_DIR=args.data_dir)
+    # Let the server's stderr through (it's silent unless RUST_LOG is set) so a
+    # crash or panic is visible instead of being swallowed during profiling.
     srv = subprocess.Popen([args.bin], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                           stderr=subprocess.DEVNULL, env=env)
+                           env=env)
     rid = 0
 
     def send(obj):

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -101,7 +101,11 @@ def main() -> None:
 
     request("shutdown", None)
     notify("exit", {})
-    srv.wait(timeout=5)
+    try:
+        srv.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        srv.kill()  # don't leave a hung server behind
+        srv.wait()
 
     sys.stderr.write(
         f"[drive] lang={args.lang} size={args.size} requests={args.requests} "

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Synchronously drive the kakehashi server through a heavy semanticTokens load.
+
+Unlike piping a static session, this waits for each response before sending the
+next request, so the server never coalesces/cancels a superseded request (it
+would otherwise answer most with `-32800 Canceled` and do no real work). Run the
+server under a sampler (samply/flamegraph) with this as the driver so the sampled
+process actually spends its time in the semantic-tokens hot path.
+
+Usage:
+    drive.py --bin ./target/profiling/kakehashi --lang rust --size 150 --requests 300
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from gen_session import gen_rust, gen_markdown_injections  # noqa: E402
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bin", required=True)
+    ap.add_argument("--lang", choices=["rust", "markdown"], default="rust")
+    ap.add_argument("--size", type=int, default=150)
+    ap.add_argument("--requests", type=int, default=300)
+    ap.add_argument("--data-dir", default=os.path.join(os.getcwd(), "deps/test/kakehashi"))
+    args = ap.parse_args()
+
+    if args.lang == "rust":
+        uri, lang, text = "file:///profile/large.rs", "rust", gen_rust(args.size)
+    else:
+        uri, lang, text = "file:///profile/inj.md", "markdown", gen_markdown_injections(args.size)
+
+    env = dict(os.environ, KAKEHASHI_DATA_DIR=args.data_dir)
+    srv = subprocess.Popen([args.bin], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                           stderr=subprocess.DEVNULL, env=env)
+    rid = 0
+
+    def send(obj):
+        body = json.dumps(obj).encode()
+        srv.stdin.write(f"Content-Length: {len(body)}\r\n\r\n".encode() + body)
+        srv.stdin.flush()
+
+    def request(method, params):
+        nonlocal rid
+        rid += 1
+        send({"jsonrpc": "2.0", "id": rid, "method": method, "params": params})
+        return read_until(rid)
+
+    def notify(method, params):
+        send({"jsonrpc": "2.0", "method": method, "params": params})
+
+    def read_message():
+        length = None
+        while True:
+            line = srv.stdout.readline()
+            if not line:
+                raise RuntimeError("server closed stdout")
+            line = line.strip()
+            if not line:
+                break
+            if line.lower().startswith(b"content-length:"):
+                length = int(line.split(b":")[1])
+        return json.loads(srv.stdout.read(length))
+
+    def read_until(want_id):
+        while True:
+            m = read_message()
+            if m.get("method"):
+                continue  # server->client notification/request
+            if m.get("id") == want_id:
+                return m
+
+    request("initialize", {"processId": None, "rootUri": None, "capabilities": {
+        "textDocument": {"semanticTokens": {"requests": {"full": {"delta": True}},
+                                            "tokenTypes": [], "tokenModifiers": [],
+                                            "formats": ["relative"]}}}})
+    notify("initialized", {})
+    notify("textDocument/didOpen", {"textDocument": {
+        "uri": uri, "languageId": lang, "version": 1, "text": text}})
+    time.sleep(0.3)  # let the initial parse settle
+
+    ok, canceled, tokens = 0, 0, 0
+    t0 = time.time()
+    for _ in range(args.requests):
+        resp = request("textDocument/semanticTokens/full", {"textDocument": {"uri": uri}})
+        if "error" in resp:
+            canceled += 1
+        else:
+            ok += 1
+            tokens = len(resp.get("result", {}).get("data", [])) // 5
+    elapsed = time.time() - t0
+
+    request("shutdown", None)
+    notify("exit", {})
+    srv.wait(timeout=5)
+
+    sys.stderr.write(
+        f"[drive] lang={args.lang} size={args.size} requests={args.requests} "
+        f"ok={ok} canceled={canceled} tokens/req={tokens} "
+        f"wall={elapsed*1000:.0f}ms ({elapsed/args.requests*1000:.2f}ms/req)\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -98,7 +98,9 @@ def main() -> None:
             canceled += 1
         else:
             ok += 1
-            tokens = len(resp.get("result", {}).get("data", [])) // 5
+            # `result` may be null (the server can answer Ok(None)); `or {}`
+            # guards against `None.get`, which a `{}` default would not.
+            tokens = len((resp.get("result") or {}).get("data", [])) // 5
     elapsed = time.time() - t0
 
     request("shutdown", None)

--- a/benches/profile/gen_session.py
+++ b/benches/profile/gen_session.py
@@ -27,7 +27,7 @@ def gen_rust(funcs: int) -> str:
             f"    for (index, value) in items.iter().enumerate() {{\n"
             f'        lookup.insert(format!("key_{{}}", index), *value);\n'
             f"    }}\n"
-            f'        let message = format!("total is {{}} for {{}}", local_total, arg_b);\n'
+            f'    let message = format!("total is {{}} for {{}}", local_total, arg_b);\n'
             f"    if local_total > 100 && !items.is_empty() {{\n"
             f'        return Err(String::from("value too large"));\n'
             f"    }}\n"

--- a/benches/profile/gen_session.py
+++ b/benches/profile/gen_session.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Emit a framed LSP session that drives heavy semanticTokens/full work.
+
+Piped into the kakehashi server under a sampling profiler (flamegraph/samply),
+this makes the server spend almost all its time in the semantic-tokens hot path,
+so the resulting flamegraph is dominated by token computation rather than IPC.
+
+Usage:
+    gen_session.py [--lang rust|markdown] [--size N] [--requests N] > session.lsp
+
+The document generators mirror benches/semantic_tokens.rs so the profile and the
+A/B benchmark exercise the same code shape.
+"""
+import argparse
+import json
+import sys
+
+
+def gen_rust(funcs: int) -> str:
+    out = ["use std::collections::HashMap;\nuse std::fmt;\n\n"]
+    for i in range(funcs):
+        out.append(
+            f"/// Documentation comment for function number {i}.\n"
+            f"pub fn function_{i}(arg_a: i32, arg_b: &str, items: &[u64]) -> Result<String, String> {{\n"
+            f"    let local_total: i64 = arg_a as i64 * 2 + {i};\n"
+            f"    let mut lookup: HashMap<String, u64> = HashMap::new();\n"
+            f"    for (index, value) in items.iter().enumerate() {{\n"
+            f'        lookup.insert(format!("key_{{}}", index), *value);\n'
+            f"    }}\n"
+            f'        let message = format!("total is {{}} for {{}}", local_total, arg_b);\n'
+            f"    if local_total > 100 && !items.is_empty() {{\n"
+            f'        return Err(String::from("value too large"));\n'
+            f"    }}\n"
+            f"    match arg_b {{\n"
+            f'        "alpha" => Ok(message),\n'
+            f'        "beta" => Ok(String::from("the beta branch")),\n'
+            f"        _ => Ok(message.clone()),\n"
+            f"    }}\n"
+            f"}}\n\n"
+        )
+    return "".join(out)
+
+
+def gen_markdown_injections(blocks: int) -> str:
+    out = ["# Benchmark Document\n\nAn introductory paragraph.\n\n"]
+    for i in range(blocks):
+        out.append(f"## Section {i}\n\nProse before the code in section {i}.\n\n")
+        kind = i % 3
+        if kind == 0:
+            out.append(
+                f"```rust\nfn rust_block_{i}(x: i32) -> i32 {{\n"
+                f"    let doubled = x * 2; // a comment\n"
+                f'    let label = "section {i}";\n'
+                f'    println!("{{}} {{}}", label, doubled);\n'
+                f"    doubled + {i}\n}}\n```\n\n"
+            )
+        elif kind == 1:
+            out.append(
+                f"```lua\nlocal function lua_block_{i}(x)\n"
+                f"    local doubled = x * 2 -- a comment\n"
+                f'    local label = "section {i}"\n'
+                f"    print(label, doubled)\n"
+                f"    return doubled + {i}\nend\n```\n\n"
+            )
+        else:
+            out.append(
+                f"```python\ndef python_block_{i}(x):\n"
+                f"    doubled = x * 2  # a comment\n"
+                f'    label = "section {i}"\n'
+                f"    print(label, doubled)\n"
+                f"    return doubled + {i}\n```\n\n"
+            )
+    return "".join(out)
+
+
+def frame(msg: dict) -> bytes:
+    body = json.dumps(msg).encode("utf-8")
+    return f"Content-Length: {len(body)}\r\n\r\n".encode("ascii") + body
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--lang", choices=["rust", "markdown"], default="rust")
+    ap.add_argument("--size", type=int, default=150,
+                    help="rust: function count; markdown: code-block count")
+    ap.add_argument("--requests", type=int, default=300,
+                    help="number of semanticTokens/full requests")
+    args = ap.parse_args()
+
+    if args.lang == "rust":
+        uri, language_id, text = "file:///profile/large.rs", "rust", gen_rust(args.size)
+    else:
+        uri, language_id, text = ("file:///profile/injections.md", "markdown",
+                                  gen_markdown_injections(args.size))
+
+    w = sys.stdout.buffer
+    rid = 0
+
+    def req(method, params):
+        nonlocal rid
+        rid += 1
+        w.write(frame({"jsonrpc": "2.0", "id": rid, "method": method, "params": params}))
+
+    def notify(method, params):
+        w.write(frame({"jsonrpc": "2.0", "method": method, "params": params}))
+
+    req("initialize", {
+        "processId": None, "rootUri": None,
+        "capabilities": {"textDocument": {"semanticTokens": {
+            "requests": {"full": {"delta": True}},
+            "tokenTypes": [], "tokenModifiers": [], "formats": ["relative"]}}},
+    })
+    notify("initialized", {})
+    notify("textDocument/didOpen", {"textDocument": {
+        "uri": uri, "languageId": language_id, "version": 1, "text": text}})
+
+    for _ in range(args.requests):
+        req("textDocument/semanticTokens/full", {"textDocument": {"uri": uri}})
+
+    req("shutdown", None)
+    notify("exit", {})
+    w.flush()
+
+    sys.stderr.write(
+        f"[gen_session] lang={args.lang} size={args.size} requests={args.requests} "
+        f"doc_bytes={len(text)}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benches/profile/profile.sh
+++ b/benches/profile/profile.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Profile the semanticTokens/full hot path and render a flamegraph.
+#
+# Drives the server synchronously (one request at a time, waiting for each
+# response) so it does real work — a piped static session would be answered with
+# `-32800 Canceled` because the server coalesces superseded requests. Samples
+# with samply (no sudo on macOS), symbolicates kakehashi frames offline with
+# atos, and renders an SVG with inferno-flamegraph.
+#
+# Requires: samply + inferno (`cargo install samply inferno`), python3, dsymutil.
+#
+# Usage:
+#   benches/profile/profile.sh [--lang rust|markdown] [--size N] [--requests N]
+set -euo pipefail
+
+LANG_ARG=rust SIZE=150 REQUESTS=150
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --lang) LANG_ARG="$2"; shift 2;;
+    --size) SIZE="$2"; shift 2;;
+    --requests) REQUESTS="$2"; shift 2;;
+    *) echo "unknown arg: $1" >&2; exit 1;;
+  esac
+done
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+HERE="benches/profile"
+BIN="target/profiling/kakehashi"
+DWARF="target/profiling/kakehashi.dSYM/Contents/Resources/DWARF/kakehashi"
+ARCH="$(uname -m)"
+OUT="/tmp/kakehashi-profile"
+mkdir -p "$OUT"
+
+echo "==> Building profiling binary (optimized + debug symbols)"
+cargo build --profile profiling --bin kakehashi
+echo "==> Generating dSYM for symbolication"
+dsymutil "$BIN"
+
+echo "==> Recording with samply (lang=$LANG_ARG size=$SIZE requests=$REQUESTS)"
+samply record -s -o "$OUT/profile.json.gz" \
+  -- python3 "$HERE/drive.py" --bin "./$BIN" --lang "$LANG_ARG" --size "$SIZE" --requests "$REQUESTS"
+
+echo "==> Analyzing + writing collapsed stacks"
+python3 "$HERE/analyze.py" "$OUT/profile.json.gz" --dsym "$DWARF" --arch "$ARCH" \
+  --folded "$OUT/profile.folded"
+
+echo "==> Rendering flamegraph"
+inferno-flamegraph --title "kakehashi semanticTokens/full ($LANG_ARG)" \
+  "$OUT/profile.folded" > "$OUT/flamegraph.svg"
+echo "flamegraph -> $OUT/flamegraph.svg"

--- a/benches/profile/profile.sh
+++ b/benches/profile/profile.sh
@@ -43,7 +43,9 @@ HERE="benches/profile"
 BIN="target/profiling/kakehashi"
 DWARF="target/profiling/kakehashi.dSYM/Contents/Resources/DWARF/kakehashi"
 ARCH="$(uname -m)"
-OUT="/tmp/kakehashi-profile"
+# Per-user output dir ($TMPDIR is already user-private on macOS) so concurrent
+# users on a shared machine don't collide on a world-writable /tmp path.
+OUT="${TMPDIR:-/tmp}/kakehashi-profile"
 mkdir -p "$OUT"
 
 echo "==> Building profiling binary (optimized + debug symbols)"

--- a/benches/profile/profile.sh
+++ b/benches/profile/profile.sh
@@ -14,6 +14,19 @@
 #   benches/profile/profile.sh [--lang rust|markdown] [--size N] [--requests N]
 set -euo pipefail
 
+# macOS-only: symbolication uses dsymutil + atos (and analyze.py assumes the
+# macOS __TEXT base). Fail early with a clear message rather than deep in the run.
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "error: this profiling harness is macOS-only (needs dsymutil/atos)." >&2
+  exit 1
+fi
+for tool in samply inferno-flamegraph dsymutil atos python3; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "error: required tool '$tool' not found (try: cargo install samply inferno)." >&2
+    exit 1
+  }
+done
+
 LANG_ARG=rust SIZE=150 REQUESTS=150
 while [ $# -gt 0 ]; do
   case "$1" in

--- a/benches/profile/profile.sh
+++ b/benches/profile/profile.sh
@@ -22,7 +22,11 @@ if [ "$(uname -s)" != "Darwin" ]; then
 fi
 for tool in samply inferno-flamegraph dsymutil atos python3; do
   command -v "$tool" >/dev/null 2>&1 || {
-    echo "error: required tool '$tool' not found (try: cargo install samply inferno)." >&2
+    case "$tool" in
+      dsymutil|atos) hint="install Xcode Command Line Tools: xcode-select --install";;
+      *) hint="cargo install samply inferno";;
+    esac
+    echo "error: required tool '$tool' not found ($hint)." >&2
     exit 1
   }
 done
@@ -47,6 +51,15 @@ ARCH="$(uname -m)"
 # users on a shared machine don't collide on a world-writable /tmp path.
 OUT="${TMPDIR:-/tmp}/kakehashi-profile"
 mkdir -p "$OUT"
+
+# The driver points the server at deps/test/kakehashi for parsers/queries. If it
+# isn't populated the server auto-installs on first request (slow, needs network)
+# and the profile is dominated by install work — warn so it's not a surprise.
+if [ ! -f "deps/test/kakehashi/.installed" ]; then
+  echo "warning: deps/test/kakehashi has no installed parsers; run" >&2
+  echo "         'cargo test --features e2e' or 'make deps/tree-sitter' first," >&2
+  echo "         else the first profiling request will auto-install (slow)." >&2
+fi
 
 echo "==> Building profiling binary (optimized + debug symbols)"
 cargo build --profile profiling --bin kakehashi

--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -334,6 +334,29 @@ fn gen_unicode_rust(funcs: usize) -> String {
     s
 }
 
+/// Rust source dense with constant-like (ALL_CAPS) and type-like identifiers.
+/// The rust highlight query runs `#lua-match?` predicates per identifier (e.g.
+/// `^[A-Z][A-Z0-9_]+$` for constants, `^[A-Z]` for constructors), so a high
+/// identifier density maximizes predicate evaluations — the path that the shared
+/// lua-match regex cache pool optimizes.
+fn gen_rust_predicate_heavy(groups: usize) -> String {
+    let mut s = String::with_capacity(groups * 320);
+    for i in 0..groups {
+        s.push_str(&format!(
+            "pub const MAX_VALUE_{i}: u64 = {i};\n\
+             pub const MIN_LIMIT_{i}: u64 = {i};\n\
+             pub const DEFAULT_NAME_{i}: &str = \"item_{i}\";\n\
+             pub static GLOBAL_COUNTER_{i}: u64 = {i};\n\
+             pub fn compute_{i}(InputValue: u64, OtherArg: u64) -> u64 {{\n\
+            \x20   let LocalResult = MAX_VALUE_{i} + MIN_LIMIT_{i} + InputValue;\n\
+            \x20   let AnotherName = GLOBAL_COUNTER_{i} * OtherArg + LocalResult;\n\
+            \x20   AnotherName.max(MAX_VALUE_{i})\n\
+             }}\n\n"
+        ));
+    }
+    s
+}
+
 // ─────────────────────────────── Statistics ───────────────────────────────────
 
 struct Stats {
@@ -517,6 +540,14 @@ fn main() {
             content: gen_rust(150),
             kind: Kind::Full,
             targets: "per-token String removal, ASCII fast-path, Arc mappings (amplified)",
+        },
+        Scenario {
+            name: "rust_predicate_heavy/full",
+            language_id: "rust",
+            uri: "file:///bench/predicates.rs",
+            content: gen_rust_predicate_heavy(120),
+            kind: Kind::Full,
+            targets: "#lua-match? predicate evaluation — shared regex lazy-DFA cache pool",
         },
         Scenario {
             name: "markdown_injections/full",

--- a/src/language/query_predicates.rs
+++ b/src/language/query_predicates.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::sync::{LazyLock, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 
 use crate::error::LockResultExt;
 use regex::Regex;
@@ -9,11 +9,19 @@ use tree_sitter::{Query, QueryCapture, QueryMatch};
 /// Avoids recompiling the same pattern on every invocation during
 /// semantic token highlighting of large files.
 ///
+/// Stored as `Arc<Regex>` (not `Regex`) and shared by reference: a `Regex`
+/// owns an internal pool of lazy-DFA caches, and `Regex::clone` would hand each
+/// caller a *fresh, empty* pool — forcing the lazy DFA to rebuild its transition
+/// table on the first match of every call. Sharing one `Arc<Regex>` keeps a
+/// single pool alive across all predicate checks (the pool is internally
+/// thread-safe, so the parallel injection workers reuse it too), which removes
+/// the per-call `Cache::new`/`init_cache` that dominated the hot path.
+///
 /// Unbounded by design: patterns originate from static `.scm` query files,
 /// not user input, so the total number of unique entries is bounded by the
 /// finite set of `#lua-match?` / `#not-lua-match?` patterns across all
 /// loaded languages (typically well under 100).
-static LUA_REGEX_CACHE: LazyLock<Mutex<HashMap<String, Option<Regex>>>> =
+static LUA_REGEX_CACHE: LazyLock<Mutex<HashMap<String, Option<Arc<Regex>>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Check if a capture passes all predicates returned by
@@ -110,7 +118,10 @@ fn check_lua_match(arg: Option<&tree_sitter::QueryPredicateArg>, node_text: &str
 
 /// Get a cached compiled regex for a Lua pattern, or compile and cache it.
 /// Returns `None` if the pattern cannot be compiled (parse/convert/compile error).
-fn get_or_compile_lua_regex(pattern_str: &str) -> Option<Regex> {
+///
+/// Returns an `Arc<Regex>` (a refcount bump) so the shared regex's lazy-DFA
+/// cache pool is reused across calls — see [`LUA_REGEX_CACHE`].
+fn get_or_compile_lua_regex(pattern_str: &str) -> Option<Arc<Regex>> {
     let mut cache = LUA_REGEX_CACHE
         .lock()
         .recover_poison("query_predicates::get_or_compile_lua_regex");
@@ -119,7 +130,7 @@ fn get_or_compile_lua_regex(pattern_str: &str) -> Option<Regex> {
         return cached.clone();
     }
 
-    let result = compile_lua_regex(pattern_str);
+    let result = compile_lua_regex(pattern_str).map(Arc::new);
     cache.insert(pattern_str.to_string(), result.clone());
     result
 }

--- a/src/language/query_predicates.rs
+++ b/src/language/query_predicates.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::{Arc, LazyLock, RwLock};
 
 use crate::error::LockResultExt;
 use regex::Regex;
@@ -17,12 +17,17 @@ use tree_sitter::{Query, QueryCapture, QueryMatch};
 /// thread-safe, so the parallel injection workers reuse it too), which removes
 /// the per-call `Cache::new`/`init_cache` that dominated the hot path.
 ///
+/// A `RwLock` (not `Mutex`) because the cache is overwhelmingly read-only after
+/// warmup: every predicate check on the hot path is a lookup, so a shared read
+/// lock lets the parallel injection workers proceed concurrently; only the rare
+/// first-compile of a pattern takes the write lock.
+///
 /// Unbounded by design: patterns originate from static `.scm` query files,
 /// not user input, so the total number of unique entries is bounded by the
 /// finite set of `#lua-match?` / `#not-lua-match?` patterns across all
 /// loaded languages (typically well under 100).
-static LUA_REGEX_CACHE: LazyLock<Mutex<HashMap<String, Option<Arc<Regex>>>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+static LUA_REGEX_CACHE: LazyLock<RwLock<HashMap<String, Option<Arc<Regex>>>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
 
 /// Check if a capture passes all predicates returned by
 /// [`Query::general_predicates`] for the capture's pattern.
@@ -122,17 +127,28 @@ fn check_lua_match(arg: Option<&tree_sitter::QueryPredicateArg>, node_text: &str
 /// Returns an `Arc<Regex>` (a refcount bump) so the shared regex's lazy-DFA
 /// cache pool is reused across calls — see [`LUA_REGEX_CACHE`].
 fn get_or_compile_lua_regex(pattern_str: &str) -> Option<Arc<Regex>> {
-    let mut cache = LUA_REGEX_CACHE
-        .lock()
-        .recover_poison("query_predicates::get_or_compile_lua_regex");
-
-    if let Some(cached) = cache.get(pattern_str) {
-        return cached.clone();
+    // Fast path: a shared read lock, so parallel injection workers look up
+    // concurrently (this is the hot path — one lookup per predicate check).
+    {
+        let cache = LUA_REGEX_CACHE
+            .read()
+            .recover_poison("query_predicates::get_or_compile_lua_regex (read)");
+        if let Some(cached) = cache.get(pattern_str) {
+            return cached.clone();
+        }
     }
 
+    // Miss (only the first time a pattern is seen): compile *outside* the lock so
+    // the CPU-bound Regex::new doesn't block other workers, then insert under a
+    // brief write lock. A concurrent miss on the same pattern just recompiles;
+    // `or_insert` keeps whichever landed first — the same regex either way.
     let result = compile_lua_regex(pattern_str).map(Arc::new);
-    cache.insert(pattern_str.to_string(), result.clone());
-    result
+    LUA_REGEX_CACHE
+        .write()
+        .recover_poison("query_predicates::get_or_compile_lua_regex (write)")
+        .entry(pattern_str.to_string())
+        .or_insert(result)
+        .clone()
 }
 
 /// Compile a Lua pattern string into a Regex. Returns None on any error.


### PR DESCRIPTION
## Summary

Flamegraph profiling of the `semanticTokens/full` hot path surfaced a single
dominant bottleneck — regex lazy-DFA **cache allocation** in `#lua-match?`
predicate evaluation — and this PR fixes it, adds a benchmark scenario that
guards it, and lands the reusable profiling harness used to find it.

## The bottleneck

`query_predicates::check_lua_match` was ~22% of total time on a large host
document, almost entirely in regex cache *allocation* (`Pool::get_slow` +
`Cache::new` + `init_cache` + dropping the Cache), not matching.

The string→Regex cache already avoided recompilation, but `get_or_compile_lua_regex`
returned `cached.clone()`. `regex::Regex::clone` hands the clone a **fresh, empty
pool** of lazy-DFA caches, so the first `is_match` of every call rebuilt the DFA
transition table from scratch — once per predicate check, of which there are many
per request (the rust highlight query runs `#lua-match?` per identifier).

## The fix

Cache and share `Arc<Regex>` instead of cloning the `Regex`, so all predicate
checks reuse one regex and one cache pool. The pool is internally thread-safe, so
the parallel injection workers reuse it too. Matching behavior is unchanged.

## Verification

Re-profiled (same 100-request load, wall-clock samples):

| metric | before | after |
|---|---:|---:|
| `check_lua_match` (inclusive) | 22.3% | 0.9% |
| regex cache alloc (`Cache::new`+`init_cache`+`get_slow`) | 13.0% | 0% |
| total samples | 13672 | 8815 (−36%) |

A/B benchmark vs `main` (`benches/compare_head_vs_main.sh`, median, lower better):

| scenario | main | this PR | Δ |
|---|---:|---:|---:|
| **rust_predicate_heavy/full** *(new)* | 12.30ms | 4.81ms | **−60.9%** |
| rust_small/full | 4.15ms | 2.01ms | −51.5% |
| unicode_rust/full | 13.40ms | 6.63ms | −50.5% |
| rust_large/full | 49.20ms | 27.85ms | −43.4% |
| rust_large/delta_noop | 53.26ms | 32.76ms | −38.5% |
| rust_large/edit_delta | 73.78ms | 49.37ms | −33.1% |
| markdown_injections_large/full | 16.58ms | 12.90ms | −22.2% |
| markdown_injections/full | 4.18ms | 3.61ms | −13.7% |

Smaller/simpler docs win most because the per-predicate cache rebuild was a fixed
overhead that dominated their otherwise-small compute.

## Also included

- **`bench(semantic)`**: a `rust_predicate_heavy/full` scenario (identifier-dense
  source) that stresses the `#lua-match?` path and guards it against regression —
  it shows the largest improvement of any scenario for this fix.
- **`chore(profile)`**: the flamegraph harness under `benches/profile/` (samply +
  offline `atos` symbolication + inferno SVG; no sudo) plus a `profiling` cargo
  profile. The README documents the macOS gotchas — notably that the server
  coalesces/cancels queued requests, so the profiler must be driven synchronously.

## Test plan

- `cargo test --features e2e` (lib + integration + e2e) green; matching behavior
  is unchanged (only the regex's internal cache-pool sharing differs).