### PR TITLE
feat(formatting): concatenated formatting pipeline — remaining slices (#340)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,16 @@ edition = "2024"
 name = "kakehashi"
 path = "src/bin/main.rs"
 
+# Mock downstream LSP formatter driven by the concatenated-formatting E2E
+# tests (tests/e2e_concatenated_formatting.rs) via CARGO_BIN_EXE_mock-lsp-formatter.
+# Gated on the e2e feature so normal builds don't ship it.
+[[bin]]
+name = "mock-lsp-formatter"
+path = "tests/bin/mock_formatter.rs"
+required-features = ["e2e"]
+test = false
+bench = false
+
 # Profiling build: optimized like release but with debug symbols retained (not
 # stripped) so flamegraph/samply + atos can symbolicate the semantic-tokens hot
 # path. Build with `cargo build --profile profiling --bin kakehashi`.

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -345,17 +345,26 @@ change without affecting the config surface.
 
 ## Decision–Implementation Gap
 
-Not yet implemented as of this decision. `textDocument/formatting` currently runs
-the `preferred` strategy per region regardless of config, and a misconfigured
-`concatenated` formatting configuration only emits a warning rather than running
-a pipeline. This record defines the target behavior for full formatting; the
-warning path is the placeholder to be replaced.
+Implemented as decided. The first vertical slice (PR #327) delivered the core
+pipeline — strategy dispatch, serial application over `priorities`, scratch
+document isolation, and the single region-replacement edit. The follow-up
+slices (issue #340) closed the rest:
 
-The current code also collapses a `null` formatting result to "no result", so a
-capable server's `null` ("already formatted") is today indistinguishable from a
-missing provider and falls through to lower-priority servers. The pipeline's
-capability-based fallback (Decision point 3.2) depends on telling these apart, so
-that collapse is part of the gap to close.
+- capability-based full → `rangeFormatting` fallback (Decision point 3.2),
+  including keeping a capable server's `null` ("already formatted",
+  `Some(vec![])`) distinct from a missing provider;
+- per-line host prefix re-application on multi-line output, with the region
+  LCP on line-count changes and trailing-whitespace trimming on empty lines
+  (Decision point 4);
+- the per-step remaining-budget timeout (5s whole-pipeline bound, the
+  explicit per-request aggregation timeout from
+  ls-bridge-server-pool-coordination) with best-effort `$/cancelRequest`
+  to the active downstream server on a timed-out step (Decision point 6);
+- discarding downstream `publishDiagnostics` targeting scratch URIs
+  (Decision point 7);
+- the misconfiguration warning narrowed to the `concatenated`-with-empty-
+  `priorities` case that actually falls back to `preferred`;
+- an E2E test driving a real two-server chain.
 
 `textDocument/rangeFormatting` keeps the `preferred` behavior **by design**, not
 just pending implementation — it is out of scope for the pipeline (see *Decision*

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -25,6 +25,7 @@ pub(crate) use coordinator::ResolvedServerConfig;
 pub use pool::LanguageServerPool;
 pub(crate) use pool::UpstreamId;
 pub(crate) use protocol::RegionOffset;
+pub(crate) use protocol::RequestId;
 pub(crate) use protocol::VirtualDocumentUri;
 pub(crate) use protocol::location_link_to_location;
 pub(crate) use protocol::translate_virtual_range_to_host;

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -535,7 +535,19 @@ async fn handle_message(
             handle_server_request(message, lang_prefix, deps).await;
         }
         MessageKind::Notification => {
-            // Notifications are silently ignored (no logging needed)
+            // Server-initiated notifications are not forwarded upstream today;
+            // `publishDiagnostics` targeting a pipeline *scratch* document is
+            // discarded EXPLICITLY (concatenated-formatting-pipeline Decision
+            // point 7: scratch state is speculative and must never reach the
+            // editor) so the invariant survives if notification forwarding is
+            // ever implemented. Everything else is silently ignored.
+            if is_scratch_publish_diagnostics(&message) {
+                debug!(
+                    target: "kakehashi::bridge::reader",
+                    "{}Discarding publishDiagnostics targeting a scratch virtual document",
+                    lang_prefix
+                );
+            }
         }
         MessageKind::Invalid => {
             warn!(
@@ -546,6 +558,24 @@ async fn handle_message(
             );
         }
     }
+}
+
+/// Whether `message` is a `textDocument/publishDiagnostics` notification
+/// targeting a concatenated-formatting *scratch* virtual document
+/// ([`VirtualDocumentUri::is_scratch_uri`]).
+///
+/// Scratch documents carry speculative pipeline text the editor has never
+/// seen; diagnostics computed against them are meaningless to the user and
+/// must be discarded, not forwarded (concatenated-formatting-pipeline
+/// Decision point 7). The prompt `didClose` after each pipeline run shrinks
+/// but cannot eliminate the window in which a downstream server pushes them.
+fn is_scratch_publish_diagnostics(message: &serde_json::Value) -> bool {
+    message.get("method").and_then(|m| m.as_str()) == Some("textDocument/publishDiagnostics")
+        && message
+            .get("params")
+            .and_then(|p| p.get("uri"))
+            .and_then(|u| u.as_str())
+            .is_some_and(crate::lsp::bridge::VirtualDocumentUri::is_scratch_uri)
 }
 
 /// Handle a server-initiated request by dispatching on its method.
@@ -1286,6 +1316,82 @@ mod tests {
             }
             _ => panic!("Expected Untracked variant"),
         }
+    }
+
+    /// Scratch-targeted publishDiagnostics must be dropped on the floor:
+    /// nothing forwarded upstream, nothing written back downstream
+    /// (concatenated-formatting-pipeline Decision point 7).
+    #[tokio::test]
+    async fn handle_message_discards_publish_diagnostics_for_scratch_uri() {
+        let router = ResponseRouter::new();
+        let (response_tx, mut response_rx) = mpsc::channel(16);
+        let dynamic_capabilities = Arc::new(DynamicCapabilityRegistry::new());
+        let (upstream_tx, mut upstream_rx) = mpsc::unbounded_channel();
+        let deps = ServerRequestDeps {
+            language: None,
+            response_tx,
+            dynamic_capabilities,
+            upstream_tx,
+        };
+
+        let message = json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics",
+            "params": {
+                "uri": "file:///project/kakehashi-virtual-uri-REGION-kakehashi-scratch-3-0.py",
+                "diagnostics": [{
+                    "range": {
+                        "start": {"line": 0, "character": 0},
+                        "end": {"line": 0, "character": 1}
+                    },
+                    "message": "speculative-state diagnostic"
+                }]
+            }
+        });
+
+        handle_message(message, &router, "", &deps).await;
+
+        assert!(
+            upstream_rx.try_recv().is_err(),
+            "scratch publishDiagnostics must not be forwarded upstream"
+        );
+        assert!(
+            response_rx.try_recv().is_err(),
+            "a notification must not trigger any downstream response"
+        );
+    }
+
+    #[test]
+    fn is_scratch_publish_diagnostics_matches_only_scratch_targets() {
+        let scratch = json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics",
+            "params": {"uri": "file:///p/kakehashi-virtual-uri-R-kakehashi-scratch-0-1.py", "diagnostics": []}
+        });
+        assert!(is_scratch_publish_diagnostics(&scratch));
+
+        // Canonical virtual document: not scratch.
+        let canonical = json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics",
+            "params": {"uri": "file:///p/kakehashi-virtual-uri-R.py", "diagnostics": []}
+        });
+        assert!(!is_scratch_publish_diagnostics(&canonical));
+
+        // Different method on a scratch URI: not publishDiagnostics.
+        let other_method = json!({
+            "jsonrpc": "2.0",
+            "method": "$/progress",
+            "params": {"uri": "file:///p/kakehashi-virtual-uri-R-kakehashi-scratch-0-1.py"}
+        });
+        assert!(!is_scratch_publish_diagnostics(&other_method));
+
+        // Missing params: must not panic, just no match.
+        let no_params = json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics"
+        });
+        assert!(!is_scratch_publish_diagnostics(&no_params));
     }
 
     #[tokio::test]

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -547,6 +547,11 @@ async fn handle_message(
                     "{}Discarding publishDiagnostics targeting a scratch virtual document",
                     lang_prefix
                 );
