### PR TITLE
feat(bridge): propagate downstream $/cancelRequest to the editor (#404)

### DIFF
--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -28,6 +28,7 @@ mod actor;
 mod client;
 mod connection;
 pub(crate) mod coordinator;
+mod inbound_request_registry;
 mod pool;
 mod progress_registry;
 mod protocol;
@@ -39,11 +40,14 @@ mod workspace;
 
 // Re-export public types
 #[cfg(test)]
+pub(crate) use actor::ForwardedRequestCancel;
+#[cfg(test)]
 pub(crate) use actor::OutboundMessage;
 pub(crate) use actor::UpstreamNotification;
 pub(crate) use actor::UpstreamRequest;
 pub(crate) use coordinator::BridgeCoordinator;
 pub(crate) use coordinator::ResolvedServerConfig;
+pub(crate) use inbound_request_registry::InboundRequestRegistry;
 pub(crate) use pool::ConnectionKey;
 pub(crate) use pool::ConnectionReadiness;
 pub use pool::LanguageServerPool;

--- a/src/lsp/bridge/actor.rs
+++ b/src/lsp/bridge/actor.rs
@@ -22,8 +22,8 @@ pub(crate) use reader::spawn_reader_task;
 #[cfg(test)]
 pub(crate) use reader::spawn_reader_task_with_liveness;
 pub(crate) use reader::{
-    ReaderTaskHandle, ServerRequestDeps, UpstreamNotification, UpstreamRequest,
-    WINDOW_NOTIFICATION_QUEUE_CAPACITY, spawn_reader_task_for_server,
+    ForwardedRequestCancel, ReaderTaskHandle, ServerRequestDeps, UpstreamNotification,
+    UpstreamRequest, WINDOW_NOTIFICATION_QUEUE_CAPACITY, spawn_reader_task_for_server,
 };
 #[cfg(test)]
 pub(crate) use response_router::RouteResult;

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -1029,6 +1029,41 @@ mod tests {
         assert_eq!(router.pending_count(), 1);
     }
 
+    /// #404: an inbound downstream `$/cancelRequest` fires the registered
+    /// in-flight request's token; an unknown id is a no-op.
+    #[tokio::test]
+    async fn handle_message_cancel_request_fires_registered_token() {
+        let router = ResponseRouter::new();
+        let (deps, _keep) = dummy_server_request_deps();
+
+        // The handler would have registered this before enqueueing the request.
+        let token = deps
+            .inbound_request_registry
+            .register(deps.progress_connection_id, jsonrpc::Id::Number(7));
+        assert!(!token.is_cancelled());
+
+        handle_message(
+            json!({ "jsonrpc": "2.0", "method": "$/cancelRequest", "params": { "id": 7 } }),
+            &router,
+            "",
+            &deps,
+        )
+        .await;
+        assert!(
+            token.is_cancelled(),
+            "inbound $/cancelRequest should fire the registered token"
+        );
+
+        // A cancel for an unknown id must not panic.
+        handle_message(
+            json!({ "jsonrpc": "2.0", "method": "$/cancelRequest", "params": { "id": 999 } }),
+            &router,
+            "",
+            &deps,
+        )
+        .await;
+    }
+
     /// Deps wired with a server name, exposing the bounded window receiver so
     /// tests can assert what was (not) forwarded to the editor.
     fn server_request_deps_for(

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -770,11 +770,10 @@ async fn handle_message(
 /// requests *to* the downstream, which the downstream can't cancel this way) are
 /// a no-op.
 fn handle_cancel_request(message: &serde_json::Value, deps: &ServerRequestDeps) {
-    let Some(request_id) = message
-        .get("params")
-        .and_then(|p| p.get("id"))
-        .cloned()
-        .and_then(|v| serde_json::from_value::<jsonrpc::Id>(v).ok())
+    // Deserialize the id straight from the borrowed value (no clone). A missing
+    // params/id indexes to `Value::Null`, which deserializes to `Id::Null` and
+    // matches nothing registered (harmless no-op).
+    let Ok(request_id) = <jsonrpc::Id as serde::Deserialize>::deserialize(&message["params"]["id"])
     else {
         return;
     };

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -752,16 +752,6 @@ async fn handle_message(
     }
 }
 
-/// Forward supported downstream notifications to the upstream editor.
-///
-/// Routes `window/logMessage`, `window/showMessage`, and `telemetry/event` to
-/// their per-method modules ([`window::log_message`], [`window::show_message`],
-/// [`telemetry::event`]); all are forwarded unconditionally so the bridge stays
-/// transparent.
-///
-/// `$/progress` is handled earlier in `handle_message` (translated and forwarded
-/// via [`window::progress::forward`]), so it never reaches here. Everything else
-/// is still silently ignored (push-based publishDiagnostics: #380).
 /// Handle an inbound downstream `$/cancelRequest`: if it targets a forwarded
 /// request still in flight (`window/showMessageRequest` / `window/showDocument`),
 /// cancel the editor-bound request so its dialog is dismissed (#404). The id is
@@ -781,6 +771,16 @@ fn handle_cancel_request(message: &serde_json::Value, deps: &ServerRequestDeps) 
         .cancel(deps.progress_connection_id, &request_id);
 }
 
+/// Forward supported downstream notifications to the upstream editor.
+///
+/// Routes `window/logMessage`, `window/showMessage`, and `telemetry/event` to
+/// their per-method modules ([`window::log_message`], [`window::show_message`],
+/// [`telemetry::event`]); all are forwarded unconditionally so the bridge stays
+/// transparent.
+///
+/// `$/progress` and `$/cancelRequest` are handled earlier in `handle_message`,
+/// so they never reach here. Everything else is still silently ignored
+/// (push-based publishDiagnostics: #380).
 fn forward_notification(
     message: &serde_json::Value,
     server_prefix: &str,

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -1036,10 +1036,13 @@ mod tests {
         let router = ResponseRouter::new();
         let (deps, _keep) = dummy_server_request_deps();
 
-        // The handler would have registered this before enqueueing the request.
+        // The handler would have registered these before enqueueing each request.
         let token = deps
             .inbound_request_registry
             .register(deps.progress_connection_id, jsonrpc::Id::Number(7));
+        let other = deps
+            .inbound_request_registry
+            .register(deps.progress_connection_id, jsonrpc::Id::Number(8));
         assert!(!token.is_cancelled());
 
         handle_message(
@@ -1053,8 +1056,9 @@ mod tests {
             token.is_cancelled(),
             "inbound $/cancelRequest should fire the registered token"
         );
+        assert!(!other.is_cancelled(), "only the targeted id is cancelled");
 
-        // A cancel for an unknown id must not panic.
+        // A cancel for an unknown id is a no-op: no panic, and no other token fires.
         handle_message(
             json!({ "jsonrpc": "2.0", "method": "$/cancelRequest", "params": { "id": 999 } }),
             &router,
@@ -1062,6 +1066,7 @@ mod tests {
             &deps,
         )
         .await;
+        assert!(!other.is_cancelled(), "unknown id must not cancel anything");
     }
 
     /// Deps wired with a server name, exposing the bounded window receiver so

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -104,9 +104,11 @@ pub(crate) enum UpstreamNotification {
 /// are user-interactive and can pend indefinitely, so awaiting one inline would
 /// freeze forwarding for every bridged server.
 ///
-/// `$/cancelRequest` propagation for an in-flight forwarded request is out of
-/// scope for now: if the downstream cancels or dies, the reader-side oneshot is
-/// dropped and the spawned waiter resolves to the protocol's default answer.
+/// Each variant carries a [`ForwardedRequestCancel`] so the forwarding loop can
+/// observe a downstream `$/cancelRequest` (or connection death) and forward the
+/// cancel to the editor — see [`InboundRequestRegistry`].
+///
+/// [`InboundRequestRegistry`]: crate::lsp::bridge::InboundRequestRegistry
 pub(crate) enum UpstreamRequest {
     /// Forward a `window/showMessageRequest`; the editor's selected action (or
     /// `None`) is relayed back to the downstream.
@@ -115,13 +117,28 @@ pub(crate) enum UpstreamRequest {
         message: String,
         actions: Option<Vec<tower_lsp_server::ls_types::MessageActionItem>>,
         reply: oneshot::Sender<Option<tower_lsp_server::ls_types::MessageActionItem>>,
+        cancel: ForwardedRequestCancel,
     },
     /// Forward a `window/showDocument` (URI passed through verbatim, including
     /// virtual-document URIs); the editor's success flag is relayed back.
     ShowDocument {
         params: tower_lsp_server::ls_types::ShowDocumentParams,
         reply: oneshot::Sender<bool>,
+        cancel: ForwardedRequestCancel,
     },
+}
+
+/// Cancellation context for a forwarded request: the originating connection and
+/// downstream request id (used to drop the registry entry once settled) plus the
+/// [`CancellationToken`] the forwarding loop awaits. Registered on the reader via
+/// [`InboundRequestRegistry`] *before* the request is enqueued, so a racing
+/// downstream `$/cancelRequest` can't miss it.
+///
+/// [`InboundRequestRegistry`]: crate::lsp::bridge::InboundRequestRegistry
+pub(crate) struct ForwardedRequestCancel {
+    pub(crate) connection_id: crate::lsp::bridge::ProgressConnectionId,
+    pub(crate) request_id: jsonrpc::Id,
+    pub(crate) token: CancellationToken,
 }
 
 /// Capacity of the bounded `window/*` forwarding queue. Sized like the
@@ -165,6 +182,9 @@ pub(crate) struct ServerRequestDeps {
     /// Unbounded: a dropped request would hang the downstream. See
     /// [`UpstreamRequest`].
     pub(crate) upstream_request_tx: mpsc::UnboundedSender<UpstreamRequest>,
+    /// Tracks in-flight forwarded requests so a downstream `$/cancelRequest`
+    /// (or connection death) can cancel the editor-bound request (#404).
+    pub(crate) inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry,
     /// The folders this connection currently serves, used to answer downstream
     /// `workspace/workspaceFolders` pulls. Mutable: a `preferSharedInstance`
     /// connection grows it as new marker roots join (#391).
@@ -188,10 +208,15 @@ struct ProgressPurgeGuard {
     registry: Arc<crate::lsp::bridge::ProgressRegistry>,
     connection_id: crate::lsp::bridge::ProgressConnectionId,
     upstream_tx: mpsc::UnboundedSender<UpstreamNotification>,
+    /// Cancel any forwarded requests still in flight when this connection's
+    /// reader exits, so their editor dialogs don't linger (#404).
+    inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry,
 }
 
 impl Drop for ProgressPurgeGuard {
     fn drop(&mut self) {
+        self.inbound_request_registry
+            .cancel_connection(self.connection_id);
         let tokens = self.registry.purge_connection(self.connection_id);
         if !tokens.is_empty() {
             let _ = self
@@ -416,6 +441,7 @@ pub(crate) fn spawn_reader_task_with_liveness(
             upstream_tx,
             window_tx,
             upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             workspace_folders: WorkspaceFolderSet::new(None),
             progress_registry,
             progress_connection_id,
@@ -505,6 +531,7 @@ async fn reader_loop(
         workspace_folders: WorkspaceFolderSet::new(None),
         window_tx,
         upstream_request_tx: mpsc::unbounded_channel().0,
+        inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
         progress_registry,
         progress_connection_id,
     };
@@ -544,6 +571,7 @@ async fn reader_loop_with_liveness(
         registry: Arc::clone(&server_request_deps.progress_registry),
         connection_id: server_request_deps.progress_connection_id,
         upstream_tx: server_request_deps.upstream_tx.clone(),
+        inbound_request_registry: server_request_deps.inbound_request_registry.clone(),
     };
 
     // Consolidated liveness timer state (ls-bridge-async-connection)
@@ -707,6 +735,8 @@ async fn handle_message(
                 );
             } else if message["method"].as_str() == Some("$/progress") {
                 window::progress::forward(&message, server_prefix, deps);
+            } else if message["method"].as_str() == Some("$/cancelRequest") {
+                handle_cancel_request(&message, deps);
             } else {
                 forward_notification(&message, server_prefix, deps);
             }
@@ -732,6 +762,26 @@ async fn handle_message(
 /// `$/progress` is handled earlier in `handle_message` (translated and forwarded
 /// via [`window::progress::forward`]), so it never reaches here. Everything else
 /// is still silently ignored (push-based publishDiagnostics: #380).
+/// Handle an inbound downstream `$/cancelRequest`: if it targets a forwarded
+/// request still in flight (`window/showMessageRequest` / `window/showDocument`),
+/// cancel the editor-bound request so its dialog is dismissed (#404). The id is
+/// parsed as a [`jsonrpc::Id`] exactly as the original request's id was, so the
+/// registry key matches. Ids that aren't tracked (e.g. the bridge's own outbound
+/// requests *to* the downstream, which the downstream can't cancel this way) are
+/// a no-op.
+fn handle_cancel_request(message: &serde_json::Value, deps: &ServerRequestDeps) {
+    let Some(request_id) = message
+        .get("params")
+        .and_then(|p| p.get("id"))
+        .cloned()
+        .and_then(|v| serde_json::from_value::<jsonrpc::Id>(v).ok())
+    else {
+        return;
+    };
+    deps.inbound_request_registry
+        .cancel(deps.progress_connection_id, &request_id);
+}
+
 fn forward_notification(
     message: &serde_json::Value,
     server_prefix: &str,
@@ -930,6 +980,7 @@ mod tests {
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
             upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry,
             progress_connection_id,
         };
@@ -1001,6 +1052,7 @@ mod tests {
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
             upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry,
             progress_connection_id,
         };
@@ -1095,6 +1147,7 @@ mod tests {
             upstream_tx,
             window_tx,
             upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             workspace_folders: WorkspaceFolderSet::new(None),
             progress_registry,
             progress_connection_id,
@@ -1169,6 +1222,7 @@ mod tests {
                 upstream_tx,
                 window_tx,
                 upstream_request_tx: mpsc::unbounded_channel().0,
+                inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
                 workspace_folders: WorkspaceFolderSet::new(None),
                 progress_registry: Arc::clone(&progress_registry),
                 progress_connection_id: conn,
@@ -1593,6 +1647,7 @@ mod tests {
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
             upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
@@ -1652,6 +1707,7 @@ mod tests {
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
             upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
@@ -1710,6 +1766,7 @@ mod tests {
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
             upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry: Arc::clone(&progress_registry),
             progress_connection_id,
         };
@@ -1768,6 +1825,7 @@ mod tests {
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
             upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry,
             progress_connection_id,
         };
@@ -1825,6 +1883,7 @@ mod tests {
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
             upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry,
             progress_connection_id,
         };
@@ -1879,6 +1938,7 @@ mod tests {
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
             upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry: Arc::clone(&progress_registry),
             progress_connection_id,
         };
@@ -1934,6 +1994,7 @@ mod tests {
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
             upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry,
             progress_connection_id,
         };
@@ -1971,6 +2032,7 @@ mod tests {
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
             upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
@@ -2024,6 +2086,7 @@ mod tests {
             upstream_tx,
             window_tx,
             upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             workspace_folders: WorkspaceFolderSet::new(Some(folders)),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
@@ -2066,6 +2129,7 @@ mod tests {
             upstream_tx,
             window_tx,
             upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             workspace_folders: WorkspaceFolderSet::new(None),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
@@ -2109,6 +2173,7 @@ mod tests {
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
             upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
@@ -2155,6 +2220,7 @@ mod tests {
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
             upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
@@ -2193,6 +2259,7 @@ mod tests {
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
             upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
@@ -2246,6 +2313,7 @@ mod tests {
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
             upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
@@ -2310,6 +2378,7 @@ mod tests {
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
             upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
@@ -2369,6 +2438,7 @@ mod tests {
             workspace_folders: WorkspaceFolderSet::new(None),
             window_tx,
             upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
@@ -2669,6 +2739,7 @@ mod tests {
             upstream_tx,
             window_tx,
             upstream_request_tx,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             workspace_folders: WorkspaceFolderSet::new(None),
             progress_registry,
             progress_connection_id,
@@ -2794,7 +2865,7 @@ mod tests {
         });
         handle_message(request, &router, "", &deps).await;
 
-        let UpstreamRequest::ShowDocument { params, reply } = request_rx
+        let UpstreamRequest::ShowDocument { params, reply, .. } = request_rx
             .recv()
             .await
             .expect("should forward an UpstreamRequest")

--- a/src/lsp/bridge/inbound_request_registry.rs
+++ b/src/lsp/bridge/inbound_request_registry.rs
@@ -1,0 +1,148 @@
+//! Cancellation registry for downstream-initiated requests forwarded to the
+//! editor (`window/showMessageRequest`, `window/showDocument`).
+//!
+//! When a downstream server sends `$/cancelRequest` for such a request — or its
+//! connection dies while one is in flight — the bridge must tell the editor to
+//! cancel so a `showMessageRequest` dialog is dismissed. tower-lsp's `Client`
+//! exposes no cancel API for an outgoing request, so the forwarding loop instead
+//! sends the request with an id it minted (see `send_editor_request`) and, on
+//! cancel, sends a correlated `$/cancelRequest` to the editor.
+//!
+//! This registry connects the two halves: the per-connection reader (which sees
+//! the downstream `$/cancelRequest` and the connection lifecycle) registers each
+//! in-flight forwarded request and fires its [`CancellationToken`]; the global
+//! forwarding loop awaits that token. Keyed by `(connection, downstream request
+//! id)`.
+//!
+//! Registration happens on the reader **before** the request is enqueued, so a
+//! `$/cancelRequest` that races in immediately after can't miss it. The token is
+//! also handed to the forwarding loop (via `UpstreamRequest`) so it awaits the
+//! same one; the loop removes the entry once the request settles.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use tokio_util::sync::CancellationToken;
+use tower_lsp_server::jsonrpc;
+
+use super::ProgressConnectionId;
+use crate::error::LockResultExt;
+
+/// Shared (cheaply cloneable) map of in-flight forwarded requests to their
+/// cancellation tokens, keyed by `(connection, downstream request id)`.
+#[derive(Clone, Default)]
+pub(crate) struct InboundRequestRegistry {
+    inner: Arc<Mutex<HashMap<(ProgressConnectionId, jsonrpc::Id), CancellationToken>>>,
+}
+
+impl InboundRequestRegistry {
+    /// Register an in-flight forwarded request and return the token the
+    /// forwarding loop awaits. Called on the reader before the request is
+    /// enqueued so a racing `$/cancelRequest` can't miss it.
+    pub(crate) fn register(
+        &self,
+        connection_id: ProgressConnectionId,
+        request_id: jsonrpc::Id,
+    ) -> CancellationToken {
+        let token = CancellationToken::new();
+        self.inner
+            .lock()
+            .recover_poison("InboundRequestRegistry::register")
+            .insert((connection_id, request_id), token.clone());
+        token
+    }
+
+    /// Cancel a specific in-flight request (a downstream `$/cancelRequest`). The
+    /// entry is left for the forwarding loop to remove when the request settles.
+    pub(crate) fn cancel(&self, connection_id: ProgressConnectionId, request_id: &jsonrpc::Id) {
+        if let Some(token) = self
+            .inner
+            .lock()
+            .recover_poison("InboundRequestRegistry::cancel")
+            .get(&(connection_id, request_id.clone()))
+        {
+            token.cancel();
+        }
+    }
+
+    /// Drop a settled request's entry (called by the forwarding loop once the
+    /// editor responded or the cancel was forwarded).
+    pub(crate) fn unregister(&self, connection_id: ProgressConnectionId, request_id: &jsonrpc::Id) {
+        self.inner
+            .lock()
+            .recover_poison("InboundRequestRegistry::unregister")
+            .remove(&(connection_id, request_id.clone()));
+    }
+
+    /// Cancel and drop every in-flight request for a connection — used when a
+    /// downstream connection's reader exits, so its forwarded requests don't
+    /// linger as open editor dialogs.
+    pub(crate) fn cancel_connection(&self, connection_id: ProgressConnectionId) {
+        self.inner
+            .lock()
+            .recover_poison("InboundRequestRegistry::cancel_connection")
+            .retain(|(conn, _), token| {
+                if *conn == connection_id {
+                    token.cancel();
+                    false
+                } else {
+                    true
+                }
+            });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn conn(n: u64) -> ProgressConnectionId {
+        ProgressConnectionId::for_test(n)
+    }
+
+    #[test]
+    fn cancel_fires_the_registered_token() {
+        let registry = InboundRequestRegistry::default();
+        let token = registry.register(conn(1), jsonrpc::Id::Number(7));
+        assert!(!token.is_cancelled());
+
+        registry.cancel(conn(1), &jsonrpc::Id::Number(7));
+        assert!(token.is_cancelled());
+    }
+
+    #[test]
+    fn cancel_is_scoped_by_connection_and_id() {
+        let registry = InboundRequestRegistry::default();
+        let other_conn = registry.register(conn(2), jsonrpc::Id::Number(7));
+        let other_id = registry.register(conn(1), jsonrpc::Id::Number(8));
+
+        // Cancelling (conn 1, id 7) must not touch a different conn or id.
+        registry.cancel(conn(1), &jsonrpc::Id::Number(7)); // not registered → no-op
+        assert!(!other_conn.is_cancelled());
+        assert!(!other_id.is_cancelled());
+    }
+
+    #[test]
+    fn unregister_removes_the_entry() {
+        let registry = InboundRequestRegistry::default();
+        let token = registry.register(conn(1), jsonrpc::Id::Number(7));
+        registry.unregister(conn(1), &jsonrpc::Id::Number(7));
+
+        // After unregister, cancel can't reach the token.
+        registry.cancel(conn(1), &jsonrpc::Id::Number(7));
+        assert!(!token.is_cancelled());
+    }
+
+    #[test]
+    fn cancel_connection_fires_all_for_that_connection_only() {
+        let registry = InboundRequestRegistry::default();
+        let a = registry.register(conn(1), jsonrpc::Id::Number(1));
+        let b = registry.register(conn(1), jsonrpc::Id::Number(2));
+        let other = registry.register(conn(2), jsonrpc::Id::Number(1));
+
+        registry.cancel_connection(conn(1));
+        assert!(a.is_cancelled());
+        assert!(b.is_cancelled());
+        assert!(!other.is_cancelled());
+    }
+}

--- a/src/lsp/bridge/inbound_request_registry.rs
+++ b/src/lsp/bridge/inbound_request_registry.rs
@@ -28,11 +28,13 @@ use tower_lsp_server::jsonrpc;
 use super::ProgressConnectionId;
 use crate::error::LockResultExt;
 
-/// Shared (cheaply cloneable) map of in-flight forwarded requests to their
-/// cancellation tokens, keyed by `(connection, downstream request id)`.
+/// Shared (cheaply cloneable) registry of in-flight forwarded requests and their
+/// cancellation tokens. Nested `connection → (request id → token)` so per-id
+/// lookups don't clone the id and a connection's requests can be cancelled and
+/// dropped together in one O(its-entries) step.
 #[derive(Clone, Default)]
 pub(crate) struct InboundRequestRegistry {
-    inner: Arc<Mutex<HashMap<(ProgressConnectionId, jsonrpc::Id), CancellationToken>>>,
+    inner: Arc<Mutex<HashMap<ProgressConnectionId, HashMap<jsonrpc::Id, CancellationToken>>>>,
 }
 
 impl InboundRequestRegistry {
@@ -48,7 +50,9 @@ impl InboundRequestRegistry {
         self.inner
             .lock()
             .recover_poison("InboundRequestRegistry::register")
-            .insert((connection_id, request_id), token.clone());
+            .entry(connection_id)
+            .or_default()
+            .insert(request_id, token.clone());
         token
     }
 
@@ -59,7 +63,8 @@ impl InboundRequestRegistry {
             .inner
             .lock()
             .recover_poison("InboundRequestRegistry::cancel")
-            .get(&(connection_id, request_id.clone()))
+            .get(&connection_id)
+            .and_then(|requests| requests.get(request_id))
         {
             token.cancel();
         }
@@ -68,27 +73,32 @@ impl InboundRequestRegistry {
     /// Drop a settled request's entry (called by the forwarding loop once the
     /// editor responded or the cancel was forwarded).
     pub(crate) fn unregister(&self, connection_id: ProgressConnectionId, request_id: &jsonrpc::Id) {
-        self.inner
+        let mut guard = self
+            .inner
             .lock()
-            .recover_poison("InboundRequestRegistry::unregister")
-            .remove(&(connection_id, request_id.clone()));
+            .recover_poison("InboundRequestRegistry::unregister");
+        if let Some(requests) = guard.get_mut(&connection_id) {
+            requests.remove(request_id);
+            if requests.is_empty() {
+                guard.remove(&connection_id);
+            }
+        }
     }
 
     /// Cancel and drop every in-flight request for a connection — used when a
     /// downstream connection's reader exits, so its forwarded requests don't
     /// linger as open editor dialogs.
     pub(crate) fn cancel_connection(&self, connection_id: ProgressConnectionId) {
-        self.inner
+        if let Some(requests) = self
+            .inner
             .lock()
             .recover_poison("InboundRequestRegistry::cancel_connection")
-            .retain(|(conn, _), token| {
-                if *conn == connection_id {
-                    token.cancel();
-                    false
-                } else {
-                    true
-                }
-            });
+            .remove(&connection_id)
+        {
+            for token in requests.into_values() {
+                token.cancel();
+            }
+        }
     }
 }
 

--- a/src/lsp/bridge/inbound_request_registry.rs
+++ b/src/lsp/bridge/inbound_request_registry.rs
@@ -73,14 +73,15 @@ impl InboundRequestRegistry {
     /// Drop a settled request's entry (called by the forwarding loop once the
     /// editor responded or the cancel was forwarded).
     pub(crate) fn unregister(&self, connection_id: ProgressConnectionId, request_id: &jsonrpc::Id) {
-        let mut guard = self
+        if let std::collections::hash_map::Entry::Occupied(mut entry) = self
             .inner
             .lock()
-            .recover_poison("InboundRequestRegistry::unregister");
-        if let Some(requests) = guard.get_mut(&connection_id) {
-            requests.remove(request_id);
-            if requests.is_empty() {
-                guard.remove(&connection_id);
+            .recover_poison("InboundRequestRegistry::unregister")
+            .entry(connection_id)
+        {
+            entry.get_mut().remove(request_id);
+            if entry.get().is_empty() {
+                entry.remove();
             }
         }
     }

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -266,6 +266,13 @@ pub struct LanguageServerPool {
     /// reader task (to register/translate) and the cancel path (to route a
     /// client `window/workDoneProgress/cancel` to the owning downstream).
     progress_registry: Arc<super::ProgressRegistry>,
+    /// Tracks downstream-initiated requests forwarded to the editor so a
+    /// downstream `$/cancelRequest` (or connection death) can cancel the
+    /// editor-bound request (#404). Shared with every reader task (to register /
+    /// fire) and the forwarding loop (to await / drop). Distinct from
+    /// `upstream_request_registry`, which is the *outbound* (editor → downstream)
+    /// cancel direction.
+    inbound_request_registry: super::InboundRequestRegistry,
 }
 
 impl Default for LanguageServerPool {
@@ -302,7 +309,15 @@ impl LanguageServerPool {
             upstream_request_tx,
             upstream_request_rx: std::sync::Mutex::new(Some(upstream_request_rx)),
             progress_registry: Arc::new(super::ProgressRegistry::new()),
+            inbound_request_registry: super::InboundRequestRegistry::default(),
         }
+    }
+
+    /// Shared registry of in-flight forwarded requests, handed to the forwarding
+    /// loop so it can await each request's cancel token and drop settled entries
+    /// (#404).
+    pub(crate) fn inbound_request_registry(&self) -> super::InboundRequestRegistry {
+        self.inbound_request_registry.clone()
     }
 
     /// Shared work-done progress token registry (for seam tests that need to
@@ -1203,6 +1218,7 @@ impl LanguageServerPool {
                 upstream_tx: self.upstream_tx.clone(),
                 window_tx: self.window_tx.clone(),
                 upstream_request_tx: self.upstream_request_tx.clone(),
+                inbound_request_registry: self.inbound_request_registry.clone(),
                 // #391: share the per-connection mutable folder set with the
                 // reader (it answers workspace/workspaceFolders pulls).
                 workspace_folders: workspace_folders.clone(),

--- a/src/lsp/bridge/window/show_document.rs
+++ b/src/lsp/bridge/window/show_document.rs
@@ -4,12 +4,11 @@
 //! client to show a resource (by URI) in the UI; the bridge forwards it to the
 //! editor and relays the editor's `success` flag back as a [`ShowDocumentResult`].
 //!
-//! **URI pass-through:** the `uri` is forwarded verbatim, including
-//! concatenated-formatting *virtual-document* URIs — the bridge performs no
-//! virtual→host translation here. If the editor cannot open such a URI it simply
-//! answers `success: false`, which is relayed downstream unchanged. This is a
-//! deliberate v1 simplification; mapping virtual URIs back to host documents is
-//! out of scope for now.
+//! **URI translation happens downstream of this handler:** the `uri` is
+//! forwarded verbatim to the global forwarding loop, which rewrites a
+//! *virtual-document* URI back to its host document (and translates the
+//! selection) before sending it to the editor (#403). This handler stays
+//! transport-only.
 //!
 //! Like [`show_message_request`](super::show_message_request) this **defers** its
 //! response on a spawned task so neither the read loop nor the global forwarding
@@ -24,7 +23,9 @@ use tokio::sync::oneshot;
 use tower_lsp_server::jsonrpc;
 use tower_lsp_server::ls_types::ShowDocumentParams;
 
-use crate::lsp::bridge::actor::{ServerRequestDeps, UpstreamRequest, send_server_response};
+use crate::lsp::bridge::actor::{
+    ForwardedRequestCancel, ServerRequestDeps, UpstreamRequest, send_server_response,
+};
 
 const METHOD: &str = "window/showDocument";
 
@@ -58,19 +59,32 @@ pub(in crate::lsp::bridge) fn handle(
         }
     };
 
+    // Register the in-flight request BEFORE enqueueing it so a racing downstream
+    // `$/cancelRequest` can't miss it (#404). See `show_message_request`.
+    let connection_id = deps.progress_connection_id;
+    let token = deps
+        .inbound_request_registry
+        .register(connection_id, id.clone());
+    let cancel = ForwardedRequestCancel {
+        connection_id,
+        request_id: id.clone(),
+        token,
+    };
+
     let (reply_tx, reply_rx) = oneshot::channel();
 
     // Spawn the responder first; it owns `reply_rx`. If the request below fails
     // to enqueue (forwarding loop gone), `reply_tx` drops and `reply_rx` resolves
     // to `Err`, which maps to `success: false` — so the downstream always gets a
     // response without a special-cased "loop gone" reply path.
+    let response_id = id.clone();
     tokio::spawn(async move {
         let success = reply_rx.await.unwrap_or(false);
         // Build the `ShowDocumentResult` shape (`{ "success": bool }`) directly
         // and infallibly — `serde_json::to_value` of the typed struct would force
         // a fallback whose only safe value is this same object anyway.
         let result = serde_json::json!({ "success": success });
-        let response = jsonrpc::Response::from_ok(id, result);
+        let response = jsonrpc::Response::from_ok(response_id, result);
         send_server_response(&response_tx, response, &server_prefix_owned, METHOD).await;
     });
 
@@ -79,9 +93,12 @@ pub(in crate::lsp::bridge) fn handle(
         .send(UpstreamRequest::ShowDocument {
             params,
             reply: reply_tx,
+            cancel,
         })
         .is_err()
     {
+        // Forwarding loop gone (shutdown): drop the registry entry we just made.
+        deps.inbound_request_registry.unregister(connection_id, &id);
         debug!(
             target: "kakehashi::bridge::reader",
             "{}Forwarding loop gone; answering {} with success:false",

--- a/src/lsp/bridge/window/show_message_request.rs
+++ b/src/lsp/bridge/window/show_message_request.rs
@@ -23,7 +23,9 @@ use tokio::sync::oneshot;
 use tower_lsp_server::jsonrpc;
 use tower_lsp_server::ls_types::ShowMessageRequestParams;
 
-use crate::lsp::bridge::actor::{ServerRequestDeps, UpstreamRequest, send_server_response};
+use crate::lsp::bridge::actor::{
+    ForwardedRequestCancel, ServerRequestDeps, UpstreamRequest, send_server_response,
+};
 
 const METHOD: &str = "window/showMessageRequest";
 
@@ -57,16 +59,31 @@ pub(in crate::lsp::bridge) fn handle(
         }
     };
 
+    // Register the in-flight request BEFORE enqueueing it, so a downstream
+    // `$/cancelRequest` racing in right after can't miss it (#404). The reader
+    // fires this token on cancel / connection death; the forwarding loop awaits
+    // it and, if fired, sends a correlated `$/cancelRequest` to the editor.
+    let connection_id = deps.progress_connection_id;
+    let token = deps
+        .inbound_request_registry
+        .register(connection_id, id.clone());
+    let cancel = ForwardedRequestCancel {
+        connection_id,
+        request_id: id.clone(),
+        token,
+    };
+
     let (reply_tx, reply_rx) = oneshot::channel();
 
     // Spawn the responder first; it owns `reply_rx`. If the request below fails
     // to enqueue (forwarding loop gone), `reply_tx` drops and `reply_rx` resolves
     // to `Err`, which maps to `None` (no selection) — so the downstream always
     // gets a response without a special-cased "loop gone" reply path.
+    let response_id = id.clone();
     tokio::spawn(async move {
         let action = reply_rx.await.unwrap_or(None);
         let result = serde_json::to_value(action).unwrap_or(serde_json::Value::Null);
-        let response = jsonrpc::Response::from_ok(id, result);
+        let response = jsonrpc::Response::from_ok(response_id, result);
         send_server_response(&response_tx, response, &server_prefix_owned, METHOD).await;
     });
 
@@ -77,9 +94,13 @@ pub(in crate::lsp::bridge) fn handle(
             message: params.message,
             actions: params.actions,
             reply: reply_tx,
+            cancel,
         })
         .is_err()
     {
+        // Forwarding loop gone (shutdown): drop the registry entry we just made.
+        // The responder still answers `null` via the dropped `reply_tx`.
+        deps.inbound_request_registry.unregister(connection_id, &id);
         debug!(
             target: "kakehashi::bridge::reader",
             "{}Forwarding loop gone; answering {} with null",

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -601,7 +601,11 @@ async fn forward_with_cancel(
     cancel_token: &tokio_util::sync::CancellationToken,
 ) -> Option<serde_json::Value> {
     tokio::select! {
-        result = send_editor_request(client, editor_id.clone(), method, params) => result,
+        // `biased`: poll the cancel branch first so an already-cancelled request
+        // (cancelled while it sat in the channel) is never sent to the editor at
+        // all — `send_editor_request` isn't polled, so no request is written and
+        // no pending slot is registered.
+        biased;
         () = cancel_token.cancelled() => {
             use tower_lsp_server::ls_types::notification::Cancel;
             use tower_lsp_server::ls_types::{CancelParams, NumberOrString};
@@ -622,6 +626,7 @@ async fn forward_with_cancel(
             client.send_notification::<Cancel>(CancelParams { id }).await;
             None
         }
+        result = send_editor_request(client, editor_id.clone(), method, params) => result,
     }
 }
 

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -586,7 +586,11 @@ async fn send_editor_request(
 /// signal (#404). If the cancel fires first, send a correlated `$/cancelRequest`
 /// to the editor with the id we minted — so a `showMessageRequest` dialog is
 /// dismissed — and return `None`, so the downstream gets the protocol default.
-/// The editor's eventual (cancelled) response is dropped.
+///
+/// On cancel the in-flight `send_editor_request` future is dropped. tower-lsp's
+/// client keeps that request's slot in its pending map (no cancel/remove API),
+/// but a conformant editor's eventual (cancelled) response reclaims it, so the
+/// leak is bounded to requests the editor never answers at all.
 async fn forward_with_cancel(
     client: &Client,
     editor_id: tower_lsp_server::jsonrpc::Id,
@@ -599,9 +603,10 @@ async fn forward_with_cancel(
         () = cancel_token.cancelled() => {
             use tower_lsp_server::ls_types::notification::Cancel;
             use tower_lsp_server::ls_types::{CancelParams, NumberOrString};
-            // The id we minted is always numeric (next_request_id); map it to the
-            // notification's NumberOrString. Values are a small monotonic counter,
-            // so the i32 narrowing is lossless in practice.
+            // The id we minted is always numeric (next_request_id, an AtomicU32
+            // counter); map it to the notification's NumberOrString. The i32
+            // narrowing is lossless until ~2.1B server→client requests in one
+            // session, far beyond any real session.
             let id = match editor_id {
                 tower_lsp_server::jsonrpc::Id::Number(n) => NumberOrString::Number(n as i32),
                 tower_lsp_server::jsonrpc::Id::String(s) => NumberOrString::String(s),

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -613,11 +613,16 @@ async fn forward_with_cancel(
     params: serde_json::Value,
     cancel_token: &tokio_util::sync::CancellationToken,
 ) -> Option<serde_json::Value> {
+    // Already cancelled before we could forward (cancelled while it sat in the
+    // channel): the editor never saw this request, so don't send it OR a
+    // `$/cancelRequest` for an id it never received — just answer the default.
+    if cancel_token.is_cancelled() {
+        return None;
+    }
     tokio::select! {
-        // `biased`: poll the cancel branch first so an already-cancelled request
-        // (cancelled while it sat in the channel) is never sent to the editor at
-        // all — `send_editor_request` isn't polled, so no request is written and
-        // no pending slot is registered.
+        // `biased`: poll the cancel branch first so a request cancelled the
+        // instant after the check above still wins the race before
+        // `send_editor_request` makes progress where possible.
         biased;
         () = cancel_token.cancelled() => {
             use tower_lsp_server::ls_types::notification::Cancel;

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -321,11 +321,13 @@ impl Kakehashi {
                 Arc::clone(&self.language),
                 Arc::clone(&self.bridge),
             )));
+            let inbound_request_registry = self.bridge.pool().inbound_request_registry();
             tokio::spawn(upstream_forwarding_loop(
                 upstream_rx,
                 window_rx,
                 upstream_request_rx,
                 show_document_translator,
+                inbound_request_registry,
                 client,
                 token,
             ));
@@ -437,6 +439,7 @@ async fn upstream_forwarding_loop(
         crate::lsp::bridge::UpstreamRequest,
     >,
     show_document_translator: Option<Arc<ShowDocumentTranslator>>,
+    inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry,
     client: Client,
     cancel_token: tokio_util::sync::CancellationToken,
 ) {
@@ -483,7 +486,12 @@ async fn upstream_forwarding_loop(
                     // requests are user-paced/low-volume, so this can't starve
                     // `window_rx` in turn.
                     Some(request) => {
-                        spawn_upstream_request(show_document_translator.clone(), &client, request)
+                        spawn_upstream_request(
+                            inbound_request_registry.clone(),
+                            show_document_translator.clone(),
+                            &client,
+                            request,
+                        )
                     }
                     None => break, // Channel closed
                 }
@@ -574,7 +582,39 @@ async fn send_editor_request(
     }
 }
 
+/// Forward a request to the editor, racing it against the downstream's cancel
+/// signal (#404). If the cancel fires first, send a correlated `$/cancelRequest`
+/// to the editor with the id we minted — so a `showMessageRequest` dialog is
+/// dismissed — and return `None`, so the downstream gets the protocol default.
+/// The editor's eventual (cancelled) response is dropped.
+async fn forward_with_cancel(
+    client: &Client,
+    editor_id: tower_lsp_server::jsonrpc::Id,
+    method: &'static str,
+    params: serde_json::Value,
+    cancel_token: &tokio_util::sync::CancellationToken,
+) -> Option<serde_json::Value> {
+    tokio::select! {
+        result = send_editor_request(client, editor_id.clone(), method, params) => result,
+        () = cancel_token.cancelled() => {
+            use tower_lsp_server::ls_types::notification::Cancel;
+            use tower_lsp_server::ls_types::{CancelParams, NumberOrString};
+            // The id we minted is always numeric (next_request_id); map it to the
+            // notification's NumberOrString. Values are a small monotonic counter,
+            // so the i32 narrowing is lossless in practice.
+            let id = match editor_id {
+                tower_lsp_server::jsonrpc::Id::Number(n) => NumberOrString::Number(n as i32),
+                tower_lsp_server::jsonrpc::Id::String(s) => NumberOrString::String(s),
+                tower_lsp_server::jsonrpc::Id::Null => return None,
+            };
+            client.send_notification::<Cancel>(CancelParams { id }).await;
+            None
+        }
+    }
+}
+
 fn spawn_upstream_request(
+    inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry,
     show_document_translator: Option<Arc<ShowDocumentTranslator>>,
     client: &Client,
     request: crate::lsp::bridge::UpstreamRequest,
@@ -591,6 +631,7 @@ fn spawn_upstream_request(
                 message,
                 actions,
                 reply,
+                cancel,
             } => {
                 let id = client.next_request_id();
                 let params = serde_json::to_value(ShowMessageRequestParams {
@@ -599,13 +640,24 @@ fn spawn_upstream_request(
                     actions,
                 })
                 .unwrap_or(serde_json::Value::Null);
-                let action = send_editor_request(&client, id, "window/showMessageRequest", params)
-                    .await
-                    .and_then(|v| serde_json::from_value::<Option<MessageActionItem>>(v).ok())
-                    .flatten();
+                let action = forward_with_cancel(
+                    &client,
+                    id,
+                    "window/showMessageRequest",
+                    params,
+                    &cancel.token,
+                )
+                .await
+                .and_then(|v| serde_json::from_value::<Option<MessageActionItem>>(v).ok())
+                .flatten();
+                inbound_request_registry.unregister(cancel.connection_id, &cancel.request_id);
                 let _ = reply.send(action);
             }
-            UpstreamRequest::ShowDocument { params, reply } => {
+            UpstreamRequest::ShowDocument {
+                params,
+                reply,
+                cancel,
+            } => {
                 // Translate a virtual-document URI + selection back to the host
                 // document before forwarding, so the editor opens the real file
                 // (#403). Falls back to the original params on any miss.
@@ -615,11 +667,13 @@ fn spawn_upstream_request(
                 };
                 let id = client.next_request_id();
                 let value = serde_json::to_value(params).unwrap_or(serde_json::Value::Null);
-                let success = send_editor_request(&client, id, "window/showDocument", value)
-                    .await
-                    .and_then(|v| serde_json::from_value::<ShowDocumentResult>(v).ok())
-                    .map(|r| r.success)
-                    .unwrap_or(false);
+                let success =
+                    forward_with_cancel(&client, id, "window/showDocument", value, &cancel.token)
+                        .await
+                        .and_then(|v| serde_json::from_value::<ShowDocumentResult>(v).ok())
+                        .map(|r| r.success)
+                        .unwrap_or(false);
+                inbound_request_registry.unregister(cancel.connection_id, &cancel.request_id);
                 let _ = reply.send(success);
             }
         }
@@ -763,6 +817,15 @@ async fn upstream_forwarding_loop_with_cancel(
 mod tests {
     use super::*;
 
+    /// A throwaway cancel context for tests that don't exercise cancellation.
+    fn test_forwarded_cancel() -> crate::lsp::bridge::ForwardedRequestCancel {
+        crate::lsp::bridge::ForwardedRequestCancel {
+            connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
+            request_id: tower_lsp_server::jsonrpc::Id::Number(1),
+            token: tokio_util::sync::CancellationToken::new(),
+        }
+    }
+
     /// Regression guard for the create-before-progress ordering the feature
     /// depends on: the forwarding loop must deliver `window/workDoneProgress/create`
     /// to the editor (and receive its reply) BEFORE the corresponding `$/progress`.
@@ -827,6 +890,7 @@ mod tests {
             window_rx,
             request_rx,
             None,
+            crate::lsp::bridge::InboundRequestRegistry::default(),
             client,
             cancel.clone(),
         ));
@@ -935,6 +999,7 @@ mod tests {
             window_rx,
             request_rx,
             None,
+            crate::lsp::bridge::InboundRequestRegistry::default(),
             client,
             cancel.clone(),
         ));
@@ -1046,6 +1111,7 @@ mod tests {
             window_rx,
             request_rx,
             None,
+            crate::lsp::bridge::InboundRequestRegistry::default(),
             client,
             cancel.clone(),
         ));
@@ -1219,6 +1285,7 @@ mod tests {
             window_rx,
             request_rx,
             None,
+            crate::lsp::bridge::InboundRequestRegistry::default(),
             client,
             cancel.clone(),
         ));
@@ -1232,6 +1299,7 @@ mod tests {
                     serde_json::from_value(serde_json::json!({ "title": "Retry" })).unwrap(),
                 ]),
                 reply: reply_tx,
+                cancel: test_forwarded_cancel(),
             })
             .unwrap();
 
@@ -1272,6 +1340,7 @@ mod tests {
             window_rx,
             request_rx,
             None,
+            crate::lsp::bridge::InboundRequestRegistry::default(),
             client,
             cancel.clone(),
         ));
@@ -1282,6 +1351,7 @@ mod tests {
                 params: serde_json::from_value(serde_json::json!({ "uri": "file:///x.rs" }))
                     .unwrap(),
                 reply: reply_tx,
+                cancel: test_forwarded_cancel(),
             })
             .unwrap();
 
@@ -1301,6 +1371,87 @@ mod tests {
         let _ = loop_handle.await;
     }
 
+    /// #404: when a downstream's in-flight forwarded request is cancelled, the
+    /// loop must forward a correlated `$/cancelRequest` to the editor (same id it
+    /// minted) so the dialog is dismissed, and answer the downstream with the
+    /// protocol default.
+    #[tokio::test]
+    async fn forwarding_loop_forwards_cancel_to_editor() {
+        use crate::lsp::bridge::{ForwardedRequestCancel, InboundRequestRegistry, UpstreamRequest};
+        use futures::StreamExt;
+        use std::time::Duration;
+        use tokio::time::timeout;
+        use tower_lsp_server::ls_types::MessageType;
+
+        let (client, mut requests, mut _responses) = init_client_and_socket().await;
+        let (_upstream_tx, upstream_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (_window_tx, window_rx) = tokio::sync::mpsc::channel(16);
+        let (request_tx, request_rx) = tokio::sync::mpsc::unbounded_channel();
+        let loop_cancel = tokio_util::sync::CancellationToken::new();
+        let loop_handle = tokio::spawn(upstream_forwarding_loop(
+            upstream_rx,
+            window_rx,
+            request_rx,
+            None,
+            InboundRequestRegistry::default(),
+            client,
+            loop_cancel.clone(),
+        ));
+
+        // The per-request cancel token the reader would have registered.
+        let request_token = tokio_util::sync::CancellationToken::new();
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        request_tx
+            .send(UpstreamRequest::ShowMessageRequest {
+                typ: MessageType::INFO,
+                message: "pick one".to_string(),
+                actions: None,
+                reply: reply_tx,
+                cancel: ForwardedRequestCancel {
+                    connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
+                    request_id: tower_lsp_server::jsonrpc::Id::Number(1),
+                    token: request_token.clone(),
+                },
+            })
+            .unwrap();
+
+        // The editor receives the forwarded request; we deliberately never answer.
+        let req = timeout(Duration::from_secs(5), requests.next())
+            .await
+            .expect("timed out awaiting showMessageRequest")
+            .expect("showMessageRequest emitted");
+        assert_eq!(req.method(), "window/showMessageRequest");
+        let editor_id = req.id().expect("request has an id").clone();
+
+        // Downstream cancels → the loop forwards `$/cancelRequest` to the editor
+        // with the same id, then answers the downstream with the default.
+        request_token.cancel();
+
+        let cancel_msg = timeout(Duration::from_secs(5), requests.next())
+            .await
+            .expect("timed out awaiting forwarded $/cancelRequest")
+            .expect("cancel forwarded to editor");
+        let wire = serde_json::to_value(&cancel_msg).expect("serialize cancel request");
+        assert_eq!(wire["method"], "$/cancelRequest");
+        assert_eq!(
+            wire["params"]["id"],
+            serde_json::to_value(&editor_id).unwrap(),
+            "cancel targets the id the editor saw"
+        );
+
+        let action = timeout(Duration::from_secs(5), reply_rx)
+            .await
+            .expect("timed out awaiting downstream reply")
+            .expect("reply delivered");
+        assert!(
+            action.is_none(),
+            "a cancelled request answers with no selection"
+        );
+
+        loop_cancel.cancel();
+        let _ = loop_handle.await;
+    }
+
     #[tokio::test]
     async fn forwarding_loop_delivers_telemetry_event() {
         use crate::lsp::bridge::UpstreamNotification;
@@ -1317,6 +1468,7 @@ mod tests {
             window_rx,
             request_rx,
             None,
+            crate::lsp::bridge::InboundRequestRegistry::default(),
             client,
             cancel.clone(),
         ));

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -604,11 +604,16 @@ async fn forward_with_cancel(
             use tower_lsp_server::ls_types::notification::Cancel;
             use tower_lsp_server::ls_types::{CancelParams, NumberOrString};
             // The id we minted is always numeric (next_request_id, an AtomicU32
-            // counter); map it to the notification's NumberOrString. The i32
-            // narrowing is lossless until ~2.1B server→client requests in one
-            // session, far beyond any real session.
+            // counter); map it to the notification's `NumberOrString`. The cancel
+            // must carry the *same* numeric id the editor saw, so for the
+            // (astronomically unlikely) ids beyond i32 — which `NumberOrString`
+            // can't represent as a number — there's no correlating cancel to
+            // send; skip it rather than wrap to a wrong id.
             let id = match editor_id {
-                tower_lsp_server::jsonrpc::Id::Number(n) => NumberOrString::Number(n as i32),
+                tower_lsp_server::jsonrpc::Id::Number(n) => match i32::try_from(n) {
+                    Ok(n) => NumberOrString::Number(n),
+                    Err(_) => return None,
+                },
                 tower_lsp_server::jsonrpc::Id::String(s) => NumberOrString::String(s),
                 tower_lsp_server::jsonrpc::Id::Null => return None,
             };

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -588,9 +588,11 @@ async fn send_editor_request(
 /// dismissed — and return `None`, so the downstream gets the protocol default.
 ///
 /// On cancel the in-flight `send_editor_request` future is dropped. tower-lsp's
-/// client keeps that request's slot in its pending map (no cancel/remove API),
-/// but a conformant editor's eventual (cancelled) response reclaims it, so the
-/// leak is bounded to requests the editor never answers at all.
+/// client registers a pending-response slot inside `call` (no cancel/remove API),
+/// so dropping the future can leave that slot parked — whether the request had
+/// already been written to the editor or cancellation won before the write. A
+/// later response from the editor reclaims the slot, so the leak is bounded to
+/// requests the editor never answers (including ones it never received).
 async fn forward_with_cancel(
     client: &Client,
     editor_id: tower_lsp_server::jsonrpc::Id,

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -569,7 +569,20 @@ async fn send_editor_request(
         .params(params)
         .finish();
     match client.clone().call(request).await {
-        Ok(Some(response)) => response.into_parts().1.ok(),
+        Ok(Some(response)) => match response.into_parts().1 {
+            Ok(value) => Some(value),
+            // An error response from the editor (e.g. method unsupported) — log
+            // for observability, then fall back to the protocol default like the
+            // replaced client.show_message_request/show_document path did.
+            Err(e) => {
+                log::debug!(
+                    target: "kakehashi::bridge",
+                    "{} returned an error from the editor: {}",
+                    method, e
+                );
+                None
+            }
+        },
         Ok(None) => None,
         Err(e) => {
             log::debug!(

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -541,12 +541,48 @@ async fn upstream_forwarding_loop(
 /// lightweight task awaiting a `oneshot` — is far smaller than the editor's
 /// per-dialog cost, so the editor pushes back first. See issue #405
 /// (closed as not planned) for the full rationale.
+/// Send a server→client request to the editor with an id *we* mint, returning
+/// the parsed result value (`None` on an error response or transport failure).
+///
+/// This mirrors what `Client::send_request` does internally, but mints the id
+/// via `next_request_id` and sends through the `Client`'s `tower::Service` so we
+/// hold the editor-facing request id — needed to cancel an in-flight request by
+/// sending a correlated `$/cancelRequest` to the editor (#404); the `Client`
+/// exposes no cancel API for outgoing requests.
+async fn send_editor_request(
+    client: &Client,
+    id: tower_lsp_server::jsonrpc::Id,
+    method: &'static str,
+    params: serde_json::Value,
+) -> Option<serde_json::Value> {
+    use tower::Service as _;
+    let request = tower_lsp_server::jsonrpc::Request::build(method)
+        .id(id)
+        .params(params)
+        .finish();
+    match client.clone().call(request).await {
+        Ok(Some(response)) => response.into_parts().1.ok(),
+        Ok(None) => None,
+        Err(e) => {
+            log::debug!(
+                target: "kakehashi::bridge",
+                "{} forwarding to editor failed: {}",
+                method, e
+            );
+            None
+        }
+    }
+}
+
 fn spawn_upstream_request(
     show_document_translator: Option<Arc<ShowDocumentTranslator>>,
     client: &Client,
     request: crate::lsp::bridge::UpstreamRequest,
 ) {
     use crate::lsp::bridge::UpstreamRequest;
+    use tower_lsp_server::ls_types::{
+        MessageActionItem, ShowDocumentResult, ShowMessageRequestParams,
+    };
     let client = client.clone();
     tokio::spawn(async move {
         match request {
@@ -556,19 +592,17 @@ fn spawn_upstream_request(
                 actions,
                 reply,
             } => {
-                let action = match client.show_message_request(typ, message, actions).await {
-                    Ok(action) => action,
-                    Err(e) => {
-                        // e.g. method-not-supported or transport failure — log for
-                        // diagnosis, still relay the protocol default (no selection).
-                        log::debug!(
-                            target: "kakehashi::bridge",
-                            "window/showMessageRequest forwarding failed: {}; answering null",
-                            e
-                        );
-                        None
-                    }
-                };
+                let id = client.next_request_id();
+                let params = serde_json::to_value(ShowMessageRequestParams {
+                    typ,
+                    message,
+                    actions,
+                })
+                .unwrap_or(serde_json::Value::Null);
+                let action = send_editor_request(&client, id, "window/showMessageRequest", params)
+                    .await
+                    .and_then(|v| serde_json::from_value::<Option<MessageActionItem>>(v).ok())
+                    .flatten();
                 let _ = reply.send(action);
             }
             UpstreamRequest::ShowDocument { params, reply } => {
@@ -579,17 +613,13 @@ fn spawn_upstream_request(
                     Some(translator) => translator.translate(params).await,
                     None => params,
                 };
-                let success = match client.show_document(params).await {
-                    Ok(success) => success,
-                    Err(e) => {
-                        log::debug!(
-                            target: "kakehashi::bridge",
-                            "window/showDocument forwarding failed: {}; answering success:false",
-                            e
-                        );
-                        false
-                    }
-                };
+                let id = client.next_request_id();
+                let value = serde_json::to_value(params).unwrap_or(serde_json::Value::Null);
+                let success = send_editor_request(&client, id, "window/showDocument", value)
+                    .await
+                    .and_then(|v| serde_json::from_value::<ShowDocumentResult>(v).ok())
+                    .map(|r| r.success)
+                    .unwrap_or(false);
                 let _ = reply.send(success);
             }
         }


### PR DESCRIPTION
## Summary

Resolves #404 (follow-up to #399). Stacked on #408 (#403) — review the #404 commits only; base retargets to `main` once #403 merges.

A downstream LSP server can cancel an in-flight forwarded `window/showMessageRequest` / `window/showDocument` via `$/cancelRequest`. Previously the bridge ignored it, so a `showMessageRequest` dialog lingered in the editor. Now the bridge forwards the cancel so the dialog is dismissed.

tower-lsp's `Client` has **no cancel API** for an outgoing request and hides the id it mints, so:

1. **Custom-send** (`send_editor_request`): mint the editor-facing id via `next_request_id()`, build the request, send through the `Client`'s `tower::Service` (`call`) — mirroring `send_request_unchecked` — so we hold the id. (Behavior-preserving; replaces `client.show_message_request`/`show_document`.)
2. **Cancellation**: `InboundRequestRegistry` maps `(connection, downstream request id) → CancellationToken`. The reader **registers each forwarded request before enqueueing it** (closes the cancel-before-send race), fires the token on an inbound `$/cancelRequest`, and cancels a connection's tokens when its reader exits (connection death). The forwarding loop races the editor request against the token; on cancel it sends a correlated `$/cancelRequest` to the editor with the minted id, answers the downstream with the protocol default, and drops the registry entry.

## Notes

- Ids beyond `i32` (astronomically unlikely — `next_request_id` is a `u32` counter) can't be represented in `CancelParams`, so the cancel is skipped rather than wrapped to a wrong id.
- On cancel the dropped editor-request future leaves a pending slot in tower-lsp's client (no remove API), reclaimed by the editor's eventual response — bounded to requests the editor never answers.

## Tests

`InboundRequestRegistry` unit tests; a reader test that an inbound `$/cancelRequest` fires only the targeted token; and a forwarding-loop test asserting the editor receives a `$/cancelRequest` with the minted id and the downstream gets the default.

Reviewed by subagent multi-perspective `/review` and Codex (both converged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)