### PR TITLE
refactor(bridge): split inbound message handling into per-method modules

### DIFF
--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -10,8 +10,22 @@
 //! - `coordinator` - BridgeCoordinator for unified pool + node tracking
 //! - `protocol` - VirtualDocumentUri, request building, and response transformation
 //! - `pool` - LanguageServerPool for server pool coordination (ls-bridge-server-pool-coordination)
+//!
+//! # Per-method namespace modules
+//!
+//! Message handling is organized by LSP namespace, one file per method, so the
+//! directory listing maps to the supported surface. The dispatcher in
+//! `actor::reader` owns the shared transport and routes each method to its file:
+//!
+//! - `text_document` - the `textDocument` namespace (mostly outbound request
+//!   senders, plus the inbound scratch `publishDiagnostics` discard)
+//! - `client` - inbound `client/*` (dynamic capability register/unregister)
+//! - `window` - inbound `window/*` (log/show message, work-done progress) plus
+//!   the bridged `$/progress` stream
+//! - `workspace` - inbound `workspace/*` (diagnostic refresh, workspace folders)
 
 mod actor;
+mod client;
 mod connection;
 pub(crate) mod coordinator;
 mod pool;
@@ -19,7 +33,8 @@ mod progress_registry;
 mod protocol;
 mod root_markers;
 mod text_document;
-mod workspace_folders;
+mod window;
+mod workspace;
 
 // Re-export public types
 #[cfg(test)]
@@ -39,7 +54,7 @@ pub(crate) use protocol::location_link_to_location;
 pub(crate) use protocol::translate_virtual_range_to_host;
 pub(crate) use text_document::host::{HostDocument, normalize_host_goto_result};
 pub(crate) use text_document::{CodeLensEnvelope, extract_code_lens_envelope};
-pub(crate) use workspace_folders::WorkspaceFolderSet;
+pub(crate) use workspace::WorkspaceFolderSet;
 
 /// Integration tests for the bridge module.
 ///

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -17,21 +17,21 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use log::{debug, warn};
-use serde::Deserialize;
 use tokio::sync::{mpsc, oneshot};
 
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tower_lsp_server::jsonrpc;
-use tower_lsp_server::ls_types::{LogMessageParams, MessageType, ShowMessageParams};
+use tower_lsp_server::ls_types::MessageType;
 
 use super::super::connection::BridgeReader;
+use super::super::{client, text_document, window};
 use super::OutboundMessage;
 use super::ResponseRouter;
 use super::response_router::RouteResult;
 use crate::error::LockResultExt;
 use crate::lsp::bridge::pool::DynamicCapabilityRegistry;
-use crate::lsp::bridge::workspace_folders::WorkspaceFolderSet;
+use crate::lsp::bridge::workspace::{self, WorkspaceFolderSet};
 
 /// Notification to forward from downstream server to upstream editor.
 ///