+            } else {
+                // All other notifications are silently ignored. The if/else
+                // makes the scratch discard structural: any future
+                // notification forwarding belongs HERE, where a
+                // scratch-targeted publishDiagnostics can never reach it.
             }
         }
         MessageKind::Invalid => {

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -575,11 +575,11 @@ async fn handle_message(
 /// Decision point 7). The prompt `didClose` after each pipeline run shrinks
 /// but cannot eliminate the window in which a downstream server pushes them.
 fn is_scratch_publish_diagnostics(message: &serde_json::Value) -> bool {
-    message.get("method").and_then(|m| m.as_str()) == Some("textDocument/publishDiagnostics")
-        && message
-            .get("params")
-            .and_then(|p| p.get("uri"))
-            .and_then(|u| u.as_str())
+    // `Value` indexing returns `Null` for missing keys / non-objects, so the
+    // lookups below are panic-free on malformed messages.
+    message["method"].as_str() == Some("textDocument/publishDiagnostics")
+        && message["params"]["uri"]
+            .as_str()
             .is_some_and(crate::lsp::bridge::VirtualDocumentUri::is_scratch_uri)
 }
 

--- a/src/lsp/bridge/actor/response_router.rs
+++ b/src/lsp/bridge/actor/response_router.rs
@@ -42,13 +42,21 @@ pub(crate) struct ResponseRouter {
 struct ResponseRouterState {
     /// Pending requests waiting for responses.
     pending: HashMap<RequestId, oneshot::Sender<serde_json::Value>>,
-    /// Maps upstream request ID (from client) to downstream request ID (to LS).
+    /// Maps upstream request ID (from client) to downstream request IDs (to LS).
     ///
     /// Used for $/cancelRequest forwarding: when the client cancels request 42,
-    /// we look up that 42 maps to downstream ID 7, and forward the cancel to LS.
+    /// we look up the downstream IDs 42 spawned and forward a cancel for each.
+    ///
+    /// One upstream id can map to SEVERAL in-flight downstream requests on the
+    /// same connection — e.g. concurrent injection regions of one formatting
+    /// request, each issuing its own downstream request. A single-value map
+    /// would let the latest registration overwrite earlier ones, so a cancel
+    /// could target the wrong request and completing one request would orphan
+    /// its siblings' mappings (PR #347 review). `Vec` keeps registration order
+    /// for deterministic behavior; entries are tiny (a handful per upstream).
     ///
     /// Supports both numeric and string IDs per LSP spec.
-    upstream_to_downstream: HashMap<UpstreamId, RequestId>,
+    upstream_to_downstream: HashMap<UpstreamId, Vec<RequestId>>,
     /// Reverse mapping: downstream request ID -> upstream request ID.
     ///
     /// Enables O(1) cleanup when a response is routed or a request is removed.
@@ -100,28 +108,37 @@ impl ResponseRouter {
 
         state.pending.insert(downstream_id, tx);
 
-        // Store bidirectional mapping if upstream_id is provided
+        // Store bidirectional mapping if upstream_id is provided. Appending
+        // (not inserting) keeps every concurrent downstream request for this
+        // upstream id cancellable, not just the latest one.
         if let Some(upstream) = upstream_id {
             state
                 .upstream_to_downstream
-                .insert(upstream.clone(), downstream_id);
+                .entry(upstream.clone())
+                .or_default()
+                .push(downstream_id);
             state.downstream_to_upstream.insert(downstream_id, upstream);
         }
 
         Some(rx)
     }
 
-    /// Look up the downstream request ID for an upstream request ID (O(1)).
+    /// Look up every in-flight downstream request ID for an upstream request
+    /// ID, in registration order (empty when none).
     ///
     /// Used by `$/cancelRequest` forwarding to translate the client's request ID
-    /// to the language server's. Does NOT remove the entry — a cancelled request
-    /// must still receive its response.
-    pub(crate) fn lookup_downstream_id(&self, upstream_id: &UpstreamId) -> Option<RequestId> {
+    /// to the language server's. Does NOT remove the entries — a cancelled
+    /// request must still receive its response.
+    pub(crate) fn lookup_downstream_ids(&self, upstream_id: &UpstreamId) -> Vec<RequestId> {
         let state = self
             .state
             .lock()
-            .recover_poison("ResponseRouter::lookup_downstream_id");
-        state.upstream_to_downstream.get(upstream_id).copied()
+            .recover_poison("ResponseRouter::lookup_downstream_ids");
+        state
+            .upstream_to_downstream
+            .get(upstream_id)
+            .cloned()
+            .unwrap_or_default()
     }
 
     /// Route a response to its pending request, also cleaning up both cancel-map
@@ -150,12 +167,19 @@ impl ResponseRouter {
         }
     }
 
-    /// Remove both cancel-map directions for a downstream request ID (O(1)).
+    /// Remove both cancel-map directions for a downstream request ID.
     ///
-    /// Caller must hold the lock.
+    /// Only this downstream id leaves the upstream's list — completing one
+    /// request must not orphan the cancel mappings of its still-in-flight
+    /// siblings sharing the same upstream id. Caller must hold the lock.
     fn remove_cancel_mapping_inner(state: &mut ResponseRouterState, downstream_id: RequestId) {
-        if let Some(upstream_id) = state.downstream_to_upstream.remove(&downstream_id) {
-            state.upstream_to_downstream.remove(&upstream_id);
+        if let Some(upstream_id) = state.downstream_to_upstream.remove(&downstream_id)
+            && let Some(ids) = state.upstream_to_downstream.get_mut(&upstream_id)
+        {
+            ids.retain(|id| *id != downstream_id);
+            if ids.is_empty() {
+                state.upstream_to_downstream.remove(&upstream_id);
+            }
         }
     }
 
@@ -488,11 +512,63 @@ mod tests {
         assert_eq!(router.pending_count(), 1);
 
         // Should be able to look up downstream ID by upstream ID
-        let looked_up = router.lookup_downstream_id(&upstream_id);
+        let looked_up = router.lookup_downstream_ids(&upstream_id);
         assert_eq!(
             looked_up,
-            Some(downstream_id),
+            vec![downstream_id],
             "lookup should return downstream ID for upstream ID"
+        );
+    }
+
+    /// One upstream id with several concurrent downstream requests (parallel
+    /// injection regions of one client request on the same connection): the
+    /// cancel map must track ALL of them, in registration order. The old
+    /// single-value map let the latest registration overwrite earlier ones,
+    /// so a timeout-driven cancel could target the wrong downstream request
+    /// (PR #347 review).
+    #[test]
+    fn cancel_map_tracks_multiple_downstream_ids_per_upstream() {
+        let router = ResponseRouter::new();
+        let upstream_id = UpstreamId::Number(100);
+
+        let _rx1 = router
+            .register_with_upstream(RequestId::new(1), Some(upstream_id.clone()))
+            .expect("first registration should succeed");
+        let _rx2 = router
+            .register_with_upstream(RequestId::new(2), Some(upstream_id.clone()))
+            .expect("second registration should succeed");
+
+        assert_eq!(
+            router.lookup_downstream_ids(&upstream_id),
+            vec![RequestId::new(1), RequestId::new(2)],
+            "both in-flight downstream requests must stay cancellable"
+        );
+    }
+
+    /// Completing one downstream request must not orphan the cancel mapping
+    /// of a still-in-flight sibling sharing the same upstream id. The old
+    /// single-value map removed the whole upstream entry when ANY of its
+    /// requests completed, leaving the sibling uncancellable.
+    #[tokio::test]
+    async fn routing_one_response_keeps_sibling_cancel_mappings() {
+        let router = ResponseRouter::new();
+        let upstream_id = UpstreamId::Number(100);
+
+        let rx1 = router
+            .register_with_upstream(RequestId::new(1), Some(upstream_id.clone()))
+            .expect("first registration should succeed");
+        let _rx2 = router
+            .register_with_upstream(RequestId::new(2), Some(upstream_id.clone()))
+            .expect("second registration should succeed");
+
+        let result = router.route(json!({"jsonrpc": "2.0", "id": 1, "result": null}));
+        assert_eq!(result, RouteResult::Delivered);
+        let _ = rx1.await;
+
+        assert_eq!(
+            router.lookup_downstream_ids(&upstream_id),
+            vec![RequestId::new(2)],
+            "sibling's cancel mapping must survive the other request's completion"
         );
     }
 
@@ -512,10 +588,10 @@ mod tests {
     fn lookup_downstream_id_returns_none_for_unknown() {
         let router = ResponseRouter::new();
 
-        let result = router.lookup_downstream_id(&UpstreamId::Number(999));
-        assert_eq!(
-            result, None,
-            "lookup should return None for unknown upstream ID"
+        let result = router.lookup_downstream_ids(&UpstreamId::Number(999));
+        assert!(
+            result.is_empty(),
+            "lookup should return no ids for unknown upstream ID"
         );
     }
 
@@ -535,8 +611,8 @@ mod tests {
 
         // Verify mapping exists before route
         assert_eq!(
-            router.lookup_downstream_id(&upstream_id),
-            Some(downstream_id)
+            router.lookup_downstream_ids(&upstream_id),
+            vec![downstream_id]
         );
 
         // Route the response
@@ -549,9 +625,8 @@ mod tests {
         assert_eq!(result, RouteResult::Delivered, "route should succeed");
 
         // Verify mapping is removed after route
-        assert_eq!(
-            router.lookup_downstream_id(&upstream_id),
-            None,
+        assert!(
+            router.lookup_downstream_ids(&upstream_id).is_empty(),
             "cancel map entry should be removed after route"
         );
 
@@ -572,8 +647,8 @@ mod tests {
 
         // Verify mapping exists before remove
         assert_eq!(
-            router.lookup_downstream_id(&upstream_id),
-            Some(downstream_id)
+            router.lookup_downstream_ids(&upstream_id),
+            vec![downstream_id]
         );
 
         // Remove the pending request
@@ -581,9 +656,8 @@ mod tests {
         assert!(removed, "remove should succeed");
 
         // Verify mapping is removed
-        assert_eq!(
-            router.lookup_downstream_id(&upstream_id),
-            None,
+        assert!(
+            router.lookup_downstream_ids(&upstream_id).is_empty(),
             "cancel map entry should be removed after remove"
         );
     }
@@ -602,25 +676,30 @@ mod tests {
 
         // Verify mappings exist
         assert!(
-            router
-                .lookup_downstream_id(&UpstreamId::Number(100))
-                .is_some()
+            !router
+                .lookup_downstream_ids(&UpstreamId::Number(100))
+                .is_empty()
         );
         assert!(
-            router
-                .lookup_downstream_id(&UpstreamId::Number(200))
-                .is_some()
+            !router
+                .lookup_downstream_ids(&UpstreamId::Number(200))
+                .is_empty()
         );
 
         router.fail_all("connection lost");
 
         // Verify mappings are cleared
-        assert_eq!(
-            router.lookup_downstream_id(&UpstreamId::Number(100)),
-            None,
+        assert!(
+            router
+                .lookup_downstream_ids(&UpstreamId::Number(100))
+                .is_empty(),
             "cancel map should be cleared by fail_all"
         );
-        assert_eq!(router.lookup_downstream_id(&UpstreamId::Number(200)), None);
+        assert!(
+            router
+                .lookup_downstream_ids(&UpstreamId::Number(200))
+                .is_empty()
+        );
     }
 
     /// Test that lookup_downstream_id does NOT remove the pending entry.
@@ -645,19 +724,19 @@ mod tests {
         // Verify initial state
         assert_eq!(router.pending_count(), 1);
         assert_eq!(
-            router.lookup_downstream_id(&upstream_id),
-            Some(downstream_id)
+            router.lookup_downstream_ids(&upstream_id),
+            vec![downstream_id]
         );
 
         // Look up the downstream ID (as we would when forwarding a cancel)
-        let looked_up = router.lookup_downstream_id(&upstream_id);
-        assert_eq!(looked_up, Some(downstream_id));
+        let looked_up = router.lookup_downstream_ids(&upstream_id);
+        assert_eq!(looked_up, vec![downstream_id]);
 
         // Key assertion: pending entry should still exist after lookup
         assert_eq!(
             router.pending_count(),
             1,
-            "lookup_downstream_id should NOT remove the pending entry"
+            "lookup_downstream_ids should NOT remove the pending entry"
         );
 
         // We should still be able to route a response
@@ -703,10 +782,10 @@ mod tests {
 
         // Look up the downstream ID multiple times
         for _ in 0..3 {
-            let result = router.lookup_downstream_id(&upstream_id);
+            let result = router.lookup_downstream_ids(&upstream_id);
             assert_eq!(
                 result,
-                Some(downstream_id),
+                vec![downstream_id],
                 "cancel map entry should persist after lookup"
             );
         }
@@ -783,13 +862,13 @@ mod tests {
             .expect("should register");
 
         // Verify mapping exists
-        assert!(router.lookup_downstream_id(&upstream_id).is_some());
+        assert!(!router.lookup_downstream_ids(&upstream_id).is_empty());
 
         // Fail the request
         router.fail_request(downstream_id, "test");
 
         // Cancel mapping should be cleaned up
-        assert_eq!(router.lookup_downstream_id(&upstream_id), None);
+        assert!(router.lookup_downstream_ids(&upstream_id).is_empty());
     }
 
     /// Test double cleanup is safe (both remove and fail_request on same ID).

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -477,6 +477,29 @@ impl LanguageServerPool {
             .await
     }
 
+    /// Whether `server_name` advertises the capability backing `method`,
+    /// spawning the server (default handshake timeout) on a connection miss.
+    ///
+    /// Thin wrapper over [`ConnectionHandle::has_capability`] for callers
+    /// outside the bridge that need a capability answer *without* issuing a
+    /// request — the concatenated formatting pipeline keys its
+    /// full-vs-rangeFormatting step decision on this
+    /// (concatenated-formatting-pipeline Decision point 3.2). Mirrors the
+    /// request handlers' own pre-flight checks: a connection still
+    /// initializing reports `false` for now, exactly as the corresponding
+    /// `send_*_request` would decline to run.
+    pub(crate) async fn server_advertises(
+        &self,
+        server_name: &str,
+        server_config: &crate::config::settings::BridgeServerConfig,
+        method: &str,
+    ) -> io::Result<bool> {
+        let handle = self
+            .get_or_create_connection(server_name, server_config)
+            .await?;
+        Ok(handle.has_capability(method))
+    }
+
     /// Get or create a connection for the specified server, spawning the server
     /// and running the LSP handshake with the default timeout on a miss.
     pub(super) async fn get_or_create_connection(

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -477,31 +477,6 @@ impl LanguageServerPool {
             .await
     }
 
-    /// Whether `server_name` advertises the capability backing `method`,
-    /// spawning the server on a connection miss and waiting (up to `timeout`)
-    /// for it to reach Ready so a cold server's capabilities are actually
-    /// known rather than reported as absent.
-    ///
-    /// Thin wrapper over [`ConnectionHandle::has_capability`] for callers
-    /// outside the bridge that need a capability answer *without* issuing a
-    /// request — the concatenated formatting pipeline keys its
-    /// full-vs-rangeFormatting step decision on this
-    /// (concatenated-formatting-pipeline Decision point 3.2) and passes its
-    /// step's remaining budget as `timeout`, so waiting through
-    /// initialization stays inside the pipeline's timing contract.
-    pub(crate) async fn server_advertises(
-        &self,
-        server_name: &str,
-        server_config: &crate::config::settings::BridgeServerConfig,
-        method: &str,
-        timeout: Duration,
-    ) -> io::Result<bool> {
-        let handle = self
-            .get_or_create_connection_wait_ready(server_name, server_config, timeout)
-            .await?;
-        Ok(handle.has_capability(method))
-    }
-
     /// Get or create a connection for the specified server, spawning the server
     /// and running the LSP handshake with the default timeout on a miss.
     pub(super) async fn get_or_create_connection(

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -478,24 +478,26 @@ impl LanguageServerPool {
     }
 
     /// Whether `server_name` advertises the capability backing `method`,
-    /// spawning the server (default handshake timeout) on a connection miss.
+    /// spawning the server on a connection miss and waiting (up to `timeout`)
+    /// for it to reach Ready so a cold server's capabilities are actually
+    /// known rather than reported as absent.
     ///
     /// Thin wrapper over [`ConnectionHandle::has_capability`] for callers
     /// outside the bridge that need a capability answer *without* issuing a
     /// request — the concatenated formatting pipeline keys its
     /// full-vs-rangeFormatting step decision on this
-    /// (concatenated-formatting-pipeline Decision point 3.2). Mirrors the
-    /// request handlers' own pre-flight checks: a connection still
-    /// initializing reports `false` for now, exactly as the corresponding
-    /// `send_*_request` would decline to run.
+    /// (concatenated-formatting-pipeline Decision point 3.2) and passes its
+    /// step's remaining budget as `timeout`, so waiting through
+    /// initialization stays inside the pipeline's timing contract.
     pub(crate) async fn server_advertises(
         &self,
         server_name: &str,
         server_config: &crate::config::settings::BridgeServerConfig,
         method: &str,
+        timeout: Duration,
     ) -> io::Result<bool> {
         let handle = self
-            .get_or_create_connection(server_name, server_config)
+            .get_or_create_connection_wait_ready(server_name, server_config, timeout)
             .await?;
         Ok(handle.has_capability(method))
     }

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -800,9 +800,13 @@ impl LanguageServerPool {
         }
     }
 
-    /// Translate `upstream_id` to the downstream ID via the cancel map and send
-    /// `$/cancelRequest` to `server_name`. The pending entry stays in place: the
-    /// server may still respond with a result or `REQUEST_CANCELLED` (-32800).
+    /// Translate `upstream_id` to its downstream ID(s) via the cancel map and
+    /// send `$/cancelRequest` to `server_name` for **each** of them — one
+    /// upstream id can have several in-flight downstream requests on the same
+    /// connection (concurrent injection regions of one request), and all of
+    /// them belong to the cancelled upstream request. The pending entries stay
+    /// in place: the server may still respond with a result or
+    /// `REQUEST_CANCELLED` (-32800).
     ///
     /// Returns `Ok(())` when the cancel is unforwardable (no connection, not
     /// Ready, or unknown upstream ID) per LSP best-effort semantics; only real
@@ -846,59 +850,66 @@ impl LanguageServerPool {
             std::sync::Arc::clone(handle)
         };
 
-        // Look up the downstream ID
-        let downstream_id = match handle.router().lookup_downstream_id(upstream_id) {
-            Some(id) => id,
-            None => {
-                // Request already completed or ID never registered.
-                // Silently drop per best-effort semantics.
-                self.cancel_metrics.record_unknown_id();
-                log::debug!(
-                    target: "kakehashi::bridge::cancel",
-                    "Cancel dropped: upstream ID {} not found for server '{}' (request may have completed)",
-                    upstream_id,
-                    server_name
-                );
-                return Ok(());
-            }
-        };
-
-        // Build and send the cancel notification via single-writer loop (ls-bridge-message-ordering)
-        // Per LSP spec: $/cancelRequest is a notification with { id: request_id }
-        let notification = JsonRpcNotification::new(
-            "$/cancelRequest",
-            CancelParams {
-                // Safe: IDs are generated from an atomic counter starting at 0,
-                // well within i32 range. ls-types constrains Number to i32.
-                id: NumberOrString::Number(downstream_id.as_i64() as i32),
-            },
-        );
-
-        match handle.send_notification(notification) {
-            NotificationSendResult::Queued => {
-                self.cancel_metrics.record_success();
-                log::debug!(
-                    target: "kakehashi::bridge::cancel",
-                    "Cancel forwarded: upstream {} -> downstream {} for server '{}'",
-                    upstream_id,
-                    downstream_id.as_i64(),
-                    server_name
-                );
-                Ok(())
-            }
-            NotificationSendResult::QueueFull => Err(io::Error::new(
-                io::ErrorKind::WouldBlock,
-                "bridge: cancel notification queue full",
-            )),
-            NotificationSendResult::ChannelClosed => Err(io::Error::new(
-                io::ErrorKind::BrokenPipe,
-                "bridge: cancel notification channel closed",
-            )),
-            NotificationSendResult::SerializationFailed => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "bridge: failed to serialize cancel notification",
-            )),
+        // Look up every in-flight downstream ID for this upstream request
+        let downstream_ids = handle.router().lookup_downstream_ids(upstream_id);
+        if downstream_ids.is_empty() {
+            // Request already completed or ID never registered.
+            // Silently drop per best-effort semantics.
+            self.cancel_metrics.record_unknown_id();
+            log::debug!(
+                target: "kakehashi::bridge::cancel",
+                "Cancel dropped: upstream ID {} not found for server '{}' (request may have completed)",
+                upstream_id,
+                server_name
+            );
+            return Ok(());
         }
+
+        // Build and send one cancel notification per downstream request via the
+        // single-writer loop (ls-bridge-message-ordering).
+        // Per LSP spec: $/cancelRequest is a notification with { id: request_id }
+        for downstream_id in downstream_ids {
+            let notification = JsonRpcNotification::new(
+                "$/cancelRequest",
+                CancelParams {
+                    // Safe: IDs are generated from an atomic counter starting at 0,
+                    // well within i32 range. ls-types constrains Number to i32.
+                    id: NumberOrString::Number(downstream_id.as_i64() as i32),
+                },
+            );
+
+            match handle.send_notification(notification) {
+                NotificationSendResult::Queued => {
+                    self.cancel_metrics.record_success();
+                    log::debug!(
+                        target: "kakehashi::bridge::cancel",
+                        "Cancel forwarded: upstream {} -> downstream {} for server '{}'",
+                        upstream_id,
+                        downstream_id.as_i64(),
+                        server_name
+                    );
+                }
+                NotificationSendResult::QueueFull => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::WouldBlock,
+                        "bridge: cancel notification queue full",
+                    ));
+                }
+                NotificationSendResult::ChannelClosed => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::BrokenPipe,
+                        "bridge: cancel notification channel closed",
+                    ));
+                }
+                NotificationSendResult::SerializationFailed => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "bridge: failed to serialize cancel notification",
+                    ));
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Fan out `$/cancelRequest` to every server registered for `upstream_id`.
@@ -2430,8 +2441,8 @@ mod tests {
         // Verify the cancel_map entry is still there (cancel does NOT remove it)
         // The mapping is only removed when the actual response arrives
         assert_eq!(
-            handle.router().lookup_downstream_id(&upstream_id),
-            Some(downstream_id),
+            handle.router().lookup_downstream_ids(&upstream_id),
+            vec![downstream_id],
             "Cancel map entry should still exist after cancel forwarding"
         );
     }
@@ -2620,9 +2631,11 @@ mod tests {
             0,
             "pending entry should be removed after response"
         );
-        assert_eq!(
-            handle.router().lookup_downstream_id(&upstream_id),
-            None,
+        assert!(
+            handle
+                .router()
+                .lookup_downstream_ids(&upstream_id)
+                .is_empty(),
             "cancel map entry should be removed after response"
         );
     }

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -45,7 +45,9 @@ use tower_lsp_server::ls_types::{CancelParams, NumberOrString};
 
 use crate::error::LockResultExt;
 
-use super::protocol::{JsonRpcNotification, VirtualDocumentUri, build_didopen_notification};
+use super::protocol::{
+    JsonRpcNotification, RequestId, VirtualDocumentUri, build_didopen_notification,
+};
 
 /// Timeout for the LSP initialize handshake and for wait-for-ready on an
 /// initializing server (ls-bridge-timeout-hierarchy Tier 0: 30-60s recommended). A downstream
@@ -816,38 +818,11 @@ impl LanguageServerPool {
         server_name: &str,
         upstream_id: &UpstreamId,
     ) -> io::Result<()> {
-        // Get the connection for this server
-        let handle = {
-            let connections = self.connections().await;
-            let Some(handle) = connections.get(server_name) else {
-                // No connection - request may have completed or server never started.
-                // Silently drop per best-effort semantics.
-                self.cancel_metrics.record_no_connection();
-                log::debug!(
-                    target: "kakehashi::bridge::cancel",
-                    "Cancel dropped: no connection for server '{}' (upstream_id: {}, expected if request completed)",
-                    server_name,
-                    upstream_id
-                );
-                return Ok(());
-            };
-
-            // Only forward if connection is Ready
-            if handle.state() != ConnectionState::Ready {
-                // Connection still initializing or failed - can't forward cancels.
-                // Silently drop per best-effort semantics.
-                self.cancel_metrics.record_not_ready();
-                log::debug!(
-                    target: "kakehashi::bridge::cancel",
-                    "Cancel dropped: connection not ready for server '{}' (upstream_id: {}, state: {:?})",
-                    server_name,
-                    upstream_id,
-                    handle.state()
-                );
-                return Ok(());
-            }
-
-            std::sync::Arc::clone(handle)
+        let Some(handle) = self
+            .ready_connection_for_cancel(server_name, &format!("upstream_id: {upstream_id}"))
+            .await
+        else {
+            return Ok(());
         };
 
         // Look up every in-flight downstream ID for this upstream request
@@ -865,51 +840,127 @@ impl LanguageServerPool {
             return Ok(());
         }
 
-        // Build and send one cancel notification per downstream request via the
-        // single-writer loop (ls-bridge-message-ordering).
-        // Per LSP spec: $/cancelRequest is a notification with { id: request_id }
         for downstream_id in downstream_ids {
-            let notification = JsonRpcNotification::new(
-                "$/cancelRequest",
-                CancelParams {
-                    // Safe: IDs are generated from an atomic counter starting at 0,
-                    // well within i32 range. ls-types constrains Number to i32.
-                    id: NumberOrString::Number(downstream_id.as_i64() as i32),
-                },
-            );
-
-            match handle.send_notification(notification) {
-                NotificationSendResult::Queued => {
-                    self.cancel_metrics.record_success();
-                    log::debug!(
-                        target: "kakehashi::bridge::cancel",
-                        "Cancel forwarded: upstream {} -> downstream {} for server '{}'",
-                        upstream_id,
-                        downstream_id.as_i64(),
-                        server_name
-                    );
-                }
-                NotificationSendResult::QueueFull => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::WouldBlock,
-                        "bridge: cancel notification queue full",
-                    ));
-                }
-                NotificationSendResult::ChannelClosed => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::BrokenPipe,
-                        "bridge: cancel notification channel closed",
-                    ));
-                }
-                NotificationSendResult::SerializationFailed => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        "bridge: failed to serialize cancel notification",
-                    ));
-                }
-            }
+            self.send_cancel_notification(&handle, server_name, downstream_id)?;
         }
         Ok(())
+    }
+
+    /// Send `$/cancelRequest` for a **specific** downstream request id on
+    /// `server_name`'s connection — no upstream-id lookup involved.
+    ///
+    /// Used by the concatenated formatting pipeline's per-step timeout, which
+    /// must cancel exactly the request it issued: routing through the
+    /// upstream id would (a) find nothing — dropping the timed-out step
+    /// future has already removed its cancel mapping via the router cleanup
+    /// guard by the time any cancel task runs — and (b) fan out to sibling
+    /// regions' in-flight requests sharing the same upstream id, spuriously
+    /// cancelling unrelated work (PR #347 review).
+    ///
+    /// Best-effort like [`forward_cancel`](Self::forward_cancel): an absent
+    /// or non-Ready connection silently drops the cancel; only real send
+    /// failures bubble up as `Err`.
+    pub(crate) async fn forward_cancel_downstream(
+        &self,
+        server_name: &str,
+        downstream_id: RequestId,
+    ) -> io::Result<()> {
+        let Some(handle) = self
+            .ready_connection_for_cancel(
+                server_name,
+                &format!("downstream_id: {}", downstream_id.as_i64()),
+            )
+            .await
+        else {
+            return Ok(());
+        };
+        self.send_cancel_notification(&handle, server_name, downstream_id)
+    }
+
+    /// Fetch `server_name`'s connection for cancel forwarding, returning
+    /// `None` (after best-effort metrics/logging) when there is no connection
+    /// or it is not Ready. `request_desc` identifies the request in logs.
+    async fn ready_connection_for_cancel(
+        &self,
+        server_name: &str,
+        request_desc: &str,
+    ) -> Option<Arc<ConnectionHandle>> {
+        let connections = self.connections().await;
+        let Some(handle) = connections.get(server_name) else {
+            // No connection - request may have completed or server never started.
+            // Silently drop per best-effort semantics.
+            self.cancel_metrics.record_no_connection();
+            log::debug!(
+                target: "kakehashi::bridge::cancel",
+                "Cancel dropped: no connection for server '{}' ({}, expected if request completed)",
+                server_name,
+                request_desc
+            );
+            return None;
+        };
+
+        // Only forward if connection is Ready
+        if handle.state() != ConnectionState::Ready {
+            // Connection still initializing or failed - can't forward cancels.
+            // Silently drop per best-effort semantics.
+            self.cancel_metrics.record_not_ready();
+            log::debug!(
+                target: "kakehashi::bridge::cancel",
+                "Cancel dropped: connection not ready for server '{}' ({}, state: {:?})",
+                server_name,
+                request_desc,
+                handle.state()
+            );
+            return None;
+        }
+
+        Some(Arc::clone(handle))
+    }
+
+    /// Build and send one `$/cancelRequest` notification for `downstream_id`
+    /// via the single-writer loop (ls-bridge-message-ordering). The pending
+    /// entry stays in place: the server may still respond with a result or
+    /// `REQUEST_CANCELLED` (-32800).
+    fn send_cancel_notification(
+        &self,
+        handle: &ConnectionHandle,
+        server_name: &str,
+        downstream_id: RequestId,
+    ) -> io::Result<()> {
+        // Per LSP spec: $/cancelRequest is a notification with { id: request_id }
+        let notification = JsonRpcNotification::new(
+            "$/cancelRequest",
+            CancelParams {
+                // Safe: IDs are generated from an atomic counter starting at 0,
+                // well within i32 range. ls-types constrains Number to i32.
+                id: NumberOrString::Number(downstream_id.as_i64() as i32),
+            },
+        );
+
+        match handle.send_notification(notification) {
+            NotificationSendResult::Queued => {
+                self.cancel_metrics.record_success();
+                log::debug!(
+                    target: "kakehashi::bridge::cancel",
+                    "Cancel forwarded: downstream {} for server '{}'",
+                    downstream_id.as_i64(),
+                    server_name
+                );
+                Ok(())
+            }
+            NotificationSendResult::QueueFull => Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "bridge: cancel notification queue full",
+            )),
+            NotificationSendResult::ChannelClosed => Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "bridge: cancel notification channel closed",
+            )),
+            NotificationSendResult::SerializationFailed => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "bridge: failed to serialize cancel notification",
+            )),
+        }
     }
 
     /// Fan out `$/cancelRequest` to every server registered for `upstream_id`.
