### PR TITLE
fix(node): reject out-of-bounds bytes in byte accessors

### DIFF
--- a/src/lsp/lsp_impl/kakehashi/node/navigation.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/navigation.rs
@@ -106,7 +106,8 @@ impl Kakehashi {
 
     /// `kakehashi/node/firstChildForByte` — the node's first child extending
     /// beyond `byte` (UTF-8, host coords), per `Node::first_child_for_byte`.
-    /// Negative bytes resolve to `null`.
+    /// Negative or out-of-bounds (past the node's `end_byte`) bytes resolve to
+    /// `null`.
     pub async fn kakehashi_node_first_child_for_byte(
         &self,
         params: NodeByteParams,
@@ -114,15 +115,21 @@ impl Kakehashi {
         let byte = usize::try_from(params.byte).ok();
         Ok(self
             .navigate_to_node(&params.text_document.uri, &params.id, |n| {
-                byte.and_then(|b| n.first_child_for_byte(b)).map(triple)
+                // Reject a byte past the node's end before handing it to
+                // tree-sitter, whose behaviour for out-of-bounds offsets is
+                // version-dependent (mirrors lookup::find_node_at).
+                byte.filter(|&b| b <= n.end_byte())
+                    .and_then(|b| n.first_child_for_byte(b))
+                    .map(triple)
             })
             .await)
     }
 
     /// `kakehashi/node/descendantForByteRange` — the smallest descendant
     /// (named + anonymous) spanning `[startByte, endByte)` within this node's
-    /// subtree, per `Node::descendant_for_byte_range`. Negative or inverted
-    /// (`startByte > endByte`) ranges resolve to `null`.
+    /// subtree, per `Node::descendant_for_byte_range`. Negative, inverted
+    /// (`startByte > endByte`), or out-of-bounds (past the node's `end_byte`)
+    /// ranges resolve to `null`.
     pub async fn kakehashi_node_descendant_for_byte_range(
         &self,
         params: NodeByteRangeParams,
@@ -131,6 +138,7 @@ impl Kakehashi {
         Ok(self
             .navigate_to_node(&params.text_document.uri, &params.id, |n| {
                 range
+                    .filter(|&(_s, e)| e <= n.end_byte())
                     .and_then(|(s, e)| n.descendant_for_byte_range(s, e))
                     .map(triple)
             })
@@ -139,8 +147,9 @@ impl Kakehashi {
 
     /// `kakehashi/node/namedDescendantForByteRange` — the smallest *named*
     /// descendant spanning `[startByte, endByte)` within this node's subtree, per
-    /// `Node::named_descendant_for_byte_range`. Negative or inverted
-    /// (`startByte > endByte`) ranges resolve to `null`.
+    /// `Node::named_descendant_for_byte_range`. Negative, inverted
+    /// (`startByte > endByte`), or out-of-bounds (past the node's `end_byte`)
+    /// ranges resolve to `null`.
     pub async fn kakehashi_node_named_descendant_for_byte_range(
         &self,
         params: NodeByteRangeParams,
@@ -149,6 +158,7 @@ impl Kakehashi {
         Ok(self
             .navigate_to_node(&params.text_document.uri, &params.id, |n| {
                 range
+                    .filter(|&(_s, e)| e <= n.end_byte())
                     .and_then(|(s, e)| n.named_descendant_for_byte_range(s, e))
                     .map(triple)
             })

--- a/tests/e2e_kakehashi_node_accessors.rs
+++ b/tests/e2e_kakehashi_node_accessors.rs
@@ -432,6 +432,45 @@ fn test_byte_based_descendant_lookups() {
         inverted_named.is_null(),
         "inverted byte range must collapse to null for the named variant too"
     );
+
+    // Out-of-bounds bytes (past the document end) collapse to null rather than
+    // being forwarded to tree-sitter, whose behaviour for ranges beyond the
+    // parsed tree is version-dependent (mirrors the defensive bound in
+    // lookup::find_node_at). `oob` is well past the end of `DOC`.
+    let oob = (DOC.len() + 10) as i64;
+
+    let oob_first_child = call(
+        &mut client,
+        "kakehashi/node/firstChildForByte",
+        json!({ "textDocument": { "uri": uri }, "id": root, "byte": oob }),
+    );
+    assert!(
+        oob_first_child.is_null(),
+        "firstChildForByte past EOF must collapse to null, got {:?}",
+        oob_first_child
+    );
+
+    let oob_desc = call(
+        &mut client,
+        "kakehashi/node/descendantForByteRange",
+        json!({ "textDocument": { "uri": uri }, "id": root, "startByte": 0, "endByte": oob }),
+    );
+    assert!(
+        oob_desc.is_null(),
+        "descendantForByteRange past EOF must collapse to null, got {:?}",
+        oob_desc
+    );
+
+    let oob_named_desc = call(
+        &mut client,
+        "kakehashi/node/namedDescendantForByteRange",
+        json!({ "textDocument": { "uri": uri }, "id": root, "startByte": 0, "endByte": oob }),
+    );
+    assert!(
+        oob_named_desc.is_null(),
+        "namedDescendantForByteRange past EOF must collapse to null, got {:?}",
+        oob_named_desc
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Follow-up to #336 (merged): harden the byte-based Node Reference Protocol accessors against out-of-bounds byte inputs, addressing the post-merge Copilot review.

`firstChildForByte`, `descendantForByteRange`, and `namedDescendantForByteRange` already rejected negative and inverted byte inputs, but forwarded **out-of-bounds** bytes (past the resolved node's `end_byte`) straight to tree-sitter. tree-sitter's behaviour for offsets beyond the parsed tree is version-dependent — concretely, `descendantForByteRange` with an `endByte` past EOF returned the `document` node instead of `null`.

## Change

Each byte is now bounded against the resolved node's `end_byte()` **inside the navigation closure** (the only scope where the node is in hand), collapsing out-of-bounds inputs to `null`. This mirrors the existing defensive bound in `lookup::find_node_at` and keeps the protocol's universal-null semantics deterministic across tree-sitter versions.

## Tests

Extended `test_byte_based_descendant_lookups` with explicit past-EOF cases (`byte`/`endByte` = `DOC.len() + 10`) for all three accessors. The `descendantForByteRange` case fails before the guard (returns the document node) and passes after.

- RED: `test(node): assert out-of-bounds bytes collapse to null`
- GREEN: `fix(node): reject out-of-bounds bytes in byte accessors`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
