### PR TITLE
fix(bridge): honor #offset! in virtual content and coordinate translation

### DIFF
--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -322,9 +322,16 @@ fn collect_injection_contexts_sync<'a>(
         let content_node = injection.content_node;
         let (inj_start_byte, inj_end_byte) = if let Some(off) = offset {
             use crate::analysis::offset_calculator::{ByteRange, calculate_effective_range};
+            use crate::language::injection::{ceil_char_boundary, floor_char_boundary};
             let byte_range = ByteRange::new(content_node.start_byte(), content_node.end_byte());
             let effective = calculate_effective_range(text, byte_range, off);
-            (effective.start, effective.end)
+            // Column deltas are byte counts; a misconfigured query could land
+            // inside a multi-byte character. Snap inward so the content slice
+            // below cannot panic (same guard as from_region_info).
+            (
+                ceil_char_boundary(text, effective.start),
+                floor_char_boundary(text, effective.end),
+            )
         } else {
             (content_node.start_byte(), content_node.end_byte())
         };

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -275,7 +275,7 @@ fn collect_injection_contexts_sync<'a>(
     content_start_byte: usize,
     parent_included_ranges: Option<&[tree_sitter::Range]>,
 ) -> (Vec<InjectionContext<'a>>, Vec<(usize, usize)>) {
-    use crate::language::injection::{collect_all_injections, parse_offset_directive_for_pattern};
+    use crate::language::injection::collect_all_injections;
 
     let current_lang = filetype.unwrap_or("unknown");
     let Some(injection_query) = coordinator.injection_query(current_lang) else {
@@ -314,8 +314,9 @@ fn collect_injection_contexts_sync<'a>(
             continue;
         };
 
-        // Get offset directive if any
-        let offset = parse_offset_directive_for_pattern(&injection_query, injection.pattern_index);
+        // Offset directive resolved at collection time (single source of truth
+        // with the bridge path, which applies it in from_region_info)
+        let offset = injection.offset;
 
         // Calculate effective content range
         let content_node = injection.content_node;

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -327,11 +327,12 @@ fn collect_injection_contexts_sync<'a>(
             let effective = calculate_effective_range(text, byte_range, off);
             // Column deltas are byte counts; a misconfigured query could land
             // inside a multi-byte character. Snap inward so the content slice
-            // below cannot panic (same guard as from_region_info).
-            (
-                ceil_char_boundary(text, effective.start),
-                floor_char_boundary(text, effective.end),
-            )
+            // below cannot panic, and normalize so a degenerate range (both
+            // ends inside one codepoint) becomes empty rather than inverted —
+            // same guards as from_region_info.
+            let start = ceil_char_boundary(text, effective.start);
+            let end = floor_char_boundary(text, effective.end);
+            (start.min(end), end)
         } else {
             (content_node.start_byte(), content_node.end_byte())
         };

--- a/src/language/injection.rs
+++ b/src/language/injection.rs
@@ -19,6 +19,21 @@ pub struct InjectionOffset {
     pub end_column: i32,
 }
 
+/// The `#offset!` directive for a pattern, normalized: a directive that
+/// parses to all zeros (malformed, or an explicit `#offset! … 0 0 0 0`) is a
+/// no-op and is reported as `None`, so consumers never disable
+/// included-range stripping — or skip raw-span fast paths — for an offset
+/// that changes nothing. Use this instead of
+/// [`parse_offset_directive_for_pattern`] anywhere behavior branches on the
+/// offset's presence.
+pub(crate) fn effective_offset_for_pattern(
+    query: &Query,
+    pattern_index: usize,
+) -> Option<InjectionOffset> {
+    parse_offset_directive_for_pattern(query, pattern_index)
+        .filter(|off| *off != InjectionOffset::default())
+}
+
 /// Parses offset directive for a specific pattern in the query.
 /// Returns None if the specified pattern has no #offset! directive for @injection.content.
 pub(crate) fn parse_offset_directive_for_pattern(
@@ -835,12 +850,7 @@ pub fn collect_all_injections<'a>(
                     content_node: capture.node,
                     pattern_index: match_.pattern_index,
                     include_children: has_include_children_for_pattern(query, match_.pattern_index),
-                    // An all-zero offset (malformed directive, or an explicit
-                    // `#offset! … 0 0 0 0`) is a no-op; normalize it to None
-                    // so consumers don't disable included-range stripping for
-                    // an offset that changes nothing.
-                    offset: parse_offset_directive_for_pattern(query, match_.pattern_index)
-                        .filter(|off| *off != InjectionOffset::default()),
+                    offset: effective_offset_for_pattern(query, match_.pattern_index),
                 });
             }
         }

