### PR TITLE
fix(install): follow query inheritance in the auto-install path

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -392,7 +392,7 @@ mod tests {
                     header.clear();
                     match reader.read_line(&mut header) {
                         Ok(0) | Err(_) => break,
-                        Ok(_) if header == "\r\n" => break,
+                        Ok(_) if header == "\r\n" || header == "\n" => break,
                         Ok(_) => {}
                     }
                 }

--- a/src/install.rs
+++ b/src/install.rs
@@ -246,7 +246,7 @@ fn install_language_blocking(
     // installer also builds paths from the name (`parser/<name>.<ext>`),
     // so reject traversal-capable names before touching either.
     if !queries::is_safe_language_name(language) {
-        let reason = format!("Language name {:?} is unsafe", language);
+        let reason = format!("Language name '{}' is unsafe", language.escape_default());
         result.parser_error = Some(reason.clone());
         result.queries_error = Some(reason);
         return result;

--- a/src/install.rs
+++ b/src/install.rs
@@ -176,7 +176,10 @@ pub mod test_support {
             match queries::install_queries_with_dependencies(lang, data_dir, false) {
                 Ok(_) | Err(queries::QueryInstallError::AlreadyExists(_)) => {}
                 Err(e) => {
-                    eprintln!("[test setup] install_queries({}) failed: {}", lang, e);
+                    eprintln!(
+                        "[test setup] install_queries_with_dependencies({}) failed: {}",
+                        lang, e
+                    );
                     all_ok = false;
                 }
             }
@@ -372,10 +375,17 @@ mod tests {
                 if reader.read_line(&mut request_line).is_err() {
                     continue;
                 }
-                // Drain headers so the client sees a clean request/response cycle
+                // Drain headers so the client sees a clean request/response
+                // cycle; bail on EOF (Ok(0)) so a half-sent request can't
+                // spin this loop forever.
                 let mut header = String::new();
-                while reader.read_line(&mut header).is_ok() && header != "\r\n" {
+                loop {
                     header.clear();
+                    match reader.read_line(&mut header) {
+                        Ok(0) | Err(_) => break,
+                        Ok(_) if header == "\r\n" => break,
+                        Ok(_) => {}
+                    }
                 }
                 let path = request_line.split_whitespace().nth(1).unwrap_or("");
                 let response = match routes.iter().find(|(p, _)| p == path) {

--- a/src/install.rs
+++ b/src/install.rs
@@ -251,9 +251,15 @@ fn install_language_blocking(
         no_cache: false,
     };
 
+    // AlreadyExists means the artifact is present and usable — success,
+    // not failure; treating it as an error made the auto-install manager
+    // degrade a fully-installed language to "installed but with warnings".
     match parser::install_parser(language, &parser_options) {
         Ok(parser_result) => {
             result.parser_path = Some(parser_result.install_path);
+        }
+        Err(parser::ParserInstallError::AlreadyExists(path)) => {
+            result.parser_path = Some(path);
         }
         Err(e) => {
             result.parser_error = Some(e.to_string());
@@ -270,6 +276,9 @@ fn install_language_blocking(
     ) {
         Ok(query_result) => {
             result.queries_path = Some(query_result.install_path);
+        }
+        Err(queries::QueryInstallError::AlreadyExists(path)) => {
+            result.queries_path = Some(path);
         }
         Err(e) => {
             result.queries_error = Some(e.to_string());
@@ -458,6 +467,43 @@ mod tests {
                 .exists(),
             "inherited parent queries should be installed alongside the child"
         );
+    }
+
+    /// A language whose parser and queries are already on disk is a
+    /// successful install, not a failure: reporting AlreadyExists as an
+    /// error made the auto-install manager degrade a fully-usable language
+    /// to "installed but with warnings".
+    #[test]
+    fn install_language_blocking_treats_already_installed_as_success() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let data_dir = temp.path();
+
+        let parser_dir = data_dir.join("parser");
+        std::fs::create_dir_all(&parser_dir).unwrap();
+        std::fs::write(
+            parser_dir.join(format!("exists_lang.{}", std::env::consts::DLL_EXTENSION)),
+            "",
+        )
+        .unwrap();
+        let queries_dir = data_dir.join("queries").join("exists_lang");
+        std::fs::create_dir_all(&queries_dir).unwrap();
+        std::fs::write(queries_dir.join("highlights.scm"), "(comment) @comment\n").unwrap();
+
+        // Everything exists, so no download may happen — point the base URL
+        // at a closed port to fail loudly if one is attempted anyway.
+        let result = install_language_blocking("exists_lang", data_dir, false, "http://127.0.0.1:1");
+
+        assert!(
+            result.is_success(),
+            "already-installed language must count as success: parser_error={:?} queries_error={:?}",
+            result.parser_error,
+            result.queries_error
+        );
+        assert_eq!(
+            result.parser_path,
+            Some(parser_dir.join(format!("exists_lang.{}", std::env::consts::DLL_EXTENSION)))
+        );
+        assert_eq!(result.queries_path, Some(queries_dir));
     }
 
     #[test]

--- a/src/install.rs
+++ b/src/install.rs
@@ -242,6 +242,16 @@ fn install_language_blocking(
         queries_error: None,
     };
 
+    // The queries installer re-checks names itself, but the parser
+    // installer also builds paths from the name (`parser/<name>.<ext>`),
+    // so reject traversal-capable names before touching either.
+    if !queries::is_safe_language_name(language) {
+        let reason = format!("Language name {:?} is unsafe", language);
+        result.parser_error = Some(reason.clone());
+        result.queries_error = Some(reason);
+        return result;
+    }
+
     // Install parser
     // For async/auto-install, always use cache (background operation)
     let parser_options = parser::InstallOptions {
@@ -506,6 +516,42 @@ mod tests {
         assert!(
             !temp.path().join("nest").join("evil").exists(),
             "install must not write outside the queries dir"
+        );
+    }
+
+    /// The queries installer validates names itself, but the parser
+    /// installer also builds paths from the language name
+    /// (`parser/<name>.<ext>`), so `install_language_blocking` must reject
+    /// unsafe names before touching either installer.
+    #[test]
+    fn install_language_blocking_rejects_unsafe_language_name() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let data_dir = temp.path().join("nest").join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        let result =
+            install_language_blocking("../../evil", &data_dir, false, "http://127.0.0.1:1");
+
+        assert!(!result.is_success(), "unsafe name must not install");
+        assert!(
+            result
+                .parser_error
+                .as_deref()
+                .is_some_and(|e| e.contains("unsafe")),
+            "parser side must be blocked by the name guard, got {:?}",
+            result.parser_error
+        );
+        assert!(
+            result
+                .queries_error
+                .as_deref()
+                .is_some_and(|e| e.contains("unsafe")),
+            "queries side must be blocked by the name guard, got {:?}",
+            result.queries_error
+        );
+        assert!(
+            !temp.path().join("nest").join("evil").exists(),
+            "nothing may be written outside the data dir"
         );
     }
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -137,7 +137,7 @@ pub mod test_support {
     /// every required install succeeded.
     ///
     /// Mirrors the install loop in `make deps/tree-sitter/.installed`.
-    /// Both `install_parser` and `install_queries` short-circuit when a
+    /// Both the parser and queries installs short-circuit when a
     /// language is up-to-date; any genuine failure is logged so tests
     /// depending on that language fail with a clearer error rather than
     /// the whole suite panicking in setup.
@@ -173,7 +173,7 @@ pub mod test_support {
                     all_ok = false;
                 }
             }
-            match queries::install_queries(lang, data_dir, false) {
+            match queries::install_queries_with_dependencies(lang, data_dir, false) {
                 Ok(_) | Err(queries::QueryInstallError::AlreadyExists(_)) => {}
                 Err(e) => {
                     eprintln!("[test setup] install_queries({}) failed: {}", lang, e);

--- a/src/install.rs
+++ b/src/install.rs
@@ -469,6 +469,46 @@ mod tests {
         );
     }
 
+    /// The top-level language name becomes a path segment
+    /// (`queries/<name>/`) and a URL segment, exactly like inherited names —
+    /// it must obey the same `[a-z0-9_]+` rule or installing `../../evil`
+    /// writes outside the data dir.
+    #[test]
+    fn install_rejects_unsafe_top_level_language_name() {
+        let temp = tempfile::TempDir::new().unwrap();
+        // Nest the data dir so an escape stays inside the TempDir.
+        let data_dir = temp.path().join("nest").join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        // Serve highlights.scm under both the raw and the dot-segment-
+        // normalized path, so the download succeeds (and the escape would
+        // persist) no matter how the HTTP client treats `..` in URLs.
+        let body = "(comment) @comment\n";
+        let base_url = spawn_query_file_server(vec![
+            ("/evil/highlights.scm", body),
+            ("/../../evil/highlights.scm", body),
+        ]);
+
+        let result = queries::install_queries_with_dependencies_from(
+            &base_url,
+            "../../evil",
+            &data_dir,
+            false,
+        );
+
+        assert!(
+            matches!(
+                result,
+                Err(queries::QueryInstallError::LanguageNotSupported(_))
+            ),
+            "unsafe top-level language name must be rejected"
+        );
+        assert!(
+            !temp.path().join("nest").join("evil").exists(),
+            "install must not write outside the queries dir"
+        );
+    }
+
     /// A language whose parser and queries are already on disk is a
     /// successful install, not a failure: reporting AlreadyExists as an
     /// error made the auto-install manager degrade a fully-usable language
@@ -491,7 +531,8 @@ mod tests {
 
         // Everything exists, so no download may happen — point the base URL
         // at a closed port to fail loudly if one is attempted anyway.
-        let result = install_language_blocking("exists_lang", data_dir, false, "http://127.0.0.1:1");
+        let result =
+            install_language_blocking("exists_lang", data_dir, false, "http://127.0.0.1:1");
 
         assert!(
             result.is_success(),

--- a/src/install.rs
+++ b/src/install.rs
@@ -221,6 +221,55 @@ impl InstallResult {
     }
 }
 
+/// Install a language synchronously (both parser and queries).
+///
+/// `queries_base_url` is injected so tests can serve query files from a
+/// local HTTP server; production callers pass
+/// [`queries::NVIM_TREESITTER_QUERIES_URL`].
+fn install_language_blocking(
+    language: &str,
+    data_dir: &std::path::Path,
+    force: bool,
+    queries_base_url: &str,
+) -> InstallResult {
+    let mut result = InstallResult {
+        parser_path: None,
+        queries_path: None,
+        parser_error: None,
+        queries_error: None,
+    };
+
+    // Install parser
+    // For async/auto-install, always use cache (background operation)
+    let parser_options = parser::InstallOptions {
+        data_dir: data_dir.to_path_buf(),
+        force,
+        verbose: false,
+        no_cache: false,
+    };
+
+    match parser::install_parser(language, &parser_options) {
+        Ok(parser_result) => {
+            result.parser_path = Some(parser_result.install_path);
+        }
+        Err(e) => {
+            result.parser_error = Some(e.to_string());
+        }
+    }
+
+    // Install queries
+    match queries::install_queries_from(queries_base_url, language, data_dir, force) {
+        Ok(query_result) => {
+            result.queries_path = Some(query_result.install_path);
+        }
+        Err(e) => {
+            result.queries_error = Some(e.to_string());
+        }
+    }
+
+    result
+}
+
 /// Install a language asynchronously (both parser and queries).
 ///
 /// Wraps the blocking install functions in `spawn_blocking` so it is safe to
@@ -230,47 +279,14 @@ pub(crate) async fn install_language_async(
     data_dir: PathBuf,
     force: bool,
 ) -> InstallResult {
-    let lang = language.clone();
-    let dir = data_dir.clone();
-
     // Run blocking install operations in a separate thread pool
     tokio::task::spawn_blocking(move || {
-        let mut result = InstallResult {
-            parser_path: None,
-            queries_path: None,
-            parser_error: None,
-            queries_error: None,
-        };
-
-        // Install parser
-        // For async/auto-install, always use cache (background operation)
-        let parser_options = parser::InstallOptions {
-            data_dir: dir.clone(),
+        install_language_blocking(
+            &language,
+            &data_dir,
             force,
-            verbose: false,
-            no_cache: false,
-        };
-
-        match parser::install_parser(&lang, &parser_options) {
-            Ok(parser_result) => {
-                result.parser_path = Some(parser_result.install_path);
-            }
-            Err(e) => {
-                result.parser_error = Some(e.to_string());
-            }
-        }
-
-        // Install queries
-        match queries::install_queries(&lang, &dir, force) {
-            Ok(query_result) => {
-                result.queries_path = Some(query_result.install_path);
-            }
-            Err(e) => {
-                result.queries_error = Some(e.to_string());
-            }
-        }
-
-        result
+            queries::NVIM_TREESITTER_QUERIES_URL,
+        )
     })
     .await
     .unwrap_or_else(|e| InstallResult {

--- a/src/install.rs
+++ b/src/install.rs
@@ -257,8 +257,14 @@ fn install_language_blocking(
         }
     }
 
-    // Install queries
-    match queries::install_queries_from(queries_base_url, language, data_dir, force) {
+    // Install queries, following `; inherits:` so languages like html
+    // (which keeps its @comment capture in html_tags) highlight correctly.
+    match queries::install_queries_with_dependencies_from(
+        queries_base_url,
+        language,
+        data_dir,
+        force,
+    ) {
         Ok(query_result) => {
             result.queries_path = Some(query_result.install_path);
         }
@@ -340,6 +346,108 @@ mod tests {
         // Should use platform default (dirs::data_dir() + "kakehashi")
         assert!(dir.is_some());
         assert!(dir.unwrap().to_string_lossy().contains("kakehashi"));
+    }
+
+    /// Serve canned query files over HTTP from an OS-assigned local port.
+    ///
+    /// `routes` maps request paths (e.g. "/lang/highlights.scm") to bodies;
+    /// unknown paths get a 404, mirroring how raw.githubusercontent.com
+    /// responds for query files a language doesn't provide. Returns the
+    /// base URL. The serving thread lives until the test process exits.
+    fn spawn_query_file_server(routes: Vec<(&str, &str)>) -> String {
+        use std::io::{BufRead, BufReader, Write};
+
+        let routes: Vec<(String, String)> = routes
+            .into_iter()
+            .map(|(p, b)| (p.to_string(), b.to_string()))
+            .collect();
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local server");
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                let mut reader = BufReader::new(&mut stream);
+                let mut request_line = String::new();
+                if reader.read_line(&mut request_line).is_err() {
+                    continue;
+                }
+                // Drain headers so the client sees a clean request/response cycle
+                let mut header = String::new();
+                while reader.read_line(&mut header).is_ok() && header != "\r\n" {
+                    header.clear();
+                }
+                let path = request_line.split_whitespace().nth(1).unwrap_or("");
+                let response = match routes.iter().find(|(p, _)| p == path) {
+                    Some((_, body)) => format!(
+                        "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    ),
+                    None => {
+                        "HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
+                            .to_string()
+                    }
+                };
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+
+        base_url
+    }
+
+    /// Auto-install must follow `; inherits:` in downloaded highlights.scm.
+    ///
+    /// Regression test: the LSP auto-install path installed only the
+    /// requested language's queries, so `html` arrived without `html_tags`
+    /// and its highlights query failed to load at runtime (the `@comment`
+    /// capture for `<!-- -->` lives in the inherited file).
+    #[test]
+    fn auto_install_installs_inherited_query_dependencies() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let data_dir = temp.path();
+
+        // Pre-create the parser artifact so install_parser short-circuits
+        // with AlreadyExists and the test never touches the network for it.
+        let parser_dir = data_dir.join("parser");
+        std::fs::create_dir_all(&parser_dir).unwrap();
+        std::fs::write(
+            parser_dir.join(format!("child_lang.{}", std::env::consts::DLL_EXTENSION)),
+            "",
+        )
+        .unwrap();
+
+        let base_url = spawn_query_file_server(vec![
+            (
+                "/child_lang/highlights.scm",
+                "; inherits: parent_lang\n(identifier) @variable\n",
+            ),
+            ("/parent_lang/highlights.scm", "(comment) @comment\n"),
+        ]);
+
+        let result = install_language_blocking("child_lang", data_dir, false, &base_url);
+
+        assert!(
+            result.queries_error.is_none(),
+            "queries install should succeed: {:?}",
+            result.queries_error
+        );
+        assert!(
+            data_dir
+                .join("queries")
+                .join("child_lang")
+                .join("highlights.scm")
+                .exists(),
+            "requested language queries should be installed"
+        );
+        assert!(
+            data_dir
+                .join("queries")
+                .join("parent_lang")
+                .join("highlights.scm")
+                .exists(),
+            "inherited parent queries should be installed alongside the child"
+        );
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -9,7 +9,7 @@ use super::http::agent_with_timeout;
 
 /// Base URL for nvim-treesitter query files on GitHub (main branch).
 /// Note: In the main branch, queries are under runtime/queries instead of queries.
-const NVIM_TREESITTER_QUERIES_URL: &str =
+pub(crate) const NVIM_TREESITTER_QUERIES_URL: &str =
     "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/main/runtime/queries";
 
 /// Query file types to download.
@@ -79,6 +79,19 @@ pub fn install_queries(
     data_dir: &Path,
     force: bool,
 ) -> Result<QueryInstallResult, QueryInstallError> {
+    install_queries_from(NVIM_TREESITTER_QUERIES_URL, language, data_dir, force)
+}
+
+/// Download and install query files for a language from a specific base URL.
+///
+/// `base_url` is injected (rather than always using the nvim-treesitter
+/// constant) so tests can serve query files from a local HTTP server.
+pub(crate) fn install_queries_from(
+    base_url: &str,
+    language: &str,
+    data_dir: &Path,
+    force: bool,
+) -> Result<QueryInstallResult, QueryInstallError> {
     let queries_dir = data_dir.join("queries").join(language);
 
     // Check if queries already exist
@@ -94,10 +107,7 @@ pub fn install_queries(
 
     // Download each query file
     for query_file in QUERY_FILES {
-        let url = format!(
-            "{}/{}/{}",
-            NVIM_TREESITTER_QUERIES_URL, language, query_file
-        );
+        let url = format!("{}/{}/{}", base_url, language, query_file);
 
         match download_file(&url) {
             Ok(content) => {
@@ -161,12 +171,24 @@ pub fn install_queries_with_dependencies(
     data_dir: &Path,
     force: bool,
 ) -> Result<QueryInstallResult, QueryInstallError> {
+    install_queries_with_dependencies_from(NVIM_TREESITTER_QUERIES_URL, language, data_dir, force)
+}
+
+/// Like [`install_queries_with_dependencies`] but downloading from `base_url`,
+/// so tests can serve query files from a local HTTP server.
+pub(crate) fn install_queries_with_dependencies_from(
+    base_url: &str,
+    language: &str,
+    data_dir: &Path,
+    force: bool,
+) -> Result<QueryInstallResult, QueryInstallError> {
     let mut installed = std::collections::HashSet::new();
-    install_queries_recursive(language, data_dir, force, &mut installed)
+    install_queries_recursive(base_url, language, data_dir, force, &mut installed)
 }
 
 /// Internal recursive helper for installing queries with dependencies.
 fn install_queries_recursive(
+    base_url: &str,
     language: &str,
     data_dir: &Path,
     force: bool,
@@ -199,7 +221,7 @@ fn install_queries_recursive(
             let parents = parse_inherits_directive(&content);
             for parent in parents {
                 // Install parent dependencies (don't force, just ensure they exist)
-                let _ = install_queries_recursive(&parent, data_dir, false, installed);
+                let _ = install_queries_recursive(base_url, &parent, data_dir, false, installed);
             }
         }
         return Err(QueryInstallError::AlreadyExists(queries_dir));
@@ -214,10 +236,7 @@ fn install_queries_recursive(
 
     // Download each query file
     for query_file in QUERY_FILES {
-        let url = format!(
-            "{}/{}/{}",
-            NVIM_TREESITTER_QUERIES_URL, language, query_file
-        );
+        let url = format!("{}/{}/{}", base_url, language, query_file);
 
         match download_file(&url) {
             Ok(content) => {
@@ -263,7 +282,7 @@ fn install_queries_recursive(
     for parent in parents_to_install {
         eprintln!("Installing inherited queries: {}", parent);
         // Don't fail if parent already exists
-        match install_queries_recursive(&parent, data_dir, false, installed) {
+        match install_queries_recursive(base_url, &parent, data_dir, false, installed) {
             Ok(_) | Err(QueryInstallError::AlreadyExists(_)) => {}
             Err(e) => {
                 eprintln!(

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -143,10 +143,13 @@ fn install_queries_recursive(
 ) -> Result<QueryInstallResult, QueryInstallError> {
     // The name becomes a path and URL segment below; reject anything that
     // could escape the data dir (e.g. a caller-provided `../../x`).
+    // Debug-format the untrusted name: the error's Display is printed raw
+    // by the CLI, so control characters must not reach the terminal.
     if !is_safe_language_name(language) {
-        return Err(QueryInstallError::LanguageNotSupported(
-            language.to_string(),
-        ));
+        return Err(QueryInstallError::LanguageNotSupported(format!(
+            "{:?}",
+            language
+        )));
     }
 
     // Skip if already installed in this session
@@ -285,6 +288,30 @@ fn download_file(url: &str) -> Result<String, QueryInstallError> {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    /// The rejected name flows into the error's `Display` (printed raw by
+    /// the CLI), so control characters in an untrusted name must be escaped
+    /// before they reach terminal output.
+    #[test]
+    fn unsafe_language_name_error_escapes_control_characters() {
+        let temp = TempDir::new().unwrap();
+        let result = install_queries_with_dependencies_from(
+            "http://127.0.0.1:1",
+            "evil\u{1b}[31m",
+            temp.path(),
+            false,
+        );
+        match result {
+            Err(QueryInstallError::LanguageNotSupported(name)) => {
+                assert!(
+                    !name.contains('\u{1b}'),
+                    "stored name must not carry raw escape bytes: {:?}",
+                    name
+                );
+            }
+            other => panic!("expected LanguageNotSupported, got {:?}", other.err()),
+        }
+    }
 
     /// Inherited language names become path segments (`queries/<name>/`) and
     /// URL segments, so anything outside nvim-treesitter's `[a-z0-9_]+`

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -79,7 +79,7 @@ pub struct QueryInstallResult {
 /// segments, so anything outside nvim-treesitter's `[a-z0-9_]+` naming is
 /// rejected: a name like `../../x` (from a caller or a `; inherits:` line in
 /// a compromised or custom query source) must not escape the data dir.
-fn is_safe_language_name(name: &str) -> bool {
+pub(crate) fn is_safe_language_name(name: &str) -> bool {
     !name.is_empty()
         && name
             .bytes()

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -75,12 +75,26 @@ pub struct QueryInstallResult {
 
 /// Parse the `; inherits: lang1,lang2` directive from query content.
 /// Returns the list of parent languages.
+///
+/// Names are used as path segments (`queries/<name>/`) and URL segments,
+/// so anything outside nvim-treesitter's `[a-z0-9_]+` naming is dropped:
+/// a `; inherits: ../../x` from a compromised or custom query source must
+/// not escape the data dir.
 fn parse_inherits_directive(content: &str) -> Vec<String> {
     let first_line = content.lines().next().unwrap_or("");
     if let Some(rest) = first_line.strip_prefix("; inherits:") {
         rest.split(',')
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty())
+            .filter(|s| {
+                let safe = s
+                    .bytes()
+                    .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'_');
+                if !safe {
+                    eprintln!("Warning: ignoring unsafe inherited language name '{}'", s);
+                }
+                safe
+            })
             .collect()
     } else {
         Vec::new()
@@ -145,7 +159,15 @@ fn install_queries_recursive(
             let parents = parse_inherits_directive(&content);
             for parent in parents {
                 // Install parent dependencies (don't force, just ensure they exist)
-                let _ = install_queries_recursive(base_url, &parent, data_dir, false, installed);
+                match install_queries_recursive(base_url, &parent, data_dir, false, installed) {
+                    Ok(_) | Err(QueryInstallError::AlreadyExists(_)) => {}
+                    Err(e) => {
+                        eprintln!(
+                            "Warning: Failed to install inherited queries '{}': {}",
+                            parent, e
+                        );
+                    }
+                }
             }
         }
         return Err(QueryInstallError::AlreadyExists(queries_dir));
@@ -246,6 +268,22 @@ fn download_file(url: &str) -> Result<String, QueryInstallError> {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    /// Inherited language names become path segments (`queries/<name>/`) and
+    /// URL segments, so anything outside nvim-treesitter's `[a-z0-9_]+`
+    /// naming must be dropped — `; inherits: ../../x` from a compromised or
+    /// custom query source must not escape the data dir.
+    #[test]
+    fn parse_inherits_directive_drops_unsafe_language_names() {
+        let parents = parse_inherits_directive(
+            "; inherits: ../../evil, html_tags, UPPER, with-dash, c3\n(comment) @comment\n",
+        );
+        assert_eq!(
+            parents,
+            vec!["html_tags".to_string(), "c3".to_string()],
+            "only lowercase/digit/underscore names may survive"
+        );
+    }
 
     #[test]
     fn test_install_queries_creates_directory_structure() {

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -73,13 +73,22 @@ pub struct QueryInstallResult {
     pub files_downloaded: Vec<String>,
 }
 
-/// Parse the `; inherits: lang1,lang2` directive from query content.
-/// Returns the list of parent languages.
+/// Whether a language name is safe to use as a path and URL segment.
 ///
-/// Names are used as path segments (`queries/<name>/`) and URL segments,
-/// so anything outside nvim-treesitter's `[a-z0-9_]+` naming is dropped:
-/// a `; inherits: ../../x` from a compromised or custom query source must
-/// not escape the data dir.
+/// Language names are used as path segments (`queries/<name>/`) and URL
+/// segments, so anything outside nvim-treesitter's `[a-z0-9_]+` naming is
+/// rejected: a name like `../../x` (from a caller or a `; inherits:` line in
+/// a compromised or custom query source) must not escape the data dir.
+fn is_safe_language_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'_')
+}
+
+/// Parse the `; inherits: lang1,lang2` directive from query content.
+/// Returns the list of parent languages, dropping unsafe names
+/// (see [`is_safe_language_name`]).
 fn parse_inherits_directive(content: &str) -> Vec<String> {
     let first_line = content.lines().next().unwrap_or("");
     if let Some(rest) = first_line.strip_prefix("; inherits:") {
@@ -87,9 +96,7 @@ fn parse_inherits_directive(content: &str) -> Vec<String> {
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty())
             .filter(|s| {
-                let safe = s
-                    .bytes()
-                    .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'_');
+                let safe = is_safe_language_name(s);
                 if !safe {
                     eprintln!("Warning: ignoring unsafe inherited language name '{}'", s);
                 }
@@ -132,6 +139,14 @@ fn install_queries_recursive(
     force: bool,
     installed: &mut std::collections::HashSet<String>,
 ) -> Result<QueryInstallResult, QueryInstallError> {
+    // The name becomes a path and URL segment below; reject anything that
+    // could escape the data dir (e.g. a caller-provided `../../x`).
+    if !is_safe_language_name(language) {
+        return Err(QueryInstallError::LanguageNotSupported(
+            language.to_string(),
+        ));
+    }
+
     // Skip if already installed in this session
     if installed.contains(language) {
         return Ok(QueryInstallResult {

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -98,7 +98,9 @@ fn parse_inherits_directive(content: &str) -> Vec<String> {
             .filter(|s| {
                 let safe = is_safe_language_name(s);
                 if !safe {
-                    eprintln!("Warning: ignoring unsafe inherited language name '{}'", s);
+                    // Debug-format: the name is untrusted input and could
+                    // smuggle ANSI escapes into the terminal if printed raw.
+                    eprintln!("Warning: ignoring unsafe inherited language name {:?}", s);
                 }
                 safe
             })

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -73,82 +73,6 @@ pub struct QueryInstallResult {
     pub files_downloaded: Vec<String>,
 }
 
-/// Download and install query files for a language.
-pub fn install_queries(
-    language: &str,
-    data_dir: &Path,
-    force: bool,
-) -> Result<QueryInstallResult, QueryInstallError> {
-    install_queries_from(NVIM_TREESITTER_QUERIES_URL, language, data_dir, force)
-}
-
-/// Download and install query files for a language from a specific base URL.
-///
-/// `base_url` is injected (rather than always using the nvim-treesitter
-/// constant) so tests can serve query files from a local HTTP server.
-pub(crate) fn install_queries_from(
-    base_url: &str,
-    language: &str,
-    data_dir: &Path,
-    force: bool,
-) -> Result<QueryInstallResult, QueryInstallError> {
-    let queries_dir = data_dir.join("queries").join(language);
-
-    // Check if queries already exist
-    if queries_dir.exists() && !force {
-        return Err(QueryInstallError::AlreadyExists(queries_dir));
-    }
-
-    // Create the queries directory
-    fs::create_dir_all(&queries_dir)?;
-
-    let mut files_downloaded = Vec::new();
-    let mut any_success = false;
-
-    // Download each query file
-    for query_file in QUERY_FILES {
-        let url = format!("{}/{}/{}", base_url, language, query_file);
-
-        match download_file(&url) {
-            Ok(content) => {
-                let file_path = queries_dir.join(query_file);
-                let mut file = fs::File::create(&file_path)?;
-                file.write_all(content.as_bytes())?;
-                files_downloaded.push(query_file.to_string());
-                any_success = true;
-            }
-            Err(e) => {
-                // highlights.scm is required, others are optional
-                if *query_file == "highlights.scm" {
-                    // Clean up the directory we created
-                    let _ = fs::remove_dir_all(&queries_dir);
-                    return Err(QueryInstallError::LanguageNotSupported(
-                        language.to_string(),
-                    ));
-                }
-                // Log but continue for optional files
-                eprintln!(
-                    "Note: {} not available for {} ({})",
-                    query_file, language, e
-                );
-            }
-        }
-    }
-
-    if !any_success {
-        let _ = fs::remove_dir_all(&queries_dir);
-        return Err(QueryInstallError::LanguageNotSupported(
-            language.to_string(),
-        ));
-    }
-
-    Ok(QueryInstallResult {
-        language: language.to_string(),
-        install_path: queries_dir,
-        files_downloaded,
-    })
-}
-
 /// Parse the `; inherits: lang1,lang2` directive from query content.
 /// Returns the list of parent languages.
 fn parse_inherits_directive(content: &str) -> Vec<String> {
@@ -329,7 +253,7 @@ mod tests {
         let data_dir = temp_dir.path().to_path_buf();
 
         // This test requires network access - skip in CI if needed
-        let result = install_queries("lua", &data_dir, false);
+        let result = install_queries_with_dependencies("lua", &data_dir, false);
 
         // The test may fail due to network issues, but structure should be correct
         if let Ok(result) = result {
@@ -381,7 +305,8 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let data_dir = temp_dir.path().to_path_buf();
 
-        let result = install_queries("nonexistent_language_xyz_123", &data_dir, false);
+        let result =
+            install_queries_with_dependencies("nonexistent_language_xyz_123", &data_dir, false);
 
         assert!(result.is_err());
         if let Err(QueryInstallError::LanguageNotSupported(lang)) = result {
@@ -400,7 +325,7 @@ mod tests {
         fs::write(queries_dir.join("highlights.scm"), "existing content").unwrap();
 
         // Without force, should error
-        let result = install_queries("lua", &data_dir, false);
+        let result = install_queries_with_dependencies("lua", &data_dir, false);
         assert!(matches!(result, Err(QueryInstallError::AlreadyExists(_))));
 
         // With force, should succeed (requires network)

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -143,13 +143,12 @@ fn install_queries_recursive(
 ) -> Result<QueryInstallResult, QueryInstallError> {
     // The name becomes a path and URL segment below; reject anything that
     // could escape the data dir (e.g. a caller-provided `../../x`).
-    // Debug-format the untrusted name: the error's Display is printed raw
-    // by the CLI, so control characters must not reach the terminal.
+    // Escape the untrusted name: the error's Display is printed raw by
+    // the CLI, so control characters must not reach the terminal.
     if !is_safe_language_name(language) {
-        return Err(QueryInstallError::LanguageNotSupported(format!(
-            "{:?}",
-            language
-        )));
+        return Err(QueryInstallError::LanguageNotSupported(
+            language.escape_default().to_string(),
+        ));
     }
 
     // Skip if already installed in this session


### PR DESCRIPTION
## Why

The LSP server's auto-install path downloaded only the requested language's query files, ignoring the `; inherits:` directive that `install_queries_with_dependencies` already handles for the CLI `kakehashi install` command. So auto-installing `html` never fetched `html_tags` — whose `highlights.scm` holds the `(comment) @comment` capture — and the inherited query failed to load at runtime (silently: the loader reports it as \"not found in search paths\"). Net effect: `<!-- foo -->` in markdown's HTML injection got no semantic tokens.

## What

- **fix:** route auto-install through the dependency-resolving installer, so both entry points (LSP auto-install and CLI) behave the same.
- **refactor (Tidy First):** extract `install_language_blocking` and thread the queries base URL as a parameter, so the regression test can serve query files from a local HTTP server — no network, no flakes.
- **refactor:** delete the now-unused inherits-ignoring `install_queries` variant entirely (it duplicated the download loop and was exactly the footgun that produced this bug).
- **hardening (review findings):** restrict `; inherits:` names to `[a-z0-9_]+` so a hostile directive like `; inherits: ../../x` can't escape the data dir; surface previously-swallowed parent-install failures as warnings.

## Test

- `install::tests::auto_install_installs_inherited_query_dependencies` — serves a child language inheriting a parent from a `127.0.0.1` listener and asserts the parent's queries land in the data dir (fails on pre-fix code).
- `install::queries::tests::parse_inherits_directive_drops_unsafe_language_names` — path-traversal names are dropped. All 328 real nvim-treesitter query dir names pass the filter.
- Full gate: clippy `-D warnings`, fmt, `cargo test --lib` (1700 tests).

## Known limitations (intentional, pre-existing)

- Users already bitten (e.g. `html` queries present but `html_tags` missing) won't self-heal via auto-install: the manager short-circuits on parser existence, and even a forced query pass reports `AlreadyExists` as an error in `InstallResult`. One-shot remedy: `kakehashi install html` (its already-exists path now installs the missing parents).
- The runtime query loader's own `; inherits:` parsing (`src/language/query_loader.rs`) is not yet sanitized the same way; it only reads local files. Follow-up candidate.