### PR TITLE
feat(node): add `childWithDescendant` two-id accessor

### DIFF
--- a/docs/architecture-decisions/node-reference-protocol.md
+++ b/docs/architecture-decisions/node-reference-protocol.md
@@ -236,8 +236,11 @@ To let clients introspect and walk the tree without re-implementing tree-sitter,
 | `firstChildForByte` (`byte`) | `NodeInfo \| null` | `first_child_for_byte(b)` |
 | `descendantForByteRange` (`startByte`, `endByte`) | `NodeInfo \| null` | `descendant_for_byte_range(s, e)` |
 | `namedDescendantForByteRange` (`startByte`, `endByte`) | `NodeInfo \| null` | `named_descendant_for_byte_range(s, e)` |
+| `childWithDescendant` (`descendantId`) | `NodeInfo \| null` | `child_with_descendant(d)` |
 
 Out-of-range / negative `index` or `byte` values collapse to `null` rather than erroring, consistent with the universal null semantics.
+
+`childWithDescendant` is the only **two-id** accessor: `{ textDocument, id, descendantId }` resolves both ids and returns the immediate child of `id` that contains `descendantId`. Both ids must have been minted in the **same** injection layer — both nodes must live in one tree for the ancestor/descendant relation to be meaningful, so a cross-layer pair collapses to `null` rather than resolving either id against the other's layer. tree-sitter leaves `child_with_descendant` undefined when the argument is not actually a descendant (byte-containment ties on equal-range unary chains); the server verifies the relation during the descent and normalizes every unrelated pair — including `descendantId == id` — to the universal `null`.
 
 **Position / range accessors** report and accept line/column as LSP `Position` (`{ line, character }`), **not** tree-sitter's native `Point`:
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -722,6 +722,10 @@ async fn run_lsp_server() {
         Kakehashi::kakehashi_node_named_children,
     )
     .custom_method(
+        "kakehashi/node/childWithDescendant",
+        Kakehashi::kakehashi_node_child_with_descendant,
+    )
+    .custom_method(
         "kakehashi/node/nextSibling",
         Kakehashi::kakehashi_node_next_sibling,
     )

--- a/src/lsp/lsp_impl/kakehashi/node/common.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/common.rs
@@ -361,6 +361,18 @@ impl Kakehashi {
             return Value::Null;
         };
 