@@ -646,14 +646,14 @@ async fn handle_message(
             // editor). The if/else makes the discard structural: notification
             // forwarding lives on the else side, where a scratch-targeted
             // publishDiagnostics can never reach it.
-            if is_scratch_publish_diagnostics(&message) {
+            if text_document::publish_diagnostics::is_scratch_publish_diagnostics(&message) {
                 debug!(
                     target: "kakehashi::bridge::reader",
                     "{}Discarding publishDiagnostics targeting a scratch virtual document",
                     server_prefix
                 );
             } else if message["method"].as_str() == Some("$/progress") {
-                forward_progress_notification(&message, server_prefix, deps);
+                window::progress::forward(&message, server_prefix, deps);
             } else {
                 forward_notification(&message, server_prefix, deps);
             }
@@ -671,177 +671,22 @@ async fn handle_message(
 
 /// Forward supported downstream notifications to the upstream editor.
 ///
-/// Both `window/logMessage` and `window/showMessage` are forwarded
-/// unconditionally — the bridge stays transparent so messages a direct
-/// connection would surface are not silently swallowed. A downstream flood
-/// cannot harm the bridge because the window channel is bounded and
-/// drop-on-full (see [`UpstreamNotification`]). Both are prefixed with the
-/// originating server name so output from multiple bridged servers stays
-/// distinguishable.
+/// Routes `window/logMessage` and `window/showMessage` to their per-method
+/// modules ([`window::log_message`], [`window::show_message`]); both are
+/// forwarded unconditionally so the bridge stays transparent.
 ///
-/// `$/progress` is handled earlier in `handle_message` (translated and
-/// forwarded via `forward_progress_notification`), so it never reaches here.
-/// Everything else is still silently ignored (push-based publishDiagnostics:
-/// #380).
+/// `$/progress` is handled earlier in `handle_message` (translated and forwarded
+/// via [`window::progress::forward`]), so it never reaches here. Everything else
+/// is still silently ignored (push-based publishDiagnostics: #380).
 fn forward_notification(
     message: &serde_json::Value,
     server_prefix: &str,
     deps: &ServerRequestDeps,
 ) {
     match message["method"].as_str() {
-        Some("window/logMessage") => {
-            // Deserialize from a reference to avoid cloning the params value.
-            match LogMessageParams::deserialize(&message["params"]) {
-                Ok(params) => send_window_notification(
-                    deps,
-                    server_prefix,
-                    "window/logMessage",
-                    UpstreamNotification::LogMessage {
-                        typ: params.typ,
-                        message: prefixed_message(deps.server_name.as_deref(), &params.message),
-                    },
-                ),
-                Err(e) => debug!(
-                    target: "kakehashi::bridge::reader",
-                    "{}Dropping window/logMessage with invalid params: {}",
-                    server_prefix,
-                    e
-                ),
-            }
-        }
-        Some("window/showMessage") => match ShowMessageParams::deserialize(&message["params"]) {
-            Ok(params) => send_window_notification(
-                deps,
-                server_prefix,
-                "window/showMessage",
-                UpstreamNotification::ShowMessage {
-                    typ: params.typ,
-                    message: prefixed_message(deps.server_name.as_deref(), &params.message),
-                },
-            ),
-            Err(e) => debug!(
-                target: "kakehashi::bridge::reader",
-                "{}Dropping window/showMessage with invalid params: {}",
-                server_prefix,
-                e
-            ),
-        },
+        Some("window/logMessage") => window::log_message::forward(message, server_prefix, deps),
+        Some("window/showMessage") => window::show_message::forward(message, server_prefix, deps),
         _ => {}
-    }
-}
-
-/// Enqueue a `window/*` notification on the bounded best-effort channel.
-///
-/// `try_send` keeps the reader task non-blocking: a full queue (editor slower
-/// than a downstream notification flood) drops the message instead of growing
-/// memory or stalling stdout reads; a closed queue (shutdown) has no one left
-/// to deliver to. Both are deliberate per the loss-tolerance split documented
-/// on [`UpstreamNotification`].
-fn send_window_notification(
-    deps: &ServerRequestDeps,
-    server_prefix: &str,
-    method: &str,
-    notification: UpstreamNotification,
-) {
-    if let Err(e) = deps.window_tx.try_send(notification) {
-        debug!(
-            target: "kakehashi::bridge::reader",
-            "{}Dropping {} ({})",
-            server_prefix,
-            method,
-            match e {
-                mpsc::error::TrySendError::Full(_) => "window notification queue full",
-                mpsc::error::TrySendError::Closed(_) => "forwarding loop gone",
-            }
-        );
-    }
-}
-
-/// `[kakehashi:<server>] <message>` — tells the user which downstream server
-/// a forwarded `window/*` notification came from (#378). Falls back to
-/// `[kakehashi] <message>` when the server name is absent (test-only spawns;
-/// production spawns always carry the name, see pool.rs).
-fn prefixed_message(server_name: Option<&str>, message: &str) -> String {
-    match server_name {
-        Some(name) => format!("[kakehashi:{name}] {message}"),
-        None => format!("[kakehashi] {message}"),
-    }
-}
-
-/// Whether `message` is a `textDocument/publishDiagnostics` notification
-/// targeting a concatenated-formatting *scratch* virtual document
-/// ([`VirtualDocumentUri::is_scratch_uri`]).
-///
-/// Scratch documents carry speculative pipeline text the editor has never
-/// seen; diagnostics computed against them are meaningless to the user and
-/// must be discarded, not forwarded (concatenated-formatting-pipeline
-/// Decision point 7). The prompt `didClose` after each pipeline run shrinks
-/// but cannot eliminate the window in which a downstream server pushes them.
-fn is_scratch_publish_diagnostics(message: &serde_json::Value) -> bool {
-    // `Value` indexing returns `Null` for missing keys / non-objects, so the
-    // lookups below are panic-free on malformed messages.
-    message["method"].as_str() == Some("textDocument/publishDiagnostics")
-        && message["params"]["uri"]
-            .as_str()
-            .is_some_and(crate::lsp::bridge::VirtualDocumentUri::is_scratch_uri)
-}
-
-/// Translate and forward a downstream `$/progress` notification to the editor.
-///
-/// Only progress reported against a token the downstream declared via
-/// `window/workDoneProgress/create` is forwarded: its token is rewritten to the
-/// bridge-minted upstream token and sent on the upstream channel. Progress for
-/// any other token (e.g. a client-provided `workDoneToken`) is **dropped** — it
-/// is out of scope for token remapping (see [`ProgressRegistry`] module docs),
-/// and forwarding it verbatim risks duplicates under request fan-out.
-///
-/// A terminating `WorkDoneProgress::End` clears the mapping after forwarding.
-///
-/// [`ProgressRegistry`]: crate::lsp::bridge::ProgressRegistry
-fn forward_progress_notification(
-    message: &serde_json::Value,
-    server_prefix: &str,
-    deps: &ServerRequestDeps,
-) {
-    use tower_lsp_server::ls_types::{ProgressParams, ProgressParamsValue, WorkDoneProgress};
-
-    // Deserialize from the borrowed `params` value (indexing yields `Null` for a
-    // missing key, which fails to parse and is dropped) — no clone of the Value.
-    let Ok(mut params) = ProgressParams::deserialize(&message["params"]) else {
-        debug!(
-            target: "kakehashi::bridge::reader",
-            "{}Dropping $/progress with missing/unparseable params",
-            server_prefix
-        );
-        return;
-    };
-
-    let Some(upstream_token) = deps
-        .progress_registry
-        .translate(deps.progress_connection_id, &params.token)
-    else {
-        // Unknown token: not a downstream-declared progress we remapped.
-        debug!(
-            target: "kakehashi::bridge::reader",
-            "{}Dropping $/progress for unmapped token {:?}",
-            server_prefix, params.token
-        );
-        return;
-    };
-
-    let is_end = matches!(
-        &params.value,
-        ProgressParamsValue::WorkDone(WorkDoneProgress::End(_))
-    );
-
-    let downstream_token = std::mem::replace(&mut params.token, upstream_token);
-    let _ = deps
-        .upstream_tx
-        .send(UpstreamNotification::Progress { params });
-
-    if is_end {
-        deps.progress_registry
-            .complete(deps.progress_connection_id, &downstream_token);
     }
 }
 
@@ -865,168 +710,18 @@ async fn handle_server_request(
 
     let body: jsonrpc::Result<serde_json::Value> = match method {
         "client/registerCapability" => {
-            if let Some(params) = message.get("params") {
-                match serde_json::from_value::<tower_lsp_server::ls_types::RegistrationParams>(
-                    params.clone(),
-                ) {
-                    Ok(reg_params) => {
-                        for reg in &reg_params.registrations {
-                            debug!(
-                                target: "kakehashi::bridge::reader",
-                                "{}Registered dynamic capability: {} (id={})",
-                                server_prefix, reg.method, reg.id
-                            );
-                        }
-                        deps.dynamic_capabilities.register(reg_params.registrations);
-                        Ok(serde_json::Value::Null)
-                    }
-                    Err(e) => {
-                        warn!(
-                            target: "kakehashi::bridge::reader",
-                            "{}Failed to parse registerCapability params: {}",
-                            server_prefix, e
-                        );
-                        Err(jsonrpc::Error::invalid_params(format!(
-                            "Invalid params: {e}"
-                        )))
-                    }
-                }
-            } else {
-                warn!(
-                    target: "kakehashi::bridge::reader",
-                    "{}Request 'client/registerCapability' is missing 'params' field",
-                    server_prefix
-                );
-                Err(jsonrpc::Error::invalid_params(
-                    "Request 'client/registerCapability' is missing 'params' field",
-                ))
-            }
+            client::register_capability::handle(&message, server_prefix, deps)
         }
         "client/unregisterCapability" => {
-            if let Some(params) = message.get("params") {
-                match serde_json::from_value::<tower_lsp_server::ls_types::UnregistrationParams>(
-                    params.clone(),
-                ) {
-                    Ok(unreg_params) => {
-                        for unreg in &unreg_params.unregisterations {
-                            debug!(
-                                target: "kakehashi::bridge::reader",
-                                "{}Unregistered dynamic capability: {} (id={})",
-                                server_prefix, unreg.method, unreg.id
-                            );
-                        }
-                        deps.dynamic_capabilities
-                            .unregister(unreg_params.unregisterations);
-                        Ok(serde_json::Value::Null)
-                    }
-                    Err(e) => {
-                        warn!(
-                            target: "kakehashi::bridge::reader",
-                            "{}Failed to parse unregisterCapability params: {}",
-                            server_prefix, e
-                        );
-                        Err(jsonrpc::Error::invalid_params(format!(
-                            "Invalid params: {e}"
-                        )))
-                    }
-                }
-            } else {
-                warn!(
-                    target: "kakehashi::bridge::reader",
-                    "{}Request 'client/unregisterCapability' is missing 'params' field",
-                    server_prefix
-                );
-                Err(jsonrpc::Error::invalid_params(
-                    "Request 'client/unregisterCapability' is missing 'params' field",
-                ))
-            }
+            client::unregister_capability::handle(&message, server_prefix, deps)
         }
         "window/workDoneProgress/create" => {
-            // A downstream is declaring a progress token. Downstreams pick tokens
-            // independently, so two of them can collide; mint a unique upstream
-            // token and remember the mapping so `$/progress` and cancel can be
-            // translated in both directions (window-work-done-progress bridging).
-            //
-            // We ack the downstream immediately with Ok(null) rather than relaying
-            // the editor's real create response: this decouples the downstream from
-            // editor latency and lets progress buffer on the FIFO upstream channel.
-            // The bridge only advertises `window.workDoneProgress` downstream when
-            // the real editor supports it (see client_capabilities merge), so the
-            // editor almost always accepts the create. If it nonetheless rejects
-            // or times out, the forwarding loop drops that token's `$/progress`
-            // (it admits a token only on a successful create), so the optimistic
-            // ack never leaks progress for a token the editor didn't create.
-            // Deserialize the token from the borrowed value (indexing yields
-            // `Null` for a missing key, which fails to parse) — no clone.
-            match tower_lsp_server::ls_types::NumberOrString::deserialize(
-                &message["params"]["token"],
-            ) {
-                Ok(downstream_token) => {
-                    // A downstream that re-`create`s a token it already declared
-                    // (without an intervening End) gets a fresh upstream token;
-                    // `register` evicts the prior one and returns it as `stale` so
-                    // we can tell the forwarding loop to forget its admission too —
-                    // otherwise it would leak in `created_tokens`.
-                    let (upstream_token, stale_upstream_token) = deps.progress_registry.register(
-                        deps.progress_connection_id,
-                        downstream_token,
-                        deps.response_tx.clone(),
-                    );
-                    debug!(
-                        target: "kakehashi::bridge::reader",
-                        "{}Bridging window/workDoneProgress/create as upstream token {:?}",
-                        server_prefix, upstream_token
-                    );
-                    if let Some(stale) = stale_upstream_token {
-                        let _ = deps
-                            .upstream_tx
-                            .send(UpstreamNotification::ForgetWorkDoneProgress(vec![stale]));
-                    }
-                    let _ = deps
-                        .upstream_tx
-                        .send(UpstreamNotification::CreateWorkDoneProgress {
-                            token: upstream_token,
-                        });
-                    Ok(serde_json::Value::Null)
-                }
-                Err(_) => {
-                    warn!(
-                        target: "kakehashi::bridge::reader",
-                        "{}window/workDoneProgress/create missing/invalid token",
-                        server_prefix
-                    );
-                    Err(jsonrpc::Error::invalid_params(
-                        "window/workDoneProgress/create requires a token",
-                    ))
-                }
-            }
+            window::work_done_progress_create::handle(&message, server_prefix, deps)
         }
         "workspace/diagnostic/refresh" => {
-            // Downstream server is requesting that the client re-pull diagnostics.
-            // Forward this upstream so the editor triggers a fresh diagnostic pull.
-            debug!(
-                target: "kakehashi::bridge::reader",
-                "{}Forwarding workspace/diagnostic/refresh upstream",
-                server_prefix
-            );
-            let _ = deps
-                .upstream_tx
-                .send(UpstreamNotification::DiagnosticRefresh);
-            Ok(serde_json::Value::Null)
+            workspace::diagnostic_refresh::handle(server_prefix, deps)
         }
-        "workspace/workspaceFolders" => {
-            // The bridge advertises workspace.workspaceFolders, so answer with
-            // the folders this connection currently serves — which a
-            // preferSharedInstance connection grows over time (#391)
-            // (WorkspaceFolder[] | null).
-            debug!(
-                target: "kakehashi::bridge::reader",
-                "{}Answering workspace/workspaceFolders from the connection's current folders",
-                server_prefix
-            );
-            Ok(serde_json::to_value(deps.workspace_folders.snapshot())
-                .unwrap_or(serde_json::Value::Null))
-        }
+        "workspace/workspaceFolders" => workspace::workspace_folders::handle(server_prefix, deps),
         _ => {
             debug!(
                 target: "kakehashi::bridge::reader",
@@ -2349,39 +2044,6 @@ mod tests {
             response_rx.try_recv().is_err(),
             "a notification must not trigger any downstream response"
         );
-    }
-
-    #[test]
-    fn is_scratch_publish_diagnostics_matches_only_scratch_targets() {
-        let scratch = json!({
-            "jsonrpc": "2.0",
-            "method": "textDocument/publishDiagnostics",
-            "params": {"uri": "file:///p/kakehashi-virtual-uri-R-kakehashi-scratch-0-1.py", "diagnostics": []}
-        });
-        assert!(is_scratch_publish_diagnostics(&scratch));
-
-        // Canonical virtual document: not scratch.
-        let canonical = json!({
-            "jsonrpc": "2.0",
-            "method": "textDocument/publishDiagnostics",
-            "params": {"uri": "file:///p/kakehashi-virtual-uri-R.py", "diagnostics": []}
-        });
-        assert!(!is_scratch_publish_diagnostics(&canonical));
-
-        // Different method on a scratch URI: not publishDiagnostics.
-        let other_method = json!({
-            "jsonrpc": "2.0",
-            "method": "$/progress",
-            "params": {"uri": "file:///p/kakehashi-virtual-uri-R-kakehashi-scratch-0-1.py"}
-        });
-        assert!(!is_scratch_publish_diagnostics(&other_method));
-
-        // Missing params: must not panic, just no match.
-        let no_params = json!({
-            "jsonrpc": "2.0",
-            "method": "textDocument/publishDiagnostics"
-        });
-        assert!(!is_scratch_publish_diagnostics(&no_params));
     }
 
     #[tokio::test]

--- a/src/lsp/bridge/client.rs
+++ b/src/lsp/bridge/client.rs
@@ -1,0 +1,13 @@
+//! Inbound `client/*` server-request handlers.
+//!
+//! The `client` LSP namespace is entirely inbound (downstream → bridge): a
+//! downstream server asks the client (the bridge, here) to register or
+//! unregister dynamic capabilities. Each method has its own file so the
+//! directory listing maps to the supported surface, mirroring
+//! [`text_document`](super::text_document).
+//!
+//! The dispatcher in [`actor::reader`](super::actor) owns the shared transport
+//! and routes each method here.
+
+pub(in crate::lsp::bridge) mod register_capability;
+pub(in crate::lsp::bridge) mod unregister_capability;

--- a/src/lsp/bridge/client/register_capability.rs
+++ b/src/lsp/bridge/client/register_capability.rs
@@ -1,0 +1,61 @@
+//! `client/registerCapability` server-request handler.
+//!
+//! Inbound (downstream → bridge). A downstream server registers a dynamic
+//! capability; the bridge records it in the shared [`DynamicCapabilityRegistry`]
+//! and acks with `null`. Param-parse failures (or a missing `params` field)
+//! reply with InvalidParams (-32602): a server that can't form its own request
+//! is buggy, and the LSP spec allows an error response to any request.
+//!
+//! [`DynamicCapabilityRegistry`]: crate::lsp::bridge::pool::DynamicCapabilityRegistry
+
+use log::{debug, warn};
+use serde::Deserialize;
+use tower_lsp_server::jsonrpc;
+use tower_lsp_server::ls_types::RegistrationParams;
+
+use crate::lsp::bridge::actor::ServerRequestDeps;
+
+/// Handle a `client/registerCapability` request, returning the JSON-RPC body
+/// the dispatcher wraps in a response.
+pub(in crate::lsp::bridge) fn handle(
+    message: &serde_json::Value,
+    server_prefix: &str,
+    deps: &ServerRequestDeps,
+) -> jsonrpc::Result<serde_json::Value> {
+    let Some(params) = message.get("params") else {
+        warn!(
+            target: "kakehashi::bridge::reader",
+            "{}Request 'client/registerCapability' is missing 'params' field",
+            server_prefix
+        );
+        return Err(jsonrpc::Error::invalid_params(
+            "Request 'client/registerCapability' is missing 'params' field",
+        ));
+    };
+
+    // Deserialize from the borrowed `params` value to avoid cloning the JSON
+    // tree, matching the by-reference pattern used across the bridge handlers.
+    match RegistrationParams::deserialize(params) {
+        Ok(reg_params) => {
+            for reg in &reg_params.registrations {
+                debug!(
+                    target: "kakehashi::bridge::reader",
+                    "{}Registered dynamic capability: {} (id={})",
+                    server_prefix, reg.method, reg.id
+                );
+            }
+            deps.dynamic_capabilities.register(reg_params.registrations);
+            Ok(serde_json::Value::Null)
+        }
+        Err(e) => {
+            warn!(
+                target: "kakehashi::bridge::reader",
+                "{}Failed to parse registerCapability params: {}",
+                server_prefix, e
+            );
+            Err(jsonrpc::Error::invalid_params(format!(
+                "Invalid params: {e}"
+            )))
+        }
+    }
+}

--- a/src/lsp/bridge/client/unregister_capability.rs
+++ b/src/lsp/bridge/client/unregister_capability.rs
@@ -1,0 +1,62 @@
+//! `client/unregisterCapability` server-request handler.
+//!
+//! Inbound (downstream → bridge). A downstream server unregisters a dynamic
+//! capability it previously registered; the bridge drops it from the shared
+//! [`DynamicCapabilityRegistry`] and acks with `null`. Param-parse failures (or
+//! a missing `params` field) reply with InvalidParams (-32602), mirroring
+//! [`register_capability`](super::register_capability).
+//!
+//! [`DynamicCapabilityRegistry`]: crate::lsp::bridge::pool::DynamicCapabilityRegistry
+
+use log::{debug, warn};
+use serde::Deserialize;
+use tower_lsp_server::jsonrpc;
+use tower_lsp_server::ls_types::UnregistrationParams;
+
+use crate::lsp::bridge::actor::ServerRequestDeps;
+
+/// Handle a `client/unregisterCapability` request, returning the JSON-RPC body
+/// the dispatcher wraps in a response.
+pub(in crate::lsp::bridge) fn handle(
+    message: &serde_json::Value,
+    server_prefix: &str,
+    deps: &ServerRequestDeps,
+) -> jsonrpc::Result<serde_json::Value> {
+    let Some(params) = message.get("params") else {
+        warn!(
+            target: "kakehashi::bridge::reader",
+            "{}Request 'client/unregisterCapability' is missing 'params' field",
+            server_prefix
+        );
+        return Err(jsonrpc::Error::invalid_params(
+            "Request 'client/unregisterCapability' is missing 'params' field",
+        ));
+    };
+
+    // Deserialize from the borrowed `params` value to avoid cloning the JSON
+    // tree, matching the by-reference pattern used across the bridge handlers.
+    match UnregistrationParams::deserialize(params) {
+        Ok(unreg_params) => {
+            for unreg in &unreg_params.unregisterations {
+                debug!(
+                    target: "kakehashi::bridge::reader",
+                    "{}Unregistered dynamic capability: {} (id={})",
+                    server_prefix, unreg.method, unreg.id
+                );
+            }
+            deps.dynamic_capabilities
+                .unregister(unreg_params.unregisterations);
+            Ok(serde_json::Value::Null)
+        }
+        Err(e) => {
+            warn!(
+                target: "kakehashi::bridge::reader",
+                "{}Failed to parse unregisterCapability params: {}",
+                server_prefix, e
+            );
+            Err(jsonrpc::Error::invalid_params(format!(
+                "Invalid params: {e}"
+            )))
+        }
+    }
+}

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -30,7 +30,7 @@ use crate::lsp::bridge::connection::SplitConnectionWriter;
 use crate::lsp::bridge::protocol::{
     JsonRpcNotification, JsonRpcRequest, RequestId, build_exit_notification, build_shutdown_request,
 };
-use crate::lsp::bridge::workspace_folders::WorkspaceFolderSet;
+use crate::lsp::bridge::workspace::WorkspaceFolderSet;
 
 /// Whether `caps` advertises everything the shared-instance opt-in (#391)
 /// needs to drive one connection across roots via

--- a/src/lsp/bridge/text_document.rs
+++ b/src/lsp/bridge/text_document.rs
@@ -33,6 +33,7 @@ mod linked_editing_range;
 mod moniker;
 mod on_type_formatting;
 mod prepare_rename;
+pub(in crate::lsp::bridge) mod publish_diagnostics;
 mod range_formatting;
 mod references;
 mod rename;

--- a/src/lsp/bridge/text_document/publish_diagnostics.rs
+++ b/src/lsp/bridge/text_document/publish_diagnostics.rs
@@ -1,0 +1,67 @@
+//! Inbound `textDocument/publishDiagnostics` handling.
+//!
+//! Unlike the other `text_document/*` files (outbound request senders), this one
+//! is **inbound** (downstream → bridge): a downstream server pushes diagnostics.
+//! The bridge does not forward push diagnostics in general (#380); the one case
+//! it must act on is a push targeting a concatenated-formatting *scratch*
+//! virtual document, which is discarded structurally by the dispatcher in
+//! [`actor::reader`](crate::lsp::bridge::actor) using [`is_scratch_publish_diagnostics`].
+
+/// Whether `message` is a `textDocument/publishDiagnostics` notification
+/// targeting a concatenated-formatting *scratch* virtual document
+/// ([`VirtualDocumentUri::is_scratch_uri`]).
+///
+/// Scratch documents carry speculative pipeline text the editor has never
+/// seen; diagnostics computed against them are meaningless to the user and
+/// must be discarded, not forwarded (concatenated-formatting-pipeline
+/// Decision point 7). The prompt `didClose` after each pipeline run shrinks
+/// but cannot eliminate the window in which a downstream server pushes them.
+///
+/// [`VirtualDocumentUri::is_scratch_uri`]: crate::lsp::bridge::VirtualDocumentUri::is_scratch_uri
+pub(in crate::lsp::bridge) fn is_scratch_publish_diagnostics(message: &serde_json::Value) -> bool {
+    // `Value` indexing returns `Null` for missing keys / non-objects, so the
+    // lookups below are panic-free on malformed messages.
+    message["method"].as_str() == Some("textDocument/publishDiagnostics")
+        && message["params"]["uri"]
+            .as_str()
+            .is_some_and(crate::lsp::bridge::VirtualDocumentUri::is_scratch_uri)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn is_scratch_publish_diagnostics_matches_only_scratch_targets() {
+        let scratch = json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics",
+            "params": {"uri": "file:///p/kakehashi-virtual-uri-R-kakehashi-scratch-0-1.py", "diagnostics": []}
+        });
+        assert!(is_scratch_publish_diagnostics(&scratch));
+
+        // Canonical virtual document: not scratch.
+        let canonical = json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics",
+            "params": {"uri": "file:///p/kakehashi-virtual-uri-R.py", "diagnostics": []}
+        });
+        assert!(!is_scratch_publish_diagnostics(&canonical));
+
+        // Different method on a scratch URI: not publishDiagnostics.
+        let other_method = json!({
+            "jsonrpc": "2.0",
+            "method": "$/progress",
+            "params": {"uri": "file:///p/kakehashi-virtual-uri-R-kakehashi-scratch-0-1.py"}
+        });
+        assert!(!is_scratch_publish_diagnostics(&other_method));
+
+        // Missing params: must not panic, just no match.
+        let no_params = json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics"
+        });
+        assert!(!is_scratch_publish_diagnostics(&no_params));
+    }
+}

