### PR TITLE
fix(config): nest layers method map under layers.aggregation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -330,7 +330,7 @@ and semantic tokens excepted); by default the host layer is tried after
 `virt` (see `layers` above), so injections keep winning inside code fences
 while the host server answers everywhere else. For formatting, combine
 fence formatters with a whole-document formatter via
-`layers."textDocument/formatting".strategy = "concatenated"`.
+`layers.aggregation."textDocument/formatting".strategy = "concatenated"`.
 
 ```toml
 [languages.markdown.bridge._self]
@@ -382,15 +382,18 @@ Example with per-method priorities, strategy, and maxFanOut:
 A request to kakehashi can be answered by up to three *result layers*:
 `virt` (the injection bridges above), `host` (a host-document language
 server — opt-in via `bridge._self` above), and `native` (kakehashi's
-own features). The per-language `layers` map orders them per LSP method:
+own features). `layers.aggregation` orders them per LSP method, mirroring
+the `bridge.<lang>.aggregation` nesting:
 
 ```json
 {
   "languages": {
     "markdown": {
       "layers": {
-        "textDocument/hover": { "order": ["virt", "native"] },
-        "_": { "order": ["virt", "host", "native"] }
+        "aggregation": {
+          "textDocument/hover": { "order": ["virt", "native"] },
+          "_": { "order": ["virt", "host", "native"] }
+        }
       }
     }
   }
@@ -404,8 +407,8 @@ own features). The per-language `layers` map orders them per LSP method:
 
 Details:
 
-- **Key**: the LSP method name, or `_` for the method wildcard (same
-  convention as `aggregation`).
+- **Key**: under `aggregation`, the LSP method name or `_` for the method
+  wildcard (same convention as `bridge.<lang>.aggregation`).
 - **Formatting**: `textDocument/rangeFormatting` shares the
   `textDocument/formatting` key.
 - **Diagnostics**: two keys, mirroring their aggregation keying — pull

--- a/docs/architecture-decisions/aggregation-priorities-wildcard.md
+++ b/docs/architecture-decisions/aggregation-priorities-wildcard.md
@@ -31,7 +31,7 @@ the strategy:
 Two problems with keeping the dual semantics:
 
 1. **Inconsistency compounds.** cross-layer-aggregation introduces a second
-   ordered list (`layers.<method>.order`). Every new list must pick a side,
+   ordered list (`layers.aggregation.<method>.order`). Every new list must pick a side,
    and users must remember which list means which.
 2. **Exclusion and demotion are inexpressible under `preferred`.** A user
    cannot say "only foo" (fallback always re-admits the rest), nor "foo

--- a/docs/architecture-decisions/cross-layer-aggregation.md
+++ b/docs/architecture-decisions/cross-layer-aggregation.md
@@ -99,16 +99,19 @@ violation that led host-document-bridge to reject its Alternative A
 
 ## Decision Outcome
 