@@ -2444,6 +2495,62 @@ mod tests {
             handle.router().lookup_downstream_ids(&upstream_id),
             vec![downstream_id],
             "Cancel map entry should still exist after cancel forwarding"
+        );
+    }
+
+    /// `forward_cancel_downstream` sends the cancel for the EXACT downstream
+    /// id it is given, with no upstream-id lookup — the formatting pipeline's
+    /// per-step timeout uses it because the timed-out step's upstream-id
+    /// mapping is already gone (router cleanup on future drop) and the
+    /// upstream id can fan out to sibling regions' requests.
+    #[tokio::test]
+    async fn forward_cancel_downstream_sends_notification_for_specific_id() {
+        use std::sync::Arc;
+
+        let pool = LanguageServerPool::new();
+        let handle = create_handle_with_state(ConnectionState::Ready).await;
+
+        // Two in-flight requests sharing one upstream id (sibling regions).
+        let upstream_id = UpstreamId::Number(42);
+        let (first_id, _rx1) = handle
+            .register_request_with_upstream(Some(upstream_id.clone()))
+            .expect("should register first request");
+        let (_second_id, _rx2) = handle
+            .register_request_with_upstream(Some(upstream_id.clone()))
+            .expect("should register second request");
+
+        pool.connections
+            .lock()
+            .await
+            .insert("lua".to_string(), Arc::clone(&handle));
+
+        // Cancel exactly the first request by its downstream id.
+        let result = pool.forward_cancel_downstream("lua", first_id).await;
+        assert!(
+            result.is_ok(),
+            "forward_cancel_downstream should succeed: {:?}",
+            result.err()
+        );
+
+        // Pending entries and cancel mappings stay (cancel never removes them;
+        // responses do).
+        assert_eq!(handle.router().pending_count(), 2);
+    }
+
+    /// `forward_cancel_downstream` silently drops when there is no connection
+    /// (best-effort semantics, same as forward_cancel).
+    #[tokio::test]
+    async fn forward_cancel_downstream_silently_drops_when_no_connection() {
+        let pool = LanguageServerPool::new();
+
+        let result = pool
+            .forward_cancel_downstream("nonexistent", RequestId::new(7))
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "best-effort cancel must not error on a missing connection: {:?}",
+            result.err()
         );
     }
 

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -1112,10 +1112,10 @@ mod tests {
             .expect("should register request");
 
         // Verify the mapping was stored in the router
-        let looked_up = handle.router().lookup_downstream_id(&upstream_id);
+        let looked_up = handle.router().lookup_downstream_ids(&upstream_id);
         assert_eq!(
             looked_up,
-            Some(downstream_id),
+            vec![downstream_id],
             "Router should have upstream->downstream mapping"
         );
     }