--- a/src/lsp/bridge/window.rs
+++ b/src/lsp/bridge/window.rs
@@ -1,0 +1,67 @@
+//! Inbound `window/*` server messages, plus the bridged `$/progress` stream.
+//!
+//! The `window` LSP namespace is entirely inbound (downstream → editor): a
+//! downstream server surfaces log/show messages or declares work-done progress,
+//! and the bridge forwards them upstream. Each method has its own file so the
+//! directory listing maps to the supported surface, mirroring
+//! [`text_document`](super::text_document).
+//!
+//! `$/progress` lives here too ([`progress`]) even though it is `$`-namespaced:
+//! it is bridged as the data half of `window/workDoneProgress/create`
+//! ([`work_done_progress_create`]), sharing the same [`ProgressRegistry`] token
+//! remapping. Splitting the two by namespace would scatter one feature, so they
+//! sit together under `window/` with this note.
+//!
+//! The dispatcher in [`actor::reader`](super::actor) owns the shared transport
+//! and routes each method here; the `window/*` forwarders reach back for the
+//! bounded best-effort window channel via [`send_window_notification`].
+//!
+//! [`ProgressRegistry`]: crate::lsp::bridge::ProgressRegistry
+
+use log::debug;
+use tokio::sync::mpsc;
+
+use crate::lsp::bridge::actor::{ServerRequestDeps, UpstreamNotification};
+
+pub(in crate::lsp::bridge) mod log_message;
+pub(in crate::lsp::bridge) mod progress;
+pub(in crate::lsp::bridge) mod show_message;
+pub(in crate::lsp::bridge) mod work_done_progress_create;
+
+/// Enqueue a `window/*` notification on the bounded best-effort channel.
+///
+/// `try_send` keeps the reader task non-blocking: a full queue (editor slower
+/// than a downstream notification flood) drops the message instead of growing
+/// memory or stalling stdout reads; a closed queue (shutdown) has no one left
+/// to deliver to. Both are deliberate per the loss-tolerance split documented
+/// on [`UpstreamNotification`].
+fn send_window_notification(
+    deps: &ServerRequestDeps,
+    server_prefix: &str,
+    method: &str,
+    notification: UpstreamNotification,
+) {
+    if let Err(e) = deps.window_tx.try_send(notification) {
+        debug!(
+            target: "kakehashi::bridge::reader",
+            "{}Dropping {} ({})",
+            server_prefix,
+            method,
+            match e {
+                mpsc::error::TrySendError::Full(_) => "window notification queue full",
+                mpsc::error::TrySendError::Closed(_) => "forwarding loop gone",
+            }
+        );
+    }
+}
+
+/// `[kakehashi:<server>] <message>` — tells the user which downstream server
+/// a forwarded `window/*` notification came from (#378). Falls back to
+/// `[kakehashi] <message>` when the server name is absent (test-only spawns;
+/// production spawns always carry the name, see pool.rs).
+fn prefixed_message(server_name: Option<&str>, message: &str) -> String {
+    match server_name {
+        Some(name) => format!("[kakehashi:{name}] {message}"),
+        None => format!("[kakehashi] {message}"),
+    }
+}

