### PR TITLE
feat(bridge): allowlist priorities with '*' wildcard + cross-layer 'layers' config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,9 +75,9 @@ percent-encoding = "2"
 rayon = "1"
 futures = "0.3.31"
 
-# Unix-only dependencies (signal handling)
+# Unix-only dependencies (signal handling; "fs" for FD_CLOEXEC in tests)
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.31", features = ["signal", "process"] }
+nix = { version = "0.31", features = ["signal", "process", "fs"] }
 
 [features]
 e2e = []

--- a/docs/README.md
+++ b/docs/README.md
@@ -374,7 +374,7 @@ own features). The per-language `layers` map orders them per LSP method:
 | Field | Description |
 |-------|-------------|
 | `order` | Ordered allowlist of layers, highest priority first. Layers omitted from the list do not participate; `[]` disables the method entirely. Default: `["virt", "host", "native"]`. Omitting `"virt"` turns off injection bridging for that method. |
-| `strategy` | Cross-layer combine strategy. Only `"preferred"` (first non-empty layer wins) is implemented today. |
+| `strategy` | Cross-layer combine strategy: `"preferred"` (first non-empty layer wins, the default for most methods) or `"concatenated"`. `"concatenated"` is honored for `textDocument/formatting` only; until host bridging ships, at most one layer produces edits, so both strategies currently yield that layer's result. |
 
 The key is the LSP method name or `_` for the method wildcard, like
 `aggregation`. Today only the `virt` layer produces results — `host` is

--- a/docs/README.md
+++ b/docs/README.md
@@ -377,10 +377,11 @@ own features). The per-language `layers` map orders them per LSP method:
 | `strategy` | Cross-layer combine strategy: `"preferred"` (first non-empty layer wins, the default for most methods) or `"concatenated"`. `"concatenated"` is honored for `textDocument/formatting` only; until host bridging ships, at most one layer produces edits, so both strategies currently yield that layer's result. |
 
 The key is the LSP method name or `_` for the method wildcard, like
-`aggregation`. Today only the `virt` layer produces results — `host` is
-reserved until host-document bridging ships, and bridged methods have no
-`native` counterpart — so the practical effect is per-method enabling and
-disabling of injection bridging.
+`aggregation`. `textDocument/rangeFormatting` shares the
+`textDocument/formatting` key (same convention as `aggregation`). Today only
+the `virt` layer produces results — `host` is reserved until host-document
+bridging ships, and bridged methods have no `native` counterpart — so the
+practical effect is per-method enabling and disabling of injection bridging.
 
 **Bridge Filter Semantics:**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -378,10 +378,14 @@ own features). The per-language `layers` map orders them per LSP method:
 
 The key is the LSP method name or `_` for the method wildcard, like
 `aggregation`. `textDocument/rangeFormatting` shares the
-`textDocument/formatting` key (same convention as `aggregation`). Today only
-the `virt` layer produces results — `host` is reserved until host-document
-bridging ships, and bridged methods have no `native` counterpart — so the
-practical effect is per-method enabling and disabling of injection bridging.
+`textDocument/formatting` key (same convention as `aggregation`). Diagnostics
+use two keys, mirroring their aggregation keying: pull diagnostics gate under
+`textDocument/diagnostic`, push diagnostics under
+`textDocument/publishDiagnostics` — disable both (or use `_`) to fully turn
+bridge diagnostics off. Today only the `virt` layer produces results —
+`host` is reserved until host-document bridging ships, and bridged methods
+have no `native` counterpart — so the practical effect is per-method
+enabling and disabling of injection bridging.
 
 **Bridge Filter Semantics:**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -326,9 +326,14 @@ When multiple language servers can handle the same injection language, `aggregat
 
 | Field | Description |
 |-------|-------------|
-| `priorities` | Ordered list of server names. The first server that returns a valid response wins. Empty list falls back to arrival-order (first-win) behavior. |
+| `priorities` | Ordered **allowlist** of server names: listed servers are queried in this order, and servers absent from the list do not run. A `"*"` element stands for every configured-but-unlisted server (first-win among themselves), so `["pyright", "*"]` means "prefer pyright, fall back to the rest" and `["*", "pylsp"]` demotes pylsp below everyone else. Omitted = `["*"]` (all servers, first-win). An explicit `[]` disables the method for this bridge entry. Note: the sequential `concatenated` formatting pipeline requires explicit names and ignores `"*"`. |
 | `strategy` | `"preferred"` or `"concatenated"`. Default depends on the LSP method: `"concatenated"` for `textDocument/diagnostic`, `"preferred"` for everything else. `"preferred"` uses the first non-empty response; `"concatenated"` collects and merges responses from all servers. |
 | `maxFanOut` | Maximum number of servers to query. `null` or omitted = no limit (default). `0` = disable fan-out entirely. Positive integer = cap at N servers. Priority servers are selected first when limiting. Negative values are treated as no limit. |
+
+> **Migration note**: `priorities` used to be a preference order only — unlisted
+> servers still participated as fallback. It is now an allowlist: `["pyright"]`
+> runs *only* pyright. Append `"*"` (`["pyright", "*"]`) to keep the old
+> fallback behavior.
 
 Example with per-method priorities, strategy, and maxFanOut:
 
@@ -338,13 +343,44 @@ Example with per-method priorities, strategy, and maxFanOut:
     "python": {
       "aggregation": {
         "textDocument/completion": { "priorities": ["pyright", "pylsp"], "maxFanOut": 1 },
-        "textDocument/diagnostic": { "strategy": "preferred", "priorities": ["pyright"] },
-        "_": { "priorities": ["pylsp"] }
+        "textDocument/diagnostic": { "strategy": "preferred", "priorities": ["pyright", "*"] },
+        "_": { "priorities": ["pylsp", "*"] }
       }
     }
   }
 }
 ```
+
+**Cross-Layer Aggregation (`layers`):**
+
+A request to kakehashi can in principle be answered by up to three *result
+layers*: `virt` (the injection bridges above), `host` (a host-document
+language server — reserved for a future release), and `native` (kakehashi's
+own features). The per-language `layers` map orders them per LSP method:
+
+```json
+{
+  "languages": {
+    "markdown": {
+      "layers": {
+        "textDocument/hover": { "order": ["virt", "native"] },
+        "_": { "order": ["virt", "host", "native"] }
+      }
+    }
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `order` | Ordered allowlist of layers, highest priority first. Layers omitted from the list do not participate; `[]` disables the method entirely. Default: `["virt", "host", "native"]`. Omitting `"virt"` turns off injection bridging for that method. |
+| `strategy` | Cross-layer combine strategy. Only `"preferred"` (first non-empty layer wins) is implemented today. |
+
+The key is the LSP method name or `_` for the method wildcard, like
+`aggregation`. Today only the `virt` layer produces results — `host` is
+reserved until host-document bridging ships, and bridged methods have no
+`native` counterpart — so the practical effect is per-method enabling and
+disabling of injection bridging.
 
 **Bridge Filter Semantics:**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -379,9 +379,9 @@ Example with per-method priorities, strategy, and maxFanOut:
 
 **Cross-Layer Aggregation (`layers`):**
 
-A request to kakehashi can in principle be answered by up to three *result
-layers*: `virt` (the injection bridges above), `host` (a host-document
-language server — reserved for a future release), and `native` (kakehashi's
+A request to kakehashi can be answered by up to three *result layers*:
+`virt` (the injection bridges above), `host` (a host-document language
+server — opt-in via `bridge._self` above), and `native` (kakehashi's
 own features). The per-language `layers` map orders them per LSP method:
 
 ```json

--- a/docs/README.md
+++ b/docs/README.md
@@ -376,16 +376,20 @@ own features). The per-language `layers` map orders them per LSP method:
 | `order` | Ordered allowlist of layers, highest priority first. Layers omitted from the list do not participate; `[]` disables the method entirely. Default: `["virt", "host", "native"]`. Omitting `"virt"` turns off injection bridging for that method. |
 | `strategy` | Cross-layer combine strategy: `"preferred"` (first non-empty layer wins, the default for most methods) or `"concatenated"`. `"concatenated"` is honored for `textDocument/formatting` only; until host bridging ships, at most one layer produces edits, so both strategies currently yield that layer's result. |
 
-The key is the LSP method name or `_` for the method wildcard, like
-`aggregation`. `textDocument/rangeFormatting` shares the
-`textDocument/formatting` key (same convention as `aggregation`). Diagnostics
-use two keys, mirroring their aggregation keying: pull diagnostics gate under
-`textDocument/diagnostic`, push diagnostics under
-`textDocument/publishDiagnostics` — disable both (or use `_`) to fully turn
-bridge diagnostics off. Today only the `virt` layer produces results —
-`host` is reserved until host-document bridging ships, and bridged methods
-have no `native` counterpart — so the practical effect is per-method
-enabling and disabling of injection bridging.
+Details:
+
+- **Key**: the LSP method name, or `_` for the method wildcard (same
+  convention as `aggregation`).
+- **Formatting**: `textDocument/rangeFormatting` shares the
+  `textDocument/formatting` key.
+- **Diagnostics**: two keys, mirroring their aggregation keying — pull
+  diagnostics gate under `textDocument/diagnostic`, push diagnostics under
+  `textDocument/publishDiagnostics`. Disable both (or use `_`) to fully turn
+  bridge diagnostics off.
+- **Current effect**: today only the `virt` layer produces results — `host`
+  is reserved until host-document bridging ships, and bridged methods have
+  no `native` counterpart — so the practical effect is per-method enabling
+  and disabling of injection bridging.
 
 **Bridge Filter Semantics:**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -320,6 +320,30 @@ Each entry in the `bridge` map configures bridging for one injection language:
 | `enabled` | Whether bridging is enabled (`true`/`false`). Omit to inherit from the `_` wildcard (defaults to `true`). |
 | `aggregation` | Per-method aggregation config. Key = LSP method name (e.g., `textDocument/completion`) or `_` for default. |
 
+**Host bridging (`bridge._self`):**
+
+The reserved `_self` key makes the host language its own bridge target: with
+it enabled, requests on the host document are forwarded to servers whose
+`languages` contains the **host** language, with the real URI and no
+coordinate translation. Currently `textDocument/definition` and
+`textDocument/hover` are wired; by default the host layer is tried after
+`virt` (see `layers` above), so injections keep winning inside code fences
+while the host server answers everywhere else.
+
+```toml
+[languages.markdown.bridge._self]
+enabled = true                       # opt-in: REQUIRED, never inherited from `_`
+
+[languageServers.marksman]
+cmd = ["marksman", "server"]
+languages = ["markdown"]             # host candidate for markdown documents
+```
+
+Unlike injection entries, `_self.enabled` does **not** inherit from the `_`
+wildcard — a server listing the host language is a *capability*, not consent
+to use it. `_self.aggregation` (priorities/strategy/maxFanOut) inherits from
+`_` as usual.
+
 **Aggregation Configuration:**
 
 When multiple language servers can handle the same injection language, `aggregation` controls which server's response is preferred. Each entry contains:
@@ -386,10 +410,12 @@ Details:
   diagnostics gate under `textDocument/diagnostic`, push diagnostics under
   `textDocument/publishDiagnostics`. Disable both (or use `_`) to fully turn
   bridge diagnostics off.
-- **Current effect**: today only the `virt` layer produces results — `host`
-  is reserved until host-document bridging ships, and bridged methods have
-  no `native` counterpart — so the practical effect is per-method enabling
-  and disabling of injection bridging.
+- **Current effect**: the `virt` layer answers inside injection regions, and
+  the `host` layer answers on the host document itself for
+  `textDocument/definition` and `textDocument/hover` when host bridging is
+  opted in (see `bridge._self` below). Bridged methods have no `native`
+  counterpart yet. For other methods the practical effect is per-method
+  enabling and disabling of injection bridging.
 
 **Bridge Filter Semantics:**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -325,10 +325,12 @@ Each entry in the `bridge` map configures bridging for one injection language:
 The reserved `_self` key makes the host language its own bridge target: with
 it enabled, requests on the host document are forwarded to servers whose
 `languages` contains the **host** language, with the real URI and no
-coordinate translation. Currently `textDocument/definition` and
-`textDocument/hover` are wired; by default the host layer is tried after
-`virt` (see `layers` above), so injections keep winning inside code fences
-while the host server answers everywhere else.
+coordinate translation. Currently `textDocument/definition`,
+`textDocument/hover`, and `textDocument/formatting` are wired; by default
+the host layer is tried after `virt` (see `layers` above), so injections
+keep winning inside code fences while the host server answers everywhere
+else. For formatting, combine fence formatters with a whole-document
+formatter via `layers."textDocument/formatting".strategy = "concatenated"`.
 
 ```toml
 [languages.markdown.bridge._self]
@@ -398,7 +400,7 @@ own features). The per-language `layers` map orders them per LSP method:
 | Field | Description |
 |-------|-------------|
 | `order` | Ordered allowlist of layers, highest priority first. Layers omitted from the list do not participate; `[]` disables the method entirely. Default: `["virt", "host", "native"]`. Omitting `"virt"` turns off injection bridging for that method. |
-| `strategy` | Cross-layer combine strategy: `"preferred"` (first non-empty layer wins, the default for most methods) or `"concatenated"`. `"concatenated"` is honored for `textDocument/formatting` only; until host bridging ships, at most one layer produces edits, so both strategies currently yield that layer's result. |
+| `strategy` | Cross-layer combine strategy: `"preferred"` (first non-empty layer wins, the default for most methods) or `"concatenated"`. `"concatenated"` is honored for `textDocument/formatting` only and runs the layers as a sequential pipeline: injection regions format first (`virt`), then the host formatter (`host`, see `bridge._self`) formats the resulting text, collapsing into one whole-document edit. |
 
 Details:
 
@@ -412,10 +414,11 @@ Details:
   bridge diagnostics off.
 - **Current effect**: the `virt` layer answers inside injection regions, and
   the `host` layer answers on the host document itself for
-  `textDocument/definition` and `textDocument/hover` when host bridging is
-  opted in (see `bridge._self` below). Bridged methods have no `native`
-  counterpart yet. For other methods the practical effect is per-method
-  enabling and disabling of injection bridging.
+  `textDocument/definition`, `textDocument/hover`, and
+  `textDocument/formatting` when host bridging is opted in (see
+  `bridge._self` below). Bridged methods have no `native` counterpart yet.
+  For other methods the practical effect is per-method enabling and
+  disabling of injection bridging.
 
 **Bridge Filter Semantics:**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -325,12 +325,12 @@ Each entry in the `bridge` map configures bridging for one injection language:
 The reserved `_self` key makes the host language its own bridge target: with
 it enabled, requests on the host document are forwarded to servers whose
 `languages` contains the **host** language, with the real URI and no
-coordinate translation. Currently `textDocument/definition`,
-`textDocument/hover`, and `textDocument/formatting` are wired; by default
-the host layer is tried after `virt` (see `layers` above), so injections
-keep winning inside code fences while the host server answers everywhere
-else. For formatting, combine fence formatters with a whole-document
-formatter via `layers."textDocument/formatting".strategy = "concatenated"`.
+coordinate translation. All bridged request methods are wired (diagnostics
+and semantic tokens excepted); by default the host layer is tried after
+`virt` (see `layers` above), so injections keep winning inside code fences
+while the host server answers everywhere else. For formatting, combine
+fence formatters with a whole-document formatter via
+`layers."textDocument/formatting".strategy = "concatenated"`.
 
 ```toml
 [languages.markdown.bridge._self]
@@ -413,12 +413,10 @@ Details:
   `textDocument/publishDiagnostics`. Disable both (or use `_`) to fully turn
   bridge diagnostics off.
 - **Current effect**: the `virt` layer answers inside injection regions, and
-  the `host` layer answers on the host document itself for
-  `textDocument/definition`, `textDocument/hover`, and
-  `textDocument/formatting` when host bridging is opted in (see
-  `bridge._self` below). Bridged methods have no `native` counterpart yet.
-  For other methods the practical effect is per-method enabling and
-  disabling of injection bridging.
+  the `host` layer answers on the host document itself for every bridged
+  request method when host bridging is opted in (see `bridge._self` below).
+  Bridged methods have no `native` counterpart yet. Diagnostics and
+  semantic tokens stay virt-only for now.
 
 **Bridge Filter Semantics:**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -414,7 +414,7 @@ Details:
   bridge diagnostics off.
 - **Current effect**: the `virt` layer answers inside injection regions, and
   the `host` layer answers on the host document itself for every bridged
-  request method when host bridging is opted in (see `bridge._self` below).
+  request method when host bridging is opted in (see `bridge._self` above).
   Bridged methods have no `native` counterpart yet. Diagnostics and
   semantic tokens stay virt-only for now.
 

--- a/docs/architecture-decisions/aggregation-priorities-wildcard.md
+++ b/docs/architecture-decisions/aggregation-priorities-wildcard.md
@@ -1,0 +1,164 @@
+# Aggregation Priorities Wildcard
+
+**Related Decisions**:
+- [ls-bridge-server-pool-coordination](ls-bridge-server-pool-coordination.md) — Fan-out/fan-in mechanics that consume `priorities`
+- [language-server-bridge-request-strategies](language-server-bridge-request-strategies.md) — Per-method strategies and merging rules
+- [concatenated-formatting-pipeline](concatenated-formatting-pipeline.md) — The formatting pipeline whose allowlist semantics this decision generalizes
+- [cross-layer-aggregation](cross-layer-aggregation.md) — Layer ordering (`order`), which adopts the same allowlist rule
+
+## Implementation Status
+
+Not implemented. This is the first phase of the cross-layer-aggregation
+roadmap: land the unified `priorities` semantics before the layer dispatch
+builds on them.
+
+## Context
+
+`AggregationConfig.priorities` currently has **two semantics depending on the
+strategy**:
+
+- Under `preferred` (the common case), it is a *preference order only*:
+  servers absent from the list still participate via first-win fallback
+  (`fan_in/preferred.rs` — "when all prioritized servers are exhausted, fall
+  back to first-win among unprioritized servers").
+- Under the `concatenated` formatting pipeline, it is an *allowlist plus
+  application order*: servers absent from the list do not run at all.
+  concatenated-formatting-pipeline documents this as a "behavioral nuance"
+  in its Negative consequences.
+
+Two problems with keeping the dual semantics:
+
+1. **Inconsistency compounds.** cross-layer-aggregation introduces a second
+   ordered list (`layers.<method>.order`). Every new list must pick a side,
+   and users must remember which list means which.
+2. **Exclusion and demotion are inexpressible under `preferred`.** A user
+   cannot say "only foo" (fallback always re-admits the rest), nor "foo
+   first, everyone else, and zzz dead last" (the rest always outranks
+   nothing — unlisted servers form one undifferentiated fallback group that
+   cannot be positioned).
+
+## Decision Drivers
+
+- **One rule for every ordered list**: `priorities` (server names) and
+  `order` (layers) should share semantics, differing only in element type.
+- **Express exclusion and demotion**, not just promotion.
+- **Defaults preserve behavior**: configs without `priorities` must behave
+  exactly as today.
+- **Sigil discipline**: `_` is established for wildcard *keys* that carry
+  field-level inheritance (`resolve_with_wildcard`). A list *element* meaning
+  "the rest" has no inheritance semantics and should not reuse that sigil.
+
+## Decision Outcome
+
+**Chosen approach**: `priorities` becomes an **ordered allowlist**. A `"*"`
+element expands to "all candidate servers not named elsewhere in the list".
+
+```toml
+priorities = ["foo", "bar", "*", "zzz"]
+# foo first; then bar; then every unlisted server (first-win group);
+# zzz only if all of the above return nothing — demotion below the rest.
+```
+
+### Resolution Rules
+
+| Configured value | Meaning |
+|---|---|
+| absent (`None` after merge) | ≡ `["*"]` — all candidates, today's default behavior |
+| `["*"]` | explicit form of the default |
+| `["foo"]` | **only** foo runs (BREAKING: was "prefer foo, fall back to the rest") |
+| `["foo", "*"]` | the old `["foo"]` behavior: foo preferred, rest as fallback |
+| `[]` | empty allowlist — no fan-out; the method is disabled for this bridge target (BREAKING: was pure first-win) |
+
+- At most one `"*"` per list: duplicates trigger a warning; the first
+  occurrence is honored and the rest are ignored.
+- A name matching no configured server is logged at warn level (typo aid)
+  and is otherwise inert — under allowlist semantics a typo now *excludes*
+  the intended server, so silence would be costly.
+- `max_fan_out` applies after `"*"` expansion. `max_fan_out = 0` now overlaps
+  `priorities = []`; both are kept (no deprecation in this decision).
+
+### Per-Strategy Interplay
+
+| Strategy | Role of the list | `"*"` handling |
+|---|---|---|
+| `preferred` | walk in order; first non-empty wins | a first-win group over the unlisted candidates at that position |
+| `concatenated`, parallel merge (diagnostics, references) | membership only — merge order is irrelevant | includes the unlisted rest in the merge |
+| `concatenated`, sequential formatting pipeline | membership **and** application order | **rejected**: `"*"` has no deterministic expansion order, and a formatter pipeline must be reproducible (concatenated-formatting-pipeline). Warn and ignore the element; if no explicit names remain, the existing empty-`priorities` misconfiguration fallback to `preferred` applies |
+
+### Migration
+
+Existing configs with a non-empty `priorities` that relied on implicit
+fallback append `"*"`:
+
+```toml
+priorities = ["pyright"]        # before: pyright preferred, others fall back
+priorities = ["pyright", "*"]   # after: identical behavior
+```
+
+Configs with no `priorities` are unaffected. Configs with an explicit `[]`
+flip from "first-win among all" to "disabled" — the new reading doubles as a
+per-method bridge kill switch, which had no spelling before.
+
+## Consequences
+
+### Positive
+
+- **One list semantics everywhere**: the formatting pipeline's
+  allowlist+order behavior stops being an exception and becomes the general
+  rule; cross-layer `order` adopts the same rule with a closed element set.
+- **New expressiveness**: per-method exclusion (`[]`, or omission from the
+  list) and demotion below the unlisted rest (`["*", "zzz"]`) were previously
+  unwritable.
+- **Defaults unchanged**: absent `priorities` still fans out to everyone.
+
+### Negative
+
+- **Breaking change** for configs with non-empty `priorities`: `["foo"]`
+  narrows from preference to allowlist, and `[]` flips from first-win to
+  disabled. Must be called out in the changelog with the `"*"` migration.
+- **Per-strategy caveat**: `"*"` is invalid in the sequential formatting
+  pipeline — one more rule to document, though it replaces the larger
+  "two meanings of `priorities`" rule it retires.
+
+### Neutral
+
+- `max_fan_out = 0` and `priorities = []` now express the same thing;
+  redundancy tolerated until one proves unnecessary.
+- The fan-in implementation keeps its buffered-win machinery; `"*"` is an
+  expansion step at config-resolution time plus a group marker in the walk,
+  not a new fan-in algorithm.
+
+## Alternatives Considered
+
+### A. Keep the dual semantics (status quo)
+
+**Rejected because**: every new ordered list (starting with cross-layer
+`order`) would have to pick a side, and the `preferred` reading cannot
+express exclusion or demotion at all.
+
+### B. `exclusive = true` flag beside `priorities`
+
+A boolean switching the list from preference to allowlist.
+
+**Rejected because**: it cannot express demotion below the rest
+(`["foo", "*", "zzz"]` has no flag equivalent — the rest's *position* is the
+point), and it adds a second knob whose interaction with the first must be
+documented anyway.
+
+### C. `_` as the wildcard element
+
+Consistent with the `_` wildcard keys used across the config.
+
+**Rejected because**: `_` keys carry field-level inheritance semantics
+(`resolve_with_wildcard`); a "rest of the candidates" list element does not.
+Reusing the sigil would suggest inheritance where none exists. Glob-like
+`"*"` matches the actual semantics (match-everything-else) and keeps the two
+mechanisms visually distinct.
+
+### D. Separate `exclude` list
+
+Keep `priorities` as preference order, add `exclude = ["zzz"]`.
+
+**Rejected because**: two lists to reconcile (what does a name in both
+mean?), and the rest's ordering relative to explicit entries remains
+inexpressible.

--- a/docs/architecture-decisions/aggregation-priorities-wildcard.md
+++ b/docs/architecture-decisions/aggregation-priorities-wildcard.md
@@ -16,8 +16,8 @@ and the no-explicit-names settings-apply warning live in
 
 ## Context
 
-`AggregationConfig.priorities` currently has **two semantics depending on the
-strategy**:
+`AggregationConfig.priorities` currently has **two semantics** depending on
+the strategy:
 
 - Under `preferred` (the common case), it is a *preference order only*:
   servers absent from the list still participate via first-win fallback

--- a/docs/architecture-decisions/aggregation-priorities-wildcard.md
+++ b/docs/architecture-decisions/aggregation-priorities-wildcard.md
@@ -71,11 +71,16 @@ priorities = ["foo", "bar", "*", "zzz"]
 | `["foo", "*"]` | the old `["foo"]` behavior: foo preferred, rest as fallback |
 | `[]` | empty allowlist — no fan-out; the method is disabled for this bridge target (BREAKING: was pure first-win) |
 
-- At most one `"*"` per list: duplicates trigger a warning; the first
-  occurrence is honored and the rest are ignored.
-- A name matching no configured server is logged at warn level (typo aid)
-  and is otherwise inert — under allowlist semantics a typo now *excludes*
-  the intended server, so silence would be costly.
+- At most one `"*"` per list: the first occurrence is honored and the rest
+  are ignored (logged at debug).
+- A name matching no configured server is dropped and logged at **debug**,
+  not warn: expansion runs on every dispatch (completion fires per
+  keystroke), and an unmatched name is routine rather than necessarily a
+  typo — priorities inherited from a `bridge._` wildcard entry legitimately
+  name servers that exist only for other injection languages of the same
+  host. A settings-apply-time typo validation (the
+  `concatenated_formatting_pairs` pattern) is the upgrade path if silent
+  exclusion proves costly in practice.
 - `max_fan_out` applies after `"*"` expansion. `max_fan_out = 0` now overlaps
   `priorities = []`; both are kept (no deprecation in this decision).
 

--- a/docs/architecture-decisions/aggregation-priorities-wildcard.md
+++ b/docs/architecture-decisions/aggregation-priorities-wildcard.md
@@ -8,9 +8,11 @@
 
 ## Implementation Status
 
-Not implemented. This is the first phase of the cross-layer-aggregation
-roadmap: land the unified `priorities` semantics before the layer dispatch
-builds on them.
+Implemented. Expansion lives in `src/lsp/aggregation/server/priority.rs`
+(`PriorityEntry`, `expand_priorities`); both fan-out and the `preferred`
+fan-in consume the same expansion. The formatting pipeline's `"*"` rejection
+and the no-explicit-names settings-apply warning live in
+`plan_region_format` / `concatenated_formatting_pairs`.
 
 ## Context
 

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -85,7 +85,12 @@ opt-in to a sequential formatter pipeline driven by `priorities`.
 2. **`priorities` is the pipeline definition.** When the pipeline is active,
    `priorities` is both the **membership list** and the **application order**.
    Servers configured for the language but **absent from `priorities` do not run**
-   for formatting — `priorities` acts as an allowlist plus order. An active
+   for formatting — `priorities` acts as an allowlist plus order. (Originally a
+   formatting-specific exception, this is now the general rule for all
+   `priorities` lists — see aggregation-priorities-wildcard. The pipeline adds
+   one restriction: the `"*"` wildcard element is rejected with a warning,
+   because "the rest" has no deterministic expansion order and a formatter
+   pipeline must be reproducible.) An active
    `concatenated` strategy with an empty `priorities` is a misconfiguration and
    falls back to `preferred` (with a warning), since order would otherwise be
    undefined.
@@ -326,6 +331,10 @@ change without affecting the config surface.
 - **`priorities` semantics overload**: for formatting, `priorities` becomes an
   allowlist+order (servers not listed do not run), unlike `preferred` where it is
   only a tie-break ordering. Documented, but a behavioral nuance.
+  *Retired*: aggregation-priorities-wildcard later unified all `priorities`
+  lists on the allowlist+order reading, so this is no longer an exception —
+  only the `"*"`-rejection restriction (Decision point 2) remains
+  pipeline-specific.
 
 ### Neutral
 
@@ -373,5 +382,6 @@ point 5), so this decision leaves it unchanged.
 ## Related Decisions
 
 - [language-server-bridge-request-strategies](language-server-bridge-request-strategies.md): Per-method bridge strategies, including formatting's edit handling
+- [aggregation-priorities-wildcard](aggregation-priorities-wildcard.md): Generalizes this pipeline's allowlist+order reading of `priorities` to all strategies, with a `"*"` wildcard element (rejected by this pipeline)
 - [ls-bridge-server-pool-coordination](ls-bridge-server-pool-coordination.md): `AggregationStrategy` enum, fan-out/fan-in, and aggregation timeout rules
 - [language-server-bridge-virtual-document-model](language-server-bridge-virtual-document-model.md): How injection regions are represented as virtual documents

--- a/docs/architecture-decisions/concatenated-formatting-pipeline.md
+++ b/docs/architecture-decisions/concatenated-formatting-pipeline.md
@@ -90,10 +90,13 @@ opt-in to a sequential formatter pipeline driven by `priorities`.
    `priorities` lists — see aggregation-priorities-wildcard. The pipeline adds
    one restriction: the `"*"` wildcard element is rejected with a warning,
    because "the rest" has no deterministic expansion order and a formatter
-   pipeline must be reproducible.) An active
-   `concatenated` strategy with an empty `priorities` is a misconfiguration and
-   falls back to `preferred` (with a warning), since order would otherwise be
-   undefined.
+   pipeline must be reproducible.) An active `concatenated` strategy whose
+   `priorities` carries **no explicit server name** — e.g. the resolved
+   default `["*"]` for an absent list — is a misconfiguration and falls back
+   to `preferred` (with a settings-apply warning), since the pipeline's order
+   would otherwise be undefined. An explicit `priorities = []` is *not* that
+   misconfiguration: under aggregation-priorities-wildcard it is the
+   deliberate per-method kill switch, and the region runs nothing.
 
 3. **Sequential application (single pass).** The pipeline seeds its initial region
    text from the host document **after parse completion** — never a half-parsed

--- a/docs/architecture-decisions/cross-layer-aggregation.md
+++ b/docs/architecture-decisions/cross-layer-aggregation.md
@@ -19,11 +19,14 @@ Phased roadmap:
    `Kakehashi::virt_layer_enabled`, the push-diagnostics scheduler via
    `resolve_layer_config_from_settings` directly (it already holds a loaded
    settings arc), keyed `textDocument/publishDiagnostics` to match its
-   aggregation config. Because host (`bridge._self`) is
-   unimplemented and bridged methods have no native contributor, the
-   stage-2 `preferred` walk degenerates to this gate — "first non-empty
-   layer in order" with one possible contributor. A fuller walk arrives
-   with the second contributor.
+   aggregation config. With host bridging (host-document-bridge) now
+   implemented for `textDocument/definition` and `textDocument/hover`,
+   those two handlers run the real stage-2 `preferred` walk
+   (`goto_definition_impl` / `hover_impl`): layers are tried lazily in
+   `order`, first non-empty wins — virt answers inside injections, host
+   answers on the host document when `bridge._self.enabled = true`. All
+   other methods keep the degenerate virt gate until they grow a second
+   contributor.
 3. **Layer-level `concatenated` for `textDocument/formatting` only** — ✅
    implemented as `combine_layer_formatting_results`: formatting dispatches
    on the resolved layer strategy. With at most one producing layer (the

--- a/docs/architecture-decisions/cross-layer-aggregation.md
+++ b/docs/architecture-decisions/cross-layer-aggregation.md
@@ -15,8 +15,11 @@ Phased roadmap:
    ✅ implemented (`src/lsp/aggregation/server/priority.rs`).
 2. **Layer dispatch, `preferred` only** — ✅ implemented: the
    `LanguageSettings.layers` schema, `resolve_layers` (wildcard merge), and
-   a virt-layer gate in every bridge entry point
-   (`Kakehashi::virt_layer_enabled`). Because host (`bridge._self`) is
+   a virt-layer gate in every bridge entry point — request handlers via
+   `Kakehashi::virt_layer_enabled`, the push-diagnostics scheduler via
+   `resolve_layer_config_from_settings` directly (it already holds a loaded
+   settings arc), keyed `textDocument/publishDiagnostics` to match its
+   aggregation config. Because host (`bridge._self`) is
    unimplemented and bridged methods have no native contributor, the
    stage-2 `preferred` walk degenerates to this gate — "first non-empty
    layer in order" with one possible contributor. A fuller walk arrives

--- a/docs/architecture-decisions/cross-layer-aggregation.md
+++ b/docs/architecture-decisions/cross-layer-aggregation.md
@@ -73,8 +73,8 @@ choose a combine strategy (first-non-empty vs. merge).
 
 ### Why the existing `priorities` field cannot express this
 
-`AggregationConfig.priorities` is a `Vec<String>` of **language server
-names** — an open, user-defined namespace scoped to a single bridge target.
+`AggregationConfig.priorities` is a `Vec<String>` of **language server names**
+— an open, user-defined namespace scoped to a single bridge target.
 Layers are a different axis: a **closed set of exactly three kinds**, sitting
 *above* the per-target aggregation. Mixing layer identifiers into a
 server-name list would conflate two namespaces in one field — the same

--- a/docs/architecture-decisions/cross-layer-aggregation.md
+++ b/docs/architecture-decisions/cross-layer-aggregation.md
@@ -21,12 +21,19 @@ Phased roadmap:
    stage-2 `preferred` walk degenerates to this gate — "first non-empty
    layer in order" with one possible contributor. A fuller walk arrives
    with the second contributor.
-3. **Layer-level `concatenated` for `textDocument/formatting` only** — not
-   implemented; expected to follow the sequential-pipeline principles of
-   concatenated-formatting-pipeline (determinism, no overlapping edits);
-   detailed mechanics are deferred to that phase. Its observable value
-   arrives with host bridging (e.g. a host formatter running over the whole
-   document after virt regions are formatted).
+3. **Layer-level `concatenated` for `textDocument/formatting` only** — ✅
+   implemented as `combine_layer_formatting_results`: formatting dispatches
+   on the resolved layer strategy. With at most one producing layer (the
+   only reachable case until host bridging ships), `concatenated`
+   degenerates to that layer's edits. Should two layers ever produce before
+   cross-layer text threading exists, the highest-priority layer's edits
+   apply alone with a warning — never merged, since naively concatenating
+   two layers' edit lists could overlap and violate LSP. The true
+   sequential pipeline (each layer formatting the previous layer's output,
+   per concatenated-formatting-pipeline principles) lands with host
+   bridging. Layer strategy applies to full formatting only;
+   `textDocument/rangeFormatting` stays on `preferred`, mirroring the
+   stage-1 rule.
 
 ## Context
 

--- a/docs/architecture-decisions/cross-layer-aggregation.md
+++ b/docs/architecture-decisions/cross-layer-aggregation.md
@@ -28,17 +28,22 @@ Phased roadmap:
    other methods keep the degenerate virt gate until they grow a second
    contributor.
 3. **Layer-level `concatenated` for `textDocument/formatting` only** — ✅
-   implemented as `combine_layer_formatting_results`: formatting dispatches
-   on the resolved layer strategy. With at most one producing layer (the
-   only reachable case until host bridging ships), `concatenated`
-   degenerates to that layer's edits. Should two layers ever produce before
-   cross-layer text threading exists, the highest-priority layer's edits
-   apply alone with a warning — never merged, since naively concatenating
-   two layers' edit lists could overlap and violate LSP. The true
-   sequential pipeline (each layer formatting the previous layer's output,
-   per concatenated-formatting-pipeline principles) lands with host
-   bridging. Layer strategy applies to full formatting only;
-   `textDocument/rangeFormatting` stays on `preferred`, mirroring the
+   implemented as a true sequential cross-layer pipeline in
+   `formatting_impl`: layers run in `order`, each formatting the previous
+   layer's output (virt region edits are applied to the host text, the host
+   formatter then formats that intermediate text). With one producing layer
+   the minimal edits pass through verbatim (they are against the original by
+   construction); with two or more the chain collapses into a single
+   whole-document replacement edit — the same overlap-free shape as the
+   within-region pipeline (concatenated-formatting-pipeline Decision
+   point 4), and `None` when the chain round-trips to the original.
+   Constraint: virt edits resolve against the parsed snapshot, so virt can
+   only run while the accumulated text still is the snapshot text — an
+   `order` placing virt after a producing layer skips virt with a warning.
+   The default order (virt before host) is unaffected. Under `preferred`
+   the walk stays lazy: the first layer producing edits wins and later
+   layers are never contacted. Layer strategy applies to full formatting
+   only; `textDocument/rangeFormatting` stays on `preferred`, mirroring the
    stage-1 rule.
 
 ## Context

--- a/docs/architecture-decisions/cross-layer-aggregation.md
+++ b/docs/architecture-decisions/cross-layer-aggregation.md
@@ -9,16 +9,20 @@
 
 ## Implementation Status
 
-Not implemented. Phased roadmap:
+Phased roadmap:
 
 1. **Allowlist `priorities` with `"*"`** (aggregation-priorities-wildcard) —
-   the list semantics `order` builds on; lands independently as a stage-1
-   change.
-2. **Layer dispatch, `preferred` only** — this decision's machinery with the
-   default `order`. Implementable before host bridging: the host layer is an
-   empty contributor until `bridge._self` exists and is enabled.
-3. **Layer-level `concatenated` for `textDocument/formatting` only** —
-   expected to follow the sequential-pipeline principles of
+   ✅ implemented (`src/lsp/aggregation/server/priority.rs`).
+2. **Layer dispatch, `preferred` only** — ✅ implemented: the
+   `LanguageSettings.layers` schema, `resolve_layers` (wildcard merge), and
+   a virt-layer gate in every bridge entry point
+   (`Kakehashi::virt_layer_enabled`). Because host (`bridge._self`) is
+   unimplemented and bridged methods have no native contributor, the
+   stage-2 `preferred` walk degenerates to this gate — "first non-empty
+   layer in order" with one possible contributor. A fuller walk arrives
+   with the second contributor.
+3. **Layer-level `concatenated` for `textDocument/formatting` only** — not
+   implemented; expected to follow the sequential-pipeline principles of
    concatenated-formatting-pipeline (determinism, no overlapping edits);
    detailed mechanics are deferred to that phase. Its observable value
    arrives with host bridging (e.g. a host formatter running over the whole

--- a/docs/architecture-decisions/cross-layer-aggregation.md
+++ b/docs/architecture-decisions/cross-layer-aggregation.md
@@ -1,0 +1,255 @@
+# Cross-Layer Result Aggregation
+
+**Related Decisions**:
+- [host-document-bridge](host-document-bridge.md) — Host bridging schema (`bridge._self`); declared cross-layer combine logic out of scope, which this decision now covers
+- [language-server-bridge-request-strategies](language-server-bridge-request-strategies.md) — Per-method strategies and multi-server merging *within* a bridge target
+- [language-server-bridge-virtual-document-model](language-server-bridge-virtual-document-model.md) — Virtual document model (virt bridges)
+- [wildcard-config-inheritance](wildcard-config-inheritance.md) — Wildcard merge machinery reused for the method-keyed map
+
+## Implementation Status
+
+Not implemented. Depends on host-document-bridge (`bridge._self`), which is
+also not yet implemented. This decision fixes the configuration schema ahead
+of implementation so that host bridging and cross-layer aggregation can land
+against a stable config surface.
+
+## Context
+
+Once host bridging exists, a single LSP request to kakehashi can be answered
+by up to three **result layers**:
+
+1. **native** — kakehashi's own features (Tree-sitter semantic tokens,
+   locals-based definition, document symbols, folding, …)
+2. **host** — the `bridge._self` route: responses from host-language servers
+   (e.g., marksman on the Markdown document), already aggregated across
+   servers by `bridge._self.aggregation`
+3. **virt** — the `bridge.<inj>` route: responses from injection-language
+   servers (e.g., pyright on a Python code block), already aggregated across
+   servers by `bridge.<inj>.aggregation`
+
+host-document-bridge deliberately scoped out "how responses from both roles
+are ordered, merged, or routed per method." This decision fills that gap:
+users need at minimum to reorder the three layers per method, and ideally to
+choose a combine strategy (first-non-empty vs. merge).
+
+### Why the existing `priorities` field cannot express this
+
+`AggregationConfig.priorities` is a `Vec<String>` of **language server
+names** — an open, user-defined namespace scoped to a single bridge target.
+Layers are a different axis: a **closed set of exactly three kinds**, sitting
+*above* the per-target aggregation. Mixing layer identifiers into a
+server-name list would conflate two namespaces in one field — the same
+violation that led host-document-bridge to reject its Alternative A
+(role-tagged priority entries).
+
+## Decision Drivers
+
+- **Namespace separation**: server names (open set) and layers (closed set)
+  must not share a field or a value space.
+- **Two-stage aggregation**: per-target server aggregation (stage 1, exists
+  today) and cross-layer aggregation (stage 2, this decision) compose; neither
+  reaches into the other.
+- **Reuse wildcard machinery**: the method-keyed map should resolve via
+  `resolve_with_wildcard`, exactly like `bridge.<key>.aggregation`.
+- **Defaults preserve current behavior**: with no user config, requests behave
+  as they do today (virt preferred where an injection exists, native
+  otherwise).
+- **Consistency with stage-1 semantics**: ordering is a *preference*, not an
+  allowlist — unlisted entries still participate, as in the `preferred`
+  fan-in.
+
+## Decision Outcome
+
+**Chosen approach**: add a `layers` field to `LanguageSettings` — a
+method-keyed map (LSP method name or `_` wildcard) whose values hold a
+closed-enum layer order plus an optional strategy. Stage-1 types
+(`AggregationConfig`, `BridgeLanguageConfig`) are untouched.
+
+### Schema
+
+```toml
+# ---- Built-in defaults (declared in code; not user-facing) ----
+[languages._.layers._]
+order = ["virt", "host", "native"]   # innermost-first; mirrors "deeper wins"
+# strategy: per-method default (concatenated for diagnostics, else preferred)
+
+# ---- User: markdown hover should prefer the host LS, and show both ----
+[languages.markdown.layers."textDocument/hover"]
+order = ["host", "virt", "native"]
+strategy = "concatenated"
+
+# ---- Stage 1 stays exactly as before: server names within one target ----
+[languages.markdown.bridge._self.aggregation."textDocument/hover"]
+priorities = ["marksman"]
+
+[languages.markdown.bridge.python.aggregation._]
+priorities = ["pyright"]
+```
+
+```rust
+/// Result layers: kakehashi native, host bridge, virt bridges.
+/// NOT injection nesting depth (tree-sitter "language layers").
+#[serde(rename_all = "lowercase")]
+pub enum LayerSource {
+    Native, // kakehashi's own features
+    Host,   // bridge._self aggregate
+    Virt,   // bridge.<inj> aggregate at the request position/document
+}
+
+pub struct LayerAggregationConfig {
+    /// Layer preference order, highest first. Omitted layers are appended
+    /// in default relative order (virt, host, native). NOT an allowlist.
+    pub order: Option<Vec<LayerSource>>,
+    /// Reuses the stage-1 strategy type; omit for the per-method default.
+    pub strategy: Option<AggregationStrategy>,
+}
+
+// On LanguageSettings, beside `bridge`:
+pub layers: Option<HashMap<String, LayerAggregationConfig>>,
+```
+
+### Two-Stage Aggregation
+
+```
+Stage 2 (this decision)   layers.order = [virt, host, native]   ← LayerSource enum
+                             │      │      └ native handler result
+                             │      └ bridge._self.aggregation.priorities  ← LS names
+                             └ bridge.<inj>.aggregation.priorities         ← LS names
+Stage 1 (exists today)    each layer resolves its own servers into
+                          one response per layer before stage 2 runs
+```
+
+Each stage owns one namespace. Stage 1 orders **server names** within a
+bridge target; stage 2 orders **layers**. The `AggregationStrategy` *type* is
+shared (the "how to combine multiple responses" semantics are identical), but
+the configured *values* are independent — e.g., diagnostics can be
+`concatenated` across layers while `bridge.python.aggregation` keeps
+`preferred` among Python servers.
+
+### Semantics
+
+- **`order` is a preference, not an allowlist.** Layers omitted from `order`
+  are appended in the built-in relative order. This matches the stage-1
+  `preferred` fan-in, where unprioritized servers still participate via
+  first-win fallback. Disabling a layer is done where it already lives:
+  `bridge._self.enabled` (host), `bridge.<inj>.enabled` (virt). Native has no
+  per-method off switch; with `preferred` it only fires when ordered layers
+  return nothing.
+- **Empty contributors are skipped.** A layer with nothing to say — no native
+  implementation for the method, host bridging disabled, no injection at the
+  request position — is an empty contributor; `preferred` falls through to
+  the next layer.
+- **Resolution reuses wildcard machinery.** The method key resolves via
+  `resolve_with_wildcard` (method-specific entry inherits unset fields from
+  `_`), and the `layers` field participates in the outer language-level
+  wildcard/base merge like `bridge` does.
+- **Strategy defaults are per-method.** `default_aggregation_strategy_for_method`
+  applies unchanged: `concatenated` for diagnostics, `preferred` otherwise.
+- **Nested injections stay implicit.** When injections nest
+  (markdown → python → sql), the virt layer resolves deepest-first,
+  consistent with the semantic-token priority convention (deeper wins). Depth
+  order is not user-configurable.
+
+### Out of Scope
+
+- **Per-virt-language ordering relative to host**: `order` ranks the three
+  layer kinds, not individual injection languages ("python virt above host,
+  sql virt below host" is not expressible). For position-based requests the
+  virt layer is effectively single-language, and document-wide methods
+  default to `concatenated`, so the practical need is unproven. If it
+  materializes, a host-relative weight on `bridge.<inj>` is the extension
+  point — not entries in `order`.
+- **Semantic tokens**: the progressive-refinement strategy
+  (language-server-bridge-request-strategies Strategy 1) is a *temporal*
+  merge — native immediately, bridged tokens replacing them later — not an
+  ordering. Semantic tokens stay outside this mechanism (native-only today);
+  a future `merged`-style strategy may bring them in.
+- **Per-method native disable switch**: suppressing the native layer entirely
+  for a method is not provided. Revisit if a concrete need appears.
+
+## Consequences
+
+### Positive
+
+- **Closed enum is typo-safe and self-documenting**: serde rejects unknown
+  layer names; the JSON schema enumerates the three values. No reserved-key
+  collision with user language names is possible (unlike a
+  `"_native"`-style string convention).
+- **Stage-1 schema untouched**: `AggregationConfig.priorities` remains purely
+  a server-name list; existing configs and resolution code are unaffected.
+- **Defaults preserve behavior**: `["virt", "host", "native"]` with per-method
+  strategy defaults reproduces today's routing for existing configs.
+- **Wildcard machinery reused**: no new resolver path; method-keyed map works
+  like `bridge.<key>.aggregation`.
+
+### Negative
+
+- **Two similarly-shaped maps**: `languages.<lang>.layers.<method>` and
+  `languages.<lang>.bridge.<key>.aggregation.<method>` are both method-keyed
+  aggregation-ish maps; users must learn which axis each controls. The
+  distinct field names (`order` of enums vs. `priorities` of server names)
+  are the guard rail.
+- **Jargon collision**: tree-sitter communities use "layer" for injection
+  nesting depth (`LanguageTree` layers). Mitigated by the doc comment on
+  `LayerSource` ("NOT injection nesting depth") and by the enum values making
+  the meaning evident.
+
+### Neutral
+
+- **`strategy` type shared across stages**: one `AggregationStrategy` enum
+  serves both. A future stage-2-only strategy (e.g., temporal `merged`) would
+  force either enum growth visible to stage 1 or a type split — acceptable
+  deferred cost.
+- **Native participates without a catalog entry**: the native layer has no
+  `languageServers` entry and no `enabled` flag; it is simply last in the
+  default order.
+
+## Alternatives Considered
+
+### A. Reserved layer keys inside a language-level `AggregationConfig`
+
+Reuse `AggregationConfig` at `languages.<lang>.aggregation.<method>` with
+reserved strings in `priorities`:
+
+```toml
+[languages.markdown.aggregation."textDocument/hover"]
+priorities = ["_self", "python", "_native"]
+```
+
+**Rejected because**:
+- Mixes two namespaces in one field: server names / language names (open,
+  user-defined) and layer identifiers (closed). A reader cannot tell what
+  kind of name a list entry is without knowing the reserved-key table.
+- Typos silently misroute (an unknown string is just "a server that never
+  responds") instead of failing deserialization.
+- Reserved strings can collide with real language names; the enum cannot.
+
+### B. Role-tagged entries in stage-1 `priorities`
+
+Extend `bridge.<key>.aggregation.priorities` entries with a role tag
+(`{ name = "marksman", role = "host" }` or `"host:marksman"`).
+
+**Rejected because**: already rejected as host-document-bridge Alternative A —
+cross-target mixing bumps the type surface of stage 1 and conflates dispatch
+policy with per-target configuration. This decision reaffirms that rejection
+and places the policy one level up instead.
+
+### C. Field named `aggregation` on `LanguageSettings`
+
+Same structure as chosen, but named `aggregation`.
+
+**Rejected because**:
+- Two fields named `aggregation` at different nesting levels with different
+  value types (server-name `priorities` vs. layer `order`) invite confusion
+  in docs, schema, and resolution code.
+- host-document-bridge already rejected a `LanguageSettings.aggregation`
+  field (its Alternative C, for host configuration); reusing the name for a
+  different purpose would muddy that history.
+
+### D. Naming: `sources` instead of `layers`
+
+`sources` avoids the tree-sitter "layer" jargon collision.
+
+**Rejected because**: "source" is at least as overloaded (source code, source
+files), and "layers" matches the mental model this decision is built on
+(three result layers). The collision is handled by one doc-comment line.

--- a/docs/architecture-decisions/cross-layer-aggregation.md
+++ b/docs/architecture-decisions/cross-layer-aggregation.md
@@ -2,16 +2,27 @@
 
 **Related Decisions**:
 - [host-document-bridge](host-document-bridge.md) — Host bridging schema (`bridge._self`); declared cross-layer combine logic out of scope, which this decision now covers
+- [aggregation-priorities-wildcard](aggregation-priorities-wildcard.md) — The unified ordered-allowlist semantics that `order` follows
 - [language-server-bridge-request-strategies](language-server-bridge-request-strategies.md) — Per-method strategies and multi-server merging *within* a bridge target
 - [language-server-bridge-virtual-document-model](language-server-bridge-virtual-document-model.md) — Virtual document model (virt bridges)
 - [wildcard-config-inheritance](wildcard-config-inheritance.md) — Wildcard merge machinery reused for the method-keyed map
 
 ## Implementation Status
 
-Not implemented. Depends on host-document-bridge (`bridge._self`), which is
-also not yet implemented. This decision fixes the configuration schema ahead
-of implementation so that host bridging and cross-layer aggregation can land
-against a stable config surface.
+Not implemented. Phased roadmap:
+
+1. **Allowlist `priorities` with `"*"`** (aggregation-priorities-wildcard) —
+   the list semantics `order` builds on; lands independently as a stage-1
+   change.
+2. **Layer dispatch, `preferred` only** — this decision's machinery with the
+   default `order`. Implementable before host bridging: the host layer is an
+   empty contributor until `bridge._self` exists and is enabled.
+3. **Layer-level `concatenated` for `textDocument/formatting` only** —
+   expected to follow the sequential-pipeline principles of
+   concatenated-formatting-pipeline (determinism, no overlapping edits);
+   detailed mechanics are deferred to that phase. Its observable value
+   arrives with host bridging (e.g. a host formatter running over the whole
+   document after virt regions are formatted).
 
 ## Context
 
@@ -53,10 +64,10 @@ violation that led host-document-bridge to reject its Alternative A
   `resolve_with_wildcard`, exactly like `bridge.<key>.aggregation`.
 - **Defaults preserve current behavior**: with no user config, requests behave
   as they do today (virt preferred where an injection exists, native
-  otherwise).
-- **Consistency with stage-1 semantics**: ordering is a *preference*, not an
-  allowlist — unlisted entries still participate, as in the `preferred`
-  fan-in.
+  otherwise; host inert until opted in).
+- **One list semantics**: `order` follows the same ordered-allowlist rule as
+  `priorities` (aggregation-priorities-wildcard), differing only in element
+  type.
 
 ## Decision Outcome
 
@@ -71,12 +82,14 @@ closed-enum layer order plus an optional strategy. Stage-1 types
 # ---- Built-in defaults (declared in code; not user-facing) ----
 [languages._.layers._]
 order = ["virt", "host", "native"]   # innermost-first; mirrors "deeper wins"
+# host is listed but contributes nothing until the user opts in via
+# bridge._self.enabled (host-document-bridge) — order ranks layers,
+# enabled flags decide whether a bridge target exists at all.
 # strategy: per-method default (concatenated for diagnostics, else preferred)
 
-# ---- User: markdown hover should prefer the host LS, and show both ----
+# ---- User: markdown hover should prefer the host LS, and drop native ----
 [languages.markdown.layers."textDocument/hover"]
-order = ["host", "virt", "native"]
-strategy = "concatenated"
+order = ["host", "virt"]             # allowlist: native does not run
 
 # ---- Stage 1 stays exactly as before: server names within one target ----
 [languages.markdown.bridge._self.aggregation."textDocument/hover"]
@@ -97,8 +110,10 @@ pub enum LayerSource {
 }
 
 pub struct LayerAggregationConfig {
-    /// Layer preference order, highest first. Omitted layers are appended
-    /// in default relative order (virt, host, native). NOT an allowlist.
+    /// Ordered allowlist, highest first: layers omitted from the list do
+    /// not participate for that method. The set is closed and three-valued,
+    /// so explicit enumeration replaces the `"*"` element used by server
+    /// `priorities` — "the rest" is always spellable by name.
     pub order: Option<Vec<LayerSource>>,
     /// Reuses the stage-1 strategy type; omit for the per-method default.
     pub strategy: Option<AggregationStrategy>,
@@ -120,21 +135,27 @@ Stage 1 (exists today)    each layer resolves its own servers into
 ```
 
 Each stage owns one namespace. Stage 1 orders **server names** within a
-bridge target; stage 2 orders **layers**. The `AggregationStrategy` *type* is
-shared (the "how to combine multiple responses" semantics are identical), but
-the configured *values* are independent — e.g., diagnostics can be
-`concatenated` across layers while `bridge.python.aggregation` keeps
-`preferred` among Python servers.
+bridge target; stage 2 orders **layers**. Both lists follow the
+ordered-allowlist rule of aggregation-priorities-wildcard. The
+`AggregationStrategy` *type* is shared (the "how to combine multiple
+responses" semantics are identical), but the configured *values* are
+independent — e.g., diagnostics can be `concatenated` across layers while
+`bridge.python.aggregation` keeps `preferred` among Python servers.
 
 ### Semantics
 
-- **`order` is a preference, not an allowlist.** Layers omitted from `order`
-  are appended in the built-in relative order. This matches the stage-1
-  `preferred` fan-in, where unprioritized servers still participate via
-  first-win fallback. Disabling a layer is done where it already lives:
-  `bridge._self.enabled` (host), `bridge.<inj>.enabled` (virt). Native has no
-  per-method off switch; with `preferred` it only fires when ordered layers
-  return nothing.
+- **`order` is an ordered allowlist.** Layers omitted from the list do not
+  participate for that method — `order = ["virt", "host"]` suppresses
+  native; `order = []` disables the method across all layers (mirroring
+  `priorities = []`). No `"*"` element is supported: with a closed
+  three-value set, "the rest" is always expressible by explicit enumeration,
+  so the enum stays pure.
+- **`order` ranks; `enabled` gates.** Host participation is additionally
+  gated by `bridge._self.enabled` (host-document-bridge), and per-injection
+  virt participation by `bridge.<inj>.enabled`. These are not a double
+  opt-in: the default `order` already lists host, so enabling
+  `bridge._self.enabled = true` is the *only* step a user takes to bring the
+  host layer in. A disabled target is simply an empty contributor.
 - **Empty contributors are skipped.** A layer with nothing to say — no native
   implementation for the method, host bridging disabled, no injection at the
   request position — is an empty contributor; `preferred` falls through to
@@ -142,9 +163,14 @@ the configured *values* are independent — e.g., diagnostics can be
 - **Resolution reuses wildcard machinery.** The method key resolves via
   `resolve_with_wildcard` (method-specific entry inherits unset fields from
   `_`), and the `layers` field participates in the outer language-level
-  wildcard/base merge like `bridge` does.
-- **Strategy defaults are per-method.** `default_aggregation_strategy_for_method`
-  applies unchanged: `concatenated` for diagnostics, `preferred` otherwise.
+  wildcard/base merge like `bridge` does. Note `order` is a single field: a
+  method-specific `order` replaces the wildcard's list wholesale, it does
+  not merge element-wise.
+- **Strategy is phased.** Phase 2 implements `preferred` only; every method
+  combines across layers by first-non-empty until then. Once layer-level
+  `concatenated` lands (formatting first, phase 3), the per-method defaults
+  of `default_aggregation_strategy_for_method` apply unchanged
+  (`concatenated` for diagnostics, `preferred` otherwise).
 - **Nested injections stay implicit.** When injections nest
   (markdown → python → sql), the virt layer resolves deepest-first,
   consistent with the semantic-token priority convention (deeper wins). Depth
@@ -164,8 +190,6 @@ the configured *values* are independent — e.g., diagnostics can be
   merge — native immediately, bridged tokens replacing them later — not an
   ordering. Semantic tokens stay outside this mechanism (native-only today);
   a future `merged`-style strategy may bring them in.
-- **Per-method native disable switch**: suppressing the native layer entirely
-  for a method is not provided. Revisit if a concrete need appears.
 
 ## Consequences
 
@@ -175,20 +199,27 @@ the configured *values* are independent — e.g., diagnostics can be
   layer names; the JSON schema enumerates the three values. No reserved-key
   collision with user language names is possible (unlike a
   `"_native"`-style string convention).
-- **Stage-1 schema untouched**: `AggregationConfig.priorities` remains purely
-  a server-name list; existing configs and resolution code are unaffected.
-- **Defaults preserve behavior**: `["virt", "host", "native"]` with per-method
-  strategy defaults reproduces today's routing for existing configs.
+- **Stage-1 schema untouched**: this decision adds no fields to
+  `AggregationConfig` or `BridgeLanguageConfig`; existing bridge configs
+  resolve as before.
+- **Defaults preserve behavior**: `["virt", "host", "native"]` with host
+  inert (opt-in off) and `preferred` reproduces today's routing exactly.
+- **Per-method layer suppression for free**: omitting a layer from `order`
+  (e.g. dropping native for hover) needs no dedicated disable switch —
+  a direct payoff of the allowlist semantics.
 - **Wildcard machinery reused**: no new resolver path; method-keyed map works
   like `bridge.<key>.aggregation`.
 
 ### Negative
 
+- **Allowlist override footgun**: writing `order = ["host"]` silently drops
+  virt and native for that method — a user promoting one layer must restate
+  the others. Mitigated by schema docs; inherent to allowlist semantics.
 - **Two similarly-shaped maps**: `languages.<lang>.layers.<method>` and
   `languages.<lang>.bridge.<key>.aggregation.<method>` are both method-keyed
-  aggregation-ish maps; users must learn which axis each controls. The
-  distinct field names (`order` of enums vs. `priorities` of server names)
-  are the guard rail.
+  ordered-allowlist configs; users must learn which axis each controls. The
+  distinct field names and element types (`order` of a closed enum vs.
+  `priorities` of open server names) are the guard rail.
 - **Jargon collision**: tree-sitter communities use "layer" for injection
   nesting depth (`LanguageTree` layers). Mitigated by the doc comment on
   `LayerSource` ("NOT injection nesting depth") and by the enum values making
@@ -197,12 +228,12 @@ the configured *values* are independent — e.g., diagnostics can be
 ### Neutral
 
 - **`strategy` type shared across stages**: one `AggregationStrategy` enum
-  serves both. A future stage-2-only strategy (e.g., temporal `merged`) would
+  serves both. A future stage-2-only strategy (e.g. temporal `merged`) would
   force either enum growth visible to stage 1 or a type split — acceptable
   deferred cost.
 - **Native participates without a catalog entry**: the native layer has no
-  `languageServers` entry and no `enabled` flag; it is simply last in the
-  default order.
+  `languageServers` entry and no `enabled` flag; its participation is
+  controlled solely by `order` membership.
 
 ## Alternatives Considered
 
@@ -253,3 +284,28 @@ Same structure as chosen, but named `aggregation`.
 **Rejected because**: "source" is at least as overloaded (source code, source
 files), and "layers" matches the mental model this decision is built on
 (three result layers). The collision is handled by one doc-comment line.
+
+### E. Preference order with implicit fallback (first draft of this decision)
+
+`order` as a pure preference: layers omitted from the list still participate,
+appended in default relative order — mirroring the *pre*-wildcard `preferred`
+fan-in.
+
+**Rejected because**: it cannot express per-method layer suppression (the
+native-for-hover case) and perpetuates exactly the dual list semantics that
+aggregation-priorities-wildcard retires. With the unified allowlist rule,
+"preference with fallback" remains spellable — list every layer — while
+exclusion becomes spellable too.
+
+### F. Default `order = ["virt", "native"]` with order as the host gate
+
+Exclude host from the default so that listing `"host"` in `order` *is* the
+host opt-in, making `bridge._self.enabled` redundant.
+
+**Rejected because**: it splits gating across two mechanisms asymmetrically —
+virt targets would gate via `bridge.<inj>.enabled` but host via `order`
+membership — and turning host on per-language would require restating the
+full layer order (allowlist override) instead of flipping one flag.
+Keeping host in the default order costs nothing: a disabled host layer is an
+empty contributor, and `enabled` remains the single opt-in switch defined by
+host-document-bridge.

--- a/docs/architecture-decisions/cross-layer-aggregation.md
+++ b/docs/architecture-decisions/cross-layer-aggregation.md
@@ -19,14 +19,20 @@ Phased roadmap:
    `Kakehashi::virt_layer_enabled`, the push-diagnostics scheduler via
    `resolve_layer_config_from_settings` directly (it already holds a loaded
    settings arc), keyed `textDocument/publishDiagnostics` to match its
-   aggregation config. With host bridging (host-document-bridge) now
-   implemented for `textDocument/definition` and `textDocument/hover`,
-   those two handlers run the real stage-2 `preferred` walk
-   (`goto_definition_impl` / `hover_impl`): layers are tried lazily in
-   `order`, first non-empty wins — virt answers inside injections, host
-   answers on the host document when `bridge._self.enabled = true`. All
-   other methods keep the degenerate virt gate until they grow a second
-   contributor.
+   aggregation config. With host bridging (host-document-bridge)
+   implemented for every bridged request method, handlers run the real
+   stage-2 `preferred` walk (`Kakehashi::walk_layers` →
+   `race_layers_preferred`): the virt and host layers fan out
+   **concurrently** — the layer-level analogue of the stage-1 `preferred`
+   fan-in — and the highest-priority non-empty result wins. A buffered
+   lower-priority result waits on a still-pending higher layer (priority
+   decides, not arrival), the losing in-flight future is dropped
+   best-effort, and layers absent from `order` are never polled. The
+   latency cost of a layer answering empty is therefore `max`, not `sum`;
+   the trade-off is downstream load — the host server is queried even when
+   virt ends up winning, mirroring how stage-1 queries every server of a
+   target. Virt answers inside injections, host answers on the host
+   document when `bridge._self.enabled = true`.
 3. **Layer-level `concatenated` for `textDocument/formatting` only** — ✅
    implemented as a true sequential cross-layer pipeline in
    `formatting_impl`: layers run in `order`, each formatting the previous

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -142,7 +142,7 @@ Practical consequences:
 
 ### Out of Scope
 
-- **Combine logic for host/virt responses at request time**: this decision defines only the schema for declaring host and virt bridges. How responses from both roles are ordered, merged, or routed per method is a separate concern decided at dispatch time, not encoded in the configuration shape. Since decided in cross-layer-aggregation (the `layers` field on `LanguageSettings`).
+- **Combine logic for host/virt responses at request time**: this decision defines only the schema for declaring host and virt bridges. How responses from both roles are ordered, merged, or routed per method is a separate concern decided at dispatch time, not encoded in the configuration shape — since decided in cross-layer-aggregation (the `layers` field on `LanguageSettings`).
 - **Editor connecting to the same LS directly**: if the user's editor talks to marksman in parallel with kakehashi, marksman sees duplicate `didOpen` events. Resolving this is the user's responsibility (route only through kakehashi). Kakehashi does not attempt to detect or mediate.
 - **Cross-language priority mixing in `priorities` entries**: the `priorities` field remains a `Vec<String>` of LS names within a single bridge target (`bridge.<inj>` or `bridge._self`). Mixing names from different bridge targets in one list is not supported by this schema.
 

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -6,6 +6,7 @@
 - [language-server-bridge-request-strategies](language-server-bridge-request-strategies.md) — Per-method bridge strategies
 - [wildcard-config-inheritance](wildcard-config-inheritance.md) — Wildcard config inheritance (foundation for `_self` resolution)
 - [pull-first-diagnostic-forwarding](pull-first-diagnostic-forwarding.md) — Diagnostic forwarding
+- [cross-layer-aggregation](cross-layer-aggregation.md) — Cross-layer (native/host/virt) result aggregation; covers what this decision scopes out
 
 ## Context
 
@@ -141,7 +142,7 @@ Practical consequences:
 
 ### Out of Scope
 
-- **Combine logic for host/virt responses at request time**: this decision defines only the schema for declaring host and virt bridges. How responses from both roles are ordered, merged, or routed per method is a separate concern decided at dispatch time, not encoded in the configuration shape.
+- **Combine logic for host/virt responses at request time**: this decision defines only the schema for declaring host and virt bridges. How responses from both roles are ordered, merged, or routed per method is a separate concern decided at dispatch time, not encoded in the configuration shape. Since decided in cross-layer-aggregation (the `layers` field on `LanguageSettings`).
 - **Editor connecting to the same LS directly**: if the user's editor talks to marksman in parallel with kakehashi, marksman sees duplicate `didOpen` events. Resolving this is the user's responsibility (route only through kakehashi). Kakehashi does not attempt to detect or mediate.
 - **Cross-language priority mixing in `priorities` entries**: the `priorities` field remains a `Vec<String>` of LS names within a single bridge target (`bridge.<inj>` or `bridge._self`). Mixing names from different bridge targets in one list is not supported by this schema.
 

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -19,12 +19,26 @@ Partially implemented:
   not leak into `_self` (equivalent to the Wildcard Merge Safety reasoning
   below, without materializing built-in default entries). Aggregation fields
   DO wildcard-merge (`resolve_host_aggregation`).
-- **Dispatch**: implemented for `textDocument/definition`,
-  `textDocument/hover`, and `textDocument/formatting`
-  (`src/lsp/bridge/text_document/host.rs`, `dispatch_host_preferred`); other
-  methods follow the same pattern as needed. The layer walk in the handlers
-  (cross-layer-aggregation) tries layers in `order` — by default virt
-  first, host as fallback. Formatting additionally supports the cross-layer
+- **Dispatch**: implemented for every bridged request method. Because the
+  host path needs no URI synthesis or coordinate translation, all methods
+  share one generic forwarder
+  (`LanguageServerPool::send_host_raw_request`): the upstream request's
+  params are forwarded **verbatim** as raw JSON (they already reference the
+  real URI and real coordinates) and the result comes back untranslated —
+  no per-method request builders or response transformers. Handlers run the
+  layer walk (`Kakehashi::walk_layers`, cross-layer-aggregation,
+  `preferred` semantics): layers are tried lazily in `order` — by default
+  virt first, host as fallback. Covered: definition, hover, declaration,
+  typeDefinition, implementation, references, completion, signatureHelp,
+  documentHighlight, rename, prepareRename, linkedEditingRange, moniker,
+  inlayHint, documentSymbol, documentLink, foldingRange, codeLens,
+  formatting, and rangeFormatting (which shares the formatting layer key).
+  Not covered: diagnostics (needs cross-layer `concatenated`; push/pull
+  stay virt-gated), semantic tokens (native-only), and the experimental
+  documentColor/colorPresentation pair. `completionItem/resolve` routes by
+  the envelope the virt fan-out stamps into `CompletionItem.data`; host
+  completion items carry no envelope and resolve falls back gracefully
+  (item returned unresolved). Formatting additionally supports the cross-layer
   `concatenated` pipeline: virt region edits apply first, the host
   formatter formats the intermediate text, and the chain collapses into one
   whole-document replacement edit. During that pipeline the host server's

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -8,6 +8,33 @@
 - [pull-first-diagnostic-forwarding](pull-first-diagnostic-forwarding.md) — Diagnostic forwarding
 - [cross-layer-aggregation](cross-layer-aggregation.md) — Cross-layer (native/host/virt) result aggregation; covers what this decision scopes out
 
+## Implementation Status
+
+Partially implemented:
+
+- **Schema & gate**: the `_self` reserved key is live. Opt-in is the explicit
+  `bridge._self.enabled = true` (`LanguageSettings::is_host_bridging_enabled`);
+  the built-in `_self.enabled = false` default is implemented as an
+  explicit-only rule — the `_` wildcard's `enabled = true` deliberately does
+  not leak into `_self` (equivalent to the Wildcard Merge Safety reasoning
+  below, without materializing built-in default entries). Aggregation fields
+  DO wildcard-merge (`resolve_host_aggregation`).
+- **Dispatch**: implemented for `textDocument/definition` and
+  `textDocument/hover` (`src/lsp/bridge/text_document/host.rs`,
+  `dispatch_host_preferred`); other methods follow the same pattern as
+  needed. The layer walk in the handlers (cross-layer-aggregation) tries
+  layers in `order` — by default virt first, host as fallback.
+- **Document sync deviation**: instead of forwarding `didChange` params
+  verbatim, sync is *lazy*: `didOpen` with the full host text fires on the
+  first request per `(uri, server)`, and a **full-text** `didChange` fires
+  when the host text's fingerprint changed since the last request. This
+  matches the virt path's full-content `didChange` forwarding and avoids
+  hooking the concurrent upstream `didChange` stream; verbatim forwarding
+  remains the target if eager sync proves necessary.
+- **Not implemented**: `publishDiagnostics` pass-through from host servers
+  (downstream notifications are not forwarded upstream today on either
+  path), and host participation in the formatting pipeline.
+
 ## Context
 
 Today kakehashi bridges LSP requests only to **injection regions** (virtual documents): a Python LS handles the Python code blocks inside a Markdown file, an SQL LS handles SQL inside a Rust string, etc. The host document itself — the Markdown, the Rust file as a whole — is parsed by kakehashi but receives no support from a *host* language server. Operations that require whole-document semantics (e.g., marksman on `.md`, or a Markdown-aware formatter) cannot be wired through kakehashi.

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -53,7 +53,7 @@ Partially implemented:
   remains the target if eager sync proves necessary.
 - **Not implemented**: `publishDiagnostics` pass-through from host servers
   (downstream notifications are not forwarded upstream today on either
-  path), and host participation in the formatting pipeline.
+  path).
 
 ## Context
 

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -19,11 +19,17 @@ Partially implemented:
   not leak into `_self` (equivalent to the Wildcard Merge Safety reasoning
   below, without materializing built-in default entries). Aggregation fields
   DO wildcard-merge (`resolve_host_aggregation`).
-- **Dispatch**: implemented for `textDocument/definition` and
-  `textDocument/hover` (`src/lsp/bridge/text_document/host.rs`,
-  `dispatch_host_preferred`); other methods follow the same pattern as
-  needed. The layer walk in the handlers (cross-layer-aggregation) tries
-  layers in `order` — by default virt first, host as fallback.
+- **Dispatch**: implemented for `textDocument/definition`,
+  `textDocument/hover`, and `textDocument/formatting`
+  (`src/lsp/bridge/text_document/host.rs`, `dispatch_host_preferred`); other
+  methods follow the same pattern as needed. The layer walk in the handlers
+  (cross-layer-aggregation) tries layers in `order` — by default virt
+  first, host as fallback. Formatting additionally supports the cross-layer
+  `concatenated` pipeline: virt region edits apply first, the host
+  formatter formats the intermediate text, and the chain collapses into one
+  whole-document replacement edit. During that pipeline the host server's
+  document state is briefly speculative (it sees the virt-applied text);
+  the lazy fingerprint sync restores the editor text on the next request.
 - **Document sync deviation**: instead of forwarding `didChange` params
   verbatim, sync is *lazy*: `didOpen` with the full host text fires on the
   first request per `(uri, server)`, and a **full-text** `didChange` fires

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -291,6 +291,10 @@ When multiple servers are configured for a language:
 | Diagnostics | Merge all, dedupe by range + message |
 | Formatting | `preferred` (first non-empty) by default; `concatenated` runs a sequential pipeline over `priorities` (which is also the membership allowlist — servers not listed do not run) — full formatting only. `textDocument/rangeFormatting` stays on `preferred` (concatenated-formatting-pipeline) |
 
+`priorities` lists follow the ordered-allowlist semantics of
+aggregation-priorities-wildcard: listed servers run in order, a `"*"` element
+stands for the unlisted rest, and absence of the list means `["*"]`.
+
 ## Consequences
 
 ### Positive
@@ -352,4 +356,5 @@ The original priority order (for reference):
 - [language-server-bridge](language-server-bridge.md): Core LSP bridge architecture
 - [language-server-bridge-virtual-document-model](language-server-bridge-virtual-document-model.md): How injections are represented as virtual documents
 - [concatenated-formatting-pipeline](concatenated-formatting-pipeline.md): Multi-server formatting via a sequential pipeline (`strategy: "concatenated"`)
+- [aggregation-priorities-wildcard](aggregation-priorities-wildcard.md): Ordered-allowlist semantics and the `"*"` element for `priorities` lists
 - [cross-layer-aggregation](cross-layer-aggregation.md): How native/host/virt layer results combine, one level above the per-target strategies defined here

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -352,3 +352,4 @@ The original priority order (for reference):
 - [language-server-bridge](language-server-bridge.md): Core LSP bridge architecture
 - [language-server-bridge-virtual-document-model](language-server-bridge-virtual-document-model.md): How injections are represented as virtual documents
 - [concatenated-formatting-pipeline](concatenated-formatting-pipeline.md): Multi-server formatting via a sequential pipeline (`strategy: "concatenated"`)
+- [cross-layer-aggregation](cross-layer-aggregation.md): How native/host/virt layer results combine, one level above the per-target strategies defined here

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -221,10 +221,10 @@ Rename can affect multiple files. For injections, only same-document renames are
 | Output | TextEdit[] |
 | Cross-file | N/A (single document) |
 | Position mapping | All edit ranges |
-| Multi-server | full formatting: `preferred` by default, `concatenated` opts into a sequential pipeline over `priorities` (also the membership allowlist — unlisted servers do not run; planned, not yet implemented). `textDocument/rangeFormatting`: `preferred` only |
+| Multi-server | full formatting: `preferred` by default, `concatenated` opts into a sequential pipeline over `priorities` (also the membership allowlist — unlisted servers do not run). `textDocument/rangeFormatting`: `preferred` only |
 
 Single-server formatting is simple—all edits are within the virtual document.
-For multiple servers, the **planned** (not yet implemented) `concatenated`
+For multiple servers, the `concatenated`
 behavior does **not** concatenate edit lists (that would overlap); it runs a
 sequential formatter pipeline over `priorities`, which is both the
 **membership allowlist** (servers not listed do not run) and the application order. This
@@ -289,7 +289,7 @@ When multiple servers are configured for a language:
 | Completion | Merge completion lists from all servers |
 | Hover | Concatenate hover content with separator |
 | Diagnostics | Merge all, dedupe by range + message |
-| Formatting | `preferred` (first non-empty) by default; `concatenated` runs a sequential pipeline over `priorities` (which is also the membership allowlist — servers not listed do not run) — planned, full formatting only, not yet implemented. `textDocument/rangeFormatting` stays on `preferred` (concatenated-formatting-pipeline) |
+| Formatting | `preferred` (first non-empty) by default; `concatenated` runs a sequential pipeline over `priorities` (which is also the membership allowlist — servers not listed do not run) — full formatting only. `textDocument/rangeFormatting` stays on `preferred` (concatenated-formatting-pipeline) |
 
 ## Consequences
 

--- a/docs/language-features.md
+++ b/docs/language-features.md
@@ -60,11 +60,13 @@ method (`strategy` in the bridge configuration):
 | Strategy | Behavior |
 |----------|----------|
 | `preferred` | Uses the first non-empty response, in your configured `priorities` order. **Default for every feature except diagnostics.** |
-| `concatenated` | Merges the responses from all servers. **Default for diagnostics.** |
+| `concatenated` | Merges the responses from all servers. **Default for diagnostics.** For full formatting it instead runs a sequential formatter pipeline over `priorities` (see [Formatting](#formatting)). |
 
-`maxFanOut` limits how many servers are queried. Formatting always uses `preferred`
-regardless of configuration (merging independent formatting results would produce
-conflicting edits).
+`priorities` is an ordered **allowlist**: servers absent from the list do not
+run, and a `"*"` element stands for the unlisted rest (see the
+[configuration reference](README.md) for details, including the `layers`
+setting that orders result layers per method). `maxFanOut` limits how many
+servers are queried.
 
 ---
 
@@ -175,9 +177,14 @@ snippet, renames are confined to that block. Default combine strategy: `preferre
 
 [`textDocument/formatting`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_formatting)
 
-Formats every embedded block in the document. When multiple servers are configured,
-the first one in `priorities` is used (formatting always uses `preferred`; merging
-multiple formatters would conflict).
+Formats every embedded block in the document. When multiple servers are
+configured, the default `preferred` strategy uses the first server in
+`priorities` that returns edits. Setting `strategy = "concatenated"` on the
+`textDocument/formatting` key instead runs a **sequential formatter pipeline**:
+the servers named in `priorities` format the block one after another, each
+seeing the previous formatter's output (e.g. `black` then `isort`). The
+pipeline requires explicitly named servers — `"*"` is ignored there, since a
+reproducible pipeline needs a deterministic order.
 
 ### Range formatting
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,7 @@ pub(crate) mod user;
 pub use expand::{set_config_file_override, set_data_dir_override};
 pub(crate) use merge::{
     merge_aggregation_configs, merge_bridge_language_configs, merge_bridge_server_configs,
-    merge_workspace_settings, resolve_with_wildcard,
+    merge_layer_aggregation_configs, merge_workspace_settings, resolve_with_wildcard,
 };
 pub(crate) use settings::{CaptureMappings, QueryTypeMappings};
 pub use settings::{LanguageSettings, RawWorkspaceSettings, WorkspaceSettings, json_schema};
@@ -122,6 +122,13 @@ fn strip_inherited_language_settings(
             .then(|| current.queries.clone())
             .flatten(),
         bridge: strip_inherited_bridge_map(inherited.bridge.as_ref(), current.bridge.as_ref()),
+        // Whole-field equality strip (like queries/aliases): a layers map
+        // that differs from the inherited one at all is kept verbatim. The
+        // per-key deep strip used for bridge is not mirrored here until the
+        // display duplication it avoids proves to matter for layers.
+        layers: (current.layers != inherited.layers)
+            .then(|| current.layers.clone())
+            .flatten(),
         aliases: (current.aliases != inherited.aliases)
             .then(|| current.aliases.clone())
             .flatten(),

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -1,5 +1,6 @@
 use super::settings::{
     AggregationConfig, BridgeLanguageConfig, BridgeServerConfig, LanguageSettings,
+    LayerAggregationConfig,
 };
 use super::{CaptureMappings, RawWorkspaceSettings, WILDCARD_KEY};
 use std::collections::{HashMap, HashSet};
@@ -97,6 +98,7 @@ pub(crate) fn merge_language_settings(
         parser: overlay.parser.clone().or_else(|| base.parser.clone()),
         queries: overlay.queries.clone().or_else(|| base.queries.clone()),
         bridge: merge_bridge_maps(base.bridge.as_ref(), overlay.bridge.as_ref()),
+        layers: merge_layers_maps(base.layers.as_ref(), overlay.layers.as_ref()),
         aliases: overlay.aliases.clone().or_else(|| base.aliases.clone()),
     }
 }
@@ -200,6 +202,51 @@ pub(crate) fn merge_aggregation_configs(
             .clone()
             .or_else(|| base.priorities.clone()),
         max_fan_out: overlay.max_fan_out.or(base.max_fan_out),
+    }
+}
+
+/// Merge two `LayerAggregationConfig`s field-by-field
+/// (cross-layer-aggregation).
+///
+/// - `order`: overlay wins if present, else inherits from base — the list
+///   replaces wholesale, never element-wise
+/// - `strategy`: overlay wins if set, else inherits from base
+pub(crate) fn merge_layer_aggregation_configs(
+    base: &LayerAggregationConfig,
+    overlay: &LayerAggregationConfig,
+) -> LayerAggregationConfig {
+    LayerAggregationConfig {
+        order: overlay.order.clone().or_else(|| base.order.clone()),
+        strategy: overlay.strategy.or(base.strategy),
+    }
+}
+
+/// Deep merge two optional `layers` HashMaps (cross-layer-aggregation).
+///
+/// Mirrors [`merge_bridge_maps`]: an empty overlay map (`Some({})`) clears
+/// the base (empty-means-clear); otherwise per-method entries merge at the
+/// field level via [`merge_layer_aggregation_configs`].
+fn merge_layers_maps(
+    base: Option<&HashMap<String, LayerAggregationConfig>>,
+    overlay: Option<&HashMap<String, LayerAggregationConfig>>,
+) -> Option<HashMap<String, LayerAggregationConfig>> {
+    match (base, overlay) {
+        (None, None) => None,
+        (Some(b), None) => Some(b.clone()),
+        (None, Some(o)) => Some(o.clone()),
+        (Some(_), Some(o)) if o.is_empty() => Some(HashMap::new()), // empty-means-clear
+        (Some(b), Some(o)) => {
+            let mut merged = b.clone();
+            for (method, overlay_config) in o {
+                merged
+                    .entry(method.clone())
+                    .and_modify(|base_config| {
+                        *base_config = merge_layer_aggregation_configs(base_config, overlay_config);
+                    })
+                    .or_insert_with(|| overlay_config.clone());
+            }
+            Some(merged)
+        }
     }
 }
 
@@ -2072,6 +2119,106 @@ mod tests {
         assert!(
             custom.bridge.is_none(),
             "custom_lang should not inherit '_'s bridge — chain stopped at _blank"
+        );
+    }
+
+    #[test]
+    fn merge_layer_aggregation_configs_overlay_fields_win() {
+        use crate::config::settings::{AggregationStrategy, LayerSource};
+        let base = LayerAggregationConfig {
+            order: Some(vec![LayerSource::Native]),
+            strategy: Some(AggregationStrategy::Preferred),
+        };
+        let overlay = LayerAggregationConfig {
+            order: Some(vec![LayerSource::Virt, LayerSource::Host]),
+            strategy: None,
+        };
+        let merged = merge_layer_aggregation_configs(&base, &overlay);
+        assert_eq!(
+            merged.order,
+            Some(vec![LayerSource::Virt, LayerSource::Host]),
+            "overlay order replaces base wholesale"
+        );
+        assert_eq!(
+            merged.strategy,
+            Some(AggregationStrategy::Preferred),
+            "unset overlay strategy inherits from base"
+        );
+    }
+
+    #[test]
+    fn merge_language_settings_merges_layers_per_method() {
+        use crate::config::settings::{AggregationStrategy, LayerSource};
+        let base = LanguageSettings {
+            layers: Some(HashMap::from([
+                (
+                    "textDocument/hover".to_string(),
+                    LayerAggregationConfig {
+                        order: Some(vec![LayerSource::Native]),
+                        strategy: Some(AggregationStrategy::Preferred),
+                    },
+                ),
+                (
+                    "textDocument/definition".to_string(),
+                    LayerAggregationConfig {
+                        order: Some(vec![LayerSource::Virt]),
+                        strategy: None,
+                    },
+                ),
+            ])),
+            ..Default::default()
+        };
+        let overlay = LanguageSettings {
+            layers: Some(HashMap::from([(
+                "textDocument/hover".to_string(),
+                LayerAggregationConfig {
+                    order: Some(vec![LayerSource::Host]),
+                    strategy: None,
+                },
+            )])),
+            ..Default::default()
+        };
+        let merged = merge_language_settings(&base, &overlay);
+        let layers = merged.layers.expect("layers must survive the merge");
+        assert_eq!(
+            layers["textDocument/hover"].order,
+            Some(vec![LayerSource::Host]),
+            "overlay entry wins per field"
+        );
+        assert_eq!(
+            layers["textDocument/hover"].strategy,
+            Some(AggregationStrategy::Preferred),
+            "unset overlay field inherits from the base entry"
+        );
+        assert_eq!(
+            layers["textDocument/definition"].order,
+            Some(vec![LayerSource::Virt]),
+            "base-only entries are preserved"
+        );
+    }
+
+    #[test]
+    fn merge_language_settings_empty_layers_map_clears_base() {
+        use crate::config::settings::LayerSource;
+        let base = LanguageSettings {
+            layers: Some(HashMap::from([(
+                "_".to_string(),
+                LayerAggregationConfig {
+                    order: Some(vec![LayerSource::Native]),
+                    strategy: None,
+                },
+            )])),
+            ..Default::default()
+        };
+        let overlay = LanguageSettings {
+            layers: Some(HashMap::new()),
+            ..Default::default()
+        };
+        let merged = merge_language_settings(&base, &overlay);
+        assert_eq!(
+            merged.layers,
+            Some(HashMap::new()),
+            "Some({{}}) clears inherited layers (empty-means-clear, like bridge)"
         );
     }
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -86,7 +86,7 @@ pub struct BridgeLanguageConfig {
 ///
 /// The set is closed and three-valued, so layer order is expressed by
 /// explicit enumeration — no `"*"` element exists on this axis.
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, JsonSchema)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Hash, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum LayerSource {
     /// kakehashi's own features (Tree-sitter based).
@@ -124,6 +124,15 @@ fn default_layer_order() -> Vec<LayerSource> {
     vec![LayerSource::Virt, LayerSource::Host, LayerSource::Native]
 }
 
+/// Drop repeated layers, keeping the first occurrence (order preserved).
+fn dedup_layer_order(order: Vec<LayerSource>) -> Vec<LayerSource> {
+    let mut seen = std::collections::HashSet::new();
+    order
+        .into_iter()
+        .filter(|layer| seen.insert(*layer))
+        .collect()
+}
+
 /// Fully resolved cross-layer settings for a single LSP method.
 ///
 /// Produced by [`LanguageSettings::resolve_layers`]; all optional fields are
@@ -131,7 +140,6 @@ fn default_layer_order() -> Vec<LayerSource> {
 #[derive(Debug, Clone)]
 pub(crate) struct ResolvedLayerConfig {
     pub(crate) order: Vec<LayerSource>,
-    #[allow(dead_code)] // consumed when layer-level `concatenated` lands (phase 3)
     pub(crate) strategy: AggregationStrategy,
 }
 
@@ -409,7 +417,10 @@ impl LanguageSettings {
         });
         match entry {
             Some(cfg) => ResolvedLayerConfig {
-                order: cfg.order.unwrap_or_else(default_layer_order),
+                // Dedup defensively (first occurrence wins): a repeated layer
+                // in user config would otherwise make downstream walks visit
+                // it twice.
+                order: dedup_layer_order(cfg.order.unwrap_or_else(default_layer_order)),
                 strategy: cfg
                     .strategy
                     .unwrap_or_else(|| default_aggregation_strategy_for_method(method)),
@@ -1522,6 +1533,30 @@ kind = "injections""#;
         let resolved = settings.resolve_layers("textDocument/hover");
         assert!(resolved.order.is_empty());
         assert!(!resolved.allows(LayerSource::Virt));
+    }
+
+    #[test]
+    fn resolve_layers_dedups_repeated_layers_first_occurrence_wins() {
+        let settings = LanguageSettings {
+            layers: Some(HashMap::from([(
+                WILDCARD_KEY.to_string(),
+                LayerAggregationConfig {
+                    order: Some(vec![
+                        LayerSource::Virt,
+                        LayerSource::Native,
+                        LayerSource::Virt,
+                    ]),
+                    strategy: None,
+                },
+            )])),
+            ..Default::default()
+        };
+        let resolved = settings.resolve_layers("textDocument/hover");
+        assert_eq!(
+            resolved.order,
+            vec![LayerSource::Virt, LayerSource::Native],
+            "a repeated layer must not be walked twice"
+        );
     }
 
     #[test]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -96,9 +96,9 @@ pub struct BridgeLanguageConfig {
 pub enum LayerSource {
     /// kakehashi's own features (Tree-sitter based).
     Native,
-    /// The host-document bridge (`bridge._self`). Reserved: an empty
-    /// contributor until host bridging (host-document-bridge) is implemented
-    /// and opted in via `bridge._self.enabled`.
+    /// The host-document bridge (`bridge._self`, host-document-bridge):
+    /// servers handling the host document itself with the real URI. An
+    /// empty contributor until opted in via `bridge._self.enabled = true`.
     Host,
     /// The injection bridges (`bridge.<language>`).
     Virt,

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -80,6 +80,77 @@ pub struct BridgeLanguageConfig {
     pub aggregation: Option<HashMap<String, AggregationConfig>>,
 }
 
+/// One result layer that can answer an LSP request
+/// (cross-layer-aggregation). NOT injection nesting depth (tree-sitter
+/// "language layers").
+///
+/// The set is closed and three-valued, so layer order is expressed by
+/// explicit enumeration — no `"*"` element exists on this axis.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum LayerSource {
+    /// kakehashi's own features (Tree-sitter based).
+    Native,
+    /// The host-document bridge (`bridge._self`). Reserved: an empty
+    /// contributor until host bridging (host-document-bridge) is implemented
+    /// and opted in via `bridge._self.enabled`.
+    Host,
+    /// The injection bridges (`bridge.<language>`).
+    Virt,
+}
+
+/// Per-method cross-layer aggregation configuration
+/// (cross-layer-aggregation). Lives in `LanguageSettings::layers`, keyed by
+/// LSP method name or `"_"` for the method wildcard.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct LayerAggregationConfig {
+    /// Ordered allowlist of result layers, highest priority first: layers
+    /// omitted from the list do not participate for the method. `[]`
+    /// disables the method across all layers. `None` = inherit (default
+    /// `["virt", "host", "native"]` — innermost first).
+    #[serde(default)]
+    pub order: Option<Vec<LayerSource>>,
+    /// Cross-layer combine strategy. Only `preferred` (first non-empty
+    /// layer wins) is implemented at the layer level today; `concatenated`
+    /// is reserved (formatting first — cross-layer-aggregation phase 3).
+    #[serde(default)]
+    pub strategy: Option<AggregationStrategy>,
+}
+
+/// The built-in default layer order: virt, host, native — innermost first,
+/// mirroring the "deeper wins" semantic-token convention.
+fn default_layer_order() -> Vec<LayerSource> {
+    vec![LayerSource::Virt, LayerSource::Host, LayerSource::Native]
+}
+
+/// Fully resolved cross-layer settings for a single LSP method.
+///
+/// Produced by [`LanguageSettings::resolve_layers`]; all optional fields are
+/// resolved with their defaults.
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedLayerConfig {
+    pub(crate) order: Vec<LayerSource>,
+    #[allow(dead_code)] // consumed when layer-level `concatenated` lands (phase 3)
+    pub(crate) strategy: AggregationStrategy,
+}
+
+impl ResolvedLayerConfig {
+    /// Defaults for a method with no `layers` configuration: the built-in
+    /// order and the per-method strategy default.
+    pub(crate) fn with_defaults(method: &str) -> Self {
+        Self {
+            order: default_layer_order(),
+            strategy: default_aggregation_strategy_for_method(method),
+        }
+    }
+
+    /// Whether the given layer participates for this method.
+    pub(crate) fn allows(&self, layer: LayerSource) -> bool {
+        self.order.contains(&layer)
+    }
+}
+
 /// Fully resolved aggregation settings for a single LSP method.
 ///
 /// Produced by [`BridgeLanguageConfig::resolve_aggregation`]. Unlike
@@ -310,12 +381,43 @@ pub struct LanguageSettings {
     pub queries: Option<Vec<QueryItem>>,
     /// Omit to bridge all configured languages (default). Use an empty object `{}` to disable bridging. Use `{ "python": { "enabled": true } }` to bridge specific languages.
     pub bridge: Option<HashMap<String, BridgeLanguageConfig>>,
+    /// Per-method cross-layer aggregation (cross-layer-aggregation).
+    /// Key = LSP method name or `"_"` for the method wildcard; value orders
+    /// the result layers (`virt`/`host`/`native`) for that method.
+    /// Omit to use the default order `["virt", "host", "native"]`.
+    pub layers: Option<HashMap<String, LayerAggregationConfig>>,
     /// Deprecated: use `base` on the derived language instead.
     /// Alternative languageId values that should use this parser.
     pub aliases: Option<Vec<String>>,
 }
 
 impl LanguageSettings {
+    /// Resolve the cross-layer settings for an LSP method
+    /// (cross-layer-aggregation), with field-level wildcard merge over the
+    /// `"_"` method entry — the same machinery as
+    /// [`BridgeLanguageConfig::resolve_aggregation`].
+    ///
+    /// `order` is a single field: a method-specific `order` replaces the
+    /// wildcard's list wholesale, it does not merge element-wise.
+    pub(crate) fn resolve_layers(&self, method: &str) -> ResolvedLayerConfig {
+        let entry = self.layers.as_ref().and_then(|map| {
+            crate::config::resolve_with_wildcard(
+                map,
+                method,
+                crate::config::merge_layer_aggregation_configs,
+            )
+        });
+        match entry {
+            Some(cfg) => ResolvedLayerConfig {
+                order: cfg.order.unwrap_or_else(default_layer_order),
+                strategy: cfg
+                    .strategy
+                    .unwrap_or_else(|| default_aggregation_strategy_for_method(method)),
+            },
+            None => ResolvedLayerConfig::with_defaults(method),
+        }
+    }
+
     /// Check if a language is allowed for bridging based on the bridge filter.
     ///
     /// Returns:
@@ -1286,6 +1388,154 @@ kind = "injections""#;
         };
         let agg = config.resolve_aggregation("textDocument/completion");
         assert_eq!(agg.priorities, &["server_a".to_string()]);
+    }
+
+    // ==========================================================================
+    // Cross-layer aggregation (cross-layer-aggregation)
+    // ==========================================================================
+
+    #[test]
+    fn layer_source_deserializes_lowercase() {
+        let order: Vec<LayerSource> = serde_json::from_str(r#"["virt", "host", "native"]"#)
+            .expect("lowercase layer names must parse");
+        assert_eq!(
+            order,
+            vec![LayerSource::Virt, LayerSource::Host, LayerSource::Native]
+        );
+    }
+
+    #[test]
+    fn layer_source_rejects_unknown_names() {
+        // Closed enum: a typo is a deserialization error, not a server that
+        // never responds (contrast with stage-1 priorities strings).
+        let result: std::result::Result<Vec<LayerSource>, _> = serde_json::from_str(r#"["virtt"]"#);
+        assert!(result.is_err(), "unknown layer names must fail to parse");
+    }
+
+    #[test]
+    fn resolve_layers_defaults_to_virt_host_native() {
+        let settings = LanguageSettings::default();
+        let resolved = settings.resolve_layers("textDocument/hover");
+        assert_eq!(
+            resolved.order,
+            vec![LayerSource::Virt, LayerSource::Host, LayerSource::Native]
+        );
+        assert_eq!(resolved.strategy, AggregationStrategy::Preferred);
+    }
+
+    #[test]
+    fn resolve_layers_strategy_defaults_per_method() {
+        let settings = LanguageSettings::default();
+        let resolved = settings.resolve_layers("textDocument/diagnostic");
+        assert_eq!(resolved.strategy, AggregationStrategy::Concatenated);
+    }
+
+    #[test]
+    fn resolve_layers_uses_method_specific_entry() {
+        let settings = LanguageSettings {
+            layers: Some(HashMap::from([(
+                "textDocument/hover".to_string(),
+                LayerAggregationConfig {
+                    order: Some(vec![LayerSource::Host, LayerSource::Virt]),
+                    strategy: None,
+                },
+            )])),
+            ..Default::default()
+        };
+        let resolved = settings.resolve_layers("textDocument/hover");
+        assert_eq!(resolved.order, vec![LayerSource::Host, LayerSource::Virt]);
+        assert!(
+            !resolved.allows(LayerSource::Native),
+            "omitted layer is excluded"
+        );
+    }
+
+    #[test]
+    fn resolve_layers_method_entry_inherits_unset_fields_from_method_wildcard() {
+        // Field-level wildcard merge: the method entry sets strategy only,
+        // the "_" entry supplies order.
+        let settings = LanguageSettings {
+            layers: Some(HashMap::from([
+                (
+                    WILDCARD_KEY.to_string(),
+                    LayerAggregationConfig {
+                        order: Some(vec![LayerSource::Native]),
+                        strategy: None,
+                    },
+                ),
+                (
+                    "textDocument/hover".to_string(),
+                    LayerAggregationConfig {
+                        order: None,
+                        strategy: Some(AggregationStrategy::Concatenated),
+                    },
+                ),
+            ])),
+            ..Default::default()
+        };
+        let resolved = settings.resolve_layers("textDocument/hover");
+        assert_eq!(resolved.order, vec![LayerSource::Native]);
+        assert_eq!(resolved.strategy, AggregationStrategy::Concatenated);
+    }
+
+    #[test]
+    fn resolve_layers_method_order_replaces_wildcard_order_wholesale() {
+        let settings = LanguageSettings {
+            layers: Some(HashMap::from([
+                (
+                    WILDCARD_KEY.to_string(),
+                    LayerAggregationConfig {
+                        order: Some(vec![LayerSource::Native, LayerSource::Host]),
+                        strategy: None,
+                    },
+                ),
+                (
+                    "textDocument/hover".to_string(),
+                    LayerAggregationConfig {
+                        order: Some(vec![LayerSource::Virt]),
+                        strategy: None,
+                    },
+                ),
+            ])),
+            ..Default::default()
+        };
+        let resolved = settings.resolve_layers("textDocument/hover");
+        assert_eq!(
+            resolved.order,
+            vec![LayerSource::Virt],
+            "order is a single field: the method entry replaces the wildcard list, no element merge"
+        );
+    }
+
+    #[test]
+    fn resolve_layers_empty_order_disables_all_layers() {
+        let settings = LanguageSettings {
+            layers: Some(HashMap::from([(
+                WILDCARD_KEY.to_string(),
+                LayerAggregationConfig {
+                    order: Some(vec![]),
+                    strategy: None,
+                },
+            )])),
+            ..Default::default()
+        };
+        let resolved = settings.resolve_layers("textDocument/hover");
+        assert!(resolved.order.is_empty());
+        assert!(!resolved.allows(LayerSource::Virt));
+    }
+
+    #[test]
+    fn layer_aggregation_config_parses_from_toml() {
+        let toml_str = r#"
+            order = ["host", "virt"]
+            strategy = "preferred"
+        "#;
+        let config: LayerAggregationConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.order,
+            Some(vec![LayerSource::Host, LayerSource::Virt])
+        );
+        assert_eq!(config.strategy, Some(AggregationStrategy::Preferred));
     }
 
     #[test]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -5,6 +5,11 @@ use std::collections::HashMap;
 
 pub(crate) type CaptureMapping = HashMap<String, String>;
 
+/// Reserved key in the `bridge` map for the host language acting as its own
+/// bridge target (host-document-bridge): requests for the host document are
+/// forwarded with the real URI and no coordinate translation.
+pub(crate) const HOST_BRIDGE_KEY: &str = "_self";
+
 /// Reserved `priorities` element standing for "every configured server not
 /// named elsewhere in the list" (aggregation-priorities-wildcard).
 ///
@@ -429,6 +434,41 @@ impl LanguageSettings {
             },
             None => ResolvedLayerConfig::with_defaults(method),
         }
+    }
+
+    /// Whether host bridging (`bridge._self`, host-document-bridge) is
+    /// enabled for this language.
+    ///
+    /// Host bridging is **opt-in**: it requires an explicit
+    /// `bridge._self.enabled = true`. Unlike injection entries, the `enabled`
+    /// field deliberately does NOT inherit from the `_` wildcard entry —
+    /// that implements the ADR's built-in `languages._.bridge._self.enabled
+    /// = false` default, which must beat the wildcard's `enabled = true`
+    /// virt default (key-specific wins). Aggregation fields DO inherit from
+    /// `_` via [`Self::resolve_host_aggregation`].
+    pub(crate) fn is_host_bridging_enabled(&self) -> bool {
+        self.bridge
+            .as_ref()
+            .and_then(|map| map.get(HOST_BRIDGE_KEY))
+            .and_then(|cfg| cfg.enabled)
+            .unwrap_or(false)
+    }
+
+    /// Resolve the per-method aggregation config for the host bridge target
+    /// (`bridge._self`), with the same field-level wildcard merge as any
+    /// other bridge key: an unset `_self` field inherits from `_`.
+    pub(crate) fn resolve_host_aggregation(&self, method: &str) -> ResolvedAggregationConfig {
+        self.bridge
+            .as_ref()
+            .and_then(|map| {
+                crate::config::resolve_with_wildcard(
+                    map,
+                    HOST_BRIDGE_KEY,
+                    crate::config::merge_bridge_language_configs,
+                )
+            })
+            .map(|cfg| cfg.resolve_aggregation(method))
+            .unwrap_or_else(ResolvedAggregationConfig::with_defaults)
     }
 
     /// Check if a language is allowed for bridging based on the bridge filter.
@@ -1401,6 +1441,102 @@ kind = "injections""#;
         };
         let agg = config.resolve_aggregation("textDocument/completion");
         assert_eq!(agg.priorities, &["server_a".to_string()]);
+    }
+
+    // ==========================================================================
+    // Host bridging (host-document-bridge)
+    // ==========================================================================
+
+    #[test]
+    fn host_bridging_is_disabled_by_default() {
+        assert!(!LanguageSettings::default().is_host_bridging_enabled());
+    }
+
+    #[test]
+    fn host_bridging_enabled_by_explicit_self_entry() {
+        let settings = LanguageSettings {
+            bridge: Some(HashMap::from([(
+                HOST_BRIDGE_KEY.to_string(),
+                BridgeLanguageConfig {
+                    enabled: Some(true),
+                    aggregation: None,
+                },
+            )])),
+            ..Default::default()
+        };
+        assert!(settings.is_host_bridging_enabled());
+    }
+
+    #[test]
+    fn host_bridging_not_enabled_by_bridge_wildcard() {
+        // The `_` wildcard's enabled = true is the VIRT default; it must not
+        // silently turn host bridging on (host-document-bridge: the built-in
+        // `_self.enabled = false` default is key-specific and wins).
+        let settings = LanguageSettings {
+            bridge: Some(HashMap::from([(
+                WILDCARD_KEY.to_string(),
+                BridgeLanguageConfig {
+                    enabled: Some(true),
+                    aggregation: None,
+                },
+            )])),
+            ..Default::default()
+        };
+        assert!(!settings.is_host_bridging_enabled());
+    }
+
+    #[test]
+    fn host_bridging_explicit_false_stays_off() {
+        let settings = LanguageSettings {
+            bridge: Some(HashMap::from([(
+                HOST_BRIDGE_KEY.to_string(),
+                BridgeLanguageConfig {
+                    enabled: Some(false),
+                    aggregation: None,
+                },
+            )])),
+            ..Default::default()
+        };
+        assert!(!settings.is_host_bridging_enabled());
+    }
+
+    #[test]
+    fn host_aggregation_inherits_from_bridge_wildcard() {
+        // Aggregation fields (unlike `enabled`) DO inherit from `_`.
+        let settings = LanguageSettings {
+            bridge: Some(HashMap::from([
+                (
+                    HOST_BRIDGE_KEY.to_string(),
+                    BridgeLanguageConfig {
+                        enabled: Some(true),
+                        aggregation: None,
+                    },
+                ),
+                (
+                    WILDCARD_KEY.to_string(),
+                    BridgeLanguageConfig {
+                        enabled: None,
+                        aggregation: Some(HashMap::from([(
+                            "_".to_string(),
+                            AggregationConfig {
+                                priorities: Some(vec!["marksman".to_string()]),
+                                ..Default::default()
+                            },
+                        )])),
+                    },
+                ),
+            ])),
+            ..Default::default()
+        };
+        let agg = settings.resolve_host_aggregation("textDocument/definition");
+        assert_eq!(agg.priorities, vec!["marksman".to_string()]);
+    }
+
+    #[test]
+    fn host_aggregation_defaults_to_wildcard_priorities_when_unconfigured() {
+        let settings = LanguageSettings::default();
+        let agg = settings.resolve_host_aggregation("textDocument/definition");
+        assert_eq!(agg.priorities, vec![PRIORITIES_WILDCARD.to_string()]);
     }
 
     // ==========================================================================

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -111,9 +111,11 @@ pub struct LayerAggregationConfig {
     /// `["virt", "host", "native"]` — innermost first).
     #[serde(default)]
     pub order: Option<Vec<LayerSource>>,
-    /// Cross-layer combine strategy. Only `preferred` (first non-empty
-    /// layer wins) is implemented at the layer level today; `concatenated`
-    /// is reserved (formatting first — cross-layer-aggregation phase 3).
+    /// Cross-layer combine strategy: `preferred` (first non-empty layer
+    /// wins) or `concatenated`. `concatenated` is honored for
+    /// `textDocument/formatting` only (cross-layer-aggregation phase 3);
+    /// other methods combine with `preferred` until a second layer can
+    /// produce results.
     #[serde(default)]
     pub strategy: Option<AggregationStrategy>,
 }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -5,6 +5,20 @@ use std::collections::HashMap;
 
 pub(crate) type CaptureMapping = HashMap<String, String>;
 
+/// Reserved `priorities` element standing for "every configured server not
+/// named elsewhere in the list" (aggregation-priorities-wildcard).
+///
+/// Glob-like `*` rather than the `_` wildcard sigil: `_` keys carry
+/// field-level inheritance semantics, a rest-of-the-candidates list element
+/// does not.
+pub(crate) const PRIORITIES_WILDCARD: &str = "*";
+
+/// The resolved default for an absent `priorities`: `["*"]`, i.e. fan out to
+/// every configured server with no ranking (first-win).
+fn default_priorities() -> Vec<String> {
+    vec![PRIORITIES_WILDCARD.to_string()]
+}
+
 /// Aggregation strategy for combining results from multiple bridge servers.
 ///
 /// - `Preferred`: Use the first non-empty response (priority-ordered).
@@ -21,15 +35,18 @@ pub enum AggregationStrategy {
 /// Per-method aggregation configuration.
 ///
 /// Controls how results from multiple bridge servers are aggregated for a
-/// specific LSP method. The `priorities` list determines server preference
-/// order — the first server in the list that returns a non-empty result wins.
-/// `Some(vec![])` degrades to first-win (arrival-order) behavior, while `None`
-/// means "inherit from wildcard/base".
+/// specific LSP method. The `priorities` list is an **ordered allowlist**
+/// (aggregation-priorities-wildcard): listed servers run in order, servers
+/// absent from the list do not run, and a `"*"` element stands for every
+/// configured-but-unlisted server (a first-win group at that position).
+/// `None` means "inherit from wildcard/base", resolving to `["*"]` when
+/// nothing is configured; `Some(vec![])` disables fan-out for the method.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct AggregationConfig {
-    /// Server names in priority order (highest first).
-    /// `Some(vec![])` = pure first-win behavior, `None` = inherit.
+    /// Server names in priority order (highest first), as an ordered
+    /// allowlist. `"*"` = all unlisted servers; `Some(vec![])` = disable
+    /// fan-out for this method; `None` = inherit (default `["*"]`).
     #[serde(default)]
     pub priorities: Option<Vec<String>>,
     /// Aggregation strategy override.
@@ -76,11 +93,12 @@ pub(crate) struct ResolvedAggregationConfig {
 }
 
 impl ResolvedAggregationConfig {
-    /// Create a config with all fields at their defaults (`Preferred` strategy).
+    /// Create a config with all fields at their defaults (`Preferred`
+    /// strategy, `["*"]` priorities = all servers, first-win).
     pub(crate) fn with_defaults() -> Self {
         Self {
             strategy: AggregationStrategy::Preferred,
-            priorities: Vec::new(),
+            priorities: default_priorities(),
             max_fan_out: None,
         }
     }
@@ -123,12 +141,15 @@ impl BridgeLanguageConfig {
                 strategy: entry
                     .strategy
                     .unwrap_or_else(|| default_aggregation_strategy_for_method(method)),
-                priorities: entry.priorities.unwrap_or_default(),
+                // None (unset after merge) resolves to ["*"] — all servers,
+                // first-win. An explicit [] survives as the per-method
+                // fan-out kill switch (aggregation-priorities-wildcard).
+                priorities: entry.priorities.unwrap_or_else(default_priorities),
                 max_fan_out: entry.max_fan_out.and_then(|raw| usize::try_from(raw).ok()),
             },
             None => ResolvedAggregationConfig {
                 strategy: default_aggregation_strategy_for_method(method),
-                priorities: Vec::new(),
+                priorities: default_priorities(),
                 max_fan_out: None,
             },
         }
@@ -1284,8 +1305,29 @@ kind = "injections""#;
     }
 
     #[test]
-    fn should_resolve_aggregation_priorities_returns_empty_when_no_aggregation() {
+    fn should_resolve_aggregation_priorities_defaults_to_wildcard_when_no_aggregation() {
+        // Absent priorities resolve to ["*"] — all servers, first-win
+        // (aggregation-priorities-wildcard). NOT [] — that now disables
+        // fan-out for the method.
         let config = BridgeLanguageConfig::default();
+        let agg = config.resolve_aggregation("textDocument/hover");
+        assert_eq!(agg.priorities, vec![PRIORITIES_WILDCARD.to_string()]);
+    }
+
+    #[test]
+    fn should_resolve_aggregation_priorities_preserves_explicit_empty_list() {
+        // Some(vec![]) is the per-method fan-out kill switch and must survive
+        // resolution verbatim, not be replaced with the ["*"] default.
+        let config = BridgeLanguageConfig {
+            enabled: Some(true),
+            aggregation: Some(HashMap::from([(
+                "textDocument/hover".to_string(),
+                AggregationConfig {
+                    priorities: Some(vec![]),
+                    ..Default::default()
+                },
+            )])),
+        };
         let agg = config.resolve_aggregation("textDocument/hover");
         assert!(agg.priorities.is_empty());
     }
@@ -1483,7 +1525,11 @@ kind = "injections""#;
     fn should_resolve_aggregation_with_defaults_returns_preferred() {
         let agg = ResolvedAggregationConfig::with_defaults();
         assert_eq!(agg.strategy, AggregationStrategy::Preferred);
-        assert!(agg.priorities.is_empty());
+        assert_eq!(
+            agg.priorities,
+            vec![PRIORITIES_WILDCARD.to_string()],
+            "default priorities must be [\"*\"] (all servers), not [] (disabled)"
+        );
         assert_eq!(agg.max_fan_out, None);
     }
 
@@ -1654,7 +1700,7 @@ kind = "injections""#;
         };
         let agg = config.resolve_aggregation("textDocument/hover");
         assert_eq!(agg.strategy, AggregationStrategy::Preferred);
-        assert!(agg.priorities.is_empty());
+        assert_eq!(agg.priorities, vec![PRIORITIES_WILDCARD.to_string()]);
         assert_eq!(agg.max_fan_out, None);
     }
 

--- a/src/config/snapshots/kakehashi__config__merge__tests__merge_workspace_settings_all_fields.snap
+++ b/src/config/snapshots/kakehashi__config__merge__tests__merge_workspace_settings_all_fields.snap
@@ -12,6 +12,7 @@ expression: result
       "parser": "/base/lua.so",
       "queries": null,
       "bridge": null,
+      "layers": null,
       "aliases": null
     },
     "python": {
@@ -29,6 +30,7 @@ expression: result
           "aggregation": null
         }
       },
+      "layers": null,
       "aliases": [
         "py3"
       ]
@@ -38,6 +40,7 @@ expression: result
       "parser": "/overlay/rust.so",
       "queries": null,
       "bridge": null,
+      "layers": null,
       "aliases": null
     }
   },

--- a/src/lsp/aggregation/server.rs
+++ b/src/lsp/aggregation/server.rs
@@ -2,6 +2,7 @@ mod concatenated_pipeline;
 mod dispatch;
 mod fan_in;
 mod fan_out;
+pub(crate) mod priority;
 
 pub(crate) use concatenated_pipeline::run_sequential_format_pipeline;
 pub(crate) use dispatch::{dispatch_concatenated, dispatch_preferred, effective_priorities_from};

--- a/src/lsp/aggregation/server.rs
+++ b/src/lsp/aggregation/server.rs
@@ -2,9 +2,11 @@ mod concatenated_pipeline;
 mod dispatch;
 mod fan_in;
 mod fan_out;
+mod host_dispatch;
 pub(crate) mod priority;
 
 pub(crate) use concatenated_pipeline::run_sequential_format_pipeline;
 pub(crate) use dispatch::{dispatch_concatenated, dispatch_preferred, effective_priorities_from};
 pub(crate) use fan_in::FanInResult;
 pub(crate) use fan_out::FanOutTask;
+pub(crate) use host_dispatch::dispatch_host_preferred;

--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -2,10 +2,13 @@
 //!
 //! [`dispatch_preferred()`] combines [`fan_out()`] with the preferred
 //! strategy, giving each handler a single call-site for the common pattern.
-//! When `ctx.priorities` is empty, it degrades to pure first-win behavior.
 //!
 //! [`dispatch_concatenated()`] combines [`fan_out()`] with the concatenated
-//! strategy, collecting every successful result from all matching servers.
+//! strategy, collecting every successful result from all selected servers.
+//!
+//! Both expand `ctx.priorities` once (aggregation-priorities-wildcard) and
+//! feed the same expansion to fan-out (membership + spawn order) and fan-in
+//! (decision order), so the two sides can never disagree.
 
 use std::collections::HashSet;
 use std::future::Future;
@@ -19,26 +22,28 @@ use crate::lsp::request_id::CancelReceiver;
 use super::fan_in::FanInResult;
 use super::fan_in::{concatenated, preferred};
 use super::fan_out::{FanOutTask, fan_out};
+use super::priority::{PriorityEntry, entry_names, expand_priorities, truncate_entries};
 
-/// Pre-filter `ctx.priorities` to keep only server names present in `ctx.configs`,
-/// dropping duplicates (first occurrence wins, order preserved).
-///
-/// Shared by the preferred fan-out and the concatenated formatting pipeline so
-/// the "priorities is a membership allowlist + order" rule has a single source.
-/// Deduping matters for the sequential pipeline: a misconfigured
-/// `priorities: ["black", "black"]` would otherwise format with the same server
-/// twice; it also avoids fanning out twice to one server in the preferred path.
-fn effective_priorities(ctx: &DocumentRequestContext) -> Vec<String> {
-    effective_priorities_from(&ctx.priorities, &ctx.configs)
+/// Expand `ctx.priorities` into the priority walk for this request:
+/// allowlist + `"*"` expansion against the configured servers, then the
+/// `max_fan_out` cap.
+fn expanded_entries(ctx: &DocumentRequestContext) -> Vec<PriorityEntry> {
+    truncate_entries(
+        expand_priorities(&ctx.priorities, &ctx.configs),
+        ctx.max_fan_out,
+    )
 }
 
-/// Slice-based core of [`effective_priorities`]: keep only `priorities` names
-/// present in `configs`, dropping duplicates (first occurrence wins, order
-/// preserved).
+/// Filter `priorities` to names present in `configs`, dropping duplicates
+/// (first occurrence wins, order preserved).
 ///
-/// Split out from the [`DocumentRequestContext`] wrapper so callers that only
-/// have the two relevant fields — notably the formatting gating decision
-/// ([`crate::lsp::lsp_impl::text_document::formatting`]) and its unit tests —
+/// Used by the concatenated formatting pipeline, where `priorities` is the
+/// membership allowlist plus application order and the `"*"` wildcard is not
+/// permitted (no deterministic expansion order — see
+/// aggregation-priorities-wildcard). Callers strip `"*"` before this filter.
+///
+/// Kept slice-based so the formatting gating decision
+/// ([`crate::lsp::lsp_impl::text_document::formatting`]) and its unit tests
 /// can reuse the exact allowlist rule without building a full context.
 pub(crate) fn effective_priorities_from(
     priorities: &[String],
@@ -55,11 +60,9 @@ pub(crate) fn effective_priorities_from(
 
 /// Server-level aggregation entry point using the preferred strategy.
 ///
-/// Fans out one task per matching server and returns the highest-priority
-/// non-empty result. When `ctx.priorities` is empty, degrades to first-win.
-///
-/// Pre-filters `ctx.priorities` against `ctx.configs` to ensure only
-/// configured server names are passed to the preferred algorithm.
+/// Fans out one task per selected server and returns the highest-priority
+/// non-empty result. A `"*"` group decides first-win among its members.
+/// `priorities = []` selects nothing and yields `NoResult`.
 pub(crate) async fn dispatch_preferred<T, F, Fut>(
     ctx: &DocumentRequestContext,
     pool: Arc<LanguageServerPool>,
@@ -72,21 +75,18 @@ where
     F: Fn(FanOutTask) -> Fut,
     Fut: Future<Output = io::Result<T>> + Send + 'static,
 {
-    let priorities = effective_priorities(ctx);
-    let mut join_set = fan_out(ctx, pool, f);
-    preferred::preferred(&mut join_set, is_nonempty, &priorities, cancel_rx).await
+    let entries = expanded_entries(ctx);
+    let mut join_set = fan_out(ctx, pool, f, &entries);
+    preferred::preferred(&mut join_set, is_nonempty, &entries, cancel_rx).await
 }
 
 /// Server-level aggregation entry point using the concatenated strategy.
 ///
-/// Fans out one task per matching server and collects every successful result.
-/// When `ctx.priorities` is non-empty, results are ordered by priority, with
-/// unlisted servers appended in insertion order.
+/// Fans out one task per selected server and collects every successful
+/// result, ordered by the expanded priority walk (named servers first in
+/// list order, then the `"*"` group in config order).
 /// Returns `Done(vec)` when at least one succeeds, `NoResult` when all fail,
 /// or `Cancelled` on cancel notification.
-///
-/// Pre-filters `ctx.priorities` against `ctx.configs` to ensure only
-/// configured server names are passed to the concatenated algorithm.
 pub(crate) async fn dispatch_concatenated<T, F, Fut>(
     ctx: &DocumentRequestContext,
     pool: Arc<LanguageServerPool>,
@@ -99,7 +99,8 @@ where
     F: Fn(FanOutTask) -> Fut,
     Fut: Future<Output = io::Result<T>> + Send + 'static,
 {
-    let priorities = effective_priorities(ctx);
-    let mut join_set = fan_out(ctx, pool, f);
-    concatenated::concatenated(&mut join_set, &priorities, cancel_rx, log_target).await
+    let entries = expanded_entries(ctx);
+    let ordering = entry_names(&entries);
+    let mut join_set = fan_out(ctx, pool, f, &entries);
+    concatenated::concatenated(&mut join_set, &ordering, cancel_rx, log_target).await
 }

--- a/src/lsp/aggregation/server/fan_in/concatenated.rs
+++ b/src/lsp/aggregation/server/fan_in/concatenated.rs
@@ -1,8 +1,10 @@
 //! Concatenated-strategy fan-in for concurrent bridge requests.
 //!
 //! [`concatenated()`] collects all successful results from a `JoinSet<TaggedResult<T>>`,
-//! returning `FanInResult<Vec<T>>`. When `priorities` is non-empty, results are
-//! ordered by priority, with unlisted servers appended in insertion order.
+//! returning `FanInResult<Vec<T>>`. Results are ordered by the caller's
+//! `priorities` list — dispatch passes the flattened priority expansion, which
+//! covers every spawned server (aggregation-priorities-wildcard), so the
+//! unlisted-server fallback below is defensive only.
 
 use indexmap::IndexMap;
 use tokio::task::JoinSet;
@@ -14,8 +16,9 @@ use crate::lsp::request_id::CancelReceiver;
 /// Reorder tagged results according to the priority list.
 ///
 /// Walks `priorities` in order, draining matching entries from the map.
-/// Remaining (unlisted) entries are appended in insertion order — consistent
-/// with the `IndexMap` convention used in `preferred.rs`.
+/// Remaining (unlisted) entries are appended in insertion order — unreachable
+/// via dispatch (the expansion names every spawned server) but kept so a
+/// stray result is surfaced rather than dropped.
 fn order_by_priority<T>(tagged: Vec<(String, T)>, priorities: &[String]) -> Vec<T> {
     if priorities.is_empty() {
         return tagged.into_iter().map(|(_, v)| v).collect();

--- a/src/lsp/aggregation/server/fan_in/preferred.rs
+++ b/src/lsp/aggregation/server/fan_in/preferred.rs
@@ -298,6 +298,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn preferred_pending_rest_group_blocks_buffered_demoted_server() {
+        use std::sync::Arc;
+        use tokio::sync::Barrier;
+
+        // ["*", "zzz"]: zzz's win is already buffered, but a group member is
+        // still in flight — the walk must WAIT for the group, not hand the
+        // position to the demoted server.
+        let barrier = Arc::new(Barrier::new(2));
+        let barrier_clone = barrier.clone();
+
+        let mut join_set: JoinSet<TaggedResult<Option<i32>>> = JoinSet::new();
+        spawn_tagged_named(&mut join_set, "zzz", Ok(Some(99)));
+        join_set.spawn(async move {
+            barrier_clone.wait().await;
+            TaggedResult {
+                server_name: "server_a".to_string(),
+                value: Ok(Some(1)),
+            }
+        });
+
+        let barrier_release = barrier.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            barrier_release.wait().await;
+        });
+
+        let entries = vec![rest(&["server_a"]), PriorityEntry::Server("zzz".into())];
+        let result = preferred(&mut join_set, |opt| opt.is_some(), &entries, None).await;
+
+        assert_eq!(
+            assert_done(result),
+            Some(1),
+            "the pending group member must win over the already-buffered demoted server"
+        );
+    }
+
+    #[tokio::test]
     async fn preferred_demoted_server_wins_when_rest_group_is_empty_results() {
         let mut join_set: JoinSet<TaggedResult<Option<i32>>> = JoinSet::new();
         spawn_tagged_named(&mut join_set, "zzz", Ok(Some(99)));

--- a/src/lsp/aggregation/server/fan_in/preferred.rs
+++ b/src/lsp/aggregation/server/fan_in/preferred.rs
@@ -1,8 +1,10 @@
 //! Preferred fan-in strategy for concurrent bridge requests.
 //!
-//! [`preferred()`] implements priority-aware collection: results from higher-priority
-//! servers are preferred over lower-priority ones, with fallback to first-win for
-//! unprioritized servers. When `priorities` is empty, degrades to pure first-win.
+//! [`preferred()`] implements priority-aware collection over the expanded
+//! [`PriorityEntry`] walk (aggregation-priorities-wildcard): named entries
+//! are strict priority positions, and a [`PriorityEntry::Rest`] group (the
+//! `"*"` element) is first-win — the earliest non-empty arrival among its
+//! members wins the position.
 
 use std::collections::HashSet;
 
@@ -12,36 +14,59 @@ use tokio::task::JoinSet;
 
 use super::FanInResult;
 use crate::lsp::aggregation::server::fan_out::TaggedResult;
+use crate::lsp::aggregation::server::priority::PriorityEntry;
 use crate::lsp::request_id::CancelReceiver;
 
-/// Pick the best result from buffered wins, respecting priority order.
+/// Take the earliest-arrived buffered win belonging to `names`, if any.
 ///
-/// Walks the priority list first; if no priority server has a buffered result,
-/// falls back to any unprioritized server.
+/// `buffered_wins` is insertion-ordered (`IndexMap`), so the first matching
+/// key is the earliest arrival — the "first win" of the group.
+fn take_first_group_win<T>(buffered_wins: &mut IndexMap<String, T>, names: &[String]) -> Option<T> {
+    let key = buffered_wins
+        .keys()
+        .find(|key| names.iter().any(|name| name == *key))
+        .cloned()?;
+    buffered_wins.shift_remove(&key)
+}
+
+/// Pick the best result from buffered wins after the JoinSet drained,
+/// walking the entries in priority order.
+///
+/// The trailing index-0 fallback covers a buffered win from a server outside
+/// every entry — unreachable via dispatch (fan-out spawns only entry
+/// members), kept as defense in depth.
 fn pick_best_buffered<T>(
     buffered_wins: &mut IndexMap<String, T>,
-    priorities: &[String],
+    entries: &[PriorityEntry],
 ) -> Option<T> {
-    for name in priorities {
-        if let Some(value) = buffered_wins.shift_remove(name.as_str()) {
-            return Some(value);
+    for entry in entries {
+        let win = match entry {
+            PriorityEntry::Server(name) => buffered_wins.shift_remove(name.as_str()),
+            PriorityEntry::Rest(names) => take_first_group_win(buffered_wins, names),
+        };
+        if win.is_some() {
+            return win;
         }
     }
     buffered_wins.shift_remove_index(0).map(|(_, v)| v)
 }
 
 /// Priority-aware fan-in: buffer results by server name, and on each arrival
-/// walk `priorities` highest-first — return the first non-empty buffered
+/// walk the entries highest-first — return the first non-empty buffered
 /// result, skipping servers that failed/returned empty, and waiting on
-/// servers that haven't responded yet. When all prioritized servers are
-/// exhausted, fall back to first-win among unprioritized servers.
+/// servers that haven't responded yet. A [`PriorityEntry::Rest`] group is
+/// decided first-win: any buffered member wins the position immediately,
+/// without waiting for the other members.
+///
+/// Empty `entries` (the `priorities = []` kill switch) pairs with an empty
+/// JoinSet from fan-out and yields `NoResult { errors: 0 }`.
 ///
 /// `JoinError` can't be attributed to a server, so a panicked prioritized
 /// server stays "pending" until the JoinSet drains, then is treated as failed.
 pub(crate) async fn preferred<T: Send + 'static>(
     join_set: &mut JoinSet<TaggedResult<T>>,
     is_nonempty: impl Fn(&T) -> bool,
-    priorities: &[String],
+    entries: &[PriorityEntry],
     cancel_rx: Option<CancelReceiver>,
 ) -> FanInResult<T> {
     let mut buffered_wins: IndexMap<String, T> = IndexMap::new();
@@ -51,19 +76,36 @@ pub(crate) async fn preferred<T: Send + 'static>(
     // Helper closure to check if we can make a decision
     let try_decide =
         |buffered_wins: &mut IndexMap<String, T>, failed_servers: &HashSet<String>| -> Option<T> {
-            // Walk priority list in order
-            for name in priorities {
-                if let Some(value) = buffered_wins.shift_remove(name.as_str()) {
-                    return Some(value);
+            for entry in entries {
+                match entry {
+                    PriorityEntry::Server(name) => {
+                        if let Some(value) = buffered_wins.shift_remove(name.as_str()) {
+                            return Some(value);
+                        }
+                        if failed_servers.contains(name.as_str()) {
+                            continue; // This priority server failed, try next
+                        }
+                        // This priority server hasn't responded yet — can't decide
+                        return None;
+                    }
+                    PriorityEntry::Rest(names) => {
+                        // First-win group: any buffered member wins now.
+                        if let Some(value) = take_first_group_win(buffered_wins, names) {
+                            return Some(value);
+                        }
+                        if names
+                            .iter()
+                            .all(|name| failed_servers.contains(name.as_str()))
+                        {
+                            continue; // Whole group failed, try next entry
+                        }
+                        // A group member is still pending — can't decide
+                        return None;
+                    }
                 }
-                if failed_servers.contains(name.as_str()) {
-                    continue; // This priority server failed, try next
-                }
-                // This priority server hasn't responded yet — can't decide
-                return None;
             }
-            // All priority servers exhausted (failed or absent) — check unprioritized buffer
-            // Return first buffered win from any unprioritized server
+            // All entries exhausted (failed or absent). Defensive fallback for
+            // a buffered win outside every entry (unreachable via dispatch).
             let first_key = buffered_wins.keys().next().cloned();
             first_key.and_then(|k| buffered_wins.shift_remove(&k))
         };
@@ -105,8 +147,8 @@ pub(crate) async fn preferred<T: Send + 'static>(
             result = join_set.join_next() => {
                 match result {
                     None => {
-                        // JoinSet drained — walk priorities for best buffered result.
-                        if let Some(value) = pick_best_buffered(&mut buffered_wins, priorities) {
+                        // JoinSet drained — walk entries for best buffered result.
+                        if let Some(value) = pick_best_buffered(&mut buffered_wins, entries) {
                             return FanInResult::Done(value);
                         }
                         return FanInResult::NoResult { errors };
@@ -135,13 +177,25 @@ mod tests {
     use super::*;
     use crate::lsp::aggregation::server::fan_in::test_helpers::*;
 
+    fn servers(names: &[&str]) -> Vec<PriorityEntry> {
+        names
+            .iter()
+            .map(|n| PriorityEntry::Server(n.to_string()))
+            .collect()
+    }
+
+    fn rest(names: &[&str]) -> PriorityEntry {
+        PriorityEntry::Rest(names.iter().map(|n| n.to_string()).collect())
+    }
+
     #[tokio::test]
-    async fn preferred_skips_empty_results_with_no_priorities() {
+    async fn preferred_skips_empty_results_in_rest_group() {
         let mut join_set: JoinSet<TaggedResult<Option<i32>>> = JoinSet::new();
         spawn_tagged_named(&mut join_set, "server_a", Ok(None));
         spawn_tagged_named(&mut join_set, "server_b", Ok(Some(42)));
 
-        let result = preferred(&mut join_set, |opt| opt.is_some(), &[], None).await;
+        let entries = vec![rest(&["server_a", "server_b"])];
+        let result = preferred(&mut join_set, |opt| opt.is_some(), &entries, None).await;
 
         assert_eq!(assert_done(result), Some(42));
     }
@@ -154,8 +208,8 @@ mod tests {
         spawn_tagged_named(&mut join_set, "server_a", Ok(Some(1)));
         spawn_tagged_named(&mut join_set, "server_b", Ok(Some(2)));
 
-        let priorities = vec!["server_a".to_string(), "server_b".to_string()];
-        let result = preferred(&mut join_set, |opt| opt.is_some(), &priorities, None).await;
+        let entries = servers(&["server_a", "server_b"]);
+        let result = preferred(&mut join_set, |opt| opt.is_some(), &entries, None).await;
 
         assert_eq!(assert_done(result), Some(1));
     }
@@ -189,7 +243,7 @@ mod tests {
             }
         });
 
-        let priorities = vec!["server_a".to_string(), "server_b".to_string()];
+        let entries = servers(&["server_a", "server_b"]);
 
         // Release server_a after a brief moment
         let barrier_release = barrier.clone();
@@ -198,10 +252,61 @@ mod tests {
             barrier_release.wait().await;
         });
 
-        let result = preferred(&mut join_set, |opt| opt.is_some(), &priorities, None).await;
+        let result = preferred(&mut join_set, |opt| opt.is_some(), &entries, None).await;
 
         // server_a should win even though server_b arrived first
         assert_eq!(assert_done(result), Some(1));
+    }
+
+    #[tokio::test]
+    async fn preferred_rest_group_is_first_win_without_waiting_for_members() {
+        // Both members are in one '*' group: the earliest non-empty arrival
+        // wins immediately, even while the other member is still pending.
+        let mut join_set: JoinSet<TaggedResult<Option<i32>>> = JoinSet::new();
+        spawn_tagged_named(&mut join_set, "server_fast", Ok(Some(1)));
+        join_set.spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+            TaggedResult {
+                server_name: "server_slow".to_string(),
+                value: Ok(Some(2)),
+            }
+        });
+
+        let entries = vec![rest(&["server_fast", "server_slow"])];
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            preferred(&mut join_set, |opt| opt.is_some(), &entries, None),
+        )
+        .await
+        .expect("group first-win must not wait for the slow member");
+
+        assert_eq!(assert_done(result), Some(1));
+    }
+
+    #[tokio::test]
+    async fn preferred_server_listed_after_rest_is_demoted_below_the_group() {
+        // ["*", "zzz"]: the rest group outranks zzz — zzz only wins when the
+        // whole group comes up empty.
+        let mut join_set: JoinSet<TaggedResult<Option<i32>>> = JoinSet::new();
+        spawn_tagged_named(&mut join_set, "zzz", Ok(Some(99)));
+        spawn_tagged_named(&mut join_set, "server_a", Ok(Some(1)));
+
+        let entries = vec![rest(&["server_a"]), PriorityEntry::Server("zzz".into())];
+        let result = preferred(&mut join_set, |opt| opt.is_some(), &entries, None).await;
+
+        assert_eq!(assert_done(result), Some(1));
+    }
+
+    #[tokio::test]
+    async fn preferred_demoted_server_wins_when_rest_group_is_empty_results() {
+        let mut join_set: JoinSet<TaggedResult<Option<i32>>> = JoinSet::new();
+        spawn_tagged_named(&mut join_set, "zzz", Ok(Some(99)));
+        spawn_tagged_named(&mut join_set, "server_a", Ok(None));
+
+        let entries = vec![rest(&["server_a"]), PriorityEntry::Server("zzz".into())];
+        let result = preferred(&mut join_set, |opt| opt.is_some(), &entries, None).await;
+
+        assert_eq!(assert_done(result), Some(99));
     }
 
     #[tokio::test]
@@ -211,22 +316,23 @@ mod tests {
         spawn_tagged_named(&mut join_set, "server_a", Err(io::Error::other("fail")));
         spawn_tagged_named(&mut join_set, "server_b", Ok(Some(42)));
 
-        let priorities = vec!["server_a".to_string(), "server_b".to_string()];
-        let result = preferred(&mut join_set, |opt| opt.is_some(), &priorities, None).await;
+        let entries = servers(&["server_a", "server_b"]);
+        let result = preferred(&mut join_set, |opt| opt.is_some(), &entries, None).await;
 
         assert_eq!(assert_done(result), Some(42));
     }
 
     #[tokio::test]
-    async fn preferred_falls_back_to_first_win_when_all_priority_servers_fail() {
-        // Both priority servers fail, unprioritized server_c succeeds
+    async fn preferred_falls_back_to_rest_group_when_all_priority_servers_fail() {
+        // Both named servers fail, the trailing '*' group's server_c succeeds
         let mut join_set: JoinSet<TaggedResult<Option<i32>>> = JoinSet::new();
         spawn_tagged_named(&mut join_set, "server_a", Err(io::Error::other("fail a")));
         spawn_tagged_named(&mut join_set, "server_b", Err(io::Error::other("fail b")));
         spawn_tagged_named(&mut join_set, "server_c", Ok(Some(99)));
 
-        let priorities = vec!["server_a".to_string(), "server_b".to_string()];
-        let result = preferred(&mut join_set, |opt| opt.is_some(), &priorities, None).await;
+        let mut entries = servers(&["server_a", "server_b"]);
+        entries.push(rest(&["server_c"]));
+        let result = preferred(&mut join_set, |opt| opt.is_some(), &entries, None).await;
 
         assert_eq!(assert_done(result), Some(99));
     }
@@ -243,9 +349,10 @@ mod tests {
             }
         });
 
+        let entries = vec![rest(&["slow"])];
         tx.send(()).unwrap();
 
-        let result = preferred(&mut join_set, |opt| opt.is_some(), &[], Some(rx)).await;
+        let result = preferred(&mut join_set, |opt| opt.is_some(), &entries, Some(rx)).await;
 
         assert_cancelled(result);
     }
@@ -273,8 +380,8 @@ mod tests {
 
         tx.send(()).unwrap();
 
-        let priorities = vec!["server_a".to_string(), "server_b".to_string()];
-        let result = preferred(&mut join_set, |opt| opt.is_some(), &priorities, Some(rx)).await;
+        let entries = servers(&["server_a", "server_b"]);
+        let result = preferred(&mut join_set, |opt| opt.is_some(), &entries, Some(rx)).await;
 
         assert_cancelled(result);
     }
@@ -285,34 +392,48 @@ mod tests {
         spawn_tagged_named(&mut join_set, "server_a", Err(io::Error::other("fail a")));
         spawn_tagged_named(&mut join_set, "server_b", Err(io::Error::other("fail b")));
 
-        let priorities = vec!["server_a".to_string()];
-        let result = preferred(&mut join_set, |opt| opt.is_some(), &priorities, None).await;
+        let entries = vec![
+            PriorityEntry::Server("server_a".into()),
+            rest(&["server_b"]),
+        ];
+        let result = preferred(&mut join_set, |opt| opt.is_some(), &entries, None).await;
 
         assert_eq!(assert_no_result(result), 2);
+    }
+
+    #[tokio::test]
+    async fn preferred_returns_no_result_for_empty_entries_and_join_set() {
+        // priorities = [] (the kill switch): fan-out spawns nothing, fan-in
+        // reports NoResult with zero errors.
+        let mut join_set: JoinSet<TaggedResult<Option<i32>>> = JoinSet::new();
+        let result = preferred(&mut join_set, |opt| opt.is_some(), &[], None).await;
+        assert_eq!(assert_no_result(result), 0);
     }
 
     #[tokio::test]
     async fn preferred_falls_back_when_priority_server_panics() {
         // A priority server panics (JoinError) — can't be attributed to a name.
         // The algorithm keeps it as "pending" until the JoinSet drains, then
-        // falls back to the unprioritized server_b's buffered result.
+        // falls back to the rest group's buffered result.
         let mut join_set: JoinSet<TaggedResult<Option<i32>>> = JoinSet::new();
         join_set.spawn(async {
             panic!("simulated panic in priority server");
         });
         spawn_tagged_named(&mut join_set, "server_b", Ok(Some(42)));
 
-        let priorities = vec!["server_a".to_string()];
-        let result = preferred(&mut join_set, |opt| opt.is_some(), &priorities, None).await;
+        let entries = vec![
+            PriorityEntry::Server("server_a".into()),
+            rest(&["server_b"]),
+        ];
+        let result = preferred(&mut join_set, |opt| opt.is_some(), &entries, None).await;
 
         assert_eq!(assert_done(result), Some(42));
     }
 
     #[tokio::test]
     async fn preferred_respects_priority_in_buffered_wins_after_panic_drain() {
-        // server_a (priority 1) panics, server_b (priority 2) and server_c (unprioritized) succeed.
-        // After drain, server_b should win over server_c because it's higher in the priority list.
-        // Without the fix, HashMap iteration order could return server_c instead.
+        // server_a (priority 1) panics, server_b (priority 2) and server_c (rest) succeed.
+        // After drain, server_b should win over server_c because it's higher in the walk.
         let mut join_set: JoinSet<TaggedResult<Option<i32>>> = JoinSet::new();
         join_set.spawn(async {
             panic!("simulated panic in priority server");
@@ -320,22 +441,26 @@ mod tests {
         spawn_tagged_named(&mut join_set, "server_b", Ok(Some(2)));
         spawn_tagged_named(&mut join_set, "server_c", Ok(Some(3)));
 
-        let priorities = vec!["server_a".to_string(), "server_b".to_string()];
-        let result = preferred(&mut join_set, |opt| opt.is_some(), &priorities, None).await;
+        let mut entries = servers(&["server_a", "server_b"]);
+        entries.push(rest(&["server_c"]));
+        let result = preferred(&mut join_set, |opt| opt.is_some(), &entries, None).await;
 
-        // server_b must win — it's in the priority list and server_a (higher priority) panicked
+        // server_b must win — it's named and server_a (higher priority) panicked
         assert_eq!(assert_done(result), Some(2));
     }
 
     #[tokio::test]
-    async fn preferred_treats_unlisted_servers_as_lowest_priority() {
-        // server_a is prioritized and fails; server_b is not listed (lowest priority) and succeeds
+    async fn preferred_treats_rest_group_as_lowest_priority() {
+        // server_a is named and fails; server_b sits in the trailing '*' group
         let mut join_set: JoinSet<TaggedResult<Option<i32>>> = JoinSet::new();
         spawn_tagged_named(&mut join_set, "server_a", Err(io::Error::other("fail")));
         spawn_tagged_named(&mut join_set, "server_b", Ok(Some(77)));
 
-        let priorities = vec!["server_a".to_string()];
-        let result = preferred(&mut join_set, |opt| opt.is_some(), &priorities, None).await;
+        let entries = vec![
+            PriorityEntry::Server("server_a".into()),
+            rest(&["server_b"]),
+        ];
+        let result = preferred(&mut join_set, |opt| opt.is_some(), &entries, None).await;
 
         assert_eq!(assert_done(result), Some(77));
     }

--- a/src/lsp/aggregation/server/fan_in/preferred.rs
+++ b/src/lsp/aggregation/server/fan_in/preferred.rs
@@ -24,7 +24,7 @@ use crate::lsp::request_id::CancelReceiver;
 fn take_first_group_win<T>(buffered_wins: &mut IndexMap<String, T>, names: &[String]) -> Option<T> {
     let key = buffered_wins
         .keys()
-        .find(|key| names.iter().any(|name| name == *key))
+        .find(|key| names.contains(*key))
         .cloned()?;
     buffered_wins.shift_remove(&key)
 }

--- a/src/lsp/aggregation/server/fan_out.rs
+++ b/src/lsp/aggregation/server/fan_out.rs
@@ -16,6 +16,8 @@ use crate::lsp::bridge::ResolvedServerConfig;
 use crate::lsp::bridge::UpstreamId;
 use crate::lsp::lsp_impl::bridge_context::DocumentRequestContext;
 
+use super::priority::{PriorityEntry, entry_names};
+
 /// Per-server arguments produced by [`fan_out()`].
 ///
 /// Each spawned task receives its own clone of the shared context fields
@@ -43,62 +45,43 @@ pub(crate) struct TaggedResult<T> {
     pub(crate) value: io::Result<T>,
 }
 
-/// Select which servers to fan out to, respecting priority ordering and max fan-out limit.
+/// Select which servers to fan out to: the expanded priority entries are the
+/// membership allowlist and spawn order (aggregation-priorities-wildcard).
 ///
-/// When `max_fan_out` is `None`, all configs are returned (priority servers first, then remaining in original order).
-/// When `max_fan_out` is `Some(0)`, an empty list is returned (fan-out disabled).
-/// When `max_fan_out` is `Some(n)`, at most `n` configs are returned.
-///
-/// Priority servers appear first (in the order listed in `priorities`),
-/// followed by remaining servers in their original order.
+/// Expansion ([`super::priority::expand_priorities`]) already filtered to
+/// configured names, deduplicated, and applied `max_fan_out`
+/// ([`super::priority::truncate_entries`]); this is a pure name → config
+/// lookup in walk order.
 pub(crate) fn select_servers(
     configs: &[ResolvedServerConfig],
-    priorities: &[String],
-    max_fan_out: Option<usize>,
+    entries: &[PriorityEntry],
 ) -> Vec<ResolvedServerConfig> {
-    let mut result: Vec<ResolvedServerConfig> = Vec::with_capacity(configs.len());
-    let mut added: std::collections::HashSet<&str> =
-        std::collections::HashSet::with_capacity(configs.len());
-
     // Build a map for O(1) lookup of configs by server name
     let config_map: std::collections::HashMap<&str, &ResolvedServerConfig> = configs
         .iter()
         .map(|c| (c.server_name.as_str(), c))
         .collect();
 
-    // Add priority servers in priority order (skip unknown/duplicate names)
-    for name in priorities {
-        if let Some(cfg) = config_map.get(name.as_str())
-            && added.insert(&cfg.server_name)
-        {
-            result.push((*cfg).clone());
-        }
-    }
-
-    // Add remaining servers in their original order
-    for cfg in configs {
-        if !added.contains(cfg.server_name.as_str()) {
-            result.push(cfg.clone());
-        }
-    }
-
-    // Truncate to max_fan_out if specified
-    if let Some(limit) = max_fan_out {
-        result.truncate(limit);
-    }
-    result
+    entry_names(entries)
+        .iter()
+        .filter_map(|name| config_map.get(name.as_str()).map(|cfg| (*cfg).clone()))
+        .collect()
 }
 
-/// Spawn one task per matching server, returning a `JoinSet` for collection.
+/// Spawn one task per selected server, returning a `JoinSet` for collection.
 ///
-/// The caller supplies a closure that receives a [`FanOutTask`] and returns
-/// the handler-specific future. Each task result is wrapped in [`TaggedResult`]
-/// so fan-in strategies can identify which server produced it.
+/// `entries` is the expanded priority walk (see
+/// [`super::priority::expand_priorities`]) — its flattened names are both the
+/// membership allowlist and the spawn order. The caller supplies a closure
+/// that receives a [`FanOutTask`] and returns the handler-specific future.
+/// Each task result is wrapped in [`TaggedResult`] so fan-in strategies can
+/// identify which server produced it.
 #[must_use = "the JoinSet must be passed to a collection strategy"]
 pub(crate) fn fan_out<T, F, Fut>(
     ctx: &DocumentRequestContext,
     pool: Arc<LanguageServerPool>,
     f: F,
+    entries: &[PriorityEntry],
 ) -> JoinSet<TaggedResult<T>>
 where
     T: Send + 'static,
@@ -106,7 +89,7 @@ where
     Fut: Future<Output = io::Result<T>> + Send + 'static,
 {
     let mut join_set = JoinSet::new();
-    let selected = select_servers(&ctx.configs, &ctx.priorities, ctx.max_fan_out);
+    let selected = select_servers(&ctx.configs, entries);
     for config in &selected {
         let server_name = config.server_name.clone();
         let task = FanOutTask {
@@ -153,116 +136,50 @@ mod tests {
         configs.iter().map(|c| c.server_name.as_str()).collect()
     }
 
+    fn server(name: &str) -> PriorityEntry {
+        PriorityEntry::Server(name.to_string())
+    }
+
+    fn rest(group: &[&str]) -> PriorityEntry {
+        PriorityEntry::Rest(group.iter().map(|n| n.to_string()).collect())
+    }
+
     #[test]
-    fn select_servers_no_limit_returns_all() {
+    fn select_servers_follows_entry_walk_order() {
         let configs = vec![
             make_config("alpha"),
             make_config("beta"),
             make_config("gamma"),
         ];
-        let result = select_servers(&configs, &[], None);
-        assert_eq!(names(&result), &["alpha", "beta", "gamma"]);
-    }
-
-    #[test]
-    fn select_servers_zero_returns_empty() {
-        let configs = vec![make_config("alpha"), make_config("beta")];
-        let result = select_servers(&configs, &[], Some(0));
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn select_servers_truncates_to_n() {
-        let configs = vec![
-            make_config("alpha"),
-            make_config("beta"),
-            make_config("gamma"),
-        ];
-        let result = select_servers(&configs, &[], Some(2));
-        assert_eq!(names(&result), &["alpha", "beta"]);
-    }
-
-    #[test]
-    fn select_servers_priority_servers_first() {
-        let configs = vec![
-            make_config("alpha"),
-            make_config("beta"),
-            make_config("gamma"),
-        ];
-        let priorities = vec!["gamma".to_string(), "alpha".to_string()];
-        let result = select_servers(&configs, &priorities, None);
+        let entries = vec![server("gamma"), rest(&["alpha", "beta"])];
+        let result = select_servers(&configs, &entries);
         assert_eq!(names(&result), &["gamma", "alpha", "beta"]);
     }
 
     #[test]
-    fn select_servers_non_priority_order_preserved() {
-        let configs = vec![
-            make_config("alpha"),
-            make_config("beta"),
-            make_config("gamma"),
-            make_config("delta"),
-        ];
-        let priorities = vec!["gamma".to_string()];
-        let result = select_servers(&configs, &priorities, None);
-        // gamma first (priority), then remaining in original order
-        assert_eq!(names(&result), &["gamma", "alpha", "beta", "delta"]);
-    }
-
-    #[test]
-    fn select_servers_truncate_after_priority_reordering() {
-        let configs = vec![
-            make_config("alpha"),
-            make_config("beta"),
-            make_config("gamma"),
-        ];
-        let priorities = vec!["gamma".to_string()];
-        let result = select_servers(&configs, &priorities, Some(2));
-        assert_eq!(names(&result), &["gamma", "alpha"]);
-    }
-
-    #[test]
-    fn select_servers_limit_larger_than_configs_returns_all() {
+    fn select_servers_is_an_allowlist() {
+        // Entries without beta: beta must not be selected.
         let configs = vec![make_config("alpha"), make_config("beta")];
-        let result = select_servers(&configs, &[], Some(10));
-        assert_eq!(names(&result), &["alpha", "beta"]);
+        let entries = vec![server("alpha")];
+        let result = select_servers(&configs, &entries);
+        assert_eq!(names(&result), &["alpha"]);
     }
 
     #[test]
-    fn select_servers_unknown_priority_ignored() {
-        let configs = vec![make_config("alpha"), make_config("beta")];
-        let priorities = vec!["unknown".to_string(), "alpha".to_string()];
-        let result = select_servers(&configs, &priorities, None);
-        assert_eq!(names(&result), &["alpha", "beta"]);
-    }
-
-    #[test]
-    fn select_servers_empty_configs_returns_empty() {
-        let result = select_servers(&[], &["alpha".to_string()], Some(5));
+    fn select_servers_empty_entries_selects_nothing() {
+        // priorities = [] (kill switch) expands to no entries.
+        let configs = vec![make_config("alpha")];
+        let result = select_servers(&configs, &[]);
         assert!(result.is_empty());
     }
 
     #[test]
-    fn select_servers_duplicate_priority_added_only_once() {
-        let configs = vec![
-            make_config("alpha"),
-            make_config("beta"),
-            make_config("gamma"),
-        ];
-        let priorities = vec!["alpha".to_string(), "alpha".to_string(), "beta".to_string()];
-        let result = select_servers(&configs, &priorities, None);
-        // alpha should appear only once despite being in priorities twice
-        assert_eq!(names(&result), &["alpha", "beta", "gamma"]);
-    }
-
-    #[test]
-    fn select_servers_all_in_priorities_uses_priority_order() {
-        let configs = vec![
-            make_config("alpha"),
-            make_config("beta"),
-            make_config("gamma"),
-        ];
-        let priorities = vec!["gamma".to_string(), "beta".to_string(), "alpha".to_string()];
-        let result = select_servers(&configs, &priorities, None);
-        assert_eq!(names(&result), &["gamma", "beta", "alpha"]);
+    fn select_servers_skips_names_without_config() {
+        // Defensive: expansion guarantees configured names, but a stale name
+        // must not panic the lookup.
+        let configs = vec![make_config("alpha")];
+        let entries = vec![server("ghost"), server("alpha")];
+        let result = select_servers(&configs, &entries);
+        assert_eq!(names(&result), &["alpha"]);
     }
 }

--- a/src/lsp/aggregation/server/fan_out.rs
+++ b/src/lsp/aggregation/server/fan_out.rs
@@ -16,7 +16,7 @@ use crate::lsp::bridge::ResolvedServerConfig;
 use crate::lsp::bridge::UpstreamId;
 use crate::lsp::lsp_impl::bridge_context::DocumentRequestContext;
 
-use super::priority::{PriorityEntry, entry_names};
+use super::priority::PriorityEntry;
 
 /// Per-server arguments produced by [`fan_out()`].
 ///
@@ -62,8 +62,12 @@ pub(crate) fn select_servers(
         .map(|c| (c.server_name.as_str(), c))
         .collect();
 
-    entry_names(entries)
+    entries
         .iter()
+        .flat_map(|entry| match entry {
+            PriorityEntry::Server(name) => std::slice::from_ref(name),
+            PriorityEntry::Rest(names) => names.as_slice(),
+        })
         .filter_map(|name| config_map.get(name.as_str()).map(|cfg| (*cfg).clone()))
         .collect()
 }

--- a/src/lsp/aggregation/server/host_dispatch.rs
+++ b/src/lsp/aggregation/server/host_dispatch.rs
@@ -1,0 +1,82 @@
+//! Host-bridge aggregation dispatch (host-document-bridge).
+//!
+//! Mirrors [`super::dispatch`] for the host path: one task per selected
+//! host-capable server, the same priority expansion
+//! (aggregation-priorities-wildcard) feeding both fan-out and fan-in, and the
+//! `preferred` strategy. The host path has no injection region — tasks carry
+//! the real URI and the host text verbatim.
+
+use std::future::Future;
+use std::io;
+use std::sync::Arc;
+
+use tokio::task::JoinSet;
+
+use crate::config::settings::BridgeServerConfig;
+use crate::lsp::bridge::{LanguageServerPool, UpstreamId};
+use crate::lsp::lsp_impl::bridge_context::HostRequestContext;
+use crate::lsp::request_id::CancelReceiver;
+
+use super::fan_in::{FanInResult, preferred};
+use super::fan_out::TaggedResult;
+use super::priority::{expand_priorities, truncate_entries};
+
+/// Per-server arguments for a host bridge request.
+///
+/// The host counterpart of [`super::fan_out::FanOutTask`]: no injection
+/// region, no offsets — the real URI and host text travel verbatim.
+pub(crate) struct HostFanOutTask {
+    pub(crate) pool: Arc<LanguageServerPool>,
+    pub(crate) server_name: String,
+    pub(crate) server_config: Arc<BridgeServerConfig>,
+    pub(crate) uri: url::Url,
+    pub(crate) language_id: String,
+    pub(crate) text: Arc<str>,
+    pub(crate) upstream_id: Option<UpstreamId>,
+}
+
+/// Host-bridge aggregation entry point using the preferred strategy.
+///
+/// Fans out one task per selected host server (allowlist + `"*"` expansion
+/// against `ctx.configs`) and returns the highest-priority non-empty result.
+pub(crate) async fn dispatch_host_preferred<T, F, Fut>(
+    ctx: &HostRequestContext,
+    pool: Arc<LanguageServerPool>,
+    f: F,
+    is_nonempty: impl Fn(&T) -> bool,
+    cancel_rx: Option<CancelReceiver>,
+) -> FanInResult<T>
+where
+    T: Send + 'static,
+    F: Fn(HostFanOutTask) -> Fut,
+    Fut: Future<Output = io::Result<T>> + Send + 'static,
+{
+    let entries = truncate_entries(
+        expand_priorities(&ctx.priorities, &ctx.configs),
+        ctx.max_fan_out,
+    );
+    let selected = super::fan_out::select_servers(&ctx.configs, &entries);
+
+    let mut join_set = JoinSet::new();
+    for config in &selected {
+        let server_name = config.server_name.clone();
+        let task = HostFanOutTask {
+            pool: Arc::clone(&pool),
+            server_name: server_name.clone(),
+            server_config: Arc::clone(&config.config),
+            uri: ctx.uri.clone(),
+            language_id: ctx.language_id.clone(),
+            text: Arc::clone(&ctx.text),
+            upstream_id: ctx.upstream_request_id.clone(),
+        };
+        let fut = f(task);
+        join_set.spawn(async move {
+            TaggedResult {
+                server_name,
+                value: fut.await,
+            }
+        });
+    }
+
+    preferred::preferred(&mut join_set, is_nonempty, &entries, cancel_rx).await
+}

--- a/src/lsp/aggregation/server/priority.rs
+++ b/src/lsp/aggregation/server/priority.rs
@@ -76,8 +76,8 @@ pub(crate) fn expand_priorities(
     if let Some(index) = rest_index {
         let rest: Vec<String> = configs
             .iter()
+            .filter(|c| !seen.contains(c.server_name.as_str()))
             .map(|c| c.server_name.clone())
-            .filter(|name| !seen.contains(name.as_str()))
             .collect();
         if rest.is_empty() {
             entries.remove(index);

--- a/src/lsp/aggregation/server/priority.rs
+++ b/src/lsp/aggregation/server/priority.rs
@@ -92,8 +92,8 @@ pub(crate) fn expand_priorities(
 /// Cap the total number of servers across all entries to `max_fan_out`.
 ///
 /// Counts flattened names in walk order; a cap landing inside a
-/// [`PriorityEntry::Rest`] truncates the group, and entries past the cap are
-/// dropped (empty groups included).
+/// [`PriorityEntry::Rest`] truncates the group (a group truncated to empty
+/// is dropped), and entries past the cap are dropped.
 pub(crate) fn truncate_entries(
     entries: Vec<PriorityEntry>,
     max_fan_out: Option<usize>,

--- a/src/lsp/aggregation/server/priority.rs
+++ b/src/lsp/aggregation/server/priority.rs
@@ -48,7 +48,10 @@ pub(crate) fn expand_priorities(
     for name in priorities {
         if name == PRIORITIES_WILDCARD {
             if rest_index.is_some() {
-                log::warn!(
+                // debug, not warn: expansion runs on every dispatch
+                // (completion fires per keystroke), so a persistent config
+                // condition would flood the log.
+                log::debug!(
                     "aggregation priorities contain more than one '{}'; only the first is honored",
                     PRIORITIES_WILDCARD
                 );
@@ -57,9 +60,13 @@ pub(crate) fn expand_priorities(
             rest_index = Some(entries.len());
             entries.push(PriorityEntry::Rest(Vec::new()));
         } else if !configured.contains(name.as_str()) {
-            log::warn!(
-                "aggregation priorities name '{name}' matches no configured server; ignored \
-                 (priorities is an allowlist — check for a typo)"
+            // debug, not warn: an unmatched name here is routine, not only a
+            // typo — priorities inherited from a `bridge._` wildcard entry
+            // legitimately name servers that exist for other injection
+            // languages of the same host.
+            log::debug!(
+                "aggregation priorities name '{name}' matches no configured server for this \
+                 target; ignored (priorities is an allowlist)"
             );
         } else if seen.insert(name.as_str()) {
             entries.push(PriorityEntry::Server(name.clone()));

--- a/src/lsp/aggregation/server/priority.rs
+++ b/src/lsp/aggregation/server/priority.rs
@@ -1,0 +1,325 @@
+//! Priority-list expansion for server aggregation
+//! (aggregation-priorities-wildcard).
+//!
+//! A `priorities` list is an **ordered allowlist** over the configured
+//! servers: servers absent from the list do not run. The `"*"` element
+//! stands for every configured server not named elsewhere in the list, as a
+//! single first-win group at that position. [`expand_priorities`] turns the
+//! raw config list into [`PriorityEntry`] values that both fan-out
+//! (membership + spawn order) and fan-in (decision order) consume, so the
+//! two sides can never disagree about which servers participate.
+
+use std::collections::HashSet;
+
+use crate::config::settings::PRIORITIES_WILDCARD;
+use crate::lsp::bridge::ResolvedServerConfig;
+
+/// One step in the resolved priority walk.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PriorityEntry {
+    /// A single named server at a strict priority position.
+    Server(String),
+    /// The `"*"` group: configured-but-unlisted servers. First-win amongst
+    /// themselves — the inner order is the spawn order (config order), not a
+    /// ranking.
+    Rest(Vec<String>),
+}
+
+/// Expand a raw `priorities` list against the configured servers.
+///
+/// - Named servers keep their position (configured-only, deduplicated;
+///   unknown names are logged and dropped — under allowlist semantics a typo
+///   would otherwise silently exclude the intended server).
+/// - The first `"*"` becomes a [`PriorityEntry::Rest`] of the configured
+///   servers not named anywhere in the list (config order). A second `"*"`
+///   is logged and ignored. An empty rest group is dropped.
+/// - An empty `priorities` expands to no entries: fan-out is disabled for
+///   this target (`[]` is the per-method kill switch).
+pub(crate) fn expand_priorities(
+    priorities: &[String],
+    configs: &[ResolvedServerConfig],
+) -> Vec<PriorityEntry> {
+    let configured: HashSet<&str> = configs.iter().map(|c| c.server_name.as_str()).collect();
+
+    let mut entries: Vec<PriorityEntry> = Vec::with_capacity(priorities.len());
+    let mut seen: HashSet<&str> = HashSet::new();
+    let mut rest_index: Option<usize> = None;
+
+    for name in priorities {
+        if name == PRIORITIES_WILDCARD {
+            if rest_index.is_some() {
+                log::warn!(
+                    "aggregation priorities contain more than one '{}'; only the first is honored",
+                    PRIORITIES_WILDCARD
+                );
+                continue;
+            }
+            rest_index = Some(entries.len());
+            entries.push(PriorityEntry::Rest(Vec::new()));
+        } else if !configured.contains(name.as_str()) {
+            log::warn!(
+                "aggregation priorities name '{name}' matches no configured server; ignored \
+                 (priorities is an allowlist — check for a typo)"
+            );
+        } else if seen.insert(name.as_str()) {
+            entries.push(PriorityEntry::Server(name.clone()));
+        }
+    }
+
+    if let Some(index) = rest_index {
+        let rest: Vec<String> = configs
+            .iter()
+            .map(|c| c.server_name.clone())
+            .filter(|name| !seen.contains(name.as_str()))
+            .collect();
+        if rest.is_empty() {
+            entries.remove(index);
+        } else {
+            entries[index] = PriorityEntry::Rest(rest);
+        }
+    }
+
+    entries
+}
+
+/// Cap the total number of servers across all entries to `max_fan_out`.
+///
+/// Counts flattened names in walk order; a cap landing inside a
+/// [`PriorityEntry::Rest`] truncates the group, and entries past the cap are
+/// dropped (empty groups included).
+pub(crate) fn truncate_entries(
+    entries: Vec<PriorityEntry>,
+    max_fan_out: Option<usize>,
+) -> Vec<PriorityEntry> {
+    let Some(limit) = max_fan_out else {
+        return entries;
+    };
+    let mut remaining = limit;
+    let mut result = Vec::with_capacity(entries.len());
+    for entry in entries {
+        if remaining == 0 {
+            break;
+        }
+        match entry {
+            PriorityEntry::Server(name) => {
+                remaining -= 1;
+                result.push(PriorityEntry::Server(name));
+            }
+            PriorityEntry::Rest(mut names) => {
+                names.truncate(remaining);
+                remaining -= names.len();
+                if !names.is_empty() {
+                    result.push(PriorityEntry::Rest(names));
+                }
+            }
+        }
+    }
+    result
+}
+
+/// Flatten entries to server names in walk order.
+///
+/// This is the fan-out membership and spawn order, and the result ordering
+/// for the concatenated strategy.
+pub(crate) fn entry_names(entries: &[PriorityEntry]) -> Vec<String> {
+    entries
+        .iter()
+        .flat_map(|entry| match entry {
+            PriorityEntry::Server(name) => std::slice::from_ref(name),
+            PriorityEntry::Rest(names) => names.as_slice(),
+        })
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::config::settings::BridgeServerConfig;
+
+    fn make_config(name: &str) -> ResolvedServerConfig {
+        ResolvedServerConfig {
+            server_name: name.to_string(),
+            config: Arc::new(BridgeServerConfig {
+                cmd: vec![name.to_string()],
+                languages: vec![],
+                initialization_options: None,
+            }),
+        }
+    }
+
+    fn configs(names: &[&str]) -> Vec<ResolvedServerConfig> {
+        names.iter().map(|n| make_config(n)).collect()
+    }
+
+    fn prios(names: &[&str]) -> Vec<String> {
+        names.iter().map(|n| n.to_string()).collect()
+    }
+
+    #[test]
+    fn expand_wildcard_only_is_one_rest_group_of_all_servers() {
+        let entries = expand_priorities(&prios(&["*"]), &configs(&["alpha", "beta", "gamma"]));
+        assert_eq!(
+            entries,
+            vec![PriorityEntry::Rest(prios(&["alpha", "beta", "gamma"]))]
+        );
+    }
+
+    #[test]
+    fn expand_named_only_is_strict_allowlist() {
+        // No '*': unlisted servers (beta) are excluded entirely.
+        let entries = expand_priorities(
+            &prios(&["gamma", "alpha"]),
+            &configs(&["alpha", "beta", "gamma"]),
+        );
+        assert_eq!(
+            entries,
+            vec![
+                PriorityEntry::Server("gamma".into()),
+                PriorityEntry::Server("alpha".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn expand_empty_priorities_disables_fan_out() {
+        let entries = expand_priorities(&[], &configs(&["alpha", "beta"]));
+        assert!(entries.is_empty(), "[] is the per-method kill switch");
+    }
+
+    #[test]
+    fn expand_wildcard_position_demotes_later_names_below_rest() {
+        // ["foo", "*", "zzz"]: zzz ranks BELOW the unlisted rest — the
+        // expressiveness a boolean exclusive-flag cannot provide (ADR).
+        let entries = expand_priorities(
+            &prios(&["foo", "*", "zzz"]),
+            &configs(&["bar", "foo", "qux", "zzz"]),
+        );
+        assert_eq!(
+            entries,
+            vec![
+                PriorityEntry::Server("foo".into()),
+                PriorityEntry::Rest(prios(&["bar", "qux"])),
+                PriorityEntry::Server("zzz".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn expand_rest_excludes_names_listed_after_wildcard() {
+        // zzz appears after '*' but must not also be in the rest group.
+        let entries = expand_priorities(&prios(&["*", "zzz"]), &configs(&["alpha", "zzz"]));
+        assert_eq!(
+            entries,
+            vec![
+                PriorityEntry::Rest(prios(&["alpha"])),
+                PriorityEntry::Server("zzz".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn expand_drops_unknown_names() {
+        let entries =
+            expand_priorities(&prios(&["unknown", "alpha"]), &configs(&["alpha", "beta"]));
+        assert_eq!(entries, vec![PriorityEntry::Server("alpha".into())]);
+    }
+
+    #[test]
+    fn expand_dedupes_repeated_names() {
+        let entries = expand_priorities(
+            &prios(&["alpha", "alpha", "beta"]),
+            &configs(&["alpha", "beta"]),
+        );
+        assert_eq!(
+            entries,
+            vec![
+                PriorityEntry::Server("alpha".into()),
+                PriorityEntry::Server("beta".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn expand_ignores_second_wildcard() {
+        let entries = expand_priorities(&prios(&["alpha", "*", "*"]), &configs(&["alpha", "beta"]));
+        assert_eq!(
+            entries,
+            vec![
+                PriorityEntry::Server("alpha".into()),
+                PriorityEntry::Rest(prios(&["beta"])),
+            ]
+        );
+    }
+
+    #[test]
+    fn expand_drops_empty_rest_group() {
+        // Every configured server is explicitly named: '*' has nothing left.
+        let entries = expand_priorities(
+            &prios(&["alpha", "beta", "*"]),
+            &configs(&["alpha", "beta"]),
+        );
+        assert_eq!(
+            entries,
+            vec![
+                PriorityEntry::Server("alpha".into()),
+                PriorityEntry::Server("beta".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn expand_rest_preserves_config_order() {
+        let entries = expand_priorities(&prios(&["*"]), &configs(&["gamma", "alpha", "beta"]));
+        assert_eq!(
+            entries,
+            vec![PriorityEntry::Rest(prios(&["gamma", "alpha", "beta"]))]
+        );
+    }
+
+    #[test]
+    fn truncate_none_keeps_all() {
+        let entries = expand_priorities(&prios(&["*"]), &configs(&["a", "b", "c"]));
+        let truncated = truncate_entries(entries.clone(), None);
+        assert_eq!(truncated, entries);
+    }
+
+    #[test]
+    fn truncate_zero_disables_fan_out() {
+        let entries = expand_priorities(&prios(&["*"]), &configs(&["a", "b"]));
+        assert!(truncate_entries(entries, Some(0)).is_empty());
+    }
+
+    #[test]
+    fn truncate_cuts_inside_rest_group() {
+        let entries = expand_priorities(&prios(&["*"]), &configs(&["a", "b", "c"]));
+        assert_eq!(
+            truncate_entries(entries, Some(2)),
+            vec![PriorityEntry::Rest(prios(&["a", "b"]))]
+        );
+    }
+
+    #[test]
+    fn truncate_drops_entries_past_cap() {
+        let entries = expand_priorities(&prios(&["a", "*", "c"]), &configs(&["a", "b", "c"]));
+        // flatten order: a, b (rest), c — cap 2 keeps a + rest[b], drops c.
+        assert_eq!(
+            truncate_entries(entries, Some(2)),
+            vec![
+                PriorityEntry::Server("a".into()),
+                PriorityEntry::Rest(prios(&["b"])),
+            ]
+        );
+    }
+
+    #[test]
+    fn entry_names_flattens_in_walk_order() {
+        let entries = expand_priorities(
+            &prios(&["foo", "*", "zzz"]),
+            &configs(&["bar", "foo", "zzz"]),
+        );
+        assert_eq!(entry_names(&entries), prios(&["foo", "bar", "zzz"]));
+    }
+}

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -29,7 +29,7 @@ pub(crate) use protocol::RequestId;
 pub(crate) use protocol::VirtualDocumentUri;
 pub(crate) use protocol::location_link_to_location;
 pub(crate) use protocol::translate_virtual_range_to_host;
-pub(crate) use text_document::host::HostDocument;
+pub(crate) use text_document::host::{HostDocument, normalize_host_goto_result};
 
 /// Integration tests for the bridge module.
 ///

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -29,6 +29,7 @@ pub(crate) use protocol::RequestId;
 pub(crate) use protocol::VirtualDocumentUri;
 pub(crate) use protocol::location_link_to_location;
 pub(crate) use protocol::translate_virtual_range_to_host;
+pub(crate) use text_document::host::HostDocument;
 
 /// Integration tests for the bridge module.
 ///

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -283,6 +283,46 @@ impl BridgeCoordinator {
         results
     }
 
+    /// Get every server config that can act as a **host** bridge for the
+    /// given host language (host-document-bridge).
+    ///
+    /// Selection mirrors [`Self::get_all_configs_for_language`] with the
+    /// host-path matching rule: servers whose `languages` contains the
+    /// *host* language itself. Gated on the explicit `bridge._self.enabled =
+    /// true` opt-in ([`LanguageSettings::is_host_bridging_enabled`]) — a
+    /// candidate server alone is not consent to use it.
+    pub(crate) fn get_host_configs_for_language(
+        &self,
+        settings: &WorkspaceSettings,
+        host_language: &str,
+    ) -> Vec<ResolvedServerConfig> {
+        let enabled = settings
+            .resolve_host_language_settings(host_language)
+            .is_some_and(|host_settings| host_settings.is_host_bridging_enabled());
+        if !enabled {
+            return Vec::new();
+        }
+
+        let servers = &settings.language_servers;
+
+        let mut results: Vec<ResolvedServerConfig> = servers
+            .keys()
+            .filter(|name| *name != "_")
+            .filter_map(|server_name| {
+                resolve_with_wildcard(servers, server_name, merge_bridge_server_configs)
+                    .filter(|c| c.languages.iter().any(|l| l == host_language))
+                    .map(|config| ResolvedServerConfig {
+                        server_name: server_name.clone(),
+                        config: Arc::new(config),
+                    })
+            })
+            .collect();
+
+        // Sort by server name for deterministic ordering
+        results.sort_by(|a, b| a.server_name.cmp(&b.server_name));
+        results
+    }
+
     // ========================================
     // Node tracker management (delegate to tracker)
     // ========================================

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -638,6 +638,16 @@ impl LanguageServerPool {
                 // Remove stale connection if present (Failed or Closed state)
                 if existing_state.is_some() {
                     connections.remove(server_name);
+                    // Drop host-document sync state with it: the replacement
+                    // process has no documents open, so the lazy host sync
+                    // must re-send didOpen instead of trusting stale entries
+                    // (host-document-bridge). Lock order: connections →
+                    // host_documents, consistent with
+                    // close_host_bridge_document's prefetch.
+                    self.host_documents
+                        .lock()
+                        .await
+                        .retain(|(_, server), _| server != server_name);
                 }
             }
         }

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -29,7 +29,7 @@ pub(crate) use connection_state::ConnectionState;
 use document_tracker::DocumentTracker;
 pub(crate) use document_tracker::OpenedVirtualDoc;
 pub(crate) use dynamic_capability_registry::DynamicCapabilityRegistry;
-pub(crate) use message_sender::ConnectionHandleSender;
+pub(crate) use message_sender::{ConnectionHandleSender, MessageSender};
 pub(crate) use shutdown_timeout::GlobalShutdownTimeout;
 
 use std::collections::HashMap;
@@ -161,11 +161,24 @@ impl CancelForwardingMetrics {
 ///
 /// `pub` so a shared pool can be wired into the cancel forwarding middleware;
 /// normal usage should go through `BridgeCoordinator`.
+/// Sync state of one host document on one downstream server
+/// (host-document-bridge): the version sent in the last `didOpen`/`didChange`
+/// and a fingerprint of the synced text for cheap change detection.
+pub(super) struct HostDocSyncState {
+    pub(super) version: i32,
+    pub(super) fingerprint: u64,
+}
+
 pub struct LanguageServerPool {
     /// Map of server_name -> connection handle (wraps connection with its state)
     connections: Mutex<HashMap<String, Arc<ConnectionHandle>>>,
     /// Document tracking for virtual documents (versions, host mappings, opened state)
     document_tracker: DocumentTracker,
+    /// Host-document sync state per `(uri, server_name)`
+    /// (host-document-bridge): the real-URI documents opened on downstream
+    /// servers via `bridge._self`, with their version and content
+    /// fingerprint for lazy full-text re-sync.
+    host_documents: Mutex<HashMap<(String, String), HostDocSyncState>>,
     /// Upstream request ID → set of downstream servers, for fan-out cancel
     /// forwarding (ls-bridge-message-ordering). Multiple servers can share an ID when a single
     /// upstream request (e.g. diagnostic) targets several injected languages.
@@ -228,6 +241,7 @@ impl LanguageServerPool {
         Self {
             connections: Mutex::new(HashMap::new()),
             document_tracker: DocumentTracker::new(),
+            host_documents: Mutex::new(HashMap::new()),
             upstream_request_registry: std::sync::Mutex::new(HashMap::new()),
             cancel_metrics: CancelForwardingMetrics::default(),
             consecutive_panic_counts: std::sync::Mutex::new(HashMap::new()),
@@ -311,6 +325,14 @@ impl LanguageServerPool {
         &self,
     ) -> tokio::sync::MutexGuard<'_, HashMap<String, Arc<ConnectionHandle>>> {
         self.connections.lock().await
+    }
+
+    /// Host-document sync state (host-document-bridge). Used by the host
+    /// request path in `text_document/host.rs`.
+    pub(super) async fn host_documents(
+        &self,
+    ) -> tokio::sync::MutexGuard<'_, HashMap<(String, String), HostDocSyncState>> {
+        self.host_documents.lock().await
     }
 
     /// Insert a pre-created connection handle for testing.

--- a/src/lsp/bridge/text_document.rs
+++ b/src/lsp/bridge/text_document.rs
@@ -23,6 +23,7 @@ mod document_link;
 mod document_symbol;
 mod folding_range;
 mod formatting;
+pub(super) mod host;
 mod hover;
 mod implementation;
 mod inlay_hint;

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 
 use tower_lsp_server::ls_types::{
     DidChangeTextDocumentParams, DidOpenTextDocumentParams, Location, LocationLink,
-    TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem, Uri,
+    TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem, TextEdit, Uri,
     VersionedTextDocumentIdentifier,
 };
 use url::Url;
@@ -209,6 +209,38 @@ impl LanguageServerPool {
         .await
     }
 
+    /// Send a host formatting request. Unlike [`Self::send_host_raw_request`],
+    /// the response keeps formatting's LSP semantics: a `null` result from a
+    /// capable server is the authoritative "no edits needed" signal
+    /// (concatenated-formatting-pipeline) and comes back as `Some(vec![])`,
+    /// distinct from `None` = no capability / error / malformed — only the
+    /// latter should trigger fallback to a lower-priority server.
+    pub(crate) async fn send_host_formatting_request(
+        &self,
+        server_name: &str,
+        server_config: &BridgeServerConfig,
+        doc: &HostDocument<'_>,
+        method: &'static str,
+        params: serde_json::Value,
+        upstream_request_id: Option<UpstreamId>,
+    ) -> io::Result<Option<Vec<TextEdit>>> {
+        let handle = self
+            .get_or_create_connection(server_name, server_config)
+            .await?;
+        if !handle.has_capability(method) {
+            return Ok(None);
+        }
+        self.execute_host_request(
+            handle,
+            server_name,
+            doc,
+            upstream_request_id,
+            |request_id| JsonRpcRequest::new(request_id.as_i64(), method, params),
+            move |response| parse_host_formatting_response(response, method),
+        )
+        .await
+    }
+
     /// Drive a host bridge request end-to-end: register for cancel
     /// forwarding, sync the host document, send, await, transform.
     ///
@@ -344,6 +376,33 @@ fn parse_host_raw_response(
     if result.is_null() { None } else { Some(result) }
 }
 
+/// Parse a host formatting response with formatting's null semantics:
+/// `null` from a capable server = authoritative "no edits needed" →
+/// `Some(vec![])`; only an error / malformed payload yields `None`
+/// (fallback).
+fn parse_host_formatting_response(
+    mut response: serde_json::Value,
+    method: &'static str,
+) -> Option<Vec<TextEdit>> {
+    if response_has_jsonrpc_error(&response, method) {
+        return None;
+    }
+    let result = response.get_mut("result")?.take();
+    if result.is_null() {
+        return Some(Vec::new());
+    }
+    match serde_json::from_value::<Vec<TextEdit>>(result) {
+        Ok(edits) => Some(edits),
+        Err(e) => {
+            log::warn!(
+                target: "kakehashi::bridge",
+                "host formatting response failed to deserialize: {e}"
+            );
+            None
+        }
+    }
+}
+
 /// Normalize a goto result (`Location | Location[] | LocationLink[]`) to
 /// `Vec<LocationLink>` **without** any URI or range rewriting — host
 /// responses already speak real-document coordinates.
@@ -460,6 +519,46 @@ mod tests {
     fn fingerprint_distinguishes_changed_text() {
         assert_eq!(fingerprint("a"), fingerprint("a"));
         assert_ne!(fingerprint("a"), fingerprint("b"));
+    }
+
+    #[test]
+    fn formatting_response_null_is_authoritative_no_edits() {
+        // LSP formatting: a capable server's `null` means "no edits needed"
+        // (concatenated-formatting-pipeline) — it must NOT read as "no usable
+        // response", which would fall through to a lower-priority formatter.
+        let response = serde_json::json!({ "jsonrpc": "2.0", "id": 1, "result": null });
+        let edits = parse_host_formatting_response(response, "textDocument/formatting")
+            .expect("null must be an authoritative empty edit list");
+        assert!(edits.is_empty());
+    }
+
+    #[test]
+    fn formatting_response_edits_pass_through_verbatim() {
+        let response = serde_json::json!({
+            "jsonrpc": "2.0", "id": 1,
+            "result": [{
+                "range": { "start": { "line": 3, "character": 0 },
+                           "end": { "line": 3, "character": 5 } },
+                "newText": "fixed"
+            }]
+        });
+        let edits =
+            parse_host_formatting_response(response, "textDocument/formatting").expect("edits");
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].new_text, "fixed");
+        assert_eq!(edits[0].range.start.line, 3, "no translation");
+    }
+
+    #[test]
+    fn formatting_response_error_falls_through() {
+        let response = serde_json::json!({
+            "jsonrpc": "2.0", "id": 1,
+            "error": { "code": -32603, "message": "boom" }
+        });
+        assert!(
+            parse_host_formatting_response(response, "textDocument/formatting").is_none(),
+            "errors must trigger fallback, unlike null"
+        );
     }
 
     #[test]

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -1,0 +1,484 @@
+//! Host-document bridge requests (host-document-bridge).
+//!
+//! Unlike the virt path, the host path forwards the **real client URI**, the
+//! **host text verbatim**, and applies **no coordinate translation** in either
+//! direction — the response is the downstream server's answer about the very
+//! document the editor sees. The pool's `(uri, server_name)` document state
+//! and the request/cancel machinery are shared with the virt path; only the
+//! document key and the (absent) translation differ.
+//!
+//! Document sync is lazy: the host document is opened on the first request
+//! per `(uri, server)` and re-synced with a full-text `didChange` whenever
+//! the host text changed since the last request (fingerprint comparison) —
+//! the same full-content sync the virt path uses for its `didChange`
+//! forwarding.
+
+use std::collections::hash_map::Entry;
+use std::hash::{Hash, Hasher};
+use std::io;
+use std::sync::Arc;
+
+use tower_lsp_server::ls_types::{
+    DidChangeTextDocumentParams, DidOpenTextDocumentParams, Hover, LocationLink, Position,
+    TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem,
+    TextDocumentPositionParams, Uri, VersionedTextDocumentIdentifier,
+};
+use url::Url;
+
+use super::super::actor::RouterCleanupGuard;
+use super::super::pool::{
+    ConnectionHandle, ConnectionHandleSender, HostDocSyncState, LanguageServerPool, MessageSender,
+    UpstreamId,
+};
+use super::super::protocol::{
+    JsonRpcNotification, JsonRpcRequest, RequestId, response_has_jsonrpc_error,
+};
+use crate::config::settings::BridgeServerConfig;
+
+/// The host document a request operates on: real URI, host language id, and
+/// the current host text (verbatim).
+pub(crate) struct HostDocument<'a> {
+    pub(crate) uri: &'a Url,
+    pub(crate) language_id: &'a str,
+    pub(crate) text: &'a str,
+}
+
+fn fingerprint(text: &str) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    text.hash(&mut hasher);
+    hasher.finish()
+}
+
+impl LanguageServerPool {
+    /// Open or re-sync the host document on a downstream server.
+    ///
+    /// - First request for `(uri, server)`: send `didOpen` with the real URI,
+    ///   the host language id, and the full host text.
+    /// - Host text changed since the last sync: send a full-text `didChange`
+    ///   with an incremented version.
+    /// - Unchanged: no-op.
+    ///
+    /// The map lock is held across the queueing so concurrent requests cannot
+    /// double-open; the single-writer loop (ls-bridge-message-ordering)
+    /// guarantees the notification reaches the wire before the request that
+    /// follows it.
+    async fn ensure_host_document_synced(
+        &self,
+        handle: &Arc<ConnectionHandle>,
+        doc: &HostDocument<'_>,
+        server_name: &str,
+    ) -> io::Result<()> {
+        let uri_lsp = host_url_to_lsp_uri(doc.uri)?;
+        let key = (doc.uri.to_string(), server_name.to_string());
+        let fp = fingerprint(doc.text);
+
+        let mut sender = ConnectionHandleSender(handle);
+        let mut docs = self.host_documents().await;
+        match docs.entry(key) {
+            Entry::Vacant(entry) => {
+                let notification = JsonRpcNotification::new(
+                    "textDocument/didOpen",
+                    DidOpenTextDocumentParams {
+                        text_document: TextDocumentItem::new(
+                            uri_lsp,
+                            doc.language_id.to_string(),
+                            1,
+                            doc.text.to_string(),
+                        ),
+                    },
+                );
+                sender.send_notification(notification).await?;
+                entry.insert(HostDocSyncState {
+                    version: 1,
+                    fingerprint: fp,
+                });
+            }
+            Entry::Occupied(mut entry) => {
+                if entry.get().fingerprint != fp {
+                    let version = entry.get().version + 1;
+                    let notification = JsonRpcNotification::new(
+                        "textDocument/didChange",
+                        DidChangeTextDocumentParams {
+                            text_document: VersionedTextDocumentIdentifier::new(uri_lsp, version),
+                            content_changes: vec![TextDocumentContentChangeEvent {
+                                range: None,
+                                range_length: None,
+                                text: doc.text.to_string(),
+                            }],
+                        },
+                    );
+                    sender.send_notification(notification).await?;
+                    *entry.get_mut() = HostDocSyncState {
+                        version,
+                        fingerprint: fp,
+                    };
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Send `didClose` for the host document to every server that has it
+    /// open via the host bridge, and drop the sync state.
+    ///
+    /// Mirrors the virt path's `close_host_document`; called from the
+    /// upstream `didClose` handler.
+    pub(crate) async fn close_host_bridge_document(&self, uri: &Url) {
+        let Ok(uri_lsp) = host_url_to_lsp_uri(uri) else {
+            return;
+        };
+        let uri_string = uri.to_string();
+        let server_names: Vec<String> = {
+            let mut docs = self.host_documents().await;
+            let names = docs
+                .keys()
+                .filter(|(doc_uri, _)| *doc_uri == uri_string)
+                .map(|(_, server)| server.clone())
+                .collect::<Vec<_>>();
+            docs.retain(|(doc_uri, _), _| *doc_uri != uri_string);
+            names
+        };
+
+        for server_name in server_names {
+            let connections = self.connections().await;
+            if let Some(handle) = connections.get(&server_name) {
+                let notification = JsonRpcNotification::new(
+                    "textDocument/didClose",
+                    DocumentIdentifierParams {
+                        text_document: TextDocumentIdentifier {
+                            uri: uri_lsp.clone(),
+                        },
+                    },
+                );
+                handle.send_notification(notification);
+            }
+        }
+    }
+
+    /// Drive a host bridge request end-to-end: register for cancel
+    /// forwarding, sync the host document, send, await, transform.
+    ///
+    /// The skeleton mirrors `execute_bridge_request_with_handle` minus the
+    /// virtual URI and the coordinate translation — host responses are the
+    /// downstream server's verbatim answer.
+    async fn execute_host_request<T, P: serde::Serialize>(
+        &self,
+        handle: Arc<ConnectionHandle>,
+        server_name: &str,
+        doc: &HostDocument<'_>,
+        upstream_request_id: Option<UpstreamId>,
+        build_request: impl FnOnce(RequestId) -> JsonRpcRequest<P>,
+        transform_response: impl FnOnce(serde_json::Value) -> T,
+    ) -> io::Result<T> {
+        if let Some(ref id) = upstream_request_id {
+            self.register_upstream_request(id.clone(), server_name);
+        }
+
+        let (request_id, response_rx) =
+            match handle.register_request_with_upstream(upstream_request_id.clone()) {
+                Ok(result) => result,
+                Err(e) => {
+                    if let Some(ref id) = upstream_request_id {
+                        self.unregister_upstream_request(id, server_name);
+                    }
+                    return Err(e);
+                }
+            };
+
+        let request = build_request(request_id);
+        let mut router_guard = RouterCleanupGuard::new(Arc::clone(handle.router()), request_id);
+
+        if let Err(e) = self
+            .ensure_host_document_synced(&handle, doc, server_name)
+            .await
+        {
+            if let Some(ref id) = upstream_request_id {
+                self.unregister_upstream_request(id, server_name);
+            }
+            return Err(e);
+        }
+
+        if let Err(e) = handle.send_request(request, request_id) {
+            if let Some(ref id) = upstream_request_id {
+                self.unregister_upstream_request(id, server_name);
+            }
+            return Err(e.into());
+        }
+
+        let response = handle.wait_for_response(request_id, response_rx).await;
+        router_guard.disarm();
+
+        if let Some(ref id) = upstream_request_id {
+            self.unregister_upstream_request(id, server_name);
+        }
+
+        Ok(transform_response(response?))
+    }
+
+    /// Send a definition request for the host document itself.
+    ///
+    /// The response is normalized to `Vec<LocationLink>` but otherwise
+    /// verbatim: URIs and ranges already live in real-document space.
+    pub(crate) async fn send_host_definition_request(
+        &self,
+        server_name: &str,
+        server_config: &BridgeServerConfig,
+        doc: &HostDocument<'_>,
+        position: Position,
+        upstream_request_id: Option<UpstreamId>,
+    ) -> io::Result<Option<Vec<LocationLink>>> {
+        let handle = self
+            .get_or_create_connection(server_name, server_config)
+            .await?;
+        if !handle.has_capability("textDocument/definition") {
+            return Ok(None);
+        }
+        let uri_lsp = host_url_to_lsp_uri(doc.uri)?;
+        self.execute_host_request(
+            handle,
+            server_name,
+            doc,
+            upstream_request_id,
+            |request_id| {
+                build_host_position_request(
+                    &uri_lsp,
+                    position,
+                    request_id,
+                    "textDocument/definition",
+                )
+            },
+            parse_host_goto_response,
+        )
+        .await
+    }
+
+    /// Send a hover request for the host document itself. Response verbatim.
+    pub(crate) async fn send_host_hover_request(
+        &self,
+        server_name: &str,
+        server_config: &BridgeServerConfig,
+        doc: &HostDocument<'_>,
+        position: Position,
+        upstream_request_id: Option<UpstreamId>,
+    ) -> io::Result<Option<Hover>> {
+        let handle = self
+            .get_or_create_connection(server_name, server_config)
+            .await?;
+        if !handle.has_capability("textDocument/hover") {
+            return Ok(None);
+        }
+        let uri_lsp = host_url_to_lsp_uri(doc.uri)?;
+        self.execute_host_request(
+            handle,
+            server_name,
+            doc,
+            upstream_request_id,
+            |request_id| {
+                build_host_position_request(&uri_lsp, position, request_id, "textDocument/hover")
+            },
+            parse_host_hover_response,
+        )
+        .await
+    }
+}
+
+/// `textDocument/didClose` params (the bridge protocol layer has no shared
+/// struct for notification-side document identifiers).
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DocumentIdentifierParams {
+    text_document: TextDocumentIdentifier,
+}
+
+fn host_url_to_lsp_uri(uri: &Url) -> io::Result<Uri> {
+    crate::lsp::lsp_impl::url_to_uri(uri)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
+}
+
+/// Build a position-based request against the real host URI (no translation).
+fn build_host_position_request(
+    uri: &Uri,
+    position: Position,
+    request_id: RequestId,
+    method: &'static str,
+) -> JsonRpcRequest<TextDocumentPositionParams> {
+    JsonRpcRequest::new(
+        request_id.as_i64(),
+        method,
+        TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier { uri: uri.clone() },
+            position,
+        },
+    )
+}
+
+/// Normalize a goto response (`Location | Location[] | LocationLink[]`) to
+/// `Vec<LocationLink>` **without** any URI or range rewriting — host
+/// responses already speak real-document coordinates.
+fn parse_host_goto_response(mut response: serde_json::Value) -> Option<Vec<LocationLink>> {
+    if response_has_jsonrpc_error(&response, "textDocument/definition (host)") {
+        return None;
+    }
+    let result = response.get_mut("result")?.take();
+    if result.is_null() {
+        return None;
+    }
+
+    use tower_lsp_server::ls_types::Location;
+    fn location_to_link(location: Location) -> LocationLink {
+        LocationLink {
+            origin_selection_range: None,
+            target_uri: location.uri,
+            target_range: location.range,
+            target_selection_range: location.range,
+        }
+    }
+
+    if let Ok(links) = serde_json::from_value::<Vec<LocationLink>>(result.clone()) {
+        return Some(links);
+    }
+    if let Ok(locations) = serde_json::from_value::<Vec<Location>>(result.clone()) {
+        return Some(locations.into_iter().map(location_to_link).collect());
+    }
+    if let Ok(location) = serde_json::from_value::<Location>(result) {
+        return Some(vec![location_to_link(location)]);
+    }
+    log::warn!(
+        target: "kakehashi::bridge",
+        "host definition response did not match Location | Location[] | LocationLink[]"
+    );
+    None
+}
+
+/// Parse a hover response verbatim (no range translation).
+fn parse_host_hover_response(mut response: serde_json::Value) -> Option<Hover> {
+    if response_has_jsonrpc_error(&response, "textDocument/hover (host)") {
+        return None;
+    }
+    let result = response.get_mut("result")?.take();
+    if result.is_null() {
+        return None;
+    }
+    match serde_json::from_value::<Hover>(result) {
+        Ok(hover) => Some(hover),
+        Err(e) => {
+            log::warn!(
+                target: "kakehashi::bridge",
+                "host hover response failed to deserialize: {e}"
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn position() -> Position {
+        Position {
+            line: 32,
+            character: 12,
+        }
+    }
+
+    #[test]
+    fn host_position_request_uses_real_uri_and_untranslated_position() {
+        let uri: Uri = "file:///project/doc.md".parse().unwrap();
+        let request = build_host_position_request(
+            &uri,
+            position(),
+            RequestId::new(7),
+            "textDocument/definition",
+        );
+        let value = serde_json::to_value(&request).unwrap();
+        assert_eq!(
+            value["params"]["textDocument"]["uri"], "file:///project/doc.md",
+            "host requests must carry the real client URI"
+        );
+        assert_eq!(
+            value["params"]["position"]["line"], 32,
+            "host positions must be forwarded untranslated"
+        );
+        assert_eq!(value["method"], "textDocument/definition");
+    }
+
+    #[test]
+    fn host_goto_response_passes_locations_through_verbatim() {
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": [{
+                "uri": "file:///project/doc.md",
+                "range": {
+                    "start": { "line": 34, "character": 0 },
+                    "end": { "line": 34, "character": 11 }
+                }
+            }]
+        });
+        let links = parse_host_goto_response(response).expect("locations must parse");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target_uri.as_str(), "file:///project/doc.md");
+        assert_eq!(
+            links[0].target_range.start.line, 34,
+            "host ranges must NOT be offset-translated"
+        );
+    }
+
+    #[test]
+    fn host_goto_response_handles_single_location() {
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "uri": "file:///other.md",
+                "range": {
+                    "start": { "line": 1, "character": 2 },
+                    "end": { "line": 1, "character": 5 }
+                }
+            }
+        });
+        let links = parse_host_goto_response(response).expect("single location must parse");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target_uri.as_str(), "file:///other.md");
+        assert_eq!(links[0].target_selection_range.start.line, 1);
+    }
+
+    #[test]
+    fn host_goto_response_null_is_none() {
+        let response = serde_json::json!({ "jsonrpc": "2.0", "id": 1, "result": null });
+        assert!(parse_host_goto_response(response).is_none());
+    }
+
+    #[test]
+    fn host_goto_response_error_is_none() {
+        let response = serde_json::json!({
+            "jsonrpc": "2.0", "id": 1,
+            "error": { "code": -32603, "message": "boom" }
+        });
+        assert!(parse_host_goto_response(response).is_none());
+    }
+
+    #[test]
+    fn host_hover_response_keeps_range_verbatim() {
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "contents": "docs",
+                "range": {
+                    "start": { "line": 9, "character": 0 },
+                    "end": { "line": 9, "character": 4 }
+                }
+            }
+        });
+        let hover = parse_host_hover_response(response).expect("hover must parse");
+        assert_eq!(hover.range.unwrap().start.line, 9);
+    }
+
+    #[test]
+    fn fingerprint_distinguishes_changed_text() {
+        assert_eq!(fingerprint("a"), fingerprint("a"));
+        assert_ne!(fingerprint("a"), fingerprint("b"));
+    }
+}

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -248,19 +248,38 @@ impl LanguageServerPool {
         // the request itself, making the server answer about different text
         // than the caller synced (fatal for the formatting pipeline's
         // speculative intermediate text). All sends are non-yielding queue
-        // writes, so holding the lock across them is cheap.
+        // writes, so holding the locks across them is cheap.
         //
-        // Known narrow window (shared with the virt document tracker): the
-        // `handle` above was fetched before this lock, so a concurrent
-        // respawn purge can run in between — this request then syncs onto
-        // the dying process's queue and records state the replacement never
-        // saw. Self-heals on the next respawn purge or upstream didClose;
-        // closing it fully would need generation-keyed sync state.
+        // The `connections` lock is held around the scope (consistent
+        // connections → host_documents order, matching the respawn purge in
+        // `pool.rs`) to verify `handle` is still the pool's LIVE connection:
+        // `handle` was fetched earlier, and a concurrent respawn could have
+        // replaced it and purged the sync state — syncing onto the dying
+        // process's queue would record state the replacement never saw,
+        // wedging the `(uri, server)` pair until the next purge. Holding
+        // `connections` here also excludes a purge from interleaving with
+        // this sync, closing the race entirely.
         {
+            let connections = self.connections().await;
+            if !connections
+                .get(server_name)
+                .is_some_and(|current| Arc::ptr_eq(current, &handle))
+            {
+                drop(connections);
+                if let Some(ref id) = upstream_request_id {
+                    self.unregister_upstream_request(id, server_name);
+                }
+                return Err(io::Error::new(
+                    io::ErrorKind::NotConnected,
+                    format!("connection to {server_name} was replaced during host sync"),
+                ));
+            }
+
             let mut docs = self.host_documents().await;
             let mut sender = ConnectionHandleSender(&handle);
             if let Err(e) = sync_host_document(&mut sender, &mut docs, doc, server_name).await {
                 drop(docs);
+                drop(connections);
                 if let Some(ref id) = upstream_request_id {
                     self.unregister_upstream_request(id, server_name);
                 }
@@ -269,6 +288,7 @@ impl LanguageServerPool {
 
             if let Err(e) = handle.send_request(request, request_id) {
                 drop(docs);
+                drop(connections);
                 if let Some(ref id) = upstream_request_id {
                     self.unregister_upstream_request(id, server_name);
                 }

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -53,77 +53,89 @@ fn fingerprint(text: &str) -> u64 {
     hasher.finish()
 }
 
-impl LanguageServerPool {
-    /// Open or re-sync the host document on a downstream server.
-    ///
-    /// - First request for `(uri, server)`: send `didOpen` with the real URI,
-    ///   the host language id, and the full host text.
-    /// - Host text changed since the last sync: send a full-text `didChange`
-    ///   with an incremented version.
-    /// - Unchanged: no-op.
-    ///
-    /// The map lock is held across the queueing so concurrent requests cannot
-    /// double-open; the single-writer loop (ls-bridge-message-ordering)
-    /// guarantees the notification reaches the wire before the request that
-    /// follows it.
-    async fn ensure_host_document_synced(
-        &self,
-        handle: &Arc<ConnectionHandle>,
-        doc: &HostDocument<'_>,
-        server_name: &str,
-    ) -> io::Result<()> {
-        let uri_lsp = host_url_to_lsp_uri(doc.uri)?;
-        let key = (doc.uri.to_string(), server_name.to_string());
-        let fp = fingerprint(doc.text);
+/// Open or re-sync the host document on a downstream server, mutating the
+/// pool's sync-state map in place.
+///
+/// - First request for `(uri, server)`: send `didOpen` with the real URI,
+///   the host language id, and the full host text.
+/// - Host text changed since the last sync: send a full-text `didChange`
+///   with an incremented version.
+/// - Unchanged: no-op.
+///
+/// The caller holds the `host_documents` lock across this call (and across
+/// the request enqueue that follows it), so concurrent requests cannot
+/// double-open and cannot interleave a different text between a sync and the
+/// request that relies on it; the single-writer loop
+/// (ls-bridge-message-ordering) guarantees wire order matches enqueue order.
+/// Generic over [`MessageSender`] so tests can observe the notifications via
+/// a channel.
+async fn sync_host_document<S: MessageSender>(
+    sender: &mut S,
+    docs: &mut std::collections::HashMap<(String, String), HostDocSyncState>,
+    doc: &HostDocument<'_>,
+    server_name: &str,
+) -> io::Result<()> {
+    let uri_lsp = host_url_to_lsp_uri(doc.uri)?;
+    let key = (doc.uri.to_string(), server_name.to_string());
+    let fp = fingerprint(doc.text);
 
-        let mut sender = ConnectionHandleSender(handle);
-        let mut docs = self.host_documents().await;
-        match docs.entry(key) {
-            Entry::Vacant(entry) => {
+    match docs.entry(key) {
+        Entry::Vacant(entry) => {
+            let notification = JsonRpcNotification::new(
+                "textDocument/didOpen",
+                DidOpenTextDocumentParams {
+                    text_document: TextDocumentItem::new(
+                        uri_lsp,
+                        doc.language_id.to_string(),
+                        1,
+                        doc.text.to_string(),
+                    ),
+                },
+            );
+            sender.send_notification(notification).await?;
+            entry.insert(HostDocSyncState {
+                version: 1,
+                fingerprint: fp,
+            });
+        }
+        Entry::Occupied(mut entry) => {
+            if entry.get().fingerprint != fp {
+                let version = entry.get().version + 1;
                 let notification = JsonRpcNotification::new(
-                    "textDocument/didOpen",
-                    DidOpenTextDocumentParams {
-                        text_document: TextDocumentItem::new(
-                            uri_lsp,
-                            doc.language_id.to_string(),
-                            1,
-                            doc.text.to_string(),
-                        ),
+                    "textDocument/didChange",
+                    DidChangeTextDocumentParams {
+                        text_document: VersionedTextDocumentIdentifier::new(uri_lsp, version),
+                        content_changes: vec![TextDocumentContentChangeEvent {
+                            range: None,
+                            range_length: None,
+                            text: doc.text.to_string(),
+                        }],
                     },
                 );
                 sender.send_notification(notification).await?;
-                entry.insert(HostDocSyncState {
-                    version: 1,
+                *entry.get_mut() = HostDocSyncState {
+                    version,
                     fingerprint: fp,
-                });
-            }
-            Entry::Occupied(mut entry) => {
-                if entry.get().fingerprint != fp {
-                    let version = entry.get().version + 1;
-                    let notification = JsonRpcNotification::new(
-                        "textDocument/didChange",
-                        DidChangeTextDocumentParams {
-                            text_document: VersionedTextDocumentIdentifier::new(uri_lsp, version),
-                            content_changes: vec![TextDocumentContentChangeEvent {
-                                range: None,
-                                range_length: None,
-                                text: doc.text.to_string(),
-                            }],
-                        },
-                    );
-                    sender.send_notification(notification).await?;
-                    *entry.get_mut() = HostDocSyncState {
-                        version,
-                        fingerprint: fp,
-                    };
-                }
+                };
             }
         }
-        Ok(())
     }
+    Ok(())
+}
 
+impl LanguageServerPool {
     /// Send `didClose` for the host document to every server that has it
     /// open via the host bridge, and drop the sync state.
+    ///
+    /// Connection handles are pre-fetched before taking the `host_documents`
+    /// lock (consistent `connections` → `host_documents` ordering with the
+    /// respawn purge in `pool.rs`), and the `didClose`s are queued while the
+    /// lock is held: a concurrent request either re-opens before this runs —
+    /// its `didOpen` precedes our `didClose` on the wire and its state entry
+    /// is removed here — or after, sending a fresh `didOpen`. Either
+    /// interleaving leaves the map and the server consistent; sending after
+    /// releasing the lock could close a document another request had just
+    /// re-opened while its state survives, wedging the pair.
     ///
     /// Mirrors the virt path's `close_host_document`; called from the
     /// upstream `didClose` handler.
@@ -132,31 +144,31 @@ impl LanguageServerPool {
             return;
         };
         let uri_string = uri.to_string();
-        let server_names: Vec<String> = {
-            let mut docs = self.host_documents().await;
-            let names = docs
-                .keys()
-                .filter(|(doc_uri, _)| *doc_uri == uri_string)
-                .map(|(_, server)| server.clone())
-                .collect::<Vec<_>>();
-            docs.retain(|(doc_uri, _), _| *doc_uri != uri_string);
-            names
+
+        let handles: Vec<(String, Arc<ConnectionHandle>)> = {
+            let connections = self.connections().await;
+            connections
+                .iter()
+                .map(|(name, handle)| (name.clone(), Arc::clone(handle)))
+                .collect()
         };
 
-        for server_name in server_names {
-            let connections = self.connections().await;
-            if let Some(handle) = connections.get(&server_name) {
-                let notification = JsonRpcNotification::new(
-                    "textDocument/didClose",
-                    DocumentIdentifierParams {
-                        text_document: TextDocumentIdentifier {
-                            uri: uri_lsp.clone(),
-                        },
-                    },
-                );
-                handle.send_notification(notification);
+        let mut docs = self.host_documents().await;
+        for (server_name, handle) in &handles {
+            if !docs.contains_key(&(uri_string.clone(), server_name.clone())) {
+                continue;
             }
+            let notification = JsonRpcNotification::new(
+                "textDocument/didClose",
+                DocumentIdentifierParams {
+                    text_document: TextDocumentIdentifier {
+                        uri: uri_lsp.clone(),
+                    },
+                },
+            );
+            handle.send_notification(notification);
         }
+        docs.retain(|(doc_uri, _), _| *doc_uri != uri_string);
     }
 
     /// Send a host bridge request with the upstream params forwarded
@@ -164,15 +176,22 @@ impl LanguageServerPool {
     /// real URI and real coordinates, so no per-method request shaping is
     /// needed. Returns the raw `result` value, or `None` for a `null`
     /// result, a JSON-RPC error, or a missing capability.
+    ///
+    /// One exception to verbatim: the progress tokens are stripped. The
+    /// bridge discards downstream notifications, so a server honoring
+    /// `partialResultToken` would stream its results into the void and could
+    /// legally return an empty final result; `workDoneToken` would likewise
+    /// report progress nowhere.
     pub(crate) async fn send_host_raw_request(
         &self,
         server_name: &str,
         server_config: &BridgeServerConfig,
         doc: &HostDocument<'_>,
         method: &'static str,
-        params: serde_json::Value,
+        mut params: serde_json::Value,
         upstream_request_id: Option<UpstreamId>,
     ) -> io::Result<Option<serde_json::Value>> {
+        strip_progress_tokens(&mut params);
         let handle = self
             .get_or_create_connection(server_name, server_config)
             .await?;
@@ -223,21 +242,31 @@ impl LanguageServerPool {
         let request = build_request(request_id);
         let mut router_guard = RouterCleanupGuard::new(Arc::clone(handle.router()), request_id);
 
-        if let Err(e) = self
-            .ensure_host_document_synced(&handle, doc, server_name)
-            .await
+        // Sync the document and enqueue the request under ONE lock scope:
+        // with the lock released in between, a concurrent host request could
+        // slide its own full-text didChange between this request's sync and
+        // the request itself, making the server answer about different text
+        // than the caller synced (fatal for the formatting pipeline's
+        // speculative intermediate text). All sends are non-yielding queue
+        // writes, so holding the lock across them is cheap.
         {
-            if let Some(ref id) = upstream_request_id {
-                self.unregister_upstream_request(id, server_name);
+            let mut docs = self.host_documents().await;
+            let mut sender = ConnectionHandleSender(&handle);
+            if let Err(e) = sync_host_document(&mut sender, &mut docs, doc, server_name).await {
+                drop(docs);
+                if let Some(ref id) = upstream_request_id {
+                    self.unregister_upstream_request(id, server_name);
+                }
+                return Err(e);
             }
-            return Err(e);
-        }
 
-        if let Err(e) = handle.send_request(request, request_id) {
-            if let Some(ref id) = upstream_request_id {
-                self.unregister_upstream_request(id, server_name);
+            if let Err(e) = handle.send_request(request, request_id) {
+                drop(docs);
+                if let Some(ref id) = upstream_request_id {
+                    self.unregister_upstream_request(id, server_name);
+                }
+                return Err(e.into());
             }
-            return Err(e.into());
         }
 
         let response = handle.wait_for_response(request_id, response_rx).await;
@@ -257,6 +286,17 @@ impl LanguageServerPool {
 #[serde(rename_all = "camelCase")]
 struct DocumentIdentifierParams {
     text_document: TextDocumentIdentifier,
+}
+
+/// Remove the LSP progress tokens from forwarded params: the bridge discards
+/// downstream notifications, so honoring `partialResultToken` downstream
+/// would stream results into the void (and possibly return an empty final
+/// result), and `workDoneToken` would report progress nowhere.
+fn strip_progress_tokens(params: &mut serde_json::Value) {
+    if let Some(object) = params.as_object_mut() {
+        object.remove("workDoneToken");
+        object.remove("partialResultToken");
+    }
 }
 
 fn host_url_to_lsp_uri(uri: &Url) -> io::Result<Uri> {
@@ -393,5 +433,113 @@ mod tests {
     fn fingerprint_distinguishes_changed_text() {
         assert_eq!(fingerprint("a"), fingerprint("a"));
         assert_ne!(fingerprint("a"), fingerprint("b"));
+    }
+
+    #[test]
+    fn strip_progress_tokens_removes_only_the_tokens() {
+        let mut params = serde_json::json!({
+            "textDocument": { "uri": "file:///doc.md" },
+            "position": { "line": 1, "character": 2 },
+            "workDoneToken": "wd-1",
+            "partialResultToken": "pr-1",
+        });
+        strip_progress_tokens(&mut params);
+        assert!(params.get("workDoneToken").is_none());
+        assert!(params.get("partialResultToken").is_none());
+        assert_eq!(params["textDocument"]["uri"], "file:///doc.md");
+        assert_eq!(params["position"]["line"], 1);
+    }
+
+    fn host_doc<'a>(uri: &'a Url, text: &'a str) -> HostDocument<'a> {
+        HostDocument {
+            uri,
+            language_id: "markdown",
+            text,
+        }
+    }
+
+    #[tokio::test]
+    async fn sync_sends_didopen_once_then_versioned_didchange_on_drift() {
+        use crate::lsp::bridge::actor::OutboundMessage;
+
+        let mut docs = std::collections::HashMap::new();
+        let (mut sender, mut rx) = tokio::sync::mpsc::channel::<OutboundMessage>(16);
+        let uri = Url::parse("file:///test/host.md").unwrap();
+
+        // First sync: didOpen with the full text, version 1.
+        sync_host_document(&mut sender, &mut docs, &host_doc(&uri, "v1"), "srv")
+            .await
+            .unwrap();
+        let msg = rx.try_recv().expect("didOpen must be queued");
+        let OutboundMessage::Untracked(payload) = msg else {
+            panic!("expected a notification");
+        };
+        assert_eq!(payload["method"], "textDocument/didOpen");
+        assert_eq!(payload["params"]["textDocument"]["text"], "v1");
+        assert_eq!(payload["params"]["textDocument"]["version"], 1);
+
+        // Unchanged text: no notification at all.
+        sync_host_document(&mut sender, &mut docs, &host_doc(&uri, "v1"), "srv")
+            .await
+            .unwrap();
+        assert!(rx.try_recv().is_err(), "unchanged text must be a no-op");
+
+        // Drifted text: full-text didChange with version 2.
+        sync_host_document(&mut sender, &mut docs, &host_doc(&uri, "v2"), "srv")
+            .await
+            .unwrap();
+        let OutboundMessage::Untracked(payload) = rx.try_recv().expect("didChange must be queued")
+        else {
+            panic!("expected a notification");
+        };
+        assert_eq!(payload["method"], "textDocument/didChange");
+        assert_eq!(payload["params"]["textDocument"]["version"], 2);
+        assert_eq!(payload["params"]["contentChanges"][0]["text"], "v2");
+
+        // Drift again: version keeps increasing monotonically.
+        sync_host_document(&mut sender, &mut docs, &host_doc(&uri, "v3"), "srv")
+            .await
+            .unwrap();
+        let OutboundMessage::Untracked(payload) = rx.try_recv().expect("didChange must be queued")
+        else {
+            panic!("expected a notification");
+        };
+        assert_eq!(payload["params"]["textDocument"]["version"], 3);
+    }
+
+    #[tokio::test]
+    async fn close_host_bridge_document_drops_only_that_uri() {
+        let pool = LanguageServerPool::new();
+        let uri_a = Url::parse("file:///test/a.md").unwrap();
+        let uri_b = Url::parse("file:///test/b.md").unwrap();
+        {
+            let mut docs = pool.host_documents().await;
+            docs.insert(
+                (uri_a.to_string(), "srv".to_string()),
+                HostDocSyncState {
+                    version: 1,
+                    fingerprint: 1,
+                },
+            );
+            docs.insert(
+                (uri_b.to_string(), "srv".to_string()),
+                HostDocSyncState {
+                    version: 1,
+                    fingerprint: 2,
+                },
+            );
+        }
+
+        pool.close_host_bridge_document(&uri_a).await;
+
+        let docs = pool.host_documents().await;
+        assert!(
+            !docs.contains_key(&(uri_a.to_string(), "srv".to_string())),
+            "closed uri's state must be dropped"
+        );
+        assert!(
+            docs.contains_key(&(uri_b.to_string(), "srv".to_string())),
+            "other documents must be untouched"
+        );
     }
 }

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -19,9 +19,10 @@ use std::io;
 use std::sync::Arc;
 
 use tower_lsp_server::ls_types::{
-    DidChangeTextDocumentParams, DidOpenTextDocumentParams, Hover, LocationLink, Position,
-    TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem,
-    TextDocumentPositionParams, Uri, VersionedTextDocumentIdentifier,
+    DidChangeTextDocumentParams, DidOpenTextDocumentParams, DocumentFormattingParams,
+    FormattingOptions, Hover, LocationLink, Position, TextDocumentContentChangeEvent,
+    TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams, TextEdit, Uri,
+    VersionedTextDocumentIdentifier,
 };
 use url::Url;
 
@@ -252,6 +253,47 @@ impl LanguageServerPool {
         .await
     }
 
+    /// Send a formatting request for the host document itself
+    /// (host-document-bridge): the host text travels verbatim and the
+    /// returned edits are already in real-document coordinates.
+    pub(crate) async fn send_host_formatting_request(
+        &self,
+        server_name: &str,
+        server_config: &BridgeServerConfig,
+        doc: &HostDocument<'_>,
+        options: FormattingOptions,
+        upstream_request_id: Option<UpstreamId>,
+    ) -> io::Result<Option<Vec<TextEdit>>> {
+        let handle = self
+            .get_or_create_connection(server_name, server_config)
+            .await?;
+        if !handle.has_capability("textDocument/formatting") {
+            return Ok(None);
+        }
+        let uri_lsp = host_url_to_lsp_uri(doc.uri)?;
+        self.execute_host_request(
+            handle,
+            server_name,
+            doc,
+            upstream_request_id,
+            |request_id| {
+                JsonRpcRequest::new(
+                    request_id.as_i64(),
+                    "textDocument/formatting",
+                    DocumentFormattingParams {
+                        text_document: TextDocumentIdentifier {
+                            uri: uri_lsp.clone(),
+                        },
+                        options,
+                        work_done_progress_params: Default::default(),
+                    },
+                )
+            },
+            parse_host_formatting_response,
+        )
+        .await
+    }
+
     /// Send a hover request for the host document itself. Response verbatim.
     pub(crate) async fn send_host_hover_request(
         &self,
@@ -348,6 +390,27 @@ fn parse_host_goto_response(mut response: serde_json::Value) -> Option<Vec<Locat
         "host definition response did not match Location | Location[] | LocationLink[]"
     );
     None
+}
+
+/// Parse a formatting response verbatim (no range translation).
+fn parse_host_formatting_response(mut response: serde_json::Value) -> Option<Vec<TextEdit>> {
+    if response_has_jsonrpc_error(&response, "textDocument/formatting (host)") {
+        return None;
+    }
+    let result = response.get_mut("result")?.take();
+    if result.is_null() {
+        return None;
+    }
+    match serde_json::from_value::<Vec<TextEdit>>(result) {
+        Ok(edits) => Some(edits),
+        Err(e) => {
+            log::warn!(
+                target: "kakehashi::bridge",
+                "host formatting response failed to deserialize: {e}"
+            );
+            None
+        }
+    }
 }
 
 /// Parse a hover response verbatim (no range translation).

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -407,6 +407,17 @@ fn parse_host_formatting_response(
 /// `Vec<LocationLink>` **without** any URI or range rewriting — host
 /// responses already speak real-document coordinates.
 pub(crate) fn normalize_host_goto_result(result: serde_json::Value) -> Option<Vec<LocationLink>> {
+    /// The three goto result shapes the LSP spec allows, deserialized in a
+    /// single pass. `Links` must come first: a `LocationLink` array would
+    /// also *partially* match the laxer shapes below.
+    #[derive(serde::Deserialize)]
+    #[serde(untagged)]
+    enum GotoResult {
+        Links(Vec<LocationLink>),
+        Locations(Vec<Location>),
+        Single(Location),
+    }
+
     fn location_to_link(location: Location) -> LocationLink {
         LocationLink {
             origin_selection_range: None,
@@ -416,20 +427,20 @@ pub(crate) fn normalize_host_goto_result(result: serde_json::Value) -> Option<Ve
         }
     }
 
-    if let Ok(links) = serde_json::from_value::<Vec<LocationLink>>(result.clone()) {
-        return Some(links);
+    match serde_json::from_value::<GotoResult>(result) {
+        Ok(GotoResult::Links(links)) => Some(links),
+        Ok(GotoResult::Locations(locations)) => {
+            Some(locations.into_iter().map(location_to_link).collect())
+        }
+        Ok(GotoResult::Single(location)) => Some(vec![location_to_link(location)]),
+        Err(_) => {
+            log::warn!(
+                target: "kakehashi::bridge",
+                "host goto response did not match Location | Location[] | LocationLink[]"
+            );
+            None
+        }
     }
-    if let Ok(locations) = serde_json::from_value::<Vec<Location>>(result.clone()) {
-        return Some(locations.into_iter().map(location_to_link).collect());
-    }
-    if let Ok(location) = serde_json::from_value::<Location>(result) {
-        return Some(vec![location_to_link(location)]);
-    }
-    log::warn!(
-        target: "kakehashi::bridge",
-        "host goto response did not match Location | Location[] | LocationLink[]"
-    );
-    None
 }
 
 #[cfg(test)]

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -249,6 +249,13 @@ impl LanguageServerPool {
         // than the caller synced (fatal for the formatting pipeline's
         // speculative intermediate text). All sends are non-yielding queue
         // writes, so holding the lock across them is cheap.
+        //
+        // Known narrow window (shared with the virt document tracker): the
+        // `handle` above was fetched before this lock, so a concurrent
+        // respawn purge can run in between — this request then syncs onto
+        // the dying process's queue and records state the replacement never
+        // saw. Self-heals on the next respawn purge or upstream didClose;
+        // closing it fully would need generation-keyed sync state.
         {
             let mut docs = self.host_documents().await;
             let mut sender = ConnectionHandleSender(&handle);

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -3,9 +3,13 @@
 //! Unlike the virt path, the host path forwards the **real client URI**, the
 //! **host text verbatim**, and applies **no coordinate translation** in either
 //! direction — the response is the downstream server's answer about the very
-//! document the editor sees. The pool's `(uri, server_name)` document state
-//! and the request/cancel machinery are shared with the virt path; only the
-//! document key and the (absent) translation differ.
+//! document the editor sees. Because of that, host requests need no
+//! per-method request builders or response transformers: the upstream
+//! request's params are forwarded as raw JSON
+//! ([`LanguageServerPool::send_host_raw_request`]) and the result comes back
+//! verbatim. The pool's `(uri, server_name)` document state and the
+//! request/cancel machinery are shared with the virt path; only the document
+//! key and the (absent) translation differ.
 //!
 //! Document sync is lazy: the host document is opened on the first request
 //! per `(uri, server)` and re-synced with a full-text `didChange` whenever
@@ -19,9 +23,8 @@ use std::io;
 use std::sync::Arc;
 
 use tower_lsp_server::ls_types::{
-    DidChangeTextDocumentParams, DidOpenTextDocumentParams, DocumentFormattingParams,
-    FormattingOptions, Hover, LocationLink, Position, TextDocumentContentChangeEvent,
-    TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams, TextEdit, Uri,
+    DidChangeTextDocumentParams, DidOpenTextDocumentParams, Location, LocationLink,
+    TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem, Uri,
     VersionedTextDocumentIdentifier,
 };
 use url::Url;
@@ -156,6 +159,37 @@ impl LanguageServerPool {
         }
     }
 
+    /// Send a host bridge request with the upstream params forwarded
+    /// **verbatim** (host-document-bridge): the params already reference the
+    /// real URI and real coordinates, so no per-method request shaping is
+    /// needed. Returns the raw `result` value, or `None` for a `null`
+    /// result, a JSON-RPC error, or a missing capability.
+    pub(crate) async fn send_host_raw_request(
+        &self,
+        server_name: &str,
+        server_config: &BridgeServerConfig,
+        doc: &HostDocument<'_>,
+        method: &'static str,
+        params: serde_json::Value,
+        upstream_request_id: Option<UpstreamId>,
+    ) -> io::Result<Option<serde_json::Value>> {
+        let handle = self
+            .get_or_create_connection(server_name, server_config)
+            .await?;
+        if !handle.has_capability(method) {
+            return Ok(None);
+        }
+        self.execute_host_request(
+            handle,
+            server_name,
+            doc,
+            upstream_request_id,
+            |request_id| JsonRpcRequest::new(request_id.as_i64(), method, params),
+            move |response| parse_host_raw_response(response, method),
+        )
+        .await
+    }
+
     /// Drive a host bridge request end-to-end: register for cancel
     /// forwarding, sync the host document, send, await, transform.
     ///
@@ -215,113 +249,6 @@ impl LanguageServerPool {
 
         Ok(transform_response(response?))
     }
-
-    /// Send a definition request for the host document itself.
-    ///
-    /// The response is normalized to `Vec<LocationLink>` but otherwise
-    /// verbatim: URIs and ranges already live in real-document space.
-    pub(crate) async fn send_host_definition_request(
-        &self,
-        server_name: &str,
-        server_config: &BridgeServerConfig,
-        doc: &HostDocument<'_>,
-        position: Position,
-        upstream_request_id: Option<UpstreamId>,
-    ) -> io::Result<Option<Vec<LocationLink>>> {
-        let handle = self
-            .get_or_create_connection(server_name, server_config)
-            .await?;
-        if !handle.has_capability("textDocument/definition") {
-            return Ok(None);
-        }
-        let uri_lsp = host_url_to_lsp_uri(doc.uri)?;
-        self.execute_host_request(
-            handle,
-            server_name,
-            doc,
-            upstream_request_id,
-            |request_id| {
-                build_host_position_request(
-                    &uri_lsp,
-                    position,
-                    request_id,
-                    "textDocument/definition",
-                )
-            },
-            parse_host_goto_response,
-        )
-        .await
-    }
-
-    /// Send a formatting request for the host document itself
-    /// (host-document-bridge): the host text travels verbatim and the
-    /// returned edits are already in real-document coordinates.
-    pub(crate) async fn send_host_formatting_request(
-        &self,
-        server_name: &str,
-        server_config: &BridgeServerConfig,
-        doc: &HostDocument<'_>,
-        options: FormattingOptions,
-        upstream_request_id: Option<UpstreamId>,
-    ) -> io::Result<Option<Vec<TextEdit>>> {
-        let handle = self
-            .get_or_create_connection(server_name, server_config)
-            .await?;
-        if !handle.has_capability("textDocument/formatting") {
-            return Ok(None);
-        }
-        let uri_lsp = host_url_to_lsp_uri(doc.uri)?;
-        self.execute_host_request(
-            handle,
-            server_name,
-            doc,
-            upstream_request_id,
-            |request_id| {
-                JsonRpcRequest::new(
-                    request_id.as_i64(),
-                    "textDocument/formatting",
-                    DocumentFormattingParams {
-                        text_document: TextDocumentIdentifier {
-                            uri: uri_lsp.clone(),
-                        },
-                        options,
-                        work_done_progress_params: Default::default(),
-                    },
-                )
-            },
-            parse_host_formatting_response,
-        )
-        .await
-    }
-
-    /// Send a hover request for the host document itself. Response verbatim.
-    pub(crate) async fn send_host_hover_request(
-        &self,
-        server_name: &str,
-        server_config: &BridgeServerConfig,
-        doc: &HostDocument<'_>,
-        position: Position,
-        upstream_request_id: Option<UpstreamId>,
-    ) -> io::Result<Option<Hover>> {
-        let handle = self
-            .get_or_create_connection(server_name, server_config)
-            .await?;
-        if !handle.has_capability("textDocument/hover") {
-            return Ok(None);
-        }
-        let uri_lsp = host_url_to_lsp_uri(doc.uri)?;
-        self.execute_host_request(
-            handle,
-            server_name,
-            doc,
-            upstream_request_id,
-            |request_id| {
-                build_host_position_request(&uri_lsp, position, request_id, "textDocument/hover")
-            },
-            parse_host_hover_response,
-        )
-        .await
-    }
 }
 
 /// `textDocument/didClose` params (the bridge protocol layer has no shared
@@ -337,36 +264,23 @@ fn host_url_to_lsp_uri(uri: &Url) -> io::Result<Uri> {
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
 }
 
-/// Build a position-based request against the real host URI (no translation).
-fn build_host_position_request(
-    uri: &Uri,
-    position: Position,
-    request_id: RequestId,
+/// Strip the JSON-RPC envelope: `None` for an error response or a `null`
+/// result, the bare `result` value otherwise.
+fn parse_host_raw_response(
+    mut response: serde_json::Value,
     method: &'static str,
-) -> JsonRpcRequest<TextDocumentPositionParams> {
-    JsonRpcRequest::new(
-        request_id.as_i64(),
-        method,
-        TextDocumentPositionParams {
-            text_document: TextDocumentIdentifier { uri: uri.clone() },
-            position,
-        },
-    )
-}
-
-/// Normalize a goto response (`Location | Location[] | LocationLink[]`) to
-/// `Vec<LocationLink>` **without** any URI or range rewriting — host
-/// responses already speak real-document coordinates.
-fn parse_host_goto_response(mut response: serde_json::Value) -> Option<Vec<LocationLink>> {
-    if response_has_jsonrpc_error(&response, "textDocument/definition (host)") {
+) -> Option<serde_json::Value> {
+    if response_has_jsonrpc_error(&response, method) {
         return None;
     }
     let result = response.get_mut("result")?.take();
-    if result.is_null() {
-        return None;
-    }
+    if result.is_null() { None } else { Some(result) }
+}
 
-    use tower_lsp_server::ls_types::Location;
+/// Normalize a goto result (`Location | Location[] | LocationLink[]`) to
+/// `Vec<LocationLink>` **without** any URI or range rewriting — host
+/// responses already speak real-document coordinates.
+pub(crate) fn normalize_host_goto_result(result: serde_json::Value) -> Option<Vec<LocationLink>> {
     fn location_to_link(location: Location) -> LocationLink {
         LocationLink {
             origin_selection_range: None,
@@ -387,156 +301,92 @@ fn parse_host_goto_response(mut response: serde_json::Value) -> Option<Vec<Locat
     }
     log::warn!(
         target: "kakehashi::bridge",
-        "host definition response did not match Location | Location[] | LocationLink[]"
+        "host goto response did not match Location | Location[] | LocationLink[]"
     );
     None
-}
-
-/// Parse a formatting response verbatim (no range translation).
-fn parse_host_formatting_response(mut response: serde_json::Value) -> Option<Vec<TextEdit>> {
-    if response_has_jsonrpc_error(&response, "textDocument/formatting (host)") {
-        return None;
-    }
-    let result = response.get_mut("result")?.take();
-    if result.is_null() {
-        return None;
-    }
-    match serde_json::from_value::<Vec<TextEdit>>(result) {
-        Ok(edits) => Some(edits),
-        Err(e) => {
-            log::warn!(
-                target: "kakehashi::bridge",
-                "host formatting response failed to deserialize: {e}"
-            );
-            None
-        }
-    }
-}
-
-/// Parse a hover response verbatim (no range translation).
-fn parse_host_hover_response(mut response: serde_json::Value) -> Option<Hover> {
-    if response_has_jsonrpc_error(&response, "textDocument/hover (host)") {
-        return None;
-    }
-    let result = response.get_mut("result")?.take();
-    if result.is_null() {
-        return None;
-    }
-    match serde_json::from_value::<Hover>(result) {
-        Ok(hover) => Some(hover),
-        Err(e) => {
-            log::warn!(
-                target: "kakehashi::bridge",
-                "host hover response failed to deserialize: {e}"
-            );
-            None
-        }
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn position() -> Position {
-        Position {
-            line: 32,
-            character: 12,
-        }
-    }
-
     #[test]
-    fn host_position_request_uses_real_uri_and_untranslated_position() {
-        let uri: Uri = "file:///project/doc.md".parse().unwrap();
-        let request = build_host_position_request(
-            &uri,
-            position(),
-            RequestId::new(7),
-            "textDocument/definition",
-        );
-        let value = serde_json::to_value(&request).unwrap();
-        assert_eq!(
-            value["params"]["textDocument"]["uri"], "file:///project/doc.md",
-            "host requests must carry the real client URI"
-        );
-        assert_eq!(
-            value["params"]["position"]["line"], 32,
-            "host positions must be forwarded untranslated"
-        );
-        assert_eq!(value["method"], "textDocument/definition");
-    }
-
-    #[test]
-    fn host_goto_response_passes_locations_through_verbatim() {
+    fn raw_response_strips_envelope_and_passes_result_verbatim() {
         let response = serde_json::json!({
             "jsonrpc": "2.0",
             "id": 1,
-            "result": [{
-                "uri": "file:///project/doc.md",
-                "range": {
-                    "start": { "line": 34, "character": 0 },
-                    "end": { "line": 34, "character": 11 }
-                }
-            }]
+            "result": [{ "uri": "file:///doc.md", "range": {
+                "start": { "line": 34, "character": 0 },
+                "end": { "line": 34, "character": 11 } } }]
         });
-        let links = parse_host_goto_response(response).expect("locations must parse");
-        assert_eq!(links.len(), 1);
-        assert_eq!(links[0].target_uri.as_str(), "file:///project/doc.md");
+        let result =
+            parse_host_raw_response(response, "textDocument/definition").expect("result expected");
+        assert_eq!(result[0]["uri"], "file:///doc.md");
         assert_eq!(
-            links[0].target_range.start.line, 34,
-            "host ranges must NOT be offset-translated"
+            result[0]["range"]["start"]["line"], 34,
+            "host results must NOT be offset-translated"
         );
     }
 
     #[test]
-    fn host_goto_response_handles_single_location() {
-        let response = serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "result": {
-                "uri": "file:///other.md",
-                "range": {
-                    "start": { "line": 1, "character": 2 },
-                    "end": { "line": 1, "character": 5 }
-                }
-            }
-        });
-        let links = parse_host_goto_response(response).expect("single location must parse");
-        assert_eq!(links.len(), 1);
-        assert_eq!(links[0].target_uri.as_str(), "file:///other.md");
-        assert_eq!(links[0].target_selection_range.start.line, 1);
-    }
-
-    #[test]
-    fn host_goto_response_null_is_none() {
+    fn raw_response_null_is_none() {
         let response = serde_json::json!({ "jsonrpc": "2.0", "id": 1, "result": null });
-        assert!(parse_host_goto_response(response).is_none());
+        assert!(parse_host_raw_response(response, "textDocument/hover").is_none());
     }
 
     #[test]
-    fn host_goto_response_error_is_none() {
+    fn raw_response_error_is_none() {
         let response = serde_json::json!({
             "jsonrpc": "2.0", "id": 1,
             "error": { "code": -32603, "message": "boom" }
         });
-        assert!(parse_host_goto_response(response).is_none());
+        assert!(parse_host_raw_response(response, "textDocument/hover").is_none());
     }
 
     #[test]
-    fn host_hover_response_keeps_range_verbatim() {
-        let response = serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "result": {
-                "contents": "docs",
-                "range": {
-                    "start": { "line": 9, "character": 0 },
-                    "end": { "line": 9, "character": 4 }
-                }
+    fn goto_normalization_passes_location_array_through_verbatim() {
+        let result = serde_json::json!([{
+            "uri": "file:///project/doc.md",
+            "range": {
+                "start": { "line": 34, "character": 0 },
+                "end": { "line": 34, "character": 11 }
+            }
+        }]);
+        let links = normalize_host_goto_result(result).expect("locations must parse");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target_uri.as_str(), "file:///project/doc.md");
+        assert_eq!(links[0].target_range.start.line, 34);
+    }
+
+    #[test]
+    fn goto_normalization_handles_single_location() {
+        let result = serde_json::json!({
+            "uri": "file:///other.md",
+            "range": {
+                "start": { "line": 1, "character": 2 },
+                "end": { "line": 1, "character": 5 }
             }
         });
-        let hover = parse_host_hover_response(response).expect("hover must parse");
-        assert_eq!(hover.range.unwrap().start.line, 9);
+        let links = normalize_host_goto_result(result).expect("single location must parse");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target_selection_range.start.line, 1);
+    }
+
+    #[test]
+    fn goto_normalization_handles_location_links() {
+        let result = serde_json::json!([{
+            "targetUri": "file:///doc.md",
+            "targetRange": {
+                "start": { "line": 0, "character": 0 },
+                "end": { "line": 0, "character": 4 }
+            },
+            "targetSelectionRange": {
+                "start": { "line": 0, "character": 0 },
+                "end": { "line": 0, "character": 4 }
+            }
+        }]);
+        let links = normalize_host_goto_result(result).expect("links must parse");
+        assert_eq!(links[0].target_uri.as_str(), "file:///doc.md");
     }
 
     #[test]

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -381,9 +381,15 @@ impl Kakehashi {
                 (Some(rx), Some(guard))
             }
             Err(e) => {
-                log::error!(
-                    "Cancel subscribe failed for {}: already subscribed. \
-                     Proceeding without cancel.",
+                // Expected under concurrent layer fan-out: `walk_layers`
+                // subscribes for the whole walk, so the virt/host arms'
+                // own subscribe attempts find the id taken. The arm runs
+                // without a local receiver; prompt cancellation is provided
+                // by the walk-level select (and downstream forwarding by the
+                // upstream-request registry, which is independent of this).
+                log::debug!(
+                    "Cancel subscribe for {}: already subscribed (another \
+                     layer holds it); proceeding without a local receiver",
                     e.0
                 );
                 (None, None)
@@ -496,12 +502,10 @@ impl Kakehashi {
     /// method (cross-layer-aggregation): when `"virt"` is absent from the
     /// resolved `layers.order`, the bridge dispatch is skipped entirely.
     ///
-    /// This gate is the whole of the stage-2 `preferred` walk for today's
-    /// contributor set — host (`bridge._self`) is unimplemented and the
-    /// bridged methods have no native contributor — so "first non-empty
-    /// layer in order" degenerates to "virt if allowed, else nothing".
-    /// Formatting consumes the full config instead (it dispatches on the
-    /// layer strategy too — see `combine_layer_formatting_results`).
+    /// Used by entry points outside the [`Self::walk_layers`] race —
+    /// notably the push-diagnostics scheduler and the virt-only handlers
+    /// (diagnostics, documentColor) that have no host contributor yet.
+    /// Handlers on the walk get layer membership from the race itself.
     pub(crate) fn virt_layer_enabled(&self, host_language: &str, method_name: &str) -> bool {
         self.resolve_layer_config(host_language, method_name)
             .allows(LayerSource::Virt)
@@ -668,7 +672,27 @@ impl Kakehashi {
         )
         .await;
         pool.unregister_all_for_upstream_id(ctx.upstream_request_id.as_ref());
-        result.handle(&self.client, request_method, None, Ok).await
+        // Quieter than `FanInResult::handle`: an all-empty host layer is the
+        // normal outcome whenever virt answers, and the virt arm already
+        // emits the client-visible "no response" LOG — only real host
+        // failures get surfaced here.
+        match result {
+            crate::lsp::aggregation::server::FanInResult::Done(value) => Ok(value),
+            crate::lsp::aggregation::server::FanInResult::NoResult { errors } => {
+                if errors > 0 {
+                    self.client
+                        .log_message(
+                            tower_lsp_server::ls_types::MessageType::WARNING,
+                            format!("No {request_method} response from any host bridge server"),
+                        )
+                        .await;
+                }
+                Ok(None)
+            }
+            crate::lsp::aggregation::server::FanInResult::Cancelled => {
+                Err(tower_lsp_server::jsonrpc::Error::request_cancelled())
+            }
+        }
     }
 
     /// Walk the resolved layer order for a request method
@@ -719,10 +743,29 @@ impl Kakehashi {
             }
         };
 
-        let result = race_layers_preferred(&layer_cfg.order, virt, host, is_nonempty).await;
-        // Sweep upstream-registry entries a dropped (losing) layer future did
-        // not get to unregister itself. Idempotent; the winning arm already
-        // cleaned up its own.
+        // Subscribe for the WHOLE walk before either arm runs: the arms'
+        // own subscribe attempts then find the id taken and proceed without
+        // a local receiver (logged at debug), and this select cancels the
+        // race — dropping both in-flight arms — the moment `$/cancelRequest`
+        // arrives, regardless of which arm would have held the subscription.
+        // Best-effort gap: between the race's completion and the next
+        // request there is no subscriber; a cancel landing there is only
+        // forwarded downstream via the upstream-request registry.
+        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(current_upstream_id().as_ref());
+        let race = race_layers_preferred(&layer_cfg.order, virt, host, is_nonempty);
+        let result = match cancel_rx {
+            Some(mut cancel_rx) => {
+                tokio::select! {
+                    biased;
+                    _ = &mut cancel_rx => Err(tower_lsp_server::jsonrpc::Error::request_cancelled()),
+                    result = race => result,
+                }
+            }
+            None => race.await,
+        };
+        // Sweep upstream-registry entries a dropped (losing or cancelled)
+        // layer future did not get to unregister itself. Idempotent; a
+        // completed arm already cleaned up its own.
         self.bridge
             .pool_arc()
             .unregister_all_for_upstream_id(current_upstream_id().as_ref());

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -36,9 +36,10 @@ pub(crate) struct DocumentRequestContext {
     pub(crate) configs: Vec<ResolvedServerConfig>,
     /// The upstream JSON-RPC request ID for cancel forwarding.
     pub(crate) upstream_request_id: Option<UpstreamId>,
-    /// Server names in priority order for aggregation.
-    /// Resolved from the bridge language config's aggregation settings.
-    /// Empty means pure first-win behavior (no priority ordering).
+    /// Server names in priority order for aggregation — an ordered allowlist
+    /// (aggregation-priorities-wildcard). `"*"` stands for the unlisted rest
+    /// (first-win group); the resolved default is `["*"]` (all servers,
+    /// first-win). Empty means fan-out is disabled for this method.
     pub(crate) priorities: Vec<String>,
     /// Aggregation strategy for this region.
     ///
@@ -120,14 +121,17 @@ pub(crate) fn resolve_aggregation_config_from_settings(
 
 /// Find every (host_language, injection_language) pair whose configured
 /// aggregation for `textDocument/formatting` is the **misconfigured**
-/// `Concatenated`-with-empty-`priorities` combination.
+/// `Concatenated`-without-explicit-`priorities` combination.
 ///
 /// Since the concatenated formatting pipeline landed
-/// (concatenated-formatting-pipeline), `strategy = "concatenated"` with a
-/// non-empty `priorities` is a valid configuration that runs the sequential
-/// pipeline — only an empty `priorities` is a misconfiguration (the pipeline's
-/// order would be undefined, so the region falls back to `preferred`; ADR
-/// Decision point 2). We warn the user once at settings-apply time
+/// (concatenated-formatting-pipeline), `strategy = "concatenated"` with
+/// explicit server names in `priorities` is a valid configuration that runs
+/// the sequential pipeline. A `priorities` carrying no explicit name — only
+/// the `"*"` wildcard, e.g. the resolved default for an absent list — is a
+/// misconfiguration (the pipeline's order would be undefined, so the region
+/// falls back to `preferred`; ADR Decision point 2). An explicit `[]` is the
+/// deliberate per-method kill switch (aggregation-priorities-wildcard) and is
+/// NOT warned about. We warn the user once at settings-apply time
 /// (initialize + didChangeConfiguration) so the mistake surfaces immediately
 /// rather than silently degrading every format request.
 ///
@@ -136,7 +140,7 @@ pub(crate) fn resolve_aggregation_config_from_settings(
 /// wildcard merge the runtime uses — so priorities supplied via the `_`
 /// wildcard entry count as configured.
 pub(crate) fn concatenated_formatting_pairs(settings: &WorkspaceSettings) -> Vec<(String, String)> {
-    use crate::config::settings::AggregationStrategy;
+    use crate::config::settings::{AggregationStrategy, PRIORITIES_WILDCARD};
 
     let mut pairs = Vec::new();
     for (host_language, lang_settings) in &settings.languages {
@@ -145,7 +149,14 @@ pub(crate) fn concatenated_formatting_pairs(settings: &WorkspaceSettings) -> Vec
         };
         for (injection_language, bridge_cfg) in bridge_map {
             let agg = bridge_cfg.resolve_aggregation("textDocument/formatting");
-            if agg.strategy == AggregationStrategy::Concatenated && agg.priorities.is_empty() {
+            let has_explicit_name = agg
+                .priorities
+                .iter()
+                .any(|name| name != PRIORITIES_WILDCARD);
+            if agg.strategy == AggregationStrategy::Concatenated
+                && !agg.priorities.is_empty()
+                && !has_explicit_name
+            {
                 pairs.push((host_language.clone(), injection_language.clone()));
             }
         }
@@ -176,10 +187,12 @@ pub(crate) fn format_concatenated_formatting_warning(pairs: &[(String, String)])
         .join(", ");
     Some(format!(
         "Bridge config sets aggregation strategy 'concatenated' for \
-         textDocument/formatting with an empty 'priorities' list on {} \
-         (host->injection) pair(s): {}. The concatenated formatting pipeline \
-         requires a non-empty 'priorities' (it defines which servers run and \
-         in what order); these pairs fall back to 'preferred'.",
+         textDocument/formatting with no explicit server names in \
+         'priorities' on {} (host->injection) pair(s): {}. The concatenated \
+         formatting pipeline requires explicitly named servers ('priorities' \
+         defines which servers run and in what order; '*' has no \
+         deterministic order and is ignored); these pairs fall back to \
+         'preferred'.",
         pairs.len(),
         listed
     ))
@@ -637,6 +650,71 @@ mod tests {
             !msg.contains("the configured strategy is ignored"),
             "stale 'strategy is ignored' phrasing must be retired; got: {msg}"
         );
+    }
+
+    #[test]
+    fn concatenated_formatting_pairs_excludes_explicit_empty_priorities() {
+        // priorities = [] is the deliberate per-method kill switch
+        // (aggregation-priorities-wildcard): the region runs nothing. That is
+        // intended behavior, not a misconfiguration — no warning.
+        let mut agg = HashMap::new();
+        agg.insert(
+            "textDocument/formatting".to_string(),
+            AggregationConfig {
+                priorities: Some(vec![]),
+                strategy: Some(AggregationStrategy::Concatenated),
+                max_fan_out: None,
+            },
+        );
+        let mut bridge = HashMap::new();
+        bridge.insert(
+            "python".to_string(),
+            BridgeLanguageConfig {
+                enabled: None,
+                aggregation: Some(agg),
+            },
+        );
+        let mut langs = HashMap::new();
+        langs.insert("markdown".to_string(), lang_settings(bridge));
+
+        let pairs = concatenated_formatting_pairs(&settings_with(langs));
+
+        assert!(
+            pairs.is_empty(),
+            "an explicit [] disables the method deliberately and must not be warned about"
+        );
+    }
+
+    #[test]
+    fn concatenated_formatting_pairs_flags_wildcard_only_priorities() {
+        // priorities = ["*"] (also the resolved default for an absent list)
+        // carries no explicit name: the pipeline's order is undefined, so the
+        // pair must be flagged for the settings-apply warning.
+        let mut agg = HashMap::new();
+        agg.insert(
+            "textDocument/formatting".to_string(),
+            AggregationConfig {
+                priorities: Some(vec![
+                    crate::config::settings::PRIORITIES_WILDCARD.to_string(),
+                ]),
+                strategy: Some(AggregationStrategy::Concatenated),
+                max_fan_out: None,
+            },
+        );
+        let mut bridge = HashMap::new();
+        bridge.insert(
+            "python".to_string(),
+            BridgeLanguageConfig {
+                enabled: None,
+                aggregation: Some(agg),
+            },
+        );
+        let mut langs = HashMap::new();
+        langs.insert("markdown".to_string(), lang_settings(bridge));
+
+        let pairs = concatenated_formatting_pairs(&settings_with(langs));
+
+        assert_eq!(pairs, vec![("markdown".to_string(), "python".to_string())]);
     }
 
     #[test]

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -345,6 +345,17 @@ impl Kakehashi {
         })
     }
 
+    /// Resolve the cross-layer config (cross-layer-aggregation) for a host
+    /// language and LSP method from the current settings.
+    pub(crate) fn resolve_layer_config(
+        &self,
+        host_language: &str,
+        method_name: &str,
+    ) -> ResolvedLayerConfig {
+        let settings = self.settings_manager.load_settings();
+        resolve_layer_config_from_settings(&settings, host_language, method_name)
+    }
+
     /// Whether the virt layer participates for this host language and LSP
     /// method (cross-layer-aggregation): when `"virt"` is absent from the
     /// resolved `layers.order`, the bridge dispatch is skipped entirely.
@@ -353,9 +364,10 @@ impl Kakehashi {
     /// contributor set — host (`bridge._self`) is unimplemented and the
     /// bridged methods have no native contributor — so "first non-empty
     /// layer in order" degenerates to "virt if allowed, else nothing".
+    /// Formatting consumes the full config instead (it dispatches on the
+    /// layer strategy too — see `combine_layer_formatting_results`).
     pub(crate) fn virt_layer_enabled(&self, host_language: &str, method_name: &str) -> bool {
-        let settings = self.settings_manager.load_settings();
-        resolve_layer_config_from_settings(&settings, host_language, method_name)
+        self.resolve_layer_config(host_language, method_name)
             .allows(LayerSource::Virt)
     }
 

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -147,6 +147,29 @@ pub(crate) fn resolve_layer_config_from_settings(
         .unwrap_or_else(|| ResolvedLayerConfig::with_defaults(method_name))
 }
 
+/// Generic emptiness check for raw host-layer results in the `preferred`
+/// fan-in: `null` and `[]` are "no result"; any other value counts.
+pub(crate) fn is_empty_layer_value(value: &serde_json::Value) -> bool {
+    value.is_null() || value.as_array().is_some_and(|items| items.is_empty())
+}
+
+/// Deserialize a verbatim host-layer result into the handler's response
+/// type, logging (not erroring) on shape mismatch.
+pub(crate) fn parse_host_verbatim<R: serde::de::DeserializeOwned>(
+    value: serde_json::Value,
+) -> Option<R> {
+    match serde_json::from_value::<R>(value) {
+        Ok(parsed) => Some(parsed),
+        Err(e) => {
+            log::warn!(
+                target: "kakehashi::bridge",
+                "host response failed to deserialize: {e}"
+            );
+            None
+        }
+    }
+}
+
 pub(crate) fn resolve_aggregation_config_from_settings(
     settings: &WorkspaceSettings,
     host_language: &str,
@@ -540,6 +563,107 @@ impl Kakehashi {
             max_fan_out: agg.max_fan_out,
             upstream_request_id: current_upstream_id(),
         })
+    }
+
+    /// Dispatch a host bridge request over a resolved [`HostRequestContext`]:
+    /// the upstream `params` are forwarded verbatim (real URI, real
+    /// coordinates) and the raw `result` value comes back untranslated.
+    pub(crate) async fn host_layer_value_with_ctx(
+        &self,
+        ctx: &HostRequestContext,
+        request_method: &'static str,
+        params: serde_json::Value,
+    ) -> tower_lsp_server::jsonrpc::Result<Option<serde_json::Value>> {
+        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(ctx.upstream_request_id.as_ref());
+        let pool = self.bridge.pool_arc();
+        let result = crate::lsp::aggregation::server::dispatch_host_preferred(
+            ctx,
+            pool.clone(),
+            move |t| {
+                let params = params.clone();
+                async move {
+                    t.pool
+                        .send_host_raw_request(
+                            &t.server_name,
+                            &t.server_config,
+                            &crate::lsp::bridge::HostDocument {
+                                uri: &t.uri,
+                                language_id: &t.language_id,
+                                text: &t.text,
+                            },
+                            request_method,
+                            params,
+                            t.upstream_id,
+                        )
+                        .await
+                }
+            },
+            |opt| matches!(opt, Some(v) if !is_empty_layer_value(v)),
+            cancel_rx,
+        )
+        .await;
+        pool.unregister_all_for_upstream_id(ctx.upstream_request_id.as_ref());
+        result.handle(&self.client, request_method, None, Ok).await
+    }
+
+    /// Walk the resolved layer order for a request method
+    /// (cross-layer-aggregation, `preferred` semantics): layers are tried
+    /// lazily in `order` and the first one producing a non-empty result wins.
+    ///
+    /// - `virt` is the handler's existing injection-bridge future, awaited
+    ///   only when (and if) the walk reaches the virt layer.
+    /// - The host layer forwards `raw_params` verbatim
+    ///   (host-document-bridge) and maps the raw result via `host_parse`.
+    /// - `layer_method` keys `layers.order` and the `_self` aggregation
+    ///   (e.g. rangeFormatting shares `textDocument/formatting`);
+    ///   `request_method` is what goes on the wire and gates capability.
+    /// - Native has no contributor for bridged methods.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn walk_layers<R>(
+        &self,
+        lsp_uri: &Uri,
+        layer_method: &'static str,
+        request_method: &'static str,
+        raw_params: serde_json::Value,
+        virt: impl Future<Output = tower_lsp_server::jsonrpc::Result<Option<R>>>,
+        host_parse: impl Fn(serde_json::Value) -> Option<R>,
+        is_nonempty: impl Fn(&R) -> bool,
+    ) -> tower_lsp_server::jsonrpc::Result<Option<R>> {
+        let Ok(uri) = uri_to_url(lsp_uri) else {
+            log::warn!("Invalid URI in {}: {}", request_method, lsp_uri.as_str());
+            return Ok(None);
+        };
+        let Some(host_language) = self.document_language(&uri) else {
+            return Ok(None);
+        };
+        let layer_cfg = self.resolve_layer_config(&host_language, layer_method);
+
+        let virt = std::pin::pin!(virt);
+        let mut virt = Some(virt);
+        for layer in &layer_cfg.order {
+            let result = match layer {
+                LayerSource::Virt => match virt.take() {
+                    Some(virt) => virt.await?,
+                    None => None,
+                },
+                LayerSource::Host => {
+                    match self.resolve_host_bridge_context(lsp_uri, layer_method) {
+                        Some(ctx) => self
+                            .host_layer_value_with_ctx(&ctx, request_method, raw_params.clone())
+                            .await?
+                            .and_then(&host_parse),
+                        None => None,
+                    }
+                }
+                LayerSource::Native => None,
+            };
+            if let Some(result) = result
+                && is_nonempty(&result)
+            {
+                return Ok(Some(result));
+            }
+        }
+        Ok(None)
     }
 
     /// Resolve injection context for a bridge endpoint request (all matching servers).

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -148,9 +148,27 @@ pub(crate) fn resolve_layer_config_from_settings(
 }
 
 /// Generic emptiness check for raw host-layer results in the `preferred`
-/// fan-in: `null` and `[]` are "no result"; any other value counts.
+/// fan-in: `null` and `[]` are "no result", as are the object-shaped
+/// "empty but valid" responses whose single canonical list field is empty —
+/// `CompletionList.items`, `SignatureHelp.signatures`,
+/// `LinkedEditingRanges.ranges`. Without the object shapes, a
+/// higher-priority host server's empty list would prematurely win the
+/// fan-in over a lower-priority server with actual results.
 pub(crate) fn is_empty_layer_value(value: &serde_json::Value) -> bool {
-    value.is_null() || value.as_array().is_some_and(|items| items.is_empty())
+    if value.is_null() {
+        return true;
+    }
+    if let Some(items) = value.as_array() {
+        return items.is_empty();
+    }
+    if let Some(object) = value.as_object() {
+        for key in ["items", "signatures", "ranges"] {
+            if let Some(list) = object.get(key).and_then(serde_json::Value::as_array) {
+                return list.is_empty();
+            }
+        }
+    }
+    false
 }
 
 /// Race the virt and host layer futures **concurrently** and decide by the
@@ -847,6 +865,43 @@ mod tests {
             enabled: None,
             aggregation: Some(agg),
         }
+    }
+
+    // ==========================================================================
+    // is_empty_layer_value (host-layer fan-in emptiness)
+    // ==========================================================================
+
+    #[test]
+    fn empty_layer_value_recognizes_null_and_empty_array() {
+        assert!(is_empty_layer_value(&serde_json::Value::Null));
+        assert!(is_empty_layer_value(&serde_json::json!([])));
+        assert!(!is_empty_layer_value(&serde_json::json!([1])));
+    }
+
+    #[test]
+    fn empty_layer_value_recognizes_object_shaped_empties() {
+        // CompletionList / SignatureHelp / LinkedEditingRanges with empty
+        // canonical lists are "empty but valid" — they must not win the
+        // host fan-in over a server with actual results.
+        assert!(is_empty_layer_value(&serde_json::json!({
+            "isIncomplete": false, "items": []
+        })));
+        assert!(is_empty_layer_value(
+            &serde_json::json!({ "signatures": [] })
+        ));
+        assert!(is_empty_layer_value(&serde_json::json!({ "ranges": [] })));
+        assert!(!is_empty_layer_value(&serde_json::json!({
+            "isIncomplete": false, "items": [{ "label": "x" }]
+        })));
+    }
+
+    #[test]
+    fn empty_layer_value_treats_other_objects_as_results() {
+        // Hover and friends: object results without a canonical list field
+        // count as results.
+        assert!(!is_empty_layer_value(&serde_json::json!({
+            "contents": "docs"
+        })));
     }
 
     // ==========================================================================

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -163,7 +163,19 @@ pub(crate) fn concatenated_formatting_pairs(settings: &WorkspaceSettings) -> Vec
         let Some(bridge_map) = lang_settings.bridge.as_ref() else {
             continue;
         };
-        for (injection_language, bridge_cfg) in bridge_map {
+        for injection_language in bridge_map.keys() {
+            // Resolve through the bridge-key wildcard merge so this warning
+            // path sees exactly what the runtime sees: priorities supplied by
+            // a `bridge._` entry must count for a `bridge.<lang>` that only
+            // sets the strategy. (For the literal `_` key this self-merges,
+            // which is idempotent for the field-level merge.)
+            let Some(bridge_cfg) = crate::config::resolve_with_wildcard(
+                bridge_map,
+                injection_language,
+                crate::config::merge_bridge_language_configs,
+            ) else {
+                continue;
+            };
             let agg = bridge_cfg.resolve_aggregation("textDocument/formatting");
             let has_explicit_name = agg
                 .priorities
@@ -198,7 +210,17 @@ pub(crate) fn format_concatenated_formatting_warning(pairs: &[(String, String)])
     }
     let listed = pairs
         .iter()
-        .map(|(host, injection)| format!("{}->{}", host, injection))
+        .map(|(host, injection)| {
+            // A `_` injection key is the wildcard template: it is not one
+            // request path but the default every injection language without
+            // its own override inherits — render it so the warning does not
+            // read as a literal language named "_".
+            if injection == crate::config::WILDCARD_KEY {
+                format!("{}->(any other injection)", host)
+            } else {
+                format!("{}->{}", host, injection)
+            }
+        })
         .collect::<Vec<_>>()
         .join(", ");
     Some(format!(
@@ -773,6 +795,57 @@ mod tests {
     }
 
     #[test]
+    fn concatenated_formatting_pairs_resolves_bridge_key_wildcard_inheritance() {
+        // Priorities supplied by the `bridge._` wildcard entry, strategy by
+        // the concrete `bridge.python` entry. The runtime merges the two
+        // (resolve_with_wildcard), so the warning path must too — flagging
+        // this valid configuration would be a false positive.
+        let mut python_agg = HashMap::new();
+        python_agg.insert(
+            "textDocument/formatting".to_string(),
+            AggregationConfig {
+                priorities: None,
+                strategy: Some(AggregationStrategy::Concatenated),
+                max_fan_out: None,
+            },
+        );
+        let mut wildcard_agg = HashMap::new();
+        wildcard_agg.insert(
+            "textDocument/formatting".to_string(),
+            AggregationConfig {
+                priorities: Some(vec!["black".to_string()]),
+                strategy: None,
+                max_fan_out: None,
+            },
+        );
+        let mut bridge = HashMap::new();
+        bridge.insert(
+            "python".to_string(),
+            BridgeLanguageConfig {
+                enabled: None,
+                aggregation: Some(python_agg),
+            },
+        );
+        bridge.insert(
+            "_".to_string(),
+            BridgeLanguageConfig {
+                enabled: None,
+                aggregation: Some(wildcard_agg),
+            },
+        );
+        let mut langs = HashMap::new();
+        langs.insert("markdown".to_string(), lang_settings(bridge));
+
+        let pairs = concatenated_formatting_pairs(&settings_with(langs));
+
+        assert!(
+            pairs.is_empty(),
+            "priorities inherited from the bridge._ wildcard entry must count \
+             as a configured pipeline definition; got: {pairs:?}"
+        );
+    }
+
+    #[test]
     fn concatenated_formatting_pairs_excludes_explicit_empty_priorities() {
         // priorities = [] is the deliberate per-method kill switch
         // (aggregation-priorities-wildcard): the region runs nothing. That is
@@ -927,6 +1000,24 @@ mod tests {
         for needle in ["markdown->lua", "markdown->python", "rust->python"] {
             assert!(msg.contains(needle), "missing '{needle}' in: {msg}");
         }
+    }
+
+    #[test]
+    fn format_concatenated_formatting_warning_renders_wildcard_injection_meaningfully() {
+        // A `_` injection key is the wildcard template every unlisted
+        // injection language inherits — the warning must not present it as a
+        // literal language named "_".
+        let msg =
+            format_concatenated_formatting_warning(&[("markdown".to_string(), "_".to_string())])
+                .expect("non-empty input must yield a message");
+        assert!(
+            msg.contains("markdown->(any other injection)"),
+            "wildcard pair must be rendered as a template, got: {msg}"
+        );
+        assert!(
+            !msg.contains("markdown->_"),
+            "raw '_' rendering must be replaced; got: {msg}"
+        );
     }
 
     #[test]

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -10,7 +10,8 @@ use url::Url;
 
 use crate::config::WorkspaceSettings;
 use crate::config::settings::{
-    AggregationStrategy, BridgeLanguageConfig, ResolvedAggregationConfig,
+    AggregationStrategy, BridgeLanguageConfig, LayerSource, ResolvedAggregationConfig,
+    ResolvedLayerConfig,
 };
 use crate::language::injection::ResolvedInjection;
 use crate::lsp::bridge::{ResolvedServerConfig, UpstreamId};
@@ -103,6 +104,21 @@ fn resolve_bridge_language_config_from_settings(
                 crate::config::merge_bridge_language_configs,
             )
         })
+}
+
+/// Resolve the cross-layer config (cross-layer-aggregation) for a host
+/// language and method. Falls back to the built-in defaults — order
+/// `[virt, host, native]`, per-method strategy — when the host language has
+/// no settings entry at all.
+pub(crate) fn resolve_layer_config_from_settings(
+    settings: &WorkspaceSettings,
+    host_language: &str,
+    method_name: &str,
+) -> ResolvedLayerConfig {
+    settings
+        .resolve_host_language_settings(host_language)
+        .map(|lang_settings| lang_settings.resolve_layers(method_name))
+        .unwrap_or_else(|| ResolvedLayerConfig::with_defaults(method_name))
 }
 
 pub(crate) fn resolve_aggregation_config_from_settings(
@@ -329,6 +345,20 @@ impl Kakehashi {
         })
     }
 
+    /// Whether the virt layer participates for this host language and LSP
+    /// method (cross-layer-aggregation): when `"virt"` is absent from the
+    /// resolved `layers.order`, the bridge dispatch is skipped entirely.
+    ///
+    /// This gate is the whole of the stage-2 `preferred` walk for today's
+    /// contributor set — host (`bridge._self`) is unimplemented and the
+    /// bridged methods have no native contributor — so "first non-empty
+    /// layer in order" degenerates to "virt if allowed, else nothing".
+    pub(crate) fn virt_layer_enabled(&self, host_language: &str, method_name: &str) -> bool {
+        let settings = self.settings_manager.load_settings();
+        resolve_layer_config_from_settings(&settings, host_language, method_name)
+            .allows(LayerSource::Virt)
+    }
+
     /// Convert a preamble result into a `DocumentRequestContext` by looking up
     /// bridge server configs for the injection language.
     ///
@@ -341,6 +371,15 @@ impl Kakehashi {
         preamble: PreambleResult,
         method_name: &str,
     ) -> Option<DocumentRequestContext> {
+        if !self.virt_layer_enabled(&preamble.language_name, method_name) {
+            log::debug!(
+                "{}: virt layer disabled for {} via layers.order",
+                method_name,
+                preamble.language_name
+            );
+            return None;
+        }
+
         let configs = self.bridge_configs_for_injection_language(
             &preamble.language_name,
             &preamble.resolved.injection_language,
@@ -445,11 +484,8 @@ mod tests {
 
     fn lang_settings(bridge: HashMap<String, BridgeLanguageConfig>) -> LanguageSettings {
         LanguageSettings {
-            base: None,
-            parser: None,
-            queries: None,
             bridge: Some(bridge),
-            aliases: None,
+            ..Default::default()
         }
     }
 
@@ -470,6 +506,78 @@ mod tests {
             enabled: None,
             aggregation: Some(agg),
         }
+    }
+
+    // ==========================================================================
+    // resolve_layer_config_from_settings (cross-layer-aggregation)
+    // ==========================================================================
+
+    #[test]
+    fn resolve_layer_config_defaults_when_language_has_no_settings() {
+        let settings = settings_with(HashMap::new());
+        let resolved =
+            resolve_layer_config_from_settings(&settings, "markdown", "textDocument/hover");
+        assert_eq!(
+            resolved.order,
+            vec![LayerSource::Virt, LayerSource::Host, LayerSource::Native]
+        );
+    }
+
+    #[test]
+    fn resolve_layer_config_respects_language_entry() {
+        let mut langs = HashMap::new();
+        langs.insert(
+            "markdown".to_string(),
+            LanguageSettings {
+                layers: Some(HashMap::from([(
+                    "textDocument/hover".to_string(),
+                    crate::config::settings::LayerAggregationConfig {
+                        order: Some(vec![LayerSource::Native]),
+                        strategy: None,
+                    },
+                )])),
+                ..Default::default()
+            },
+        );
+        let settings = settings_with(langs);
+
+        let hover = resolve_layer_config_from_settings(&settings, "markdown", "textDocument/hover");
+        assert_eq!(hover.order, vec![LayerSource::Native]);
+        assert!(!hover.allows(LayerSource::Virt));
+
+        let definition =
+            resolve_layer_config_from_settings(&settings, "markdown", "textDocument/definition");
+        assert!(
+            definition.allows(LayerSource::Virt),
+            "unconfigured methods keep the default order"
+        );
+    }
+
+    #[test]
+    fn resolve_layer_config_falls_back_to_language_wildcard_entry() {
+        // resolve_host_language_settings falls back to the "_" language for
+        // hosts without their own entry, so layers configured there apply.
+        let mut langs = HashMap::new();
+        langs.insert(
+            "_".to_string(),
+            LanguageSettings {
+                layers: Some(HashMap::from([(
+                    "_".to_string(),
+                    crate::config::settings::LayerAggregationConfig {
+                        order: Some(vec![]),
+                        strategy: None,
+                    },
+                )])),
+                ..Default::default()
+            },
+        );
+        let settings = settings_with(langs);
+        let resolved =
+            resolve_layer_config_from_settings(&settings, "markdown", "textDocument/hover");
+        assert!(
+            resolved.order.is_empty(),
+            "wildcard-language layers must apply to unconfigured hosts"
+        );
     }
 
     #[test]

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -53,6 +53,32 @@ pub(crate) struct DocumentRequestContext {
     pub(crate) max_fan_out: Option<usize>,
 }
 
+/// All resolved context needed to send a **host** bridge request
+/// (host-document-bridge): the real URI, the host language and text
+/// verbatim, plus the servers selected for the host role and the `_self`
+/// aggregation settings.
+///
+/// The layer strategy is not carried: host dispatch is `preferred`-only
+/// today (cross-layer `concatenated` is honored for formatting, which has no
+/// host path yet).
+pub(crate) struct HostRequestContext {
+    /// The real client URI (forwarded verbatim — no virtual URI).
+    pub(crate) uri: Url,
+    /// The host language, used as the downstream `languageId`.
+    pub(crate) language_id: String,
+    /// The current host text, shared across per-server tasks.
+    pub(crate) text: std::sync::Arc<str>,
+    /// Host-capable server configs (`languages` contains the host language),
+    /// gated on the explicit `bridge._self.enabled = true` opt-in.
+    pub(crate) configs: Vec<ResolvedServerConfig>,
+    /// Ordered allowlist from `bridge._self.aggregation` (wildcard-merged).
+    pub(crate) priorities: Vec<String>,
+    /// Fan-out cap from `bridge._self.aggregation`.
+    pub(crate) max_fan_out: Option<usize>,
+    /// The upstream JSON-RPC request ID for cancel forwarding.
+    pub(crate) upstream_request_id: Option<UpstreamId>,
+}
+
 /// Document context plus a cursor position.
 ///
 /// Used by position-based handlers (definition, hover, completion, etc.).
@@ -463,6 +489,57 @@ impl Kakehashi {
             injection_language,
             method_name,
         )
+    }
+
+    /// Resolve the context for a **host** bridge request
+    /// (host-document-bridge): the host language's own servers, gated on the
+    /// explicit `bridge._self.enabled = true` opt-in.
+    ///
+    /// Returns `None` when the document is missing, host bridging is not
+    /// opted in, or no configured server lists the host language.
+    pub(crate) fn resolve_host_bridge_context(
+        &self,
+        lsp_uri: &Uri,
+        method_name: &str,
+    ) -> Option<HostRequestContext> {
+        let uri = uri_to_url(lsp_uri).ok()?;
+        let snapshot = self.documents.get(&uri)?.snapshot()?;
+        let language_name = self.document_language(&uri)?;
+
+        let settings = self.settings_manager.load_settings();
+        let lang_settings = settings.resolve_host_language_settings(&language_name)?;
+        if !lang_settings.is_host_bridging_enabled() {
+            log::debug!(
+                "{}: host bridging not opted in for {} (bridge._self.enabled)",
+                method_name,
+                language_name
+            );
+            return None;
+        }
+
+        let configs = self
+            .bridge
+            .get_host_configs_for_language(&settings, &language_name);
+        if configs.is_empty() {
+            log::debug!(
+                "{}: no host-capable server configured for {}",
+                method_name,
+                language_name
+            );
+            return None;
+        }
+
+        let agg = lang_settings.resolve_host_aggregation(method_name);
+
+        Some(HostRequestContext {
+            uri,
+            text: std::sync::Arc::from(snapshot.text()),
+            language_id: language_name,
+            configs,
+            priorities: agg.priorities,
+            max_fan_out: agg.max_fan_out,
+            upstream_request_id: current_upstream_id(),
+        })
     }
 
     /// Resolve injection context for a bridge endpoint request (all matching servers).

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -58,9 +58,9 @@ pub(crate) struct DocumentRequestContext {
 /// verbatim, plus the servers selected for the host role and the `_self`
 /// aggregation settings.
 ///
-/// The layer strategy is not carried: host dispatch is `preferred`-only
-/// today (cross-layer `concatenated` is honored for formatting, which has no
-/// host path yet).
+/// The layer strategy is not carried: within the host layer, servers
+/// combine with `preferred` only. The cross-layer strategy lives in the
+/// caller (`walk_layers` / the formatting pipeline).
 pub(crate) struct HostRequestContext {
     /// The real client URI (forwarded verbatim — no virtual URI).
     pub(crate) uri: Url,
@@ -151,6 +151,71 @@ pub(crate) fn resolve_layer_config_from_settings(
 /// fan-in: `null` and `[]` are "no result"; any other value counts.
 pub(crate) fn is_empty_layer_value(value: &serde_json::Value) -> bool {
     value.is_null() || value.as_array().is_some_and(|items| items.is_empty())
+}
+
+/// Race the virt and host layer futures **concurrently** and decide by the
+/// resolved layer `order` (cross-layer-aggregation, `preferred` semantics) —
+/// the layer-level analogue of the stage-1 `preferred` fan-in:
+///
+/// - both layers' requests are in flight at once (latency = max, not sum);
+/// - a completed lower-priority result is buffered while a higher-priority
+///   layer is still pending — priority decides, not arrival order;
+/// - a higher-priority layer that completes non-empty wins immediately and
+///   the still-pending loser future is dropped (best-effort abandonment,
+///   like the stage-1 `abort_all`);
+/// - layers absent from `order` are never polled (their future is created
+///   but async blocks are lazy);
+/// - native has no contributor and is skipped.
+pub(crate) async fn race_layers_preferred<R>(
+    order: &[LayerSource],
+    virt: impl Future<Output = tower_lsp_server::jsonrpc::Result<Option<R>>>,
+    host: impl Future<Output = tower_lsp_server::jsonrpc::Result<Option<R>>>,
+    is_nonempty: impl Fn(&R) -> bool,
+) -> tower_lsp_server::jsonrpc::Result<Option<R>> {
+    let mut virt_fut = std::pin::pin!(virt);
+    let mut host_fut = std::pin::pin!(host);
+    // `None` = still pending; `Some(result)` = completed. Layers not in
+    // `order` start as completed-empty so their guard never enables and the
+    // decision walk skips them.
+    let mut virt_state: Option<Option<R>> = (!order.contains(&LayerSource::Virt)).then_some(None);
+    let mut host_state: Option<Option<R>> = (!order.contains(&LayerSource::Host)).then_some(None);
+
+    loop {
+        // Decision walk in priority order: a pending higher-priority layer
+        // blocks; a completed empty one falls through; a completed non-empty
+        // one wins.
+        let mut blocked = false;
+        for layer in order {
+            let slot = match layer {
+                LayerSource::Virt => &mut virt_state,
+                LayerSource::Host => &mut host_state,
+                LayerSource::Native => continue,
+            };
+            match slot {
+                None => {
+                    blocked = true;
+                    break;
+                }
+                Some(result) => {
+                    if result.as_ref().is_some_and(&is_nonempty) {
+                        return Ok(result.take());
+                    }
+                }
+            }
+        }
+        if !blocked {
+            return Ok(None);
+        }
+
+        tokio::select! {
+            result = &mut virt_fut, if virt_state.is_none() => {
+                virt_state = Some(result?);
+            }
+            result = &mut host_fut, if host_state.is_none() => {
+                host_state = Some(result?);
+            }
+        }
+    }
 }
 
 /// Deserialize a verbatim host-layer result into the handler's response
@@ -607,17 +672,23 @@ impl Kakehashi {
     }
 
     /// Walk the resolved layer order for a request method
-    /// (cross-layer-aggregation, `preferred` semantics): layers are tried
-    /// lazily in `order` and the first one producing a non-empty result wins.
+    /// (cross-layer-aggregation, `preferred` semantics): the virt and host
+    /// layers fan out **concurrently** ([`race_layers_preferred`]) and the
+    /// highest-priority non-empty result wins.
     ///
-    /// - `virt` is the handler's existing injection-bridge future, awaited
-    ///   only when (and if) the walk reaches the virt layer.
+    /// - `virt` is the handler's existing injection-bridge future, polled
+    ///   only when the virt layer is in `order`.
     /// - The host layer forwards `raw_params` verbatim
     ///   (host-document-bridge) and maps the raw result via `host_parse`.
     /// - `layer_method` keys `layers.order` and the `_self` aggregation
     ///   (e.g. rangeFormatting shares `textDocument/formatting`);
     ///   `request_method` is what goes on the wire and gates capability.
     /// - Native has no contributor for bridged methods.
+    ///
+    /// A losing in-flight future is dropped; its RAII guards clean up the
+    /// response router and cancel subscription, and the trailing
+    /// `unregister_all_for_upstream_id` sweeps any upstream-registry entries
+    /// the dropped future did not get to remove itself.
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn walk_layers<R>(
         &self,
@@ -638,32 +709,24 @@ impl Kakehashi {
         };
         let layer_cfg = self.resolve_layer_config(&host_language, layer_method);
 
-        let virt = std::pin::pin!(virt);
-        let mut virt = Some(virt);
-        for layer in &layer_cfg.order {
-            let result = match layer {
-                LayerSource::Virt => match virt.take() {
-                    Some(virt) => virt.await?,
-                    None => None,
-                },
-                LayerSource::Host => {
-                    match self.resolve_host_bridge_context(lsp_uri, layer_method) {
-                        Some(ctx) => self
-                            .host_layer_value_with_ctx(&ctx, request_method, raw_params.clone())
-                            .await?
-                            .and_then(&host_parse),
-                        None => None,
-                    }
-                }
-                LayerSource::Native => None,
-            };
-            if let Some(result) = result
-                && is_nonempty(&result)
-            {
-                return Ok(Some(result));
+        let host = async {
+            match self.resolve_host_bridge_context(lsp_uri, layer_method) {
+                Some(ctx) => Ok(self
+                    .host_layer_value_with_ctx(&ctx, request_method, raw_params.clone())
+                    .await?
+                    .and_then(&host_parse)),
+                None => Ok(None),
             }
-        }
-        Ok(None)
+        };
+
+        let result = race_layers_preferred(&layer_cfg.order, virt, host, is_nonempty).await;
+        // Sweep upstream-registry entries a dropped (losing) layer future did
+        // not get to unregister itself. Idempotent; the winning arm already
+        // cleaned up its own.
+        self.bridge
+            .pool_arc()
+            .unregister_all_for_upstream_id(current_upstream_id().as_ref());
+        result
     }
 
     /// Resolve injection context for a bridge endpoint request (all matching servers).
@@ -741,6 +804,113 @@ mod tests {
             enabled: None,
             aggregation: Some(agg),
         }
+    }
+
+    // ==========================================================================
+    // race_layers_preferred (cross-layer-aggregation, parallel fan-out)
+    // ==========================================================================
+
+    const VHN: &[LayerSource] = &[LayerSource::Virt, LayerSource::Host, LayerSource::Native];
+
+    fn ok<R>(value: Option<R>) -> tower_lsp_server::jsonrpc::Result<Option<R>> {
+        Ok(value)
+    }
+
+    #[tokio::test]
+    async fn race_prefers_higher_layer_even_when_lower_arrives_first() {
+        // Host completes instantly with a result; virt completes later but
+        // non-empty. Priority decides, not arrival order.
+        let virt = async {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            ok(Some("virt"))
+        };
+        let host = async { ok(Some("host")) };
+        let won = race_layers_preferred(VHN, virt, host, |_| true)
+            .await
+            .unwrap();
+        assert_eq!(won, Some("virt"));
+    }
+
+    #[tokio::test]
+    async fn race_falls_back_to_host_when_virt_is_empty() {
+        let virt = async { ok(None) };
+        let host = async { ok(Some("host")) };
+        let won = race_layers_preferred(VHN, virt, host, |_| true)
+            .await
+            .unwrap();
+        assert_eq!(won, Some("host"));
+    }
+
+    #[tokio::test]
+    async fn race_polls_layers_concurrently_not_serially() {
+        // The virt future only completes AFTER the host future completed
+        // (oneshot handshake). A serial walk (virt awaited to completion
+        // before host is even polled) would deadlock here; the concurrent
+        // race completes promptly.
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let virt = async move {
+            let _ = rx.await;
+            ok(Some("virt"))
+        };
+        let host = async move {
+            let _ = tx.send(());
+            // Stay pending long enough that the race must keep polling virt.
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            ok(Some("host"))
+        };
+        let won = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            race_layers_preferred(VHN, virt, host, |_| true),
+        )
+        .await
+        .expect("layers must fan out concurrently — a serial walk deadlocks this handshake")
+        .unwrap();
+        assert_eq!(won, Some("virt"), "priority still decides");
+    }
+
+    #[tokio::test]
+    async fn race_never_polls_layers_absent_from_order() {
+        // An allowlist without virt must not poll the virt future at all.
+        let virt = async {
+            panic!("virt must not be polled when absent from order");
+            #[allow(unreachable_code)]
+            ok(Some("virt"))
+        };
+        let host = async { ok(Some("host")) };
+        let won = race_layers_preferred(&[LayerSource::Host], virt, host, |_| true)
+            .await
+            .unwrap();
+        assert_eq!(won, Some("host"));
+    }
+
+    #[tokio::test]
+    async fn race_returns_none_when_all_layers_are_empty() {
+        let virt = async { ok(None) };
+        let host = async { ok(None) };
+        let won: Option<&str> = race_layers_preferred(VHN, virt, host, |_| true)
+            .await
+            .unwrap();
+        assert_eq!(won, None);
+    }
+
+    #[tokio::test]
+    async fn race_treats_empty_results_via_is_nonempty() {
+        // A Some result that the emptiness check rejects falls through.
+        let virt = async { ok(Some(Vec::<i32>::new())) };
+        let host = async { ok(Some(vec![1])) };
+        let won = race_layers_preferred(VHN, virt, host, |v: &Vec<i32>| !v.is_empty())
+            .await
+            .unwrap();
+        assert_eq!(won, Some(vec![1]));
+    }
+
+    #[tokio::test]
+    async fn race_propagates_errors() {
+        let virt =
+            async { Err::<Option<&str>, _>(tower_lsp_server::jsonrpc::Error::request_cancelled()) };
+        let host = async { ok(Some("host")) };
+        let result = race_layers_preferred(VHN, virt, host, |_| true).await;
+        assert!(result.is_err(), "a layer error must propagate");
     }
 
     // ==========================================================================

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -113,6 +113,26 @@ impl DiagnosticScheduler {
             (snapshot, language_name)
         };
 
+        // Layer gate (cross-layer-aggregation), keyed by the same method name
+        // as the aggregation config below. Returning an empty snapshot (not
+        // None) publishes an empty diagnostics list, clearing anything a
+        // previously-enabled configuration left in the editor.
+        let settings = self.settings_manager.load_settings();
+        if !crate::lsp::lsp_impl::bridge_context::resolve_layer_config_from_settings(
+            &settings,
+            &language_name,
+            "textDocument/publishDiagnostics",
+        )
+        .allows(crate::config::settings::LayerSource::Virt)
+        {
+            log::debug!(
+                target: LOG_TARGET,
+                "virt layer disabled for {} via layers.order",
+                language_name
+            );
+            return Some(Vec::new());
+        }
+
         let injection_query = self.language.injection_query(&language_name)?;
 
         let all_regions = InjectionResolver::resolve_all(
@@ -129,7 +149,6 @@ impl DiagnosticScheduler {
         }
 
         let mut contexts = Vec::new();
-        let settings = self.settings_manager.load_settings();
         for resolved in all_regions {
             let configs = self.bridge.get_all_configs_for_language(
                 &settings,

--- a/src/lsp/lsp_impl/text_document/code_lens.rs
+++ b/src/lsp/lsp_impl/text_document/code_lens.rs
@@ -10,9 +10,11 @@ impl Kakehashi {
         &self,
         params: CodeLensParams,
     ) -> Result<Option<Vec<CodeLens>>> {
+        let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
         self.whole_document_preferred_fan_out(
             &params.text_document.uri,
             "textDocument/codeLens",
+            raw_params,
             |t| async move {
                 t.pool
                     .send_code_lens_request(

--- a/src/lsp/lsp_impl/text_document/completion.rs
+++ b/src/lsp/lsp_impl/text_document/completion.rs
@@ -1,22 +1,53 @@
 //! Completion method for Kakehashi.
+//!
+//! Walks the resolved layer order (cross-layer-aggregation): the virt layer
+//! bridges the injection region under the cursor, the host layer
+//! (host-document-bridge) bridges the host document itself with the real URI
+//! and the response verbatim. The first layer producing a non-empty result
+//! wins (`preferred`).
 
 use tower_lsp_server::jsonrpc::Result;
-use tower_lsp_server::ls_types::{CompletionParams, CompletionResponse};
+use tower_lsp_server::ls_types::{CompletionParams, CompletionResponse, Position, Uri};
 
 use super::super::Kakehashi;
 use crate::lsp::aggregation::server::dispatch_preferred;
+use crate::lsp::lsp_impl::bridge_context::parse_host_verbatim;
+
+const METHOD: &str = "textDocument/completion";
 
 impl Kakehashi {
     pub(crate) async fn completion_impl(
         &self,
         params: CompletionParams,
     ) -> Result<Option<CompletionResponse>> {
+        let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
         let lsp_uri = params.text_document_position.text_document.uri;
         let position = params.text_document_position.position;
 
+        let virt = self.completion_virt_layer(&lsp_uri, position);
+        self.walk_layers(
+            &lsp_uri,
+            METHOD,
+            METHOD,
+            raw_params,
+            virt,
+            parse_host_verbatim::<CompletionResponse>,
+            |resp: &CompletionResponse| match resp {
+                CompletionResponse::Array(items) => !items.is_empty(),
+                CompletionResponse::List(list) => !list.items.is_empty(),
+            },
+        )
+        .await
+    }
+
+    /// Virt layer: bridge the injection region under the cursor.
+    async fn completion_virt_layer(
+        &self,
+        lsp_uri: &Uri,
+        position: Position,
+    ) -> Result<Option<CompletionResponse>> {
         // Use shared preamble to resolve injection context with ALL matching servers
-        let Some(ctx) = self.resolve_bridge_contexts(&lsp_uri, position, "textDocument/completion")
-        else {
+        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
             return Ok(None);
         };
 

--- a/src/lsp/lsp_impl/text_document/declaration.rs
+++ b/src/lsp/lsp_impl/text_document/declaration.rs
@@ -1,25 +1,53 @@
 //! Goto declaration method for Kakehashi.
+//!
+//! Walks the resolved layer order (cross-layer-aggregation): the virt layer
+//! bridges the injection region under the cursor, the host layer
+//! (host-document-bridge) bridges the host document itself with the real URI
+//! and no coordinate translation. The first layer producing a non-empty
+//! result wins (`preferred`).
 
 use tower_lsp_server::jsonrpc::Result;
-use tower_lsp_server::ls_types::Location;
 use tower_lsp_server::ls_types::request::{GotoDeclarationParams, GotoDeclarationResponse};
+use tower_lsp_server::ls_types::{Location, LocationLink, Position, Uri};
 
-use crate::lsp::bridge::location_link_to_location;
+use crate::lsp::bridge::{location_link_to_location, normalize_host_goto_result};
 
 use super::super::Kakehashi;
 use crate::lsp::aggregation::server::dispatch_preferred;
+
+const METHOD: &str = "textDocument/declaration";
 
 impl Kakehashi {
     pub(crate) async fn goto_declaration_impl(
         &self,
         params: GotoDeclarationParams,
     ) -> Result<Option<GotoDeclarationResponse>> {
+        let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
         let lsp_uri = params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
 
-        let Some(ctx) =
-            self.resolve_bridge_contexts(&lsp_uri, position, "textDocument/declaration")
-        else {
+        let virt = self.declaration_virt_layer(&lsp_uri, position);
+        let links = self
+            .walk_layers(
+                &lsp_uri,
+                METHOD,
+                METHOD,
+                raw_params,
+                virt,
+                normalize_host_goto_result,
+                |links: &Vec<LocationLink>| !links.is_empty(),
+            )
+            .await?;
+        Ok(links.map(|links| self.declaration_response(links)))
+    }
+
+    /// Virt layer: bridge the injection region under the cursor.
+    async fn declaration_virt_layer(
+        &self,
+        lsp_uri: &Uri,
+        position: Position,
+    ) -> Result<Option<Vec<LocationLink>>> {
+        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
             return Ok(None);
         };
 
@@ -52,20 +80,17 @@ impl Kakehashi {
         )
         .await;
         pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
+        result.handle(&self.client, "declaration", None, Ok).await
+    }
 
-        result
-            .handle(&self.client, "declaration", None, |value| match value {
-                Some(links) => {
-                    if self.settings_manager.supports_declaration_link() {
-                        Ok(Some(GotoDeclarationResponse::Link(links)))
-                    } else {
-                        let locations: Vec<Location> =
-                            links.into_iter().map(location_link_to_location).collect();
-                        Ok(Some(GotoDeclarationResponse::Array(locations)))
-                    }
-                }
-                None => Ok(None),
-            })
-            .await
+    /// Shape the winning links per the client's `LocationLink` support.
+    fn declaration_response(&self, links: Vec<LocationLink>) -> GotoDeclarationResponse {
+        if self.settings_manager.supports_declaration_link() {
+            GotoDeclarationResponse::Link(links)
+        } else {
+            let locations: Vec<Location> =
+                links.into_iter().map(location_link_to_location).collect();
+            GotoDeclarationResponse::Array(locations)
+        }
     }
 }

--- a/src/lsp/lsp_impl/text_document/definition.rs
+++ b/src/lsp/lsp_impl/text_document/definition.rs
@@ -1,12 +1,23 @@
 //! Goto definition method for Kakehashi.
+//!
+//! Walks the resolved layer order (cross-layer-aggregation): the virt layer
+//! bridges the injection region under the cursor, the host layer
+//! (host-document-bridge) bridges the host document itself with the real URI
+//! and no coordinate translation. The first layer producing a non-empty
+//! result wins (`preferred`).
 
 use tower_lsp_server::jsonrpc::Result;
-use tower_lsp_server::ls_types::{GotoDefinitionParams, GotoDefinitionResponse, Location};
+use tower_lsp_server::ls_types::{
+    GotoDefinitionParams, GotoDefinitionResponse, Location, LocationLink, Position, Uri,
+};
 
+use crate::config::settings::LayerSource;
 use crate::lsp::bridge::location_link_to_location;
 
-use super::super::Kakehashi;
-use crate::lsp::aggregation::server::dispatch_preferred;
+use super::super::{Kakehashi, uri_to_url};
+use crate::lsp::aggregation::server::{dispatch_host_preferred, dispatch_preferred};
+
+const METHOD: &str = "textDocument/definition";
 
 impl Kakehashi {
     pub(crate) async fn goto_definition_impl(
@@ -16,15 +27,44 @@ impl Kakehashi {
         let lsp_uri = params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
 
-        let Some(ctx) = self.resolve_bridge_contexts(&lsp_uri, position, "textDocument/definition")
-        else {
+        let Ok(uri) = uri_to_url(&lsp_uri) else {
+            log::warn!("Invalid URI in definition: {}", lsp_uri.as_str());
+            return Ok(None);
+        };
+        let Some(host_language) = self.document_language(&uri) else {
+            return Ok(None);
+        };
+
+        let layer_cfg = self.resolve_layer_config(&host_language, METHOD);
+        for layer in &layer_cfg.order {
+            let links = match layer {
+                LayerSource::Virt => self.definition_virt_layer(&lsp_uri, position).await?,
+                LayerSource::Host => self.definition_host_layer(&lsp_uri, position).await?,
+                // No native definition implementation: empty contributor.
+                LayerSource::Native => None,
+            };
+            if let Some(links) = links
+                && !links.is_empty()
+            {
+                return Ok(Some(self.definition_response(links)));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Virt layer: bridge the injection region under the cursor.
+    async fn definition_virt_layer(
+        &self,
+        lsp_uri: &Uri,
+        position: Position,
+    ) -> Result<Option<Vec<LocationLink>>> {
+        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
             return Ok(None);
         };
 
         let (cancel_rx, _cancel_guard) =
             self.subscribe_cancel(ctx.document.upstream_request_id.as_ref());
 
-        // Fan-out definition requests to all matching servers
         let pool = self.bridge.pool_arc();
         let position = ctx.position;
         let result = dispatch_preferred(
@@ -50,20 +90,57 @@ impl Kakehashi {
         )
         .await;
         pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
+        result.handle(&self.client, "definition", None, Ok).await
+    }
 
-        result
-            .handle(&self.client, "definition", None, |value| match value {
-                Some(links) => {
-                    if self.settings_manager.supports_definition_link() {
-                        Ok(Some(GotoDefinitionResponse::Link(links)))
-                    } else {
-                        let locations: Vec<Location> =
-                            links.into_iter().map(location_link_to_location).collect();
-                        Ok(Some(GotoDefinitionResponse::Array(locations)))
-                    }
-                }
-                None => Ok(None),
-            })
-            .await
+    /// Host layer: bridge the host document itself (real URI, responses
+    /// verbatim — host-document-bridge).
+    async fn definition_host_layer(
+        &self,
+        lsp_uri: &Uri,
+        position: Position,
+    ) -> Result<Option<Vec<LocationLink>>> {
+        let Some(ctx) = self.resolve_host_bridge_context(lsp_uri, METHOD) else {
+            return Ok(None);
+        };
+
+        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(ctx.upstream_request_id.as_ref());
+
+        let pool = self.bridge.pool_arc();
+        let result = dispatch_host_preferred(
+            &ctx,
+            pool.clone(),
+            |t| async move {
+                t.pool
+                    .send_host_definition_request(
+                        &t.server_name,
+                        &t.server_config,
+                        &crate::lsp::bridge::HostDocument {
+                            uri: &t.uri,
+                            language_id: &t.language_id,
+                            text: &t.text,
+                        },
+                        position,
+                        t.upstream_id,
+                    )
+                    .await
+            },
+            |opt| matches!(opt, Some(v) if !v.is_empty()),
+            cancel_rx,
+        )
+        .await;
+        pool.unregister_all_for_upstream_id(ctx.upstream_request_id.as_ref());
+        result.handle(&self.client, "definition", None, Ok).await
+    }
+
+    /// Shape the winning links per the client's `LocationLink` support.
+    fn definition_response(&self, links: Vec<LocationLink>) -> GotoDefinitionResponse {
+        if self.settings_manager.supports_definition_link() {
+            GotoDefinitionResponse::Link(links)
+        } else {
+            let locations: Vec<Location> =
+                links.into_iter().map(location_link_to_location).collect();
+            GotoDefinitionResponse::Array(locations)
+        }
     }
 }

--- a/src/lsp/lsp_impl/text_document/definition.rs
+++ b/src/lsp/lsp_impl/text_document/definition.rs
@@ -11,11 +11,10 @@ use tower_lsp_server::ls_types::{
     GotoDefinitionParams, GotoDefinitionResponse, Location, LocationLink, Position, Uri,
 };
 
-use crate::config::settings::LayerSource;
-use crate::lsp::bridge::location_link_to_location;
+use crate::lsp::bridge::{location_link_to_location, normalize_host_goto_result};
 
-use super::super::{Kakehashi, uri_to_url};
-use crate::lsp::aggregation::server::{dispatch_host_preferred, dispatch_preferred};
+use super::super::Kakehashi;
+use crate::lsp::aggregation::server::dispatch_preferred;
 
 const METHOD: &str = "textDocument/definition";
 
@@ -24,32 +23,23 @@ impl Kakehashi {
         &self,
         params: GotoDefinitionParams,
     ) -> Result<Option<GotoDefinitionResponse>> {
+        let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
         let lsp_uri = params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
 
-        let Ok(uri) = uri_to_url(&lsp_uri) else {
-            log::warn!("Invalid URI in definition: {}", lsp_uri.as_str());
-            return Ok(None);
-        };
-        let Some(host_language) = self.document_language(&uri) else {
-            return Ok(None);
-        };
-
-        let layer_cfg = self.resolve_layer_config(&host_language, METHOD);
-        for layer in &layer_cfg.order {
-            let links = match layer {
-                LayerSource::Virt => self.definition_virt_layer(&lsp_uri, position).await?,
-                LayerSource::Host => self.definition_host_layer(&lsp_uri, position).await?,
-                // No native definition implementation: empty contributor.
-                LayerSource::Native => None,
-            };
-            if let Some(links) = links
-                && !links.is_empty()
-            {
-                return Ok(Some(self.definition_response(links)));
-            }
-        }
-        Ok(None)
+        let virt = self.definition_virt_layer(&lsp_uri, position);
+        let links = self
+            .walk_layers(
+                &lsp_uri,
+                METHOD,
+                METHOD,
+                raw_params,
+                virt,
+                normalize_host_goto_result,
+                |links: &Vec<LocationLink>| !links.is_empty(),
+            )
+            .await?;
+        Ok(links.map(|links| self.definition_response(links)))
     }
 
     /// Virt layer: bridge the injection region under the cursor.
@@ -90,46 +80,6 @@ impl Kakehashi {
         )
         .await;
         pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
-        result.handle(&self.client, "definition", None, Ok).await
-    }
-
-    /// Host layer: bridge the host document itself (real URI, responses
-    /// verbatim — host-document-bridge).
-    async fn definition_host_layer(
-        &self,
-        lsp_uri: &Uri,
-        position: Position,
-    ) -> Result<Option<Vec<LocationLink>>> {
-        let Some(ctx) = self.resolve_host_bridge_context(lsp_uri, METHOD) else {
-            return Ok(None);
-        };
-
-        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(ctx.upstream_request_id.as_ref());
-
-        let pool = self.bridge.pool_arc();
-        let result = dispatch_host_preferred(
-            &ctx,
-            pool.clone(),
-            |t| async move {
-                t.pool
-                    .send_host_definition_request(
-                        &t.server_name,
-                        &t.server_config,
-                        &crate::lsp::bridge::HostDocument {
-                            uri: &t.uri,
-                            language_id: &t.language_id,
-                            text: &t.text,
-                        },
-                        position,
-                        t.upstream_id,
-                    )
-                    .await
-            },
-            |opt| matches!(opt, Some(v) if !v.is_empty()),
-            cancel_rx,
-        )
-        .await;
-        pool.unregister_all_for_upstream_id(ctx.upstream_request_id.as_ref());
         result.handle(&self.client, "definition", None, Ok).await
     }
 

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -100,6 +100,15 @@ impl Kakehashi {
             return Ok(empty_diagnostic_report());
         };
 
+        if !self.virt_layer_enabled(&language_name, "textDocument/diagnostic") {
+            log::debug!(
+                target: "kakehashi::diagnostic",
+                "virt layer disabled for {} via layers.order",
+                language_name
+            );
+            return Ok(empty_diagnostic_report());
+        }
+
         // Get injection query to detect injection regions
         let Some(injection_query) = self.language.injection_query(&language_name) else {
             return Ok(empty_diagnostic_report());

--- a/src/lsp/lsp_impl/text_document/did_close.rs
+++ b/src/lsp/lsp_impl/text_document/did_close.rs
@@ -66,6 +66,13 @@ impl Kakehashi {
             );
         }
 
+        // Close the host document itself on any servers it was opened on via
+        // the host bridge (host-document-bridge).
+        self.bridge
+            .pool_arc()
+            .close_host_bridge_document(&uri)
+            .await;
+
         self.notifier().log_info("file closed!").await;
     }
 }

--- a/src/lsp/lsp_impl/text_document/document_color.rs
+++ b/src/lsp/lsp_impl/text_document/document_color.rs
@@ -50,6 +50,15 @@ impl Kakehashi {
             return Ok(Vec::new());
         };
 
+        if !self.virt_layer_enabled(&language_name, "textDocument/documentColor") {
+            log::debug!(
+                target: "kakehashi::document_color",
+                "virt layer disabled for {} via layers.order",
+                language_name
+            );
+            return Ok(Vec::new());
+        }
+
         // Get injection query to detect injection regions
         let Some(injection_query) = self.language.injection_query(&language_name) else {
             return Ok(Vec::new());

--- a/src/lsp/lsp_impl/text_document/document_highlight.rs
+++ b/src/lsp/lsp_impl/text_document/document_highlight.rs
@@ -1,22 +1,49 @@
 //! Document highlight method for Kakehashi.
+//!
+//! Walks the resolved layer order (cross-layer-aggregation): the virt layer
+//! bridges the injection region under the cursor, the host layer
+//! (host-document-bridge) bridges the host document itself with the real URI
+//! and the response verbatim. The first layer producing a non-empty result
+//! wins (`preferred`).
 
 use tower_lsp_server::jsonrpc::Result;
-use tower_lsp_server::ls_types::{DocumentHighlight, DocumentHighlightParams};
+use tower_lsp_server::ls_types::{DocumentHighlight, DocumentHighlightParams, Position, Uri};
 
 use super::super::Kakehashi;
 use crate::lsp::aggregation::server::dispatch_preferred;
+use crate::lsp::lsp_impl::bridge_context::parse_host_verbatim;
+
+const METHOD: &str = "textDocument/documentHighlight";
 
 impl Kakehashi {
     pub(crate) async fn document_highlight_impl(
         &self,
         params: DocumentHighlightParams,
     ) -> Result<Option<Vec<DocumentHighlight>>> {
+        let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
         let lsp_uri = params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
 
-        let Some(ctx) =
-            self.resolve_bridge_contexts(&lsp_uri, position, "textDocument/documentHighlight")
-        else {
+        let virt = self.document_highlight_virt_layer(&lsp_uri, position);
+        self.walk_layers(
+            &lsp_uri,
+            METHOD,
+            METHOD,
+            raw_params,
+            virt,
+            parse_host_verbatim::<Vec<DocumentHighlight>>,
+            |highlights: &Vec<DocumentHighlight>| !highlights.is_empty(),
+        )
+        .await
+    }
+
+    /// Virt layer: bridge the injection region under the cursor.
+    async fn document_highlight_virt_layer(
+        &self,
+        lsp_uri: &Uri,
+        position: Position,
+    ) -> Result<Option<Vec<DocumentHighlight>>> {
+        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
             return Ok(None);
         };
 

--- a/src/lsp/lsp_impl/text_document/document_link.rs
+++ b/src/lsp/lsp_impl/text_document/document_link.rs
@@ -10,9 +10,11 @@ impl Kakehashi {
         &self,
         params: DocumentLinkParams,
     ) -> Result<Option<Vec<DocumentLink>>> {
+        let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
         self.whole_document_preferred_fan_out(
             &params.text_document.uri,
             "textDocument/documentLink",
+            raw_params,
             |t| async move {
                 t.pool
                     .send_document_link_request(

--- a/src/lsp/lsp_impl/text_document/document_symbol.rs
+++ b/src/lsp/lsp_impl/text_document/document_symbol.rs
@@ -1,4 +1,10 @@
 //! Document symbol method for Kakehashi.
+//!
+//! Walks the resolved layer order (cross-layer-aggregation): the virt layer
+//! bridges every injection region and concatenates the per-region symbols,
+//! the host layer (host-document-bridge) bridges the host document itself
+//! with the real URI and the response verbatim. The first layer producing a
+//! non-empty result wins (`preferred`).
 
 use std::sync::Arc;
 
@@ -11,19 +17,43 @@ use tower_lsp_server::ls_types::{
 use crate::language::InjectionResolver;
 use crate::lsp::aggregation::server::FanInResult;
 use crate::lsp::aggregation::server::dispatch_preferred;
-use crate::lsp::lsp_impl::bridge_context::DocumentRequestContext;
+use crate::lsp::lsp_impl::bridge_context::{DocumentRequestContext, parse_host_verbatim};
 
 use super::super::{Kakehashi, uri_to_url};
+
+const METHOD: &str = "textDocument/documentSymbol";
 
 impl Kakehashi {
     pub(crate) async fn document_symbol_impl(
         &self,
         params: DocumentSymbolParams,
     ) -> Result<Option<DocumentSymbolResponse>> {
+        let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
         let lsp_uri = params.text_document.uri;
 
+        let virt = self.document_symbol_virt_layer(&lsp_uri);
+        self.walk_layers(
+            &lsp_uri,
+            METHOD,
+            METHOD,
+            raw_params,
+            virt,
+            parse_host_verbatim::<DocumentSymbolResponse>,
+            |resp: &DocumentSymbolResponse| match resp {
+                DocumentSymbolResponse::Flat(symbols) => !symbols.is_empty(),
+                DocumentSymbolResponse::Nested(symbols) => !symbols.is_empty(),
+            },
+        )
+        .await
+    }
+
+    /// Virt layer: bridge every injection region and concatenate symbols.
+    async fn document_symbol_virt_layer(
+        &self,
+        lsp_uri: &Uri,
+    ) -> Result<Option<DocumentSymbolResponse>> {
         // Convert ls_types::Uri to url::Url for internal use
-        let Ok(uri) = uri_to_url(&lsp_uri) else {
+        let Ok(uri) = uri_to_url(lsp_uri) else {
             log::warn!("Invalid URI in documentSymbol: {}", lsp_uri.as_str());
             return Ok(None);
         };
@@ -51,15 +81,6 @@ impl Kakehashi {
             log::debug!(target: "kakehashi::document_symbol", "No language detected");
             return Ok(None);
         };
-
-        if !self.virt_layer_enabled(&language_name, "textDocument/documentSymbol") {
-            log::debug!(
-                target: "kakehashi::document_symbol",
-                "virt layer disabled for {} via layers.order",
-                language_name
-            );
-            return Ok(None);
-        }
 
         // Get injection query to detect injection regions
         let Some(injection_query) = self.language.injection_query(&language_name) else {
@@ -105,7 +126,7 @@ impl Kakehashi {
             let agg = self.resolve_aggregation_config(
                 &language_name,
                 &resolved.injection_language,
-                "textDocument/documentSymbol",
+                METHOD,
             );
             let region_ctx = DocumentRequestContext {
                 uri: uri.clone(),
@@ -164,7 +185,7 @@ impl Kakehashi {
 
         Ok(format_document_symbol_response(
             all_symbols,
-            &lsp_uri,
+            lsp_uri,
             self.settings_manager
                 .supports_hierarchical_document_symbol(),
         ))

--- a/src/lsp/lsp_impl/text_document/document_symbol.rs
+++ b/src/lsp/lsp_impl/text_document/document_symbol.rs
@@ -52,6 +52,15 @@ impl Kakehashi {
             return Ok(None);
         };
 
+        if !self.virt_layer_enabled(&language_name, "textDocument/documentSymbol") {
+            log::debug!(
+                target: "kakehashi::document_symbol",
+                "virt layer disabled for {} via layers.order",
+                language_name
+            );
+            return Ok(None);
+        }
+
         // Get injection query to detect injection regions
         let Some(injection_query) = self.language.injection_query(&language_name) else {
             return Ok(None);

--- a/src/lsp/lsp_impl/text_document/folding_range.rs
+++ b/src/lsp/lsp_impl/text_document/folding_range.rs
@@ -10,9 +10,11 @@ impl Kakehashi {
         &self,
         params: FoldingRangeParams,
     ) -> Result<Option<Vec<FoldingRange>>> {
+        let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
         self.whole_document_preferred_fan_out(
             &params.text_document.uri,
             "textDocument/foldingRange",
+            raw_params,
             |t| async move {
                 t.pool
                     .send_folding_range_request(

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -184,6 +184,7 @@ impl Kakehashi {
                 region_ctx.strategy,
                 &region_ctx.priorities,
                 &region_ctx.configs,
+                region_ctx.max_fan_out,
             ) {
                 RegionFormatPlan::Concatenated(servers) => {
                     // Capture the region's per-line host prefixes now, while
@@ -351,11 +352,14 @@ enum RegionFormatPlan {
 }
 
 /// Decide the [`RegionFormatPlan`] for a region from its aggregation `strategy`,
-/// `priorities`, and configured server `configs`.
+/// `priorities`, configured server `configs`, and `max_fan_out` cap.
 ///
 /// Mirrors concatenated-formatting-pipeline Decision points 1–2 under the
 /// aggregation-priorities-wildcard list semantics:
 /// - `priorities = []` → `Disabled` (the kill switch applies to every strategy);
+/// - `maxFanOut = 0` → `Disabled` ("disable fan-out entirely" holds for the
+///   sequential pipeline too; for `Preferred` the dispatch enforces the cap
+///   itself, this just short-circuits the region consistently);
 /// - any non-`concatenated` strategy → `Preferred` (first-non-empty-wins;
 ///   the `"*"` wildcard is honored by the preferred dispatch);
 /// - `concatenated` whose `priorities` carries no explicit name (only `"*"`,
@@ -363,17 +367,22 @@ enum RegionFormatPlan {
 ///   would be undefined — → `Preferred` (a once-per-config warning is emitted
 ///   at settings-apply time, see `format_concatenated_formatting_warning`);
 /// - `concatenated` with explicit names puts the allowlist in force: run the
-///   effective (configured ∩ explicit) servers as a pipeline, or — when none
-///   of the listed names are configured — `Skip`, since the allowlist forbids
-///   running the non-listed servers `preferred` would pick. A `"*"` mixed
-///   into the list is ignored (no deterministic expansion order for a
-///   sequential pipeline); the caller warns.
+///   effective (configured ∩ explicit) servers as a pipeline, capped to
+///   `max_fan_out` steps like the parallel paths cap servers queried, or —
+///   when none of the listed names are configured — `Skip`, since the
+///   allowlist forbids running the non-listed servers `preferred` would pick.
+///   A `"*"` mixed into the list is ignored (no deterministic expansion order
+///   for a sequential pipeline); the caller warns.
 fn plan_region_format(
     strategy: AggregationStrategy,
     priorities: &[String],
     configs: &[ResolvedServerConfig],
+    max_fan_out: Option<usize>,
 ) -> RegionFormatPlan {
     if priorities.is_empty() {
+        return RegionFormatPlan::Disabled;
+    }
+    if max_fan_out == Some(0) {
         return RegionFormatPlan::Disabled;
     }
     if strategy != AggregationStrategy::Concatenated {
@@ -387,12 +396,14 @@ fn plan_region_format(
     if explicit.is_empty() {
         return RegionFormatPlan::Preferred;
     }
-    let effective = effective_priorities_from(&explicit, configs);
+    let mut effective = effective_priorities_from(&explicit, configs);
     if effective.is_empty() {
-        RegionFormatPlan::Skip
-    } else {
-        RegionFormatPlan::Concatenated(effective)
+        return RegionFormatPlan::Skip;
     }
+    if let Some(cap) = max_fan_out {
+        effective.truncate(cap);
+    }
+    RegionFormatPlan::Concatenated(effective)
 }
 
 /// Whole-pipeline time budget for one region's concatenated formatting run.
@@ -1515,7 +1526,7 @@ mod tests {
         let configs = vec![config("black"), config("isort")];
         let priorities = vec!["black".to_string()];
         assert_eq!(
-            plan_region_format(AggregationStrategy::Preferred, &priorities, &configs),
+            plan_region_format(AggregationStrategy::Preferred, &priorities, &configs, None),
             RegionFormatPlan::Preferred
         );
     }
@@ -1527,7 +1538,12 @@ mod tests {
         let configs = vec![config("black"), config("isort")];
         let priorities = vec!["isort".to_string(), "black".to_string()];
         assert_eq!(
-            plan_region_format(AggregationStrategy::Concatenated, &priorities, &configs),
+            plan_region_format(
+                AggregationStrategy::Concatenated,
+                &priorities,
+                &configs,
+                None
+            ),
             RegionFormatPlan::Concatenated(vec!["isort".to_string(), "black".to_string()])
         );
     }
@@ -1609,11 +1625,11 @@ mod tests {
         // to a wildcard-only list (see the test below).
         let configs = vec![config("black")];
         assert_eq!(
-            plan_region_format(AggregationStrategy::Concatenated, &[], &configs),
+            plan_region_format(AggregationStrategy::Concatenated, &[], &configs, None),
             RegionFormatPlan::Disabled
         );
         assert_eq!(
-            plan_region_format(AggregationStrategy::Preferred, &[], &configs),
+            plan_region_format(AggregationStrategy::Preferred, &[], &configs, None),
             RegionFormatPlan::Disabled
         );
     }
@@ -1626,7 +1642,12 @@ mod tests {
         let configs = vec![config("black")];
         let priorities = vec![PRIORITIES_WILDCARD.to_string()];
         assert_eq!(
-            plan_region_format(AggregationStrategy::Concatenated, &priorities, &configs),
+            plan_region_format(
+                AggregationStrategy::Concatenated,
+                &priorities,
+                &configs,
+                None
+            ),
             RegionFormatPlan::Preferred
         );
     }
@@ -1638,8 +1659,55 @@ mod tests {
         let configs = vec![config("black"), config("isort")];
         let priorities = vec!["black".to_string(), PRIORITIES_WILDCARD.to_string()];
         assert_eq!(
-            plan_region_format(AggregationStrategy::Concatenated, &priorities, &configs),
+            plan_region_format(
+                AggregationStrategy::Concatenated,
+                &priorities,
+                &configs,
+                None
+            ),
             RegionFormatPlan::Concatenated(vec!["black".to_string()])
+        );
+    }
+
+    #[test]
+    fn plan_max_fan_out_zero_disables_the_region_for_any_strategy() {
+        // maxFanOut = 0 documents "disable fan-out entirely" — the
+        // sequential pipeline must honor it like the parallel paths do.
+        let configs = vec![config("black")];
+        let priorities = vec!["black".to_string()];
+        assert_eq!(
+            plan_region_format(
+                AggregationStrategy::Concatenated,
+                &priorities,
+                &configs,
+                Some(0)
+            ),
+            RegionFormatPlan::Disabled
+        );
+        assert_eq!(
+            plan_region_format(
+                AggregationStrategy::Preferred,
+                &priorities,
+                &configs,
+                Some(0)
+            ),
+            RegionFormatPlan::Disabled
+        );
+    }
+
+    #[test]
+    fn plan_max_fan_out_caps_pipeline_length() {
+        let configs = vec![config("black"), config("isort")];
+        let priorities = vec!["black".to_string(), "isort".to_string()];
+        assert_eq!(
+            plan_region_format(
+                AggregationStrategy::Concatenated,
+                &priorities,
+                &configs,
+                Some(1)
+            ),
+            RegionFormatPlan::Concatenated(vec!["black".to_string()]),
+            "a positive cap bounds the pipeline steps in priority order"
         );
     }
 
@@ -1653,7 +1721,12 @@ mod tests {
         let configs = vec![config("black"), config("isort")];
         let priorities = vec!["blackk".to_string(), "ruff".to_string()];
         assert_eq!(
-            plan_region_format(AggregationStrategy::Concatenated, &priorities, &configs),
+            plan_region_format(
+                AggregationStrategy::Concatenated,
+                &priorities,
+                &configs,
+                None
+            ),
             RegionFormatPlan::Skip
         );
     }
@@ -1665,7 +1738,12 @@ mod tests {
         let configs = vec![config("black"), config("isort")];
         let priorities = vec!["ruff".to_string(), "black".to_string()];
         assert_eq!(
-            plan_region_format(AggregationStrategy::Concatenated, &priorities, &configs),
+            plan_region_format(
+                AggregationStrategy::Concatenated,
+                &priorities,
+                &configs,
+                None
+            ),
             RegionFormatPlan::Concatenated(vec!["black".to_string()])
         );
     }

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -34,6 +34,7 @@ use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::{DocumentFormattingParams, Position, Range, TextEdit};
 
 use crate::config::settings::AggregationStrategy;
+use crate::config::settings::PRIORITIES_WILDCARD;
 use crate::error::LockResultExt;
 use crate::language::InjectionResolver;
 use crate::lsp::aggregation::region::collect_region_results_with_cancel;
@@ -141,6 +142,29 @@ impl Kakehashi {
             // fan-out, or skip — from its resolved aggregation config. See
             // [`plan_region_format`] for the allowlist rule
             // (concatenated-formatting-pipeline Decision point 2).
+            if region_ctx.strategy == AggregationStrategy::Concatenated
+                && region_ctx
+                    .priorities
+                    .iter()
+                    .any(|name| name == PRIORITIES_WILDCARD)
+                && region_ctx
+                    .priorities
+                    .iter()
+                    .any(|name| name != PRIORITIES_WILDCARD)
+            {
+                // ADR aggregation-priorities-wildcard: '*' has no deterministic
+                // expansion order, and a formatter pipeline must be
+                // reproducible — the element is dropped, explicit names run.
+                log::warn!(
+                    target: "kakehashi::formatting",
+                    "concatenated formatting for {}->{} lists '{}' in priorities; \
+                     the wildcard is ignored by the sequential pipeline (explicit \
+                     order required) and only the named servers run",
+                    language_name,
+                    region_ctx.resolved.injection_language,
+                    PRIORITIES_WILDCARD,
+                );
+            }
             let pipeline = match plan_region_format(
                 region_ctx.strategy,
                 &region_ctx.priorities,
@@ -184,6 +208,18 @@ impl Kakehashi {
                     );
                     continue;
                 }
+                RegionFormatPlan::Disabled => {
+                    // priorities = []: the per-method fan-out kill switch
+                    // (aggregation-priorities-wildcard). Deliberate config, so
+                    // no warning — just skip the region.
+                    log::debug!(
+                        target: "kakehashi::formatting",
+                        "formatting disabled for {}->{} (priorities = [])",
+                        language_name,
+                        region_ctx.resolved.injection_language,
+                    );
+                    continue;
+                }
             };
 
             let pool = Arc::clone(&pool);
@@ -224,43 +260,63 @@ impl Kakehashi {
 #[derive(Debug, PartialEq, Eq)]
 enum RegionFormatPlan {
     /// Run the sequential concatenated pipeline over these effective servers
-    /// (`priorities` filtered to configured servers, deduped, order preserved).
+    /// (explicit `priorities` names filtered to configured servers, deduped,
+    /// order preserved — the `"*"` wildcard is excluded, see
+    /// aggregation-priorities-wildcard).
     Concatenated(Vec<String>),
     /// Use the `preferred` first-non-empty-wins fan-out over the region's servers.
     Preferred,
-    /// Run nothing for this region. Reached only when `concatenated` is active
-    /// with a NON-empty `priorities` whose names are all unconfigured/typo'd, so
-    /// the effective list is empty: every configured server is *absent from the
-    /// allowlist*, and the allowlist (concatenated-formatting-pipeline Decision
-    /// point 2) forbids running any of them. Falling through to `preferred` here
-    /// would wrongly run exactly the servers the user's `priorities` excluded.
+    /// Run nothing for this region. Reached when `concatenated` is active with
+    /// explicit `priorities` names that are all unconfigured/typo'd: every
+    /// configured server is *absent from the allowlist*, and the allowlist
+    /// (concatenated-formatting-pipeline Decision point 2) forbids running
+    /// them. Falling through to `preferred` here would wrongly run exactly the
+    /// servers the user's `priorities` excluded.
     Skip,
+    /// `priorities = []`: the per-method fan-out kill switch
+    /// (aggregation-priorities-wildcard) — the region runs no servers at all,
+    /// regardless of strategy.
+    Disabled,
 }
 
 /// Decide the [`RegionFormatPlan`] for a region from its aggregation `strategy`,
 /// `priorities`, and configured server `configs`.
 ///
-/// Mirrors concatenated-formatting-pipeline Decision points 1–2:
-/// - any non-`concatenated` strategy → `Preferred` (first-non-empty-wins);
-/// - `concatenated` with an **empty** `priorities` is a misconfiguration (order
-///   would be undefined) → `Preferred` (a once-per-config warning is emitted at
-///   settings-apply time, see `format_concatenated_formatting_warning`);
-/// - `concatenated` with a **non-empty** `priorities` puts the allowlist in
-///   force: run the effective (configured ∩ `priorities`) servers as a pipeline,
-///   or — when none of the listed names are configured — `Skip`, since the
-///   allowlist forbids running the non-listed servers `preferred` would pick.
+/// Mirrors concatenated-formatting-pipeline Decision points 1–2 under the
+/// aggregation-priorities-wildcard list semantics:
+/// - `priorities = []` → `Disabled` (the kill switch applies to every strategy);
+/// - any non-`concatenated` strategy → `Preferred` (first-non-empty-wins;
+///   the `"*"` wildcard is honored by the preferred dispatch);
+/// - `concatenated` whose `priorities` carries no explicit name (only `"*"`,
+///   e.g. the resolved default) is a misconfiguration — the pipeline's order
+///   would be undefined — → `Preferred` (a once-per-config warning is emitted
+///   at settings-apply time, see `format_concatenated_formatting_warning`);
+/// - `concatenated` with explicit names puts the allowlist in force: run the
+///   effective (configured ∩ explicit) servers as a pipeline, or — when none
+///   of the listed names are configured — `Skip`, since the allowlist forbids
+///   running the non-listed servers `preferred` would pick. A `"*"` mixed
+///   into the list is ignored (no deterministic expansion order for a
+///   sequential pipeline); the caller warns.
 fn plan_region_format(
     strategy: AggregationStrategy,
     priorities: &[String],
     configs: &[ResolvedServerConfig],
 ) -> RegionFormatPlan {
+    if priorities.is_empty() {
+        return RegionFormatPlan::Disabled;
+    }
     if strategy != AggregationStrategy::Concatenated {
         return RegionFormatPlan::Preferred;
     }
-    if priorities.is_empty() {
+    let explicit: Vec<String> = priorities
+        .iter()
+        .filter(|name| name.as_str() != PRIORITIES_WILDCARD)
+        .cloned()
+        .collect();
+    if explicit.is_empty() {
         return RegionFormatPlan::Preferred;
     }
-    let effective = effective_priorities_from(priorities, configs);
+    let effective = effective_priorities_from(&explicit, configs);
     if effective.is_empty() {
         RegionFormatPlan::Skip
     } else {
@@ -1406,13 +1462,44 @@ mod tests {
     }
 
     #[test]
-    fn plan_concatenated_with_empty_priorities_falls_back_to_preferred() {
-        // ADR point 2: `concatenated` with an EMPTY `priorities` is a
-        // misconfiguration (order is undefined) and falls back to `preferred`.
+    fn plan_empty_priorities_disables_the_region_for_any_strategy() {
+        // priorities = [] is the per-method fan-out kill switch
+        // (aggregation-priorities-wildcard): nothing runs, regardless of
+        // strategy. It is NOT the misconfiguration fallback — that role moved
+        // to a wildcard-only list (see the test below).
         let configs = vec![config("black")];
         assert_eq!(
             plan_region_format(AggregationStrategy::Concatenated, &[], &configs),
+            RegionFormatPlan::Disabled
+        );
+        assert_eq!(
+            plan_region_format(AggregationStrategy::Preferred, &[], &configs),
+            RegionFormatPlan::Disabled
+        );
+    }
+
+    #[test]
+    fn plan_concatenated_with_wildcard_only_priorities_falls_back_to_preferred() {
+        // ADR point 2: the pipeline needs explicit names for a deterministic
+        // order. The resolved default ["*"] (absent priorities) carries none,
+        // so the region falls back to `preferred`.
+        let configs = vec![config("black")];
+        let priorities = vec![PRIORITIES_WILDCARD.to_string()];
+        assert_eq!(
+            plan_region_format(AggregationStrategy::Concatenated, &priorities, &configs),
             RegionFormatPlan::Preferred
+        );
+    }
+
+    #[test]
+    fn plan_concatenated_ignores_wildcard_mixed_with_explicit_names() {
+        // ["black", "*"]: the wildcard has no deterministic expansion order
+        // for a sequential pipeline, so only the named servers run.
+        let configs = vec![config("black"), config("isort")];
+        let priorities = vec!["black".to_string(), PRIORITIES_WILDCARD.to_string()];
+        assert_eq!(
+            plan_region_format(AggregationStrategy::Concatenated, &priorities, &configs),
+            RegionFormatPlan::Concatenated(vec!["black".to_string()])
         );
     }
 

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -34,7 +34,7 @@ use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::{DocumentFormattingParams, Position, Range, TextEdit};
 
 use crate::config::settings::AggregationStrategy;
-use crate::config::settings::PRIORITIES_WILDCARD;
+use crate::config::settings::{LayerSource, PRIORITIES_WILDCARD};
 use crate::error::LockResultExt;
 use crate::language::InjectionResolver;
 use crate::lsp::aggregation::region::collect_region_results_with_cancel;
@@ -85,7 +85,13 @@ impl Kakehashi {
             return Ok(None);
         };
 
-        if !self.virt_layer_enabled(&language_name, "textDocument/formatting") {
+        // Formatting consumes the full layer config (order AND strategy):
+        // it is the first method with a layer-level `concatenated` dispatch
+        // (cross-layer-aggregation phase 3).
+        let layer_cfg = self.resolve_layer_config(&language_name, "textDocument/formatting");
+        if !layer_cfg.allows(LayerSource::Virt) {
+            // Host and native contribute nothing today, so a virt-less order
+            // cannot produce edits under either strategy.
             log::debug!(
                 target: "kakehashi::formatting",
                 "virt layer disabled for {} via layers.order",
@@ -260,8 +266,64 @@ impl Kakehashi {
 
         let response = finalize_formatting_edits(outer_join_set, cancel_state.token.clone()).await;
         pool.unregister_all_for_upstream_id(upstream_request_id.as_ref());
-        response
+
+        // Cross-layer combine (cross-layer-aggregation phase 3). The virt
+        // result is computed above; host and native are empty contributors,
+        // evaluated as None without cost.
+        let virt_edits = response?;
+        let layer_results: Vec<(LayerSource, Option<Vec<TextEdit>>)> = layer_cfg
+            .order
+            .iter()
+            .map(|layer| match layer {
+                LayerSource::Virt => (*layer, virt_edits.clone()),
+                LayerSource::Host | LayerSource::Native => (*layer, None),
+            })
+            .collect();
+        Ok(combine_layer_formatting_results(
+            layer_cfg.strategy,
+            layer_results,
+        ))
     }
+}
+
+/// Combine per-layer formatting results (cross-layer-aggregation phase 3).
+///
+/// `results` is in resolved `layers.order` (highest priority first); a layer
+/// "produces" when it returns `Some` with at least one edit.
+///
+/// - `preferred`: the first producing layer wins.
+/// - `concatenated`: meant as a sequential cross-layer pipeline (each layer
+///   formatting the previous layer's output, by analogy with
+///   concatenated-formatting-pipeline). With at most one producing layer —
+///   the only case reachable today, since host (`bridge._self`) is
+///   unimplemented and there is no native formatter — the pipeline
+///   degenerates to that layer's edits. Should two layers ever produce
+///   before the text-threading machinery exists, the highest-priority
+///   layer's edits are applied alone (never merged: naively concatenating
+///   two layers' edit lists could overlap, violating LSP) and a warning
+///   names the dropped layers.
+fn combine_layer_formatting_results(
+    strategy: AggregationStrategy,
+    results: Vec<(LayerSource, Option<Vec<TextEdit>>)>,
+) -> Option<Vec<TextEdit>> {
+    let mut producing = results
+        .into_iter()
+        .filter_map(|(layer, edits)| match edits {
+            Some(edits) if !edits.is_empty() => Some((layer, edits)),
+            _ => None,
+        });
+    let first = producing.next();
+    let dropped: Vec<LayerSource> = producing.map(|(layer, _)| layer).collect();
+    if !dropped.is_empty() && strategy == AggregationStrategy::Concatenated {
+        log::warn!(
+            target: "kakehashi::formatting",
+            "cross-layer concatenated formatting with multiple producing layers \
+             is not yet implemented; applying {:?} and dropping {:?}",
+            first.as_ref().map(|(layer, _)| layer),
+            dropped,
+        );
+    }
+    first.map(|(_, edits)| edits)
 }
 
 /// How a single injection region should be formatted, derived from its resolved
@@ -1468,6 +1530,75 @@ mod tests {
             plan_region_format(AggregationStrategy::Concatenated, &priorities, &configs),
             RegionFormatPlan::Concatenated(vec!["isort".to_string(), "black".to_string()])
         );
+    }
+
+    // ==========================================================================
+    // combine_layer_formatting_results (cross-layer-aggregation phase 3)
+    // ==========================================================================
+
+    fn layer_edit(text: &str) -> TextEdit {
+        edit(0, 0, text)
+    }
+
+    #[test]
+    fn combine_layers_preferred_picks_first_producing_layer() {
+        let results = vec![
+            (LayerSource::Virt, None),
+            (LayerSource::Host, Some(vec![layer_edit("host")])),
+            (LayerSource::Native, Some(vec![layer_edit("native")])),
+        ];
+        let combined =
+            combine_layer_formatting_results(AggregationStrategy::Preferred, results).unwrap();
+        assert_eq!(combined[0].new_text, "host");
+    }
+
+    #[test]
+    fn combine_layers_treats_empty_edit_list_as_non_producing() {
+        let results = vec![
+            (LayerSource::Virt, Some(vec![])),
+            (LayerSource::Native, Some(vec![layer_edit("native")])),
+        ];
+        let combined =
+            combine_layer_formatting_results(AggregationStrategy::Preferred, results).unwrap();
+        assert_eq!(combined[0].new_text, "native");
+    }
+
+    #[test]
+    fn combine_layers_returns_none_when_no_layer_produces() {
+        let results = vec![(LayerSource::Virt, None), (LayerSource::Host, Some(vec![]))];
+        assert!(
+            combine_layer_formatting_results(AggregationStrategy::Preferred, results).is_none()
+        );
+    }
+
+    #[test]
+    fn combine_layers_concatenated_single_producer_passes_through() {
+        let results = vec![
+            (LayerSource::Virt, Some(vec![layer_edit("virt")])),
+            (LayerSource::Host, None),
+            (LayerSource::Native, None),
+        ];
+        let combined =
+            combine_layer_formatting_results(AggregationStrategy::Concatenated, results).unwrap();
+        assert_eq!(combined.len(), 1);
+        assert_eq!(combined[0].new_text, "virt");
+    }
+
+    #[test]
+    fn combine_layers_concatenated_multiple_producers_applies_highest_priority_only() {
+        // Unreachable today (host/native contribute nothing), but the
+        // fail-safe matters: naively concatenating two layers' edit lists
+        // could produce overlapping edits, violating LSP. The
+        // highest-priority layer wins alone until cross-layer text threading
+        // exists.
+        let results = vec![
+            (LayerSource::Virt, Some(vec![layer_edit("virt")])),
+            (LayerSource::Host, Some(vec![layer_edit("host")])),
+        ];
+        let combined =
+            combine_layer_formatting_results(AggregationStrategy::Concatenated, results).unwrap();
+        assert_eq!(combined.len(), 1, "edit lists must never be merged");
+        assert_eq!(combined[0].new_text, "virt");
     }
 
     #[test]

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -96,37 +96,25 @@ impl Kakehashi {
 
         let result = match layer_cfg.strategy {
             AggregationStrategy::Preferred => {
-                // Lazy walk: the first layer producing edits wins; later
-                // layers are never contacted.
-                let mut winner = None;
-                for layer in &layer_cfg.order {
-                    let edits = match layer {
-                        LayerSource::Virt => {
-                            self.virt_format_edits(
-                                &uri,
-                                &snapshot,
-                                &language_name,
-                                &options,
-                                &upstream_request_id,
-                                &cancel_state,
-                            )
-                            .await?
-                        }
-                        LayerSource::Host => {
-                            self.host_format_edits(&lsp_uri, &original, &options, &cancel_state)
-                                .await?
-                        }
-                        // No native formatter: empty contributor.
-                        LayerSource::Native => None,
-                    };
-                    if let Some(edits) = edits
-                        && !edits.is_empty()
-                    {
-                        winner = Some(edits);
-                        break;
-                    }
-                }
-                winner
+                // Concurrent fan-out with priority decision
+                // (race_layers_preferred): both layers' requests are in
+                // flight at once; the highest-priority non-empty result wins.
+                let virt = self.virt_format_edits(
+                    &uri,
+                    &snapshot,
+                    &language_name,
+                    &options,
+                    &upstream_request_id,
+                    &cancel_state,
+                );
+                let host = self.host_format_edits(&lsp_uri, &original, &options, &cancel_state);
+                crate::lsp::lsp_impl::bridge_context::race_layers_preferred(
+                    &layer_cfg.order,
+                    virt,
+                    host,
+                    |edits: &Vec<TextEdit>| !edits.is_empty(),
+                )
+                .await?
             }
             AggregationStrategy::Concatenated => {
                 // Sequential cross-layer pipeline (cross-layer-aggregation

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -393,17 +393,21 @@ impl Kakehashi {
         };
         ctx.text = Arc::from(text);
 
+        let params = serde_json::json!({
+            "textDocument": { "uri": lsp_uri.as_str() },
+            "options": options,
+        });
+
         let cancel_rx = cancel_state.derive_receiver();
         let pool = self.bridge.pool_arc();
-        let options = options.clone();
         let result = crate::lsp::aggregation::server::dispatch_host_preferred(
             &ctx,
             pool.clone(),
             move |t| {
-                let options = options.clone();
+                let params = params.clone();
                 async move {
                     t.pool
-                        .send_host_formatting_request(
+                        .send_host_raw_request(
                             &t.server_name,
                             &t.server_config,
                             &crate::lsp::bridge::HostDocument {
@@ -411,18 +415,23 @@ impl Kakehashi {
                                 language_id: &t.language_id,
                                 text: &t.text,
                             },
-                            options,
+                            "textDocument/formatting",
+                            params,
                             t.upstream_id,
                         )
                         .await
                 }
             },
-            |opt| matches!(opt, Some(v) if !v.is_empty()),
+            |opt| {
+                matches!(opt, Some(v) if !crate::lsp::lsp_impl::bridge_context::is_empty_layer_value(v))
+            },
             cancel_rx,
         )
         .await;
         pool.unregister_all_for_upstream_id(ctx.upstream_request_id.as_ref());
-        result.handle(&self.client, "formatting", None, Ok).await
+        let value = result.handle(&self.client, "formatting", None, Ok).await?;
+        Ok(value
+            .and_then(crate::lsp::lsp_impl::bridge_context::parse_host_verbatim::<Vec<TextEdit>>))
     }
 }
 

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -395,7 +395,7 @@ impl Kakehashi {
                 let params = params.clone();
                 async move {
                     t.pool
-                        .send_host_raw_request(
+                        .send_host_formatting_request(
                             &t.server_name,
                             &t.server_config,
                             &crate::lsp::bridge::HostDocument {
@@ -410,9 +410,11 @@ impl Kakehashi {
                         .await
                 }
             },
-            |opt| {
-                matches!(opt, Some(v) if !crate::lsp::lsp_impl::bridge_context::is_empty_layer_value(v))
-            },
+            // `Some(vec![])` (and a capable server's `null`, normalized to it)
+            // is the authoritative "no edits needed" — accept it instead of
+            // falling through to a lower-priority host formatter that might
+            // re-format the same text. Mirrors the virt preferred predicate.
+            |opt| opt.is_some(),
             cancel_rx,
         )
         .await;
@@ -420,8 +422,8 @@ impl Kakehashi {
         // Quiet on an all-empty host layer (the virt arm already emits the
         // client-visible LOG); only real host failures get surfaced —
         // mirroring `host_layer_value_with_ctx`.
-        let value = match result {
-            FanInResult::Done(value) => value,
+        match result {
+            FanInResult::Done(value) => Ok(value),
             FanInResult::NoResult { errors } => {
                 if errors > 0 {
                     self.client
@@ -431,14 +433,10 @@ impl Kakehashi {
                         )
                         .await;
                 }
-                None
+                Ok(None)
             }
-            FanInResult::Cancelled => {
-                return Err(tower_lsp_server::jsonrpc::Error::request_cancelled());
-            }
-        };
-        Ok(value
-            .and_then(crate::lsp::lsp_impl::bridge_context::parse_host_verbatim::<Vec<TextEdit>>))
+            FanInResult::Cancelled => Err(tower_lsp_server::jsonrpc::Error::request_cancelled()),
+        }
     }
 }
 

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -85,6 +85,15 @@ impl Kakehashi {
             return Ok(None);
         };
 
+        if !self.virt_layer_enabled(&language_name, "textDocument/formatting") {
+            log::debug!(
+                target: "kakehashi::formatting",
+                "virt layer disabled for {} via layers.order",
+                language_name
+            );
+            return Ok(None);
+        }
+
         let Some(injection_query) = self.language.injection_query(&language_name) else {
             return Ok(None);
         };

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -427,6 +427,11 @@ impl Kakehashi {
 /// against `original` (the same overlap-free output shape as the
 /// within-region pipeline, concatenated-formatting-pipeline Decision
 /// point 4). `None` when the chain round-tripped to the original text.
+///
+/// Line counting treats `\n` as the only line break: a document using bare
+/// `\r` separators (which LSP also recognizes) would get an end position on
+/// the wrong line. Tree-sitter parsing upstream shares the `\n` assumption,
+/// so such documents do not reach this path in practice.
 fn whole_document_replacement(original: &str, formatted: &str) -> Option<Vec<TextEdit>> {
     if original == formatted {
         return None;

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -417,7 +417,26 @@ impl Kakehashi {
         )
         .await;
         pool.unregister_all_for_upstream_id(ctx.upstream_request_id.as_ref());
-        let value = result.handle(&self.client, "formatting", None, Ok).await?;
+        // Quiet on an all-empty host layer (the virt arm already emits the
+        // client-visible LOG); only real host failures get surfaced —
+        // mirroring `host_layer_value_with_ctx`.
+        let value = match result {
+            FanInResult::Done(value) => value,
+            FanInResult::NoResult { errors } => {
+                if errors > 0 {
+                    self.client
+                        .log_message(
+                            tower_lsp_server::ls_types::MessageType::WARNING,
+                            "No textDocument/formatting response from any host bridge server",
+                        )
+                        .await;
+                }
+                None
+            }
+            FanInResult::Cancelled => {
+                return Err(tower_lsp_server::jsonrpc::Error::request_cancelled());
+            }
+        };
         Ok(value
             .and_then(crate::lsp::lsp_impl::bridge_context::parse_host_verbatim::<Vec<TextEdit>>))
     }

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -89,25 +89,131 @@ impl Kakehashi {
         // it is the first method with a layer-level `concatenated` dispatch
         // (cross-layer-aggregation phase 3).
         let layer_cfg = self.resolve_layer_config(&language_name, "textDocument/formatting");
-        if !layer_cfg.allows(LayerSource::Virt) {
-            // Host and native contribute nothing today, so a virt-less order
-            // cannot produce edits under either strategy.
-            log::debug!(
-                target: "kakehashi::formatting",
-                "virt layer disabled for {} via layers.order",
-                language_name
-            );
-            return Ok(None);
-        }
 
-        let Some(injection_query) = self.language.injection_query(&language_name) else {
+        let upstream_request_id = crate::lsp::current_upstream_id();
+        let cancel_state = self.setup_formatting_cancel_token(upstream_request_id.as_ref());
+        let original = snapshot.text().to_string();
+
+        let result = match layer_cfg.strategy {
+            AggregationStrategy::Preferred => {
+                // Lazy walk: the first layer producing edits wins; later
+                // layers are never contacted.
+                let mut winner = None;
+                for layer in &layer_cfg.order {
+                    let edits = match layer {
+                        LayerSource::Virt => {
+                            self.virt_format_edits(
+                                &uri,
+                                &snapshot,
+                                &language_name,
+                                &options,
+                                &upstream_request_id,
+                                &cancel_state,
+                            )
+                            .await?
+                        }
+                        LayerSource::Host => {
+                            self.host_format_edits(&lsp_uri, &original, &options, &cancel_state)
+                                .await?
+                        }
+                        // No native formatter: empty contributor.
+                        LayerSource::Native => None,
+                    };
+                    if let Some(edits) = edits
+                        && !edits.is_empty()
+                    {
+                        winner = Some(edits);
+                        break;
+                    }
+                }
+                winner
+            }
+            AggregationStrategy::Concatenated => {
+                // Sequential cross-layer pipeline (cross-layer-aggregation
+                // phase 3): each layer formats the previous layer's output.
+                // Virt edits are resolved against the parsed snapshot, so virt
+                // can only run while the accumulated text still IS the
+                // snapshot text — i.e. before any text-changing layer. The
+                // default order (virt before host) satisfies this; an order
+                // placing virt after a producing host is skipped with a
+                // warning rather than formatting against stale regions.
+                let mut current = original.clone();
+                let mut producers = 0usize;
+                let mut sole_edits: Option<Vec<TextEdit>> = None;
+                for layer in &layer_cfg.order {
+                    let edits = match layer {
+                        LayerSource::Virt => {
+                            if current != original {
+                                log::warn!(
+                                    target: "kakehashi::formatting",
+                                    "cross-layer concatenated formatting: virt placed after a \
+                                     text-producing layer in layers.order; injection regions \
+                                     cannot be re-resolved against modified text — skipping virt"
+                                );
+                                continue;
+                            }
+                            self.virt_format_edits(
+                                &uri,
+                                &snapshot,
+                                &language_name,
+                                &options,
+                                &upstream_request_id,
+                                &cancel_state,
+                            )
+                            .await?
+                        }
+                        LayerSource::Host => {
+                            self.host_format_edits(&lsp_uri, &current, &options, &cancel_state)
+                                .await?
+                        }
+                        LayerSource::Native => None,
+                    };
+                    if let Some(edits) = edits
+                        && !edits.is_empty()
+                    {
+                        current = crate::text::edit::apply_text_edits(&current, &edits);
+                        producers += 1;
+                        sole_edits = Some(edits);
+                    }
+                }
+                match producers {
+                    0 => None,
+                    // A single producing layer ran against the original text
+                    // (virt by the guard above; host because nothing before
+                    // it produced), so its minimal edits apply verbatim.
+                    1 => sole_edits,
+                    // Multiple producers: later layers' edits are relative to
+                    // intermediate text, so collapse the chain into one
+                    // whole-document replacement (the same overlap-free shape
+                    // as the within-region pipeline, concatenated-formatting-
+                    // pipeline Decision point 4).
+                    _ => whole_document_replacement(&original, &current),
+                }
+            }
+        };
+        Ok(result)
+    }
+
+    /// Format every injection region (the **virt** layer): resolve regions
+    /// from the parsed snapshot, format each one per its aggregation config,
+    /// and concatenate the per-region edits (disjoint spans).
+    async fn virt_format_edits(
+        &self,
+        uri: &url::Url,
+        snapshot: &crate::document::model::DocumentSnapshot,
+        language_name: &str,
+        options: &tower_lsp_server::ls_types::FormattingOptions,
+        upstream_request_id: &Option<UpstreamId>,
+        cancel_state: &FormattingCancelState<'_>,
+    ) -> Result<Option<Vec<TextEdit>>> {
+        let Some(injection_query) = self.language.injection_query(language_name) else {
             return Ok(None);
         };
 
         let all_regions = InjectionResolver::resolve_all(
             &self.language,
             self.bridge.node_tracker(),
-            &uri,
+            uri,
             snapshot.tree(),
             snapshot.text(),
             injection_query.as_ref(),
@@ -117,8 +223,6 @@ impl Kakehashi {
             return Ok(None);
         }
 
-        let upstream_request_id = crate::lsp::current_upstream_id();
-        let cancel_state = self.setup_formatting_cancel_token(upstream_request_id.as_ref());
         let pool = self.bridge.pool_arc();
 
         // Outer JoinSet: one task per injection region, all in parallel
@@ -131,16 +235,14 @@ impl Kakehashi {
         let mut host_mapper: Option<crate::text::PositionMapper> = None;
 
         for resolved in all_regions {
-            let configs = self.bridge_configs_for_injection_language(
-                &language_name,
-                &resolved.injection_language,
-            );
+            let configs = self
+                .bridge_configs_for_injection_language(language_name, &resolved.injection_language);
             if configs.is_empty() {
                 continue;
             }
 
             let agg = self.resolve_aggregation_config(
-                &language_name,
+                language_name,
                 &resolved.injection_language,
                 "textDocument/formatting",
             );
@@ -267,64 +369,87 @@ impl Kakehashi {
 
         let response = finalize_formatting_edits(outer_join_set, cancel_state.token.clone()).await;
         pool.unregister_all_for_upstream_id(upstream_request_id.as_ref());
+        response
+    }
 
-        // Cross-layer combine (cross-layer-aggregation phase 3). The virt
-        // result is computed above; host and native are empty contributors,
-        // evaluated as None without cost.
-        let virt_edits = response?;
-        let layer_results: Vec<(LayerSource, Option<Vec<TextEdit>>)> = layer_cfg
-            .order
-            .iter()
-            .map(|layer| match layer {
-                LayerSource::Virt => (*layer, virt_edits.clone()),
-                LayerSource::Host | LayerSource::Native => (*layer, None),
-            })
-            .collect();
-        Ok(combine_layer_formatting_results(
-            layer_cfg.strategy,
-            layer_results,
-        ))
+    /// Format the host document itself (the **host** layer,
+    /// host-document-bridge): forward `text` with the real URI to the
+    /// host-capable servers and return their edits verbatim.
+    ///
+    /// `text` is the text to format — under the cross-layer `concatenated`
+    /// pipeline it may already carry the virt layer's edits, in which case
+    /// the host server's document state is temporarily speculative; the lazy
+    /// fingerprint sync restores it to the editor text on the next request.
+    async fn host_format_edits(
+        &self,
+        lsp_uri: &tower_lsp_server::ls_types::Uri,
+        text: &str,
+        options: &tower_lsp_server::ls_types::FormattingOptions,
+        cancel_state: &FormattingCancelState<'_>,
+    ) -> Result<Option<Vec<TextEdit>>> {
+        let Some(mut ctx) = self.resolve_host_bridge_context(lsp_uri, "textDocument/formatting")
+        else {
+            return Ok(None);
+        };
+        ctx.text = Arc::from(text);
+
+        let cancel_rx = cancel_state.derive_receiver();
+        let pool = self.bridge.pool_arc();
+        let options = options.clone();
+        let result = crate::lsp::aggregation::server::dispatch_host_preferred(
+            &ctx,
+            pool.clone(),
+            move |t| {
+                let options = options.clone();
+                async move {
+                    t.pool
+                        .send_host_formatting_request(
+                            &t.server_name,
+                            &t.server_config,
+                            &crate::lsp::bridge::HostDocument {
+                                uri: &t.uri,
+                                language_id: &t.language_id,
+                                text: &t.text,
+                            },
+                            options,
+                            t.upstream_id,
+                        )
+                        .await
+                }
+            },
+            |opt| matches!(opt, Some(v) if !v.is_empty()),
+            cancel_rx,
+        )
+        .await;
+        pool.unregister_all_for_upstream_id(ctx.upstream_request_id.as_ref());
+        result.handle(&self.client, "formatting", None, Ok).await
     }
 }
 
-/// Combine per-layer formatting results (cross-layer-aggregation phase 3).
-///
-/// `results` is in resolved `layers.order` (highest priority first); a layer
-/// "produces" when it returns `Some` with at least one edit.
-///
-/// - `preferred`: the first producing layer wins.
-/// - `concatenated`: meant as a sequential cross-layer pipeline (each layer
-///   formatting the previous layer's output, by analogy with
-///   concatenated-formatting-pipeline). With at most one producing layer —
-///   the only case reachable today, since host (`bridge._self`) is
-///   unimplemented and there is no native formatter — the pipeline
-///   degenerates to that layer's edits. Should two layers ever produce
-///   before the text-threading machinery exists, the highest-priority
-///   layer's edits are applied alone (never merged: naively concatenating
-///   two layers' edit lists could overlap, violating LSP) and a warning
-///   names the dropped layers.
-fn combine_layer_formatting_results(
-    strategy: AggregationStrategy,
-    results: Vec<(LayerSource, Option<Vec<TextEdit>>)>,
-) -> Option<Vec<TextEdit>> {
-    let mut producing = results
-        .into_iter()
-        .filter_map(|(layer, edits)| match edits {
-            Some(edits) if !edits.is_empty() => Some((layer, edits)),
-            _ => None,
-        });
-    let first = producing.next();
-    let dropped: Vec<LayerSource> = producing.map(|(layer, _)| layer).collect();
-    if !dropped.is_empty() && strategy == AggregationStrategy::Concatenated {
-        log::warn!(
-            target: "kakehashi::formatting",
-            "cross-layer concatenated formatting with multiple producing layers \
-             is not yet implemented; applying {:?} and dropping {:?}",
-            first.as_ref().map(|(layer, _)| layer),
-            dropped,
-        );
+/// Collapse a formatted text into a single whole-document replacement edit
+/// against `original` (the same overlap-free output shape as the
+/// within-region pipeline, concatenated-formatting-pipeline Decision
+/// point 4). `None` when the chain round-tripped to the original text.
+fn whole_document_replacement(original: &str, formatted: &str) -> Option<Vec<TextEdit>> {
+    if original == formatted {
+        return None;
     }
-    first.map(|(_, edits)| edits)
+    let end_line = original.matches('\n').count() as u32;
+    let last_line_start = original.rfind('\n').map(|i| i + 1).unwrap_or(0);
+    let end_character = original[last_line_start..].encode_utf16().count() as u32;
+    Some(vec![TextEdit {
+        range: Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: end_line,
+                character: end_character,
+            },
+        },
+        new_text: formatted.to_string(),
+    }])
 }
 
 /// How a single injection region should be formatted, derived from its resolved
@@ -1549,72 +1674,44 @@ mod tests {
     }
 
     // ==========================================================================
-    // combine_layer_formatting_results (cross-layer-aggregation phase 3)
+    // whole_document_replacement (cross-layer-aggregation phase 3)
     // ==========================================================================
 
-    fn layer_edit(text: &str) -> TextEdit {
-        edit(0, 0, text)
-    }
-
     #[test]
-    fn combine_layers_preferred_picks_first_producing_layer() {
-        let results = vec![
-            (LayerSource::Virt, None),
-            (LayerSource::Host, Some(vec![layer_edit("host")])),
-            (LayerSource::Native, Some(vec![layer_edit("native")])),
-        ];
-        let combined =
-            combine_layer_formatting_results(AggregationStrategy::Preferred, results).unwrap();
-        assert_eq!(combined[0].new_text, "host");
-    }
-
-    #[test]
-    fn combine_layers_treats_empty_edit_list_as_non_producing() {
-        let results = vec![
-            (LayerSource::Virt, Some(vec![])),
-            (LayerSource::Native, Some(vec![layer_edit("native")])),
-        ];
-        let combined =
-            combine_layer_formatting_results(AggregationStrategy::Preferred, results).unwrap();
-        assert_eq!(combined[0].new_text, "native");
-    }
-
-    #[test]
-    fn combine_layers_returns_none_when_no_layer_produces() {
-        let results = vec![(LayerSource::Virt, None), (LayerSource::Host, Some(vec![]))];
-        assert!(
-            combine_layer_formatting_results(AggregationStrategy::Preferred, results).is_none()
+    fn whole_document_replacement_covers_the_entire_original() {
+        let original = "line1\nline2";
+        let formatted = "LINE1\nLINE2\n";
+        let edits = whole_document_replacement(original, formatted).unwrap();
+        assert_eq!(edits.len(), 1, "one overlap-free replacement edit");
+        assert_eq!(edits[0].range.start, Position::new(0, 0));
+        assert_eq!(
+            edits[0].range.end,
+            Position::new(1, 5),
+            "end must be the original's last position (line 1, after 'line2')"
         );
+        assert_eq!(edits[0].new_text, formatted);
     }
 
     #[test]
-    fn combine_layers_concatenated_single_producer_passes_through() {
-        let results = vec![
-            (LayerSource::Virt, Some(vec![layer_edit("virt")])),
-            (LayerSource::Host, None),
-            (LayerSource::Native, None),
-        ];
-        let combined =
-            combine_layer_formatting_results(AggregationStrategy::Concatenated, results).unwrap();
-        assert_eq!(combined.len(), 1);
-        assert_eq!(combined[0].new_text, "virt");
+    fn whole_document_replacement_handles_trailing_newline() {
+        // With a trailing newline the last line is empty: end = (lines, 0).
+        let original = "a\nb\n";
+        let edits = whole_document_replacement(original, "c\n").unwrap();
+        assert_eq!(edits[0].range.end, Position::new(2, 0));
     }
 
     #[test]
-    fn combine_layers_concatenated_multiple_producers_applies_highest_priority_only() {
-        // Unreachable today (host/native contribute nothing), but the
-        // fail-safe matters: naively concatenating two layers' edit lists
-        // could produce overlapping edits, violating LSP. The
-        // highest-priority layer wins alone until cross-layer text threading
-        // exists.
-        let results = vec![
-            (LayerSource::Virt, Some(vec![layer_edit("virt")])),
-            (LayerSource::Host, Some(vec![layer_edit("host")])),
-        ];
-        let combined =
-            combine_layer_formatting_results(AggregationStrategy::Concatenated, results).unwrap();
-        assert_eq!(combined.len(), 1, "edit lists must never be merged");
-        assert_eq!(combined[0].new_text, "virt");
+    fn whole_document_replacement_counts_end_character_in_utf16() {
+        // 'é' is 1 UTF-16 unit but 2 UTF-8 bytes; '𠮷' is 2 UTF-16 units.
+        let original = "é𠮷";
+        let edits = whole_document_replacement(original, "x").unwrap();
+        assert_eq!(edits[0].range.end, Position::new(0, 3));
+    }
+
+    #[test]
+    fn whole_document_replacement_returns_none_for_round_trip() {
+        // A chain whose layers undo each other must produce no edit at all.
+        assert!(whole_document_replacement("same", "same").is_none());
     }
 
     #[test]

--- a/src/lsp/lsp_impl/text_document/hover.rs
+++ b/src/lsp/lsp_impl/text_document/hover.rs
@@ -9,39 +9,29 @@
 use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::{Hover, HoverParams, Position, Uri};
 
-use crate::config::settings::LayerSource;
-
-use super::super::{Kakehashi, uri_to_url};
-use crate::lsp::aggregation::server::{dispatch_host_preferred, dispatch_preferred};
+use super::super::Kakehashi;
+use crate::lsp::aggregation::server::dispatch_preferred;
+use crate::lsp::lsp_impl::bridge_context::parse_host_verbatim;
 
 const METHOD: &str = "textDocument/hover";
 
 impl Kakehashi {
     pub(crate) async fn hover_impl(&self, params: HoverParams) -> Result<Option<Hover>> {
+        let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
         let lsp_uri = params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
 
-        let Ok(uri) = uri_to_url(&lsp_uri) else {
-            log::warn!("Invalid URI in hover: {}", lsp_uri.as_str());
-            return Ok(None);
-        };
-        let Some(host_language) = self.document_language(&uri) else {
-            return Ok(None);
-        };
-
-        let layer_cfg = self.resolve_layer_config(&host_language, METHOD);
-        for layer in &layer_cfg.order {
-            let hover = match layer {
-                LayerSource::Virt => self.hover_virt_layer(&lsp_uri, position).await?,
-                LayerSource::Host => self.hover_host_layer(&lsp_uri, position).await?,
-                // No native hover implementation: empty contributor.
-                LayerSource::Native => None,
-            };
-            if hover.is_some() {
-                return Ok(hover);
-            }
-        }
-        Ok(None)
+        let virt = self.hover_virt_layer(&lsp_uri, position);
+        self.walk_layers(
+            &lsp_uri,
+            METHOD,
+            METHOD,
+            raw_params,
+            virt,
+            parse_host_verbatim::<Hover>,
+            |_| true,
+        )
+        .await
     }
 
     /// Virt layer: bridge the injection region under the cursor.
@@ -78,42 +68,6 @@ impl Kakehashi {
         )
         .await;
         pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
-        result.handle(&self.client, "hover", None, Ok).await
-    }
-
-    /// Host layer: bridge the host document itself (real URI, response
-    /// verbatim — host-document-bridge).
-    async fn hover_host_layer(&self, lsp_uri: &Uri, position: Position) -> Result<Option<Hover>> {
-        let Some(ctx) = self.resolve_host_bridge_context(lsp_uri, METHOD) else {
-            return Ok(None);
-        };
-
-        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(ctx.upstream_request_id.as_ref());
-
-        let pool = self.bridge.pool_arc();
-        let result = dispatch_host_preferred(
-            &ctx,
-            pool.clone(),
-            |t| async move {
-                t.pool
-                    .send_host_hover_request(
-                        &t.server_name,
-                        &t.server_config,
-                        &crate::lsp::bridge::HostDocument {
-                            uri: &t.uri,
-                            language_id: &t.language_id,
-                            text: &t.text,
-                        },
-                        position,
-                        t.upstream_id,
-                    )
-                    .await
-            },
-            |opt| opt.is_some(),
-            cancel_rx,
-        )
-        .await;
-        pool.unregister_all_for_upstream_id(ctx.upstream_request_id.as_ref());
         result.handle(&self.client, "hover", None, Ok).await
     }
 }

--- a/src/lsp/lsp_impl/text_document/hover.rs
+++ b/src/lsp/lsp_impl/text_document/hover.rs
@@ -1,26 +1,58 @@
 //! Hover method for Kakehashi.
+//!
+//! Walks the resolved layer order (cross-layer-aggregation): the virt layer
+//! bridges the injection region under the cursor, the host layer
+//! (host-document-bridge) bridges the host document itself with the real URI
+//! and the response verbatim. The first layer producing a non-empty result
+//! wins (`preferred`).
 
 use tower_lsp_server::jsonrpc::Result;
-use tower_lsp_server::ls_types::{Hover, HoverParams};
+use tower_lsp_server::ls_types::{Hover, HoverParams, Position, Uri};
 
-use super::super::Kakehashi;
-use crate::lsp::aggregation::server::dispatch_preferred;
+use crate::config::settings::LayerSource;
+
+use super::super::{Kakehashi, uri_to_url};
+use crate::lsp::aggregation::server::{dispatch_host_preferred, dispatch_preferred};
+
+const METHOD: &str = "textDocument/hover";
 
 impl Kakehashi {
     pub(crate) async fn hover_impl(&self, params: HoverParams) -> Result<Option<Hover>> {
         let lsp_uri = params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
 
-        // Use shared preamble to resolve injection context with ALL matching servers
-        let Some(ctx) = self.resolve_bridge_contexts(&lsp_uri, position, "textDocument/hover")
-        else {
+        let Ok(uri) = uri_to_url(&lsp_uri) else {
+            log::warn!("Invalid URI in hover: {}", lsp_uri.as_str());
+            return Ok(None);
+        };
+        let Some(host_language) = self.document_language(&uri) else {
+            return Ok(None);
+        };
+
+        let layer_cfg = self.resolve_layer_config(&host_language, METHOD);
+        for layer in &layer_cfg.order {
+            let hover = match layer {
+                LayerSource::Virt => self.hover_virt_layer(&lsp_uri, position).await?,
+                LayerSource::Host => self.hover_host_layer(&lsp_uri, position).await?,
+                // No native hover implementation: empty contributor.
+                LayerSource::Native => None,
+            };
+            if hover.is_some() {
+                return Ok(hover);
+            }
+        }
+        Ok(None)
+    }
+
+    /// Virt layer: bridge the injection region under the cursor.
+    async fn hover_virt_layer(&self, lsp_uri: &Uri, position: Position) -> Result<Option<Hover>> {
+        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
             return Ok(None);
         };
 
         let (cancel_rx, _cancel_guard) =
             self.subscribe_cancel(ctx.document.upstream_request_id.as_ref());
 
-        // Fan-out hover requests to all matching servers
         let pool = self.bridge.pool_arc();
         let position = ctx.position;
         let result = dispatch_preferred(
@@ -46,6 +78,42 @@ impl Kakehashi {
         )
         .await;
         pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
+        result.handle(&self.client, "hover", None, Ok).await
+    }
+
+    /// Host layer: bridge the host document itself (real URI, response
+    /// verbatim — host-document-bridge).
+    async fn hover_host_layer(&self, lsp_uri: &Uri, position: Position) -> Result<Option<Hover>> {
+        let Some(ctx) = self.resolve_host_bridge_context(lsp_uri, METHOD) else {
+            return Ok(None);
+        };
+
+        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(ctx.upstream_request_id.as_ref());
+
+        let pool = self.bridge.pool_arc();
+        let result = dispatch_host_preferred(
+            &ctx,
+            pool.clone(),
+            |t| async move {
+                t.pool
+                    .send_host_hover_request(
+                        &t.server_name,
+                        &t.server_config,
+                        &crate::lsp::bridge::HostDocument {
+                            uri: &t.uri,
+                            language_id: &t.language_id,
+                            text: &t.text,
+                        },
+                        position,
+                        t.upstream_id,
+                    )
+                    .await
+            },
+            |opt| opt.is_some(),
+            cancel_rx,
+        )
+        .await;
+        pool.unregister_all_for_upstream_id(ctx.upstream_request_id.as_ref());
         result.handle(&self.client, "hover", None, Ok).await
     }
 }

--- a/src/lsp/lsp_impl/text_document/implementation.rs
+++ b/src/lsp/lsp_impl/text_document/implementation.rs
@@ -1,25 +1,53 @@
 //! Goto implementation method for Kakehashi.
+//!
+//! Walks the resolved layer order (cross-layer-aggregation): the virt layer
+//! bridges the injection region under the cursor, the host layer
+//! (host-document-bridge) bridges the host document itself with the real URI
+//! and no coordinate translation. The first layer producing a non-empty
+//! result wins (`preferred`).
 
 use tower_lsp_server::jsonrpc::Result;
-use tower_lsp_server::ls_types::Location;
 use tower_lsp_server::ls_types::request::{GotoImplementationParams, GotoImplementationResponse};
+use tower_lsp_server::ls_types::{Location, LocationLink, Position, Uri};
 
-use crate::lsp::bridge::location_link_to_location;
+use crate::lsp::bridge::{location_link_to_location, normalize_host_goto_result};
 
 use super::super::Kakehashi;
 use crate::lsp::aggregation::server::dispatch_preferred;
+
+const METHOD: &str = "textDocument/implementation";
 
 impl Kakehashi {
     pub(crate) async fn goto_implementation_impl(
         &self,
         params: GotoImplementationParams,
     ) -> Result<Option<GotoImplementationResponse>> {
+        let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
         let lsp_uri = params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
 
-        let Some(ctx) =
-            self.resolve_bridge_contexts(&lsp_uri, position, "textDocument/implementation")
-        else {
+        let virt = self.implementation_virt_layer(&lsp_uri, position);
+        let links = self
+            .walk_layers(
+                &lsp_uri,
+                METHOD,
+                METHOD,
+                raw_params,
+                virt,
+                normalize_host_goto_result,
+                |links: &Vec<LocationLink>| !links.is_empty(),
+            )
+            .await?;
+        Ok(links.map(|links| self.implementation_response(links)))
+    }
+
+    /// Virt layer: bridge the injection region under the cursor.
+    async fn implementation_virt_layer(
+        &self,
+        lsp_uri: &Uri,
+        position: Position,
+    ) -> Result<Option<Vec<LocationLink>>> {
+        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
             return Ok(None);
         };
 
@@ -52,20 +80,19 @@ impl Kakehashi {
         )
         .await;
         pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
-
         result
-            .handle(&self.client, "implementation", None, |value| match value {
-                Some(links) => {
-                    if self.settings_manager.supports_implementation_link() {
-                        Ok(Some(GotoImplementationResponse::Link(links)))
-                    } else {
-                        let locations: Vec<Location> =
-                            links.into_iter().map(location_link_to_location).collect();
-                        Ok(Some(GotoImplementationResponse::Array(locations)))
-                    }
-                }
-                None => Ok(None),
-            })
+            .handle(&self.client, "implementation", None, Ok)
             .await
+    }
+
+    /// Shape the winning links per the client's `LocationLink` support.
+    fn implementation_response(&self, links: Vec<LocationLink>) -> GotoImplementationResponse {
+        if self.settings_manager.supports_implementation_link() {
+            GotoImplementationResponse::Link(links)
+        } else {
+            let locations: Vec<Location> =
+                links.into_iter().map(location_link_to_location).collect();
+            GotoImplementationResponse::Array(locations)
+        }
     }
 }

--- a/src/lsp/lsp_impl/text_document/inlay_hint.rs
+++ b/src/lsp/lsp_impl/text_document/inlay_hint.rs
@@ -1,22 +1,49 @@
 //! Inlay hint method for Kakehashi.
+//!
+//! Walks the resolved layer order (cross-layer-aggregation): the virt layer
+//! bridges the injection region under the requested range, the host layer
+//! (host-document-bridge) bridges the host document itself with the real URI
+//! and the response verbatim. The first layer producing a non-empty result
+//! wins (`preferred`).
 
 use tower_lsp_server::jsonrpc::Result;
-use tower_lsp_server::ls_types::{InlayHint, InlayHintParams};
+use tower_lsp_server::ls_types::{InlayHint, InlayHintParams, Range, Uri};
 
 use super::super::Kakehashi;
 use crate::lsp::aggregation::server::dispatch_preferred;
+use crate::lsp::lsp_impl::bridge_context::parse_host_verbatim;
+
+const METHOD: &str = "textDocument/inlayHint";
 
 impl Kakehashi {
     pub(crate) async fn inlay_hint_impl(
         &self,
         params: InlayHintParams,
     ) -> Result<Option<Vec<InlayHint>>> {
+        let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
         let lsp_uri = params.text_document.uri;
         let range = params.range;
 
-        let Some(ctx) =
-            self.resolve_bridge_contexts_for_range(&lsp_uri, range, "textDocument/inlayHint")
-        else {
+        let virt = self.inlay_hint_virt_layer(&lsp_uri, range);
+        self.walk_layers(
+            &lsp_uri,
+            METHOD,
+            METHOD,
+            raw_params,
+            virt,
+            parse_host_verbatim::<Vec<InlayHint>>,
+            |hints: &Vec<InlayHint>| !hints.is_empty(),
+        )
+        .await
+    }
+
+    /// Virt layer: bridge the injection region under the requested range.
+    async fn inlay_hint_virt_layer(
+        &self,
+        lsp_uri: &Uri,
+        range: Range,
+    ) -> Result<Option<Vec<InlayHint>>> {
+        let Some(ctx) = self.resolve_bridge_contexts_for_range(lsp_uri, range, METHOD) else {
             return Ok(None);
         };
 

--- a/src/lsp/lsp_impl/text_document/linked_editing_range.rs
+++ b/src/lsp/lsp_impl/text_document/linked_editing_range.rs
@@ -1,22 +1,49 @@
 //! LinkedEditingRange method for Kakehashi.
+//!
+//! Walks the resolved layer order (cross-layer-aggregation): the virt layer
+//! bridges the injection region under the cursor, the host layer
+//! (host-document-bridge) bridges the host document itself with the real URI
+//! and the response verbatim. The first layer producing a non-empty result
+//! wins (`preferred`).
 
 use tower_lsp_server::jsonrpc::Result;
-use tower_lsp_server::ls_types::{LinkedEditingRangeParams, LinkedEditingRanges};
+use tower_lsp_server::ls_types::{LinkedEditingRangeParams, LinkedEditingRanges, Position, Uri};
 
 use super::super::Kakehashi;
 use crate::lsp::aggregation::server::dispatch_preferred;
+use crate::lsp::lsp_impl::bridge_context::parse_host_verbatim;
+
+const METHOD: &str = "textDocument/linkedEditingRange";
 
 impl Kakehashi {
     pub(crate) async fn linked_editing_range_impl(
         &self,
         params: LinkedEditingRangeParams,
     ) -> Result<Option<LinkedEditingRanges>> {
+        let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
         let lsp_uri = params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
 
-        let Some(ctx) =
-            self.resolve_bridge_contexts(&lsp_uri, position, "textDocument/linkedEditingRange")
-        else {
+        let virt = self.linked_editing_range_virt_layer(&lsp_uri, position);
+        self.walk_layers(
+            &lsp_uri,
+            METHOD,
+            METHOD,
+            raw_params,
+            virt,
+            parse_host_verbatim::<LinkedEditingRanges>,
+            |r: &LinkedEditingRanges| !r.ranges.is_empty(),
+        )
+        .await
+    }
+
+    /// Virt layer: bridge the injection region under the cursor.
+    async fn linked_editing_range_virt_layer(
+        &self,
+        lsp_uri: &Uri,
+        position: Position,
+    ) -> Result<Option<LinkedEditingRanges>> {
+        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
             return Ok(None);
         };
 

--- a/src/lsp/lsp_impl/text_document/moniker.rs
+++ b/src/lsp/lsp_impl/text_document/moniker.rs
@@ -1,18 +1,46 @@
 //! Moniker method for Kakehashi.
+//!
+//! Walks the resolved layer order (cross-layer-aggregation): the virt layer
+//! bridges the injection region under the cursor, the host layer
+//! (host-document-bridge) bridges the host document itself with the real URI
+//! and the response verbatim. The first layer producing a non-empty result
+//! wins (`preferred`).
 
 use tower_lsp_server::jsonrpc::Result;
-use tower_lsp_server::ls_types::{Moniker, MonikerParams};
+use tower_lsp_server::ls_types::{Moniker, MonikerParams, Position, Uri};
 
 use super::super::Kakehashi;
 use crate::lsp::aggregation::server::dispatch_preferred;
+use crate::lsp::lsp_impl::bridge_context::parse_host_verbatim;
+
+const METHOD: &str = "textDocument/moniker";
 
 impl Kakehashi {
     pub(crate) async fn moniker_impl(&self, params: MonikerParams) -> Result<Option<Vec<Moniker>>> {
+        let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
         let lsp_uri = params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
 
-        let Some(ctx) = self.resolve_bridge_contexts(&lsp_uri, position, "textDocument/moniker")
-        else {
+        let virt = self.moniker_virt_layer(&lsp_uri, position);
+        self.walk_layers(
+            &lsp_uri,
+            METHOD,
+            METHOD,
+            raw_params,
+            virt,
+            parse_host_verbatim::<Vec<Moniker>>,
+            |monikers: &Vec<Moniker>| !monikers.is_empty(),
+        )
+        .await
+    }
+
+    /// Virt layer: bridge the injection region under the cursor.
+    async fn moniker_virt_layer(
+        &self,
+        lsp_uri: &Uri,
+        position: Position,
+    ) -> Result<Option<Vec<Moniker>>> {
+        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
             return Ok(None);
         };
 

--- a/src/lsp/lsp_impl/text_document/prepare_rename.rs
+++ b/src/lsp/lsp_impl/text_document/prepare_rename.rs
@@ -1,22 +1,51 @@
 //! PrepareRename method for Kakehashi.
+//!
+//! Walks the resolved layer order (cross-layer-aggregation): the virt layer
+//! bridges the injection region under the cursor, the host layer
+//! (host-document-bridge) bridges the host document itself with the real URI
+//! and the response verbatim. The first layer producing a non-empty result
+//! wins (`preferred`).
 
 use tower_lsp_server::jsonrpc::Result;
-use tower_lsp_server::ls_types::{PrepareRenameResponse, TextDocumentPositionParams};
+use tower_lsp_server::ls_types::{
+    Position, PrepareRenameResponse, TextDocumentPositionParams, Uri,
+};
 
 use super::super::Kakehashi;
 use crate::lsp::aggregation::server::dispatch_preferred;
+use crate::lsp::lsp_impl::bridge_context::parse_host_verbatim;
+
+const METHOD: &str = "textDocument/prepareRename";
 
 impl Kakehashi {
     pub(crate) async fn prepare_rename_impl(
         &self,
         params: TextDocumentPositionParams,
     ) -> Result<Option<PrepareRenameResponse>> {
+        let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
         let lsp_uri = params.text_document.uri;
         let position = params.position;
 
-        let Some(ctx) =
-            self.resolve_bridge_contexts(&lsp_uri, position, "textDocument/prepareRename")
-        else {
+        let virt = self.prepare_rename_virt_layer(&lsp_uri, position);
+        self.walk_layers(
+            &lsp_uri,
+            METHOD,
+            METHOD,
+            raw_params,
+            virt,
+            parse_host_verbatim::<PrepareRenameResponse>,
+            |_| true,
+        )
+        .await
+    }
+
+    /// Virt layer: bridge the injection region under the cursor.
+    async fn prepare_rename_virt_layer(
+        &self,
+        lsp_uri: &Uri,
+        position: Position,
+    ) -> Result<Option<PrepareRenameResponse>> {
+        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
             return Ok(None);
         };
 

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -30,7 +30,7 @@ use tower_lsp_server::ls_types::{DocumentRangeFormattingParams, Range, TextEdit}
 use crate::language::InjectionResolver;
 use crate::lsp::aggregation::server::FanInResult;
 use crate::lsp::aggregation::server::dispatch_preferred;
-use crate::lsp::lsp_impl::bridge_context::DocumentRequestContext;
+use crate::lsp::lsp_impl::bridge_context::{DocumentRequestContext, parse_host_verbatim};
 use crate::text::PositionMapper;
 
 use super::super::{Kakehashi, uri_to_url};
@@ -41,240 +41,261 @@ impl Kakehashi {
         &self,
         params: DocumentRangeFormattingParams,
     ) -> Result<Option<Vec<TextEdit>>> {
-        let lsp_uri = params.text_document.uri;
-        let options = params.options;
-        let host_range = params.range;
+        let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
+        let lsp_uri = params.text_document.uri.clone();
+        let virt = async {
+            let lsp_uri = params.text_document.uri;
+            let options = params.options;
+            let host_range = params.range;
 
-        let Ok(uri) = uri_to_url(&lsp_uri) else {
-            log::warn!("Invalid URI in rangeFormatting: {}", lsp_uri.as_str());
-            return Ok(None);
-        };
-
-        log::debug!("rangeFormatting called for {} range {:?}", uri, host_range);
-
-        // Tower-LSP runs requests concurrently, so a rangeFormatting call can
-        // arrive before didOpen/didChange has finished parsing. Wait briefly
-        // for any in-flight parse to land a tree before snapshotting, matching
-        // the read-handler pattern (semantic tokens, node lookups); otherwise
-        // an otherwise-valid request would degrade to `Ok(None)` purely due to
-        // a parse race.
-        self.documents
-            .wait_for_parse_completion(&uri, Duration::from_millis(200))
-            .await;
-
-        let snapshot = match self.documents.get(&uri) {
-            None => {
-                log::debug!("rangeFormatting: No document found for {}", uri);
+            let Ok(uri) = uri_to_url(&lsp_uri) else {
+                log::warn!("Invalid URI in rangeFormatting: {}", lsp_uri.as_str());
                 return Ok(None);
-            }
-            Some(doc) => match doc.snapshot() {
+            };
+
+            log::debug!("rangeFormatting called for {} range {:?}", uri, host_range);
+
+            // Tower-LSP runs requests concurrently, so a rangeFormatting call can
+            // arrive before didOpen/didChange has finished parsing. Wait briefly
+            // for any in-flight parse to land a tree before snapshotting, matching
+            // the read-handler pattern (semantic tokens, node lookups); otherwise
+            // an otherwise-valid request would degrade to `Ok(None)` purely due to
+            // a parse race.
+            self.documents
+                .wait_for_parse_completion(&uri, Duration::from_millis(200))
+                .await;
+
+            let snapshot = match self.documents.get(&uri) {
                 None => {
-                    log::debug!(
-                        "rangeFormatting: Document not fully initialized for {}",
-                        uri
-                    );
+                    log::debug!("rangeFormatting: No document found for {}", uri);
                     return Ok(None);
                 }
-                Some(snapshot) => snapshot,
-            },
-        };
-
-        let Some(language_name) = self.document_language(&uri) else {
-            log::debug!(target: "kakehashi::rangeFormatting", "No language detected");
-            return Ok(None);
-        };
-
-        // Layer gating keys off "textDocument/formatting", matching the
-        // aggregation config below: range formatting is the partial-document
-        // counterpart of full formatting and shares its configuration key.
-        if !self.virt_layer_enabled(&language_name, "textDocument/formatting") {
-            log::debug!(
-                target: "kakehashi::rangeFormatting",
-                "virt layer disabled for {} via layers.order",
-                language_name
-            );
-            return Ok(None);
-        }
-
-        let Some(injection_query) = self.language.injection_query(&language_name) else {
-            return Ok(None);
-        };
-
-        let all_regions = InjectionResolver::resolve_all(
-            &self.language,
-            self.bridge.node_tracker(),
-            &uri,
-            snapshot.tree(),
-            snapshot.text(),
-            injection_query.as_ref(),
-        );
-
-        if all_regions.is_empty() {
-            return Ok(None);
-        }
-
-        let upstream_request_id = crate::lsp::current_upstream_id();
-        let cancel_state = self.setup_formatting_cancel_token(upstream_request_id.as_ref());
-        let pool = self.bridge.pool_arc();
-
-        // Clip the request to each region's actual byte bounds (not just
-        // its line span). Line-only clipping is incorrect for two cases
-        // that matter for inline injections (`start_column > 0`):
-        //
-        // 1. Request shares a line with the injection but lies entirely
-        //    before/after the injected content. Byte intersection
-        //    correctly skips the region; line-only would mis-overlap.
-        // 2. Request straddles an injection boundary (e.g., starts before
-        //    the injection's opening column, ends past its closing
-        //    column on the same line). Byte intersection clips the
-        //    endpoints to the injected content; line-only would pass the
-        //    out-of-bounds columns to `translate_host_range_to_virtual`,
-        //    where `saturating_sub` produces a virtual range past the
-        //    virtual document's actual columns and the downstream
-        //    formatter may error or format more than the user selected.
-        //
-        // Multi-line code-fence injections (`start_column == 0`) are
-        // unchanged because their line and byte bounds are equivalent.
-        let mapper = PositionMapper::new(snapshot.text());
-        let request_bytes = clamp_request_to_document(&mapper, host_range);
-
-        let mut outer_join_set: JoinSet<Option<Vec<TextEdit>>> = JoinSet::new();
-
-        for resolved in all_regions {
-            // A covering request (its byte span encloses the whole region)
-            // prefers full formatting; a partial request range-formats the
-            // clipped span. Either way we compute the clipped+content-clamped
-            // host range: the partial path sends it, and the covering path
-            // keeps it as a fallback for servers that support `rangeFormatting`
-            // but not `formatting`. For a covering request, clipping against
-            // the region yields the whole region.
-            let is_covering = request_covers_region(&request_bytes, &resolved.region.byte_range);
-
-            let Some(clipped) =
-                clip_request_to_region(&request_bytes, &resolved.region.byte_range, &mapper)
-            else {
-                continue;
-            };
-            // The byte-range clip can still leave an endpoint inside a stripped
-            // per-line prefix (e.g. blockquoted code's `> `); pull both
-            // endpoints onto the actual injected content. A partial selection
-            // lying entirely in prefix bytes collapses and the region is
-            // skipped (a covering selection spans real content, so it never
-            // collapses).
-            let Some(clipped_host_range) = clamp_range_to_content_columns(
-                clipped,
-                resolved.region.line_range.start,
-                &resolved.line_column_offsets,
-            ) else {
-                continue;
+                Some(doc) => match doc.snapshot() {
+                    None => {
+                        log::debug!(
+                            "rangeFormatting: Document not fully initialized for {}",
+                            uri
+                        );
+                        return Ok(None);
+                    }
+                    Some(snapshot) => snapshot,
+                },
             };
 
-            let configs = self.bridge_configs_for_injection_language(
-                &language_name,
-                &resolved.injection_language,
-            );
-            if configs.is_empty() {
-                continue;
+            let Some(language_name) = self.document_language(&uri) else {
+                log::debug!(target: "kakehashi::rangeFormatting", "No language detected");
+                return Ok(None);
+            };
+
+            // Layer gating keys off "textDocument/formatting", matching the
+            // aggregation config below: range formatting is the partial-document
+            // counterpart of full formatting and shares its configuration key.
+            if !self.virt_layer_enabled(&language_name, "textDocument/formatting") {
+                log::debug!(
+                    target: "kakehashi::rangeFormatting",
+                    "virt layer disabled for {} via layers.order",
+                    language_name
+                );
+                return Ok(None);
             }
 
-            // Resolve aggregation under "textDocument/formatting", not
-            // "textDocument/rangeFormatting". Range formatting is the
-            // partial-document counterpart of full formatting and shares its
-            // server priorities and strategy (see language-server-bridge-request-strategies, which groups the
-            // two). There is no separate rangeFormatting config key, and
-            // `resolve_aggregation_entry` only falls back method → `_`
-            // wildcard — never formatting → rangeFormatting — so keying off
-            // "textDocument/rangeFormatting" would silently ignore a user's
-            // "textDocument/formatting" configuration.
-            let agg = self.resolve_aggregation_config(
-                &language_name,
-                &resolved.injection_language,
-                "textDocument/formatting",
-            );
-            let region_ctx = DocumentRequestContext {
-                uri: uri.clone(),
-                resolved,
-                configs,
-                upstream_request_id: upstream_request_id.clone(),
-                priorities: agg.priorities,
-                strategy: agg.strategy,
-                max_fan_out: agg.max_fan_out,
+            let Some(injection_query) = self.language.injection_query(&language_name) else {
+                return Ok(None);
             };
-            let pool = Arc::clone(&pool);
-            let options = options.clone();
-            let region_cancel_rx = cancel_state.derive_receiver();
 
-            outer_join_set.spawn(async move {
-                let result = dispatch_preferred(
-                    &region_ctx,
-                    pool.clone(),
-                    move |t| {
-                        let options = options.clone();
-                        async move {
-                            // Covering request: prefer full formatting, but fall
-                            // back to rangeFormatting over the whole region when
-                            // the server has no `documentFormattingProvider`
-                            // (`Ok(None)`) — otherwise a range-only server would
-                            // format nothing. Errors propagate (no fallback);
-                            // `Ok(Some(_))` (incl. an empty edit list) is an
-                            // authoritative result.
-                            if is_covering {
-                                match t
-                                    .pool
-                                    .send_formatting_request(
+            let all_regions = InjectionResolver::resolve_all(
+                &self.language,
+                self.bridge.node_tracker(),
+                &uri,
+                snapshot.tree(),
+                snapshot.text(),
+                injection_query.as_ref(),
+            );
+
+            if all_regions.is_empty() {
+                return Ok(None);
+            }
+
+            let upstream_request_id = crate::lsp::current_upstream_id();
+            let cancel_state = self.setup_formatting_cancel_token(upstream_request_id.as_ref());
+            let pool = self.bridge.pool_arc();
+
+            // Clip the request to each region's actual byte bounds (not just
+            // its line span). Line-only clipping is incorrect for two cases
+            // that matter for inline injections (`start_column > 0`):
+            //
+            // 1. Request shares a line with the injection but lies entirely
+            //    before/after the injected content. Byte intersection
+            //    correctly skips the region; line-only would mis-overlap.
+            // 2. Request straddles an injection boundary (e.g., starts before
+            //    the injection's opening column, ends past its closing
+            //    column on the same line). Byte intersection clips the
+            //    endpoints to the injected content; line-only would pass the
+            //    out-of-bounds columns to `translate_host_range_to_virtual`,
+            //    where `saturating_sub` produces a virtual range past the
+            //    virtual document's actual columns and the downstream
+            //    formatter may error or format more than the user selected.
+            //
+            // Multi-line code-fence injections (`start_column == 0`) are
+            // unchanged because their line and byte bounds are equivalent.
+            let mapper = PositionMapper::new(snapshot.text());
+            let request_bytes = clamp_request_to_document(&mapper, host_range);
+
+            let mut outer_join_set: JoinSet<Option<Vec<TextEdit>>> = JoinSet::new();
+
+            for resolved in all_regions {
+                // A covering request (its byte span encloses the whole region)
+                // prefers full formatting; a partial request range-formats the
+                // clipped span. Either way we compute the clipped+content-clamped
+                // host range: the partial path sends it, and the covering path
+                // keeps it as a fallback for servers that support `rangeFormatting`
+                // but not `formatting`. For a covering request, clipping against
+                // the region yields the whole region.
+                let is_covering =
+                    request_covers_region(&request_bytes, &resolved.region.byte_range);
+
+                let Some(clipped) =
+                    clip_request_to_region(&request_bytes, &resolved.region.byte_range, &mapper)
+                else {
+                    continue;
+                };
+                // The byte-range clip can still leave an endpoint inside a stripped
+                // per-line prefix (e.g. blockquoted code's `> `); pull both
+                // endpoints onto the actual injected content. A partial selection
+                // lying entirely in prefix bytes collapses and the region is
+                // skipped (a covering selection spans real content, so it never
+                // collapses).
+                let Some(clipped_host_range) = clamp_range_to_content_columns(
+                    clipped,
+                    resolved.region.line_range.start,
+                    &resolved.line_column_offsets,
+                ) else {
+                    continue;
+                };
+
+                let configs = self.bridge_configs_for_injection_language(
+                    &language_name,
+                    &resolved.injection_language,
+                );
+                if configs.is_empty() {
+                    continue;
+                }
+
+                // Resolve aggregation under "textDocument/formatting", not
+                // "textDocument/rangeFormatting". Range formatting is the
+                // partial-document counterpart of full formatting and shares its
+                // server priorities and strategy (see language-server-bridge-request-strategies, which groups the
+                // two). There is no separate rangeFormatting config key, and
+                // `resolve_aggregation_entry` only falls back method → `_`
+                // wildcard — never formatting → rangeFormatting — so keying off
+                // "textDocument/rangeFormatting" would silently ignore a user's
+                // "textDocument/formatting" configuration.
+                let agg = self.resolve_aggregation_config(
+                    &language_name,
+                    &resolved.injection_language,
+                    "textDocument/formatting",
+                );
+                let region_ctx = DocumentRequestContext {
+                    uri: uri.clone(),
+                    resolved,
+                    configs,
+                    upstream_request_id: upstream_request_id.clone(),
+                    priorities: agg.priorities,
+                    strategy: agg.strategy,
+                    max_fan_out: agg.max_fan_out,
+                };
+                let pool = Arc::clone(&pool);
+                let options = options.clone();
+                let region_cancel_rx = cancel_state.derive_receiver();
+
+                outer_join_set.spawn(async move {
+                    let result = dispatch_preferred(
+                        &region_ctx,
+                        pool.clone(),
+                        move |t| {
+                            let options = options.clone();
+                            async move {
+                                // Covering request: prefer full formatting, but fall
+                                // back to rangeFormatting over the whole region when
+                                // the server has no `documentFormattingProvider`
+                                // (`Ok(None)`) — otherwise a range-only server would
+                                // format nothing. Errors propagate (no fallback);
+                                // `Ok(Some(_))` (incl. an empty edit list) is an
+                                // authoritative result.
+                                if is_covering {
+                                    match t
+                                        .pool
+                                        .send_formatting_request(
+                                            &t.server_name,
+                                            &t.server_config,
+                                            &t.uri,
+                                            &t.injection_language,
+                                            &t.region_id,
+                                            t.offset.clone(),
+                                            &t.virtual_content,
+                                            options.clone(),
+                                            t.upstream_id.clone(),
+                                            None,
+                                        )
+                                        .await
+                                    {
+                                        Ok(None) => {} // fall through to rangeFormatting
+                                        other => return other,
+                                    }
+                                }
+                                t.pool
+                                    .send_range_formatting_request(
                                         &t.server_name,
                                         &t.server_config,
                                         &t.uri,
                                         &t.injection_language,
                                         &t.region_id,
-                                        t.offset.clone(),
+                                        t.offset,
                                         &t.virtual_content,
-                                        options.clone(),
-                                        t.upstream_id.clone(),
+                                        clipped_host_range,
+                                        options,
+                                        t.upstream_id,
                                         None,
                                     )
                                     .await
-                                {
-                                    Ok(None) => {} // fall through to rangeFormatting
-                                    other => return other,
-                                }
                             }
-                            t.pool
-                                .send_range_formatting_request(
-                                    &t.server_name,
-                                    &t.server_config,
-                                    &t.uri,
-                                    &t.injection_language,
-                                    &t.region_id,
-                                    t.offset,
-                                    &t.virtual_content,
-                                    clipped_host_range,
-                                    options,
-                                    t.upstream_id,
-                                    None,
-                                )
-                                .await
-                        }
-                    },
-                    // Same semantics as full formatting: `Some(vec![])` is
-                    // an authoritative "no edits needed" (e.g., the range is
-                    // already perfectly formatted) — keep it and stop. `None`
-                    // means "no response" and falls through to lower-priority
-                    // servers.
-                    |opt| opt.is_some(),
-                    region_cancel_rx,
-                )
-                .await;
-                match result {
-                    FanInResult::Done(edits) => edits,
-                    FanInResult::NoResult { .. } | FanInResult::Cancelled => None,
-                }
-            });
-        }
+                        },
+                        // Same semantics as full formatting: `Some(vec![])` is
+                        // an authoritative "no edits needed" (e.g., the range is
+                        // already perfectly formatted) — keep it and stop. `None`
+                        // means "no response" and falls through to lower-priority
+                        // servers.
+                        |opt| opt.is_some(),
+                        region_cancel_rx,
+                    )
+                    .await;
+                    match result {
+                        FanInResult::Done(edits) => edits,
+                        FanInResult::NoResult { .. } | FanInResult::Cancelled => None,
+                    }
+                });
+            }
 
-        let response = finalize_formatting_edits(outer_join_set, cancel_state.token.clone()).await;
-        pool.unregister_all_for_upstream_id(upstream_request_id.as_ref());
-        response
+            let response =
+                finalize_formatting_edits(outer_join_set, cancel_state.token.clone()).await;
+            pool.unregister_all_for_upstream_id(upstream_request_id.as_ref());
+            response
+        };
+
+        // layer_method keys off "textDocument/formatting" ON PURPOSE: range
+        // formatting is the partial-document counterpart of full formatting
+        // and shares its layer order and aggregation key. request_method is
+        // what goes on the wire to host-capable servers.
+        self.walk_layers(
+            &lsp_uri,
+            "textDocument/formatting",
+            "textDocument/rangeFormatting",
+            raw_params,
+            virt,
+            parse_host_verbatim::<Vec<TextEdit>>,
+            |edits: &Vec<TextEdit>| !edits.is_empty(),
+        )
+        .await
     }
 }
 

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -84,6 +84,18 @@ impl Kakehashi {
             return Ok(None);
         };
 
+        // Layer gating keys off "textDocument/formatting", matching the
+        // aggregation config below: range formatting is the partial-document
+        // counterpart of full formatting and shares its configuration key.
+        if !self.virt_layer_enabled(&language_name, "textDocument/formatting") {
+            log::debug!(
+                target: "kakehashi::rangeFormatting",
+                "virt layer disabled for {} via layers.order",
+                language_name
+            );
+            return Ok(None);
+        }
+
         let Some(injection_query) = self.language.injection_query(&language_name) else {
             return Ok(None);
         };

--- a/src/lsp/lsp_impl/text_document/references.rs
+++ b/src/lsp/lsp_impl/text_document/references.rs
@@ -1,22 +1,51 @@
 //! Find references method for Kakehashi.
+//!
+//! Walks the resolved layer order (cross-layer-aggregation): the virt layer
+//! bridges the injection region under the cursor, the host layer
+//! (host-document-bridge) bridges the host document itself with the real URI
+//! and the response verbatim. The first layer producing a non-empty result
+//! wins (`preferred`).
 
 use tower_lsp_server::jsonrpc::Result;
-use tower_lsp_server::ls_types::{Location, ReferenceParams};
+use tower_lsp_server::ls_types::{Location, Position, ReferenceParams, Uri};
 
 use super::super::Kakehashi;
 use crate::lsp::aggregation::server::dispatch_preferred;
+use crate::lsp::lsp_impl::bridge_context::parse_host_verbatim;
+
+const METHOD: &str = "textDocument/references";
 
 impl Kakehashi {
     pub(crate) async fn references_impl(
         &self,
         params: ReferenceParams,
     ) -> Result<Option<Vec<Location>>> {
+        let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
         let lsp_uri = params.text_document_position.text_document.uri;
         let position = params.text_document_position.position;
         let include_declaration = params.context.include_declaration;
 
-        let Some(ctx) = self.resolve_bridge_contexts(&lsp_uri, position, "textDocument/references")
-        else {
+        let virt = self.references_virt_layer(&lsp_uri, position, include_declaration);
+        self.walk_layers(
+            &lsp_uri,
+            METHOD,
+            METHOD,
+            raw_params,
+            virt,
+            parse_host_verbatim::<Vec<Location>>,
+            |locations: &Vec<Location>| !locations.is_empty(),
+        )
+        .await
+    }
+
+    /// Virt layer: bridge the injection region under the cursor.
+    async fn references_virt_layer(
+        &self,
+        lsp_uri: &Uri,
+        position: Position,
+        include_declaration: bool,
+    ) -> Result<Option<Vec<Location>>> {
+        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
             return Ok(None);
         };
 

--- a/src/lsp/lsp_impl/text_document/rename.rs
+++ b/src/lsp/lsp_impl/text_document/rename.rs
@@ -1,19 +1,48 @@
 //! Rename method for Kakehashi.
+//!
+//! Walks the resolved layer order (cross-layer-aggregation): the virt layer
+//! bridges the injection region under the cursor, the host layer
+//! (host-document-bridge) bridges the host document itself with the real URI
+//! and the response verbatim. The first layer producing a non-empty result
+//! wins (`preferred`).
 
 use tower_lsp_server::jsonrpc::Result;
-use tower_lsp_server::ls_types::{RenameParams, WorkspaceEdit};
+use tower_lsp_server::ls_types::{Position, RenameParams, Uri, WorkspaceEdit};
 
 use super::super::Kakehashi;
 use crate::lsp::aggregation::server::dispatch_preferred;
+use crate::lsp::lsp_impl::bridge_context::parse_host_verbatim;
+
+const METHOD: &str = "textDocument/rename";
 
 impl Kakehashi {
     pub(crate) async fn rename_impl(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
+        let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
         let lsp_uri = params.text_document_position.text_document.uri;
         let position = params.text_document_position.position;
         let new_name = params.new_name;
 
-        let Some(ctx) = self.resolve_bridge_contexts(&lsp_uri, position, "textDocument/rename")
-        else {
+        let virt = self.rename_virt_layer(&lsp_uri, position, &new_name);
+        self.walk_layers(
+            &lsp_uri,
+            METHOD,
+            METHOD,
+            raw_params,
+            virt,
+            parse_host_verbatim::<WorkspaceEdit>,
+            |_| true,
+        )
+        .await
+    }
+
+    /// Virt layer: bridge the injection region under the cursor.
+    async fn rename_virt_layer(
+        &self,
+        lsp_uri: &Uri,
+        position: Position,
+        new_name: &str,
+    ) -> Result<Option<WorkspaceEdit>> {
+        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
             return Ok(None);
         };
 
@@ -27,7 +56,7 @@ impl Kakehashi {
             &ctx.document,
             pool.clone(),
             |t| {
-                let new_name = new_name.clone();
+                let new_name = new_name.to_string();
                 async move {
                     t.pool
                         .send_rename_request(

--- a/src/lsp/lsp_impl/text_document/signature_help.rs
+++ b/src/lsp/lsp_impl/text_document/signature_help.rs
@@ -32,7 +32,10 @@ impl Kakehashi {
             raw_params,
             virt,
             parse_host_verbatim::<SignatureHelp>,
-            |_| true,
+            // An empty-but-shaped response ({ signatures: [] }) is "nothing
+            // here" — fall through to the next layer instead of letting it
+            // win, consistent with the host fan-in's empty-shape handling.
+            |help: &SignatureHelp| !help.signatures.is_empty(),
         )
         .await
     }

--- a/src/lsp/lsp_impl/text_document/signature_help.rs
+++ b/src/lsp/lsp_impl/text_document/signature_help.rs
@@ -1,23 +1,50 @@
 //! Signature help method for Kakehashi.
+//!
+//! Walks the resolved layer order (cross-layer-aggregation): the virt layer
+//! bridges the injection region under the cursor, the host layer
+//! (host-document-bridge) bridges the host document itself with the real URI
+//! and the response verbatim. The first layer producing a non-empty result
+//! wins (`preferred`).
 
 use tower_lsp_server::jsonrpc::Result;
-use tower_lsp_server::ls_types::{SignatureHelp, SignatureHelpParams};
+use tower_lsp_server::ls_types::{Position, SignatureHelp, SignatureHelpParams, Uri};
 
 use super::super::Kakehashi;
 use crate::lsp::aggregation::server::dispatch_preferred;
+use crate::lsp::lsp_impl::bridge_context::parse_host_verbatim;
+
+const METHOD: &str = "textDocument/signatureHelp";
 
 impl Kakehashi {
     pub(crate) async fn signature_help_impl(
         &self,
         params: SignatureHelpParams,
     ) -> Result<Option<SignatureHelp>> {
+        let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
         let lsp_uri = params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
 
+        let virt = self.signature_help_virt_layer(&lsp_uri, position);
+        self.walk_layers(
+            &lsp_uri,
+            METHOD,
+            METHOD,
+            raw_params,
+            virt,
+            parse_host_verbatim::<SignatureHelp>,
+            |_| true,
+        )
+        .await
+    }
+
+    /// Virt layer: bridge the injection region under the cursor.
+    async fn signature_help_virt_layer(
+        &self,
+        lsp_uri: &Uri,
+        position: Position,
+    ) -> Result<Option<SignatureHelp>> {
         // Use shared preamble to resolve injection context with ALL matching servers
-        let Some(ctx) =
-            self.resolve_bridge_contexts(&lsp_uri, position, "textDocument/signatureHelp")
-        else {
+        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
             return Ok(None);
         };
 

--- a/src/lsp/lsp_impl/text_document/type_definition.rs
+++ b/src/lsp/lsp_impl/text_document/type_definition.rs
@@ -1,25 +1,53 @@
 //! Goto type definition method for Kakehashi.
+//!
+//! Walks the resolved layer order (cross-layer-aggregation): the virt layer
+//! bridges the injection region under the cursor, the host layer
+//! (host-document-bridge) bridges the host document itself with the real URI
+//! and no coordinate translation. The first layer producing a non-empty
+//! result wins (`preferred`).
 
 use tower_lsp_server::jsonrpc::Result;
-use tower_lsp_server::ls_types::Location;
 use tower_lsp_server::ls_types::request::{GotoTypeDefinitionParams, GotoTypeDefinitionResponse};
+use tower_lsp_server::ls_types::{Location, LocationLink, Position, Uri};
 
-use crate::lsp::bridge::location_link_to_location;
+use crate::lsp::bridge::{location_link_to_location, normalize_host_goto_result};
 
 use super::super::Kakehashi;
 use crate::lsp::aggregation::server::dispatch_preferred;
+
+const METHOD: &str = "textDocument/typeDefinition";
 
 impl Kakehashi {
     pub(crate) async fn goto_type_definition_impl(
         &self,
         params: GotoTypeDefinitionParams,
     ) -> Result<Option<GotoTypeDefinitionResponse>> {
+        let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
         let lsp_uri = params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
 
-        let Some(ctx) =
-            self.resolve_bridge_contexts(&lsp_uri, position, "textDocument/typeDefinition")
-        else {
+        let virt = self.type_definition_virt_layer(&lsp_uri, position);
+        let links = self
+            .walk_layers(
+                &lsp_uri,
+                METHOD,
+                METHOD,
+                raw_params,
+                virt,
+                normalize_host_goto_result,
+                |links: &Vec<LocationLink>| !links.is_empty(),
+            )
+            .await?;
+        Ok(links.map(|links| self.type_definition_response(links)))
+    }
+
+    /// Virt layer: bridge the injection region under the cursor.
+    async fn type_definition_virt_layer(
+        &self,
+        lsp_uri: &Uri,
+        position: Position,
+    ) -> Result<Option<Vec<LocationLink>>> {
+        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
             return Ok(None);
         };
 
@@ -52,20 +80,19 @@ impl Kakehashi {
         )
         .await;
         pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
-
         result
-            .handle(&self.client, "type definition", None, |value| match value {
-                Some(links) => {
-                    if self.settings_manager.supports_type_definition_link() {
-                        Ok(Some(GotoTypeDefinitionResponse::Link(links)))
-                    } else {
-                        let locations: Vec<Location> =
-                            links.into_iter().map(location_link_to_location).collect();
-                        Ok(Some(GotoTypeDefinitionResponse::Array(locations)))
-                    }
-                }
-                None => Ok(None),
-            })
+            .handle(&self.client, "type definition", None, Ok)
             .await
+    }
+
+    /// Shape the winning links per the client's `LocationLink` support.
+    fn type_definition_response(&self, links: Vec<LocationLink>) -> GotoTypeDefinitionResponse {
+        if self.settings_manager.supports_type_definition_link() {
+            GotoTypeDefinitionResponse::Link(links)
+        } else {
+            let locations: Vec<Location> =
+                links.into_iter().map(location_link_to_location).collect();
+            GotoTypeDefinitionResponse::Array(locations)
+        }
     }
 }

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -83,6 +83,15 @@ impl Kakehashi {
             return Ok(None);
         };
 
+        if !self.virt_layer_enabled(&language_name, method_name) {
+            log::debug!(
+                "{}: virt layer disabled for {} via layers.order",
+                method_name,
+                language_name
+            );
+            return Ok(None);
+        }
+
         // Get injection query to detect injection regions
         let Some(injection_query) = self.language.injection_query(&language_name) else {
             return Ok(None);

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -5,6 +5,11 @@
 //! uses the preferred strategy within each region, and concatenates the
 //! per-region results. This module hosts that shape once; the per-method
 //! handlers supply only the LSP method name and the downstream send call.
+//!
+//! The fan-out is the virt layer of the resolved layer order
+//! (cross-layer-aggregation); the host layer (host-document-bridge) bridges
+//! the host document itself with the real URI and the response verbatim. The
+//! first layer producing a non-empty result wins (`preferred`).
 
 use std::future::Future;
 use std::io;
@@ -17,7 +22,7 @@ use tower_lsp_server::ls_types::Uri;
 use crate::language::InjectionResolver;
 use crate::lsp::aggregation::server::{FanInResult, FanOutTask, dispatch_preferred};
 
-use super::bridge_context::DocumentRequestContext;
+use super::bridge_context::{DocumentRequestContext, parse_host_verbatim};
 use super::{Kakehashi, uri_to_url};
 
 impl Kakehashi {
@@ -32,162 +37,167 @@ impl Kakehashi {
         &self,
         lsp_uri: &Uri,
         method_name: &'static str,
+        raw_params: serde_json::Value,
         send: F,
     ) -> Result<Option<Vec<T>>>
     where
-        T: Send + 'static,
+        T: Send + 'static + serde::de::DeserializeOwned,
         F: Fn(FanOutTask) -> Fut + Clone + Send + 'static,
         Fut: Future<Output = io::Result<Option<Vec<T>>>> + Send + 'static,
     {
-        // Convert ls_types::Uri to url::Url for internal use
-        let Ok(uri) = uri_to_url(lsp_uri) else {
-            log::warn!("Invalid URI in {}: {}", method_name, lsp_uri.as_str());
-            return Ok(None);
-        };
-
-        log::debug!("{} called for {}", method_name, uri);
-
-        // Tower-LSP runs requests concurrently, so a whole-document request can
-        // arrive before didOpen/didChange has finished parsing. Wait briefly
-        // for any in-flight parse to land a tree before snapshotting, matching
-        // the read-handler pattern (semantic tokens, rangeFormatting, node
-        // lookups); otherwise an otherwise-valid request would degrade to
-        // `Ok(None)` purely due to a parse race.
-        self.documents
-            .wait_for_parse_completion(&uri, std::time::Duration::from_millis(200))
-            .await;
-
-        // Get document snapshot (minimizes lock duration)
-        let snapshot = match self.documents.get(&uri) {
-            None => {
-                log::debug!("{}: No document found for {}", method_name, uri);
+        let virt = async {
+            // Convert ls_types::Uri to url::Url for internal use
+            let Ok(uri) = uri_to_url(lsp_uri) else {
+                log::warn!("Invalid URI in {}: {}", method_name, lsp_uri.as_str());
                 return Ok(None);
-            }
-            Some(doc) => match doc.snapshot() {
+            };
+
+            log::debug!("{} called for {}", method_name, uri);
+
+            // Tower-LSP runs requests concurrently, so a whole-document request can
+            // arrive before didOpen/didChange has finished parsing. Wait briefly
+            // for any in-flight parse to land a tree before snapshotting, matching
+            // the read-handler pattern (semantic tokens, rangeFormatting, node
+            // lookups); otherwise an otherwise-valid request would degrade to
+            // `Ok(None)` purely due to a parse race.
+            self.documents
+                .wait_for_parse_completion(&uri, std::time::Duration::from_millis(200))
+                .await;
+
+            // Get document snapshot (minimizes lock duration)
+            let snapshot = match self.documents.get(&uri) {
                 None => {
-                    log::debug!(
-                        "{}: Document not fully initialized for {}",
-                        method_name,
-                        uri
-                    );
+                    log::debug!("{}: No document found for {}", method_name, uri);
                     return Ok(None);
                 }
-                Some(snapshot) => snapshot,
-            },
-            // doc automatically dropped here, lock released
-        };
+                Some(doc) => match doc.snapshot() {
+                    None => {
+                        log::debug!(
+                            "{}: Document not fully initialized for {}",
+                            method_name,
+                            uri
+                        );
+                        return Ok(None);
+                    }
+                    Some(snapshot) => snapshot,
+                },
+                // doc automatically dropped here, lock released
+            };
 
-        // Get the language for this document
-        let Some(language_name) = self.document_language(&uri) else {
-            log::debug!("{}: No language detected", method_name);
-            return Ok(None);
-        };
+            // Get the language for this document
+            let Some(language_name) = self.document_language(&uri) else {
+                log::debug!("{}: No language detected", method_name);
+                return Ok(None);
+            };
 
-        if !self.virt_layer_enabled(&language_name, method_name) {
-            log::debug!(
-                "{}: virt layer disabled for {} via layers.order",
-                method_name,
-                language_name
+            // Get injection query to detect injection regions
+            let Some(injection_query) = self.language.injection_query(&language_name) else {
+                return Ok(None);
+            };
+
+            // Collect all injection regions
+            let all_regions = InjectionResolver::resolve_all(
+                &self.language,
+                self.bridge.node_tracker(),
+                &uri,
+                snapshot.tree(),
+                snapshot.text(),
+                injection_query.as_ref(),
             );
-            return Ok(None);
-        }
 
-        // Get injection query to detect injection regions
-        let Some(injection_query) = self.language.injection_query(&language_name) else {
-            return Ok(None);
-        };
-
-        // Collect all injection regions
-        let all_regions = InjectionResolver::resolve_all(
-            &self.language,
-            self.bridge.node_tracker(),
-            &uri,
-            snapshot.tree(),
-            snapshot.text(),
-            injection_query.as_ref(),
-        );
-
-        if all_regions.is_empty() {
-            return Ok(None);
-        }
-
-        // Get upstream request ID from task-local storage (set by RequestIdCapture middleware)
-        let upstream_request_id = crate::lsp::current_upstream_id();
-
-        // Subscribe to cancel notifications so we can abort early on $/cancelRequest.
-        // _cancel_guard ensures automatic unsubscribe when this scope exits.
-        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(upstream_request_id.as_ref());
-
-        let pool = self.bridge.pool_arc();
-
-        // Outer JoinSet: one task per injection region, all in parallel
-        let mut outer_join_set: JoinSet<Option<Vec<T>>> = JoinSet::new();
-
-        for resolved in all_regions {
-            // Get ALL bridge server configs for this injection language
-            let configs = self.bridge_configs_for_injection_language(
-                &language_name,
-                &resolved.injection_language,
-            );
-            if configs.is_empty() {
-                continue;
+            if all_regions.is_empty() {
+                return Ok(None);
             }
 
-            let agg = self.resolve_aggregation_config(
-                &language_name,
-                &resolved.injection_language,
-                method_name,
-            );
-            let region_ctx = DocumentRequestContext {
-                uri: uri.clone(),
-                resolved,
-                configs,
-                upstream_request_id: upstream_request_id.clone(),
-                priorities: agg.priorities,
-                strategy: agg.strategy,
-                max_fan_out: agg.max_fan_out,
-            };
-            let pool = Arc::clone(&pool);
-            let send = send.clone();
+            // Get upstream request ID from task-local storage (set by RequestIdCapture middleware)
+            let upstream_request_id = crate::lsp::current_upstream_id();
 
-            outer_join_set.spawn(async move {
-                let result = dispatch_preferred(
-                    &region_ctx,
-                    pool.clone(),
-                    send,
-                    |opt| matches!(opt, Some(v) if !v.is_empty()),
-                    None,
-                )
-                .await;
-                match result {
-                    FanInResult::Done(items) => items,
-                    FanInResult::NoResult { .. } | FanInResult::Cancelled => None,
-                }
-            });
-        }
+            // Subscribe to cancel notifications so we can abort early on $/cancelRequest.
+            // _cancel_guard ensures automatic unsubscribe when this scope exits.
+            let (cancel_rx, _cancel_guard) = self.subscribe_cancel(upstream_request_id.as_ref());
 
-        // Collect results, aborting early if $/cancelRequest arrives.
-        let all_items = crate::lsp::aggregation::region::collect_region_results_with_cancel(
-            outer_join_set,
-            cancel_rx,
-            |acc, opt: Option<Vec<T>>| {
-                if let Some(items) = opt {
-                    acc.extend(items);
+            let pool = self.bridge.pool_arc();
+
+            // Outer JoinSet: one task per injection region, all in parallel
+            let mut outer_join_set: JoinSet<Option<Vec<T>>> = JoinSet::new();
+
+            for resolved in all_regions {
+                // Get ALL bridge server configs for this injection language
+                let configs = self.bridge_configs_for_injection_language(
+                    &language_name,
+                    &resolved.injection_language,
+                );
+                if configs.is_empty() {
+                    continue;
                 }
-            },
+
+                let agg = self.resolve_aggregation_config(
+                    &language_name,
+                    &resolved.injection_language,
+                    method_name,
+                );
+                let region_ctx = DocumentRequestContext {
+                    uri: uri.clone(),
+                    resolved,
+                    configs,
+                    upstream_request_id: upstream_request_id.clone(),
+                    priorities: agg.priorities,
+                    strategy: agg.strategy,
+                    max_fan_out: agg.max_fan_out,
+                };
+                let pool = Arc::clone(&pool);
+                let send = send.clone();
+
+                outer_join_set.spawn(async move {
+                    let result = dispatch_preferred(
+                        &region_ctx,
+                        pool.clone(),
+                        send,
+                        |opt| matches!(opt, Some(v) if !v.is_empty()),
+                        None,
+                    )
+                    .await;
+                    match result {
+                        FanInResult::Done(items) => items,
+                        FanInResult::NoResult { .. } | FanInResult::Cancelled => None,
+                    }
+                });
+            }
+
+            // Collect results, aborting early if $/cancelRequest arrives.
+            let all_items = crate::lsp::aggregation::region::collect_region_results_with_cancel(
+                outer_join_set,
+                cancel_rx,
+                |acc, opt: Option<Vec<T>>| {
+                    if let Some(items) = opt {
+                        acc.extend(items);
+                    }
+                },
+            )
+            .await;
+
+            // Clean up stale upstream registry entries once all region tasks have completed
+            // (or been aborted via JoinSet drop). Must happen after the JoinSet is drained
+            // so cancel forwarding remains intact for all in-flight downstream requests.
+            pool.unregister_all_for_upstream_id(upstream_request_id.as_ref());
+
+            let all_items = all_items?;
+            Ok(if all_items.is_empty() {
+                None
+            } else {
+                Some(all_items)
+            })
+        };
+
+        self.walk_layers(
+            lsp_uri,
+            method_name,
+            method_name,
+            raw_params,
+            virt,
+            parse_host_verbatim::<Vec<T>>,
+            |items: &Vec<T>| !items.is_empty(),
         )
-        .await;
-
-        // Clean up stale upstream registry entries once all region tasks have completed
-        // (or been aborted via JoinSet drop). Must happen after the JoinSet is drained
-        // so cancel forwarding remains intact for all in-flight downstream requests.
-        pool.unregister_all_for_upstream_id(upstream_request_id.as_ref());
-
-        let all_items = all_items?;
-        Ok(if all_items.is_empty() {
-            None
-        } else {
-            Some(all_items)
-        })
+        .await
     }
 }

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -17,6 +17,12 @@
 //!   uppercases the text. Exercises the pipeline's capability-based
 //!   whole-region rangeFormatting fallback (concatenated-formatting-pipeline
 //!   Decision point 3.2).
+//! - `definition` — advertises `definitionProvider` + `hoverProvider`;
+//!   answers definition with a fixed Location that **echoes the requested
+//!   URI** (and hover with the URI in the contents), but only for documents
+//!   it received via `didOpen`. Used by `tests/e2e_host_bridge.rs` to prove
+//!   the host bridge forwards the real client URI and returns the response
+//!   verbatim (host-document-bridge).
 //!
 //! Only built for E2E runs (`required-features = ["e2e"]` in Cargo.toml).
 
@@ -44,16 +50,20 @@ fn main() {
 
         match method {
             "initialize" => {
-                let capabilities = if mode == "range-upper" {
-                    json!({
+                let capabilities = match mode.as_str() {
+                    "range-upper" => json!({
                         "documentRangeFormattingProvider": true,
                         "textDocumentSync": 1
-                    })
-                } else {
-                    json!({
+                    }),
+                    "definition" => json!({
+                        "definitionProvider": true,
+                        "hoverProvider": true,
+                        "textDocumentSync": 1
+                    }),
+                    _ => json!({
                         "documentFormattingProvider": true,
                         "textDocumentSync": 1
-                    })
+                    }),
                 };
                 respond(&mut writer, id, json!({ "capabilities": capabilities }));
             }
@@ -95,6 +105,35 @@ fn main() {
                 {
                     documents.remove(uri);
                 }
+            }
+            "textDocument/definition" => {
+                // Echo the requested URI back in a fixed Location — but only
+                // for documents this server actually received via didOpen,
+                // so the test also proves the host document was synced.
+                let result = message
+                    .pointer("/params/textDocument/uri")
+                    .and_then(Value::as_str)
+                    .filter(|uri| documents.contains_key(*uri))
+                    .map(|uri| {
+                        json!({
+                            "uri": uri,
+                            "range": {
+                                "start": { "line": 1, "character": 0 },
+                                "end": { "line": 1, "character": 4 }
+                            }
+                        })
+                    })
+                    .unwrap_or(Value::Null);
+                respond(&mut writer, id, result);
+            }
+            "textDocument/hover" => {
+                let result = message
+                    .pointer("/params/textDocument/uri")
+                    .and_then(Value::as_str)
+                    .filter(|uri| documents.contains_key(*uri))
+                    .map(|uri| json!({ "contents": format!("mock-hover:{uri}") }))
+                    .unwrap_or(Value::Null);
+                respond(&mut writer, id, result);
             }
             "textDocument/formatting" | "textDocument/rangeFormatting" => {
                 let result = message

--- a/tests/e2e_host_bridge.rs
+++ b/tests/e2e_host_bridge.rs
@@ -404,3 +404,41 @@ strategy = "concatenated"
 
     shutdown(&mut client);
 }
+
+/// The generic raw-forward path serves the other methods too: hover on the
+/// host document round-trips verbatim (the mock echoes the requested URI in
+/// its hover contents — a virtual URI would betray a translation).
+#[test]
+fn e2e_host_bridge_hover_round_trips_verbatim() {
+    let (mut client, _config_dir) = init_client(
+        r#"
+[languages.markdown.bridge._self]
+enabled = true
+"#,
+    );
+
+    let mut hover_contents = None;
+    for _ in 0..300 {
+        let response = client.send_request(
+            "textDocument/hover",
+            json!({
+                "textDocument": { "uri": MARKDOWN_URI },
+                "position": { "line": 2, "character": 6 },
+            }),
+        );
+        assert!(response.get("error").is_none(), "hover must not error");
+        if let Some(contents) = response.pointer("/result/contents").and_then(Value::as_str) {
+            hover_contents = Some(contents.to_string());
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let contents = hover_contents.expect("host hover must produce a result");
+    assert_eq!(
+        contents,
+        format!("mock-hover:{MARKDOWN_URI}"),
+        "hover must carry the real URI to the server and return verbatim"
+    );
+
+    shutdown(&mut client);
+}

--- a/tests/e2e_host_bridge.rs
+++ b/tests/e2e_host_bridge.rs
@@ -1,0 +1,240 @@
+//! E2E tests for the host-document bridge (host-document-bridge): with
+//! `bridge._self.enabled = true`, requests on the host document itself are
+//! forwarded to host-capable servers with the **real client URI** and the
+//! response returned **verbatim** (no coordinate translation).
+//!
+//! The `mock-lsp-formatter` binary's `definition` mode answers definition
+//! with a Location echoing the requested URI — but only for documents it
+//! received via `didOpen` — so a successful response proves three things at
+//! once: the host document was synced, the request carried the real URI, and
+//! the response came back untranslated.
+
+#![cfg(feature = "e2e")]
+
+mod helpers;
+
+use helpers::lsp_client::LspClient;
+use serde_json::{Value, json};
+
+fn mock_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_mock-lsp-formatter")
+}
+
+/// Markdown host document. The definition request targets the prose link on
+/// LSP line 2 — outside any injection, so only the host layer can answer.
+const MARKDOWN: &str = "# Title\n\nSee [reference].\n\n[reference]: https://example.com\n";
+const MARKDOWN_URI: &str = "file:///test_host_bridge.md";
+
+fn init_client(config_toml: &str) -> (LspClient, tempfile::TempDir) {
+    let config_dir = tempfile::TempDir::new().expect("Failed to create config temp dir");
+    let config_path = config_dir.path().join("host_bridge.toml");
+    std::fs::write(&config_path, config_toml).expect("Failed to write config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("temp path should be UTF-8"))
+        .build();
+
+    let _init_response = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": {
+                "languageServers": {
+                    "mock-host": {
+                        "cmd": [mock_bin(), "definition"],
+                        "languages": ["markdown"]
+                    }
+                }
+            }
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": MARKDOWN_URI,
+                "languageId": "markdown",
+                "version": 1,
+                "text": MARKDOWN
+            }
+        }),
+    );
+    (client, config_dir)
+}
+
+fn send_definition(client: &mut LspClient) -> Value {
+    let response = client.send_request(
+        "textDocument/definition",
+        json!({
+            "textDocument": { "uri": MARKDOWN_URI },
+            "position": { "line": 2, "character": 6 },
+        }),
+    );
+    assert!(
+        response.get("error").is_none(),
+        "definition must not surface a top-level error; got: {:?}",
+        response.get("error")
+    );
+    response["result"].clone()
+}
+
+fn shutdown(client: &mut LspClient) {
+    let _ = client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
+fn e2e_host_bridge_definition_uses_real_uri_verbatim() {
+    let (mut client, _config_dir) = init_client(
+        r#"
+[languages.markdown.bridge._self]
+enabled = true
+"#,
+    );
+
+    // Retry while the downstream server warms up.
+    let mut hit = None;
+    for _ in 0..300 {
+        let result = send_definition(&mut client);
+        if !result.is_null() {
+            hit = Some(result);
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let result = hit.expect("host bridge definition must produce a result");
+
+    // The mock echoes the URI it was asked about: the request must have
+    // carried the REAL host URI (not a kakehashi-virtual-uri), and the
+    // response must come back verbatim — same URI, untranslated range.
+    let entry = result
+        .as_array()
+        .and_then(|a| a.first())
+        .unwrap_or(&result)
+        .clone();
+    let uri = entry["uri"]
+        .as_str()
+        .or_else(|| entry["targetUri"].as_str())
+        .expect("definition entry must carry a uri");
+    assert_eq!(
+        uri, MARKDOWN_URI,
+        "host bridge must forward the real client URI and pass the response through"
+    );
+    let line = entry
+        .pointer("/range/start/line")
+        .or_else(|| entry.pointer("/targetRange/start/line"))
+        .and_then(Value::as_u64)
+        .expect("definition entry must carry a range");
+    assert_eq!(line, 1, "host ranges must NOT be offset-translated");
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_host_bridge_is_opt_in() {
+    // Without bridge._self.enabled = true, a host-capable server alone does
+    // nothing (host-document-bridge: capability declaration is not consent).
+    // Warm-then-flip in reverse: prove the gate by enabling at runtime —
+    // null while disabled, results after the flip.
+    let (mut client, _config_dir) = init_client("");
+
+    // While disabled, the request must stay null. A short stabilization loop
+    // (rather than a single probe) guards against a slow first response.
+    for _ in 0..10 {
+        let result = send_definition(&mut client);
+        assert!(
+            result.is_null(),
+            "host bridging is opt-in: no _self.enabled, no result; got {result}"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": {
+                "languages": {
+                    "markdown": { "bridge": { "_self": { "enabled": true } } }
+                }
+            }
+        }),
+    );
+
+    let mut enabled_result = None;
+    for _ in 0..300 {
+        let result = send_definition(&mut client);
+        if !result.is_null() {
+            enabled_result = Some(result);
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(
+        enabled_result.is_some(),
+        "after opting in via didChangeConfiguration, the host bridge must respond"
+    );
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_host_bridge_respects_layers_order() {
+    // Omitting "host" from layers.order must gate the host layer off even
+    // though _self is enabled.
+    let (mut client, _config_dir) = init_client(
+        r#"
+[languages.markdown.bridge._self]
+enabled = true
+"#,
+    );
+
+    // Warm up: host layer answers.
+    let mut warmed = false;
+    for _ in 0..300 {
+        if !send_definition(&mut client).is_null() {
+            warmed = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(
+        warmed,
+        "precondition: host bridge must answer before the flip"
+    );
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": {
+                "languages": {
+                    "markdown": {
+                        "layers": {
+                            "textDocument/definition": { "order": ["virt", "native"] }
+                        }
+                    }
+                }
+            }
+        }),
+    );
+
+    let mut went_null = false;
+    for _ in 0..300 {
+        if send_definition(&mut client).is_null() {
+            went_null = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(
+        went_null,
+        "layers.order without 'host' must gate the host layer off"
+    );
+
+    shutdown(&mut client);
+}

--- a/tests/e2e_host_bridge.rs
+++ b/tests/e2e_host_bridge.rs
@@ -238,3 +238,169 @@ enabled = true
 
     shutdown(&mut client);
 }
+
+// ==========================================================================
+// Host formatting (host-document-bridge + cross-layer-aggregation phase 3)
+// ==========================================================================
+
+fn send_formatting(client: &mut LspClient, uri: &str) -> Value {
+    let response = client.send_request(
+        "textDocument/formatting",
+        json!({
+            "textDocument": { "uri": uri },
+            "options": { "tabSize": 4, "insertSpaces": true },
+        }),
+    );
+    assert!(
+        response.get("error").is_none(),
+        "formatting must not surface a top-level error; got: {:?}",
+        response.get("error")
+    );
+    response["result"].clone()
+}
+
+/// Host-only formatting under the default `preferred` layer order: no virt
+/// server is configured, so the host layer's whole-document edits win and
+/// pass through verbatim.
+#[test]
+fn e2e_host_formatting_preferred_falls_through_to_host() {
+    let config_dir = tempfile::TempDir::new().expect("config dir");
+    let config_path = config_dir.path().join("host_fmt.toml");
+    std::fs::write(
+        &config_path,
+        r#"
+[languages.markdown.bridge._self]
+enabled = true
+"#,
+    )
+    .expect("write config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().unwrap())
+        .build();
+    let _init = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": {
+                "languageServers": {
+                    "mock-host-upper": { "cmd": [mock_bin(), "upper"], "languages": ["markdown"] },
+                }
+            }
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    let uri = "file:///test_host_fmt_preferred.md";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": { "uri": uri, "languageId": "markdown", "version": 1,
+                              "text": "# title\n\nbody text\n" }
+        }),
+    );
+
+    let mut hit = None;
+    for _ in 0..300 {
+        let result = send_formatting(&mut client, uri);
+        if result.as_array().is_some_and(|a| !a.is_empty()) {
+            hit = Some(result);
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let result = hit.expect("host formatting must produce edits");
+    let new_text = result[0]["newText"].as_str().expect("edit newText");
+    assert!(
+        new_text.contains("# TITLE"),
+        "host formatter's whole-document edit must pass through verbatim; got: {new_text:?}"
+    );
+
+    shutdown(&mut client);
+}
+
+/// Cross-layer `concatenated` formatting: virt formats the lua fence first
+/// (appending a lowercase marker), then the host formatter runs ON THE VIRT
+/// OUTPUT (uppercasing everything). The marker arriving uppercased proves the
+/// serial virt → host threading; the response collapses into one
+/// whole-document replacement edit.
+#[test]
+fn e2e_host_formatting_concatenated_threads_virt_then_host() {
+    let config_dir = tempfile::TempDir::new().expect("config dir");
+    let config_path = config_dir.path().join("host_fmt_concat.toml");
+    std::fs::write(
+        &config_path,
+        r#"
+[languages.markdown.bridge._self]
+enabled = true
+
+[languages.markdown.layers."textDocument/formatting"]
+strategy = "concatenated"
+"#,
+    )
+    .expect("write config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().unwrap())
+        .build();
+    let _init = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": {
+                "languageServers": {
+                    "mock-host-upper": { "cmd": [mock_bin(), "upper"], "languages": ["markdown"] },
+                    "mock-virt-append": { "cmd": [mock_bin(), "append"], "languages": ["lua"] },
+                }
+            }
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    let uri = "file:///test_host_fmt_concat.md";
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": { "uri": uri, "languageId": "markdown", "version": 1,
+                              "text": "# title\n\n```lua\nprint(1)\n```\n" }
+        }),
+    );
+
+    // Retry until BOTH layers have produced: the uppercased marker can only
+    // exist if the host formatter ran on the virt layer's output.
+    let mut final_text = None;
+    for _ in 0..300 {
+        let result = send_formatting(&mut client, uri);
+        if let Some(text) = result
+            .as_array()
+            .and_then(|a| a.first())
+            .and_then(|e| e["newText"].as_str())
+            && text.contains("MOCK-MARKER")
+        {
+            final_text = Some(text.to_string());
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let text = final_text
+        .expect("concatenated cross-layer formatting must thread virt output into the host layer");
+
+    assert!(
+        text.contains("# TITLE"),
+        "host layer must have formatted the whole document; got: {text:?}"
+    );
+    assert!(
+        !text.contains("mock-marker"),
+        "the marker must be uppercased — host ran AFTER virt, on virt's output; got: {text:?}"
+    );
+
+    shutdown(&mut client);
+}

--- a/tests/e2e_layers_and_allowlist.rs
+++ b/tests/e2e_layers_and_allowlist.rs
@@ -1,0 +1,184 @@
+//! E2E tests for the aggregation-priorities-wildcard allowlist semantics and
+//! the cross-layer-aggregation `layers` gate, over the full LSP protocol with
+//! a real downstream server (`mock-lsp-formatter`).
+//!
+//! Both tests use the same deterministic transition pattern: warm up until
+//! formatting *succeeds* (proving the downstream server is ready and the
+//! bridge path works), then flip the configuration via
+//! `workspace/didChangeConfiguration` and assert formatting goes null —
+//! ruling out "server not ready yet" as an alternative explanation for the
+//! null.
+
+#![cfg(feature = "e2e")]
+
+mod helpers;
+
+use helpers::lsp_client::LspClient;
+use serde_json::{Value, json};
+
+fn mock_formatter_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_mock-lsp-formatter")
+}
+
+const MARKDOWN: &str = "# Test\n\n```lua\nlocal x = 1\n```\n";
+const MARKDOWN_URI: &str = "file:///test_layers_allowlist.md";
+
+/// Spawn kakehashi with the mock formatter configured for lua injections and
+/// complete the handshake plus didOpen.
+///
+/// An empty `--config-file` isolates the test from any user-level
+/// configuration; all settings flow through `initializationOptions` and
+/// `workspace/didChangeConfiguration`.
+fn init_warm_client() -> (LspClient, tempfile::TempDir) {
+    let config_dir = tempfile::TempDir::new().expect("Failed to create config temp dir");
+    let config_path = config_dir.path().join("empty.toml");
+    std::fs::write(&config_path, "").expect("Failed to write config");
+
+    let bin = mock_formatter_bin();
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("temp path should be UTF-8"))
+        .build();
+
+    let _init_response = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": {
+                "languageServers": {
+                    "mock-upper": { "cmd": [bin, "upper"], "languages": ["lua"] },
+                }
+            }
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": MARKDOWN_URI,
+                "languageId": "markdown",
+                "version": 1,
+                "text": MARKDOWN
+            }
+        }),
+    );
+    (client, config_dir)
+}
+
+fn send_formatting(client: &mut LspClient) -> Value {
+    let response = client.send_request(
+        "textDocument/formatting",
+        json!({
+            "textDocument": { "uri": MARKDOWN_URI },
+            "options": { "tabSize": 4, "insertSpaces": true },
+        }),
+    );
+    assert!(
+        response.get("error").is_none(),
+        "formatting must not surface a top-level error; got: {:?}",
+        response.get("error")
+    );
+    response["result"].clone()
+}
+
+/// Poll until formatting yields a non-empty edit list (downstream warm).
+fn wait_until_formatting_succeeds(client: &mut LspClient) {
+    for _ in 0..300 {
+        let result = send_formatting(client);
+        if result.as_array().is_some_and(|edits| !edits.is_empty()) {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    panic!("formatting never succeeded — downstream server did not warm up");
+}
+
+/// Poll until formatting yields null/empty (the config flip has applied).
+fn wait_until_formatting_is_null(client: &mut LspClient, context: &str) {
+    for _ in 0..300 {
+        let result = send_formatting(client);
+        let is_null_or_empty =
+            result.is_null() || result.as_array().is_some_and(|edits| edits.is_empty());
+        if is_null_or_empty {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    panic!("formatting still produced edits — {context}");
+}
+
+fn shutdown(client: &mut LspClient) {
+    let _ = client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+/// aggregation-priorities-wildcard: `priorities` is an allowlist. Naming only
+/// a server that is not configured for the region must exclude the configured
+/// server entirely — under the old preference semantics, mock-upper would
+/// have kept formatting as the implicit fallback.
+#[test]
+fn e2e_priorities_allowlist_excludes_unlisted_servers() {
+    let (mut client, _config_dir) = init_warm_client();
+    wait_until_formatting_succeeds(&mut client);
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": {
+                "languages": {
+                    "markdown": {
+                        "bridge": {
+                            "lua": {
+                                "aggregation": {
+                                    "textDocument/formatting": { "priorities": ["ghost"] }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }),
+    );
+
+    wait_until_formatting_is_null(
+        &mut client,
+        "priorities = [\"ghost\"] must exclude the unlisted mock-upper (allowlist), \
+         not fall back to it",
+    );
+    shutdown(&mut client);
+}
+
+/// cross-layer-aggregation: omitting "virt" from `layers.order` disables
+/// injection bridging for the method even though a working downstream server
+/// is configured.
+#[test]
+fn e2e_layers_order_without_virt_disables_bridging() {
+    let (mut client, _config_dir) = init_warm_client();
+    wait_until_formatting_succeeds(&mut client);
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": {
+                "languages": {
+                    "markdown": {
+                        "layers": {
+                            "textDocument/formatting": { "order": ["native"] }
+                        }
+                    }
+                }
+            }
+        }),
+    );
+
+    wait_until_formatting_is_null(
+        &mut client,
+        "layers.order = [\"native\"] must gate off the virt bridge for formatting",
+    );
+    shutdown(&mut client);
+}

--- a/tests/e2e_synthetic_push_diagnostic.rs
+++ b/tests/e2e_synthetic_push_diagnostic.rs
@@ -373,3 +373,71 @@ print(((
 
     shutdown_client(&mut client);
 }
+
+/// E2E test: layers.order without "virt" gates push diagnostics off
+/// (cross-layer-aggregation), publishing an EMPTY diagnostics list so that
+/// anything published before the config flip is cleared rather than frozen.
+///
+/// The gate fires before any downstream interaction, so the empty publish is
+/// deterministic — it does not depend on lua-language-server being installed
+/// or producing results.
+#[test]
+fn e2e_synthetic_push_respects_layers_gate() {
+    let (mut client, _config_dir) = create_lua_configured_client();
+
+    // Disable the virt layer for push diagnostics before opening anything.
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": {
+                "languages": {
+                    "markdown": {
+                        "layers": {
+                            "textDocument/publishDiagnostics": { "order": ["native"] }
+                        }
+                    }
+                }
+            }
+        }),
+    );
+
+    // Invalid Lua that would normally yield diagnostics from lua-ls.
+    let markdown_content = "# Test\n\n```lua\nlocal x =\n```\n";
+    let markdown_uri = "file:///test_synthetic_push_layers_gate.md";
+
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": markdown_uri,
+                "languageId": "markdown",
+                "version": 1,
+                "text": markdown_content
+            }
+        }),
+    );
+
+    let notification =
+        client.wait_for_notification("textDocument/publishDiagnostics", Duration::from_secs(10));
+
+    let params = notification.expect(
+        "the layers gate publishes an empty diagnostics list deterministically \
+         (no downstream dependency), so a notification must arrive",
+    );
+    assert_eq!(
+        params.get("uri").and_then(|u| u.as_str()),
+        Some(markdown_uri),
+        "publishDiagnostics should be for the opened document"
+    );
+    let diagnostics = params
+        .get("diagnostics")
+        .and_then(|d| d.as_array())
+        .expect("publishDiagnostics should have diagnostics array");
+    assert!(
+        diagnostics.is_empty(),
+        "virt layer is gated off via layers.order, so the publish must carry \
+         no bridge diagnostics; got: {diagnostics:?}"
+    );
+
+    shutdown_client(&mut client);
+}

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1013,6 +1013,18 @@ fn run_with_broken_stdout_pipe(args: &[&str]) -> std::process::Output {
     use std::process::Stdio;
 
     let (read_fd, write_fd): (OwnedFd, OwnedFd) = nix::unistd::pipe().expect("create pipe");
+    // Mark both ends CLOEXEC immediately: `pipe()` creates inheritable fds,
+    // and tests run in parallel threads — a concurrently spawned child of
+    // ANOTHER test could inherit our read end and keep it open, in which
+    // case the child under test writes into a live pipe and exits 0 instead
+    // of dying by SIGPIPE (the historical flake in these tests). CLOEXEC
+    // stops the leak; `Stdio::from(write_fd)` still works because std dup2s
+    // stdio fds for the child, which clears CLOEXEC on the duplicate.
+    // (macOS has no `pipe2`, so the flags are set in a second syscall; the
+    // remaining pipe()-to-fcntl window is a few instructions wide.)
+    use nix::fcntl::{FcntlArg, FdFlag, fcntl};
+    fcntl(&read_fd, FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC)).expect("set CLOEXEC on read end");
+    fcntl(&write_fd, FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC)).expect("set CLOEXEC on write end");
     // Close the read end before spawning: the child gets only the write end, so
     // there is no reader and the first write hits EPIPE.
     drop(read_fd);


### PR DESCRIPTION
## Summary

Implements two new architecture decisions plus the first cross-layer dispatch, in three phases:

1. **`priorities` becomes an ordered allowlist with a `"*"` wildcard** ([aggregation-priorities-wildcard](docs/architecture-decisions/aggregation-priorities-wildcard.md))
   - Listed servers run in order; unlisted servers do not run; `"*"` stands for the configured-but-unlisted rest as a first-win group, so `["foo", "*", "zzz"]` demotes `zzz` below everyone else.
   - Absent `priorities` resolves to `["*"]` (today's behavior); an explicit `[]` becomes a per-method fan-out kill switch.
   - One expansion (`priority.rs`) feeds both fan-out (membership + spawn order) and fan-in (decision order), so the two sides can never disagree — this also fixes a latent fan-out/fan-in mismatch under `maxFanOut`.
   - The sequential `concatenated` formatting pipeline rejects `"*"` (no deterministic order); the settings-apply warning now flags concatenated formatting with no explicit names and resolves bridge-key wildcard inheritance exactly like the runtime.
2. **Per-method cross-layer `layers` config** ([cross-layer-aggregation](docs/architecture-decisions/cross-layer-aggregation.md))
   - `languages.<lang>.layers.<method|_> = { order, strategy }` with a closed `LayerSource` enum (`virt`/`host`/`native`) — a typo'd layer fails deserialization.
   - `order` is an ordered allowlist; default `["virt", "host", "native"]` reproduces today's routing exactly (host is reserved until host-document bridging ships).
   - Every bridge entry point is gated on the virt layer, including the push-diagnostics scheduler (keyed `textDocument/publishDiagnostics`, publishing an empty list so a config flip clears stale diagnostics).
3. **Formatting dispatches on the layer strategy** — layer-level `concatenated` machinery with an explicit fail-safe: edit lists are never merged across layers (overlap would violate LSP); with at most one producing layer (the only reachable case today) both strategies yield that layer's edits.

## Breaking changes

- `priorities = ["foo"]` narrows from "prefer foo, fall back to the rest" to "only foo" — migrate with `["foo", "*"]`.
- `priorities = []` flips from first-win to per-method disable.
- Concatenated diagnostics/references merge order changes from arrival order (racy) to config order (deterministic).

## Review history

Three internal review cycles before this PR: a 10-perspective subagent review (1 HIGH + 3 MEDIUM + 4 LOW, all fixed — notably the push-diagnostics gate bypass), a verification round (3 follow-ups fixed), and a Codex review (bridge-key wildcard resolution in the misconfig scan, fixed), each converging on no findings.

## Test plan

- `cargo test --lib`: 1706 passed (new: priority expansion, fan-in group walks, layers resolution/merge, formatting plan + layer combine, misconfig scan)
- `cargo test --features e2e`: green (new: warm-then-flip e2e for the allowlist and the layers gate; deterministic empty-publish e2e for the push-diagnostics gate)
- `cargo clippy --lib --all-features -- -D warnings`: clean