### PR TITLE
feat(lsp): per-document wire-order gate at ingress

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -616,7 +616,9 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
 #[tokio::main]
 async fn run_lsp_server() {
     use env_logger::Builder;
-    use kakehashi::lsp::{CancelForwarder, Kakehashi, LanguageServerPool, RequestIdCapture};
+    use kakehashi::lsp::{
+        CancelForwarder, IngressOrderGate, Kakehashi, LanguageServerPool, RequestIdCapture,
+    };
     use std::sync::Arc;
     use tokio::io::{stdin, stdout};
     use tower_lsp_server::{LspService, Server};
@@ -794,6 +796,11 @@ async fn run_lsp_server() {
     // 1. Capture upstream request IDs (for ls-bridge-server-pool-coordination bridge requests)
     // 2. Forward $/cancelRequest notifications to downstream servers
     let service = RequestIdCapture::with_cancel_forwarder(service, cancel_forwarder);
+
+    // Outermost: assign per-document sequence tickets in wire order so
+    // didChange/didClose apply strictly ordered and semanticTokens requests
+    // observe every edit that preceded them on the wire (#342).
+    let service = IngressOrderGate::new(service);
 
     Server::new(stdin, stdout, socket).serve(service).await;
 }

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -9,6 +9,7 @@ mod synthetic_diagnostics;
 mod text_sync;
 
 mod aggregation;
+mod ingress_order;
 mod lsp_impl;
 mod progress;
 mod request_id;
@@ -16,6 +17,7 @@ mod semantic_request_tracker;
 mod settings;
 
 pub use bridge::LanguageServerPool;
+pub use ingress_order::IngressOrderGate;
 pub use lsp_impl::Kakehashi;
 pub(crate) use request_id::current_upstream_id;
 pub use request_id::{CancelForwarder, RequestIdCapture};

--- a/src/lsp/ingress_order.rs
+++ b/src/lsp/ingress_order.rs
@@ -1,0 +1,407 @@
+//! Tower middleware enforcing per-document wire order between document
+//! mutations and tree-reading requests at LSP ingress (#342).
+//!
+//! tower-lsp-server dispatches handler futures through `buffer_unordered`,
+//! which polls them concurrently: a `didChange` received *before* a
+//! `semanticTokens` request can be first-polled *after* it, so the request
+//! may snapshot a document missing edits that preceded it on the wire. The
+//! per-URI `edit_lock` acquired as a handler's first `.await` follows
+//! first-poll order — a strong practical mitigation but not a guarantee.
+//!
+//! `Server::serve` calls `service.call(req)` synchronously in wire order
+//! *before* buffering the returned futures, so this middleware can assign
+//! per-URI sequence tickets at `call` time:
+//!
+//! - **Writers** (`didOpen` / `didChange` / `didClose`) take the next ticket
+//!   and run only after the previous writer for the same document finished,
+//!   so edits and closes apply in strict wire order.
+//! - **Readers** (the `semanticTokens` family) snapshot the current tail
+//!   ticket at `call` time and run only once that ticket is done, so a
+//!   request observes every edit that preceded it on the wire — without
+//!   serializing token computation against later edits or other documents.
+//!
+//! Everything else passes through untouched.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use dashmap::DashMap;
+use tokio::sync::watch;
+use tower::Service;
+use tower_lsp_server::jsonrpc::{Request, Response};
+
+/// Per-document sequencing state.
+struct DocSeq {
+    /// Last issued writer ticket (tickets start at 1; 0 = none issued).
+    tail: u64,
+    /// Highest completed writer ticket. Waiters subscribe to this channel;
+    /// dropping the sender (entry removal after a close) wakes them with an
+    /// error, which they treat as "nothing left to wait for".
+    done: watch::Sender<u64>,
+}
+
+/// Issues per-document writer tickets and reader barriers in wire order.
+///
+/// `issue_writer_ticket` / `reader_barrier` are synchronous so they can run
+/// inside `Service::call`, which tower-lsp-server invokes in wire order; the
+/// returned values are awaited later, inside the buffered handler future.
+#[derive(Default)]
+pub(crate) struct DocumentSequencer {
+    docs: DashMap<String, DocSeq>,
+}
+
+impl DocumentSequencer {
+    /// Take the next writer ticket for `uri`.
+    pub(crate) fn issue_writer_ticket(&self, uri: &str) -> WriterGate {
+        let mut entry = self.docs.entry(uri.to_string()).or_insert_with(|| DocSeq {
+            tail: 0,
+            done: watch::Sender::new(0),
+        });
+        entry.tail += 1;
+        WriterGate {
+            ticket: entry.tail,
+            rx: entry.done.subscribe(),
+            guard: CompletionGuard {
+                ticket: entry.tail,
+                tx: entry.done.clone(),
+            },
+        }
+    }
+
+    /// Snapshot the barrier a reader of `uri` must wait behind: the writer
+    /// ticket tail at call time. Returns `None` when no writer is pending
+    /// (no entry, or every issued ticket already completed).
+    pub(crate) fn reader_barrier(&self, uri: &str) -> Option<ReaderBarrier> {
+        let entry = self.docs.get(uri)?;
+        if *entry.done.borrow() >= entry.tail {
+            return None;
+        }
+        Some(ReaderBarrier {
+            target: entry.tail,
+            rx: entry.done.subscribe(),
+        })
+    }
+
+    /// Drop `uri`'s sequencing state after a close completed, unless later
+    /// writers were already ticketed behind it. Dropping the entry also drops
+    /// the `done` sender, waking any stragglers still subscribed.
+    pub(crate) fn finish_close(&self, uri: &str, ticket: u64) {
+        self.docs.remove_if(uri, |_, seq| seq.tail == ticket);
+    }
+}
+
+/// A writer's place in its document's queue: await [`WriterGate::wait_turn`]
+/// before mutating, then drop the gate (or the whole future) to mark the
+/// ticket done — completion-on-drop keeps successors from wedging even if
+/// the handler future is cancelled at shutdown.
+pub(crate) struct WriterGate {
+    ticket: u64,
+    rx: watch::Receiver<u64>,
+    #[allow(dead_code)] // held for its Drop impl
+    guard: CompletionGuard,
+}
+
+impl WriterGate {
+    pub(crate) fn ticket(&self) -> u64 {
+        self.ticket
+    }
+
+    /// Wait until the previous writer ticket for this document completed.
+    pub(crate) async fn wait_turn(&mut self) {
+        let target = self.ticket - 1;
+        // Err means the sender was dropped (entry removed after a close):
+        // nothing is pending anymore, so proceed.
+        let _ = self.rx.wait_for(|done| *done >= target).await;
+    }
+}
+
+/// Marks a writer ticket complete on drop.
+struct CompletionGuard {
+    ticket: u64,
+    tx: watch::Sender<u64>,
+}
+
+impl Drop for CompletionGuard {
+    fn drop(&mut self) {
+        self.tx.send_modify(|done| {
+            if self.ticket > *done {
+                *done = self.ticket;
+            }
+        });
+    }
+}
+
+/// A reader's wait target: the writer tail ticket snapshotted at `call` time.
+pub(crate) struct ReaderBarrier {
+    target: u64,
+    rx: watch::Receiver<u64>,
+}
+
+impl ReaderBarrier {
+    /// Wait until every writer ticketed before this reader completed.
+    pub(crate) async fn wait(mut self) {
+        // Err means the sender was dropped (entry removed after a close):
+        // every prior writer finished, so proceed.
+        let _ = self.rx.wait_for(|done| *done >= self.target).await;
+    }
+}
+
+/// How a request participates in per-document ordering.
+enum Role {
+    /// Mutates document state; applies in strict wire order per URI.
+    Writer { uri: String, close: bool },
+    /// Reads the document tree; waits for writers that preceded it.
+    Reader { uri: String },
+}
+
+/// Classify a request and extract its `textDocument.uri`, both synchronously.
+fn classify(req: &Request) -> Option<Role> {
+    let close = match req.method() {
+        "textDocument/didOpen" | "textDocument/didChange" => false,
+        "textDocument/didClose" => true,
+        "textDocument/semanticTokens/full"
+        | "textDocument/semanticTokens/full/delta"
+        | "textDocument/semanticTokens/range" => {
+            let uri = text_document_uri(req)?;
+            return Some(Role::Reader { uri });
+        }
+        _ => return None,
+    };
+    let uri = text_document_uri(req)?;
+    Some(Role::Writer { uri, close })
+}
+
+fn text_document_uri(req: &Request) -> Option<String> {
+    Some(
+        req.params()?
+            .get("textDocument")?
+            .get("uri")?
+            .as_str()?
+            .to_string(),
+    )
+}
+
+/// Tower middleware applying [`DocumentSequencer`] ordering to the LSP
+/// request stream. Wraps the outermost service handed to `Server::serve` so
+/// ticket assignment happens in wire order.
+pub struct IngressOrderGate<S> {
+    inner: S,
+    sequencer: Arc<DocumentSequencer>,
+}
+
+impl<S> IngressOrderGate<S> {
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner,
+            sequencer: Arc::new(DocumentSequencer::default()),
+        }
+    }
+}
+
+impl<S> Service<Request> for IngressOrderGate<S>
+where
+    S: Service<Request, Response = Option<Response>>,
+    S::Future: Send + 'static,
+    S::Error: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        let role = classify(&req);
+        // The inner call must stay synchronous inside `call` so nested
+        // middleware (e.g. RequestIdCapture) keeps seeing wire order too.
+        let inner_fut = self.inner.call(req);
+        match role {
+            None => Box::pin(inner_fut),
+            Some(Role::Writer { uri, close }) => {
+                let sequencer = Arc::clone(&self.sequencer);
+                let mut gate = sequencer.issue_writer_ticket(&uri);
+                Box::pin(async move {
+                    gate.wait_turn().await;
+                    let result = inner_fut.await;
+                    let ticket = gate.ticket();
+                    // Mark done before any cleanup decision.
+                    drop(gate);
+                    if close {
+                        sequencer.finish_close(&uri, ticket);
+                    }
+                    result
+                })
+            }
+            Some(Role::Reader { uri }) => {
+                let barrier = self.sequencer.reader_barrier(&uri);
+                Box::pin(async move {
+                    if let Some(barrier) = barrier {
+                        barrier.wait().await;
+                    }
+                    inner_fut.await
+                })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const URI: &str = "file:///test/doc.md";
+
+    fn pending<F: Future>(fut: &mut Pin<&mut F>) -> bool {
+        let waker = std::task::Waker::noop();
+        let mut cx = Context::from_waker(waker);
+        fut.as_mut().poll(&mut cx).is_pending()
+    }
+
+    #[tokio::test]
+    async fn writers_run_in_ticket_order() {
+        let seq = DocumentSequencer::default();
+        let mut first = seq.issue_writer_ticket(URI);
+        let mut second = seq.issue_writer_ticket(URI);
+
+        // First writer proceeds immediately.
+        {
+            let mut first_wait = std::pin::pin!(first.wait_turn());
+            assert!(!pending(&mut first_wait), "ticket 1 must not wait");
+        }
+
+        // Second writer is blocked until the first completes.
+        {
+            let mut second_wait = std::pin::pin!(second.wait_turn());
+            assert!(pending(&mut second_wait), "ticket 2 must wait for ticket 1");
+        }
+
+        drop(first); // completion-on-drop
+        second.wait_turn().await; // must resolve now
+    }
+
+    #[tokio::test]
+    async fn reader_waits_for_writers_before_it_only() {
+        let seq = DocumentSequencer::default();
+        let first = seq.issue_writer_ticket(URI);
+
+        let barrier = seq.reader_barrier(URI).expect("writer pending");
+
+        // A writer arriving AFTER the reader must not extend its wait.
+        let second = seq.issue_writer_ticket(URI);
+
+        let mut wait = std::pin::pin!(barrier.wait());
+        assert!(pending(&mut wait), "reader must wait for ticket 1");
+
+        drop(first);
+        wait.await; // resolves even though ticket 2 is still pending
+
+        drop(second);
+    }
+
+    #[tokio::test]
+    async fn reader_with_no_pending_writers_does_not_wait() {
+        let seq = DocumentSequencer::default();
+        assert!(
+            seq.reader_barrier(URI).is_none(),
+            "no entry means no waiting"
+        );
+
+        let first = seq.issue_writer_ticket(URI);
+        drop(first);
+        assert!(
+            seq.reader_barrier(URI).is_none(),
+            "all tickets done means no waiting"
+        );
+    }
+
+    #[tokio::test]
+    async fn documents_sequence_independently() {
+        let seq = DocumentSequencer::default();
+        let _other = seq.issue_writer_ticket("file:///test/other.md");
+
+        let mut here = seq.issue_writer_ticket(URI);
+        let mut wait = std::pin::pin!(here.wait_turn());
+        assert!(
+            !pending(&mut wait),
+            "a pending writer on another document must not block this one"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_writer_still_unblocks_successor() {
+        let seq = DocumentSequencer::default();
+        let first = seq.issue_writer_ticket(URI);
+        let mut second = seq.issue_writer_ticket(URI);
+
+        // Simulate the first writer's future being dropped without running
+        // (e.g. shutdown): the completion guard must still mark it done.
+        drop(first);
+
+        second.wait_turn().await;
+    }
+
+    #[tokio::test]
+    async fn finish_close_removes_state_and_wakes_stragglers() {
+        let seq = DocumentSequencer::default();
+        let close = seq.issue_writer_ticket(URI);
+        let barrier = seq.reader_barrier(URI).expect("close pending");
+
+        let ticket = close.ticket();
+        drop(close);
+        seq.finish_close(URI, ticket);
+        assert!(!seq.docs.contains_key(URI), "entry removed after close");
+
+        // A barrier subscribed before removal must still resolve.
+        barrier.wait().await;
+    }
+
+    #[tokio::test]
+    async fn finish_close_keeps_state_for_later_writers() {
+        let seq = DocumentSequencer::default();
+        let close = seq.issue_writer_ticket(URI);
+        let ticket = close.ticket();
+        let reopen = seq.issue_writer_ticket(URI); // reopen ticketed behind the close
+
+        drop(close);
+        seq.finish_close(URI, ticket);
+        assert!(
+            seq.docs.contains_key(URI),
+            "entry must survive while later tickets are pending"
+        );
+        drop(reopen);
+    }
+
+    fn notification(method: &'static str, uri: &str) -> Request {
+        Request::build(method)
+            .params(serde_json::json!({ "textDocument": { "uri": uri } }))
+            .finish()
+    }
+
+    #[test]
+    fn classify_routes_methods() {
+        let writer = classify(&notification("textDocument/didChange", URI));
+        assert!(matches!(writer, Some(Role::Writer { close: false, .. })));
+
+        let close = classify(&notification("textDocument/didClose", URI));
+        assert!(matches!(close, Some(Role::Writer { close: true, .. })));
+
+        let open = classify(&notification("textDocument/didOpen", URI));
+        assert!(matches!(open, Some(Role::Writer { close: false, .. })));
+
+        let reader = classify(&notification("textDocument/semanticTokens/full", URI));
+        assert!(matches!(reader, Some(Role::Reader { .. })));
+
+        assert!(
+            classify(&notification("textDocument/hover", URI)).is_none(),
+            "unrelated methods pass through"
+        );
+        assert!(
+            classify(&Request::build("textDocument/didChange").finish()).is_none(),
+            "missing params pass through rather than panic"
+        );
+    }
+}

--- a/src/lsp/ingress_order.rs
+++ b/src/lsp/ingress_order.rs
@@ -66,10 +66,7 @@ impl DocCompletion {
     /// `send_if_modified` keeps an out-of-order completion (ledger insert,
     /// `done` unchanged) from spuriously waking every waiter.
     fn complete(&self, ticket: u64) {
-        let mut early = self
-            .early
-            .lock()
-            .recover_poison("DocCompletion::complete");
+        let mut early = self.early.lock().recover_poison("DocCompletion::complete");
         self.done.send_if_modified(|done| {
             if ticket == *done + 1 {
                 *done = ticket;
@@ -207,13 +204,14 @@ enum Role {
 ///
 /// Readers are the tree-snapshotting request families: `semanticTokens`
 /// (including `range`, which never had the in-handler `edit_lock` settle),
-/// the `kakehashi/captures` triple, which mirrors it, and the formatting
-/// requests — their `TextEdit`s are applied by the client to its current
-/// text, so edits computed against a stale snapshot corrupt the document.
-/// The `kakehashi/node/*` protocol stays unclassified on purpose: node ids
-/// carry their own staleness handling (`null` → client re-acquires), so
-/// gating those point lookups would add latency without changing observable
-/// behavior.
+/// the `kakehashi/captures` triple, which mirrors it, and the edit-producing
+/// requests (formatting, rename) — their edits are applied by the client to
+/// its current text, so edits computed against a stale snapshot corrupt the
+/// document. `textDocument/codeAction` belongs in the same class once it is
+/// implemented (#352). The `kakehashi/node/*` protocol stays unclassified on
+/// purpose: node ids carry their own staleness handling (`null` → client
+/// re-acquires), so gating those point lookups would add latency without
+/// changing observable behavior.
 fn classify(req: &Request) -> Option<Role> {
     let close = match req.method() {
         "textDocument/didOpen" | "textDocument/didChange" => false,
@@ -223,6 +221,8 @@ fn classify(req: &Request) -> Option<Role> {
         | "textDocument/semanticTokens/range"
         | "textDocument/formatting"
         | "textDocument/rangeFormatting"
+        | "textDocument/rename"
+        | "textDocument/prepareRename"
         | "kakehashi/captures/full"
         | "kakehashi/captures/full/delta"
         | "kakehashi/captures/range" => {
@@ -491,6 +491,8 @@ mod tests {
             "textDocument/semanticTokens/range",
             "textDocument/formatting",
             "textDocument/rangeFormatting",
+            "textDocument/rename",
+            "textDocument/prepareRename",
             "kakehashi/captures/full",
             "kakehashi/captures/full/delta",
             "kakehashi/captures/range",

--- a/src/lsp/ingress_order.rs
+++ b/src/lsp/ingress_order.rs
@@ -157,13 +157,23 @@ enum Role {
 }
 
 /// Classify a request and extract its `textDocument.uri`, both synchronously.
+///
+/// Readers are the tree-snapshotting request families: `semanticTokens`
+/// (including `range`, which never had the in-handler `edit_lock` settle) and
+/// the `kakehashi/captures` triple, which mirrors it. The `kakehashi/node/*`
+/// protocol stays unclassified on purpose: node ids carry their own staleness
+/// handling (`null` → client re-acquires), so gating those point lookups
+/// would add latency without changing observable behavior.
 fn classify(req: &Request) -> Option<Role> {
     let close = match req.method() {
         "textDocument/didOpen" | "textDocument/didChange" => false,
         "textDocument/didClose" => true,
         "textDocument/semanticTokens/full"
         | "textDocument/semanticTokens/full/delta"
-        | "textDocument/semanticTokens/range" => {
+        | "textDocument/semanticTokens/range"
+        | "kakehashi/captures/full"
+        | "kakehashi/captures/full/delta"
+        | "kakehashi/captures/range" => {
             let uri = text_document_uri(req)?;
             return Some(Role::Reader { uri });
         }
@@ -173,13 +183,18 @@ fn classify(req: &Request) -> Option<Role> {
     Some(Role::Writer { uri, close })
 }
 
+/// Extract `params.textDocument.uri`, normalized through `Url` so spelling
+/// variants of the same document (percent-encoding, default ports) sequence
+/// together — internal document state is keyed on parsed `Url`s, and the
+/// gate's keys must not be finer-grained than that. Falls back to the raw
+/// wire string when it doesn't parse (such requests fail in handlers anyway;
+/// gating them consistently by spelling is harmless).
 fn text_document_uri(req: &Request) -> Option<String> {
+    let raw = req.params()?.get("textDocument")?.get("uri")?.as_str()?;
     Some(
-        req.params()?
-            .get("textDocument")?
-            .get("uri")?
-            .as_str()?
-            .to_string(),
+        url::Url::parse(raw)
+            .map(String::from)
+            .unwrap_or_else(|_| raw.to_string()),
     )
 }
 
@@ -392,8 +407,20 @@ mod tests {
         let open = classify(&notification("textDocument/didOpen", URI));
         assert!(matches!(open, Some(Role::Writer { close: false, .. })));
 
-        let reader = classify(&notification("textDocument/semanticTokens/full", URI));
-        assert!(matches!(reader, Some(Role::Reader { .. })));
+        for method in [
+            "textDocument/semanticTokens/full",
+            "textDocument/semanticTokens/full/delta",
+            "textDocument/semanticTokens/range",
+            "kakehashi/captures/full",
+            "kakehashi/captures/full/delta",
+            "kakehashi/captures/range",
+        ] {
+            let reader = classify(&notification(method, URI));
+            assert!(
+                matches!(reader, Some(Role::Reader { .. })),
+                "{method} must be a reader"
+            );
+        }
 
         assert!(
             classify(&notification("textDocument/hover", URI)).is_none(),
@@ -403,5 +430,94 @@ mod tests {
             classify(&Request::build("textDocument/didChange").finish()).is_none(),
             "missing params pass through rather than panic"
         );
+    }
+
+    #[test]
+    fn classify_normalizes_uri_spellings() {
+        // Url::parse normalizes scheme casing and dot segments — the same
+        // normalization the internal document store applies when parsing, so
+        // these spellings must share one sequence.
+        let a = classify(&notification("textDocument/didChange", "FILE:///tmp/a.md"));
+        let b = classify(&notification(
+            "textDocument/didChange",
+            "file:///tmp/./a.md",
+        ));
+        let (Some(Role::Writer { uri: uri_a, .. }), Some(Role::Writer { uri: uri_b, .. })) =
+            (a, b)
+        else {
+            panic!("both must classify as writers");
+        };
+        assert_eq!(
+            uri_a, uri_b,
+            "spelling variants of one document must share a sequence"
+        );
+    }
+
+    /// Inner mock: the writer's future stalls on a oneshot; everything else
+    /// resolves immediately. Completion order lands in `log`.
+    struct MockInner {
+        log: Arc<std::sync::Mutex<Vec<&'static str>>>,
+        writer_release: Option<tokio::sync::oneshot::Receiver<()>>,
+    }
+
+    impl Service<Request> for MockInner {
+        type Response = Option<Response>;
+        type Error = std::convert::Infallible;
+        type Future =
+            Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, req: Request) -> Self::Future {
+            let log = Arc::clone(&self.log);
+            if req.method() == "textDocument/didChange" {
+                let release = self
+                    .writer_release
+                    .take()
+                    .expect("one writer call expected");
+                Box::pin(async move {
+                    let _ = release.await;
+                    log.lock().unwrap().push("writer");
+                    Ok(None)
+                })
+            } else {
+                Box::pin(async move {
+                    log.lock().unwrap().push("reader");
+                    Ok(None)
+                })
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn gate_runs_reader_only_after_preceding_writer() {
+        let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let mut gate = IngressOrderGate::new(MockInner {
+            log: Arc::clone(&log),
+            writer_release: Some(release_rx),
+        });
+
+        // Wire order: didChange, then semanticTokens/full.
+        let writer_fut = gate.call(notification("textDocument/didChange", URI));
+        let reader_fut = gate.call(notification("textDocument/semanticTokens/full", URI));
+
+        let mut writer = tokio_test::task::spawn(writer_fut);
+        let mut reader = tokio_test::task::spawn(reader_fut);
+
+        // The reader must not run while the earlier writer is in flight,
+        // regardless of poll order (this is the buffer_unordered reorder).
+        assert!(reader.poll().is_pending());
+        assert!(writer.poll().is_pending(), "writer stalls on the oneshot");
+        assert!(reader.poll().is_pending(), "reader still gated");
+
+        release_tx.send(()).expect("writer is waiting");
+        assert!(writer.poll().is_ready());
+        assert!(reader.is_woken(), "writer completion must wake the reader");
+        assert!(reader.poll().is_ready());
+
+        assert_eq!(*log.lock().unwrap(), vec!["writer", "reader"]);
     }
 }

--- a/src/lsp/ingress_order.rs
+++ b/src/lsp/ingress_order.rs
@@ -190,7 +190,9 @@ fn classify(req: &Request) -> Option<Role> {
 /// wire string when it doesn't parse (such requests fail in handlers anyway;
 /// gating them consistently by spelling is harmless).
 fn text_document_uri(req: &Request) -> Option<String> {
-    let raw = req.params()?.get("textDocument")?.get("uri")?.as_str()?;
+    // Indexing a missing key or non-object yields Value::Null, whose as_str()
+    // returns None — same outcome as get() chains, less noise.
+    let raw = req.params()?["textDocument"]["uri"].as_str()?;
     Some(
         url::Url::parse(raw)
             .map(String::from)

--- a/src/lsp/ingress_order.rs
+++ b/src/lsp/ingress_order.rs
@@ -106,6 +106,12 @@ pub(crate) struct DocumentSequencer {
 impl DocumentSequencer {
     /// Take the next writer ticket for `uri`.
     pub(crate) fn issue_writer_ticket(&self, uri: &str) -> WriterGate {
+        // Fast path: rapid didChange streams hit an existing entry, where
+        // `get_mut` borrows the key without allocating; only a miss pays for
+        // the owned key.
+        if let Some(mut entry) = self.docs.get_mut(uri) {
+            return Self::next_ticket(&mut entry);
+        }
         let mut entry = self.docs.entry(uri.to_string()).or_insert_with(|| DocSeq {
             tail: 0,
             completion: Arc::new(DocCompletion {
@@ -113,13 +119,16 @@ impl DocumentSequencer {
                 early: std::sync::Mutex::new(std::collections::BTreeSet::new()),
             }),
         });
-        entry.tail += 1;
-        // Copy out and release the shard guard before building the gate so
-        // the map write lock spans only the ticket bump.
-        let ticket = entry.tail;
-        let rx = entry.completion.done.subscribe();
-        let completion = Arc::clone(&entry.completion);
-        drop(entry);
+        Self::next_ticket(&mut entry)
+    }
+
+    /// Bump `seq`'s tail and build the gate for the new ticket. Only copies
+    /// fields out, so callers' shard guards span just the bump.
+    fn next_ticket(seq: &mut DocSeq) -> WriterGate {
+        seq.tail += 1;
+        let ticket = seq.tail;
+        let rx = seq.completion.done.subscribe();
+        let completion = Arc::clone(&seq.completion);
         WriterGate {
             ticket,
             rx,

--- a/src/lsp/ingress_order.rs
+++ b/src/lsp/ingress_order.rs
@@ -442,8 +442,7 @@ mod tests {
             "textDocument/didChange",
             "file:///tmp/./a.md",
         ));
-        let (Some(Role::Writer { uri: uri_a, .. }), Some(Role::Writer { uri: uri_b, .. })) =
-            (a, b)
+        let (Some(Role::Writer { uri: uri_a, .. }), Some(Role::Writer { uri: uri_b, .. })) = (a, b)
         else {
             panic!("both must classify as writers");
         };
@@ -463,8 +462,7 @@ mod tests {
     impl Service<Request> for MockInner {
         type Response = Option<Response>;
         type Error = std::convert::Infallible;
-        type Future =
-            Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+        type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
         fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
             Poll::Ready(Ok(()))

--- a/src/lsp/ingress_order.rs
+++ b/src/lsp/ingress_order.rs
@@ -36,10 +36,45 @@ use tower_lsp_server::jsonrpc::{Request, Response};
 struct DocSeq {
     /// Last issued writer ticket (tickets start at 1; 0 = none issued).
     tail: u64,
-    /// Highest completed writer ticket. Waiters subscribe to this channel;
-    /// dropping the sender (entry removal after a close) wakes them with an
-    /// error, which they treat as "nothing left to wait for".
+    /// Completion channel + out-of-order ledger shared with issued guards.
+    completion: Arc<DocCompletion>,
+}
+
+/// Completion tracking shared between a document's entry and its in-flight
+/// writer guards.
+struct DocCompletion {
+    /// Highest **contiguously** completed writer ticket. Waiters subscribe to
+    /// this channel; dropping the sender (entry removal after a close) wakes
+    /// them with an error, which they treat as "nothing left to wait for".
     done: watch::Sender<u64>,
+    /// Tickets completed ahead of a still-running predecessor. `done` only
+    /// advances through consecutive tickets, so a hypothetical selectively
+    /// cancelled middle writer can never unblock its successor while an
+    /// earlier writer is still running — the guarantee holds locally instead
+    /// of leaning on the transport never dropping individual notification
+    /// futures.
+    early: std::sync::Mutex<std::collections::BTreeSet<u64>>,
+}
+
+impl DocCompletion {
+    /// Record `ticket` as complete, advancing `done` only through
+    /// consecutive completions and cascading any tickets that finished early.
+    fn complete(&self, ticket: u64) {
+        let mut early = self
+            .early
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        self.done.send_modify(|done| {
+            if ticket == *done + 1 {
+                *done = ticket;
+                while early.remove(&(*done + 1)) {
+                    *done += 1;
+                }
+            } else if ticket > *done {
+                early.insert(ticket);
+            }
+        });
+    }
 }
 
 /// Issues per-document writer tickets and reader barriers in wire order.
@@ -57,15 +92,18 @@ impl DocumentSequencer {
     pub(crate) fn issue_writer_ticket(&self, uri: &str) -> WriterGate {
         let mut entry = self.docs.entry(uri.to_string()).or_insert_with(|| DocSeq {
             tail: 0,
-            done: watch::Sender::new(0),
+            completion: Arc::new(DocCompletion {
+                done: watch::Sender::new(0),
+                early: std::sync::Mutex::new(std::collections::BTreeSet::new()),
+            }),
         });
         entry.tail += 1;
         WriterGate {
             ticket: entry.tail,
-            rx: entry.done.subscribe(),
+            rx: entry.completion.done.subscribe(),
             guard: CompletionGuard {
                 ticket: entry.tail,
-                tx: entry.done.clone(),
+                completion: Arc::clone(&entry.completion),
             },
         }
     }
@@ -75,12 +113,12 @@ impl DocumentSequencer {
     /// (no entry, or every issued ticket already completed).
     pub(crate) fn reader_barrier(&self, uri: &str) -> Option<ReaderBarrier> {
         let entry = self.docs.get(uri)?;
-        if *entry.done.borrow() >= entry.tail {
+        if *entry.completion.done.borrow() >= entry.tail {
             return None;
         }
         Some(ReaderBarrier {
             target: entry.tail,
-            rx: entry.done.subscribe(),
+            rx: entry.completion.done.subscribe(),
         })
     }
 
@@ -120,16 +158,12 @@ impl WriterGate {
 /// Marks a writer ticket complete on drop.
 struct CompletionGuard {
     ticket: u64,
-    tx: watch::Sender<u64>,
+    completion: Arc<DocCompletion>,
 }
 
 impl Drop for CompletionGuard {
     fn drop(&mut self) {
-        self.tx.send_modify(|done| {
-            if self.ticket > *done {
-                *done = self.ticket;
-            }
-        });
+        self.completion.complete(self.ticket);
     }
 }
 
@@ -359,6 +393,30 @@ mod tests {
         drop(first);
 
         second.wait_turn().await;
+    }
+
+    #[tokio::test]
+    async fn cancelled_middle_writer_does_not_unblock_successor_prematurely() {
+        let seq = DocumentSequencer::default();
+        let first = seq.issue_writer_ticket(URI);
+        let second = seq.issue_writer_ticket(URI);
+        let mut third = seq.issue_writer_ticket(URI);
+
+        // The middle writer's future is dropped while the first is still
+        // running: `done` must stay contiguous, so the third writer keeps
+        // waiting for the first.
+        drop(second);
+        {
+            let mut third_wait = std::pin::pin!(third.wait_turn());
+            assert!(
+                pending(&mut third_wait),
+                "third writer must keep waiting for the first even after the second is cancelled"
+            );
+        }
+
+        // First completing cascades through the early-completed second.
+        drop(first);
+        third.wait_turn().await;
     }
 
     #[tokio::test]

--- a/src/lsp/ingress_order.rs
+++ b/src/lsp/ingress_order.rs
@@ -34,6 +34,8 @@ use tokio::sync::watch;
 use tower::Service;
 use tower_lsp_server::jsonrpc::{Request, Response};
 
+use crate::error::LockResultExt;
+
 /// Per-document sequencing state.
 struct DocSeq {
     /// Last issued writer ticket (tickets start at 1; 0 = none issued).
@@ -67,7 +69,7 @@ impl DocCompletion {
         let mut early = self
             .early
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+            .recover_poison("DocCompletion::complete");
         self.done.send_if_modified(|done| {
             if ticket == *done + 1 {
                 *done = ticket;
@@ -106,13 +108,16 @@ impl DocumentSequencer {
             }),
         });
         entry.tail += 1;
+        // Copy out and release the shard guard before building the gate so
+        // the map write lock spans only the ticket bump.
+        let ticket = entry.tail;
+        let rx = entry.completion.done.subscribe();
+        let completion = Arc::clone(&entry.completion);
+        drop(entry);
         WriterGate {
-            ticket: entry.tail,
-            rx: entry.completion.done.subscribe(),
-            guard: CompletionGuard {
-                ticket: entry.tail,
-                completion: Arc::clone(&entry.completion),
-            },
+            ticket,
+            rx,
+            guard: CompletionGuard { ticket, completion },
         }
     }
 
@@ -124,10 +129,10 @@ impl DocumentSequencer {
         if *entry.completion.done.borrow() >= entry.tail {
             return None;
         }
-        Some(ReaderBarrier {
-            target: entry.tail,
-            rx: entry.completion.done.subscribe(),
-        })
+        let target = entry.tail;
+        let rx = entry.completion.done.subscribe();
+        drop(entry);
+        Some(ReaderBarrier { target, rx })
     }
 
     /// Drop `uri`'s sequencing state after a close completed, unless later

--- a/src/lsp/ingress_order.rs
+++ b/src/lsp/ingress_order.rs
@@ -15,10 +15,12 @@
 //! - **Writers** (`didOpen` / `didChange` / `didClose`) take the next ticket
 //!   and run only after the previous writer for the same document finished,
 //!   so edits and closes apply in strict wire order.
-//! - **Readers** (the `semanticTokens` family) snapshot the current tail
-//!   ticket at `call` time and run only once that ticket is done, so a
-//!   request observes every edit that preceded it on the wire — without
-//!   serializing token computation against later edits or other documents.
+//! - **Readers** (the `semanticTokens` family, the `kakehashi/captures`
+//!   triple, and formatting requests, whose stale edits a client would apply
+//!   to newer text) snapshot the current tail ticket at `call` time and run
+//!   only once that ticket is done, so a request observes every edit that
+//!   preceded it on the wire — without serializing its computation against
+//!   later edits or other documents.
 //!
 //! Everything else passes through untouched.
 
@@ -59,19 +61,25 @@ struct DocCompletion {
 impl DocCompletion {
     /// Record `ticket` as complete, advancing `done` only through
     /// consecutive completions and cascading any tickets that finished early.
+    /// `send_if_modified` keeps an out-of-order completion (ledger insert,
+    /// `done` unchanged) from spuriously waking every waiter.
     fn complete(&self, ticket: u64) {
         let mut early = self
             .early
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        self.done.send_modify(|done| {
+        self.done.send_if_modified(|done| {
             if ticket == *done + 1 {
                 *done = ticket;
                 while early.remove(&(*done + 1)) {
                     *done += 1;
                 }
-            } else if ticket > *done {
-                early.insert(ticket);
+                true
+            } else {
+                if ticket > *done {
+                    early.insert(ticket);
+                }
+                false
             }
         });
     }
@@ -193,11 +201,14 @@ enum Role {
 /// Classify a request and extract its `textDocument.uri`, both synchronously.
 ///
 /// Readers are the tree-snapshotting request families: `semanticTokens`
-/// (including `range`, which never had the in-handler `edit_lock` settle) and
-/// the `kakehashi/captures` triple, which mirrors it. The `kakehashi/node/*`
-/// protocol stays unclassified on purpose: node ids carry their own staleness
-/// handling (`null` → client re-acquires), so gating those point lookups
-/// would add latency without changing observable behavior.
+/// (including `range`, which never had the in-handler `edit_lock` settle),
+/// the `kakehashi/captures` triple, which mirrors it, and the formatting
+/// requests — their `TextEdit`s are applied by the client to its current
+/// text, so edits computed against a stale snapshot corrupt the document.
+/// The `kakehashi/node/*` protocol stays unclassified on purpose: node ids
+/// carry their own staleness handling (`null` → client re-acquires), so
+/// gating those point lookups would add latency without changing observable
+/// behavior.
 fn classify(req: &Request) -> Option<Role> {
     let close = match req.method() {
         "textDocument/didOpen" | "textDocument/didChange" => false,
@@ -205,6 +216,8 @@ fn classify(req: &Request) -> Option<Role> {
         "textDocument/semanticTokens/full"
         | "textDocument/semanticTokens/full/delta"
         | "textDocument/semanticTokens/range"
+        | "textDocument/formatting"
+        | "textDocument/rangeFormatting"
         | "kakehashi/captures/full"
         | "kakehashi/captures/full/delta"
         | "kakehashi/captures/range" => {
@@ -471,6 +484,8 @@ mod tests {
             "textDocument/semanticTokens/full",
             "textDocument/semanticTokens/full/delta",
             "textDocument/semanticTokens/range",
+            "textDocument/formatting",
+            "textDocument/rangeFormatting",
             "kakehashi/captures/full",
             "kakehashi/captures/full/delta",
             "kakehashi/captures/range",

--- a/src/lsp/ingress_order.rs
+++ b/src/lsp/ingress_order.rs
@@ -19,8 +19,9 @@
 //!   which in turn can wait on upstream client interaction — ticketing it
 //!   deadlocks a client that blocks on a gated request (e.g. a readiness
 //!   poll via `textDocument/diagnostic`) while the server waits for that
-//!   same client. Handlers already tolerate open/edit reordering for
-//!   missing documents, the pre-gate status quo.
+//!   same client. The residual open/edit and close/reopen first-poll-order
+//!   races are the pre-gate status quo; gating `didOpen` properly (fast
+//!   handler + spawned downstream work) is tracked in #374.
 //! - **Readers** (the `semanticTokens` family, the `kakehashi/captures`
 //!   triple, the edit-producing formatting/rename requests, pull
 //!   diagnostics, and `didSave`'s diagnostic snapshot) snapshot the current

--- a/src/lsp/ingress_order.rs
+++ b/src/lsp/ingress_order.rs
@@ -12,15 +12,21 @@
 //! *before* buffering the returned futures, so this middleware can assign
 //! per-URI sequence tickets at `call` time:
 //!
-//! - **Writers** (`didOpen` / `didChange` / `didClose`) take the next ticket
-//!   and run only after the previous writer for the same document finished,
-//!   so edits and closes apply in strict wire order.
+//! - **Writers** (`didChange` / `didClose`) take the next ticket and run
+//!   only after the previous writer for the same document finished, so edits
+//!   and closes apply in strict wire order. `didOpen` is deliberately NOT a
+//!   writer: its handler can await downstream-server spawn/initialization,
+//!   which in turn can wait on upstream client interaction — ticketing it
+//!   deadlocks a client that blocks on a gated request (e.g. a readiness
+//!   poll via `textDocument/diagnostic`) while the server waits for that
+//!   same client. Handlers already tolerate open/edit reordering for
+//!   missing documents, the pre-gate status quo.
 //! - **Readers** (the `semanticTokens` family, the `kakehashi/captures`
-//!   triple, and formatting requests, whose stale edits a client would apply
-//!   to newer text) snapshot the current tail ticket at `call` time and run
-//!   only once that ticket is done, so a request observes every edit that
-//!   preceded it on the wire — without serializing its computation against
-//!   later edits or other documents.
+//!   triple, the edit-producing formatting/rename requests, pull
+//!   diagnostics, and `didSave`'s diagnostic snapshot) snapshot the current
+//!   tail ticket at `call` time and run only once that ticket is done, so a
+//!   request observes every edit that preceded it on the wire — without
+//!   serializing its computation against later edits or other documents.
 //!
 //! Everything else passes through untouched.
 
@@ -64,10 +70,12 @@ impl DocCompletion {
     /// Record `ticket` as complete, advancing `done` only through
     /// consecutive completions and cascading any tickets that finished early.
     /// `send_if_modified` keeps an out-of-order completion (ledger insert,
-    /// `done` unchanged) from spuriously waking every waiter.
+    /// `done` unchanged) from spuriously waking every waiter; the ledger lock
+    /// lives inside the closure, so it is released before subscribers are
+    /// notified.
     fn complete(&self, ticket: u64) {
-        let mut early = self.early.lock().recover_poison("DocCompletion::complete");
         self.done.send_if_modified(|done| {
+            let mut early = self.early.lock().recover_poison("DocCompletion::complete");
             if ticket == *done + 1 {
                 *done = ticket;
                 while early.remove(&(*done + 1)) {
@@ -202,20 +210,28 @@ enum Role {
 
 /// Classify a request and extract its `textDocument.uri`, both synchronously.
 ///
-/// Readers are the tree-snapshotting request families: `semanticTokens`
+/// Readers are the document-snapshotting request families: `semanticTokens`
 /// (including `range`, which never had the in-handler `edit_lock` settle),
-/// the `kakehashi/captures` triple, which mirrors it, and the edit-producing
-/// requests (formatting, rename) — their edits are applied by the client to
+/// the `kakehashi/captures` triple, which mirrors it, the edit-producing
+/// requests (formatting, rename — their edits are applied by the client to
 /// its current text, so edits computed against a stale snapshot corrupt the
-/// document. `textDocument/codeAction` belongs in the same class once it is
+/// document), pull diagnostics, and `didSave` (its synthetic-diagnostic task
+/// snapshots the document, which must reflect every edit before the save).
+/// `textDocument/codeAction` belongs in the same class once it is
 /// implemented (#352). The `kakehashi/node/*` protocol stays unclassified on
 /// purpose: node ids carry their own staleness handling (`null` → client
 /// re-acquires), so gating those point lookups would add latency without
 /// changing observable behavior.
 fn classify(req: &Request) -> Option<Role> {
-    let close = match req.method() {
-        "textDocument/didOpen" | "textDocument/didChange" => false,
-        "textDocument/didClose" => true,
+    let method = req.method();
+    match method {
+        "textDocument/didChange" | "textDocument/didClose" => {
+            let uri = text_document_uri(req)?;
+            Some(Role::Writer {
+                uri,
+                close: method == "textDocument/didClose",
+            })
+        }
         "textDocument/semanticTokens/full"
         | "textDocument/semanticTokens/full/delta"
         | "textDocument/semanticTokens/range"
@@ -223,16 +239,16 @@ fn classify(req: &Request) -> Option<Role> {
         | "textDocument/rangeFormatting"
         | "textDocument/rename"
         | "textDocument/prepareRename"
+        | "textDocument/diagnostic"
+        | "textDocument/didSave"
         | "kakehashi/captures/full"
         | "kakehashi/captures/full/delta"
         | "kakehashi/captures/range" => {
             let uri = text_document_uri(req)?;
-            return Some(Role::Reader { uri });
+            Some(Role::Reader { uri })
         }
-        _ => return None,
-    };
-    let uri = text_document_uri(req)?;
-    Some(Role::Writer { uri, close })
+        _ => None,
+    }
 }
 
 /// Extract `params.textDocument.uri`, normalized through `Url` so spelling
@@ -482,8 +498,13 @@ mod tests {
         let close = classify(&notification("textDocument/didClose", URI));
         assert!(matches!(close, Some(Role::Writer { close: true, .. })));
 
-        let open = classify(&notification("textDocument/didOpen", URI));
-        assert!(matches!(open, Some(Role::Writer { close: false, .. })));
+        // didOpen passes through: its handler can await downstream spawn
+        // that itself waits on the client, so ticketing it deadlocks
+        // synchronous clients polling readiness behind the gate.
+        assert!(
+            classify(&notification("textDocument/didOpen", URI)).is_none(),
+            "didOpen must not be gated"
+        );
 
         for method in [
             "textDocument/semanticTokens/full",
@@ -493,6 +514,8 @@ mod tests {
             "textDocument/rangeFormatting",
             "textDocument/rename",
             "textDocument/prepareRename",
+            "textDocument/diagnostic",
+            "textDocument/didSave",
             "kakehashi/captures/full",
             "kakehashi/captures/full/delta",
             "kakehashi/captures/range",


### PR DESCRIPTION
## Summary

Closes #342.

tower-lsp-server dispatches handler futures through `buffer_unordered`, so a `didChange` received *before* a `semanticTokens` request could be first-polled *after* it — the request could snapshot a document missing edits that preceded it on the wire. The per-URI `edit_lock` acquired as a handler's first `.await` follows first-poll order: a strong practical mitigation, but not a hard guarantee.

## Design (as proposed in #342)

`Server::serve` calls `service.call(req)` synchronously **in wire order** before buffering the returned futures (verified against tower-lsp-server 0.23 `transport.rs`), so the new outermost middleware `IngressOrderGate` assigns per-URI sequence tickets at `call` time:

- **Writers** (`didChange`/`didClose`) take the next ticket and run only after the previous writer for the same document finished. Completion is marked on drop and `done` advances only through **consecutive** tickets (an out-of-order ledger cascades early completions), so neither shutdown cancellation nor a hypothetical selectively-dropped middle writer can unblock a successor early.
- **Readers** (`semanticTokens` full/delta/range, the `kakehashi/captures` triple, formatting/rangeFormatting, rename/prepareRename, pull diagnostics, and `didSave`'s diagnostic snapshot) snapshot the tail ticket at `call` time and wait only for writers that preceded them on the wire — later edits and other documents are never serialized against their computation.
- `didClose` removes the per-document state unless later tickets were already issued behind it (close/reopen burst); dropping the state's watch sender wakes any stragglers.

Notes:

- **`didOpen` is deliberately NOT gated**: its handler awaits downstream-server spawn (`process_injections`) which can wait on upstream client interaction — ticketing it deadlocks synchronous clients that poll readiness via a gated request (reproduced by the synthetic-push e2e suite). The residual open/edit and close/reopen first-poll-order races are the pre-gate status quo; proper didOpen gating (fast handler + spawned downstream work) is tracked in #374.
- Gate keys normalize through `Url::parse` (scheme casing, dot segments), matching the granularity of the internal `Url`-keyed document store.
- `kakehashi/node/*` stays ungated on purpose — that protocol's `null → re-acquire` staleness handling already covers reordering.
- The existing `edit_lock` remains as the in-handler critical section; the gate supersedes only its ordering role.

## Acceptance criteria (from #342)

- ✅ Edits/closes for one URI apply in strict wire order (writer tickets serialize per document)
- ✅ A semantic request waits for all edits that preceded it on the wire (reader barrier on the call-time tail ticket)
- ✅ No serialization of token computation across documents or with later edits (barrier target is fixed at call time; other URIs sequence independently)

## Tests

- Unit tests for the sequencer protocol: ticket ordering, reader barrier scoping, no-wait fast paths, per-document independence, cancellation safety (including a cancelled middle writer NOT unblocking its successor), close cleanup + close/reopen bursts, straggler wakeup after state removal.
- Mock-service test for the middleware wiring: a reader polled before a stalled earlier writer stays pending regardless of poll order and wakes on the writer's completion.
- Full e2e suite passes, including the synthetic-push diagnostics tests that exposed the didOpen deadlock and `test_semantic_tokens_large_paste_covers_last_line` (320 rapid didChange chunks + immediate token request).