--- a/src/lsp/bridge/window/log_message.rs
+++ b/src/lsp/bridge/window/log_message.rs
@@ -1,0 +1,43 @@
+//! `window/logMessage` notification forwarder.
+//!
+//! Inbound (downstream → editor). Forwarded unconditionally so the bridge stays
+//! transparent: messages a direct connection would surface are not silently
+//! swallowed. A downstream flood cannot harm the bridge because the window
+//! channel is bounded and drop-on-full (see [`UpstreamNotification`]). The text
+//! is prefixed with the originating server name so output from multiple bridged
+//! servers stays distinguishable.
+//!
+//! [`UpstreamNotification`]: crate::lsp::bridge::actor::UpstreamNotification
+
+use log::debug;
+use serde::Deserialize;
+use tower_lsp_server::ls_types::LogMessageParams;
+
+use super::{prefixed_message, send_window_notification};
+use crate::lsp::bridge::actor::{ServerRequestDeps, UpstreamNotification};
+
+/// Forward a `window/logMessage` notification to the editor.
+pub(in crate::lsp::bridge) fn forward(
+    message: &serde_json::Value,
+    server_prefix: &str,
+    deps: &ServerRequestDeps,
+) {
+    // Deserialize from a reference to avoid cloning the params value.
+    match LogMessageParams::deserialize(&message["params"]) {
+        Ok(params) => send_window_notification(
+            deps,
+            server_prefix,
+            "window/logMessage",
+            UpstreamNotification::LogMessage {
+                typ: params.typ,
+                message: prefixed_message(deps.server_name.as_deref(), &params.message),
+            },
+        ),
+        Err(e) => debug!(
+            target: "kakehashi::bridge::reader",
+            "{}Dropping window/logMessage with invalid params: {}",
+            server_prefix,
+            e
+        ),
+    }
+}

