### PR TITLE
fix(node): null coordinate args landing in excluded injection gaps

### DIFF
--- a/src/lsp/lsp_impl/kakehashi/node/common.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/common.rs
@@ -17,7 +17,7 @@ use tower_lsp_server::ls_types::{Position, TextDocumentIdentifier, Uri};
 use ulid::Ulid;
 use url::Url;
 
-use crate::lsp::lsp_impl::kakehashi::node::injection_stack::with_resolved_node;
+use crate::lsp::lsp_impl::kakehashi::node::injection_stack::with_resolved_node_ranges;
 use crate::lsp::lsp_impl::{Kakehashi, uri_to_url};
 
 /// A tracked node's `(start_byte, end_byte, kind)` triple, as produced by a
@@ -152,6 +152,23 @@ impl Kakehashi {
         id: &str,
         mut f: impl FnMut(tree_sitter::Node<'_>, &str) -> R,
     ) -> Option<(Url, usize, R)> {
+        // Most accessors don't need the minting layer's included ranges.
+        self.with_node_text_ranges(lsp_uri, id, move |node, text, _ranges| f(node, text))
+            .await
+    }
+
+    /// Like [`with_node_text`](Self::with_node_text) but additionally hands the
+    /// closure the included ranges the minting layer's tree was parsed against
+    /// (host coordinates; the whole document for layer 0). The coordinate-input
+    /// accessors use them to reject byte/point arguments that land in an
+    /// injected layer's excluded gaps — e.g. blockquote `> ` prefixes — which
+    /// are inside a node's contiguous span but are not injected content (#341).
+    pub(super) async fn with_node_text_ranges<R>(
+        &self,
+        lsp_uri: &Uri,
+        id: &str,
+        mut f: impl FnMut(tree_sitter::Node<'_>, &str, &[tree_sitter::Range]) -> R,
+    ) -> Option<(Url, usize, R)> {
         // An unparseable URI signals a misbehaving client; warn for parity with
         // `node` / `node/text` / `node/parent` / `node/children` while still
         // collapsing to `null`.
@@ -192,7 +209,7 @@ impl Kakehashi {
         // diagnosing drift — mirroring `node/parent` and `node/children` — and
         // is distinct from the silent `None` cases above (never-issued ULID,
         // unparsed document), which are expected and collapse to `null` quietly.
-        let Some(result) = with_resolved_node(
+        let Some(result) = with_resolved_node_ranges(
             &self.language,
             &host_language,
             host_text,
@@ -201,7 +218,7 @@ impl Kakehashi {
             end,
             kind,
             layer,
-            |node| f(node, host_text),
+            |node, ranges| f(node, host_text, ranges),
         ) else {
             log::warn!(
                 target: "kakehashi::node",
@@ -246,6 +263,25 @@ impl Kakehashi {
         f: impl FnMut(tree_sitter::Node<'_>) -> Option<NodeTriple>,
     ) -> Value {
         let Some((uri, layer, picked)) = self.with_node_by_id(lsp_uri, id, f).await else {
+            return Value::Null;
+        };
+        match picked {
+            Some(triple) => self.mint_node_info(&uri, layer, triple),
+            None => Value::Null,
+        }
+    }
+
+    /// Like [`navigate_to_node`](Self::navigate_to_node), but `f` also receives
+    /// the host text and the minting layer's included ranges. Used by the
+    /// coordinate-input accessors so they can reject byte/point arguments
+    /// landing in an injected layer's excluded gaps (#341).
+    pub(super) async fn navigate_to_node_in_ranges(
+        &self,
+        lsp_uri: &Uri,
+        id: &str,
+        f: impl FnMut(tree_sitter::Node<'_>, &str, &[tree_sitter::Range]) -> Option<NodeTriple>,
+    ) -> Value {
+        let Some((uri, layer, picked)) = self.with_node_text_ranges(lsp_uri, id, f).await else {
             return Value::Null;
         };
         match picked {

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -248,6 +248,42 @@ pub(super) fn with_resolved_node<R>(
     layer: usize,
     mut f: impl FnMut(tree_sitter::Node<'_>) -> R,
 ) -> Option<R> {
+    with_resolved_node_ranges(
+        coordinator,
+        host_language,
+        host_text,
+        host_tree,
+        start,
+        end,
+        kind,
+        layer,
+        |node, _ranges| f(node),
+    )
+}
+
+/// Like [`with_resolved_node`], but also hands the closure the **included
+/// ranges the minting layer's tree was parsed against** (host coordinates).
+///
+/// The coordinate-input accessors (`firstChildForByte`,
+/// `descendant*For{Byte,Point}Range`) need them: an injected layer parsed with
+/// non-contiguous `included_ranges` (e.g. blockquoted code, where `> `
+/// prefixes are excluded) has *gap* bytes inside a node's contiguous span that
+/// are not real injected content. A coordinate argument landing in a gap must
+/// collapse to `null` — consistent with the entry point, which never pushes an
+/// injection layer for a gap byte (#341). For the host layer the ranges are
+/// the whole document, so gap checks are vacuous there.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn with_resolved_node_ranges<R>(
+    coordinator: &LanguageCoordinator,
+    host_language: &str,
+    host_text: &str,
+    host_tree: &tree_sitter::Tree,
+    start: usize,
+    end: usize,
+    kind: &'static str,
+    layer: usize,
+    mut f: impl FnMut(tree_sitter::Node<'_>, &[tree_sitter::Range]) -> R,
+) -> Option<R> {
     // Reject obviously-invalid ranges up front — same guard `find_node_at`
     // applies internally, but checking here also avoids the expensive
     // `injection_stack_at` walk (which clones and re-parses layers) for a
@@ -259,15 +295,16 @@ pub(super) fn with_resolved_node<R>(
     // Host layer: resolve against the host tree without the stack walk.
     if layer == 0 {
         let node = find_node_at(host_tree, start, end, kind)?;
-        return Some(f(node));
+        let ranges = [whole_document_range(host_text)];
+        return Some(f(node, &ranges));
     }
 
     // Deeper layer: rebuild the stack at `start` and search the minting layer
     // only. `stack.get(layer)` is None when the nesting is now shallower.
     let stack = injection_stack_at(coordinator, host_language, host_text, host_tree, start);
-    let layer_tree = &stack.get(layer)?.tree;
-    let node = find_node_at(layer_tree, start, end, kind)?;
-    Some(f(node))
+    let layer_entry = stack.get(layer)?;
+    let node = find_node_at(&layer_entry.tree, start, end, kind)?;
+    Some(f(node, &layer_entry.ranges))
 }
 
 /// Collect the injection languages along the cursor's injection path at
@@ -511,7 +548,14 @@ fn build_effective_ranges(
 /// Half-open containment over a list of disjoint ranges, with the node-reference-protocol decision's
 /// end-of-document exception (`byte == host_len` includes nodes whose
 /// `end_byte == host_len`).
-fn ranges_contain_byte(ranges: &[tree_sitter::Range], byte: usize, host_len: usize) -> bool {
+///
+/// `pub(super)` so the coordinate accessors can apply the same rule the entry
+/// point uses to their byte / start-position arguments (#341).
+pub(super) fn ranges_contain_byte(
+    ranges: &[tree_sitter::Range],
+    byte: usize,
+    host_len: usize,
+) -> bool {
     let at_eod = byte == host_len;
     ranges.iter().any(|r| {
         let s = r.start_byte;
@@ -522,6 +566,20 @@ fn ranges_contain_byte(ranges: &[tree_sitter::Range], byte: usize, host_len: usi
             s <= byte && byte < e
         }
     })
+}
+
+/// Whether `byte` is acceptable as the **exclusive end bound** of a range
+/// argument against a layer's included ranges.
+///
+/// Unlike [`ranges_contain_byte`], a value equal to a range's `end_byte` is
+/// admitted: an exclusive end points one past the last byte actually queried,
+/// so landing exactly on a gap start still means "query up to the end of the
+/// included content". A value strictly inside a gap (its last queried byte
+/// would be excluded content) is rejected (#341).
+pub(super) fn ranges_admit_end_bound(ranges: &[tree_sitter::Range], byte: usize) -> bool {
+    ranges
+        .iter()
+        .any(|r| r.start_byte <= byte && byte <= r.end_byte)
 }
 
 /// Total byte length covered by `ranges`. Used as the smallest-injection

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -568,20 +568,6 @@ pub(super) fn ranges_contain_byte(
     })
 }
 
-/// Whether `byte` is acceptable as the **exclusive end bound** of a range
-/// argument against a layer's included ranges.
-///
-/// Unlike [`ranges_contain_byte`], a value equal to a range's `end_byte` is
-/// admitted: an exclusive end points one past the last byte actually queried,
-/// so landing exactly on a gap start still means "query up to the end of the
-/// included content". A value strictly inside a gap (its last queried byte
-/// would be excluded content) is rejected (#341).
-pub(super) fn ranges_admit_end_bound(ranges: &[tree_sitter::Range], byte: usize) -> bool {
-    ranges
-        .iter()
-        .any(|r| r.start_byte <= byte && byte <= r.end_byte)
-}
-
 /// Total byte length covered by `ranges`. Used as the smallest-injection
 /// tiebreaker — narrower effective spans win.
 fn total_span(ranges: &[tree_sitter::Range]) -> usize {

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -295,7 +295,18 @@ pub(super) fn with_resolved_node_ranges<R>(
     // Host layer: resolve against the host tree without the stack walk.
     if layer == 0 {
         let node = find_node_at(host_tree, start, end, kind)?;
-        let ranges = [whole_document_range(host_text)];
+        // This is the shared prelude for EVERY id-based accessor, so the
+        // whole-document range must be O(1): reuse the root's end position
+        // instead of whole_document_range, whose byte_to_point would rescan
+        // the document on each call. The end point only matters if a consumer
+        // ever reads it — the gap checks are byte-based — and the root's end
+        // position is the document end for a whole-document parse anyway.
+        let ranges = [tree_sitter::Range {
+            start_byte: 0,
+            end_byte: host_text.len(),
+            start_point: tree_sitter::Point { row: 0, column: 0 },
+            end_point: host_tree.root_node().end_position(),
+        }];
         return Some(f(node, &ranges));
     }
 

--- a/src/lsp/lsp_impl/kakehashi/node/navigation.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/navigation.rs
@@ -20,6 +20,9 @@ use crate::lsp::lsp_impl::Kakehashi;
 use crate::lsp::lsp_impl::kakehashi::node::common::{
     NodeByteParams, NodeByteRangeParams, NodeIdParams, NodeIndexParams,
 };
+use crate::lsp::lsp_impl::kakehashi::node::injection_stack::{
+    ranges_admit_end_bound, ranges_contain_byte,
+};
 
 /// Map a tree-sitter node to the `(start, end, kind)` triple the navigation
 /// helpers re-mint from.
@@ -107,19 +110,22 @@ impl Kakehashi {
     /// `kakehashi/node/firstChildForByte` — the node's first child extending
     /// beyond `byte` (UTF-8, host coords), per `Node::first_child_for_byte`.
     /// `byte` is rejected (→ `null`) unless `node.start_byte <= byte <=
-    /// node.end_byte` — i.e. negative, before the node, or past its end.
+    /// node.end_byte` — i.e. negative, before the node, or past its end — and,
+    /// for injected layers, unless it lies in the layer's included ranges
+    /// (an excluded-gap byte is not injected content, #341).
     pub async fn kakehashi_node_first_child_for_byte(
         &self,
         params: NodeByteParams,
     ) -> Result<Value> {
         let byte = usize::try_from(params.byte).ok();
         Ok(self
-            .navigate_to_node(&params.text_document.uri, &params.id, |n| {
+            .navigate_to_node_in_ranges(&params.text_document.uri, &params.id, |n, text, ranges| {
                 // Keep the byte inside the node's own span before handing it to
                 // tree-sitter, whose behaviour for offsets outside the queried
                 // node is version-dependent (mirrors lookup::find_node_at). These
                 // are node-scoped accessors, so an out-of-node argument is null.
                 byte.filter(|&b| n.start_byte() <= b && b <= n.end_byte())
+                    .filter(|&b| ranges_contain_byte(ranges, b, text.len()))
                     .and_then(|b| n.first_child_for_byte(b))
                     .map(triple)
             })
@@ -130,16 +136,18 @@ impl Kakehashi {
     /// (named + anonymous) spanning `[startByte, endByte)` within this node's
     /// subtree, per `Node::descendant_for_byte_range`. The range is rejected
     /// (→ `null`) unless `node.start_byte <= startByte <= endByte <=
-    /// node.end_byte` — i.e. negative, inverted, or reaching outside the node.
+    /// node.end_byte` — i.e. negative, inverted, or reaching outside the node —
+    /// and unless both bounds clear the minting layer's included ranges (#341).
     pub async fn kakehashi_node_descendant_for_byte_range(
         &self,
         params: NodeByteRangeParams,
     ) -> Result<Value> {
         let range = byte_range(&params);
         Ok(self
-            .navigate_to_node(&params.text_document.uri, &params.id, |n| {
+            .navigate_to_node_in_ranges(&params.text_document.uri, &params.id, |n, text, ranges| {
                 range
                     .filter(|&(s, e)| n.start_byte() <= s && e <= n.end_byte())
+                    .filter(|&(s, e)| range_bounds_in_ranges(ranges, s, e, text.len()))
                     .and_then(|(s, e)| n.descendant_for_byte_range(s, e))
                     .map(triple)
             })
@@ -150,21 +158,39 @@ impl Kakehashi {
     /// descendant spanning `[startByte, endByte)` within this node's subtree, per
     /// `Node::named_descendant_for_byte_range`. The range is rejected (→ `null`)
     /// unless `node.start_byte <= startByte <= endByte <= node.end_byte` — i.e.
-    /// negative, inverted, or reaching outside the node.
+    /// negative, inverted, or reaching outside the node — and unless both bounds
+    /// clear the minting layer's included ranges (#341).
     pub async fn kakehashi_node_named_descendant_for_byte_range(
         &self,
         params: NodeByteRangeParams,
     ) -> Result<Value> {
         let range = byte_range(&params);
         Ok(self
-            .navigate_to_node(&params.text_document.uri, &params.id, |n| {
+            .navigate_to_node_in_ranges(&params.text_document.uri, &params.id, |n, text, ranges| {
                 range
                     .filter(|&(s, e)| n.start_byte() <= s && e <= n.end_byte())
+                    .filter(|&(s, e)| range_bounds_in_ranges(ranges, s, e, text.len()))
                     .and_then(|(s, e)| n.named_descendant_for_byte_range(s, e))
                     .map(triple)
             })
             .await)
     }
+}
+
+/// Gap check for a `[start, end)` coordinate-range argument against the
+/// minting layer's included ranges (#341): the start (a queried byte) must lie
+/// in included content under the entry point's half-open rule, and the end (an
+/// exclusive bound) must not point past excluded content. Per-bound — not
+/// "both in one range" — because nodes legitimately span gaps (a multi-line
+/// statement in blockquoted code), and querying across a gap with both bounds
+/// on real content should still resolve that spanning node.
+pub(super) fn range_bounds_in_ranges(
+    ranges: &[tree_sitter::Range],
+    start: usize,
+    end: usize,
+    host_len: usize,
+) -> bool {
+    ranges_contain_byte(ranges, start, host_len) && ranges_admit_end_bound(ranges, end)
 }
 
 /// Convert the signed byte bounds to `usize`, returning `None` (→ `null`) if
@@ -175,8 +201,8 @@ impl Kakehashi {
 /// it up front rather than relying on the C bindings' behaviour.
 ///
 /// Per-call the handlers additionally bound the range to the queried node's
-/// contiguous span. Known limitation (#341): that span check does not exclude
-/// bytes in the gaps of an injected layer's non-contiguous included ranges.
+/// contiguous span and to the minting layer's included ranges
+/// ([`range_bounds_in_ranges`], #341).
 fn byte_range(params: &NodeByteRangeParams) -> Option<(usize, usize)> {
     let start = usize::try_from(params.start_byte).ok()?;
     let end = usize::try_from(params.end_byte).ok()?;

--- a/src/lsp/lsp_impl/kakehashi/node/navigation.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/navigation.rs
@@ -20,9 +20,7 @@ use crate::lsp::lsp_impl::Kakehashi;
 use crate::lsp::lsp_impl::kakehashi::node::common::{
     NodeByteParams, NodeByteRangeParams, NodeIdParams, NodeIndexParams,
 };
-use crate::lsp::lsp_impl::kakehashi::node::injection_stack::{
-    ranges_admit_end_bound, ranges_contain_byte,
-};
+use crate::lsp::lsp_impl::kakehashi::node::injection_stack::ranges_contain_byte;
 
 /// Map a tree-sitter node to the `(start, end, kind)` triple the navigation
 /// helpers re-mint from.
@@ -178,19 +176,27 @@ impl Kakehashi {
 }
 
 /// Gap check for a `[start, end)` coordinate-range argument against the
-/// minting layer's included ranges (#341): the start (a queried byte) must lie
-/// in included content under the entry point's half-open rule, and the end (an
-/// exclusive bound) must not point past excluded content. Per-bound — not
-/// "both in one range" — because nodes legitimately span gaps (a multi-line
-/// statement in blockquoted code), and querying across a gap with both bounds
-/// on real content should still resolve that spanning node.
+/// minting layer's included ranges (#341): both the first queried byte
+/// (`start`) and the last queried byte (`end - 1`, since `end` is exclusive)
+/// must lie in included content under the entry point's half-open rule.
+/// `end` itself may sit on a gap start — one past the last included byte —
+/// but an `end` whose final queried byte falls in a gap (including an `end`
+/// anchored to a *later* range's start across a gap) queries excluded
+/// content and is rejected. Per-bound — not "both in one range" — because
+/// nodes legitimately span gaps (a multi-line statement in blockquoted code),
+/// and querying across a gap with both bounds on real content should still
+/// resolve that spanning node.
 pub(super) fn range_bounds_in_ranges(
     ranges: &[tree_sitter::Range],
     start: usize,
     end: usize,
     host_len: usize,
 ) -> bool {
-    ranges_contain_byte(ranges, start, host_len) && ranges_admit_end_bound(ranges, end)
+    if !ranges_contain_byte(ranges, start, host_len) {
+        return false;
+    }
+    // Zero-width queries are covered by the start check alone.
+    end == start || ranges_contain_byte(ranges, end - 1, host_len)
 }
 
 /// Convert the signed byte bounds to `usize`, returning `None` (→ `null`) if

--- a/src/lsp/lsp_impl/kakehashi/node/position.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/position.rs
@@ -28,6 +28,7 @@ use tower_lsp_server::jsonrpc::Result;
 
 use crate::lsp::lsp_impl::Kakehashi;
 use crate::lsp::lsp_impl::kakehashi::node::common::{NodeIdParams, NodePointRangeParams};
+use crate::lsp::lsp_impl::kakehashi::node::navigation::range_bounds_in_ranges;
 use crate::text::PositionMapper;
 
 impl Kakehashi {
@@ -114,7 +115,7 @@ impl Kakehashi {
         let start = params.start;
         let end = params.end;
         let resolved = self
-            .with_node_text(&params.text_document.uri, &params.id, |n, text| {
+            .with_node_text_ranges(&params.text_document.uri, &params.id, |n, text, ranges| {
                 let mapper = PositionMapper::new(text);
                 // Strict conversion: a `character` past a line's end must mean
                 // "no such location" (null), NOT spill onto a later line as plain
@@ -124,12 +125,13 @@ impl Kakehashi {
                 // Mirror the byte-range guards: reject inverted ranges and any
                 // range not contained in the node's own span, whose tree-sitter
                 // behaviour is unspecified (see navigation.rs / lookup::find_node_at).
-                //
-                // Known limitation (#341): for an injected layer with
-                // non-contiguous included ranges (e.g. blockquoted code), this
-                // contiguous-span check does not exclude bytes in the gaps, so a
-                // coordinate on an excluded prefix can still resolve a node.
                 if start_byte < n.start_byte() || start_byte > end_byte || end_byte > n.end_byte() {
+                    return None;
+                }
+                // And reject coordinates landing in an injected layer's
+                // excluded gaps (e.g. blockquote `> ` prefixes) — they are not
+                // injected content (#341; same rule as the byte accessors).
+                if !range_bounds_in_ranges(ranges, start_byte, end_byte, text.len()) {
                     return None;
                 }
                 let descendant = if named {

--- a/tests/e2e_kakehashi_node_accessors.rs
+++ b/tests/e2e_kakehashi_node_accessors.rs
@@ -970,23 +970,42 @@ fn test_byte_lookups_in_excluded_gap_are_null() {
         "descendantForByteRange on included code bytes must resolve"
     );
 
-    // The `> ` prefix bytes (20..22) are an excluded gap → null.
-    for method in [
+    // A range crossing the gap with both endpoints on real content resolves
+    // the spanning node: [14, 23) starts on `x` and its last queried byte is
+    // the `y` at 22.
+    let spanning = call(
+        &mut client,
         "kakehashi/node/descendantForByteRange",
-        "kakehashi/node/namedDescendantForByteRange",
-    ] {
-        let v = call(
-            &mut client,
-            method,
-            json!({ "textDocument": { "uri": uri }, "id": root,
-                    "startByte": 20, "endByte": 21 }),
-        );
-        assert!(
-            v.is_null(),
-            "{} on excluded-gap bytes must return null, got {:?}",
-            method,
-            v
-        );
+        json!({ "textDocument": { "uri": uri }, "id": root,
+                "startByte": 14, "endByte": 23 }),
+    );
+    assert!(
+        !spanning.is_null(),
+        "a gap-spanning range with both bounds on code must still resolve"
+    );
+
+    // The `> ` prefix bytes (20..22) are an excluded gap → null. This covers
+    // a range inside the gap (20..21) and a range whose exclusive end lands
+    // on the next block's start (14..22): its last queried byte (21) is gap
+    // content even though 22 itself starts an included range.
+    for (start, end) in [(20, 21), (14, 22)] {
+        for method in [
+            "kakehashi/node/descendantForByteRange",
+            "kakehashi/node/namedDescendantForByteRange",
+        ] {
+            let v = call(
+                &mut client,
+                method,
+                json!({ "textDocument": { "uri": uri }, "id": root,
+                        "startByte": start, "endByte": end }),
+            );
+            assert!(
+                v.is_null(),
+                "{} on [{start}, {end}) must return null (gap content), got {:?}",
+                method,
+                v
+            );
+        }
     }
 
     let v = call(

--- a/tests/e2e_kakehashi_node_accessors.rs
+++ b/tests/e2e_kakehashi_node_accessors.rs
@@ -901,7 +901,8 @@ fn test_position_accessors_return_null_for_unknown_id() {
 const BLOCKQUOTED_PYTHON: &str = "> ```python\n> x = 1\n> y = 2\n> ```\n";
 
 /// Resolve the injected python layer's root by entering the layer at a cursor
-/// on `x` (line 1, character 4 — after the `> ` prefix) and climbing parents;
+/// at the `=` of `x = 1` (line 1, character 4 — past the `> ` prefix) and
+/// climbing parents;
 /// per-layer scope keeps the walk inside the python tree.
 fn python_layer_root(client: &mut LspClient, uri: &str) -> String {
     let node = call(

--- a/tests/e2e_kakehashi_node_accessors.rs
+++ b/tests/e2e_kakehashi_node_accessors.rs
@@ -881,3 +881,166 @@ fn test_position_accessors_return_null_for_unknown_id() {
         "descendantForPointRange on unknown id must be null"
     );
 }
+
+// ============================================================
+// Excluded-gap coordinates in injected layers (#341)
+// ============================================================
+//
+// A blockquoted python fence parses the injected python layer with
+// non-contiguous included ranges: each line's code is included, the `> `
+// prefixes are excluded gaps. A coordinate landing in a gap is not real
+// injected content, so the coordinate accessors must return null — matching
+// the entry point (`kakehashi/node`), which never pushes an injection layer
+// for a gap byte.
+//
+// Byte map of the fixture (every line starts with a 2-byte `> ` prefix):
+//   line 0 `> ```python\n`  bytes  0..12   (prefix  0..2)
+//   line 1 `> x = 1\n`      bytes 12..20   (prefix 12..14, code 14..20)
+//   line 2 `> y = 2\n`      bytes 20..28   (prefix 20..22, code 22..28)
+//   line 3 `> ```\n`        bytes 28..34
+const BLOCKQUOTED_PYTHON: &str = "> ```python\n> x = 1\n> y = 2\n> ```\n";
+
+/// Resolve the injected python layer's root by entering the layer at a cursor
+/// on `x` (line 1, character 4 — after the `> ` prefix) and climbing parents;
+/// per-layer scope keeps the walk inside the python tree.
+fn python_layer_root(client: &mut LspClient, uri: &str) -> String {
+    let node = call(
+        client,
+        "kakehashi/node",
+        json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": 1, "character": 4 },
+            "injection": true,
+        }),
+    );
+    assert!(
+        !node.is_null(),
+        "expected an injected python node at the cursor"
+    );
+    let mut current = id_of(&node);
+    for _ in 0..32 {
+        let parent = call(client, "kakehashi/node/parent", id_params(uri, &current));
+        if parent.is_null() {
+            return current;
+        }
+        current = id_of(&parent);
+    }
+    panic!("did not reach the injected layer root within 32 hops");
+}
+
+/// The python root's contiguous span covers the line-2 `> ` prefix (an
+/// excluded gap), so this asserts the test premise: the gap bytes pass the
+/// node-span bound and only the included-ranges check can reject them.
+fn assert_gap_inside_root_span(client: &mut LspClient, uri: &str, root: &str) {
+    let range = call(client, "kakehashi/node/byteRange", id_params(uri, root));
+    let start = range
+        .get("startByte")
+        .and_then(Value::as_u64)
+        .expect("startByte");
+    let end = range
+        .get("endByte")
+        .and_then(Value::as_u64)
+        .expect("endByte");
+    assert!(
+        start <= 20 && 22 < end,
+        "fixture premise: python root span [{start}, {end}) must cover the \
+         line-2 `> ` prefix bytes 20..22"
+    );
+}
+
+#[test]
+fn test_byte_lookups_in_excluded_gap_are_null() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+    let uri = "file:///accessors_gap_bytes.md";
+    open_markdown(&mut client, uri, BLOCKQUOTED_PYTHON);
+
+    let root = python_layer_root(&mut client, uri);
+    assert_gap_inside_root_span(&mut client, uri, &root);
+
+    // Control: a code byte (the `y` at byte 22) resolves normally.
+    let on_code = call(
+        &mut client,
+        "kakehashi/node/descendantForByteRange",
+        json!({ "textDocument": { "uri": uri }, "id": root,
+                "startByte": 22, "endByte": 23 }),
+    );
+    assert!(
+        !on_code.is_null(),
+        "descendantForByteRange on included code bytes must resolve"
+    );
+
+    // The `> ` prefix bytes (20..22) are an excluded gap → null.
+    for method in [
+        "kakehashi/node/descendantForByteRange",
+        "kakehashi/node/namedDescendantForByteRange",
+    ] {
+        let v = call(
+            &mut client,
+            method,
+            json!({ "textDocument": { "uri": uri }, "id": root,
+                    "startByte": 20, "endByte": 21 }),
+        );
+        assert!(
+            v.is_null(),
+            "{} on excluded-gap bytes must return null, got {:?}",
+            method,
+            v
+        );
+    }
+
+    let v = call(
+        &mut client,
+        "kakehashi/node/firstChildForByte",
+        json!({ "textDocument": { "uri": uri }, "id": root, "byte": 20 }),
+    );
+    assert!(
+        v.is_null(),
+        "firstChildForByte on an excluded-gap byte must return null, got {:?}",
+        v
+    );
+}
+
+#[test]
+fn test_point_lookups_in_excluded_gap_are_null() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+    let uri = "file:///accessors_gap_points.md";
+    open_markdown(&mut client, uri, BLOCKQUOTED_PYTHON);
+
+    let root = python_layer_root(&mut client, uri);
+    assert_gap_inside_root_span(&mut client, uri, &root);
+
+    // Control: positions on the code (`y` at line 2, characters 2..3) resolve.
+    let on_code = call(
+        &mut client,
+        "kakehashi/node/descendantForPointRange",
+        json!({ "textDocument": { "uri": uri }, "id": root,
+                "start": { "line": 2, "character": 2 },
+                "end":   { "line": 2, "character": 3 } }),
+    );
+    assert!(
+        !on_code.is_null(),
+        "descendantForPointRange on included code must resolve"
+    );
+
+    // Positions on the line-2 `> ` prefix are an excluded gap → null.
+    for method in [
+        "kakehashi/node/descendantForPointRange",
+        "kakehashi/node/namedDescendantForPointRange",
+    ] {
+        let v = call(
+            &mut client,
+            method,
+            json!({ "textDocument": { "uri": uri }, "id": root,
+                    "start": { "line": 2, "character": 0 },
+                    "end":   { "line": 2, "character": 1 } }),
+        );
+        assert!(
+            v.is_null(),
+            "{} on an excluded-gap position must return null, got {:?}",
+            method,
+            v
+        );
+    }
+}


### PR DESCRIPTION
The coordinate-input accessors (`firstChildForByte`, `descendant*ForByteRange`, `descendant*ForPointRange`) bounded their arguments to the queried node's contiguous span only. In an injected layer parsed with non-contiguous `included_ranges` (blockquoted code, where each line's `> ` prefix is excluded), a coordinate landing in an excluded gap passed that check and tree-sitter resolved the enclosing injected node (e.g. `module`) instead of `null`.

## Approach

The entry point (`kakehashi/node`) already treats gap bytes as outside the injection (`ranges_contain_byte`); the accessors now apply the same rule by threading the minting layer's included ranges out of the resolution prelude (`with_resolved_node_ranges`).

Checks are **per-bound**, not single-range containment: nodes legitimately span gaps (multi-line statements in blockquoted code), so a range query with both bounds on real content still resolves the spanning node, while an exclusive end bound may sit on a gap start (one past the last included byte).

Host-layer behavior is unchanged (layer 0's range is the whole document, so the gap check is vacuous there).

Tests: e2e coverage over a blockquoted python fence — gap bytes/positions return `null` for the byte/point accessors while code bytes still resolve, with the fixture premise (gap inside the root's contiguous span) asserted explicitly.

Closes #341