-**Chosen approach**: add a `layers` field to `LanguageSettings` — a
-method-keyed map (LSP method name or `_` wildcard) whose values hold a
-closed-enum layer order plus an optional strategy. Stage-1 types
-(`AggregationConfig`, `BridgeLanguageConfig`) are untouched.
+**Chosen approach**: add a `layers` field to `LanguageSettings` whose
+`aggregation` member is a method-keyed map (LSP method name or `_`
+wildcard) of closed-enum layer orders plus an optional strategy. The
+nesting mirrors `bridge.<key>.aggregation` — "aggregation" uniformly names
+the method-keyed map across the config — and keeps headroom for future
+layer-wide fields on `layers` without colliding with method names.
+Stage-1 types (`AggregationConfig`, `BridgeLanguageConfig`) are untouched.
 
 ### Schema
 
 ```toml
 # ---- Built-in defaults (declared in code; not user-facing) ----
-[languages._.layers._]
+[languages._.layers.aggregation._]
 order = ["virt", "host", "native"]   # innermost-first; mirrors "deeper wins"
 # host is listed but contributes nothing until the user opts in via
 # bridge._self.enabled (host-document-bridge) — order ranks layers,
@@ -116,7 +119,7 @@ order = ["virt", "host", "native"]   # innermost-first; mirrors "deeper wins"
 # strategy: per-method default (concatenated for diagnostics, else preferred)
 
 # ---- User: markdown hover should prefer the host LS, and drop native ----
-[languages.markdown.layers."textDocument/hover"]
+[languages.markdown.layers.aggregation."textDocument/hover"]
 order = ["host", "virt"]             # allowlist: native does not run
 
 # ---- Stage 1 stays exactly as before: server names within one target ----
@@ -147,14 +150,19 @@ pub struct LayerAggregationConfig {
     pub strategy: Option<AggregationStrategy>,
 }
 
+pub struct LayersConfig {
+    /// Per-method map, keyed by LSP method name or "_" (wildcard).
+    pub aggregation: Option<HashMap<String, LayerAggregationConfig>>,
+}
+
 // On LanguageSettings, beside `bridge`:
-pub layers: Option<HashMap<String, LayerAggregationConfig>>,
+pub layers: Option<LayersConfig>,
 ```
 
 ### Two-Stage Aggregation
 
 ```
-Stage 2 (this decision)   layers.order = [virt, host, native]   ← LayerSource enum
+Stage 2 (this decision)   layers.aggregation.<m>.order = [virt, host, native]   ← LayerSource enum
                              │      │      └ native handler result
                              │      └ bridge._self.aggregation.priorities  ← LS names
                              └ bridge.<inj>.aggregation.priorities         ← LS names
@@ -243,7 +251,7 @@ independent — e.g., diagnostics can be `concatenated` across layers while
 - **Allowlist override footgun**: writing `order = ["host"]` silently drops
   virt and native for that method — a user promoting one layer must restate
   the others. Mitigated by schema docs; inherent to allowlist semantics.
-- **Two similarly-shaped maps**: `languages.<lang>.layers.<method>` and
+- **Two similarly-shaped maps**: `languages.<lang>.layers.aggregation.<method>` and
   `languages.<lang>.bridge.<key>.aggregation.<method>` are both method-keyed
   ordered-allowlist configs; users must learn which axis each controls. The
   distinct field names and element types (`order` of a closed enum vs.

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -1,6 +1,6 @@
 use super::settings::{
     AggregationConfig, BridgeLanguageConfig, BridgeServerConfig, LanguageSettings,
-    LayerAggregationConfig,
+    LayerAggregationConfig, LayersConfig,
 };
 use super::{CaptureMappings, RawWorkspaceSettings, WILDCARD_KEY};
 use std::collections::{HashMap, HashSet};
@@ -98,7 +98,7 @@ pub(crate) fn merge_language_settings(
         parser: overlay.parser.clone().or_else(|| base.parser.clone()),
         queries: overlay.queries.clone().or_else(|| base.queries.clone()),
         bridge: merge_bridge_maps(base.bridge.as_ref(), overlay.bridge.as_ref()),
-        layers: merge_layers_maps(base.layers.as_ref(), overlay.layers.as_ref()),
+        layers: merge_layers_configs(base.layers.as_ref(), overlay.layers.as_ref()),
         aliases: overlay.aliases.clone().or_else(|| base.aliases.clone()),
     }
 }
@@ -221,12 +221,32 @@ pub(crate) fn merge_layer_aggregation_configs(
     }
 }
 
-/// Deep merge two optional `layers` HashMaps (cross-layer-aggregation).
+/// Field-level merge of two optional `layers` configs
+/// (cross-layer-aggregation).
+fn merge_layers_configs(
+    base: Option<&LayersConfig>,
+    overlay: Option<&LayersConfig>,
+) -> Option<LayersConfig> {
+    match (base, overlay) {
+        (None, None) => None,
+        (Some(b), None) => Some(b.clone()),
+        (None, Some(o)) => Some(o.clone()),
+        (Some(b), Some(o)) => Some(LayersConfig {
+            aggregation: merge_layers_aggregation_maps(
+                b.aggregation.as_ref(),
+                o.aggregation.as_ref(),
+            ),
+        }),
+    }
+}
+
+/// Deep merge two optional `layers.aggregation` HashMaps
+/// (cross-layer-aggregation).
 ///
 /// Mirrors [`merge_bridge_maps`]: an empty overlay map (`Some({})`) clears
 /// the base (empty-means-clear); otherwise per-method entries merge at the
 /// field level via [`merge_layer_aggregation_configs`].
-fn merge_layers_maps(
+fn merge_layers_aggregation_maps(
     base: Option<&HashMap<String, LayerAggregationConfig>>,
     overlay: Option<&HashMap<String, LayerAggregationConfig>>,
 ) -> Option<HashMap<String, LayerAggregationConfig>> {
@@ -2150,48 +2170,56 @@ mod tests {
     fn merge_language_settings_merges_layers_per_method() {
         use crate::config::settings::{AggregationStrategy, LayerSource};
         let base = LanguageSettings {
-            layers: Some(HashMap::from([
-                (
-                    "textDocument/hover".to_string(),
-                    LayerAggregationConfig {
-                        order: Some(vec![LayerSource::Native]),
-                        strategy: Some(AggregationStrategy::Preferred),
-                    },
-                ),
-                (
-                    "textDocument/definition".to_string(),
-                    LayerAggregationConfig {
-                        order: Some(vec![LayerSource::Virt]),
-                        strategy: None,
-                    },
-                ),
-            ])),
+            layers: Some(LayersConfig {
+                aggregation: Some(HashMap::from([
+                    (
+                        "textDocument/hover".to_string(),
+                        LayerAggregationConfig {
+                            order: Some(vec![LayerSource::Native]),
+                            strategy: Some(AggregationStrategy::Preferred),
+                        },
+                    ),
+                    (
+                        "textDocument/definition".to_string(),
+                        LayerAggregationConfig {
+                            order: Some(vec![LayerSource::Virt]),
+                            strategy: None,
+                        },
+                    ),
+                ])),
+            }),
             ..Default::default()
         };
         let overlay = LanguageSettings {
-            layers: Some(HashMap::from([(
-                "textDocument/hover".to_string(),
-                LayerAggregationConfig {
-                    order: Some(vec![LayerSource::Host]),
-                    strategy: None,
-                },
-            )])),
+            layers: Some(LayersConfig {
+                aggregation: Some(HashMap::from([(
+                    "textDocument/hover".to_string(),
+                    LayerAggregationConfig {
+                        order: Some(vec![LayerSource::Host]),
+                        strategy: None,
+                    },
+                )])),
+            }),
             ..Default::default()
         };
         let merged = merge_language_settings(&base, &overlay);
-        let layers = merged.layers.expect("layers must survive the merge");
+        let aggregation = merged
+            .layers
+            .expect("layers must survive the merge")
+            .aggregation
+            .expect("aggregation must survive the merge");
         assert_eq!(
-            layers["textDocument/hover"].order,
+            aggregation["textDocument/hover"].order,
             Some(vec![LayerSource::Host]),
             "overlay entry wins per field"
         );
         assert_eq!(
-            layers["textDocument/hover"].strategy,
+            aggregation["textDocument/hover"].strategy,
             Some(AggregationStrategy::Preferred),
             "unset overlay field inherits from the base entry"
         );
         assert_eq!(
-            layers["textDocument/definition"].order,
+            aggregation["textDocument/definition"].order,
             Some(vec![LayerSource::Virt]),
             "base-only entries are preserved"
         );
@@ -2201,24 +2229,30 @@ mod tests {
     fn merge_language_settings_empty_layers_map_clears_base() {
         use crate::config::settings::LayerSource;
         let base = LanguageSettings {
-            layers: Some(HashMap::from([(
-                "_".to_string(),
-                LayerAggregationConfig {
-                    order: Some(vec![LayerSource::Native]),
-                    strategy: None,
-                },
-            )])),
+            layers: Some(LayersConfig {
+                aggregation: Some(HashMap::from([(
+                    "_".to_string(),
+                    LayerAggregationConfig {
+                        order: Some(vec![LayerSource::Native]),
+                        strategy: None,
+                    },
+                )])),
+            }),
             ..Default::default()
         };
         let overlay = LanguageSettings {
-            layers: Some(HashMap::new()),
+            layers: Some(LayersConfig {
+                aggregation: Some(HashMap::new()),
+            }),
             ..Default::default()
         };
         let merged = merge_language_settings(&base, &overlay);
         assert_eq!(
             merged.layers,
-            Some(HashMap::new()),
-            "Some({{}}) clears inherited layers (empty-means-clear, like bridge)"
+            Some(LayersConfig {
+                aggregation: Some(HashMap::new()),
+            }),
+            "aggregation = {{}} clears inherited entries (empty-means-clear, like bridge)"
         );
     }
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -104,8 +104,24 @@ pub enum LayerSource {
     Virt,
 }
 
+/// Cross-layer configuration for one host language
+/// (cross-layer-aggregation). Lives at `languages.<lang>.layers`.
+///
+/// The per-method map sits under `aggregation`, mirroring
+/// `bridge.<key>.aggregation`: "aggregation" uniformly names the
+/// method-keyed map across the config, and `layers` keeps headroom for
+/// future layer-wide fields without colliding with method names.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct LayersConfig {
+    /// Per-method cross-layer aggregation. Key = LSP method name (e.g.,
+    /// `textDocument/formatting`) or `"_"` for the method wildcard.
+    #[serde(default)]
+    pub aggregation: Option<HashMap<String, LayerAggregationConfig>>,
+}
+
 /// Per-method cross-layer aggregation configuration
-/// (cross-layer-aggregation). Lives in `LanguageSettings::layers`, keyed by
+/// (cross-layer-aggregation). Lives in `LayersConfig::aggregation`, keyed by
 /// LSP method name or `"_"` for the method wildcard.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -396,11 +412,11 @@ pub struct LanguageSettings {
     pub queries: Option<Vec<QueryItem>>,
     /// Omit to bridge all configured languages (default). Use an empty object `{}` to disable bridging. Use `{ "python": { "enabled": true } }` to bridge specific languages.
     pub bridge: Option<HashMap<String, BridgeLanguageConfig>>,
-    /// Per-method cross-layer aggregation (cross-layer-aggregation).
-    /// Key = LSP method name or `"_"` for the method wildcard; value orders
-    /// the result layers (`virt`/`host`/`native`) for that method.
+    /// Cross-layer configuration (cross-layer-aggregation): the
+    /// `aggregation` map under it orders the result layers
+    /// (`virt`/`host`/`native`) per LSP method (`"_"` = method wildcard).
     /// Omit to use the default order `["virt", "host", "native"]`.
-    pub layers: Option<HashMap<String, LayerAggregationConfig>>,
+    pub layers: Option<LayersConfig>,
     /// Deprecated: use `base` on the derived language instead.
     /// Alternative languageId values that should use this parser.
     pub aliases: Option<Vec<String>>,
@@ -415,13 +431,17 @@ impl LanguageSettings {
     /// `order` is a single field: a method-specific `order` replaces the
     /// wildcard's list wholesale, it does not merge element-wise.
     pub(crate) fn resolve_layers(&self, method: &str) -> ResolvedLayerConfig {
-        let entry = self.layers.as_ref().and_then(|map| {
-            crate::config::resolve_with_wildcard(
-                map,
-                method,
-                crate::config::merge_layer_aggregation_configs,
-            )
-        });
+        let entry = self
+            .layers
+            .as_ref()
+            .and_then(|layers| layers.aggregation.as_ref())
+            .and_then(|map| {
+                crate::config::resolve_with_wildcard(
+                    map,
+                    method,
+                    crate::config::merge_layer_aggregation_configs,
+                )
+            });
         match entry {
             Some(cfg) => ResolvedLayerConfig {
                 // Dedup defensively (first occurrence wins): a repeated layer
@@ -1582,13 +1602,15 @@ kind = "injections""#;
     #[test]
     fn resolve_layers_uses_method_specific_entry() {
         let settings = LanguageSettings {
-            layers: Some(HashMap::from([(
-                "textDocument/hover".to_string(),
-                LayerAggregationConfig {
-                    order: Some(vec![LayerSource::Host, LayerSource::Virt]),
-                    strategy: None,
-                },
-            )])),
+            layers: Some(LayersConfig {
+                aggregation: Some(HashMap::from([(
+                    "textDocument/hover".to_string(),
+                    LayerAggregationConfig {
+                        order: Some(vec![LayerSource::Host, LayerSource::Virt]),
+                        strategy: None,
+                    },
+                )])),
+            }),
             ..Default::default()
         };
         let resolved = settings.resolve_layers("textDocument/hover");
@@ -1604,22 +1626,24 @@ kind = "injections""#;
         // Field-level wildcard merge: the method entry sets strategy only,
         // the "_" entry supplies order.
         let settings = LanguageSettings {
-            layers: Some(HashMap::from([
-                (
-                    WILDCARD_KEY.to_string(),
-                    LayerAggregationConfig {
-                        order: Some(vec![LayerSource::Native]),
-                        strategy: None,
-                    },
-                ),
-                (
-                    "textDocument/hover".to_string(),
-                    LayerAggregationConfig {
-                        order: None,
-                        strategy: Some(AggregationStrategy::Concatenated),
-                    },
-                ),
-            ])),
+            layers: Some(LayersConfig {
+                aggregation: Some(HashMap::from([
+                    (
+                        WILDCARD_KEY.to_string(),
+                        LayerAggregationConfig {
+                            order: Some(vec![LayerSource::Native]),
+                            strategy: None,
+                        },
+                    ),
+                    (
+                        "textDocument/hover".to_string(),
+                        LayerAggregationConfig {
+                            order: None,
+                            strategy: Some(AggregationStrategy::Concatenated),
+                        },
+                    ),
+                ])),
+            }),
             ..Default::default()
         };
         let resolved = settings.resolve_layers("textDocument/hover");
@@ -1630,22 +1654,24 @@ kind = "injections""#;
     #[test]
     fn resolve_layers_method_order_replaces_wildcard_order_wholesale() {
         let settings = LanguageSettings {
-            layers: Some(HashMap::from([
-                (
-                    WILDCARD_KEY.to_string(),
-                    LayerAggregationConfig {
-                        order: Some(vec![LayerSource::Native, LayerSource::Host]),
-                        strategy: None,
-                    },
-                ),
-                (
-                    "textDocument/hover".to_string(),
-                    LayerAggregationConfig {
-                        order: Some(vec![LayerSource::Virt]),
-                        strategy: None,
-                    },
-                ),
-            ])),
+            layers: Some(LayersConfig {
+                aggregation: Some(HashMap::from([
+                    (
+                        WILDCARD_KEY.to_string(),
+                        LayerAggregationConfig {
+                            order: Some(vec![LayerSource::Native, LayerSource::Host]),
+                            strategy: None,
+                        },
+                    ),
+                    (
+                        "textDocument/hover".to_string(),
+                        LayerAggregationConfig {
+                            order: Some(vec![LayerSource::Virt]),
+                            strategy: None,
+                        },
+                    ),
+                ])),
+            }),
             ..Default::default()
         };
         let resolved = settings.resolve_layers("textDocument/hover");
@@ -1659,13 +1685,15 @@ kind = "injections""#;
     #[test]
     fn resolve_layers_empty_order_disables_all_layers() {
         let settings = LanguageSettings {
-            layers: Some(HashMap::from([(
-                WILDCARD_KEY.to_string(),
-                LayerAggregationConfig {
-                    order: Some(vec![]),
-                    strategy: None,
-                },
-            )])),
+            layers: Some(LayersConfig {
+                aggregation: Some(HashMap::from([(
+                    WILDCARD_KEY.to_string(),
+                    LayerAggregationConfig {
+                        order: Some(vec![]),
+                        strategy: None,
+                    },
+                )])),
+            }),
             ..Default::default()
         };
         let resolved = settings.resolve_layers("textDocument/hover");
@@ -1676,17 +1704,19 @@ kind = "injections""#;
     #[test]
     fn resolve_layers_dedups_repeated_layers_first_occurrence_wins() {
         let settings = LanguageSettings {
-            layers: Some(HashMap::from([(
-                WILDCARD_KEY.to_string(),
-                LayerAggregationConfig {
-                    order: Some(vec![
-                        LayerSource::Virt,
-                        LayerSource::Native,
-                        LayerSource::Virt,
-                    ]),
-                    strategy: None,
-                },
-            )])),
+            layers: Some(LayersConfig {
+                aggregation: Some(HashMap::from([(
+                    WILDCARD_KEY.to_string(),
+                    LayerAggregationConfig {
+                        order: Some(vec![
+                            LayerSource::Virt,
+                            LayerSource::Native,
+                            LayerSource::Virt,
+                        ]),
+                        strategy: None,
+                    },
+                )])),
+            }),
             ..Default::default()
         };
         let resolved = settings.resolve_layers("textDocument/hover");

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -543,7 +543,7 @@ impl Kakehashi {
     ) -> Option<DocumentRequestContext> {
         if !self.virt_layer_enabled(&preamble.language_name, method_name) {
             log::debug!(
-                "{}: virt layer disabled for {} via layers.order",
+                "{}: virt layer disabled for {} via layers.aggregation order",
                 method_name,
                 preamble.language_name
             );
@@ -1032,13 +1032,15 @@ mod tests {
         langs.insert(
             "markdown".to_string(),
             LanguageSettings {
-                layers: Some(HashMap::from([(
-                    "textDocument/hover".to_string(),
-                    crate::config::settings::LayerAggregationConfig {
-                        order: Some(vec![LayerSource::Native]),
-                        strategy: None,
-                    },
-                )])),
+                layers: Some(crate::config::settings::LayersConfig {
+                    aggregation: Some(HashMap::from([(
+                        "textDocument/hover".to_string(),
+                        crate::config::settings::LayerAggregationConfig {
+                            order: Some(vec![LayerSource::Native]),
+                            strategy: None,
+                        },
+                    )])),
+                }),
                 ..Default::default()
             },
         );
@@ -1064,13 +1066,15 @@ mod tests {
         langs.insert(
             "_".to_string(),
             LanguageSettings {
-                layers: Some(HashMap::from([(
-                    "_".to_string(),
-                    crate::config::settings::LayerAggregationConfig {
-                        order: Some(vec![]),
-                        strategy: None,
-                    },
-                )])),
+                layers: Some(crate::config::settings::LayersConfig {
+                    aggregation: Some(HashMap::from([(
+                        "_".to_string(),
+                        crate::config::settings::LayerAggregationConfig {
+                            order: Some(vec![]),
+                            strategy: None,
+                        },
+                    )])),
+                }),
                 ..Default::default()
             },
         );

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -127,7 +127,7 @@ impl DiagnosticScheduler {
         {
             log::debug!(
                 target: LOG_TARGET,
-                "virt layer disabled for {} via layers.order",
+                "virt layer disabled for {} via layers.aggregation order",
                 language_name
             );
             return Some(Vec::new());

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -103,7 +103,7 @@ impl Kakehashi {
         if !self.virt_layer_enabled(&language_name, "textDocument/diagnostic") {
             log::debug!(
                 target: "kakehashi::diagnostic",
-                "virt layer disabled for {} via layers.order",
+                "virt layer disabled for {} via layers.aggregation order",
                 language_name
             );
             return Ok(empty_diagnostic_report());

--- a/src/lsp/lsp_impl/text_document/document_color.rs
+++ b/src/lsp/lsp_impl/text_document/document_color.rs
@@ -53,7 +53,7 @@ impl Kakehashi {
         if !self.virt_layer_enabled(&language_name, "textDocument/documentColor") {
             log::debug!(
                 target: "kakehashi::document_color",
-                "virt layer disabled for {} via layers.order",
+                "virt layer disabled for {} via layers.aggregation order",
                 language_name
             );
             return Ok(Vec::new());

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -93,7 +93,7 @@ impl Kakehashi {
             if !self.virt_layer_enabled(&language_name, "textDocument/formatting") {
                 log::debug!(
                     target: "kakehashi::rangeFormatting",
-                    "virt layer disabled for {} via layers.order",
+                    "virt layer disabled for {} via layers.aggregation order",
                     language_name
                 );
                 return Ok(None);

--- a/tests/e2e_host_bridge.rs
+++ b/tests/e2e_host_bridge.rs
@@ -215,7 +215,9 @@ enabled = true
                 "languages": {
                     "markdown": {
                         "layers": {
-                            "textDocument/definition": { "order": ["virt", "native"] }
+                            "aggregation": {
+                                "textDocument/definition": { "order": ["virt", "native"] }
+                            }
                         }
                     }
                 }
@@ -338,7 +340,7 @@ fn e2e_host_formatting_concatenated_threads_virt_then_host() {
 [languages.markdown.bridge._self]
 enabled = true
 
-[languages.markdown.layers."textDocument/formatting"]
+[languages.markdown.layers.aggregation."textDocument/formatting"]
 strategy = "concatenated"
 "#,
     )

--- a/tests/e2e_layers_and_allowlist.rs
+++ b/tests/e2e_layers_and_allowlist.rs
@@ -168,7 +168,9 @@ fn e2e_layers_order_without_virt_disables_bridging() {
                 "languages": {
                     "markdown": {
                         "layers": {
-                            "textDocument/formatting": { "order": ["native"] }
+                            "aggregation": {
+                                "textDocument/formatting": { "order": ["native"] }
+                            }
                         }
                     }
                 }

--- a/tests/e2e_synthetic_push_diagnostic.rs
+++ b/tests/e2e_synthetic_push_diagnostic.rs
@@ -393,7 +393,9 @@ fn e2e_synthetic_push_respects_layers_gate() {
                 "languages": {
                     "markdown": {
                         "layers": {
-                            "textDocument/publishDiagnostics": { "order": ["native"] }
+                            "aggregation": {
+                                "textDocument/publishDiagnostics": { "order": ["native"] }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Moves the cross-layer config from `languages.<lang>.layers.<method>` to `languages.<lang>.layers.aggregation.<method>`, mirroring `bridge.<key>.aggregation`:

- **Uniform convention**: `aggregation` now names the method-keyed map everywhere in the config — `bridge.<lang>.aggregation.<method>` (servers) and `layers.aggregation.<method>` (layers) share the same nesting shape.
- **Extensibility**: the `layers` object gains headroom for future layer-wide fields (e.g. an `enabled` flag) without colliding with the open method-name keyspace.

```toml
# before                                          # after
[languages.markdown.layers."textDocument/formatting"]   [languages.markdown.layers.aggregation."textDocument/formatting"]
strategy = "concatenated"                                strategy = "concatenated"
```

`LanguageSettings.layers` becomes `Option<LayersConfig>` (with an `aggregation` member); resolution, field-level merge (wrapping the per-method deep merge and its empty-means-clear rule), docs, the ADR schema section, and the e2e configs follow.

**Breaking** for the unreleased `layers` feature only (merged in #373, not yet released — agreed to change without compatibility shims). Unknown keys under `layers` are ignored by serde, so an unmigrated config degrades to defaults rather than erroring.

## Test plan

- `cargo test --lib`: 1774 passed (resolution/merge tests updated to the nested shape)
- e2e: host bridge / layers gating / push-diagnostics gating suites green — notably the `strategy = "concatenated"` formatting e2e, which fails under the old key (silent fallback to `preferred` breaks the serial-marker assertion), proving the new key is live end to end
- `cargo clippy --lib --all-features -- -D warnings`: clean