+        // Silent stale-range guard, mirroring the single-id prelude: an
+        // invalid tracked range can't name a real node and must collapse to
+        // null *without* the drift warning below — `with_resolved_node_pair`
+        // would also reject it, but through the warn-logging arm.
+        if start > end
+            || end > host_text.len()
+            || desc_start > desc_end
+            || desc_end > host_text.len()
+        {
+            return Value::Null;
+        }
+
         let Some(picked) = with_resolved_node_pair(
             &self.language,
             &host_language,

--- a/src/lsp/lsp_impl/kakehashi/node/common.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/common.rs
@@ -383,12 +383,15 @@ impl Kakehashi {
             layer,
             f,
         ) else {
-            // A tracker hit that fails pair resolution mirrors the single-id
-            // drift warning: worth surfacing for diagnosis, still null on the
-            // wire.
-            log::warn!(
+            // Unlike the single-id drift warning, pair-resolution failure is
+            // an expected outcome, not just drift: ids minted at the same
+            // depth in *different* regions (two separate code blocks, or the
+            // #350 overlap caveat) legitimately fail to share a tree and
+            // collapse to the contract's null. debug, not warn — a normal
+            // cross-region query must not look like document drift in logs.
+            log::debug!(
                 target: "kakehashi::node",
-                "tracker hit but pair did not resolve in minting layer {} for uri={} self=[{},{}) {} descendant=[{},{}) {}",
+                "pair did not resolve in one minting-layer tree (layer {}) for uri={} self=[{},{}) {} descendant=[{},{}) {}",
                 layer, uri, start, end, kind, desc_start, desc_end, desc_kind
             );
             return Value::Null;

--- a/src/lsp/lsp_impl/kakehashi/node/common.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/common.rs
@@ -17,7 +17,9 @@ use tower_lsp_server::ls_types::{Position, TextDocumentIdentifier, Uri};
 use ulid::Ulid;
 use url::Url;
 
-use crate::lsp::lsp_impl::kakehashi::node::injection_stack::with_resolved_node_ranges;
+use crate::lsp::lsp_impl::kakehashi::node::injection_stack::{
+    with_resolved_node_pair, with_resolved_node_ranges,
+};
 use crate::lsp::lsp_impl::{Kakehashi, uri_to_url};
 
 /// A tracked node's `(start_byte, end_byte, kind)` triple, as produced by a
@@ -62,6 +64,18 @@ pub struct NodeFieldNameParams {
     pub text_document: TextDocumentIdentifier,
     pub id: String,
     pub name: String,
+}
+
+/// Request parameters for the two-id accessor `childWithDescendant`
+/// (issue #335): `id` names the prospective ancestor, `descendantId` the node
+/// whose containing immediate child is requested. Both ids must have been
+/// minted in the same injection layer; a cross-layer pair collapses to `null`.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeDescendantParams {
+    pub text_document: TextDocumentIdentifier,
+    pub id: String,
+    pub descendant_id: String,
 }
 
 /// Request parameters for `firstChildForByte`.
@@ -282,6 +296,89 @@ impl Kakehashi {
         f: impl FnMut(tree_sitter::Node<'_>, &str, &[tree_sitter::Range]) -> Option<NodeTriple>,
     ) -> Value {
         let Some((uri, layer, picked)) = self.with_node_text_ranges(lsp_uri, id, f).await else {
+            return Value::Null;
+        };
+        match picked {
+            Some(triple) => self.mint_node_info(&uri, layer, triple),
+            None => Value::Null,
+        }
+    }
+
+    /// Resolve `id` **and** `descendant_id` in the layer that minted them, run
+    /// `f` on the pair to pick a related node, and return its `NodeInfo` — or
+    /// JSON `null` (issue #335, two-id contract).
+    ///
+    /// On top of the single-id null cases (invalid URI, malformed/unknown
+    /// ULID, unparsed document, drifted range), the pair collapses to `null`
+    /// when the two ids were minted in **different** layers: both nodes must
+    /// live in one tree for tree-sitter's ancestor/descendant queries to be
+    /// meaningful, and resolving them against different layers' trees would
+    /// break the per-layer Scope rule. The result is re-minted in that shared
+    /// layer, like every other navigation accessor.
+    pub(super) async fn navigate_with_descendant(
+        &self,
+        lsp_uri: &Uri,
+        id: &str,
+        descendant_id: &str,
+        f: impl FnMut(tree_sitter::Node<'_>, tree_sitter::Node<'_>) -> Option<NodeTriple>,
+    ) -> Value {
+        let Ok(uri) = uri_to_url(lsp_uri) else {
+            log::warn!(target: "kakehashi::node", "invalid URI: {}", lsp_uri.as_str());
+            return Value::Null;
+        };
+
+        // Either ULID being malformed collapses to null, like a never-issued id.
+        let Ok(ulid) = id.parse::<Ulid>() else {
+            return Value::Null;
+        };
+        let Ok(descendant_ulid) = descendant_id.parse::<Ulid>() else {
+            return Value::Null;
+        };
+
+        let tracker = self.bridge.node_tracker();
+        let Some((start, end, kind, layer)) = tracker.lookup_node(&uri, &ulid) else {
+            return Value::Null;
+        };
+        let Some((desc_start, desc_end, desc_kind, desc_layer)) =
+            tracker.lookup_node(&uri, &descendant_ulid)
+        else {
+            return Value::Null;
+        };
+        // Two-id same-layer contract: ids minted in different layers never
+        // share a tree, so the relation is undefined — null, not an error.
+        if layer != desc_layer {
+            return Value::Null;
+        }
+
+        // Same didOpen race guard as the single-id prelude.
+        self.ensure_parsed_for_node_lookup(&uri).await;
+        let Some(snapshot) = self.documents.get(&uri).and_then(|doc| doc.snapshot()) else {
+            return Value::Null;
+        };
+        let host_text = snapshot.text();
+        let host_tree = snapshot.tree();
+        let Some(host_language) = self.document_language(&uri) else {
+            return Value::Null;
+        };
+
+        let Some(picked) = with_resolved_node_pair(
+            &self.language,
+            &host_language,
+            host_text,
+            host_tree,
+            (start, end, kind),
+            (desc_start, desc_end, desc_kind),
+            layer,
+            f,
+        ) else {
+            // A tracker hit that fails pair resolution mirrors the single-id
+            // drift warning: worth surfacing for diagnosis, still null on the
+            // wire.
+            log::warn!(
+                target: "kakehashi::node",
+                "tracker hit but pair did not resolve in minting layer {} for uri={} self=[{},{}) {} descendant=[{},{}) {}",
+                layer, uri, start, end, kind, desc_start, desc_end, desc_kind
+            );
             return Value::Null;
         };
         match picked {

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -318,6 +318,55 @@ pub(super) fn with_resolved_node_ranges<R>(
     Some(f(node, &layer_entry.ranges))
 }
 
+/// Resolve **two** tracked nodes in the **same** minting layer and run `f` on
+/// the pair — the two-id contract behind `childWithDescendant` (issue #335).
+///
+/// Both `(start, end, kind)` triples must name nodes in one tree: the layer's
+/// tree is materialised once and both lookups run against it, so the pair can
+/// never straddle two layers. The stack walk is anchored at the *descendant's*
+/// start byte — the method's contract requires the descendant to lie inside
+/// `node`, so when the pair is genuinely related the smallest-region path at
+/// that byte reaches the layer that minted both. An unrelated pair (descendant
+/// outside `node`, or minted from a different same-depth region — the #350
+/// overlap caveat applies here too) simply fails one of the lookups and
+/// collapses to `None`, the protocol's re-acquire signal.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn with_resolved_node_pair<R>(
+    coordinator: &LanguageCoordinator,
+    host_language: &str,
+    host_text: &str,
+    host_tree: &tree_sitter::Tree,
+    node: (usize, usize, &'static str),
+    descendant: (usize, usize, &'static str),
+    layer: usize,
+    mut f: impl FnMut(tree_sitter::Node<'_>, tree_sitter::Node<'_>) -> R,
+) -> Option<R> {
+    let (node_start, node_end, node_kind) = node;
+    let (desc_start, desc_end, desc_kind) = descendant;
+    // Same defensive range guards as the single-node path: a stale tracker
+    // entry must collapse to null before any tree work.
+    if node_start > node_end
+        || node_end > host_text.len()
+        || desc_start > desc_end
+        || desc_end > host_text.len()
+    {
+        return None;
+    }
+
+    // Host layer: both resolve against the host tree, no stack walk.
+    if layer == 0 {
+        let resolved_node = find_node_at(host_tree, node_start, node_end, node_kind)?;
+        let resolved_desc = find_node_at(host_tree, desc_start, desc_end, desc_kind)?;
+        return Some(f(resolved_node, resolved_desc));
+    }
+
+    let stack = injection_stack_at(coordinator, host_language, host_text, host_tree, desc_start);
+    let layer_entry = stack.get(layer)?;
+    let resolved_node = find_node_at(&layer_entry.tree, node_start, node_end, node_kind)?;
+    let resolved_desc = find_node_at(&layer_entry.tree, desc_start, desc_end, desc_kind)?;
+    Some(f(resolved_node, resolved_desc))
+}
+
 /// Collect the injection languages along the cursor's injection path at
 /// `byte`, at all depths that are currently parseable.
 ///

--- a/src/lsp/lsp_impl/kakehashi/node/navigation.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/navigation.rs
@@ -18,7 +18,7 @@ use tower_lsp_server::jsonrpc::Result;
 
 use crate::lsp::lsp_impl::Kakehashi;
 use crate::lsp::lsp_impl::kakehashi::node::common::{
-    NodeByteParams, NodeByteRangeParams, NodeIdParams, NodeIndexParams,
+    NodeByteParams, NodeByteRangeParams, NodeDescendantParams, NodeIdParams, NodeIndexParams,
 };
 use crate::lsp::lsp_impl::kakehashi::node::injection_stack::ranges_contain_byte;
 
@@ -62,6 +62,42 @@ impl Kakehashi {
                 let mut cursor = n.walk();
                 n.named_children(&mut cursor).map(triple).collect()
             })
+            .await)
+    }
+
+    /// `kakehashi/node/childWithDescendant` — the immediate child of `id` that
+    /// contains `descendantId`, per `Node::child_with_descendant` (issue #335).
+    ///
+    /// The only two-id accessor: both ids must have been minted in the
+    /// **same** injection layer (a cross-layer pair is `null`), and `null`
+    /// also covers a descendant that is not actually inside `id` — including
+    /// `descendantId == id`, since no child contains the node itself.
+    pub async fn kakehashi_node_child_with_descendant(
+        &self,
+        params: NodeDescendantParams,
+    ) -> Result<Value> {
+        Ok(self
+            .navigate_with_descendant(
+                &params.text_document.uri,
+                &params.id,
+                &params.descendant_id,
+                |node, descendant| {
+                    // tree-sitter leaves child_with_descendant undefined when
+                    // `descendant` is not in `node`'s subtree: byte containment
+                    // ties on equal-range unary chains (e.g. markdown's
+                    // document → section) make it return a child for
+                    // descendant == self or an ancestor. The first step of the
+                    // descent is the answer; keep descending until we actually
+                    // reach `descendant` by node id, so every unrelated pair
+                    // normalizes to the protocol's universal null instead.
+                    let answer = node.child_with_descendant(descendant)?;
+                    let mut current = answer;
+                    while current.id() != descendant.id() {
+                        current = current.child_with_descendant(descendant)?;
+                    }
+                    Some(triple(answer))
+                },
+            )
             .await)
     }
 

--- a/tests/e2e_kakehashi_node_accessors.rs
+++ b/tests/e2e_kakehashi_node_accessors.rs
@@ -1194,3 +1194,59 @@ fn test_child_with_descendant_rejects_cross_layer_pair() {
         cross
     );
 }
+
+/// The two-id contract also holds **inside** an injection layer: with both ids
+/// minted in the python layer (layer 1), the immediate child resolves through
+/// the pair path that rebuilds the injection stack, and `descendant == self`
+/// still collapses to `null` there.
+#[test]
+fn test_child_with_descendant_in_injection_layer() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+    let uri = "file:///accessors_cwd_injection.md";
+    open_markdown(&mut client, uri, BLOCKQUOTED_PYTHON);
+
+    let python_root = python_layer_root(&mut client, uri);
+    let children = call(
+        &mut client,
+        "kakehashi/node/children",
+        id_params(uri, &python_root),
+    );
+    let child = &children.as_array().expect("python children array")[0];
+    let child_id = id_of(child);
+    let grandchildren = call(
+        &mut client,
+        "kakehashi/node/children",
+        id_params(uri, &child_id),
+    );
+    let grandchild_id = id_of(
+        &grandchildren
+            .as_array()
+            .expect("python grandchildren array")[0],
+    );
+
+    let via_grandchild = call(
+        &mut client,
+        "kakehashi/node/childWithDescendant",
+        descendant_params(uri, &python_root, &grandchild_id),
+    );
+    assert!(
+        !via_grandchild.is_null(),
+        "childWithDescendant must resolve inside an injection layer"
+    );
+    assert_eq!(
+        id_of(&via_grandchild),
+        child_id,
+        "must return the immediate python-layer child containing the descendant"
+    );
+
+    let self_pair = call(
+        &mut client,
+        "kakehashi/node/childWithDescendant",
+        descendant_params(uri, &python_root, &python_root),
+    );
+    assert!(
+        self_pair.is_null(),
+        "descendant == self must be null in an injection layer too"
+    );
+}

--- a/tests/e2e_kakehashi_node_accessors.rs
+++ b/tests/e2e_kakehashi_node_accessors.rs
@@ -6,7 +6,7 @@
 //! `isMissing`, `startByte`, `endByte`, `byteRange`, `childCount`,
 //! `namedChildCount`, `descendantCount`, `toSexp`, `child`, `namedChild`,
 //! `namedChildren`, `nextSibling`, `prevSibling`, `nextNamedSibling`,
-//! `prevNamedSibling`, `firstChildForByte`, `descendantForByteRange`,
+//! `prevNamedSibling`, `childWithDescendant`, `firstChildForByte`, `descendantForByteRange`,
 //! `namedDescendantForByteRange`, `childByFieldName`, `childrenByFieldName`,
 //! `fieldNameForChild`, `fieldNameForNamedChild`, `range`, `startPosition`,
 //! `endPosition`, `descendantForPointRange`, `namedDescendantForPointRange`.
@@ -1063,4 +1063,134 @@ fn test_point_lookups_in_excluded_gap_are_null() {
             v
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// childWithDescendant (two-id, same-layer contract — issue #335)
+// ---------------------------------------------------------------------------
+
+/// `{ textDocument, id, descendantId }` request body for `childWithDescendant`.
+fn descendant_params(uri: &str, id: &str, descendant_id: &str) -> serde_json::Value {
+    json!({ "textDocument": { "uri": uri }, "id": id, "descendantId": descendant_id })
+}
+
+/// `childWithDescendant(self, descendant)` returns the immediate child of
+/// `self` on the path to `descendant` — for a grandchild that is the
+/// intermediate child, and for an immediate child it is the child itself
+/// (mirroring `Node::child_with_descendant`).
+#[test]
+fn test_child_with_descendant_returns_child_on_path() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+    let uri = "file:///accessors_cwd_path.md";
+    open_markdown(&mut client, uri, DOC);
+    let root = root_id(&mut client, uri);
+
+    // Walk two levels down: child = children(root)[0], grandchild = children(child)[0].
+    let children = call(
+        &mut client,
+        "kakehashi/node/children",
+        id_params(uri, &root),
+    );
+    let child = &children.as_array().expect("children array")[0];
+    let child_id = id_of(child);
+    let grandchildren = call(
+        &mut client,
+        "kakehashi/node/children",
+        id_params(uri, &child_id),
+    );
+    let grandchild_id = id_of(&grandchildren.as_array().expect("grandchildren array")[0]);
+
+    // Grandchild: the immediate child on the path is `child` (same minted id).
+    let via_grandchild = call(
+        &mut client,
+        "kakehashi/node/childWithDescendant",
+        descendant_params(uri, &root, &grandchild_id),
+    );
+    assert!(
+        !via_grandchild.is_null(),
+        "childWithDescendant(root, grandchild) must resolve"
+    );
+    assert_eq!(
+        id_of(&via_grandchild),
+        child_id,
+        "must return the immediate child containing the descendant"
+    );
+
+    // Immediate child: returns the child itself.
+    let via_child = call(
+        &mut client,
+        "kakehashi/node/childWithDescendant",
+        descendant_params(uri, &root, &child_id),
+    );
+    assert!(!via_child.is_null());
+    assert_eq!(id_of(&via_child), child_id);
+}
+
+/// Degenerate relations collapse to `null`: `descendant == self` (no child
+/// contains the node itself), an inverted pair (root is not a descendant of
+/// its child), and a malformed `descendantId`.
+#[test]
+fn test_child_with_descendant_null_for_non_descendants() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+    let uri = "file:///accessors_cwd_null.md";
+    open_markdown(&mut client, uri, DOC);
+    let root = root_id(&mut client, uri);
+
+    let children = call(
+        &mut client,
+        "kakehashi/node/children",
+        id_params(uri, &root),
+    );
+    let child_id = id_of(&children.as_array().expect("children array")[0]);
+
+    let self_pair = call(
+        &mut client,
+        "kakehashi/node/childWithDescendant",
+        descendant_params(uri, &root, &root),
+    );
+    assert!(self_pair.is_null(), "descendant == self must be null");
+
+    let inverted = call(
+        &mut client,
+        "kakehashi/node/childWithDescendant",
+        descendant_params(uri, &child_id, &root),
+    );
+    assert!(
+        inverted.is_null(),
+        "an ancestor is not a descendant — must be null"
+    );
+
+    let malformed = call(
+        &mut client,
+        "kakehashi/node/childWithDescendant",
+        descendant_params(uri, &root, "not-a-ulid"),
+    );
+    assert!(malformed.is_null(), "malformed descendantId must be null");
+}
+
+/// Both ids must have been minted in the **same** injection layer: pairing a
+/// markdown host node with a python injected-layer node collapses to `null`,
+/// even though the injected node's span lies inside the host node's span.
+#[test]
+fn test_child_with_descendant_rejects_cross_layer_pair() {
+    let mut client = LspClient::new();
+    initialize(&mut client);
+    let uri = "file:///accessors_cwd_cross_layer.md";
+    open_markdown(&mut client, uri, BLOCKQUOTED_PYTHON);
+
+    let host_root = root_id(&mut client, uri);
+    let python_root = python_layer_root(&mut client, uri);
+
+    let cross = call(
+        &mut client,
+        "kakehashi/node/childWithDescendant",
+        descendant_params(uri, &host_root, &python_root),
+    );
+    assert!(
+        cross.is_null(),
+        "host-layer self with injected-layer descendant must be null, got {:?}",
+        cross
+    );
 }


