### PR TITLE
feat(bridge): support wildcard `"_"` in `BridgeServerConfig.languages`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -308,7 +308,7 @@ Configure language servers for bridging LSP requests in injection regions.
 | Field | Description |
 |-------|-------------|
 | `cmd` | Command and arguments to start the language server |
-| `languages` | Languages this server handles |
+| `languages` | Languages this server handles. Use `"_"` as a wildcard to match any injection language (e.g., `["_"]` for a generic formatter like efm-langserver). |
 | `initializationOptions` | Optional initialization options forwarded during the downstream server's `initialize` request |
 
 **Bridge Language Configuration:**

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -1250,10 +1250,11 @@ mod tests {
 
             if let Some(resolved_config) =
                 resolve_with_wildcard(&servers, server_name, merge_bridge_server_configs)
+                // Mirrors BridgeCoordinator::server_handles_language ("_" = any language)
                 && resolved_config
                     .languages
                     .iter()
-                    .any(|l| l == injection_language)
+                    .any(|l| l == "_" || l == injection_language)
             {
                 found_server = Some(resolved_config);
                 break;

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -1250,7 +1250,7 @@ mod tests {
 
             if let Some(resolved_config) =
                 resolve_with_wildcard(&servers, server_name, merge_bridge_server_configs)
-                // Mirrors BridgeCoordinator::server_handles_language ("_" = any language)
+                // Mirrors BridgeCoordinator::language_match ("_" = any language)
                 && resolved_config
                     .languages
                     .iter()

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -145,7 +145,9 @@ pub struct BridgeServerConfig {
     /// Command array: first element is the program, rest are arguments
     /// e.g., ["rust-analyzer"] or ["pyright-langserver", "--stdio"]
     pub cmd: Vec<String>,
-    /// Languages this server handles (e.g., ["rust"], ["python"])
+    /// Languages this server handles (e.g., ["rust"], ["python"]).
+    /// Use "_" as a wildcard to match any injection language
+    /// (e.g., ["_"] for a generic formatter like efm-langserver).
     pub languages: Vec<String>,
     /// Optional initialization options to pass to the server during initialize
     pub initialization_options: Option<Value>,

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -145,9 +145,9 @@ pub struct BridgeServerConfig {
     /// Command array: first element is the program, rest are arguments
     /// e.g., ["rust-analyzer"] or ["pyright-langserver", "--stdio"]
     pub cmd: Vec<String>,
-    /// Languages this server handles (e.g., ["rust"], ["python"]).
-    /// Use "_" as a wildcard to match any injection language
-    /// (e.g., ["_"] for a generic formatter like efm-langserver).
+    /// Languages this server handles (e.g., `["rust"]`, `["python"]`).
+    /// Use `"_"` as a wildcard to match any injection language
+    /// (e.g., `["_"]` for a generic formatter like efm-langserver).
     pub languages: Vec<String>,
     /// Optional initialization options to pass to the server during initialize
     pub initialization_options: Option<Value>,

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -207,13 +207,16 @@ impl BridgeCoordinator {
         config: &BridgeServerConfig,
         injection_language: &str,
     ) -> Option<LanguageMatch> {
-        if config.languages.iter().any(|l| l == injection_language) {
-            Some(LanguageMatch::Exact)
-        } else if config.languages.iter().any(|l| l == "_") {
-            Some(LanguageMatch::Wildcard)
-        } else {
-            None
+        let mut has_wildcard = false;
+        for lang in &config.languages {
+            if lang == injection_language {
+                return Some(LanguageMatch::Exact);
+            }
+            if lang == "_" {
+                has_wildcard = true;
+            }
         }
+        has_wildcard.then_some(LanguageMatch::Wildcard)
     }
 
     /// Resolve `bridge.servers` for `injection_language`, returning the
@@ -262,9 +265,7 @@ impl BridgeCoordinator {
                 let language_match = Self::language_match(&resolved_config, injection_language)?;
                 Some((language_match, server_name, resolved_config))
             })
-            .min_by(|(match_a, name_a, _), (match_b, name_b, _)| {
-                match_a.cmp(match_b).then_with(|| name_a.cmp(name_b))
-            })
+            .min_by_key(|&(language_match, server_name, _)| (language_match, server_name))
             .map(|(_, server_name, resolved_config)| ResolvedServerConfig {
                 server_name: server_name.clone(),
                 config: Arc::new(resolved_config),

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -49,6 +49,19 @@ pub(crate) struct ResolvedServerConfig {
     pub(crate) config: Arc<BridgeServerConfig>,
 }
 
+/// How a server's `languages` list matched an injection language.
+///
+/// Ordered by specificity: `Exact` < `Wildcard`, so `Ord::min` selects the
+/// more specific match when one server lists the language explicitly and
+/// another relies on the `"_"` wildcard.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum LanguageMatch {
+    /// The injection language appears verbatim in `languages`.
+    Exact,
+    /// Matched only via the `"_"` wildcard entry.
+    Wildcard,
+}
+
 /// A batch of eager-open task handles with a generation counter.
 ///
 /// The generation counter enables detection of stale pushes: when a concurrent
@@ -180,18 +193,26 @@ impl BridgeCoordinator {
     // Config lookup (moved from Kakehashi)
     // ========================================
 
-    /// Whether a server's `languages` list covers `injection_language`.
+    /// How a server's `languages` list covers `injection_language`, if at all.
     ///
     /// `"_"` is a wildcard matching any injection language, consistent with
     /// the wildcard convention used elsewhere in the config
     /// (`languageServers._`, `languages._`). The host-language bridge filter
     /// is enforced separately by the callers, so a wildcard server still
-    /// only sees languages the host allows.
-    fn server_handles_language(config: &BridgeServerConfig, injection_language: &str) -> bool {
-        config
-            .languages
-            .iter()
-            .any(|l| l == "_" || l == injection_language)
+    /// only sees languages the host allows. An exact entry outranks the
+    /// wildcard so that single-server selection can prefer the more specific
+    /// config (see `get_config_for_language`).
+    fn language_match(
+        config: &BridgeServerConfig,
+        injection_language: &str,
+    ) -> Option<LanguageMatch> {
+        if config.languages.iter().any(|l| l == injection_language) {
+            Some(LanguageMatch::Exact)
+        } else if config.languages.iter().any(|l| l == "_") {
+            Some(LanguageMatch::Wildcard)
+        } else {
+            None
+        }
     }
 
     /// Resolve `bridge.servers` for `injection_language`, returning the
@@ -225,25 +246,28 @@ impl BridgeCoordinator {
         // Look for a server that handles this language
         // wildcard-config-inheritance: Resolve each server with wildcard BEFORE checking languages,
         // because languages list may be inherited from languageServers._
+        //
+        // HashMap iteration order is arbitrary, so pick the winner by
+        // (match specificity, server name): an exact `languages` entry beats
+        // the "_" wildcard, and names break ties for determinism.
         let servers = &settings.language_servers;
-        for server_name in servers.keys() {
+        servers
+            .keys()
             // Skip wildcard entry - we use it for inheritance, not direct lookup
-            if server_name == "_" {
-                continue;
-            }
-
-            if let Some(resolved_config) =
-                resolve_with_wildcard(servers, server_name, merge_bridge_server_configs)
-                    .filter(|c| Self::server_handles_language(c, injection_language))
-            {
-                return Some(ResolvedServerConfig {
-                    server_name: server_name.clone(),
-                    config: Arc::new(resolved_config),
-                });
-            }
-        }
-
-        None
+            .filter(|name| *name != "_")
+            .filter_map(|server_name| {
+                let resolved_config =
+                    resolve_with_wildcard(servers, server_name, merge_bridge_server_configs)?;
+                let language_match = Self::language_match(&resolved_config, injection_language)?;
+                Some((language_match, server_name, resolved_config))
+            })
+            .min_by(|(match_a, name_a, _), (match_b, name_b, _)| {
+                match_a.cmp(match_b).then_with(|| name_a.cmp(name_b))
+            })
+            .map(|(_, server_name, resolved_config)| ResolvedServerConfig {
+                server_name: server_name.clone(),
+                config: Arc::new(resolved_config),
+            })
     }
 
     /// Get all bridge server configs for a given injection language from settings.
@@ -284,7 +308,7 @@ impl BridgeCoordinator {
             .filter(|name| *name != "_")
             .filter_map(|server_name| {
                 resolve_with_wildcard(servers, server_name, merge_bridge_server_configs)
-                    .filter(|c| Self::server_handles_language(c, injection_language))
+                    .filter(|c| Self::language_match(c, injection_language).is_some())
                     .map(|config| ResolvedServerConfig {
                         server_name: server_name.clone(),
                         config: Arc::new(config),
@@ -774,6 +798,78 @@ mod tests {
                 .get_config_for_language(&settings, "markdown", "rust")
                 .is_some(),
             "wildcard listed alongside exact language should match other languages"
+        );
+    }
+
+    #[test]
+    fn test_get_config_prefers_exact_match_over_wildcard_server() {
+        let coordinator = BridgeCoordinator::new();
+
+        // "a-efm" sorts before "pyright", so only the exact-over-wildcard
+        // preference (not name ordering) can make pyright win.
+        let mut servers = HashMap::new();
+        servers.insert(
+            "a-efm".to_string(),
+            BridgeServerConfig {
+                cmd: vec!["efm-langserver".to_string()],
+                languages: vec!["_".to_string()],
+                initialization_options: None,
+            },
+        );
+        servers.insert(
+            "pyright".to_string(),
+            BridgeServerConfig {
+                cmd: vec!["pyright-langserver".to_string()],
+                languages: vec!["python".to_string()],
+                initialization_options: None,
+            },
+        );
+
+        let settings = WorkspaceSettings {
+            languages: HashMap::new(),
+            auto_install: false,
+            language_servers: servers,
+            ..Default::default()
+        };
+
+        let result = coordinator
+            .get_config_for_language(&settings, "markdown", "python")
+            .expect("python should match");
+        assert_eq!(
+            result.server_name, "pyright",
+            "exact-match server should win over wildcard server"
+        );
+    }
+
+    #[test]
+    fn test_get_config_breaks_ties_by_server_name() {
+        let coordinator = BridgeCoordinator::new();
+
+        let mut servers = HashMap::new();
+        for name in ["b-linter", "a-linter"] {
+            servers.insert(
+                name.to_string(),
+                BridgeServerConfig {
+                    cmd: vec![name.to_string()],
+                    languages: vec!["_".to_string()],
+                    initialization_options: None,
+                },
+            );
+        }
+
+        let settings = WorkspaceSettings {
+            languages: HashMap::new(),
+            auto_install: false,
+            language_servers: servers,
+            ..Default::default()
+        };
+
+        let result = coordinator
+            .get_config_for_language(&settings, "markdown", "python")
+            .expect("wildcard should match");
+        assert_eq!(
+            result.server_name, "a-linter",
+            "ties between equally-specific servers should resolve by name for determinism"
         );
     }
 

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -180,6 +180,20 @@ impl BridgeCoordinator {
     // Config lookup (moved from Kakehashi)
     // ========================================
 
+    /// Whether a server's `languages` list covers `injection_language`.
+    ///
+    /// `"_"` is a wildcard matching any injection language, consistent with
+    /// the wildcard convention used elsewhere in the config
+    /// (`languageServers._`, `languages._`). The host-language bridge filter
+    /// is enforced separately by the callers, so a wildcard server still
+    /// only sees languages the host allows.
+    fn server_handles_language(config: &BridgeServerConfig, injection_language: &str) -> bool {
+        config
+            .languages
+            .iter()
+            .any(|l| l == "_" || l == injection_language)
+    }
+
     /// Resolve `bridge.servers` for `injection_language`, returning the
     /// `ResolvedServerConfig` (server name for pooling + spawn config) or
     /// `None` when no server matches, or the host's bridge filter excludes
@@ -220,7 +234,7 @@ impl BridgeCoordinator {
 
             if let Some(resolved_config) =
                 resolve_with_wildcard(servers, server_name, merge_bridge_server_configs)
-                    .filter(|c| c.languages.iter().any(|l| l == injection_language))
+                    .filter(|c| Self::server_handles_language(c, injection_language))
             {
                 return Some(ResolvedServerConfig {
                     server_name: server_name.clone(),
@@ -270,7 +284,7 @@ impl BridgeCoordinator {
             .filter(|name| *name != "_")
             .filter_map(|server_name| {
                 resolve_with_wildcard(servers, server_name, merge_bridge_server_configs)
-                    .filter(|c| c.languages.iter().any(|l| l == injection_language))
+                    .filter(|c| Self::server_handles_language(c, injection_language))
                     .map(|config| ResolvedServerConfig {
                         server_name: server_name.clone(),
                         config: Arc::new(config),
@@ -691,6 +705,167 @@ mod tests {
         let resolved = result.unwrap();
         assert_eq!(resolved.server_name, "rust-analyzer");
         assert_eq!(resolved.config.cmd, vec!["rust-analyzer".to_string()]);
+    }
+
+    #[test]
+    fn test_get_config_wildcard_language_matches_any_injection_language() {
+        let coordinator = BridgeCoordinator::new();
+
+        // efm-langserver style: one server attached to every injection language
+        let mut servers = HashMap::new();
+        servers.insert(
+            "efm".to_string(),
+            BridgeServerConfig {
+                cmd: vec!["efm-langserver".to_string()],
+                languages: vec!["_".to_string()],
+                initialization_options: None,
+            },
+        );
+
+        let settings = WorkspaceSettings {
+            languages: HashMap::new(),
+            auto_install: false,
+            language_servers: servers,
+            ..Default::default()
+        };
+
+        for injection_language in ["rust", "python", "lua"] {
+            let result =
+                coordinator.get_config_for_language(&settings, "markdown", injection_language);
+            assert!(
+                result.is_some(),
+                "wildcard languages should match {injection_language}"
+            );
+            assert_eq!(result.unwrap().server_name, "efm");
+        }
+    }
+
+    #[test]
+    fn test_get_config_wildcard_mixed_with_exact_language_still_matches() {
+        let coordinator = BridgeCoordinator::new();
+
+        let mut servers = HashMap::new();
+        servers.insert(
+            "efm".to_string(),
+            BridgeServerConfig {
+                cmd: vec!["efm-langserver".to_string()],
+                languages: vec!["_".to_string(), "python".to_string()],
+                initialization_options: None,
+            },
+        );
+
+        let settings = WorkspaceSettings {
+            languages: HashMap::new(),
+            auto_install: false,
+            language_servers: servers,
+            ..Default::default()
+        };
+
+        // exact entry still matches
+        assert!(
+            coordinator
+                .get_config_for_language(&settings, "markdown", "python")
+                .is_some(),
+            "exact language listed alongside wildcard should match"
+        );
+        // wildcard entry matches everything else
+        assert!(
+            coordinator
+                .get_config_for_language(&settings, "markdown", "rust")
+                .is_some(),
+            "wildcard listed alongside exact language should match other languages"
+        );
+    }
+
+    #[test]
+    fn test_get_all_configs_wildcard_server_included_with_exact_servers() {
+        let coordinator = BridgeCoordinator::new();
+
+        let mut servers = HashMap::new();
+        servers.insert(
+            "pyright".to_string(),
+            BridgeServerConfig {
+                cmd: vec!["pyright-langserver".to_string()],
+                languages: vec!["python".to_string()],
+                initialization_options: None,
+            },
+        );
+        servers.insert(
+            "efm".to_string(),
+            BridgeServerConfig {
+                cmd: vec!["efm-langserver".to_string()],
+                languages: vec!["_".to_string()],
+                initialization_options: None,
+            },
+        );
+
+        let settings = WorkspaceSettings {
+            languages: HashMap::new(),
+            auto_install: false,
+            language_servers: servers,
+            ..Default::default()
+        };
+
+        let result = coordinator.get_all_configs_for_language(&settings, "markdown", "python");
+        let names: Vec<&str> = result.iter().map(|r| r.server_name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["efm", "pyright"],
+            "wildcard server should fan out together with exact-match servers"
+        );
+    }
+
+    #[test]
+    fn test_get_config_wildcard_language_still_respects_bridge_filter() {
+        let coordinator = BridgeCoordinator::new();
+
+        // markdown host only allows python bridging
+        let mut languages = HashMap::new();
+        let mut bridge_filter = HashMap::new();
+        bridge_filter.insert(
+            "python".to_string(),
+            BridgeLanguageConfig {
+                enabled: Some(true),
+                ..Default::default()
+            },
+        );
+        languages.insert(
+            "markdown".to_string(),
+            LanguageSettings {
+                bridge: Some(bridge_filter),
+                ..Default::default()
+            },
+        );
+
+        let mut servers = HashMap::new();
+        servers.insert(
+            "efm".to_string(),
+            BridgeServerConfig {
+                cmd: vec!["efm-langserver".to_string()],
+                languages: vec!["_".to_string()],
+                initialization_options: None,
+            },
+        );
+
+        let settings = WorkspaceSettings {
+            languages,
+            auto_install: false,
+            language_servers: servers,
+            ..Default::default()
+        };
+
+        assert!(
+            coordinator
+                .get_config_for_language(&settings, "markdown", "rust")
+                .is_none(),
+            "host bridge filter must still block languages even for wildcard servers"
+        );
+        assert!(
+            coordinator
+                .get_config_for_language(&settings, "markdown", "python")
+                .is_some(),
+            "wildcard server should match languages allowed by the host bridge filter"
+        );
     }
 
     #[test]

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -51,9 +51,10 @@ pub(crate) struct ResolvedServerConfig {
 
 /// How a server's `languages` list matched an injection language.
 ///
-/// Ordered by specificity: `Exact` < `Wildcard`, so `Ord::min` selects the
-/// more specific match when one server lists the language explicitly and
-/// another relies on the `"_"` wildcard.
+/// The enum sorts from most- to least-specific: `Exact` orders before
+/// `Wildcard`, so taking the minimum selects the most specific match when
+/// one server lists the language explicitly and another relies on the `"_"`
+/// wildcard.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum LanguageMatch {
     /// The injection language appears verbatim in `languages`.


### PR DESCRIPTION
Closes #360

## Summary

`BridgeServerConfig.languages` now accepts `"_"` as a wildcard matching **any** injection language, so generic servers (e.g. `efm-langserver` as formatter/linter/spell checker) no longer need every language enumerated:

```jsonc
{
  "languageServers": {
    "efm": { "cmd": ["efm-langserver"], "languages": ["_"] }
  }
}
```

This mirrors the existing wildcard convention (`languageServers._` config inheritance, `languages._` host defaults). The host-language `bridge` filter is still enforced before server lookup, so a wildcard server only sees languages the host allows.

## Changes

- `src/lsp/bridge/coordinator.rs`: predicate extracted to `server_handles_language` (private) and applied at both config-lookup callsites (`get_config_for_language`, `get_all_configs_for_language`); 4 new unit tests (wildcard match, mixed exact+wildcard, fan-out alongside exact servers, bridge-filter gating)
- `src/config/settings.rs`: doc comment on `languages` (feeds the generated JSON schema)
- `docs/README.md`: server-configuration table updated
- `src/config/merge.rs`: test-only lookup simulation aligned with the new predicate (review finding)

## Acceptance criteria (from #360)

- [x] `languages: ["_"]` matches any injection language
- [x] `languages: ["_", "python"]` still works (no regression)
- [x] Unit tests for the wildcard match in `coordinator.rs`
- [x] Config schema / docs updated

## Review

Subagent-orchestrated multi-perspective review (10 perspectives, fact-checked): round 1 found one nit (stale test-only predicate in `merge.rs`, fixed in d60a4cb8); round 2: no confirmed issues.