### PR TITLE
fix: highlighting disappears / large paste goes white (concurrent didChange race)

### DIFF
--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -20,8 +20,11 @@ pub struct DocumentStore {
     /// stale base text, so a later edit's range (authored against a newer state)
     /// is applied to an older one — corrupting the text and, before clamping,
     /// panicking in `replace_range`. Holding this per-URI async lock across a
-    /// document's edit critical section forces edits to apply in arrival order,
-    /// each seeing the previous one's persisted result. Different documents keep
+    /// document's edit critical section gives each edit mutual exclusion and lets
+    /// it see the previous one's persisted result. Handlers take the lock as their
+    /// first `.await`, so acquisition follows first-poll order — a practical
+    /// mitigation, not a hard JSON-RPC wire-order guarantee (tracked in
+    /// <https://github.com/atusy/kakehashi/issues/342>). Different documents keep
     /// their own locks and run concurrently.
     edit_locks: DashMap<Url, Arc<Mutex<()>>>,
 }
@@ -236,6 +239,18 @@ impl DocumentStore {
             .clone()
     }
 
+    /// Drop the per-URI edit lock entry without touching the document itself.
+    ///
+    /// `edit_lock` get-or-inserts, so a handler that takes the lock and then
+    /// finds the document missing (a `didChange`/semantic request for a never-
+    /// opened or already-closed URI, e.g. a reordered notification) would leave a
+    /// lock entry behind forever. Such handlers call this on their miss path to
+    /// keep the map bounded. Safe to call while holding the lock's `Arc` guard —
+    /// the guard keeps the mutex alive; only the map entry is removed.
+    pub(crate) fn remove_edit_lock(&self, uri: &Url) {
+        self.edit_locks.remove(uri);
+    }
+
     // Lock safety: Single remove() call - no read lock held before or during write
     pub(crate) fn remove(&self, uri: &Url) -> Option<Document> {
         self.parse_states.remove(uri);
@@ -405,15 +420,23 @@ mod tests {
         );
 
         // Removing the document drops its lock entry; a later edit_lock call
-        // creates a fresh one (no unbounded growth across open/close cycles).
-        drop((a1, a2));
+        // mints a fresh, distinct lock (open/close cycles don't reuse a stale
+        // mutex). Compare pointer identity directly — `a1` is kept alive so the
+        // check doesn't depend on incidental Arc clone counts.
         store.remove(&uri_a);
         let a3 = store.edit_lock(&uri_a);
-        // The map entry was cleared, so this is a newly allocated lock.
-        assert_eq!(
-            Arc::strong_count(&a3),
-            2,
-            "fresh lock after remove should only be held by the map and this binding"
+        assert!(
+            !Arc::ptr_eq(&a1, &a3),
+            "lock after remove must be a fresh instance, not the cleared one"
+        );
+
+        // remove_edit_lock drops the entry on the document-missing path, so the
+        // next lock for the same URI is again a fresh instance.
+        store.remove_edit_lock(&uri_a);
+        let a4 = store.edit_lock(&uri_a);
+        assert!(
+            !Arc::ptr_eq(&a3, &a4),
+            "lock after remove_edit_lock must be a fresh instance"
         );
     }
 

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -3,7 +3,8 @@ use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;
 use dashmap::mapref::one::Ref;
 use std::ops::Deref;
-use tokio::sync::watch;
+use std::sync::Arc;
+use tokio::sync::{Mutex, watch};
 use tree_sitter::{InputEdit, Tree};
 use url::Url;
 
@@ -11,6 +12,18 @@ use url::Url;
 pub struct DocumentStore {
     documents: DashMap<Url, Document>,
     parse_states: DashMap<Url, watch::Sender<ParseState>>,
+    /// Per-document serialization lock for `didChange` application.
+    ///
+    /// `didChange` handlers read the current text, apply incremental ranges, and
+    /// only persist the result after an async reparse. Without serialization,
+    /// concurrently-dispatched handlers for the same document all read the same
+    /// stale base text, so a later edit's range (authored against a newer state)
+    /// is applied to an older one — corrupting the text and, before clamping,
+    /// panicking in `replace_range`. Holding this per-URI async lock across a
+    /// document's edit critical section forces edits to apply in arrival order,
+    /// each seeing the previous one's persisted result. Different documents keep
+    /// their own locks and run concurrently.
+    edit_locks: DashMap<Url, Arc<Mutex<()>>>,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -43,6 +56,7 @@ impl Default for DocumentStore {
         Self {
             documents: DashMap::new(),
             parse_states: DashMap::new(),
+            edit_locks: DashMap::new(),
         }
     }
 }
@@ -211,9 +225,21 @@ impl DocumentStore {
         })
     }
 
