### PR TITLE
feat(node): position/range accessors as LSP Position (closes #331)

### DIFF
--- a/docs/architecture-decisions/node-reference-protocol.md
+++ b/docs/architecture-decisions/node-reference-protocol.md
@@ -56,9 +56,9 @@ type NodeInfo = {
 
 The field is named `kind`, matching the Rust binding (`node.kind()`) that the server is built on. Keeping the wire name aligned with the implementation removes the type/kind translation at the serialization boundary and keeps the protocol vocabulary consistent with the rest of Kakehashi, which already speaks of a node's `(start, end, kind)` triple throughout the tracker and injection layers.
 
-Positional information (`range`) is **intentionally omitted** for two reasons:
+Positional information (`range`) is **intentionally omitted from `NodeInfo`** for two reasons:
 
-1. **Orthogonality**: A future `kakehashi/node/range` endpoint can return positions when needed, mirroring the `text` endpoint shape
+1. **Orthogonality**: positions are served by the dedicated `range` / `startPosition` / `endPosition` accessors (see [Node Accessor Methods](#node-accessor-methods)), mirroring the `text` endpoint shape, rather than riding inline on every `NodeInfo`
 2. **Cheap navigation**: `parent`/`children` traversals do not need to resolve positions, keeping per-call cost low
 
 The cost is N+1 round trips for clients that need ranges of every child, accepted as an explicit trade-off. A bulk endpoint (e.g., `childrenWithRange`) may be added later if profiling shows it is needed.
@@ -223,7 +223,7 @@ To let clients introspect and walk the tree without re-implementing tree-sitter,
 | `descendantCount` | `{ "descendantCount": int }` | `descendant_count()` |
 | `toSexp` | `{ "sexp": string }` | `to_sexp()` |
 
-**Byte offsets are UTF-8** in host-document coordinates — tree-sitter's native space, the same one `text` slices and the byte-input accessors consume. This deliberately differs from `Position.character` (UTF-16); line/column reporting is the deferred `range` design below.
+**Byte offsets are UTF-8** in host-document coordinates — tree-sitter's native space, the same one `text` slices and the byte-input accessors consume. This deliberately differs from `Position.character` (UTF-16); line/column reporting lives in the position/range accessors below, which speak LSP `Position`.
 
 **Navigation accessors** return `NodeInfo | null` (single) or `NodeInfo[] | null` (list — `null` only for an unresolvable id; an empty relation yields `[]`):
 
@@ -238,6 +238,20 @@ To let clients introspect and walk the tree without re-implementing tree-sitter,
 | `namedDescendantForByteRange` (`startByte`, `endByte`) | `NodeInfo \| null` | `named_descendant_for_byte_range(s, e)` |
 
 Out-of-range / negative `index` or `byte` values collapse to `null` rather than erroring, consistent with the universal null semantics.
+
+**Position / range accessors** report and accept line/column as LSP `Position` (`{ line, character }`), **not** tree-sitter's native `Point`:
+
+| Method | Input | Response | tree-sitter |
+|---|---|---|---|
+| `startPosition` | `{ id }` | `{ "startPosition": Position }` | `start_position()` |
+| `endPosition` | `{ id }` | `{ "endPosition": Position }` | `end_position()` |
+| `range` | `{ id }` | `{ "start": Position, "end": Position }` | `range()` |
+| `descendantForPointRange` | `{ id, start, end }` | `NodeInfo \| null` | `descendant_for_point_range(s, e)` |
+| `namedDescendantForPointRange` | `{ id, start, end }` | `NodeInfo \| null` | `named_descendant_for_point_range(s, e)` |
+
+**Why LSP `Position`, not tree-sitter `Point`**: tree-sitter's `Point.column` is a **UTF-8 byte** offset within the line, whereas the protocol speaks LSP `Position` (UTF-16 code units) everywhere else (§"Position Encoding"). Returning native points would diverge from every other LSP coordinate around non-ASCII (emoji, CJK) and force clients to special-case these accessors. Instead the server converts each end via `PositionMapper`: byte → `Position` on output, `Position` → byte on input (reusing the byte-range search and its inverted / out-of-bounds guards). Clients that genuinely want byte-native spans use `startByte` / `endByte` / `byteRange` and `descendant*ForByteRange`, which are unambiguous. A `Position` that cannot be mapped into the current document collapses to `null`.
+
+This supersedes the earlier deferral of range reporting (Alternative C): rather than a single bulk `kakehashi/node/range` endpoint, each tree-sitter method is exposed individually for 1:1 parity with the `Node` API; bulk range retrieval (e.g. `childrenWithRange`) remains a possible future addition if profiling shows the N+1 cost dominates.
 
 **Field accessors** expose the name-keyed half of tree-sitter's field API:
 
@@ -311,7 +325,7 @@ All three collapse to `null`. This is a deliberate consequence of the no-tombsto
 
 ### Negative
 
-- **N+1 for positions**: Clients building outline views must call `kakehashi/node/range` (future) once per node, or accept paying for it only when needed
+- **N+1 for positions**: Clients building outline views must call `range` once per node (a bulk `childrenWithRange` remains a possible future addition), or accept paying for it only when needed
 - **No invalidate diagnostics**: Clients cannot tell why an ID failed; they must re-acquire blindly
 - **Cross-injection navigation is two-step**: `parent` does not transparently cross into a host tree
 - **`injection` mixed mode**: `true` saturates while integer indices are strict (resolve via a single formula, return `null` when out of bounds) — clients must remember which mode they want
@@ -344,8 +358,8 @@ Identify nodes by `(uri, start_byte, end_byte, type)` directly.
 
 Include `range` in every `NodeInfo` returned.
 
-* Acceptable trade-off, but rejected for now in favor of the orthogonal `kakehashi/node/range` endpoint (future)
-* Reconsider if profiling shows the N+1 round-trip cost dominates
+* Acceptable trade-off, but rejected in favor of orthogonal `range` / `startPosition` / `endPosition` accessors (now implemented — see [Node Accessor Methods](#node-accessor-methods))
+* Reconsider a bulk variant (`childrenWithRange`) if profiling shows the N+1 round-trip cost dominates
 
 ### Alternative D: Auto-Cross Injection in `parent`
 
@@ -392,7 +406,7 @@ Split the entry point into anonymous-inclusive and named-only methods instead of
 |--------|----------|
 | **Methods** | `kakehashi/node`, `/parent`, `/children`, `/namedChildren`, `/text` |
 | **Common params** | All methods carry `TextDocumentIdentifier` |
-| **`NodeInfo` shape** | `{ id, kind }` (no range, no `named` — both deferred) |
+| **`NodeInfo` shape** | `{ id, kind }` (range via separate `range`/`startPosition`/`endPosition` accessors, not inline; `named` deferred) |
 | **Entry resolution** | Smallest containing node at selected injection layer |
 | **Injection selector** | `boolean \| number`, default `false` |
 | **Named selection** | `namedOnly` param on entry (`named_descendant_for_byte_range`); `namedChildren` method (`named_children()`); no `parent` variant (tree-sitter has no `named_parent`) |

--- a/docs/language-features.md
+++ b/docs/language-features.md
@@ -227,8 +227,11 @@ support.
 
 Beyond the standard LSP features, kakehashi exposes custom methods under the
 `kakehashi/` namespace so that editor plugins and scripts can query the syntax tree
-directly — identify the node at a position, walk to its parent or children, and read
-its current text — **without bundling Tree-sitter on the client side**.
+directly — identify the node at a position, walk it (parent, children, siblings,
+descendants, fields), introspect it (kind, flags, byte/line-column spans), and read
+its current text — **without bundling Tree-sitter on the client side**. These
+mirror the Tree-sitter
+[`Node`](https://docs.rs/tree-sitter/latest/tree_sitter/struct.Node.html) API.
 
 A handle to a node (its `id`) stays valid across edits as long as the node survives,
 so a plugin can hold a reference to "this function" and keep using it while the user
@@ -242,11 +245,11 @@ types.
 ```typescript
 type NodeInfo = {
   id: string;    // stable handle, valid across edits until the node changes
-  type: string;  // tree-sitter node type, e.g. "fenced_code_block"
+  kind: string;  // tree-sitter node kind, e.g. "fenced_code_block"
 };
 ```
 
-### Methods
+### Core methods
 
 Every method takes a `textDocument`. The `id`-based methods are tied to the document
 they came from; querying with an `id` from a different document returns `null`.
@@ -255,7 +258,8 @@ they came from; querying with an `id` from a different document returns `null`.
 |--------|-------|--------|---------|
 | `kakehashi/node` | `{ textDocument, position, injection? }` | `NodeInfo \| null` | The smallest node at a position (on the chosen embedding layer) |
 | `kakehashi/node/parent` | `{ textDocument, id }` | `NodeInfo \| null` | The node's parent (within the same language tree) |
-| `kakehashi/node/children` | `{ textDocument, id }` | `NodeInfo[] \| null` | The node's immediate children, in document order |
+| `kakehashi/node/children` | `{ textDocument, id }` | `NodeInfo[] \| null` | The node's immediate children (named + anonymous), in document order |
+| `kakehashi/node/namedChildren` | `{ textDocument, id }` | `NodeInfo[] \| null` | The node's immediate **named** children, in document order |
 | `kakehashi/node/text` | `{ textDocument, id }` | `{ text: string } \| null` | The node's current text |
 
 Positions use the LSP default encoding, UTF-16 code units. kakehashi does not
@@ -279,6 +283,61 @@ inside the regex: `0` resolves the Markdown node, `1` the Python node,
 `2` / `true` / `-1` the regex node, and `3` returns `null` (only three layers
 exist).
 
+### Node accessors
+
+Once you hold a node `id`, these methods expose the rest of the Tree-sitter
+[`Node`](https://docs.rs/tree-sitter/latest/tree_sitter/struct.Node.html) API
+one-for-one, so you can introspect and walk the tree without bundling Tree-sitter.
+Every accessor takes `{ textDocument, id }` (plus the extra fields noted below);
+any unresolvable `id` — or out-of-range argument — returns `null`.
+
+**Introspection** — one property per call, returned as a single-field object
+(e.g. `{ "kind": "fenced_code_block" }`):
+
+| Method | Output |
+|--------|--------|
+| `kakehashi/node/kind` | `{ kind: string }` — the node's grammar symbol |
+| `kakehashi/node/grammarName` | `{ grammarName: string }` — grammar name (differs from `kind` for aliased nodes) |
+| `kakehashi/node/isNamed` · `isExtra` | `{ isNamed: bool }` · `{ isExtra: bool }` |
+| `kakehashi/node/hasError` · `isError` · `isMissing` | `{ hasError: bool }` … (error-recovery flags) |
+| `kakehashi/node/startByte` · `endByte` | `{ startByte: int }` · `{ endByte: int }` |
+| `kakehashi/node/byteRange` | `{ startByte: int, endByte: int }` |
+| `kakehashi/node/childCount` · `namedChildCount` · `descendantCount` | `{ childCount: int }` … |
+| `kakehashi/node/toSexp` | `{ sexp: string }` — the subtree as an s-expression |
+
+**Navigation** — returns `NodeInfo | null` (or `NodeInfo[] | null`), minted in the
+same embedding layer as the input:
+
+| Method | Extra input | Output |
+|--------|-------------|--------|
+| `kakehashi/node/child` · `namedChild` | `index` | `NodeInfo \| null` |
+| `kakehashi/node/nextSibling` · `prevSibling` | — | `NodeInfo \| null` |
+| `kakehashi/node/nextNamedSibling` · `prevNamedSibling` | — | `NodeInfo \| null` |
+| `kakehashi/node/firstChildForByte` | `byte` | `NodeInfo \| null` |
+| `kakehashi/node/descendantForByteRange` · `namedDescendantForByteRange` | `startByte`, `endByte` | `NodeInfo \| null` |
+
+**Fields** — children labelled by the grammar (e.g. a function's `name` / `body`):
+
+| Method | Extra input | Output |
+|--------|-------------|--------|
+| `kakehashi/node/childByFieldName` | `name` | `NodeInfo \| null` |
+| `kakehashi/node/childrenByFieldName` | `name` | `NodeInfo[] \| null` |
+| `kakehashi/node/fieldNameForChild` · `fieldNameForNamedChild` | `index` | `{ fieldName: string \| null } \| null` |
+
+**Position / range** — line/column as LSP `Position` (`{ line, character }`, UTF-16):
+
+| Method | Extra input | Output |
+|--------|-------------|--------|
+| `kakehashi/node/startPosition` · `endPosition` | — | `{ startPosition: Position }` · `{ endPosition: Position }` |
+| `kakehashi/node/range` | — | `{ start: Position, end: Position }` |
+| `kakehashi/node/descendantForPointRange` · `namedDescendantForPointRange` | `start`, `end` (Positions) | `NodeInfo \| null` |
+
+> **Two coordinate systems.** Byte accessors (`startByte`, `byteRange`,
+> `descendantForByteRange`, `firstChildForByte`, …) use **UTF-8 byte offsets** —
+> Tree-sitter's native space, matching `kakehashi/node/text`. Position accessors use
+> **LSP `Position` (UTF-16)**, matching `kakehashi/node` and every other LSP request.
+> Pick whichever your client already works in; they address the same nodes.
+
 ### Result semantics
 
 - **`null` means "not currently resolvable."** Whether the `id` was invalidated by
@@ -292,8 +351,9 @@ exist).
   embedded block's root returns `null`, not the host node containing it — to cross
   that boundary, call `kakehashi/node` again at the position.
 
-> `kakehashi/node/namedChildren` and a `namedOnly` option on `kakehashi/node`
-> (named-only navigation) are planned but **not yet available**.
+> A `namedOnly` option on `kakehashi/node` (resolving the smallest *named* node at
+> a position) is planned but **not yet available**. For named-only navigation today,
+> use `kakehashi/node/namedChildren` and the `named*` accessors.
 
 ---
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -735,6 +735,24 @@ async fn run_lsp_server() {
         "kakehashi/node/namedDescendantForByteRange",
         Kakehashi::kakehashi_node_named_descendant_for_byte_range,
     )
+    // Position / range accessors (node-reference-protocol) — LSP Position (UTF-16).
+    .custom_method("kakehashi/node/range", Kakehashi::kakehashi_node_range)
+    .custom_method(
+        "kakehashi/node/startPosition",
+        Kakehashi::kakehashi_node_start_position,
+    )
+    .custom_method(
+        "kakehashi/node/endPosition",
+        Kakehashi::kakehashi_node_end_position,
+    )
+    .custom_method(
+        "kakehashi/node/descendantForPointRange",
+        Kakehashi::kakehashi_node_descendant_for_point_range,
+    )
+    .custom_method(
+        "kakehashi/node/namedDescendantForPointRange",
+        Kakehashi::kakehashi_node_named_descendant_for_point_range,
+    )
     // Field-aware accessors (node-reference-protocol).
     .custom_method(
         "kakehashi/node/childByFieldName",

--- a/src/lsp/lsp_impl/kakehashi/node.rs
+++ b/src/lsp/lsp_impl/kakehashi/node.rs
@@ -17,4 +17,5 @@ mod lookup;
 mod metadata;
 mod navigation;
 mod parent;
+mod position;
 mod text;

--- a/src/lsp/lsp_impl/kakehashi/node/common.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/common.rs
@@ -19,7 +19,6 @@ use url::Url;
 
 use crate::lsp::lsp_impl::kakehashi::node::injection_stack::with_resolved_node;
 use crate::lsp::lsp_impl::{Kakehashi, uri_to_url};
-use crate::text::PositionMapper;
 
 /// A tracked node's `(start_byte, end_byte, kind)` triple, as produced by a
 /// navigation closure and consumed by the re-minting helpers below. `kind` is
@@ -132,21 +131,26 @@ impl Kakehashi {
         id: &str,
         mut f: impl FnMut(tree_sitter::Node<'_>) -> R,
     ) -> Option<(Url, usize, R)> {
-        // Most accessors don't need positions; ignore the mapper.
-        self.with_node_mapped(lsp_uri, id, move |node, _mapper| f(node))
+        // Most accessors don't need the document text; ignore it.
+        self.with_node_text(lsp_uri, id, move |node, _text| f(node))
             .await
     }
 
     /// Like [`with_node_by_id`](Self::with_node_by_id) but also hands the closure
-    /// a [`PositionMapper`] over the host document, so position/range accessors
-    /// can convert tree-sitter byte offsets ↔ LSP `Position` (UTF-16) without a
-    /// second snapshot. This is the actual shared prelude; `with_node_by_id`
-    /// delegates here with the mapper ignored.
-    pub(super) async fn with_node_mapped<R>(
+    /// the host document text, so the position/range accessors can build a
+    /// [`PositionMapper`] to convert tree-sitter byte offsets ↔ LSP `Position`
+    /// (UTF-16) without a second snapshot.
+    ///
+    /// The text — not a pre-built `PositionMapper` — is passed because
+    /// `PositionMapper::new` indexes the whole document (O(doc)); building it
+    /// unconditionally here would tax every scalar/navigation accessor that never
+    /// touches positions. Only the handful of position accessors build the mapper,
+    /// inside their own closure.
+    pub(super) async fn with_node_text<R>(
         &self,
         lsp_uri: &Uri,
         id: &str,
-        mut f: impl FnMut(tree_sitter::Node<'_>, &PositionMapper) -> R,
+        mut f: impl FnMut(tree_sitter::Node<'_>, &str) -> R,
     ) -> Option<(Url, usize, R)> {
         // An unparseable URI signals a misbehaving client; warn for parity with
         // `node` / `node/text` / `node/parent` / `node/children` while still
@@ -181,7 +185,6 @@ impl Kakehashi {
 
         let host_tree = snapshot.tree();
         let host_language = self.document_language(&uri)?;
-        let mapper = PositionMapper::new(host_text);
 
         // A tracker hit that fails to resolve in its minting layer means the
         // tree drifted out from under the tracked range (e.g. an edit
@@ -198,7 +201,7 @@ impl Kakehashi {
             end,
             kind,
             layer,
-            |node| f(node, &mapper),
+            |node| f(node, host_text),
         ) else {
             log::warn!(
                 target: "kakehashi::node",

--- a/src/lsp/lsp_impl/kakehashi/node/common.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/common.rs
@@ -13,11 +13,13 @@
 
 use serde::Deserialize;
 use serde_json::{Value, json};
-use tower_lsp_server::ls_types::{TextDocumentIdentifier, Uri};
+use tower_lsp_server::ls_types::{Position, TextDocumentIdentifier, Uri};
 use ulid::Ulid;
+use url::Url;
 
 use crate::lsp::lsp_impl::kakehashi::node::injection_stack::with_resolved_node;
 use crate::lsp::lsp_impl::{Kakehashi, uri_to_url};
+use crate::text::PositionMapper;
 
 /// A tracked node's `(start_byte, end_byte, kind)` triple, as produced by a
 /// navigation closure and consumed by the re-minting helpers below. `kind` is
@@ -90,6 +92,23 @@ pub struct NodeByteRangeParams {
     pub end_byte: i64,
 }
 
+/// Request parameters for point-range descendant lookups
+/// (`descendantForPointRange`, `namedDescendantForPointRange`).
+///
+/// `start` / `end` are LSP `Position`s (`{ line, character }`, **UTF-16** code
+/// units per the protocol's position encoding). The server converts each to a
+/// UTF-8 byte offset via [`PositionMapper`] before searching, so clients use the
+/// same coordinate space as every other LSP request — never tree-sitter's
+/// byte-column points.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodePointRangeParams {
+    pub text_document: TextDocumentIdentifier,
+    pub id: String,
+    pub start: Position,
+    pub end: Position,
+}
+
 impl Kakehashi {
     /// Resolve `id` to its tree-sitter node and run `f` on it, returning the
     /// minting `layer` alongside the closure's result.
@@ -111,8 +130,24 @@ impl Kakehashi {
         &self,
         lsp_uri: &Uri,
         id: &str,
-        f: impl FnMut(tree_sitter::Node<'_>) -> R,
-    ) -> Option<(url::Url, usize, R)> {
+        mut f: impl FnMut(tree_sitter::Node<'_>) -> R,
+    ) -> Option<(Url, usize, R)> {
+        // Most accessors don't need positions; ignore the mapper.
+        self.with_node_mapped(lsp_uri, id, move |node, _mapper| f(node))
+            .await
+    }
+
+    /// Like [`with_node_by_id`](Self::with_node_by_id) but also hands the closure
+    /// a [`PositionMapper`] over the host document, so position/range accessors
+    /// can convert tree-sitter byte offsets ↔ LSP `Position` (UTF-16) without a
+    /// second snapshot. This is the actual shared prelude; `with_node_by_id`
+    /// delegates here with the mapper ignored.
+    pub(super) async fn with_node_mapped<R>(
+        &self,
+        lsp_uri: &Uri,
+        id: &str,
+        mut f: impl FnMut(tree_sitter::Node<'_>, &PositionMapper) -> R,
+    ) -> Option<(Url, usize, R)> {
         // An unparseable URI signals a misbehaving client; warn for parity with
         // `node` / `node/text` / `node/parent` / `node/children` while still
         // collapsing to `null`.
@@ -146,6 +181,7 @@ impl Kakehashi {
 
         let host_tree = snapshot.tree();
         let host_language = self.document_language(&uri)?;
+        let mapper = PositionMapper::new(host_text);
 
         // A tracker hit that fails to resolve in its minting layer means the
         // tree drifted out from under the tracked range (e.g. an edit
@@ -162,7 +198,7 @@ impl Kakehashi {
             end,
             kind,
             layer,
-            f,
+            |node| f(node, &mapper),
         ) else {
             log::warn!(
                 target: "kakehashi::node",
@@ -172,6 +208,18 @@ impl Kakehashi {
             return None;
         };
         Some((uri, layer, result))
+    }
+
+    /// Mint (or reuse) a stable ULID for a related node in `layer` and shape it
+    /// as a `NodeInfo`. Shared by every handler that returns a single resolved
+    /// node, so the wire shape stays identical.
+    pub(super) fn mint_node_info(&self, uri: &Url, layer: usize, triple: NodeTriple) -> Value {
+        let (start, end, kind) = triple;
+        let ulid = self
+            .bridge
+            .node_tracker()
+            .get_or_create_in_layer(uri, start, end, kind, layer);
+        json!({ "id": ulid.to_string(), "kind": kind })
     }
 
     /// Resolve `id`, run `f` to pick a single related node (child, sibling,
@@ -192,14 +240,10 @@ impl Kakehashi {
         let Some((uri, layer, picked)) = self.with_node_by_id(lsp_uri, id, f).await else {
             return Value::Null;
         };
-        let Some((start, end, kind)) = picked else {
-            return Value::Null;
-        };
-        let ulid = self
-            .bridge
-            .node_tracker()
-            .get_or_create_in_layer(&uri, start, end, kind, layer);
-        json!({ "id": ulid.to_string(), "kind": kind })
+        match picked {
+            Some(triple) => self.mint_node_info(&uri, layer, triple),
+            None => Value::Null,
+        }
     }
 
     /// Resolve `id`, run `f` to collect a list of related nodes (children,
@@ -217,13 +261,9 @@ impl Kakehashi {
         let Some((uri, layer, items)) = self.with_node_by_id(lsp_uri, id, f).await else {
             return Value::Null;
         };
-        let tracker = self.bridge.node_tracker();
         let infos: Vec<Value> = items
             .into_iter()
-            .map(|(start, end, kind)| {
-                let ulid = tracker.get_or_create_in_layer(&uri, start, end, kind, layer);
-                json!({ "id": ulid.to_string(), "kind": kind })
-            })
+            .map(|triple| self.mint_node_info(&uri, layer, triple))
             .collect();
         Value::Array(infos)
     }

--- a/src/lsp/lsp_impl/kakehashi/node/common.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/common.rs
@@ -96,9 +96,9 @@ pub struct NodeByteRangeParams {
 ///
 /// `start` / `end` are LSP `Position`s (`{ line, character }`, **UTF-16** code
 /// units per the protocol's position encoding). The server converts each to a
-/// UTF-8 byte offset via [`PositionMapper`] before searching, so clients use the
-/// same coordinate space as every other LSP request — never tree-sitter's
-/// byte-column points.
+/// UTF-8 byte offset via [`PositionMapper`](crate::text::PositionMapper) before
+/// searching, so clients use the same coordinate space as every other LSP
+/// request — never tree-sitter's byte-column points.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NodePointRangeParams {
@@ -138,8 +138,8 @@ impl Kakehashi {
 
     /// Like [`with_node_by_id`](Self::with_node_by_id) but also hands the closure
     /// the host document text, so the position/range accessors can build a
-    /// [`PositionMapper`] to convert tree-sitter byte offsets ↔ LSP `Position`
-    /// (UTF-16) without a second snapshot.
+    /// [`PositionMapper`](crate::text::PositionMapper) to convert tree-sitter byte
+    /// offsets ↔ LSP `Position` (UTF-16) without a second snapshot.
     ///
     /// The text — not a pre-built `PositionMapper` — is passed because
     /// `PositionMapper::new` indexes the whole document (O(doc)); building it

--- a/src/lsp/lsp_impl/kakehashi/node/navigation.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/navigation.rs
@@ -173,6 +173,10 @@ impl Kakehashi {
 /// The inversion guard mirrors `lookup::find_node_at`: tree-sitter's
 /// `descendant_for_byte_range` is not specified for `start > end`, so we reject
 /// it up front rather than relying on the C bindings' behaviour.
+///
+/// Per-call the handlers additionally bound the range to the queried node's
+/// contiguous span. Known limitation (#341): that span check does not exclude
+/// bytes in the gaps of an injected layer's non-contiguous included ranges.
 fn byte_range(params: &NodeByteRangeParams) -> Option<(usize, usize)> {
     let start = usize::try_from(params.start_byte).ok()?;
     let end = usize::try_from(params.end_byte).ok()?;

--- a/src/lsp/lsp_impl/kakehashi/node/navigation.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/navigation.rs
@@ -106,7 +106,8 @@ impl Kakehashi {
 
     /// `kakehashi/node/firstChildForByte` — the node's first child extending
     /// beyond `byte` (UTF-8, host coords), per `Node::first_child_for_byte`.
-    /// Negative bytes resolve to `null`.
+    /// Negative or out-of-bounds (past the node's `end_byte`) bytes resolve to
+    /// `null`.
     pub async fn kakehashi_node_first_child_for_byte(
         &self,
         params: NodeByteParams,
@@ -114,15 +115,21 @@ impl Kakehashi {
         let byte = usize::try_from(params.byte).ok();
         Ok(self
             .navigate_to_node(&params.text_document.uri, &params.id, |n| {
-                byte.and_then(|b| n.first_child_for_byte(b)).map(triple)
+                // Reject a byte past the node's end before handing it to
+                // tree-sitter, whose behaviour for out-of-bounds offsets is
+                // version-dependent (mirrors lookup::find_node_at).
+                byte.filter(|&b| b <= n.end_byte())
+                    .and_then(|b| n.first_child_for_byte(b))
+                    .map(triple)
             })
             .await)
     }
 
     /// `kakehashi/node/descendantForByteRange` — the smallest descendant
     /// (named + anonymous) spanning `[startByte, endByte)` within this node's
-    /// subtree, per `Node::descendant_for_byte_range`. Negative or inverted
-    /// (`startByte > endByte`) ranges resolve to `null`.
+    /// subtree, per `Node::descendant_for_byte_range`. Negative, inverted
+    /// (`startByte > endByte`), or out-of-bounds (past the node's `end_byte`)
+    /// ranges resolve to `null`.
     pub async fn kakehashi_node_descendant_for_byte_range(
         &self,
         params: NodeByteRangeParams,
@@ -131,6 +138,7 @@ impl Kakehashi {
         Ok(self
             .navigate_to_node(&params.text_document.uri, &params.id, |n| {
                 range
+                    .filter(|&(_s, e)| e <= n.end_byte())
                     .and_then(|(s, e)| n.descendant_for_byte_range(s, e))
                     .map(triple)
             })
@@ -139,8 +147,9 @@ impl Kakehashi {
 
     /// `kakehashi/node/namedDescendantForByteRange` — the smallest *named*
     /// descendant spanning `[startByte, endByte)` within this node's subtree, per
-    /// `Node::named_descendant_for_byte_range`. Negative or inverted
-    /// (`startByte > endByte`) ranges resolve to `null`.
+    /// `Node::named_descendant_for_byte_range`. Negative, inverted
+    /// (`startByte > endByte`), or out-of-bounds (past the node's `end_byte`)
+    /// ranges resolve to `null`.
     pub async fn kakehashi_node_named_descendant_for_byte_range(
         &self,
         params: NodeByteRangeParams,
@@ -149,6 +158,7 @@ impl Kakehashi {
         Ok(self
             .navigate_to_node(&params.text_document.uri, &params.id, |n| {
                 range
+                    .filter(|&(_s, e)| e <= n.end_byte())
                     .and_then(|(s, e)| n.named_descendant_for_byte_range(s, e))
                     .map(triple)
             })

--- a/src/lsp/lsp_impl/kakehashi/node/navigation.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/navigation.rs
@@ -106,8 +106,8 @@ impl Kakehashi {
 
     /// `kakehashi/node/firstChildForByte` — the node's first child extending
     /// beyond `byte` (UTF-8, host coords), per `Node::first_child_for_byte`.
-    /// A `byte` outside the node's own `[start_byte, end_byte]` span (negative,
-    /// before the node, or past its end) resolves to `null`.
+    /// `byte` is rejected (→ `null`) unless `node.start_byte <= byte <=
+    /// node.end_byte` — i.e. negative, before the node, or past its end.
     pub async fn kakehashi_node_first_child_for_byte(
         &self,
         params: NodeByteParams,
@@ -128,9 +128,9 @@ impl Kakehashi {
 
     /// `kakehashi/node/descendantForByteRange` — the smallest descendant
     /// (named + anonymous) spanning `[startByte, endByte)` within this node's
-    /// subtree, per `Node::descendant_for_byte_range`. A range that is negative,
-    /// inverted (`startByte > endByte`), or not contained in the node's own
-    /// `[start_byte, end_byte]` span resolves to `null`.
+    /// subtree, per `Node::descendant_for_byte_range`. The range is rejected
+    /// (→ `null`) unless `node.start_byte <= startByte <= endByte <=
+    /// node.end_byte` — i.e. negative, inverted, or reaching outside the node.
     pub async fn kakehashi_node_descendant_for_byte_range(
         &self,
         params: NodeByteRangeParams,
@@ -148,9 +148,9 @@ impl Kakehashi {
 
     /// `kakehashi/node/namedDescendantForByteRange` — the smallest *named*
     /// descendant spanning `[startByte, endByte)` within this node's subtree, per
-    /// `Node::named_descendant_for_byte_range`. A range that is negative,
-    /// inverted (`startByte > endByte`), or not contained in the node's own
-    /// `[start_byte, end_byte]` span resolves to `null`.
+    /// `Node::named_descendant_for_byte_range`. The range is rejected (→ `null`)
+    /// unless `node.start_byte <= startByte <= endByte <= node.end_byte` — i.e.
+    /// negative, inverted, or reaching outside the node.
     pub async fn kakehashi_node_named_descendant_for_byte_range(
         &self,
         params: NodeByteRangeParams,

--- a/src/lsp/lsp_impl/kakehashi/node/navigation.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/navigation.rs
@@ -106,8 +106,8 @@ impl Kakehashi {
 
     /// `kakehashi/node/firstChildForByte` — the node's first child extending
     /// beyond `byte` (UTF-8, host coords), per `Node::first_child_for_byte`.
-    /// Negative or out-of-bounds (past the node's `end_byte`) bytes resolve to
-    /// `null`.
+    /// A `byte` outside the node's own `[start_byte, end_byte]` span (negative,
+    /// before the node, or past its end) resolves to `null`.
     pub async fn kakehashi_node_first_child_for_byte(
         &self,
         params: NodeByteParams,
@@ -115,10 +115,11 @@ impl Kakehashi {
         let byte = usize::try_from(params.byte).ok();
         Ok(self
             .navigate_to_node(&params.text_document.uri, &params.id, |n| {
-                // Reject a byte past the node's end before handing it to
-                // tree-sitter, whose behaviour for out-of-bounds offsets is
-                // version-dependent (mirrors lookup::find_node_at).
-                byte.filter(|&b| b <= n.end_byte())
+                // Keep the byte inside the node's own span before handing it to
+                // tree-sitter, whose behaviour for offsets outside the queried
+                // node is version-dependent (mirrors lookup::find_node_at). These
+                // are node-scoped accessors, so an out-of-node argument is null.
+                byte.filter(|&b| n.start_byte() <= b && b <= n.end_byte())
                     .and_then(|b| n.first_child_for_byte(b))
                     .map(triple)
             })
@@ -127,9 +128,9 @@ impl Kakehashi {
 
     /// `kakehashi/node/descendantForByteRange` — the smallest descendant
     /// (named + anonymous) spanning `[startByte, endByte)` within this node's
-    /// subtree, per `Node::descendant_for_byte_range`. Negative, inverted
-    /// (`startByte > endByte`), or out-of-bounds (past the node's `end_byte`)
-    /// ranges resolve to `null`.
+    /// subtree, per `Node::descendant_for_byte_range`. A range that is negative,
+    /// inverted (`startByte > endByte`), or not contained in the node's own
+    /// `[start_byte, end_byte]` span resolves to `null`.
     pub async fn kakehashi_node_descendant_for_byte_range(
         &self,
         params: NodeByteRangeParams,
@@ -138,7 +139,7 @@ impl Kakehashi {
         Ok(self
             .navigate_to_node(&params.text_document.uri, &params.id, |n| {
                 range
-                    .filter(|&(_s, e)| e <= n.end_byte())
+                    .filter(|&(s, e)| n.start_byte() <= s && e <= n.end_byte())
                     .and_then(|(s, e)| n.descendant_for_byte_range(s, e))
                     .map(triple)
             })
@@ -147,9 +148,9 @@ impl Kakehashi {
 
     /// `kakehashi/node/namedDescendantForByteRange` — the smallest *named*
     /// descendant spanning `[startByte, endByte)` within this node's subtree, per
-    /// `Node::named_descendant_for_byte_range`. Negative, inverted
-    /// (`startByte > endByte`), or out-of-bounds (past the node's `end_byte`)
-    /// ranges resolve to `null`.
+    /// `Node::named_descendant_for_byte_range`. A range that is negative,
+    /// inverted (`startByte > endByte`), or not contained in the node's own
+    /// `[start_byte, end_byte]` span resolves to `null`.
     pub async fn kakehashi_node_named_descendant_for_byte_range(
         &self,
         params: NodeByteRangeParams,
@@ -158,7 +159,7 @@ impl Kakehashi {
         Ok(self
             .navigate_to_node(&params.text_document.uri, &params.id, |n| {
                 range
-                    .filter(|&(_s, e)| e <= n.end_byte())
+                    .filter(|&(s, e)| n.start_byte() <= s && e <= n.end_byte())
                     .and_then(|(s, e)| n.named_descendant_for_byte_range(s, e))
                     .map(triple)
             })

--- a/src/lsp/lsp_impl/kakehashi/node/position.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/position.rs
@@ -15,7 +15,7 @@
 //! tree-sitter `Point.column` is a UTF-8 byte offset, which diverges from LSP
 //! around any non-ASCII character (emoji, CJK). Returning native points would
 //! make these the only accessors a client must special-case. Instead the server
-//! converts each end via [`PositionMapper`](crate::text::PositionMapper):
+//! converts each end via [`PositionMapper`]:
 //! byte → `Position` on output, `Position` → byte on input. Byte-native spans
 //! remain available unambiguously via `startByte` / `endByte` / `byteRange` and
 //! `descendant*ForByteRange`.

--- a/src/lsp/lsp_impl/kakehashi/node/position.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/position.rs
@@ -113,8 +113,11 @@ impl Kakehashi {
         let end = params.end;
         let resolved = self
             .with_node_mapped(&params.text_document.uri, &params.id, |n, mapper| {
-                let start_byte = mapper.position_to_byte(start)?;
-                let end_byte = mapper.position_to_byte(end)?;
+                // Strict conversion: a `character` past a line's end must mean
+                // "no such location" (null), NOT spill onto a later line as plain
+                // `position_to_byte` would (it computes line_start + character).
+                let start_byte = mapper.position_to_byte_strict(start)?;
+                let end_byte = mapper.position_to_byte_strict(end)?;
                 // Mirror the byte-range guards: reject inverted ranges and any
                 // range not contained in the node's own span, whose tree-sitter
                 // behaviour is unspecified (see navigation.rs / lookup::find_node_at).

--- a/src/lsp/lsp_impl/kakehashi/node/position.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/position.rs
@@ -115,10 +115,10 @@ impl Kakehashi {
             .with_node_mapped(&params.text_document.uri, &params.id, |n, mapper| {
                 let start_byte = mapper.position_to_byte(start)?;
                 let end_byte = mapper.position_to_byte(end)?;
-                // Mirror the byte-range guards: reject inverted ranges and ones
-                // reaching past the node, whose tree-sitter behaviour is
-                // unspecified (see navigation.rs / lookup::find_node_at).
-                if start_byte > end_byte || end_byte > n.end_byte() {
+                // Mirror the byte-range guards: reject inverted ranges and any
+                // range not contained in the node's own span, whose tree-sitter
+                // behaviour is unspecified (see navigation.rs / lookup::find_node_at).
+                if start_byte < n.start_byte() || start_byte > end_byte || end_byte > n.end_byte() {
                     return None;
                 }
                 let descendant = if named {

--- a/src/lsp/lsp_impl/kakehashi/node/position.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/position.rs
@@ -28,6 +28,7 @@ use tower_lsp_server::jsonrpc::Result;
 
 use crate::lsp::lsp_impl::Kakehashi;
 use crate::lsp::lsp_impl::kakehashi::node::common::{NodeIdParams, NodePointRangeParams};
+use crate::text::PositionMapper;
 
 impl Kakehashi {
     /// `kakehashi/node/range` — the node's span as a pair of LSP `Position`s,
@@ -35,7 +36,8 @@ impl Kakehashi {
     /// `null`.
     pub async fn kakehashi_node_range(&self, params: NodeIdParams) -> Result<Value> {
         let value = self
-            .with_node_mapped(&params.text_document.uri, &params.id, |n, mapper| {
+            .with_node_text(&params.text_document.uri, &params.id, |n, text| {
+                let mapper = PositionMapper::new(text);
                 Some((
                     mapper.byte_to_position(n.start_byte())?,
                     mapper.byte_to_position(n.end_byte())?,
@@ -53,8 +55,8 @@ impl Kakehashi {
     /// `null`.
     pub async fn kakehashi_node_start_position(&self, params: NodeIdParams) -> Result<Value> {
         let value = self
-            .with_node_mapped(&params.text_document.uri, &params.id, |n, mapper| {
-                mapper.byte_to_position(n.start_byte())
+            .with_node_text(&params.text_document.uri, &params.id, |n, text| {
+                PositionMapper::new(text).byte_to_position(n.start_byte())
             })
             .await
             .and_then(|(_uri, _layer, pos)| pos)
@@ -67,8 +69,8 @@ impl Kakehashi {
     /// `Node::end_position`. Returns `{ "endPosition": Position }` or `null`.
     pub async fn kakehashi_node_end_position(&self, params: NodeIdParams) -> Result<Value> {
         let value = self
-            .with_node_mapped(&params.text_document.uri, &params.id, |n, mapper| {
-                mapper.byte_to_position(n.end_byte())
+            .with_node_text(&params.text_document.uri, &params.id, |n, text| {
+                PositionMapper::new(text).byte_to_position(n.end_byte())
             })
             .await
             .and_then(|(_uri, _layer, pos)| pos)
@@ -112,7 +114,8 @@ impl Kakehashi {
         let start = params.start;
         let end = params.end;
         let resolved = self
-            .with_node_mapped(&params.text_document.uri, &params.id, |n, mapper| {
+            .with_node_text(&params.text_document.uri, &params.id, |n, text| {
+                let mapper = PositionMapper::new(text);
                 // Strict conversion: a `character` past a line's end must mean
                 // "no such location" (null), NOT spill onto a later line as plain
                 // `position_to_byte` would (it computes line_start + character).
@@ -121,6 +124,11 @@ impl Kakehashi {
                 // Mirror the byte-range guards: reject inverted ranges and any
                 // range not contained in the node's own span, whose tree-sitter
                 // behaviour is unspecified (see navigation.rs / lookup::find_node_at).
+                //
+                // Known limitation (#341): for an injected layer with
+                // non-contiguous included ranges (e.g. blockquoted code), this
+                // contiguous-span check does not exclude bytes in the gaps, so a
+                // coordinate on an excluded prefix can still resolve a node.
                 if start_byte < n.start_byte() || start_byte > end_byte || end_byte > n.end_byte() {
                     return None;
                 }

--- a/src/lsp/lsp_impl/kakehashi/node/position.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/position.rs
@@ -1,0 +1,139 @@
+//! Position / range accessors for the Node Reference Protocol (node-reference-protocol).
+//!
+//! These mirror tree-sitter's
+//! [`Node`](https://docs.rs/tree-sitter/latest/tree_sitter/struct.Node.html)
+//! `range` / `start_position` / `end_position` /
+//! `descendant_for_point_range` / `named_descendant_for_point_range`, but speak
+//! **LSP `Position` (UTF-16 code units)** on the wire rather than tree-sitter's
+//! native `Point` (whose `column` is a UTF-8 byte offset).
+//!
+//! ## Why LSP `Position`, not tree-sitter `Point`
+//!
+//! The whole protocol accepts and returns LSP `Position` at its boundary
+//! (node-reference-protocol §"Position Encoding"); kakehashi advertises no
+//! `positionEncoding`, so `character` is a UTF-16 code unit per LSP 3.18. A
+//! tree-sitter `Point.column` is a UTF-8 byte offset, which diverges from LSP
+//! around any non-ASCII character (emoji, CJK). Returning native points would
+//! make these the only accessors a client must special-case. Instead the server
+//! converts each end via [`PositionMapper`](crate::text::PositionMapper):
+//! byte → `Position` on output, `Position` → byte on input. Byte-native spans
+//! remain available unambiguously via `startByte` / `endByte` / `byteRange` and
+//! `descendant*ForByteRange`.
+//!
+//! Any unresolvable reference (and any `Position` that cannot be mapped into the
+//! current document) collapses to JSON `null`.
+
+use serde_json::{Value, json};
+use tower_lsp_server::jsonrpc::Result;
+
+use crate::lsp::lsp_impl::Kakehashi;
+use crate::lsp::lsp_impl::kakehashi::node::common::{NodeIdParams, NodePointRangeParams};
+
+impl Kakehashi {
+    /// `kakehashi/node/range` — the node's span as a pair of LSP `Position`s,
+    /// per `Node::range`. Returns `{ "start": Position, "end": Position }` or
+    /// `null`.
+    pub async fn kakehashi_node_range(&self, params: NodeIdParams) -> Result<Value> {
+        let value = self
+            .with_node_mapped(&params.text_document.uri, &params.id, |n, mapper| {
+                Some((
+                    mapper.byte_to_position(n.start_byte())?,
+                    mapper.byte_to_position(n.end_byte())?,
+                ))
+            })
+            .await
+            .and_then(|(_uri, _layer, span)| span)
+            .map(|(start, end)| json!({ "start": start, "end": end }))
+            .unwrap_or(Value::Null);
+        Ok(value)
+    }
+
+    /// `kakehashi/node/startPosition` — the node's start as an LSP `Position`,
+    /// per `Node::start_position`. Returns `{ "startPosition": Position }` or
+    /// `null`.
+    pub async fn kakehashi_node_start_position(&self, params: NodeIdParams) -> Result<Value> {
+        let value = self
+            .with_node_mapped(&params.text_document.uri, &params.id, |n, mapper| {
+                mapper.byte_to_position(n.start_byte())
+            })
+            .await
+            .and_then(|(_uri, _layer, pos)| pos)
+            .map(|pos| json!({ "startPosition": pos }))
+            .unwrap_or(Value::Null);
+        Ok(value)
+    }
+
+    /// `kakehashi/node/endPosition` — the node's end as an LSP `Position`, per
+    /// `Node::end_position`. Returns `{ "endPosition": Position }` or `null`.
+    pub async fn kakehashi_node_end_position(&self, params: NodeIdParams) -> Result<Value> {
+        let value = self
+            .with_node_mapped(&params.text_document.uri, &params.id, |n, mapper| {
+                mapper.byte_to_position(n.end_byte())
+            })
+            .await
+            .and_then(|(_uri, _layer, pos)| pos)
+            .map(|pos| json!({ "endPosition": pos }))
+            .unwrap_or(Value::Null);
+        Ok(value)
+    }
+
+    /// `kakehashi/node/descendantForPointRange` — the smallest descendant
+    /// (named + anonymous) spanning `[start, end)` within this node's subtree,
+    /// per `Node::descendant_for_point_range`, with the bounds given as LSP
+    /// `Position`s. `null` for an unresolvable id, an unmappable `Position`, or an
+    /// inverted / out-of-bounds range.
+    pub async fn kakehashi_node_descendant_for_point_range(
+        &self,
+        params: NodePointRangeParams,
+    ) -> Result<Value> {
+        self.point_range_descendant(params, false).await
+    }
+
+    /// `kakehashi/node/namedDescendantForPointRange` — the smallest *named*
+    /// descendant spanning `[start, end)` within this node's subtree, per
+    /// `Node::named_descendant_for_point_range`. Same `Position` handling as the
+    /// anonymous-inclusive variant.
+    pub async fn kakehashi_node_named_descendant_for_point_range(
+        &self,
+        params: NodePointRangeParams,
+    ) -> Result<Value> {
+        self.point_range_descendant(params, true).await
+    }
+
+    /// Shared body for the two point-range descendant lookups. Converts the LSP
+    /// `Position` bounds to byte offsets, applies the same inverted /
+    /// out-of-bounds guards as the byte-range accessors, then mints the result in
+    /// the input node's layer.
+    async fn point_range_descendant(
+        &self,
+        params: NodePointRangeParams,
+        named: bool,
+    ) -> Result<Value> {
+        let start = params.start;
+        let end = params.end;
+        let resolved = self
+            .with_node_mapped(&params.text_document.uri, &params.id, |n, mapper| {
+                let start_byte = mapper.position_to_byte(start)?;
+                let end_byte = mapper.position_to_byte(end)?;
+                // Mirror the byte-range guards: reject inverted ranges and ones
+                // reaching past the node, whose tree-sitter behaviour is
+                // unspecified (see navigation.rs / lookup::find_node_at).
+                if start_byte > end_byte || end_byte > n.end_byte() {
+                    return None;
+                }
+                let descendant = if named {
+                    n.named_descendant_for_byte_range(start_byte, end_byte)
+                } else {
+                    n.descendant_for_byte_range(start_byte, end_byte)
+                };
+                descendant.map(|d| (d.start_byte(), d.end_byte(), d.kind()))
+            })
+            .await;
+
+        let value = match resolved {
+            Some((uri, layer, Some(triple))) => self.mint_node_info(&uri, layer, triple),
+            _ => Value::Null,
+        };
+        Ok(value)
+    }
+}

--- a/src/text/position.rs
+++ b/src/text/position.rs
@@ -63,6 +63,22 @@ impl PositionMapper {
         }
     }
 
+    /// Convert an LSP `Position` to a byte offset, returning `None` for any
+    /// position that does not address a real location in the document.
+    ///
+    /// Unlike [`position_to_byte`](Self::position_to_byte) — which, as its own
+    /// callers' docs note, spills a `character` past a line's end into a byte on
+    /// a *later* line (`line_start + character`) — this validates the input by
+    /// requiring the offset to round-trip: `byte_to_position(b) == position`. An
+    /// over-long column maps to some `b` whose real position differs from the
+    /// requested one, so it is rejected rather than silently resolving the wrong
+    /// location. Use this for *client-supplied* positions where an out-of-bounds
+    /// column must mean "no such location" (null), not "snap somewhere".
+    pub fn position_to_byte_strict(&self, position: Position) -> Option<usize> {
+        let byte = self.position_to_byte(position)?;
+        (self.byte_to_position(byte)? == position).then_some(byte)
+    }
+
     /// Convert byte offset to LSP Position
     pub fn byte_to_position(&self, offset: usize) -> Option<Position> {
         // Convert byte offset to LineCol
@@ -252,6 +268,33 @@ mod tests {
         let text = "hello\nworld\n";
         let mapper = PositionMapper::new(text);
         assert_eq!(mapper.position_to_byte_clamped(Position::new(0, 999)), 6);
+    }
+
+    #[test]
+    fn strict_accepts_in_bounds_and_rejects_overlong_or_eof() {
+        let text = "hello\nworld\n";
+        let mapper = PositionMapper::new(text);
+
+        // In-bounds positions map exactly, identical to position_to_byte.
+        assert_eq!(mapper.position_to_byte_strict(Position::new(0, 0)), Some(0));
+        assert_eq!(mapper.position_to_byte_strict(Position::new(0, 5)), Some(5)); // end of "hello"
+        assert_eq!(mapper.position_to_byte_strict(Position::new(1, 2)), Some(8));
+
+        // A character past the line's end must NOT spill onto the next line.
+        assert_eq!(mapper.position_to_byte_strict(Position::new(0, 999)), None);
+        // A line past EOF is rejected too.
+        assert_eq!(mapper.position_to_byte_strict(Position::new(99, 0)), None);
+    }
+
+    #[test]
+    fn strict_rejects_overlong_column_for_multibyte_line() {
+        // "あい" is 2 chars / 6 bytes / 2 UTF-16 units on line 0.
+        let text = "あい\nx\n";
+        let mapper = PositionMapper::new(text);
+        // col 2 = end of "あい" (byte 6) is valid.
+        assert_eq!(mapper.position_to_byte_strict(Position::new(0, 2)), Some(6));
+        // col 5 is past the line's end → None, not a byte on line 1.
+        assert_eq!(mapper.position_to_byte_strict(Position::new(0, 5)), None);
     }
 
     #[test]

--- a/tests/e2e_kakehashi_node_accessors.rs
+++ b/tests/e2e_kakehashi_node_accessors.rs
@@ -474,6 +474,57 @@ fn test_byte_based_descendant_lookups() {
     );
 }
 
+/// Byte/range arguments are scoped to the queried node: an offset *before* the
+/// node's own `start_byte` is outside it and must collapse to `null`, just like
+/// one past its end. Uses a node on line 2 (which starts well after byte 0).
+#[test]
+fn test_byte_lookups_before_node_start_are_null() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+    let uri = "file:///accessors_byte_lowerbound.md";
+    open_markdown(&mut client, uri, DOC);
+
+    // A node inside the line-2 paragraph starts after "# Heading\n\n" (byte 11).
+    let node = node_at(&mut client, uri, 2, 2);
+    assert!(!node.is_null(), "expected a node on line 2");
+    let id = id_of(&node);
+    let start_byte = call(&mut client, "kakehashi/node/startByte", id_params(uri, &id))
+        .get("startByte")
+        .and_then(Value::as_u64)
+        .expect("startByte");
+    assert!(start_byte > 0, "fixture node must start after byte 0");
+
+    // firstChildForByte at byte 0 is before this node → null.
+    let before = call(
+        &mut client,
+        "kakehashi/node/firstChildForByte",
+        json!({ "textDocument": { "uri": uri }, "id": id, "byte": 0 }),
+    );
+    assert!(
+        before.is_null(),
+        "firstChildForByte before the node's start must be null, got {:?}",
+        before
+    );
+
+    // A range whose start is before this node → null (both variants).
+    for method in [
+        "kakehashi/node/descendantForByteRange",
+        "kakehashi/node/namedDescendantForByteRange",
+    ] {
+        let v = call(
+            &mut client,
+            method,
+            json!({ "textDocument": { "uri": uri }, "id": id, "startByte": 0, "endByte": start_byte }),
+        );
+        assert!(
+            v.is_null(),
+            "{} with a start before the node must be null, got {:?}",
+            method,
+            v
+        );
+    }
+}
+
 #[test]
 fn test_field_name_for_child_reports_or_nulls() {
     let mut client = LspClient::new();

--- a/tests/e2e_kakehashi_node_accessors.rs
+++ b/tests/e2e_kakehashi_node_accessors.rs
@@ -8,7 +8,8 @@
 //! `namedChildren`, `nextSibling`, `prevSibling`, `nextNamedSibling`,
 //! `prevNamedSibling`, `firstChildForByte`, `descendantForByteRange`,
 //! `namedDescendantForByteRange`, `childByFieldName`, `childrenByFieldName`,
-//! `fieldNameForChild`, `fieldNameForNamedChild`.
+//! `fieldNameForChild`, `fieldNameForNamedChild`, `range`, `startPosition`,
+//! `endPosition`, `descendantForPointRange`, `namedDescendantForPointRange`.
 //!
 //! Run with: `cargo test --test e2e_kakehashi_node_accessors --features e2e`
 
@@ -637,4 +638,179 @@ fn test_accessors_return_null_for_unknown_id() {
         json!({ "textDocument": { "uri": uri }, "id": stray, "name": "left" }),
     );
     assert!(v.is_null(), "childByFieldName on unknown id must be null");
+}
+
+/// Read an LSP `Position` object as `(line, character)`.
+fn lsp_pos(v: &Value) -> (u64, u64) {
+    (
+        v.get("line")
+            .and_then(Value::as_u64)
+            .expect("Position.line"),
+        v.get("character")
+            .and_then(Value::as_u64)
+            .expect("Position.character"),
+    )
+}
+
+#[test]
+fn test_position_accessors_return_lsp_positions() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+    let uri = "file:///accessors_position.md";
+    open_markdown(&mut client, uri, DOC);
+    let root = root_id(&mut client, uri);
+
+    // The document root starts at the very beginning.
+    let start_pos = call(
+        &mut client,
+        "kakehashi/node/startPosition",
+        id_params(uri, &root),
+    );
+    assert_eq!(
+        lsp_pos(start_pos.get("startPosition").expect("startPosition field")),
+        (0, 0),
+        "root startPosition must be line 0, character 0"
+    );
+
+    let end_pos = call(
+        &mut client,
+        "kakehashi/node/endPosition",
+        id_params(uri, &root),
+    );
+    let end = lsp_pos(end_pos.get("endPosition").expect("endPosition field"));
+
+    // range bundles the two into { start, end } and must agree with the singular
+    // accessors.
+    let range = call(&mut client, "kakehashi/node/range", id_params(uri, &root));
+    assert_eq!(
+        lsp_pos(range.get("start").expect("range.start")),
+        (0, 0),
+        "range.start must match startPosition"
+    );
+    assert_eq!(
+        lsp_pos(range.get("end").expect("range.end")),
+        end,
+        "range.end must match endPosition"
+    );
+}
+
+/// `character` is a UTF-16 code unit offset (LSP), NOT tree-sitter's UTF-8 byte
+/// column. With an all-CJK line each character is 3 UTF-8 bytes but 1 UTF-16
+/// code unit, so the reported column must be `endByte / 3`, strictly less than
+/// the byte offset — proving the server converts rather than leaking byte points.
+#[test]
+fn test_positions_are_utf16_not_byte_columns() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+    let uri = "file:///accessors_utf16.md";
+    // Two CJK characters on line 0 (3 UTF-8 bytes each), then a newline.
+    open_markdown(&mut client, uri, "あい\n");
+
+    // Smallest node at the very start — some inline/text node spanning CJK bytes.
+    let node = node_at(&mut client, uri, 0, 0);
+    assert!(!node.is_null(), "expected a node at the CJK line start");
+    let id = id_of(&node);
+
+    let end_byte = call(&mut client, "kakehashi/node/endByte", id_params(uri, &id))
+        .get("endByte")
+        .and_then(Value::as_u64)
+        .expect("endByte");
+    let end_pos = call(
+        &mut client,
+        "kakehashi/node/endPosition",
+        id_params(uri, &id),
+    );
+    let (line, character) = lsp_pos(end_pos.get("endPosition").expect("endPosition field"));
+
+    assert_eq!(line, 0, "the node ends on line 0");
+    assert!(
+        end_byte >= 3 && end_byte.is_multiple_of(3),
+        "CJK node end byte should fall on a 3-byte boundary, got {}",
+        end_byte
+    );
+    assert_eq!(
+        character,
+        end_byte / 3,
+        "endPosition.character must be the UTF-16 column ({}), not the byte column ({})",
+        end_byte / 3,
+        end_byte
+    );
+    assert!(
+        character < end_byte,
+        "UTF-16 column must be strictly less than the byte offset for CJK content"
+    );
+}
+
+#[test]
+fn test_descendant_for_point_range_takes_lsp_positions() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+    let uri = "file:///accessors_point_range.md";
+    open_markdown(&mut client, uri, DOC);
+    let root = root_id(&mut client, uri);
+
+    // A Position range covering the first byte resolves a descendant.
+    let desc = call(
+        &mut client,
+        "kakehashi/node/descendantForPointRange",
+        json!({ "textDocument": { "uri": uri }, "id": root,
+                "start": { "line": 0, "character": 0 },
+                "end":   { "line": 0, "character": 1 } }),
+    );
+    assert!(
+        !desc.is_null(),
+        "descendantForPointRange must resolve a node"
+    );
+    assert!(desc.get("id").and_then(Value::as_str).is_some());
+
+    let named = call(
+        &mut client,
+        "kakehashi/node/namedDescendantForPointRange",
+        json!({ "textDocument": { "uri": uri }, "id": root,
+                "start": { "line": 0, "character": 0 },
+                "end":   { "line": 0, "character": 1 } }),
+    );
+    assert!(
+        !named.is_null(),
+        "namedDescendantForPointRange must resolve"
+    );
+
+    // Inverted Position range collapses to null.
+    let inverted = call(
+        &mut client,
+        "kakehashi/node/descendantForPointRange",
+        json!({ "textDocument": { "uri": uri }, "id": root,
+                "start": { "line": 0, "character": 5 },
+                "end":   { "line": 0, "character": 1 } }),
+    );
+    assert!(inverted.is_null(), "inverted Position range must be null");
+}
+
+#[test]
+fn test_position_accessors_return_null_for_unknown_id() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+    let uri = "file:///accessors_position_unknown.md";
+    open_markdown(&mut client, uri, DOC);
+    let stray = "01HXXXXXXXXXXXXXXXXXXXXXXX";
+
+    for method in [
+        "kakehashi/node/range",
+        "kakehashi/node/startPosition",
+        "kakehashi/node/endPosition",
+    ] {
+        let v = call(&mut client, method, id_params(uri, stray));
+        assert!(v.is_null(), "{} must return null for an unknown id", method);
+    }
+    let v = call(
+        &mut client,
+        "kakehashi/node/descendantForPointRange",
+        json!({ "textDocument": { "uri": uri }, "id": stray,
+                "start": { "line": 0, "character": 0 },
+                "end":   { "line": 0, "character": 1 } }),
+    );
+    assert!(
+        v.is_null(),
+        "descendantForPointRange on unknown id must be null"
+    );
 }

--- a/tests/e2e_kakehashi_node_accessors.rs
+++ b/tests/e2e_kakehashi_node_accessors.rs
@@ -835,6 +835,22 @@ fn test_descendant_for_point_range_takes_lsp_positions() {
                 "end":   { "line": 0, "character": 1 } }),
     );
     assert!(inverted.is_null(), "inverted Position range must be null");
+
+    // A `character` past line 0's end ("# Heading" = 9 cols) must NOT spill onto
+    // a later line — an over-long column means "no such location" → null, not a
+    // descendant resolved elsewhere in the document.
+    let overlong = call(
+        &mut client,
+        "kakehashi/node/descendantForPointRange",
+        json!({ "textDocument": { "uri": uri }, "id": root,
+                "start": { "line": 0, "character": 0 },
+                "end":   { "line": 0, "character": 999 } }),
+    );
+    assert!(
+        overlong.is_null(),
+        "an over-long character must collapse to null, not spill to a later line, got {:?}",
+        overlong
+    );
 }
 
 #[test]

--- a/tests/e2e_kakehashi_node_accessors.rs
+++ b/tests/e2e_kakehashi_node_accessors.rs
@@ -432,6 +432,45 @@ fn test_byte_based_descendant_lookups() {
         inverted_named.is_null(),
         "inverted byte range must collapse to null for the named variant too"
     );
+
+    // Out-of-bounds bytes (past the document end) collapse to null rather than
+    // being forwarded to tree-sitter, whose behaviour for ranges beyond the
+    // parsed tree is version-dependent (mirrors the defensive bound in
+    // lookup::find_node_at). `oob` is well past the end of `DOC`.
+    let oob = (DOC.len() + 10) as i64;
+
+    let oob_first_child = call(
+        &mut client,
+        "kakehashi/node/firstChildForByte",
+        json!({ "textDocument": { "uri": uri }, "id": root, "byte": oob }),
+    );
+    assert!(
+        oob_first_child.is_null(),
+        "firstChildForByte past EOF must collapse to null, got {:?}",
+        oob_first_child
+    );
+
+    let oob_desc = call(
+        &mut client,
+        "kakehashi/node/descendantForByteRange",
+        json!({ "textDocument": { "uri": uri }, "id": root, "startByte": 0, "endByte": oob }),
+    );
+    assert!(
+        oob_desc.is_null(),
+        "descendantForByteRange past EOF must collapse to null, got {:?}",
+        oob_desc
+    );
+
+    let oob_named_desc = call(
+        &mut client,
+        "kakehashi/node/namedDescendantForByteRange",
+        json!({ "textDocument": { "uri": uri }, "id": root, "startByte": 0, "endByte": oob }),
+    );
+    assert!(
+        oob_named_desc.is_null(),
+        "namedDescendantForByteRange past EOF must collapse to null, got {:?}",
+        oob_named_desc
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Implements the five deferred **position/range accessors** of the [Node Reference Protocol](../blob/main/docs/architecture-decisions/node-reference-protocol.md) accessor family, closing #331:

| Method | Input | Output |
|---|---|---|
| `range` | `{ id }` | `{ start: Position, end: Position }` |
| `startPosition` | `{ id }` | `{ startPosition: Position }` |
| `endPosition` | `{ id }` | `{ endPosition: Position }` |
| `descendantForPointRange` | `{ id, start, end }` | `NodeInfo \| null` |
| `namedDescendantForPointRange` | `{ id, start, end }` | `NodeInfo \| null` |

## The design decision (#331)

tree-sitter's `Point.column` is a **UTF-8 byte** offset; the protocol speaks LSP `Position` (**UTF-16** code units) everywhere else. Returning native points would diverge from every other LSP coordinate around non-ASCII (emoji/CJK) and force clients to special-case these accessors.

**Resolution** (confirmed with @atusy): speak **LSP `Position`** on the wire, converting at the boundary via `PositionMapper` — byte → `Position` on output, `Position` → byte on input. **API shape**: one method per tree-sitter `Node` method (1:1 parity), not a bulk endpoint; a bulk `childrenWithRange` remains a possible future addition. Byte-native spans stay available unambiguously via the existing `startByte`/`endByte`/`byteRange` and `descendant*ForByteRange`.

## Implementation

- New `with_node_mapped` shared prelude hands each closure a `PositionMapper`; `with_node_by_id` now delegates to it (mapper ignored). A small `mint_node_info` helper de-duplicates NodeInfo minting across `navigate_to_node`/`navigate_to_nodes`/the point-range handlers.
- Point-range inputs convert each `Position` → byte and reuse the byte-range search and its inverted / out-of-bounds guards.
- Handlers live in a new `node/position.rs`.

## Also included (byte-accessor hardening)

Two preliminary commits finish a TDD cycle on the already-merged byte accessors: `firstChildForByte` / `descendant*ForByteRange` now reject bytes past the node's `end_byte` (tree-sitter's behaviour beyond the parsed tree is version-dependent), mirroring `lookup::find_node_at`.

## Verification

- `cargo fmt --check` ✅
- `cargo clippy --all-targets --features e2e -- -D warnings` ✅
- `cargo test --lib` → 1527 passed ✅
- `cargo test --features e2e --test e2e_kakehashi_node --test e2e_kakehashi_node_accessors` → 46 + 29 passed ✅

New e2e tests assert the LSP `Position` response shapes, that **columns are UTF-16 not byte columns** (CJK fixture: `endPosition.character == endByte/3`), point-range resolution (+ named variant), and null on unknown id / inverted range.

## Docs

ADR updated: new **Position / range accessors** table + "Why LSP Position, not tree-sitter Point" rationale; superseded the Alternative C deferral and the stale "future `kakehashi/node/range`" references.

Closes #331.