--- a/src/lsp/bridge/window/progress.rs
+++ b/src/lsp/bridge/window/progress.rs
@@ -1,0 +1,71 @@
+//! `$/progress` notification forwarder (the data half of work-done progress).
+//!
+//! Inbound (downstream → editor). Although `$/progress` is `$`-namespaced, it is
+//! bridged as part of `window/workDoneProgress/create`
+//! ([`work_done_progress_create`](super::work_done_progress_create)) and shares
+//! its [`ProgressRegistry`] token remapping, so it lives under `window/`.
+//!
+//! [`ProgressRegistry`]: crate::lsp::bridge::ProgressRegistry
+
+use log::debug;
+use serde::Deserialize;
+use tower_lsp_server::ls_types::{ProgressParams, ProgressParamsValue, WorkDoneProgress};
+
+use crate::lsp::bridge::actor::{ServerRequestDeps, UpstreamNotification};
+
+/// Translate and forward a downstream `$/progress` notification to the editor.
+///
+/// Only progress reported against a token the downstream declared via
+/// `window/workDoneProgress/create` is forwarded: its token is rewritten to the
+/// bridge-minted upstream token and sent on the upstream channel. Progress for
+/// any other token (e.g. a client-provided `workDoneToken`) is **dropped** — it
+/// is out of scope for token remapping (see [`ProgressRegistry`] module docs),
+/// and forwarding it verbatim risks duplicates under request fan-out.
+///
+/// A terminating `WorkDoneProgress::End` clears the mapping after forwarding.
+///
+/// [`ProgressRegistry`]: crate::lsp::bridge::ProgressRegistry
+pub(in crate::lsp::bridge) fn forward(
+    message: &serde_json::Value,
+    server_prefix: &str,
+    deps: &ServerRequestDeps,
+) {
+    // Deserialize from the borrowed `params` value (indexing yields `Null` for a
+    // missing key, which fails to parse and is dropped) — no clone of the Value.
+    let Ok(mut params) = ProgressParams::deserialize(&message["params"]) else {
+        debug!(
+            target: "kakehashi::bridge::reader",
+            "{}Dropping $/progress with missing/unparseable params",
+            server_prefix
+        );
+        return;
+    };
+
+    let Some(upstream_token) = deps
+        .progress_registry
+        .translate(deps.progress_connection_id, &params.token)
+    else {
+        // Unknown token: not a downstream-declared progress we remapped.
+        debug!(
+            target: "kakehashi::bridge::reader",
+            "{}Dropping $/progress for unmapped token {:?}",
+            server_prefix, params.token
+        );
+        return;
+    };
+
+    let is_end = matches!(
+        &params.value,
+        ProgressParamsValue::WorkDone(WorkDoneProgress::End(_))
+    );
+
+    let downstream_token = std::mem::replace(&mut params.token, upstream_token);
+    let _ = deps
+        .upstream_tx
+        .send(UpstreamNotification::Progress { params });
+
+    if is_end {
+        deps.progress_registry
+            .complete(deps.progress_connection_id, &downstream_token);
+    }
+}

