### PR TITLE
feat(bridge): bridge textDocument/onTypeFormatting with config-driven triggers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ Current bridge-backed requests include:
 - Moniker / Inlay Hint
 - Code Lens (incl. `codeLens/resolve` routed back to the origin server; resolution fails soft when the region was edited since the lens was produced)
 - Pull Diagnostics
+- On Type Formatting (config-driven; see `onTypeFormattingTriggers`)
 
 The server does not currently advertise `textDocument/codeAction`.
 
@@ -312,6 +313,7 @@ Configure language servers for bridging LSP requests in injection regions.
 | `languages` | Languages this server handles |
 | `initializationOptions` | Optional initialization options forwarded during the downstream server's `initialize` request |
 | `rootMarkers` | Marker files/directories (e.g. `[".git", "Cargo.toml"]`) locating the workspace root the server is initialized with: ancestors of the document that triggered the spawn are searched nearest-first, and the first directory containing any marker becomes the server's `rootUri` and sole workspace folder. Default: `[".git"]`. No marker hit falls back to the client-supplied root; an explicit `[]` disables the search. The first spawn decides the root for the server's lifetime. |
+| `onTypeFormattingTriggers` | Trigger characters for bridged `textDocument/onTypeFormatting` (e.g. `["}", ";"]`). kakehashi advertises the sorted union across all servers at initialize and forwards a request to a downstream server only when that server's own capabilities declare the typed character. Unset everywhere (default) → the capability is not advertised. |
 
 A `languageServers._` wildcard entry supplies defaults that every server
 inherits field-by-field (wildcard-config-inheritance) — e.g. set

--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -140,7 +140,7 @@ final_config = [defaults, user_config, project_config, InitializationOptions]
 
 **Bridge servers HashMap** (`languageServers`):
 - **Deep merge at server level**: Keys (server names) from later sources override same keys from earlier sources
