### PR TITLE
fix(e2e): give LspClient notification waits exact deadlines (#385)

### DIFF
--- a/tests/e2e_notification_timeout.rs
+++ b/tests/e2e_notification_timeout.rs
@@ -1,0 +1,54 @@
+//! End-to-end test pinning the exact-deadline guarantee of the E2E LspClient
+//! notification waits (issue #385).
+//!
+//! Run with: `cargo test --test e2e_notification_timeout --features e2e`
+//!
+//! Background: `wait_for_notification` used to poll `BufReader::fill_buf()`,
+//! which blocks on a pipe with no data. Against a server that stays *alive but
+//! silent* — exactly the situation a forwarding regression produces — the wait
+//! would hang indefinitely instead of returning at its deadline. The fix routes
+//! reads through a background thread + `mpsc::recv_timeout`, so the deadline is
+//! honored exactly. This test would hang on the old implementation and returns
+//! at ~the requested timeout on the new one.
+
+#![cfg(feature = "e2e")]
+
+mod helpers;
+
+use helpers::lsp_client::LspClient;
+use serde_json::json;
+use std::time::{Duration, Instant};
+
+#[test]
+fn wait_for_notification_honors_deadline_against_silent_server() {
+    let mut client = LspClient::new();
+
+    // Bring the server up so it is genuinely alive — not exited — for the wait.
+    let init = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {}
+        }),
+    );
+    assert!(init.get("result").is_some(), "initialize should succeed");
+    client.send_notification("initialized", json!({}));
+
+    // The server will never emit this method, and we open no documents, so it
+    // stays alive and silent. The wait must return None at its deadline.
+    let timeout = Duration::from_secs(1);
+    let start = Instant::now();
+    let result = client.wait_for_notification("nonexistent/method", timeout);
+    let elapsed = start.elapsed();
+
+    assert!(
+        result.is_none(),
+        "no notification should arrive for a method the server never sends"
+    );
+    assert!(
+        elapsed < Duration::from_secs(3),
+        "wait must return at its deadline against an alive-but-silent server, \
+         took {elapsed:?} (would hang on the pre-fix fill_buf implementation)"
+    );
+}

--- a/tests/e2e_notification_timeout.rs
+++ b/tests/e2e_notification_timeout.rs
@@ -46,9 +46,25 @@ fn wait_for_notification_honors_deadline_against_silent_server() {
         result.is_none(),
         "no notification should arrive for a method the server never sends"
     );
+    // Upper bound: the wait must not hang past its deadline (the pre-fix
+    // fill_buf implementation blocks forever here).
     assert!(
         elapsed < Duration::from_secs(3),
         "wait must return at its deadline against an alive-but-silent server, \
          took {elapsed:?} (would hang on the pre-fix fill_buf implementation)"
+    );
+    // Lower bound + liveness: the wait must have actually blocked until ~the
+    // deadline against a *live* server — not returned early because the server
+    // exited (a disconnect also yields None). This is what pins the
+    // "alive but silent" guarantee rather than merely "returns None".
+    assert!(
+        elapsed >= timeout.saturating_sub(Duration::from_millis(100)),
+        "wait returned before its deadline ({elapsed:?}); the server must stay \
+         silent for the full timeout, not disconnect early"
+    );
+    assert!(
+        client.is_running(),
+        "server must still be alive after the wait — the deadline guarantee is \
+         only meaningful against a live, silent server"
     );
 }

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -251,7 +251,7 @@ fn read_framed_message<R: BufRead>(reader: &mut R) -> ReadOutcome {
 
             return match serde_json::from_slice(&body) {
                 Ok(value) => ReadOutcome::Message(value),
-                Err(e) => ReadOutcome::Error(format!("Failed to parse response: {e}")),
+                Err(e) => ReadOutcome::Error(format!("Failed to parse JSON-RPC message body: {e}")),
             };
         }
 

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -12,6 +12,8 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::OnceLock;
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
+use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 /// Project-local persistent data directory used by every spawned
@@ -54,12 +56,55 @@ fn test_data_dir() -> &'static Path {
 ///
 /// Handles JSON-RPC 2.0 message framing with Content-Length headers,
 /// request/response matching, and server-initiated notifications.
