### PR TITLE
feat(bridge): forward telemetry/event, window/showMessageRequest, window/showDocument

### DIFF
--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -32,6 +32,7 @@ mod pool;
 mod progress_registry;
 mod protocol;
 mod root_markers;
+mod telemetry;
 mod text_document;
 mod window;
 mod workspace;
@@ -40,6 +41,7 @@ mod workspace;
 #[cfg(test)]
 pub(crate) use actor::OutboundMessage;
 pub(crate) use actor::UpstreamNotification;
+pub(crate) use actor::UpstreamRequest;
 pub(crate) use coordinator::BridgeCoordinator;
 pub(crate) use coordinator::ResolvedServerConfig;
 pub(crate) use pool::ConnectionKey;

--- a/src/lsp/bridge/actor.rs
+++ b/src/lsp/bridge/actor.rs
@@ -16,13 +16,14 @@ mod writer;
 
 pub(crate) use outbound_message::OutboundMessage;
 
+pub(in crate::lsp::bridge) use reader::send_server_response;
 #[cfg(test)]
 pub(crate) use reader::spawn_reader_task;
 #[cfg(test)]
 pub(crate) use reader::spawn_reader_task_with_liveness;
 pub(crate) use reader::{
-    ReaderTaskHandle, ServerRequestDeps, UpstreamNotification, WINDOW_NOTIFICATION_QUEUE_CAPACITY,
-    spawn_reader_task_for_server,
+    ReaderTaskHandle, ServerRequestDeps, UpstreamNotification, UpstreamRequest,
+    WINDOW_NOTIFICATION_QUEUE_CAPACITY, spawn_reader_task_for_server,
 };
 #[cfg(test)]
 pub(crate) use response_router::RouteResult;

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -25,7 +25,7 @@ use tower_lsp_server::jsonrpc;
 use tower_lsp_server::ls_types::MessageType;
 
 use super::super::connection::BridgeReader;
-use super::super::{client, text_document, window};
+use super::super::{client, telemetry, text_document, window};
 use super::OutboundMessage;
 use super::ResponseRouter;
 use super::response_router::RouteResult;
@@ -42,13 +42,16 @@ use crate::lsp::bridge::workspace::{self, WorkspaceFolderSet};
 /// - `DiagnosticRefresh` travels on an **unbounded** channel: dropping one
 ///   would silently stale the editor's diagnostics, and its volume is tiny
 ///   (one per downstream `workspace/diagnostic/refresh`).
-/// - `LogMessage`/`ShowMessage` travel on a **bounded** channel
+/// - `LogMessage`/`ShowMessage`/`TelemetryEvent` travel on a **bounded** channel
 ///   ([`WINDOW_NOTIFICATION_QUEUE_CAPACITY`]) with drop-on-full: a downstream
-///   server stuck in a tight logMessage loop must not grow memory without
-///   bound or starve `DiagnosticRefresh` behind a burst (the forwarding loop
-///   drains the unbounded channel first). Within the bounded channel FIFO
+///   server stuck in a tight logMessage (or telemetry) loop must not grow memory
+///   without bound or starve `DiagnosticRefresh` behind a burst (the forwarding
+///   loop drains the unbounded channel first). Within the bounded channel FIFO
 ///   order is preserved, which the window-notification e2e relies on.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// `Eq` is intentionally not derived: `TelemetryEvent` carries an arbitrary
