### PR TITLE
fix: deadlock/panic hardening round 2 — offset panics, lock order, bridge shutdown, install lifecycle

### DIFF
--- a/src/analysis/offset_calculator.rs
+++ b/src/analysis/offset_calculator.rs
@@ -1,4 +1,4 @@
-use crate::language::injection::InjectionOffset;
+use crate::language::injection::{InjectionOffset, ceil_char_boundary, floor_char_boundary};
 
 /// Represents a byte range with start and end positions
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -28,7 +28,9 @@ impl EffectiveRange {
 
 /// Calculates the effective range by applying both row and column offsets
 ///
-/// This function clamps the resulting range to `[0, text.len()]` and ensures
+/// This function clamps the resulting range to `[0, text.len()]`, snaps both
+/// ends inward to char boundaries (column deltas are byte counts, so a
+/// misconfigured query can land inside a multi-byte character), and ensures
 /// `start <= end` to prevent panics when slicing. Malformed or malicious
 /// query offsets cannot crash the server.
 pub fn calculate_effective_range(
@@ -56,16 +58,16 @@ pub fn calculate_effective_range(
         (start, end)
     };
 
-    // Clamp to valid range [0, text.len()]
-    let clamped_start = raw_start.min(text_len);
-    let clamped_end = raw_end.min(text_len);
+    // Clamp to valid range [0, text.len()] and snap inward to char boundaries
+    let snapped_start = ceil_char_boundary(text, raw_start.min(text_len));
+    let snapped_end = floor_char_boundary(text, raw_end.min(text_len));
 
     // Ensure start <= end invariant
-    let (final_start, final_end) = if clamped_start <= clamped_end {
-        (clamped_start, clamped_end)
+    let (final_start, final_end) = if snapped_start <= snapped_end {
+        (snapped_start, snapped_end)
     } else {
-        // When start > end, return empty range at clamped_end
-        (clamped_end, clamped_end)
+        // When start > end, return empty range at snapped_end
+        (snapped_end, snapped_end)
     };
 
     EffectiveRange::new(final_start, final_end)
@@ -175,6 +177,20 @@ mod tests {
         ByteRange::new(0, 6),
         InjectionOffset { start_row: 0, start_column: 0, end_row: 5, end_column: 0 },
         "row offset moving end beyond last line"
+    )]
+    #[case::start_lands_mid_multibyte_char(
+        "aあいう",
+        ByteRange::new(0, 10),
+        InjectionOffset { start_row: 0, start_column: 2, end_row: 0, end_column: 0 },
+        "column offsets are byte counts; +2 lands inside あ (bytes 1..4) \
+         and must snap to a char boundary so slicing cannot panic"
+    )]
+    #[case::end_lands_mid_multibyte_char(
+        "あいう",
+        ByteRange::new(0, 9),
+        InjectionOffset { start_row: 0, start_column: 0, end_row: 0, end_column: -1 },
+        "column offsets are byte counts; -1 lands inside う (bytes 6..9) \
+         and must snap to a char boundary so slicing cannot panic"
     )]
     fn test_offset_clamping_edge_cases(
         #[case] text: &str,

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -423,17 +423,12 @@ fn collect_injection_contexts_sync<'a>(
         let content_node = injection.content_node;
         let (inj_start_byte, inj_end_byte) = if let Some(off) = offset {
             use crate::analysis::offset_calculator::{ByteRange, calculate_effective_range};
-            use crate::language::injection::{ceil_char_boundary, floor_char_boundary};
             let byte_range = ByteRange::new(content_node.start_byte(), content_node.end_byte());
+            // calculate_effective_range clamps, snaps inward to char
+            // boundaries, and normalizes start <= end, so the content slice
+            // below cannot panic.
             let effective = calculate_effective_range(text, byte_range, off);
-            // Column deltas are byte counts; a misconfigured query could land
-            // inside a multi-byte character. Snap inward so the content slice
-            // below cannot panic, and normalize so a degenerate range (both
-            // ends inside one codepoint) becomes empty rather than inverted —
-            // same guards as from_region_info.
-            let start = ceil_char_boundary(text, effective.start);
-            let end = floor_char_boundary(text, effective.end);
-            (start.min(end), end)
+            (effective.start, effective.end)
         } else {
             (content_node.start_byte(), content_node.end_byte())
         };

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -288,13 +288,20 @@ impl DocumentStore {
     /// have no document — the cleanup for an [`open_generation`](Self::open_generation)
     /// ask that raced a `didClose`. Safety does not depend on this (the
     /// counter is monotonic, so a pre-close generation can never equal any
-    /// later one); it only prevents entries accumulating for closed URIs. The
-    /// removal re-checks absence so a concurrent reopen's live entry is left
-    /// alone; losing that race merely hands the reopened document a fresh
-    /// number on its next ask, which is the conservative direction.
+    /// later one); it only prevents entries accumulating for closed URIs.
+    /// Check-then-remove rather than `remove_if`: the predicate would read
+    /// `documents` while holding the `open_generations` shard write lock,
+    /// inverting the documents → open_generations order taken by callers
+    /// that hold a document `Ref` while asking for the generation — a latent
+    /// ABBA deadlock under a writer-preferring shard lock. The TOCTOU this
+    /// opens (a reopen racing between check and removal loses its entry)
+    /// merely hands the reopened document a fresh number on its next ask,
+    /// which is the conservative direction.
     pub(crate) fn forget_open_generation_if_closed(&self, uri: &Url) {
-        self.open_generations
-            .remove_if(uri, |_, _| self.documents.get(uri).is_none());
+        if self.documents.get(uri).is_some() {
+            return;
+        }
+        self.open_generations.remove(uri);
     }
 }
 
@@ -305,6 +312,39 @@ mod tests {
     use std::thread;
     use std::time::Duration;
     use tokio::time::timeout;
+
+    #[test]
+    fn forget_open_generation_keeps_live_document_entry() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///gen.rs").unwrap();
+        store.insert(uri.clone(), "x".to_string(), Some("rust".to_string()), None);
+        let generation = store.open_generation(&uri);
+
+        store.forget_open_generation_if_closed(&uri);
+
+        assert_eq!(
+            store.open_generation(&uri),
+            generation,
+            "cleanup must not disturb the generation of an open document"
+        );
+    }
+
+    #[test]
+    fn forget_open_generation_drops_entry_for_closed_document() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///gen.rs").unwrap();
+        // A generation asked while no document exists (request racing didClose)
+        let stale = store.open_generation(&uri);
+
+        store.forget_open_generation_if_closed(&uri);
+
+        store.insert(uri.clone(), "x".to_string(), Some("rust".to_string()), None);
+        assert_ne!(
+            store.open_generation(&uri),
+            stale,
+            "a closed URI's entry must be dropped so a reopen draws a fresh generation"
+        );
+    }
 
     #[test]
     fn test_concurrent_update_and_get_no_deadlock() {

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -365,20 +365,30 @@ const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(120);
 /// diagnostics go to stderr, which stays inherited for the logs.
 fn git_command(args: &[&str], current_dir: Option<&Path>) -> Command {
     let mut cmd = Command::new("git");
-    // Extend rather than replace a user-provided GIT_SSH_COMMAND (custom keys,
-    // agents, wrappers): for OpenSSH the first -o value obtained wins, so the
-    // appended BatchMode only applies when the user didn't set one themselves.
-    let ssh_command = std::env::var("GIT_SSH_COMMAND")
-        .ok()
-        .filter(|s| !s.trim().is_empty())
-        .unwrap_or_else(|| "ssh".to_string());
     cmd.args(args)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .env("GIT_TERMINAL_PROMPT", "0")
         .env("GIT_ASKPASS", "true")
-        .env("SSH_ASKPASS", "true")
-        .env("GIT_SSH_COMMAND", format!("{ssh_command} -oBatchMode=yes"));
+        .env("SSH_ASKPASS", "true");
+    // GIT_SSH_COMMAND: extend an OpenSSH command with BatchMode so ssh auth
+    // fails fast instead of prompting; for OpenSSH the first -o value obtained
+    // wins, so a user-set BatchMode is respected. Leave non-OpenSSH commands
+    // (plink etc. reject -o flags) untouched, and when unset set nothing so a
+    // core.sshCommand gitconfig keeps working — run_with_timeout's deadline
+    // still bounds any prompt that slips through.
+    if let Ok(ssh_command) = std::env::var("GIT_SSH_COMMAND")
+        && !ssh_command.trim().is_empty()
+    {
+        let is_openssh = ssh_command
+            .split_whitespace()
+            .next()
+            .and_then(|word| std::path::Path::new(word).file_name())
+            .is_some_and(|name| name == "ssh");
+        if is_openssh {
+            cmd.env("GIT_SSH_COMMAND", format!("{ssh_command} -oBatchMode=yes"));
+        }
+    }
     if let Some(dir) = current_dir {
         cmd.current_dir(dir);
     }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -346,14 +346,69 @@ fn archive_root_dir_name(repo_name: &str, revision: &str) -> String {
     format!("{}-{}", repo_name, clean_revision)
 }
 
+/// Upper bound for each git operation in the clone fallback.
+///
+/// The archive-download path bounds its HTTP calls (`ARCHIVE_HTTP_TIMEOUT`);
+/// git has none of its own, and the install runs inside a non-cancellable
+/// `spawn_blocking` task — an unbounded hang keeps the language's in-progress
+/// marker held for the whole session (every reopen skips parsing) and blocks
+/// process exit while the runtime drains blocking tasks.
+const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Build a git command that can never prompt: stdin is nulled and
+/// `GIT_TERMINAL_PROMPT=0` set, so a private/renamed repository fails fast
+/// instead of waiting for credentials nobody can type.
+fn git_command(args: &[&str], current_dir: Option<&Path>) -> Command {
+    let mut cmd = Command::new("git");
+    cmd.args(args)
+        .stdin(std::process::Stdio::null())
+        .env("GIT_TERMINAL_PROMPT", "0");
+    if let Some(dir) = current_dir {
+        cmd.current_dir(dir);
+    }
+    cmd
+}
+
+/// Run a command to completion under a hard deadline, killing it on expiry.
+///
+/// Poll-based (`try_wait` + sleep) because this executes on a blocking
+/// thread; `context` names the operation in the error message.
+fn run_with_timeout(
+    mut cmd: Command,
+    timeout: Duration,
+    context: &str,
+) -> Result<std::process::ExitStatus, ParserInstallError> {
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| ParserInstallError::GitError(format!("{}: {}", context, e)))?;
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Ok(status),
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(ParserInstallError::GitError(format!(
+                        "{} timed out after {:?}",
+                        context, timeout
+                    )));
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(e) => {
+                return Err(ParserInstallError::GitError(format!("{}: {}", context, e)));
+            }
+        }
+    }
+}
+
 /// Clone a git repository at a specific revision.
 fn clone_repo(url: &str, revision: &str, dest: &Path) -> Result<(), ParserInstallError> {
     // First, clone with depth 1 (we'll fetch the specific revision)
-    let status = Command::new("git")
-        .args(["clone", "--depth", "1", url])
-        .arg(dest)
-        .status()
-        .map_err(|e| ParserInstallError::GitError(e.to_string()))?;
+    let mut clone = git_command(&["clone", "--depth", "1", url], None);
+    clone.arg(dest);
+    let status = run_with_timeout(clone, GIT_COMMAND_TIMEOUT, "git clone")?;
 
     if !status.success() {
         return Err(ParserInstallError::GitError(format!(
@@ -363,11 +418,11 @@ fn clone_repo(url: &str, revision: &str, dest: &Path) -> Result<(), ParserInstal
     }
 
     // Fetch the specific revision
-    let status = Command::new("git")
-        .current_dir(dest)
-        .args(["fetch", "--depth", "1", "origin", revision])
-        .status()
-        .map_err(|e| ParserInstallError::GitError(e.to_string()))?;
+    let status = run_with_timeout(
+        git_command(&["fetch", "--depth", "1", "origin", revision], Some(dest)),
+        GIT_COMMAND_TIMEOUT,
+        "git fetch",
+    )?;
 
     if !status.success() {
         return Err(ParserInstallError::GitError(format!(
@@ -382,11 +437,11 @@ fn clone_repo(url: &str, revision: &str, dest: &Path) -> Result<(), ParserInstal
     //   but doesn't create a local tag ref, so `git checkout v0.25.0` fails
     // - For commits: FETCH_HEAD also works correctly
     // - FETCH_HEAD always contains what we just fetched
-    let status = Command::new("git")
-        .current_dir(dest)
-        .args(["checkout", "FETCH_HEAD"])
-        .status()
-        .map_err(|e| ParserInstallError::GitError(e.to_string()))?;
+    let status = run_with_timeout(
+        git_command(&["checkout", "FETCH_HEAD"], Some(dest)),
+        GIT_COMMAND_TIMEOUT,
+        "git checkout",
+    )?;
 
     if !status.success() {
         return Err(ParserInstallError::GitError(format!(
@@ -410,6 +465,39 @@ mod tests {
     fn test_dll_extension_is_valid() {
         let ext = std::env::consts::DLL_EXTENSION;
         assert!(ext == "so" || ext == "dylib" || ext == "dll");
+    }
+
+    #[test]
+    fn run_with_timeout_kills_stuck_command() {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "sleep 30"]);
+
+        let started = std::time::Instant::now();
+        let result = run_with_timeout(cmd, Duration::from_millis(200), "test sleep");
+
+        match result {
+            Err(ParserInstallError::GitError(message)) => {
+                assert!(
+                    message.contains("timed out"),
+                    "expected timeout error, got: {message}"
+                );
+            }
+            other => panic!("expected GitError timeout, got {other:?}"),
+        }
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "stuck child must be killed promptly, not waited out"
+        );
+    }
+
+    #[test]
+    fn run_with_timeout_returns_status_of_finished_command() {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "exit 0"]);
+
+        let status = run_with_timeout(cmd, Duration::from_secs(10), "test exit")
+            .expect("fast command should complete within the deadline");
+        assert!(status.success());
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -368,7 +368,10 @@ fn git_command(args: &[&str], current_dir: Option<&Path>) -> Command {
     // Extend rather than replace a user-provided GIT_SSH_COMMAND (custom keys,
     // agents, wrappers): for OpenSSH the first -o value obtained wins, so the
     // appended BatchMode only applies when the user didn't set one themselves.
-    let ssh_command = std::env::var("GIT_SSH_COMMAND").unwrap_or_else(|_| "ssh".to_string());
+    let ssh_command = std::env::var("GIT_SSH_COMMAND")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "ssh".to_string());
     cmd.args(args)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -365,13 +365,17 @@ const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(120);
 /// diagnostics go to stderr, which stays inherited for the logs.
 fn git_command(args: &[&str], current_dir: Option<&Path>) -> Command {
     let mut cmd = Command::new("git");
+    // Extend rather than replace a user-provided GIT_SSH_COMMAND (custom keys,
+    // agents, wrappers): for OpenSSH the first -o value obtained wins, so the
+    // appended BatchMode only applies when the user didn't set one themselves.
+    let ssh_command = std::env::var("GIT_SSH_COMMAND").unwrap_or_else(|_| "ssh".to_string());
     cmd.args(args)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .env("GIT_TERMINAL_PROMPT", "0")
         .env("GIT_ASKPASS", "true")
         .env("SSH_ASKPASS", "true")
-        .env("GIT_SSH_COMMAND", "ssh -oBatchMode=yes");
+        .env("GIT_SSH_COMMAND", format!("{ssh_command} -oBatchMode=yes"));
     if let Some(dir) = current_dir {
         cmd.current_dir(dir);
     }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -397,6 +397,10 @@ fn run_with_timeout(
                 std::thread::sleep(Duration::from_millis(50));
             }
             Err(e) => {
+                // try_wait failing is practically unreachable, but don't
+                // leak a running child on that path either.
+                let _ = child.kill();
+                let _ = child.wait();
                 return Err(ParserInstallError::GitError(format!("{}: {}", context, e)));
             }
         }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -383,8 +383,9 @@ fn git_command(args: &[&str], current_dir: Option<&Path>) -> Command {
         let is_openssh = ssh_command
             .split_whitespace()
             .next()
-            .and_then(|word| std::path::Path::new(word).file_name())
-            .is_some_and(|name| name == "ssh");
+            .and_then(|word| std::path::Path::new(word).file_stem())
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.eq_ignore_ascii_case("ssh"));
         if is_openssh {
             cmd.env("GIT_SSH_COMMAND", format!("{ssh_command} -oBatchMode=yes"));
         }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -386,10 +386,19 @@ fn git_command(args: &[&str], current_dir: Option<&Path>) -> Command {
     if let Ok(ssh_command) = std::env::var("GIT_SSH_COMMAND")
         && !ssh_command.trim().is_empty()
     {
-        let is_openssh = ssh_command
-            .split_whitespace()
-            .next()
-            .and_then(|word| std::path::Path::new(word).file_stem())
+        // The command word may be a quoted path containing spaces (common on
+        // Windows: "C:\Program Files\...\ssh.exe" -i key); take the quoted
+        // token whole instead of splitting on its inner spaces.
+        let trimmed = ssh_command.trim_start();
+        let cmd_word = if let Some(rest) = trimmed.strip_prefix('"') {
+            rest.split('"').next().unwrap_or("")
+        } else if let Some(rest) = trimmed.strip_prefix('\'') {
+            rest.split('\'').next().unwrap_or("")
+        } else {
+            trimmed.split_whitespace().next().unwrap_or("")
+        };
+        let is_openssh = std::path::Path::new(cmd_word)
+            .file_stem()
             .and_then(|name| name.to_str())
             .is_some_and(|name| name.eq_ignore_ascii_case("ssh"));
         if is_openssh {

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -358,9 +358,9 @@ const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(120);
 /// Build a git command that can never prompt, so a private/renamed
 /// repository fails fast instead of waiting for credentials nobody can type:
 /// stdin is nulled, `GIT_TERMINAL_PROMPT=0` covers terminal prompts,
-/// `GIT_ASKPASS`/`SSH_ASKPASS` are pointed at `true` (immediately answers
-/// with an empty string), and ssh runs in BatchMode (fails instead of
-/// prompting). stdout is nulled too — when this runs inside the LSP server,
+/// `GIT_ASKPASS`/`SSH_ASKPASS` are pointed at `true` on unix (immediately
+/// answers with an empty string), and ssh runs in BatchMode (fails instead
+/// of prompting). stdout is nulled too — when this runs inside the LSP server,
 /// stdout is the JSON-RPC channel and no child chatter may reach it; git's
 /// diagnostics go to stderr, which stays inherited for the logs.
 fn git_command(args: &[&str], current_dir: Option<&Path>) -> Command {
@@ -368,9 +368,15 @@ fn git_command(args: &[&str], current_dir: Option<&Path>) -> Command {
     cmd.args(args)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .env("GIT_ASKPASS", "true")
-        .env("SSH_ASKPASS", "true");
+        .env("GIT_TERMINAL_PROMPT", "0");
+    // `true` as an askpass helper answers any credential prompt with an empty
+    // string immediately. POSIX guarantees the binary; Windows does not ship
+    // one (git would fail trying to run it), so gate to unix — Windows relies
+    // on GIT_TERMINAL_PROMPT plus run_with_timeout's deadline.
+    #[cfg(unix)]
+    {
+        cmd.env("GIT_ASKPASS", "true").env("SSH_ASKPASS", "true");
+    }
     // GIT_SSH_COMMAND: extend an OpenSSH command with BatchMode so ssh auth
     // fails fast instead of prompting; for OpenSSH the first -o value obtained
     // wins, so a user-set BatchMode is respected. Leave non-OpenSSH commands
@@ -498,6 +504,8 @@ mod tests {
         assert!(ext == "so" || ext == "dylib" || ext == "dll");
     }
 
+    // Unix-only: relies on the `sleep` binary.
+    #[cfg(unix)]
     #[test]
     fn run_with_timeout_kills_stuck_command() {
         // Spawn `sleep` directly: with `sh -c` the kill would reach the
@@ -524,6 +532,8 @@ mod tests {
         );
     }
 
+    // Unix-only: relies on `sh`.
+    #[cfg(unix)]
     #[test]
     fn run_with_timeout_returns_status_of_finished_command() {
         let mut cmd = Command::new("sh");

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -355,14 +355,23 @@ fn archive_root_dir_name(repo_name: &str, revision: &str) -> String {
 /// process exit while the runtime drains blocking tasks.
 const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(120);
 
-/// Build a git command that can never prompt: stdin is nulled and
-/// `GIT_TERMINAL_PROMPT=0` set, so a private/renamed repository fails fast
-/// instead of waiting for credentials nobody can type.
+/// Build a git command that can never prompt, so a private/renamed
+/// repository fails fast instead of waiting for credentials nobody can type:
+/// stdin is nulled, `GIT_TERMINAL_PROMPT=0` covers terminal prompts,
+/// `GIT_ASKPASS`/`SSH_ASKPASS` are pointed at `true` (immediately answers
+/// with an empty string), and ssh runs in BatchMode (fails instead of
+/// prompting). stdout is nulled too — when this runs inside the LSP server,
+/// stdout is the JSON-RPC channel and no child chatter may reach it; git's
+/// diagnostics go to stderr, which stays inherited for the logs.
 fn git_command(args: &[&str], current_dir: Option<&Path>) -> Command {
     let mut cmd = Command::new("git");
     cmd.args(args)
         .stdin(std::process::Stdio::null())
-        .env("GIT_TERMINAL_PROMPT", "0");
+        .stdout(std::process::Stdio::null())
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_ASKPASS", "true")
+        .env("SSH_ASKPASS", "true")
+        .env("GIT_SSH_COMMAND", "ssh -oBatchMode=yes");
     if let Some(dir) = current_dir {
         cmd.current_dir(dir);
     }
@@ -473,8 +482,11 @@ mod tests {
 
     #[test]
     fn run_with_timeout_kills_stuck_command() {
-        let mut cmd = Command::new("sh");
-        cmd.args(["-c", "sleep 30"]);
+        // Spawn `sleep` directly: with `sh -c` the kill would reach the
+        // shell, and reaching `sleep` would depend on the shell exec'ing
+        // single commands.
+        let mut cmd = Command::new("sleep");
+        cmd.arg("30");
 
         let started = std::time::Instant::now();
         let result = run_with_timeout(cmd, Duration::from_millis(200), "test sleep");

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -185,6 +185,12 @@ fn install_queries_recursive(
 
     // Check if queries already exist
     if queries_dir.exists() && !force {
+        // Mark as installed BEFORE recursing into parents: an inheritance
+        // cycle among on-disk query files (self-inherit typo, A↔B) would
+        // otherwise recurse forever and overflow the stack. The download
+        // branch below already inserts before its parent loop.
+        installed.insert(language.to_string());
+
         // Even if skipping, we need to check for inherited dependencies
         let highlights_path = queries_dir.join("highlights.scm");
         if highlights_path.exists()
@@ -196,7 +202,6 @@ fn install_queries_recursive(
                 let _ = install_queries_recursive(&parent, data_dir, false, installed);
             }
         }
-        installed.insert(language.to_string());
         return Err(QueryInstallError::AlreadyExists(queries_dir));
     }
 
@@ -317,6 +322,39 @@ mod tests {
                     .contains(&"highlights.scm".to_string())
             );
         }
+    }
+
+    #[test]
+    fn install_with_dependencies_survives_inheritance_cycles_on_disk() {
+        let temp_dir = TempDir::new().unwrap();
+        let data_dir = temp_dir.path().to_path_buf();
+
+        // Self-cycle: a query file inheriting its own language (a one-word
+        // typo in a real highlights.scm). No network: both branches hit the
+        // already-exists path.
+        let a_dir = data_dir.join("queries").join("cyclic_a");
+        fs::create_dir_all(&a_dir).unwrap();
+        std::fs::write(a_dir.join("highlights.scm"), "; inherits: cyclic_a\n").unwrap();
+
+        let result = install_queries_with_dependencies("cyclic_a", &data_dir, false);
+        assert!(
+            matches!(result, Err(QueryInstallError::AlreadyExists(_))),
+            "self-inheriting installed queries must terminate with AlreadyExists"
+        );
+
+        // Mutual cycle between two installed languages.
+        let b_dir = data_dir.join("queries").join("cyclic_b");
+        let c_dir = data_dir.join("queries").join("cyclic_c");
+        fs::create_dir_all(&b_dir).unwrap();
+        fs::create_dir_all(&c_dir).unwrap();
+        std::fs::write(b_dir.join("highlights.scm"), "; inherits: cyclic_c\n").unwrap();
+        std::fs::write(c_dir.join("highlights.scm"), "; inherits: cyclic_b\n").unwrap();
+
+        let result = install_queries_with_dependencies("cyclic_b", &data_dir, false);
+        assert!(
+            matches!(result, Err(QueryInstallError::AlreadyExists(_))),
+            "mutually-inheriting installed queries must terminate with AlreadyExists"
+        );
     }
 
     #[test]

--- a/src/language/injection.rs
+++ b/src/language/injection.rs
@@ -890,22 +890,18 @@ impl CacheableInjectionRegion {
         let (start_byte, end_byte) = match info.offset {
             Some(offset) => {
                 use crate::analysis::offset_calculator::{ByteRange, calculate_effective_range};
+                // calculate_effective_range clamps, snaps inward to char
+                // boundaries, and normalizes start <= end, so slicing below
+                // cannot panic.
                 let effective = calculate_effective_range(
                     text,
                     ByteRange::new(node.start_byte(), node.end_byte()),
                     offset,
                 );
-                // Column deltas are byte counts; a misconfigured query could
-                // land inside a multi-byte character. Snap inward so slicing
-                // below cannot panic.
-                (
-                    ceil_char_boundary(text, effective.start),
-                    floor_char_boundary(text, effective.end),
-                )
+                (effective.start, effective.end)
             }
             None => (node.start_byte(), node.end_byte()),
         };
-        let (start_byte, end_byte) = (start_byte.min(end_byte), end_byte);
 
         let content = &text[start_byte..end_byte];
 

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -119,10 +119,12 @@ impl std::fmt::Debug for AutoInstallManager {
 }
 
 /// RAII marker for an in-flight install: clears the `InstallingLanguages`
-/// entry on drop. `try_install` awaits the actual install; if the calling
-/// future is dropped at that point, a manually-cleared marker would leak,
-/// leaving the language stuck `AlreadyInstalling` (and, via
-/// `should_skip_parse`, never parsed) for the server's lifetime.
+/// entry on drop. Manual `finish_install` calls would leak the marker if the
+/// calling future were dropped at an await, leaving the language stuck
+/// `AlreadyInstalling` (and, via `should_skip_parse`, never parsed) for the
+/// server's lifetime. For the install itself the guard moves into the
+/// spawned install task, so it tracks the blocking work's true lifetime
+/// rather than the caller's.
 struct InstallMarkerGuard {
     installing: InstallingLanguages,
     language: String,
@@ -262,7 +264,7 @@ impl AutoInstallManager {
                 events,
             };
         }
-        let _install_marker = InstallMarkerGuard {
+        let install_marker = InstallMarkerGuard {
             installing: self.installing_languages.clone(),
             language: language.to_string(),
         };
@@ -310,10 +312,33 @@ impl AutoInstallManager {
             message: format!("Auto-installing language '{}' in background...", language),
         });
 
-        // Run the actual installation
+        // Run the actual installation in its own task that owns the marker:
+        // the blocking install keeps running even if this caller is cancelled
+        // at the await, so clearing the marker on caller-drop would let a
+        // retry race the still-running install on the same parser/query
+        // paths. Owned by the task, the marker is held until the install
+        // truly finishes (the task itself is never cancelled).
         let lang = language.to_string();
-        let result =
-            crate::install::install_language_async(lang.clone(), data_dir.clone(), false).await;
+        let task_lang = lang.clone();
+        let task_data_dir = data_dir.clone();
+        let install_task = tokio::spawn(async move {
+            let _marker = install_marker;
+            crate::install::install_language_async(task_lang, task_data_dir, false).await
+        });
+        let result = match install_task.await {
+            Ok(result) => result,
+            Err(join_error) => {
+                events.push(InstallEvent::ProgressEnd { success: false });
+                events.push(InstallEvent::Log {
+                    level: MessageType::ERROR,
+                    message: format!("Install task for '{}' failed: {}", lang, join_error),
+                });
+                return InstallResult {
+                    outcome: InstallOutcome::Failed,
+                    events,
+                };
+            }
+        };
 
         // Check if parser file exists after install attempt (even if queries failed)
         let parser_exists = crate::install::parser_file_exists(&lang, &data_dir).is_some();

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -118,6 +118,22 @@ impl std::fmt::Debug for AutoInstallManager {
     }
 }
 
+/// RAII marker for an in-flight install: clears the `InstallingLanguages`
+/// entry on drop. `try_install` awaits the actual install; if the calling
+/// future is dropped at that point, a manually-cleared marker would leak,
+/// leaving the language stuck `AlreadyInstalling` (and, via
+/// `should_skip_parse`, never parsed) for the server's lifetime.
+struct InstallMarkerGuard {
+    installing: InstallingLanguages,
+    language: String,
+}
+
+impl Drop for InstallMarkerGuard {
+    fn drop(&mut self) {
+        self.installing.finish_install(&self.language);
+    }
+}
+
 impl AutoInstallManager {
     /// Create a new `AutoInstallManager`.
     pub fn new(
@@ -246,6 +262,10 @@ impl AutoInstallManager {
                 events,
             };
         }
+        let _install_marker = InstallMarkerGuard {
+            installing: self.installing_languages.clone(),
+            language: language.to_string(),
+        };
 
         // Progress begin
         events.push(InstallEvent::ProgressBegin);
@@ -259,7 +279,6 @@ impl AutoInstallManager {
                     message: "Could not determine data directory for auto-install".to_string(),
                 });
                 events.push(InstallEvent::ProgressEnd { success: false });
-                self.installing_languages.finish_install(language);
                 return InstallResult {
                     outcome: InstallOutcome::NoDataDir,
                     events,
@@ -277,7 +296,6 @@ impl AutoInstallManager {
                 ),
             });
             events.push(InstallEvent::ProgressEnd { success: true });
-            self.installing_languages.finish_install(language);
             return InstallResult {
                 outcome: InstallOutcome::AlreadyExists {
                     data_dir: data_dir.clone(),
@@ -296,9 +314,6 @@ impl AutoInstallManager {
         let lang = language.to_string();
         let result =
             crate::install::install_language_async(lang.clone(), data_dir.clone(), false).await;
-
-        // Mark installation as complete
-        self.installing_languages.finish_install(&lang);
 
         // Check if parser file exists after install attempt (even if queries failed)
         let parser_exists = crate::install::parser_file_exists(&lang, &data_dir).is_some();
@@ -397,6 +412,24 @@ mod tests {
 
         // Parser should not be marked as failed
         assert!(!manager.is_parser_failed("lua"));
+    }
+
+    #[test]
+    fn install_marker_guard_releases_on_drop() {
+        let installing = InstallingLanguages::new();
+        assert!(installing.try_start_install("lua"));
+
+        let guard = InstallMarkerGuard {
+            installing: installing.clone(),
+            language: "lua".to_string(),
+        };
+        drop(guard);
+
+        assert!(
+            installing.try_start_install("lua"),
+            "marker must be released when the guard drops, even if try_install \
+             is cancelled at its install await"
+        );
     }
 
     #[tokio::test]

--- a/src/lsp/bridge/actor/writer.rs
+++ b/src/lsp/bridge/actor/writer.rs
@@ -328,9 +328,13 @@ mod tests {
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
         loop {
             match process_stat(pid) {
-                None => break,
-                Some(stat) if stat.starts_with('Z') => break,
-                Some(stat) => {
+                Err(e) => {
+                    eprintln!("Skipping child-liveness assertion: ps unavailable ({e})");
+                    return;
+                }
+                Ok(None) => break,
+                Ok(Some(stat)) if stat.starts_with('Z') => break,
+                Ok(Some(stat)) => {
                     assert!(
                         std::time::Instant::now() < deadline,
                         "child {pid} still alive (stat {stat}): cancelled writer task \

--- a/src/lsp/bridge/actor/writer.rs
+++ b/src/lsp/bridge/actor/writer.rs
@@ -111,6 +111,15 @@ pub(crate) fn spawn_writer_task(
     }
 }
 
+/// Fail every request still sitting in the outbound queue.
+fn fail_queued(rx: &mut mpsc::Receiver<OutboundMessage>, router: &ResponseRouter, reason: &str) {
+    while let Ok(msg) = rx.try_recv() {
+        if let OutboundMessage::Tracked { request_id, .. } = msg {
+            router.fail_request(request_id, reason);
+        }
+    }
+}
+
 /// The main writer loop - writes messages from queue to stdin.
 ///
 /// Handles four shutdown paths: graceful stop drains the queue and returns the
@@ -166,11 +175,7 @@ async fn writer_loop(
                     target: "kakehashi::bridge::writer",
                     "Writer stop channel closed, shutting down"
                 );
-                while let Ok(msg) = rx.try_recv() {
-                    if let OutboundMessage::Tracked { request_id, .. } = msg {
-                        router.fail_request(request_id, "connection closing");
-                    }
-                }
+                fail_queued(&mut rx, &router, "connection closing");
                 return;
             }
 
@@ -181,11 +186,7 @@ async fn writer_loop(
                     "Writer task cancelled, shutting down"
                 );
                 // Drain remaining queued requests and fail them
-                while let Ok(msg) = rx.try_recv() {
-                    if let OutboundMessage::Tracked { request_id, .. } = msg {
-                        router.fail_request(request_id, "connection closing");
-                    }
-                }
+                fail_queued(&mut rx, &router, "connection closing");
                 // Don't send idle/writer - caller is force-cancelling
                 return;
             }

--- a/src/lsp/bridge/actor/writer.rs
+++ b/src/lsp/bridge/actor/writer.rs
@@ -149,16 +149,32 @@ async fn writer_loop(
                     );
                     // Drain remaining messages (best-effort write)
                     while let Ok(msg) = rx.try_recv() {
-                        if let Err(e) = write_message(&mut writer, &msg).await {
-                            log::warn!(
-                                target: "kakehashi::bridge::writer",
-                                "Write error during drain: {}",
-                                e
-                            );
-                            // Fail the request if write failed
-                            if let OutboundMessage::Tracked { request_id, .. } = msg {
-                                router.fail_request(request_id, "write error during shutdown");
+                        match write_or_cancelled(&mut writer, &msg, &cancel_token).await {
+                            None => {
+                                log::debug!(
+                                    target: "kakehashi::bridge::writer",
+                                    "Writer task cancelled during shutdown drain"
+                                );
+                                if let OutboundMessage::Tracked { request_id, .. } = msg {
+                                    router.fail_request(request_id, "connection closing");
+                                }
+                                fail_queued(&mut rx, &router, "connection closing");
+                                // Don't send idle/writer: dropping the writer
+                                // kills the hung child.
+                                return;
                             }
+                            Some(Err(e)) => {
+                                log::warn!(
+                                    target: "kakehashi::bridge::writer",
+                                    "Write error during drain: {}",
+                                    e
+                                );
+                                // Fail the request if write failed
+                                if let OutboundMessage::Tracked { request_id, .. } = msg {
+                                    router.fail_request(request_id, "write error during shutdown");
+                                }
+                            }
+                            Some(Ok(())) => {}
                         }
                     }
                     // Signal idle (queue drained)
@@ -195,18 +211,34 @@ async fn writer_loop(
             msg = rx.recv() => {
                 match msg {
                     Some(outbound) => {
-                        if let Err(e) = write_message(&mut writer, &outbound).await {
-                            log::warn!(
-                                target: "kakehashi::bridge::writer",
-                                "Write error: {}, failing request",
-                                e
-                            );
-                            // Clean up request from router if write failed
-                            if let OutboundMessage::Tracked { request_id, .. } = &outbound {
-                                router.fail_request(*request_id, "write error");
+                        match write_or_cancelled(&mut writer, &outbound, &cancel_token).await {
+                            None => {
+                                log::debug!(
+                                    target: "kakehashi::bridge::writer",
+                                    "Writer task cancelled during write, shutting down"
+                                );
+                                if let OutboundMessage::Tracked { request_id, .. } = &outbound {
+                                    router.fail_request(*request_id, "connection closing");
+                                }
+                                fail_queued(&mut rx, &router, "connection closing");
+                                // Exiting drops the writer, whose Drop kills
+                                // the hung child.
+                                return;
                             }
-                            // Note: Connection will transition to Failed via reader task
-                            // when it detects the write error (broken pipe, etc.)
+                            Some(Err(e)) => {
+                                log::warn!(
+                                    target: "kakehashi::bridge::writer",
+                                    "Write error: {}, failing request",
+                                    e
+                                );
+                                // Clean up request from router if write failed
+                                if let OutboundMessage::Tracked { request_id, .. } = &outbound {
+                                    router.fail_request(*request_id, "write error");
+                                }
+                                // Note: Connection will transition to Failed via reader task
+                                // when it detects the write error (broken pipe, etc.)
+                            }
+                            Some(Ok(())) => {}
                         }
                     }
                     None => {
@@ -222,6 +254,26 @@ async fn writer_loop(
                 }
             }
         }
+    }
+}
+
+/// Race a write against the cancel token, returning `None` when cancelled.
+///
+/// A hung child that stops reading stdin leaves the kernel pipe buffer full
+/// and the write parked forever; the writer loop's select arms cannot preempt
+/// a write that already began, so the write itself must observe cancellation
+/// or a cancelled writer task leaks itself, the writer, and the child.
+/// Cancelling mid-frame may leave a partial message in the pipe — acceptable
+/// because every cancellation path tears the connection down.
+async fn write_or_cancelled(
+    writer: &mut SplitConnectionWriter,
+    msg: &OutboundMessage,
+    cancel_token: &CancellationToken,
+) -> Option<std::io::Result<()>> {
+    tokio::select! {
+        biased;
+        _ = cancel_token.cancelled() => None,
+        result = write_message(writer, msg) => Some(result),
     }
 }
 
@@ -243,6 +295,52 @@ mod tests {
     use crate::lsp::bridge::protocol::RequestId;
     use serde_json::json;
     use std::time::Duration;
+
+    /// A child that never reads stdin leaves the kernel pipe buffer full and
+    /// the in-flight write parked forever. The select arms can't preempt a
+    /// write that already began, so the write itself must race the cancel
+    /// token; exiting drops the writer, whose Drop kills the child. Without
+    /// that race a cancelled writer task leaks itself, the writer, and the
+    /// child process.
+    #[tokio::test]
+    async fn cancel_reclaims_writer_blocked_on_full_stdin_pipe() {
+        use crate::lsp::bridge::pool::test_helpers::process_stat;
+
+        let mut conn = AsyncBridgeConnection::spawn(vec!["sleep".to_string(), "30".to_string()])
+            .await
+            .expect("should spawn sleep process");
+        let (writer, _reader) = conn.split();
+        let pid = writer.child_id().expect("child should have a pid");
+        let router = Arc::new(ResponseRouter::new());
+        let (tx, rx) = mpsc::channel(16);
+        let handle = spawn_writer_task(writer, rx, Arc::clone(&router));
+
+        // Far larger than the kernel pipe buffer so the write parks mid-frame.
+        let huge = json!({"method": "blocked", "params": {"data": "x".repeat(4 * 1024 * 1024)}});
+        tx.send(OutboundMessage::Untracked(huge)).await.unwrap();
+
+        // Let the writer task pick the message up and block on the full pipe.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        handle.cancel();
+
+        // Dead means reaped (None) or zombie (Z…).
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            match process_stat(pid) {
+                None => break,
+                Some(stat) if stat.starts_with('Z') => break,
+                Some(stat) => {
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "child {pid} still alive (stat {stat}): cancelled writer task \
+                         failed to exit while blocked on a full stdin pipe"
+                    );
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            }
+        }
+    }
 
     /// Test that writer task maintains FIFO order.
     #[tokio::test]

--- a/src/lsp/bridge/actor/writer.rs
+++ b/src/lsp/bridge/actor/writer.rs
@@ -302,6 +302,9 @@ mod tests {
     /// token; exiting drops the writer, whose Drop kills the child. Without
     /// that race a cancelled writer task leaks itself, the writer, and the
     /// child process.
+    ///
+    /// Unix-only: spawns `sleep` and probes child liveness via `ps`.
+    #[cfg(unix)]
     #[tokio::test]
     async fn cancel_reclaims_writer_blocked_on_full_stdin_pipe() {
         use crate::lsp::bridge::pool::test_helpers::process_stat;

--- a/src/lsp/bridge/connection.rs
+++ b/src/lsp/bridge/connection.rs
@@ -122,6 +122,12 @@ pub(crate) struct SplitConnectionWriter {
 }
 
 impl SplitConnectionWriter {
+    /// Child process id, exposed so tests can assert the process really dies.
+    #[cfg(test)]
+    pub(crate) fn child_id(&self) -> Option<u32> {
+        self.child.id()
+    }
+
     /// Write a JSON-RPC message to the child process stdin.
     pub(crate) async fn write_message(
         &mut self,

--- a/src/lsp/bridge/pool/shutdown.rs
+++ b/src/lsp/bridge/pool/shutdown.rs
@@ -248,9 +248,13 @@ mod tests {
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
         loop {
             match process_stat(pid) {
-                None => break,
-                Some(stat) if stat.starts_with('Z') => break,
-                Some(stat) => {
+                Err(e) => {
+                    eprintln!("Skipping child-liveness assertion: ps unavailable ({e})");
+                    return;
+                }
+                Ok(None) => break,
+                Ok(Some(stat)) if stat.starts_with('Z') => break,
+                Ok(Some(stat)) => {
                     assert!(
                         std::time::Instant::now() < deadline,
                         "sink child {pid} still running (stat {stat}) after force_kill_all"

--- a/src/lsp/bridge/pool/shutdown.rs
+++ b/src/lsp/bridge/pool/shutdown.rs
@@ -223,7 +223,9 @@ impl LanguageServerPool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
     use crate::lsp::bridge::pool::test_helpers::{create_handle_with_state_and_pid, process_stat};
+    #[cfg(unix)]
     use std::time::Duration;
 
     /// A sink server never answers the shutdown request, so its
@@ -232,6 +234,10 @@ mod tests {
     /// task: aborting drops the reclaimed writer, whose Drop kills the child.
     /// Without the abort the task lingers detached, the writer stays alive,
     /// and the child survives until process exit.
+    ///
+    /// Unix-only: probes child liveness via `ps`, like the other shutdown
+    /// lifecycle tests.
+    #[cfg(unix)]
     #[tokio::test]
     async fn force_kill_timeout_aborts_shutdown_task_and_kills_child() {
         let (handle, pid) = create_handle_with_state_and_pid(ConnectionState::Ready).await;

--- a/src/lsp/bridge/pool/shutdown.rs
+++ b/src/lsp/bridge/pool/shutdown.rs
@@ -223,19 +223,8 @@ impl LanguageServerPool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lsp::bridge::pool::test_helpers::create_handle_with_state_and_pid;
+    use crate::lsp::bridge::pool::test_helpers::{create_handle_with_state_and_pid, process_stat};
     use std::time::Duration;
-
-    /// `ps -o stat= -p` snapshot: `Some(state)` while the process exists
-    /// (zombies show as `Z…`), `None` once it is gone/reaped.
-    fn process_stat(pid: u32) -> Option<String> {
-        let output = std::process::Command::new("ps")
-            .args(["-o", "stat=", "-p", &pid.to_string()])
-            .output()
-            .expect("ps should run");
-        let stat = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        (!stat.is_empty()).then_some(stat)
-    }
 
     /// A sink server never answers the shutdown request, so its
     /// graceful_shutdown blocks forever on the response wait and force-kill

--- a/src/lsp/bridge/pool/shutdown.rs
+++ b/src/lsp/bridge/pool/shutdown.rs
@@ -177,6 +177,7 @@ impl LanguageServerPool {
                 let handle_for_shutdown = Arc::clone(&handle);
                 let shutdown_task =
                     tokio::spawn(async move { handle_for_shutdown.graceful_shutdown().await });
+                let shutdown_abort = shutdown_task.abort_handle();
 
                 match tokio::time::timeout(FORCE_KILL_TIMEOUT, shutdown_task).await {
                     Ok(Ok(_)) => {
@@ -194,7 +195,15 @@ impl LanguageServerPool {
                         handle.complete_shutdown();
                     }
                     Err(_) => {
-                        // The graceful_shutdown task timed out.
+                        // The graceful_shutdown task timed out. Abort it:
+                        // graceful_shutdown has no internal timeout (its
+                        // response wait is unbounded by design), so dropping
+                        // the JoinHandle alone would leave it running detached
+                        // — still holding the reclaimed writer and thus the
+                        // child process — until runtime shutdown. Aborting
+                        // drops the future and the writer's Drop kills the
+                        // child, same as abort_all() in the first phase.
+                        shutdown_abort.abort();
                         log::warn!(
                             target: "kakehashi::bridge",
                             "Force-kill timeout for {} connection, marking as closed",
@@ -208,5 +217,58 @@ impl LanguageServerPool {
 
         // Wait for all force-kills to complete
         Self::drain_join_set(&mut join_set, "Force-kill task").await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lsp::bridge::pool::test_helpers::create_handle_with_state_and_pid;
+    use std::time::Duration;
+
+    /// `ps -o stat= -p` snapshot: `Some(state)` while the process exists
+    /// (zombies show as `Z…`), `None` once it is gone/reaped.
+    fn process_stat(pid: u32) -> Option<String> {
+        let output = std::process::Command::new("ps")
+            .args(["-o", "stat=", "-p", &pid.to_string()])
+            .output()
+            .expect("ps should run");
+        let stat = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        (!stat.is_empty()).then_some(stat)
+    }
+
+    /// A sink server never answers the shutdown request, so its
+    /// graceful_shutdown blocks forever on the response wait and force-kill
+    /// hits the timeout arm. That arm must abort the still-running shutdown
+    /// task: aborting drops the reclaimed writer, whose Drop kills the child.
+    /// Without the abort the task lingers detached, the writer stays alive,
+    /// and the child survives until process exit.
+    #[tokio::test]
+    async fn force_kill_timeout_aborts_shutdown_task_and_kills_child() {
+        let (handle, pid) = create_handle_with_state_and_pid(ConnectionState::Ready).await;
+        let pool = LanguageServerPool::new();
+        pool.connections
+            .lock()
+            .await
+            .insert("lua".to_string(), handle);
+
+        pool.force_kill_all().await;
+
+        // Dead means reaped (None) or zombie (Z…); allow a short grace for
+        // the kill to land after the abort.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            match process_stat(pid) {
+                None => break,
+                Some(stat) if stat.starts_with('Z') => break,
+                Some(stat) => {
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "sink child {pid} still running (stat {stat}) after force_kill_all"
+                    );
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            }
+        }
     }
 }

--- a/src/lsp/bridge/pool/test_helpers.rs
+++ b/src/lsp/bridge/pool/test_helpers.rs
@@ -77,6 +77,7 @@ pub(in crate::lsp::bridge) fn devnull_config_for_language(language: &str) -> Bri
 /// (zombies show as `Z…`), `Ok(None)` once it is gone/reaped. For tests that
 /// assert a child process actually dies. `Err` means `ps` itself could not
 /// run (sandboxed runners) — callers should skip rather than fail.
+#[cfg(unix)]
 pub(in crate::lsp::bridge) fn process_stat(pid: u32) -> std::io::Result<Option<String>> {
     let output = std::process::Command::new("ps")
         .args(["-o", "stat=", "-p", &pid.to_string()])

--- a/src/lsp/bridge/pool/test_helpers.rs
+++ b/src/lsp/bridge/pool/test_helpers.rs
@@ -73,16 +73,16 @@ pub(in crate::lsp::bridge) fn devnull_config_for_language(language: &str) -> Bri
     }
 }
 
-/// `ps -o stat= -p` snapshot: `Some(state)` while the process exists
-/// (zombies show as `Z…`), `None` once it is gone/reaped. For tests that
-/// assert a child process actually dies.
-pub(in crate::lsp::bridge) fn process_stat(pid: u32) -> Option<String> {
+/// `ps -o stat= -p` snapshot: `Ok(Some(state))` while the process exists
+/// (zombies show as `Z…`), `Ok(None)` once it is gone/reaped. For tests that
+/// assert a child process actually dies. `Err` means `ps` itself could not
+/// run (sandboxed runners) — callers should skip rather than fail.
+pub(in crate::lsp::bridge) fn process_stat(pid: u32) -> std::io::Result<Option<String>> {
     let output = std::process::Command::new("ps")
         .args(["-o", "stat=", "-p", &pid.to_string()])
-        .output()
-        .expect("ps should run");
+        .output()?;
     let stat = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    (!stat.is_empty()).then_some(stat)
+    Ok((!stat.is_empty()).then_some(stat))
 }
 
 /// Helper function to convert url::Url to tower_lsp_server::ls_types::Uri for tests.

--- a/src/lsp/bridge/pool/test_helpers.rs
+++ b/src/lsp/bridge/pool/test_helpers.rs
@@ -73,6 +73,18 @@ pub(in crate::lsp::bridge) fn devnull_config_for_language(language: &str) -> Bri
     }
 }
 
+/// `ps -o stat= -p` snapshot: `Some(state)` while the process exists
+/// (zombies show as `Z…`), `None` once it is gone/reaped. For tests that
+/// assert a child process actually dies.
+pub(in crate::lsp::bridge) fn process_stat(pid: u32) -> Option<String> {
+    let output = std::process::Command::new("ps")
+        .args(["-o", "stat=", "-p", &pid.to_string()])
+        .output()
+        .expect("ps should run");
+    let stat = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!stat.is_empty()).then_some(stat)
+}
+
 /// Helper function to convert url::Url to tower_lsp_server::ls_types::Uri for tests.
 pub(in crate::lsp::bridge) fn url_to_uri(url: &Url) -> tower_lsp_server::ls_types::Uri {
     crate::lsp::lsp_impl::url_to_uri(url).expect("test URL should convert to URI")

--- a/src/lsp/bridge/pool/test_helpers.rs
+++ b/src/lsp/bridge/pool/test_helpers.rs
@@ -82,7 +82,17 @@ pub(in crate::lsp::bridge) fn process_stat(pid: u32) -> std::io::Result<Option<S
         .args(["-o", "stat=", "-p", &pid.to_string()])
         .output()?;
     let stat = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    Ok((!stat.is_empty()).then_some(stat))
+    if !stat.is_empty() {
+        return Ok(Some(stat));
+    }
+    // Empty stdout is ambiguous: a gone pid makes ps exit non-zero silently,
+    // while a restricted environment's failing ps reports on stderr. Surface
+    // the latter as Err so callers skip instead of vacuously passing.
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if !stderr.is_empty() {
+        return Err(std::io::Error::other(format!("ps failed: {stderr}")));
+    }
+    Ok(None)
 }
 
 /// Helper function to convert url::Url to tower_lsp_server::ls_types::Uri for tests.

--- a/src/lsp/bridge/pool/test_helpers.rs
+++ b/src/lsp/bridge/pool/test_helpers.rs
@@ -91,6 +91,14 @@ pub(in crate::lsp::bridge) fn test_host_uri(name: &str) -> Url {
 /// these are correctly classified as ServerRequest rather than Response,
 /// causing shutdown handshakes to hang.
 pub async fn create_handle_with_state(state: ConnectionState) -> Arc<ConnectionHandle> {
+    create_handle_with_state_and_pid(state).await.0
+}
+
+/// Like [`create_handle_with_state`], but also returns the sink child's pid
+/// so tests can assert the process actually dies (e.g. kill-on-timeout paths).
+pub async fn create_handle_with_state_and_pid(
+    state: ConnectionState,
+) -> (Arc<ConnectionHandle>, u32) {
     // Create a mock server process (sink — discards all input, no output)
     let mut conn = AsyncBridgeConnection::spawn(vec![
         "sh".to_string(),
@@ -102,10 +110,11 @@ pub async fn create_handle_with_state(state: ConnectionState) -> Arc<ConnectionH
 
     // Split connection and spawn reader task (new architecture)
     let (writer, reader) = conn.split();
+    let pid = writer.child_id().expect("sink child should have a pid");
     let router = Arc::new(ResponseRouter::new());
     let reader_handle = spawn_reader_task(reader, Arc::clone(&router));
 
     let handle = Arc::new(ConnectionHandle::new(writer, router, reader_handle));
     handle.set_state(state);
-    handle
+    (handle, pid)
 }

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -304,9 +304,13 @@ impl Kakehashi {
         let uri = computed.uri;
         let edit_lock = self.documents.edit_lock(&uri);
         let _guard = edit_lock.lock().await;
-        if self.documents.get(&uri).is_some()
-            && self.documents.open_generation(&uri) == computed.open_generation
-        {
+        // Separate statement so the documents Ref (a shard read lock) drops
+        // before open_generation's entry() takes an open_generations shard
+        // write — holding a Ref across another map's write acquisition is
+        // the lock-order half of a latent ABBA inversion (see
+        // forget_open_generation_if_closed).
+        let document_is_open = self.documents.get(&uri).is_some();
+        if document_is_open && self.documents.open_generation(&uri) == computed.open_generation {
             let mut entry = self.captures_cache.entry((uri, kind)).or_default();
             entry[usize::from(injection)] = Some((result_id, computed.matches));
         }

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -18,9 +18,9 @@
 use crate::analysis::offset_calculator::{ByteRange, calculate_effective_range};
 use crate::language::LanguageCoordinator;
 use crate::language::injection::{
-    MAX_INJECTION_DEPTH, byte_to_point, byte_to_point_anchored, ceil_char_boundary,
-    collect_all_injections, compute_included_ranges, compute_included_ranges_clipped,
-    effective_offset_for_pattern, floor_char_boundary, intersect_included_ranges,
+    MAX_INJECTION_DEPTH, byte_to_point, byte_to_point_anchored, collect_all_injections,
+    compute_included_ranges, compute_included_ranges_clipped, effective_offset_for_pattern,
+    intersect_included_ranges,
 };
 use crate::lsp::lsp_impl::kakehashi::node::lookup::find_node_at;
 
@@ -542,49 +542,30 @@ fn build_effective_ranges(
     let content_start = region.content_node.start_byte();
     let content_start_pos = region.content_node.start_position();
     let absolute_ranges: Vec<tree_sitter::Range> = if offset.is_some() {
-        // #offset! shifts are byte arithmetic over i32 deltas, so the effective
-        // bounds can land mid-codepoint. Snap inward to UTF-8 boundaries
-        // (ceil the start, floor the end — matching the semantic and bridge
-        // paths) before handing them to tree-sitter: a mid-char byte in
-        // set_included_ranges is UB / panic territory, and flooring the start
-        // would re-include bytes the offset meant to exclude.
-        let aligned_start = ceil_char_boundary(host_text, eff_start);
-        let aligned_end = floor_char_boundary(host_text, eff_end);
-        // The alignment could, in pathological cases, collapse the range
-        // (e.g. both ends fall inside the same multi-byte char). Guard so we
-        // never emit a zero/negative-width range to the parser.
-        if aligned_start >= aligned_end {
-            return Vec::new();
-        }
+        // calculate_effective_range already clamped, snapped inward to UTF-8
+        // boundaries, and normalized start <= end, so eff_start/eff_end are
+        // safe to hand to tree-sitter (a mid-char byte in set_included_ranges
+        // is UB / panic territory); the degenerate case returned above.
         match compute_included_ranges_clipped(
             &region.content_node,
             region.include_children,
             host_text,
-            aligned_start..aligned_end,
+            eff_start..eff_end,
         ) {
             Some(gaps) => {
-                let window_start_pos = byte_to_point_anchored(
-                    host_text,
-                    aligned_start,
-                    content_start,
-                    content_start_pos,
-                );
+                let window_start_pos =
+                    byte_to_point_anchored(host_text, eff_start, content_start, content_start_pos);
                 gaps.into_iter()
-                    .map(|r| absolutize_range(r, aligned_start, window_start_pos))
+                    .map(|r| absolutize_range(r, eff_start, window_start_pos))
                     .collect()
             }
             None => {
-                let start_point = byte_to_point_anchored(
-                    host_text,
-                    aligned_start,
-                    content_start,
-                    content_start_pos,
-                );
-                let end_point =
-                    byte_to_point_anchored(host_text, aligned_end, aligned_start, start_point);
+                let start_point =
+                    byte_to_point_anchored(host_text, eff_start, content_start, content_start_pos);
+                let end_point = byte_to_point_anchored(host_text, eff_end, eff_start, start_point);
                 vec![tree_sitter::Range {
-                    start_byte: aligned_start,
-                    end_byte: aligned_end,
+                    start_byte: eff_start,
+                    end_byte: eff_end,
                     start_point,
                     end_point,
                 }]

--- a/src/lsp/lsp_impl/text_document/selection_range.rs
+++ b/src/lsp/lsp_impl/text_document/selection_range.rs
@@ -68,6 +68,12 @@ impl Kakehashi {
                 let _guard = edit_lock.lock().await;
                 let still_current = {
                     let Some(doc) = self.documents.get(&uri) else {
+                        // edit_lock() get-or-inserts; a didClose that raced the
+                        // parse already removed the entry, so drop the one we
+                        // just recreated rather than leaking it (same miss-path
+                        // cleanup as semantic_tokens).
+                        drop(_guard);
+                        self.documents.remove_edit_lock(&uri);
                         return Ok(None);
                     };
                     doc.text() == text

--- a/src/lsp/lsp_impl/text_document/selection_range.rs
+++ b/src/lsp/lsp_impl/text_document/selection_range.rs
@@ -54,11 +54,28 @@ impl Kakehashi {
                 })
                 .await;
 
-            if let Some(tree) = sync_parse_result {
-                self.documents
-                    .update_document(uri.clone(), text, Some(tree));
-            } else {
+            let Some(tree) = sync_parse_result else {
                 return Ok(None);
+            };
+
+            // Persist under the per-URI edit lock and only if the document is
+            // still alive with the text we parsed: a didClose racing the parse
+            // must not be undone by re-inserting the document, and a didChange
+            // must not be clobbered with the older text/tree. Block-scoped so
+            // the edit lock is released before the pool wait below.
+            {
+                let edit_lock = self.documents.edit_lock(&uri);
+                let _guard = edit_lock.lock().await;
+                let still_current = {
+                    let Some(doc) = self.documents.get(&uri) else {
+                        return Ok(None);
+                    };
+                    doc.text() == text
+                };
+                if still_current {
+                    self.documents
+                        .update_document(uri.clone(), text, Some(tree));
+                }
             }
         }
 

--- a/src/lsp/lsp_impl/text_document/selection_range.rs
+++ b/src/lsp/lsp_impl/text_document/selection_range.rs
@@ -32,16 +32,18 @@ impl Kakehashi {
             return Ok(None);
         }
 
-        // Get document
-        let Some(doc) = self.documents.get(&uri) else {
-            return Ok(None);
+        // Take what the on-demand parse needs and drop the Ref at the block's
+        // end: a DashMap Ref held across an .await keeps the shard read-locked
+        // while this task is parked, stalling didOpen/didChange writers.
+        let unparsed_text = {
+            let Some(doc) = self.documents.get(&uri) else {
+                return Ok(None);
+            };
+            doc.tree().is_none().then(|| doc.text().to_string())
         };
 
-        // Check if document has a tree, if not parse it on-demand
-        if doc.tree().is_none() {
-            let text = doc.text().to_string();
-            drop(doc); // Release lock before acquiring parser pool
-
+        // Parse on-demand if the document has no tree yet
+        if let Some(text) = unparsed_text {
             let text_clone = text.clone();
 
             let sync_parse_result = self
@@ -58,21 +60,14 @@ impl Kakehashi {
             } else {
                 return Ok(None);
             }
-
-            // Re-acquire document after update
-            let Some(doc) = self.documents.get(&uri) else {
-                return Ok(None);
-            };
-
-            // Use full injection parsing handler with coordinator and parser pool
-            let mut pool = self.parser_pool.lock().await;
-            let result = handle_selection_range(&doc, &positions, &self.language, &mut pool);
-
-            return Ok(Some(result));
         }
 
-        // Use full injection parsing handler with coordinator and parser pool
+        // Lock the pool before re-acquiring the document so the Ref is never
+        // held across an await, then run the full injection parsing handler.
         let mut pool = self.parser_pool.lock().await;
+        let Some(doc) = self.documents.get(&uri) else {
+            return Ok(None);
+        };
         let result = handle_selection_range(&doc, &positions, &self.language, &mut pool);
 
         Ok(Some(result))


### PR DESCRIPTION
## Summary

Second round of the comprehensive deadlock/panic audit (follow-up to #366). Four review-fix-verify cycles over the whole crate, then a pre-PR review gauntlet (multi-perspective subagent review ×3 + Codex high-effort sessions to traced convergence).

### Panics fixed
- **selectionRange UTF-8 panic**: `#offset!` column deltas are byte counts; one landing mid-codepoint panicked the handler. Snapping is now centralized inside `calculate_effective_range` (and the now-redundant caller-side snaps were removed).
- **CLI stack overflow**: `; inherits:` cycles among on-disk query files recursed forever in `install_queries_recursive`'s already-exists branch.

### Hangs / leaks fixed
- **Writer task wedged on a full stdin pipe**: a hung child that stops reading parks `write_message` forever, beyond select arms and cancel tokens. Writes now race the cancel token; exiting drops the writer, whose `Drop` kills the child.
- **force_kill_all never killed**: the timeout arm dropped the JoinHandle without aborting, detaching `graceful_shutdown` (which by design has no internal timeout) with the writer + child held forever.
- **git clone fallback unbounded**: no timeout, inherited stdin, promptable. Now: 120s hard deadline per command, stdin/stdout nulled, `GIT_TERMINAL_PROMPT=0` + askpass/ssh-BatchMode prompt-proofing (user `GIT_SSH_COMMAND` extended, not clobbered).
- **Auto-install marker wedge / race**: the in-progress marker is now an RAII guard owned by a spawned task tied to the blocking install's true lifetime — a cancelled caller can no longer wedge the language as `AlreadyInstalling` forever, nor clear the marker while the install still runs.

### Latent hazards hardened
- **ABBA lock-order inversion** between the `documents` and `open_generations` DashMaps (un-nested on both sides). Not exploitable today — dashmap 6.2's shard lock is reader-preferring — but a landmine for any fair-lock upgrade.
- **selectionRange lock hygiene**: no DashMap `Ref` held across an await; the on-demand parse persists under the per-URI edit lock and only when the document is still alive with the parsed text (no resurrection after didClose, no clobbering a didChange).

### Tests
Regression tests verify the kill/leak fixes against real child processes (sink servers, full-pipe writers, stuck commands), with a shared `ps`-probe helper that skips gracefully on sandboxed runners. Every fix's RED state was verified locally before the fix (the pre-commit gate rejects failing-test commits, so test+fix land together — noted in each commit body).