--- a/src/lsp/bridge/window/show_message.rs
+++ b/src/lsp/bridge/window/show_message.rs
@@ -1,0 +1,40 @@
+//! `window/showMessage` notification forwarder.
+//!
+//! Inbound (downstream → editor). Forwarded unconditionally so the bridge stays
+//! transparent, prefixed with the originating server name, on the same bounded
+//! drop-on-full channel as [`log_message`](super::log_message). See that module
+//! and [`UpstreamNotification`] for the loss-tolerance rationale.
+//!
+//! [`UpstreamNotification`]: crate::lsp::bridge::actor::UpstreamNotification
+
+use log::debug;
+use serde::Deserialize;
+use tower_lsp_server::ls_types::ShowMessageParams;
+
+use super::{prefixed_message, send_window_notification};
+use crate::lsp::bridge::actor::{ServerRequestDeps, UpstreamNotification};
+
+/// Forward a `window/showMessage` notification to the editor.
+pub(in crate::lsp::bridge) fn forward(
+    message: &serde_json::Value,
+    server_prefix: &str,
+    deps: &ServerRequestDeps,
+) {
+    match ShowMessageParams::deserialize(&message["params"]) {
+        Ok(params) => send_window_notification(
+            deps,
+            server_prefix,
+            "window/showMessage",
+            UpstreamNotification::ShowMessage {
+                typ: params.typ,
+                message: prefixed_message(deps.server_name.as_deref(), &params.message),
+            },
+        ),
+        Err(e) => debug!(
+            target: "kakehashi::bridge::reader",
+            "{}Dropping window/showMessage with invalid params: {}",
+            server_prefix,
+            e
+        ),
+    }
+}