+/// `serde_json::Value` (which is `PartialEq` but not `Eq` because of floats).
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) enum UpstreamNotification {
     /// Request upstream to re-pull diagnostics.
     /// Sent when downstream server issues `workspace/diagnostic/refresh`.
@@ -59,6 +62,10 @@ pub(crate) enum UpstreamNotification {
     /// Forward a downstream `window/showMessage` to the editor.
     /// `message` is already prefixed with the originating server name.
     ShowMessage { typ: MessageType, message: String },
+    /// Forward a downstream `telemetry/event` notification to the editor
+    /// verbatim. `data` is the raw notification `params` (arbitrary LSPAny);
+    /// telemetry has no client capability and is always passed through.
+    TelemetryEvent { data: serde_json::Value },
     /// Ask the editor to create a work-done progress for `token`.
     /// Sent when a downstream issues `window/workDoneProgress/create`; `token`
     /// is the bridge-minted *upstream* token, not the downstream's own.
@@ -77,6 +84,44 @@ pub(crate) enum UpstreamNotification {
     /// progress still in flight, so the loop's created-token set can't leak
     /// entries across crashes/respawns (window-work-done-progress bridging).
     ForgetWorkDoneProgress(Vec<tower_lsp_server::ls_types::NumberOrString>),
+}
+
+/// A downstream-initiated **request** the bridge forwards to the editor and
+/// whose response must be relayed back to that downstream server.
+///
+/// Unlike [`UpstreamNotification`] (fire-and-forget), these need the editor's
+/// answer routed back, so each variant carries a `oneshot` reply the forwarding
+/// loop fulfills with the editor's typed result. The reader-side handler then
+/// frames the JSON-RPC response and writes it to the originating connection's
+/// `response_tx`. This keeps the bridge decoupled from tower-lsp's `Client`
+/// (the loop owns the `Client`) and the forwarding loop decoupled from
+/// [`OutboundMessage`] / JSON-RPC framing (the reader side owns that).
+///
+/// A separate **unbounded** channel carries these (a dropped request would hang
+/// the downstream waiting for a response that never comes); the channel is held
+/// off [`UpstreamNotification`] because `oneshot::Sender` is neither `Clone` nor
+/// `Eq`. The forwarding loop must service each request on a spawned task — these
+/// are user-interactive and can pend indefinitely, so awaiting one inline would
+/// freeze forwarding for every bridged server.
+///
+/// `$/cancelRequest` propagation for an in-flight forwarded request is out of
+/// scope for now: if the downstream cancels or dies, the reader-side oneshot is
+/// dropped and the spawned waiter resolves to the protocol's default answer.
+pub(crate) enum UpstreamRequest {
+    /// Forward a `window/showMessageRequest`; the editor's selected action (or
+    /// `None`) is relayed back to the downstream.
+    ShowMessageRequest {
+        typ: MessageType,
+        message: String,
+        actions: Option<Vec<tower_lsp_server::ls_types::MessageActionItem>>,
+        reply: oneshot::Sender<Option<tower_lsp_server::ls_types::MessageActionItem>>,
+    },
+    /// Forward a `window/showDocument` (URI passed through verbatim, including
+    /// virtual-document URIs); the editor's success flag is relayed back.
+    ShowDocument {
+        params: tower_lsp_server::ls_types::ShowDocumentParams,
+        reply: oneshot::Sender<bool>,
+    },
 }
 
 /// Capacity of the bounded `window/*` forwarding queue. Sized like the
@@ -112,8 +157,14 @@ pub(crate) struct ServerRequestDeps {
     /// Loss-intolerant notifications (`DiagnosticRefresh` and work-done
     /// progress create/$progress/forget); unbounded.
     pub(crate) upstream_tx: mpsc::UnboundedSender<UpstreamNotification>,
-    /// Best-effort `window/*` notifications; bounded, dropped when full.
+    /// Best-effort `window/*` (and `telemetry/event`) notifications; bounded,
+    /// dropped when full.
     pub(crate) window_tx: mpsc::Sender<UpstreamNotification>,
+    /// Downstream-initiated requests forwarded to the editor with a response
+    /// relayed back (`window/showMessageRequest`, `window/showDocument`).
+    /// Unbounded: a dropped request would hang the downstream. See
+    /// [`UpstreamRequest`].
+    pub(crate) upstream_request_tx: mpsc::UnboundedSender<UpstreamRequest>,
     /// The folders this connection currently serves, used to answer downstream
     /// `workspace/workspaceFolders` pulls. Mutable: a `preferSharedInstance`
     /// connection grows it as new marker roots join (#391).
@@ -364,6 +415,7 @@ pub(crate) fn spawn_reader_task_with_liveness(
             dynamic_capabilities,
             upstream_tx,
             window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
             workspace_folders: WorkspaceFolderSet::new(None),
             progress_registry,
             progress_connection_id,
@@ -452,6 +504,7 @@ async fn reader_loop(
         upstream_tx,
         workspace_folders: WorkspaceFolderSet::new(None),
         window_tx,
+        upstream_request_tx: mpsc::unbounded_channel().0,
         progress_registry,
         progress_connection_id,
     };
@@ -671,9 +724,10 @@ async fn handle_message(
 
 /// Forward supported downstream notifications to the upstream editor.
 ///
-/// Routes `window/logMessage` and `window/showMessage` to their per-method
-/// modules ([`window::log_message`], [`window::show_message`]); both are
-/// forwarded unconditionally so the bridge stays transparent.
+/// Routes `window/logMessage`, `window/showMessage`, and `telemetry/event` to
+/// their per-method modules ([`window::log_message`], [`window::show_message`],
+/// [`telemetry::event`]); all are forwarded unconditionally so the bridge stays
+/// transparent.
 ///
 /// `$/progress` is handled earlier in `handle_message` (translated and forwarded
 /// via [`window::progress::forward`]), so it never reaches here. Everything else
@@ -686,6 +740,7 @@ fn forward_notification(
     match message["method"].as_str() {
         Some("window/logMessage") => window::log_message::forward(message, server_prefix, deps),
         Some("window/showMessage") => window::show_message::forward(message, server_prefix, deps),
+        Some("telemetry/event") => telemetry::event::forward(message, server_prefix, deps),
         _ => {}
     }
 }
@@ -707,6 +762,22 @@ async fn handle_server_request(
         .and_then(|v| serde_json::from_value(v).ok())
         .unwrap_or_default();
     let method = message.get("method").and_then(|v| v.as_str()).unwrap_or("");
+
+    // Deferred request handlers forward to the editor and relay its response
+    // back asynchronously (the editor may pend on user interaction), so they own
+    // their entire response lifecycle on a spawned task rather than returning a
+    // synchronous `body` to frame-and-send below.
+    match method {
+        "window/showMessageRequest" => {
+            window::show_message_request::handle(&message, id, server_prefix, deps);
+            return;
+        }
+        "window/showDocument" => {
+            window::show_document::handle(&message, id, server_prefix, deps);
+            return;
+        }
+        _ => {}
+    }
 
     let body: jsonrpc::Result<serde_json::Value> = match method {
         "client/registerCapability" => {
@@ -733,9 +804,32 @@ async fn handle_server_request(
     };
 
     let response = match body {
-        Ok(result) => jsonrpc::Response::from_ok(id.clone(), result),
+        Ok(result) => jsonrpc::Response::from_ok(id, result),
         Err(error) => jsonrpc::Response::from_error(id, error),
     };
+    send_server_response(&deps.response_tx, response, server_prefix, method).await;
+}
+
+/// Frame a server-request response and send it to the downstream server via the
+/// writer channel.
+///
+/// Used both by the synchronous dispatch in [`handle_server_request`] and by the
+/// deferred request handlers ([`window::show_message_request`],
+/// [`window::show_document`]) that relay an editor response back asynchronously.
+///
+/// We use [`OutboundMessage::Untracked`] because a server-initiated response has
+/// no [`ResponseRouter`] entry to clean up on failure (unlike `Tracked`
+/// requests). `send_timeout(5s)` (rather than `try_send`) guarantees delivery
+/// under transient backpressure without risking the deadlock a bare
+/// `send().await` could cause if the queue is full while the writer is blocked
+/// on stdin and the server on stdout — the response is dropped only after 5s of
+/// sustained backpressure, far better than instant loss.
+pub(in crate::lsp::bridge) async fn send_server_response(
+    response_tx: &mpsc::Sender<OutboundMessage>,
+    response: jsonrpc::Response,
+    server_prefix: &str,
+    method: &str,
+) {
     // Response implements Serialize, so convert to Value for OutboundMessage.
     // Serialization cannot fail in practice, but the project bans panics in
     // production code; dropping the response is the only sane fallback here.
@@ -751,22 +845,7 @@ async fn handle_server_request(
         }
     };
 
-    // Send response via the writer channel.
-    // We use OutboundMessage::Untracked because a server-initiated response has
-    // no ResponseRouter entry to clean up on failure (unlike Tracked requests).
-    //
-    // We use send_timeout(5s) instead of try_send() to guarantee delivery under
-    // transient backpressure. try_send() silently drops the response if the queue
-    // (capacity 256) is momentarily full — a correctness bug for server-initiated
-    // requests like client/registerCapability that require acknowledgment.
-    //
-    // We avoid bare send().await because it could theoretically deadlock if the
-    // queue is full, the writer is blocked on stdin, and the downstream server is
-    // blocked on stdout — creating a circular wait. send_timeout(5s) provides an
-    // explicit safety net: the response is dropped only after 5 seconds of
-    // sustained backpressure, which is far better than instant loss.
-    if let Err(e) = deps
-        .response_tx
+    if let Err(e) = response_tx
         .send_timeout(OutboundMessage::Untracked(response), Duration::from_secs(5))
         .await
     {
@@ -850,6 +929,7 @@ mod tests {
             upstream_tx,
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
             progress_registry,
             progress_connection_id,
         };
@@ -920,6 +1000,7 @@ mod tests {
             upstream_tx,
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
             progress_registry,
             progress_connection_id,
         };
@@ -1013,6 +1094,7 @@ mod tests {
             dynamic_capabilities: caps,
             upstream_tx,
             window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
             workspace_folders: WorkspaceFolderSet::new(None),
             progress_registry,
             progress_connection_id,
@@ -1086,6 +1168,7 @@ mod tests {
                 dynamic_capabilities: Arc::new(DynamicCapabilityRegistry::new()),
                 upstream_tx,
                 window_tx,
+                upstream_request_tx: mpsc::unbounded_channel().0,
                 workspace_folders: WorkspaceFolderSet::new(None),
                 progress_registry: Arc::clone(&progress_registry),
                 progress_connection_id: conn,
@@ -1509,6 +1592,7 @@ mod tests {
             upstream_tx,
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
@@ -1567,6 +1651,7 @@ mod tests {
             upstream_tx,
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
@@ -1624,6 +1709,7 @@ mod tests {
             upstream_tx,
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
             progress_registry: Arc::clone(&progress_registry),
             progress_connection_id,
         };
@@ -1681,6 +1767,7 @@ mod tests {
             upstream_tx,
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
             progress_registry,
             progress_connection_id,
         };
@@ -1737,6 +1824,7 @@ mod tests {
             upstream_tx,
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
             progress_registry,
             progress_connection_id,
         };
@@ -1790,6 +1878,7 @@ mod tests {
             upstream_tx,
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
             progress_registry: Arc::clone(&progress_registry),
             progress_connection_id,
         };
@@ -1844,6 +1933,7 @@ mod tests {
             upstream_tx,
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
             progress_registry,
             progress_connection_id,
         };
@@ -1880,6 +1970,7 @@ mod tests {
             upstream_tx,
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
@@ -1932,6 +2023,7 @@ mod tests {
             dynamic_capabilities,
             upstream_tx,
             window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
             workspace_folders: WorkspaceFolderSet::new(Some(folders)),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
@@ -1973,6 +2065,7 @@ mod tests {
             dynamic_capabilities,
             upstream_tx,
             window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
             workspace_folders: WorkspaceFolderSet::new(None),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
@@ -2015,6 +2108,7 @@ mod tests {
             upstream_tx,
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
@@ -2060,6 +2154,7 @@ mod tests {
             upstream_tx,
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
@@ -2097,6 +2192,7 @@ mod tests {
             upstream_tx,
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
@@ -2149,6 +2245,7 @@ mod tests {
             upstream_tx,
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
@@ -2212,6 +2309,7 @@ mod tests {
             upstream_tx,
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
@@ -2270,6 +2368,7 @@ mod tests {
             upstream_tx,
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
@@ -2525,5 +2624,236 @@ mod tests {
             0,
             "Pending should be 0 after timeout"
         );
+    }
+
+    #[tokio::test]
+    async fn handle_message_forwards_telemetry_event_upstream() {
+        let router = ResponseRouter::new();
+        let (deps, mut window_rx, _keep) = server_request_deps_for(Some("mock-ls"));
+
+        let notification = json!({
+            "jsonrpc": "2.0",
+            "method": "telemetry/event",
+            "params": { "kind": "metric", "value": 42 }
+        });
+        handle_message(notification, &router, "", &deps).await;
+
+        match window_rx
+            .try_recv()
+            .expect("telemetry/event should be forwarded")
+        {
+            UpstreamNotification::TelemetryEvent { data } => {
+                assert_eq!(data, json!({ "kind": "metric", "value": 42 }));
+            }
+            other => panic!("expected TelemetryEvent, got {other:?}"),
+        }
+    }
+
+    /// Deps exposing the response receiver and the upstream-request receiver, for
+    /// the deferred request-relay handlers (showMessageRequest / showDocument).
+    fn server_request_deps_with_request_rx() -> (
+        ServerRequestDeps,
+        mpsc::Receiver<OutboundMessage>,
+        mpsc::UnboundedReceiver<UpstreamRequest>,
+    ) {
+        let (response_tx, response_rx) = mpsc::channel(16);
+        let (upstream_tx, _upstream_rx) = mpsc::unbounded_channel();
+        let (window_tx, _window_rx) = mpsc::channel(16);
+        let (upstream_request_tx, upstream_request_rx) = mpsc::unbounded_channel();
+        let progress_registry = Arc::new(crate::lsp::bridge::ProgressRegistry::new());
+        let progress_connection_id = progress_registry.new_connection_id();
+        let deps = ServerRequestDeps {
+            server_name: Some("mock-ls".to_string()),
+            response_tx,
+            dynamic_capabilities: Arc::new(DynamicCapabilityRegistry::new()),
+            upstream_tx,
+            window_tx,
+            upstream_request_tx,
+            workspace_folders: WorkspaceFolderSet::new(None),
+            progress_registry,
+            progress_connection_id,
+        };
+        (deps, response_rx, upstream_request_rx)
+    }
+
+    /// Await the next outbound response, unwrapping the `Untracked` envelope.
+    async fn recv_untracked(
+        response_rx: &mut mpsc::Receiver<OutboundMessage>,
+    ) -> serde_json::Value {
+        match response_rx.recv().await.expect("a response should be sent") {
+            OutboundMessage::Untracked(value) => value,
+            other => panic!("expected Untracked response, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_message_show_message_request_relays_selected_action() {
+        let router = ResponseRouter::new();
+        let (deps, mut response_rx, mut request_rx) = server_request_deps_with_request_rx();
+
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "window/showMessageRequest",
+            "params": {
+                "type": 3,
+                "message": "pick one",
+                "actions": [{ "title": "Retry" }, { "title": "Cancel" }]
+            }
+        });
+        handle_message(request, &router, "", &deps).await;
+
+        // The bridge forwards an UpstreamRequest carrying the reply channel.
+        let UpstreamRequest::ShowMessageRequest {
+            message,
+            actions,
+            reply,
+            ..
+        } = request_rx
+            .recv()
+            .await
+            .expect("should forward an UpstreamRequest")
+        else {
+            panic!("expected ShowMessageRequest");
+        };
+        assert_eq!(message, "pick one");
+        assert_eq!(actions.expect("actions present").len(), 2);
+
+        // Simulate the editor selecting "Retry".
+        reply
+            .send(Some(
+                serde_json::from_value(json!({ "title": "Retry" })).unwrap(),
+            ))
+            .expect("reply channel open");
+
+        // The downstream receives a response whose result is the selected action.
+        let response = recv_untracked(&mut response_rx).await;
+        assert_eq!(response["id"], 7);
+        assert_eq!(response["result"]["title"], "Retry");
+    }
+
+    #[tokio::test]
+    async fn handle_message_show_message_request_editor_error_responds_null() {
+        let router = ResponseRouter::new();
+        let (deps, mut response_rx, mut request_rx) = server_request_deps_with_request_rx();
+
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "window/showMessageRequest",
+            "params": { "type": 1, "message": "oops" }
+        });
+        handle_message(request, &router, "", &deps).await;
+
+        // Dropping the request (and its reply sender) simulates the editor failing
+        // to answer; the downstream must still get a `null` (no selection).
+        let request = request_rx.recv().await.expect("forwarded");
+        drop(request);
+
+        let response = recv_untracked(&mut response_rx).await;
+        assert_eq!(response["id"], 8);
+        assert_eq!(response["result"], serde_json::Value::Null);
+    }
+
+    #[tokio::test]
+    async fn handle_message_show_message_request_invalid_params_responds_error() {
+        let router = ResponseRouter::new();
+        let (deps, mut response_rx, mut request_rx) = server_request_deps_with_request_rx();
+
+        // Missing the required `type` field.
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "window/showMessageRequest",
+            "params": { "message": "no type" }
+        });
+        handle_message(request, &router, "", &deps).await;
+
+        let response = recv_untracked(&mut response_rx).await;
+        assert_eq!(response["id"], 9);
+        assert!(
+            response["error"].is_object(),
+            "invalid params should produce an error response: {response}"
+        );
+        // No request should have been forwarded to the editor.
+        assert!(request_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn handle_message_show_document_relays_success_and_passes_virtual_uri_through() {
+        let router = ResponseRouter::new();
+        let (deps, mut response_rx, mut request_rx) = server_request_deps_with_request_rx();
+
+        // A virtual-document URI is passed through verbatim (no translation).
+        let virtual_uri = "file:///p/kakehashi-virtual-uri-R.py";
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 10,
+            "method": "window/showDocument",
+            "params": { "uri": virtual_uri }
+        });
+        handle_message(request, &router, "", &deps).await;
+
+        let UpstreamRequest::ShowDocument { params, reply } = request_rx
+            .recv()
+            .await
+            .expect("should forward an UpstreamRequest")
+        else {
+            panic!("expected ShowDocument");
+        };
+        assert_eq!(params.uri.as_str(), virtual_uri);
+
+        reply.send(true).expect("reply channel open");
+
+        let response = recv_untracked(&mut response_rx).await;
+        assert_eq!(response["id"], 10);
+        assert_eq!(response["result"]["success"], true);
+    }
+
+    #[tokio::test]
+    async fn handle_message_show_document_editor_failure_responds_success_false() {
+        let router = ResponseRouter::new();
+        let (deps, mut response_rx, mut request_rx) = server_request_deps_with_request_rx();
+
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 11,
+            "method": "window/showDocument",
+            "params": { "uri": "file:///nope.rs" }
+        });
+        handle_message(request, &router, "", &deps).await;
+
+        let UpstreamRequest::ShowDocument { reply, .. } =
+            request_rx.recv().await.expect("forwarded")
+        else {
+            panic!("expected ShowDocument");
+        };
+        // Editor could not open the document.
+        reply.send(false).expect("reply channel open");
+
+        let response = recv_untracked(&mut response_rx).await;
+        assert_eq!(response["id"], 11);
+        assert_eq!(response["result"]["success"], false);
+    }
+
+    #[tokio::test]
+    async fn handle_message_show_document_loop_gone_responds_success_false() {
+        let router = ResponseRouter::new();
+        let (deps, mut response_rx, request_rx) = server_request_deps_with_request_rx();
+
+        // Forwarding loop gone before the request is handled.
+        drop(request_rx);
+
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 12,
+            "method": "window/showDocument",
+            "params": { "uri": "file:///x.rs" }
+        });
+        handle_message(request, &router, "", &deps).await;
+
+        let response = recv_untracked(&mut response_rx).await;
+        assert_eq!(response["id"], 12);
+        assert_eq!(response["result"]["success"], false);
     }
 }

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -2837,6 +2837,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn handle_message_show_document_invalid_params_responds_error() {
+        let router = ResponseRouter::new();
+        let (deps, mut response_rx, mut request_rx) = server_request_deps_with_request_rx();
+
+        // Missing the required `uri` field.
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 13,
+            "method": "window/showDocument",
+            "params": { "external": true }
+        });
+        handle_message(request, &router, "", &deps).await;
+
+        let response = recv_untracked(&mut response_rx).await;
+        assert_eq!(response["id"], 13);
+        assert!(
+            response["error"].is_object(),
+            "invalid params should produce an error response: {response}"
+        );
+        assert!(request_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
     async fn handle_message_show_document_loop_gone_responds_success_false() {
         let router = ResponseRouter::new();
         let (deps, mut response_rx, request_rx) = server_request_deps_with_request_rx();

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -402,6 +402,16 @@ impl BridgeCoordinator {
         self.pool.take_window_rx()
     }
 
+    /// Take the upstream request receiver for forwarding to the editor.
+    ///
+    /// Returns `Some(receiver)` on first call, `None` on subsequent calls.
+    /// Delegates to the underlying pool.
+    pub(crate) fn take_upstream_request_rx(
+        &self,
+    ) -> Option<tokio::sync::mpsc::UnboundedReceiver<super::actor::UpstreamRequest>> {
+        self.pool.take_upstream_request_rx()
+    }
+
     /// Graceful shutdown of all downstream language server connections.
     pub(crate) async fn shutdown_all(&self) {
         self.pool.shutdown_all().await;

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -72,7 +72,7 @@ pub(crate) enum ConnectionReadiness {
 
 use super::actor::{
     OUTBOUND_QUEUE_CAPACITY, OutboundMessage, ResponseRouter, ServerRequestDeps,
-    UpstreamNotification, spawn_reader_task_for_server,
+    UpstreamNotification, UpstreamRequest, spawn_reader_task_for_server,
 };
 use super::connection::AsyncBridgeConnection;
 
@@ -252,6 +252,15 @@ pub struct LanguageServerPool {
     window_tx: tokio::sync::mpsc::Sender<UpstreamNotification>,
     /// Receiver for window notifications, taken once by the forwarding task.
     window_rx: std::sync::Mutex<Option<tokio::sync::mpsc::Receiver<UpstreamNotification>>>,
+    /// Sender for downstream-initiated requests forwarded to the editor with a
+    /// response relayed back (`window/showMessageRequest`, `window/showDocument`).
+    ///
+    /// Cloned into each reader task. Unbounded: a dropped request would hang the
+    /// downstream waiting for a response (loss-intolerant, like `upstream_tx`).
+    upstream_request_tx: tokio::sync::mpsc::UnboundedSender<UpstreamRequest>,
+    /// Receiver for upstream requests, taken once by the forwarding task.
+    upstream_request_rx:
+        std::sync::Mutex<Option<tokio::sync::mpsc::UnboundedReceiver<UpstreamRequest>>>,
     /// Remaps downstream-declared work-done progress tokens to globally unique
     /// upstream tokens (window-work-done-progress bridging). Shared with every
     /// reader task (to register/translate) and the cancel path (to route a
@@ -275,6 +284,7 @@ impl LanguageServerPool {
         let (upstream_tx, upstream_rx) = tokio::sync::mpsc::unbounded_channel();
         let (window_tx, window_rx) =
             tokio::sync::mpsc::channel(super::actor::WINDOW_NOTIFICATION_QUEUE_CAPACITY);
+        let (upstream_request_tx, upstream_request_rx) = tokio::sync::mpsc::unbounded_channel();
         Self {
             connections: Mutex::new(HashMap::new()),
             document_tracker: DocumentTracker::new(),
@@ -289,6 +299,8 @@ impl LanguageServerPool {
             upstream_rx: std::sync::Mutex::new(Some(upstream_rx)),
             window_tx,
             window_rx: std::sync::Mutex::new(Some(window_rx)),
+            upstream_request_tx,
+            upstream_request_rx: std::sync::Mutex::new(Some(upstream_request_rx)),
             progress_registry: Arc::new(super::ProgressRegistry::new()),
         }
     }
@@ -371,6 +383,21 @@ impl LanguageServerPool {
             .window_rx
             .lock()
             .recover_poison("LanguageServerPool::take_window_rx");
+        guard.take()
+    }
+
+    /// Take the upstream request receiver for forwarding to the editor.
+    ///
+    /// Returns `Some(receiver)` on first call, `None` on subsequent calls.
+    /// The receiver should be consumed by the same forwarding task as
+    /// `take_upstream_rx`'s.
+    pub(crate) fn take_upstream_request_rx(
+        &self,
+    ) -> Option<tokio::sync::mpsc::UnboundedReceiver<UpstreamRequest>> {
+        let mut guard = self
+            .upstream_request_rx
+            .lock()
+            .recover_poison("LanguageServerPool::take_upstream_request_rx");
         guard.take()
     }
 
@@ -1168,6 +1195,7 @@ impl LanguageServerPool {
                 dynamic_capabilities: Arc::clone(&dynamic_capabilities),
                 upstream_tx: self.upstream_tx.clone(),
                 window_tx: self.window_tx.clone(),
+                upstream_request_tx: self.upstream_request_tx.clone(),
                 // #391: share the per-connection mutable folder set with the
                 // reader (it answers workspace/workspaceFolders pulls).
                 workspace_folders: workspace_folders.clone(),

--- a/src/lsp/bridge/protocol/client_capabilities.rs
+++ b/src/lsp/bridge/protocol/client_capabilities.rs
@@ -114,11 +114,16 @@ fn build_baseline_capabilities() -> ClientCapabilities {
 /// `completionItem.{documentationFormat, snippetSupport, deprecatedSupport,
 /// tagSupport, commitCharactersSupport, resolveSupport, insertTextModeSupport,
 /// labelDetailsSupport, preselectSupport}`, `hover.contentFormat`,
-/// `signatureHelp.signatureInformation`, `window.workDoneProgress`.
+/// `signatureHelp.signatureInformation`, `window.workDoneProgress`,
+/// `window.showDocument`, `window.showMessage`.
 ///
-/// `window.workDoneProgress` is gated on the real upstream editor so the bridge
-/// only invites downstream server-initiated progress (`window/workDoneProgress/create`)
-/// when it can actually relay it to the editor — see ls-bridge-work-done-progress.
+/// `window.workDoneProgress` and `window.showDocument` are gated on the real
+/// upstream editor so the bridge only invites a downstream server-initiated
+/// request (`window/workDoneProgress/create`, `window/showDocument`) when it can
+/// actually relay it to the editor — see ls-bridge-work-done-progress.
+/// `window.showMessage` (the `messageActionItem` refinement) is a plain
+/// pass-through: `window/showMessageRequest` is a base-protocol request the
+/// bridge always relays.
 fn merge_upstream_capabilities(
     mut base: ClientCapabilities,
     upstream: Option<&ClientCapabilities>,
@@ -233,6 +238,40 @@ fn merge_upstream_capabilities(
         base.window
             .get_or_insert_with(Default::default)
             .work_done_progress = Some(true);
+    }
+
+    // --- window.showDocument (gated on real upstream support) ---
+    // Same rationale as workDoneProgress: advertise downstream ONLY when the
+    // editor genuinely supports `window/showDocument` (`support == true`), so the
+    // bridge never invites a request it could only ever answer `success:false`.
+    // An absent or `false` capability leaves `window.showDocument` unadvertised
+    // (and never materializes an empty `window: {}` the baseline lacked).
+    if upstream
+        .window
+        .as_ref()
+        .and_then(|w| w.show_document.as_ref())
+        .map(|s| s.support)
+        == Some(true)
+    {
+        use tower_lsp_server::ls_types::ShowDocumentClientCapabilities;
+        base.window
+            .get_or_insert_with(Default::default)
+            .show_document = Some(ShowDocumentClientCapabilities { support: true });
+    }
+
+    // --- window.showMessage messageActionItem (passthrough) ---
+    // `window/showMessageRequest` is a base-protocol request the bridge always
+    // relays, so this only forwards the editor's `messageActionItem` refinement
+    // (e.g. `additionalPropertiesSupport`) when present, keeping the action items
+    // the downstream receives — and the selection it sends back — faithful.
+    if let Some(show_message) = upstream
+        .window
+        .as_ref()
+        .and_then(|w| w.show_message.as_ref())
+    {
+        base.window
+            .get_or_insert_with(Default::default)
+            .show_message = Some(show_message.clone());
     }
 
     base
@@ -593,6 +632,75 @@ mod tests {
         assert!(
             merged.window.is_none(),
             "explicit false must leave window unadvertised, not materialize workDoneProgress:false"
+        );
+    }
+
+    #[test]
+    fn merge_advertises_show_document_only_when_upstream_supports() {
+        use tower_lsp_server::ls_types::{
+            ShowDocumentClientCapabilities, WindowClientCapabilities,
+        };
+
+        // Upstream supports showDocument → advertised downstream.
+        let supporting = ClientCapabilities {
+            window: Some(WindowClientCapabilities {
+                show_document: Some(ShowDocumentClientCapabilities { support: true }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let merged = merge_upstream_capabilities(build_baseline_capabilities(), Some(&supporting));
+        assert_eq!(
+            merged
+                .window
+                .and_then(|w| w.show_document)
+                .map(|s| s.support),
+            Some(true),
+            "must advertise showDocument when the editor supports it"
+        );
+
+        // Upstream support=false → not advertised, no empty `window` materialized.
+        let unsupported = ClientCapabilities {
+            window: Some(WindowClientCapabilities {
+                show_document: Some(ShowDocumentClientCapabilities { support: false }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let merged = merge_upstream_capabilities(build_baseline_capabilities(), Some(&unsupported));
+        assert!(
+            merged.window.is_none(),
+            "support=false must leave window unadvertised (bridge would only answer success:false)"
+        );
+    }
+
+    #[test]
+    fn merge_passes_through_show_message_message_action_item() {
+        use tower_lsp_server::ls_types::{
+            MessageActionItemCapabilities, ShowMessageRequestClientCapabilities,
+            WindowClientCapabilities,
+        };
+
+        let upstream = ClientCapabilities {
+            window: Some(WindowClientCapabilities {
+                show_message: Some(ShowMessageRequestClientCapabilities {
+                    message_action_item: Some(MessageActionItemCapabilities {
+                        additional_properties_support: Some(true),
+                    }),
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let merged = merge_upstream_capabilities(build_baseline_capabilities(), Some(&upstream));
+        assert_eq!(
+            merged
+                .window
+                .and_then(|w| w.show_message)
+                .and_then(|s| s.message_action_item)
+                .and_then(|m| m.additional_properties_support),
+            Some(true),
+            "showMessage messageActionItem must pass through from upstream"
         );
     }
 

--- a/src/lsp/bridge/telemetry.rs
+++ b/src/lsp/bridge/telemetry.rs
@@ -1,0 +1,11 @@
+//! Inbound `telemetry/*` notifications.
+//!
+//! The `telemetry` LSP namespace is inbound here (downstream → editor): a
+//! downstream server emits `telemetry/event`, which the bridge forwards to the
+//! editor verbatim. One file per method keeps the directory listing a map of
+//! the supported surface, mirroring [`text_document`](super::text_document).
+//!
+//! The dispatcher in [`actor::reader`](super::actor) owns the shared transport
+//! and routes the method here.
+
+pub(in crate::lsp::bridge) mod event;

--- a/src/lsp/bridge/telemetry/event.rs
+++ b/src/lsp/bridge/telemetry/event.rs
@@ -1,0 +1,33 @@
+//! `telemetry/event` notification forwarder.
+//!
+//! Inbound (downstream → editor). `telemetry/event` has no client capability
+//! gating it, so it is always passed through; the raw `params` (arbitrary
+//! LSPAny) is forwarded to the editor verbatim. It rides the same bounded
+//! best-effort channel as `window/*` (see [`send_window_notification`]) because
+//! telemetry is high-volume and loss-tolerant: dropping events under a flood is
+//! preferable to unbounded memory growth or starving loss-intolerant
+//! notifications.
+//!
+//! [`send_window_notification`]: crate::lsp::bridge::window::send_window_notification
+
+use crate::lsp::bridge::actor::{ServerRequestDeps, UpstreamNotification};
+use crate::lsp::bridge::window::send_window_notification;
+
+/// Forward a `telemetry/event` notification to the editor.
+pub(in crate::lsp::bridge) fn forward(
+    message: &serde_json::Value,
+    server_prefix: &str,
+    deps: &ServerRequestDeps,
+) {
+    // `params` is arbitrary LSPAny; forward it verbatim (absent → `null`).
+    let data = message
+        .get("params")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    send_window_notification(
+        deps,
+        server_prefix,
+        "telemetry/event",
+        UpstreamNotification::TelemetryEvent { data },
+    );
+}

--- a/src/lsp/bridge/window.rs
+++ b/src/lsp/bridge/window.rs
@@ -25,17 +25,24 @@ use crate::lsp::bridge::actor::{ServerRequestDeps, UpstreamNotification};
 
 pub(in crate::lsp::bridge) mod log_message;
 pub(in crate::lsp::bridge) mod progress;
+pub(in crate::lsp::bridge) mod show_document;
 pub(in crate::lsp::bridge) mod show_message;
+pub(in crate::lsp::bridge) mod show_message_request;
 pub(in crate::lsp::bridge) mod work_done_progress_create;
 
-/// Enqueue a `window/*` notification on the bounded best-effort channel.
+/// Enqueue a notification on the bounded best-effort channel.
+///
+/// Shared by the `window/*` forwarders and [`telemetry::event`] (which rides the
+/// same loss-tolerant channel); hence `pub(in crate::lsp::bridge)`.
 ///
 /// `try_send` keeps the reader task non-blocking: a full queue (editor slower
 /// than a downstream notification flood) drops the message instead of growing
 /// memory or stalling stdout reads; a closed queue (shutdown) has no one left
 /// to deliver to. Both are deliberate per the loss-tolerance split documented
 /// on [`UpstreamNotification`].
-fn send_window_notification(
+///
+/// [`telemetry::event`]: crate::lsp::bridge::telemetry::event
+pub(in crate::lsp::bridge) fn send_window_notification(
     deps: &ServerRequestDeps,
     server_prefix: &str,
     method: &str,

--- a/src/lsp/bridge/window/show_document.rs
+++ b/src/lsp/bridge/window/show_document.rs
@@ -44,7 +44,7 @@ pub(in crate::lsp::bridge) fn handle(
         Err(e) => {
             warn!(
                 target: "kakehashi::bridge::reader",
-                "{}Dropping {} with invalid params: {}",
+                "{}Rejecting {} with InvalidParams (unparseable params): {}",
                 server_prefix, METHOD, e
             );
             tokio::spawn(async move {

--- a/src/lsp/bridge/window/show_document.rs
+++ b/src/lsp/bridge/window/show_document.rs
@@ -1,0 +1,89 @@
+//! `window/showDocument` server-request handler.
+//!
+//! Inbound (downstream → bridge → editor → downstream). A downstream asks the
+//! client to show a resource (by URI) in the UI; the bridge forwards it to the
+//! editor and relays the editor's `success` flag back as a [`ShowDocumentResult`].
+//!
+//! **URI pass-through:** the `uri` is forwarded verbatim, including
+//! concatenated-formatting *virtual-document* URIs — the bridge performs no
+//! virtual→host translation here. If the editor cannot open such a URI it simply
+//! answers `success: false`, which is relayed downstream unchanged. This is a
+//! deliberate v1 simplification; mapping virtual URIs back to host documents is
+//! out of scope for now.
+//!
+//! Like [`show_message_request`](super::show_message_request) this **defers** its
+//! response on a spawned task so neither the read loop nor the global forwarding
+//! loop blocks. If the editor errors, or the downstream dies before an answer
+//! (the reply channel drops), the downstream receives `success: false`.
+//!
+//! [`ShowDocumentResult`]: tower_lsp_server::ls_types::ShowDocumentResult
+
+use log::{debug, warn};
+use serde::Deserialize;
+use tokio::sync::oneshot;
+use tower_lsp_server::jsonrpc;
+use tower_lsp_server::ls_types::{ShowDocumentParams, ShowDocumentResult};
+
+use crate::lsp::bridge::actor::{ServerRequestDeps, UpstreamRequest, send_server_response};
+
+const METHOD: &str = "window/showDocument";
+
+/// Handle a `window/showDocument` request, relaying the editor's success flag
+/// back to the downstream asynchronously.
+pub(in crate::lsp::bridge) fn handle(
+    message: &serde_json::Value,
+    id: jsonrpc::Id,
+    server_prefix: &str,
+    deps: &ServerRequestDeps,
+) {
+    let response_tx = deps.response_tx.clone();
+    let server_prefix_owned = server_prefix.to_string();
+
+    let params = match ShowDocumentParams::deserialize(&message["params"]) {
+        Ok(params) => params,
+        Err(e) => {
+            warn!(
+                target: "kakehashi::bridge::reader",
+                "{}Dropping {} with invalid params: {}",
+                server_prefix, METHOD, e
+            );
+            tokio::spawn(async move {
+                let response = jsonrpc::Response::from_error(
+                    id,
+                    jsonrpc::Error::invalid_params(format!("Invalid params: {e}")),
+                );
+                send_server_response(&response_tx, response, &server_prefix_owned, METHOD).await;
+            });
+            return;
+        }
+    };
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+
+    // Spawn the responder first; it owns `reply_rx`. If the request below fails
+    // to enqueue (forwarding loop gone), `reply_tx` drops and `reply_rx` resolves
+    // to `Err`, which maps to `success: false` — so the downstream always gets a
+    // response without a special-cased "loop gone" reply path.
+    tokio::spawn(async move {
+        let success = reply_rx.await.unwrap_or(false);
+        let result =
+            serde_json::to_value(ShowDocumentResult { success }).unwrap_or(serde_json::Value::Null);
+        let response = jsonrpc::Response::from_ok(id, result);
+        send_server_response(&response_tx, response, &server_prefix_owned, METHOD).await;
+    });
+
+    if deps
+        .upstream_request_tx
+        .send(UpstreamRequest::ShowDocument {
+            params,
+            reply: reply_tx,
+        })
+        .is_err()
+    {
+        debug!(
+            target: "kakehashi::bridge::reader",
+            "{}Forwarding loop gone; answering {} with success:false",
+            server_prefix, METHOD
+        );
+    }
+}

--- a/src/lsp/bridge/window/show_document.rs
+++ b/src/lsp/bridge/window/show_document.rs
@@ -22,7 +22,7 @@ use log::{debug, warn};
 use serde::Deserialize;
 use tokio::sync::oneshot;
 use tower_lsp_server::jsonrpc;
-use tower_lsp_server::ls_types::{ShowDocumentParams, ShowDocumentResult};
+use tower_lsp_server::ls_types::ShowDocumentParams;
 
 use crate::lsp::bridge::actor::{ServerRequestDeps, UpstreamRequest, send_server_response};
 
@@ -66,8 +66,10 @@ pub(in crate::lsp::bridge) fn handle(
     // response without a special-cased "loop gone" reply path.
     tokio::spawn(async move {
         let success = reply_rx.await.unwrap_or(false);
-        let result =
-            serde_json::to_value(ShowDocumentResult { success }).unwrap_or(serde_json::Value::Null);
+        // Build the `ShowDocumentResult` shape (`{ "success": bool }`) directly
+        // and infallibly — `serde_json::to_value` of the typed struct would force
+        // a fallback whose only safe value is this same object anyway.
+        let result = serde_json::json!({ "success": success });
         let response = jsonrpc::Response::from_ok(id, result);
         send_server_response(&response_tx, response, &server_prefix_owned, METHOD).await;
     });

--- a/src/lsp/bridge/window/show_message_request.rs
+++ b/src/lsp/bridge/window/show_message_request.rs
@@ -1,0 +1,89 @@
+//! `window/showMessageRequest` server-request handler.
+//!
+//! Inbound (downstream → bridge → editor → downstream). A downstream asks the
+//! client to show a message with a set of action items and wait for the user's
+//! choice; the bridge forwards it to the editor and relays the selected
+//! [`MessageActionItem`] (or `null`) back to the downstream.
+//!
+//! Unlike the ack-immediately handlers, this **defers** its response: the editor
+//! may pend on user interaction for an unbounded time. So the handler returns at
+//! once after handing an [`UpstreamRequest`] to the forwarding loop, and a
+//! spawned task relays the editor's answer back via `response_tx` — the read
+//! loop and the global forwarding loop are never blocked, and no bridge-imposed
+//! timeout truncates a legitimately slow user. If the editor errors, or the
+//! downstream connection dies before an answer arrives (the reply channel
+//! drops), the downstream receives `null` (no selection) per the protocol.
+//!
+//! [`MessageActionItem`]: tower_lsp_server::ls_types::MessageActionItem
+//! [`UpstreamRequest`]: crate::lsp::bridge::actor::UpstreamRequest
+
+use log::{debug, warn};
+use serde::Deserialize;
+use tokio::sync::oneshot;
+use tower_lsp_server::jsonrpc;
+use tower_lsp_server::ls_types::ShowMessageRequestParams;
+
+use crate::lsp::bridge::actor::{ServerRequestDeps, UpstreamRequest, send_server_response};
+
+const METHOD: &str = "window/showMessageRequest";
+
+/// Handle a `window/showMessageRequest` request, relaying the editor's selected
+/// action back to the downstream asynchronously.
+pub(in crate::lsp::bridge) fn handle(
+    message: &serde_json::Value,
+    id: jsonrpc::Id,
+    server_prefix: &str,
+    deps: &ServerRequestDeps,
+) {
+    let response_tx = deps.response_tx.clone();
+    let server_prefix_owned = server_prefix.to_string();
+
+    let params = match ShowMessageRequestParams::deserialize(&message["params"]) {
+        Ok(params) => params,
+        Err(e) => {
+            warn!(
+                target: "kakehashi::bridge::reader",
+                "{}Dropping {} with invalid params: {}",
+                server_prefix, METHOD, e
+            );
+            tokio::spawn(async move {
+                let response = jsonrpc::Response::from_error(
+                    id,
+                    jsonrpc::Error::invalid_params(format!("Invalid params: {e}")),
+                );
+                send_server_response(&response_tx, response, &server_prefix_owned, METHOD).await;
+            });
+            return;
+        }
+    };
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+
+    // Spawn the responder first; it owns `reply_rx`. If the request below fails
+    // to enqueue (forwarding loop gone), `reply_tx` drops and `reply_rx` resolves
+    // to `Err`, which maps to `None` (no selection) — so the downstream always
+    // gets a response without a special-cased "loop gone" reply path.
+    tokio::spawn(async move {
+        let action = reply_rx.await.unwrap_or(None);
+        let result = serde_json::to_value(action).unwrap_or(serde_json::Value::Null);
+        let response = jsonrpc::Response::from_ok(id, result);
+        send_server_response(&response_tx, response, &server_prefix_owned, METHOD).await;
+    });
+
+    if deps
+        .upstream_request_tx
+        .send(UpstreamRequest::ShowMessageRequest {
+            typ: params.typ,
+            message: params.message,
+            actions: params.actions,
+            reply: reply_tx,
+        })
+        .is_err()
+    {
+        debug!(
+            target: "kakehashi::bridge::reader",
+            "{}Forwarding loop gone; answering {} with null",
+            server_prefix, METHOD
+        );
+    }
+}

--- a/src/lsp/bridge/window/show_message_request.rs
+++ b/src/lsp/bridge/window/show_message_request.rs
@@ -43,7 +43,7 @@ pub(in crate::lsp::bridge) fn handle(
         Err(e) => {
             warn!(
                 target: "kakehashi::bridge::reader",
-                "{}Dropping {} with invalid params: {}",
+                "{}Rejecting {} with InvalidParams (unparseable params): {}",
                 server_prefix, METHOD, e
             );
             tokio::spawn(async move {

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -390,25 +390,30 @@ async fn forward_upstream_request(
     }
 }
 
-/// Forward upstream notifications from downstream language servers to the editor.
+/// Forward downstream-initiated messages from language servers to the editor.
 ///
-/// Consumes notifications from two channels (loss-tolerance split, #378) and
-/// dispatches them to the LSP client:
+/// Consumes from three channels (loss-tolerance split, #378) and dispatches them
+/// to the LSP client:
 /// - `upstream_rx` (unbounded): `DiagnosticRefresh` — forwarded as
 ///   `workspace/diagnostic/refresh` — and the server-declared work-done
 ///   progress notifications (`CreateWorkDoneProgress`/`Progress`/
 ///   `ForgetWorkDoneProgress`, window-work-done-progress), which must not be
 ///   lost or reordered.
-/// - `window_rx` (bounded, reader drops on full): `LogMessage`/`ShowMessage` —
-///   downstream `window/*` notifications, forwarded unconditionally and
-///   already prefixed with the originating server name.
+/// - `upstream_request_rx` (unbounded): downstream-initiated *requests*
+///   (`window/showMessageRequest`, `window/showDocument`) forwarded with the
+///   editor's response relayed back; loss-intolerant (a dropped request hangs
+///   the downstream). Serviced via [`spawn_upstream_request`] so a slow/human
+///   editor never stalls the loop.
+/// - `window_rx` (bounded, reader drops on full): `LogMessage`/`ShowMessage` and
+///   `telemetry/event` — best-effort notifications, forwarded unconditionally.
 ///
-/// Each dispatch awaits tower-lsp's internal bounded channel, so a slow editor
-/// stalls the loop — but the `biased` select drains `upstream_rx` first, so a
-/// `window/*` burst cannot starve `DiagnosticRefresh` or progress, and the
-/// bounded window queue caps memory. FIFO order is preserved within each channel
-/// (the window-notification e2e relies on window-channel FIFO; create-before-
-/// progress relies on upstream-channel FIFO).
+/// Notification dispatch awaits tower-lsp's internal bounded channel, so a slow
+/// editor stalls the loop — but the `biased` select drains the two loss-intolerant
+/// channels (`upstream_rx`, then `upstream_request_rx`) before the best-effort
+/// `window_rx`, so a `window/*` burst cannot starve `DiagnosticRefresh`, progress,
+/// or request forwarding, and the bounded window queue caps memory. FIFO order is
+/// preserved within each channel (the window-notification e2e relies on
+/// window-channel FIFO; create-before-progress relies on upstream-channel FIFO).
 ///
 /// Exits when:
 /// - Either channel is closed (all senders dropped — both senders live in the
@@ -453,23 +458,29 @@ async fn upstream_forwarding_loop(
                 }
             }
 
-            notification = window_rx.recv() => {
-                match notification {
-                    Some(notification) => {
-                        deliver_upstream_notification(&client, notification, &mut created_tokens)
-                            .await
-                    }
-                    None => break, // Channel closed
-                }
-            }
-
             request = upstream_request_rx.recv() => {
                 match request {
                     // Serviced on a spawned task, never awaited inline: these are
                     // user-interactive (showMessageRequest can pend for minutes),
                     // so awaiting here would freeze forwarding for every bridged
                     // server. The reply travels back through the request's oneshot.
+                    //
+                    // Ordered before `window_rx` (best-effort) so a `window/*` flood
+                    // (e.g. logMessage) can't starve loss-intolerant request
+                    // forwarding under `biased`. Servicing is just a spawn, and
+                    // requests are user-paced/low-volume, so this can't starve
+                    // `window_rx` in turn.
                     Some(request) => spawn_upstream_request(&client, request),
+                    None => break, // Channel closed
+                }
+            }
+
+            notification = window_rx.recv() => {
+                match notification {
+                    Some(notification) => {
+                        deliver_upstream_notification(&client, notification, &mut created_tokens)
+                            .await
+                    }
                     None => break, // Channel closed
                 }
             }

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -296,10 +296,15 @@ impl Kakehashi {
     pub(crate) async fn initialized_impl(&self, _: InitializedParams) {
         self.notifier().log_info("server is ready").await;
 
-        // Forward downstream server notifications to upstream editor.
-        // The reader tasks feed two channels (loss-tolerance split, #378):
-        // unbounded for DiagnosticRefresh (must not be lost) and bounded for
-        // best-effort window/logMessage / window/showMessage forwarding.
+        // Forward downstream-initiated messages to the upstream editor. The
+        // reader tasks feed three channels:
+        // - unbounded `upstream_rx` (loss-intolerant): DiagnosticRefresh and
+        //   work-done progress (create/$progress/forget).
+        // - bounded `window_rx` (best-effort, drop-on-full): window/logMessage,
+        //   window/showMessage, and telemetry/event.
+        // - unbounded `upstream_request_rx` (loss-intolerant): downstream
+        //   requests forwarded with a response relayed back
+        //   (window/showMessageRequest, window/showDocument).
         if let Some(upstream_rx) = self.bridge.take_upstream_rx()
             && let Some(window_rx) = self.bridge.take_window_rx()
             && let Some(upstream_request_rx) = self.bridge.take_upstream_request_rx()
@@ -508,14 +513,33 @@ fn spawn_upstream_request(client: &Client, request: crate::lsp::bridge::Upstream
                 actions,
                 reply,
             } => {
-                let action = client
-                    .show_message_request(typ, message, actions)
-                    .await
-                    .unwrap_or(None);
+                let action = match client.show_message_request(typ, message, actions).await {
+                    Ok(action) => action,
+                    Err(e) => {
+                        // e.g. method-not-supported or transport failure — log for
+                        // diagnosis, still relay the protocol default (no selection).
+                        log::debug!(
+                            target: "kakehashi::bridge",
+                            "window/showMessageRequest forwarding failed: {}; answering null",
+                            e
+                        );
+                        None
+                    }
+                };
                 let _ = reply.send(action);
             }
             UpstreamRequest::ShowDocument { params, reply } => {
-                let success = client.show_document(params).await.unwrap_or(false);
+                let success = match client.show_document(params).await {
+                    Ok(success) => success,
+                    Err(e) => {
+                        log::debug!(
+                            target: "kakehashi::bridge",
+                            "window/showDocument forwarding failed: {}; answering success:false",
+                            e
+                        );
+                        false
+                    }
+                };
                 let _ = reply.send(success);
             }
         }

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -302,12 +302,14 @@ impl Kakehashi {
         // best-effort window/logMessage / window/showMessage forwarding.
         if let Some(upstream_rx) = self.bridge.take_upstream_rx()
             && let Some(window_rx) = self.bridge.take_window_rx()
+            && let Some(upstream_request_rx) = self.bridge.take_upstream_request_rx()
         {
             let client = self.client.clone();
             let token = self.shutdown_token.clone();
             tokio::spawn(upstream_forwarding_loop(
                 upstream_rx,
                 window_rx,
+                upstream_request_rx,
                 client,
                 token,
             ));
@@ -410,6 +412,9 @@ async fn forward_upstream_request(
 async fn upstream_forwarding_loop(
     mut upstream_rx: tokio::sync::mpsc::UnboundedReceiver<crate::lsp::bridge::UpstreamNotification>,
     mut window_rx: tokio::sync::mpsc::Receiver<crate::lsp::bridge::UpstreamNotification>,
+    mut upstream_request_rx: tokio::sync::mpsc::UnboundedReceiver<
+        crate::lsp::bridge::UpstreamRequest,
+    >,
     client: Client,
     cancel_token: tokio_util::sync::CancellationToken,
 ) {
@@ -452,8 +457,55 @@ async fn upstream_forwarding_loop(
                     None => break, // Channel closed
                 }
             }
+
+            request = upstream_request_rx.recv() => {
+                match request {
+                    // Serviced on a spawned task, never awaited inline: these are
+                    // user-interactive (showMessageRequest can pend for minutes),
+                    // so awaiting here would freeze forwarding for every bridged
+                    // server. The reply travels back through the request's oneshot.
+                    Some(request) => spawn_upstream_request(&client, request),
+                    None => break, // Channel closed
+                }
+            }
         }
     }
+}
+
+/// Service a downstream-initiated request by forwarding it to the editor on a
+/// detached task and relaying the editor's answer through the request's `reply`
+/// oneshot.
+///
+/// Spawned (not awaited) so the shared forwarding loop keeps draining
+/// notifications while the editor — possibly a human — takes its time. No
+/// bridge-imposed timeout: `showMessageRequest` legitimately pends on user
+/// interaction, and `showDocument` is relayed as-is. On editor error the
+/// protocol default is sent (`None` selection / `success:false`); if the
+/// downstream connection drops, the receiving oneshot end is gone and
+/// `reply.send` simply no-ops.
+fn spawn_upstream_request(client: &Client, request: crate::lsp::bridge::UpstreamRequest) {
+    use crate::lsp::bridge::UpstreamRequest;
+    let client = client.clone();
+    tokio::spawn(async move {
+        match request {
+            UpstreamRequest::ShowMessageRequest {
+                typ,
+                message,
+                actions,
+                reply,
+            } => {
+                let action = client
+                    .show_message_request(typ, message, actions)
+                    .await
+                    .unwrap_or(None);
+                let _ = reply.send(action);
+            }
+            UpstreamRequest::ShowDocument { params, reply } => {
+                let success = client.show_document(params).await.unwrap_or(false);
+                let _ = reply.send(success);
+            }
+        }
+    });
 }
 
 /// Dispatch one upstream notification to the editor client.
@@ -483,6 +535,14 @@ async fn deliver_upstream_notification(
         }
         UpstreamNotification::ShowMessage { typ, message } => {
             client.show_message(typ, message).await;
+        }
+        UpstreamNotification::TelemetryEvent { data } => {
+            // `telemetry/event` params are LSPAny, but the notification type
+            // models them as object-or-array (`OneOf<Map, Vec>`). `telemetry_event`
+            // performs exactly that conversion (object → as-is, array → as-is, any
+            // other JSON scalar → wrapped in a single-element array), so objects
+            // and arrays — the conformant payloads — pass through unchanged.
+            client.telemetry_event(data).await;
         }
         UpstreamNotification::CreateWorkDoneProgress { token } => {
             // Awaited inline so the editor processes the create before the
@@ -626,9 +686,13 @@ mod tests {
         // Keep `_window_tx` alive so the bounded window channel does not close
         // and break the loop early; this test exercises only the upstream channel.
         let (_window_tx, window_rx) = tokio::sync::mpsc::channel(16);
+        // Keep `_request_tx` alive so the request channel does not close and
+        // break the loop early; this test exercises only the upstream channel.
+        let (_request_tx, request_rx) = tokio::sync::mpsc::unbounded_channel();
         let loop_handle = tokio::spawn(upstream_forwarding_loop(
             rx,
             window_rx,
+            request_rx,
             client,
             cancel.clone(),
         ));
@@ -729,9 +793,13 @@ mod tests {
         // Keep `_window_tx` alive so the bounded window channel does not close
         // and break the loop early; this test exercises only the upstream channel.
         let (_window_tx, window_rx) = tokio::sync::mpsc::channel(16);
+        // Keep `_request_tx` alive so the request channel does not close and
+        // break the loop early; this test exercises only the upstream channel.
+        let (_request_tx, request_rx) = tokio::sync::mpsc::unbounded_channel();
         let loop_handle = tokio::spawn(upstream_forwarding_loop(
             rx,
             window_rx,
+            request_rx,
             client,
             cancel.clone(),
         ));
@@ -835,9 +903,13 @@ mod tests {
         // Keep `_window_tx` alive so the bounded window channel does not close
         // and break the loop early; this test exercises only the upstream channel.
         let (_window_tx, window_rx) = tokio::sync::mpsc::channel(16);
+        // Keep `_request_tx` alive so the request channel does not close and
+        // break the loop early; this test exercises only the upstream channel.
+        let (_request_tx, request_rx) = tokio::sync::mpsc::unbounded_channel();
         let loop_handle = tokio::spawn(upstream_forwarding_loop(
             rx,
             window_rx,
+            request_rx,
             client,
             cancel.clone(),
         ));
@@ -941,5 +1013,189 @@ mod tests {
             join_result.is_ok(),
             "upstream_forwarding_loop task panicked or was aborted after cancellation"
         );
+    }
+
+    /// Build an initialized tower-lsp `Client` plus the socket halves, so a test
+    /// can observe server→client traffic and answer requests. Server→client
+    /// messages are suppressed until the client is `Initialized`, so an
+    /// `initialize` request is driven through first.
+    #[cfg(test)]
+    async fn init_client_and_socket() -> (
+        Client,
+        impl futures::Stream<Item = tower_lsp_server::jsonrpc::Request> + Unpin,
+        impl futures::Sink<tower_lsp_server::jsonrpc::Response> + Unpin,
+    ) {
+        use std::sync::{Arc, Mutex};
+        use tower::{Service, ServiceExt};
+        use tower_lsp_server::jsonrpc::Request;
+        use tower_lsp_server::ls_types::{InitializeParams, InitializeResult};
+        use tower_lsp_server::{LanguageServer, LspService};
+
+        struct Dummy;
+        impl LanguageServer for Dummy {
+            async fn initialize(
+                &self,
+                _: InitializeParams,
+            ) -> tower_lsp_server::jsonrpc::Result<InitializeResult> {
+                Ok(InitializeResult::default())
+            }
+            async fn shutdown(&self) -> tower_lsp_server::jsonrpc::Result<()> {
+                Ok(())
+            }
+        }
+
+        let captured: Arc<Mutex<Option<Client>>> = Arc::new(Mutex::new(None));
+        let captured_for_init = Arc::clone(&captured);
+        let (mut service, socket) = LspService::build(move |client| {
+            *captured_for_init.lock().unwrap() = Some(client);
+            Dummy
+        })
+        .finish();
+        let client = captured.lock().unwrap().take().unwrap();
+
+        let init = Request::build("initialize")
+            .params(serde_json::json!({ "capabilities": {} }))
+            .id(1)
+            .finish();
+        let _ = service.ready().await.unwrap().call(init).await;
+
+        let (requests, responses) = socket.split();
+        (client, requests, responses)
+    }
+
+    #[tokio::test]
+    async fn forwarding_loop_relays_show_message_request_response() {
+        use crate::lsp::bridge::UpstreamRequest;
+        use futures::{SinkExt, StreamExt};
+        use tower_lsp_server::jsonrpc::Response;
+        use tower_lsp_server::ls_types::MessageType;
+
+        let (client, mut requests, mut responses) = init_client_and_socket().await;
+
+        // `_upstream_tx`/`_window_tx` kept alive so those channels stay open and
+        // the loop doesn't exit early; this test drives only the request channel.
+        let (_upstream_tx, upstream_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (_window_tx, window_rx) = tokio::sync::mpsc::channel(16);
+        let (request_tx, request_rx) = tokio::sync::mpsc::unbounded_channel();
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let loop_handle = tokio::spawn(upstream_forwarding_loop(
+            upstream_rx,
+            window_rx,
+            request_rx,
+            client,
+            cancel.clone(),
+        ));
+
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        request_tx
+            .send(UpstreamRequest::ShowMessageRequest {
+                typ: MessageType::INFO,
+                message: "pick one".to_string(),
+                actions: Some(vec![
+                    serde_json::from_value(serde_json::json!({ "title": "Retry" })).unwrap(),
+                ]),
+                reply: reply_tx,
+            })
+            .unwrap();
+
+        // The editor receives the request and answers with the selected action.
+        let req = requests.next().await.expect("showMessageRequest emitted");
+        assert_eq!(req.method(), "window/showMessageRequest");
+        let id = req.id().expect("request has an id").clone();
+        let _ = responses
+            .send(Response::from_ok(
+                id,
+                serde_json::json!({ "title": "Retry" }),
+            ))
+            .await;
+
+        let action = reply_rx.await.expect("reply delivered");
+        assert_eq!(action.expect("an action selected").title, "Retry");
+
+        cancel.cancel();
+        let _ = loop_handle.await;
+    }
+
+    #[tokio::test]
+    async fn forwarding_loop_relays_show_document_response() {
+        use crate::lsp::bridge::UpstreamRequest;
+        use futures::{SinkExt, StreamExt};
+        use tower_lsp_server::jsonrpc::Response;
+
+        let (client, mut requests, mut responses) = init_client_and_socket().await;
+
+        // `_upstream_tx`/`_window_tx` kept alive so those channels stay open and
+        // the loop doesn't exit early; this test drives only the request channel.
+        let (_upstream_tx, upstream_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (_window_tx, window_rx) = tokio::sync::mpsc::channel(16);
+        let (request_tx, request_rx) = tokio::sync::mpsc::unbounded_channel();
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let loop_handle = tokio::spawn(upstream_forwarding_loop(
+            upstream_rx,
+            window_rx,
+            request_rx,
+            client,
+            cancel.clone(),
+        ));
+
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        request_tx
+            .send(UpstreamRequest::ShowDocument {
+                params: serde_json::from_value(serde_json::json!({ "uri": "file:///x.rs" }))
+                    .unwrap(),
+                reply: reply_tx,
+            })
+            .unwrap();
+
+        let req = requests.next().await.expect("showDocument emitted");
+        assert_eq!(req.method(), "window/showDocument");
+        let id = req.id().expect("request has an id").clone();
+        let _ = responses
+            .send(Response::from_ok(
+                id,
+                serde_json::json!({ "success": true }),
+            ))
+            .await;
+
+        assert!(reply_rx.await.expect("reply delivered"));
+
+        cancel.cancel();
+        let _ = loop_handle.await;
+    }
+
+    #[tokio::test]
+    async fn forwarding_loop_delivers_telemetry_event() {
+        use crate::lsp::bridge::UpstreamNotification;
+        use futures::StreamExt;
+
+        let (client, mut requests, _responses) = init_client_and_socket().await;
+
+        let (upstream_tx, upstream_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (_window_tx, window_rx) = tokio::sync::mpsc::channel(16);
+        let (_request_tx, request_rx) = tokio::sync::mpsc::unbounded_channel();
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let loop_handle = tokio::spawn(upstream_forwarding_loop(
+            upstream_rx,
+            window_rx,
+            request_rx,
+            client,
+            cancel.clone(),
+        ));
+
+        upstream_tx
+            .send(UpstreamNotification::TelemetryEvent {
+                data: serde_json::json!({ "kind": "metric", "value": 42 }),
+            })
+            .unwrap();
+
+        let event = requests.next().await.expect("telemetry/event emitted");
+        assert_eq!(event.method(), "telemetry/event");
+        assert_eq!(
+            event.params().expect("telemetry params"),
+            &serde_json::json!({ "kind": "metric", "value": 42 })
+        );
+
+        cancel.cancel();
+        let _ = loop_handle.await;
     }
 }

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -477,12 +477,26 @@ async fn upstream_forwarding_loop(
 /// oneshot.
 ///
 /// Spawned (not awaited) so the shared forwarding loop keeps draining
-/// notifications while the editor — possibly a human — takes its time. No
-/// bridge-imposed timeout: `showMessageRequest` legitimately pends on user
-/// interaction, and `showDocument` is relayed as-is. On editor error the
-/// protocol default is sent (`None` selection / `success:false`); if the
-/// downstream connection drops, the receiving oneshot end is gone and
+/// notifications while the editor — possibly a human — takes its time. On editor
+/// error the protocol default is sent (`None` selection / `success:false`); if
+/// the downstream connection drops, the receiving oneshot end is gone and
 /// `reply.send` simply no-ops.
+///
+/// **No bridge-imposed timeout** (unlike `create_work_done_progress`):
+/// `showMessageRequest` legitimately pends on user interaction, and `showDocument`
+/// deliberately opts out too — a timeout there would answer `success:false` while
+/// the editor might still open the document moments later, which is worse than
+/// waiting. Both are relayed as-is and resolve when the editor answers or the
+/// client closes.
+///
+/// **No concurrency cap / unbounded request channel** is a deliberate tradeoff,
+/// matching the unbounded loss-intolerant `upstream_tx`: a forwarded request must
+/// be answered (a dropped one would hang the downstream), and these are
+/// user-paced, low-volume requests rather than a flood-prone stream like
+/// `window/logMessage` (which is what the *bounded* window channel guards). The
+/// detached tasks are not tracked for abort on shutdown, but they self-terminate:
+/// when the service shuts down the editor `Client` closes, so each pending
+/// `client.*` call returns `Err` promptly and the task ends.
 fn spawn_upstream_request(client: &Client, request: crate::lsp::bridge::UpstreamRequest) {
     use crate::lsp::bridge::UpstreamRequest;
     let client = client.clone();

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -547,7 +547,9 @@ fn spawn_upstream_request(client: &Client, request: crate::lsp::bridge::Upstream
 }
 
 /// A `telemetry/event` notification whose `Params` is raw `serde_json::Value`,
-/// so the downstream payload is forwarded to the editor byte-for-byte. The
+/// so the downstream payload is forwarded to the editor as the same JSON value
+/// (its shape is preserved — scalars are not wrapped, no fields added/dropped;
+/// re-serialization may still normalize whitespace/number formatting). The
 /// `ls_types` `TelemetryEvent` models params as `OneOf<Map, Vec>`, which can't
 /// carry a scalar LSPAny payload unchanged.
 enum RawTelemetryEvent {}
@@ -586,12 +588,13 @@ async fn deliver_upstream_notification(
             client.show_message(typ, message).await;
         }
         UpstreamNotification::TelemetryEvent { data } => {
-            // Forward the raw LSPAny `params` verbatim. We can't use
-            // `client.telemetry_event` (it wraps any non-object/array scalar in a
-            // single-element array) or `send_notification::<ls_types TelemetryEvent>`
-            // (its `Params` is `OneOf<Map, Vec>`, rejecting scalars). A local
-            // marker with `Params = serde_json::Value` keeps the payload byte-for-
-            // byte identical, matching how `$/progress` is forwarded.
+            // Forward the raw LSPAny `params` as the same JSON value. We can't
+            // use `client.telemetry_event` (it wraps any non-object/array scalar
+            // in a single-element array) or `send_notification::<ls_types
+            // TelemetryEvent>` (its `Params` is `OneOf<Map, Vec>`, rejecting
+            // scalars). A local marker with `Params = serde_json::Value` preserves
+            // the payload's JSON shape (no scalar-wrapping), matching how
+            // `$/progress` is forwarded.
             client.send_notification::<RawTelemetryEvent>(data).await;
         }
         UpstreamNotification::CreateWorkDoneProgress { token } => {

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -522,6 +522,17 @@ fn spawn_upstream_request(client: &Client, request: crate::lsp::bridge::Upstream
     });
 }
 
+/// A `telemetry/event` notification whose `Params` is raw `serde_json::Value`,
+/// so the downstream payload is forwarded to the editor byte-for-byte. The
+/// `ls_types` `TelemetryEvent` models params as `OneOf<Map, Vec>`, which can't
+/// carry a scalar LSPAny payload unchanged.
+enum RawTelemetryEvent {}
+
+impl tower_lsp_server::ls_types::notification::Notification for RawTelemetryEvent {
+    type Params = serde_json::Value;
+    const METHOD: &'static str = "telemetry/event";
+}
+
 /// Dispatch one upstream notification to the editor client.
 ///
 /// `created_tokens` tracks work-done progress tokens the editor successfully
@@ -551,12 +562,13 @@ async fn deliver_upstream_notification(
             client.show_message(typ, message).await;
         }
         UpstreamNotification::TelemetryEvent { data } => {
-            // `telemetry/event` params are LSPAny, but the notification type
-            // models them as object-or-array (`OneOf<Map, Vec>`). `telemetry_event`
-            // performs exactly that conversion (object → as-is, array → as-is, any
-            // other JSON scalar → wrapped in a single-element array), so objects
-            // and arrays — the conformant payloads — pass through unchanged.
-            client.telemetry_event(data).await;
+            // Forward the raw LSPAny `params` verbatim. We can't use
+            // `client.telemetry_event` (it wraps any non-object/array scalar in a
+            // single-element array) or `send_notification::<ls_types TelemetryEvent>`
+            // (its `Params` is `OneOf<Map, Vec>`, rejecting scalars). A local
+            // marker with `Params = serde_json::Value` keeps the payload byte-for-
+            // byte identical, matching how `$/progress` is forwarded.
+            client.send_notification::<RawTelemetryEvent>(data).await;
         }
         UpstreamNotification::CreateWorkDoneProgress { token } => {
             // Awaited inline so the editor processes the create before the
@@ -1196,6 +1208,7 @@ mod tests {
             cancel.clone(),
         ));
 
+        // An object payload passes through unchanged.
         upstream_tx
             .send(UpstreamNotification::TelemetryEvent {
                 data: serde_json::json!({ "kind": "metric", "value": 42 }),
@@ -1207,6 +1220,23 @@ mod tests {
         assert_eq!(
             event.params().expect("telemetry params"),
             &serde_json::json!({ "kind": "metric", "value": 42 })
+        );
+
+        // A scalar payload is forwarded verbatim, NOT wrapped in an array (which
+        // is what `client.telemetry_event` would do) — this is why a raw-`Value`
+        // notification marker is used.
+        upstream_tx
+            .send(UpstreamNotification::TelemetryEvent {
+                data: serde_json::json!(42),
+            })
+            .unwrap();
+
+        let scalar = requests.next().await.expect("scalar telemetry emitted");
+        assert_eq!(scalar.method(), "telemetry/event");
+        assert_eq!(
+            scalar.params().expect("telemetry params"),
+            &serde_json::json!(42),
+            "scalar telemetry payload must be forwarded verbatim, not wrapped"
         );
 
         cancel.cancel();


### PR DESCRIPTION
## Summary

Extends the bridge's **inbound** surface (downstream LSP server → kakehashi → editor) with three methods, each a per-method module under the namespace layout from #393:

- **`telemetry/event`** (`bridge/telemetry/event.rs`) — notification, forwarded to the editor **verbatim** (raw LSPAny payload, scalars included) on the bounded best-effort channel.
- **`window/showMessageRequest`** (`bridge/window/show_message_request.rs`) — request; the editor's selected `MessageActionItem` (or `null`) is relayed back to the downstream, action included.
- **`window/showDocument`** (`bridge/window/show_document.rs`) — request; the URI is passed through verbatim (including virtual-document URIs — no translation); the editor's `success` flag is relayed back. If the editor can't open it, the downstream gets `success:false`.

## Request round-trip design

The two requests need the editor's response routed back to the originating downstream, and `showMessageRequest` can pend on user interaction for a long time. A new `UpstreamRequest` enum + dedicated unbounded channel carries them with a `oneshot` reply:

- The reader spawns a task that awaits the reply and frames the JSON-RPC response via `response_tx` — the **read loop never blocks**.
- The global forwarding loop services each request on its **own spawned task** (never inline) — a slow/never-answering editor can't freeze forwarding for other servers.
- **No bridge-imposed timeout** (a legitimately slow user isn't truncated; `showDocument` opts out too to avoid a false `success:false` while the editor opens it moments later).
- On editor error, forwarding-loop-gone, or downstream death, the downstream always receives the protocol default (`null` / `success:false`) — exactly one response per request.

`UpstreamRequest` is kept off `UpstreamNotification` (`oneshot::Sender` is neither `Clone` nor `Eq`); `UpstreamNotification` drops its `Eq` derive to admit `TelemetryEvent { data: Value }`.

## Capabilities

Advertise `window.showDocument` downstream **only when the real editor supports it** (gated like `workDoneProgress` — else the bridge could only ever answer `success:false`); pass through `window.showMessage`'s `messageActionItem`. `telemetry/event` has no capability gate.

## Scope notes

- Inbound `$/cancelRequest` propagation for an in-flight forwarded request is out of scope for v1 (documented).
- The unbounded request channel mirrors the existing loss-intolerant `upstream_tx`; requests are user-paced, not flood-prone.

## Tests

Reader-dispatcher tests (relay, editor-error→default, invalid-params→error, loop-gone, virtual-URI passthrough), capability-gating tests, and forwarding-loop tests driving a real tower-lsp `Client` (showMessageRequest/showDocument relay, telemetry incl. scalar-verbatim). Full gate green (`make lint format test test_e2e`).

Reviewed by subagent multi-perspective `/review` and Codex (both converged, no remaining findings).

Refs #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)