### PR TITLE
perf(semantic): eliminate O(N²) host-text rescans in token collection

### DIFF
--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -135,8 +135,11 @@ def main() -> None:
             srv.kill()
             srv.wait()
 
+    n_lines = text.count("\n")
+    source = (f"file={args.file} ({len(text)}B/{n_lines}L)"
+              if args.file else f"size={args.size}")
     sys.stderr.write(
-        f"[drive] lang={args.lang} size={args.size} requests={args.requests} "
+        f"[drive] lang={args.lang} {source} requests={args.requests} "
         f"ok={ok} canceled={canceled} tokens/req={tokens} "
         f"wall={elapsed*1000:.0f}ms ({elapsed/args.requests*1000:.2f}ms/req)\n")
 

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -27,6 +27,8 @@ def main() -> None:
     ap.add_argument("--lang", choices=["rust", "markdown"], default="rust")
     ap.add_argument("--size", type=int, default=150)
     ap.add_argument("--requests", type=int, default=300)
+    ap.add_argument("--file", help="drive with this file's content instead of a "
+                                   "generated document (language from --lang)")
     ap.add_argument(
         "--data-dir", default=os.path.join(os.getcwd(), "deps/test/kakehashi"),
         help="parser/query data dir; must already contain installed parsers "
@@ -36,7 +38,11 @@ def main() -> None:
     if args.requests <= 0:
         ap.error("--requests must be positive")  # avoids divide-by-zero in the summary
 
-    if args.lang == "rust":
+    if args.file:
+        ext = "rs" if args.lang == "rust" else "md"
+        with open(args.file) as f:
+            uri, lang, text = f"file:///profile/input.{ext}", args.lang, f.read()
+    elif args.lang == "rust":
         uri, lang, text = "file:///profile/large.rs", "rust", gen_rust(args.size)
     else:
         uri, lang, text = "file:///profile/inj.md", "markdown", gen_markdown_injections(args.size)

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -135,8 +135,9 @@ def main() -> None:
             srv.kill()
             srv.wait()
 
+    n_bytes = len(text.encode("utf-8"))
     n_lines = text.count("\n")
-    source = (f"file={args.file} ({len(text)}B/{n_lines}L)"
+    source = (f"file={args.file} ({n_bytes}B/{n_lines}L)"
               if args.file else f"size={args.size}")
     sys.stderr.write(
         f"[drive] lang={args.lang} {source} requests={args.requests} "

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -40,7 +40,7 @@ def main() -> None:
 
     if args.file:
         ext = "rs" if args.lang == "rust" else "md"
-        with open(args.file) as f:
+        with open(args.file, encoding="utf-8") as f:
             uri, lang, text = f"file:///profile/input.{ext}", args.lang, f.read()
     elif args.lang == "rust":
         uri, lang, text = "file:///profile/large.rs", "rust", gen_rust(args.size)

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -28,7 +28,8 @@ def main() -> None:
     ap.add_argument("--size", type=int, default=150)
     ap.add_argument("--requests", type=int, default=300)
     ap.add_argument("--file", help="drive with this file's content instead of a "
-                                   "generated document (language from --lang)")
+                                   "generated document (language inferred from the "
+                                   "extension, falling back to --lang)")
     ap.add_argument(
         "--data-dir", default=os.path.join(os.getcwd(), "deps/test/kakehashi"),
         help="parser/query data dir; must already contain installed parsers "
@@ -39,9 +40,15 @@ def main() -> None:
         ap.error("--requests must be positive")  # avoids divide-by-zero in the summary
 
     if args.file:
-        ext = "rs" if args.lang == "rust" else "md"
+        if args.file.endswith(".md"):
+            lang, ext = "markdown", "md"
+        elif args.file.endswith(".rs"):
+            lang, ext = "rust", "rs"
+        else:
+            lang = args.lang
+            ext = "rs" if lang == "rust" else "md"
         with open(args.file, encoding="utf-8") as f:
-            uri, lang, text = f"file:///profile/input.{ext}", args.lang, f.read()
+            uri, text = f"file:///profile/input.{ext}", f.read()
     elif args.lang == "rust":
         uri, lang, text = "file:///profile/large.rs", "rust", gen_rust(args.size)
     else:
@@ -136,11 +143,11 @@ def main() -> None:
             srv.wait()
 
     n_bytes = len(text.encode("utf-8"))
-    n_lines = text.count("\n")
+    n_lines = len(text.splitlines())
     source = (f"file={args.file} ({n_bytes}B/{n_lines}L)"
               if args.file else f"size={args.size}")
     sys.stderr.write(
-        f"[drive] lang={args.lang} {source} requests={args.requests} "
+        f"[drive] lang={lang} {source} requests={args.requests} "
         f"ok={ok} canceled={canceled} tokens/req={tokens} "
         f"wall={elapsed*1000:.0f}ms ({elapsed/args.requests*1000:.2f}ms/req)\n")
 

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -68,6 +68,7 @@ pub(crate) async fn handle_semantic_tokens_full(
         let (injection_tokens, active_injection_regions) = collect_injection_tokens_parallel(
             &text,
             &lines,
+            &line_starts,
             &tree,
             filetype.as_deref(),
             &coordinator,

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -20,7 +20,7 @@ use parallel::collect_injection_tokens_parallel;
 
 // Internal re-exports for production code
 use finalize::finalize_tokens;
-use token_collector::{RawToken, collect_host_tokens};
+use token_collector::{RawToken, build_line_start_bytes, collect_host_tokens};
 
 // Test-only imports
 #[cfg(test)]
@@ -43,6 +43,7 @@ pub(crate) async fn handle_semantic_tokens_full(
     tokio::task::spawn_blocking(move || {
         let mut all_tokens: Vec<RawToken> = Vec::with_capacity(1000);
         let lines: Vec<&str> = text.lines().collect();
+        let line_starts = build_line_start_bytes(&text);
 
         // Collect host document tokens first (no exclusion — finalize handles it).
         collect_host_tokens(
@@ -53,6 +54,7 @@ pub(crate) async fn handle_semantic_tokens_full(
             capture_mappings.as_deref(),
             &text,
             &lines,
+            &line_starts,
             0,
             0,
             supports_multiline,

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -15,7 +15,9 @@ use std::collections::HashMap;
 use tree_sitter::{Parser, Tree};
 
 use super::injection::InjectionContext;
-use super::token_collector::{ActiveInjectionBounds, RawToken, collect_host_tokens};
+use super::token_collector::{
+    ActiveInjectionBounds, RawToken, build_line_start_bytes, collect_host_tokens,
+};
 use crate::config::CaptureMappings;
 use crate::language::LanguageCoordinator;
 use crate::language::injection::{
@@ -178,6 +180,7 @@ impl ThreadLocalParserFactory {
 
 /// Parse one injection and collect its tokens (plus any nested injections,
 /// recursed on the same thread). `depth = 0` is the host document.
+/// `host_line_starts` must come from `build_line_start_bytes(host_text)`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn process_injection_sync(
     ctx: &InjectionContext<'_>,
@@ -186,6 +189,7 @@ pub(crate) fn process_injection_sync(
     capture_mappings: Option<&CaptureMappings>,
     host_text: &str,
     host_lines: &[&str],
+    host_line_starts: &[usize],
     depth: usize,
     supports_multiline: bool,
 ) -> Vec<RawToken> {
@@ -227,6 +231,7 @@ pub(crate) fn process_injection_sync(
         capture_mappings,
         host_text,
         host_lines,
+        host_line_starts,
         ctx.host_start_byte,
         depth,
         supports_multiline,
@@ -244,6 +249,7 @@ pub(crate) fn process_injection_sync(
             capture_mappings,
             host_text,
             host_lines,
+            host_line_starts,
             depth + 1,
             supports_multiline,
         );
@@ -441,6 +447,10 @@ pub(crate) fn collect_injection_tokens_parallel(
     // Create factory from coordinator's registry (cloned for thread safety)
     let factory = ThreadLocalParserFactory::new(coordinator.language_registry_for_parallel());
 
+    // Built once and shared by every injection (and the active-region conversion
+    // below) so byte→line/col mapping never rescans the host text per injection.
+    let host_line_starts = build_line_start_bytes(host_text);
+
     // Threshold for parallel processing - below this, Rayon scheduling overhead exceeds benefit
     const PARALLEL_THRESHOLD: usize = 4;
 
@@ -457,6 +467,7 @@ pub(crate) fn collect_injection_tokens_parallel(
                     capture_mappings,
                     host_text,
                     host_lines,
+                    &host_line_starts,
                     1, // depth 1 (first level of injection, host is 0)
                     supports_multiline,
                 )
@@ -474,6 +485,7 @@ pub(crate) fn collect_injection_tokens_parallel(
                     capture_mappings,
                     host_text,
                     host_lines,
+                    &host_line_starts,
                     1,
                     supports_multiline,
                 )
@@ -489,6 +501,7 @@ pub(crate) fn collect_injection_tokens_parallel(
     let active_regions = compute_active_injection_regions(
         host_text,
         host_lines,
+        &host_line_starts,
         &exclusion_byte_ranges,
         &all_tokens,
     );
@@ -507,20 +520,18 @@ pub(crate) fn collect_injection_tokens_parallel(
 fn compute_active_injection_regions(
     host_text: &str,
     host_lines: &[&str],
+    line_starts: &[usize],
     byte_ranges: &[(usize, usize)],
     tokens: &[RawToken],
 ) -> Vec<ActiveInjectionBounds> {
-    // Precompute line-start offsets once so each conversion below is a binary
-    // search rather than an O(offset) scan (was O(regions × offset)).
-    let line_starts = build_line_start_bytes(host_text);
     byte_ranges
         .iter()
         .filter_map(|&(start_byte, end_byte)| {
             // Convert byte range to line/col
             let (start_line, start_col) =
-                byte_to_line_col(host_text, host_lines, &line_starts, start_byte);
+                byte_to_line_col(host_text, host_lines, line_starts, start_byte);
             let (end_line, end_col) =
-                byte_to_line_col(host_text, host_lines, &line_starts, end_byte);
+                byte_to_line_col(host_text, host_lines, line_starts, end_byte);
 
             // Binary-search the first token at or after the region start, then
             // scan forward only while tokens remain inside the region.
@@ -544,23 +555,6 @@ fn compute_active_injection_regions(
             }
         })
         .collect()
-}
-
-/// Build an ascending index of the byte offset at which each line starts.
-///
-/// `line_starts[0]` is always 0; every subsequent entry is the byte just after
-/// a `\n`. Built once per request so each `byte_to_line_col` lookup is a binary
-/// search instead of an O(offset) scan of the host text. Scanning raw bytes for
-/// `\n` is safe because UTF-8 never places `0x0A` inside a multi-byte sequence.
-fn build_line_start_bytes(host_text: &str) -> Vec<usize> {
-    let mut starts = Vec::with_capacity(host_text.len() / 32 + 1);
-    starts.push(0);
-    for (i, b) in host_text.bytes().enumerate() {
-        if b == b'\n' {
-            starts.push(i + 1);
-        }
-    }
-    starts
 }
 
 /// Convert a byte offset in host_text to a (line, utf16_col) pair.
@@ -840,6 +834,7 @@ mod tests {
             None,
             host_text,
             &host_lines,
+            &build_line_start_bytes(host_text),
             1, // depth 1 (not host document)
             false,
         );
@@ -897,6 +892,7 @@ mod tests {
             None,
             host_text,
             &host_lines,
+            &build_line_start_bytes(host_text),
             MAX_INJECTION_DEPTH,
             false,
         );

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -559,7 +559,9 @@ fn compute_active_injection_regions(
 
 /// Convert a byte offset in host_text to a (line, utf16_col) pair.
 ///
-/// `line_starts` must come from [`build_line_start_bytes`] for the same text.
+/// `line_starts` must come from
+/// [`build_line_start_bytes`](super::token_collector::build_line_start_bytes)
+/// for the same text.
 fn byte_to_line_col(
     host_text: &str,
     host_lines: &[&str],

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -15,9 +15,7 @@ use std::collections::HashMap;
 use tree_sitter::{Parser, Tree};
 
 use super::injection::InjectionContext;
-use super::token_collector::{
-    ActiveInjectionBounds, RawToken, build_line_start_bytes, collect_host_tokens,
-};
+use super::token_collector::{ActiveInjectionBounds, RawToken, collect_host_tokens};
 use crate::config::CaptureMappings;
 use crate::language::LanguageCoordinator;
 use crate::language::injection::{
@@ -422,12 +420,18 @@ fn collect_injection_contexts_sync<'a>(
 /// recurse on the same worker thread — no extra parallelism to avoid coordination
 /// overhead.
 ///
+/// `host_line_starts` must come from `build_line_start_bytes(host_text)`; the
+/// caller builds it once per request and it is shared by every injection (and
+/// the active-region conversion below) so byte→line/col mapping never rescans
+/// the host text per injection.
+///
 /// A region is *active* only if at least one token was produced from it (depth ≥ 1);
 /// resolved-but-empty injections don't suppress parent tokens.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn collect_injection_tokens_parallel(
     host_text: &str,
     host_lines: &[&str],
+    host_line_starts: &[usize],
     host_tree: &Tree,
     host_filetype: Option<&str>,
     coordinator: &LanguageCoordinator,
@@ -447,10 +451,6 @@ pub(crate) fn collect_injection_tokens_parallel(
     // Create factory from coordinator's registry (cloned for thread safety)
     let factory = ThreadLocalParserFactory::new(coordinator.language_registry_for_parallel());
 
-    // Built once and shared by every injection (and the active-region conversion
-    // below) so byte→line/col mapping never rescans the host text per injection.
-    let host_line_starts = build_line_start_bytes(host_text);
-
     // Threshold for parallel processing - below this, Rayon scheduling overhead exceeds benefit
     const PARALLEL_THRESHOLD: usize = 4;
 
@@ -467,7 +467,7 @@ pub(crate) fn collect_injection_tokens_parallel(
                     capture_mappings,
                     host_text,
                     host_lines,
-                    &host_line_starts,
+                    host_line_starts,
                     1, // depth 1 (first level of injection, host is 0)
                     supports_multiline,
                 )
@@ -485,7 +485,7 @@ pub(crate) fn collect_injection_tokens_parallel(
                     capture_mappings,
                     host_text,
                     host_lines,
-                    &host_line_starts,
+                    host_line_starts,
                     1,
                     supports_multiline,
                 )
@@ -501,7 +501,7 @@ pub(crate) fn collect_injection_tokens_parallel(
     let active_regions = compute_active_injection_regions(
         host_text,
         host_lines,
-        &host_line_starts,
+        host_line_starts,
         &exclusion_byte_ranges,
         &all_tokens,
     );
@@ -592,6 +592,7 @@ mod tests {
 
     use tree_sitter::Query;
 
+    use super::super::token_collector::build_line_start_bytes;
     use super::*;
     use crate::language::registry::LanguageRegistry;
 
@@ -946,6 +947,7 @@ mod tests {
         let (tokens, _regions) = collect_injection_tokens_parallel(
             text,
             &host_lines,
+            &build_line_start_bytes(text),
             &tree,
             Some("markdown"),
             &coordinator,
@@ -1000,6 +1002,7 @@ local x = 42
         let (tokens, _regions) = collect_injection_tokens_parallel(
             text,
             &host_lines,
+            &build_line_start_bytes(text),
             &tree,
             Some("markdown"),
             &coordinator,
@@ -1082,6 +1085,7 @@ local b = 2
         let (tokens, _regions) = collect_injection_tokens_parallel(
             text,
             &host_lines,
+            &build_line_start_bytes(text),
             &tree,
             Some("markdown"),
             &coordinator,

--- a/src/analysis/semantic/token_collector.rs
+++ b/src/analysis/semantic/token_collector.rs
@@ -142,6 +142,25 @@ pub(crate) struct ActiveInjectionBounds {
     pub end_col: usize,
 }
 
+/// Build an ascending index of the byte offset at which each line starts.
+///
+/// `line_starts[0]` is always 0; every subsequent entry is the byte just after
+/// a `\n`. Built once per request and shared across all injections so that
+/// byte→line/col conversions are binary searches instead of O(offset) scans of
+/// the host text (which made token collection O(injections × document size)).
+/// Scanning raw bytes for `\n` is safe because UTF-8 never places `0x0A` inside
+/// a multi-byte sequence.
+pub(super) fn build_line_start_bytes(host_text: &str) -> Vec<usize> {
+    let mut starts = Vec::with_capacity(host_text.len() / 32 + 1);
+    starts.push(0);
+    for (i, b) in host_text.bytes().enumerate() {
+        if b == b'\n' {
+            starts.push(i + 1);
+        }
+    }
+    starts
+}
+
 /// Calculate the `(line_start_byte, line_end_byte)` host-coordinate offsets for one
 /// row of a multiline token, mapping from injected-content to host coordinates.
 fn calculate_line_byte_offsets(
@@ -279,6 +298,10 @@ fn effective_prefix_widths(node: &Node, prefix_byte_widths: &[usize]) -> Vec<usi
 /// Collect tokens from a single document's highlight query (no injection processing),
 /// mapping positions from content-local to host document coordinates.
 ///
+/// `host_line_starts` must come from [`build_line_start_bytes`] for `host_text`;
+/// it is built once per request so the per-injection byte→line/col mapping below
+/// is a binary search rather than an O(content_start_byte) scan.
+///
 /// When `supports_multiline` is false, multiline tokens are split into per-line tokens
 /// for clients that lack `multilineTokenSupport` (LSP 3.16.0+).
 #[allow(clippy::too_many_arguments)]
@@ -290,6 +313,7 @@ pub(super) fn collect_host_tokens(
     capture_mappings: Option<&CaptureMappings>,
     host_text: &str,
     host_lines: &[&str],
+    host_line_starts: &[usize],
     content_start_byte: usize,
     depth: usize,
     supports_multiline: bool,
@@ -303,25 +327,17 @@ pub(super) fn collect_host_tokens(
         return;
     }
 
-    // Calculate position mapping from content-local to host document
-    let content_start_line = if content_start_byte == 0 {
-        0
-    } else {
-        host_text[..content_start_byte]
-            .chars()
-            .filter(|c| *c == '\n')
-            .count()
-    };
-
-    let content_start_col = if content_start_byte == 0 {
-        0
-    } else {
-        let last_newline = host_text[..content_start_byte].rfind('\n');
-        match last_newline {
-            Some(pos) => content_start_byte - pos - 1,
-            None => content_start_byte,
-        }
-    };
+    // Calculate position mapping from content-local to host document.
+    // Largest line whose start byte is <= content_start_byte; line_starts[0] == 0,
+    // so the predicate holds for at least one element.
+    let content_start_line = host_line_starts
+        .partition_point(|&s| s <= content_start_byte)
+        .saturating_sub(1);
+    let content_start_col = content_start_byte
+        - host_line_starts
+            .get(content_start_line)
+            .copied()
+            .unwrap_or(0);
 
     // Split content text into lines for byte offset calculations
     let content_lines: Vec<&str> = text.lines().collect();
@@ -690,6 +706,7 @@ mod tests {
             None,
             code,
             &lines,
+            &build_line_start_bytes(code),
             0,
             0,
             false,
@@ -712,6 +729,7 @@ mod tests {
             None,
             code,
             &lines,
+            &build_line_start_bytes(code),
             0,
             0,
             false,
@@ -746,6 +764,7 @@ mod tests {
             None,
             code,
             &lines,
+            &build_line_start_bytes(code),
             0,
             0,
             false,
@@ -780,6 +799,7 @@ mod tests {
             None,
             code,
             &lines,
+            &build_line_start_bytes(code),
             0,
             0,
             false,
@@ -805,6 +825,7 @@ mod tests {
             None,
             code,
             &lines,
+            &build_line_start_bytes(code),
             0,
             0,
             false,


### PR DESCRIPTION
## Summary

Opening a large markdown file made `semanticTokens/full` painfully slow. Flamegraph profiling (`benches/profile/`) showed **58.7% of all self-time inside `collect_host_tokens`**: its prologue recomputed the content-local→host position mapping by scanning the host text from byte 0 (`chars().filter(|c| *c == '\n').count()`) **once per injection**. Markdown turns every paragraph and heading into a `markdown_inline` injection, so the total cost was O(injections × document size) = **O(N²)**.

## Fix

Reuse the line-start byte index that `compute_active_injection_regions` already built to solve the same problem on a smaller scale:

- hoist `build_line_start_bytes` from `parallel.rs` into `token_collector.rs`
- build it **once per request** (`handle_semantic_tokens_full` / `collect_injection_tokens_parallel`)
- thread `host_line_starts: &[usize]` through `process_injection_sync` → `collect_host_tokens`, replacing the O(document) scan with a `partition_point` binary search

Also adds `--file` to `benches/profile/drive.py` so a real document (not just generated ones) can be replayed through the synchronous driver.

## Results (profiling build, generated markdown, ms/request)

| code blocks | before | after | speedup |
|---|---|---|---|
| 500 | 72 | 26 | 2.8× |
| 1000 | 505 | 58 | 8.8× |
| 2000 | 1,570 | 141 | 11× |
| 4000 | 5,969 | 391 | 15× |

After the fix `collect_host_tokens` no longer appears in the flamegraph self-time top 10; the remaining compute hotspot is `finalize_tokens` (~13%).

## Notes

- No behavioral change intended: positions are computed identically (covered by the existing 1,571 lib tests; the line/col math edge cases — offset at a newline byte, offset 0, multibyte — behave the same under both formulations).
- The original 7-second user report was amplified by running a debug build with `RUST_LOG=trace`; the quadratic curve above is measured on the optimized build and is real independent of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)