+    /// Return the per-document `didChange` serialization lock, creating it on
+    /// first use. Callers hold the guard across the document's edit critical
+    /// section so concurrent edits to the same document apply in order. See the
+    /// `edit_locks` field docs for why this is required.
+    pub(crate) fn edit_lock(&self, uri: &Url) -> Arc<Mutex<()>> {
+        self.edit_locks
+            .entry(uri.clone())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    }
+
     // Lock safety: Single remove() call - no read lock held before or during write
     pub(crate) fn remove(&self, uri: &Url) -> Option<Document> {
         self.parse_states.remove(uri);
+        self.edit_locks.remove(uri);
         self.documents.remove(uri).map(|(_, doc)| doc)
     }
 }
@@ -357,6 +383,38 @@ mod tests {
         let doc = store.get(&uri).unwrap();
         assert_eq!(doc.text(), text2);
         assert_eq!(doc.language_id(), Some("rust"));
+    }
+
+    #[test]
+    fn test_edit_lock_is_stable_per_uri_and_cleared_on_remove() {
+        let store = DocumentStore::new();
+        let uri_a = Url::parse("file:///a.rs").unwrap();
+        let uri_b = Url::parse("file:///b.rs").unwrap();
+
+        // Same URI yields the same lock instance, so concurrent didChange
+        // handlers for one document serialize on a shared mutex.
+        let a1 = store.edit_lock(&uri_a);
+        let a2 = store.edit_lock(&uri_a);
+        assert!(Arc::ptr_eq(&a1, &a2), "same URI must share one edit lock");
+
+        // Different URIs get distinct locks so unrelated documents stay parallel.
+        let b1 = store.edit_lock(&uri_b);
+        assert!(
+            !Arc::ptr_eq(&a1, &b1),
+            "different URIs must not share an edit lock"
+        );
+
+        // Removing the document drops its lock entry; a later edit_lock call
+        // creates a fresh one (no unbounded growth across open/close cycles).
+        drop((a1, a2));
+        store.remove(&uri_a);
+        let a3 = store.edit_lock(&uri_a);
+        // The map entry was cleared, so this is a newly allocated lock.
+        assert_eq!(
+            Arc::strong_count(&a3),
+            2,
+            "fresh lock after remove should only be held by the map and this binding"
+        );
     }
 
     #[test]

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -16,19 +16,24 @@ impl Kakehashi {
             return;
         };
 
+        // Serialize edits to this document, acquired as the FIRST `.await` of
+        // the handler. `didChange` handlers are dispatched concurrently and the
+        // read-of-old-text → reparse → persist cycle below is not atomic, so
+        // without this a later edit can read the same stale base text as an
+        // earlier one and apply its range to the wrong state (corrupting the
+        // text, and — before clamping — panicking in `replace_range`). Taking
+        // the lock before any other `.await` removes the known pre-lock yield,
+        // so handlers acquire it in first-poll order. That is a strong practical
+        // mitigation, not a hard guarantee of JSON-RPC wire order (tower-lsp
+        // first-polls buffered futures); hard ingress-level ordering is tracked
+        // in https://github.com/atusy/kakehashi/issues/342. Other documents are
+        // unaffected.
+        let edit_lock = self.documents.edit_lock(&uri);
+        let _edit_guard = edit_lock.lock().await;
+
         self.notifier()
             .log_trace(format!("[DID_CHANGE] START uri={}", uri))
             .await;