### PR DESCRIPTION
Closes #335

## Summary

Adds `kakehashi/node/childWithDescendant` — the `Node::child_with_descendant` mirror deferred in #335 and the protocol's only **two-id** accessor: `{ textDocument, id, descendantId }` returns the immediate child of `id` containing `descendantId`, re-minted in the shared layer.

## Contract (per the issue)

- Both ids must resolve **in the same injection layer** — a cross-layer pair collapses to `null` (per-layer Scope rule; resolving one id against the other's layer would be meaningless).
- `descendantId` must actually be a descendant of `id`. tree-sitter leaves `child_with_descendant` **undefined** for non-descendant arguments (byte-containment ties on equal-range unary chains like markdown's `document → section` make it return a child even for `descendant == self`), so the handler verifies the relation by descending until it reaches the descendant by node id and normalizes every unrelated pair — including `descendantId == id` — to the universal `null`.
- The result child is re-minted in the same layer.

## Changes

- `node/common.rs`: `NodeDescendantParams` + `navigate_with_descendant` prelude (two ULID lookups, layer-equality check, silent stale-range guard mirroring the single-id prelude, drift warning parity)
- `node/injection_stack.rs`: `with_resolved_node_pair` — resolves both triples in **one** layer tree, stack walk anchored at the descendant's start byte
- `node/navigation.rs`: handler with descent verification
- `src/bin/main.rs`: `custom_method("kakehashi/node/childWithDescendant", …)`
- ADR `node-reference-protocol.md`: navigation table row + two-id contract paragraph
- e2e: 4 tests — grandchild/immediate-child path, null for self/inverted/malformed pairs, cross-layer rejection, and the injection-layer (layer 1) happy path

## Review

Subagent-orchestrated multi-perspective review (10 perspectives, fact-checked): round 1 found 1 minor (injection-layer path untested) + 1 nit (spurious drift warn for stale ranges), both fixed in 168b4a04; round 2: no confirmed issues.