--- a/src/lsp/bridge/pool/execute.rs
+++ b/src/lsp/bridge/pool/execute.rs
@@ -54,6 +54,44 @@ impl LanguageServerPool {
         build_request: impl FnOnce(&VirtualDocumentUri, RequestId) -> JsonRpcRequest<P>,
         transform_response: impl FnOnce(serde_json::Value, &BridgeResponseContext<'_>) -> T,
     ) -> io::Result<T> {
+        self.execute_bridge_request_observed(
+            handle,
+            server_name,
+            host_uri,
+            injection_language,
+            region_id,
+            offset,
+            virtual_content,
+            upstream_request_id,
+            build_request,
+            transform_response,
+            None,
+        )
+        .await
+    }
+
+    /// Like [`execute_bridge_request_with_handle`](Self::execute_bridge_request_with_handle),
+    /// but additionally publishes the allocated downstream [`RequestId`] into
+    /// `downstream_id_probe` as soon as it is known. A caller that may drop
+    /// this future (e.g. the formatting pipeline's per-step timeout) can then
+    /// still cancel the in-flight downstream request precisely by that id —
+    /// the upstream-id cancel mapping is removed by the router cleanup guard
+    /// the moment the future is dropped, so it cannot be looked up afterward.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn execute_bridge_request_observed<T, P: serde::Serialize>(
+        &self,
+        handle: Arc<ConnectionHandle>,
+        server_name: &str,
+        host_uri: &Url,
+        injection_language: &str,
+        region_id: &str,
+        offset: &RegionOffset,
+        virtual_content: &str,
+        upstream_request_id: Option<UpstreamId>,
+        build_request: impl FnOnce(&VirtualDocumentUri, RequestId) -> JsonRpcRequest<P>,
+        transform_response: impl FnOnce(serde_json::Value, &BridgeResponseContext<'_>) -> T,
+        downstream_id_probe: Option<&std::sync::OnceLock<RequestId>>,
+    ) -> io::Result<T> {
         // Convert host_uri to lsp_types::Uri for bridge protocol functions
         let host_uri_lsp = crate::lsp::lsp_impl::url_to_uri(host_uri)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
@@ -81,6 +119,12 @@ impl LanguageServerPool {
                     return Err(e);
                 }
             };
+
+        // Publish the downstream id immediately so a caller that drops this
+        // future (per-step timeout) can still cancel the request precisely.
+        if let Some(probe) = downstream_id_probe {
+            let _ = probe.set(request_id);
+        }
 
         // Build the request via caller-provided closure
         let request = build_request(&virtual_uri, request_id);

--- a/src/lsp/bridge/protocol/virtual_uri.rs
+++ b/src/lsp/bridge/protocol/virtual_uri.rs
@@ -111,6 +111,24 @@ impl VirtualDocumentUri {
                 .is_some_and(|(_name, ext)| !ext.is_empty())
     }
 
+    /// Marker embedded in the `region_id` of throwaway scratch documents the
+    /// concatenated formatting pipeline opens per step
+    /// (concatenated-formatting-pipeline Decision point 7). Shared here so the
+    /// id construction (`scratch_region_id` in the formatting handler) and the
+    /// notification filtering ([`Self::is_scratch_uri`]) can never drift apart.
+    pub(crate) const SCRATCH_ID_MARKER: &str = "-kakehashi-scratch-";
+
+    /// Check if a URI string identifies a pipeline *scratch* virtual document
+    /// — a virtual URI whose region id carries [`Self::SCRATCH_ID_MARKER`].
+    ///
+    /// Scratch documents hold speculative pipeline state the editor never
+    /// sees; server-initiated notifications targeting them (notably
+    /// `textDocument/publishDiagnostics`) must be discarded rather than
+    /// forwarded (Decision point 7).
+    pub(crate) fn is_scratch_uri(uri: &str) -> bool {
+        Self::is_virtual_uri(uri) && uri.contains(Self::SCRATCH_ID_MARKER)
+    }
+
     /// Format: `{scheme}:///{host_dir}/kakehashi-virtual-uri-{region_id}.{ext}`,
     /// preserving the host URI's scheme (file://, https://, …) and directory so
     /// downstream servers can resolve relative imports and discover project
@@ -185,6 +203,46 @@ mod tests {
     // Helper function to convert url::Url to tower_lsp_server::ls_types::Uri for tests
     fn url_to_uri(url: &Url) -> Uri {
         crate::lsp::lsp_impl::url_to_uri(url).expect("test URL should convert to URI")
+    }
+
+    // ==========================================================================
+    // is_scratch_uri tests (concatenated-formatting-pipeline Decision point 7)
+    // ==========================================================================
+
+    #[test]
+    fn is_scratch_uri_detects_pipeline_scratch_documents() {
+        // The shape `scratch_region_id` produces: canonical region id plus the
+        // scratch marker and run/step counters, flowed through the virtual URI.
+        let host_uri = Url::parse("file:///project/doc.md").unwrap();
+        let scratch_id = format!("01ARZ3NDEKTSV4{}7-0", VirtualDocumentUri::SCRATCH_ID_MARKER);
+        let uri =
+            VirtualDocumentUri::new(&url_to_uri(&host_uri), "python", &scratch_id).to_uri_string();
+        assert!(
+            VirtualDocumentUri::is_scratch_uri(&uri),
+            "scratch virtual URI must be detected: {uri}"
+        );
+    }
+
+    #[test]
+    fn is_scratch_uri_rejects_canonical_virtual_documents() {
+        // The canonical region virtual document (hover/diagnostics keep it
+        // open) is NOT scratch — its notifications follow the normal rules.
+        let host_uri = Url::parse("file:///project/doc.md").unwrap();
+        let uri = VirtualDocumentUri::new(&url_to_uri(&host_uri), "python", "01ARZ3NDEKTSV4")
+            .to_uri_string();
+        assert!(!VirtualDocumentUri::is_scratch_uri(&uri));
+    }
+
+    #[test]
+    fn is_scratch_uri_rejects_real_files_even_with_marker_in_path() {
+        // A real file that merely contains the marker somewhere in its name is
+        // not a virtual document at all, let alone a scratch one.
+        assert!(!VirtualDocumentUri::is_scratch_uri(
+            "file:///project/notes-kakehashi-scratch-1.md"
+        ));
+        assert!(!VirtualDocumentUri::is_scratch_uri(
+            "file:///project/src/main.rs"
+        ));
     }
 
     // ==========================================================================

--- a/src/lsp/bridge/protocol/virtual_uri.rs
+++ b/src/lsp/bridge/protocol/virtual_uri.rs
@@ -126,7 +126,9 @@ impl VirtualDocumentUri {
     /// `textDocument/publishDiagnostics`) must be discarded rather than
     /// forwarded (Decision point 7).
     pub(crate) fn is_scratch_uri(uri: &str) -> bool {
-        Self::is_virtual_uri(uri) && uri.contains(Self::SCRATCH_ID_MARKER)
+        // Substring check first: it cheaply rejects the vast majority of URIs
+        // (every non-scratch one) before `is_virtual_uri`'s URL parse.
+        uri.contains(Self::SCRATCH_ID_MARKER) && Self::is_virtual_uri(uri)
     }
 
     /// Format: `{scheme}:///{host_dir}/kakehashi-virtual-uri-{region_id}.{ext}`,

--- a/src/lsp/bridge/text_document/formatting.rs
+++ b/src/lsp/bridge/text_document/formatting.rs
@@ -135,7 +135,14 @@ fn build_formatting_request(
 }
 
 /// Translate each `TextEdit` from virtual to host coordinates via `offset`.
-/// LSP returns `TextEdit[] | null`, so `null` or missing `result` collapses to `None`.
+///
+/// LSP returns `TextEdit[] | null`. A `null` result from a server that handled
+/// the request is the authoritative "no changes / already formatted" signal and
+/// maps to `Some(vec![])`; only a genuinely missing result — a JSON-RPC error
+/// or malformed payload — collapses to `None`. Keeping the two apart is what
+/// lets the concatenated pipeline's capability-based fallback distinguish
+/// "capable server, nothing to change" from "no usable response"
+/// (concatenated-formatting-pipeline Decision point 3.2).
 ///
 /// Downstream formatters often emit edits past the virtual EOF (e.g. enforce a
 /// trailing newline) as if it were a real file; the host bytes immediately past
@@ -156,7 +163,9 @@ pub(super) fn transform_formatting_response_to_host(
     let result = response.get_mut("result").map(serde_json::Value::take)?;
 
     if result.is_null() {
-        return None;
+        // Authoritative "no changes / already formatted" — an empty edit list,
+        // not a missing result (see function docs).
+        return Some(Vec::new());
     }
 
     // A non-null `result` that fails to deserialize as `Vec<TextEdit>` means
@@ -368,13 +377,32 @@ mod tests {
     }
 
     #[rstest]
-    #[case::null_result(json!({"jsonrpc": "2.0", "id": 42, "result": null}))]
     #[case::no_result_key(json!({"jsonrpc": "2.0", "id": 42, "error": {"code": -32600, "message": "Invalid Request"}}))]
     #[case::malformed_result(json!({"jsonrpc": "2.0", "id": 42, "result": "not_an_array"}))]
     fn formatting_response_returns_none_for_invalid_response(#[case] response: serde_json::Value) {
         let transformed =
             transform_formatting_response_to_host(response, &RegionOffset::new(5, 0), UNBOUNDED);
         assert!(transformed.is_none());
+    }
+
+    #[test]
+    fn formatting_response_null_result_is_authoritative_empty_edit_list() {
+        // Per LSP, `null` from a server that handled the request means
+        // "no changes / already formatted" — an authoritative answer, not a
+        // missing one. It must come back as Some(vec![]) so callers can tell
+        // it apart from `None` ("no result": error or missing provider), which
+        // the concatenated pipeline's capability fallback depends on (ADR
+        // concatenated-formatting-pipeline Decision point 3.2).
+        let response = json!({"jsonrpc": "2.0", "id": 42, "result": null});
+
+        let transformed =
+            transform_formatting_response_to_host(response, &RegionOffset::new(5, 0), UNBOUNDED);
+
+        assert_eq!(
+            transformed,
+            Some(Vec::new()),
+            "null result must be an authoritative empty edit list, not None"
+        );
     }
 
     #[test]

--- a/src/lsp/bridge/text_document/formatting.rs
+++ b/src/lsp/bridge/text_document/formatting.rs
@@ -42,6 +42,11 @@ impl LanguageServerPool {
     ///
     /// Returns `Ok(None)` when the downstream server does not advertise
     /// `documentFormattingProvider`.
+    ///
+    /// `downstream_id_probe`, when provided, receives the allocated downstream
+    /// request id as soon as it is known so a caller that drops this future
+    /// (the pipeline's per-step timeout) can still cancel the in-flight
+    /// request precisely.
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn send_formatting_request(
         &self,
@@ -54,6 +59,7 @@ impl LanguageServerPool {
         virtual_content: &str,
         options: FormattingOptions,
         upstream_request_id: Option<UpstreamId>,
+        downstream_id_probe: Option<&std::sync::OnceLock<RequestId>>,
     ) -> io::Result<Option<Vec<TextEdit>>> {
         let handle = self
             .get_or_create_connection(server_name, server_config)
@@ -62,7 +68,7 @@ impl LanguageServerPool {
             return Ok(None);
         }
         let virtual_line_count = count_lines(virtual_content);
-        self.execute_bridge_request_with_handle(
+        self.execute_bridge_request_observed(
             handle,
             server_name,
             host_uri,
@@ -75,6 +81,7 @@ impl LanguageServerPool {
             |response, ctx| {
                 transform_formatting_response_to_host(response, ctx.offset, virtual_line_count)
             },
+            downstream_id_probe,
         )
         .await
     }

--- a/src/lsp/bridge/text_document/range_formatting.rs
+++ b/src/lsp/bridge/text_document/range_formatting.rs
@@ -59,6 +59,7 @@ impl LanguageServerPool {
         host_range: Range,
         options: FormattingOptions,
         upstream_request_id: Option<UpstreamId>,
+        downstream_id_probe: Option<&std::sync::OnceLock<RequestId>>,
     ) -> io::Result<Option<Vec<TextEdit>>> {
         let handle = self
             .get_or_create_connection(server_name, server_config)
@@ -68,7 +69,7 @@ impl LanguageServerPool {
         }
         let virtual_line_count = count_lines(virtual_content);
         let offset_for_request = offset.clone();
-        self.execute_bridge_request_with_handle(
+        self.execute_bridge_request_observed(
             handle,
             server_name,
             host_uri,
@@ -89,6 +90,7 @@ impl LanguageServerPool {
             |response, ctx| {
                 transform_formatting_response_to_host(response, ctx.offset, virtual_line_count)
             },
+            downstream_id_probe,
         )
         .await
     }

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -251,10 +251,12 @@ impl Kakehashi {
     }
 
     /// Emit a single client-visible warning summarizing all (host, injection)
-    /// pairs whose configured `textDocument/formatting` aggregation strategy
-    /// is `Concatenated`. The formatting handler ignores `Concatenated`
-    /// because merging edits from multiple formatters produces overlapping
-    /// `TextEdit`s (an LSP spec violation); surfacing the mismatch at
+    /// pairs whose configured `textDocument/formatting` aggregation is the
+    /// misconfigured `Concatenated`-with-empty-`priorities` combination. The
+    /// concatenated formatting pipeline requires a non-empty `priorities`
+    /// list (it defines pipeline membership and order — ADR
+    /// concatenated-formatting-pipeline Decision point 2); without one the
+    /// region falls back to `preferred`. Surfacing the mismatch at
     /// settings-apply time avoids silent misbehavior on every format request.
     ///
     /// Previously this emitted one notification per pair, which floods the

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -119,19 +119,22 @@ pub(crate) fn resolve_aggregation_config_from_settings(
 }
 
 /// Find every (host_language, injection_language) pair whose configured
-/// aggregation strategy for `textDocument/formatting` is `Concatenated`.
+/// aggregation for `textDocument/formatting` is the **misconfigured**
+/// `Concatenated`-with-empty-`priorities` combination.
 ///
-/// The formatting handler intentionally ignores `Concatenated` — running
-/// multiple formatters over the same region produces overlapping `TextEdit`s
-/// and violates the LSP "edits must not overlap" rule. We warn the user once
-/// at settings-apply time (initialize + didChangeConfiguration) so the
-/// configuration mistake surfaces immediately rather than silently degrading
-/// every format request.
+/// Since the concatenated formatting pipeline landed
+/// (concatenated-formatting-pipeline), `strategy = "concatenated"` with a
+/// non-empty `priorities` is a valid configuration that runs the sequential
+/// pipeline — only an empty `priorities` is a misconfiguration (the pipeline's
+/// order would be undefined, so the region falls back to `preferred`; ADR
+/// Decision point 2). We warn the user once at settings-apply time
+/// (initialize + didChangeConfiguration) so the mistake surfaces immediately
+/// rather than silently degrading every format request.
 ///
-/// Walks the explicit configuration tree (not the resolved-with-wildcard
-/// view): both per-method (`textDocument/formatting`) and per-bridge wildcard
-/// (`_`) strategy entries are considered, with the per-method entry winning
-/// when both are present.
+/// Each bridge entry is resolved through
+/// [`BridgeLanguageConfig::resolve_aggregation`] — the same field-level
+/// wildcard merge the runtime uses — so priorities supplied via the `_`
+/// wildcard entry count as configured.
 pub(crate) fn concatenated_formatting_pairs(settings: &WorkspaceSettings) -> Vec<(String, String)> {
     use crate::config::settings::AggregationStrategy;
 
@@ -141,15 +144,8 @@ pub(crate) fn concatenated_formatting_pairs(settings: &WorkspaceSettings) -> Vec
             continue;
         };
         for (injection_language, bridge_cfg) in bridge_map {
-            let Some(agg_map) = bridge_cfg.aggregation.as_ref() else {
-                continue;
-            };
-            let method_strategy = agg_map
-                .get("textDocument/formatting")
-                .and_then(|a| a.strategy);
-            let wildcard_strategy = agg_map.get("_").and_then(|a| a.strategy);
-            // Per-method entry wins over wildcard, matching resolve_aggregation.
-            if method_strategy.or(wildcard_strategy) == Some(AggregationStrategy::Concatenated) {
+            let agg = bridge_cfg.resolve_aggregation("textDocument/formatting");
+            if agg.strategy == AggregationStrategy::Concatenated && agg.priorities.is_empty() {
                 pairs.push((host_language.clone(), injection_language.clone()));
             }
         }
@@ -180,9 +176,10 @@ pub(crate) fn format_concatenated_formatting_warning(pairs: &[(String, String)])
         .join(", ");
     Some(format!(
         "Bridge config sets aggregation strategy 'concatenated' for \
-         textDocument/formatting on {} (host->injection) pair(s): {}. \
-         Formatting always uses 'preferred' to avoid overlapping TextEdits; \
-         the configured strategy is ignored.",
+         textDocument/formatting with an empty 'priorities' list on {} \
+         (host->injection) pair(s): {}. The concatenated formatting pipeline \
+         requires a non-empty 'priorities' (it defines which servers run and \
+         in what order); these pairs fall back to 'preferred'.",
         pairs.len(),
         listed
     ))
@@ -538,6 +535,107 @@ mod tests {
         assert!(
             pairs.is_empty(),
             "method-specific Preferred must override wildcard Concatenated"
+        );
+    }
+
+    #[test]
+    fn concatenated_formatting_pairs_excludes_pairs_with_non_empty_priorities() {
+        // Since the concatenated formatting pipeline landed (#327), a
+        // `concatenated` strategy WITH a non-empty `priorities` list is a valid
+        // configuration that runs the pipeline — it must NOT be warned about.
+        let mut agg = HashMap::new();
+        agg.insert(
+            "textDocument/formatting".to_string(),
+            AggregationConfig {
+                priorities: Some(vec!["black".to_string(), "isort".to_string()]),
+                strategy: Some(AggregationStrategy::Concatenated),
+                max_fan_out: None,
+            },
+        );
+        let mut bridge = HashMap::new();
+        bridge.insert(
+            "python".to_string(),
+            BridgeLanguageConfig {
+                enabled: None,
+                aggregation: Some(agg),
+            },
+        );
+        let mut langs = HashMap::new();
+        langs.insert("markdown".to_string(), lang_settings(bridge));
+
+        let pairs = concatenated_formatting_pairs(&settings_with(langs));
+
+        assert!(
+            pairs.is_empty(),
+            "concatenated formatting with non-empty priorities runs the \
+             pipeline and must not be flagged as a misconfiguration"
+        );
+    }
+
+    #[test]
+    fn concatenated_formatting_pairs_inherits_priorities_from_wildcard_entry() {
+        // Field-level wildcard inheritance: the method entry sets the strategy,
+        // the "_" wildcard supplies the priorities. The resolved config has a
+        // non-empty priorities list, so the pipeline runs — no warning.
+        let mut agg = HashMap::new();
+        agg.insert(
+            "textDocument/formatting".to_string(),
+            AggregationConfig {
+                priorities: None,
+                strategy: Some(AggregationStrategy::Concatenated),
+                max_fan_out: None,
+            },
+        );
+        agg.insert(
+            "_".to_string(),
+            AggregationConfig {
+                priorities: Some(vec!["black".to_string()]),
+                strategy: None,
+                max_fan_out: None,
+            },
+        );
+        let mut bridge = HashMap::new();
+        bridge.insert(
+            "python".to_string(),
+            BridgeLanguageConfig {
+                enabled: None,
+                aggregation: Some(agg),
+            },
+        );
+        let mut langs = HashMap::new();
+        langs.insert("markdown".to_string(), lang_settings(bridge));
+
+        let pairs = concatenated_formatting_pairs(&settings_with(langs));
+
+        assert!(
+            pairs.is_empty(),
+            "priorities inherited from the wildcard entry must count as \
+             a configured (non-empty) pipeline definition"
+        );
+    }
+
+    #[test]
+    fn format_concatenated_formatting_warning_explains_empty_priorities_fallback() {
+        // The warning is now scoped to the actual misconfiguration —
+        // `concatenated` with EMPTY priorities — so the message must say the
+        // pipeline needs a non-empty priorities list and that these pairs fall
+        // back to 'preferred', not that the strategy is always ignored.
+        let msg = format_concatenated_formatting_warning(&[(
+            "markdown".to_string(),
+            "python".to_string(),
+        )])
+        .expect("non-empty input must yield a message");
+        assert!(
+            msg.contains("priorities"),
+            "message must mention the empty priorities cause; got: {msg}"
+        );
+        assert!(
+            msg.contains("preferred"),
+            "message must state the preferred fallback; got: {msg}"
+        );
+        assert!(
+            !msg.contains("the configured strategy is ignored"),
+            "stale 'strategy is ignored' phrasing must be retired; got: {msg}"
         );
     }
 

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -427,9 +427,10 @@ async fn dispatch_preferred_formatting(
 /// upstream `$/cancelRequest` reaches the in-flight downstream server through
 /// the `RequestIdCapture` middleware's existing fan-out.
 ///
-/// TODO(concatenated-formatting-pipeline): still to build (see the ADR):
-///   - discarding downstream `publishDiagnostics` targeting scratch URIs;
-///     prompt didClose currently minimizes (but does not eliminate) the window.
+/// Downstream `publishDiagnostics` targeting scratch URIs are discarded by
+/// the bridge reader (ADR Decision point 7; `is_scratch_publish_diagnostics`
+/// in `src/lsp/bridge/actor/reader.rs`), so the scratch documents this run
+/// opens can never surface speculative diagnostics to the editor.
 async fn dispatch_concatenated_formatting(
     region_ctx: &DocumentRequestContext,
     pool: Arc<crate::lsp::bridge::LanguageServerPool>,

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -1056,7 +1056,14 @@ fn reapply_host_line_prefixes(final_text: &str, host_line_prefixes: &[String]) -
         longest_common_prefix(host_line_prefixes)
     };
 
-    let mut out = String::with_capacity(final_text.len());
+    // Reserve for the prefixes being prepended too (slight over-reserve when
+    // empty lines get a trimmed prefix), so the string never reallocates.
+    let added_len = if line_count_preserved {
+        host_line_prefixes.iter().skip(1).map(String::len).sum()
+    } else {
+        (lines.len() - 1) * lcp.len()
+    };
+    let mut out = String::with_capacity(final_text.len() + added_len);
     for (i, line) in lines.iter().enumerate() {
         if i == 0 {
             out.push_str(line);

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -1092,7 +1092,7 @@ fn reapply_host_line_prefixes(final_text: &str, host_line_prefixes: &[String]) -
 
     let line_count_preserved = lines.len() == host_line_prefixes.len();
     let lcp = if line_count_preserved {
-        String::new()
+        ""
     } else {
         // A region whose content ends with '\n' carries a trailing
         // empty-prefix entry for the synthetic line bucket after the final
@@ -1136,7 +1136,7 @@ fn reapply_host_line_prefixes(final_text: &str, host_line_prefixes: &[String]) -
             // would double the marker.
             ""
         } else {
-            lcp.as_str()
+            lcp
         };
         // Empty output lines take the prefix with trailing whitespace
         // trimmed so the pipeline introduces no trailing-whitespace
@@ -1152,11 +1152,12 @@ fn reapply_host_line_prefixes(final_text: &str, host_line_prefixes: &[String]) -
 }
 
 /// Longest common prefix of all strings, on char boundaries. Empty input or
-/// any empty string yields the empty prefix.
-fn longest_common_prefix(strings: &[String]) -> String {
+/// any empty string yields the empty prefix. Returns a slice of the first
+/// string (the prefix is by definition a substring of it), so no allocation.
+fn longest_common_prefix(strings: &[String]) -> &str {
     let mut iter = strings.iter();
     let Some(first) = iter.next() else {
-        return String::new();
+        return "";
     };
     let mut prefix = first.as_str();
     for s in iter {
@@ -1171,7 +1172,7 @@ fn longest_common_prefix(strings: &[String]) -> String {
             break;
         }
     }
-    prefix.to_string()
+    prefix
 }
 
 /// Sort `edits` in place by `range.start` (line, then character).

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -372,6 +372,7 @@ async fn dispatch_preferred_formatting(
                         &t.virtual_content,
                         options,
                         t.upstream_id,
+                        None,
                     )
                     .await
             }
@@ -584,7 +585,15 @@ async fn dispatch_concatenated_formatting(
 
                 // Keep a copy for $/cancelRequest propagation on timeout: the
                 // request future inside the timeout consumes `upstream_id`.
-                let upstream_id_for_cancel = upstream_id.clone();
+                // Receives this step's downstream request id as soon as the
+                // bridge allocates it. The timeout arm below needs it because
+                // dropping the timed-out step future removes the request's
+                // upstream-id cancel mapping (router cleanup guard) before any
+                // cancel task could look it up — and the upstream id may also
+                // map to sibling regions' in-flight requests, which must NOT
+                // be cancelled by this step's timeout.
+                let step_downstream_id: std::sync::OnceLock<crate::lsp::bridge::RequestId> =
+                    std::sync::OnceLock::new();
 
                 // Everything that talks to the downstream server — capability
                 // probe (which may spawn/handshake a cold server), scratch
@@ -689,6 +698,7 @@ async fn dispatch_concatenated_formatting(
                             &current_text,
                             options,
                             upstream_id,
+                            Some(&step_downstream_id),
                         )
                         .await
                     } else {
@@ -711,6 +721,7 @@ async fn dispatch_concatenated_formatting(
                                     whole_region,
                                     options,
                                     upstream_id,
+                                    Some(&step_downstream_id),
                                 )
                                 .await
                             }
@@ -748,10 +759,16 @@ async fn dispatch_concatenated_formatting(
                         // step future abandons our side of the request, but the
                         // downstream server is still computing; per the ADR
                         // Consequences cancellation note, tell it to stop via
-                        // $/cancelRequest. Best-effort and detached: the
-                        // mapping may already be gone (the dropped future's
-                        // router cleanup races this), in which case
-                        // forward_cancel silently no-ops.
+                        // $/cancelRequest — scoped to the step's OWN downstream
+                        // request id (captured via the probe before the drop):
+                        // the upstream-id route is unusable here, both because
+                        // the dropped future's router cleanup has already
+                        // removed the mapping and because the upstream id can
+                        // fan out to sibling regions' in-flight requests.
+                        // Best-effort and detached. The probe is unset only
+                        // when the timeout fired before the request was even
+                        // registered (capability probe / didOpen), where there
+                        // is nothing to cancel.
                         log::warn!(
                             target: "kakehashi::formatting",
                             "concatenated formatting step for server {} timed out \
@@ -759,11 +776,13 @@ async fn dispatch_concatenated_formatting(
                             server_name,
                             step_budget
                         );
-                        if let Some(id) = upstream_id_for_cancel {
+                        if let Some(downstream_id) = step_downstream_id.get().copied() {
                             let pool = Arc::clone(&pool);
                             let server_name = server_name.clone();
                             tokio::spawn(async move {
-                                let _ = pool.forward_cancel(&server_name, &id).await;
+                                let _ = pool
+                                    .forward_cancel_downstream(&server_name, downstream_id)
+                                    .await;
                             });
                         }
                         None

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -108,6 +108,12 @@ impl Kakehashi {
         // Outer JoinSet: one task per injection region, all in parallel
         let mut outer_join_set: JoinSet<Option<Vec<TextEdit>>> = JoinSet::new();
 
+        // Shared host-text position mapper for prefix extraction, built at
+        // most once per request: constructing it is O(document size), so
+        // rebuilding per region would make many-region documents quadratic.
+        // Lazy because only concatenated-plan regions need it.
+        let mut host_mapper: Option<crate::text::PositionMapper> = None;
+
         for resolved in all_regions {
             let configs = self.bridge_configs_for_injection_language(
                 &language_name,
@@ -147,7 +153,10 @@ impl Kakehashi {
                     // (Decision point 4, `reapply_host_line_prefixes`).
                     let virtual_line_count =
                         region_ctx.resolved.virtual_content.matches('\n').count() + 1;
+                    let mapper = host_mapper
+                        .get_or_insert_with(|| crate::text::PositionMapper::new(snapshot.text()));
                     let host_line_prefixes = extract_host_line_prefixes(
+                        mapper,
                         snapshot.text(),
                         region_ctx.resolved.region.line_range.start,
                         &region_ctx.resolved.line_column_offsets,
@@ -1020,13 +1029,17 @@ fn region_replacement_range(original_virtual: &str, offset: &RegionOffset) -> Op
 /// An unresolvable position (stale offsets racing a host edit) degrades to an
 /// empty prefix for that line rather than failing the whole region — the same
 /// saturating posture the position translation code takes.
+///
+/// `mapper` must be built over the same `host_text`; the caller shares one
+/// mapper across all regions of a request, since constructing it is
+/// O(document size).
 fn extract_host_line_prefixes(
+    mapper: &crate::text::PositionMapper,
     host_text: &str,
     region_start_line: u32,
     line_column_offsets: &[u32],
     virtual_line_count: usize,
 ) -> Vec<String> {
-    let mapper = crate::text::PositionMapper::new(host_text);
     (0..virtual_line_count)
         .map(|i| {
             let column = line_column_offsets.get(i).copied().unwrap_or(0);
@@ -1797,7 +1810,8 @@ mod tests {
         // Region: python inside a blockquote, host lines 1..=2, content starts
         // at column 2 on each line ("> " prefix).
         let host = "before\n> x = 1\n> y = 2\nafter\n";
-        let prefixes = extract_host_line_prefixes(host, 1, &[2, 2], 2);
+        let mapper = crate::text::PositionMapper::new(host);
+        let prefixes = extract_host_line_prefixes(&mapper, host, 1, &[2, 2], 2);
         assert_eq!(prefixes, vec!["> ".to_string(), "> ".to_string()]);
     }
 
@@ -1806,7 +1820,8 @@ mod tests {
         // Non-blockquote regions carry a single-entry offset list (line 0
         // only); continuation lines have no prefix.
         let host = "# Doc\ncode line 0\ncode line 1\n";
-        let prefixes = extract_host_line_prefixes(host, 1, &[0], 2);
+        let mapper = crate::text::PositionMapper::new(host);
+        let prefixes = extract_host_line_prefixes(&mapper, host, 1, &[0], 2);
         assert_eq!(prefixes, vec![String::new(), String::new()]);
     }
 
@@ -1816,7 +1831,8 @@ mod tests {
         // correct byte boundary.
         let host = "héllo→x = 1\n";
         // "héllo→" is 6 UTF-16 code units (é and → are 1 each).
-        let prefixes = extract_host_line_prefixes(host, 0, &[6], 1);
+        let mapper = crate::text::PositionMapper::new(host);
+        let prefixes = extract_host_line_prefixes(&mapper, host, 0, &[6], 1);
         assert_eq!(prefixes, vec!["héllo→".to_string()]);
     }
 

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -321,32 +321,20 @@ fn select_pipeline_step_request(supports_full: bool, supports_range: bool) -> Pi
 /// needed, and waiting up to `timeout` — the step's remaining budget — for a
 /// cold server to finish initializing so its capabilities are actually
 /// known) and map them to the step's request kind via
-/// [`select_pipeline_step_request`]. The second probe is skipped when full
-/// formatting is advertised — the answer can no longer matter — and reuses
-/// the already-Ready connection when it does run.
+/// [`select_pipeline_step_request`]. The connection handle is fetched once
+/// and both capabilities are read off it directly, so the probe locks the
+/// pool's connection map a single time.
 async fn pipeline_step_request_kind(
     pool: &crate::lsp::bridge::LanguageServerPool,
     server_name: &str,
     server_config: &crate::config::settings::BridgeServerConfig,
     timeout: std::time::Duration,
 ) -> std::io::Result<PipelineStepRequest> {
-    let supports_full = pool
-        .server_advertises(
-            server_name,
-            server_config,
-            "textDocument/formatting",
-            timeout,
-        )
+    let handle = pool
+        .get_or_create_connection_wait_ready(server_name, server_config, timeout)
         .await?;
-    let supports_range = !supports_full
-        && pool
-            .server_advertises(
-                server_name,
-                server_config,
-                "textDocument/rangeFormatting",
-                timeout,
-            )
-            .await?;
+    let supports_full = handle.has_capability("textDocument/formatting");
+    let supports_range = handle.has_capability("textDocument/rangeFormatting");
     Ok(select_pipeline_step_request(supports_full, supports_range))
 }
 

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -259,6 +259,35 @@ fn plan_region_format(
     }
 }
 
+/// Whole-pipeline time budget for one region's concatenated formatting run.
+///
+/// Reuses the explicit per-request aggregation timeout from
+/// ls-bridge-server-pool-coordination (5s for explicit user actions) as the
+/// whole-pipeline bound, per the concatenated-formatting-pipeline Consequences
+/// note — no formatting-specific timeout config is introduced. Each step's
+/// deadline is the *remaining* share of this budget
+/// ([`remaining_step_budget`]), so a slow early step exhausts the budget and
+/// the rest are skipped instead of stacking serial round-trips past the
+/// client's own request timeout.
+const PIPELINE_BUDGET: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Minimum per-step budget worth issuing a request for (ADR Decision point 6:
+/// "below a small floor the pipeline skips the rest outright rather than
+/// issuing requests almost certain to time out").
+const PIPELINE_STEP_FLOOR: std::time::Duration = std::time::Duration::from_millis(50);
+
+/// Per-step deadline: the remaining share of the whole-pipeline budget
+/// (`budget − elapsed`), or `None` when the remainder is below `floor` (skip
+/// the step — and, since `elapsed` only grows, every step after it).
+fn remaining_step_budget(
+    budget: std::time::Duration,
+    elapsed: std::time::Duration,
+    floor: std::time::Duration,
+) -> Option<std::time::Duration> {
+    let remaining = budget.checked_sub(elapsed)?;
+    (remaining >= floor).then_some(remaining)
+}
+
 /// Which request one concatenated-pipeline step issues for a server, keyed on
 /// the capabilities it advertises (concatenated-formatting-pipeline Decision
 /// point 3.2).
@@ -388,9 +417,15 @@ async fn dispatch_preferred_formatting(
 /// "already formatted" (`Some(vec![])` from the bridge transform) and never
 /// triggers the fallback.
 ///
+/// Each step runs under the remaining share of the whole-pipeline budget
+/// ([`PIPELINE_BUDGET`] / [`remaining_step_budget`], ADR Decision point 6): a
+/// timed-out step is skipped (its downstream request is best-effort cancelled
+/// via `$/cancelRequest`) and the budget keeps shrinking, so the pipeline can
+/// never stack serial round-trips past the client's own request timeout. An
+/// upstream `$/cancelRequest` reaches the in-flight downstream server through
+/// the `RequestIdCapture` middleware's existing fan-out.
+///
 /// TODO(concatenated-formatting-pipeline): still to build (see the ADR):
-///   - per-step remaining-budget timeout and concurrent $/cancelRequest
-///     propagation (Decision points 6 and the Consequences cancellation note);
 ///   - discarding downstream `publishDiagnostics` targeting scratch URIs;
 ///     prompt didClose currently minimizes (but does not eliminate) the window.
 async fn dispatch_concatenated_formatting(
@@ -473,6 +508,11 @@ async fn dispatch_concatenated_formatting(
     let _scratch_guard =
         ScratchCleanupGuard::new(Arc::clone(&pool), uri.clone(), Arc::clone(&open_scratch));
 
+    // Start of the whole-pipeline budget window (ADR Decision point 6): every
+    // step's deadline is measured against this single origin, so serial
+    // round-trips share one bound instead of each getting a fresh timeout.
+    let pipeline_start = std::time::Instant::now();
+
     let pipeline_fut = run_sequential_format_pipeline(original_virtual, &server_names, {
         let pool = Arc::clone(&pool);
         let open_scratch = Arc::clone(&open_scratch);
@@ -494,139 +534,201 @@ async fn dispatch_concatenated_formatting(
                     return (current_text, None);
                 };
 
-                // ADR Decision point 3.2: the pipeline prefers full formatting;
-                // the fallback to whole-region rangeFormatting keys on
-                // CAPABILITY, never on the response (a capable server's `null`
-                // is the authoritative "already formatted" and arrives as
-                // `Some(vec![])` from the bridge transform). A probe error
-                // (connection spawn/handshake failure) is a failed step:
-                // skip-and-continue (ADR point 6).
-                let step_request =
-                    match pipeline_step_request_kind(&pool, &server_name, &server_config).await {
-                        Ok(kind) => kind,
+                // ADR Decision point 6: this step's deadline is the REMAINING
+                // share of the whole-pipeline budget. Below the floor, skip
+                // outright — a request almost certain to time out is pure
+                // waste, and every later step will skip the same way.
+                let Some(step_budget) = remaining_step_budget(
+                    PIPELINE_BUDGET,
+                    pipeline_start.elapsed(),
+                    PIPELINE_STEP_FLOOR,
+                ) else {
+                    log::warn!(
+                        target: "kakehashi::formatting",
+                        "concatenated formatting step for server {} skipped: \
+                         pipeline budget ({:?}) exhausted (ADR point 6)",
+                        server_name,
+                        PIPELINE_BUDGET
+                    );
+                    return (current_text, None);
+                };
+
+                // Keep a copy for $/cancelRequest propagation on timeout: the
+                // request future inside the timeout consumes `upstream_id`.
+                let upstream_id_for_cancel = upstream_id.clone();
+
+                // Everything that talks to the downstream server — capability
+                // probe (which may spawn/handshake a cold server), scratch
+                // didOpen, and the formatting request itself — runs under this
+                // step's deadline, so a hung or slow server can only consume
+                // its remaining share of the budget.
+                let step_fut = async {
+                    // ADR Decision point 3.2: the pipeline prefers full
+                    // formatting; the fallback to whole-region rangeFormatting
+                    // keys on CAPABILITY, never on the response (a capable
+                    // server's `null` is the authoritative "already formatted"
+                    // and arrives as `Some(vec![])` from the bridge transform).
+                    // A probe error (connection spawn/handshake failure) is a
+                    // failed step: skip-and-continue (ADR point 6).
+                    let step_request =
+                        match pipeline_step_request_kind(&pool, &server_name, &server_config).await
+                        {
+                            Ok(kind) => kind,
+                            Err(e) => {
+                                log::warn!(
+                                    target: "kakehashi::formatting",
+                                    "concatenated formatting step for server {} failed during \
+                                     capability probe; skipping (ADR point 6): {}",
+                                    server_name,
+                                    e
+                                );
+                                return None;
+                            }
+                        };
+                    if step_request == PipelineStepRequest::Skip {
+                        // Neither documentFormattingProvider nor
+                        // documentRangeFormattingProvider: contribute nothing and
+                        // send no unsupported request (ADR point 3.2).
+                        log::debug!(
+                            target: "kakehashi::formatting",
+                            "concatenated formatting step for server {} skipped: \
+                             server advertises neither documentFormattingProvider \
+                             nor documentRangeFormattingProvider",
+                            server_name
+                        );
+                        return None;
+                    }
+
+                    let step = step_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    let scratch_id = scratch_region_id(&region_id, run_seq, step);
+
+                    // Build the scratch URI up front and register it as "open" in
+                    // the shared tracker BEFORE the request, so that if this
+                    // future is dropped mid-send by a cancel or the step timeout,
+                    // `ScratchCleanupGuard`'s Drop still closes it. Skipped only
+                    // when the host URL could not be converted (then no didClose
+                    // is possible anyway).
+                    let scratch_uri = host_uri_lsp
+                        .as_ref()
+                        .map(|h| VirtualDocumentUri::new(h, &injection_language, &scratch_id));
+                    if let Some(scratch_uri) = scratch_uri.as_ref() {
+                        push_open_scratch(
+                            &open_scratch,
+                            OpenScratchDoc {
+                                uri: scratch_uri.clone(),
+                                server_name: server_name.clone(),
+                            },
+                        );
+                    }
+
+                    // The bridge translates the returned edits back to host
+                    // coordinates, but the pipeline applies them to the *virtual*
+                    // accumulated text, so request a fresh virtual-coordinate
+                    // result by passing the zero offset for the response transform.
+                    // The region offset is only re-applied once, when the final
+                    // text is collapsed into the host replacement edit below.
+                    //
+                    // Per-step host-transform interaction: `send_formatting_request`
+                    // runs `transform_formatting_response_to_host`, which clamps
+                    // edits to a synthetic EOF and drops any past `virtual_line_count`
+                    // for *this step's* `current_text`. Because we pass
+                    // `RegionOffset::new(0, 0)` (an identity translation) and the
+                    // step's own current text, those edits come back already
+                    // EOF-clamped and host-translated by a zero offset — i.e. still
+                    // in virtual coordinates relative to `current_text` — so applying
+                    // them to the virtual accumulated text is correct. The single
+                    // real region-offset translation happens once in the precomputed
+                    // `region_replacement_range`.
+                    // (`apply_text_edits` does its own clamping as a general safety
+                    // net, independent of this transform.)
+                    let send_result = if step_request == PipelineStepRequest::Full {
+                        pool.send_formatting_request(
+                            &server_name,
+                            &server_config,
+                            &uri,
+                            &injection_language,
+                            &scratch_id,
+                            RegionOffset::new(0, 0),
+                            &current_text,
+                            options,
+                            upstream_id,
+                        )
+                        .await
+                    } else {
+                        // WholeRegionRange (Skip already returned above): the
+                        // range-only server formats the entire region, expressed
+                        // as a range over the step's current text. With the zero
+                        // offset, host and virtual coordinates coincide, so the
+                        // whole-region replacement range doubles as the request
+                        // range.
+                        match region_replacement_range(&current_text, &RegionOffset::new(0, 0)) {
+                            Some(whole_region) => {
+                                pool.send_range_formatting_request(
+                                    &server_name,
+                                    &server_config,
+                                    &uri,
+                                    &injection_language,
+                                    &scratch_id,
+                                    RegionOffset::new(0, 0),
+                                    &current_text,
+                                    whole_region,
+                                    options,
+                                    upstream_id,
+                                )
+                                .await
+                            }
+                            // Unresolvable end position (mapper bug / corrupt
+                            // content): treat as a failed step rather than sending
+                            // an unbounded range downstream.
+                            None => Ok(None),
+                        }
+                    };
+
+                    // ADR Decision point 6 (best-effort, skip-and-continue): a
+                    // failed step is skipped — never surfaced to the editor — but is
+                    // logged so the misbehaving server stays diagnosable. We log the
+                    // downstream error here (before mapping to `None`) instead of
+                    // silently dropping it with `.ok().flatten()`.
+                    match send_result {
+                        Ok(edits) => edits,
                         Err(e) => {
                             log::warn!(
                                 target: "kakehashi::formatting",
-                                "concatenated formatting step for server {} failed during \
-                                 capability probe; skipping (ADR point 6): {}",
+                                "concatenated formatting step for server {} failed; skipping (ADR point 6): {}",
                                 server_name,
                                 e
                             );
-                            return (current_text, None);
+                            None
                         }
-                    };
-                if step_request == PipelineStepRequest::Skip {
-                    // Neither documentFormattingProvider nor
-                    // documentRangeFormattingProvider: contribute nothing and
-                    // send no unsupported request (ADR point 3.2).
-                    log::debug!(
-                        target: "kakehashi::formatting",
-                        "concatenated formatting step for server {} skipped: \
-                         server advertises neither documentFormattingProvider \
-                         nor documentRangeFormattingProvider",
-                        server_name
-                    );
-                    return (current_text, None);
-                }
-
-                let step = step_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                let scratch_id = scratch_region_id(&region_id, run_seq, step);
-
-                // Build the scratch URI up front and register it as "open" in the
-                // shared tracker BEFORE the request, so that if this future is
-                // dropped mid-send by a cancel, `ScratchCleanupGuard`'s Drop still
-                // closes it. Skipped only when the host URL could not be
-                // converted (then no didClose is possible anyway).
-                let scratch_uri = host_uri_lsp
-                    .as_ref()
-                    .map(|h| VirtualDocumentUri::new(h, &injection_language, &scratch_id));
-                if let Some(scratch_uri) = scratch_uri.as_ref() {
-                    push_open_scratch(
-                        &open_scratch,
-                        OpenScratchDoc {
-                            uri: scratch_uri.clone(),
-                            server_name: server_name.clone(),
-                        },
-                    );
-                }
-
-                // The bridge translates the returned edits back to host
-                // coordinates, but the pipeline applies them to the *virtual*
-                // accumulated text, so request a fresh virtual-coordinate
-                // result by passing the zero offset for the response transform.
-                // The region offset is only re-applied once, when the final
-                // text is collapsed into the host replacement edit below.
-                //
-                // Per-step host-transform interaction: `send_formatting_request`
-                // runs `transform_formatting_response_to_host`, which clamps
-                // edits to a synthetic EOF and drops any past `virtual_line_count`
-                // for *this step's* `current_text`. Because we pass
-                // `RegionOffset::new(0, 0)` (an identity translation) and the
-                // step's own current text, those edits come back already
-                // EOF-clamped and host-translated by a zero offset — i.e. still
-                // in virtual coordinates relative to `current_text` — so applying
-                // them to the virtual accumulated text is correct. The single
-                // real region-offset translation happens once in the precomputed
-                // `region_replacement_range`.
-                // (`apply_text_edits` does its own clamping as a general safety
-                // net, independent of this transform.)
-                let send_result = if step_request == PipelineStepRequest::Full {
-                    pool.send_formatting_request(
-                        &server_name,
-                        &server_config,
-                        &uri,
-                        &injection_language,
-                        &scratch_id,
-                        RegionOffset::new(0, 0),
-                        &current_text,
-                        options,
-                        upstream_id,
-                    )
-                    .await
-                } else {
-                    // WholeRegionRange (Skip already returned above): the
-                    // range-only server formats the entire region, expressed
-                    // as a range over the step's current text. With the zero
-                    // offset, host and virtual coordinates coincide, so the
-                    // whole-region replacement range doubles as the request
-                    // range.
-                    match region_replacement_range(&current_text, &RegionOffset::new(0, 0)) {
-                        Some(whole_region) => {
-                            pool.send_range_formatting_request(
-                                &server_name,
-                                &server_config,
-                                &uri,
-                                &injection_language,
-                                &scratch_id,
-                                RegionOffset::new(0, 0),
-                                &current_text,
-                                whole_region,
-                                options,
-                                upstream_id,
-                            )
-                            .await
-                        }
-                        // Unresolvable end position (mapper bug / corrupt
-                        // content): treat as a failed step rather than sending
-                        // an unbounded range downstream.
-                        None => Ok(None),
                     }
                 };
 
-                // ADR Decision point 6 (best-effort, skip-and-continue): a
-                // failed step is skipped — never surfaced to the editor — but is
-                // logged so the misbehaving server stays diagnosable. We log the
-                // downstream error here (before mapping to `None`) instead of
-                // silently dropping it with `.ok().flatten()`.
-                let result = match send_result {
-                    Ok(edits) => edits,
-                    Err(e) => {
+                let result = match tokio::time::timeout(step_budget, step_fut).await {
+                    Ok(result) => result,
+                    Err(_) => {
+                        // Per-step timeout: a failed step (ADR point 6) — skip
+                        // and continue with the unchanged text. Dropping the
+                        // step future abandons our side of the request, but the
+                        // downstream server is still computing; per the ADR
+                        // Consequences cancellation note, tell it to stop via
+                        // $/cancelRequest. Best-effort and detached: the
+                        // mapping may already be gone (the dropped future's
+                        // router cleanup races this), in which case
+                        // forward_cancel silently no-ops.
                         log::warn!(
                             target: "kakehashi::formatting",
-                            "concatenated formatting step for server {} failed; skipping (ADR point 6): {}",
+                            "concatenated formatting step for server {} timed out \
+                             after {:?}; skipping (ADR point 6)",
                             server_name,
-                            e
+                            step_budget
                         );
+                        if let Some(id) = upstream_id_for_cancel {
+                            let pool = Arc::clone(&pool);
+                            let server_name = server_name.clone();
+                            tokio::spawn(async move {
+                                let _ = pool.forward_cancel(&server_name, &id).await;
+                            });
+                        }
                         None
                     }
                 };
@@ -653,8 +755,11 @@ async fn dispatch_concatenated_formatting(
     // On cancel we just stop polling the pipeline and return None; the scratch
     // documents the run opened are closed by `_scratch_guard`'s Drop (which fires
     // on this return as well as on a future-level abort), so there is no explicit
-    // sweep to interrupt. (Per-step $/cancelRequest propagation to the downstream
-    // server is a follow-up — TODO(concatenated-formatting-pipeline).)
+    // sweep to interrupt. Downstream $/cancelRequest propagation needs no work
+    // here: the `RequestIdCapture` middleware already fans the upstream cancel
+    // out to every downstream server registered for this upstream id — which
+    // includes the step currently in flight (`forward_cancel_by_upstream_id`).
+    // The step-timeout path propagates its own cancel inside the step closure.
     let cancelled;
     let final_text = match cancel_rx {
         Some(mut rx) => {
@@ -1426,6 +1531,71 @@ mod tests {
             drained.len(),
             1,
             "poison recovery must preserve tracked scratch docs"
+        );
+    }
+
+    // ==========================================================================
+    // remaining_step_budget (concatenated-formatting-pipeline Decision point 6:
+    // per-step deadline = remaining share of the whole-pipeline budget)
+    // ==========================================================================
+
+    #[test]
+    fn step_budget_is_the_remaining_share_of_the_pipeline_budget() {
+        use std::time::Duration;
+        // 5s budget, 2s elapsed → the next step gets the remaining 3s, not a
+        // fixed per-step value: a slow early step must not let cumulative
+        // latency overrun the client's request timeout.
+        assert_eq!(
+            remaining_step_budget(
+                Duration::from_secs(5),
+                Duration::from_secs(2),
+                Duration::from_millis(50)
+            ),
+            Some(Duration::from_secs(3))
+        );
+    }
+
+    #[test]
+    fn step_budget_skips_steps_below_the_floor() {
+        use std::time::Duration;
+        // Less than the floor remaining: issuing a request almost certain to
+        // time out is pointless — skip the rest outright (ADR point 6).
+        assert_eq!(
+            remaining_step_budget(
+                Duration::from_secs(5),
+                Duration::from_millis(4970),
+                Duration::from_millis(50)
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn step_budget_exactly_at_floor_still_runs() {
+        use std::time::Duration;
+        // Boundary: exactly the floor remaining is still worth issuing.
+        assert_eq!(
+            remaining_step_budget(
+                Duration::from_secs(5),
+                Duration::from_millis(4950),
+                Duration::from_millis(50)
+            ),
+            Some(Duration::from_millis(50))
+        );
+    }
+
+    #[test]
+    fn step_budget_handles_elapsed_beyond_budget() {
+        use std::time::Duration;
+        // Elapsed past the budget (a step blocked long): no underflow panic,
+        // just skip.
+        assert_eq!(
+            remaining_step_budget(
+                Duration::from_secs(5),
+                Duration::from_secs(60),
+                Duration::from_millis(50)
+            ),
+            None
         );
     }
 

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -244,6 +244,54 @@ fn plan_region_format(
     }
 }
 
+/// Which request one concatenated-pipeline step issues for a server, keyed on
+/// the capabilities it advertises (concatenated-formatting-pipeline Decision
+/// point 3.2).
+#[derive(Debug, PartialEq, Eq)]
+enum PipelineStepRequest {
+    /// `documentFormattingProvider` advertised: full `textDocument/formatting`.
+    Full,
+    /// Range-only server (`documentRangeFormattingProvider` without
+    /// `documentFormattingProvider`): `textDocument/rangeFormatting` over the
+    /// entire region, so the server still participates in the pipeline.
+    WholeRegionRange,
+    /// Neither provider advertised: the step contributes nothing and sends no
+    /// unsupported request downstream.
+    Skip,
+}
+
+/// Pure capability-to-request mapping for one pipeline step (ADR Decision
+/// point 3.2). Full formatting always wins when advertised; the range
+/// fallback is itself gated on the range capability.
+fn select_pipeline_step_request(supports_full: bool, supports_range: bool) -> PipelineStepRequest {
+    if supports_full {
+        PipelineStepRequest::Full
+    } else if supports_range {
+        PipelineStepRequest::WholeRegionRange
+    } else {
+        PipelineStepRequest::Skip
+    }
+}
+
+/// Probe the server's advertised formatting capabilities (spawning it if
+/// needed) and map them to the step's request kind via
+/// [`select_pipeline_step_request`]. The second probe is skipped when full
+/// formatting is advertised — the answer can no longer matter.
+async fn pipeline_step_request_kind(
+    pool: &crate::lsp::bridge::LanguageServerPool,
+    server_name: &str,
+    server_config: &crate::config::settings::BridgeServerConfig,
+) -> std::io::Result<PipelineStepRequest> {
+    let supports_full = pool
+        .server_advertises(server_name, server_config, "textDocument/formatting")
+        .await?;
+    let supports_range = !supports_full
+        && pool
+            .server_advertises(server_name, server_config, "textDocument/rangeFormatting")
+            .await?;
+    Ok(select_pipeline_step_request(supports_full, supports_range))
+}
+
 /// `preferred`-strategy formatting for one region: the existing
 /// first-non-empty-wins fan-out, factored out of the per-region task body.
 async fn dispatch_preferred_formatting(
@@ -274,10 +322,12 @@ async fn dispatch_preferred_formatting(
             }
         },
         // `Some(vec![])` is an authoritative "no edits needed" from the
-        // formatter (e.g., ruff signaling the code is already formatted) —
+        // formatter — both an explicit empty list and (since the bridge
+        // transform stopped collapsing it) a `null` response per LSP — so
         // accept it instead of falling through to a lower-priority server that
-        // might re-format the same code. `None` still means "no response" and
-        // triggers fallback.
+        // might re-format the same code. `None` now strictly means "no usable
+        // response" (missing provider, error, malformed payload) and triggers
+        // fallback.
         |opt| opt.is_some(),
         region_cancel_rx,
     )
@@ -315,9 +365,15 @@ async fn dispatch_preferred_formatting(
 /// removes the cancel-during-cleanup edge cases the old awaited sweep had: a
 /// cancel mid-`didClose` can no longer orphan a downstream doc.
 ///
+/// Each step keys its request on the server's advertised capabilities
+/// ([`select_pipeline_step_request`], ADR Decision point 3.2): full formatting
+/// when `documentFormattingProvider` is advertised, whole-region
+/// `rangeFormatting` for range-only servers, and no request at all for servers
+/// advertising neither. A capable server's `null` response is authoritative
+/// "already formatted" (`Some(vec![])` from the bridge transform) and never
+/// triggers the fallback.
+///
 /// TODO(concatenated-formatting-pipeline): still to build (see the ADR):
-///   - capability-based full -> rangeFormatting fallback for range-only servers,
-///     distinguishing "no capability" from a `null` "already formatted";
 ///   - per-step remaining-budget timeout and concurrent $/cancelRequest
 ///     propagation (Decision points 6 and the Consequences cancellation note);
 ///   - discarding downstream `publishDiagnostics` targeting scratch URIs;
@@ -418,6 +474,42 @@ async fn dispatch_concatenated_formatting(
                 let Some(server_config) = server_config else {
                     return (current_text, None);
                 };
+
+                // ADR Decision point 3.2: the pipeline prefers full formatting;
+                // the fallback to whole-region rangeFormatting keys on
+                // CAPABILITY, never on the response (a capable server's `null`
+                // is the authoritative "already formatted" and arrives as
+                // `Some(vec![])` from the bridge transform). A probe error
+                // (connection spawn/handshake failure) is a failed step:
+                // skip-and-continue (ADR point 6).
+                let step_request =
+                    match pipeline_step_request_kind(&pool, &server_name, &server_config).await {
+                        Ok(kind) => kind,
+                        Err(e) => {
+                            log::warn!(
+                                target: "kakehashi::formatting",
+                                "concatenated formatting step for server {} failed during \
+                                 capability probe; skipping (ADR point 6): {}",
+                                server_name,
+                                e
+                            );
+                            return (current_text, None);
+                        }
+                    };
+                if step_request == PipelineStepRequest::Skip {
+                    // Neither documentFormattingProvider nor
+                    // documentRangeFormattingProvider: contribute nothing and
+                    // send no unsupported request (ADR point 3.2).
+                    log::debug!(
+                        target: "kakehashi::formatting",
+                        "concatenated formatting step for server {} skipped: \
+                         server advertises neither documentFormattingProvider \
+                         nor documentRangeFormattingProvider",
+                        server_name
+                    );
+                    return (current_text, None);
+                }
+
                 let step = step_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 let scratch_id = scratch_region_id(&region_id, run_seq, step);
 
@@ -459,8 +551,8 @@ async fn dispatch_concatenated_formatting(
                 // `region_replacement_range`.
                 // (`apply_text_edits` does its own clamping as a general safety
                 // net, independent of this transform.)
-                let send_result = pool
-                    .send_formatting_request(
+                let send_result = if step_request == PipelineStepRequest::Full {
+                    pool.send_formatting_request(
                         &server_name,
                         &server_config,
                         &uri,
@@ -471,7 +563,36 @@ async fn dispatch_concatenated_formatting(
                         options,
                         upstream_id,
                     )
-                    .await;
+                    .await
+                } else {
+                    // WholeRegionRange (Skip already returned above): the
+                    // range-only server formats the entire region, expressed
+                    // as a range over the step's current text. With the zero
+                    // offset, host and virtual coordinates coincide, so the
+                    // whole-region replacement range doubles as the request
+                    // range.
+                    match region_replacement_range(&current_text, &RegionOffset::new(0, 0)) {
+                        Some(whole_region) => {
+                            pool.send_range_formatting_request(
+                                &server_name,
+                                &server_config,
+                                &uri,
+                                &injection_language,
+                                &scratch_id,
+                                RegionOffset::new(0, 0),
+                                &current_text,
+                                whole_region,
+                                options,
+                                upstream_id,
+                            )
+                            .await
+                        }
+                        // Unresolvable end position (mapper bug / corrupt
+                        // content): treat as a failed step rather than sending
+                        // an unbounded range downstream.
+                        None => Ok(None),
+                    }
+                };
 
                 // ADR Decision point 6 (best-effort, skip-and-continue): a
                 // failed step is skipped — never surfaced to the editor — but is
@@ -964,6 +1085,46 @@ mod tests {
         assert_eq!(
             plan_region_format(AggregationStrategy::Concatenated, &priorities, &configs),
             RegionFormatPlan::Concatenated(vec!["black".to_string()])
+        );
+    }
+
+    // ==========================================================================
+    // select_pipeline_step_request (concatenated-formatting-pipeline Decision
+    // point 3.2: capability-based full -> rangeFormatting fallback)
+    // ==========================================================================
+
+    #[test]
+    fn step_request_prefers_full_formatting_when_advertised() {
+        // A server with documentFormattingProvider gets a full formatting
+        // request — even if it also advertises range formatting.
+        assert_eq!(
+            select_pipeline_step_request(true, true),
+            PipelineStepRequest::Full
+        );
+        assert_eq!(
+            select_pipeline_step_request(true, false),
+            PipelineStepRequest::Full
+        );
+    }
+
+    #[test]
+    fn step_request_falls_back_to_whole_region_range_for_range_only_server() {
+        // No documentFormattingProvider but documentRangeFormattingProvider:
+        // the step issues rangeFormatting over the entire region so the
+        // range-only server still participates in the pipeline.
+        assert_eq!(
+            select_pipeline_step_request(false, true),
+            PipelineStepRequest::WholeRegionRange
+        );
+    }
+
+    #[test]
+    fn step_request_skips_server_advertising_neither_provider() {
+        // Neither provider: contribute nothing, and crucially send no
+        // unsupported request downstream.
+        assert_eq!(
+            select_pipeline_step_request(false, false),
+            PipelineStepRequest::Skip
         );
     }
 

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -917,12 +917,15 @@ fn lock_open_scratch(
 /// region — no host-file collision) and appends a `-kakehashi-scratch-{run}-{step}`
 /// suffix: the `run` (a process-global sequence) keeps concurrent runs for the
 /// same region distinct, and `step` keeps each step within a run distinct. The
-/// `kakehashi-scratch` marker (Decision point 7) lets external tools (file
-/// watchers, build tools, test runners) recognize and ignore these throwaway
-/// documents. It still flows through [`VirtualDocumentUri::new`], which also
-/// wraps it in the `kakehashi-virtual-uri-` filename marker and preserves the
-/// host directory and language extension required for downstream config and
-/// parser discovery.
+/// scratch marker ([`VirtualDocumentUri::SCRATCH_ID_MARKER`], Decision
+/// point 7) lets external tools (file watchers, build tools, test runners)
+/// recognize and ignore these throwaway documents, and is what the bridge
+/// reader keys on to discard downstream `publishDiagnostics` targeting them
+/// (`VirtualDocumentUri::is_scratch_uri`). It still flows through
+/// [`VirtualDocumentUri::new`], which also wraps it in the
+/// `kakehashi-virtual-uri-` filename marker and preserves the host directory
+/// and language extension required for downstream config and parser
+/// discovery.
 /// Process-global, monotonically increasing pipeline-run sequence. The per-step
 /// counter alone only makes scratch ids unique *within* a single pipeline run;
 /// two concatenated-formatting requests for the same host region overlapping in
@@ -934,7 +937,8 @@ fn lock_open_scratch(
 static SCRATCH_RUN_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
 fn scratch_region_id(region_id: &str, run: usize, step: usize) -> String {
-    format!("{region_id}-kakehashi-scratch-{run}-{step}")
+    let marker = VirtualDocumentUri::SCRATCH_ID_MARKER;
+    format!("{region_id}{marker}{run}-{step}")
 }
 
 /// Compute the host-coordinate `Range` that the concatenated pipeline's single
@@ -1443,6 +1447,24 @@ mod tests {
             VirtualDocumentUri::is_virtual_uri(&uri_string),
             "scratch URI must be recognized as virtual: {uri_string}"
         );
+    }
+
+    #[test]
+    fn scratch_region_id_produces_uri_recognized_as_scratch() {
+        // The reader discards downstream publishDiagnostics for scratch URIs
+        // by keying on the shared SCRATCH_ID_MARKER; the id construction and
+        // that detection must agree (Decision point 7).
+        use crate::lsp::bridge::VirtualDocumentUri;
+        let host_uri: tower_lsp_server::ls_types::Uri = "file:///project/doc.md".parse().unwrap();
+        let id = scratch_region_id("REGION", 4, 2);
+        let uri = VirtualDocumentUri::new(&host_uri, "python", &id).to_uri_string();
+        assert!(
+            VirtualDocumentUri::is_scratch_uri(&uri),
+            "scratch id must yield a URI the reader recognizes as scratch: {uri}"
+        );
+        // And the canonical region document must NOT be flagged.
+        let canonical = VirtualDocumentUri::new(&host_uri, "python", "REGION").to_uri_string();
+        assert!(!VirtualDocumentUri::is_scratch_uri(&canonical));
     }
 
     // ==========================================================================

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -512,6 +512,10 @@ async fn dispatch_concatenated_formatting(
     // step's deadline is measured against this single origin, so serial
     // round-trips share one bound instead of each getting a fresh timeout.
     let pipeline_start = std::time::Instant::now();
+    // One-way sentinel so budget exhaustion is WARNed once per pipeline run:
+    // every remaining server skips the same way, and one WARN per skipped
+    // server would spam the log for a single formatting request.
+    let budget_exhaustion_warned = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
     let pipeline_fut = run_sequential_format_pipeline(original_virtual, &server_names, {
         let pool = Arc::clone(&pool);
@@ -525,6 +529,7 @@ async fn dispatch_concatenated_formatting(
             let upstream_id = upstream_id.clone();
             let server_config = server_config_for(&server_name);
             let step_counter = Arc::clone(&step_counter);
+            let budget_exhaustion_warned = Arc::clone(&budget_exhaustion_warned);
             let host_uri_lsp = host_uri_lsp.clone();
             let open_scratch = Arc::clone(&open_scratch);
             async move {
@@ -543,13 +548,25 @@ async fn dispatch_concatenated_formatting(
                     pipeline_start.elapsed(),
                     PIPELINE_STEP_FLOOR,
                 ) else {
-                    log::warn!(
-                        target: "kakehashi::formatting",
-                        "concatenated formatting step for server {} skipped: \
-                         pipeline budget ({:?}) exhausted (ADR point 6)",
-                        server_name,
-                        PIPELINE_BUDGET
-                    );
+                    // WARN only for the first exhausted step; the remaining
+                    // servers skip identically, so they get debug level.
+                    if !budget_exhaustion_warned.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                        log::warn!(
+                            target: "kakehashi::formatting",
+                            "concatenated formatting pipeline budget ({:?}) \
+                             exhausted; skipping server {} and all remaining \
+                             steps (ADR point 6)",
+                            PIPELINE_BUDGET,
+                            server_name
+                        );
+                    } else {
+                        log::debug!(
+                            target: "kakehashi::formatting",
+                            "concatenated formatting step for server {} skipped: \
+                             pipeline budget exhausted",
+                            server_name
+                        );
+                    }
                     return (current_text, None);
                 };
 

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -588,12 +588,16 @@ async fn dispatch_concatenated_formatting(
                     if step_request == PipelineStepRequest::Skip {
                         // Neither documentFormattingProvider nor
                         // documentRangeFormattingProvider: contribute nothing and
-                        // send no unsupported request (ADR point 3.2).
+                        // send no unsupported request (ADR point 3.2). The probe
+                        // also reports no capability while the connection is
+                        // still initializing (cold start), so the log mentions
+                        // that case — a later request will see the Ready server.
                         log::debug!(
                             target: "kakehashi::formatting",
                             "concatenated formatting step for server {} skipped: \
                              server advertises neither documentFormattingProvider \
-                             nor documentRangeFormattingProvider",
+                             nor documentRangeFormattingProvider (or its \
+                             connection is still initializing)",
                             server_name
                         );
                         return None;
@@ -1016,8 +1020,15 @@ fn extract_host_line_prefixes(
                 line,
                 character: column,
             });
+            // `get` instead of indexing: the offsets come from the same
+            // snapshot so they always land on char boundaries, but if that
+            // invariant were ever violated, degrading to "no prefix" beats
+            // both a panic and a fabricated misaligned prefix.
             match (start, end) {
-                (Some(start), Some(end)) if start <= end => host_text[start..end].to_string(),
+                (Some(start), Some(end)) if start <= end => host_text
+                    .get(start..end)
+                    .map(str::to_string)
+                    .unwrap_or_default(),
                 _ => String::new(),
             }
         })
@@ -1039,6 +1050,12 @@ fn extract_host_line_prefixes(
 /// - **Line count changed**: the pipeline computes no diff/alignment, so
 ///   every continuation line takes the region's longest common prefix — exact
 ///   for the usual uniform-prefix region, a documented limitation otherwise.
+///   The LCP excludes trailing empty-prefix entries: a region whose content
+///   ends with `\n` carries a synthetic final line bucket whose host prefix
+///   belongs to the line *after* the replacement range, and including its
+///   empty prefix would collapse the LCP to `""` for uniformly prefixed
+///   blockquotes. Symmetrically, a trailing **empty** output line stays
+///   unprefixed — it abuts the host's own prefix at the region end.
 /// - **Empty output lines** get the prefix with trailing whitespace trimmed
 ///   (`>` not `> `; a space-only prefix is left off entirely) so the pipeline
 ///   introduces no trailing-whitespace violations.
@@ -1053,7 +1070,20 @@ fn reapply_host_line_prefixes(final_text: &str, host_line_prefixes: &[String]) -
     let lcp = if line_count_preserved {
         String::new()
     } else {
-        longest_common_prefix(host_line_prefixes)
+        // A region whose content ends with '\n' carries a trailing
+        // empty-prefix entry for the synthetic line bucket after the final
+        // newline; that host line's own prefix sits OUTSIDE the replacement
+        // range (the range ends at its column 0). Including it would
+        // collapse the LCP to "" for a uniformly prefixed blockquote, so the
+        // LCP is computed over the content lines' prefixes only.
+        let mut content_prefixes = host_line_prefixes;
+        while let [rest @ .., last] = content_prefixes {
+            if !last.is_empty() {
+                break;
+            }
+            content_prefixes = rest;
+        }
+        longest_common_prefix(content_prefixes)
     };
 
     // Reserve for the prefixes being prepended too (slight over-reserve when
@@ -1070,14 +1100,24 @@ fn reapply_host_line_prefixes(final_text: &str, host_line_prefixes: &[String]) -
             continue;
         }
         out.push('\n');
+        // `split('\n')` keeps a trailing '\r' on CRLF content; a line is
+        // "empty" for the prefix rules with or without it.
+        let line_is_empty = line.trim_end_matches('\r').is_empty();
         let prefix = if line_count_preserved {
             host_line_prefixes[i].as_str()
+        } else if line_is_empty && i == lines.len() - 1 {
+            // The trailing empty output line sits at the region end, where
+            // the host's own prefix (e.g. the closing fence's "> ") follows
+            // immediately outside the replacement range — prefixing it here
+            // would double the marker.
+            ""
         } else {
             lcp.as_str()
         };
-        // `split('\n')` keeps a trailing '\r' on CRLF content; a line is
-        // "empty" for the trailing-whitespace rule with or without it.
-        if line.trim_end_matches('\r').is_empty() {
+        // Empty output lines take the prefix with trailing whitespace
+        // trimmed so the pipeline introduces no trailing-whitespace
+        // violations.
+        if line_is_empty {
             out.push_str(prefix.trim_end());
         } else {
             out.push_str(prefix);
@@ -1670,6 +1710,33 @@ mod tests {
             reapply_host_line_prefixes("a\nb\nc\nd", &prefixes),
             "a\n> b\n> c\n> d"
         );
+    }
+
+    #[test]
+    fn reapply_lcp_ignores_trailing_synthetic_empty_prefix() {
+        // A blockquote region whose content ends with '\n' carries a trailing
+        // empty-prefix entry for the synthetic line after the final newline
+        // (its host prefix belongs to the closing-fence line, OUTSIDE the
+        // replacement range). The LCP must be computed over the content
+        // lines' prefixes only — otherwise it collapses to "" and a uniformly
+        // "> "-prefixed blockquote loses every marker on a line-count change.
+        let prefixes = vec!["> ".to_string(), "> ".to_string(), String::new()];
+        // 4 output lines vs 3 region lines → LCP path. The trailing empty
+        // output line sits at the region end and must stay unprefixed (the
+        // host's own "> " follows it).
+        assert_eq!(
+            reapply_host_line_prefixes("a\nb\nc\n", &prefixes),
+            "a\n> b\n> c\n"
+        );
+    }
+
+    #[test]
+    fn reapply_lcp_keeps_trailing_empty_output_line_unprefixed() {
+        // Even with a uniformly non-empty prefix list, a trailing empty
+        // output line abuts the host's own prefix on the region's end line —
+        // prefixing it would double the marker (">> ```").
+        let prefixes = vec!["> ".to_string(), "> ".to_string(), String::new()];
+        assert_eq!(reapply_host_line_prefixes("a\n", &prefixes), "a\n");
     }
 
     #[test]

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -135,12 +135,26 @@ impl Kakehashi {
             // fan-out, or skip — from its resolved aggregation config. See
             // [`plan_region_format`] for the allowlist rule
             // (concatenated-formatting-pipeline Decision point 2).
-            let pipeline_servers = match plan_region_format(
+            let pipeline = match plan_region_format(
                 region_ctx.strategy,
                 &region_ctx.priorities,
                 &region_ctx.configs,
             ) {
-                RegionFormatPlan::Concatenated(servers) => Some(servers),
+                RegionFormatPlan::Concatenated(servers) => {
+                    // Capture the region's per-line host prefixes now, while
+                    // the host snapshot is at hand: the pipeline's whole-region
+                    // replacement must re-apply them to its multi-line output
+                    // (Decision point 4, `reapply_host_line_prefixes`).
+                    let virtual_line_count =
+                        region_ctx.resolved.virtual_content.matches('\n').count() + 1;
+                    let host_line_prefixes = extract_host_line_prefixes(
+                        snapshot.text(),
+                        region_ctx.resolved.region.line_range.start,
+                        &region_ctx.resolved.line_column_offsets,
+                        virtual_line_count,
+                    );
+                    Some((servers, host_line_prefixes))
+                }
                 RegionFormatPlan::Preferred => None,
                 RegionFormatPlan::Skip => {
                     // `concatenated` with a non-empty `priorities` that names only
@@ -168,12 +182,13 @@ impl Kakehashi {
             let region_cancel_rx = cancel_state.derive_receiver();
 
             outer_join_set.spawn(async move {
-                if let Some(servers) = pipeline_servers {
+                if let Some((servers, host_line_prefixes)) = pipeline {
                     dispatch_concatenated_formatting(
                         &region_ctx,
                         pool.clone(),
                         options,
                         servers,
+                        host_line_prefixes,
                         region_cancel_rx,
                     )
                     .await
@@ -385,6 +400,10 @@ async fn dispatch_concatenated_formatting(
     // The effective (configured, deduped, order-preserving) priority list,
     // computed by the caller — which also gates entry on it being non-empty.
     server_names: Vec<String>,
+    // Per-line host prefixes of the region (caller extracts them from the
+    // host snapshot), re-applied to the final multi-line output (Decision
+    // point 4, `reapply_host_line_prefixes`).
+    host_line_prefixes: Vec<String>,
     cancel_rx: Option<CancelReceiver>,
 ) -> Option<Vec<TextEdit>> {
     let offset = RegionOffset::with_per_line_offsets(
@@ -657,6 +676,10 @@ async fn dispatch_concatenated_formatting(
     }
 
     let final_text = final_text?;
+    // Decision point 4: the virtual output starts at column 0 of the embedded
+    // language, so every continuation line must re-gain its host prefix before
+    // the whole-region replacement is emitted.
+    let final_text = reapply_host_line_prefixes(&final_text, &host_line_prefixes);
     Some(vec![TextEdit {
         range: replacement_range,
         new_text: final_text,
@@ -824,13 +847,9 @@ fn scratch_region_id(region_id: &str, run: usize, step: usize) -> String {
 /// a host edit spanning essentially the whole file — silently corrupting it. We
 /// emit no edit for that region instead, which is the safe degradation.
 ///
-/// TODO(concatenated-formatting-pipeline): Decision point 4 also requires
-/// re-applying the region's per-line host prefix/indentation to every line of
-/// `final_text` (and the region LCP for new lines on a line-count change), plus
-/// trimming trailing whitespace on empty lines. This slice emits `final_text`
-/// verbatim and relies on the existing range translation only, so multi-line /
-/// blockquoted regions still drop host indentation on replacement lines — the
-/// same limitation documented in `src/lsp/bridge/text_document/formatting.rs`.
+/// The replacement's `new_text` is built by [`reapply_host_line_prefixes`],
+/// which restores the host prefix on every continuation line (Decision
+/// point 4); this function only provides the range.
 fn region_replacement_range(original_virtual: &str, offset: &RegionOffset) -> Option<Range> {
     // Virtual end position = the position one past the last byte (EOF), derived
     // via the shared PositionMapper from `original_virtual.len()` so line-ending
@@ -850,6 +869,129 @@ fn region_replacement_range(original_virtual: &str, offset: &RegionOffset) -> Op
     };
     translate_virtual_range_to_host(&mut range, offset);
     Some(range)
+}
+
+/// Extract the host-text prefix of every line of an injection region.
+///
+/// `prefixes[i]` is the host text that precedes the region's content on
+/// virtual line `i` — the blockquote `> ` markers and/or indentation that the
+/// injection extraction stripped. `line_column_offsets` carries the UTF-16
+/// column where content starts on each line (`ResolvedInjection`
+/// semantics: a single-entry list means only line 0 is offset; missing
+/// entries default to column 0, i.e. no prefix).
+///
+/// An unresolvable position (stale offsets racing a host edit) degrades to an
+/// empty prefix for that line rather than failing the whole region — the same
+/// saturating posture the position translation code takes.
+fn extract_host_line_prefixes(
+    host_text: &str,
+    region_start_line: u32,
+    line_column_offsets: &[u32],
+    virtual_line_count: usize,
+) -> Vec<String> {
+    let mapper = crate::text::PositionMapper::new(host_text);
+    (0..virtual_line_count)
+        .map(|i| {
+            let column = line_column_offsets.get(i).copied().unwrap_or(0);
+            if column == 0 {
+                return String::new();
+            }
+            let Some(line) = u32::try_from(i)
+                .ok()
+                .and_then(|i| region_start_line.checked_add(i))
+            else {
+                return String::new();
+            };
+            let start = mapper.position_to_byte(Position { line, character: 0 });
+            let end = mapper.position_to_byte(Position {
+                line,
+                character: column,
+            });
+            match (start, end) {
+                (Some(start), Some(end)) if start <= end => host_text[start..end].to_string(),
+                _ => String::new(),
+            }
+        })
+        .collect()
+}
+
+/// Re-apply the region's host per-line prefixes to the pipeline's final text
+/// (concatenated-formatting-pipeline Decision point 4).
+///
+/// The whole-region replacement range starts *after* the first line's host
+/// prefix, but every later line of `new_text` lands at host column 0 — so
+/// without this step a blockquoted/indented injection loses its `> ` markers
+/// or indentation on every continuation line.
+///
+/// - **Line count preserved** (output lines == region lines): each output
+///   line `i` re-gains its own original prefix `host_line_prefixes[i]` — a
+///   1:1 mapping, exact even when prefixes differ per line (nested
+///   blockquotes).
+/// - **Line count changed**: the pipeline computes no diff/alignment, so
+///   every continuation line takes the region's longest common prefix — exact
+///   for the usual uniform-prefix region, a documented limitation otherwise.
+/// - **Empty output lines** get the prefix with trailing whitespace trimmed
+///   (`>` not `> `; a space-only prefix is left off entirely) so the pipeline
+///   introduces no trailing-whitespace violations.
+fn reapply_host_line_prefixes(final_text: &str, host_line_prefixes: &[String]) -> String {
+    let lines: Vec<&str> = final_text.split('\n').collect();
+    if lines.len() <= 1 {
+        // Single-line output sits entirely after the first line's host prefix.
+        return final_text.to_string();
+    }
+
+    let line_count_preserved = lines.len() == host_line_prefixes.len();
+    let lcp = if line_count_preserved {
+        String::new()
+    } else {
+        longest_common_prefix(host_line_prefixes)
+    };
+
+    let mut out = String::with_capacity(final_text.len());
+    for (i, line) in lines.iter().enumerate() {
+        if i == 0 {
+            out.push_str(line);
+            continue;
+        }
+        out.push('\n');
+        let prefix = if line_count_preserved {
+            host_line_prefixes[i].as_str()
+        } else {
+            lcp.as_str()
+        };
+        // `split('\n')` keeps a trailing '\r' on CRLF content; a line is
+        // "empty" for the trailing-whitespace rule with or without it.
+        if line.trim_end_matches('\r').is_empty() {
+            out.push_str(prefix.trim_end());
+        } else {
+            out.push_str(prefix);
+        }
+        out.push_str(line);
+    }
+    out
+}
+
+/// Longest common prefix of all strings, on char boundaries. Empty input or
+/// any empty string yields the empty prefix.
+fn longest_common_prefix(strings: &[String]) -> String {
+    let mut iter = strings.iter();
+    let Some(first) = iter.next() else {
+        return String::new();
+    };
+    let mut prefix = first.as_str();
+    for s in iter {
+        let common_len = prefix
+            .chars()
+            .zip(s.chars())
+            .take_while(|(a, b)| a == b)
+            .map(|(a, _)| a.len_utf8())
+            .sum();
+        prefix = &prefix[..common_len];
+        if prefix.is_empty() {
+            break;
+        }
+    }
+    prefix.to_string()
 }
 
 /// Sort `edits` in place by `range.start` (line, then character).
@@ -1285,6 +1427,106 @@ mod tests {
             1,
             "poison recovery must preserve tracked scratch docs"
         );
+    }
+
+    // ==========================================================================
+    // reapply_host_line_prefixes / extract_host_line_prefixes
+    // (concatenated-formatting-pipeline Decision point 4: multi-line output
+    // must re-gain the host prefix per line)
+    // ==========================================================================
+
+    #[test]
+    fn reapply_uses_per_line_prefixes_when_line_count_is_preserved() {
+        // 3 output lines, 3 region lines: 1:1 mapping. The first line needs no
+        // prefix (the replacement range starts after its host prefix); each
+        // later line re-gains its own original prefix.
+        let prefixes = vec!["> ".to_string(), "> ".to_string(), "> ".to_string()];
+        assert_eq!(
+            reapply_host_line_prefixes("a\nb\nc", &prefixes),
+            "a\n> b\n> c"
+        );
+    }
+
+    #[test]
+    fn reapply_handles_per_line_prefixes_that_differ() {
+        // Nested blockquote: line prefixes differ per line and must be applied
+        // per line (not the first line's prefix everywhere).
+        let prefixes = vec!["> ".to_string(), "> > ".to_string(), "> ".to_string()];
+        assert_eq!(
+            reapply_host_line_prefixes("a\nb\nc", &prefixes),
+            "a\n> > b\n> c"
+        );
+    }
+
+    #[test]
+    fn reapply_uses_region_lcp_when_line_count_changes() {
+        // Formatter changed the line count (2 output lines, 3 region lines):
+        // there is no diff/alignment, so every continuation line takes the
+        // region's longest common prefix (ADR point 4).
+        let prefixes = vec!["> ".to_string(), "> ".to_string(), "> ".to_string()];
+        assert_eq!(reapply_host_line_prefixes("a\nb", &prefixes), "a\n> b");
+        // Non-uniform prefixes: the LCP is the shared "> ".
+        let prefixes = vec!["> ".to_string(), "> > ".to_string(), "> ".to_string()];
+        assert_eq!(
+            reapply_host_line_prefixes("a\nb\nc\nd", &prefixes),
+            "a\n> b\n> c\n> d"
+        );
+    }
+
+    #[test]
+    fn reapply_trims_trailing_whitespace_on_empty_output_lines() {
+        // ADR point 4: an empty output line must not gain trailing whitespace —
+        // emit ">" (not "> "), and leave a space-only prefix off entirely.
+        let prefixes = vec!["> ".to_string(), "> ".to_string(), "> ".to_string()];
+        assert_eq!(reapply_host_line_prefixes("a\n\nb", &prefixes), "a\n>\n> b");
+        let prefixes = vec!["  ".to_string(), "  ".to_string(), "  ".to_string()];
+        assert_eq!(reapply_host_line_prefixes("a\n\nb", &prefixes), "a\n\n  b");
+    }
+
+    #[test]
+    fn reapply_leaves_single_line_output_verbatim() {
+        // A single-line output sits entirely after the first line's host
+        // prefix; nothing to re-apply.
+        let prefixes = vec!["> ".to_string()];
+        assert_eq!(reapply_host_line_prefixes("a", &prefixes), "a");
+    }
+
+    #[test]
+    fn reapply_is_identity_for_unprefixed_regions() {
+        // The common fenced-code-block case: every continuation line starts at
+        // host column 0, so the output passes through unchanged — both for
+        // preserved and changed line counts.
+        let prefixes = vec![String::new(), String::new()];
+        assert_eq!(reapply_host_line_prefixes("a\nb", &prefixes), "a\nb");
+        assert_eq!(reapply_host_line_prefixes("a\nb\nc", &prefixes), "a\nb\nc");
+    }
+
+    #[test]
+    fn extract_prefixes_reads_blockquote_markers_from_host_lines() {
+        // Region: python inside a blockquote, host lines 1..=2, content starts
+        // at column 2 on each line ("> " prefix).
+        let host = "before\n> x = 1\n> y = 2\nafter\n";
+        let prefixes = extract_host_line_prefixes(host, 1, &[2, 2], 2);
+        assert_eq!(prefixes, vec!["> ".to_string(), "> ".to_string()]);
+    }
+
+    #[test]
+    fn extract_prefixes_defaults_missing_offsets_to_column_zero() {
+        // Non-blockquote regions carry a single-entry offset list (line 0
+        // only); continuation lines have no prefix.
+        let host = "# Doc\ncode line 0\ncode line 1\n";
+        let prefixes = extract_host_line_prefixes(host, 1, &[0], 2);
+        assert_eq!(prefixes, vec![String::new(), String::new()]);
+    }
+
+    #[test]
+    fn extract_prefixes_handles_utf16_columns() {
+        // Offsets are UTF-16 code units; a multibyte prefix must slice on the
+        // correct byte boundary.
+        let host = "héllo→x = 1\n";
+        // "héllo→" is 6 UTF-16 code units (é and → are 1 each).
+        let prefixes = extract_host_line_prefixes(host, 0, &[6], 1);
+        assert_eq!(prefixes, vec!["héllo→".to_string()]);
     }
 
     // ==========================================================================

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -318,20 +318,34 @@ fn select_pipeline_step_request(supports_full: bool, supports_range: bool) -> Pi
 }
 
 /// Probe the server's advertised formatting capabilities (spawning it if
-/// needed) and map them to the step's request kind via
+/// needed, and waiting up to `timeout` — the step's remaining budget — for a
+/// cold server to finish initializing so its capabilities are actually
+/// known) and map them to the step's request kind via
 /// [`select_pipeline_step_request`]. The second probe is skipped when full
-/// formatting is advertised — the answer can no longer matter.
+/// formatting is advertised — the answer can no longer matter — and reuses
+/// the already-Ready connection when it does run.
 async fn pipeline_step_request_kind(
     pool: &crate::lsp::bridge::LanguageServerPool,
     server_name: &str,
     server_config: &crate::config::settings::BridgeServerConfig,
+    timeout: std::time::Duration,
 ) -> std::io::Result<PipelineStepRequest> {
     let supports_full = pool
-        .server_advertises(server_name, server_config, "textDocument/formatting")
+        .server_advertises(
+            server_name,
+            server_config,
+            "textDocument/formatting",
+            timeout,
+        )
         .await?;
     let supports_range = !supports_full
         && pool
-            .server_advertises(server_name, server_config, "textDocument/rangeFormatting")
+            .server_advertises(
+                server_name,
+                server_config,
+                "textDocument/rangeFormatting",
+                timeout,
+            )
             .await?;
     Ok(select_pipeline_step_request(supports_full, supports_range))
 }
@@ -587,34 +601,38 @@ async fn dispatch_concatenated_formatting(
                     // and arrives as `Some(vec![])` from the bridge transform).
                     // A probe error (connection spawn/handshake failure) is a
                     // failed step: skip-and-continue (ADR point 6).
-                    let step_request =
-                        match pipeline_step_request_kind(&pool, &server_name, &server_config).await
-                        {
-                            Ok(kind) => kind,
-                            Err(e) => {
-                                log::warn!(
-                                    target: "kakehashi::formatting",
-                                    "concatenated formatting step for server {} failed during \
-                                     capability probe; skipping (ADR point 6): {}",
-                                    server_name,
-                                    e
-                                );
-                                return None;
-                            }
-                        };
+                    let step_request = match pipeline_step_request_kind(
+                        &pool,
+                        &server_name,
+                        &server_config,
+                        step_budget,
+                    )
+                    .await
+                    {
+                        Ok(kind) => kind,
+                        Err(e) => {
+                            log::warn!(
+                                target: "kakehashi::formatting",
+                                "concatenated formatting step for server {} failed during \
+                                 capability probe; skipping (ADR point 6): {}",
+                                server_name,
+                                e
+                            );
+                            return None;
+                        }
+                    };
                     if step_request == PipelineStepRequest::Skip {
                         // Neither documentFormattingProvider nor
                         // documentRangeFormattingProvider: contribute nothing and
                         // send no unsupported request (ADR point 3.2). The probe
-                        // also reports no capability while the connection is
-                        // still initializing (cold start), so the log mentions
-                        // that case — a later request will see the Ready server.
+                        // waits (within the step budget) for an initializing
+                        // connection to reach Ready, so this is a genuine
+                        // capability answer, not a cold-start artifact.
                         log::debug!(
                             target: "kakehashi::formatting",
                             "concatenated formatting step for server {} skipped: \
                              server advertises neither documentFormattingProvider \
-                             nor documentRangeFormattingProvider (or its \
-                             connection is still initializing)",
+                             nor documentRangeFormattingProvider",
                             server_name
                         );
                         return None;

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -219,6 +219,7 @@ impl Kakehashi {
                                         &t.virtual_content,
                                         options.clone(),
                                         t.upstream_id.clone(),
+                                        None,
                                     )
                                     .await
                                 {
@@ -238,6 +239,7 @@ impl Kakehashi {
                                     clipped_host_range,
                                     options,
                                     t.upstream_id,
+                                    None,
                                 )
                                 .await
                         }

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -1,0 +1,179 @@
+//! Minimal mock LSP formatter for E2E tests of the concatenated formatting
+//! pipeline (`tests/e2e_concatenated_formatting.rs`).
+//!
+//! Speaks just enough LSP over stdio to participate in the bridge: it answers
+//! `initialize` with formatting capabilities, tracks document text via
+//! `didOpen`/`didChange`/`didClose`, and answers formatting requests with a
+//! single whole-document replacement edit whose content is a deterministic
+//! transformation of the tracked text. The transformation is selected by the
+//! first CLI argument so a chain of two instances can prove serial pipeline
+//! order end-to-end:
+//!
+//! - `upper` — advertises `documentFormattingProvider`; uppercases the text.
+//! - `append` — advertises `documentFormattingProvider`; appends a
+//!   `-- mock-marker` line (lowercase, so a later `upper` step would be
+//!   detectable).
+//! - `range-upper` — advertises ONLY `documentRangeFormattingProvider`;
+//!   uppercases the text. Exercises the pipeline's capability-based
+//!   whole-region rangeFormatting fallback (concatenated-formatting-pipeline
+//!   Decision point 3.2).
+//!
+//! Only built for E2E runs (`required-features = ["e2e"]` in Cargo.toml).
+
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Write};
+
+use serde_json::{Value, json};
+
+fn main() {
+    let mode = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "upper".to_string());
+    let stdin = std::io::stdin();
+    let mut reader = BufReader::new(stdin.lock());
+    let stdout = std::io::stdout();
+    let mut writer = stdout.lock();
+    let mut documents: HashMap<String, String> = HashMap::new();
+
+    while let Some(message) = read_message(&mut reader) {
+        let method = message
+            .get("method")
+            .and_then(|m| m.as_str())
+            .unwrap_or_default();
+        let id = message.get("id").cloned();
+
+        match method {
+            "initialize" => {
+                let capabilities = if mode == "range-upper" {
+                    json!({
+                        "documentRangeFormattingProvider": true,
+                        "textDocumentSync": 1
+                    })
+                } else {
+                    json!({
+                        "documentFormattingProvider": true,
+                        "textDocumentSync": 1
+                    })
+                };
+                respond(&mut writer, id, json!({ "capabilities": capabilities }));
+            }
+            "shutdown" => respond(&mut writer, id, Value::Null),
+            "exit" => break,
+            "textDocument/didOpen" => {
+                if let (Some(uri), Some(text)) = (
+                    message
+                        .pointer("/params/textDocument/uri")
+                        .and_then(Value::as_str),
+                    message
+                        .pointer("/params/textDocument/text")
+                        .and_then(Value::as_str),
+                ) {
+                    documents.insert(uri.to_string(), text.to_string());
+                }
+            }
+            "textDocument/didChange" => {
+                // Full-sync only (textDocumentSync: 1): the last content
+                // change carries the complete new text.
+                if let (Some(uri), Some(text)) = (
+                    message
+                        .pointer("/params/textDocument/uri")
+                        .and_then(Value::as_str),
+                    message
+                        .pointer("/params/contentChanges")
+                        .and_then(Value::as_array)
+                        .and_then(|changes| changes.last())
+                        .and_then(|change| change.get("text"))
+                        .and_then(Value::as_str),
+                ) {
+                    documents.insert(uri.to_string(), text.to_string());
+                }
+            }
+            "textDocument/didClose" => {
+                if let Some(uri) = message
+                    .pointer("/params/textDocument/uri")
+                    .and_then(Value::as_str)
+                {
+                    documents.remove(uri);
+                }
+            }
+            "textDocument/formatting" | "textDocument/rangeFormatting" => {
+                let result = message
+                    .pointer("/params/textDocument/uri")
+                    .and_then(Value::as_str)
+                    .and_then(|uri| documents.get(uri))
+                    .map(|text| whole_document_edit(text, &mode))
+                    .unwrap_or(Value::Null);
+                respond(&mut writer, id, result);
+            }
+            _ => {
+                // Unknown REQUESTS get a null result so the client never
+                // hangs; notifications are ignored.
+                if id.is_some() {
+                    respond(&mut writer, id, Value::Null);
+                }
+            }
+        }
+    }
+}
+
+/// Apply the mode's transformation and wrap it in a single whole-document
+/// `TextEdit[]`. The end position stays within the document's real line
+/// count (the bridge drops edits past the virtual EOF).
+fn whole_document_edit(text: &str, mode: &str) -> Value {
+    let new_text = match mode {
+        "append" => {
+            // Keep the trailing newline shape so the host document's closing
+            // fence stays on its own line when the edit is applied.
+            match text.strip_suffix('\n') {
+                Some(stripped) => format!("{stripped}\n-- mock-marker\n"),
+                None => format!("{text}\n-- mock-marker"),
+            }
+        }
+        // "upper" and "range-upper"
+        _ => text.to_uppercase(),
+    };
+
+    let end_line = text.matches('\n').count();
+    let last_line_start = text.rfind('\n').map(|i| i + 1).unwrap_or(0);
+    let end_character = text[last_line_start..].encode_utf16().count();
+
+    json!([{
+        "range": {
+            "start": { "line": 0, "character": 0 },
+            "end": { "line": end_line, "character": end_character }
+        },
+        "newText": new_text
+    }])
+}
+
+/// Read one Content-Length-framed JSON-RPC message; `None` on EOF or framing
+/// errors (the main loop then exits).
+fn read_message<R: BufRead>(reader: &mut R) -> Option<Value> {
+    let mut content_length: Option<usize> = None;
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line).ok()? == 0 {
+            return None;
+        }
+        let line = line.trim_end();
+        if line.is_empty() {
+            break;
+        }
+        if let Some(value) = line.strip_prefix("Content-Length:") {
+            content_length = value.trim().parse().ok();
+        }
+    }
+    let mut body = vec![0u8; content_length?];
+    reader.read_exact(&mut body).ok()?;
+    serde_json::from_slice(&body).ok()
+}
+
+/// Send a JSON-RPC success response for `id` (no-op for notifications).
+fn respond<W: Write>(writer: &mut W, id: Option<Value>, result: Value) {
+    let Some(id) = id else {
+        return;
+    };
+    let body = json!({ "jsonrpc": "2.0", "id": id, "result": result }).to_string();
+    let _ = write!(writer, "Content-Length: {}\r\n\r\n{body}", body.len());
+    let _ = writer.flush();
+}

--- a/tests/e2e_concatenated_formatting.rs
+++ b/tests/e2e_concatenated_formatting.rs
@@ -1,0 +1,195 @@
+//! E2E tests for the concatenated formatting pipeline
+//! (concatenated-formatting-pipeline): a real multi-server chain over the
+//! full LSP protocol, using the `mock-lsp-formatter` test binary as the
+//! downstream servers (see `tests/bin/mock_formatter.rs`).
+//!
+//! The chain proves *serial* semantics end-to-end: the `append` step's marker
+//! stays lowercase only if it ran AFTER the `upper` step — i.e. each server
+//! formatted the previous server's output, not the original region text.
+
+#![cfg(feature = "e2e")]
+
+mod helpers;
+
+use helpers::lsp_client::LspClient;
+use serde_json::{Value, json};
+
+/// Path to the mock downstream formatter binary (built by Cargo for E2E runs;
+/// `required-features = ["e2e"]`).
+fn mock_formatter_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_mock-lsp-formatter")
+}
+
+/// Spawn kakehashi with `config_toml` as its config file and the given
+/// `languageServers` map, and complete the initialize handshake.
+fn init_client(config_toml: &str, language_servers: Value) -> (LspClient, tempfile::TempDir) {
+    let config_dir = tempfile::TempDir::new().expect("Failed to create config temp dir");
+    let config_path = config_dir.path().join("concatenated.toml");
+    std::fs::write(&config_path, config_toml).expect("Failed to write config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("temp path should be UTF-8"))
+        .build();
+
+    let _init_response = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": { "languageServers": language_servers }
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+    (client, config_dir)
+}
+
+/// Issue `textDocument/formatting`, retrying while the result is null.
+///
+/// Cold downstream servers are still handshaking when the first request
+/// arrives; the pipeline treats a not-yet-ready server as a failed step
+/// (skip-and-continue), which yields a null result. Retrying until the
+/// servers are Ready keeps the test free of timing assumptions.
+fn request_formatting_with_retry(client: &mut LspClient, uri: &str) -> Option<Vec<Value>> {
+    for _ in 0..30 {
+        let response = client.send_request(
+            "textDocument/formatting",
+            json!({
+                "textDocument": { "uri": uri },
+                "options": { "tabSize": 4, "insertSpaces": true },
+            }),
+        );
+        assert!(
+            response.get("error").is_none(),
+            "kakehashi must not surface a top-level formatting error; got: {:?}",
+            response.get("error")
+        );
+        if let Some(edits) = response.get("result").and_then(Value::as_array)
+            && !edits.is_empty()
+        {
+            return Some(edits.clone());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+    None
+}
+
+fn shutdown(client: &mut LspClient) {
+    let _ = client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+/// Markdown host: the lua fence content sits on host line 3.
+const MARKDOWN: &str = "# Test\n\n```lua\nlocal x = 1\n```\n";
+const MARKDOWN_URI: &str = "file:///test_concatenated_formatting.md";
+
+fn open_markdown(client: &mut LspClient) {
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": MARKDOWN_URI,
+                "languageId": "markdown",
+                "version": 1,
+                "text": MARKDOWN
+            }
+        }),
+    );
+    // Give kakehashi time to parse the host document and resolve injections.
+    std::thread::sleep(std::time::Duration::from_millis(1000));
+}
+
+#[test]
+fn e2e_concatenated_formatting_chains_two_servers_in_priority_order() {
+    let bin = mock_formatter_bin();
+    let (mut client, _config_dir) = init_client(
+        r#"
+[languages.markdown.bridge.lua.aggregation."textDocument/formatting"]
+strategy = "concatenated"
+priorities = ["mock-upper", "mock-append"]
+"#,
+        json!({
+            "mock-upper": { "cmd": [bin, "upper"], "languages": ["lua"] },
+            "mock-append": { "cmd": [bin, "append"], "languages": ["lua"] },
+        }),
+    );
+
+    open_markdown(&mut client);
+
+    let edits = request_formatting_with_retry(&mut client, MARKDOWN_URI)
+        .expect("concatenated pipeline must produce a region replacement edit");
+
+    // The pipeline collapses the whole chain into ONE region-replacement edit
+    // (Decision point 4), never one edit per server.
+    assert_eq!(
+        edits.len(),
+        1,
+        "expected a single region replacement edit, got: {edits:?}"
+    );
+
+    let new_text = edits[0]["newText"]
+        .as_str()
+        .expect("replacement edit must carry newText");
+
+    // Step 1 (upper) ran: the original lua got uppercased.
+    assert!(
+        new_text.contains("LOCAL X = 1"),
+        "upper step must have formatted the region; newText: {new_text:?}"
+    );
+    // Step 2 (append) ran ON STEP 1'S OUTPUT: its marker is present and still
+    // lowercase. Had the order been reversed, upper would have shouted the
+    // marker too — this is the serial-semantics proof.
+    assert!(
+        new_text.contains("-- mock-marker"),
+        "append step must have added its marker; newText: {new_text:?}"
+    );
+    assert!(
+        !new_text.contains("MOCK-MARKER"),
+        "marker must stay lowercase: append runs after upper, each server \
+         formats the previous server's output; newText: {new_text:?}"
+    );
+
+    // The replacement targets the fence content in host coordinates
+    // (content starts at host line 3, column 0).
+    assert_eq!(edits[0]["range"]["start"]["line"], 3);
+    assert_eq!(edits[0]["range"]["start"]["character"], 0);
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_concatenated_formatting_falls_back_to_range_formatting_for_range_only_server() {
+    // The mock advertises ONLY documentRangeFormattingProvider, so the
+    // pipeline must fall back to whole-region rangeFormatting (Decision
+    // point 3.2) — sending textDocument/formatting would get no provider.
+    let bin = mock_formatter_bin();
+    let (mut client, _config_dir) = init_client(
+        r#"
+[languages.markdown.bridge.lua.aggregation."textDocument/formatting"]
+strategy = "concatenated"
+priorities = ["mock-range-upper"]
+"#,
+        json!({
+            "mock-range-upper": { "cmd": [bin, "range-upper"], "languages": ["lua"] },
+        }),
+    );
+
+    open_markdown(&mut client);
+
+    let edits = request_formatting_with_retry(&mut client, MARKDOWN_URI)
+        .expect("range-only server must still format via the whole-region fallback");
+
+    assert_eq!(edits.len(), 1, "expected one region replacement edit");
+    let new_text = edits[0]["newText"]
+        .as_str()
+        .expect("replacement edit must carry newText");
+    assert!(
+        new_text.contains("LOCAL X = 1"),
+        "range-only server must have formatted the region through the \
+         rangeFormatting fallback; newText: {new_text:?}"
+    );
+
+    shutdown(&mut client);
+}

--- a/tests/e2e_concatenated_formatting.rs
+++ b/tests/e2e_concatenated_formatting.rs
@@ -46,12 +46,13 @@ fn init_client(config_toml: &str, language_servers: Value) -> (LspClient, tempfi
     (client, config_dir)
 }
 
-/// Issue `textDocument/formatting`, retrying while the result is null.
+/// Issue `textDocument/formatting`, retrying while the result is null or an
+/// empty edit list.
 ///
 /// Cold downstream servers are still handshaking when the first request
 /// arrives; the pipeline treats a not-yet-ready server as a failed step
-/// (skip-and-continue), which yields a null result. Retrying until the
-/// servers are Ready keeps the test free of timing assumptions.
+/// (skip-and-continue), which yields a null (or empty) result. Retrying
+/// until the servers are Ready keeps the test free of timing assumptions.
 fn request_formatting_with_retry(client: &mut LspClient, uri: &str) -> Option<Vec<Value>> {
     for _ in 0..30 {
         let response = client.send_request(

--- a/tests/e2e_concatenated_formatting.rs
+++ b/tests/e2e_concatenated_formatting.rs
@@ -54,7 +54,11 @@ fn init_client(config_toml: &str, language_servers: Value) -> (LspClient, tempfi
 /// (skip-and-continue), which yields a null (or empty) result. Retrying
 /// until the servers are Ready keeps the test free of timing assumptions.
 fn request_formatting_with_retry(client: &mut LspClient, uri: &str) -> Option<Vec<Value>> {
-    for _ in 0..30 {
+    // Short interval, many attempts (~15s total): the capability probe
+    // already waits for initializing servers, so the loop usually succeeds
+    // on the first or second attempt — fast polling just keeps the rare
+    // retry cheap.
+    for _ in 0..300 {
         let response = client.send_request(
             "textDocument/formatting",
             json!({
@@ -72,7 +76,7 @@ fn request_formatting_with_retry(client: &mut LspClient, uri: &str) -> Option<Ve
         {
             return Some(edits.clone());
         }
-        std::thread::sleep(std::time::Duration::from_millis(500));
+        std::thread::sleep(std::time::Duration::from_millis(50));
     }
     None
 }


### PR DESCRIPTION
Closes #340.

Completes the concatenated formatting pipeline (ADR: `docs/architecture-decisions/concatenated-formatting-pipeline.md`) whose first vertical slice landed in #327. Each slice from the issue is one commit, independently revertible.

## Slices

### 1. Capability-based full → rangeFormatting fallback (ADR Decision point 3.2) — `9603a39a`
- The bridge transform no longer collapses a downstream `null` formatting result to "no result": per LSP, `null` from a server that handled the request is the authoritative "already formatted" signal and now maps to `Some(vec![])`. `None` is reserved for a genuinely missing result (error / malformed payload). This also fixes the `preferred` path, where a capable server's `null` used to fall through to lower-priority servers.
- Each pipeline step keys its request on advertised capabilities: full formatting when `documentFormattingProvider` is present, **whole-region rangeFormatting** for range-only servers, and no request at all when neither is advertised.

### 2. Per-line / LCP host-prefix re-application (ADR Decision point 4) — `c20aaa5e`
- The pipeline's whole-region replacement previously emitted `final_text` verbatim, dropping blockquote markers / indentation on every continuation line.
- Now: 1:1 per-line prefixes when the formatter preserves the line count (exact even for nested blockquotes), region LCP when the count changes, trailing-whitespace trimming on empty output lines.

### 3. Per-step remaining-budget timeout + cancel propagation (ADR Decision point 6) — `69a4abd2`
- 5s whole-pipeline budget (the explicit per-request aggregation timeout from ls-bridge-server-pool-coordination, reused as the whole-pipeline bound). Each step's deadline is the remaining share; below a 50ms floor the rest skip outright. The deadline covers the capability probe (which may spawn a cold server).
- A timed-out step gets a best-effort, detached `$/cancelRequest` to its downstream server. Upstream cancellation needed no new plumbing — the `RequestIdCapture` middleware already fans it out to the in-flight server; the stale comment claiming otherwise is corrected.

### 4. Discard downstream `publishDiagnostics` for scratch URIs (ADR Decision point 7) — `f0f98097`
- The scratch marker is now shared (`VirtualDocumentUri::SCRATCH_ID_MARKER`) between id construction and the new `is_scratch_uri` detection, and the bridge reader explicitly discards scratch-targeted `publishDiagnostics` — making the invariant explicit and tested rather than an accident of the reader's current ignore-all-notifications behavior.

### 5. Retire the stale misconfiguration warning — `50abeb48`
- The warning now fires only for the actual remaining misconfiguration: `concatenated` with an **empty** resolved `priorities` (which falls back to `preferred`). Detection reuses `resolve_aggregation`, so wildcard-inherited priorities count as configured.

### 6. E2E multi-server chain — `17af3cd2`
- New `mock-lsp-formatter` test binary (Cargo bin target, `required-features = ["e2e"]`) drives a real two-server chain over the full protocol. Serial-order proof: the second server's lowercase marker survives only if it ran after the uppercasing first server. A second test exercises the range-only fallback live.

Plus `00a44c24` updating the ADR's Decision–Implementation Gap section to the implemented state.

## Testing
- `make check` clean; `cargo test --features e2e` (full unit + integration + E2E suite) green.
- Each commit passed the pre-commit quality gate (clippy `-D warnings`, fmt, lib tests, e2e suite). RED phases were verified locally before each test+impl commit (the gate rejects failing tests, per the repo's TDD adaptation).