### PR TITLE
fix(injection): honor child exclusion inside #offset! windows

### DIFF
--- a/src/analysis/selection/range_builder.rs
+++ b/src/analysis/selection/range_builder.rs
@@ -17,7 +17,7 @@ use super::injection_aware::{
 };
 use crate::analysis::offset_calculator::{ByteRange, calculate_effective_range};
 use crate::language::injection::{
-    self, compute_included_ranges, has_include_children_for_pattern,
+    self, compute_included_ranges_clipped, has_include_children_for_pattern,
     parse_offset_directive_for_pattern, parse_with_ranges,
 };
 use crate::text::PositionMapper;
@@ -93,25 +93,24 @@ pub fn build_from_node_in_injection(
 ///
 /// Computes included ranges to exclude named children (e.g., `block_continuation`
 /// nodes in blockquote code blocks), then delegates to [`parse_with_ranges`] for
-/// the set/parse/reset protocol. Skipped when an offset directive is active because
-/// `compute_included_ranges()` returns ranges relative to `content_node.start_byte()`,
-/// which would be misaligned with the offset-adjusted `content_text`.
+/// the set/parse/reset protocol. `effective_window` is the post-`#offset!`
+/// span of `content_text` within `text` (the coordinate space of
+/// `content_node`); gaps are clipped to it so child exclusion and offset
+/// directives compose (#186). Without an offset the window equals the content
+/// node span.
 ///
 /// Returns `None` if `set_included_ranges` fails (after logging a warning).
 fn parse_with_included_ranges(
     parser: &mut Parser,
+    text: &str,
     content_text: &str,
     content_node: &Node,
-    has_offset: bool,
+    effective_window: std::ops::Range<usize>,
     include_children: bool,
     lang_name: &str,
 ) -> Option<Tree> {
-    // Skip included ranges when offset directive is active (misaligned byte ranges)
-    let included_ranges = if has_offset {
-        None
-    } else {
-        compute_included_ranges(content_node, include_children)
-    };
+    let included_ranges =
+        compute_included_ranges_clipped(content_node, include_children, text, effective_window);
 
     parse_with_ranges(
         parser,
@@ -178,28 +177,25 @@ pub fn build(
         return build_fallback();
     };
 
-    let (content_text, effective_start_byte) = if let Some(offset) = offset_from_query {
+    let effective_window = if let Some(offset) = offset_from_query {
         let byte_range = ByteRange::new(content_node.start_byte(), content_node.end_byte());
         let effective = calculate_effective_range(doc_ctx.text, byte_range, offset);
-        (
-            &doc_ctx.text[effective.start..effective.end],
-            effective.start,
-        )
+        effective.start..effective.end
     } else {
-        (
-            &doc_ctx.text[content_node.byte_range()],
-            content_node.start_byte(),
-        )
+        content_node.byte_range()
     };
+    let content_text = &doc_ctx.text[effective_window.clone()];
+    let effective_start_byte = effective_window.start;
 
     let include_children =
         injection_query_ref.is_some_and(|q| has_include_children_for_pattern(q, pattern_index));
 
     let Some(injected_tree) = parse_with_included_ranges(
         &mut parser,
+        doc_ctx.text,
         content_text,
         &content_node,
-        offset_from_query.is_some(),
+        effective_window,
         include_children,
         injected_lang,
     ) else {
@@ -308,19 +304,15 @@ fn build_nested_injection(
     }
 
     let offset = parse_offset_directive_for_pattern(injection_query, pattern_index);
-    let (nested_text, nested_effective_start_byte) = if let Some(off) = offset {
+    let nested_window = if let Some(off) = offset {
         let byte_range = ByteRange::new(content_node.start_byte(), content_node.end_byte());
         let effective = calculate_effective_range(text, byte_range, off);
-        (
-            &text[effective.start..effective.end],
-            parent_start_byte + effective.start,
-        )
+        effective.start..effective.end
     } else {
-        (
-            &text[content_node.byte_range()],
-            parent_start_byte + content_node.start_byte(),
-        )
+        content_node.byte_range()
     };
+    let nested_text = &text[nested_window.clone()];
+    let nested_effective_start_byte = parent_start_byte + nested_window.start;
 
     let Some(mut nested_parser) = inj_ctx.acquire_parser(&nested_lang) else {
         return build_from_node_in_injection(*node, parent_start_byte, doc_ctx.mapper);
@@ -330,9 +322,10 @@ fn build_nested_injection(
 
     let Some(nested_tree) = parse_with_included_ranges(
         &mut nested_parser,
+        text,
         nested_text,
         &content_node,
-        offset.is_some(),
+        nested_window,
         include_children,
         &nested_lang,
     ) else {
@@ -488,5 +481,90 @@ fn splice_effective_range_into_hierarchy(
     SelectionRange {
         range: selection.range,
         parent,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::language::injection::collect_all_injections;
+
+    #[test]
+    fn parse_with_included_ranges_strips_prefixes_inside_offset_window() {
+        // #186: #offset! WITHOUT injection.include-children. The selection
+        // path must still exclude blockquote `> ` prefixes when parsing the
+        // post-offset window.
+        //
+        // Byte map:
+        //   "> ```rust\n"      0..10
+        //   "> let a = 1;\n"  10..23   (trimmed by the offset)
+        //   "> let b = 2;\n"  23..36   (prefix at 23..25)
+        //   "> ```\n"         36..42
+        let md_language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        let mut md_parser = Parser::new();
+        md_parser
+            .set_language(&md_language)
+            .expect("set md language");
+        let text = "> ```rust\n> let a = 1;\n> let b = 2;\n> ```\n";
+        let md_tree = md_parser.parse(text, None).expect("parse markdown");
+
+        let query = tree_sitter::Query::new(
+            &md_language,
+            r#"
+            ((fenced_code_block
+               (info_string (language) @injection.language)
+               (code_fence_content) @injection.content)
+              (#offset! @injection.content 1 0 0 0))
+            "#,
+        )
+        .expect("valid offset injection query");
+
+        let regions = collect_all_injections(&md_tree.root_node(), text, Some(&query))
+            .expect("should find injections");
+        assert_eq!(regions.len(), 1);
+        let content_node = regions[0].content_node;
+        assert!(!regions[0].include_children);
+
+        let offset = parse_offset_directive_for_pattern(&query, regions[0].pattern_index)
+            .expect("offset directive");
+        let byte_range = ByteRange::new(content_node.start_byte(), content_node.end_byte());
+        let effective = calculate_effective_range(text, byte_range, offset);
+        let content_text = &text[effective.start..effective.end];
+
+        // Control: without child exclusion the parser sees the `> ` prefix
+        // and produces an erroneous tree — this is what the old gate did.
+        let rust_language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        let mut control_parser = Parser::new();
+        control_parser
+            .set_language(&rust_language)
+            .expect("set rust language");
+        let control_tree = control_parser
+            .parse(content_text, None)
+            .expect("parse control");
+        assert!(
+            control_tree.root_node().has_error(),
+            "control: prefix-polluted content must not parse cleanly"
+        );
+
+        let mut rust_parser = Parser::new();
+        rust_parser
+            .set_language(&rust_language)
+            .expect("set rust language");
+        let tree = parse_with_included_ranges(
+            &mut rust_parser,
+            text,
+            content_text,
+            &content_node,
+            effective.start..effective.end,
+            regions[0].include_children,
+            "rust",
+        )
+        .expect("parse injected content");
+
+        assert!(
+            !tree.root_node().has_error(),
+            "prefixes must be excluded inside the offset window; got tree: {}",
+            tree.root_node().to_sexp()
+        );
     }
 }

--- a/src/analysis/selection/range_builder.rs
+++ b/src/analysis/selection/range_builder.rs
@@ -17,8 +17,9 @@ use super::injection_aware::{
 };
 use crate::analysis::offset_calculator::{ByteRange, calculate_effective_range};
 use crate::language::injection::{
-    self, compute_included_ranges_clipped, has_include_children_for_pattern,
-    parse_offset_directive_for_pattern, parse_with_ranges,
+    self, InjectionOffset, ceil_char_boundary, compute_included_ranges_clipped,
+    floor_char_boundary, has_include_children_for_pattern, parse_offset_directive_for_pattern,
+    parse_with_ranges,
 };
 use crate::text::PositionMapper;
 
@@ -86,6 +87,30 @@ pub fn build_from_node_in_injection(
     SelectionRange {
         range: adjust_range_to_host(node, content_start_byte, mapper),
         parent,
+    }
+}
+
+/// Effective (post-`#offset!`) window of `content_node` within `text`.
+///
+/// Offset deltas are byte counts and can land mid-codepoint, so the bounds
+/// are snapped inward to char boundaries (ceil the start, floor the end —
+/// matching the semantic and bridge paths) before callers slice `text` with
+/// them; a degenerate result collapses to an empty window instead of an
+/// inverted one. Without an offset the window is the content node span.
+fn effective_window_for(
+    text: &str,
+    content_node: &Node,
+    offset: Option<InjectionOffset>,
+) -> std::ops::Range<usize> {
+    match offset {
+        Some(off) => {
+            let byte_range = ByteRange::new(content_node.start_byte(), content_node.end_byte());
+            let effective = calculate_effective_range(text, byte_range, off);
+            let start = ceil_char_boundary(text, effective.start);
+            let end = floor_char_boundary(text, effective.end);
+            start.min(end)..end
+        }
+        None => content_node.byte_range(),
     }
 }
 
@@ -177,13 +202,7 @@ pub fn build(
         return build_fallback();
     };
 
-    let effective_window = if let Some(offset) = offset_from_query {
-        let byte_range = ByteRange::new(content_node.start_byte(), content_node.end_byte());
-        let effective = calculate_effective_range(doc_ctx.text, byte_range, offset);
-        effective.start..effective.end
-    } else {
-        content_node.byte_range()
-    };
+    let effective_window = effective_window_for(doc_ctx.text, &content_node, offset_from_query);
     let content_text = &doc_ctx.text[effective_window.clone()];
     let effective_start_byte = effective_window.start;
 
@@ -304,15 +323,10 @@ fn build_nested_injection(
     }
 
     let offset = parse_offset_directive_for_pattern(injection_query, pattern_index);
-    let nested_window = if let Some(off) = offset {
-        let byte_range = ByteRange::new(content_node.start_byte(), content_node.end_byte());
-        let effective = calculate_effective_range(text, byte_range, off);
-        effective.start..effective.end
-    } else {
-        content_node.byte_range()
-    };
+    let nested_window = effective_window_for(text, &content_node, offset);
     let nested_text = &text[nested_window.clone()];
-    let nested_effective_start_byte = parent_start_byte + nested_window.start;
+    let nested_window_start = nested_window.start;
+    let nested_effective_start_byte = parent_start_byte + nested_window_start;
 
     let Some(mut nested_parser) = inj_ctx.acquire_parser(&nested_lang) else {
         return build_from_node_in_injection(*node, parent_start_byte, doc_ctx.mapper);
@@ -333,13 +347,9 @@ fn build_nested_injection(
         return build_from_node_in_injection(*node, parent_start_byte, doc_ctx.mapper);
     };
 
-    let nested_relative_byte = if let Some(off) = offset {
-        let byte_range = ByteRange::new(content_node.start_byte(), content_node.end_byte());
-        let effective = calculate_effective_range(text, byte_range, off);
-        cursor_byte.saturating_sub(effective.start)
-    } else {
-        cursor_byte.saturating_sub(content_node.start_byte())
-    };
+    // Relative to the snapped window start so it stays consistent with the
+    // sliced `nested_text`.
+    let nested_relative_byte = cursor_byte.saturating_sub(nested_window_start);
 
     let nested_root = nested_tree.root_node();
 
@@ -488,6 +498,47 @@ fn splice_effective_range_into_hierarchy(
 mod tests {
     use super::*;
     use crate::language::injection::collect_all_injections;
+
+    #[test]
+    fn effective_window_for_snaps_offset_to_char_boundaries() {
+        // Offsets are byte deltas; +1 into "あ" (3 bytes) lands mid-codepoint
+        // and would panic the `&text[window]` content slice without snapping.
+        let rust_language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        let mut parser = Parser::new();
+        parser
+            .set_language(&rust_language)
+            .expect("set rust language");
+        let text = "let s = \"あい\";";
+        let tree = parser.parse(text, None).expect("parse rust");
+        let content = tree
+            .root_node()
+            .descendant_for_byte_range(9, 15)
+            .expect("string_content node");
+        assert_eq!(content.kind(), "string_content");
+        assert_eq!(content.byte_range(), 9..15);
+
+        let offset = InjectionOffset {
+            start_row: 0,
+            start_column: 1,
+            end_row: 0,
+            end_column: 0,
+        };
+        let window = effective_window_for(text, &content, Some(offset));
+        assert_eq!(window, 12..15, "start snaps forward past the mid-codepoint");
+        assert_eq!(&text[window], "い");
+
+        // Degenerate after snapping: both ends collapse into an empty window
+        // rather than an inverted (panicking) one.
+        let collapse = InjectionOffset {
+            start_row: 0,
+            start_column: 1,
+            end_row: 0,
+            end_column: -1,
+        };
+        let window = effective_window_for(text, &content, Some(collapse));
+        assert!(window.is_empty());
+        assert!(text.get(window).is_some(), "window must be sliceable");
+    }
 
     #[test]
     fn parse_with_included_ranges_strips_prefixes_inside_offset_window() {

--- a/src/analysis/selection/range_builder.rs
+++ b/src/analysis/selection/range_builder.rs
@@ -17,9 +17,9 @@ use super::injection_aware::{
 };
 use crate::analysis::offset_calculator::{ByteRange, calculate_effective_range};
 use crate::language::injection::{
-    self, InjectionOffset, ceil_char_boundary, compute_included_ranges_clipped,
-    floor_char_boundary, has_include_children_for_pattern, parse_offset_directive_for_pattern,
-    parse_with_ranges,
+    self, InjectionOffset, ceil_char_boundary, compute_included_ranges,
+    compute_included_ranges_clipped, effective_offset_for_pattern, floor_char_boundary,
+    has_include_children_for_pattern, parse_with_ranges,
 };
 use crate::text::PositionMapper;
 
@@ -134,8 +134,14 @@ fn parse_with_included_ranges(
     include_children: bool,
     lang_name: &str,
 ) -> Option<Tree> {
-    let included_ranges =
-        compute_included_ranges_clipped(content_node, include_children, text, effective_window);
+    // The offset-free window equals the node span; the node-anchored variant
+    // then gives the same gaps while reusing tree-sitter's cached node Points
+    // instead of scanning text for the window's Points.
+    let included_ranges = if effective_window == content_node.byte_range() {
+        compute_included_ranges(content_node, include_children)
+    } else {
+        compute_included_ranges_clipped(content_node, include_children, text, effective_window)
+    };
 
     parse_with_ranges(
         parser,
@@ -177,7 +183,7 @@ pub fn build(
     }
 
     let offset_from_query =
-        injection_query_ref.and_then(|q| parse_offset_directive_for_pattern(q, pattern_index));
+        injection_query_ref.and_then(|q| effective_offset_for_pattern(q, pattern_index));
 
     if let Some(offset) = offset_from_query
         && !is_cursor_within_effective_range(doc_ctx.text, &content_node, cursor_byte, offset)
@@ -246,7 +252,7 @@ pub fn build(
             nested_injection_info
         {
             let nested_offset =
-                parse_offset_directive_for_pattern(nested_inj_query.as_ref(), nested_pattern_index);
+                effective_offset_for_pattern(nested_inj_query.as_ref(), nested_pattern_index);
 
             let cursor_in_nested = match nested_offset {
                 Some(offset) => is_cursor_within_effective_range(
@@ -322,7 +328,7 @@ fn build_nested_injection(
         return build_from_node_in_injection(*node, parent_start_byte, doc_ctx.mapper);
     }
 
-    let offset = parse_offset_directive_for_pattern(injection_query, pattern_index);
+    let offset = effective_offset_for_pattern(injection_query, pattern_index);
     let nested_window = effective_window_for(text, &content_node, offset);
     let nested_text = &text[nested_window.clone()];
     let nested_window_start = nested_window.start;
@@ -576,7 +582,7 @@ mod tests {
         let content_node = regions[0].content_node;
         assert!(!regions[0].include_children);
 
-        let offset = parse_offset_directive_for_pattern(&query, regions[0].pattern_index)
+        let offset = effective_offset_for_pattern(&query, regions[0].pattern_index)
             .expect("offset directive");
         let byte_range = ByteRange::new(content_node.start_byte(), content_node.end_byte());
         let effective = calculate_effective_range(text, byte_range, offset);

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -20,8 +20,8 @@ use crate::config::CaptureMappings;
 use crate::language::LanguageCoordinator;
 use crate::language::injection::{
     InjectionRegionInfo, MAX_INJECTION_DEPTH, compute_included_ranges,
-    effective_offset_for_pattern, has_combined_for_pattern, intersect_included_ranges,
-    parse_with_ranges, sub_select_included_ranges,
+    compute_included_ranges_clipped, effective_offset_for_pattern, has_combined_for_pattern,
+    intersect_included_ranges, parse_with_ranges, sub_select_included_ranges,
 };
 use crate::text::position::byte_to_utf16_col;
 
@@ -448,30 +448,35 @@ fn collect_injection_contexts_sync<'a>(
         // (e.g., block_continuation), we compute gap ranges so the injection parser
         // only sees actual code content.
         //
-        // Disabled when an offset directive is active: compute_included_ranges()
-        // returns ranges relative to content_node.start_byte(), but content_text
-        // starts at inj_start_byte (offset-adjusted). Passing misaligned ranges
-        // to the parser would produce incorrect results.
-        let included_ranges = if offset.is_some() {
-            None
+        // With an offset directive, content_text starts at inj_start_byte
+        // (offset-adjusted) rather than content_node.start_byte(), so gaps are
+        // clipped to the effective window and relativized to it (#186). The
+        // non-offset path keeps the node-anchored variant, which reuses the
+        // node's cached Points instead of rescanning text.
+        let from_children = if offset.is_some() {
+            compute_included_ranges_clipped(
+                &injection.content_node,
+                injection.include_children,
+                text,
+                inj_start_byte..inj_end_byte,
+            )
         } else {
-            let from_children =
-                compute_included_ranges(&injection.content_node, injection.include_children);
-            let from_parent = parent_included_ranges.and_then(|parent_ranges| {
-                sub_select_included_ranges(parent_ranges, inj_start_byte, inj_end_byte)
-            });
-            match (from_children, from_parent) {
-                (Some(child_ranges), Some(parent_ranges)) => {
-                    let intersected = intersect_included_ranges(&child_ranges, &parent_ranges);
-                    if intersected.is_empty() {
-                        None
-                    } else {
-                        Some(intersected)
-                    }
+            compute_included_ranges(&injection.content_node, injection.include_children)
+        };
+        let from_parent = parent_included_ranges.and_then(|parent_ranges| {
+            sub_select_included_ranges(parent_ranges, inj_start_byte, inj_end_byte)
+        });
+        let included_ranges = match (from_children, from_parent) {
+            (Some(child_ranges), Some(parent_ranges)) => {
+                let intersected = intersect_included_ranges(&child_ranges, &parent_ranges);
+                if intersected.is_empty() {
+                    None
+                } else {
+                    Some(intersected)
                 }
-                (Some(ranges), None) | (None, Some(ranges)) => Some(ranges),
-                (None, None) => None,
             }
+            (Some(ranges), None) | (None, Some(ranges)) => Some(ranges),
+            (None, None) => None,
         };
 
         // Record exclusion ranges for parent token suppression (Problem 2: host token leaking).
@@ -479,13 +484,12 @@ fn collect_injection_contexts_sync<'a>(
         // so that compute_active_injection_regions() produces per-line ActiveInjectionBounds values.
         // Otherwise, push the single full content range as before.
         if let Some(ref ranges) = included_ranges {
-            // compute_included_ranges returns ranges relative to content_node.start_byte().
-            // In this branch, offset.is_none(), so inj_start_byte == content_node.start_byte();
-            // we use content_node.start_byte() explicitly as the base for clarity.
-            let base_byte = content_node.start_byte();
+            // Gap ranges are relative to the effective window start: with an
+            // offset directive that is inj_start_byte; without one,
+            // inj_start_byte == content_node.start_byte().
             for r in ranges {
-                let abs_start = base_byte + r.start_byte;
-                let abs_end = base_byte + r.end_byte;
+                let abs_start = inj_start_byte + r.start_byte;
+                let abs_end = inj_start_byte + r.end_byte;
                 exclusion_ranges.push((abs_start, abs_end));
             }
         } else {
@@ -1286,6 +1290,111 @@ local x = 42
             has_local_keyword,
             "Should have 'local' keyword token at line 3, col 0. Got: {:?}",
             tokens
+        );
+    }
+
+    #[test]
+    fn test_collect_injection_tokens_offset_with_child_exclusion() {
+        use crate::config::WorkspaceSettings;
+
+        let coordinator = LanguageCoordinator::new();
+        let settings = WorkspaceSettings {
+            search_paths: vec![test_search_path()],
+            ..Default::default()
+        };
+        let _summary = coordinator.load_settings(&settings);
+
+        let md_result = coordinator.ensure_language_loaded("markdown");
+        let lua_result = coordinator.ensure_language_loaded("lua");
+        if !md_result.success || !lua_result.success {
+            eprintln!("Skipping: markdown or lua parser not available");
+            return;
+        }
+
+        // #186: #offset! WITHOUT injection.include-children. The row offset
+        // trims the first content line; blockquote `> ` prefixes
+        // (block_continuation children) must still be excluded within the
+        // remaining window.
+        let md_language = coordinator
+            .language_registry_for_parallel()
+            .get("markdown")
+            .expect("markdown language must be loaded");
+        let query = Query::new(
+            &md_language,
+            r#"
+            ((fenced_code_block
+               (info_string (language) @injection.language)
+               (code_fence_content) @injection.content)
+              (#offset! @injection.content 1 0 0 0))
+            "#,
+        )
+        .expect("valid offset injection query");
+        coordinator
+            .query_store()
+            .insert_injection_query("markdown".to_string(), Arc::new(query));
+
+        // Line 0: > ```lua
+        // Line 1: > local a = 1   (trimmed by the offset)
+        // Line 2: > local b = 2   (only surviving content line)
+        // Line 3: > ```
+        let text = "> ```lua\n> local a = 1\n> local b = 2\n> ```\n";
+        let mut parser_pool = coordinator.create_document_parser_pool();
+        let Some(mut parser) = parser_pool.acquire("markdown") else {
+            eprintln!("Skipping: markdown parser not available");
+            return;
+        };
+        let Some(tree) = parser.parse(text, None) else {
+            eprintln!("Skipping: failed to parse document");
+            return;
+        };
+        parser_pool.release("markdown".to_string(), parser);
+
+        let host_lines: Vec<&str> = text.lines().collect();
+        let (tokens, regions) = collect_injection_tokens_parallel(
+            text,
+            &host_lines,
+            &build_line_start_bytes(text),
+            &tree,
+            Some("markdown"),
+            &coordinator,
+            None,
+            false,
+        );
+
+        // The surviving `local` keyword maps to host line 2, col 2 (after the
+        // stripped `> ` prefix).
+        let (keyword_type, keyword_mods) =
+            crate::analysis::semantic::legend::map_capture_to_token_type_and_modifiers("keyword")
+                .unwrap();
+        assert!(
+            tokens.iter().any(|t| {
+                t.line == 2
+                    && t.column == 2
+                    && t.kind
+                        == crate::analysis::semantic::token_collector::TokenKind::Mapped(
+                            keyword_type,
+                            keyword_mods,
+                        )
+            }),
+            "Should have 'local' keyword token at line 2, col 2. Got: {:?}",
+            tokens
+        );
+
+        // No injection token may land on the excluded `> ` prefix.
+        assert!(
+            tokens.iter().all(|t| !(t.line == 2 && t.column < 2)),
+            "No token may cover the excluded blockquote prefix. Got: {:?}",
+            tokens
+        );
+
+        // Active regions must start after the prefix, proving the exclusion
+        // ranges were clipped to the post-offset window rather than dropped.
+        assert!(
+            regions
+                .iter()
+                .any(|r| r.start_line == 2 && r.start_col == 2),
+            "Active region should start at line 2 col 2 (post-offset, post-prefix). Got: {:?}",
+            regions
         );
     }
 

--- a/src/language/injection.rs
+++ b/src/language/injection.rs
@@ -2327,15 +2327,10 @@ mod tests {
         let tree = parser.parse(text, None).unwrap();
         let func = tree.root_node().named_child(0).expect("function_item");
 
-        let unclipped =
-            compute_included_ranges(&func, false).expect("named children produce gaps");
-        let clipped = compute_included_ranges_clipped(
-            &func,
-            false,
-            text,
-            func.start_byte()..func.end_byte(),
-        )
-        .expect("full window should produce the same gaps");
+        let unclipped = compute_included_ranges(&func, false).expect("named children produce gaps");
+        let clipped =
+            compute_included_ranges_clipped(&func, false, text, func.start_byte()..func.end_byte())
+                .expect("full window should produce the same gaps");
 
         assert_eq!(
             clipped, unclipped,
@@ -2360,8 +2355,14 @@ mod tests {
 
         assert_eq!(ranges.len(), 1);
         assert_eq!((ranges[0].start_byte, ranges[0].end_byte), (5, 6));
-        assert_eq!(ranges[0].start_point, tree_sitter::Point { row: 0, column: 5 });
-        assert_eq!(ranges[0].end_point, tree_sitter::Point { row: 0, column: 6 });
+        assert_eq!(
+            ranges[0].start_point,
+            tree_sitter::Point { row: 0, column: 5 }
+        );
+        assert_eq!(
+            ranges[0].end_point,
+            tree_sitter::Point { row: 0, column: 6 }
+        );
     }
 
     #[test]
@@ -2411,9 +2412,15 @@ mod tests {
         // Gap [9..10) relative to window start 6.
         assert_eq!((ranges[0].start_byte, ranges[0].end_byte), (3, 4));
         // Same row as window start: column is relative (4 - 1 = 3).
-        assert_eq!(ranges[0].start_point, tree_sitter::Point { row: 0, column: 3 });
+        assert_eq!(
+            ranges[0].start_point,
+            tree_sitter::Point { row: 0, column: 3 }
+        );
         // Next row: column stays absolute.
-        assert_eq!(ranges[0].end_point, tree_sitter::Point { row: 1, column: 0 });
+        assert_eq!(
+            ranges[0].end_point,
+            tree_sitter::Point { row: 1, column: 0 }
+        );
     }
 
     #[test]

--- a/src/language/injection.rs
+++ b/src/language/injection.rs
@@ -606,14 +606,19 @@ fn extract_virtual_content_and_offsets(
     // Child-exclusion gaps restricted to the effective window (#186):
     // cacheable.byte_range already reflects any #offset! directive (applied
     // and char-boundary-aligned by from_region_info), so gaps are clipped to
-    // it and relativized to its start — without an offset the window equals
-    // the content node span and this matches compute_included_ranges.
-    let included_ranges = compute_included_ranges_clipped(
-        &region.content_node,
-        region.include_children,
-        text,
-        cacheable.byte_range.clone(),
-    );
+    // it and relativized to its start. Without an offset the window equals
+    // the content node span, so the node-anchored variant gives the same
+    // result while reusing tree-sitter's cached node Points (no text scan).
+    let included_ranges = if region.offset.is_some() {
+        compute_included_ranges_clipped(
+            &region.content_node,
+            region.include_children,
+            text,
+            cacheable.byte_range.clone(),
+        )
+    } else {
+        compute_included_ranges(&region.content_node, region.include_children)
+    };
     let virtual_content = extract_clean_content(
         text,
         cacheable.byte_range.clone(),

--- a/src/language/injection.rs
+++ b/src/language/injection.rs
@@ -722,6 +722,24 @@ fn position_of_byte(
     (row as u32, column)
 }
 
+/// Convert an absolute byte offset to a `tree_sitter::Point` (byte-based
+/// column). Used when an offset directive shifts the injection boundary away
+/// from a known node position, so we can't reuse the content node's
+/// start/end points.
+pub(crate) fn byte_to_point(text: &str, byte: usize) -> tree_sitter::Point {
+    // Align first — slicing `&text[..clamped]` on a mid-character byte would
+    // panic and crash the LSP server.
+    let clamped = floor_char_boundary(text, byte);
+    let prefix = &text[..clamped];
+    let row = prefix.bytes().filter(|b| *b == b'\n').count();
+    let last_nl = prefix.rfind('\n');
+    let column = match last_nl {
+        Some(idx) => clamped - idx - 1,
+        None => clamped,
+    };
+    tree_sitter::Point { row, column }
+}
+
 /// Snap `index` forward to the nearest char boundary (stable alternative to
 /// the unstable `str::ceil_char_boundary`).
 pub(crate) fn ceil_char_boundary(text: &str, mut index: usize) -> usize {

--- a/src/language/injection.rs
+++ b/src/language/injection.rs
@@ -232,6 +232,55 @@ pub(crate) fn compute_included_ranges(
     content_node: &tree_sitter::Node,
     include_children: bool,
 ) -> Option<Vec<tree_sitter::Range>> {
+    compute_included_ranges_in_window(
+        content_node,
+        include_children,
+        content_node.start_byte(),
+        content_node.start_position(),
+        content_node.end_byte(),
+        content_node.end_position(),
+    )
+}
+
+/// Like [`compute_included_ranges`], but restricted to an effective byte
+/// window — the post-`#offset!` span (#186). Children outside the window are
+/// ignored; children straddling a window edge are clipped to it. Returned
+/// ranges are relative to `window.start`, matching the content slice handed
+/// to the injection parser.
+///
+/// `window` bounds must lie on char boundaries (callers snap with
+/// `ceil_char_boundary` / `floor_char_boundary` before slicing the content).
+pub(crate) fn compute_included_ranges_clipped(
+    content_node: &tree_sitter::Node,
+    include_children: bool,
+    text: &str,
+    window: std::ops::Range<usize>,
+) -> Option<Vec<tree_sitter::Range>> {
+    if window.start >= window.end {
+        return None;
+    }
+    compute_included_ranges_in_window(
+        content_node,
+        include_children,
+        window.start,
+        byte_to_point(text, window.start),
+        window.end,
+        byte_to_point(text, window.end),
+    )
+}
+
+/// Shared core of [`compute_included_ranges`] /
+/// [`compute_included_ranges_clipped`]: gaps between the content node's named
+/// children, restricted to `[window_start_byte, window_end_byte)` and
+/// relativized to the window start.
+fn compute_included_ranges_in_window(
+    content_node: &tree_sitter::Node,
+    include_children: bool,
+    window_start_byte: usize,
+    window_start_point: tree_sitter::Point,
+    window_end_byte: usize,
+    window_end_point: tree_sitter::Point,
+) -> Option<Vec<tree_sitter::Range>> {
     if include_children || content_node.named_child_count() == 0 {
         return None;
     }
@@ -250,19 +299,15 @@ pub(crate) fn compute_included_ranges(
         return None;
     }
 
-    let node_start_byte = content_node.start_byte();
-    let node_start_pos = content_node.start_position();
-    let node_end_byte = content_node.end_byte();
-    let node_end_pos = content_node.end_position();
-
-    // Helper to make a Point relative to the content node's start.
-    // Column is only adjusted when the point is on the same row as the node start,
-    // because only that row has a non-zero column offset from the node origin.
+    // Helper to make a Point relative to the window's start.
+    // Column is only adjusted when the point is on the same row as the window
+    // start, because only that row has a non-zero column offset from the
+    // window origin.
     let relativize_point = |p: tree_sitter::Point| -> tree_sitter::Point {
         tree_sitter::Point {
-            row: p.row.saturating_sub(node_start_pos.row),
-            column: if p.row == node_start_pos.row {
-                p.column.saturating_sub(node_start_pos.column)
+            row: p.row.saturating_sub(window_start_point.row),
+            column: if p.row == window_start_point.row {
+                p.column.saturating_sub(window_start_point.column)
             } else {
                 p.column
             },
@@ -270,8 +315,8 @@ pub(crate) fn compute_included_ranges(
     };
 
     let mut ranges = Vec::new();
-    let mut cursor_byte = node_start_byte;
-    let mut cursor_point = node_start_pos;
+    let mut cursor_byte = window_start_byte;
+    let mut cursor_point = window_start_point;
 
     let mut tree_cursor = content_node.walk();
     for child in content_node.named_children(&mut tree_cursor) {
@@ -286,14 +331,33 @@ pub(crate) fn compute_included_ranges(
             continue;
         }
 
+        // Entirely before the window (or before an earlier child that already
+        // advanced the cursor): nothing to exclude here.
+        if child_end_byte <= cursor_byte {
+            continue;
+        }
+        // Children are in document order; the first one at/after the window
+        // end means no later child can affect the window either.
+        if child_start_byte >= window_end_byte {
+            break;
+        }
+
         // Gap before this child
         if cursor_byte < child_start_byte {
             ranges.push(tree_sitter::Range {
-                start_byte: cursor_byte - node_start_byte,
-                end_byte: child_start_byte - node_start_byte,
+                start_byte: cursor_byte - window_start_byte,
+                end_byte: child_start_byte - window_start_byte,
                 start_point: relativize_point(cursor_point),
                 end_point: relativize_point(child.start_position()),
             });
+        }
+
+        // A child running past the window end is clipped: the window's tail
+        // is covered, so no final gap remains.
+        if child_end_byte >= window_end_byte {
+            cursor_byte = window_end_byte;
+            cursor_point = window_end_point;
+            break;
         }
 
         cursor_byte = child_end_byte;
@@ -301,12 +365,12 @@ pub(crate) fn compute_included_ranges(
     }
 
     // Gap after last child
-    if cursor_byte < node_end_byte {
+    if cursor_byte < window_end_byte {
         ranges.push(tree_sitter::Range {
-            start_byte: cursor_byte - node_start_byte,
-            end_byte: node_end_byte - node_start_byte,
+            start_byte: cursor_byte - window_start_byte,
+            end_byte: window_end_byte - window_start_byte,
             start_point: relativize_point(cursor_point),
-            end_point: relativize_point(node_end_pos),
+            end_point: relativize_point(window_end_point),
         });
     }
 
@@ -528,17 +592,17 @@ fn extract_virtual_content_and_offsets(
     cacheable: &CacheableInjectionRegion,
     text: &str,
 ) -> (String, Vec<u32>) {
-    // Disabled when an offset directive is active: compute_included_ranges()
-    // returns ranges relative to content_node.start_byte(), but with #offset!
-    // the cacheable byte_range starts elsewhere — misaligned ranges would
-    // extract wrong content. Mirrors the semantic path (parallel.rs); the
-    // offset × child-exclusion interaction is tracked in #186 (every vendored
-    // #offset! query sets include-children, so nothing is lost today).
-    let included_ranges = if region.offset.is_some() {
-        None
-    } else {
-        compute_included_ranges(&region.content_node, region.include_children)
-    };
+    // Child-exclusion gaps restricted to the effective window (#186):
+    // cacheable.byte_range already reflects any #offset! directive (applied
+    // and char-boundary-aligned by from_region_info), so gaps are clipped to
+    // it and relativized to its start — without an offset the window equals
+    // the content node span and this matches compute_included_ranges.
+    let included_ranges = compute_included_ranges_clipped(
+        &region.content_node,
+        region.include_children,
+        text,
+        cacheable.byte_range.clone(),
+    );
     let virtual_content = extract_clean_content(
         text,
         cacheable.byte_range.clone(),
@@ -1608,6 +1672,39 @@ mod tests {
         assert_eq!(resolved[0].line_column_offsets, vec![0]);
     }
 
+    #[test]
+    fn test_resolved_virtual_content_combines_offset_with_child_exclusion() {
+        // #186: a query with #offset! but WITHOUT injection.include-children.
+        // Blockquote `> ` prefixes (block_continuation children) must still be
+        // stripped, restricted to the post-offset window — previously the
+        // child-exclusion step was skipped entirely whenever an offset was
+        // active, leaking prefixes into the virtual document.
+        let md_language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        let mut parser = Parser::new();
+        parser.set_language(&md_language).expect("set md language");
+        let text = "> ```lua\n> local a = 1\n> local b = 2\n> ```\n";
+        let tree = parser.parse(text, None).expect("parse markdown");
+
+        let query_str = r#"
+            ((fenced_code_block
+               (info_string (language) @injection.language)
+               (code_fence_content) @injection.content)
+              (#offset! @injection.content 1 0 0 0))
+        "#;
+        let query = Query::new(&md_language, query_str).expect("valid query");
+
+        let coordinator = test_coordinator();
+        let tracker = NodeTracker::new();
+        let uri = test_uri("offset_blockquote");
+
+        let resolved =
+            InjectionResolver::resolve_all(&coordinator, &tracker, &uri, &tree, text, &query);
+        assert_eq!(resolved.len(), 1);
+        // The row offset trims the first content line; child exclusion strips
+        // the remaining `> ` prefixes.
+        assert_eq!(resolved[0].virtual_content, "local b = 2\n");
+    }
+
     // ============================================================
     // Tests for InjectionResolver region_id generation
     // ============================================================
@@ -2221,6 +2318,102 @@ mod tests {
             covered.iter().all(|&b| b),
             "Gaps + children should cover the entire node"
         );
+    }
+
+    #[test]
+    fn test_compute_included_ranges_clipped_full_window_matches_unclipped() {
+        let mut parser = create_rust_parser();
+        let text = "fn main() {}";
+        let tree = parser.parse(text, None).unwrap();
+        let func = tree.root_node().named_child(0).expect("function_item");
+
+        let unclipped =
+            compute_included_ranges(&func, false).expect("named children produce gaps");
+        let clipped = compute_included_ranges_clipped(
+            &func,
+            false,
+            text,
+            func.start_byte()..func.end_byte(),
+        )
+        .expect("full window should produce the same gaps");
+
+        assert_eq!(
+            clipped, unclipped,
+            "window covering the whole node must reproduce compute_included_ranges"
+        );
+    }
+
+    #[test]
+    fn test_compute_included_ranges_clipped_drops_children_before_window() {
+        // "fn main() {}": named children of function_item are
+        // main(3..7), parameters(7..9), body(10..12); gaps are [0..3) and [9..10).
+        let mut parser = create_rust_parser();
+        let text = "fn main() {}";
+        let tree = parser.parse(text, None).unwrap();
+        let func = tree.root_node().named_child(0).expect("function_item");
+
+        // Window starts inside `main` (3..7): the straddling child is clipped,
+        // the "fn " gap disappears, and only the " " gap [9..10) remains,
+        // relative to the window start.
+        let ranges = compute_included_ranges_clipped(&func, false, text, 4..12)
+            .expect("gap inside window should survive");
+
+        assert_eq!(ranges.len(), 1);
+        assert_eq!((ranges[0].start_byte, ranges[0].end_byte), (5, 6));
+        assert_eq!(ranges[0].start_point, tree_sitter::Point { row: 0, column: 5 });
+        assert_eq!(ranges[0].end_point, tree_sitter::Point { row: 0, column: 6 });
+    }
+
+    #[test]
+    fn test_compute_included_ranges_clipped_truncates_at_window_end() {
+        let mut parser = create_rust_parser();
+        let text = "fn main() {}";
+        let tree = parser.parse(text, None).unwrap();
+        let func = tree.root_node().named_child(0).expect("function_item");
+
+        // Window ends inside the body (10..12): both gaps survive, and no
+        // spurious gap is emitted after the clipped body.
+        let ranges = compute_included_ranges_clipped(&func, false, text, 0..11)
+            .expect("gaps inside window should survive");
+
+        let bytes: Vec<(usize, usize)> =
+            ranges.iter().map(|r| (r.start_byte, r.end_byte)).collect();
+        assert_eq!(bytes, vec![(0, 3), (9, 10)]);
+    }
+
+    #[test]
+    fn test_compute_included_ranges_clipped_returns_none_when_children_cover_window() {
+        let mut parser = create_rust_parser();
+        let text = "fn main() {}";
+        let tree = parser.parse(text, None).unwrap();
+        let func = tree.root_node().named_child(0).expect("function_item");
+
+        // Window [10..12) lies entirely inside the body child: no gaps.
+        assert!(
+            compute_included_ranges_clipped(&func, false, text, 10..12).is_none(),
+            "window fully covered by a child has no gaps"
+        );
+    }
+
+    #[test]
+    fn test_compute_included_ranges_clipped_relativizes_points_to_window_start() {
+        // Two statements on separate lines; gaps are the newlines [4..5) and [9..10).
+        let mut parser = create_rust_parser();
+        let text = "a();\nb();\n";
+        let tree = parser.parse(text, None).unwrap();
+        let root = tree.root_node();
+
+        // Window starts at byte 6 = row 1, column 1 (inside `b();`).
+        let ranges = compute_included_ranges_clipped(&root, false, text, 6..10)
+            .expect("trailing newline gap should survive");
+
+        assert_eq!(ranges.len(), 1);
+        // Gap [9..10) relative to window start 6.
+        assert_eq!((ranges[0].start_byte, ranges[0].end_byte), (3, 4));
+        // Same row as window start: column is relative (4 - 1 = 3).
+        assert_eq!(ranges[0].start_point, tree_sitter::Point { row: 0, column: 3 });
+        // Next row: column stays absolute.
+        assert_eq!(ranges[0].end_point, tree_sitter::Point { row: 1, column: 0 });
     }
 
     #[test]

--- a/src/language/injection.rs
+++ b/src/language/injection.rs
@@ -236,9 +236,8 @@ pub(crate) fn compute_included_ranges(
         content_node,
         include_children,
         content_node.start_byte(),
-        content_node.start_position(),
         content_node.end_byte(),
-        content_node.end_position(),
+        || (content_node.start_position(), content_node.end_position()),
     )
 }
 
@@ -263,23 +262,33 @@ pub(crate) fn compute_included_ranges_clipped(
         content_node,
         include_children,
         window.start,
-        byte_to_point(text, window.start),
         window.end,
-        byte_to_point(text, window.end),
+        || {
+            // Anchor the scans on the content node's cached position so we only
+            // walk the (typically small) span between the node start and the
+            // window edges, not the whole document prefix. Lazy: skipped entirely
+            // when the guards in the core return early.
+            let anchor_byte = content_node.start_byte();
+            let anchor_point = content_node.start_position();
+            let start = byte_to_point_anchored(text, window.start, anchor_byte, anchor_point);
+            let end = byte_to_point_anchored(text, window.end, window.start, start);
+            (start, end)
+        },
     )
 }
 
 /// Shared core of [`compute_included_ranges`] /
 /// [`compute_included_ranges_clipped`]: gaps between the content node's named
 /// children, restricted to `[window_start_byte, window_end_byte)` and
-/// relativized to the window start.
+/// relativized to the window start. `window_points` lazily supplies the
+/// window bounds' Points — it is only invoked once the guards have decided
+/// gaps actually need computing.
 fn compute_included_ranges_in_window(
     content_node: &tree_sitter::Node,
     include_children: bool,
     window_start_byte: usize,
-    window_start_point: tree_sitter::Point,
     window_end_byte: usize,
-    window_end_point: tree_sitter::Point,
+    window_points: impl FnOnce() -> (tree_sitter::Point, tree_sitter::Point),
 ) -> Option<Vec<tree_sitter::Range>> {
     if include_children || content_node.named_child_count() == 0 {
         return None;
@@ -298,6 +307,8 @@ fn compute_included_ranges_in_window(
     if !has_nonzero_children {
         return None;
     }
+
+    let (window_start_point, window_end_point) = window_points();
 
     // Helper to make a Point relative to the window's start.
     // Column is only adjusted when the point is on the same row as the window
@@ -802,6 +813,35 @@ pub(crate) fn byte_to_point(text: &str, byte: usize) -> tree_sitter::Point {
         None => clamped,
     };
     tree_sitter::Point { row, column }
+}
+
+/// Like [`byte_to_point`], but scans only the span between a known anchor
+/// and `byte` instead of the whole prefix of `text` — the anchor is
+/// typically a tree-sitter node's cached `start_position()`. Falls back to a
+/// full scan when `byte` precedes the anchor (e.g. a negative `#offset!`
+/// extending before the content node). `anchor_byte` must lie on a char
+/// boundary, with `anchor_point` its Point in `text`.
+pub(crate) fn byte_to_point_anchored(
+    text: &str,
+    byte: usize,
+    anchor_byte: usize,
+    anchor_point: tree_sitter::Point,
+) -> tree_sitter::Point {
+    let clamped = floor_char_boundary(text, byte);
+    if clamped < anchor_byte {
+        return byte_to_point(text, clamped);
+    }
+    let segment = &text[anchor_byte..clamped];
+    match segment.rfind('\n') {
+        Some(last_nl) => tree_sitter::Point {
+            row: anchor_point.row + segment.bytes().filter(|b| *b == b'\n').count(),
+            column: segment.len() - last_nl - 1,
+        },
+        None => tree_sitter::Point {
+            row: anchor_point.row,
+            column: anchor_point.column + segment.len(),
+        },
+    }
 }
 
 /// Snap `index` forward to the nearest char boundary (stable alternative to
@@ -2318,6 +2358,23 @@ mod tests {
             covered.iter().all(|&b| b),
             "Gaps + children should cover the entire node"
         );
+    }
+
+    #[test]
+    fn test_byte_to_point_anchored_matches_full_scan() {
+        // Exhaustive equivalence with the full-prefix scan, covering the
+        // before-anchor fallback, same-row and cross-row targets, and
+        // mid-codepoint clamping (bytes inside あ floor to its start).
+        let text = "abc\ndefあ\nghi";
+        let anchor_byte = 4; // start of "def"
+        let anchor_point = byte_to_point(text, anchor_byte);
+        for byte in 0..=text.len() {
+            assert_eq!(
+                byte_to_point_anchored(text, byte, anchor_byte, anchor_point),
+                byte_to_point(text, byte),
+                "anchored and full scans must agree at byte {byte}"
+            );
+        }
     }
 
     #[test]

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -18,8 +18,9 @@
 use crate::analysis::offset_calculator::{ByteRange, calculate_effective_range};
 use crate::language::LanguageCoordinator;
 use crate::language::injection::{
-    MAX_INJECTION_DEPTH, ceil_char_boundary, collect_all_injections, compute_included_ranges,
-    effective_offset_for_pattern, floor_char_boundary, intersect_included_ranges,
+    MAX_INJECTION_DEPTH, byte_to_point, ceil_char_boundary, collect_all_injections,
+    compute_included_ranges, effective_offset_for_pattern, floor_char_boundary,
+    intersect_included_ranges,
 };
 use crate::lsp::lsp_impl::kakehashi::node::lookup::find_node_at;
 
@@ -892,19 +893,3 @@ fn discover_child_languages(
     }
 }
 
-/// Convert an absolute byte offset to a `tree_sitter::Point`. Used when an
-/// offset directive shifts the injection boundary away from a known node
-/// position, so we can't reuse the content node's start/end points.
-fn byte_to_point(text: &str, byte: usize) -> tree_sitter::Point {
-    // Align first — slicing `&text[..clamped]` on a mid-character byte would
-    // panic and crash the LSP server.
-    let clamped = floor_char_boundary(text, byte);
-    let prefix = &text[..clamped];
-    let row = prefix.bytes().filter(|b| *b == b'\n').count();
-    let last_nl = prefix.rfind('\n');
-    let column = match last_nl {
-        Some(idx) => clamped - idx - 1,
-        None => clamped,
-    };
-    tree_sitter::Point { row, column }
-}

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -18,9 +18,9 @@
 use crate::analysis::offset_calculator::{ByteRange, calculate_effective_range};
 use crate::language::LanguageCoordinator;
 use crate::language::injection::{
-    MAX_INJECTION_DEPTH, byte_to_point, ceil_char_boundary, collect_all_injections,
-    compute_included_ranges, compute_included_ranges_clipped, effective_offset_for_pattern,
-    floor_char_boundary, intersect_included_ranges,
+    MAX_INJECTION_DEPTH, byte_to_point, byte_to_point_anchored, ceil_char_boundary,
+    collect_all_injections, compute_included_ranges, compute_included_ranges_clipped,
+    effective_offset_for_pattern, floor_char_boundary, intersect_included_ranges,
 };
 use crate::lsp::lsp_impl::kakehashi::node::lookup::find_node_at;
 
@@ -563,17 +563,32 @@ fn build_effective_ranges(
             aligned_start..aligned_end,
         ) {
             Some(gaps) => {
-                let window_start_pos = byte_to_point(host_text, aligned_start);
+                let window_start_pos = byte_to_point_anchored(
+                    host_text,
+                    aligned_start,
+                    content_start,
+                    content_start_pos,
+                );
                 gaps.into_iter()
                     .map(|r| absolutize_range(r, aligned_start, window_start_pos))
                     .collect()
             }
-            None => vec![tree_sitter::Range {
-                start_byte: aligned_start,
-                end_byte: aligned_end,
-                start_point: byte_to_point(host_text, aligned_start),
-                end_point: byte_to_point(host_text, aligned_end),
-            }],
+            None => {
+                let start_point = byte_to_point_anchored(
+                    host_text,
+                    aligned_start,
+                    content_start,
+                    content_start_pos,
+                );
+                let end_point =
+                    byte_to_point_anchored(host_text, aligned_end, aligned_start, start_point);
+                vec![tree_sitter::Range {
+                    start_byte: aligned_start,
+                    end_byte: aligned_end,
+                    start_point,
+                    end_point,
+                }]
+            }
         }
     } else {
         match compute_included_ranges(&region.content_node, region.include_children) {

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -19,8 +19,8 @@ use crate::analysis::offset_calculator::{ByteRange, calculate_effective_range};
 use crate::language::LanguageCoordinator;
 use crate::language::injection::{
     MAX_INJECTION_DEPTH, byte_to_point, ceil_char_boundary, collect_all_injections,
-    compute_included_ranges, effective_offset_for_pattern, floor_char_boundary,
-    intersect_included_ranges,
+    compute_included_ranges, compute_included_ranges_clipped, effective_offset_for_pattern,
+    floor_char_boundary, intersect_included_ranges,
 };
 use crate::lsp::lsp_impl::kakehashi::node::lookup::find_node_at;
 
@@ -505,12 +505,11 @@ fn parse_with_absolute_ranges(
 
 /// Compute the absolute byte-range list that the injection parser would see
 /// for `region` given the host's `@injection.content` node, any `#offset!`
-/// directive on the pattern, and `compute_included_ranges` gap exclusions.
+/// directive on the pattern, and child-exclusion gap ranges (clipped to the
+/// post-offset window when both are active, #186).
 ///
-/// Returns an empty `Vec` when:
-/// - the offset-adjusted range is degenerate (`start >= end`); or
-/// - `compute_included_ranges` returns gaps that all fall outside the
-///   offset-adjusted span (intersection is empty).
+/// Returns an empty `Vec` when the offset-adjusted range is degenerate
+/// (`start >= end`, including after char-boundary alignment).
 fn build_effective_ranges(
     region: &crate::language::injection::InjectionRegionInfo<'_>,
     host_text: &str,
@@ -536,16 +535,10 @@ fn build_effective_ranges(
         return Vec::new();
     }
 
-    // 2. Compute compute_included_ranges gap list (relative coords inside
-    // content_node) and shift to absolute. Intersect each gap with the
-    // offset-adjusted span so blockquote prefixes excluded by the gap list and
-    // bytes trimmed by the offset directive are both honoured.
-    //
-    // Skip the include-gap step when an offset directive is active: gaps from
-    // `compute_included_ranges` are relative to `content_node.start_byte()`,
-    // but the offset may have moved the effective start away from there, and
-    // mixing the two coordinate frames would yield wrong ranges. The semantic-
-    // tokens parallel collector takes the same trade-off (see parallel.rs).
+    // 2. Compute the child-exclusion gap list (relative coords inside the
+    // effective window) and shift to absolute, so blockquote prefixes excluded
+    // by the gap list and bytes trimmed by the offset directive are both
+    // honoured (#186).
     let content_start = region.content_node.start_byte();
     let content_start_pos = region.content_node.start_position();
     let absolute_ranges: Vec<tree_sitter::Range> = if offset.is_some() {
@@ -563,36 +556,30 @@ fn build_effective_ranges(
         if aligned_start >= aligned_end {
             return Vec::new();
         }
-        vec![tree_sitter::Range {
-            start_byte: aligned_start,
-            end_byte: aligned_end,
-            start_point: byte_to_point(host_text, aligned_start),
-            end_point: byte_to_point(host_text, aligned_end),
-        }]
+        match compute_included_ranges_clipped(
+            &region.content_node,
+            region.include_children,
+            host_text,
+            aligned_start..aligned_end,
+        ) {
+            Some(gaps) => {
+                let window_start_pos = byte_to_point(host_text, aligned_start);
+                gaps.into_iter()
+                    .map(|r| absolutize_range(r, aligned_start, window_start_pos))
+                    .collect()
+            }
+            None => vec![tree_sitter::Range {
+                start_byte: aligned_start,
+                end_byte: aligned_end,
+                start_point: byte_to_point(host_text, aligned_start),
+                end_point: byte_to_point(host_text, aligned_end),
+            }],
+        }
     } else {
         match compute_included_ranges(&region.content_node, region.include_children) {
             Some(gaps) => gaps
                 .into_iter()
-                .map(|r| tree_sitter::Range {
-                    start_byte: content_start + r.start_byte,
-                    end_byte: content_start + r.end_byte,
-                    start_point: tree_sitter::Point {
-                        row: content_start_pos.row + r.start_point.row,
-                        column: if r.start_point.row == 0 {
-                            content_start_pos.column + r.start_point.column
-                        } else {
-                            r.start_point.column
-                        },
-                    },
-                    end_point: tree_sitter::Point {
-                        row: content_start_pos.row + r.end_point.row,
-                        column: if r.end_point.row == 0 {
-                            content_start_pos.column + r.end_point.column
-                        } else {
-                            r.end_point.column
-                        },
-                    },
-                })
+                .map(|r| absolutize_range(r, content_start, content_start_pos))
                 .collect(),
             None => vec![tree_sitter::Range {
                 start_byte: region.content_node.start_byte(),
@@ -604,6 +591,32 @@ fn build_effective_ranges(
     };
 
     absolute_ranges
+}
+
+/// Shift a window-relative gap range (as produced by
+/// `compute_included_ranges` / `compute_included_ranges_clipped`) into
+/// absolute host coordinates anchored at `base_byte` / `base_pos`. Columns
+/// are only shifted on the window's first row — later rows already carry
+/// absolute columns.
+fn absolutize_range(
+    r: tree_sitter::Range,
+    base_byte: usize,
+    base_pos: tree_sitter::Point,
+) -> tree_sitter::Range {
+    let absolutize_point = |p: tree_sitter::Point| tree_sitter::Point {
+        row: base_pos.row + p.row,
+        column: if p.row == 0 {
+            base_pos.column + p.column
+        } else {
+            p.column
+        },
+    };
+    tree_sitter::Range {
+        start_byte: base_byte + r.start_byte,
+        end_byte: base_byte + r.end_byte,
+        start_point: absolutize_point(r.start_point),
+        end_point: absolutize_point(r.end_point),
+    }
 }
 
 /// Half-open containment over a list of disjoint ranges, with the node-reference-protocol decision's
@@ -893,3 +906,63 @@ fn discover_child_languages(
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_effective_ranges_combines_offset_with_child_exclusion() {
+        // #186: #offset! WITHOUT injection.include-children. The row offset
+        // trims the first content line; blockquote `> ` prefixes
+        // (block_continuation children) must still be excluded within the
+        // remaining window.
+        //
+        // Byte map:
+        //   "> ```lua\n"       0..9
+        //   "> local a = 1\n"  9..23   (trimmed by the offset)
+        //   "> local b = 2\n" 23..37   (prefix at 23..25)
+        //   "> ```\n"         37..43
+        let md_language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&md_language).expect("set md language");
+        let text = "> ```lua\n> local a = 1\n> local b = 2\n> ```\n";
+        let tree = parser.parse(text, None).expect("parse markdown");
+
+        let query = tree_sitter::Query::new(
+            &md_language,
+            r#"
+            ((fenced_code_block
+               (info_string (language) @injection.language)
+               (code_fence_content) @injection.content)
+              (#offset! @injection.content 1 0 0 0))
+            "#,
+        )
+        .expect("valid offset injection query");
+
+        let regions = collect_all_injections(&tree.root_node(), text, Some(&query))
+            .expect("should find injections");
+        assert_eq!(regions.len(), 1);
+        assert!(
+            !regions[0].include_children,
+            "query must not set include-children for this scenario"
+        );
+
+        let ranges = build_effective_ranges(&regions[0], text, &query);
+
+        let bytes: Vec<(usize, usize)> =
+            ranges.iter().map(|r| (r.start_byte, r.end_byte)).collect();
+        assert_eq!(
+            bytes,
+            vec![(25, 37)],
+            "only the post-offset code (sans `> ` prefix) should remain"
+        );
+        assert_eq!(
+            ranges[0].start_point,
+            tree_sitter::Point { row: 2, column: 2 }
+        );
+        assert_eq!(
+            ranges[0].end_point,
+            tree_sitter::Point { row: 3, column: 0 }
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #186.

Queries combining `#offset!` with child exclusion (`injection.include-children` NOT set) previously lost the exclusion step entirely: every consumer skipped `compute_included_ranges` whenever an offset directive was active, because its gap ranges were anchored to the raw content node rather than the offset-shifted span. Blockquote `> ` prefixes then leaked into injection parsers, virtual documents, and selection hierarchies.

## Changes

- **`compute_included_ranges_clipped`** (`src/language/injection.rs`): computes child-exclusion gaps restricted to an effective (post-`#offset!`) byte window — children outside the window are dropped, straddlers are clipped, ranges are relativized to the window start. Shares a single core (`compute_included_ranges_in_window`) with the existing `compute_included_ranges`, so the two paths cannot diverge; the non-offset path keeps using the node's cached Points (no extra text scans on the hot path).
- Wired into all four consumers that previously gated on `offset.is_some()`:
  - semantic tokens parallel collector (`src/analysis/semantic/parallel.rs`) — also gains parent-range sub-selection in the offset case, and exclusion ranges now use the effective window start as base
  - bridge virtual content extraction (`src/language/injection.rs`)
  - node-reference-protocol injection stack (`src/lsp/lsp_impl/kakehashi/node/injection_stack.rs`) — relative→absolute mapping extracted into a shared `absolutize_range`
  - selectionRange builder (`src/analysis/selection/range_builder.rs`)
- `byte_to_point` moved from `injection_stack.rs` to the shared injection module (structural, Tidy First).

## Implementation notes (from #186)

1. ✅ Apply offset to compute effective byte range (was already done by each consumer)
2. ✅ Filter children to only those within the effective range
3. ✅ Clip partially-overlapping children to the effective range boundaries

## Tests

- Unit tests for window clipping semantics (full-window equivalence, drop-before-window, truncate-at-window-end, fully-covered window, point relativization mid-line)
- Per-consumer regression tests using a blockquote fenced code block with `#offset! 1 0 0 0` and no `include-children` (the exact interaction #186 deferred): virtual content, semantic token positions + active region bounds, absolute effective ranges, selection-path parse cleanliness (with a control assertion proving the discriminator)