### PR TITLE
fix(injection): harden read-path string slicing against stale-tree desync (#401)

### DIFF
--- a/src/language/injection/content.rs
+++ b/src/language/injection/content.rs
@@ -153,14 +153,14 @@ pub(crate) fn byte_to_point_anchored(
     anchor_point: tree_sitter::Point,
 ) -> tree_sitter::Point {
     let clamped = floor_char_boundary(text, byte);
-    // Compare against the raw anchor so a stale anchor past `clamped` still takes
-    // the full-scan fallback (rather than reusing a stale `anchor_point`).
-    if clamped < anchor_byte {
+    // Reuse the cached `anchor_point` only when `anchor_byte` is a real position
+    // in the current text: if it's past the target, out of bounds, or
+    // mid-codepoint (a stale tree), `anchor_point` no longer matches it and the
+    // `text[anchor_byte..clamped]` slice could panic — fall back to a full scan,
+    // which depends on neither.
+    if clamped < anchor_byte || !text.is_char_boundary(anchor_byte) {
         return byte_to_point(text, clamped);
     }
-    // Here `anchor_byte <= clamped <= text.len()`, so snapping it to a char
-    // boundary (a stale tree may land it mid-codepoint) makes the slice safe.
-    let anchor_byte = floor_char_boundary(text, anchor_byte);
     let segment = &text[anchor_byte..clamped];
     match segment.rfind('\n') {
         Some(last_nl) => tree_sitter::Point {

--- a/src/language/injection/content.rs
+++ b/src/language/injection/content.rs
@@ -146,10 +146,11 @@ pub(crate) fn byte_to_point(text: &str, byte: usize) -> tree_sitter::Point {
 
 /// Like [`byte_to_point`], but scans only the span between a known anchor
 /// and `byte` instead of the whole prefix of `text` — the anchor is
-/// typically a tree-sitter node's cached `start_position()`. Falls back to a
-/// full scan when `byte` precedes the anchor (e.g. a negative `#offset!`
-/// extending before the content node). `anchor_byte` must lie on a char
-/// boundary, with `anchor_point` its Point in `text`.
+/// typically a tree-sitter node's cached `start_position()`. The anchored fast
+/// path is taken only when `anchor_byte` is an in-bounds char boundary and
+/// `anchor_point` is its Point in `text`; otherwise — `byte` before the anchor
+/// (e.g. a negative `#offset!`), or a stale anchor that's out of bounds or
+/// mid-codepoint — it falls back to the full scan, which trusts neither.
 pub(crate) fn byte_to_point_anchored(
     text: &str,
     byte: usize,

--- a/src/language/injection/content.rs
+++ b/src/language/injection/content.rs
@@ -16,14 +16,18 @@ pub(crate) fn extract_clean_content(
 ) -> String {
     // `clamped_slice` guards against byte offsets from a stale tree that no
     // longer matches `host_text` (out of bounds or mid-codepoint).
-    let content = clamped_slice(host_text, byte_range.clone());
+    let content = clamped_slice(host_text, byte_range);
     match included_ranges {
         None => content.to_string(),
         Some(ranges) => {
+            // The output is a concatenation of sub-slices of `content`, so it
+            // can't exceed `content.len()`. Cap the preallocation there (and sum
+            // saturating) so stale, oversized ranges can't request a huge buffer.
             let capacity: usize = ranges
                 .iter()
                 .map(|r| r.end_byte.saturating_sub(r.start_byte))
-                .sum();
+                .fold(0usize, usize::saturating_add)
+                .min(content.len());
             let mut result = String::with_capacity(capacity);
             for range in ranges {
                 result.push_str(clamped_slice(content, range.start_byte..range.end_byte));

--- a/src/language/injection/content.rs
+++ b/src/language/injection/content.rs
@@ -153,13 +153,15 @@ pub(crate) fn byte_to_point_anchored(
     anchor_point: tree_sitter::Point,
 ) -> tree_sitter::Point {
     let clamped = floor_char_boundary(text, byte);
-    // Snap the anchor too: on a stale tree it may be out of bounds or land
-    // mid-codepoint, which would panic the `text[anchor_byte..clamped]` slice.
-    let anchor_byte = floor_char_boundary(text, anchor_byte);
+    // Compare against the raw anchor so a stale anchor past `clamped` still takes
+    // the full-scan fallback (rather than reusing a stale `anchor_point`).
     if clamped < anchor_byte {
         return byte_to_point(text, clamped);
     }
-    let segment = clamped_slice(text, anchor_byte..clamped);
+    // Here `anchor_byte <= clamped <= text.len()`, so snapping it to a char
+    // boundary (a stale tree may land it mid-codepoint) makes the slice safe.
+    let anchor_byte = floor_char_boundary(text, anchor_byte);
+    let segment = &text[anchor_byte..clamped];
     match segment.rfind('\n') {
         Some(last_nl) => tree_sitter::Point {
             row: anchor_point.row + segment.bytes().filter(|b| *b == b'\n').count(),

--- a/src/language/injection/content.rs
+++ b/src/language/injection/content.rs
@@ -2,7 +2,7 @@
 //! selection-range paths: clean-content extraction, per-line column offsets,
 //! parsing with included ranges, and byte→`Point` coordinate conversion.
 
-use crate::text::floor_char_boundary;
+use crate::text::{clamped_slice, floor_char_boundary};
 
 /// Extract clean injection content, stripping child node bytes when `included_ranges` present.
 ///
@@ -14,14 +14,19 @@ pub(crate) fn extract_clean_content(
     byte_range: std::ops::Range<usize>,
     included_ranges: Option<&[tree_sitter::Range]>,
 ) -> String {
-    let content = &host_text[byte_range.clone()];
+    // `clamped_slice` guards against byte offsets from a stale tree that no
+    // longer matches `host_text` (out of bounds or mid-codepoint).
+    let content = clamped_slice(host_text, byte_range.clone());
     match included_ranges {
         None => content.to_string(),
         Some(ranges) => {
-            let capacity: usize = ranges.iter().map(|r| r.end_byte - r.start_byte).sum();
+            let capacity: usize = ranges
+                .iter()
+                .map(|r| r.end_byte.saturating_sub(r.start_byte))
+                .sum();
             let mut result = String::with_capacity(capacity);
             for range in ranges {
-                result.push_str(&content[range.start_byte..range.end_byte]);
+                result.push_str(clamped_slice(content, range.start_byte..range.end_byte));
             }
             result
         }
@@ -67,8 +72,9 @@ pub(super) fn compute_line_column_offsets(
                             // The gap's start_byte is relative to content node start.
                             // The line starts at the byte after the previous newline.
                             let gap_abs_byte = byte_range.start + range.start_byte;
-                            let line_start_byte = gap_abs_byte - range.start_point.column;
-                            let prefix = &host_text[line_start_byte..gap_abs_byte];
+                            let line_start_byte =
+                                gap_abs_byte.saturating_sub(range.start_point.column);
+                            let prefix = clamped_slice(host_text, line_start_byte..gap_abs_byte);
                             offsets[line] = prefix.encode_utf16().count() as u32;
                         }
                     }
@@ -147,10 +153,13 @@ pub(crate) fn byte_to_point_anchored(
     anchor_point: tree_sitter::Point,
 ) -> tree_sitter::Point {
     let clamped = floor_char_boundary(text, byte);
+    // Snap the anchor too: on a stale tree it may be out of bounds or land
+    // mid-codepoint, which would panic the `text[anchor_byte..clamped]` slice.
+    let anchor_byte = floor_char_boundary(text, anchor_byte);
     if clamped < anchor_byte {
         return byte_to_point(text, clamped);
     }
-    let segment = &text[anchor_byte..clamped];
+    let segment = clamped_slice(text, anchor_byte..clamped);
     match segment.rfind('\n') {
         Some(last_nl) => tree_sitter::Point {
             row: anchor_point.row + segment.bytes().filter(|b| *b == b'\n').count(),
@@ -388,5 +397,49 @@ mod tests {
             vec![2, 2],
             "Both 'let' keywords should be at column 2 (from Range.start_point), not 0"
         );
+    }
+
+    // --- stale-tree hardening: byte offsets that no longer match `text` must
+    // degrade gracefully instead of panicking (#401). ---
+
+    fn range_at(
+        start_byte: usize,
+        end_byte: usize,
+        row: usize,
+        column: usize,
+    ) -> tree_sitter::Range {
+        tree_sitter::Range {
+            start_byte,
+            end_byte,
+            start_point: tree_sitter::Point { row, column },
+            end_point: tree_sitter::Point { row, column },
+        }
+    }
+
+    #[test]
+    fn extract_clean_content_out_of_bounds_does_not_panic() {
+        assert_eq!(extract_clean_content("hi", 0..100, None), "hi");
+        assert_eq!(extract_clean_content("hi", 50..100, None), "");
+        // Included sub-ranges past the end of the (clamped) content are skipped.
+        let oversized = [range_at(0, 999, 0, 0)];
+        assert_eq!(extract_clean_content("hi", 0..2, Some(&oversized)), "hi");
+    }
+
+    #[test]
+    fn compute_line_column_offsets_oversized_column_does_not_panic() {
+        // A non-first line whose start_point.column exceeds its absolute byte
+        // position would underflow `gap_abs_byte - column` and slice past the end.
+        let ranges = [range_at(2, 3, 1, 100)];
+        let offsets = compute_line_column_offsets("hello", 0..5, 0, Some(&ranges));
+        assert_eq!(offsets.len(), 2);
+    }
+
+    #[test]
+    fn byte_to_point_anchored_stale_anchor_does_not_panic() {
+        // "あ" is 3 bytes; an anchor landing mid-codepoint (byte 1) or past the
+        // end must not panic the `text[anchor..clamped]` slice.
+        let p = byte_to_point_anchored("あ", 3, 1, tree_sitter::Point { row: 0, column: 0 });
+        assert_eq!(p.row, 0);
+        let _ = byte_to_point_anchored("あ", 99, 50, tree_sitter::Point { row: 0, column: 0 });
     }
 }

--- a/src/language/injection/content.rs
+++ b/src/language/injection/content.rs
@@ -75,7 +75,7 @@ pub(super) fn compute_line_column_offsets(
                             // Convert byte column to UTF-16 code units.
                             // The gap's start_byte is relative to content node start.
                             // The line starts at the byte after the previous newline.
-                            let gap_abs_byte = byte_range.start + range.start_byte;
+                            let gap_abs_byte = byte_range.start.saturating_add(range.start_byte);
                             let line_start_byte =
                                 gap_abs_byte.saturating_sub(range.start_point.column);
                             let prefix = clamped_slice(host_text, line_start_byte..gap_abs_byte);

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -16,7 +16,7 @@ use super::ranges::{
 use crate::language::LanguageCoordinator;
 use crate::language::node_tracker::NodeTracker;
 use crate::language::query_predicates::check_predicate;
-use crate::text::{clamped_slice, floor_char_boundary, fnv1a_hash};
+use crate::text::{ceil_char_boundary, clamped_slice, floor_char_boundary, fnv1a_hash};
 
 /// Iterates over `@injection.content` captures that pass general predicate filtering.
 ///
@@ -200,8 +200,15 @@ impl CacheableInjectionRegion {
             None => (node.start_byte(), node.end_byte()),
         };
 
-        // Guard against a stale node whose byte range no longer fits `text`.
-        let content = clamped_slice(text, start_byte..end_byte);
+        // Snap the range to valid in-bounds char boundaries (ceil start / floor
+        // end) so the `byte_range` stored below is always safe to slice — a stale
+        // node can't leave an out-of-bounds range for downstream consumers, and
+        // the direct `content` slice here can't panic. Valid ranges are
+        // unchanged; a stale node also stops matching `node.start_byte()` below,
+        // routing through the safe `position_of_byte` path.
+        let start_byte = ceil_char_boundary(text, start_byte);
+        let end_byte = floor_char_boundary(text, end_byte).max(start_byte);
+        let content = &text[start_byte..end_byte];
 
         // Convert tree-sitter byte column to UTF-16 code units for LSP compatibility.
         // Tree-sitter reports columns as byte offsets, but LSP positions use UTF-16.
@@ -1463,9 +1470,16 @@ local y = "duplicate"
         let regions = collect_all_injections(&root, text, Some(&query)).expect("injections");
         assert!(!regions.is_empty());
 
-        let cacheable = CacheableInjectionRegion::from_region_info(&regions[0], "id", "x");
+        let short_text = "x";
+        let cacheable = CacheableInjectionRegion::from_region_info(&regions[0], "id", short_text);
         // Completed without panicking; metadata is still populated.
         assert_eq!(cacheable.language, "md");
         assert_eq!(cacheable.region_id, "id");
+        // byte_range is snapped in-bounds, so a downstream `&text[byte_range]`
+        // can't panic either.
+        assert!(cacheable.byte_range.start <= short_text.len());
+        assert!(cacheable.byte_range.end <= short_text.len());
+        assert!(cacheable.byte_range.start <= cacheable.byte_range.end);
+        assert_eq!(&short_text[cacheable.byte_range.clone()], "");
     }
 }

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -16,7 +16,7 @@ use super::ranges::{
 use crate::language::LanguageCoordinator;
 use crate::language::node_tracker::NodeTracker;
 use crate::language::query_predicates::check_predicate;
-use crate::text::fnv1a_hash;
+use crate::text::{clamped_slice, floor_char_boundary, fnv1a_hash};
 
 /// Iterates over `@injection.content` captures that pass general predicate filtering.
 ///
@@ -103,6 +103,10 @@ fn position_of_byte(
     anchor_byte: usize,
     anchor_row: usize,
 ) -> (u32, u32) {
+    // Snap both offsets to in-bounds char boundaries: on a stale tree they can
+    // be out of range or mid-codepoint, which would panic the slices below.
+    let byte_pos = floor_char_boundary(text, byte_pos);
+    let anchor_byte = floor_char_boundary(text, anchor_byte);
     let (lo, hi) = (byte_pos.min(anchor_byte), byte_pos.max(anchor_byte));
     let newlines = text[lo..hi].bytes().filter(|&b| b == b'\n').count();
     let row = if byte_pos >= anchor_byte {
@@ -196,7 +200,8 @@ impl CacheableInjectionRegion {
             None => (node.start_byte(), node.end_byte()),
         };
 
-        let content = &text[start_byte..end_byte];
+        // Guard against a stale node whose byte range no longer fits `text`.
+        let content = clamped_slice(text, start_byte..end_byte);
 
         // Convert tree-sitter byte column to UTF-16 code units for LSP compatibility.
         // Tree-sitter reports columns as byte offsets, but LSP positions use UTF-16.
@@ -206,8 +211,8 @@ impl CacheableInjectionRegion {
         // when the line contains multi-byte UTF-8 characters before the node.
         let (start_line, start_column) = if start_byte == node.start_byte() {
             let byte_column = node.start_position().column;
-            let line_start_byte = node.start_byte() - byte_column;
-            let line_prefix = &text[line_start_byte..node.start_byte()];
+            let line_start_byte = node.start_byte().saturating_sub(byte_column);
+            let line_prefix = clamped_slice(text, line_start_byte..node.start_byte());
             (
                 node.start_position().row as u32,
                 line_prefix.encode_utf16().count() as u32,
@@ -1431,5 +1436,36 @@ local y = "duplicate"
         assert!(unique_languages.contains("lua"));
         assert!(unique_languages.contains("python"));
         assert_eq!(injections.len(), 3, "2 lua + 1 python");
+    }
+
+    // --- stale-tree hardening (#401): byte offsets that no longer match `text`
+    // must degrade gracefully instead of panicking. ---
+
+    #[test]
+    fn position_of_byte_out_of_bounds_does_not_panic() {
+        // Offsets past the end, and an anchor landing mid-codepoint (byte 1 of あ).
+        let _ = position_of_byte("あ", 99, 50, 0);
+        let (row, col) = position_of_byte("あ", 1, 0, 0);
+        assert_eq!((row, col), (0, 0));
+    }
+
+    #[test]
+    fn from_region_info_stale_node_does_not_panic() {
+        // A node parsed from `text` but resolved against a much shorter text
+        // (as if the document shrank before the tree was refreshed).
+        let mut parser = create_rust_parser();
+        let text = r#"fn main() { let s = "a fairly long string literal"; }"#;
+        let tree = parse_rust_code(&mut parser, text);
+        let root = tree.root_node();
+        let query_str = r#"((string_literal) @injection.content (#set! injection.language "md"))"#;
+        let language = tree_sitter_rust::LANGUAGE.into();
+        let query = Query::new(&language, query_str).expect("valid query");
+        let regions = collect_all_injections(&root, text, Some(&query)).expect("injections");
+        assert!(!regions.is_empty());
+
+        let cacheable = CacheableInjectionRegion::from_region_info(&regions[0], "id", "x");
+        // Completed without panicking; metadata is still populated.
+        assert_eq!(cacheable.language, "md");
+        assert_eq!(cacheable.region_id, "id");
     }
 }

--- a/src/language/injection/language.rs
+++ b/src/language/injection/language.rs
@@ -50,8 +50,14 @@ fn extract_dynamic_language(query: &Query, match_: &QueryMatch, text: &str) -> O
             && *capture_name == "injection.language"
         {
             // `clamped_slice` guards a stale capture node whose range no longer
-            // fits `text` (out of bounds / mid-codepoint).
+            // fits `text` (out of bounds / mid-codepoint). An empty result means
+            // the capture didn't resolve to real text — treat it as "no language"
+            // rather than emitting an empty language id (which would create a
+            // bogus injection region downstream), mirroring the info-string path.
             let lang_text = clamped_slice(text, capture.node.byte_range());
+            if lang_text.is_empty() {
+                return None;
+            }
             return Some(lang_text.to_string());
         }
     }
@@ -117,9 +123,10 @@ mod tests {
         let m = matches.next().expect("one match");
 
         // Resolve against a much shorter text, as if the document shrank before
-        // the tree was refreshed: the capture's byte range no longer fits.
+        // the tree was refreshed: the capture's byte range no longer fits, so the
+        // slice clamps to "" — reported as "no language" (None), without panicking.
         let lang = extract_dynamic_language(&query, m, "x");
-        assert_eq!(lang.as_deref(), Some(""));
+        assert_eq!(lang, None);
     }
 
     #[test]

--- a/src/language/injection/language.rs
+++ b/src/language/injection/language.rs
@@ -121,4 +121,29 @@ mod tests {
         let lang = extract_dynamic_language(&query, m, "x");
         assert_eq!(lang.as_deref(), Some(""));
     }
+
+    #[test]
+    fn extract_language_from_info_string_stale_capture_does_not_panic() {
+        // Same stale-tree guard as above, via the #set-lang-from-info-string!
+        // path (language.rs:81), which slices a capture node identically.
+        let md: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        let mut parser = Parser::new();
+        parser.set_language(&md).expect("load markdown");
+        let text = "```rust\nfn main() {}\n```\n";
+        let tree = parser.parse(text, None).expect("parse markdown");
+        let query = Query::new(
+            &md,
+            r#"(fenced_code_block (info_string) @_info (#set-lang-from-info-string! @_info))"#,
+        )
+        .expect("valid query");
+
+        let mut cursor = QueryCursor::new();
+        let mut matches = cursor.matches(&query, tree.root_node(), text.as_bytes());
+        let m = matches.next().expect("one match");
+
+        // Out-of-bounds capture range against the shorter text → empty after
+        // normalization → None, but crucially no panic.
+        let lang = extract_language_from_info_string(&query, m, "x");
+        assert_eq!(lang, None);
+    }
 }

--- a/src/language/injection/language.rs
+++ b/src/language/injection/language.rs
@@ -3,6 +3,7 @@
 //! `@injection.language` capture.
 
 use crate::language::predicate_accessor::{UnifiedPredicate, get_all_predicates};
+use crate::text::clamped_slice;
 use tree_sitter::{Query, QueryMatch};
 
 /// Extracts the injection language from query properties or captures.
@@ -48,7 +49,9 @@ fn extract_dynamic_language(query: &Query, match_: &QueryMatch, text: &str) -> O
         if let Some(capture_name) = query.capture_names().get(capture.index as usize)
             && *capture_name == "injection.language"
         {
-            let lang_text = &text[capture.node.byte_range()];
+            // `clamped_slice` guards a stale capture node whose range no longer
+            // fits `text` (out of bounds / mid-codepoint).
+            let lang_text = clamped_slice(text, capture.node.byte_range());
             return Some(lang_text.to_string());
         }
     }
@@ -75,7 +78,7 @@ fn extract_language_from_info_string(
                 for capture in match_.captures {
                     if capture.index == *capture_id {
                         // Extract the text from the captured node as the language
-                        let lang_text = &text[capture.node.byte_range()];
+                        let lang_text = clamped_slice(text, capture.node.byte_range());
                         // Normalize the language name (lowercase, trim)
                         let normalized = lang_text.trim().to_lowercase();
                         if !normalized.is_empty() {
@@ -87,4 +90,35 @@ fn extract_language_from_info_string(
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tree_sitter::{Parser, QueryCursor, StreamingIterator};
+
+    #[test]
+    fn extract_dynamic_language_stale_capture_does_not_panic() {
+        // #401: a capture node from a tree that no longer matches `text` must
+        // not panic the `text[capture.node.byte_range()]` slice.
+        let md: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        let mut parser = Parser::new();
+        parser.set_language(&md).expect("load markdown");
+        let text = "```rust\nfn main() {}\n```\n";
+        let tree = parser.parse(text, None).expect("parse markdown");
+        let query = Query::new(
+            &md,
+            "(fenced_code_block (info_string (language) @injection.language))",
+        )
+        .expect("valid query");
+
+        let mut cursor = QueryCursor::new();
+        let mut matches = cursor.matches(&query, tree.root_node(), text.as_bytes());
+        let m = matches.next().expect("one match");
+
+        // Resolve against a much shorter text, as if the document shrank before
+        // the tree was refreshed: the capture's byte range no longer fits.
+        let lang = extract_dynamic_language(&query, m, "x");
+        assert_eq!(lang.as_deref(), Some(""));
+    }
 }

--- a/src/text.rs
+++ b/src/text.rs
@@ -9,6 +9,6 @@ pub(crate) mod edit;
 mod hash;
 pub(crate) mod position;
 
-pub(crate) use char_boundary::{ceil_char_boundary, floor_char_boundary};
+pub(crate) use char_boundary::{ceil_char_boundary, clamped_slice, floor_char_boundary};
 pub(crate) use hash::fnv1a_hash;
 pub(crate) use position::PositionMapper;

--- a/src/text/char_boundary.rs
+++ b/src/text/char_boundary.rs
@@ -29,10 +29,10 @@ pub(crate) fn floor_char_boundary(text: &str, mut index: usize) -> usize {
 /// Byte offsets that come from a tree-sitter node are only guaranteed valid for
 /// the exact text the tree was parsed from; if the tree and text desync (a stale
 /// tree after a concurrent edit), an offset can be out of bounds or land
-/// mid-codepoint, and `&text[range]` would panic and crash the LSP server. Both
-/// ends are clamped to the length and floored to char boundaries, and a
-/// degenerate (start > end) range yields `""`. For a range that is already valid
-/// this returns exactly `&text[range]`.
+/// mid-codepoint, and `&text[range]` would panic and crash the LSP server. The
+/// start is floored and the end is ceiled to UTF-8 char boundaries (both clamped
+/// to `text.len()`), and a degenerate (start > end) range yields `""`. For a
+/// range that is already valid this returns exactly `&text[range]`.
 pub(crate) fn clamped_slice(text: &str, range: std::ops::Range<usize>) -> &str {
     let start = floor_char_boundary(text, range.start);
     let end = ceil_char_boundary(text, range.end);
@@ -60,7 +60,7 @@ mod tests {
     fn clamped_slice_mid_codepoint_floors_to_boundary() {
         // "あ" is 3 bytes (0..3); slicing at 1 or 2 would panic with `&text[..]`.
         let s = "あい";
-        assert_eq!(clamped_slice(s, 0..2), "あ"); // end floored 2 -> 3
+        assert_eq!(clamped_slice(s, 0..2), "あ"); // end ceiled 2 -> 3
         assert_eq!(clamped_slice(s, 1..6), "あい"); // start floored 1 -> 0
     }
 

--- a/src/text/char_boundary.rs
+++ b/src/text/char_boundary.rs
@@ -23,3 +23,51 @@ pub(crate) fn floor_char_boundary(text: &str, mut index: usize) -> usize {
     }
     index
 }
+
+/// Slice `text` by a byte range without ever panicking.
+///
+/// Byte offsets that come from a tree-sitter node are only guaranteed valid for
+/// the exact text the tree was parsed from; if the tree and text desync (a stale
+/// tree after a concurrent edit), an offset can be out of bounds or land
+/// mid-codepoint, and `&text[range]` would panic and crash the LSP server. Both
+/// ends are clamped to the length and floored to char boundaries, and a
+/// degenerate (start > end) range yields `""`. For a range that is already valid
+/// this returns exactly `&text[range]`.
+pub(crate) fn clamped_slice(text: &str, range: std::ops::Range<usize>) -> &str {
+    let start = floor_char_boundary(text, range.start);
+    let end = ceil_char_boundary(text, range.end);
+    text.get(start..end.max(start)).unwrap_or("")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamped_slice_valid_range_is_unchanged() {
+        assert_eq!(clamped_slice("hello world", 0..5), "hello");
+        assert_eq!(clamped_slice("hello world", 6..11), "world");
+    }
+
+    #[test]
+    fn clamped_slice_out_of_bounds_does_not_panic() {
+        // A stale tree can report offsets past the end of the current text.
+        assert_eq!(clamped_slice("hi", 0..100), "hi");
+        assert_eq!(clamped_slice("hi", 50..100), "");
+    }
+
+    #[test]
+    fn clamped_slice_mid_codepoint_floors_to_boundary() {
+        // "あ" is 3 bytes (0..3); slicing at 1 or 2 would panic with `&text[..]`.
+        let s = "あい";
+        assert_eq!(clamped_slice(s, 0..2), "あ"); // end floored 2 -> 3
+        assert_eq!(clamped_slice(s, 1..6), "あい"); // start floored 1 -> 0
+    }
+
+    #[test]
+    fn clamped_slice_inverted_range_yields_empty() {
+        // Build the range from values so it isn't a literal reversed range.
+        let (start, end) = (4usize, 2usize);
+        assert_eq!(clamped_slice("hello", start..end), "");
+    }
+}

--- a/src/text/char_boundary.rs
+++ b/src/text/char_boundary.rs
@@ -30,13 +30,18 @@ pub(crate) fn floor_char_boundary(text: &str, mut index: usize) -> usize {
 /// the exact text the tree was parsed from; if the tree and text desync (a stale
 /// tree after a concurrent edit), an offset can be out of bounds or land
 /// mid-codepoint, and `&text[range]` would panic and crash the LSP server. The
-/// start is floored and the end is ceiled to UTF-8 char boundaries (both clamped
-/// to `text.len()`), and a degenerate (start > end) range yields `""`. For a
-/// range that is already valid this returns exactly `&text[range]`.
+/// start is ceiled and the end is floored to UTF-8 char boundaries (both clamped
+/// to `text.len()`) — so the result is always a subset of the requested bytes,
+/// never spilling into an adjacent codepoint — and a degenerate or inverted
+/// range (after snapping, `start >= end`) yields `""`. For a range that is
+/// already valid this returns exactly `&text[range]`.
 pub(crate) fn clamped_slice(text: &str, range: std::ops::Range<usize>) -> &str {
-    let start = floor_char_boundary(text, range.start);
-    let end = ceil_char_boundary(text, range.end);
-    text.get(start..end.max(start)).unwrap_or("")
+    let start = ceil_char_boundary(text, range.start);
+    let end = floor_char_boundary(text, range.end);
+    if start >= end {
+        return "";
+    }
+    text.get(start..end).unwrap_or("")
 }
 
 #[cfg(test)]
@@ -57,11 +62,14 @@ mod tests {
     }
 
     #[test]
-    fn clamped_slice_mid_codepoint_floors_to_boundary() {
-        // "あ" is 3 bytes (0..3); slicing at 1 or 2 would panic with `&text[..]`.
+    fn clamped_slice_mid_codepoint_snaps_inward() {
+        // "あ"/"い" are 3 bytes each (0..3, 3..6); slicing at 1, 2, 4, 5 would
+        // panic with `&text[..]`. Snapping inward (ceil start / floor end) keeps
+        // the result a subset of the requested bytes.
         let s = "あい";
-        assert_eq!(clamped_slice(s, 0..2), "あ"); // end ceiled 2 -> 3
-        assert_eq!(clamped_slice(s, 1..6), "あい"); // start floored 1 -> 0
+        assert_eq!(clamped_slice(s, 0..2), ""); // ceil 0->0, floor 2->0 => empty
+        assert_eq!(clamped_slice(s, 1..6), "い"); // ceil 1->3, floor 6->6
+        assert_eq!(clamped_slice(s, 0..4), "あ"); // ceil 0->0, floor 4->3
     }
 
     #[test]
@@ -69,5 +77,9 @@ mod tests {
         // Build the range from values so it isn't a literal reversed range.
         let (start, end) = (4usize, 2usize);
         assert_eq!(clamped_slice("hello", start..end), "");
+        // An inverted multibyte range must not snap into a non-empty slice
+        // (e.g. 2..1 -> 0..3 would wrongly yield "あ").
+        let (ms, me) = (2usize, 1usize);
+        assert_eq!(clamped_slice("あい", ms..me), "");
     }
 }


### PR DESCRIPTION
Closes #401.

## Problem
The injection read paths slice host text with byte offsets taken from tree-sitter node ranges. Those offsets are only valid for the exact text the tree was parsed from. If the tree and text desync — a stale tree after a concurrent edit — an offset can be out of bounds or land mid-codepoint, and a direct `&text[a..b]` slice **panics and crashes the LSP server** (the same crash class as #348).

## Fix
Add a shared helper `crate::text::clamped_slice(text, range)` and route the unsafe slices through it:
- ceils the start, floors the end to UTF-8 char boundaries (so the result is always a **subset** of the requested bytes — never spilling into an adjacent codepoint), clamps both to `text.len()`, and yields `""` for a degenerate/inverted range (`start >= end` after snapping);
- for any **valid** range it returns exactly `&text[range]` — so the happy path is byte-identical and there is no behavioral regression.

Column arithmetic that could underflow (`gap_abs_byte - column`, `node.start_byte() - byte_column`) uses `saturating_sub`.

Hardened sites (all in `src/language/injection/`):
- `content.rs` — `extract_clean_content`, `compute_line_column_offsets`, `byte_to_point_anchored`
- `discovery.rs` — `position_of_byte` (snaps both offsets), `from_region_info`
- `language.rs` — `extract_dynamic_language`, `extract_language_from_info_string`

The `#offset!` branch of `from_region_info` was already safe (it goes through `calculate_effective_range`, which snaps). After this change, every production `&text[..]` in the injection submodules is either routed through `clamped_slice` or guarded by a prior `floor_char_boundary` snap / validity check.

## Tests
Each hardened function gets a regression test feeding deliberately out-of-bounds / mid-codepoint / underflowing / inverted offsets and asserting graceful degradation instead of a panic (these would panic on `main`).

## Verification
- `make lint` (clippy `--all-targets --all-features -D warnings`) clean; all unit tests pass; e2e passed via pre-commit hooks on every commit.
- Reviewed by subagent multi-perspective review (converged), codex (no findings), and the Copilot + Gemini PR review cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)