-- **Deep merge within each server**: Individual fields (`cmd`, `languages`, `initializationOptions`) are merged
+- **Deep merge within each server**: Individual fields (`cmd`, `languages`, `initializationOptions`, `onTypeFormattingTriggers`) are merged (list options like `onTypeFormattingTriggers` are overlay-wins-when-present, not unioned)
 - Example:
   ```toml
   # user config

--- a/docs/architecture-decisions/language-server-bridge.md
+++ b/docs/architecture-decisions/language-server-bridge.md
@@ -181,6 +181,7 @@ The bridge requires knowing which server to use for each language. Language serv
 | `languageServers.*.cmd` | Yes | Command array: first element is program, rest are arguments |
 | `languageServers.*.languages` | Yes | Languages this server handles |
 | `languageServers.*.initializationOptions` | No | Passed to server's `initialize` request |
+| `languageServers.*.onTypeFormattingTriggers` | No | Trigger characters for bridged `textDocument/onTypeFormatting`; the sorted union is advertised at initialize, and requests are forwarded only when the downstream also declares the typed character (#354) |
 
 #### Per-Host Language Bridge Configuration
 

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -36,6 +36,7 @@ fn default_language_servers() -> HashMap<String, BridgeServerConfig> {
             languages: vec![],
             initialization_options: None,
             root_markers: Some(vec![".git".to_string()]),
+            on_type_formatting_triggers: None,
         },
     )])
 }

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -87,6 +87,10 @@ pub(crate) fn merge_bridge_server_configs(
             .root_markers
             .clone()
             .or_else(|| base.root_markers.clone()),
+        on_type_formatting_triggers: overlay
+            .on_type_formatting_triggers
+            .clone()
+            .or_else(|| base.on_type_formatting_triggers.clone()),
     }
 }
 
@@ -502,6 +506,7 @@ mod tests {
                         languages: vec!["rust".to_string()],
                         initialization_options: Some(json!({"checkOnSave": true})),
                         root_markers: None,
+                        on_type_formatting_triggers: None,
                     },
                 ),
                 (
@@ -511,6 +516,7 @@ mod tests {
                         languages: vec!["lua".to_string()],
                         initialization_options: None,
                         root_markers: None,
+                        on_type_formatting_triggers: None,
                     },
                 ),
             ])),
@@ -579,6 +585,7 @@ mod tests {
                         languages: vec![],
                         initialization_options: Some(json!({"linkedProjects": ["./Cargo.toml"]})),
                         root_markers: None,
+                        on_type_formatting_triggers: None,
                     },
                 ),
                 (
@@ -589,6 +596,7 @@ mod tests {
                         languages: vec!["python".to_string()],
                         initialization_options: None,
                         root_markers: None,
+                        on_type_formatting_triggers: None,
                     },
                 ),
             ])),
@@ -654,6 +662,7 @@ mod tests {
                     languages: vec!["rust".to_string()],
                     initialization_options: None,
                     root_markers: None,
+                    on_type_formatting_triggers: None,
                 },
             )])),
             ..Default::default()
@@ -1041,6 +1050,7 @@ mod tests {
                 languages: vec!["any".to_string()],
                 initialization_options: None,
                 root_markers: None,
+                on_type_formatting_triggers: None,
             },
         )]);
         let resolved = resolve_with_wildcard(&servers, "ra", merge_bridge_server_configs).unwrap();
@@ -1055,6 +1065,7 @@ mod tests {
                 languages: vec!["rust".to_string()],
                 initialization_options: None,
                 root_markers: None,
+                on_type_formatting_triggers: None,
             },
         )]);
         let resolved = resolve_with_wildcard(&servers, "ra", merge_bridge_server_configs).unwrap();
@@ -1070,6 +1081,7 @@ mod tests {
                     languages: vec!["any".to_string()],
                     initialization_options: Some(json!({"defaultOption": true})),
                     root_markers: None,
+                    on_type_formatting_triggers: None,
                 },
             ),
             (
@@ -1079,6 +1091,7 @@ mod tests {
                     languages: vec![],
                     initialization_options: Some(json!({"linkedProjects": ["./Cargo.toml"]})),
                     root_markers: None,
+                    on_type_formatting_triggers: None,
                 },
             ),
         ]);
@@ -1106,6 +1119,7 @@ mod tests {
             languages: vec![],
             initialization_options: None,
             root_markers: Some(vec![".git".to_string()]),
+            on_type_formatting_triggers: None,
         };
 
         // Unset overlay inherits from base (wildcard default applies)
@@ -1114,6 +1128,7 @@ mod tests {
             languages: vec!["rust".to_string()],
             initialization_options: None,
             root_markers: None,
+            on_type_formatting_triggers: None,
         };
         let merged = merge_bridge_server_configs(&base, &inheriting);
         assert_eq!(merged.root_markers, Some(vec![".git".to_string()]));
@@ -1155,6 +1170,7 @@ mod tests {
                 "nested": { "base_only": 1, "shared": "base" }
             })),
             root_markers: None,
+            on_type_formatting_triggers: None,
         };
         let overlay = BridgeServerConfig {
             cmd: vec!["rust-analyzer".to_string()],
@@ -1165,6 +1181,7 @@ mod tests {
                 "nested": { "overlay_only": 2, "shared": "overlay" }
             })),
             root_markers: None,
+            on_type_formatting_triggers: None,
         };
 
         let resolved = merge_bridge_server_configs(&base, &overlay);
@@ -1173,6 +1190,36 @@ mod tests {
         snap_settings.bind(|| {
             insta::assert_json_snapshot!(resolved.initialization_options);
         });
+    }
+
+    /// `onTypeFormattingTriggers` merges overlay-wins-when-present, so a
+    /// wildcard `languageServers._` default applies unless the server entry
+    /// overrides it.
+    #[test]
+    fn test_merge_bridge_server_configs_on_type_formatting_triggers_overlay_wins() {
+        use settings::BridgeServerConfig;
+
+        let server = |triggers: Option<Vec<&str>>| BridgeServerConfig {
+            cmd: vec![],
+            languages: vec![],
+            initialization_options: None,
+            root_markers: None,
+            on_type_formatting_triggers: triggers
+                .map(|t| t.into_iter().map(String::from).collect()),
+        };
+
+        let base = server(Some(vec!["}"]));
+        assert_eq!(
+            merge_bridge_server_configs(&base, &server(None)).on_type_formatting_triggers,
+            Some(vec!["}".to_string()]),
+            "unset overlay inherits the base (wildcard) value"
+        );
+        assert_eq!(
+            merge_bridge_server_configs(&base, &server(Some(vec![";"])))
+                .on_type_formatting_triggers,
+            Some(vec![";".to_string()]),
+            "explicit overlay replaces the base list (no union at merge level)"
+        );
     }
 
     // Wildcard config resolution tests
@@ -1308,6 +1355,7 @@ mod tests {
                     languages: vec![],
                     initialization_options: Some(json!({ "checkOnSave": true })),
                     root_markers: None,
+                    on_type_formatting_triggers: None,
                 },
             ),
             // rust-analyzer: only specifies cmd and languages
@@ -1318,6 +1366,7 @@ mod tests {
                     languages: vec!["rust".to_string()],
                     initialization_options: None, // Should inherit from wildcard
                     root_markers: None,
+                    on_type_formatting_triggers: None,
                 },
             ),
         ]);
@@ -1355,6 +1404,7 @@ mod tests {
                     languages: vec!["rust".to_string(), "python".to_string()],
                     initialization_options: None,
                     root_markers: None,
+                    on_type_formatting_triggers: None,
                 },
             ),
             // rust-analyzer: specifies only cmd, inherits languages from wildcard
@@ -1365,6 +1415,7 @@ mod tests {
                     languages: vec![], // Empty - should inherit from wildcard
                     initialization_options: None,
                     root_markers: None,
+                    on_type_formatting_triggers: None,
                 },
             ),
         ]);

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -299,6 +299,39 @@ pub struct BridgeServerConfig {
     /// disables the search (the client-supplied root is forwarded as-is).
     /// When no marker matches, the client-supplied root is the fallback.
     pub root_markers: Option<Vec<String>>,
+    /// Trigger characters for bridged `textDocument/onTypeFormatting` (#354).
+    ///
+    /// kakehashi cannot know downstream trigger characters at initialize time
+    /// (servers spawn lazily), so users declare them here. The union across
+    /// all servers is advertised as `documentOnTypeFormattingProvider`; a
+    /// request is forwarded to a downstream server only when that server's
+    /// own capabilities also declare the typed character. Unset or empty
+    /// everywhere → the capability is not advertised (today's behavior).
+    pub on_type_formatting_triggers: Option<Vec<String>>,
+}
+
+/// Union of every server's `onTypeFormattingTriggers`, shaped for the LSP
+/// `documentOnTypeFormattingProvider` capability: `(first, more)`.
+///
+/// Sorted and deduplicated so the advertisement is deterministic regardless of
+/// `HashMap` iteration order. Returns `None` when no server declares any
+/// trigger (capability stays unadvertised). Includes the wildcard `_` entry:
+/// its triggers apply to every concrete server through wildcard merging.
+pub(crate) fn on_type_formatting_trigger_union(
+    servers: &HashMap<String, BridgeServerConfig>,
+) -> Option<(String, Vec<String>)> {
+    let mut triggers: Vec<String> = servers
+        .values()
+        .filter_map(|s| s.on_type_formatting_triggers.as_ref())
+        .flatten()
+        .filter(|t| !t.is_empty())
+        .cloned()
+        .collect();
+    triggers.sort();
+    triggers.dedup();
+    let mut iter = triggers.into_iter();
+    let first = iter.next()?;
+    Some((first, iter.collect()))
 }
 
 /// Custom mappings from Tree-sitter capture names to semantic token types, per query kind.
@@ -1211,6 +1244,78 @@ mod tests {
         snap_settings.bind(|| {
             insta::assert_json_snapshot!(settings.language_servers);
         });
+    }
+
+    #[test]
+    fn should_parse_on_type_formatting_triggers() {
+        let config_json = r#"{
+            "languageServers": {
+                "clangd": {
+                    "cmd": ["clangd"],
+                    "languages": ["cpp"],
+                    "onTypeFormattingTriggers": ["}", ";"]
+                },
+                "pyright": {
+                    "cmd": ["pyright-langserver", "--stdio"],
+                    "languages": ["python"]
+                }
+            }
+        }"#;
+
+        let settings: RawWorkspaceSettings = serde_json::from_str(config_json).unwrap();
+        let servers = settings.language_servers.expect("languageServers parses");
+        assert_eq!(
+            servers["clangd"].on_type_formatting_triggers,
+            Some(vec!["}".to_string(), ";".to_string()]),
+            "explicit trigger list is preserved"
+        );
+        assert_eq!(
+            servers["pyright"].on_type_formatting_triggers, None,
+            "absent onTypeFormattingTriggers parses as None"
+        );
+    }
+
+    #[test]
+    fn on_type_formatting_trigger_union_is_sorted_and_deduped() {
+        let server = |triggers: Option<Vec<&str>>| BridgeServerConfig {
+            cmd: vec!["x".to_string()],
+            languages: vec![],
+            initialization_options: None,
+            root_markers: None,
+            on_type_formatting_triggers: triggers
+                .map(|t| t.into_iter().map(String::from).collect()),
+        };
+        let servers = HashMap::from([
+            ("a".to_string(), server(Some(vec!["}", ";"]))),
+            ("b".to_string(), server(Some(vec![";", "\n"]))),
+            ("c".to_string(), server(None)),
+        ]);
+
+        let (first, more) =
+            on_type_formatting_trigger_union(&servers).expect("triggers configured");
+        // Sorted + deduped: deterministic regardless of HashMap iteration order.
+        assert_eq!(first, "\n");
+        assert_eq!(more, vec![";".to_string(), "}".to_string()]);
+    }
+
+    #[test]
+    fn on_type_formatting_trigger_union_without_triggers_is_none() {
+        let servers = HashMap::from([(
+            "a".to_string(),
+            BridgeServerConfig {
+                cmd: vec!["x".to_string()],
+                languages: vec![],
+                initialization_options: None,
+                root_markers: None,
+                on_type_formatting_triggers: Some(vec![String::new()]),
+            },
+        )]);
+        assert_eq!(
+            on_type_formatting_trigger_union(&servers),
+            None,
+            "empty-string triggers are ignored; no triggers means no capability"
+        );
+        assert_eq!(on_type_formatting_trigger_union(&HashMap::new()), None);
     }
 
     #[test]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -307,6 +307,14 @@ pub struct BridgeServerConfig {
     /// request is forwarded to a downstream server only when that server's
     /// own capabilities also declare the typed character. Unset or empty
     /// everywhere → the capability is not advertised (today's behavior).
+    ///
+    /// Note: this field feeds *only* the `initialize`-time capability
+    /// advertisement; it is never consulted when forwarding a request (that
+    /// filter uses the downstream server's own declared triggers). The
+    /// capability is negotiated once and frozen for the session, so updating
+    /// the triggers via `didChangeConfiguration` has no runtime effect at all
+    /// — neither re-advertising the capability nor changing forwarding. A
+    /// restart is required for new triggers to take effect.
     pub on_type_formatting_triggers: Option<Vec<String>>,
 }
 
@@ -315,8 +323,12 @@ pub struct BridgeServerConfig {
 ///
 /// Sorted and deduplicated so the advertisement is deterministic regardless of
 /// `HashMap` iteration order. Returns `None` when no server declares any
-/// trigger (capability stays unadvertised). Includes the wildcard `_` entry:
-/// its triggers apply to every concrete server through wildcard merging.
+/// trigger (capability stays unadvertised). A `_` wildcard key is treated like
+/// any other entry: its triggers join the union as-is (wildcard merging into
+/// concrete servers happens at request dispatch, not here). Known edge case: a
+/// concrete server overriding the wildcard with an explicit empty list still
+/// leaves the wildcard's triggers advertised; the bridge-side trigger filter
+/// keeps such requests from reaching servers that don't declare the character.
 pub(crate) fn on_type_formatting_trigger_union(
     servers: &HashMap<String, BridgeServerConfig>,
 ) -> Option<(String, Vec<String>)> {
@@ -1296,6 +1308,19 @@ mod tests {
         // Sorted + deduped: deterministic regardless of HashMap iteration order.
         assert_eq!(first, "\n");
         assert_eq!(more, vec![";".to_string(), "}".to_string()]);
+
+        // Same logical contents inserted in a different order must produce
+        // the identical advertisement.
+        let servers_reordered = HashMap::from([
+            ("c".to_string(), server(None)),
+            ("b".to_string(), server(Some(vec![";", "\n"]))),
+            ("a".to_string(), server(Some(vec!["}", ";"]))),
+        ]);
+        assert_eq!(
+            on_type_formatting_trigger_union(&servers_reordered),
+            Some((first, more)),
+            "union must not depend on map construction order"
+        );
     }
 
     #[test]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -336,7 +336,7 @@ pub(crate) fn on_type_formatting_trigger_union(
         .values()
         .filter_map(|s| s.on_type_formatting_triggers.as_ref())
         .flatten()
-        .filter(|t| !t.is_empty())
+        .filter(|t| t.chars().count() == 1)
         .cloned()
         .collect();
     triggers.sort();

--- a/src/config/snapshots/kakehashi__config__merge__tests__merge_workspace_settings_all_fields.snap
+++ b/src/config/snapshots/kakehashi__config__merge__tests__merge_workspace_settings_all_fields.snap
@@ -84,7 +84,8 @@ expression: result
         "lua"
       ],
       "initializationOptions": null,
-      "rootMarkers": null
+      "rootMarkers": null,
+      "onTypeFormattingTriggers": null
     },
     "pyright": {
       "cmd": [
@@ -95,7 +96,8 @@ expression: result
         "python"
       ],
       "initializationOptions": null,
-      "rootMarkers": null
+      "rootMarkers": null,
+      "onTypeFormattingTriggers": null
     },
     "rust-analyzer": {
       "cmd": [
@@ -110,7 +112,8 @@ expression: result
           "./Cargo.toml"
         ]
       },
-      "rootMarkers": null
+      "rootMarkers": null,
+      "onTypeFormattingTriggers": null
     }
   }
 }

--- a/src/config/snapshots/kakehashi__config__settings__tests__should_parse_language_servers_at_root.snap
+++ b/src/config/snapshots/kakehashi__config__settings__tests__should_parse_language_servers_at_root.snap
@@ -12,7 +12,8 @@ expression: settings.language_servers
       "python"
     ],
     "initializationOptions": null,
-    "rootMarkers": null
+    "rootMarkers": null,
+    "onTypeFormattingTriggers": null
   },
   "rust-analyzer": {
     "cmd": [
@@ -22,6 +23,7 @@ expression: settings.language_servers
       "rust"
     ],
     "initializationOptions": null,
-    "rootMarkers": null
+    "rootMarkers": null,
+    "onTypeFormattingTriggers": null
   }
 }

--- a/src/lsp/aggregation/server/fan_out.rs
+++ b/src/lsp/aggregation/server/fan_out.rs
@@ -133,6 +133,7 @@ mod tests {
                 languages: vec![],
                 initialization_options: None,
                 root_markers: None,
+                on_type_formatting_triggers: None,
             }),
         }
     }

--- a/src/lsp/aggregation/server/priority.rs
+++ b/src/lsp/aggregation/server/priority.rs
@@ -154,6 +154,7 @@ mod tests {
                 languages: vec![],
                 initialization_options: None,
                 root_markers: None,
+                on_type_formatting_triggers: None,
             }),
         }
     }

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -709,6 +709,7 @@ mod tests {
                 languages: vec!["rust".to_string()],
                 initialization_options: None,
                 root_markers: None,
+                on_type_formatting_triggers: None,
             },
         );
 
@@ -743,6 +744,7 @@ mod tests {
                 languages: vec!["rust".to_string()],
                 initialization_options: None,
                 root_markers: None,
+                on_type_formatting_triggers: None,
             },
         );
 
@@ -779,6 +781,7 @@ mod tests {
                 languages: vec!["rust".to_string()],
                 initialization_options: None,
                 root_markers: Some(vec![".git".to_string()]),
+                on_type_formatting_triggers: None,
             },
         );
         servers.insert(
@@ -788,6 +791,7 @@ mod tests {
                 languages: vec!["rust".to_string()],
                 initialization_options: None,
                 root_markers: None,
+                on_type_formatting_triggers: None,
             },
         );
 
@@ -851,6 +855,7 @@ mod tests {
                 languages: vec!["python".to_string()],
                 initialization_options: None,
                 root_markers: None,
+                on_type_formatting_triggers: None,
             },
         );
         servers.insert(
@@ -860,6 +865,7 @@ mod tests {
                 languages: vec!["python".to_string()],
                 initialization_options: None,
                 root_markers: None,
+                on_type_formatting_triggers: None,
             },
         );
 
@@ -911,6 +917,7 @@ mod tests {
                 languages: vec!["rust".to_string()],
                 initialization_options: None,
                 root_markers: None,
+                on_type_formatting_triggers: None,
             },
         );
 
@@ -945,6 +952,7 @@ mod tests {
                 languages: vec!["rust".to_string()],
                 initialization_options: None,
                 root_markers: None,
+                on_type_formatting_triggers: None,
             },
         );
 
@@ -1058,6 +1066,7 @@ mod tests {
                 languages: vec!["rust".to_string()],
                 initialization_options: None,
                 root_markers: None,
+                on_type_formatting_triggers: None,
             },
         );
 
@@ -1277,6 +1286,7 @@ mod tests {
                 languages: vec!["lua".to_string()],
                 initialization_options: None,
                 root_markers: None,
+                on_type_formatting_triggers: None,
             },
         );
 

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1592,6 +1592,7 @@ mod tests {
             languages: vec!["lua".to_string()],
             initialization_options: None,
             root_markers: None,
+            on_type_formatting_triggers: None,
         };
 
         let result = pool

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -1718,6 +1718,17 @@ mod tests {
                     });
                 }),
             ),
+            (
+                "textDocument/onTypeFormatting",
+                Box::new(|c| {
+                    c.document_on_type_formatting_provider = Some(
+                        tower_lsp_server::ls_types::DocumentOnTypeFormattingOptions {
+                            first_trigger_character: "}".to_string(),
+                            more_trigger_character: None,
+                        },
+                    );
+                }),
+            ),
         ];
 
         for (method, set_cap) in &cases {
@@ -1868,6 +1879,7 @@ mod tests {
             "textDocument/colorPresentation",
             "textDocument/codeLens",
             "codeLens/resolve",
+            "textDocument/onTypeFormatting",
         ];
         for method in methods {
             assert!(

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -471,6 +471,7 @@ impl ConnectionHandle {
                     Some(OneOf::Left(true) | OneOf::Right(_))
                 )
             }
+            "textDocument/onTypeFormatting" => caps.document_on_type_formatting_provider.is_some(),
             "textDocument/documentSymbol" => {
                 matches!(
                     caps.document_symbol_provider,

--- a/src/lsp/bridge/pool/test_helpers.rs
+++ b/src/lsp/bridge/pool/test_helpers.rs
@@ -52,6 +52,7 @@ pub(in crate::lsp::bridge) fn lua_ls_config() -> BridgeServerConfig {
         languages: vec!["lua".to_string()],
         initialization_options: None,
         root_markers: None,
+        on_type_formatting_triggers: None,
     }
 }
 
@@ -72,6 +73,7 @@ pub(in crate::lsp::bridge) fn devnull_config_for_language(language: &str) -> Bri
         languages: vec![language.to_string()],
         initialization_options: None,
         root_markers: None,
+        on_type_formatting_triggers: None,
     }
 }
 

--- a/src/lsp/bridge/text_document.rs
+++ b/src/lsp/bridge/text_document.rs
@@ -31,6 +31,7 @@ mod implementation;
 mod inlay_hint;
 mod linked_editing_range;
 mod moniker;
+mod on_type_formatting;
 mod prepare_rename;
 mod range_formatting;
 mod references;

--- a/src/lsp/bridge/text_document/on_type_formatting.rs
+++ b/src/lsp/bridge/text_document/on_type_formatting.rs
@@ -1,0 +1,190 @@
+//! `textDocument/onTypeFormatting` bridge handler (#354).
+//!
+//! Position-based like hover/completion, but returns `TextEdit[]` that must be
+//! translated virtual→host like formatting — so the request side reuses
+//! [`build_text_document_position_params`] and the response side reuses
+//! [`super::formatting::transform_formatting_response_to_host`].
+//!
+//! # Double filter (#354)
+//!
+//! kakehashi advertises a config-driven trigger-character union upstream
+//! (downstream trigger sets are unknown at initialize time). A typed character
+//! from that union is forwarded to a downstream server only when that server's
+//! own `documentOnTypeFormattingProvider` declares it, so a misconfigured
+//! superset degrades to no-ops instead of bad requests.
+
+use std::io;
+
+use crate::config::settings::BridgeServerConfig;
+use tower_lsp_server::ls_types::{
+    DocumentOnTypeFormattingParams, FormattingOptions, Position, TextEdit,
+};
+use url::Url;
+
+use super::super::pool::{ConnectionHandle, LanguageServerPool, UpstreamId};
+use super::super::protocol::{
+    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri,
+    build_text_document_position_params,
+};
+use super::formatting::{count_lines, transform_formatting_response_to_host};
+
+impl LanguageServerPool {
+    /// Send an onTypeFormatting request and wait for the response.
+    ///
+    /// Returns `Ok(None)` when the downstream server does not advertise
+    /// `documentOnTypeFormattingProvider`, or advertises it without declaring
+    /// the typed character `ch` as a trigger.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn send_on_type_formatting_request(
+        &self,
+        server_name: &str,
+        server_config: &BridgeServerConfig,
+        host_uri: &Url,
+        host_position: Position,
+        ch: &str,
+        options: FormattingOptions,
+        injection_language: &str,
+        region_id: &str,
+        offset: RegionOffset,
+        virtual_content: &str,
+        upstream_request_id: Option<UpstreamId>,
+    ) -> io::Result<Option<Vec<TextEdit>>> {
+        let handle = self
+            .get_or_create_connection(server_name, server_config)
+            .await?;
+        if !handle.has_capability("textDocument/onTypeFormatting") {
+            return Ok(None);
+        }
+        if !downstream_declares_trigger(&handle, ch) {
+            log::debug!(
+                target: "kakehashi::bridge",
+                "[{}] onTypeFormatting: downstream does not declare {:?} as a trigger; skipping",
+                server_name,
+                ch
+            );
+            return Ok(None);
+        }
+        let virtual_line_count = count_lines(virtual_content);
+        self.execute_position_bridge_request_with_handle(
+            handle,
+            server_name,
+            host_uri,
+            injection_language,
+            region_id,
+            &offset,
+            virtual_content,
+            upstream_request_id,
+            host_position,
+            "textDocument/onTypeFormatting",
+            |virtual_uri, request_id| {
+                build_on_type_formatting_request(
+                    virtual_uri,
+                    host_position,
+                    ch,
+                    options,
+                    &offset,
+                    request_id,
+                )
+            },
+            |response, ctx| {
+                transform_formatting_response_to_host(response, ctx.offset, virtual_line_count)
+            },
+        )
+        .await
+    }
+}
+
+/// Whether the downstream's `documentOnTypeFormattingProvider` declares `ch`
+/// as a trigger character (the second half of the double filter).
+///
+/// A server whose method support comes only from dynamic registration carries
+/// its trigger set in registration options the bridge does not parse; forward
+/// in that case and let the server answer (it may return null).
+fn downstream_declares_trigger(handle: &ConnectionHandle, ch: &str) -> bool {
+    let Some(provider) = handle
+        .server_capabilities()
+        .and_then(|caps| caps.document_on_type_formatting_provider.as_ref())
+    else {
+        // has_capability passed without a static provider → dynamic
+        // registration granted the method; trust it.
+        return true;
+    };
+    provider.first_trigger_character == ch
+        || provider
+            .more_trigger_character
+            .as_ref()
+            .is_some_and(|more| more.iter().any(|t| t == ch))
+}
+
+/// Build a JSON-RPC onTypeFormatting request for a downstream language server:
+/// position translated host→virtual, typed character and editor formatting
+/// options forwarded unchanged.
+fn build_on_type_formatting_request(
+    virtual_uri: &VirtualDocumentUri,
+    host_position: Position,
+    ch: &str,
+    options: FormattingOptions,
+    offset: &RegionOffset,
+    request_id: RequestId,
+) -> JsonRpcRequest<DocumentOnTypeFormattingParams> {
+    let params = DocumentOnTypeFormattingParams {
+        text_document_position: build_text_document_position_params(
+            virtual_uri,
+            host_position,
+            offset,
+        ),
+        ch: ch.to_string(),
+        options,
+    };
+    JsonRpcRequest::new(request_id.as_i64(), "textDocument/onTypeFormatting", params)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_helpers::*;
+    use super::*;
+
+    fn default_options() -> FormattingOptions {
+        FormattingOptions {
+            tab_size: 4,
+            insert_spaces: true,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn on_type_formatting_request_uses_virtual_uri() {
+        let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
+        let request = build_on_type_formatting_request(
+            &virtual_uri,
+            test_position(),
+            "}",
+            default_options(),
+            &RegionOffset::new(3, 0),
+            test_request_id(),
+        );
+
+        assert_uses_virtual_uri(&request, "lua");
+    }
+
+    #[test]
+    fn on_type_formatting_request_translates_position_and_forwards_ch_and_options() {
+        // Host line 5, region starts at line 3 -> virtual line 2.
+        let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
+        let request = build_on_type_formatting_request(
+            &virtual_uri,
+            test_position(),
+            "}",
+            default_options(),
+            &RegionOffset::new(3, 0),
+            RequestId::new(7),
+        );
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["method"], "textDocument/onTypeFormatting");
+        assert_eq!(json["params"]["position"]["line"], 2);
+        assert_eq!(json["params"]["ch"], "}");
+        assert_eq!(json["params"]["options"]["tabSize"], 4);
+        assert_eq!(json["params"]["options"]["insertSpaces"], true);
+    }
+}

--- a/src/lsp/bridge/text_document/on_type_formatting.rs
+++ b/src/lsp/bridge/text_document/on_type_formatting.rs
@@ -56,9 +56,21 @@ impl LanguageServerPool {
         if !handle.has_capability("textDocument/onTypeFormatting") {
             return Ok(None);
         }
-        let static_provider = handle
-            .server_capabilities()
-            .and_then(|caps| caps.document_on_type_formatting_provider.as_ref());
+        // A dynamic registration's trigger set lives in registration options
+        // the bridge does not parse, and it may legitimately differ from (or
+        // extend) the static provider. Whenever one exists, bypass the static
+        // trigger filter entirely and let the server answer — filtering by the
+        // static set could drop dynamically-registered triggers.
+        let static_provider = if handle
+            .dynamic_capabilities()
+            .has_registration("textDocument/onTypeFormatting")
+        {
+            None
+        } else {
+            handle
+                .server_capabilities()
+                .and_then(|caps| caps.document_on_type_formatting_provider.as_ref())
+        };
         if !downstream_declares_trigger(static_provider, ch) {
             log::debug!(
                 target: "kakehashi::bridge",

--- a/src/lsp/bridge/text_document/on_type_formatting.rs
+++ b/src/lsp/bridge/text_document/on_type_formatting.rs
@@ -17,11 +17,12 @@ use std::io;
 
 use crate::config::settings::BridgeServerConfig;
 use tower_lsp_server::ls_types::{
-    DocumentOnTypeFormattingParams, FormattingOptions, Position, TextEdit,
+    DocumentOnTypeFormattingOptions, DocumentOnTypeFormattingParams, FormattingOptions, Position,
+    TextEdit,
 };
 use url::Url;
 
-use super::super::pool::{ConnectionHandle, LanguageServerPool, UpstreamId};
+use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri,
     build_text_document_position_params,
@@ -55,7 +56,10 @@ impl LanguageServerPool {
         if !handle.has_capability("textDocument/onTypeFormatting") {
             return Ok(None);
         }
-        if !downstream_declares_trigger(&handle, ch) {
+        let static_provider = handle
+            .server_capabilities()
+            .and_then(|caps| caps.document_on_type_formatting_provider.as_ref());
+        if !downstream_declares_trigger(static_provider, ch) {
             log::debug!(
                 target: "kakehashi::bridge",
                 "[{}] onTypeFormatting: downstream does not declare {:?} as a trigger; skipping",
@@ -97,16 +101,16 @@ impl LanguageServerPool {
 /// Whether the downstream's `documentOnTypeFormattingProvider` declares `ch`
 /// as a trigger character (the second half of the double filter).
 ///
-/// A server whose method support comes only from dynamic registration carries
-/// its trigger set in registration options the bridge does not parse; forward
-/// in that case and let the server answer (it may return null).
-fn downstream_declares_trigger(handle: &ConnectionHandle, ch: &str) -> bool {
-    let Some(provider) = handle
-        .server_capabilities()
-        .and_then(|caps| caps.document_on_type_formatting_provider.as_ref())
-    else {
-        // has_capability passed without a static provider → dynamic
-        // registration granted the method; trust it.
+/// `static_provider` is the provider from the initialize response, if any.
+/// `None` means the method support came only from dynamic registration, whose
+/// trigger set lives in registration options the bridge does not parse —
+/// forward in that case and let the server answer (it may return null). Only
+/// called after `has_capability` confirmed the method is supported.
+fn downstream_declares_trigger(
+    static_provider: Option<&DocumentOnTypeFormattingOptions>,
+    ch: &str,
+) -> bool {
+    let Some(provider) = static_provider else {
         return true;
     };
     provider.first_trigger_character == ch
@@ -165,6 +169,45 @@ mod tests {
         );
 
         assert_uses_virtual_uri(&request, "lua");
+    }
+
+    fn provider(first: &str, more: Option<Vec<&str>>) -> DocumentOnTypeFormattingOptions {
+        DocumentOnTypeFormattingOptions {
+            first_trigger_character: first.to_string(),
+            more_trigger_character: more.map(|m| m.into_iter().map(String::from).collect()),
+        }
+    }
+
+    #[test]
+    fn trigger_filter_accepts_first_trigger_character() {
+        let p = provider("}", Some(vec![";"]));
+        assert!(downstream_declares_trigger(Some(&p), "}"));
+    }
+
+    #[test]
+    fn trigger_filter_accepts_more_trigger_character() {
+        let p = provider("}", Some(vec![";"]));
+        assert!(downstream_declares_trigger(Some(&p), ";"));
+    }
+
+    #[test]
+    fn trigger_filter_rejects_undeclared_character() {
+        let p = provider("}", Some(vec![";"]));
+        assert!(!downstream_declares_trigger(Some(&p), "x"));
+
+        let no_more = provider("}", None);
+        assert!(
+            !downstream_declares_trigger(Some(&no_more), ";"),
+            "absent moreTriggerCharacter declares nothing beyond the first"
+        );
+    }
+
+    #[test]
+    fn trigger_filter_trusts_dynamic_only_registration() {
+        // No static provider = the method came from dynamic registration whose
+        // trigger set the bridge does not parse; forward and let the server
+        // answer (it may return null).
+        assert!(downstream_declares_trigger(None, "x"));
     }
 
     #[test]

--- a/src/lsp/bridge/text_document/on_type_formatting.rs
+++ b/src/lsp/bridge/text_document/on_type_formatting.rs
@@ -51,7 +51,7 @@ impl LanguageServerPool {
         upstream_request_id: Option<UpstreamId>,
     ) -> io::Result<Option<Vec<TextEdit>>> {
         let handle = self
-            .get_or_create_connection(server_name, server_config)
+            .get_or_create_connection(server_name, server_config, Some(host_uri))
             .await?;
         if !handle.has_capability("textDocument/onTypeFormatting") {
             return Ok(None);
@@ -102,11 +102,15 @@ impl LanguageServerPool {
                     request_id,
                 )
             },
+            // The transform promotes error responses, missing results, and
+            // malformed payloads to `Err` (request failure) — only the
+            // capability/trigger early returns above yield `Ok(None)`.
             |response, ctx| {
                 transform_formatting_response_to_host(response, ctx.offset, virtual_line_count)
+                    .map(Some)
             },
         )
-        .await
+        .await?
     }
 }
 

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -17,15 +17,15 @@ use tower_lsp_server::ls_types::{
     DidChangeConfigurationParams, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
     DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentDiagnosticParams,
     DocumentDiagnosticReportResult, DocumentFormattingParams, DocumentHighlight,
-    DocumentHighlightParams, DocumentLink, DocumentLinkParams, DocumentRangeFormattingParams,
-    DocumentSymbolParams, DocumentSymbolResponse, FoldingRange, FoldingRangeParams,
-    GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams, InitializeParams,
-    InitializeResult, InitializedParams, InlayHint, InlayHintParams, LinkedEditingRangeParams,
-    LinkedEditingRanges, Location, Moniker, MonikerParams, PrepareRenameResponse, ReferenceParams,
-    RenameParams, SelectionRange, SelectionRangeParams, SemanticTokensDeltaParams,
-    SemanticTokensFullDeltaResult, SemanticTokensParams, SemanticTokensRangeParams,
-    SemanticTokensRangeResult, SemanticTokensResult, SignatureHelp, SignatureHelpParams,
-    TextDocumentPositionParams, TextEdit, Uri, WorkspaceEdit,
+    DocumentHighlightParams, DocumentLink, DocumentLinkParams, DocumentOnTypeFormattingParams,
+    DocumentRangeFormattingParams, DocumentSymbolParams, DocumentSymbolResponse, FoldingRange,
+    FoldingRangeParams, GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams,
+    InitializeParams, InitializeResult, InitializedParams, InlayHint, InlayHintParams,
+    LinkedEditingRangeParams, LinkedEditingRanges, Location, Moniker, MonikerParams,
+    PrepareRenameResponse, ReferenceParams, RenameParams, SelectionRange, SelectionRangeParams,
+    SemanticTokensDeltaParams, SemanticTokensFullDeltaResult, SemanticTokensParams,
+    SemanticTokensRangeParams, SemanticTokensRangeResult, SemanticTokensResult, SignatureHelp,
+    SignatureHelpParams, TextDocumentPositionParams, TextEdit, Uri, WorkspaceEdit,
 };
 #[cfg(feature = "experimental")]
 use tower_lsp_server::ls_types::{
@@ -470,6 +470,13 @@ impl LanguageServer for Kakehashi {
         params: DocumentRangeFormattingParams,
     ) -> Result<Option<Vec<TextEdit>>> {
         self.range_formatting_impl(params).await
+    }
+
+    async fn on_type_formatting(
+        &self,
+        params: DocumentOnTypeFormattingParams,
+    ) -> Result<Option<Vec<TextEdit>>> {
+        self.on_type_formatting_impl(params).await
     }
 
     async fn prepare_rename(

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -905,6 +905,7 @@ mod tests {
             languages: vec!["lua".to_string()],
             initialization_options: None,
             root_markers: None,
+            on_type_formatting_triggers: None,
         }
     }
 

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -6,11 +6,11 @@ use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::ColorProviderCapability;
 use tower_lsp_server::ls_types::{
     CodeLensOptions, CompletionOptions, DeclarationCapability, DiagnosticOptions,
-    DiagnosticServerCapabilities, DocumentLinkOptions, FoldingRangeProviderCapability,
-    HoverProviderCapability, ImplementationProviderCapability, InitializeParams, InitializeResult,
-    InitializedParams, LinkedEditingRangeServerCapabilities, OneOf, RenameOptions, SaveOptions,
-    SelectionRangeProviderCapability, SemanticTokenModifier, SemanticTokenType,
-    SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
+    DiagnosticServerCapabilities, DocumentLinkOptions, DocumentOnTypeFormattingOptions,
+    FoldingRangeProviderCapability, HoverProviderCapability, ImplementationProviderCapability,
+    InitializeParams, InitializeResult, InitializedParams, LinkedEditingRangeServerCapabilities,
+    OneOf, RenameOptions, SaveOptions, SelectionRangeProviderCapability, SemanticTokenModifier,
+    SemanticTokenType, SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
     SemanticTokensServerCapabilities, ServerCapabilities, ServerInfo, SignatureHelpOptions,
     TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
     TextDocumentSyncSaveOptions, TypeDefinitionProviderCapability, Uri, WorkDoneProgressOptions,
@@ -188,6 +188,13 @@ impl Kakehashi {
             };
             (raw_settings, settings)
         };
+        // Derive the onTypeFormatting trigger union before settings move into
+        // apply_raw_settings: kakehashi cannot know downstream trigger
+        // characters at initialize time (servers spawn lazily), so the
+        // advertised set is config-driven (#354). No config → None →
+        // capability not advertised, matching previous behavior.
+        let on_type_formatting_triggers =
+            crate::config::settings::on_type_formatting_trigger_union(&settings.language_servers);
         self.apply_raw_settings(raw_settings, settings).await;
 
         self.notifier().log_info("server initialized!").await;
@@ -258,6 +265,12 @@ impl Kakehashi {
                 })),
                 document_formatting_provider: Some(OneOf::Left(true)),
                 document_range_formatting_provider: Some(OneOf::Left(true)),
+                document_on_type_formatting_provider: on_type_formatting_triggers.map(
+                    |(first, more)| DocumentOnTypeFormattingOptions {
+                        first_trigger_character: first,
+                        more_trigger_character: (!more.is_empty()).then_some(more),
+                    },
+                ),
                 inlay_hint_provider: Some(OneOf::Left(true)),
                 linked_editing_range_provider: Some(LinkedEditingRangeServerCapabilities::Simple(
                     true,

--- a/src/lsp/lsp_impl/text_document.rs
+++ b/src/lsp/lsp_impl/text_document.rs
@@ -24,6 +24,7 @@ mod implementation;
 mod inlay_hint;
 mod linked_editing_range;
 mod moniker;
+mod on_type_formatting;
 mod prepare_rename;
 pub(crate) mod publish_diagnostic;
 mod range_formatting;

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -181,6 +181,7 @@ mod tests {
                 languages: vec!["rust".to_string()],
                 initialization_options: None,
                 root_markers: None,
+                on_type_formatting_triggers: None,
             },
         );
         server.settings_manager.apply_settings(WorkspaceSettings {

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -1740,6 +1740,7 @@ mod tests {
                 languages: vec![],
                 initialization_options: None,
                 root_markers: None,
+                on_type_formatting_triggers: None,
             }),
         }
     }

--- a/src/lsp/lsp_impl/text_document/on_type_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/on_type_formatting.rs
@@ -1,0 +1,96 @@
+//! `textDocument/onTypeFormatting` handler (#354).
+//!
+//! Position-based like hover: the typed character sits inside (at most) one
+//! injection region, so the virt layer resolves the region under the cursor
+//! and fans out per the preferred strategy. The downstream-side trigger
+//! filter (the second half of #354's double filter) lives in the bridge
+//! method; this handler only routes.
+
+use tower_lsp_server::jsonrpc::Result;
+use tower_lsp_server::ls_types::{
+    DocumentOnTypeFormattingParams, FormattingOptions, Position, TextEdit, Uri,
+};
+
+use super::super::Kakehashi;
+use crate::lsp::aggregation::server::dispatch_preferred;
+use crate::lsp::lsp_impl::bridge_context::parse_host_verbatim;
+
+const METHOD: &str = "textDocument/onTypeFormatting";
+
+impl Kakehashi {
+    pub(crate) async fn on_type_formatting_impl(
+        &self,
+        params: DocumentOnTypeFormattingParams,
+    ) -> Result<Option<Vec<TextEdit>>> {
+        let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
+        let lsp_uri = params.text_document_position.text_document.uri;
+        let position = params.text_document_position.position;
+
+        let virt =
+            self.on_type_formatting_virt_layer(&lsp_uri, position, &params.ch, params.options);
+        self.walk_layers(
+            &lsp_uri,
+            METHOD,
+            METHOD,
+            raw_params,
+            virt,
+            parse_host_verbatim::<Vec<TextEdit>>,
+            |edits: &Vec<TextEdit>| !edits.is_empty(),
+        )
+        .await
+    }
+
+    /// Virt layer: bridge the injection region under the typed character.
+    async fn on_type_formatting_virt_layer(
+        &self,
+        lsp_uri: &Uri,
+        position: Position,
+        ch: &str,
+        options: FormattingOptions,
+    ) -> Result<Option<Vec<TextEdit>>> {
+        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
+            return Ok(None);
+        };
+
+        let (cancel_rx, _cancel_guard) =
+            self.subscribe_cancel(ctx.document.upstream_request_id.as_ref());
+
+        let pool = self.bridge.pool_arc();
+        let position = ctx.position;
+        let result = dispatch_preferred(
+            &ctx.document,
+            pool.clone(),
+            move |t| {
+                let ch = ch.to_string();
+                let options = options.clone();
+                async move {
+                    t.pool
+                        .send_on_type_formatting_request(
+                            &t.server_name,
+                            &t.server_config,
+                            &t.uri,
+                            position,
+                            &ch,
+                            options,
+                            &t.injection_language,
+                            &t.region_id,
+                            t.offset,
+                            &t.virtual_content,
+                            t.upstream_id,
+                        )
+                        .await
+                }
+            },
+            // Like formatting: `Some(vec![])` is an authoritative "no edits
+            // needed" and stops the fan-out; `None` (no provider / trigger not
+            // declared / no response) falls through to lower-priority servers.
+            |opt| opt.is_some(),
+            cancel_rx,
+        )
+        .await;
+        pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
+        result
+            .handle(&self.client, "onTypeFormatting", None, Ok)
+            .await
+    }
+}

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -44,6 +44,10 @@
 //!   that echoes the requested URI, but only for documents it received via
 //!   `didOpen`. Used to prove cross-layer diagnostic aggregation merges the
 //!   host layer in (cross-layer-aggregation).
+//! - `on-type` — advertises `documentOnTypeFormattingProvider` with `}` and
+//!   `;` as triggers; answers `textDocument/onTypeFormatting` with the
+//!   uppercasing whole-document edit for ANY typed character (bridge-side
+//!   trigger filtering is what `tests/e2e_on_type_formatting.rs` proves).
 //!
 //! Only built for E2E runs (`required-features = ["e2e"]` in Cargo.toml).
 
@@ -89,6 +93,13 @@ fn main() {
                         "diagnosticProvider": {
                             "interFileDependencies": false,
                             "workspaceDiagnostics": false
+                        },
+                        "textDocumentSync": 1
+                    }),
+                    "on-type" => json!({
+                        "documentOnTypeFormattingProvider": {
+                            "firstTriggerCharacter": "}",
+                            "moreTriggerCharacter": [";"]
                         },
                         "textDocumentSync": 1
                     }),
@@ -236,6 +247,21 @@ fn main() {
                         "data": data
                     }),
                 );
+            }
+            "textDocument/onTypeFormatting" => {
+                // Answer with the whole-document transformation REGARDLESS of
+                // the typed character: the bridge is supposed to filter
+                // undeclared triggers before the request ever reaches this
+                // server, so a null upstream result for an undeclared char
+                // proves bridge-side filtering, not mock refusal.
+                let options = message.pointer("/params/options").cloned();
+                let result = message
+                    .pointer("/params/textDocument/uri")
+                    .and_then(Value::as_str)
+                    .and_then(|uri| documents.get(uri))
+                    .map(|text| whole_document_edit(text, &mode, options.as_ref()))
+                    .unwrap_or(Value::Null);
+                respond(&mut writer, id, result);
             }
             "textDocument/formatting" | "textDocument/rangeFormatting" => {
                 if mode == "fail-request" {

--- a/tests/e2e_on_type_formatting.rs
+++ b/tests/e2e_on_type_formatting.rs
@@ -1,0 +1,183 @@
+//! E2E tests for bridged `textDocument/onTypeFormatting` (#354), using the
+//! `mock-lsp-formatter` test binary in `on-type` mode.
+//!
+//! Proves the config-driven design end-to-end:
+//! - `onTypeFormattingTriggers` on a `languageServers` entry makes kakehashi
+//!   advertise `documentOnTypeFormattingProvider` (sorted union) at
+//!   initialize; no config keeps the capability unadvertised.
+//! - A request whose typed character the downstream declares comes back as
+//!   host-translated `TextEdit[]`.
+//! - A typed character the downstream does NOT declare is filtered by the
+//!   bridge (the mock answers ANY character, so a null result proves the
+//!   filter, not mock refusal).
+
+#![cfg(feature = "e2e")]
+
+mod helpers;
+
+use helpers::lsp_client::LspClient;
+use serde_json::{Value, json};
+
+/// Path to the mock downstream server binary (built by Cargo for E2E runs;
+/// `required-features = ["e2e"]`).
+fn mock_formatter_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_mock-lsp-formatter")
+}
+
+/// Spawn kakehashi with the given `languageServers` map and complete the
+/// initialize handshake. Returns the initialize response for capability
+/// assertions.
+fn init_client(language_servers: Value) -> (LspClient, Value, tempfile::TempDir) {
+    let config_dir = tempfile::TempDir::new().expect("Failed to create config temp dir");
+    let config_path = config_dir.path().join("on_type_formatting.toml");
+    std::fs::write(&config_path, "").expect("Failed to write config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("temp path should be UTF-8"))
+        .build();
+
+    let init_response = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": { "languageServers": language_servers }
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+    (client, init_response, config_dir)
+}
+
+/// Markdown host: the lua fence content sits on host line 3.
+const MARKDOWN: &str = "# Test\n\n```lua\nlocal x = 1\n```\n";
+const MARKDOWN_URI: &str = "file:///test_on_type_formatting.md";
+
+fn open_markdown(client: &mut LspClient) {
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": MARKDOWN_URI,
+                "languageId": "markdown",
+                "version": 1,
+                "text": MARKDOWN
+            }
+        }),
+    );
+    // Give kakehashi time to parse the host document and resolve injections.
+    std::thread::sleep(std::time::Duration::from_millis(1000));
+}
+
+fn on_type_formatting_params(ch: &str) -> Value {
+    json!({
+        // Inside the lua fence content ("local x = 1" on host line 3).
+        "textDocument": { "uri": MARKDOWN_URI },
+        "position": { "line": 3, "character": 11 },
+        "ch": ch,
+        "options": { "tabSize": 4, "insertSpaces": true },
+    })
+}
+
+/// Issue `textDocument/onTypeFormatting`, retrying while the result is null
+/// (cold downstream servers are still handshaking when the first request
+/// arrives; a not-yet-ready server yields null).
+fn request_with_retry(client: &mut LspClient, ch: &str) -> Option<Vec<Value>> {
+    for _ in 0..300 {
+        let response = client.send_request(
+            "textDocument/onTypeFormatting",
+            on_type_formatting_params(ch),
+        );
+        assert!(
+            response.get("error").is_none(),
+            "kakehashi must not surface a top-level onTypeFormatting error; got: {:?}",
+            response.get("error")
+        );
+        if let Some(edits) = response.get("result").and_then(Value::as_array)
+            && !edits.is_empty()
+        {
+            return Some(edits.clone());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    None
+}
+
+fn shutdown(client: &mut LspClient) {
+    let _ = client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
+fn e2e_on_type_formatting_advertises_sorted_trigger_union_and_translates_edits() {
+    let bin = mock_formatter_bin();
+    let (mut client, init_response, _config_dir) = init_client(json!({
+        "mock-ontype": {
+            "cmd": [bin, "on-type"],
+            "languages": ["lua"],
+            "onTypeFormattingTriggers": ["}", ";"]
+        }
+    }));
+
+    // Capability: sorted, deduplicated union of configured triggers.
+    let provider = &init_response["result"]["capabilities"]["documentOnTypeFormattingProvider"];
+    assert_eq!(
+        provider["firstTriggerCharacter"], ";",
+        "first trigger is the lexicographically first of the union; got: {provider:?}"
+    );
+    assert_eq!(
+        provider["moreTriggerCharacter"],
+        json!(["}"]),
+        "remaining triggers follow sorted"
+    );
+
+    open_markdown(&mut client);
+
+    // Declared trigger: the mock uppercases the virtual document; the edit
+    // must come back in HOST coordinates (fence content is host line 3).
+    let edits = request_with_retry(&mut client, "}")
+        .expect("onTypeFormatting with a declared trigger should return edits");
+    assert_eq!(edits.len(), 1);
+    assert_eq!(edits[0]["newText"], "LOCAL X = 1\n");
+    assert_eq!(
+        edits[0]["range"]["start"]["line"], 3,
+        "virtual line 0 must translate to the fence content's host line"
+    );
+
+    // Undeclared trigger: the downstream is warm now (previous request
+    // succeeded) and would answer any character, so a null result proves the
+    // bridge filtered the request before it reached the server.
+    let response = client.send_request(
+        "textDocument/onTypeFormatting",
+        on_type_formatting_params("x"),
+    );
+    assert!(response.get("error").is_none());
+    assert_eq!(
+        response["result"],
+        Value::Null,
+        "a character the downstream does not declare must be filtered by the bridge"
+    );
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_on_type_formatting_capability_absent_without_config() {
+    let bin = mock_formatter_bin();
+    let (mut client, init_response, _config_dir) = init_client(json!({
+        "mock-ontype": {
+            "cmd": [bin, "on-type"],
+            "languages": ["lua"]
+        }
+    }));
+
+    assert_eq!(
+        init_response["result"]["capabilities"]["documentOnTypeFormattingProvider"],
+        Value::Null,
+        "no onTypeFormattingTriggers config -> capability not advertised"
+    );
+
+    shutdown(&mut client);
+}

--- a/tests/e2e_on_type_formatting.rs
+++ b/tests/e2e_on_type_formatting.rs
@@ -83,8 +83,10 @@ fn on_type_formatting_params(ch: &str) -> Value {
 
 /// Issue `textDocument/onTypeFormatting`, retrying while the result is null
 /// (cold downstream servers are still handshaking when the first request
-/// arrives; a not-yet-ready server yields null).
-fn request_with_retry(client: &mut LspClient, ch: &str) -> Option<Vec<Value>> {
+/// arrives; a not-yet-ready server yields null). An authoritative empty edit
+/// list (`[]` — server ran, nothing to change) terminates immediately so a
+/// misbehaving path fails fast instead of spinning out the retry budget.
+fn request_with_retry(client: &mut LspClient, ch: &str) -> Vec<Value> {
     for _ in 0..300 {
         let response = client.send_request(
             "textDocument/onTypeFormatting",
@@ -95,14 +97,17 @@ fn request_with_retry(client: &mut LspClient, ch: &str) -> Option<Vec<Value>> {
             "kakehashi must not surface a top-level onTypeFormatting error; got: {:?}",
             response.get("error")
         );
-        if let Some(edits) = response.get("result").and_then(Value::as_array)
-            && !edits.is_empty()
-        {
-            return Some(edits.clone());
+        let result = &response["result"];
+        if result.is_null() {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            continue;
         }
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        return result
+            .as_array()
+            .cloned()
+            .expect("non-null onTypeFormatting result must be a TextEdit array");
     }
-    None
+    panic!("timed out waiting for a non-null onTypeFormatting result");
 }
 
 fn shutdown(client: &mut LspClient) {
@@ -137,8 +142,7 @@ fn e2e_on_type_formatting_advertises_sorted_trigger_union_and_translates_edits()
 
     // Declared trigger: the mock uppercases the virtual document; the edit
     // must come back in HOST coordinates (fence content is host line 3).
-    let edits = request_with_retry(&mut client, "}")
-        .expect("onTypeFormatting with a declared trigger should return edits");
+    let edits = request_with_retry(&mut client, "}");
     assert_eq!(edits.len(), 1);
     assert_eq!(edits[0]["newText"], "LOCAL X = 1\n");
     assert_eq!(
@@ -148,7 +152,10 @@ fn e2e_on_type_formatting_advertises_sorted_trigger_union_and_translates_edits()
 
     // Undeclared trigger: the downstream is warm now (previous request
     // succeeded) and would answer any character, so a null result proves the
-    // bridge filtered the request before it reached the server.
+    // bridge filtered the request before it reached the server. (Strictly,
+    // null could also mean the injection region failed to resolve — but the
+    // immediately preceding request resolved the same region and returned
+    // edits, so that alternative is ruled out for this sequence.)
     let response = client.send_request(
         "textDocument/onTypeFormatting",
         on_type_formatting_params("x"),


### PR DESCRIPTION
Closes #354

## Summary

Bridges `textDocument/onTypeFormatting` to downstream language servers for injected regions, using the maintainer-approved **option 2 (config-driven triggers)**:

- `documentOnTypeFormattingProvider` requires concrete trigger characters at initialize, but downstream servers spawn lazily — so users declare `onTypeFormattingTriggers` per `languageServers` entry (wildcard-mergeable, overlay-wins). kakehashi advertises the **sorted, deduplicated union**; no config keeps the capability unadvertised, so users who don't opt in see zero new requests.
- **Double filter**: a request is forwarded to a downstream server only when that server's own `documentOnTypeFormattingProvider` declares the typed character, so a misconfigured superset degrades to no-ops rather than bad edits. Dynamically-registered providers are trusted without trigger inspection (their trigger set lives in registration options the bridge doesn't parse).

## Design

The handler mirrors hover's position-based shape (`walk_layers` + per-region `dispatch_preferred` under its own `textDocument/onTypeFormatting` aggregation key); the response path reuses the formatting family's virtual→host `TextEdit` translation including past-EOF protection, and `Some(vec![])` keeps its authoritative "no edits" semantics.

## Tests

- Unit: trigger-union determinism (sorted/deduped, order-independent), overlay-wins merge, request wire shape, all four `downstream_declares_trigger` branches, `has_capability` tables.
- E2E (`tests/e2e_on_type_formatting.rs`, new `on-type` mock mode): sorted union advertised at initialize (absent without config); a declared trigger returns host-translated edits; an undeclared character is filtered bridge-side (the mock answers ANY character, so the null result can only come from the filter).

## Review notes

Pre-reviewed via 10-perspective subagent review (all findings addressed: trigger-filter unit tests, doc corrections incl. the capability-frozen-after-initialize note and the wildcard-union edge case) and a Codex session that traced the full request path and converged with no comments.