### PR TITLE
feat(cli): add `kakehashi format <paths...>` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,6 +689,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +854,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,6 +1008,7 @@ dependencies = [
  "filetime",
  "flate2",
  "futures",
+ "ignore",
  "indexmap",
  "insta",
  "libloading",
@@ -1666,7 +1696,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,9 @@ serde_json = "1"
 shellexpand = "3"
 similar = "3"
 flate2 = "1"
+# Gitignore-respecting file walker for `kakehashi format <paths...>`; also
+# provides the gitignore-style Override matcher backing --excludes.
+ignore = "0.4"
 # Floor 0.4.46: RUSTSEC-2026-0067/0068 + GHSA-3pv8-6f4r-ffg2 — kakehashi
 # unpacks network-downloaded parser archives, so tar extraction CVEs apply.
 tar = "0.4.46"

--- a/docs/README.md
+++ b/docs/README.md
@@ -558,7 +558,10 @@ kakehashi format . --tab-size 2 --insert-spaces false
 
 Exit codes: `0` nothing to change (or changes written without
 `--fail-on-change`), `1` changes detected under `--check`/`--fail-on-change`,
-`2` usage or I/O error.
+`2` usage error, I/O error, or downstream formatter failure (a configured
+server failed to start, errored on the request, timed out, or returned a
+protocol-invalid response — even when a fallback server still produced
+output).
 
 ## Editor Integration
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -523,6 +523,43 @@ kakehashi config init --output ./kakehashi.toml --force
 
 `--force` only applies when `--output` is used.
 
+### Formatting
+
+`kakehashi format` formats files through the same downstream language servers
+the LSP bridge uses: each injection region (e.g. a fenced code block in
+Markdown) is sent to the servers configured for its language, and the edits
+are applied back to the host file. Configuration comes from the usual config
+files (`./kakehashi.toml` etc.) or `--config-file`.
+
+```bash
+# Format files in place
+kakehashi format README.md docs/
+
+# Directories are walked recursively, respecting .gitignore;
+# explicitly listed files are formatted even when gitignored
+kakehashi format .
+
+# Exclude paths (gitignore-style pattern, repeatable)
+kakehashi format . --excludes vendor/ --excludes "*.gen.md"
+
+# CI: don't write, exit 1 if anything would change
+kakehashi format . --check
+
+# Write changes but exit 1 if anything changed
+kakehashi format . --fail-on-change
+
+# Format stdin (result goes to stdout); the filename drives language detection
+cat README.md | kakehashi format --stdin-filename README.md
+
+# Indentation hints forwarded as LSP FormattingOptions (servers may ignore
+# them in favor of their own config; defaults: --tab-size 4 --insert-spaces true)
+kakehashi format . --tab-size 2 --insert-spaces false
+```
+
+Exit codes: `0` nothing to change (or changes written without
+`--fail-on-change`), `1` changes detected under `--check`/`--fail-on-change`,
+`2` usage or I/O error.
+
 ## Editor Integration
 
 ### Neovim

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -13,8 +13,8 @@ struct Cli {
     #[arg(long, global = true)]
     data_dir: Option<PathBuf>,
 
-    /// Config file(s) to use instead of default locations (LSP mode only).
-    /// Can be specified multiple times; files merge in order.
+    /// Config file(s) to use instead of default locations (LSP and format
+    /// modes). Can be specified multiple times; files merge in order.
     /// Skips ~/.config/kakehashi/kakehashi.toml and ./kakehashi.toml.
     #[arg(long, global = true)]
     config_file: Vec<PathBuf>,
@@ -34,6 +34,40 @@ enum Commands {
     Config {
         #[command(subcommand)]
         action: ConfigAction,
+    },
+    /// Format files via the configured downstream language servers
+    ///
+    /// Directories are walked recursively respecting .gitignore; explicitly
+    /// listed files are formatted even when gitignored.
+    Format {
+        /// Files or directories to format ("-" for stdin with --stdin-filename)
+        paths: Vec<PathBuf>,
+
+        /// Don't write changes; exit 1 if any file would be reformatted
+        #[arg(long)]
+        check: bool,
+
+        /// Read from stdin, treat content as this file path, print result to stdout
+        #[arg(long)]
+        stdin_filename: Option<PathBuf>,
+
+        /// Exclude paths matching this gitignore-style pattern (repeatable)
+        #[arg(long = "excludes")]
+        excludes: Vec<String>,
+
+        /// Write changes, but exit 1 if any file was changed
+        #[arg(long)]
+        fail_on_change: bool,
+
+        /// Indentation-width hint sent to downstream servers
+        /// (LSP FormattingOptions.tabSize; servers may ignore it)
+        #[arg(long, default_value_t = 4)]
+        tab_size: u32,
+
+        /// Prefer-spaces-over-tabs hint sent to downstream servers
+        /// (LSP FormattingOptions.insertSpaces; servers may ignore it)
+        #[arg(long, default_value_t = true, action = clap::ArgAction::Set, num_args = 1)]
+        insert_spaces: bool,
     },
 }
 
@@ -215,6 +249,23 @@ fn main() -> ExitCode {
             ConfigAction::Init { output, force } => run_config_init(output, force),
             ConfigAction::Schema { output, force } => run_config_schema(output, force),
         },
+        Some(Commands::Format {
+            paths,
+            check,
+            stdin_filename,
+            excludes,
+            fail_on_change,
+            tab_size,
+            insert_spaces,
+        }) => run_format(kakehashi::cli::format::FormatOptions {
+            paths,
+            check,
+            stdin_filename,
+            excludes,
+            fail_on_change,
+            tab_size,
+            insert_spaces,
+        }),
         None => {
             // Start LSP server (backward compatible default behavior)
             // Only LSP mode needs a tokio runtime; CLI subcommands are synchronous
@@ -609,6 +660,24 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
     } else {
         eprintln!("\nPartially installed '{}' language support.", language);
         Err(ExitCode::FAILURE)
+    }
+}
+
+/// Run the format command. Formatting goes through the same downstream
+/// language-server bridge as LSP mode, so it builds its own tokio runtime
+/// inside `cli::format::run`.
+fn run_format(options: kakehashi::cli::format::FormatOptions) -> Result<(), ExitCode> {
+    // Logging to stderr, configured via RUST_LOG — same posture as LSP mode
+    // (stdout carries formatted output in stdin mode).
+    env_logger::Builder::from_default_env()
+        .target(env_logger::Target::Stderr)
+        .init();
+
+    let code = kakehashi::cli::format::run(options);
+    if code == 0 {
+        Ok(())
+    } else {
+        Err(ExitCode::from(code))
     }
 }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -223,9 +223,14 @@ fn main() -> ExitCode {
     }
 
     // LSP server mode keeps SIGPIPE ignored so the bridge sees a closed
-    // downstream peer as a recoverable BrokenPipe error; subcommands keep the
+    // downstream peer as a recoverable BrokenPipe error. The format command
+    // drives the same bridge (it writes to downstream language-server
+    // stdin), so it needs the same disposition — otherwise a crashed
+    // downstream server would kill the CLI with SIGPIPE instead of exiting 2
+    // with a useful error; its own stdout writes handle BrokenPipe
+    // explicitly (see `cli::format::run_stdin`). Other subcommands keep the
     // default disposition restored above.
-    if cli.command.is_none() {
+    if matches!(cli.command, None | Some(Commands::Format { .. })) {
         ignore_sigpipe();
     }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -674,7 +674,7 @@ fn run_format(options: kakehashi::cli::format::FormatOptions) -> Result<(), Exit
         .init();
 
     let code = kakehashi::cli::format::run(options);
-    if code == 0 {
+    if code == kakehashi::cli::format::EXIT_OK {
         Ok(())
     } else {
         Err(ExitCode::from(code))

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,8 @@
+//! CLI-mode commands that reuse the LSP server's machinery in-process.
+//!
+//! Unlike the thin install/config subcommands in `src/bin/main.rs`, the
+//! commands here need the full server stack (config loading, parser
+//! registry, injection resolution, downstream language-server bridge), so
+//! they live in the library crate where `pub(crate)` internals are reachable.
+
+pub mod format;

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -164,7 +164,7 @@ async fn run_stdin(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
     } else {
         cwd.join(name)
     };
-    let formatted = server
+    let outcome = server
         .cli_format_text(
             &absolute,
             &text,
@@ -172,9 +172,15 @@ async fn run_stdin(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
             SERVER_READY_TIMEOUT,
         )
         .await;
-    let changed = formatted.as_deref().is_some_and(|f| f != text);
+    for failure in &outcome.server_failures {
+        eprintln!("error: {failure}");
+    }
+    let changed = outcome.formatted.as_deref().is_some_and(|f| f != text);
 
     if options.check {
+        if !outcome.server_failures.is_empty() {
+            return EXIT_ERROR;
+        }
         if changed {
             eprintln!("Would reformat: {}", name.display());
             return EXIT_CHANGED;
@@ -182,7 +188,7 @@ async fn run_stdin(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
         return EXIT_OK;
     }
 
-    let output = match &formatted {
+    let output = match &outcome.formatted {
         Some(f) if changed => f.as_str(),
         _ => text.as_str(),
     };
@@ -190,7 +196,9 @@ async fn run_stdin(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
     use std::io::Write as _;
     let _ = std::io::stdout().flush();
 
-    if changed && options.fail_on_change {
+    if !outcome.server_failures.is_empty() {
+        EXIT_ERROR
+    } else if changed && options.fail_on_change {
         EXIT_CHANGED
     } else {
         EXIT_OK
@@ -215,8 +223,10 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
     };
 
     let mut changed = 0usize;
+    let mut unchanged = 0usize;
     let mut read_errors = 0usize;
     let mut write_errors = 0usize;
+    let mut server_errors = 0usize;
     for file in &files {
         let text = match std::fs::read_to_string(file) {
             Ok(text) => text,
@@ -231,39 +241,48 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
         } else {
             cwd.join(file)
         };
-        let Some(formatted) = server
+        let outcome = server
             .cli_format_text(
                 &absolute,
                 &text,
                 options.formatting_options(),
                 SERVER_READY_TIMEOUT,
             )
-            .await
-        else {
-            continue;
-        };
-        if formatted == text {
-            continue;
+            .await;
+        // A configured-but-broken downstream server means this file's
+        // formatting is incomplete or unverifiable — an error, not
+        // "unchanged" (docs: I/O errors exit 2). Any partial output another
+        // server produced is still applied below.
+        for failure in &outcome.server_failures {
+            eprintln!("error: {}: {failure}", file.display());
         }
-        changed += 1;
-        if options.check {
-            eprintln!("Would reformat: {}", file.display());
-        } else {
-            match write_atomically(file, &formatted) {
-                Ok(()) => eprintln!("Reformatted: {}", file.display()),
-                Err(e) => {
-                    eprintln!("error: cannot write '{}': {e}", file.display());
-                    write_errors += 1;
+        let server_failed = !outcome.server_failures.is_empty();
+        if server_failed {
+            server_errors += 1;
+        }
+        match outcome.formatted {
+            Some(formatted) if formatted != text => {
+                changed += 1;
+                if options.check {
+                    eprintln!("Would reformat: {}", file.display());
+                } else {
+                    match write_atomically(file, &formatted) {
+                        Ok(()) => eprintln!("Reformatted: {}", file.display()),
+                        Err(e) => {
+                            eprintln!("error: cannot write '{}': {e}", file.display());
+                            write_errors += 1;
+                        }
+                    }
                 }
             }
+            // A server-failed file is not "already formatted" — it was never
+            // (fully) inspected; it is reported via server_errors instead.
+            _ if server_failed => {}
+            _ => unchanged += 1,
         }
     }
 
-    // Unreadable files were never inspected by a formatter, so they belong in
-    // neither the changed nor the "already formatted" bucket. (Write-failed
-    // files stay in `changed` — the formatter did produce a change for them.)
-    let unchanged = files.len() - changed - read_errors;
-    let errors = read_errors + write_errors;
+    let errors = read_errors + write_errors + server_errors;
     let error_suffix = if errors > 0 {
         format!(", {errors} error(s)")
     } else {
@@ -301,6 +320,12 @@ fn write_atomically(path: &Path, content: &str) -> std::io::Result<()> {
     let dir = target.parent().filter(|p| !p.as_os_str().is_empty());
     let mut tmp = tempfile::NamedTempFile::new_in(dir.unwrap_or(Path::new(".")))?;
     tmp.write_all(content.as_bytes())?;
+    // The temp file is created with restrictive default permissions (0600 on
+    // Unix); rename would impose those on the target, silently stripping
+    // group/other bits or the executable bit. Carry the target's own mode
+    // over — after writing, so a read-only target mode can't block the write.
+    tmp.as_file()
+        .set_permissions(std::fs::metadata(&target)?.permissions())?;
     tmp.persist(&target).map_err(|e| e.error)?;
     Ok(())
 }
@@ -346,12 +371,12 @@ fn collect_files(
         let metadata = std::fs::metadata(path)
             .map_err(|e| format!("cannot access '{}': {e}", path.display()))?;
         if metadata.is_dir() {
-            if exclude_matcher.matched(path, true).is_ignore() {
+            if is_excluded(&exclude_matcher, path, true) {
                 continue;
             }
             walk_directory(path, &exclude_matcher, is_formattable, &mut files);
         } else {
-            if exclude_matcher.matched(path, false).is_ignore() {
+            if is_excluded(&exclude_matcher, path, false) {
                 continue;
             }
             files.push(path.clone());
@@ -360,6 +385,24 @@ fn collect_files(
     files.sort();
     files.dedup();
     Ok(files)
+}
+
+/// Whether `path` or any of its ancestor directories matches an `--excludes`
+/// pattern.
+///
+/// A directory-only pattern (`vendor/`) never matches a file path directly —
+/// during a walk it works by pruning the directory, but an explicitly listed
+/// file (`kakehashi format vendor/dep.md`) skips the walk, so its ancestors
+/// must be tested as directories too or the documented "excludes filter
+/// everything" contract breaks for exactly that pattern shape.
+fn is_excluded(matcher: &ignore::overrides::Override, path: &Path, is_dir: bool) -> bool {
+    if matcher.matched(path, is_dir).is_ignore() {
+        return true;
+    }
+    path.ancestors()
+        .skip(1)
+        .take_while(|a| !a.as_os_str().is_empty())
+        .any(|a| matcher.matched(a, true).is_ignore())
 }
 
 /// Walk `dir` respecting `.gitignore` and `--excludes`, appending every
@@ -463,6 +506,24 @@ mod tests {
             tmp.path(),
             &[tmp.path().join("dropped.md")],
             &["dropped.md".to_string()],
+            &markdown_only,
+        )
+        .unwrap();
+
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn excludes_directory_pattern_filters_explicit_file_inside() {
+        // "vendor/" is a directory-only pattern: a walk prunes the directory,
+        // but an explicit file skips the walk, so its ancestors must match.
+        let tmp = tempfile::tempdir().unwrap();
+        write(&tmp.path().join("vendor/dep.md"), "x");
+
+        let files = collect_files(
+            tmp.path(),
+            &[tmp.path().join("vendor/dep.md")],
+            &["vendor/".to_string()],
             &markdown_only,
         )
         .unwrap();

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -293,7 +293,10 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
             "{changed} file(s) would be reformatted, {unchanged} already formatted{error_suffix}"
         );
     } else {
-        eprintln!("{changed} file(s) reformatted, {unchanged} unchanged{error_suffix}");
+        // Write failures stay in `changed` for exit-code purposes, but the
+        // summary must not claim a file was reformatted when its write failed.
+        let reformatted = changed - write_errors;
+        eprintln!("{reformatted} file(s) reformatted, {unchanged} unchanged{error_suffix}");
     }
 
     if errors > 0 {

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -148,8 +148,13 @@ async fn run_stdin(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
         .stdin_filename
         .as_ref()
         .expect("run_stdin requires stdin_filename");
-    if options.paths.iter().any(|p| p.as_os_str() != "-") {
-        eprintln!("error: --stdin-filename cannot be combined with file paths");
+    // Documented contract: with --stdin-filename, paths must be empty or
+    // exactly ["-"]; anything else (real paths, or repeated "-") is a usage
+    // error rather than a silently tolerated variant.
+    let stdin_paths_ok = options.paths.is_empty()
+        || (options.paths.len() == 1 && options.paths[0].as_os_str() == "-");
+    if !stdin_paths_ok {
+        eprintln!("error: --stdin-filename accepts no paths (optionally a single \"-\")");
         return EXIT_ERROR;
     }
 
@@ -374,12 +379,12 @@ fn collect_files(
         let metadata = std::fs::metadata(path)
             .map_err(|e| format!("cannot access '{}': {e}", path.display()))?;
         if metadata.is_dir() {
-            if is_excluded(&exclude_matcher, path, true) {
+            if is_excluded(&exclude_matcher, base, path, true) {
                 continue;
             }
             walk_directory(path, &exclude_matcher, is_formattable, &mut files);
         } else {
-            if is_excluded(&exclude_matcher, path, false) {
+            if is_excluded(&exclude_matcher, base, path, false) {
                 continue;
             }
             files.push(path.clone());
@@ -390,19 +395,32 @@ fn collect_files(
     Ok(files)
 }
 
-/// Whether `path` or any of its ancestor directories matches an `--excludes`
-/// pattern.
+/// Whether `path` or any of its ancestor directories *within `base`* matches
+/// an `--excludes` pattern.
 ///
 /// A directory-only pattern (`vendor/`) never matches a file path directly —
 /// during a walk it works by pruning the directory, but an explicitly listed
 /// file (`kakehashi format vendor/dep.md`) skips the walk, so its ancestors
 /// must be tested as directories too or the documented "excludes filter
 /// everything" contract breaks for exactly that pattern shape.
-fn is_excluded(matcher: &ignore::overrides::Override, path: &Path, is_dir: bool) -> bool {
-    if matcher.matched(path, is_dir).is_ignore() {
+///
+/// The path is made relative to `base` first: patterns are defined relative
+/// to the current directory, so ancestors *above* it must not participate —
+/// otherwise running from a directory whose own name matches a pattern
+/// (e.g. `--excludes vendor/` inside a checkout living under `…/vendor/…`)
+/// would exclude every file.
+fn is_excluded(
+    matcher: &ignore::overrides::Override,
+    base: &Path,
+    path: &Path,
+    is_dir: bool,
+) -> bool {
+    let relative = path.strip_prefix(base).unwrap_or(path);
+    if matcher.matched(relative, is_dir).is_ignore() {
         return true;
     }
-    path.ancestors()
+    relative
+        .ancestors()
         .skip(1)
         .take_while(|a| !a.as_os_str().is_empty())
         .any(|a| matcher.matched(a, true).is_ignore())
@@ -532,6 +550,26 @@ mod tests {
         .unwrap();
 
         assert!(files.is_empty());
+    }
+
+    #[test]
+    fn excludes_do_not_match_ancestors_above_the_base() {
+        // Patterns are relative to the current directory: a checkout living
+        // under a directory whose name matches a pattern (here the base is
+        // itself named "vendor") must not have everything excluded.
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("vendor");
+        write(&base.join("kept.md"), "x");
+
+        let files = collect_files(
+            &base,
+            &[base.join("kept.md")],
+            &["vendor/".to_string()],
+            &markdown_only,
+        )
+        .unwrap();
+
+        assert_eq!(files, vec![base.join("kept.md")]);
     }
 
     #[test]

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -739,6 +739,25 @@ mod tests {
     }
 
     #[test]
+    fn explicitly_named_hidden_directory_is_walked() {
+        // The walker's hidden-file filter applies to entries, not to the
+        // walk root: explicitly naming a hidden directory must format its
+        // (non-hidden) contents.
+        let tmp = tempfile::tempdir().unwrap();
+        write(&tmp.path().join(".hidden/doc.md"), "x");
+
+        let files = collect_files(
+            tmp.path(),
+            &[tmp.path().join(".hidden")],
+            &[],
+            &markdown_only,
+        )
+        .unwrap();
+
+        assert_eq!(files, vec![tmp.path().join(".hidden/doc.md")]);
+    }
+
+    #[test]
     fn gitignored_directory_contents_are_formatted_when_directory_is_explicit() {
         // "paths win over gitignore" extends to directories: walking an
         // explicitly named directory starts a fresh walk rooted there, so a

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -328,6 +328,11 @@ fn write_atomically(path: &Path, content: &str) -> std::io::Result<()> {
     let dir = target.parent().filter(|p| !p.as_os_str().is_empty());
     let mut tmp = tempfile::NamedTempFile::new_in(dir.unwrap_or(Path::new(".")))?;
     tmp.write_all(content.as_bytes())?;
+    // Flush file data to disk before the rename: rename atomicity only
+    // guarantees which *name* maps to which inode — without the fsync, a
+    // power loss shortly after the rename could leave the new name pointing
+    // at not-yet-flushed (truncated) data, defeating the crash-safety goal.
+    tmp.as_file().sync_all()?;
     // The temp file is created with restrictive default permissions (0600 on
     // Unix); rename would impose those on the target, silently stripping
     // group/other bits or the executable bit. Carry the target's own mode

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -436,7 +436,14 @@ fn is_excluded(
     path: &Path,
     is_dir: bool,
 ) -> bool {
-    let relative = path.strip_prefix(base).unwrap_or(path);
+    // Patterns are defined relative to `base` (the current directory); a
+    // path outside it has no base-relative form, so no pattern can
+    // meaningfully match it — matching the absolute path instead would let
+    // directories above `base` (and unrelated absolute components) trigger
+    // patterns.
+    let Ok(relative) = path.strip_prefix(base) else {
+        return false;
+    };
     if matcher.matched(relative, is_dir).is_ignore() {
         return true;
     }
@@ -571,6 +578,27 @@ mod tests {
         .unwrap();
 
         assert!(files.is_empty());
+    }
+
+    #[test]
+    fn excludes_do_not_apply_to_paths_outside_the_base() {
+        // A pattern is cwd-relative; an explicit file outside the cwd has no
+        // cwd-relative form, so patterns (here one matching a component of
+        // its absolute path) must not exclude it.
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("workspace");
+        std::fs::create_dir_all(&base).unwrap();
+        write(&tmp.path().join("outside/doc.md"), "x");
+
+        let files = collect_files(
+            &base,
+            &[tmp.path().join("outside/doc.md")],
+            &["outside/".to_string()],
+            &markdown_only,
+        )
+        .unwrap();
+
+        assert_eq!(files, vec![tmp.path().join("outside/doc.md")]);
     }
 
     #[test]

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -67,7 +67,9 @@ pub const EXIT_OK: u8 = 0;
 /// At least one file changed (with `--fail-on-change`) or would change
 /// (with `--check`).
 pub const EXIT_CHANGED: u8 = 1;
-/// Usage or I/O error.
+/// Usage error, I/O error, or downstream formatter failure (a configured
+/// server failed to start, errored on the request, timed out, or returned a
+/// protocol-invalid response).
 pub const EXIT_ERROR: u8 = 2;
 
 /// Per-server bound for waiting on cold downstream language servers. Spawning
@@ -233,22 +235,20 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
     let mut write_errors = 0usize;
     let mut server_errors = 0usize;
     for file in &files {
+        // Collected paths are absolute (normalize_path); report them
+        // cwd-relative so the output stays readable in deep trees.
+        let display = file.strip_prefix(cwd).unwrap_or(file).display();
         let text = match std::fs::read_to_string(file) {
             Ok(text) => text,
             Err(e) => {
-                eprintln!("error: cannot read '{}': {e}", file.display());
+                eprintln!("error: cannot read '{display}': {e}");
                 read_errors += 1;
                 continue;
             }
         };
-        let absolute = if file.is_absolute() {
-            file.clone()
-        } else {
-            cwd.join(file)
-        };
         let outcome = server
             .cli_format_text(
-                &absolute,
+                file,
                 &text,
                 options.formatting_options(),
                 SERVER_READY_TIMEOUT,
@@ -259,7 +259,7 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
         // "unchanged" (docs: I/O errors exit 2). Any partial output another
         // server produced is still applied below.
         for failure in &outcome.server_failures {
-            eprintln!("error: {}: {failure}", file.display());
+            eprintln!("error: {display}: {failure}");
         }
         let server_failed = !outcome.server_failures.is_empty();
         if server_failed {
@@ -269,12 +269,12 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
             Some(formatted) if formatted != text => {
                 changed += 1;
                 if options.check {
-                    eprintln!("Would reformat: {}", file.display());
+                    eprintln!("Would reformat: {display}");
                 } else {
                     match write_atomically(file, &formatted) {
-                        Ok(()) => eprintln!("Reformatted: {}", file.display()),
+                        Ok(()) => eprintln!("Reformatted: {display}"),
                         Err(e) => {
-                            eprintln!("error: cannot write '{}': {e}", file.display());
+                            eprintln!("error: cannot write '{display}': {e}");
                             write_errors += 1;
                         }
                     }
@@ -381,9 +381,11 @@ fn collect_files(
 
     let mut files = Vec::new();
     for path in paths {
-        let metadata = std::fs::metadata(path)
-            .map_err(|e| format!("cannot access '{}': {e}", path.display()))?;
+        // Normalize before stat: a relative path must resolve against
+        // `base`, not against whatever the process cwd happens to be.
         let path = normalize_path(base, path);
+        let metadata = std::fs::metadata(&path)
+            .map_err(|e| format!("cannot access '{}': {e}", path.display()))?;
         if metadata.is_dir() {
             if is_excluded(&exclude_matcher, base, &path, true) {
                 continue;

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -1,0 +1,531 @@
+//! `kakehashi format <paths...>` — format files through the same
+//! injection-region bridge pipeline the LSP server uses.
+//!
+//! The command runs the LSP server in-process (no JSON-RPC framing): it
+//! builds the [`tower_lsp_server::LspService`] the same way `run_lsp_server`
+//! does, then drives `initialize` → `didOpen` → `textDocument/formatting` →
+//! `didClose` by calling the handler implementations directly. This reuses
+//! config loading, language detection, injection resolution, and the
+//! downstream language-server pool verbatim, so CLI formatting can never
+//! drift from editor formatting.
+//!
+//! File selection semantics:
+//! - Directories are walked recursively, **respecting `.gitignore`** (also
+//!   outside git repositories) and skipping hidden files.
+//! - Explicitly listed files are always formatted, even when gitignored —
+//!   naming a path is a stronger signal than a `.gitignore` entry.
+//! - `--excludes` patterns (gitignore syntax, relative to the current
+//!   directory) filter *everything*, including explicitly listed paths.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use tower_lsp_server::LspService;
+
+use crate::lsp::Kakehashi;
+
+/// Options for the `format` subcommand, mirroring its CLI flags.
+pub struct FormatOptions {
+    /// Files or directories to format. With `--stdin-filename`, must be
+    /// empty or exactly `["-"]`.
+    pub paths: Vec<PathBuf>,
+    /// Dry-run: report files that would change, write nothing, exit 1 if
+    /// any file would change.
+    pub check: bool,
+    /// Read content from stdin, treat it as this file path (for language
+    /// detection and config resolution), and print the result to stdout.
+    pub stdin_filename: Option<PathBuf>,
+    /// Gitignore-style exclusion patterns, relative to the current directory.
+    pub excludes: Vec<String>,
+    /// Write changes, but exit 1 if any file was changed.
+    pub fail_on_change: bool,
+    /// `FormattingOptions.tabSize` sent to downstream servers. LSP makes the
+    /// field mandatory; whether to honor it is each server's decision (most
+    /// read their own config instead).
+    pub tab_size: u32,
+    /// `FormattingOptions.insertSpaces` sent to downstream servers; a hint,
+    /// like `tab_size`.
+    pub insert_spaces: bool,
+}
+
+impl FormatOptions {
+    /// The LSP `FormattingOptions` every formatting request carries. In LSP
+    /// mode the editor fills this from its buffer settings; in CLI mode the
+    /// flags (or their defaults) stand in for them.
+    fn formatting_options(&self) -> tower_lsp_server::ls_types::FormattingOptions {
+        tower_lsp_server::ls_types::FormattingOptions {
+            tab_size: self.tab_size,
+            insert_spaces: self.insert_spaces,
+            ..Default::default()
+        }
+    }
+}
+
+/// Exit status of the `format` run, kept as plain `u8` so the binary can map
+/// it onto `std::process::ExitCode` without this module depending on it.
+pub const EXIT_OK: u8 = 0;
+/// At least one file changed (with `--fail-on-change`) or would change
+/// (with `--check`).
+pub const EXIT_CHANGED: u8 = 1;
+/// Usage or I/O error.
+pub const EXIT_ERROR: u8 = 2;
+
+/// Per-server bound for waiting on cold downstream language servers. Spawning
+/// and the LSP initialize handshake usually complete well under a second;
+/// the generous bound covers slow first launches (e.g. an interpreter-based
+/// server warming caches) without hanging an unconfigured run forever.
+const SERVER_READY_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Entry point for `kakehashi format`. Returns the process exit code.
+pub fn run(options: FormatOptions) -> u8 {
+    let runtime = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(e) => {
+            eprintln!("error: failed to start async runtime: {e}");
+            return EXIT_ERROR;
+        }
+    };
+    runtime.block_on(run_async(options))
+}
+
+async fn run_async(options: FormatOptions) -> u8 {
+    let cwd = match std::env::current_dir() {
+        Ok(dir) => dir,
+        Err(e) => {
+            eprintln!("error: cannot determine current directory: {e}");
+            return EXIT_ERROR;
+        }
+    };
+
+    // Same construction as LSP server mode, but the loopback client socket is
+    // pumped by a stub instead of an editor, and handlers are called directly.
+    let (service, socket) = LspService::new(Kakehashi::new);
+    spawn_client_pump(socket);
+    let server = service.inner();
+    server.cli_initialize(&cwd).await;
+
+    let code = if options.stdin_filename.is_some() {
+        run_stdin(server, &cwd, &options).await
+    } else {
+        run_paths(server, &cwd, &options).await
+    };
+
+    // Graceful downstream shutdown even on the error paths above this point
+    // is unnecessary — servers only spawn once formatting starts.
+    server.cli_shutdown().await;
+    code
+}
+
+/// Drain server→client traffic so `Client` calls never block: notifications
+/// (logMessage etc.) are dropped — the CLI reports its own progress — and the
+/// rare server→client *request* (e.g. workDoneProgress/create) is answered
+/// with `null` so the awaiting handler proceeds.
+fn spawn_client_pump(socket: tower_lsp_server::ClientSocket) {
+    use futures::{SinkExt, StreamExt};
+    use tower_lsp_server::jsonrpc::Response;
+
+    let (mut requests, mut responses) = socket.split();
+    tokio::spawn(async move {
+        while let Some(request) = requests.next().await {
+            let (_method, id, _params) = request.into_parts();
+            if let Some(id) = id {
+                let _ = responses
+                    .send(Response::from_parts(id, Ok(serde_json::Value::Null)))
+                    .await;
+            }
+        }
+    });
+}
+
+/// Stdin mode: format stdin as if it were `--stdin-filename`, writing the
+/// result (changed or not) to stdout. `--check` writes nothing and reports
+/// via exit code, mirroring file mode.
+async fn run_stdin(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u8 {
+    let name = options
+        .stdin_filename
+        .as_ref()
+        .expect("run_stdin requires stdin_filename");
+    if options.paths.iter().any(|p| p.as_os_str() != "-") {
+        eprintln!("error: --stdin-filename cannot be combined with file paths");
+        return EXIT_ERROR;
+    }
+
+    let mut text = String::new();
+    if let Err(e) = std::io::Read::read_to_string(&mut std::io::stdin().lock(), &mut text) {
+        eprintln!("error: failed to read stdin: {e}");
+        return EXIT_ERROR;
+    }
+
+    let absolute = if name.is_absolute() {
+        name.clone()
+    } else {
+        cwd.join(name)
+    };
+    let formatted = server
+        .cli_format_text(
+            &absolute,
+            &text,
+            options.formatting_options(),
+            SERVER_READY_TIMEOUT,
+        )
+        .await;
+    let changed = formatted.as_deref().is_some_and(|f| f != text);
+
+    if options.check {
+        if changed {
+            eprintln!("Would reformat: {}", name.display());
+            return EXIT_CHANGED;
+        }
+        return EXIT_OK;
+    }
+
+    let output = match &formatted {
+        Some(f) if changed => f.as_str(),
+        _ => text.as_str(),
+    };
+    print!("{output}");
+    use std::io::Write as _;
+    let _ = std::io::stdout().flush();
+
+    if changed && options.fail_on_change {
+        EXIT_CHANGED
+    } else {
+        EXIT_OK
+    }
+}
+
+/// File mode: expand `paths`, format each file, and write/report per flags.
+async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u8 {
+    if options.paths.is_empty() {
+        eprintln!("error: no paths given; pass files/directories or use --stdin-filename");
+        return EXIT_ERROR;
+    }
+
+    let files = match collect_files(cwd, &options.paths, &options.excludes, &|path| {
+        server.cli_can_format_path(path)
+    }) {
+        Ok(files) => files,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return EXIT_ERROR;
+        }
+    };
+
+    let mut changed = 0usize;
+    let mut had_error = false;
+    for file in &files {
+        let text = match std::fs::read_to_string(file) {
+            Ok(text) => text,
+            Err(e) => {
+                eprintln!("error: cannot read '{}': {e}", file.display());
+                had_error = true;
+                continue;
+            }
+        };
+        let absolute = if file.is_absolute() {
+            file.clone()
+        } else {
+            cwd.join(file)
+        };
+        let Some(formatted) = server
+            .cli_format_text(
+                &absolute,
+                &text,
+                options.formatting_options(),
+                SERVER_READY_TIMEOUT,
+            )
+            .await
+        else {
+            continue;
+        };
+        if formatted == text {
+            continue;
+        }
+        changed += 1;
+        if options.check {
+            eprintln!("Would reformat: {}", file.display());
+        } else {
+            match std::fs::write(file, &formatted) {
+                Ok(()) => eprintln!("Reformatted: {}", file.display()),
+                Err(e) => {
+                    eprintln!("error: cannot write '{}': {e}", file.display());
+                    had_error = true;
+                }
+            }
+        }
+    }
+
+    let unchanged = files.len() - changed;
+    if options.check {
+        eprintln!("{changed} file(s) would be reformatted, {unchanged} already formatted");
+    } else {
+        eprintln!("{changed} file(s) reformatted, {unchanged} unchanged");
+    }
+
+    if had_error {
+        EXIT_ERROR
+    } else if changed > 0 && (options.check || options.fail_on_change) {
+        EXIT_CHANGED
+    } else {
+        EXIT_OK
+    }
+}
+
+/// Build the `--excludes` matcher: gitignore-style patterns rooted at `base`
+/// (the current directory). [`ignore::overrides::Override`] is
+/// whitelist-oriented, so each user pattern is added negated (`!pattern`) to
+/// mean "exclude"; paths matching no pattern pass through.
+fn build_exclude_matcher(
+    base: &Path,
+    excludes: &[String],
+) -> Result<ignore::overrides::Override, ignore::Error> {
+    let mut builder = ignore::overrides::OverrideBuilder::new(base);
+    for pattern in excludes {
+        builder.add(&format!("!{pattern}"))?;
+    }
+    builder.build()
+}
+
+/// Expand `paths` into the list of files to format.
+///
+/// - An explicit file is included unconditionally (bypassing `.gitignore`
+///   and the `is_formattable` filter) unless an `--excludes` pattern
+///   matches it.
+/// - A directory is walked respecting `.gitignore` (even outside a git
+///   repository), hidden-file filtering, and `--excludes`; only files for
+///   which `is_formattable` returns true (language detectable from the
+///   path) are kept.
+/// - A path that does not exist is an error.
+///
+/// The result is sorted and deduplicated for deterministic processing order.
+fn collect_files(
+    base: &Path,
+    paths: &[PathBuf],
+    excludes: &[String],
+    is_formattable: &dyn Fn(&Path) -> bool,
+) -> Result<Vec<PathBuf>, String> {
+    let exclude_matcher = build_exclude_matcher(base, excludes)
+        .map_err(|e| format!("invalid --excludes pattern: {e}"))?;
+
+    let mut files = Vec::new();
+    for path in paths {
+        let metadata = std::fs::metadata(path)
+            .map_err(|e| format!("cannot access '{}': {e}", path.display()))?;
+        if metadata.is_dir() {
+            if exclude_matcher.matched(path, true).is_ignore() {
+                continue;
+            }
+            walk_directory(path, &exclude_matcher, is_formattable, &mut files);
+        } else {
+            if exclude_matcher.matched(path, false).is_ignore() {
+                continue;
+            }
+            files.push(path.clone());
+        }
+    }
+    files.sort();
+    files.dedup();
+    Ok(files)
+}
+
+/// Walk `dir` respecting `.gitignore` and `--excludes`, appending every
+/// formattable file to `out`. Unreadable entries are warned about and
+/// skipped rather than failing the whole run.
+fn walk_directory(
+    dir: &Path,
+    exclude_matcher: &ignore::overrides::Override,
+    is_formattable: &dyn Fn(&Path) -> bool,
+    out: &mut Vec<PathBuf>,
+) {
+    let walker = ignore::WalkBuilder::new(dir)
+        .overrides(exclude_matcher.clone())
+        // Respect .gitignore files even outside a git repository: the
+        // command's contract is "gitignore applies", not "gitignore applies
+        // only when git initialized the directory".
+        .require_git(false)
+        .build();
+    for entry in walker {
+        match entry {
+            Ok(entry) => {
+                if entry.file_type().is_some_and(|t| t.is_file()) && is_formattable(entry.path()) {
+                    out.push(entry.path().to_path_buf());
+                }
+            }
+            Err(e) => {
+                eprintln!("warning: skipping unreadable entry: {e}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, content).unwrap();
+    }
+
+    fn markdown_only(path: &Path) -> bool {
+        path.extension().is_some_and(|e| e == "md")
+    }
+
+    #[test]
+    fn directory_walk_respects_gitignore_without_git_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        write(&tmp.path().join("kept.md"), "x");
+        write(&tmp.path().join("ignored.md"), "x");
+        write(&tmp.path().join(".gitignore"), "ignored.md\n");
+
+        let files =
+            collect_files(tmp.path(), &[tmp.path().to_path_buf()], &[], &markdown_only).unwrap();
+
+        assert_eq!(files, vec![tmp.path().join("kept.md")]);
+    }
+
+    #[test]
+    fn explicit_file_bypasses_gitignore() {
+        let tmp = tempfile::tempdir().unwrap();
+        write(&tmp.path().join("ignored.md"), "x");
+        write(&tmp.path().join(".gitignore"), "ignored.md\n");
+
+        let files = collect_files(
+            tmp.path(),
+            &[tmp.path().join("ignored.md")],
+            &[],
+            &markdown_only,
+        )
+        .unwrap();
+
+        assert_eq!(files, vec![tmp.path().join("ignored.md")]);
+    }
+
+    #[test]
+    fn excludes_filter_walked_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        write(&tmp.path().join("kept.md"), "x");
+        write(&tmp.path().join("dropped.md"), "x");
+
+        let files = collect_files(
+            tmp.path(),
+            &[tmp.path().to_path_buf()],
+            &["dropped.md".to_string()],
+            &markdown_only,
+        )
+        .unwrap();
+
+        assert_eq!(files, vec![tmp.path().join("kept.md")]);
+    }
+
+    #[test]
+    fn excludes_filter_explicit_files_too() {
+        let tmp = tempfile::tempdir().unwrap();
+        write(&tmp.path().join("dropped.md"), "x");
+
+        let files = collect_files(
+            tmp.path(),
+            &[tmp.path().join("dropped.md")],
+            &["dropped.md".to_string()],
+            &markdown_only,
+        )
+        .unwrap();
+
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn excludes_match_directories() {
+        let tmp = tempfile::tempdir().unwrap();
+        write(&tmp.path().join("vendor/dep.md"), "x");
+        write(&tmp.path().join("kept.md"), "x");
+
+        let files = collect_files(
+            tmp.path(),
+            &[tmp.path().to_path_buf()],
+            &["vendor/".to_string()],
+            &markdown_only,
+        )
+        .unwrap();
+
+        assert_eq!(files, vec![tmp.path().join("kept.md")]);
+    }
+
+    #[test]
+    fn directory_walk_keeps_only_formattable_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        write(&tmp.path().join("doc.md"), "x");
+        write(&tmp.path().join("notes.txt"), "x");
+
+        let files =
+            collect_files(tmp.path(), &[tmp.path().to_path_buf()], &[], &markdown_only).unwrap();
+
+        assert_eq!(files, vec![tmp.path().join("doc.md")]);
+    }
+
+    #[test]
+    fn explicit_file_bypasses_formattable_filter() {
+        // Language detection for explicit files happens later from content
+        // (first-line detection), so collection must not drop them by path.
+        let tmp = tempfile::tempdir().unwrap();
+        write(&tmp.path().join("script"), "#!/usr/bin/env lua");
+
+        let files = collect_files(
+            tmp.path(),
+            &[tmp.path().join("script")],
+            &[],
+            &markdown_only,
+        )
+        .unwrap();
+
+        assert_eq!(files, vec![tmp.path().join("script")]);
+    }
+
+    #[test]
+    fn missing_path_is_an_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let result = collect_files(
+            tmp.path(),
+            &[tmp.path().join("no-such-file.md")],
+            &[],
+            &markdown_only,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn duplicates_are_deduplicated() {
+        let tmp = tempfile::tempdir().unwrap();
+        write(&tmp.path().join("doc.md"), "x");
+
+        let files = collect_files(
+            tmp.path(),
+            &[tmp.path().join("doc.md"), tmp.path().to_path_buf()],
+            &[],
+            &markdown_only,
+        )
+        .unwrap();
+
+        assert_eq!(files, vec![tmp.path().join("doc.md")]);
+    }
+
+    #[test]
+    fn gitignored_directory_contents_are_formatted_when_directory_is_explicit() {
+        // "paths win over gitignore" extends to directories: walking an
+        // explicitly named directory starts a fresh walk rooted there, so a
+        // parent rule ignoring the directory itself does not empty it.
+        let tmp = tempfile::tempdir().unwrap();
+        write(&tmp.path().join(".gitignore"), "build/\n");
+        write(&tmp.path().join("build/out.md"), "x");
+
+        let files =
+            collect_files(tmp.path(), &[tmp.path().join("build")], &[], &markdown_only).unwrap();
+
+        assert_eq!(files, vec![tmp.path().join("build/out.md")]);
+    }
+}

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -199,9 +199,20 @@ async fn run_stdin(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
         Some(f) if changed => f.as_str(),
         _ => text.as_str(),
     };
-    print!("{output}");
+    // SIGPIPE is ignored in format mode (the bridge needs BrokenPipe as a
+    // recoverable error), so a consumer that stops reading surfaces here as
+    // a write error instead of killing the process. A broken pipe is the
+    // consumer's normal early exit (`kakehashi format … | head`), not ours.
     use std::io::Write as _;
-    let _ = std::io::stdout().flush();
+    let mut stdout = std::io::stdout().lock();
+    if let Err(e) = stdout
+        .write_all(output.as_bytes())
+        .and_then(|()| stdout.flush())
+        && e.kind() != std::io::ErrorKind::BrokenPipe
+    {
+        eprintln!("error: failed to write stdout: {e}");
+        return EXIT_ERROR;
+    }
 
     if !outcome.server_failures.is_empty() {
         EXIT_ERROR
@@ -340,6 +351,15 @@ fn write_atomically(path: &Path, content: &str) -> std::io::Result<()> {
     tmp.as_file()
         .set_permissions(std::fs::metadata(&target)?.permissions())?;
     tmp.persist(&target).map_err(|e| e.error)?;
+    // Best-effort directory fsync: on some filesystems the rename's
+    // directory-entry update is itself buffered, so without this a power
+    // loss could revert the name to the old inode. The data is already
+    // durable either way (sync_all above), so failure here is not an error.
+    if let Some(dir) = target.parent()
+        && let Ok(dir_handle) = std::fs::File::open(dir)
+    {
+        let _ = dir_handle.sync_all();
+    }
     Ok(())
 }
 

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -290,13 +290,18 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
 /// mid-write (OOM kill, power loss) can never leave a truncated source file
 /// behind. The temp file lives in the target's directory: `persist` renames,
 /// and rename is only atomic within one filesystem.
+///
+/// The path is canonicalized first so a symlinked source file keeps being a
+/// symlink — renaming over the link itself would silently replace it with a
+/// regular file and leave the link's target stale (chezmoi/stow setups).
 fn write_atomically(path: &Path, content: &str) -> std::io::Result<()> {
     use std::io::Write as _;
 
-    let dir = path.parent().filter(|p| !p.as_os_str().is_empty());
+    let target = std::fs::canonicalize(path)?;
+    let dir = target.parent().filter(|p| !p.as_os_str().is_empty());
     let mut tmp = tempfile::NamedTempFile::new_in(dir.unwrap_or(Path::new(".")))?;
     tmp.write_all(content.as_bytes())?;
-    tmp.persist(path).map_err(|e| e.error)?;
+    tmp.persist(&target).map_err(|e| e.error)?;
     Ok(())
 }
 

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -215,13 +215,14 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
     };
 
     let mut changed = 0usize;
-    let mut had_error = false;
+    let mut read_errors = 0usize;
+    let mut write_errors = 0usize;
     for file in &files {
         let text = match std::fs::read_to_string(file) {
             Ok(text) => text,
             Err(e) => {
                 eprintln!("error: cannot read '{}': {e}", file.display());
-                had_error = true;
+                read_errors += 1;
                 continue;
             }
         };
@@ -248,30 +249,55 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
         if options.check {
             eprintln!("Would reformat: {}", file.display());
         } else {
-            match std::fs::write(file, &formatted) {
+            match write_atomically(file, &formatted) {
                 Ok(()) => eprintln!("Reformatted: {}", file.display()),
                 Err(e) => {
                     eprintln!("error: cannot write '{}': {e}", file.display());
-                    had_error = true;
+                    write_errors += 1;
                 }
             }
         }
     }
 
-    let unchanged = files.len() - changed;
-    if options.check {
-        eprintln!("{changed} file(s) would be reformatted, {unchanged} already formatted");
+    // Unreadable files were never inspected by a formatter, so they belong in
+    // neither the changed nor the "already formatted" bucket. (Write-failed
+    // files stay in `changed` — the formatter did produce a change for them.)
+    let unchanged = files.len() - changed - read_errors;
+    let errors = read_errors + write_errors;
+    let error_suffix = if errors > 0 {
+        format!(", {errors} error(s)")
     } else {
-        eprintln!("{changed} file(s) reformatted, {unchanged} unchanged");
+        String::new()
+    };
+    if options.check {
+        eprintln!(
+            "{changed} file(s) would be reformatted, {unchanged} already formatted{error_suffix}"
+        );
+    } else {
+        eprintln!("{changed} file(s) reformatted, {unchanged} unchanged{error_suffix}");
     }
 
-    if had_error {
+    if errors > 0 {
         EXIT_ERROR
     } else if changed > 0 && (options.check || options.fail_on_change) {
         EXIT_CHANGED
     } else {
         EXIT_OK
     }
+}
+
+/// Replace `path`'s content via write-to-temp + atomic rename, so a crash
+/// mid-write (OOM kill, power loss) can never leave a truncated source file
+/// behind. The temp file lives in the target's directory: `persist` renames,
+/// and rename is only atomic within one filesystem.
+fn write_atomically(path: &Path, content: &str) -> std::io::Result<()> {
+    use std::io::Write as _;
+
+    let dir = path.parent().filter(|p| !p.as_os_str().is_empty());
+    let mut tmp = tempfile::NamedTempFile::new_in(dir.unwrap_or(Path::new(".")))?;
+    tmp.write_all(content.as_bytes())?;
+    tmp.persist(path).map_err(|e| e.error)?;
+    Ok(())
 }
 
 /// Build the `--excludes` matcher: gitignore-style patterns rooted at `base`

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -378,21 +378,35 @@ fn collect_files(
     for path in paths {
         let metadata = std::fs::metadata(path)
             .map_err(|e| format!("cannot access '{}': {e}", path.display()))?;
+        let path = normalize_path(base, path);
         if metadata.is_dir() {
-            if is_excluded(&exclude_matcher, base, path, true) {
+            if is_excluded(&exclude_matcher, base, &path, true) {
                 continue;
             }
-            walk_directory(path, &exclude_matcher, is_formattable, &mut files);
+            walk_directory(&path, &exclude_matcher, is_formattable, &mut files);
         } else {
-            if is_excluded(&exclude_matcher, base, path, false) {
+            if is_excluded(&exclude_matcher, base, &path, false) {
                 continue;
             }
-            files.push(path.clone());
+            files.push(path);
         }
     }
     files.sort();
     files.dedup();
     Ok(files)
+}
+
+/// Absolutize `path` against `base` and clean `.`/`..` components, so the
+/// same file always collects to one canonical form — without this, passing
+/// `doc.md` and `/abs/to/doc.md` (or `sub/../doc.md`) together would defeat
+/// `dedup()` and format the file twice.
+fn normalize_path(base: &Path, path: &Path) -> PathBuf {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        base.join(path)
+    };
+    path_clean::clean(absolute)
 }
 
 /// Whether `path` or any of its ancestor directories *within `base`* matches
@@ -639,6 +653,28 @@ mod tests {
         let files = collect_files(
             tmp.path(),
             &[tmp.path().join("doc.md"), tmp.path().to_path_buf()],
+            &[],
+            &markdown_only,
+        )
+        .unwrap();
+
+        assert_eq!(files, vec![tmp.path().join("doc.md")]);
+    }
+
+    #[test]
+    fn duplicates_under_different_spellings_are_deduplicated() {
+        // The same file via a clean path and a `sub/..`-detour must collapse
+        // to one entry, or it would be formatted (and rewritten) twice.
+        let tmp = tempfile::tempdir().unwrap();
+        write(&tmp.path().join("doc.md"), "x");
+        std::fs::create_dir_all(tmp.path().join("sub")).unwrap();
+
+        let files = collect_files(
+            tmp.path(),
+            &[
+                tmp.path().join("doc.md"),
+                tmp.path().join("sub").join("..").join("doc.md"),
+            ],
             &[],
             &markdown_only,
         )

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -752,6 +752,33 @@ impl LanguageCoordinator {
         self.filetype_resolver.language_for_path(path)
     }
 
+    /// Path-only language detection for CLI directory walks
+    /// (`kakehashi format <dir>`), loading the parser on first sight.
+    ///
+    /// [`Self::detect_language`] only accepts a candidate whose parser is
+    /// already **loaded**, which works in LSP mode because `didOpen` loads
+    /// parsers before anything queries the chain — but a directory walk
+    /// filters paths before any document is opened, when the registry is
+    /// still empty. This variant tries to load the candidate (and its
+    /// configured base) from the search paths, so "installed but not yet
+    /// loaded" counts as formattable. Auto-install is never triggered:
+    /// a language whose parser is not installed is silently skipped.
+    pub(crate) fn loadable_language_for_path(&self, path: &str) -> Option<String> {
+        let candidate = self.language_for_path(path).or_else(|| {
+            let token = super::heuristic::extract_token_from_path(path)?;
+            // Normalize via syntect ("md" → "markdown"); fall back to the
+            // raw token for extensions syntect doesn't know but a config
+            // entry (possibly via `base`) might.
+            Some(super::heuristic::detect_from_token(token).unwrap_or_else(|| token.to_string()))
+        })?;
+
+        if self.ensure_language_loaded(&candidate).success {
+            return Some(candidate);
+        }
+        let base = self.resolve_base(&candidate)?;
+        self.ensure_language_loaded(&base).success.then_some(base)
+    }
+
     /// Check if a parser is available for a given language name.
     ///
     /// Used by the detection fallback chain (language-detection-fallback-chain) to determine whether

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -772,6 +772,30 @@ impl LanguageCoordinator {
             Some(super::heuristic::detect_from_token(token).unwrap_or_else(|| token.to_string()))
         })?;
 
+        self.load_candidate_or_base(candidate)
+    }
+
+    /// Like [`Self::loadable_language_for_path`], but falls back to
+    /// first-line content detection (shebang, mode line) for extensionless
+    /// files. `detect_language`'s own first-line stage only accepts
+    /// already-loaded parsers, so an explicit CLI path like a
+    /// `#!/usr/bin/env lua` script would otherwise silently fail detection
+    /// before anything had a chance to load the lua parser.
+    pub(crate) fn loadable_language_for_document(
+        &self,
+        path: &str,
+        content: &str,
+    ) -> Option<String> {
+        if let Some(lang) = self.loadable_language_for_path(path) {
+            return Some(lang);
+        }
+        let candidate = super::heuristic::detect_from_first_line(content)?;
+        self.load_candidate_or_base(candidate)
+    }
+
+    /// Load `candidate` (or its configured base) from the search paths,
+    /// returning the name that actually loaded.
+    fn load_candidate_or_base(&self, candidate: String) -> Option<String> {
         if self.ensure_language_loaded(&candidate).success {
             return Some(candidate);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub(crate) mod analysis;
+pub mod cli;
 pub mod config;
 pub(crate) mod document;
 pub(crate) mod error;

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -541,6 +541,22 @@ impl BridgeCoordinator {
     /// Called immediately after each `tokio::spawn`. The handle is aborted (not
     /// registered) if the entry was removed by a concurrent `cancel_eager_open`,
     /// or its generation doesn't match (a concurrent `supersede` replaced it).
+    /// Whether every eager-open task registered for `uri` has finished
+    /// (no batch counts as finished).
+    ///
+    /// Used by CLI-mode formatting to serialize with eager opens: an
+    /// eager-open task claims each virtual document BEFORE its `didOpen`
+    /// reaches the writer queue (`is_document_opened` is true pre-send), so
+    /// a formatting request issued in that window skips its own `didOpen`
+    /// and overtakes the eager one on the wire. Once the tasks are finished,
+    /// every `didOpen` is enqueued and the single-writer FIFO
+    /// (ls-bridge-message-ordering) keeps later requests behind them.
+    pub(crate) fn eager_open_tasks_finished(&self, uri: &Url) -> bool {
+        self.eager_open_tasks
+            .get(uri)
+            .is_none_or(|batch| batch.handles.iter().all(|h| h.is_finished()))
+    }
+
     fn push_or_abort_eager_open_handle(
         &self,
         uri: &Url,

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -546,6 +546,16 @@ impl BridgeCoordinator {
     /// and overtakes the eager one on the wire. Once the tasks are finished,
     /// every `didOpen` is enqueued and the single-writer FIFO
     /// (ls-bridge-message-ordering) keeps later requests behind them.
+    ///
+    /// Precondition: the `didOpen` that triggered the eager spawn has been
+    /// **awaited to completion** (CLI mode awaits `did_open_impl`, which
+    /// registers every handle before returning). `supersede` inserts an
+    /// empty placeholder batch before the handles are pushed, so a caller
+    /// polling *concurrently with registration* could observe a zero-handle
+    /// batch as "finished"; conversely an empty batch must stay "finished"
+    /// here, because documents with no bridge-capable injections keep zero
+    /// handles forever and treating that as pending would stall them for
+    /// the caller's whole timeout.
     pub(crate) fn eager_open_tasks_finished(&self, uri: &Url) -> bool {
         self.eager_open_tasks
             .get(uri)

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -536,11 +536,6 @@ impl BridgeCoordinator {
         generation
     }
 
-    /// Push an abort handle into an existing entry, or abort it if stale/removed.
-    ///
-    /// Called immediately after each `tokio::spawn`. The handle is aborted (not
-    /// registered) if the entry was removed by a concurrent `cancel_eager_open`,
-    /// or its generation doesn't match (a concurrent `supersede` replaced it).
     /// Whether every eager-open task registered for `uri` has finished
     /// (no batch counts as finished).
     ///
@@ -557,6 +552,11 @@ impl BridgeCoordinator {
             .is_none_or(|batch| batch.handles.iter().all(|h| h.is_finished()))
     }
 
+    /// Push an abort handle into an existing entry, or abort it if stale/removed.
+    ///
+    /// Called immediately after each `tokio::spawn`. The handle is aborted (not
+    /// registered) if the entry was removed by a concurrent `cancel_eager_open`,
+    /// or its generation doesn't match (a concurrent `supersede` replaced it).
     fn push_or_abort_eager_open_handle(
         &self,
         uri: &Url,

--- a/src/lsp/bridge/text_document/formatting.rs
+++ b/src/lsp/bridge/text_document/formatting.rs
@@ -78,22 +78,12 @@ impl LanguageServerPool {
             virtual_content,
             upstream_request_id,
             |virtual_uri, request_id| build_formatting_request(virtual_uri, options, request_id),
+            // The transform promotes error responses, missing results, and
+            // malformed payloads to `Err` (request failure) — only the
+            // no-capability early return above yields `Ok(None)`.
             |response, ctx| {
-                // Promote a JSON-RPC error response to a request failure
-                // (`Err`) instead of collapsing it into the `None` that also
-                // means "no capability": the preferred fan-in counts `Err`s —
-                // CLI mode maps them onto its error exit code, and the editor
-                // path logs them at WARNING severity.
-                if response_has_jsonrpc_error(&response, "textDocument/formatting") {
-                    return Err(io::Error::other(
-                        "downstream server answered textDocument/formatting with an error response",
-                    ));
-                }
-                Ok(transform_formatting_response_to_host(
-                    response,
-                    ctx.offset,
-                    virtual_line_count,
-                ))
+                transform_formatting_response_to_host(response, ctx.offset, virtual_line_count)
+                    .map(Some)
             },
             downstream_id_probe,
         )
@@ -159,11 +149,12 @@ fn build_formatting_request(
 ///
 /// LSP returns `TextEdit[] | null`. A `null` result from a server that handled
 /// the request is the authoritative "no changes / already formatted" signal and
-/// maps to `Some(vec![])`; only a genuinely missing result — a JSON-RPC error
-/// or malformed payload — collapses to `None`. Keeping the two apart is what
-/// lets the concatenated pipeline's capability-based fallback distinguish
-/// "capable server, nothing to change" from "no usable response"
-/// (concatenated-formatting-pipeline Decision point 3.2).
+/// maps to `Ok(vec![])`. A JSON-RPC error response, a success response with no
+/// `result` member (protocol violation), or a `result` that fails to
+/// deserialize as `TextEdit[]` is a request **failure** (`Err`): collapsing it
+/// into the same value as "no capability" would let a broken formatter pass as
+/// "nothing to format" — the fan-in counts `Err`s, which CLI mode maps onto
+/// its error exit code and the editor path logs at WARNING.
 ///
 /// Downstream formatters often emit edits past the virtual EOF (e.g. enforce a
 /// trailing newline) as if it were a real file; the host bytes immediately past
@@ -177,29 +168,35 @@ pub(super) fn transform_formatting_response_to_host(
     mut response: serde_json::Value,
     offset: &RegionOffset,
     virtual_line_count: u32,
-) -> Option<Vec<TextEdit>> {
+) -> io::Result<Vec<TextEdit>> {
     if response_has_jsonrpc_error(&response, "formatting-style request") {
-        return None;
+        return Err(io::Error::other(
+            "downstream server answered the formatting request with an error response",
+        ));
     }
-    let result = response.get_mut("result").map(serde_json::Value::take)?;
+    let Some(result) = response.get_mut("result").map(serde_json::Value::take) else {
+        return Err(io::Error::other(
+            "formatting response carries neither result nor error (protocol violation)",
+        ));
+    };
 
     if result.is_null() {
         // Authoritative "no changes / already formatted" — an empty edit list,
         // not a missing result (see function docs).
-        return Some(Vec::new());
+        return Ok(Vec::new());
     }
 
     // A non-null `result` that fails to deserialize as `Vec<TextEdit>` means
     // the downstream server returned a malformed `textDocument/formatting`
-    // payload (wrong shape, missing fields, etc.). Returning `None` is the
-    // right user-facing behavior — the bridge has no edits to apply — but
-    // silently swallowing the parse error makes this class of bug invisible.
-    // Log it so operators can spot the misbehaving downstream from the log.
+    // payload (wrong shape, missing fields, etc.) — a request failure; the
+    // log keeps the misbehaving downstream diagnosable.
     let mut edits: Vec<TextEdit> = match serde_json::from_value(result) {
         Ok(edits) => edits,
         Err(err) => {
             warn!(target: "kakehashi::bridge", "Failed to deserialize formatting-style result as TextEdit[]: {}", err);
-            return None;
+            return Err(io::Error::other(format!(
+                "malformed formatting result from downstream server: {err}"
+            )));
         }
     };
 
@@ -247,7 +244,7 @@ pub(super) fn transform_formatting_response_to_host(
         translate_virtual_range_to_host(&mut edit.range, offset);
     }
 
-    Some(edits)
+    Ok(edits)
 }
 
 #[cfg(test)]
@@ -398,31 +395,39 @@ mod tests {
     }
 
     #[rstest]
-    #[case::no_result_key(json!({"jsonrpc": "2.0", "id": 42, "error": {"code": -32600, "message": "Invalid Request"}}))]
+    #[case::error_response(json!({"jsonrpc": "2.0", "id": 42, "error": {"code": -32600, "message": "Invalid Request"}}))]
+    #[case::missing_result(json!({"jsonrpc": "2.0", "id": 42}))]
     #[case::malformed_result(json!({"jsonrpc": "2.0", "id": 42, "result": "not_an_array"}))]
-    fn formatting_response_returns_none_for_invalid_response(#[case] response: serde_json::Value) {
+    fn formatting_response_is_a_request_failure_for_invalid_response(
+        #[case] response: serde_json::Value,
+    ) {
+        // Error / missing / malformed must be `Err` (request failure) — not
+        // the no-capability `None` — so the fan-in counts it and CLI mode
+        // can exit non-zero for a broken formatter.
         let transformed =
             transform_formatting_response_to_host(response, &RegionOffset::new(5, 0), UNBOUNDED);
-        assert!(transformed.is_none());
+        assert!(transformed.is_err());
     }
 
     #[test]
     fn formatting_response_null_result_is_authoritative_empty_edit_list() {
         // Per LSP, `null` from a server that handled the request means
         // "no changes / already formatted" — an authoritative answer, not a
-        // missing one. It must come back as Some(vec![]) so callers can tell
-        // it apart from `None` ("no result": error or missing provider), which
-        // the concatenated pipeline's capability fallback depends on (ADR
+        // missing one. It must come back as Ok(vec![]) so callers can tell
+        // it apart from a request failure (`Err`) and from the caller-level
+        // "no capability" `None`, which the concatenated pipeline's
+        // capability fallback depends on (ADR
         // concatenated-formatting-pipeline Decision point 3.2).
         let response = json!({"jsonrpc": "2.0", "id": 42, "result": null});
 
         let transformed =
-            transform_formatting_response_to_host(response, &RegionOffset::new(5, 0), UNBOUNDED);
+            transform_formatting_response_to_host(response, &RegionOffset::new(5, 0), UNBOUNDED)
+                .expect("null result is a handled response, not a failure");
 
         assert_eq!(
             transformed,
-            Some(Vec::new()),
-            "null result must be an authoritative empty edit list, not None"
+            Vec::new(),
+            "null result must be an authoritative empty edit list"
         );
     }
 

--- a/src/lsp/bridge/text_document/formatting.rs
+++ b/src/lsp/bridge/text_document/formatting.rs
@@ -79,11 +79,25 @@ impl LanguageServerPool {
             upstream_request_id,
             |virtual_uri, request_id| build_formatting_request(virtual_uri, options, request_id),
             |response, ctx| {
-                transform_formatting_response_to_host(response, ctx.offset, virtual_line_count)
+                // Promote a JSON-RPC error response to a request failure
+                // (`Err`) instead of collapsing it into the `None` that also
+                // means "no capability": the preferred fan-in counts `Err`s —
+                // CLI mode maps them onto its error exit code, and the editor
+                // path logs them at WARNING severity.
+                if response_has_jsonrpc_error(&response, "textDocument/formatting") {
+                    return Err(io::Error::other(
+                        "downstream server answered textDocument/formatting with an error response",
+                    ));
+                }
+                Ok(transform_formatting_response_to_host(
+                    response,
+                    ctx.offset,
+                    virtual_line_count,
+                ))
             },
             downstream_id_probe,
         )
-        .await
+        .await?
     }
 }
 

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -236,9 +236,20 @@ impl LanguageServerPool {
             doc,
             upstream_request_id,
             |request_id| JsonRpcRequest::new(request_id.as_i64(), method, params),
-            move |response| parse_host_formatting_response(response, method),
+            // Promote a JSON-RPC error response to a request failure (`Err`)
+            // instead of collapsing it into the `None` that also means "no
+            // capability" — mirrors `send_formatting_request`: the fan-in
+            // counts `Err`s, which CLI mode maps onto its error exit code.
+            move |response| {
+                if response_has_jsonrpc_error(&response, method) {
+                    return Err(io::Error::other(format!(
+                        "downstream server answered {method} with an error response"
+                    )));
+                }
+                Ok(parse_host_formatting_response(response, method))
+            },
         )
-        .await
+        .await?
     }
 
     /// Drive a host bridge request end-to-end: register for cancel

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -210,11 +210,14 @@ impl LanguageServerPool {
     }
 
     /// Send a host formatting request. Unlike [`Self::send_host_raw_request`],
-    /// the response keeps formatting's LSP semantics: a `null` result from a
-    /// capable server is the authoritative "no edits needed" signal
-    /// (concatenated-formatting-pipeline) and comes back as `Some(vec![])`,
-    /// distinct from `None` = no capability / error / malformed — only the
-    /// latter should trigger fallback to a lower-priority server.
+    /// the response keeps formatting's LSP semantics, mirroring
+    /// [`Self::send_formatting_request`]: a `null` result from a capable
+    /// server is the authoritative "no edits needed" signal
+    /// (concatenated-formatting-pipeline) and comes back as `Ok(Some(vec![]))`;
+    /// `Ok(None)` means the server does not advertise the capability (the
+    /// only fallback-without-failure case); an error response, a success
+    /// without a `result` member, or a malformed payload is a counted
+    /// request failure (`Err`).
     pub(crate) async fn send_host_formatting_request(
         &self,
         server_name: &str,

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -236,18 +236,12 @@ impl LanguageServerPool {
             doc,
             upstream_request_id,
             |request_id| JsonRpcRequest::new(request_id.as_i64(), method, params),
-            // Promote a JSON-RPC error response to a request failure (`Err`)
-            // instead of collapsing it into the `None` that also means "no
-            // capability" — mirrors `send_formatting_request`: the fan-in
-            // counts `Err`s, which CLI mode maps onto its error exit code.
-            move |response| {
-                if response_has_jsonrpc_error(&response, method) {
-                    return Err(io::Error::other(format!(
-                        "downstream server answered {method} with an error response"
-                    )));
-                }
-                Ok(parse_host_formatting_response(response, method))
-            },
+            // The parser promotes error responses, missing results, and
+            // malformed payloads to `Err` (request failure) — mirrors
+            // `send_formatting_request`: the fan-in counts `Err`s, which CLI
+            // mode maps onto its error exit code. Only the no-capability
+            // early return above yields `Ok(None)`.
+            move |response| parse_host_formatting_response(response, method).map(Some),
         )
         .await?
     }
@@ -389,27 +383,38 @@ fn parse_host_raw_response(
 
 /// Parse a host formatting response with formatting's null semantics:
 /// `null` from a capable server = authoritative "no edits needed" →
-/// `Some(vec![])`; only an error / malformed payload yields `None`
-/// (fallback).
+/// `Ok(vec![])`. An error response, a success response without a `result`
+/// member (protocol violation), or a malformed payload is a request failure
+/// (`Err`), mirroring `transform_formatting_response_to_host` — collapsing
+/// it into the no-capability value would let a broken host formatter pass
+/// as "nothing to format".
 fn parse_host_formatting_response(
     mut response: serde_json::Value,
     method: &'static str,
-) -> Option<Vec<TextEdit>> {
+) -> io::Result<Vec<TextEdit>> {
     if response_has_jsonrpc_error(&response, method) {
-        return None;
+        return Err(io::Error::other(format!(
+            "downstream server answered {method} with an error response"
+        )));
     }
-    let result = response.get_mut("result")?.take();
+    let Some(result) = response.get_mut("result").map(serde_json::Value::take) else {
+        return Err(io::Error::other(format!(
+            "{method} response carries neither result nor error (protocol violation)"
+        )));
+    };
     if result.is_null() {
-        return Some(Vec::new());
+        return Ok(Vec::new());
     }
     match serde_json::from_value::<Vec<TextEdit>>(result) {
-        Ok(edits) => Some(edits),
+        Ok(edits) => Ok(edits),
         Err(e) => {
             log::warn!(
                 target: "kakehashi::bridge",
                 "host formatting response failed to deserialize: {e}"
             );
-            None
+            Err(io::Error::other(format!(
+                "malformed {method} result from downstream server: {e}"
+            )))
         }
     }
 }
@@ -572,14 +577,14 @@ mod tests {
     }
 
     #[test]
-    fn formatting_response_error_falls_through() {
+    fn formatting_response_error_is_a_request_failure() {
         let response = serde_json::json!({
             "jsonrpc": "2.0", "id": 1,
             "error": { "code": -32603, "message": "boom" }
         });
         assert!(
-            parse_host_formatting_response(response, "textDocument/formatting").is_none(),
-            "errors must trigger fallback, unlike null"
+            parse_host_formatting_response(response, "textDocument/formatting").is_err(),
+            "errors must be a counted request failure, unlike null"
         );
     }
 

--- a/src/lsp/bridge/text_document/range_formatting.rs
+++ b/src/lsp/bridge/text_document/range_formatting.rs
@@ -28,8 +28,7 @@ use url::Url;
 
 use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::{
-    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, response_has_jsonrpc_error,
-    translate_host_range_to_virtual,
+    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, translate_host_range_to_virtual,
 };
 use super::formatting::{count_lines, transform_formatting_response_to_host};
 
@@ -88,21 +87,12 @@ impl LanguageServerPool {
                     request_id,
                 )
             },
+            // The transform promotes error responses, missing results, and
+            // malformed payloads to `Err` (request failure) — only the
+            // no-capability early return above yields `Ok(None)`.
             |response, ctx| {
-                // Same error-response promotion as `send_formatting_request`:
-                // an error reply is a request failure (`Err`), not the `None`
-                // that also means "no capability".
-                if response_has_jsonrpc_error(&response, "textDocument/rangeFormatting") {
-                    return Err(io::Error::other(
-                        "downstream server answered textDocument/rangeFormatting \
-                         with an error response",
-                    ));
-                }
-                Ok(transform_formatting_response_to_host(
-                    response,
-                    ctx.offset,
-                    virtual_line_count,
-                ))
+                transform_formatting_response_to_host(response, ctx.offset, virtual_line_count)
+                    .map(Some)
             },
             downstream_id_probe,
         )

--- a/src/lsp/bridge/text_document/range_formatting.rs
+++ b/src/lsp/bridge/text_document/range_formatting.rs
@@ -28,7 +28,8 @@ use url::Url;
 
 use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::{
-    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, translate_host_range_to_virtual,
+    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, response_has_jsonrpc_error,
+    translate_host_range_to_virtual,
 };
 use super::formatting::{count_lines, transform_formatting_response_to_host};
 
@@ -88,11 +89,24 @@ impl LanguageServerPool {
                 )
             },
             |response, ctx| {
-                transform_formatting_response_to_host(response, ctx.offset, virtual_line_count)
+                // Same error-response promotion as `send_formatting_request`:
+                // an error reply is a request failure (`Err`), not the `None`
+                // that also means "no capability".
+                if response_has_jsonrpc_error(&response, "textDocument/rangeFormatting") {
+                    return Err(io::Error::other(
+                        "downstream server answered textDocument/rangeFormatting \
+                         with an error response",
+                    ));
+                }
+                Ok(transform_formatting_response_to_host(
+                    response,
+                    ctx.offset,
+                    virtual_line_count,
+                ))
             },
             downstream_id_probe,
         )
-        .await
+        .await?
     }
 }
 

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -1,4 +1,5 @@
 pub(crate) mod bridge_context;
+mod cli_format;
 mod coordinator;
 mod kakehashi;
 mod lifecycle;

--- a/src/lsp/lsp_impl/cli_format.rs
+++ b/src/lsp/lsp_impl/cli_format.rs
@@ -116,7 +116,16 @@ impl Kakehashi {
         })
         .await;
 
-        let edits = result.ok().flatten()?;
+        // An Err from formatting_impl is currently unreachable in CLI mode
+        // (it only signals upstream cancellation, and there is no upstream
+        // request id here) — but if a future code path introduces one, a
+        // silent "no change" would hide it, so surface it in the log.
+        let edits = result
+            .inspect_err(|e| {
+                log::warn!(target: "kakehashi::cli", "formatting failed for {url}: {e}");
+            })
+            .ok()
+            .flatten()?;
         if edits.is_empty() {
             return None;
         }

--- a/src/lsp/lsp_impl/cli_format.rs
+++ b/src/lsp/lsp_impl/cli_format.rs
@@ -24,6 +24,19 @@ use crate::language::InjectionResolver;
 
 use super::{Kakehashi, url_to_uri};
 
+/// Result of one CLI formatting attempt ([`Kakehashi::cli_format_text`]).
+pub(crate) struct CliFormatOutcome {
+    /// The full formatted text when formatting produced edits; `None` when
+    /// nothing applied (unknown language, no regions, no servers, no edits).
+    pub(crate) formatted: Option<String>,
+    /// Human-readable descriptions of configured downstream servers that
+    /// failed to spawn or initialize within the ready timeout. Non-empty
+    /// means the document's formatting is incomplete or unverifiable — the
+    /// CLI maps this to its error exit code instead of reporting the file
+    /// as "unchanged".
+    pub(crate) server_failures: Vec<String>,
+}
+
 impl Kakehashi {
     /// Run the LSP initialize/initialized lifecycle for CLI mode, loading
     /// configuration from `root` (typically the current directory) exactly
@@ -60,10 +73,13 @@ impl Kakehashi {
             .is_some_and(|p| self.language.loadable_language_for_path(p).is_some())
     }
 
-    /// Format `text` as if it were the document at absolute `path`, returning
-    /// the formatted text — or `None` when no formatting applies (unknown
-    /// language, no injection regions, no configured servers, or the
-    /// formatters returned no edits).
+    /// Format `text` as if it were the document at absolute `path`.
+    ///
+    /// `formatted` is `None` when no formatting applies (unknown language,
+    /// no injection regions, no configured servers, or the formatters
+    /// returned no edits); `server_failures` lists configured downstream
+    /// servers that failed to come up, so the caller can distinguish
+    /// "nothing to do" from "the formatter is broken".
     ///
     /// Downstream servers are spawned cold on the first file; the explicit
     /// ready-wait (bounded by `ready_timeout` per server) keeps a cold start
@@ -75,17 +91,25 @@ impl Kakehashi {
         text: &str,
         formatting_options: FormattingOptions,
         ready_timeout: Duration,
-    ) -> Option<String> {
-        let url = Url::from_file_path(path).ok()?;
-        let lsp_uri = url_to_uri(&url).ok()?;
+    ) -> CliFormatOutcome {
+        let none = CliFormatOutcome {
+            formatted: None,
+            server_failures: Vec::new(),
+        };
+        let Ok(url) = Url::from_file_path(path) else {
+            return none;
+        };
+        let Ok(lsp_uri) = url_to_uri(&url) else {
+            return none;
+        };
 
-        // Path-based detection first: it loads an installed-but-unloaded
-        // parser, which the content-based chain (used second, for shebangs
-        // and mode lines) requires to already be loaded.
+        // Path-based detection first, then first-line content detection —
+        // both via the loading chain, because `detect_language`'s own stages
+        // only accept parsers that are already loaded, and nothing is loaded
+        // before the first didOpen in CLI mode.
         let language_id = self
             .language
-            .loadable_language_for_path(url.path())
-            .or_else(|| self.language.detect_language(url.path(), text, None, None))
+            .loadable_language_for_document(url.path(), text)
             .unwrap_or_default();
 
         self.did_open_impl(DidOpenTextDocumentParams {
@@ -98,7 +122,7 @@ impl Kakehashi {
         })
         .await;
 
-        self.wait_bridge_servers_ready(&url, ready_timeout).await;
+        let server_failures = self.wait_bridge_servers_ready(&url, ready_timeout).await;
         self.wait_eager_open_finished(&url, ready_timeout).await;
 
         let result = self
@@ -120,16 +144,18 @@ impl Kakehashi {
         // (it only signals upstream cancellation, and there is no upstream
         // request id here) — but if a future code path introduces one, a
         // silent "no change" would hide it, so surface it in the log.
-        let edits = result
+        let formatted = result
             .inspect_err(|e| {
                 log::warn!(target: "kakehashi::cli", "formatting failed for {url}: {e}");
             })
             .ok()
-            .flatten()?;
-        if edits.is_empty() {
-            return None;
+            .flatten()
+            .filter(|edits| !edits.is_empty())
+            .map(|edits| crate::text::edit::apply_text_edits(text, &edits));
+        CliFormatOutcome {
+            formatted,
+            server_failures,
         }
-        Some(crate::text::edit::apply_text_edits(text, &edits))
     }
 
     /// Gracefully shut down downstream language servers (LSP shutdown/exit
@@ -166,22 +192,23 @@ impl Kakehashi {
     }
 
     /// Wait (up to `timeout` per server) until every downstream server
-    /// configured for the document's injection regions is Ready.
+    /// configured for the document's injection regions is Ready, returning a
+    /// description of each server that failed to come up.
     ///
     /// `formatting_impl` treats a not-yet-ready server as a failed step and
     /// skips it — correct for an editor where the next request retries, but a
     /// one-shot CLI run would silently produce no edits. Spawning is
     /// idempotent (`get_or_create_connection_wait_ready`), so this overlaps
     /// with the eager-open `didOpen` triggered.
-    async fn wait_bridge_servers_ready(&self, uri: &Url, timeout: Duration) {
+    async fn wait_bridge_servers_ready(&self, uri: &Url, timeout: Duration) -> Vec<String> {
         let Some(language_name) = self.document_language(uri) else {
-            return;
+            return Vec::new();
         };
         let Some(injection_query) = self.language.injection_query(&language_name) else {
-            return;
+            return Vec::new();
         };
         let Some(snapshot) = self.documents.get(uri).and_then(|doc| doc.snapshot()) else {
-            return;
+            return Vec::new();
         };
 
         let regions = InjectionResolver::resolve_all(
@@ -195,6 +222,7 @@ impl Kakehashi {
 
         let pool = self.bridge.pool_arc();
         let mut waited: HashSet<String> = HashSet::new();
+        let mut failures = Vec::new();
         for resolved in regions {
             for config in self
                 .bridge_configs_for_injection_language(&language_name, &resolved.injection_language)
@@ -213,8 +241,13 @@ impl Kakehashi {
                         "downstream server {} not ready: {e}",
                         config.server_name
                     );
+                    failures.push(format!(
+                        "downstream server '{}' failed to start: {e}",
+                        config.server_name
+                    ));
                 }
             }
         }
+        failures
     }
 }

--- a/src/lsp/lsp_impl/cli_format.rs
+++ b/src/lsp/lsp_impl/cli_format.rs
@@ -67,10 +67,13 @@ impl Kakehashi {
     /// Whether the path alone identifies a formattable language (loading the
     /// parser if installed but not yet loaded). Used to filter directory
     /// walks; explicit files skip this (content-based detection still
-    /// applies when they are opened).
+    /// applies when they are opened). Lossy conversion keeps non-UTF-8
+    /// paths eligible for extension matching, consistent with
+    /// [`Self::cli_format_text`].
     pub(crate) fn cli_can_format_path(&self, path: &Path) -> bool {
-        path.to_str()
-            .is_some_and(|p| self.language.loadable_language_for_path(p).is_some())
+        self.language
+            .loadable_language_for_path(&path.to_string_lossy())
+            .is_some()
     }
 
     /// Format `text` as if it were the document at absolute `path`.

--- a/src/lsp/lsp_impl/cli_format.rs
+++ b/src/lsp/lsp_impl/cli_format.rs
@@ -122,17 +122,24 @@ impl Kakehashi {
         })
         .await;
 
-        let server_failures = self.wait_bridge_servers_ready(&url, ready_timeout).await;
+        let mut server_failures = self.wait_bridge_servers_ready(&url, ready_timeout).await;
         self.wait_eager_open_finished(&url, ready_timeout).await;
 
+        // Counts requests that fail AFTER the server came up (crash, error
+        // response, per-step timeout) — the ready-wait above cannot see
+        // those, and without the counter they collapse into "no edits".
+        let request_errors = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let result = self
-            .formatting_impl(DocumentFormattingParams {
-                text_document: TextDocumentIdentifier {
-                    uri: lsp_uri.clone(),
+            .formatting_impl_with_error_sink(
+                DocumentFormattingParams {
+                    text_document: TextDocumentIdentifier {
+                        uri: lsp_uri.clone(),
+                    },
+                    options: formatting_options,
+                    work_done_progress_params: Default::default(),
                 },
-                options: formatting_options,
-                work_done_progress_params: Default::default(),
-            })
+                Some(std::sync::Arc::clone(&request_errors)),
+            )
             .await;
 
         self.did_close_impl(DidCloseTextDocumentParams {
@@ -152,6 +159,14 @@ impl Kakehashi {
             .flatten()
             .filter(|edits| !edits.is_empty())
             .map(|edits| crate::text::edit::apply_text_edits(text, &edits));
+
+        let request_errors = request_errors.load(std::sync::atomic::Ordering::Relaxed);
+        if request_errors > 0 {
+            server_failures.push(format!(
+                "{request_errors} downstream formatting request(s) failed \
+                 (run with RUST_LOG=kakehashi=warn for details)"
+            ));
+        }
         CliFormatOutcome {
             formatted,
             server_failures,

--- a/src/lsp/lsp_impl/cli_format.rs
+++ b/src/lsp/lsp_impl/cli_format.rs
@@ -134,7 +134,16 @@ impl Kakehashi {
         .await;
 
         let mut server_failures = self.wait_bridge_servers_ready(&url, ready_timeout).await;
-        self.wait_eager_open_finished(&url, ready_timeout).await;
+        if !self.wait_eager_open_finished(&url, ready_timeout).await {
+            // Formatting would race the still-pending didOpens (the
+            // downstream server may see an unknown URI and answer null =
+            // "no edits") — report instead of silently mis-reporting
+            // "unchanged".
+            server_failures.push(format!(
+                "eager-open tasks did not finish within {ready_timeout:?}; \
+                 formatting results would be unreliable"
+            ));
+        }
 
         // Counts requests that fail AFTER the server came up (crash, error
         // response, per-step timeout) — the ready-wait above cannot see
@@ -204,7 +213,11 @@ impl Kakehashi {
     /// one-shot CLI run must instead wait the tasks out: once finished,
     /// every `didOpen` is enqueued and the single-writer FIFO keeps the
     /// formatting request behind them.
-    async fn wait_eager_open_finished(&self, uri: &Url, timeout: Duration) {
+    ///
+    /// Returns `false` when the deadline expired with tasks still pending —
+    /// the caller reports that as a failure rather than formatting into the
+    /// race.
+    async fn wait_eager_open_finished(&self, uri: &Url, timeout: Duration) -> bool {
         let deadline = tokio::time::Instant::now() + timeout;
         while !self.bridge.eager_open_tasks_finished(uri) {
             if tokio::time::Instant::now() >= deadline {
@@ -213,10 +226,11 @@ impl Kakehashi {
                     "eager-open tasks for {uri} did not finish within {timeout:?}; \
                      formatting may race their didOpen"
                 );
-                return;
+                return false;
             }
             tokio::time::sleep(Duration::from_millis(5)).await;
         }
+        true
     }
 
     /// Wait (up to `timeout` per server) until every downstream server

--- a/src/lsp/lsp_impl/cli_format.rs
+++ b/src/lsp/lsp_impl/cli_format.rs
@@ -215,54 +215,66 @@ impl Kakehashi {
     }
 
     /// Wait (up to `timeout` per server) until every downstream server
-    /// configured for the document's injection regions is Ready, returning a
-    /// description of each server that failed to come up.
+    /// configured for the document — injection-region (virt) servers and,
+    /// when `bridge._self.enabled`, host-layer servers — is Ready, returning
+    /// a description of each server that failed to come up.
     ///
     /// `formatting_impl` treats a not-yet-ready server as a failed step and
     /// skips it — correct for an editor where the next request retries, but a
-    /// one-shot CLI run would silently produce no edits. Spawning is
-    /// idempotent (`get_or_create_connection_wait_ready`), so this overlaps
-    /// with the eager-open `didOpen` triggered.
+    /// one-shot CLI run would silently produce no edits. Host requests do
+    /// run their own handshake wait inside `get_or_create_connection`, but
+    /// that time is spent inside the request's own budget — pre-warming here
+    /// keeps a slow cold host server from surfacing as a spurious request
+    /// failure. Spawning is idempotent
+    /// (`get_or_create_connection_wait_ready`), so this overlaps with the
+    /// eager-open `didOpen` triggered.
     async fn wait_bridge_servers_ready(&self, uri: &Url, timeout: Duration) -> Vec<String> {
-        let Some(language_name) = self.document_language(uri) else {
-            return Vec::new();
-        };
-        let Some(injection_query) = self.language.injection_query(&language_name) else {
-            return Vec::new();
-        };
-        let Some(snapshot) = self.documents.get(uri).and_then(|doc| doc.snapshot()) else {
-            return Vec::new();
-        };
+        let mut configs = Vec::new();
 
-        let regions = InjectionResolver::resolve_all(
-            &self.language,
-            self.bridge.node_tracker(),
-            uri,
-            snapshot.tree(),
-            snapshot.text(),
-            injection_query.as_ref(),
-        );
+        // Virt layer: servers configured for the document's injection regions.
+        if let Some(language_name) = self.document_language(uri)
+            && let Some(injection_query) = self.language.injection_query(&language_name)
+            && let Some(snapshot) = self.documents.get(uri).and_then(|doc| doc.snapshot())
+        {
+            let regions = InjectionResolver::resolve_all(
+                &self.language,
+                self.bridge.node_tracker(),
+                uri,
+                snapshot.tree(),
+                snapshot.text(),
+                injection_query.as_ref(),
+            );
+            for resolved in regions {
+                configs.extend(self.bridge_configs_for_injection_language(
+                    &language_name,
+                    &resolved.injection_language,
+                ));
+            }
+        }
+
+        // Host layer (bridge._self): resolves to nothing unless opted in.
+        if let Ok(lsp_uri) = url_to_uri(uri)
+            && let Some(ctx) = self.resolve_host_bridge_context(&lsp_uri, "textDocument/formatting")
+        {
+            configs.extend(ctx.configs);
+        }
 
         let pool = self.bridge.pool_arc();
         let mut waited: HashSet<String> = HashSet::new();
         let mut ready_waits = Vec::new();
-        for resolved in regions {
-            for config in self
-                .bridge_configs_for_injection_language(&language_name, &resolved.injection_language)
-            {
-                if waited.insert(config.server_name.clone()) {
-                    let pool = std::sync::Arc::clone(&pool);
-                    ready_waits.push(async move {
-                        let result = pool
-                            .get_or_create_connection_wait_ready(
-                                &config.server_name,
-                                &config.config,
-                                timeout,
-                            )
-                            .await;
-                        (config.server_name, result)
-                    });
-                }
+        for config in configs {
+            if waited.insert(config.server_name.clone()) {
+                let pool = std::sync::Arc::clone(&pool);
+                ready_waits.push(async move {
+                    let result = pool
+                        .get_or_create_connection_wait_ready(
+                            &config.server_name,
+                            &config.config,
+                            timeout,
+                        )
+                        .await;
+                    (config.server_name, result)
+                });
             }
         }
 

--- a/src/lsp/lsp_impl/cli_format.rs
+++ b/src/lsp/lsp_impl/cli_format.rs
@@ -92,24 +92,32 @@ impl Kakehashi {
         formatting_options: FormattingOptions,
         ready_timeout: Duration,
     ) -> CliFormatOutcome {
-        let none = CliFormatOutcome {
+        // A path we cannot express as a URI cannot be opened as an LSP
+        // document at all — report it as a failure (the CLI maps it to its
+        // error exit code) instead of silently skipping the file.
+        let uri_failure = |what: &str| CliFormatOutcome {
             formatted: None,
-            server_failures: Vec::new(),
+            server_failures: vec![format!(
+                "cannot convert path '{}' to {what}",
+                path.display()
+            )],
         };
         let Ok(url) = Url::from_file_path(path) else {
-            return none;
+            return uri_failure("a file URL");
         };
         let Ok(lsp_uri) = url_to_uri(&url) else {
-            return none;
+            return uri_failure("an LSP URI");
         };
 
         // Path-based detection first, then first-line content detection —
         // both via the loading chain, because `detect_language`'s own stages
         // only accept parsers that are already loaded, and nothing is loaded
-        // before the first didOpen in CLI mode.
+        // before the first didOpen in CLI mode. Detect on the raw path, not
+        // `url.path()`: URL paths percent-encode special characters, which
+        // would break extension/filename matching for such files.
         let language_id = self
             .language
-            .loadable_language_for_document(url.path(), text)
+            .loadable_language_for_document(&path.to_string_lossy(), text)
             .unwrap_or_default();
 
         self.did_open_impl(DidOpenTextDocumentParams {
@@ -237,30 +245,39 @@ impl Kakehashi {
 
         let pool = self.bridge.pool_arc();
         let mut waited: HashSet<String> = HashSet::new();
-        let mut failures = Vec::new();
+        let mut ready_waits = Vec::new();
         for resolved in regions {
             for config in self
                 .bridge_configs_for_injection_language(&language_name, &resolved.injection_language)
             {
-                if waited.insert(config.server_name.clone())
-                    && let Err(e) = pool
-                        .get_or_create_connection_wait_ready(
-                            &config.server_name,
-                            &config.config,
-                            timeout,
-                        )
-                        .await
-                {
-                    log::warn!(
-                        target: "kakehashi::cli",
-                        "downstream server {} not ready: {e}",
-                        config.server_name
-                    );
-                    failures.push(format!(
-                        "downstream server '{}' failed to start: {e}",
-                        config.server_name
-                    ));
+                if waited.insert(config.server_name.clone()) {
+                    let pool = std::sync::Arc::clone(&pool);
+                    ready_waits.push(async move {
+                        let result = pool
+                            .get_or_create_connection_wait_ready(
+                                &config.server_name,
+                                &config.config,
+                                timeout,
+                            )
+                            .await;
+                        (config.server_name, result)
+                    });
                 }
+            }
+        }
+
+        // Wait concurrently so several broken servers cost one `timeout`
+        // total, not one each.
+        let mut failures = Vec::new();
+        for (server_name, result) in futures::future::join_all(ready_waits).await {
+            if let Err(e) = result {
+                log::warn!(
+                    target: "kakehashi::cli",
+                    "downstream server {server_name} not ready: {e}"
+                );
+                failures.push(format!(
+                    "downstream server '{server_name}' failed to start: {e}"
+                ));
             }
         }
         failures

--- a/src/lsp/lsp_impl/cli_format.rs
+++ b/src/lsp/lsp_impl/cli_format.rs
@@ -1,0 +1,211 @@
+//! In-process driving of the LSP handlers for `kakehashi format` (CLI mode).
+//!
+//! The CLI runs the same `Kakehashi` instance the editor would talk to, but
+//! calls the handler implementations directly instead of going through
+//! JSON-RPC framing. These wrappers package the per-file lifecycle —
+//! `didOpen` → wait for downstream servers → `textDocument/formatting` →
+//! `didClose` — so `crate::cli::format` never touches server internals.
+//!
+//! Lives under `lsp_impl` (not `crate::cli`) because the ready-wait needs the
+//! private `language` / `documents` / `bridge` fields.
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::time::Duration;
+
+use tower_lsp_server::ls_types::{
+    DidCloseTextDocumentParams, DidOpenTextDocumentParams, DocumentFormattingParams,
+    FormattingOptions, InitializeParams, InitializedParams, TextDocumentIdentifier,
+    TextDocumentItem, WorkspaceFolder,
+};
+use url::Url;
+
+use crate::language::InjectionResolver;
+
+use super::{Kakehashi, url_to_uri};
+
+impl Kakehashi {
+    /// Run the LSP initialize/initialized lifecycle for CLI mode, loading
+    /// configuration from `root` (typically the current directory) exactly
+    /// like an editor session rooted there would.
+    pub(crate) async fn cli_initialize(&self, root: &Path) {
+        let workspace_folders = Url::from_file_path(root)
+            .ok()
+            .and_then(|url| url_to_uri(&url).ok())
+            .map(|uri| {
+                vec![WorkspaceFolder {
+                    uri,
+                    name: root
+                        .file_name()
+                        .map(|n| n.to_string_lossy().into_owned())
+                        .unwrap_or_else(|| "workspace".to_string()),
+                }]
+            });
+        let params = InitializeParams {
+            workspace_folders,
+            ..Default::default()
+        };
+        if let Err(e) = self.initialize_impl(params).await {
+            log::warn!(target: "kakehashi::cli", "initialize failed: {e}");
+        }
+        self.initialized_impl(InitializedParams {}).await;
+    }
+
+    /// Whether the path alone identifies a formattable language (loading the
+    /// parser if installed but not yet loaded). Used to filter directory
+    /// walks; explicit files skip this (content-based detection still
+    /// applies when they are opened).
+    pub(crate) fn cli_can_format_path(&self, path: &Path) -> bool {
+        path.to_str()
+            .is_some_and(|p| self.language.loadable_language_for_path(p).is_some())
+    }
+
+    /// Format `text` as if it were the document at absolute `path`, returning
+    /// the formatted text — or `None` when no formatting applies (unknown
+    /// language, no injection regions, no configured servers, or the
+    /// formatters returned no edits).
+    ///
+    /// Downstream servers are spawned cold on the first file; the explicit
+    /// ready-wait (bounded by `ready_timeout` per server) keeps a cold start
+    /// from being misread as "nothing to format" — the race editor clients
+    /// paper over by retrying.
+    pub(crate) async fn cli_format_text(
+        &self,
+        path: &Path,
+        text: &str,
+        formatting_options: FormattingOptions,
+        ready_timeout: Duration,
+    ) -> Option<String> {
+        let url = Url::from_file_path(path).ok()?;
+        let lsp_uri = url_to_uri(&url).ok()?;
+
+        // Path-based detection first: it loads an installed-but-unloaded
+        // parser, which the content-based chain (used second, for shebangs
+        // and mode lines) requires to already be loaded.
+        let language_id = self
+            .language
+            .loadable_language_for_path(url.path())
+            .or_else(|| self.language.detect_language(url.path(), text, None, None))
+            .unwrap_or_default();
+
+        self.did_open_impl(DidOpenTextDocumentParams {
+            text_document: TextDocumentItem {
+                uri: lsp_uri.clone(),
+                language_id,
+                version: 1,
+                text: text.to_string(),
+            },
+        })
+        .await;
+
+        self.wait_bridge_servers_ready(&url, ready_timeout).await;
+        self.wait_eager_open_finished(&url, ready_timeout).await;
+
+        let result = self
+            .formatting_impl(DocumentFormattingParams {
+                text_document: TextDocumentIdentifier {
+                    uri: lsp_uri.clone(),
+                },
+                options: formatting_options,
+                work_done_progress_params: Default::default(),
+            })
+            .await;
+
+        self.did_close_impl(DidCloseTextDocumentParams {
+            text_document: TextDocumentIdentifier { uri: lsp_uri },
+        })
+        .await;
+
+        let edits = result.ok().flatten()?;
+        if edits.is_empty() {
+            return None;
+        }
+        Some(crate::text::edit::apply_text_edits(text, &edits))
+    }
+
+    /// Gracefully shut down downstream language servers (LSP shutdown/exit
+    /// handshake, escalating for unresponsive ones).
+    pub(crate) async fn cli_shutdown(&self) {
+        let _ = self.shutdown_impl().await;
+    }
+
+    /// Wait (up to `timeout`) until the eager-open tasks `didOpen` spawned
+    /// for this document have finished.
+    ///
+    /// An eager-open task claims each region's virtual document BEFORE its
+    /// `didOpen` reaches the writer queue, so a formatting request issued in
+    /// that window skips its own `didOpen` (already claimed) and overtakes
+    /// the eager one on the wire — the downstream server then sees an
+    /// unknown URI and answers `null`, which the preferred fan-in accepts as
+    /// authoritative "no edits". Editors retry past this cold-start race; a
+    /// one-shot CLI run must instead wait the tasks out: once finished,
+    /// every `didOpen` is enqueued and the single-writer FIFO keeps the
+    /// formatting request behind them.
+    async fn wait_eager_open_finished(&self, uri: &Url, timeout: Duration) {
+        let deadline = tokio::time::Instant::now() + timeout;
+        while !self.bridge.eager_open_tasks_finished(uri) {
+            if tokio::time::Instant::now() >= deadline {
+                log::warn!(
+                    target: "kakehashi::cli",
+                    "eager-open tasks for {uri} did not finish within {timeout:?}; \
+                     formatting may race their didOpen"
+                );
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    }
+
+    /// Wait (up to `timeout` per server) until every downstream server
+    /// configured for the document's injection regions is Ready.
+    ///
+    /// `formatting_impl` treats a not-yet-ready server as a failed step and
+    /// skips it — correct for an editor where the next request retries, but a
+    /// one-shot CLI run would silently produce no edits. Spawning is
+    /// idempotent (`get_or_create_connection_wait_ready`), so this overlaps
+    /// with the eager-open `didOpen` triggered.
+    async fn wait_bridge_servers_ready(&self, uri: &Url, timeout: Duration) {
+        let Some(language_name) = self.document_language(uri) else {
+            return;
+        };
+        let Some(injection_query) = self.language.injection_query(&language_name) else {
+            return;
+        };
+        let Some(snapshot) = self.documents.get(uri).and_then(|doc| doc.snapshot()) else {
+            return;
+        };
+
+        let regions = InjectionResolver::resolve_all(
+            &self.language,
+            self.bridge.node_tracker(),
+            uri,
+            snapshot.tree(),
+            snapshot.text(),
+            injection_query.as_ref(),
+        );
+
+        let pool = self.bridge.pool_arc();
+        let mut waited: HashSet<String> = HashSet::new();
+        for resolved in regions {
+            for config in self
+                .bridge_configs_for_injection_language(&language_name, &resolved.injection_language)
+            {
+                if waited.insert(config.server_name.clone())
+                    && let Err(e) = pool
+                        .get_or_create_connection_wait_ready(
+                            &config.server_name,
+                            &config.config,
+                            timeout,
+                        )
+                        .await
+                {
+                    log::warn!(
+                        target: "kakehashi::cli",
+                        "downstream server {} not ready: {e}",
+                        config.server_name
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/lsp/lsp_impl/cli_format.rs
+++ b/src/lsp/lsp_impl/cli_format.rs
@@ -173,8 +173,10 @@ impl Kakehashi {
 
         let request_errors = request_errors.load(std::sync::atomic::Ordering::Relaxed);
         if request_errors > 0 {
+            // "operation(s)": the counter also covers capability-probe
+            // failures and pipeline step timeouts, not just request errors.
             server_failures.push(format!(
-                "{request_errors} downstream formatting request(s) failed \
+                "{request_errors} downstream formatting operation(s) failed \
                  (run with RUST_LOG=kakehashi=warn for details)"
             ));
         }

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -477,6 +477,13 @@ impl Kakehashi {
 /// ready-wait. `None` in LSP mode, where failed requests are log-only
 /// because the editor retries; `Some` in CLI mode, where a one-shot run
 /// must map them onto a non-zero exit instead of "nothing changed".
+///
+/// Counts **observed** failures only, by design: a request abandoned
+/// because a racing layer or higher-priority server already won (its future
+/// dropped mid-flight by `race_layers_preferred` or the preferred fan-in)
+/// was *cancelled*, not failed — it never produced a verdict, and counting
+/// it would require draining every loser to completion, trading the race's
+/// latency win for accounting of requests whose outcome no longer matters.
 pub(crate) type RequestErrorSink = Option<Arc<std::sync::atomic::AtomicUsize>>;
 
 /// Add `n` request failures to the sink, if one is installed.

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -407,13 +407,19 @@ impl Kakehashi {
 
         let cancel_rx = cancel_state.derive_receiver();
         let pool = self.bridge.pool_arc();
+        // Source-level error counting, mirroring the virt preferred dispatch:
+        // `Done` discards the fan-in's error count, so counting here is what
+        // keeps a failed-but-rescued host formatter visible to CLI mode.
+        let request_error_sink = cancel_state.request_error_sink.clone();
         let result = crate::lsp::aggregation::server::dispatch_host_preferred(
             &ctx,
             pool.clone(),
             move |t| {
                 let params = params.clone();
+                let request_error_sink = request_error_sink.clone();
                 async move {
-                    t.pool
+                    let result = t
+                        .pool
                         .send_host_formatting_request(
                             &t.server_name,
                             &t.server_config,
@@ -426,7 +432,11 @@ impl Kakehashi {
                             params,
                             t.upstream_id,
                         )
-                        .await
+                        .await;
+                    if result.is_err() {
+                        count_request_errors(&request_error_sink, 1);
+                    }
+                    result
                 }
             },
             // `Some(vec![])` (and a capable server's `null`, normalized to it)
@@ -444,8 +454,9 @@ impl Kakehashi {
         match result {
             FanInResult::Done(value) => Ok(value),
             FanInResult::NoResult { errors } => {
+                // Request errors were already counted at the source (the
+                // dispatch closure above); this arm only chooses log severity.
                 if errors > 0 {
-                    count_request_errors(&cancel_state.request_error_sink, errors);
                     self.client
                         .log_message(
                             tower_lsp_server::ls_types::MessageType::WARNING,
@@ -680,8 +691,15 @@ async fn dispatch_preferred_formatting(
         pool,
         move |t| {
             let options = options.clone();
+            // Count request failures at the SOURCE, not from the fan-in
+            // verdict: `FanInResult::Done` discards the error count, so a
+            // failed higher-priority formatter rescued by a fallback server
+            // would otherwise go unreported and a CLI run would exit 0
+            // despite a broken configured formatter.
+            let request_error_sink = request_error_sink.clone();
             async move {
-                t.pool
+                let result = t
+                    .pool
                     .send_formatting_request(
                         &t.server_name,
                         &t.server_config,
@@ -694,7 +712,11 @@ async fn dispatch_preferred_formatting(
                         t.upstream_id,
                         None,
                     )
-                    .await
+                    .await;
+                if result.is_err() {
+                    count_request_errors(&request_error_sink, 1);
+                }
+                result
             }
         },
         // `Some(vec![])` is an authoritative "no edits needed" from the
@@ -710,11 +732,7 @@ async fn dispatch_preferred_formatting(
     .await;
     match result {
         FanInResult::Done(edits) => edits,
-        FanInResult::NoResult { errors } => {
-            count_request_errors(&request_error_sink, errors);
-            None
-        }
-        FanInResult::Cancelled => None,
+        FanInResult::NoResult { .. } | FanInResult::Cancelled => None,
     }
 }
 

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -56,6 +56,21 @@ impl Kakehashi {
         &self,
         params: DocumentFormattingParams,
     ) -> Result<Option<Vec<TextEdit>>> {
+        self.formatting_impl_with_error_sink(params, None).await
+    }
+
+    /// [`Self::formatting_impl`] with an optional request-failure counter.
+    ///
+    /// In LSP mode failed downstream requests are log-only — the editor
+    /// simply retries — so `formatting_impl` passes `None`. CLI mode is
+    /// one-shot: without the counter, a ready server that then fails its
+    /// formatting request (crash, error response, timeout) is
+    /// indistinguishable from "nothing to format" and would exit 0.
+    pub(crate) async fn formatting_impl_with_error_sink(
+        &self,
+        params: DocumentFormattingParams,
+        request_error_sink: RequestErrorSink,
+    ) -> Result<Option<Vec<TextEdit>>> {
         let lsp_uri = params.text_document.uri;
         let options = params.options;
 
@@ -91,7 +106,8 @@ impl Kakehashi {
         let layer_cfg = self.resolve_layer_config(&language_name, "textDocument/formatting");
 
         let upstream_request_id = crate::lsp::current_upstream_id();
-        let cancel_state = self.setup_formatting_cancel_token(upstream_request_id.as_ref());
+        let mut cancel_state = self.setup_formatting_cancel_token(upstream_request_id.as_ref());
+        cancel_state.request_error_sink = request_error_sink;
         let original = snapshot.text().to_string();
 
         let result = match layer_cfg.strategy {
@@ -331,6 +347,7 @@ impl Kakehashi {
             let pool = Arc::clone(&pool);
             let options = options.clone();
             let region_cancel_rx = cancel_state.derive_receiver();
+            let request_error_sink = cancel_state.request_error_sink.clone();
 
             outer_join_set.spawn(async move {
                 if let Some((servers, host_line_prefixes)) = pipeline {
@@ -341,6 +358,7 @@ impl Kakehashi {
                         servers,
                         host_line_prefixes,
                         region_cancel_rx,
+                        request_error_sink,
                     )
                     .await
                 } else {
@@ -349,6 +367,7 @@ impl Kakehashi {
                         pool.clone(),
                         options,
                         region_cancel_rx,
+                        request_error_sink,
                     )
                     .await
                 }
@@ -426,6 +445,7 @@ impl Kakehashi {
             FanInResult::Done(value) => Ok(value),
             FanInResult::NoResult { errors } => {
                 if errors > 0 {
+                    count_request_errors(&cancel_state.request_error_sink, errors);
                     self.client
                         .log_message(
                             tower_lsp_server::ls_types::MessageType::WARNING,
@@ -437,6 +457,23 @@ impl Kakehashi {
             }
             FanInResult::Cancelled => Err(tower_lsp_server::jsonrpc::Error::request_cancelled()),
         }
+    }
+}
+
+/// Optional counter for downstream formatting requests that failed at
+/// request time (I/O error, error response, per-step timeout) — as opposed
+/// to startup failures, which CLI mode detects separately via its
+/// ready-wait. `None` in LSP mode, where failed requests are log-only
+/// because the editor retries; `Some` in CLI mode, where a one-shot run
+/// must map them onto a non-zero exit instead of "nothing changed".
+pub(crate) type RequestErrorSink = Option<Arc<std::sync::atomic::AtomicUsize>>;
+
+/// Add `n` request failures to the sink, if one is installed.
+fn count_request_errors(sink: &RequestErrorSink, n: usize) {
+    if n > 0
+        && let Some(sink) = sink
+    {
+        sink.fetch_add(n, std::sync::atomic::Ordering::Relaxed);
     }
 }
 
@@ -636,6 +673,7 @@ async fn dispatch_preferred_formatting(
     pool: Arc<crate::lsp::bridge::LanguageServerPool>,
     options: tower_lsp_server::ls_types::FormattingOptions,
     region_cancel_rx: Option<CancelReceiver>,
+    request_error_sink: RequestErrorSink,
 ) -> Option<Vec<TextEdit>> {
     let result = dispatch_preferred(
         region_ctx,
@@ -672,7 +710,11 @@ async fn dispatch_preferred_formatting(
     .await;
     match result {
         FanInResult::Done(edits) => edits,
-        FanInResult::NoResult { .. } | FanInResult::Cancelled => None,
+        FanInResult::NoResult { errors } => {
+            count_request_errors(&request_error_sink, errors);
+            None
+        }
+        FanInResult::Cancelled => None,
     }
 }
 
@@ -735,6 +777,7 @@ async fn dispatch_concatenated_formatting(
     // point 4, `reapply_host_line_prefixes`).
     host_line_prefixes: Vec<String>,
     cancel_rx: Option<CancelReceiver>,
+    request_error_sink: RequestErrorSink,
 ) -> Option<Vec<TextEdit>> {
     let offset = RegionOffset::with_per_line_offsets(
         region_ctx.resolved.region.line_range.start,
@@ -827,6 +870,7 @@ async fn dispatch_concatenated_formatting(
             let budget_exhaustion_warned = Arc::clone(&budget_exhaustion_warned);
             let host_uri_lsp = host_uri_lsp.clone();
             let open_scratch = Arc::clone(&open_scratch);
+            let request_error_sink = request_error_sink.clone();
             async move {
                 // No config for this server name: skip-and-continue, handing the
                 // unchanged text back to the pipeline (ADR Decision point 6).
@@ -907,6 +951,7 @@ async fn dispatch_concatenated_formatting(
                                 server_name,
                                 e
                             );
+                            count_request_errors(&request_error_sink, 1);
                             return None;
                         }
                     };
@@ -1028,6 +1073,7 @@ async fn dispatch_concatenated_formatting(
                                 server_name,
                                 e
                             );
+                            count_request_errors(&request_error_sink, 1);
                             None
                         }
                     }
@@ -1058,6 +1104,7 @@ async fn dispatch_concatenated_formatting(
                             server_name,
                             step_budget
                         );
+                        count_request_errors(&request_error_sink, 1);
                         if let Some(downstream_id) = step_downstream_id.get().copied() {
                             let pool = Arc::clone(&pool);
                             let server_name = server_name.clone();
@@ -1542,6 +1589,11 @@ pub(super) struct FormattingCancelState<'a> {
     /// from the cancel forwarder. `None` when there is no upstream
     /// subscription to manage.
     _guard: Option<CancelSubscriptionGuard<'a>>,
+    /// CLI-mode counter for request-time downstream failures (see
+    /// [`RequestErrorSink`]); `None` in LSP mode. Carried here because it
+    /// shares the cancel state's lifecycle: one per formatting request,
+    /// cloned into every per-region dispatcher.
+    request_error_sink: RequestErrorSink,
 }
 
 impl<'a> FormattingCancelState<'a> {
@@ -1586,6 +1638,7 @@ impl Kakehashi {
         FormattingCancelState {
             token,
             _guard: guard,
+            request_error_sink: None,
         }
     }
 }

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -23,6 +23,10 @@
 //!   it received via `didOpen`. Used by `tests/e2e_host_bridge.rs` to prove
 //!   the host bridge forwards the real client URI and returns the response
 //!   verbatim (host-document-bridge).
+//! - `options-echo` — advertises `documentFormattingProvider`; replaces the
+//!   text with a line echoing the received `FormattingOptions` (`tabSize`,
+//!   `insertSpaces`), so tests can assert the options a client sent actually
+//!   reach the downstream server (e.g. `kakehashi format --tab-size`).
 //!
 //! Only built for E2E runs (`required-features = ["e2e"]` in Cargo.toml).
 
@@ -136,11 +140,12 @@ fn main() {
                 respond(&mut writer, id, result);
             }
             "textDocument/formatting" | "textDocument/rangeFormatting" => {
+                let options = message.pointer("/params/options").cloned();
                 let result = message
                     .pointer("/params/textDocument/uri")
                     .and_then(Value::as_str)
                     .and_then(|uri| documents.get(uri))
-                    .map(|text| whole_document_edit(text, &mode))
+                    .map(|text| whole_document_edit(text, &mode, options.as_ref()))
                     .unwrap_or(Value::Null);
                 respond(&mut writer, id, result);
             }
@@ -158,7 +163,7 @@ fn main() {
 /// Apply the mode's transformation and wrap it in a single whole-document
 /// `TextEdit[]`. The end position stays within the document's real line
 /// count (the bridge drops edits past the virtual EOF).
-fn whole_document_edit(text: &str, mode: &str) -> Value {
+fn whole_document_edit(text: &str, mode: &str, options: Option<&Value>) -> Value {
     let new_text = match mode {
         "append" => {
             // Keep the trailing newline shape so the host document's closing
@@ -167,6 +172,17 @@ fn whole_document_edit(text: &str, mode: &str) -> Value {
                 Some(stripped) => format!("{stripped}\n-- mock-marker\n"),
                 None => format!("{text}\n-- mock-marker"),
             }
+        }
+        "options-echo" => {
+            let tab_size = options
+                .and_then(|o| o.get("tabSize"))
+                .map(Value::to_string)
+                .unwrap_or_else(|| "missing".to_string());
+            let insert_spaces = options
+                .and_then(|o| o.get("insertSpaces"))
+                .map(Value::to_string)
+                .unwrap_or_else(|| "missing".to_string());
+            format!("-- tabSize={tab_size} insertSpaces={insert_spaces}\n")
         }
         // "upper" and "range-upper"
         _ => text.to_uppercase(),

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -27,6 +27,10 @@
 //!   text with a line echoing the received `FormattingOptions` (`tabSize`,
 //!   `insertSpaces`), so tests can assert the options a client sent actually
 //!   reach the downstream server (e.g. `kakehashi format --tab-size`).
+//! - `fail-request` — advertises `documentFormattingProvider`, handshakes
+//!   normally, then answers every formatting request with a JSON-RPC error.
+//!   Exercises the request-time failure path (vs. a server that never
+//!   starts), which `kakehashi format` must report instead of exiting 0.
 //!
 //! Only built for E2E runs (`required-features = ["e2e"]` in Cargo.toml).
 
@@ -140,6 +144,13 @@ fn main() {
                 respond(&mut writer, id, result);
             }
             "textDocument/formatting" | "textDocument/rangeFormatting" => {
+                if mode == "fail-request" {
+                    // Healthy handshake, broken request: exercises the
+                    // request-time failure path (vs. a server that never
+                    // starts), which clients must not read as "no edits".
+                    respond_error(&mut writer, id, -32603, "mock formatter request failure");
+                    continue;
+                }
                 let options = message.pointer("/params/options").cloned();
                 let result = message
                     .pointer("/params/textDocument/uri")
@@ -229,6 +240,21 @@ fn respond<W: Write>(writer: &mut W, id: Option<Value>, result: Value) {
         return;
     };
     let body = json!({ "jsonrpc": "2.0", "id": id, "result": result }).to_string();
+    let _ = write!(writer, "Content-Length: {}\r\n\r\n{body}", body.len());
+    let _ = writer.flush();
+}
+
+/// Send a JSON-RPC error response (`fail-request` mode).
+fn respond_error<W: Write>(writer: &mut W, id: Option<Value>, code: i64, message: &str) {
+    let Some(id) = id else {
+        return;
+    };
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": { "code": code, "message": message }
+    })
+    .to_string();
     let _ = write!(writer, "Content-Length: {}\r\n\r\n{body}", body.len());
     let _ = writer.flush();
 }

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -31,6 +31,10 @@
 //!   normally, then answers every formatting request with a JSON-RPC error.
 //!   Exercises the request-time failure path (vs. a server that never
 //!   starts), which `kakehashi format` must report instead of exiting 0.
+//! - `malformed` — advertises `documentFormattingProvider`, handshakes
+//!   normally, then answers formatting with a JSON-RPC *success* whose
+//!   `result` is not a `TextEdit[]`. Exercises the malformed-payload
+//!   request-failure path.
 //!
 //! Only built for E2E runs (`required-features = ["e2e"]` in Cargo.toml).
 
@@ -149,6 +153,13 @@ fn main() {
                     // request-time failure path (vs. a server that never
                     // starts), which clients must not read as "no edits".
                     respond_error(&mut writer, id, -32603, "mock formatter request failure");
+                    continue;
+                }
+                if mode == "malformed" {
+                    // JSON-RPC success whose result is not TextEdit[]: a
+                    // protocol-invalid formatter that must count as a request
+                    // failure, not as "no edits".
+                    respond(&mut writer, id, json!("not-a-textedit-array"));
                     continue;
                 }
                 let options = message.pointer("/params/options").cloned();

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -373,6 +373,44 @@ languages = ["lua"]
     );
 }
 
+#[test]
+fn e2e_request_time_server_failure_exits_with_error() {
+    // The server handshakes fine but errors on the formatting request —
+    // distinct from never starting; must also exit 2, not "unchanged"/0.
+    let ws = workspace_with(&[("doc.md", MARKDOWN)]);
+    std::fs::write(
+        ws.path().join("kakehashi.toml"),
+        format!(
+            r#"autoInstall = false
+
+[languageServers.mock-fail]
+cmd = ["{}", "fail-request"]
+languages = ["lua"]
+"#,
+            env!("CARGO_BIN_EXE_mock-lsp-formatter")
+        ),
+    )
+    .expect("write fail-request config");
+
+    let output = run_format(ws.path(), &["doc.md"]);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "a request-time downstream failure must exit 2; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("request(s) failed"),
+        "stderr should report the failed request; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        read(ws.path(), "doc.md"),
+        MARKDOWN,
+        "the file must be left untouched"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn e2e_format_preserves_file_permissions() {

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -412,6 +412,47 @@ languages = ["lua"]
 }
 
 #[test]
+fn e2e_failed_formatter_rescued_by_fallback_still_exits_with_error() {
+    // Preferred fan-out: the priority server errors, the fallback formats.
+    // The file gets the fallback's output, but the broken configured
+    // formatter must still surface as exit 2 — otherwise CI never learns
+    // the primary formatter is broken.
+    let ws = workspace_with(&[("doc.md", MARKDOWN)]);
+    std::fs::write(
+        ws.path().join("kakehashi.toml"),
+        format!(
+            r#"autoInstall = false
+
+[languages.markdown.bridge.lua.aggregation."textDocument/formatting"]
+priorities = ["mock-fail", "mock-upper"]
+
+[languageServers.mock-fail]
+cmd = ["{bin}", "fail-request"]
+languages = ["lua"]
+
+[languageServers.mock-upper]
+cmd = ["{bin}", "upper"]
+languages = ["lua"]
+"#,
+            bin = env!("CARGO_BIN_EXE_mock-lsp-formatter")
+        ),
+    )
+    .expect("write fail+fallback config");
+
+    let output = run_format(ws.path(), &["doc.md"]);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "a failed formatter must exit 2 even when a fallback rescued the file; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        read(ws.path(), "doc.md").contains("LOCAL X = 1"),
+        "the fallback formatter's output is still written"
+    );
+}
+
+#[test]
 fn e2e_host_layer_request_failure_exits_with_error() {
     // Same request-time failure, but through the HOST layer
     // (bridge._self.enabled): the host fan-in must also count the error

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -1,0 +1,311 @@
+//! E2E tests for the `kakehashi format` CLI subcommand.
+//!
+//! Spawns the real `kakehashi` binary with a workspace-local `kakehashi.toml`
+//! that bridges lua injections to the `mock-lsp-formatter` test binary
+//! (`upper` mode: uppercases the region), then asserts on exit codes and
+//! on-disk effects for the plain, `--check`, `--fail-on-change`, stdin, and
+//! gitignore-walk behaviors.
+
+#![cfg(feature = "e2e")]
+
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::sync::OnceLock;
+
+/// Shared persistent data dir with markdown/lua parsers preinstalled (same
+/// one the LSP e2e suite uses; see `tests/helpers/lsp_client.rs`).
+fn data_dir() -> &'static Path {
+    static DIR: OnceLock<PathBuf> = OnceLock::new();
+    let dir = DIR.get_or_init(|| {
+        let dir = kakehashi::install::test_support::test_data_dir_path();
+        let _ = std::fs::create_dir_all(&dir);
+        let _ = kakehashi::install::test_support::ensure_test_languages_installed(&dir);
+        dir
+    });
+    // Clear crash-recovery state before every spawn so an earlier test's
+    // mid-parse shutdown can't poison this one.
+    let _ = std::fs::remove_file(dir.join("parsing_in_progress"));
+    let _ = std::fs::remove_file(dir.join("failed_parsers"));
+    dir.as_path()
+}
+
+/// Workspace config bridging lua injections to the uppercasing mock server.
+fn config_toml() -> String {
+    format!(
+        r#"autoInstall = false
+
+[languageServers.mock-upper]
+cmd = ["{}", "upper"]
+languages = ["lua"]
+"#,
+        env!("CARGO_BIN_EXE_mock-lsp-formatter")
+    )
+}
+
+const MARKDOWN: &str = "# Test\n\n```lua\nlocal x = 1\n```\n";
+
+/// Create a workspace tempdir holding `kakehashi.toml` plus `files`.
+fn workspace_with(files: &[(&str, &str)]) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("create workspace tempdir");
+    std::fs::write(dir.path().join("kakehashi.toml"), config_toml()).expect("write config");
+    for (name, content) in files {
+        let path = dir.path().join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent dirs");
+        }
+        std::fs::write(path, content).expect("write workspace file");
+    }
+    dir
+}
+
+/// Run `kakehashi format <args>` with the workspace as cwd. The workspace
+/// `kakehashi.toml` is passed via `--config-file` so the developer's own
+/// `~/.config/kakehashi/kakehashi.toml` can never leak into the test (it
+/// would e.g. add host-layer servers like marksman to the formatting race).
+fn run_format(workspace: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .arg("format")
+        .arg("--config-file")
+        .arg("kakehashi.toml")
+        .args(args)
+        .current_dir(workspace)
+        .env("KAKEHASHI_DATA_DIR", data_dir())
+        .env("RUST_LOG", "kakehashi=debug")
+        .output()
+        .expect("spawn kakehashi format")
+}
+
+fn read(workspace: &Path, name: &str) -> String {
+    std::fs::read_to_string(workspace.join(name)).expect("read workspace file")
+}
+
+#[test]
+fn e2e_format_rewrites_file_in_place_and_is_idempotent() {
+    let ws = workspace_with(&[("doc.md", MARKDOWN)]);
+
+    let output = run_format(ws.path(), &["doc.md"]);
+    assert!(
+        output.status.success(),
+        "format should succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let formatted = read(ws.path(), "doc.md");
+    assert!(
+        formatted.contains("LOCAL X = 1"),
+        "lua region should be uppercased by the mock formatter; got: {formatted:?}; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        formatted.contains("```lua"),
+        "host markdown around the region must be preserved; got: {formatted:?}"
+    );
+
+    // Second run: the mock's output is a fixpoint, so nothing changes and
+    // even --fail-on-change passes.
+    let output = run_format(ws.path(), &["doc.md", "--fail-on-change"]);
+    assert!(
+        output.status.success(),
+        "second run should be a no-op; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(read(ws.path(), "doc.md"), formatted);
+}
+
+#[test]
+fn e2e_check_reports_without_writing() {
+    let ws = workspace_with(&[("doc.md", MARKDOWN)]);
+
+    let output = run_format(ws.path(), &["doc.md", "--check"]);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "--check must exit 1 for an unformatted file; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        read(ws.path(), "doc.md"),
+        MARKDOWN,
+        "--check must not modify the file"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Would reformat"),
+        "--check should name the file; stderr: {stderr}"
+    );
+
+    // Format for real, then --check passes.
+    let output = run_format(ws.path(), &["doc.md"]);
+    assert!(output.status.success());
+    let output = run_format(ws.path(), &["doc.md", "--check"]);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "--check must exit 0 once formatted; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn e2e_fail_on_change_writes_and_exits_nonzero() {
+    let ws = workspace_with(&[("doc.md", MARKDOWN)]);
+
+    let output = run_format(ws.path(), &["doc.md", "--fail-on-change"]);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "--fail-on-change must exit 1 when a file changed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        read(ws.path(), "doc.md").contains("LOCAL X = 1"),
+        "--fail-on-change still writes the change"
+    );
+}
+
+#[test]
+fn e2e_stdin_mode_prints_formatted_content() {
+    let ws = workspace_with(&[]);
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "format",
+            "--config-file",
+            "kakehashi.toml",
+            "--stdin-filename",
+            "doc.md",
+        ])
+        .current_dir(ws.path())
+        .env("KAKEHASHI_DATA_DIR", data_dir())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn kakehashi format (stdin mode)");
+    child
+        .stdin
+        .take()
+        .expect("stdin piped")
+        .write_all(MARKDOWN.as_bytes())
+        .expect("write stdin");
+    let output = child.wait_with_output().expect("wait for kakehashi");
+
+    assert!(
+        output.status.success(),
+        "stdin mode should succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("LOCAL X = 1"),
+        "formatted content goes to stdout; got: {stdout:?}"
+    );
+}
+
+#[test]
+fn e2e_directory_walk_respects_gitignore_but_explicit_path_wins() {
+    let ws = workspace_with(&[
+        ("kept.md", MARKDOWN),
+        ("ignored.md", MARKDOWN),
+        (".gitignore", "ignored.md\n"),
+    ]);
+
+    let output = run_format(ws.path(), &["."]);
+    assert!(
+        output.status.success(),
+        "directory format should succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        read(ws.path(), "kept.md").contains("LOCAL X = 1"),
+        "non-ignored file is formatted"
+    );
+    assert_eq!(
+        read(ws.path(), "ignored.md"),
+        MARKDOWN,
+        "gitignored file is skipped by the walk"
+    );
+
+    // Explicitly naming the gitignored file formats it anyway.
+    let output = run_format(ws.path(), &["ignored.md"]);
+    assert!(
+        output.status.success(),
+        "explicit gitignored path should format; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        read(ws.path(), "ignored.md").contains("LOCAL X = 1"),
+        "explicitly named path wins over gitignore"
+    );
+}
+
+#[test]
+fn e2e_tab_size_and_insert_spaces_reach_the_downstream_server() {
+    // Workspace whose mock server echoes the FormattingOptions it received.
+    let ws = workspace_with(&[("doc.md", MARKDOWN)]);
+    std::fs::write(
+        ws.path().join("kakehashi.toml"),
+        format!(
+            r#"autoInstall = false
+
+[languageServers.mock-echo]
+cmd = ["{}", "options-echo"]
+languages = ["lua"]
+"#,
+            env!("CARGO_BIN_EXE_mock-lsp-formatter")
+        ),
+    )
+    .expect("write options-echo config");
+
+    // Defaults: tabSize=4, insertSpaces=true.
+    let output = run_format(ws.path(), &["doc.md"]);
+    assert!(
+        output.status.success(),
+        "format should succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let formatted = read(ws.path(), "doc.md");
+    assert!(
+        formatted.contains("tabSize=4 insertSpaces=true"),
+        "defaults should reach the downstream server; got: {formatted:?}; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Explicit flags override the defaults.
+    std::fs::write(ws.path().join("doc.md"), MARKDOWN).expect("reset doc.md");
+    let output = run_format(
+        ws.path(),
+        &["doc.md", "--tab-size", "2", "--insert-spaces", "false"],
+    );
+    assert!(
+        output.status.success(),
+        "format with options should succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let formatted = read(ws.path(), "doc.md");
+    assert!(
+        formatted.contains("tabSize=2 insertSpaces=false"),
+        "--tab-size/--insert-spaces should reach the downstream server; got: {formatted:?}"
+    );
+}
+
+#[test]
+fn e2e_excludes_filters_directory_walk() {
+    let ws = workspace_with(&[("kept.md", MARKDOWN), ("vendor/dep.md", MARKDOWN)]);
+
+    let output = run_format(ws.path(), &[".", "--excludes", "vendor/"]);
+    assert!(
+        output.status.success(),
+        "directory format should succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        read(ws.path(), "kept.md").contains("LOCAL X = 1"),
+        "non-excluded file is formatted"
+    );
+    assert_eq!(
+        read(ws.path(), "vendor/dep.md"),
+        MARKDOWN,
+        "--excludes pattern skips matching paths"
+    );
+}

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -163,10 +163,9 @@ fn e2e_fail_on_change_writes_and_exits_nonzero() {
     );
 }
 
-#[test]
-fn e2e_stdin_mode_prints_formatted_content() {
-    let ws = workspace_with(&[]);
-
+/// Run `kakehashi format --stdin-filename doc.md <extra args>` feeding
+/// `MARKDOWN` on stdin.
+fn run_format_stdin(workspace: &Path, extra_args: &[&str]) -> Output {
     let mut child = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
         .args([
             "format",
@@ -175,7 +174,8 @@ fn e2e_stdin_mode_prints_formatted_content() {
             "--stdin-filename",
             "doc.md",
         ])
-        .current_dir(ws.path())
+        .args(extra_args)
+        .current_dir(workspace)
         .env("KAKEHASHI_DATA_DIR", data_dir())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -188,7 +188,14 @@ fn e2e_stdin_mode_prints_formatted_content() {
         .expect("stdin piped")
         .write_all(MARKDOWN.as_bytes())
         .expect("write stdin");
-    let output = child.wait_with_output().expect("wait for kakehashi");
+    child.wait_with_output().expect("wait for kakehashi")
+}
+
+#[test]
+fn e2e_stdin_mode_prints_formatted_content() {
+    let ws = workspace_with(&[]);
+
+    let output = run_format_stdin(ws.path(), &[]);
 
     assert!(
         output.status.success(),
@@ -199,6 +206,48 @@ fn e2e_stdin_mode_prints_formatted_content() {
     assert!(
         stdout.contains("LOCAL X = 1"),
         "formatted content goes to stdout; got: {stdout:?}"
+    );
+}
+
+#[test]
+fn e2e_stdin_check_keeps_stdout_clean_and_exits_nonzero() {
+    let ws = workspace_with(&[]);
+
+    let output = run_format_stdin(ws.path(), &["--check"]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "--check on unformatted stdin must exit 1; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "--check must not write content to stdout; got: {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("Would reformat"),
+        "--check should name the stdin file on stderr; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn e2e_stdin_fail_on_change_prints_content_and_exits_nonzero() {
+    let ws = workspace_with(&[]);
+
+    let output = run_format_stdin(ws.path(), &["--fail-on-change"]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "--fail-on-change on changed stdin must exit 1; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("LOCAL X = 1"),
+        "--fail-on-change still prints the formatted content to stdout"
     );
 }
 

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -19,8 +19,9 @@ fn data_dir() -> &'static Path {
     static DIR: OnceLock<PathBuf> = OnceLock::new();
     let dir = DIR.get_or_init(|| {
         let dir = kakehashi::install::test_support::test_data_dir_path();
-        let _ = std::fs::create_dir_all(&dir);
-        let _ = kakehashi::install::test_support::ensure_test_languages_installed(&dir);
+        std::fs::create_dir_all(&dir).expect("create shared test data dir");
+        kakehashi::install::test_support::ensure_test_languages_installed(&dir)
+            .expect("install test parsers into the shared data dir");
         dir
     });
     // Clear crash-recovery state before every spawn so an earlier test's

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -411,6 +411,43 @@ languages = ["lua"]
     );
 }
 
+#[test]
+fn e2e_host_layer_request_failure_exits_with_error() {
+    // Same request-time failure, but through the HOST layer
+    // (bridge._self.enabled): the host fan-in must also count the error
+    // response so the CLI exits 2.
+    let ws = workspace_with(&[("doc.md", MARKDOWN)]);
+    std::fs::write(
+        ws.path().join("kakehashi.toml"),
+        format!(
+            r#"autoInstall = false
+
+[languages.markdown.bridge._self]
+enabled = true
+
+[languageServers.mock-fail-host]
+cmd = ["{}", "fail-request"]
+languages = ["markdown"]
+"#,
+            env!("CARGO_BIN_EXE_mock-lsp-formatter")
+        ),
+    )
+    .expect("write host fail-request config");
+
+    let output = run_format(ws.path(), &["doc.md"]);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "a host-layer request failure must exit 2; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        read(ws.path(), "doc.md"),
+        MARKDOWN,
+        "the file must be left untouched"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn e2e_format_preserves_file_permissions() {

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -400,7 +400,7 @@ languages = ["lua"]
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
-        String::from_utf8_lossy(&output.stderr).contains("request(s) failed"),
+        String::from_utf8_lossy(&output.stderr).contains("operation(s) failed"),
         "stderr should report the failed request; stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -453,6 +453,46 @@ languages = ["lua"]
 }
 
 #[test]
+fn e2e_malformed_formatter_response_exits_with_error() {
+    // A protocol-invalid success (result is not TextEdit[]) is a request
+    // failure too: the fallback still formats the file, but the run must
+    // exit 2 so the broken formatter surfaces.
+    let ws = workspace_with(&[("doc.md", MARKDOWN)]);
+    std::fs::write(
+        ws.path().join("kakehashi.toml"),
+        format!(
+            r#"autoInstall = false
+
+[languages.markdown.bridge.lua.aggregation."textDocument/formatting"]
+priorities = ["mock-malformed", "mock-upper"]
+
+[languageServers.mock-malformed]
+cmd = ["{bin}", "malformed"]
+languages = ["lua"]
+
+[languageServers.mock-upper]
+cmd = ["{bin}", "upper"]
+languages = ["lua"]
+"#,
+            bin = env!("CARGO_BIN_EXE_mock-lsp-formatter")
+        ),
+    )
+    .expect("write malformed+fallback config");
+
+    let output = run_format(ws.path(), &["doc.md"]);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "a malformed formatter response must exit 2; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        read(ws.path(), "doc.md").contains("LOCAL X = 1"),
+        "the fallback formatter's output is still written"
+    );
+}
+
+#[test]
 fn e2e_host_layer_request_failure_exits_with_error() {
     // Same request-time failure, but through the HOST layer
     // (bridge._self.enabled): the host fan-in must also count the error

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -36,7 +36,7 @@ fn config_toml() -> String {
         r#"autoInstall = false
 
 [languageServers.mock-upper]
-cmd = ["{}", "upper"]
+cmd = ['{}', 'upper']
 languages = ["lua"]
 "#,
         env!("CARGO_BIN_EXE_mock-lsp-formatter")
@@ -298,7 +298,7 @@ fn e2e_tab_size_and_insert_spaces_reach_the_downstream_server() {
             r#"autoInstall = false
 
 [languageServers.mock-echo]
-cmd = ["{}", "options-echo"]
+cmd = ['{}', 'options-echo']
 languages = ["lua"]
 "#,
             env!("CARGO_BIN_EXE_mock-lsp-formatter")
@@ -384,7 +384,7 @@ fn e2e_request_time_server_failure_exits_with_error() {
             r#"autoInstall = false
 
 [languageServers.mock-fail]
-cmd = ["{}", "fail-request"]
+cmd = ['{}', 'fail-request']
 languages = ["lua"]
 "#,
             env!("CARGO_BIN_EXE_mock-lsp-formatter")
@@ -427,11 +427,11 @@ fn e2e_failed_formatter_rescued_by_fallback_still_exits_with_error() {
 priorities = ["mock-fail", "mock-upper"]
 
 [languageServers.mock-fail]
-cmd = ["{bin}", "fail-request"]
+cmd = ['{bin}', 'fail-request']
 languages = ["lua"]
 
 [languageServers.mock-upper]
-cmd = ["{bin}", "upper"]
+cmd = ['{bin}', 'upper']
 languages = ["lua"]
 "#,
             bin = env!("CARGO_BIN_EXE_mock-lsp-formatter")
@@ -467,11 +467,11 @@ fn e2e_malformed_formatter_response_exits_with_error() {
 priorities = ["mock-malformed", "mock-upper"]
 
 [languageServers.mock-malformed]
-cmd = ["{bin}", "malformed"]
+cmd = ['{bin}', 'malformed']
 languages = ["lua"]
 
 [languageServers.mock-upper]
-cmd = ["{bin}", "upper"]
+cmd = ['{bin}', 'upper']
 languages = ["lua"]
 "#,
             bin = env!("CARGO_BIN_EXE_mock-lsp-formatter")
@@ -507,7 +507,7 @@ fn e2e_host_layer_request_failure_exits_with_error() {
 enabled = true
 
 [languageServers.mock-fail-host]
-cmd = ["{}", "fail-request"]
+cmd = ['{}', 'fail-request']
 languages = ["markdown"]
 "#,
             env!("CARGO_BIN_EXE_mock-lsp-formatter")

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -339,6 +339,65 @@ languages = ["lua"]
 }
 
 #[test]
+fn e2e_broken_downstream_server_exits_with_error() {
+    // A configured-but-unstartable formatter must surface as exit 2, not as
+    // a silent "0 file(s) reformatted" success (docs: I/O errors exit 2).
+    let ws = workspace_with(&[("doc.md", MARKDOWN)]);
+    std::fs::write(
+        ws.path().join("kakehashi.toml"),
+        r#"autoInstall = false
+
+[languageServers.broken]
+cmd = ["/nonexistent/kakehashi-test-formatter"]
+languages = ["lua"]
+"#,
+    )
+    .expect("write broken-server config");
+
+    let output = run_format(ws.path(), &["doc.md"]);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "a broken configured server must exit 2; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("failed to start"),
+        "stderr should name the broken server; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        read(ws.path(), "doc.md"),
+        MARKDOWN,
+        "the file must be left untouched"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn e2e_format_preserves_file_permissions() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let ws = workspace_with(&[("doc.md", MARKDOWN)]);
+    let path = ws.path().join("doc.md");
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o754))
+        .expect("set permissions");
+
+    let output = run_format(ws.path(), &["doc.md"]);
+    assert!(
+        output.status.success(),
+        "format should succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(read(ws.path(), "doc.md").contains("LOCAL X = 1"));
+    let mode = std::fs::metadata(&path).expect("stat").permissions().mode() & 0o777;
+    assert_eq!(
+        mode, 0o754,
+        "atomic write must carry the original permissions over"
+    );
+}
+
+#[test]
 fn e2e_excludes_filters_directory_walk() {
     let ws = workspace_with(&[("kept.md", MARKDOWN), ("vendor/dep.md", MARKDOWN)]);
 


### PR DESCRIPTION
## Summary

Adds a `kakehashi format <paths...>` CLI subcommand that formats files through the same downstream language-server bridge the LSP server uses: the command runs the server in-process (`initialize` → `didOpen` → `textDocument/formatting` → `didClose` via direct handler calls), so CLI results can never drift from editor results.

### File selection
- Directories are walked recursively with the `ignore` crate, **respecting `.gitignore`** (also outside git repos) and skipping hidden files
- **Explicitly listed paths win over gitignore** (naming a path is a stronger signal than an ignore entry); explicitly named gitignored *directories* are walked as fresh roots
- `--excludes <pattern>` (gitignore syntax, repeatable) filters everything — including explicit paths and their ancestor directories

### Flags
- `--check` — dry-run; exit 1 if any file would change
- `--fail-on-change` — write, but exit 1 if anything changed (CI)
- `--stdin-filename <path>` — format stdin to stdout, detecting language/config from the given path
- `--tab-size` / `--insert-spaces` — fill the LSP-mandatory `FormattingOptions` fields (honoring them remains each server's decision); pinned end-to-end by a mock that echoes the received options

### Robustness (one-shot semantics)
Editor clients paper over cold-start and failure races by retrying; a one-shot CLI cannot, so the branch closes those gaps explicitly:
- waits for downstream servers to be Ready **and** for eager-open `didOpen` tasks to finish before formatting (otherwise the request can overtake the didOpen on the wire and read the server's `null` as authoritative "no edits")
- atomic writes (canonicalize → temp file → rename) preserving symlinks and file permissions
- exit code 2 for configured-but-broken formatters: startup failures, error responses, protocol-invalid payloads (missing/malformed `result`), and pipeline step timeouts are all counted — even when a fallback server rescued the file
- extensionless files (`#!/usr/bin/env lua`) detect through the parser-loading chain

### Exit codes
`0` nothing to change / changes written; `1` changes under `--check`/`--fail-on-change`; `2` usage or I/O error.

## Test plan
- 11 unit tests for file collection (gitignore/excludes/dedup semantics)
- 15 e2e tests spawning the real binary against mock LSP formatters (`tests/e2e_cli_format.rs`): in-place rewrite + idempotence, --check / --fail-on-change / stdin variants, gitignore + explicit-path precedence, --excludes, options passthrough, permission preservation (unix), broken-server / error-response / malformed-response / failed-then-rescued exit codes
- Full gate: `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --lib` (1788), formatting/host-bridge e2e suites