### PR TITLE
chore(cargo): set default-run so `cargo run` needs no --bin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kakehashi"
 version = "0.6.0"
 edition = "2024"
+default-run = "kakehashi"
 
 [[bin]]
 name = "kakehashi"


### PR DESCRIPTION
## Why

`cargo run` was ambiguous because the crate ships two `[[bin]]` targets — `kakehashi` and the e2e-only `mock-lsp-formatter` — so it errored without an explicit `--bin`.

## What

Pin `default-run = "kakehashi"` in `[package]`, making `cargo run` (no `--bin`) launch the primary binary. The mock formatter is still reachable via `cargo run --bin mock-lsp-formatter` when needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)