+///
+/// Server stdout is drained by a dedicated background thread that frames
+/// messages and pushes them onto an `mpsc` channel. Reads therefore become
+/// `recv_timeout` with **exact** deadlines — a notification-wait against an
+/// alive-but-silent server returns at its timeout instead of blocking on a
+/// quiet pipe (see issue #385).
 pub struct LspClient {
     child: Child,
     stdin: Option<ChildStdin>,
-    stdout: BufReader<ChildStdout>,
+    /// Framed messages from the background reader thread, in arrival order.
+    /// A `Disconnected` recv means the reader thread ended (clean EOF).
+    rx: Receiver<ReaderEvent>,
+    /// Handle to the background reader thread, joined on drop after the child
+    /// is killed (which closes stdout and unblocks the thread).
+    reader: Option<JoinHandle<()>>,
     stderr: Option<std::process::ChildStderr>,
     request_id: i64,
+}
+
+/// Message pushed from the background reader thread to the client.
+///
+/// A clean EOF is signaled out-of-band by the thread dropping its [`Sender`],
+/// which surfaces to the client as a `Disconnected` recv.
+enum ReaderEvent {
+    /// A complete, parsed JSON-RPC message.
+    Message(Value),
+    /// A framing/parse failure with a precise diagnostic. The reader thread
+    /// terminates after sending this.
+    Error(String),
+}
+
+/// Background reader thread body: frame messages off `reader` and forward them
+/// over `tx` until EOF, a framing error, or the consumer goes away.
+fn reader_loop(mut reader: BufReader<ChildStdout>, tx: Sender<ReaderEvent>) {
+    loop {
+        match read_framed_message(&mut reader) {
+            ReadOutcome::Message(value) => {
+                if tx.send(ReaderEvent::Message(value)).is_err() {
+                    return; // consumer dropped the receiver
+                }
+            }
+            // Clean EOF: drop tx so the consumer observes `Disconnected`.
+            ReadOutcome::Eof => return,
+            ReadOutcome::Error(e) => {
+                let _ = tx.send(ReaderEvent::Error(e));
+                return;
+            }
+        }
+    }
 }
 
 /// Builder for creating LspClient instances with custom configuration.
@@ -123,19 +168,8 @@ impl LspClientBuilder {
             cmd.env(key, value);
         }
 
-        let mut child = cmd.spawn().expect("Failed to spawn kakehashi binary");
-
-        let stdin = child.stdin.take().expect("Failed to get stdin");
-        let stdout = BufReader::new(child.stdout.take().expect("Failed to get stdout"));
-        let stderr = child.stderr.take();
-
-        LspClient {
-            child,
-            stdin: Some(stdin),
-            stdout,
-            stderr,
-            request_id: 0,
-        }
+        let child = cmd.spawn().expect("Failed to spawn kakehashi binary");
+        LspClient::from_child(child)
     }
 }
 
@@ -264,16 +298,25 @@ impl LspClient {
             cmd.env("RUST_LOG", "debug");
         }
 
-        let mut child = cmd.spawn().expect("Failed to spawn kakehashi binary");
+        let child = cmd.spawn().expect("Failed to spawn kakehashi binary");
+        Self::from_child(child)
+    }
 
+    /// Wire up a spawned child: take its stdio handles and start the background
+    /// reader thread that drains stdout into the message channel.
+    fn from_child(mut child: Child) -> Self {
         let stdin = child.stdin.take().expect("Failed to get stdin");
         let stdout = BufReader::new(child.stdout.take().expect("Failed to get stdout"));
         let stderr = child.stderr.take();
 
+        let (tx, rx) = mpsc::channel();
+        let reader = std::thread::spawn(move || reader_loop(stdout, tx));
+
         Self {
             child,
             stdin: Some(stdin),
-            stdout,
+            rx,
+            reader: Some(reader),
             stderr,
             request_id: 0,
         }
@@ -393,15 +436,20 @@ impl LspClient {
         }
     }
 
