### PR TITLE
perf(injection): micro-optimizations in range/offset helpers (#402)

### DIFF
--- a/src/language/injection/content.rs
+++ b/src/language/injection/content.rs
@@ -58,30 +58,29 @@ pub(super) fn compute_line_column_offsets(
             let mut offsets = Vec::new();
             for range in ranges {
                 let gap_start_line = range.start_point.row;
-                // How many virtual lines does this gap span?
                 let gap_end_line = range.end_point.row;
-                for line in gap_start_line..=gap_end_line {
-                    offsets.resize(line + 1, 0);
-                    if line == gap_start_line {
-                        // The column offset is the gap's start column within the host line.
-                        // For the first line (row 0) of the content node, use start_column
-                        // (which accounts for the full prefix from the line start).
-                        // For subsequent lines, the start_point.column from
-                        // compute_included_ranges is already the raw byte column
-                        // within the line — convert to UTF-16.
-                        if line == 0 {
-                            offsets[line] = start_column;
-                        } else {
-                            // Convert byte column to UTF-16 code units.
-                            // The gap's start_byte is relative to content node start.
-                            // The line starts at the byte after the previous newline.
-                            let gap_abs_byte = byte_range.start.saturating_add(range.start_byte);
-                            let line_start_byte =
-                                gap_abs_byte.saturating_sub(range.start_point.column);
-                            let prefix = clamped_slice(host_text, line_start_byte..gap_abs_byte);
-                            offsets[line] = prefix.encode_utf16().count() as u32;
-                        }
-                    }
+                // Only the gap's start line carries a column offset; the rest of
+                // its spanned rows stay at the default 0. Gaps arrive in document
+                // order (ascending, non-overlapping rows), so resizing once to
+                // `gap_end_line + 1` only grows `offsets` — equivalent to the
+                // previous per-row resize loop, without re-resizing each row.
+                offsets.resize(gap_end_line + 1, 0);
+                // The column offset is the gap's start column within the host line.
+                // For the first line (row 0) of the content node, use start_column
+                // (which accounts for the full prefix from the line start).
+                // For subsequent lines, the start_point.column from
+                // compute_included_ranges is already the raw byte column
+                // within the line — convert to UTF-16.
+                if gap_start_line == 0 {
+                    offsets[gap_start_line] = start_column;
+                } else {
+                    // Convert byte column to UTF-16 code units.
+                    // The gap's start_byte is relative to content node start.
+                    // The line starts at the byte after the previous newline.
+                    let gap_abs_byte = byte_range.start.saturating_add(range.start_byte);
+                    let line_start_byte = gap_abs_byte.saturating_sub(range.start_point.column);
+                    let prefix = clamped_slice(host_text, line_start_byte..gap_abs_byte);
+                    offsets[gap_start_line] = prefix.encode_utf16().count() as u32;
                 }
             }
             if offsets.is_empty() {

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -291,13 +291,22 @@ pub(crate) fn collect_all_injections<'a>(
             }
             if let Some(language) = extract_injection_language(query, match_, text) {
                 let key = (capture.node.start_byte(), capture.node.end_byte());
-                injections_map.entry(key).or_insert(InjectionRegionInfo {
-                    language,
-                    content_node: capture.node,
-                    pattern_index: match_.pattern_index,
-                    include_children: has_include_children_for_pattern(query, match_.pattern_index),
-                    offset: effective_offset_for_pattern(query, match_.pattern_index),
-                });
+                // `or_insert_with` so the per-pattern predicate scans
+                // (`has_include_children_for_pattern` / `effective_offset_for_pattern`)
+                // are skipped when this content-node range was already inserted by
+                // an earlier matching pattern. Same resulting map, fewer scans.
+                injections_map
+                    .entry(key)
+                    .or_insert_with(|| InjectionRegionInfo {
+                        language,
+                        content_node: capture.node,
+                        pattern_index: match_.pattern_index,
+                        include_children: has_include_children_for_pattern(
+                            query,
+                            match_.pattern_index,
+                        ),
+                        offset: effective_offset_for_pattern(query, match_.pattern_index),
+                    });
             }
         }
     }


### PR DESCRIPTION
Implements #402.

> **Stacked on #407 (#401).** Base is `fix/401-injection-slice-hardening`; this PR's diff is only the perf delta. It will retarget to `main` automatically once #407 merges. The `compute_line_column_offsets` change builds on the hardened version from #401, which is why it's stacked rather than parallel.

## Implemented

1. **`collect_all_injections`: `or_insert` → `or_insert_with`** — when several injection patterns match the same content-node range, only the first insertion is kept. Deferring the `InjectionRegionInfo` construction skips the `has_include_children_for_pattern` / `effective_offset_for_pattern` predicate scans for the discarded duplicates. Same resulting map.
2. **`compute_line_column_offsets`: hoist the per-row resize** — the inner `for line in gap_start_line..=gap_end_line { offsets.resize(line+1,0); … }` only ever wrote the gap's start row, so it collapses to a single `resize(gap_end_line+1, 0)`. Gaps arrive in ascending, non-overlapping document order (built by `compute_included_ranges_in_window`'s forward walk), so the resize only grows — equivalent output, fewer resize calls.

Both are behavior-preserving for the actual inputs; valid behavior is unchanged.

## Evaluated and intentionally **not** changed

The issue listed two more items; after analysis both are declined:

- **`compute_included_ranges_in_window` pre-check removal** — the suggested "filter a trivial whole-window range to `None` at the end" is **not behavior-preserving**: when non-zero children all fall outside the `#offset!`-clipped window, the loop emits `Some([whole-window range])`, and `compute_line_column_offsets` returns different output for `None` (`vec![start_column]`) vs `Some([range])` (per-line offsets). The existing pre-check is also already an `.any()` short-circuit (O(1) common case), so there's little to gain.
- **`sub_select_included_ranges` first-range `end_point.column`** — this is the function's already-documented "Known limitation" (clipped ranges adjust bytes, not points; tree-sitter validates byte ordering only; the first-range `column = 0` deliberately avoids double-counting the `> ` prefix, and is locked by a passing test). It's pre-existing, not a regression, and untouched by this PR.

## Verification
- `make lint` (clippy `--all-targets --all-features -D warnings`) clean; all unit tests pass; e2e passed via pre-commit hooks.
- Reviewed by subagent multi-perspective review and codex — both confirmed the two changes are behavior-preserving and that items 2 & 4 were correctly declined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)