--- a/src/lsp/bridge/window/work_done_progress_create.rs
+++ b/src/lsp/bridge/window/work_done_progress_create.rs
@@ -1,0 +1,81 @@
+//! `window/workDoneProgress/create` server-request handler.
+//!
+//! Inbound (downstream → bridge → editor). A downstream declares a progress
+//! token; the bridge mints a unique *upstream* token, records the mapping in the
+//! shared [`ProgressRegistry`], and asks the editor to create the progress. The
+//! data half of the feature — translating the downstream's `$/progress` to the
+//! upstream token — lives in [`progress`](super::progress).
+//!
+//! [`ProgressRegistry`]: crate::lsp::bridge::ProgressRegistry
+
+use log::{debug, warn};
+use serde::Deserialize;
+use tower_lsp_server::jsonrpc;
+use tower_lsp_server::ls_types::NumberOrString;
+
+use crate::lsp::bridge::actor::{ServerRequestDeps, UpstreamNotification};
+
+/// Handle a `window/workDoneProgress/create` request, returning the JSON-RPC
+/// body the dispatcher wraps in a response.
+pub(in crate::lsp::bridge) fn handle(
+    message: &serde_json::Value,
+    server_prefix: &str,
+    deps: &ServerRequestDeps,
+) -> jsonrpc::Result<serde_json::Value> {
+    // A downstream is declaring a progress token. Downstreams pick tokens
+    // independently, so two of them can collide; mint a unique upstream
+    // token and remember the mapping so `$/progress` and cancel can be
+    // translated in both directions (window-work-done-progress bridging).
+    //
+    // We ack the downstream immediately with Ok(null) rather than relaying
+    // the editor's real create response: this decouples the downstream from
+    // editor latency and lets progress buffer on the FIFO upstream channel.
+    // The bridge only advertises `window.workDoneProgress` downstream when
+    // the real editor supports it (see client_capabilities merge), so the
+    // editor almost always accepts the create. If it nonetheless rejects
+    // or times out, the forwarding loop drops that token's `$/progress`
+    // (it admits a token only on a successful create), so the optimistic
+    // ack never leaks progress for a token the editor didn't create.
+    // Deserialize the token from the borrowed value (indexing yields
+    // `Null` for a missing key, which fails to parse) — no clone.
+    match NumberOrString::deserialize(&message["params"]["token"]) {
+        Ok(downstream_token) => {
+            // A downstream that re-`create`s a token it already declared
+            // (without an intervening End) gets a fresh upstream token;
+            // `register` evicts the prior one and returns it as `stale` so
+            // we can tell the forwarding loop to forget its admission too —
+            // otherwise it would leak in `created_tokens`.
+            let (upstream_token, stale_upstream_token) = deps.progress_registry.register(
+                deps.progress_connection_id,
+                downstream_token,
+                deps.response_tx.clone(),
+            );
+            debug!(
+                target: "kakehashi::bridge::reader",
+                "{}Bridging window/workDoneProgress/create as upstream token {:?}",
+                server_prefix, upstream_token
+            );
+            if let Some(stale) = stale_upstream_token {
+                let _ = deps
+                    .upstream_tx
+                    .send(UpstreamNotification::ForgetWorkDoneProgress(vec![stale]));
+            }
+            let _ = deps
+                .upstream_tx
+                .send(UpstreamNotification::CreateWorkDoneProgress {
+                    token: upstream_token,
+                });
+            Ok(serde_json::Value::Null)
+        }
+        Err(_) => {
+            warn!(
+                target: "kakehashi::bridge::reader",
+                "{}window/workDoneProgress/create missing/invalid token",
+                server_prefix
+            );
+            Err(jsonrpc::Error::invalid_params(
+                "window/workDoneProgress/create requires a token",
+            ))
+        }
+    }
+}