-    /// Receive a single LSP message with Content-Length framing.
-    /// Validates Content-Length to prevent excessive memory allocation.
+    /// Receive a single LSP message from the background reader thread.
+    /// Times out after 30 seconds to prevent indefinite blocking on an
+    /// unresponsive (alive but silent) server.
     fn receive_message(&mut self) -> Value {
-        match read_framed_message(&mut self.stdout) {
-            ReadOutcome::Message(value) => value,
-            ReadOutcome::Eof => {
-                panic!("Server closed connection prematurely while reading header")
+        const TIMEOUT: Duration = Duration::from_secs(30);
+        match self.rx.recv_timeout(TIMEOUT) {
+            Ok(ReaderEvent::Message(value)) => value,
+            Ok(ReaderEvent::Error(e)) => panic!("{e}"),
+            Err(RecvTimeoutError::Timeout) => {
+                panic!("Timeout reading LSP message after {TIMEOUT:?}")
             }
-            ReadOutcome::Error(e) => panic!("{e}"),
+            Err(RecvTimeoutError::Disconnected) => {
+                panic!("Server closed connection prematurely (reader thread ended at EOF)")
+            }
         }
     }
 
@@ -473,30 +521,23 @@ impl LspClient {
         let start_time = Instant::now();
 
         loop {
-            // Check timeout
-            if start_time.elapsed() > timeout {
-                return None;
-            }
-
-            // Use a short poll timeout to check the overall timeout frequently
             let remaining = timeout.saturating_sub(start_time.elapsed());
             if remaining.is_zero() {
                 return None;
             }
 
-            // Try to read a message with remaining timeout
-            if let Some(message) =
-                self.try_receive_message(remaining.min(Duration::from_millis(100)))
+            // Block up to the *remaining* deadline. None means the deadline
+            // elapsed or the server disconnected — either way, give up.
+            let message = self.try_receive_message(remaining)?;
+
+            // Notifications have no "id" field and must match the expected method.
+            if message.get("id").is_none()
+                && message.get("method").and_then(|m| m.as_str()) == Some(expected_method)
             {
-                // Check if this is the notification we're waiting for
-                // Notifications have no "id" field and must match the expected method
-                if message.get("id").is_none()
-                    && message.get("method").and_then(|m| m.as_str()) == Some(expected_method)
-                {
-                    return message.get("params").cloned();
-                }
-                // Otherwise it's a response or server-to-client request, skip it
+                return message.get("params").cloned();
             }
+            // Otherwise it's a response or server-to-client request; skip it
+            // and keep waiting within the deadline.
         }
     }
 
@@ -521,9 +562,11 @@ impl LspClient {
                 return None;
             }
 
-            if let Some(message) =
-                self.try_receive_message(remaining.min(Duration::from_millis(100)))
-                && message.get("id").is_none()
+            // Block up to the *remaining* deadline. None means the deadline
+            // elapsed or the server disconnected — either way, give up.
+            let message = self.try_receive_message(remaining)?;
+
+            if message.get("id").is_none()
                 && let Some(method) = message.get("method").and_then(|m| m.as_str())
                 && methods.contains(&method)
             {
@@ -535,44 +578,20 @@ impl LspClient {
         }
     }
 
-    /// Try to receive a message with a timeout, returning None if no message available.
+    /// Try to receive a message within `timeout`, returning None if none arrives.
     ///
-    /// # Known Limitation
-    ///
-    /// The `fill_buf()` call can potentially block on pipes if no data is available,
-    /// which may cause the timeout to be approximate rather than exact. In practice,
-    /// this works well for test scenarios where:
-    /// 1. The server is expected to respond (tests wait after sending requests)
-    /// 2. The server process eventually terminates (EOF triggers return)
-    ///
-    /// For truly non-blocking behavior, platform-specific non-blocking I/O or async
-    /// would be required, but this adds significant complexity for test helper code.
+    /// Backed by the background reader thread's channel, so the deadline is
+    /// exact: against an alive-but-silent server this blocks for precisely
+    /// `timeout` and then returns None, rather than hanging on a quiet pipe.
+    /// A disconnect (reader thread ended at EOF) also returns None — no further
+    /// messages can arrive. A framing/parse error panics with its diagnostic.
     fn try_receive_message(&mut self, timeout: Duration) -> Option<Value> {
-        let start_time = Instant::now();
-
-        // Polling loop with short sleeps between buffer checks.
-        // Note: fill_buf() may block briefly if the pipe has no data, making
-        // the timeout approximate. This is acceptable for test code where we
-        // expect the server to respond or terminate.
-        while start_time.elapsed() < timeout {
-            // Check if data is already available in the buffer
-            if !self.stdout.buffer().is_empty() {
-                return Some(self.receive_message());
-            }
-
-            // Try to fill the buffer with available data.
-            // This may block briefly on pipes, but typically returns quickly
-            // if data is being sent or the server has terminated.
-            let _ = self.stdout.fill_buf();
-            if !self.stdout.buffer().is_empty() {
-                return Some(self.receive_message());
-            }
-
-            // No data yet, sleep briefly and retry
-            std::thread::sleep(Duration::from_millis(10));
+        match self.rx.recv_timeout(timeout) {
+            Ok(ReaderEvent::Message(value)) => Some(value),
+            Ok(ReaderEvent::Error(e)) => panic!("{e}"),
+            Err(RecvTimeoutError::Timeout) => None,
+            Err(RecvTimeoutError::Disconnected) => None,
         }
-
-        None
     }
 
     /// Check if the server process is still running.
@@ -604,7 +623,12 @@ impl LspClient {
 
 impl Drop for LspClient {
     fn drop(&mut self) {
+        // Kill first: closing the child's stdout unblocks the reader thread's
+        // pending read, so the subsequent join returns promptly.
         self.kill();
+        if let Some(handle) = self.reader.take() {
+            let _ = handle.join();
+        }
     }
 }
 

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -139,6 +139,106 @@ impl LspClientBuilder {
     }
 }
 
+/// Outcome of reading one Content-Length-framed message from the server.
+enum ReadOutcome {
+    /// A complete, parsed JSON-RPC message.
+    Message(Value),
+    /// Clean end-of-stream at a message boundary (server closed stdout).
+    Eof,
+    /// Protocol/framing failure carrying a precise, human-readable diagnostic.
+    Error(String),
+}
+
+/// Read a single Content-Length-framed JSON-RPC message from `reader`.
+///
+/// Blocks until a full message is available. Returns [`ReadOutcome::Eof`] only
+/// for a clean stream end at a message boundary (the next header read yields 0
+/// bytes); every malformed header, oversized/zero `Content-Length`, truncated
+/// body, or invalid JSON becomes [`ReadOutcome::Error`] so the caller — or the
+/// background reader thread — can surface the exact failure rather than a
+/// generic disconnect.
+fn read_framed_message(reader: &mut BufReader<ChildStdout>) -> ReadOutcome {
+    const MAX_HEADERS: u32 = 100;
+    const MAX_MESSAGE_SIZE: usize = 100 * 1024 * 1024; // 100MB limit
+
+    let mut header = String::new();
+    let mut header_count = 0u32;
+
+    loop {
+        if header_count >= MAX_HEADERS {
+            return ReadOutcome::Error(format!(
+                "Exceeded maximum header count ({MAX_HEADERS}) - server may be sending malformed headers"
+            ));
+        }
+
+        header.clear();
+        let bytes_read = match reader.read_line(&mut header) {
+            Ok(n) => n,
+            Err(e) => return ReadOutcome::Error(format!("Failed to read header line: {e}")),
+        };
+
+        // EOF while awaiting the next header is a clean shutdown at a message
+        // boundary.
+        if bytes_read == 0 {
+            return ReadOutcome::Eof;
+        }
+        header_count += 1;
+
+        if header == "\r\n" {
+            continue;
+        }
+
+        let Some(rest) = header.strip_prefix("Content-Length:") else {
+            // Unknown header line; ignore and keep reading (mirrors prior behavior).
+            continue;
+        };
+
+        let len: usize = match rest.trim().parse() {
+            Ok(n) => n,
+            Err(_) => {
+                return ReadOutcome::Error(format!(
+                    "Invalid Content-Length value: {:?}",
+                    rest.trim()
+                ));
+            }
+        };
+
+        // Validate Content-Length to prevent excessive allocations.
+        if len > MAX_MESSAGE_SIZE {
+            return ReadOutcome::Error(format!(
+                "Content-Length {len} exceeds maximum allowed size {MAX_MESSAGE_SIZE}"
+            ));
+        }
+        if len == 0 {
+            return ReadOutcome::Error(
+                "Invalid Content-Length: 0 - message body cannot be empty".to_string(),
+            );
+        }
+
+        // Read the blank line separating headers from the body.
+        let mut empty = String::new();
+        let bytes_read = match reader.read_line(&mut empty) {
+            Ok(n) => n,
+            Err(e) => return ReadOutcome::Error(format!("Failed to read empty line: {e}")),
+        };
+        if bytes_read == 0 {
+            return ReadOutcome::Error(
+                "Server closed connection prematurely after header".to_string(),
+            );
+        }
+
+        let mut body = vec![0u8; len];
+        if let Err(e) = std::io::Read::read_exact(reader, &mut body) {
+            return ReadOutcome::Error(format!("Failed to read body: {e}"));
+        }
+
+        return match serde_json::from_slice(&body) {
+            Ok(value) => ReadOutcome::Message(value),
+            Err(e) => ReadOutcome::Error(format!("Failed to parse response: {e}")),
+        };
+    }
+}
+
 impl LspClient {
     /// Spawn the kakehashi binary and create a new LSP client.
     pub fn new() -> Self {
@@ -294,89 +394,14 @@ impl LspClient {
     }
 
     /// Receive a single LSP message with Content-Length framing.
-    /// Times out after 30 seconds to prevent indefinite blocking on unresponsive servers.
     /// Validates Content-Length to prevent excessive memory allocation.
     fn receive_message(&mut self) -> Value {
-        const MAX_HEADERS: u32 = 100;
-        const TIMEOUT: Duration = Duration::from_secs(30);
-        const MAX_MESSAGE_SIZE: usize = 100 * 1024 * 1024; // 100MB limit
-
-        let start_time = Instant::now();
-        let mut header_count = 0u32;
-
-        // Read Content-Length header
-        let mut header = String::new();
-        loop {
-            // Check timeout
-            if start_time.elapsed() > TIMEOUT {
-                panic!(
-                    "Timeout reading LSP message header. Elapsed: {:?}",
-                    start_time.elapsed()
-                );
+        match read_framed_message(&mut self.stdout) {
+            ReadOutcome::Message(value) => value,
+            ReadOutcome::Eof => {
+                panic!("Server closed connection prematurely while reading header")
             }
-
-            // Check header count threshold
-            if header_count >= MAX_HEADERS {
-                panic!(
-                    "Exceeded maximum header count ({}) - server may be sending malformed headers",
-                    MAX_HEADERS
-                );
-            }
-
-            header.clear();
-            let bytes_read = self
-                .stdout
-                .read_line(&mut header)
-                .expect("Failed to read header line");
-
-            // EOF detection: if read_line returns 0 bytes, the connection closed
-            if bytes_read == 0 {
-                panic!("Server closed connection prematurely while reading header");
-            }
-
-            header_count += 1;
-
-            if header == "\r\n" {
-                continue;
-            }
-
-            if header.starts_with("Content-Length:") {
-                let len: usize = header
-                    .trim_start_matches("Content-Length:")
-                    .trim()
-                    .parse()
-                    .expect("Invalid Content-Length value");
-
-                // Validate Content-Length to prevent excessive allocations
-                if len > MAX_MESSAGE_SIZE {
-                    panic!(
-                        "Content-Length {} exceeds maximum allowed size {}",
-                        len, MAX_MESSAGE_SIZE
-                    );
-                }
-
-                if len == 0 {
-                    panic!("Invalid Content-Length: 0 - message body cannot be empty");
-                }
-
-                // Read empty line
-                let mut empty = String::new();
-                let bytes_read = self
-                    .stdout
-                    .read_line(&mut empty)
-                    .expect("Failed to read empty line");
-
-                if bytes_read == 0 {
-                    panic!("Server closed connection prematurely after header");
-                }
-
-                // Read body
-                let mut body = vec![0u8; len];
-                std::io::Read::read_exact(&mut self.stdout, &mut body)
-                    .expect("Failed to read body");
-
-                return serde_json::from_slice(&body).expect("Failed to parse response");
-            }
+            ReadOutcome::Error(e) => panic!("{e}"),
         }
     }
 

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -255,17 +255,22 @@ fn read_framed_message<R: BufRead>(reader: &mut R) -> ReadOutcome {
             };
         }
 
-        let Some(rest) = header.strip_prefix("Content-Length:") else {
-            // Some other header (e.g. Content-Type); ignore and keep reading.
+        // LSP header names are case-insensitive (HTTP-style framing), so match
+        // the field name accordingly. Lines without a colon, or other headers
+        // (e.g. Content-Type), are ignored.
+        let Some((name, value)) = header.split_once(':') else {
             continue;
         };
+        if !name.trim().eq_ignore_ascii_case("Content-Length") {
+            continue;
+        }
 
-        let len: usize = match rest.trim().parse() {
+        let len: usize = match value.trim().parse() {
             Ok(n) => n,
             Err(_) => {
                 return ReadOutcome::Error(format!(
                     "Invalid Content-Length value: {:?}",
-                    rest.trim()
+                    value.trim()
                 ));
             }
         };
@@ -691,6 +696,16 @@ mod tests {
             Content-Length: 13\r\n\
             \r\n\
             {\"jsonrpc\":1}"[..];
+        match read_framed_message(&mut input) {
+            ReadOutcome::Message(v) => assert_eq!(v, json!({"jsonrpc": 1})),
+            other => panic!("expected Message, got {:?}", outcome_label(&other)),
+        }
+    }
+
+    /// LSP header names are case-insensitive, so `content-length` must parse.
+    #[test]
+    fn read_framed_message_matches_content_length_case_insensitively() {
+        let mut input = &b"content-length: 13\r\n\r\n{\"jsonrpc\":1}"[..];
         match read_framed_message(&mut input) {
             ReadOutcome::Message(v) => assert_eq!(v, json!({"jsonrpc": 1})),
             other => panic!("expected Message, got {:?}", outcome_label(&other)),

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -418,24 +418,36 @@ impl LspClient {
         let mut message_count = 0u32;
 
         loop {
-            // Check timeout
-            if start_time.elapsed() > TIMEOUT {
+            // Check message count threshold
+            if message_count >= MAX_MESSAGES {
                 panic!(
-                    "Timeout waiting for response with id {}. Elapsed: {:?}",
-                    expected_id,
+                    "Exceeded maximum message threshold ({MAX_MESSAGES}) waiting for response with id {expected_id}"
+                );
+            }
+
+            // Bound each wait by the *remaining* overall budget so the
+            // documented 30s timeout stays accurate even across many
+            // intervening notifications — without this, a single blocking read
+            // could itself wait a full 30s and overshoot the budget.
+            let remaining = TIMEOUT.saturating_sub(start_time.elapsed());
+            if remaining.is_zero() {
+                panic!(
+                    "Timeout waiting for response with id {expected_id}. Elapsed: {:?}",
                     start_time.elapsed()
                 );
             }
 
-            // Check message count threshold
-            if message_count >= MAX_MESSAGES {
-                panic!(
-                    "Exceeded maximum message threshold ({}) waiting for response with id {}",
-                    MAX_MESSAGES, expected_id
-                );
-            }
-
-            let message = self.receive_message();
+            let message = match self.rx.recv_timeout(remaining) {
+                Ok(ReaderEvent::Message(value)) => value,
+                Ok(ReaderEvent::Error(e)) => panic!("{e}"),
+                Err(RecvTimeoutError::Timeout) => panic!(
+                    "Timeout waiting for response with id {expected_id}. Elapsed: {:?}",
+                    start_time.elapsed()
+                ),
+                Err(RecvTimeoutError::Disconnected) => panic!(
+                    "Server closed connection prematurely while waiting for response with id {expected_id}"
+                ),
+            };
             message_count += 1;
 
             // Check if this is a response to our request
@@ -450,23 +462,6 @@ impl LspClient {
                 }
             }
             // Otherwise it's a notification like window/logMessage, skip it
-        }
-    }
-
-    /// Receive a single LSP message from the background reader thread.
-    /// Times out after 30 seconds to prevent indefinite blocking on an
-    /// unresponsive (alive but silent) server.
-    fn receive_message(&mut self) -> Value {
-        const TIMEOUT: Duration = Duration::from_secs(30);
-        match self.rx.recv_timeout(TIMEOUT) {
-            Ok(ReaderEvent::Message(value)) => value,
-            Ok(ReaderEvent::Error(e)) => panic!("{e}"),
-            Err(RecvTimeoutError::Timeout) => {
-                panic!("Timeout reading LSP message after {TIMEOUT:?}")
-            }
-            Err(RecvTimeoutError::Disconnected) => {
-                panic!("Server closed connection prematurely (reader thread ended at EOF)")
-            }
         }
     }
 

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -59,8 +59,9 @@ fn test_data_dir() -> &'static Path {
 ///
 /// Server stdout is drained by a dedicated background thread that frames
 /// messages and pushes them onto an `mpsc` channel. Reads therefore become
-/// `recv_timeout` with **exact** deadlines — a notification-wait against an
-/// alive-but-silent server returns at its timeout instead of blocking on a
+/// `recv_timeout`, so waits honor their deadline (modulo scheduler jitter)
+/// instead of blocking indefinitely — a notification-wait against an
+/// alive-but-silent server returns at its timeout rather than hanging on a
 /// quiet pipe (see issue #385).
 pub struct LspClient {
     child: Child,
@@ -510,9 +511,11 @@ impl LspClient {
 
     /// Wait for a notification with a specific method name.
     ///
-    /// Returns the notification params if received within the timeout,
-    /// or None if timeout occurs without receiving the expected notification.
-    /// Skips other notifications and server-to-client requests while waiting.
+    /// Returns the notification params if received within the timeout, or None
+    /// if the timeout elapses (or the server disconnects) without it. Skips
+    /// other notifications and server-to-client requests while waiting. Panics
+    /// if the stream is malformed (a framing/parse error is surfaced, not
+    /// hidden behind the `Option`).
     pub(crate) fn wait_for_notification(
         &mut self,
         expected_method: &str,
@@ -544,10 +547,12 @@ impl LspClient {
     /// Wait for the first notification whose method is in `methods` AND whose
     /// params satisfy `predicate`, preserving arrival order across methods.
     ///
-    /// Returns `(method, params)` for the first match, or None on timeout.
-    /// Unlike `wait_for_notification`, this can observe the ORDER of several
-    /// notification methods (e.g. prove showMessage arrives before a later
-    /// logMessage). Non-matching messages are skipped.
+    /// Returns `(method, params)` for the first match, or None on timeout (or
+    /// server disconnect). Unlike `wait_for_notification`, this can observe the
+    /// ORDER of several notification methods (e.g. prove showMessage arrives
+    /// before a later logMessage). Non-matching messages are skipped. Panics if
+    /// the stream is malformed (a framing/parse error is surfaced, not hidden
+    /// behind the `Option`).
     pub(crate) fn wait_for_notification_where(
         &mut self,
         methods: &[&str],
@@ -581,10 +586,11 @@ impl LspClient {
     /// Try to receive a message within `timeout`, returning None if none arrives.
     ///
     /// Backed by the background reader thread's channel, so the deadline is
-    /// exact: against an alive-but-silent server this blocks for precisely
-    /// `timeout` and then returns None, rather than hanging on a quiet pipe.
-    /// A disconnect (reader thread ended at EOF) also returns None — no further
-    /// messages can arrive. A framing/parse error panics with its diagnostic.
+    /// honored (modulo scheduler jitter): against an alive-but-silent server
+    /// this blocks for about `timeout` and then returns None, rather than
+    /// hanging on a quiet pipe. A disconnect (reader thread ended at EOF) also
+    /// returns None — no further messages can arrive. A framing/parse error
+    /// panics with its diagnostic.
     fn try_receive_message(&mut self, timeout: Duration) -> Option<Value> {
         match self.rx.recv_timeout(timeout) {
             Ok(ReaderEvent::Message(value)) => Some(value),

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -221,12 +221,17 @@ fn read_framed_message<R: BufRead>(reader: &mut R) -> ReadOutcome {
         };
 
         if bytes_read == 0 {
-            // EOF. Clean only at a message boundary (no Content-Length seen yet
-            // for an in-progress message); otherwise the stream was truncated.
-            return if content_length.is_some() {
-                ReadOutcome::Error("Server closed connection prematurely after header".to_string())
-            } else {
+            // EOF. Clean only at a true message boundary — i.e. before any
+            // header line of the next message. If we have already consumed one
+            // or more header lines (whether or not Content-Length was among
+            // them), the stream was truncated mid-message.
+            return if header_count == 0 {
                 ReadOutcome::Eof
+            } else {
+                ReadOutcome::Error(
+                    "Server closed connection prematurely mid-message (incomplete header block)"
+                        .to_string(),
+                )
             };
         }
         header_count += 1;
@@ -728,6 +733,17 @@ mod tests {
     #[test]
     fn read_framed_message_premature_eof_is_error() {
         let mut input = &b"Content-Length: 99\r\n\r\n"[..];
+        assert!(matches!(
+            read_framed_message(&mut input),
+            ReadOutcome::Error(_)
+        ));
+    }
+
+    /// EOF after a partial header block that has NOT yet included
+    /// Content-Length is still a mid-message truncation, not a clean boundary.
+    #[test]
+    fn read_framed_message_eof_after_partial_headers_is_error() {
+        let mut input = &b"Content-Type: application/vscode-jsonrpc\r\n"[..];
         assert!(matches!(
             read_framed_message(&mut input),
             ReadOutcome::Error(_)

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -186,18 +186,26 @@ enum ReadOutcome {
 
 /// Read a single Content-Length-framed JSON-RPC message from `reader`.
 ///
+/// Reads every header line until the blank separator line, capturing
+/// `Content-Length` wherever it appears — so the order of headers and the
+/// presence of others (e.g. `Content-Type`) does not matter — then reads
+/// exactly that many body bytes. Both `\r\n` and bare `\n` line endings are
+/// accepted.
+///
 /// Blocks until a full message is available. Returns [`ReadOutcome::Eof`] only
-/// for a clean stream end at a message boundary (the next header read yields 0
-/// bytes); every malformed header, oversized/zero `Content-Length`, truncated
-/// body, or invalid JSON becomes [`ReadOutcome::Error`] so the caller — or the
-/// background reader thread — can surface the exact failure rather than a
-/// generic disconnect.
-fn read_framed_message(reader: &mut BufReader<ChildStdout>) -> ReadOutcome {
+/// for a clean stream end at a message boundary (EOF before any header of the
+/// next message); a stream that ends mid-message, a malformed/missing
+/// `Content-Length`, an oversized/zero length, a truncated body, or invalid
+/// JSON all become [`ReadOutcome::Error`] so the caller — or the background
+/// reader thread — can surface the exact failure rather than a generic
+/// disconnect.
+fn read_framed_message<R: BufRead>(reader: &mut R) -> ReadOutcome {
     const MAX_HEADERS: u32 = 100;
     const MAX_MESSAGE_SIZE: usize = 100 * 1024 * 1024; // 100MB limit
 
     let mut header = String::new();
     let mut header_count = 0u32;
+    let mut content_length: Option<usize> = None;
 
     loop {
         if header_count >= MAX_HEADERS {
@@ -212,19 +220,38 @@ fn read_framed_message(reader: &mut BufReader<ChildStdout>) -> ReadOutcome {
             Err(e) => return ReadOutcome::Error(format!("Failed to read header line: {e}")),
         };
 
-        // EOF while awaiting the next header is a clean shutdown at a message
-        // boundary.
         if bytes_read == 0 {
-            return ReadOutcome::Eof;
+            // EOF. Clean only at a message boundary (no Content-Length seen yet
+            // for an in-progress message); otherwise the stream was truncated.
+            return if content_length.is_some() {
+                ReadOutcome::Error("Server closed connection prematurely after header".to_string())
+            } else {
+                ReadOutcome::Eof
+            };
         }
         header_count += 1;
 
-        if header == "\r\n" {
-            continue;
+        // Blank line: headers are done, the body follows.
+        if header == "\r\n" || header == "\n" {
+            let Some(len) = content_length else {
+                return ReadOutcome::Error(
+                    "Missing Content-Length header before message body".to_string(),
+                );
+            };
+
+            let mut body = vec![0u8; len];
+            if let Err(e) = std::io::Read::read_exact(reader, &mut body) {
+                return ReadOutcome::Error(format!("Failed to read body: {e}"));
+            }
+
+            return match serde_json::from_slice(&body) {
+                Ok(value) => ReadOutcome::Message(value),
+                Err(e) => ReadOutcome::Error(format!("Failed to parse response: {e}")),
+            };
         }
 
         let Some(rest) = header.strip_prefix("Content-Length:") else {
-            // Unknown header line; ignore and keep reading (mirrors prior behavior).
+            // Some other header (e.g. Content-Type); ignore and keep reading.
             continue;
         };
 
@@ -249,28 +276,7 @@ fn read_framed_message(reader: &mut BufReader<ChildStdout>) -> ReadOutcome {
                 "Invalid Content-Length: 0 - message body cannot be empty".to_string(),
             );
         }
-
-        // Read the blank line separating headers from the body.
-        let mut empty = String::new();
-        let bytes_read = match reader.read_line(&mut empty) {
-            Ok(n) => n,
-            Err(e) => return ReadOutcome::Error(format!("Failed to read empty line: {e}")),
-        };
-        if bytes_read == 0 {
-            return ReadOutcome::Error(
-                "Server closed connection prematurely after header".to_string(),
-            );
-        }
-
-        let mut body = vec![0u8; len];
-        if let Err(e) = std::io::Read::read_exact(reader, &mut body) {
-            return ReadOutcome::Error(format!("Failed to read body: {e}"));
-        }
-
-        return match serde_json::from_slice(&body) {
-            Ok(value) => ReadOutcome::Message(value),
-            Err(e) => ReadOutcome::Error(format!("Failed to parse response: {e}")),
-        };
+        content_length = Some(len);
     }
 }
 
@@ -657,5 +663,82 @@ mod tests {
 
         assert!(response.get("result").is_some());
         assert!(response["result"].get("capabilities").is_some());
+    }
+
+    /// The canonical framing: a single `Content-Length` header followed by the
+    /// blank line and body.
+    #[test]
+    fn read_framed_message_parses_basic_frame() {
+        let mut input = &b"Content-Length: 13\r\n\r\n{\"jsonrpc\":1}"[..];
+        match read_framed_message(&mut input) {
+            ReadOutcome::Message(v) => assert_eq!(v, json!({"jsonrpc": 1})),
+            other => panic!("expected Message, got {:?}", outcome_label(&other)),
+        }
+    }
+
+    /// Header order is irrelevant and unrelated headers (e.g. `Content-Type`)
+    /// must not be mistaken for the blank separator line. This is the case
+    /// Gemini flagged: a header after `Content-Length` previously got consumed
+    /// as the blank line and corrupted the body read.
+    #[test]
+    fn read_framed_message_handles_reordered_and_extra_headers() {
+        let mut input = &b"Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n\
+            Content-Length: 13\r\n\
+            \r\n\
+            {\"jsonrpc\":1}"[..];
+        match read_framed_message(&mut input) {
+            ReadOutcome::Message(v) => assert_eq!(v, json!({"jsonrpc": 1})),
+            other => panic!("expected Message, got {:?}", outcome_label(&other)),
+        }
+    }
+
+    /// Bare `\n` line endings (no `\r`) are accepted as header terminators.
+    #[test]
+    fn read_framed_message_accepts_lf_only_line_endings() {
+        let mut input = &b"Content-Length: 13\n\n{\"jsonrpc\":1}"[..];
+        match read_framed_message(&mut input) {
+            ReadOutcome::Message(v) => assert_eq!(v, json!({"jsonrpc": 1})),
+            other => panic!("expected Message, got {:?}", outcome_label(&other)),
+        }
+    }
+
+    /// Two messages back to back are framed independently, so the reader thread
+    /// can loop over a continuous stream.
+    #[test]
+    fn read_framed_message_reads_consecutive_frames() {
+        let mut input =
+            &b"Content-Length: 7\r\n\r\n{\"a\":1}Content-Length: 7\r\n\r\n{\"b\":2}"[..];
+        assert!(
+            matches!(read_framed_message(&mut input), ReadOutcome::Message(v) if v == json!({"a": 1}))
+        );
+        assert!(
+            matches!(read_framed_message(&mut input), ReadOutcome::Message(v) if v == json!({"b": 2}))
+        );
+    }
+
+    /// A clean EOF at a message boundary is `Eof`, not an error.
+    #[test]
+    fn read_framed_message_clean_eof_at_boundary() {
+        let mut input = &b""[..];
+        assert!(matches!(read_framed_message(&mut input), ReadOutcome::Eof));
+    }
+
+    /// EOF after a header but before the body is a truncated stream, not a
+    /// clean boundary.
+    #[test]
+    fn read_framed_message_premature_eof_is_error() {
+        let mut input = &b"Content-Length: 99\r\n\r\n"[..];
+        assert!(matches!(
+            read_framed_message(&mut input),
+            ReadOutcome::Error(_)
+        ));
+    }
+
+    fn outcome_label(o: &ReadOutcome) -> &'static str {
+        match o {
+            ReadOutcome::Message(_) => "Message",
+            ReadOutcome::Eof => "Eof",
+            ReadOutcome::Error(_) => "Error",
+        }
     }
 }


### PR DESCRIPTION
Closes #385.

## Problem

`tests/helpers/lsp_client.rs` `try_receive_message` polled `BufReader::fill_buf()`, which blocks on a pipe with no data. So the timeouts of `wait_for_notification` / `wait_for_notification_where` were only approximate (documented as a Known Limitation). Against a server that stays **alive but silent** — exactly the situation a forwarding regression produces — a notification-wait could hang or pass late instead of failing cleanly at its deadline.

## Fix

Drain the child's stdout in a dedicated background thread that frames messages and pushes them onto an `mpsc` channel. Reads become `recv_timeout`, so waits honor their deadline (modulo scheduler jitter) instead of blocking on a quiet pipe.

- **Framing extracted** into a free `read_framed_message(reader) -> ReadOutcome` (`Message` / `Eof` / `Error`). Every framing failure becomes `ReadOutcome::Error(String)` carrying a precise diagnostic, so a corrupt stream still surfaces its exact error across the thread boundary instead of collapsing into a generic disconnect.
- **Background reader thread** (`reader_loop`) forwards `ReaderEvent::{Message, Error}`; a clean EOF drops the sender so the consumer observes `Disconnected`. The wait loops block for the full remaining deadline (no more 100 ms poll cap, no `fill_buf`) and return `None` at the deadline or on disconnect.
- **Drop** kills the child first (closing stdout unblocks the reader's pending read), then joins the thread.

## Test

New `tests/e2e_notification_timeout.rs` pins the guarantee: against an initialized-but-silent server, `wait_for_notification` returns at its 1 s deadline (asserts upper bound, lower bound, and `is_running()` so it can't pass on an early disconnect). This test hangs on the pre-fix `fill_buf` implementation.

## Verification

- `cargo test --features e2e` — full suite green (no behavior drift in existing notification-wait tests).
- `cargo clippy --tests --features e2e -- -D warnings` and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)