### PR TITLE
feat(bridge): translate window/showDocument virtual URIs to host (#403)

### DIFF
--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -132,15 +132,15 @@ impl BridgeCoordinator {
     // Accessor methods (leaky but pragmatic)
     // ========================================
 
-    /// Access the underlying node tracker.
-    ///
-    /// Used by handlers for `InjectionResolver::resolve_at_byte_offset()`.
     /// Resolve a virtual-document URI string to its `(host_url, region_id)`
     /// (used by `window/showDocument` translation). Delegates to the pool.
     pub(crate) async fn resolve_virtual_uri(&self, virtual_uri: &str) -> Option<(Url, String)> {
         self.pool.resolve_virtual_uri(virtual_uri).await
     }
 
+    /// Access the underlying node tracker.
+    ///
+    /// Used by handlers for `InjectionResolver::resolve_at_byte_offset()`.
     pub(crate) fn node_tracker(&self) -> &NodeTracker {
         &self.node_tracker
     }

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -135,6 +135,12 @@ impl BridgeCoordinator {
     /// Access the underlying node tracker.
     ///
     /// Used by handlers for `InjectionResolver::resolve_at_byte_offset()`.
+    /// Resolve a virtual-document URI string to its `(host_url, region_id)`
+    /// (used by `window/showDocument` translation). Delegates to the pool.
+    pub(crate) async fn resolve_virtual_uri(&self, virtual_uri: &str) -> Option<(Url, String)> {
+        self.pool.resolve_virtual_uri(virtual_uri).await
+    }
+
     pub(crate) fn node_tracker(&self) -> &NodeTracker {
         &self.node_tracker
     }

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -504,7 +504,7 @@ impl LanguageServerPool {
     /// Resolve a virtual-document URI string to its `(host_url, region_id)`
     /// (used by `window/showDocument` translation). See
     /// [`DocumentTracker::resolve_virtual_uri`].
-    pub(crate) async fn resolve_virtual_uri(&self, virtual_uri: &str) -> Option<(Url, String)> {
+    pub(super) async fn resolve_virtual_uri(&self, virtual_uri: &str) -> Option<(Url, String)> {
         self.document_tracker.resolve_virtual_uri(virtual_uri).await
     }
 

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -501,6 +501,13 @@ impl LanguageServerPool {
         self.document_tracker.is_document_opened(virtual_uri)
     }
 
+    /// Resolve a virtual-document URI string to its `(host_url, region_id)`
+    /// (used by `window/showDocument` translation). See
+    /// [`DocumentTracker::resolve_virtual_uri`].
+    pub(crate) async fn resolve_virtual_uri(&self, virtual_uri: &str) -> Option<(Url, String)> {
+        self.document_tracker.resolve_virtual_uri(virtual_uri).await
+    }
+
     /// Find ALL connections (`(server, root)` keys) that have opened a given
     /// virtual document URI.
     ///

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -439,10 +439,20 @@ impl DocumentTracker {
     /// derived without a scan). `window/showDocument` is rare, so the scan is
     /// acceptable.
     pub(super) async fn resolve_virtual_uri(&self, virtual_uri: &str) -> Option<(Url, String)> {
+        // Pre-filter on `region_id` (parsed once): it's a globally-unique
+        // per-position ULID, so a cheap `&str` compare skips the per-entry
+        // `to_uri_string()` allocation for every non-matching doc. The full URI
+        // compare still confirms the match (and is the only check if the target's
+        // region_id can't be parsed).
+        let target_region_id = VirtualDocumentUri::region_id_of(virtual_uri);
         let host_map = self.host_to_virtual.lock().await;
         for (host, docs) in host_map.iter() {
             for doc in docs {
-                if doc.virtual_uri.to_uri_string() == virtual_uri {
+                let region_id_matches = match &target_region_id {
+                    Some(id) => doc.virtual_uri.region_id() == id.as_str(),
+                    None => true,
+                };
+                if region_id_matches && doc.virtual_uri.to_uri_string() == virtual_uri {
                     return Some((host.clone(), doc.virtual_uri.region_id().to_string()));
                 }
             }

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -451,7 +451,9 @@ impl DocumentTracker {
                 if doc.virtual_uri.region_id() == target_region_id.as_str()
                     && doc.virtual_uri.to_uri_string() == virtual_uri
                 {
-                    return Some((host.clone(), doc.virtual_uri.region_id().to_string()));
+                    // region_id == target_region_id here, so reuse the already-
+                    // owned String instead of allocating it again.
+                    return Some((host.clone(), target_region_id));
                 }
             }
         }

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -439,20 +439,18 @@ impl DocumentTracker {
     /// derived without a scan). `window/showDocument` is rare, so the scan is
     /// acceptable.
     pub(super) async fn resolve_virtual_uri(&self, virtual_uri: &str) -> Option<(Url, String)> {
-        // Pre-filter on `region_id` (parsed once): it's a globally-unique
-        // per-position ULID, so a cheap `&str` compare skips the per-entry
-        // `to_uri_string()` allocation for every non-matching doc. The full URI
-        // compare still confirms the match (and is the only check if the target's
-        // region_id can't be parsed).
-        let target_region_id = VirtualDocumentUri::region_id_of(virtual_uri);
+        // A non-virtual URI can't match any open virtual document, so bail before
+        // taking the lock. The parsed `region_id` is then a cheap `&str` pre-filter
+        // (globally-unique per-position ULID), skipping the per-entry
+        // `to_uri_string()` allocation for non-matching docs; the full URI compare
+        // still confirms the match.
+        let target_region_id = VirtualDocumentUri::region_id_of(virtual_uri)?;
         let host_map = self.host_to_virtual.lock().await;
         for (host, docs) in host_map.iter() {
             for doc in docs {
-                let region_id_matches = match &target_region_id {
-                    Some(id) => doc.virtual_uri.region_id() == id.as_str(),
-                    None => true,
-                };
-                if region_id_matches && doc.virtual_uri.to_uri_string() == virtual_uri {
+                if doc.virtual_uri.region_id() == target_region_id.as_str()
+                    && doc.virtual_uri.to_uri_string() == virtual_uri
+                {
                     return Some((host.clone(), doc.virtual_uri.region_id().to_string()));
                 }
             }

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -426,6 +426,29 @@ impl DocumentTracker {
             .map(|entry| entry.value().clone())
             .unwrap_or_default()
     }
+
+    /// Resolve a virtual-document URI string back to its `(host_url, region_id)`.
+    ///
+    /// Used by the inbound `window/showDocument` translation to recover which
+    /// host document and injection region a downstream-supplied virtual URI
+    /// refers to. Returns `None` when the URI is not a currently-open virtual
+    /// document.
+    ///
+    /// O(N) over open virtual docs (the virtual URI string encodes only the host
+    /// *directory* + region id, not the host filename, so the host can't be
+    /// derived without a scan). `window/showDocument` is rare, so the scan is
+    /// acceptable.
+    pub(crate) async fn resolve_virtual_uri(&self, virtual_uri: &str) -> Option<(Url, String)> {
+        let host_map = self.host_to_virtual.lock().await;
+        for (host, docs) in host_map.iter() {
+            for doc in docs {
+                if doc.virtual_uri.to_uri_string() == virtual_uri {
+                    return Some((host.clone(), doc.virtual_uri.region_id().to_string()));
+                }
+            }
+        }
+        None
+    }
 }
 
 #[cfg(test)]
@@ -1348,6 +1371,33 @@ mod tests {
         assert_eq!(
             tracker.get_all_connections_for_virtual_uri(&virtual_uri_tsx),
             vec![ConnectionKey::for_server("tsgo")]
+        );
+    }
+
+    /// `resolve_virtual_uri` recovers the host URL + region id for an open
+    /// virtual document, and returns `None` for an unknown URI.
+    #[tokio::test]
+    async fn resolve_virtual_uri_recovers_host_and_region() {
+        let tracker = DocumentTracker::new();
+        let host_uri = Url::parse("file:///project/doc.md").unwrap();
+        let virtual_uri = VirtualDocumentUri::new(&url_to_uri(&host_uri), "lua", "lua-0");
+        tracker
+            .register_opened_document(&host_uri, &virtual_uri, &ConnectionKey::for_server("lua"))
+            .await;
+
+        assert_eq!(
+            tracker
+                .resolve_virtual_uri(&virtual_uri.to_uri_string())
+                .await,
+            Some((host_uri, "lua-0".to_string()))
+        );
+
+        // A URI that was never opened resolves to None (pass-through case).
+        assert_eq!(
+            tracker
+                .resolve_virtual_uri("file:///project/other.lua")
+                .await,
+            None
         );
     }
 }

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -441,9 +441,9 @@ impl DocumentTracker {
     pub(super) async fn resolve_virtual_uri(&self, virtual_uri: &str) -> Option<(Url, String)> {
         // A non-virtual URI can't match any open virtual document, so bail before
         // taking the lock. The parsed `region_id` is then a cheap `&str` pre-filter
-        // (globally-unique per-position ULID), skipping the per-entry
-        // `to_uri_string()` allocation for non-matching docs; the full URI compare
-        // still confirms the match.
+        // skipping the per-entry `to_uri_string()` allocation for non-matching
+        // docs; the full URI compare is what actually confirms the match, so this
+        // stays correct even if two docs ever shared a `region_id`.
         let target_region_id = VirtualDocumentUri::region_id_of(virtual_uri)?;
         let host_map = self.host_to_virtual.lock().await;
         for (host, docs) in host_map.iter() {

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -438,7 +438,7 @@ impl DocumentTracker {
     /// *directory* + region id, not the host filename, so the host can't be
     /// derived without a scan). `window/showDocument` is rare, so the scan is
     /// acceptable.
-    pub(crate) async fn resolve_virtual_uri(&self, virtual_uri: &str) -> Option<(Url, String)> {
+    pub(super) async fn resolve_virtual_uri(&self, virtual_uri: &str) -> Option<(Url, String)> {
         let host_map = self.host_to_virtual.lock().await;
         for (host, docs) in host_map.iter() {
             for doc in docs {

--- a/src/lsp/bridge/protocol/virtual_uri.rs
+++ b/src/lsp/bridge/protocol/virtual_uri.rs
@@ -102,13 +102,15 @@ impl VirtualDocumentUri {
             return false;
         };
 
-        // Check for {VIRTUAL_URI_PREFIX}{region_id}.{ext} pattern
-        // Requires non-empty extension after the last dot
+        // Check for {VIRTUAL_URI_PREFIX}{region_id}.{ext} pattern. Both the
+        // region_id and the extension must be non-empty — a real virtual URI
+        // always has both (`new` asserts a non-empty region_id), so requiring
+        // them rejects degenerate shapes like `kakehashi-virtual-uri-.lua`.
         filename.starts_with(VIRTUAL_URI_PREFIX)
             && filename
                 .get(VIRTUAL_URI_PREFIX.len()..)
                 .and_then(|s| s.rsplit_once('.'))
-                .is_some_and(|(_name, ext)| !ext.is_empty())
+                .is_some_and(|(region_id, ext)| !region_id.is_empty() && !ext.is_empty())
     }
 
     /// Extract the `region_id` from a virtual-document URI string, or `None` if
@@ -123,7 +125,9 @@ impl VirtualDocumentUri {
         let (region_id, ext) = filename
             .strip_prefix(VIRTUAL_URI_PREFIX)?
             .rsplit_once('.')?;
-        if ext.is_empty() {
+        // A real virtual URI always has a non-empty region_id and extension; an
+        // empty region_id (`kakehashi-virtual-uri-.lua`) matches no open document.
+        if region_id.is_empty() || ext.is_empty() {
             return None;
         }
         Some(region_id.to_string())
@@ -691,6 +695,7 @@ mod tests {
     #[case::kakehashi_in_dir("file:///home/.kakehashi/config.lua", false)]
     #[case::kakehashi_prefix_no_virtual("file:///project/kakehashi.config.lua", false)]
     #[case::no_extension("file:///project/kakehashi-virtual-uri-lua", false)]
+    #[case::empty_region_id("file:///project/kakehashi-virtual-uri-.lua", false)]
     #[case::not_a_url("not a url", false)]
     #[case::empty_string("", false)]
     #[case::missing_scheme("://missing-scheme", false)]
@@ -788,6 +793,13 @@ mod tests {
         // Non-virtual URIs yield None.
         assert_eq!(
             VirtualDocumentUri::region_id_of("file:///project/main.rs"),
+            None
+        );
+
+        // A virtual-shaped filename with an empty region_id is rejected (a real
+        // virtual URI always has a non-empty region_id).
+        assert_eq!(
+            VirtualDocumentUri::region_id_of("file:///project/kakehashi-virtual-uri-.lua"),
             None
         );
     }

--- a/src/lsp/bridge/protocol/virtual_uri.rs
+++ b/src/lsp/bridge/protocol/virtual_uri.rs
@@ -113,9 +113,10 @@ impl VirtualDocumentUri {
 
     /// Extract the `region_id` from a virtual-document URI string, or `None` if
     /// it isn't one. Parses the same `{prefix}{region_id}.{ext}` filename shape
-    /// as [`Self::is_virtual_uri`] (the `region_id` is a dot-free ULID, so the
-    /// last `.` separates it from the extension). Used as a cheap pre-filter when
-    /// scanning open virtual documents (`DocumentTracker::resolve_virtual_uri`).
+    /// as [`Self::is_virtual_uri`]; `region_id`s are dot-free (a ULID in
+    /// production, also scratch/test ids), so the last `.` separates the id from
+    /// the extension. Used as a cheap pre-filter when scanning open virtual
+    /// documents (`DocumentTracker::resolve_virtual_uri`).
     pub(crate) fn region_id_of(uri: &str) -> Option<String> {
         let url = url::Url::parse(uri).ok()?;
         let filename = url.path_segments().and_then(|mut s| s.next_back())?;

--- a/src/lsp/bridge/protocol/virtual_uri.rs
+++ b/src/lsp/bridge/protocol/virtual_uri.rs
@@ -111,6 +111,23 @@ impl VirtualDocumentUri {
                 .is_some_and(|(_name, ext)| !ext.is_empty())
     }
 
+    /// Extract the `region_id` from a virtual-document URI string, or `None` if
+    /// it isn't one. Parses the same `{prefix}{region_id}.{ext}` filename shape
+    /// as [`Self::is_virtual_uri`] (the `region_id` is a dot-free ULID, so the
+    /// last `.` separates it from the extension). Used as a cheap pre-filter when
+    /// scanning open virtual documents (`DocumentTracker::resolve_virtual_uri`).
+    pub(crate) fn region_id_of(uri: &str) -> Option<String> {
+        let url = url::Url::parse(uri).ok()?;
+        let filename = url.path_segments().and_then(|mut s| s.next_back())?;
+        let (region_id, ext) = filename
+            .strip_prefix(VIRTUAL_URI_PREFIX)?
+            .rsplit_once('.')?;
+        if ext.is_empty() {
+            return None;
+        }
+        Some(region_id.to_string())
+    }
+
     /// Marker embedded in the `region_id` of throwaway scratch documents the
     /// concatenated formatting pipeline opens per step
     /// (concatenated-formatting-pipeline Decision point 7). Shared here so the
@@ -750,6 +767,27 @@ mod tests {
             VirtualDocumentUri::is_virtual_uri(&uri_string),
             "Fallback URI should be detected as virtual: {}",
             uri_string
+        );
+    }
+
+    #[test]
+    fn region_id_of_round_trips_to_uri_string() {
+        // Standard (file://) form and the cannot-be-a-base fallback form both
+        // recover the region_id.
+        for host in ["file:///project/doc.md", "untitled:Untitled-1"] {
+            let host_uri: Uri = host.parse().unwrap();
+            let uri = VirtualDocumentUri::new(&host_uri, "lua", "01ARZ3NDEKTSV4RRFFQ69G5FAV");
+            assert_eq!(
+                VirtualDocumentUri::region_id_of(&uri.to_uri_string()).as_deref(),
+                Some("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+                "round-trip region_id for host {host}"
+            );
+        }
+
+        // Non-virtual URIs yield None.
+        assert_eq!(
+            VirtualDocumentUri::region_id_of("file:///project/main.rs"),
+            None
         );
     }
 }

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -3,6 +3,7 @@ mod cli_format;
 mod coordinator;
 mod kakehashi;
 mod lifecycle;
+mod show_document_translation;
 pub(crate) mod text_document;
 mod whole_document;
 mod workspace;

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -574,7 +574,10 @@ fn spawn_upstream_request(
             UpstreamRequest::ShowDocument { params, reply } => {
                 // Translate a virtual-document URI + selection back to the host
                 // document before forwarding, so the editor opens the real file
-                // (#403). Falls back to the original params on any miss.
+                // (#403). For a resolvable virtual URI the host URI is always
+                // used (selection translated, or dropped if the offset can't be
+                // rebuilt); only a non-virtual/unresolvable URI is forwarded
+                // unchanged. See `ShowDocumentTranslator::translate`.
                 let params = match &show_document_translator {
                     Some(translator) => translator.translate(params).await,
                     None => params,

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1,5 +1,7 @@
 //! Lifecycle methods for Kakehashi (initialize, initialized, shutdown).
 
+use std::sync::Arc;
+
 use tower_lsp_server::Client;
 use tower_lsp_server::jsonrpc::Result;
 #[cfg(feature = "experimental")]
@@ -22,6 +24,7 @@ use crate::config::WorkspaceSettings;
 use crate::lsp::client::check_semantic_tokens_refresh_support;
 use crate::lsp::{SettingsSource, load_settings};
 
+use super::show_document_translation::ShowDocumentTranslator;
 use super::{Kakehashi, uri_to_url};
 
 fn lsp_legend_types() -> Vec<SemanticTokenType> {
@@ -311,10 +314,18 @@ impl Kakehashi {
         {
             let client = self.client.clone();
             let token = self.shutdown_token.clone();
+            // Translates downstream-initiated window/showDocument virtual URIs +
+            // selections back to host coordinates before forwarding (#403).
+            let show_document_translator = Some(Arc::new(ShowDocumentTranslator::new(
+                Arc::clone(&self.documents),
+                Arc::clone(&self.language),
+                Arc::clone(&self.bridge),
+            )));
             tokio::spawn(upstream_forwarding_loop(
                 upstream_rx,
                 window_rx,
                 upstream_request_rx,
+                show_document_translator,
                 client,
                 token,
             ));
@@ -425,6 +436,7 @@ async fn upstream_forwarding_loop(
     mut upstream_request_rx: tokio::sync::mpsc::UnboundedReceiver<
         crate::lsp::bridge::UpstreamRequest,
     >,
+    show_document_translator: Option<Arc<ShowDocumentTranslator>>,
     client: Client,
     cancel_token: tokio_util::sync::CancellationToken,
 ) {
@@ -470,7 +482,9 @@ async fn upstream_forwarding_loop(
                     // forwarding under `biased`. Servicing is just a spawn, and
                     // requests are user-paced/low-volume, so this can't starve
                     // `window_rx` in turn.
-                    Some(request) => spawn_upstream_request(&client, request),
+                    Some(request) => {
+                        spawn_upstream_request(show_document_translator.clone(), &client, request)
+                    }
                     None => break, // Channel closed
                 }
             }
@@ -527,7 +541,11 @@ async fn upstream_forwarding_loop(
 /// lightweight task awaiting a `oneshot` — is far smaller than the editor's
 /// per-dialog cost, so the editor pushes back first. See issue #405
 /// (closed as not planned) for the full rationale.
-fn spawn_upstream_request(client: &Client, request: crate::lsp::bridge::UpstreamRequest) {
+fn spawn_upstream_request(
+    show_document_translator: Option<Arc<ShowDocumentTranslator>>,
+    client: &Client,
+    request: crate::lsp::bridge::UpstreamRequest,
+) {
     use crate::lsp::bridge::UpstreamRequest;
     let client = client.clone();
     tokio::spawn(async move {
@@ -554,6 +572,13 @@ fn spawn_upstream_request(client: &Client, request: crate::lsp::bridge::Upstream
                 let _ = reply.send(action);
             }
             UpstreamRequest::ShowDocument { params, reply } => {
+                // Translate a virtual-document URI + selection back to the host
+                // document before forwarding, so the editor opens the real file
+                // (#403). Falls back to the original params on any miss.
+                let params = match &show_document_translator {
+                    Some(translator) => translator.translate(params).await,
+                    None => params,
+                };
                 let success = match client.show_document(params).await {
                     Ok(success) => success,
                     Err(e) => {
@@ -771,6 +796,7 @@ mod tests {
             rx,
             window_rx,
             request_rx,
+            None,
             client,
             cancel.clone(),
         ));
@@ -878,6 +904,7 @@ mod tests {
             rx,
             window_rx,
             request_rx,
+            None,
             client,
             cancel.clone(),
         ));
@@ -988,6 +1015,7 @@ mod tests {
             rx,
             window_rx,
             request_rx,
+            None,
             client,
             cancel.clone(),
         ));
@@ -1160,6 +1188,7 @@ mod tests {
             upstream_rx,
             window_rx,
             request_rx,
+            None,
             client,
             cancel.clone(),
         ));
@@ -1212,6 +1241,7 @@ mod tests {
             upstream_rx,
             window_rx,
             request_rx,
+            None,
             client,
             cancel.clone(),
         ));
@@ -1256,6 +1286,7 @@ mod tests {
             upstream_rx,
             window_rx,
             request_rx,
+            None,
             client,
             cancel.clone(),
         ));

--- a/src/lsp/lsp_impl/show_document_translation.rs
+++ b/src/lsp/lsp_impl/show_document_translation.rs
@@ -126,9 +126,12 @@ impl ShowDocumentTranslator {
         if resolved.region.region_id != region_id {
             return None;
         }
+        // `start` is `Copy`; move `line_column_offsets` out (no clone — `resolved`
+        // is dropped after this).
+        let start_line = resolved.region.line_range.start;
         Some(RegionOffset::with_per_line_offsets(
-            resolved.region.line_range.start,
-            resolved.line_column_offsets.clone(),
+            start_line,
+            resolved.line_column_offsets,
         ))
     }
 }

--- a/src/lsp/lsp_impl/show_document_translation.rs
+++ b/src/lsp/lsp_impl/show_document_translation.rs
@@ -28,9 +28,7 @@ use url::Url;
 
 use crate::document::DocumentStore;
 use crate::language::{InjectionResolver, LanguageCoordinator};
-use crate::lsp::bridge::{
-    BridgeCoordinator, RegionOffset, VirtualDocumentUri, translate_virtual_range_to_host,
-};
+use crate::lsp::bridge::{BridgeCoordinator, RegionOffset, translate_virtual_range_to_host};
 
 /// Translates `window/showDocument` params whose URI is a virtual document back
 /// to the host document + host coordinates. Holds shared (cheaply cloneable)
@@ -62,9 +60,9 @@ impl ShowDocumentTranslator {
         if params.external == Some(true) {
             return params;
         }
-        if !VirtualDocumentUri::is_virtual_uri(params.uri.as_str()) {
-            return params;
-        }
+        // `resolve_virtual_uri` returns `None` for any non-virtual URI (it parses
+        // the region_id first), so a separate `is_virtual_uri` check would just
+        // parse the URL twice.
         let Some((host_url, region_id)) =
             self.bridge.resolve_virtual_uri(params.uri.as_str()).await
         else {
@@ -139,6 +137,7 @@ impl ShowDocumentTranslator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lsp::bridge::VirtualDocumentUri;
     use std::str::FromStr;
     use tower_lsp_server::ls_types::{Position, Range, Uri};
 

--- a/src/lsp/lsp_impl/show_document_translation.rs
+++ b/src/lsp/lsp_impl/show_document_translation.rs
@@ -72,18 +72,17 @@ impl ShowDocumentTranslator {
             return params;
         };
 
-        match &params.selection {
-            // Only a selection needs the region offset. If it can't be resolved
-            // (region invalidated by edits), pass through rather than send a
-            // selection in stale/virtual coordinates.
-            Some(_) => match self.region_offset(&host_url, &region_id) {
-                Some(offset) => Self::apply_host_translation(params, host_uri, &offset),
-                None => params,
-            },
-            // No selection: just point the editor at the host document — this
-            // works even when the region offset is unavailable.
+        match self.region_offset(&host_url, &region_id) {
+            // Offset resolved: rewrite the URI and translate the selection (if any).
+            Some(offset) => Self::apply_host_translation(params, host_uri, &offset),
+            // Offset unavailable (region invalidated by edits, or unresolvable):
+            // still open the host document, but drop a selection we can't
+            // translate — a virtual-coordinate selection on the host URI would
+            // point at the wrong place, and keeping the virtual URI would leave
+            // the editor unable to open it at all.
             None => {
                 params.uri = host_uri;
+                params.selection = None;
                 params
             }
         }

--- a/src/lsp/lsp_impl/show_document_translation.rs
+++ b/src/lsp/lsp_impl/show_document_translation.rs
@@ -1,0 +1,111 @@
+//! Virtual→host translation for inbound `window/showDocument` requests.
+//!
+//! A bridged downstream server only knows the *virtual* document it was handed
+//! (one per injected region), so a `window/showDocument` it issues carries a
+//! virtual URI and a `selection` in virtual coordinates. Before the bridge
+//! forwards the request to the editor, [`ShowDocumentTranslator`] rewrites the
+//! URI back to the host document and the selection back to host coordinates —
+//! mirroring how goto/location responses are remapped (see
+//! [`transform_goto_response_to_host`]) — so the editor opens the real file at
+//! the right spot.
+//!
+//! The offset is rebuilt from the live parse exactly as the goto path does
+//! (`region_id → node byte range → resolve injection → RegionOffset`), so a
+//! showDocument-to-a-region can't disagree with goto on the same region. Any
+//! miss — not a virtual URI, `external: true`, no host mapping, or a region
+//! invalidated by edits (`lookup_node` returns `None`) — falls back to
+//! forwarding the params unchanged, which is the pre-translation behavior.
+//!
+//! [`transform_goto_response_to_host`]: crate::lsp::bridge
+//! (response translation lives in the bridge protocol layer)
+
+use std::sync::Arc;
+
+use tower_lsp_server::ls_types::ShowDocumentParams;
+use url::Url;
+
+use crate::document::DocumentStore;
+use crate::language::{InjectionResolver, LanguageCoordinator};
+use crate::lsp::bridge::{
+    BridgeCoordinator, RegionOffset, VirtualDocumentUri, translate_virtual_range_to_host,
+};
+
+/// Translates `window/showDocument` params whose URI is a virtual document back
+/// to the host document + host coordinates. Holds shared (cheaply cloneable)
+/// handles to the document store, language coordinator, and bridge so it can run
+/// off the forwarding loop without the `Kakehashi` receiver.
+pub(crate) struct ShowDocumentTranslator {
+    documents: Arc<DocumentStore>,
+    language: Arc<LanguageCoordinator>,
+    bridge: Arc<BridgeCoordinator>,
+}
+
+impl ShowDocumentTranslator {
+    pub(crate) fn new(
+        documents: Arc<DocumentStore>,
+        language: Arc<LanguageCoordinator>,
+        bridge: Arc<BridgeCoordinator>,
+    ) -> Self {
+        Self {
+            documents,
+            language,
+            bridge,
+        }
+    }
+
+    /// Translate a virtual-document `showDocument` to host coordinates, or return
+    /// `params` unchanged on any miss (see module docs for the fallback cases).
+    pub(crate) async fn translate(&self, mut params: ShowDocumentParams) -> ShowDocumentParams {
+        // `external: true` is a browser/OS resource, never a virtual document.
+        if params.external == Some(true) {
+            return params;
+        }
+        if !VirtualDocumentUri::is_virtual_uri(params.uri.as_str()) {
+            return params;
+        }
+        let Some((host_url, region_id)) =
+            self.bridge.resolve_virtual_uri(params.uri.as_str()).await
+        else {
+            return params; // not a currently-open virtual document
+        };
+        let Some(offset) = self.region_offset(&host_url, &region_id) else {
+            return params; // region invalidated by edits, or unresolvable
+        };
+        let Ok(host_uri) = super::url_to_uri(&host_url) else {
+            return params;
+        };
+
+        if let Some(range) = params.selection.as_mut() {
+            translate_virtual_range_to_host(range, &offset);
+        }
+        params.uri = host_uri;
+        params
+    }
+
+    /// Rebuild the region's current host offset from the live parse, keyed by its
+    /// `region_id` (a ULID). Mirrors the goto request path's offset construction.
+    fn region_offset(&self, host_url: &Url, region_id: &str) -> Option<RegionOffset> {
+        let ulid = ulid::Ulid::from_string(region_id).ok()?;
+        let (start_byte, _end, _kind, _layer) =
+            self.bridge.node_tracker().lookup_node(host_url, &ulid)?;
+        // Snapshot is owned, so the document handle (a store lock) is released
+        // before `detect_document_language` reaches back into the store.
+        let snapshot = self.documents.get(host_url)?.snapshot()?;
+        let language_name =
+            super::detect_document_language(&self.language, &self.documents, host_url)?;
+        let injection_query = self.language.injection_query(&language_name)?;
+        let resolved = InjectionResolver::resolve_at_byte_offset(
+            &self.language,
+            self.bridge.node_tracker(),
+            host_url,
+            snapshot.tree(),
+            snapshot.text(),
+            injection_query.as_ref(),
+            start_byte,
+        )?;
+        Some(RegionOffset::with_per_line_offsets(
+            resolved.region.line_range.start,
+            resolved.line_column_offsets.clone(),
+        ))
+    }
+}

--- a/src/lsp/lsp_impl/show_document_translation.rs
+++ b/src/lsp/lsp_impl/show_document_translation.rs
@@ -12,12 +12,14 @@
 //! The offset is rebuilt from the live parse exactly as the goto path does
 //! (`region_id → node byte range → resolve injection → RegionOffset`), so a
 //! showDocument-to-a-region can't disagree with goto on the same region. Any
-//! miss — not a virtual URI, `external: true`, no host mapping, or a region
-//! invalidated by edits (`lookup_node` returns `None`) — falls back to
-//! forwarding the params unchanged, which is the pre-translation behavior.
+//! miss falls back to forwarding the params unchanged (the pre-translation
+//! behavior): not a virtual URI, `external: true`, an unmappable host URI, a
+//! `region_id` that isn't a ULID, no host mapping for the URI, a region
+//! invalidated by edits (`lookup_node` returns `None`), a missing
+//! document/snapshot/language/injection-query, or a `region_id` that no longer
+//! matches the region the live parse resolves at that byte (edit race).
 //!
-//! [`transform_goto_response_to_host`]: crate::lsp::bridge
-//! (response translation lives in the bridge protocol layer)
+//! [`transform_goto_response_to_host`]: crate::lsp::bridge::protocol::transform_goto_response_to_host
 
 use std::sync::Arc;
 
@@ -34,14 +36,14 @@ use crate::lsp::bridge::{
 /// to the host document + host coordinates. Holds shared (cheaply cloneable)
 /// handles to the document store, language coordinator, and bridge so it can run
 /// off the forwarding loop without the `Kakehashi` receiver.
-pub(crate) struct ShowDocumentTranslator {
+pub(super) struct ShowDocumentTranslator {
     documents: Arc<DocumentStore>,
     language: Arc<LanguageCoordinator>,
     bridge: Arc<BridgeCoordinator>,
 }
 
 impl ShowDocumentTranslator {
-    pub(crate) fn new(
+    pub(super) fn new(
         documents: Arc<DocumentStore>,
         language: Arc<LanguageCoordinator>,
         bridge: Arc<BridgeCoordinator>,
@@ -55,7 +57,7 @@ impl ShowDocumentTranslator {
 
     /// Translate a virtual-document `showDocument` to host coordinates, or return
     /// `params` unchanged on any miss (see module docs for the fallback cases).
-    pub(crate) async fn translate(&self, mut params: ShowDocumentParams) -> ShowDocumentParams {
+    pub(super) async fn translate(&self, params: ShowDocumentParams) -> ShowDocumentParams {
         // `external: true` is a browser/OS resource, never a virtual document.
         if params.external == Some(true) {
             return params;
@@ -75,8 +77,19 @@ impl ShowDocumentTranslator {
             return params;
         };
 
+        Self::apply_host_translation(params, host_uri, &offset)
+    }
+
+    /// Rewrite `params` to the host document: set `uri`, and translate the
+    /// `selection` (if any) from virtual to host coordinates. Pure mutation,
+    /// split out so it can be unit-tested without a live parse.
+    fn apply_host_translation(
+        mut params: ShowDocumentParams,
+        host_uri: tower_lsp_server::ls_types::Uri,
+        offset: &RegionOffset,
+    ) -> ShowDocumentParams {
         if let Some(range) = params.selection.as_mut() {
-            translate_virtual_range_to_host(range, &offset);
+            translate_virtual_range_to_host(range, offset);
         }
         params.uri = host_uri;
         params
@@ -103,6 +116,16 @@ impl ShowDocumentTranslator {
             injection_query.as_ref(),
             start_byte,
         )?;
+        // `region_id`/`start_byte` came from the tracker + node map, but
+        // `resolved` came from a separately-fetched snapshot. If an edit landed
+        // in between, `start_byte` could fall inside a *different* live region —
+        // `resolve_at_byte_offset` returns whichever region contains the byte. A
+        // mismatched `region_id` means we'd translate the selection against the
+        // wrong region, so bail to verbatim pass-through instead (the goto path
+        // can't hit this: there `resolved` and `region_id` come from one call).
+        if resolved.region.region_id != region_id {
+            return None;
+        }
         Some(RegionOffset::with_per_line_offsets(
             resolved.region.line_range.start,
             resolved.line_column_offsets.clone(),
@@ -160,5 +183,45 @@ mod tests {
         let original = params(&virtual_uri);
         let out = translator().translate(original.clone()).await;
         assert_eq!(out, original);
+    }
+
+    #[test]
+    fn apply_host_translation_rewrites_uri_and_translates_selection() {
+        let host = Uri::from_str("file:///project/doc.md").unwrap();
+        let virtual_uri =
+            VirtualDocumentUri::new(&host, "lua", "01ARZ3NDEKTSV4RRFFQ69G5FAV").to_uri_string();
+        let mut original = params(&virtual_uri);
+        // Selection on virtual line 0 so both the line and column offsets apply.
+        original.selection = Some(Range::new(Position::new(0, 2), Position::new(0, 6)));
+
+        // Region starts at host line 10, column 5.
+        let out = ShowDocumentTranslator::apply_host_translation(
+            original,
+            host.clone(),
+            &RegionOffset::new(10, 5),
+        );
+
+        assert_eq!(out.uri, host);
+        assert_eq!(
+            out.selection,
+            Some(Range::new(Position::new(10, 7), Position::new(10, 11))),
+            "line 0 selection shifts by the region's (line, column) offset"
+        );
+    }
+
+    #[test]
+    fn apply_host_translation_without_selection_only_rewrites_uri() {
+        let host = Uri::from_str("file:///project/doc.md").unwrap();
+        let mut original = params("file:///ignored.lua");
+        original.selection = None;
+
+        let out = ShowDocumentTranslator::apply_host_translation(
+            original,
+            host.clone(),
+            &RegionOffset::new(3, 0),
+        );
+
+        assert_eq!(out.uri, host);
+        assert_eq!(out.selection, None);
     }
 }

--- a/src/lsp/lsp_impl/show_document_translation.rs
+++ b/src/lsp/lsp_impl/show_document_translation.rs
@@ -139,8 +139,10 @@ impl ShowDocumentTranslator {
         // in between, `start_byte` could fall inside a *different* live region —
         // `resolve_at_byte_offset` returns whichever region contains the byte. A
         // mismatched `region_id` means we'd translate the selection against the
-        // wrong region, so bail to verbatim pass-through instead (the goto path
-        // can't hit this: there `resolved` and `region_id` come from one call).
+        // wrong region, so return `None` (no offset); the caller then opens the
+        // host document without a selection rather than risk a wrong one. (The
+        // goto path can't hit this: there `resolved` and `region_id` come from
+        // one call.)
         if resolved.region.region_id != region_id {
             return None;
         }

--- a/src/lsp/lsp_impl/show_document_translation.rs
+++ b/src/lsp/lsp_impl/show_document_translation.rs
@@ -11,13 +11,20 @@
 //!
 //! The offset is rebuilt from the live parse exactly as the goto path does
 //! (`region_id → node byte range → resolve injection → RegionOffset`), so a
-//! showDocument-to-a-region can't disagree with goto on the same region. Any
-//! miss falls back to forwarding the params unchanged (the pre-translation
-//! behavior): not a virtual URI, `external: true`, an unmappable host URI, a
-//! `region_id` that isn't a ULID, no host mapping for the URI, a region
-//! invalidated by edits (`lookup_node` returns `None`), a missing
-//! document/snapshot/language/injection-query, or a `region_id` that no longer
-//! matches the region the live parse resolves at that byte (edit race).
+//! showDocument-to-a-region can't disagree with goto on the same region.
+//!
+//! Once the URI resolves to a currently-open virtual document, the editor always
+//! gets the **host** document URI. The selection is translated when the region
+//! offset can be rebuilt; when it can't — region invalidated by edits
+//! (`lookup_node` returns `None`), a `region_id` that no longer matches the live
+//! parse at that byte (edit race), or a missing document/snapshot/language/query
+//! — the selection is **dropped** (a stale virtual-coordinate selection would
+//! point at the wrong place) but the host document still opens.
+//!
+//! Forwarding the params **unchanged** (the pre-translation behavior) only
+//! happens when the URI isn't a resolvable virtual document at all: not a
+//! virtual URI / `external: true` / a `region_id` that isn't a valid id / no
+//! host mapping for the URI / an unmappable host URI.
 //!
 //! [`transform_goto_response_to_host`]: crate::lsp::bridge::protocol::transform_goto_response_to_host
 
@@ -53,8 +60,10 @@ impl ShowDocumentTranslator {
         }
     }
 
-    /// Translate a virtual-document `showDocument` to host coordinates, or return
-    /// `params` unchanged on any miss (see module docs for the fallback cases).
+    /// Translate a virtual-document `showDocument` to the host document (and host
+    /// coordinates when the offset resolves); forward `params` unchanged only when
+    /// the URI isn't a resolvable virtual document. See the module docs for the
+    /// exact behavior.
     pub(super) async fn translate(&self, mut params: ShowDocumentParams) -> ShowDocumentParams {
         // `external: true` is a browser/OS resource, never a virtual document.
         if params.external == Some(true) {
@@ -72,20 +81,20 @@ impl ShowDocumentTranslator {
             return params;
         };
 
-        match self.region_offset(&host_url, &region_id) {
-            // Offset resolved: rewrite the URI and translate the selection (if any).
-            Some(offset) => Self::apply_host_translation(params, host_uri, &offset),
-            // Offset unavailable (region invalidated by edits, or unresolvable):
-            // still open the host document, but drop a selection we can't
-            // translate — a virtual-coordinate selection on the host URI would
-            // point at the wrong place, and keeping the virtual URI would leave
-            // the editor unable to open it at all.
-            None => {
-                params.uri = host_uri;
-                params.selection = None;
-                params
+        // Only a selection needs the (live-parse) region offset, so skip
+        // resolving it when there's nothing to translate.
+        if params.selection.is_some() {
+            match self.region_offset(&host_url, &region_id) {
+                Some(offset) => return Self::apply_host_translation(params, host_uri, &offset),
+                // Offset unavailable (region invalidated by edits, or otherwise
+                // unresolvable): drop the selection we can't translate — a
+                // virtual-coordinate selection on the host URI would point at the
+                // wrong place — but still open the host document below.
+                None => params.selection = None,
             }
         }
+        params.uri = host_uri;
+        params
     }
 
     /// Rewrite `params` to the host document: set `uri`, and translate the

--- a/src/lsp/lsp_impl/show_document_translation.rs
+++ b/src/lsp/lsp_impl/show_document_translation.rs
@@ -55,7 +55,7 @@ impl ShowDocumentTranslator {
 
     /// Translate a virtual-document `showDocument` to host coordinates, or return
     /// `params` unchanged on any miss (see module docs for the fallback cases).
-    pub(super) async fn translate(&self, params: ShowDocumentParams) -> ShowDocumentParams {
+    pub(super) async fn translate(&self, mut params: ShowDocumentParams) -> ShowDocumentParams {
         // `external: true` is a browser/OS resource, never a virtual document.
         if params.external == Some(true) {
             return params;
@@ -68,14 +68,25 @@ impl ShowDocumentTranslator {
         else {
             return params; // not a currently-open virtual document
         };
-        let Some(offset) = self.region_offset(&host_url, &region_id) else {
-            return params; // region invalidated by edits, or unresolvable
-        };
         let Ok(host_uri) = super::url_to_uri(&host_url) else {
             return params;
         };
 
-        Self::apply_host_translation(params, host_uri, &offset)
+        match &params.selection {
+            // Only a selection needs the region offset. If it can't be resolved
+            // (region invalidated by edits), pass through rather than send a
+            // selection in stale/virtual coordinates.
+            Some(_) => match self.region_offset(&host_url, &region_id) {
+                Some(offset) => Self::apply_host_translation(params, host_uri, &offset),
+                None => params,
+            },
+            // No selection: just point the editor at the host document — this
+            // works even when the region offset is unavailable.
+            None => {
+                params.uri = host_uri;
+                params
+            }
+        }
     }
 
     /// Rewrite `params` to the host document: set `uri`, and translate the
@@ -94,7 +105,8 @@ impl ShowDocumentTranslator {
     }
 
     /// Rebuild the region's current host offset from the live parse, keyed by its
-    /// `region_id` (a ULID). Mirrors the goto request path's offset construction.
+    /// `region_id` (a ULID in production). Mirrors the goto request path's offset
+    /// construction.
     fn region_offset(&self, host_url: &Url, region_id: &str) -> Option<RegionOffset> {
         let ulid = ulid::Ulid::from_string(region_id).ok()?;
         let (start_byte, _end, _kind, _layer) =

--- a/src/lsp/lsp_impl/show_document_translation.rs
+++ b/src/lsp/lsp_impl/show_document_translation.rs
@@ -109,3 +109,56 @@ impl ShowDocumentTranslator {
         ))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+    use tower_lsp_server::ls_types::{Position, Range, Uri};
+
+    fn translator() -> ShowDocumentTranslator {
+        ShowDocumentTranslator::new(
+            Arc::new(DocumentStore::new()),
+            Arc::new(LanguageCoordinator::new()),
+            Arc::new(BridgeCoordinator::new()),
+        )
+    }
+
+    fn params(uri: &str) -> ShowDocumentParams {
+        ShowDocumentParams {
+            uri: Uri::from_str(uri).unwrap(),
+            external: None,
+            take_focus: None,
+            selection: Some(Range::new(Position::new(1, 2), Position::new(3, 4))),
+        }
+    }
+
+    #[tokio::test]
+    async fn passes_through_non_virtual_uri_unchanged() {
+        let original = params("file:///project/main.rs");
+        let out = translator().translate(original.clone()).await;
+        assert_eq!(out, original);
+    }
+
+    #[tokio::test]
+    async fn passes_through_external_resource_unchanged() {
+        let mut original = params("https://example.com/");
+        original.external = Some(true);
+        let out = translator().translate(original.clone()).await;
+        assert_eq!(out, original);
+    }
+
+    #[tokio::test]
+    async fn passes_through_unknown_virtual_uri_unchanged() {
+        // A well-formed virtual URI that no open document maps to: the tracker
+        // miss must fall back to verbatim forwarding (no host translation).
+        let host = Uri::from_str("file:///project/doc.md").unwrap();
+        let virtual_uri =
+            VirtualDocumentUri::new(&host, "lua", "01ARZ3NDEKTSV4RRFFQ69G5FAV").to_uri_string();
+        assert!(VirtualDocumentUri::is_virtual_uri(&virtual_uri));
+
+        let original = params(&virtual_uri);
+        let out = translator().translate(original.clone()).await;
+        assert_eq!(out, original);
+    }
+}


### PR DESCRIPTION
## Summary

Resolves #403 (follow-up to #399). A bridged downstream LSP server issues `window/showDocument` with the **virtual**-document URI it was handed (one per injected code region) and a `selection` in virtual coordinates. Until now the bridge forwarded that verbatim, so the editor couldn't open it and answered `success:false`.

Now, before forwarding, `ShowDocumentTranslator` rewrites the virtual URI → host document URI and the `selection` → host coordinates — reusing the **same region→offset construction as the goto path** (`region_id → node byte range → resolve injection → RegionOffset::with_per_line_offsets`), so it can't disagree with goto on the same region.

## Behavior

- `external:true` and non-virtual URIs (anything that isn't a resolvable virtual document) pass through **unchanged**.
- Once the URI resolves to a currently-open virtual document, the editor always gets the **host** document URI:
  - selection present + region offset resolvable → URI + selection translated to host coordinates;
  - selection present + offset **unresolvable** (region invalidated by edits / `region_id` no longer matches the live parse / missing doc/snapshot/language/query) → rewrite the URI to the host document and **drop** the untranslatable selection (a stale virtual-coordinate selection would point at the wrong place);
  - no selection → rewrite the URI (offset resolution skipped — nothing to translate).
- Region resolution is keyed by `region_id` (a globally-unique per-position ULID); `resolve_virtual_uri` pre-filters on it and confirms with the full URI compare.

## Tests

`DocumentTracker::resolve_virtual_uri` lookup; `region_id_of` round-trip + empty/non-virtual rejection; translator pass-through/fallback cases; and the extracted pure `apply_host_translation` (selection translated by the region offset; no-selection only rewrites the uri). The live-parse `region_offset` path is covered transitively by the shared goto offset construction + `translate_virtual_range_to_host`'s own tests.

Reviewed by subagent multi-perspective `/review` and Codex (both converged), plus Copilot + Gemini review rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)