-
-        // Serialize edits to this document. `didChange` handlers are dispatched
-        // concurrently; the read-of-old-text → reparse → persist cycle below is
-        // not atomic, so without this lock a later edit can read the same stale
-        // base text as an earlier one and apply its range to the wrong state
-        // (corrupting the text, and — before clamping — panicking in
-        // `replace_range`). Holding this guard for the whole handler forces
-        // edits to apply in arrival order; other documents are unaffected.
-        let edit_lock = self.documents.edit_lock(&uri);
-        let _edit_guard = edit_lock.lock().await;
 
         // Retrieve the stored document info
         let (language_id, old_text) = {

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -20,6 +20,16 @@ impl Kakehashi {
             .log_trace(format!("[DID_CHANGE] START uri={}", uri))
             .await;
 
+        // Serialize edits to this document. `didChange` handlers are dispatched
+        // concurrently; the read-of-old-text → reparse → persist cycle below is
+        // not atomic, so without this lock a later edit can read the same stale
+        // base text as an earlier one and apply its range to the wrong state
+        // (corrupting the text, and — before clamping — panicking in
+        // `replace_range`). Holding this guard for the whole handler forces
+        // edits to apply in arrival order; other documents are unaffected.
+        let edit_lock = self.documents.edit_lock(&uri);
+        let _edit_guard = edit_lock.lock().await;
+
         // Retrieve the stored document info
         let (language_id, old_text) = {
             let doc = self.documents.get(&uri);

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -44,6 +44,10 @@ impl Kakehashi {
                     self.notifier()
                         .log_warning("Document not found for change event")
                         .await;
+                    // We created an edit-lock entry above for a document that
+                    // doesn't exist (a stray/reordered notification). Drop it so
+                    // the map can't grow unboundedly from such notifications.
+                    self.documents.remove_edit_lock(&uri);
                     return;
                 }
             }

--- a/src/lsp/lsp_impl/text_document/did_close.rs
+++ b/src/lsp/lsp_impl/text_document/did_close.rs
@@ -14,9 +14,20 @@ impl Kakehashi {
             return;
         };
 
-        // Remove the document from the store when it's closed
-        // This ensures that reopening the file will properly reinitialize everything
-        self.documents.remove(&uri);
+        // Remove the document from the store when it's closed.
+        // This ensures that reopening the file will properly reinitialize everything.
+        //
+        // Serialize the removal behind any in-flight edit by acquiring this
+        // document's edit lock first (the same lock `did_change` holds across its
+        // reparse). Without it, `remove` could drop the lock entry while an edit
+        // still holds the old `Arc`, so a later edit would create a *fresh* lock
+        // and stop serializing with the in-flight one. The guard is dropped right
+        // after the removal — the remaining cleanups touch other subsystems.
+        {
+            let edit_lock = self.documents.edit_lock(&uri);
+            let _edit_guard = edit_lock.lock().await;
+            self.documents.remove(&uri);
+        }
 
         // Clean up all caches for this document (semantic tokens, injections, requests)
         self.cache.remove_document(&uri);

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -71,14 +71,18 @@ impl Kakehashi {
         // The handle is dropped immediately; we only need the existence check.
         self.documents.get(uri)?;
 
-        // Settle pending edits before snapshotting. A large paste arrives as
+        // Settle in-flight edits before snapshotting. A large paste arrives as
         // several back-to-back `didChange` chunks; the editor then sends one
         // semantic-tokens request for the final state. Each `didChange` holds
         // the document's edit lock across its reparse, so acquiring the same
-        // lock here blocks until every edit received before this request has
-        // been applied and parsed. Without it the request can snapshot a tree
-        // from a half-applied paste and return tokens for only the first chunks
-        // — the later lines render unhighlighted (white). The guard is held
+        // lock here waits for any edit currently applying/parsing to finish
+        // before snapshotting. Without it the request can snapshot a tree from a
+        // half-applied paste and return tokens for only the first chunks — the
+        // later lines render unhighlighted (white). Acquisition follows first-poll
+        // order (a practical mitigation, not a hard JSON-RPC wire-order
+        // guarantee — see https://github.com/atusy/kakehashi/issues/342), so a
+        // request polled before a still-pending edit may not wait for it; the
+        // common debounced-after-paste case settles correctly. The guard is held
         // across the tree read (and the on-demand parse fallback) so no edit can
         // interleave between settling and snapshotting; it is released when this
         // function returns, before token computation, so edits never wait on the

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -64,6 +64,21 @@ impl Kakehashi {
     /// Returns `(tree, text)` tuple where tree was verified to be parsed from text,
     /// or `None` if the document is missing or parsing failed.
     async fn get_tree_with_wait(&self, uri: &Url, language_name: &str) -> Option<(Tree, String)> {
+        // Settle pending edits before snapshotting. A large paste arrives as
+        // several back-to-back `didChange` chunks; the editor then sends one
+        // semantic-tokens request for the final state. Each `didChange` holds
+        // the document's edit lock across its reparse, so acquiring the same
+        // lock here blocks until every edit received before this request has
+        // been applied and parsed. Without it the request can snapshot a tree
+        // from a half-applied paste and return tokens for only the first chunks
+        // — the later lines render unhighlighted (white). The guard is held
+        // across the tree read (and the on-demand parse fallback) so no edit can
+        // interleave between settling and snapshotting; it is released when this
+        // function returns, before token computation, so edits never wait on the
+        // (slower) tokenization.
+        let edit_lock = self.documents.edit_lock(uri);
+        let _settle_guard = edit_lock.lock().await;
+
         // Wait for any in-flight parse to complete
         self.documents
             .wait_for_parse_completion(uri, Duration::from_millis(200))

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -86,6 +86,18 @@ impl Kakehashi {
         let edit_lock = self.documents.edit_lock(uri);
         let _settle_guard = edit_lock.lock().await;
 
+        // Re-check existence now that we hold the lock: the document could have
+        // been closed between the pre-check and here (e.g. `didClose` took the
+        // edit lock first, removed the document — and its lock entry — then
+        // released). In that case `edit_lock()` above re-created a fresh entry,
+        // so drop it and bail rather than leaving an orphan behind for a gone
+        // document.
+        if self.documents.get(uri).is_none() {
+            drop(_settle_guard);
+            self.documents.remove_edit_lock(uri);
+            return None;
+        }
+
         // Wait for any in-flight parse to complete
         self.documents
             .wait_for_parse_completion(uri, Duration::from_millis(200))

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -64,6 +64,13 @@ impl Kakehashi {
     /// Returns `(tree, text)` tuple where tree was verified to be parsed from text,
     /// or `None` if the document is missing or parsing failed.
     async fn get_tree_with_wait(&self, uri: &Url, language_name: &str) -> Option<(Tree, String)> {
+        // If the document isn't open there is nothing to settle or snapshot.
+        // Return before taking the edit lock so we don't create a lock entry for
+        // a never-opened/closed URI (language detection can resolve a language
+        // from the path alone, so this point is reachable without a document).
+        // The handle is dropped immediately; we only need the existence check.
+        self.documents.get(uri)?;
+
         // Settle pending edits before snapshotting. A large paste arrives as
         // several back-to-back `didChange` chunks; the editor then sends one
         // semantic-tokens request for the final state. Each `didChange` holds

--- a/src/lsp/text_sync.rs
+++ b/src/lsp/text_sync.rs
@@ -32,10 +32,20 @@ pub(crate) fn apply_content_changes_with_edits(
 
     for change in content_changes {
         if let Some(range) = change.range {
-            // Incremental change - create InputEdit for tree editing
+            // Incremental change - create InputEdit for tree editing.
+            //
+            // Use the *clamped* position→byte mapping: `position_to_byte` returns
+            // `line_start + character` without bounding it to the line/document,
+            // so a range end past the current text yields an offset > text.len().
+            // That overflows `replace_range` below ("range end index N out of
+            // range for slice of length M"). This is reachable when a stale,
+            // shorter base text is edited with a range authored against a later
+            // document state (concurrent `didChange` processing). Clamping keeps
+            // the splice in bounds; `start <= end` is enforced so the range never
+            // inverts.
             let mapper = PositionMapper::new(&text);
-            let start_offset = mapper.position_to_byte(range.start).unwrap_or(text.len());
-            let end_offset = mapper.position_to_byte(range.end).unwrap_or(text.len());
+            let start_offset = mapper.position_to_byte_clamped(range.start);
+            let end_offset = mapper.position_to_byte_clamped(range.end).max(start_offset);
             let new_end_offset = start_offset + change.text.len();
 
             // Calculate the new end position for tree-sitter (using byte columns)
@@ -132,6 +142,43 @@ mod tests {
         assert_eq!(edits[0].start_byte, 6);
         assert_eq!(edits[0].old_end_byte, 11);
         assert_eq!(edits[0].new_end_byte, 10); // "rust" is 4 bytes
+    }
+
+    #[test]
+    fn test_apply_content_changes_out_of_range_does_not_panic() {
+        // Regression: a change whose range extends past the current text must not
+        // panic in `replace_range`. This happens under concurrent `didChange`
+        // processing, where a handler reads a stale (shorter) base text but the
+        // client-authored range targets a later, longer document state. Here the
+        // base text is "local x = {\n}\n" (14 bytes); the range end maps to byte
+        // 15 (line 1, col 3 = line_start 12 + 3), one past the text — the exact
+        // shape of the observed `range end index 15 out of range for slice of
+        // length 14` crash. The change must be applied (clamped), not panic.
+        let old_text = "local x = {\n}\n"; // 14 bytes
+        let changes = vec![TextDocumentContentChangeEvent {
+            range: Some(Range {
+                start: Position {
+                    line: 1,
+                    character: 2,
+                },
+                end: Position {
+                    line: 1,
+                    character: 3,
+                },
+            }),
+            range_length: Some(1),
+            text: "\n  }".to_string(),
+        }];
+
+        // Must not panic.
+        let (new_text, edits) = apply_content_changes_with_edits(old_text, changes);
+        assert!(
+            !edits.is_empty(),
+            "incremental change should produce an edit"
+        );
+        // The offsets are clamped to the text length, so the edit stays in bounds
+        // and the resulting text is well-formed (no slice panic).
+        assert!(new_text.starts_with("local x = {"));
     }
 
     #[test]

--- a/src/lsp/text_sync.rs
+++ b/src/lsp/text_sync.rs
@@ -13,9 +13,29 @@
 //! for tree-sitter's incremental parsing API.
 
 use tower_lsp_server::ls_types::TextDocumentContentChangeEvent;
-use tree_sitter::InputEdit;
+use tree_sitter::{InputEdit, Point};
 
 use crate::text::PositionMapper;
+
+/// Tree-sitter `Point` (row, byte-column) of a byte offset within `text`.
+///
+/// Derived from the *byte offset* — not the original LSP position — so it stays
+/// consistent with the (possibly clamped) `start_byte`/`old_end_byte` of an
+/// `InputEdit`. Tree-sitter requires the byte offsets and points of an edit to
+/// agree; a point taken from an out-of-bounds LSP position (which spills onto a
+/// later row as `line_start + character`) would not, and corrupts incremental
+/// parsing. The offset is snapped back to a char boundary defensively so the
+/// `\n` count never slices mid-character.
+fn byte_to_point(text: &str, byte: usize) -> Point {
+    let mut b = byte.min(text.len());
+    while b > 0 && !text.is_char_boundary(b) {
+        b -= 1;
+    }
+    let prefix = &text[..b];
+    let row = prefix.bytes().filter(|&c| c == b'\n').count();
+    let col = b - prefix.rfind('\n').map(|p| p + 1).unwrap_or(0);
+    Point::new(row, col)
+}
 
 /// Apply LSP content changes to `old_text`, returning the updated text and the
 /// matching tree-sitter `InputEdit`s. Changes with `range` build an `InputEdit`;
@@ -54,22 +74,18 @@ pub(crate) fn apply_content_changes_with_edits(
             // last_line_len is in BYTES (not UTF-16) because .len() on &str returns byte count
             let last_line_len = lines.last().map(|l| l.len()).unwrap_or(0);
 
-            // Get start position with proper byte column conversion
-            let start_point =
-                mapper
-                    .position_to_point(range.start)
-                    .unwrap_or(tree_sitter::Point::new(
-                        range.start.line as usize,
-                        start_offset,
-                    ));
+            // Points are derived from the (clamped) byte offsets, not the raw LSP
+            // positions, so they stay consistent with start_byte/old_end_byte.
+            let start_point = byte_to_point(&text, start_offset);
+            let old_end_point = byte_to_point(&text, end_offset);
 
             // Calculate new end Point (tree-sitter uses byte columns)
             let new_end_point = if line_count > 1 {
                 // New content spans multiple lines
-                tree_sitter::Point::new(start_point.row + line_count - 1, last_line_len)
+                Point::new(start_point.row + line_count - 1, last_line_len)
             } else {
                 // New content is on same line as start
-                tree_sitter::Point::new(start_point.row, start_point.column + last_line_len)
+                Point::new(start_point.row, start_point.column + last_line_len)
             };
 
             // Create InputEdit for incremental parsing
@@ -78,9 +94,7 @@ pub(crate) fn apply_content_changes_with_edits(
                 old_end_byte: end_offset,
                 new_end_byte: new_end_offset,
                 start_position: start_point,
-                old_end_position: mapper
-                    .position_to_point(range.end)
-                    .unwrap_or(tree_sitter::Point::new(range.end.line as usize, end_offset)),
+                old_end_position: old_end_point,
                 new_end_position: new_end_point,
             };
             edits.push(edit);
@@ -179,6 +193,58 @@ mod tests {
         // The offsets are clamped to the text length, so the edit stays in bounds
         // and the resulting text is well-formed (no slice panic).
         assert!(new_text.starts_with("local x = {"));
+    }
+
+    #[test]
+    fn test_out_of_range_edit_keeps_inputedit_byte_and_point_consistent() {
+        // When the range is clamped, the InputEdit's tree-sitter points must be
+        // derived from the clamped byte offsets, not the original out-of-bounds
+        // LSP positions — otherwise byte and point disagree and incremental
+        // parsing corrupts. Base "local x = {\n}\n" (14 bytes): line 1 is "}"
+        // (one char), so character 2/3 are past it. Both ends clamp to byte 14,
+        // which is row 2, col 0 — NOT the raw position's row 1.
+        let old_text = "local x = {\n}\n";
+        let changes = vec![TextDocumentContentChangeEvent {
+            range: Some(Range {
+                start: Position {
+                    line: 1,
+                    character: 2,
+                },
+                end: Position {
+                    line: 1,
+                    character: 3,
+                },
+            }),
+            range_length: Some(1),
+            text: "\n  }".to_string(),
+        }];
+
+        let (_new_text, edits) = apply_content_changes_with_edits(old_text, changes);
+        let edit = edits.first().expect("one edit");
+
+        // Each point must match the row/col of its byte offset in the old text.
+        let point_of = |byte: usize| {
+            let prefix = &old_text[..byte];
+            let row = prefix.bytes().filter(|&c| c == b'\n').count();
+            let col = byte - prefix.rfind('\n').map(|p| p + 1).unwrap_or(0);
+            (row, col)
+        };
+        assert_eq!(
+            (edit.start_position.row, edit.start_position.column),
+            point_of(edit.start_byte),
+            "start_position must correspond to start_byte"
+        );
+        assert_eq!(
+            (edit.old_end_position.row, edit.old_end_position.column),
+            point_of(edit.old_end_byte),
+            "old_end_position must correspond to old_end_byte"
+        );
+        // Concretely: both ends clamped to byte 14 → row 2, col 0.
+        assert_eq!(edit.old_end_byte, 14);
+        assert_eq!(
+            (edit.old_end_position.row, edit.old_end_position.column),
+            (2, 0)
+        );
     }
 
     #[test]

--- a/src/lsp/text_sync.rs
+++ b/src/lsp/text_sync.rs
@@ -17,26 +17,6 @@ use tree_sitter::{InputEdit, Point};
 
 use crate::text::PositionMapper;
 
-/// Tree-sitter `Point` (row, byte-column) of a byte offset within `text`.
-///
-/// Derived from the *byte offset* — not the original LSP position — so it stays
-/// consistent with the (possibly clamped) `start_byte`/`old_end_byte` of an
-/// `InputEdit`. Tree-sitter requires the byte offsets and points of an edit to
-/// agree; a point taken from an out-of-bounds LSP position (which spills onto a
-/// later row as `line_start + character`) would not, and corrupts incremental
-/// parsing. The offset is snapped back to a char boundary defensively so the
-/// `\n` count never slices mid-character.
-fn byte_to_point(text: &str, byte: usize) -> Point {
-    let mut b = byte.min(text.len());
-    while b > 0 && !text.is_char_boundary(b) {
-        b -= 1;
-    }
-    let prefix = &text[..b];
-    let row = prefix.bytes().filter(|&c| c == b'\n').count();
-    let col = b - prefix.rfind('\n').map(|p| p + 1).unwrap_or(0);
-    Point::new(row, col)
-}
-
 /// Apply LSP content changes to `old_text`, returning the updated text and the
 /// matching tree-sitter `InputEdit`s. Changes with `range` build an `InputEdit`;
 /// rangeless full-sync changes replace the whole text and emit no edit.
@@ -74,10 +54,11 @@ pub(crate) fn apply_content_changes_with_edits(
             // last_line_len is in BYTES (not UTF-16) because .len() on &str returns byte count
             let last_line_len = lines.last().map(|l| l.len()).unwrap_or(0);
 
-            // Points are derived from the (clamped) byte offsets, not the raw LSP
-            // positions, so they stay consistent with start_byte/old_end_byte.
-            let start_point = byte_to_point(&text, start_offset);
-            let old_end_point = byte_to_point(&text, end_offset);
+            // Points are derived from the (clamped) byte offsets via the same
+            // `LineIndex` (O(log n)), not the raw LSP positions, so they stay
+            // consistent with start_byte/old_end_byte for incremental parsing.
+            let start_point = mapper.byte_to_point(start_offset);
+            let old_end_point = mapper.byte_to_point(end_offset);
 
             // Calculate new end Point (tree-sitter uses byte columns)
             let new_end_point = if line_count > 1 {

--- a/src/text/position.rs
+++ b/src/text/position.rs
@@ -241,6 +241,27 @@ mod tests {
     }
 
     #[test]
+    fn byte_to_point_for_multibyte() {
+        // Multi-line, multi-byte: byte→Point must use BYTE columns (tree-sitter),
+        // so a hiragana past the prefix lands at byte col 9 (9 ASCII), and the
+        // first char of line 1 is row 1 col 0. Covers the UTF-16→byte→Point path
+        // now that `byte_to_point` feeds the incremental-parse `InputEdit`.
+        let text = "let x = \"あいう\";\nlocal y = 2\n";
+        let mapper = PositionMapper::new(text);
+
+        // Start of the first hiragana (byte 9, after `let x = "`).
+        let p = mapper.byte_to_point(9);
+        assert_eq!((p.row, p.column), (0, 9));
+        // Just after the 3 hiragana (9 + 3×3 = byte 18) — still row 0, byte col 18.
+        let p = mapper.byte_to_point(18);
+        assert_eq!((p.row, p.column), (0, 18));
+        // First byte of line 1 (`local`) is row 1, col 0.
+        let line1_start = text.find("local").unwrap();
+        let p = mapper.byte_to_point(line1_start);
+        assert_eq!((p.row, p.column), (1, 0));
+    }
+
+    #[test]
     fn clamped_maps_in_bounds_position_exactly() {
         let text = "hello\nworld\n";
         let mapper = PositionMapper::new(text);

--- a/src/text/position.rs
+++ b/src/text/position.rs
@@ -79,6 +79,28 @@ impl PositionMapper {
         (self.byte_to_position(byte)? == position).then_some(byte)
     }
 
+    /// Convert a byte offset to a tree-sitter `Point` (row, byte-column).
+    ///
+    /// Reuses the precomputed `LineIndex` (O(log n) line lookup) instead of
+    /// rescanning the text, and yields a byte-based column — exactly what a
+    /// tree-sitter `InputEdit` needs. The offset is clamped to the document
+    /// length, so `try_line_col` resolves for every input; the `None` arm is
+    /// unreachable and degrades to the document start.
+    pub fn byte_to_point(&self, offset: usize) -> tree_sitter::Point {
+        let len: usize = self.line_index.len().into();
+        let offset = offset.min(len);
+        match offset
+            .try_into()
+            .ok()
+            .and_then(|o| self.line_index.try_line_col(o))
+        {
+            Some(line_col) => {
+                tree_sitter::Point::new(line_col.line as usize, line_col.col as usize)
+            }
+            None => tree_sitter::Point::new(0, 0),
+        }
+    }
+
     /// Convert byte offset to LSP Position
     pub fn byte_to_position(&self, offset: usize) -> Option<Position> {
         // Convert byte offset to LineCol

--- a/src/text/position.rs
+++ b/src/text/position.rs
@@ -89,24 +89,6 @@ impl PositionMapper {
 
         Some(Position::new(wide_line_col.line, wide_line_col.col))
     }
-
-    /// Convert LSP Position to tree-sitter Point with proper byte column
-    ///
-    /// LSP Position uses UTF-16 code units for the character field.
-    /// Tree-sitter Point uses byte offsets for the column field.
-    /// This method performs the correct conversion.
-    pub fn position_to_point(&self, position: Position) -> Option<tree_sitter::Point> {
-        // First get the byte offset for this position
-        let byte_offset = self.position_to_byte(position)?;
-
-        // Then get the LineCol (which has byte-based column) from the byte offset
-        let line_col = self.line_index.try_line_col(byte_offset.try_into().ok()?)?;
-
-        Some(tree_sitter::Point::new(
-            line_col.line as usize,
-            line_col.col as usize,
-        ))
-    }
 }
 
 /// Convert byte column position to UTF-16 column position within a line.
@@ -216,19 +198,6 @@ mod tests {
         assert_eq!(byte_to_utf16_col(line, 2), 1);
         // byte 3 is mid-emoji → falls back to 1
         assert_eq!(byte_to_utf16_col(line, 3), 1);
-    }
-
-    #[test]
-    fn utf16_to_byte_column_for_multibyte() {
-        // "あいうx" — each hiragana is 3 bytes UTF-8, 1 code unit UTF-16
-        // UTF-16 col 3 (after 3 hiragana) → byte col 9
-        let text = "あいうx\n";
-        let mapper = PositionMapper::new(text);
-        let point = mapper
-            .position_to_point(tower_lsp_server::ls_types::Position::new(0, 3))
-            .expect("valid position");
-        assert_eq!(point.row, 0);
-        assert_eq!(point.column, 9);
     }
 
     #[test]

--- a/tests/e2e_semantic.rs
+++ b/tests/e2e_semantic.rs
@@ -627,3 +627,123 @@ fn test_snapshot_heading_inline_decoration_binary() {
 
     insta::assert_json_snapshot!("heading_inline_decoration_binary", data_u32);
 }
+
+/// Regression: a large paste split into several back-to-back `didChange`
+/// chunks must not leave the later lines unhighlighted (rendered white).
+///
+/// The editor sends the paste as multiple incremental `didChange`s and then a
+/// single `semanticTokens/full` for the final state. Those notifications are
+/// dispatched concurrently with the token request, so without serialization the
+/// request could snapshot a half-applied document and return tokens covering
+/// only the first chunks — the symptom this guards against. The server must
+/// settle all pending edits before computing, so the tokens reach the last
+/// line.
+#[test]
+fn test_semantic_tokens_large_paste_covers_last_line() {
+    let mut client = LspClient::new();
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {
+                "textDocument": {
+                    "semanticTokens": {
+                        "dynamicRegistration": false,
+                        "requests": { "full": { "delta": true } },
+                        "tokenTypes": ["keyword", "variable", "function"],
+                        "tokenModifiers": [],
+                        "formats": ["relative"]
+                    }
+                }
+            }
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    let uri = "file:///large_paste.lua";
+    // Open an empty Lua buffer, then let the parser/language load.
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": { "uri": uri, "languageId": "lua", "version": 1, "text": "" }
+        }),
+    );
+    std::thread::sleep(Duration::from_millis(500));
+
+    // Simulate a large paste: several chunks appended back-to-back with NO
+    // delay between them, so the edits and the following token request race.
+    const CHUNKS: usize = 6;
+    const LINES_PER_CHUNK: usize = 25;
+    let mut text = String::new();
+    let mut version = 1i64;
+    for c in 0..CHUNKS {
+        // End-of-document position: line = number of newlines so far, col 0
+        // (every chunk ends in a newline, so the insertion point is the start
+        // of the trailing empty line).
+        let end_line = text.matches('\n').count() as u32;
+        let end_col = (text.len() - text.rfind('\n').map(|p| p + 1).unwrap_or(0)) as u32;
+
+        let mut chunk = String::new();
+        for l in 0..LINES_PER_CHUNK {
+            let n = c * LINES_PER_CHUNK + l;
+            chunk.push_str(&format!("local var_{n} = {n}\n"));
+        }
+
+        version += 1;
+        client.send_notification(
+            "textDocument/didChange",
+            json!({
+                "textDocument": { "uri": uri, "version": version },
+                "contentChanges": [{
+                    "range": {
+                        "start": { "line": end_line, "character": end_col },
+                        "end": { "line": end_line, "character": end_col },
+                    },
+                    "text": chunk,
+                }],
+            }),
+        );
+        text.push_str(&chunk);
+    }
+
+    let total_lines = CHUNKS * LINES_PER_CHUNK; // lines 0..total_lines-1 carry code
+    let last_code_line = (total_lines - 1) as u32; // e.g. line 149
+
+    // Immediately request tokens for the final state — the server must settle
+    // the pending edits before answering.
+    let response = client.send_request(
+        "textDocument/semanticTokens/full",
+        json!({ "textDocument": { "uri": uri } }),
+    );
+
+    let result = response
+        .get("result")
+        .unwrap_or_else(|| panic!("semantic tokens response missing result: {response:?}"));
+    let data = result
+        .get("data")
+        .expect("result should have data")
+        .as_array()
+        .expect("data should be array");
+    let data_u32: Vec<u32> = data.iter().map(|v| v.as_u64().unwrap() as u32).collect();
+    let tokens = decode_semantic_tokens(&data_u32);
+
+    let max_line = tokens.iter().map(|t| t.line).max().unwrap_or(0);
+    assert!(
+        max_line >= last_code_line,
+        "tokens must cover the whole pasted document: last code line is {last_code_line} \
+         but tokens stop at line {max_line} ({} tokens) — the later part would render white",
+        tokens.len()
+    );
+
+    // The last line is `local var_N = N`; its `local` keyword must be tokenized.
+    let last_line_keyword = tokens
+        .iter()
+        .find(|t| t.line == last_code_line && t.start == 0)
+        .map(|t| token_type_name(t.token_type));
+    assert_eq!(
+        last_line_keyword,
+        Some("keyword"),
+        "the `local` keyword on the last pasted line ({last_code_line}) must be highlighted"
+    );
+}

--- a/tests/e2e_semantic.rs
+++ b/tests/e2e_semantic.rs
@@ -671,10 +671,14 @@ fn test_semantic_tokens_large_paste_covers_last_line() {
     );
     std::thread::sleep(Duration::from_millis(500));
 
-    // Simulate a large paste: several chunks appended back-to-back with NO
-    // delay between them, so the edits and the following token request race.
-    const CHUNKS: usize = 6;
-    const LINES_PER_CHUNK: usize = 25;
+    // Simulate a large paste: many chunks appended back-to-back with NO delay
+    // between them, immediately followed by the token request, so the edits are
+    // still being applied/parsed when the request arrives. The paste is sized
+    // generously (hundreds of lines) so the race window is reliably open even on
+    // a fast machine — without the settle fix the request snapshots a partially
+    // applied document and the assertion below fails.
+    const CHUNKS: usize = 8;
+    const LINES_PER_CHUNK: usize = 40;
     let mut text = String::new();
     let mut version = 1i64;
     for c in 0..CHUNKS {

--- a/tests/e2e_semantic.rs
+++ b/tests/e2e_semantic.rs
@@ -712,7 +712,7 @@ fn test_semantic_tokens_large_paste_covers_last_line() {
     }
 
     let total_lines = CHUNKS * LINES_PER_CHUNK; // lines 0..total_lines-1 carry code
-    let last_code_line = (total_lines - 1) as u32; // e.g. line 149
+    let last_code_line = (total_lines - 1) as u32; // 8 * 40 - 1 = line 319
 
     // Immediately request tokens for the final state — the server must settle
     // the pending edits before answering.


### PR DESCRIPTION
## Symptoms fixed

Two user-visible bugs, both rooted in **one** race: `didChange` notification handlers are dispatched concurrently by tower-lsp-server, and the read-old-text → reparse → persist cycle is not atomic.

1. **Highlighting vanishes while editing.** Back-to-back edits (e.g. autopair `{`/`}` then typing inside) made a later handler read a stale, shorter base text and apply a range authored against a newer state. The offset ran past the text and `String::replace_range` panicked (`range end index N out of range for slice of length M`), killing the LSP loop so all semantic tokens stopped.

2. **A large paste leaves its later lines white.** A paste arrives as several back-to-back `didChange` chunks, then the editor sends one `semanticTokens/full(/delta)`. The token request raced the still-applying edits and snapshotted a half-applied document, so tokens covered only the first chunks; the editor accepted that as final and never re-requested.

Both were reproduced from captured LSP logs by replaying the sessions at their original message timing, and verified fixed the same way (in-session delta went from 345 tokens / lines 0..92 to 525 / 0..165).

## Fix

- **Clamp splice offsets** in `apply_content_changes_with_edits` (`position_to_byte_clamped`, `end = max(start, end)`) so `replace_range` can never panic, for any inputs. `InputEdit` points are derived from the clamped byte offsets (new `byte_to_point`) so byte/point stay consistent for incremental parsing.
- **Per-URI async edit lock** (`DocumentStore::edit_lock`) held across `did_change_impl` (acquired as its first `.await`) and `did_close_impl`, so edits/closes to one document serialize; different documents stay concurrent.
- **Semantic requests settle pending edits**: `get_tree_with_wait` briefly acquires the same edit lock before snapshotting the tree, so a token request waits for in-flight edits to apply+parse instead of snapshotting a half-applied paste. Released before tokenization, so edits never wait on the slower compute.

## Tests

- `text_sync`: out-of-range edit no longer panics; `InputEdit` byte/point stay consistent.
- `document::store`: per-URI edit lock identity + cleanup contract.
- e2e `test_semantic_tokens_large_paste_covers_last_line`: pastes 320 lines in 8 rapid chunks and asserts the last line's `local` keyword is highlighted (fails without the settle fix).
- Full suite green; clippy `-D warnings` + fmt clean.

## Review

Refined through a Codex high-effort review (byte/point consistency, lock-acquisition ordering, didClose serialization). One residual is intentionally deferred with tracking: hard JSON-RPC **wire-order** ordering would need an ingress-level `tower::Service` sequencing wrapper — tracked in #342. The clamp removes the crash class regardless of ordering, and first-await locking materially narrows the stale-base window.