--- a/src/lsp/bridge/workspace.rs
+++ b/src/lsp/bridge/workspace.rs
@@ -1,0 +1,21 @@
+//! Inbound `workspace/*` server-request handlers.
+//!
+//! The `workspace` LSP namespace is inbound here (downstream → bridge): a
+//! downstream server asks the client (the bridge) to re-pull diagnostics, or
+//! pulls the workspace folders it serves. Each method has its own file so the
+//! directory listing maps to the supported surface, mirroring
+//! [`text_document`](super::text_document).
+//!
+//! [`folder_set`] holds the per-connection [`WorkspaceFolderSet`] *data type*
+//! that [`workspace_folders`] answers pulls from; keeping the type and its
+//! handler in separate files avoids a name collision while both stay under the
+//! namespace they belong to.
+//!
+//! The dispatcher in [`actor::reader`](super::actor) owns the shared transport
+//! and routes each method here.
+
+pub(in crate::lsp::bridge) mod diagnostic_refresh;
+mod folder_set;
+pub(in crate::lsp::bridge) mod workspace_folders;
+
+pub(crate) use folder_set::WorkspaceFolderSet;

--- a/src/lsp/bridge/workspace/diagnostic_refresh.rs
+++ b/src/lsp/bridge/workspace/diagnostic_refresh.rs
@@ -1,0 +1,28 @@
+//! `workspace/diagnostic/refresh` server-request handler.
+//!
+//! Inbound (downstream → bridge → editor). A downstream server asks the client
+//! to re-pull diagnostics; the bridge forwards the request upstream so the
+//! editor triggers a fresh diagnostic pull, then acks the downstream with
+//! `null`.
+
+use log::debug;
+use tower_lsp_server::jsonrpc;
+
+use crate::lsp::bridge::actor::{ServerRequestDeps, UpstreamNotification};
+
+/// Handle a `workspace/diagnostic/refresh` request, returning the JSON-RPC body
+/// the dispatcher wraps in a response.
+pub(in crate::lsp::bridge) fn handle(
+    server_prefix: &str,
+    deps: &ServerRequestDeps,
+) -> jsonrpc::Result<serde_json::Value> {
+    debug!(
+        target: "kakehashi::bridge::reader",
+        "{}Forwarding workspace/diagnostic/refresh upstream",
+        server_prefix
+    );
+    let _ = deps
+        .upstream_tx
+        .send(UpstreamNotification::DiagnosticRefresh);
+    Ok(serde_json::Value::Null)
+}

--- a/src/lsp/bridge/workspace/folder_set.rs
+++ b/src/lsp/bridge/workspace/folder_set.rs
@@ -1,5 +1,9 @@
 //! Per-connection, mutable workspace-folder set.
 //!
+//! This is the *data type* backing the `workspace/workspaceFolders` pull; the
+//! pull *handler* that answers a downstream query from it lives in
+//! [`workspace_folders`](super::workspace_folders).
+//!
 //! Historically the folders a downstream connection serves were frozen at spawn
 //! in an immutable `Arc<Option<Vec<WorkspaceFolder>>>`: set once from the
 //! resolved root (or the upstream fallback) and only ever read, to answer

--- a/src/lsp/bridge/workspace/workspace_folders.rs
+++ b/src/lsp/bridge/workspace/workspace_folders.rs
@@ -1,0 +1,27 @@
+//! `workspace/workspaceFolders` server-request handler.
+//!
+//! Inbound (downstream → bridge). The bridge advertises the
+//! `workspace.workspaceFolders` capability, so a downstream may pull the folders
+//! it serves; the bridge answers from this connection's current
+//! [`WorkspaceFolderSet`](super::folder_set::WorkspaceFolderSet) (the
+//! `WorkspaceFolder[] | null` response), which a `preferSharedInstance`
+//! connection grows over time (#391).
+
+use log::debug;
+use tower_lsp_server::jsonrpc;
+
+use crate::lsp::bridge::actor::ServerRequestDeps;
+
+/// Handle a `workspace/workspaceFolders` request, returning the JSON-RPC body
+/// the dispatcher wraps in a response.
+pub(in crate::lsp::bridge) fn handle(
+    server_prefix: &str,
+    deps: &ServerRequestDeps,
+) -> jsonrpc::Result<serde_json::Value> {
+    debug!(
+        target: "kakehashi::bridge::reader",
+        "{}Answering workspace/workspaceFolders from the connection's current folders",
+        server_prefix
+    );
+    Ok(serde_json::to_value(deps.workspace_folders.snapshot()).unwrap_or(serde_json::Value::Null))
+}


### PR DESCRIPTION
## Summary

Resolves #393. Organizes the bridge's **inbound** message handling (downstream server → editor) into per-method modules by LSP namespace, extending the "directory listing = map of supported methods" pattern that `text_document/*` already uses on the outbound side.

Previously the whole inbound surface was inline in `actor/reader.rs`, so the structure gave no hint of which server messages the bridge supports. Now `reader.rs` keeps only the shared transport (`ServerRequestDeps`, `UpstreamNotification`, channels) and a dispatcher that routes each method to its module:

- `client/` — `register_capability.rs`, `unregister_capability.rs`
- `window/` — `log_message.rs`, `show_message.rs`, `work_done_progress_create.rs`, `progress.rs`
- `workspace/` — `diagnostic_refresh.rs`, `workspace_folders.rs` (handler), `folder_set.rs` (the `WorkspaceFolderSet` data type, moved from `workspace_folders.rs`)
- `text_document/publish_diagnostics.rs` — the inbound scratch `publishDiagnostics` discard

This is the issue's "option 2" (whole inbound surface). It includes methods that did not exist when #393 was filed (`client/*`, `window/workDoneProgress/create`, `$/progress`).

## Design notes

- **`$/progress` lives under `window/`** despite being `$`-namespaced: it is bridged as the data half of `window/workDoneProgress/create`, sharing the same `ProgressRegistry` token remapping. Splitting them by namespace would scatter one feature.
- **`WorkspaceFolderSet` → `workspace/folder_set.rs`** to avoid a name collision with the `workspace/workspaceFolders` pull handler.
- Handlers reachable only by the dispatcher use `pub(in crate::lsp::bridge)` (project's private-by-default rule).

## Behavior

Pure structural Tidy — no behavior change. Return values, error responses, ack semantics, dispatch ordering (scratch-discard-first, then `$/progress`), and log targets (`kakehashi::bridge::reader`) are all preserved. Full suite green (`make lint format test test_e2e`); the moved `is_scratch_publish_diagnostics` unit test moves intact to its new module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)