--- a/src/language/injection.rs
+++ b/src/language/injection.rs
@@ -495,7 +495,17 @@ fn extract_virtual_content_and_offsets(
     cacheable: &CacheableInjectionRegion,
     text: &str,
 ) -> (String, Vec<u32>) {
-    let included_ranges = compute_included_ranges(&region.content_node, region.include_children);
+    // Disabled when an offset directive is active: compute_included_ranges()
+    // returns ranges relative to content_node.start_byte(), but with #offset!
+    // the cacheable byte_range starts elsewhere — misaligned ranges would
+    // extract wrong content. Mirrors the semantic path (parallel.rs); the
+    // offset × child-exclusion interaction is tracked in #186 (every vendored
+    // #offset! query sets include-children, so nothing is lost today).
+    let included_ranges = if region.offset.is_some() {
+        None
+    } else {
+        compute_included_ranges(&region.content_node, region.include_children)
+    };
     let virtual_content = extract_clean_content(
         text,
         cacheable.byte_range.clone(),
@@ -617,6 +627,11 @@ pub struct InjectionRegionInfo<'a> {
     /// When true, the injection parser sees the full content node (including named children).
     /// When false, named children (e.g., `block_continuation`) should be excluded.
     pub include_children: bool,
+    /// The `#offset!` directive for this pattern, resolved at collection time
+    /// (the query goes out of scope before consumers like
+    /// `CacheableInjectionRegion::from_region_info` run). `None` when the
+    /// pattern has no directive.
+    pub offset: Option<InjectionOffset>,
 }
 
 use std::ops::Range;
@@ -648,6 +663,46 @@ pub struct CacheableInjectionRegion {
     pub content_hash: u64,
 }
 
+/// Compute the (row, UTF-16 column) of `byte_pos`, using a nearby byte with a
+/// known row as an anchor so only the span between them is scanned (offset
+/// deltas are typically a few lines, never the whole document).
+fn position_of_byte(
+    text: &str,
+    byte_pos: usize,
+    anchor_byte: usize,
+    anchor_row: usize,
+) -> (u32, u32) {
+    let (lo, hi) = (byte_pos.min(anchor_byte), byte_pos.max(anchor_byte));
+    let newlines = text[lo..hi].bytes().filter(|&b| b == b'\n').count();
+    let row = if byte_pos >= anchor_byte {
+        anchor_row + newlines
+    } else {
+        anchor_row - newlines
+    };
+    let line_start = text[..byte_pos].rfind('\n').map(|i| i + 1).unwrap_or(0);
+    let column = text[line_start..byte_pos].encode_utf16().count() as u32;
+    (row as u32, column)
+}
+
+/// Snap `index` forward to the nearest char boundary (stable alternative to
+/// the unstable `str::ceil_char_boundary`).
+fn ceil_char_boundary(text: &str, mut index: usize) -> usize {
+    while index < text.len() && !text.is_char_boundary(index) {
+        index += 1;
+    }
+    index.min(text.len())
+}
+
+/// Snap `index` backward to the nearest char boundary (stable alternative to
+/// the unstable `str::floor_char_boundary`).
+fn floor_char_boundary(text: &str, mut index: usize) -> usize {
+    index = index.min(text.len());
+    while index > 0 && !text.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}
+
 impl CacheableInjectionRegion {
     /// Create from an InjectionRegionInfo, extracting position data from the node.
     ///
@@ -661,7 +716,33 @@ impl CacheableInjectionRegion {
             "from_region_info called with zero-width node at byte {}",
             node.start_byte(),
         );
-        let content = &text[node.start_byte()..node.end_byte()];
+
+        // #offset! narrows the raw node span to the effective content range
+        // (e.g. trimming `---` frontmatter delimiters). The bridge consumes
+        // byte_range / line_range / start_column for virtual-document content
+        // extraction and coordinate translation, so all of them must reflect
+        // the effective range, mirroring the semantic path (#183).
+        let (start_byte, end_byte) = match info.offset {
+            Some(offset) => {
+                use crate::analysis::offset_calculator::{ByteRange, calculate_effective_range};
+                let effective = calculate_effective_range(
+                    text,
+                    ByteRange::new(node.start_byte(), node.end_byte()),
+                    offset,
+                );
+                // Column deltas are byte counts; a misconfigured query could
+                // land inside a multi-byte character. Snap inward so slicing
+                // below cannot panic.
+                (
+                    ceil_char_boundary(text, effective.start),
+                    floor_char_boundary(text, effective.end),
+                )
+            }
+            None => (node.start_byte(), node.end_byte()),
+        };
+        let (start_byte, end_byte) = (start_byte.min(end_byte), end_byte);
+
+        let content = &text[start_byte..end_byte];
 
         // Convert tree-sitter byte column to UTF-16 code units for LSP compatibility.
         // Tree-sitter reports columns as byte offsets, but LSP positions use UTF-16.
@@ -669,26 +750,43 @@ impl CacheableInjectionRegion {
         // tree-sitter's `column` is a byte offset from the line start, so
         // `start_byte() - column` correctly recovers the line-start byte even
         // when the line contains multi-byte UTF-8 characters before the node.
-        let byte_column = node.start_position().column;
-        let line_start_byte = node.start_byte() - byte_column;
-        let line_prefix = &text[line_start_byte..node.start_byte()];
-        let start_column = line_prefix.encode_utf16().count() as u32;
+        let (start_line, start_column) = if start_byte == node.start_byte() {
+            let byte_column = node.start_position().column;
+            let line_start_byte = node.start_byte() - byte_column;
+            let line_prefix = &text[line_start_byte..node.start_byte()];
+            (
+                node.start_position().row as u32,
+                line_prefix.encode_utf16().count() as u32,
+            )
+        } else {
+            position_of_byte(
+                text,
+                start_byte,
+                node.start_byte(),
+                node.start_position().row,
+            )
+        };
 
-        let start_line = node.start_position().row as u32;
-        let end_pos = node.end_position();
         // end_position() points past the last byte. When that position is mid-line
         // (column > 0), the node still occupies that row → exclusive end is row + 1.
         // When column == 0 (node ended with newline), the row is already one past
         // the last occupied line — use it directly.
-        let end_line = if end_pos.column > 0 {
-            end_pos.row as u32 + 1
+        let end_line = if end_byte == node.end_byte() {
+            let end_pos = node.end_position();
+            if end_pos.column > 0 {
+                end_pos.row as u32 + 1
+            } else {
+                end_pos.row as u32
+            }
         } else {
-            end_pos.row as u32
+            let (end_row, end_column) =
+                position_of_byte(text, end_byte, node.end_byte(), node.end_position().row);
+            if end_column > 0 { end_row + 1 } else { end_row }
         };
 
         Self {
             language: info.language.clone(),
-            byte_range: node.start_byte()..node.end_byte(),
+            byte_range: start_byte..end_byte,
             line_range: start_line..end_line,
             start_column,
             region_id: region_id.to_string(),
@@ -732,6 +830,7 @@ pub fn collect_all_injections<'a>(
                     content_node: capture.node,
                     pattern_index: match_.pattern_index,
                     include_children: has_include_children_for_pattern(query, match_.pattern_index),
+                    offset: parse_offset_directive_for_pattern(query, match_.pattern_index),
                 });
             }
         }
@@ -1364,6 +1463,95 @@ mod tests {
         assert_eq!(cacheable.region_id, "test-result-id");
     }
 
+    #[test]
+    fn test_from_region_info_applies_column_offset() {
+        // #offset! with a column delta (e.g. regex content after a prefix)
+        // must shift byte_range and start_column to the effective position,
+        // so the bridge extracts the right content and translates coordinates
+        // correctly (#183).
+        let mut parser = create_rust_parser();
+        let text = "// regex content";
+        let tree = parse_rust_code(&mut parser, text);
+        let root = tree.root_node();
+
+        let query_str = r#"
+            ((line_comment) @injection.content
+              (#set! injection.language "regex")
+              (#offset! @injection.content 0 3 0 0))
+        "#;
+        let language = tree_sitter_rust::LANGUAGE.into();
+        let query = Query::new(&language, query_str).expect("valid query");
+
+        let regions = collect_all_injections(&root, text, Some(&query)).expect("injections");
+        assert_eq!(regions.len(), 1);
+        let cacheable = CacheableInjectionRegion::from_region_info(&regions[0], "test-id", text);
+
+        assert_eq!(&text[cacheable.byte_range.clone()], "regex content");
+        assert_eq!(cacheable.byte_range, 3..text.len());
+        assert_eq!(cacheable.start_column, 3);
+        assert_eq!(cacheable.line_range, 0..1);
+    }
+
+    #[test]
+    fn test_from_region_info_applies_row_offset_for_frontmatter() {
+        // The vendored markdown query trims `---` frontmatter delimiters via
+        // (#offset! @injection.content 1 0 -1 0); the cacheable region must
+        // reflect the effective (delimiter-free) range (#183).
+        let md_language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        let mut parser = Parser::new();
+        parser.set_language(&md_language).expect("set md language");
+        let text = "---\ntitle: x\n---\n\n# heading\n";
+        let tree = parser.parse(text, None).expect("parse markdown");
+        let root = tree.root_node();
+
+        let query_str = r#"
+            ((minus_metadata) @injection.content
+              (#set! injection.language "yaml")
+              (#set! injection.include-children)
+              (#offset! @injection.content 1 0 -1 0))
+        "#;
+        let query = Query::new(&md_language, query_str).expect("valid query");
+
+        let regions = collect_all_injections(&root, text, Some(&query)).expect("injections");
+        assert_eq!(regions.len(), 1);
+        let cacheable = CacheableInjectionRegion::from_region_info(&regions[0], "test-id", text);
+
+        assert_eq!(&text[cacheable.byte_range.clone()], "title: x\n");
+        assert_eq!(cacheable.line_range, 1..2);
+        assert_eq!(cacheable.start_column, 0);
+    }
+
+    #[test]
+    fn test_resolved_injection_virtual_content_honors_offset() {
+        // End-to-end through the bridge resolution path: the virtual document
+        // sent downstream must contain only the effective (post-offset)
+        // content, not the raw node text with delimiters (#183).
+        let md_language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        let mut parser = Parser::new();
+        parser.set_language(&md_language).expect("set md language");
+        let text = "---\ntitle: x\n---\n\n# heading\n";
+        let tree = parser.parse(text, None).expect("parse markdown");
+
+        let query_str = r#"
+            ((minus_metadata) @injection.content
+              (#set! injection.language "yaml")
+              (#set! injection.include-children)
+              (#offset! @injection.content 1 0 -1 0))
+        "#;
+        let query = Query::new(&md_language, query_str).expect("valid query");
+
+        let coordinator = test_coordinator();
+        let tracker = NodeTracker::new();
+        let uri = test_uri("offset_frontmatter");
+
+        let resolved =
+            InjectionResolver::resolve_all(&coordinator, &tracker, &uri, &tree, text, &query);
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].virtual_content, "title: x\n");
+        assert_eq!(resolved[0].region.line_range.start, 1);
+        assert_eq!(resolved[0].line_column_offsets, vec![0]);
+    }
+
     // ============================================================
     // Tests for InjectionResolver region_id generation
     // ============================================================
@@ -1556,18 +1744,21 @@ mod tests {
                 content_node: nodes[0],
                 pattern_index: 0,
                 include_children: false,
+                offset: None,
             },
             InjectionRegionInfo {
                 language: "python".to_string(),
                 content_node: nodes[1],
                 pattern_index: 0,
                 include_children: false,
+                offset: None,
             },
             InjectionRegionInfo {
                 language: "lua".to_string(),
                 content_node: nodes[2],
                 pattern_index: 0,
                 include_children: false,
+                offset: None,
             },
         ];
 
@@ -1633,18 +1824,21 @@ mod tests {
                 content_node: nodes[0],
                 pattern_index: 0,
                 include_children: false,
+                offset: None,
             },
             InjectionRegionInfo {
                 language: "python".to_string(),
                 content_node: nodes[1],
                 pattern_index: 0,
                 include_children: false,
+                offset: None,
             },
             InjectionRegionInfo {
                 language: "lua".to_string(),
                 content_node: nodes[2],
                 pattern_index: 0,
                 include_children: false,
+                offset: None,
             },
         ];
 

--- a/src/language/injection.rs
+++ b/src/language/injection.rs
@@ -664,8 +664,11 @@ pub struct CacheableInjectionRegion {
 }
 
 /// Compute the (row, UTF-16 column) of `byte_pos`, using a nearby byte with a
-/// known row as an anchor so only the span between them is scanned (offset
-/// deltas are typically a few lines, never the whole document).
+/// known row as an anchor: the row counts newlines only in the span between
+/// them (offset deltas are typically a few lines, never the whole document).
+/// The column additionally scans back from `byte_pos` to its line start —
+/// bounded by the current line's length, or by `byte_pos` itself in a
+/// document without newlines.
 fn position_of_byte(
     text: &str,
     byte_pos: usize,

--- a/src/language/injection.rs
+++ b/src/language/injection.rs
@@ -832,7 +832,12 @@ pub fn collect_all_injections<'a>(
                     content_node: capture.node,
                     pattern_index: match_.pattern_index,
                     include_children: has_include_children_for_pattern(query, match_.pattern_index),
-                    offset: parse_offset_directive_for_pattern(query, match_.pattern_index),
+                    // An all-zero offset (malformed directive, or an explicit
+                    // `#offset! … 0 0 0 0`) is a no-op; normalize it to None
+                    // so consumers don't disable included-range stripping for
+                    // an offset that changes nothing.
+                    offset: parse_offset_directive_for_pattern(query, match_.pattern_index)
+                        .filter(|off| *off != InjectionOffset::default()),
                 });
             }
         }

--- a/src/language/injection.rs
+++ b/src/language/injection.rs
@@ -677,7 +677,9 @@ fn position_of_byte(
     let row = if byte_pos >= anchor_byte {
         anchor_row + newlines
     } else {
-        anchor_row - newlines
+        // Defensive: a stale tree whose row metadata disagrees with `text`
+        // must not panic the server on underflow.
+        anchor_row.saturating_sub(newlines)
     };
     let line_start = text[..byte_pos].rfind('\n').map(|i| i + 1).unwrap_or(0);
     let column = text[line_start..byte_pos].encode_utf16().count() as u32;
@@ -686,7 +688,7 @@ fn position_of_byte(
 
 /// Snap `index` forward to the nearest char boundary (stable alternative to
 /// the unstable `str::ceil_char_boundary`).
-fn ceil_char_boundary(text: &str, mut index: usize) -> usize {
+pub(crate) fn ceil_char_boundary(text: &str, mut index: usize) -> usize {
     while index < text.len() && !text.is_char_boundary(index) {
         index += 1;
     }
@@ -695,7 +697,7 @@ fn ceil_char_boundary(text: &str, mut index: usize) -> usize {
 
 /// Snap `index` backward to the nearest char boundary (stable alternative to
 /// the unstable `str::floor_char_boundary`).
-fn floor_char_boundary(text: &str, mut index: usize) -> usize {
+pub(crate) fn floor_char_boundary(text: &str, mut index: usize) -> usize {
     index = index.min(text.len());
     while index > 0 && !text.is_char_boundary(index) {
         index -= 1;

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -18,8 +18,8 @@
 use crate::analysis::offset_calculator::{ByteRange, calculate_effective_range};
 use crate::language::LanguageCoordinator;
 use crate::language::injection::{
-    MAX_INJECTION_DEPTH, collect_all_injections, compute_included_ranges, floor_char_boundary,
-    intersect_included_ranges, parse_offset_directive_for_pattern,
+    MAX_INJECTION_DEPTH, ceil_char_boundary, collect_all_injections, compute_included_ranges,
+    floor_char_boundary, intersect_included_ranges, parse_offset_directive_for_pattern,
 };
 use crate::lsp::lsp_impl::kakehashi::node::lookup::find_node_at;
 
@@ -452,11 +452,12 @@ fn build_effective_ranges(
     let content_start_pos = region.content_node.start_position();
     let absolute_ranges: Vec<tree_sitter::Range> = if offset.is_some() {
         // #offset! shifts are byte arithmetic over i32 deltas, so the effective
-        // bounds can land mid-codepoint. Align both ends down to a UTF-8
-        // boundary before handing them to tree-sitter — passing a mid-char
-        // byte to set_included_ranges is UB / panic territory, and it would
-        // also desync from byte_to_point (which aligns internally).
-        let aligned_start = floor_char_boundary(host_text, eff_start);
+        // bounds can land mid-codepoint. Snap inward to UTF-8 boundaries
+        // (ceil the start, floor the end — matching the semantic and bridge
+        // paths) before handing them to tree-sitter: a mid-char byte in
+        // set_included_ranges is UB / panic territory, and flooring the start
+        // would re-include bytes the offset meant to exclude.
+        let aligned_start = ceil_char_boundary(host_text, eff_start);
         let aligned_end = floor_char_boundary(host_text, eff_end);
         // The alignment could, in pathological cases, collapse the range
         // (e.g. both ends fall inside the same multi-byte char). Guard so we

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -18,7 +18,7 @@
 use crate::analysis::offset_calculator::{ByteRange, calculate_effective_range};
 use crate::language::LanguageCoordinator;
 use crate::language::injection::{
-    MAX_INJECTION_DEPTH, collect_all_injections, compute_included_ranges,
+    MAX_INJECTION_DEPTH, collect_all_injections, compute_included_ranges, floor_char_boundary,
     intersect_included_ranges, parse_offset_directive_for_pattern,
 };
 use crate::lsp::lsp_impl::kakehashi::node::lookup::find_node_at;
@@ -456,8 +456,8 @@ fn build_effective_ranges(
         // boundary before handing them to tree-sitter — passing a mid-char
         // byte to set_included_ranges is UB / panic territory, and it would
         // also desync from byte_to_point (which aligns internally).
-        let aligned_start = align_down(host_text, eff_start);
-        let aligned_end = align_down(host_text, eff_end);
+        let aligned_start = floor_char_boundary(host_text, eff_start);
+        let aligned_end = floor_char_boundary(host_text, eff_end);
         // The alignment could, in pathological cases, collapse the range
         // (e.g. both ends fall inside the same multi-byte char). Guard so we
         // never emit a zero/negative-width range to the parser.
@@ -530,19 +530,6 @@ fn total_span(ranges: &[tree_sitter::Range]) -> usize {
         .iter()
         .map(|r| r.end_byte.saturating_sub(r.start_byte))
         .sum()
-}
-
-/// Clamp `byte` into `text` and round down to the nearest UTF-8 character
-/// boundary. Byte values derived from `#offset!` directives (i32 deltas in
-/// byte space) are not guaranteed to land on boundaries; feeding a mid-char
-/// byte to tree-sitter's `set_included_ranges` or to a string slice would
-/// panic. Rounding down keeps the offset inside the intended content.
-fn align_down(text: &str, byte: usize) -> usize {
-    let mut aligned = byte.min(text.len());
-    while aligned > 0 && !text.is_char_boundary(aligned) {
-        aligned -= 1;
-    }
-    aligned
 }
 
 /// Materialize every child injection region of `parent_tree` with its
@@ -806,7 +793,7 @@ fn discover_child_languages(
 fn byte_to_point(text: &str, byte: usize) -> tree_sitter::Point {
     // Align first — slicing `&text[..clamped]` on a mid-character byte would
     // panic and crash the LSP server.
-    let clamped = align_down(text, byte);
+    let clamped = floor_char_boundary(text, byte);
     let prefix = &text[..clamped];
     let row = prefix.bytes().filter(|b| *b == b'\n').count();
     let last_nl = prefix.rfind('\n');

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -19,7 +19,7 @@ use crate::analysis::offset_calculator::{ByteRange, calculate_effective_range};
 use crate::language::LanguageCoordinator;
 use crate::language::injection::{
     MAX_INJECTION_DEPTH, ceil_char_boundary, collect_all_injections, compute_included_ranges,
-    floor_char_boundary, intersect_included_ranges, parse_offset_directive_for_pattern,
+    effective_offset_for_pattern, floor_char_boundary, intersect_included_ranges,
 };
 use crate::lsp::lsp_impl::kakehashi::node::lookup::find_node_at;
 
@@ -44,7 +44,7 @@ pub(super) struct InjectionLayer {
 /// the raw-content-node fast bounds check is safe: an offset can extend the
 /// effective range past the raw node, so the shortcut only holds without one.
 fn pattern_has_offset(injection_query: &tree_sitter::Query, pattern_index: usize) -> bool {
-    parse_offset_directive_for_pattern(injection_query, pattern_index).is_some()
+    effective_offset_for_pattern(injection_query, pattern_index).is_some()
 }
 
 /// Build the full-document range used to seed the host layer.
@@ -419,7 +419,7 @@ fn build_effective_ranges(
     injection_query: &tree_sitter::Query,
 ) -> Vec<tree_sitter::Range> {
     // 1. Apply #offset! to the raw content_node span.
-    let offset = parse_offset_directive_for_pattern(injection_query, region.pattern_index);
+    let offset = effective_offset_for_pattern(injection_query, region.pattern_index);
     let (eff_start, eff_end) = match offset {
         Some(off) => {
             let byte_range = ByteRange::new(


### PR DESCRIPTION
The `#offset!` directive was applied in semantic/selection analysis but ignored by the bridge layer: `CacheableInjectionRegion` captured the raw node span, so a query like markdown's frontmatter trim (`#offset! @injection.content 1 0 -1 0`) would send delimiter text (`---`) to the downstream server and translate coordinates from the wrong start position.

## Approach

- The offset is resolved once at collection time and stored on `InjectionRegionInfo` (the `Query` goes out of scope before `from_region_info` runs).
- `from_region_info` derives `byte_range`, `line_range`, `start_column`, and `content_hash` from the effective (post-offset) range, using an anchored line scan rather than an O(doc) pass.
- The semantic path now reads the same stored offset instead of re-parsing the directive — one source of truth.
- Effective byte positions are snapped to char boundaries so a misconfigured column delta cannot panic mid-UTF-8.
- Included-range stripping is skipped when an offset is active, mirroring the semantic path's exclusivity decision (interaction tracked in #186).

Tests: column-offset and frontmatter row-offset unit tests on `from_region_info`, plus an end-to-end `resolve_all` test asserting the virtual document content excludes the delimiters.

Closes #183