### PR TITLE
docs(adr): bridge progress lifecycle decisions (#413, #414)

### DIFF
--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -80,12 +80,15 @@ request just returns its result (today's behavior, minus the strip).
 
   Accumulated `report`s may be coalesced into one notification
   (`Begin → report → report (2, 3) → End`) to bound notification volume.
-- **Begin/End pairing invariant.** An open work-done `Begin` is closed exactly
-  once, whenever the request terminates — normal completion, winner failure,
-  fall-through exhaustion, or client cancellation (the fan-in returns
-  `Cancelled`) — with the real `End` if the source sent one, otherwise a
-  bridge-synthesized `End`. A request that opened no `Begin` emits no `End`. (The
-  per-branch rules below are instances of this invariant.)
+- **Begin/End pairing invariant.** An open work-done `Begin` is closed by exactly
+  one `End`, fired when the *request* terminates — normal completion, winner
+  failure, fall-through exhaustion, or client cancellation (the fan-in returns
+  `Cancelled`). When the lifecycle tracks a single source to completion (N = 1, or
+  *preferred*), that `End` is the source's real one; under *concatenated* the
+  bridge emits a single aggregate-timed `End` and suppresses the winner's own
+  (which fires before collection finishes). If the source cannot send one (it
+  died), the bridge synthesizes it. A request that opened no `Begin` emits no
+  `End`. (The per-branch rules below are instances of this invariant.)
 - **Graceful degradation on committed-server failure.** The branch turns on
   *whether the editor has already been shown data*:
   - *preferred, winner already streamed partials*: data is on screen, so promote

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -56,8 +56,9 @@ is produced then depends on the strategy, because the two deliver differently:
   latency race, not knowable in advance. (One documented edge: after a
   fall-through, an earlier anchor's title can linger; see Consequences.)
 - *concatenated* merges **all** contributors, so no single source owns the title:
-  the bridge **always composes a synthetic neutral `Begin`** (e.g. a
-  request-derived title) and reports collection progress,
+  the bridge **always composes its own synthetic neutral `Begin`** (never
+  borrowing a downstream's title; e.g. a request-derived one) and reports
+  collection progress,
   **ignoring every downstream's own `$/progress`**. This trades per-server
   granularity for a title
   that stays accurate across the whole aggregate — borrowing one contributor's
@@ -155,8 +156,8 @@ bridge composes the terminal rather than relaying a downstream's `End`.
 - **Forward the first contributor's `Begin` opportunistically.** Lights the
   indicator a few milliseconds sooner, but `Begin` carries a required `title`, so
   it can surface a non-anchor's label that LSP will not let the bridge amend
-  later. Rejected in favor of anchoring `Begin` on the anchor (its real `Begin`,
-  or a bridge-owned synthetic when it has none).
+  later. Rejected in favor of anchoring `Begin` on the anchor's real `Begin` under
+  *preferred*, and a bridge-composed synthetic under *concatenated*.
 - **Track every contributor's progress and merge it.** Most information, but
   collapsing N independent `Begin`/`report`/`End` streams (distinct titles,
   percentages) into one coherent indicator is messy and rarely meaningful.

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -39,29 +39,30 @@ downstream→upstream `$/progress` and partial-result notifications, and aggrega
 them so the editor sees **one coherent lifecycle** that stays consistent with the
 result actually delivered.
 
-**Core principle.** The progress narrative is **anchored on the priority anchor**
-— the highest-priority *named* candidate currently tracked (a `Rest`/wildcard
-member is never an anchor) — and the data the editor
-receives stays consistent with the result actually delivered: the `End` coincides
-with the result being complete, and no `report` carries data the editor will not
-receive. The anchor follows the **priority walk** (honoring explicit
-`priorities`, with the wildcard `Rest` resolved first-win by earliest non-empty
-arrival), not a pure latency race that could put the title and progress on one
-server while the delivered result comes from another. A candidate that returns
-empty — or fails before producing any data — is no **winner** (reserved for the
-source whose result, possibly a promoted partial prefix, is delivered), so the
-anchor falls through to the next candidate. Within the unordered `Rest` (wildcard)
-group no member is the a priori anchor — which one wins is a latency race, not
-knowable in advance — so the bridge never forwards a `Rest` member's own `Begin`
-as the title; that group's progress is handled as a silent anchor (a synthetic
-neutral `Begin` under *concatenated*, nothing under *preferred*).
+**Core principle.** Whatever the editor sees stays consistent with the result
+actually delivered: the `End` coincides with the result being complete, and no
+`report` carries data the editor will not receive. How the title-bearing `Begin`
+is produced then depends on the strategy, because the two deliver differently:
 
-**Only the anchor's own progress is ever tracked**; other contributors influence
-the lifecycle solely by *completing* (their result arriving), never through their
-own `$/progress`. So the `Begin` title comes from the current anchor — normally
-the delivered winner, or (under *concatenated*) a bridge-owned synthetic when the
-anchor is silent — never an arbitrary non-anchor. (One documented edge: after a
-fall-through, an earlier anchor's title can linger; see Consequences.)
+- *preferred* delivers a single **winner**, so progress is **anchored** on that
+  source: the title is the winner's own `Begin`, and only the anchor's own
+  progress is tracked. The winner is found by the **priority walk** — explicit
+  `priorities` in order, the wildcard `Rest` resolved first-win by earliest
+  non-empty arrival. A candidate that returns empty, or fails before producing
+  any data, is no winner (reserved for the delivered source, possibly a promoted
+  partial prefix), so the **anchor** (the highest-priority *named* candidate)
+  falls through to the next. The bridge never forwards a non-anchor's `Begin` as
+  the title — including a `Rest` member's, since which `Rest` member wins is a
+  latency race, not knowable in advance. (One documented edge: after a
+  fall-through, an earlier anchor's title can linger; see Consequences.)
+- *concatenated* merges **all** contributors, so no single source owns the title:
+  the bridge **always composes a synthetic neutral `Begin`** (e.g. a
+  request-derived title) and reports collection progress,
+  **ignoring every downstream's own `$/progress`**. This trades per-server
+  granularity for a title
+  that stays accurate across the whole aggregate — borrowing one contributor's
+  title would go stale the moment that contributor finishes while others are
+  still pending (see Consequences).
 
 The lifecycle engages only when there is progress worth showing; otherwise the
 request just returns its result (today's behavior, minus the strip).
@@ -72,39 +73,31 @@ request just returns its result (today's behavior, minus the strip).
   the sole server was selected via the wildcard: the `Rest`-never-anchor rule
   disambiguates among *racing* contenders, and a single downstream has none — so
   its real `Begin` is safe to forward.
-- **preferred, N > 1.** The delivered result is a single winner, and preferred
-  short-circuits (it does not wait for the losers), so there is no collection
-  count to report. If the anchor emits its own progress, forward its
-  `Begin`/`report`/`End` (real title) and suppress every other candidate's
-  progress; if the anchor returns a complete result with no progress phase, show
-  nothing.
-- **concatenated, N > 1.** The delivered result merges *all* contributors, so the
-  bridge waits for every one and reports collection progress:
-  - if the anchor emits its own `Begin`, forward it (real title) and track the
-    anchor's `report`s — but **suppress the anchor's own `End`**, since the
-    aggregate is not done until every contributor is collected; *interleave* the
-    other contributors' **result arrivals** as `report`s (`n/m` collected);
-  - if the anchor emits no `Begin`, the bridge synthesizes one (neutral title,
-    e.g. request-derived) once the anchor is **known to be silent** — it returned
-    its result with no `Begin`. Contributors that completed earlier are counted
-    into the first `n/m` report, and the rest advance it as they arrive. (Waiting
-    for the anchor to resolve, rather than firing on the first arbitrary result,
-    keeps a real anchor `Begin` from being pre-empted by a non-anchor.)
-  - either way the `End` fires once **every** contributor's result is collected,
-    and non-anchor contributors' own `$/progress` is ignored.
-
-  Accumulated `report`s may be coalesced into one notification
-  (`Begin → report → report (2, 3) → End`) to bound notification volume.
+- **preferred, N > 1.** Preferred short-circuits (it does not wait for the
+  losers), so there is no collection count to report. If the anchor emits its own
+  progress, forward its `Begin`/`report`/`End` (real title) and suppress every
+  other candidate's progress; if the anchor returns a complete result with no
+  progress phase, show nothing.
+- **concatenated, N > 1.** The bridge waits for every contributor and
+  **drives the whole lifecycle itself**: synthesize a neutral `Begin` once
+  collection is known
+  to be staggered (a result is in while others are still pending), report `n/m` as
+  each result arrives, and fire one `End` when **every** contributor is collected.
+  Downstreams' own `Begin`/`report`/`End` are **ignored entirely** — there is no
+  anchor `Begin` to forward, suppress, or wait for. If all results are already in
+  at first observation, no progress is shown. Accumulated `report`s may be
+  coalesced into one notification (`Begin → report → report (2, 3) → End`) to
+  bound notification volume.
 - **Begin/End pairing invariant.** An open work-done `Begin` is closed by exactly
   one `End`, fired when the *request* terminates — normal completion, anchor
   failure, fall-through exhaustion, or client cancellation (the fan-in returns
-  `Cancelled`). When the lifecycle tracks a single source to completion (N = 1, or
-  *preferred*), that `End` is the source's real one; under *concatenated* the
-  bridge emits a single aggregate-timed `End` and suppresses the anchor's own
-  (which fires before collection finishes). If the source cannot send one — it
-  died, or the request was cancelled (the fan-in aborts the downstreams) — the
-  bridge synthesizes it. A request that opened no `Begin` emits no `End`. (The
-  per-branch rules below are instances of this invariant.)
+  `Cancelled`). Under *preferred* (and N = 1) the lifecycle tracks a single
+  source, so that `End` is the source's real one — or a bridge-synthesized one if
+  the source died or was cancelled before sending it. Under *concatenated* the
+  bridge composes the whole lifecycle, so the terminal is always its own
+  aggregate-timed `End` (fired when all results are collected, or synthesized on
+  cancellation). A request that opened no `Begin` emits no `End`. (The per-branch
+  rules above are instances of this invariant.)
 - **Graceful degradation on committed-server failure.** The branch turns on
   *whether the editor has already been shown data*:
   - *preferred, anchor already streamed partials*: data is on screen, so promote
@@ -132,12 +125,10 @@ request just returns its result (today's behavior, minus the strip).
     otherwise emit none.
   - *concatenated*: a failed contributor contributes whatever it already streamed
     (possibly nothing) and is **dropped from the expected set** (the `n/m`
-    denominator shrinks); the others proceed, and `End` fires once the remaining
-    expected results are collected. If the *anchor* (highest-priority named
-    contributor) is the one that fails before opening a `Begin`, the anchor role
-    moves to the next named-priority survivor — its `Begin` if it has one; if only
-    `Rest`-group members remain, the group stays silent and the synthetic
-    neutral `Begin` applies.
+    denominator shrinks); the others proceed, and the aggregate `End` fires once
+    the remaining expected results are collected. Because the bridge owns the
+    synthetic title and terminal here, a failed contributor never affects the
+    `Begin` — there is no anchor handoff.
 - **partialResultToken — translate, then merge.** Partial-result chunks carry
   locations needing the *same* injection offset and URI translation as final
   responses, applied incrementally per chunk through the existing aggregation
@@ -169,8 +160,16 @@ bridge composes the terminal rather than relaying a downstream's `End`.
 - **Track every contributor's progress and merge it.** Most information, but
   collapsing N independent `Begin`/`report`/`End` streams (distinct titles,
   percentages) into one coherent indicator is messy and rarely meaningful.
-  Rejected in favor of tracking only the anchor's progress and folding the rest
-  in as result-arrival counts.
+  Rejected in favor of one source's progress under *preferred* and a
+  bridge-composed aggregate under *concatenated*.
+- **Borrow the anchor's `Begin` under concatenated.** Reuses a real, specific
+  title for free, but the concatenated lifecycle outlives the anchor's own work
+  (it runs until every contributor is collected), so that title goes stale the
+  moment the anchor finishes while others are still pending — and LSP forbids
+  retitling after `Begin`. Rejected in favor of a synthetic neutral title that
+  stays accurate for the whole aggregate; the cost is losing the anchor's
+  per-server granularity, accepted because collection `n/m` is the meaningful
+  metric for a merge and *preferred* still relays granular single-source progress.
 - **Wait for the next-priority candidate after partial data was shown.**
   Avoids delivering incomplete data, but freezes the already-shown
   results until the slower candidate finishes and risks a late swap. Rejected in
@@ -183,10 +182,10 @@ bridge composes the terminal rather than relaying a downstream's `End`.
 
 - Client-requested progress (`workDoneToken`) reaches the editor for the first
   time.
-- The progress signals (`report`/`End`) stay consistent with the delivered
-  result's source — no jarring swap and no freeze of shown data (under *preferred*
-  both track the one winner; under *concatenated* both span the same contributor
-  set).
+- The progress signals stay consistent with the delivered result — no jarring
+  swap and no freeze of shown data. Under *preferred* the title and `report`/`End`
+  track the one winner; under *concatenated* the bridge composes a neutral title
+  and `n/m` that describe the aggregate, so the title never goes stale mid-flight.
 - partialResult streaming becomes possible without mis-translated locations.
 - Progress engages only when meaningful: a fast or single-server request with no
   downstream progress shows nothing, so there is no spurious spinner. The `Begin`
@@ -210,7 +209,13 @@ bridge composes the terminal rather than relaying a downstream's `End`.
 - If the anchor emits a `Begin` and then loses (returns empty) or dies, its
   `title` lingers on the already-open progress until `End`, since LSP forbids
   retitling. Rare (the anchor both reported progress and failed) and cosmetic;
-  accepted.
+  accepted. (This is a *preferred*-only edge — *concatenated* never adopts a
+  downstream title.)
+- Under *concatenated* a downstream's own granular progress (e.g. "indexing
+  45%") is discarded in favor of the aggregate `n/m`; a long, dominant
+  contributor surrounded by fast ones shows a coarser, possibly stalled count
+  instead of its real percentage. Accepted: `n/m` is the honest metric for a
+  merge, and a stale borrowed title would be worse.
 
 ### Neutral
 
@@ -239,8 +244,12 @@ are stripped before fan-out. Specific points to settle during implementation:
   through to the next candidate, which is acceptable.
 - Percentage composition under *concatenated* (`n/m`) is a display heuristic, not
   a contract.
-- The synthetic `Begin` title used when a *concatenated* anchor is silent is a
+- The synthetic `Begin` title the bridge always composes under *concatenated* is a
   presentation choice (e.g. derived from the request method); not specified here.
+- The exact "collection is staggered" trigger for the *concatenated* synthetic
+  `Begin` (e.g. first result while ≥1 contributor is still pending, or a small
+  delay threshold) is an implementation tuning choice; the requirement is only
+  that an all-instant fan-out show nothing.
 - Ordering `partialResultToken` chunks to match the *concatenated* priority order
   means holding a lower-priority contributor's chunks until the higher-priority
   ones are in — trading streaming latency for ordering fidelity. An

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -17,15 +17,16 @@ languages, fanned out per language-server-bridge-request-strategies). Each
 downstream may emit `$/progress` and partial results against the same
 client-provided token. Forwarding them verbatim duplicates the lifecycle (N
 `Begin`, N `End`) and corrupts the indicator; concatenating result chunks
-verbatim mis-orders data. Because of fan-out,
-**the bridge always composes the upstream terminal itself** — it aggregates N
-downstreams and never simply relays one downstream's `End` or final response.
+verbatim mis-orders data. So
+**under fan-out the bridge composes the upstream terminal itself** — it
+aggregates N downstreams and does not simply relay one downstream's `End` or
+final response (as it could for a request that reaches a single server).
 
 Today the bridge does not forward client-provided tokens to downstreams at all.
 The host raw-request path strips them (`strip_progress_tokens`,
 `src/lsp/bridge/text_document/host.rs`), and the per-method virtual request
 builders construct fresh params with default (empty) progress fields, so no
-token is carried either way. A downstream honouring them would stream into the
+token is carried either way. A downstream honoring them would stream into the
 void, since the bridge discards downstream notifications, and could legally
 return an empty final result. The cost is that client-requested progress never
 reaches the editor.
@@ -113,16 +114,16 @@ bridge composes the terminal rather than relaying a downstream's.
   Rejected.
 - **Latency-based selector (track the first responder).** Lower time-to-first
   paint, but the data-bearing progress and the delivered result can come from
-  different servers — the jarring swap this decision avoids. Rejected in favour
+  different servers — the jarring swap this decision avoids. Rejected in favor
   of priority.
 - **Delay `Begin` until the source is known.** Keeps the opening title
   source-consistent from the first frame, but defeats the point of progress (no
-  early "something is happening" signal). Rejected in favour of an opportunistic
+  early "something is happening" signal). Rejected in favor of an opportunistic
   first `Begin` with `report`/`End` gated per strategy.
 - **Wait for the next-priority candidate after partial data was shown.**
   Avoids delivering incomplete data, but freezes the already-shown
   results until the slower candidate finishes and risks a late swap. Rejected in
-  favour of promoting the streamed partials. (An empty winner that showed
+  favor of promoting the streamed partials. (An empty winner that showed
   *nothing* still falls through normally — that is plain latency, not a freeze.)
 
 ## Consequences
@@ -160,9 +161,9 @@ bridge composes the terminal rather than relaying a downstream's.
 - Namespacing is unnecessary here (client tokens are already unique), so the
   `ProgressRegistry` of ls-bridge-work-done-progress is not involved; this path
   is distinct from server-declared progress.
-- The bridge always composes the upstream terminal `End` and response (it
-  aggregates fan-out), so failure handling changes only that payload, not the
-  mechanism.
+- Under fan-out the bridge composes the upstream terminal `End` and response (it
+  aggregates the downstreams), so failure handling changes only that payload, not
+  the mechanism.
 
 ## Decision–Implementation Gap
 
@@ -170,7 +171,7 @@ Not yet implemented (tracked in issue #414); today both client-provided tokens
 are stripped before fan-out. Specific points to settle during implementation:
 
 - The empty-vs-non-empty threshold that triggers fall-through must
-  **match the existing preferred-strategy empty-result behaviour** — a uniform
+  **match the existing preferred-strategy empty-result behavior** — a uniform
   fall-through-on-empty across the priority walk, not a per-method exception.
   Align with the preferred strategy; do not invent a new threshold.
 - `partialResultToken` support depends on the aggregation layer accepting

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -40,16 +40,22 @@ them so the editor sees **one coherent lifecycle** whose data-bearing signals
 **Core principle.** Every *data-bearing* signal the editor sees — each `report`,
 the delivered result, and the terminal `End` — must come from the *same server
 whose result is actually delivered*, so progress and data never diverge. The
-opening `Begin` is exempt: it is a content-free "work has started" signal
-forwarded opportunistically from whichever contributor reports first (the winner
-is not yet known then) and carries no server-identifying data. A swap can only
-occur before any data has been shown; once data is delivered, the lifecycle is
-committed.
+opening `Begin` is exempt: the winner is not yet known when it must be sent, so
+it is forwarded opportunistically from whichever contributor reports first,
+purely to light the indicator promptly. `Begin` is not content-free — it carries
+a `title` (and optional `message`) — so that opening text may originate from a
+non-winner. LSP does not allow amending a `title` after `Begin`, so this is
+accepted as a transient cosmetic detail: the data-bearing `report`/result/`End`
+that follow all come from the winner. (A bridge-owned neutral `title` could avoid
+surfacing a non-winner's; either way the data-bearing guarantee holds.) A swap of
+*delivered data* can only occur before any data has been shown; once data is
+delivered, the lifecycle is committed.
 
 - **Selector — priority-based.** The tracked and delivered server is the
   *priority winner* of the preferred fan-in, not the first responder.
-  Latency-based selection is rejected because it can make progress (the fastest
-  server) and delivered data (the priority winner) come from different servers.
+  Latency-based selection is rejected because it can make the data-bearing
+  progress (`report`/`End`, the fastest server) and the delivered result (the
+  priority winner) come from different servers.
 - **Begin — opportunistic.** The winner is unknown when `Begin` arrives (`Begin`
   precedes any result), so forward the *first* `Begin` from any contributor to
   light the indicator immediately; gate only `report`/`End` on the
@@ -99,8 +105,9 @@ bridge composes the terminal rather than relaying a downstream's.
   client-requested progress never surfaces — the gap this decision closes.
   Rejected.
 - **Latency-based selector (track the first responder).** Lower time-to-first
-  paint, but progress and delivered data can come from different servers — the
-  jarring swap this decision avoids. Rejected in favour of priority.
+  paint, but the data-bearing progress and the delivered result can come from
+  different servers — the jarring swap this decision avoids. Rejected in favour
+  of priority.
 - **Delay `Begin` until the winner is known.** Keeps progress source-consistent
   from the first frame, but defeats the point of progress (no early "something is
   happening" signal). Rejected in favour of an opportunistic first `Begin` with
@@ -134,6 +141,10 @@ bridge composes the terminal rather than relaying a downstream's.
 - When a winner fails *after* streaming, the delivered result may be incomplete
   (only the streamed prefix); accepted as graceful degradation over freezing or
   swapping.
+- The opening `Begin`'s `title`/`message` may briefly reflect a non-winner
+  contributor (the winner is unknown when `Begin` must fire, and LSP forbids
+  amending a `title` afterwards). Accepted as transient and cosmetic, or avoided
+  by emitting a bridge-owned neutral `title`.
 
 ### Neutral
 

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -80,6 +80,12 @@ request just returns its result (today's behavior, minus the strip).
 
   Accumulated `report`s may be coalesced into one notification
   (`Begin → report → report (2, 3) → End`) to bound notification volume.
+- **Begin/End pairing invariant.** An open work-done `Begin` is closed exactly
+  once, whenever the request terminates — normal completion, winner failure,
+  fall-through exhaustion, or client cancellation (the fan-in returns
+  `Cancelled`) — with the real `End` if the source sent one, otherwise a
+  bridge-synthesized `End`. A request that opened no `Begin` emits no `End`. (The
+  per-branch rules below are instances of this invariant.)
 - **Graceful degradation on committed-server failure.** The branch turns on
   *whether the editor has already been shown data*:
   - *preferred, winner already streamed partials*: data is on screen, so promote
@@ -116,8 +122,11 @@ request just returns its result (today's behavior, minus the strip).
   locations needing the *same* injection offset and URI translation as final
   responses, applied incrementally per chunk through the existing aggregation
   path (which assumes a single final blob today and must accept incremental
-  input). Under *preferred* the bridge streams the winner's translated chunks;
-  under *concatenated* it concatenates all contributors' translated chunks.
+  input). Under *preferred* the bridge streams the winner's translated chunks.
+  Under *concatenated* the final result is priority-ordered, so chunks must be
+  released in that same order (buffer per contributor, flush in priority order) —
+  otherwise the streamed prefix would diverge from the delivered ordering. This
+  costs some streaming latency; see the gap.
 
 The terminal `End` the bridge emits on failure is the same primitive
 ls-bridge-progress-disconnect-cleanup uses for server-declared tokens — the
@@ -211,3 +220,8 @@ are stripped before fan-out. Specific points to settle during implementation:
   a contract.
 - The synthetic `Begin` title used when a *concatenated* winner is silent is a
   presentation choice (e.g. derived from the request method); not specified here.
+- Ordering `partialResultToken` chunks to match the *concatenated* priority order
+  means holding a lower-priority contributor's chunks until the higher-priority
+  ones are in — trading streaming latency for ordering fidelity. An
+  implementation may relax this if a method's partial results are
+  order-insensitive.

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -50,8 +50,8 @@ because the two deliver differently:
   title; only the anchor's own progress is tracked. The winner (the delivered
   source) is usually that anchor, but the priority walk resolves the wildcard
   `Rest` group first-win by earliest non-empty arrival, so a `Rest` member can be
-  the winner without being an anchor: its own progress is **not** shown (no safe a
-  priori title for a latency race), unless it is the sole server (N = 1). A
+  the winner without being an anchor: its own progress is **not** shown (no safe
+  a priori title for a latency race), unless it is the sole server (N = 1). A
   candidate that returns empty, or fails before producing any data, is no winner
   (reserved for the delivered source, possibly a promoted partial prefix), so the
   anchor falls through to the next *named* candidate. The bridge never forwards a
@@ -76,7 +76,7 @@ request just returns its result (today's behavior, minus the strip).
   the sole server was selected via the wildcard: the `Rest`-never-anchor rule
   disambiguates among *racing* contenders, and a single downstream has none — so
   its real `Begin` is safe to forward.
-- **preferred, N > 1.** Preferred short-circuits (it does not wait for the
+- **preferred, N > 1.** This strategy short-circuits (it does not wait for the
   losers), so there is no collection count to report. If the anchor emits its own
   progress, forward its `Begin`/`report`/`End` (real title) and suppress every
   other candidate's progress; if the anchor returns a complete result with no
@@ -162,7 +162,7 @@ bridge composes the terminal rather than relaying a downstream's `End`.
   percentages) into one coherent indicator is messy and rarely meaningful.
   Rejected in favor of one source's progress under *preferred* and a
   bridge-composed aggregate under *concatenated*.
-- **Borrow the anchor's `Begin` under concatenated.** Reuses a real, specific
+- **Borrow the anchor's `Begin` under *concatenated*.** Reuses a real, specific
   title for free, but the concatenated lifecycle outlives the anchor's own work
   (it runs until every contributor is collected), so that title goes stale the
   moment the anchor finishes while others are still pending — and LSP forbids

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -17,10 +17,10 @@ languages, fanned out per language-server-bridge-request-strategies). Each
 downstream may emit `$/progress` and partial results against the same
 client-provided token. Forwarding them verbatim duplicates the lifecycle (N
 `Begin`, N `End`) and corrupts the indicator; concatenating result chunks
-verbatim mis-orders data. So
-**under fan-out the bridge composes the upstream terminal itself** — it
-aggregates N downstreams and does not simply relay one downstream's `End` or
-final response (as it could for a request that reaches a single server).
+verbatim mis-orders data. So **under fan-out the bridge must own the upstream
+terminal** — it cannot blindly relay all N downstreams' `End`s/responses (they
+collide); it forwards exactly one or composes one, as the Decision details. (A
+request that reaches a single server is just relayed.)
 
 Today the bridge does not forward client-provided tokens to downstreams at all.
 The host raw-request path strips them (`strip_progress_tokens`,
@@ -93,8 +93,9 @@ request just returns its result (today's behavior, minus the strip).
     — see Consequences) and only `report`/`End` re-anchor onto the new winner.
     This recurses down the priority order.
   - *concatenated*: a failed contributor contributes whatever it already streamed
-    (possibly nothing); the collection count adjusts and the others proceed, with
-    `End` once the rest are collected.
+    (possibly nothing) and is **dropped from the expected set** (the `n/m`
+    denominator shrinks); the others proceed, and `End` fires once the remaining
+    expected results are collected.
 - **partialResultToken — translate, then merge.** Partial-result chunks carry
   locations needing the *same* injection offset and URI translation as final
   responses, applied incrementally per chunk through the existing aggregation
@@ -170,9 +171,9 @@ bridge composes the terminal rather than relaying a downstream's.
 - Namespacing is unnecessary here (client tokens are already unique), so the
   `ProgressRegistry` of ls-bridge-work-done-progress is not involved; this path
   is distinct from server-declared progress.
-- Under fan-out the bridge composes the upstream terminal `End` and response (it
-  aggregates the downstreams), so failure handling changes only that payload, not
-  the mechanism.
+- Under fan-out the bridge owns the upstream terminal — relaying the winner's
+  under *preferred*, composing one under *concatenated* and on failure — so
+  failure handling changes only that payload, not the mechanism.
 - A fast *concatenated* fan-out can briefly flash `Begin`→`End`; editors
   typically debounce short-lived progress, so it is rarely visible.
 

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -34,8 +34,8 @@ reaches the editor.
 
 Stop stripping client-provided tokens (selectively), route the resulting
 downstream→upstream `$/progress` and partial-result notifications, and aggregate
-them so the editor sees **one coherent lifecycle** whose source matches the
-delivered result.
+them so the editor sees **one coherent lifecycle** whose data-bearing signals
+(`report`, the result, the terminal `End`) all come from the delivered server.
 
 **Core principle.** Every *data-bearing* signal the editor sees — each `report`,
 the delivered result, and the terminal `End` — must come from the *same server
@@ -117,8 +117,8 @@ bridge composes the terminal rather than relaying a downstream's.
 
 - Client-requested progress (`workDoneToken`) reaches the editor for the first
   time.
-- Progress UI and delivered results always share one source — no jarring swap and
-  no freeze of shown data.
+- The data-bearing progress signals (`report`/`End`) and the delivered result
+  always share one source — no jarring swap and no freeze of shown data.
 - partialResult streaming becomes possible without mis-translated locations.
 - Failure degrades gracefully: if data was shown the editor keeps it and the
   lifecycle terminates cleanly; if not, the request falls through to the next

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -46,8 +46,9 @@ stays consistent with the result actually delivered: the `End` coincides with th
 result being complete, and no `report` carries data the editor will not receive.
 **Only the winner's own progress is ever tracked**; other contributors influence
 the lifecycle solely by *completing* (their result arriving), never through their
-own `$/progress`. So the `Begin` title comes from the winner — or, when the winner
-emits none, from a bridge-owned synthetic — never from an arbitrary non-winner.
+own `$/progress`. So the `Begin` title comes from the winner, or (under
+*concatenated*) from a bridge-owned synthetic when the winner emits none — never
+from an arbitrary non-winner.
 The winner is chosen by **priority, not latency**: a latency anchor could put the
 title and progress on one server while the delivered result comes from another.
 

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -1,0 +1,152 @@
+# LS Bridge Client Progress
+
+**Related Decisions**: [ls-bridge-work-done-progress](ls-bridge-work-done-progress.md), [language-server-bridge-request-strategies](language-server-bridge-request-strategies.md), [aggregation-priorities-wildcard](aggregation-priorities-wildcard.md), [ls-bridge-progress-disconnect-cleanup](ls-bridge-progress-disconnect-cleanup.md)
+
+## Context
+
+A client (editor) request may carry its own progress tokens: a `workDoneToken`
+(a UI progress indicator) and a `partialResultToken` (streamed result chunks).
+These differ from the server-declared tokens handled in
+ls-bridge-work-done-progress: client-provided tokens are already globally unique
+because the client mints them, so token *namespacing* — the problem that
+motivated the `ProgressRegistry` — does not apply here.
+
+The problem is **fan-out**. The bridge multiplexes one editor request onto
+several downstream servers (e.g. a references request spanning several injected
+languages, fanned out per language-server-bridge-request-strategies). Each
+downstream may emit `$/progress` and partial results against the same
+client-provided token. Forwarding them verbatim duplicates the lifecycle (N
+`Begin`, N `End`) and corrupts the indicator; concatenating result chunks
+verbatim mis-orders data. Because of fan-out the bridge is **always the party
+that composes the upstream terminal `End` and the final response** — it
+aggregates N downstreams and never simply relays one downstream's terminal.
+
+Today the bridge sidesteps all of this by **stripping both tokens** before
+sending a downstream request (`strip_progress_tokens`,
+`src/lsp/bridge/text_document/host.rs`): a downstream honouring them would stream
+into the void, since the bridge discards downstream notifications, and could
+legally return an empty final result. The cost is that client-requested progress
+never reaches the editor.
+
+## Decision
+
+Stop stripping client-provided tokens (selectively), route the resulting
+downstream→upstream `$/progress` and partial-result notifications, and aggregate
+them so the editor sees **one coherent lifecycle whose source matches the
+delivered result**.
+
+**Core principle.** The progress the editor sees must track the *same server
+whose result is actually delivered*, so progress and data never diverge. A swap
+can only occur before any data has been shown; once data is delivered, the
+lifecycle is committed.
+
+- **Selector — priority-based.** The tracked and delivered server is the
+  *priority winner* of the preferred (`l`) fan-in, not the first responder.
+  Latency-based selection is rejected because it can make progress (the fastest
+  server) and delivered data (the priority winner) come from different servers.
+- **Begin — opportunistic.** The winner is unknown when `Begin` arrives (`Begin`
+  precedes any result), so forward the *first* `Begin` from any contributor to
+  light the indicator immediately; gate only `report`/`End` on the
+  currently-chosen server.
+- **report / End — per aggregation strategy.**
+  - *preferred (`l`)*: forward only the winner's `report`; emit `End` when the
+    winner's final response is aggregated; discard other servers' progress and
+    results. If the winner's first response is already complete (not partial),
+    do not track other servers at all.
+  - *concatenated (`led`)*: keep progress alive until *all* contributors finish
+    (no premature `End`); `report` may reflect `n/m` contributors done as a
+    percentage; `End` on the last contributor.
+- **Graceful degradation on committed-server failure.** The branch turns on
+  *whether the editor has already been shown data*:
+  - *preferred, winner already streamed partials*: data is on screen, so promote
+    the accumulated partials into the winner's result and `End` immediately — do
+    not wait for another candidate (that would freeze the shown data) and do not
+    swap in a different server's result. The result may be incomplete; accepted
+    as graceful degradation.
+  - *preferred, winner produced nothing* (died before any partial result): its
+    result is empty, which — exactly as for any empty or absent winner result
+    under `l` — falls through to the next-priority candidate. Nothing was shown
+    yet, so this is ordinary request latency, not a freeze and not a swap. The
+    opportunistic `Begin` stays open and `report`/`End` re-gate onto the new
+    candidate (no new `Begin`); this recurses down the priority order.
+  - *concatenated*: a failed contributor donates its accumulated partials
+    (possibly empty) and the others concatenate as usual; nothing special is
+    needed.
+- **partialResultToken — translate, then merge.** Partial-result chunks carry
+  locations needing the *same* injection offset and URI translation as final
+  responses, applied incrementally per chunk through the existing aggregation
+  path (which assumes a single final blob today and must accept incremental
+  input). Preferred streams the winner's translated chunks; concatenated
+  concatenates all contributors' translated chunks.
+
+The terminal `End` the bridge emits on failure is the same primitive
+ls-bridge-progress-disconnect-cleanup uses for server-declared tokens — the
+bridge composes the terminal rather than relaying a downstream's.
+
+## Considered Options
+
+- **Keep stripping both tokens (status quo).** Simplest and zero-risk, but
+  client-requested progress never surfaces — the gap this decision closes.
+  Rejected.
+- **Latency-based selector (track the first responder).** Lower time-to-first
+  paint, but progress and delivered data can come from different servers — the
+  jarring swap this decision avoids. Rejected in favour of priority.
+- **Delay `Begin` until the winner is known.** Keeps progress source-consistent
+  from the first frame, but defeats the point of progress (no early "something is
+  happening" signal). Rejected in favour of an opportunistic first `Begin` with
+  source-gated `report`/`End`.
+- **On failure after partial data was shown, wait for the next-priority
+  candidate.** Avoids delivering incomplete data, but freezes the already-shown
+  results until the slower candidate finishes and risks a late swap. Rejected in
+  favour of promoting the streamed partials. (An empty winner that showed
+  *nothing* still falls through normally — that is plain latency, not a freeze.)
+
+## Consequences
+
+### Positive
+
+- Client-requested progress (`workDoneToken`) reaches the editor for the first
+  time.
+- Progress UI and delivered results always share one source — no jarring swap and
+  no freeze of shown data.
+- partialResult streaming becomes possible without mis-translated locations.
+- Failure degrades gracefully: if data was shown the editor keeps it and the
+  lifecycle terminates cleanly; if not, the request falls through to the next
+  server like any empty result.
+
+### Negative
+
+- Requires undoing the deliberate token strip and adding downstream→upstream
+  notification routing for client tokens — the real cost, independent of the
+  merge policy.
+- The aggregation path must move from a single final blob to incremental input to
+  support partialResult merging.
+- When a winner fails *after* streaming, the delivered result may be incomplete
+  (only the streamed prefix); accepted as graceful degradation over freezing or
+  swapping.
+
+### Neutral
+
+- Namespacing is unnecessary here (client tokens are already unique), so the
+  `ProgressRegistry` of ls-bridge-work-done-progress is not involved; this path
+  is distinct from server-declared progress.
+- The bridge always composes the upstream terminal `End` and response (it
+  aggregates fan-out), so failure handling changes only that payload, not the
+  mechanism.
+
+## Decision–Implementation Gap
+
+Not yet implemented (tracked in issue #414); today both client-provided tokens
+are stripped before fan-out. Specific points to settle during implementation:
+
+- The empty-vs-non-empty threshold that triggers fall-through must **match the
+  existing `l` empty-result behaviour**, which may be method-specific (e.g.
+  `host.rs` treats an empty `vec![]` as a usable result that must not read as "no
+  result"). Align with `l`; do not invent a new threshold.
+- `partialResultToken` support depends on the aggregation layer accepting
+  incremental input. Until that lands, `partialResultToken` may stay stripped
+  while `workDoneToken` is bridged — a valid intermediate phase. Without
+  partial-result accumulation a failed winner always looks empty and falls
+  through to the next candidate, which is acceptable.
+- Percentage composition under `concatenated` (`n/m`) is a display heuristic, not
+  a contract.

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -82,13 +82,15 @@ request just returns its result (today's behavior, minus the strip).
 - **Graceful degradation on committed-server failure.** The branch turns on
   *whether the editor has already been shown data*:
   - *preferred, winner already streamed partials*: data is on screen, so promote
-    the accumulated partials into the winner's result and immediately emit a
-    *synthetic* `End` — the downstream is gone and cannot send a real one, so the
-    bridge composes the terminal itself (the same primitive
-    ls-bridge-progress-disconnect-cleanup uses). Do not wait for another
-    candidate (that would freeze the shown data) and do not swap in a different
-    server's result. The result may be incomplete; accepted as graceful
-    degradation.
+    the accumulated partials into the winner's result and complete the request.
+    `partialResultToken` (data) and `workDoneToken` (progress) are separate
+    tokens, so close the *progress* only if a work-done `Begin` is actually
+    open — then emit a *synthetic* `End` (the downstream is gone and cannot send a
+    real one, the same primitive ls-bridge-progress-disconnect-cleanup uses); a
+    winner that streamed only partial-result data without opening work-done
+    progress needs no `End`. Do not wait for another candidate (that would freeze
+    the shown data) and do not swap in a different server's result. The result may
+    be incomplete; accepted as graceful degradation.
   - *preferred, winner produced nothing* (died before any partial result): its
     empty result falls through to the next-priority candidate, exactly as any
     empty result does under preferred. If the dead winner had opened no `Begin`,
@@ -102,7 +104,10 @@ request just returns its result (today's behavior, minus the strip).
   - *concatenated*: a failed contributor contributes whatever it already streamed
     (possibly nothing) and is **dropped from the expected set** (the `n/m`
     denominator shrinks); the others proceed, and `End` fires once the remaining
-    expected results are collected.
+    expected results are collected. If the *anchor* (highest-priority contributor)
+    is the one that fails before opening a `Begin`, the anchor role moves to the
+    next-priority survivor — its `Begin` if it has one, else the silent-anchor
+    synthesis above.
 - **partialResultToken — translate, then merge.** Partial-result chunks carry
   locations needing the *same* injection offset and URI translation as final
   responses, applied incrementally per chunk through the existing aggregation

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -47,9 +47,10 @@ stays consistent with the result actually delivered: the `End` coincides with th
 result being complete, and no `report` carries data the editor will not receive.
 **Only the winner's own progress is ever tracked**; other contributors influence
 the lifecycle solely by *completing* (their result arriving), never through their
-own `$/progress`. So the `Begin` title comes from the winner, or (under
-*concatenated*) from a bridge-owned synthetic when the winner emits none — never
-from an arbitrary non-winner.
+own `$/progress`. So the `Begin` title comes from the current priority anchor —
+normally the delivered winner, or (under *concatenated*) a bridge-owned synthetic
+when the anchor is silent — never an arbitrary non-anchor. (One documented edge:
+after a fall-through, an earlier anchor's title can linger; see Consequences.)
 The winner is chosen by **priority, not latency**: a latency anchor could put the
 title and progress on one server while the delivered result comes from another.
 
@@ -86,9 +87,10 @@ request just returns its result (today's behavior, minus the strip).
   `Cancelled`). When the lifecycle tracks a single source to completion (N = 1, or
   *preferred*), that `End` is the source's real one; under *concatenated* the
   bridge emits a single aggregate-timed `End` and suppresses the winner's own
-  (which fires before collection finishes). If the source cannot send one (it
-  died), the bridge synthesizes it. A request that opened no `Begin` emits no
-  `End`. (The per-branch rules below are instances of this invariant.)
+  (which fires before collection finishes). If the source cannot send one — it
+  died, or the request was cancelled (the fan-in aborts the downstreams) — the
+  bridge synthesizes it. A request that opened no `Begin` emits no `End`. (The
+  per-branch rules below are instances of this invariant.)
 - **Graceful degradation on committed-server failure.** The branch turns on
   *whether the editor has already been shown data*:
   - *preferred, winner already streamed partials*: data is on screen, so promote
@@ -173,8 +175,9 @@ bridge composes the terminal rather than relaying a downstream's.
 - partialResult streaming becomes possible without mis-translated locations.
 - Progress engages only when meaningful: a fast or single-server request with no
   downstream progress shows nothing, so there is no spurious spinner. The `Begin`
-  title always reflects the winner (or a neutral bridge title), never an
-  arbitrary server.
+  title reflects the priority anchor (or a neutral bridge title), never an
+  arbitrary server — apart from the rare lingering-title case after fall-through
+  noted below.
 - Failure degrades gracefully: if data was shown the editor keeps it and the
   lifecycle terminates cleanly; if not, the request falls through to the next
   server like any empty result.

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -17,10 +17,11 @@ languages, fanned out per language-server-bridge-request-strategies). Each
 downstream may emit `$/progress` and partial results against the same
 client-provided token. Forwarding them verbatim duplicates the lifecycle (N
 `Begin`, N `End`) and corrupts the indicator; concatenating result chunks
-verbatim mis-orders data. So **under fan-out the bridge must own the upstream
-terminal** — it cannot blindly relay all N downstreams' `End`s/responses (they
-collide); it forwards exactly one or composes one, as the Decision details. (A
-request that reaches a single server is just relayed.)
+verbatim mis-orders data. So, under fan-out,
+**the bridge must own the upstream terminal**: it cannot blindly relay all N
+downstreams' `End`s/responses (they collide); it forwards exactly one or composes
+one, as the Decision details. (A request that reaches a single server is just
+relayed.)
 
 Today the bridge does not forward client-provided tokens to downstreams at all.
 The host raw-request path strips them (`strip_progress_tokens`,

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -69,7 +69,10 @@ request just returns its result (today's behavior, minus the strip).
 
 - **Single downstream (N = 1).** Relay that server's own `Begin`/`report`/`End`
   against the client's original token (client tokens are already unique, so no
-  remapping). If it emits none, the editor sees no progress.
+  remapping). If it emits none, the editor sees no progress. This holds even when
+  the sole server was selected via the wildcard: the `Rest`-never-anchor rule
+  disambiguates among *racing* contenders, and a single downstream has none — so
+  its real `Begin` is safe to forward.
 - **preferred, N > 1.** The delivered result is a single winner, and preferred
   short-circuits (it does not wait for the losers), so there is no collection
   count to report. If the anchor emits its own progress, forward its

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -44,17 +44,18 @@ actually delivered: the `End` coincides with the result being complete, and no
 `report` carries data the editor will not receive. How the title-bearing `Begin`
 is produced then depends on the strategy, because the two deliver differently:
 
-- *preferred* delivers a single **winner**, so progress is **anchored** on that
-  source: the title is the winner's own `Begin`, and only the anchor's own
-  progress is tracked. The winner is found by the **priority walk** — explicit
-  `priorities` in order, the wildcard `Rest` resolved first-win by earliest
-  non-empty arrival. A candidate that returns empty, or fails before producing
-  any data, is no winner (reserved for the delivered source, possibly a promoted
-  partial prefix), so the **anchor** (the highest-priority *named* candidate)
-  falls through to the next. The bridge never forwards a non-anchor's `Begin` as
-  the title — including a `Rest` member's, since which `Rest` member wins is a
-  latency race, not knowable in advance. (One documented edge: after a
-  fall-through, an earlier anchor's title can linger; see Consequences.)
+- *preferred* delivers a single **winner**, and progress is **anchored** on the
+  **anchor** — the highest-priority *named* candidate — whose own `Begin` is the
+  title; only the anchor's own progress is tracked. The winner (the delivered
+  source) is usually that anchor, but the priority walk resolves the wildcard
+  `Rest` group first-win by earliest non-empty arrival, so a `Rest` member can be
+  the winner without being an anchor: its own progress is **not** shown (no safe a
+  priori title for a latency race), unless it is the sole server (N = 1). A
+  candidate that returns empty, or fails before producing any data, is no winner
+  (reserved for the delivered source, possibly a promoted partial prefix), so the
+  anchor falls through to the next *named* candidate. The bridge never forwards a
+  non-anchor's `Begin` as the title. (One documented edge: after a fall-through,
+  an earlier anchor's title can linger; see Consequences.)
 - *concatenated* merges **all** contributors, so no single source owns the title:
   the bridge **always composes its own synthetic neutral `Begin`** (never
   borrowing a downstream's title; e.g. a request-derived one) and reports
@@ -92,9 +93,11 @@ request just returns its result (today's behavior, minus the strip).
 - **Begin/End pairing invariant.** An open work-done `Begin` is closed by exactly
   one `End`, fired when the *request* terminates — normal completion, anchor
   failure, fall-through exhaustion, or client cancellation (the fan-in returns
-  `Cancelled`). Under *preferred* (and N = 1) the lifecycle tracks a single
-  source, so that `End` is the source's real one — or a bridge-synthesized one if
-  the source died or was cancelled before sending it. Under *concatenated* the
+  `Cancelled`). Under *preferred* (and N = 1) there is one open lifecycle per
+  token, normally closed by the tracked source's real `End`; after a fall-through
+  the open `Begin` may be an earlier anchor's while the new anchor supplies the
+  `End`, and the bridge synthesizes the `End` if the source died, was cancelled,
+  or completes with no progress phase. Under *concatenated* the
   bridge composes the whole lifecycle, so the terminal is always its own
   aggregate-timed `End` (fired when all results are collected, or synthesized on
   cancellation). A request that opened no `Begin` emits no `End`. (The per-branch
@@ -184,9 +187,11 @@ bridge composes the terminal rather than relaying a downstream's `End`.
 - Client-requested progress (`workDoneToken`) reaches the editor for the first
   time.
 - The progress signals stay consistent with the delivered result — no jarring
-  swap and no freeze of shown data. Under *preferred* the title and `report`/`End`
-  track the one winner; under *concatenated* the bridge composes a neutral title
-  and `n/m` that describe the aggregate, so the title never goes stale mid-flight.
+  swap and no freeze of shown data. Under *preferred* the `report`/`End` track the
+  current anchor (normally the winner; after a fall-through the title may be an
+  earlier anchor's — see below); under *concatenated* the bridge composes a
+  neutral title and `n/m` that describe the aggregate, so the title never goes
+  stale mid-flight.
 - partialResult streaming becomes possible without mis-translated locations.
 - Progress engages only when meaningful: a fast or single-server request with no
   downstream progress shows nothing, so there is no spurious spinner. The `Begin`

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -49,7 +49,9 @@ because the two deliver differently:
   **anchor** — the highest-priority *named* candidate — whose own `Begin` is the
   title; only the anchor's own progress is tracked. The winner (the delivered
   source) is usually that anchor, but the priority walk resolves the wildcard
-  `Rest` group first-win by earliest non-empty arrival, so a `Rest` member can be
+  `Rest` group — the `"*"` element of `priorities` (aggregation-priorities-wildcard),
+  i.e. every server not named explicitly — first-win by earliest non-empty
+  arrival, so a `Rest` member can be
   the winner without being an anchor: its own progress is **not** shown (no safe
   a priori title for a latency race), unless it is the sole server (N = 1). A
   candidate that returns empty, or fails before producing any data, is no winner

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -85,9 +85,12 @@ request just returns its result (today's behavior, minus the strip).
     degradation.
   - *preferred, winner produced nothing* (died before any partial result): its
     empty result falls through to the next-priority candidate, exactly as any
-    empty result does under preferred. Nothing was shown yet, so this is ordinary
-    latency, not a freeze or swap; the progress re-anchors on the new winner (its
-    own `Begin`, if any), recursing down the priority order.
+    empty result does under preferred. If the dead winner had opened no `Begin`,
+    nothing was shown — ordinary latency, not a freeze or swap — and the new
+    winner's own `Begin` opens the lifecycle. If it had already opened a `Begin`,
+    LSP permits only one per token, so that `Begin` stays open (its title lingers
+    — see Consequences) and only `report`/`End` re-anchor onto the new winner.
+    This recurses down the priority order.
   - *concatenated*: a failed contributor contributes whatever it already streamed
     (possibly nothing); the collection count adjusts and the others proceed, with
     `End` once the rest are collected.

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -21,12 +21,14 @@ verbatim mis-orders data. Because of fan-out,
 **the bridge always composes the upstream terminal itself** — it aggregates N
 downstreams and never simply relays one downstream's `End` or final response.
 
-Today the bridge sidesteps all of this by **stripping both tokens** before
-sending a downstream request (`strip_progress_tokens`,
-`src/lsp/bridge/text_document/host.rs`): a downstream honouring them would stream
-into the void, since the bridge discards downstream notifications, and could
-legally return an empty final result. The cost is that client-requested progress
-never reaches the editor.
+Today the bridge does not forward client-provided tokens to downstreams at all.
+The host raw-request path strips them (`strip_progress_tokens`,
+`src/lsp/bridge/text_document/host.rs`), and the per-method virtual request
+builders construct fresh params with default (empty) progress fields, so no
+token is carried either way. A downstream honouring them would stream into the
+void, since the bridge discards downstream notifications, and could legally
+return an empty final result. The cost is that client-requested progress never
+reaches the editor.
 
 ## Decision
 
@@ -35,10 +37,14 @@ downstream→upstream `$/progress` and partial-result notifications, and aggrega
 them so the editor sees **one coherent lifecycle** whose source matches the
 delivered result.
 
-**Core principle.** The progress the editor sees must track the *same server
-whose result is actually delivered*, so progress and data never diverge. A swap
-can only occur before any data has been shown; once data is delivered, the
-lifecycle is committed.
+**Core principle.** Every *data-bearing* signal the editor sees — each `report`,
+the delivered result, and the terminal `End` — must come from the *same server
+whose result is actually delivered*, so progress and data never diverge. The
+opening `Begin` is exempt: it is a content-free "work has started" signal
+forwarded opportunistically from whichever contributor reports first (the winner
+is not yet known then) and carries no server-identifying data. A swap can only
+occur before any data has been shown; once data is delivered, the lifecycle is
+committed.
 
 - **Selector — priority-based.** The tracked and delivered server is the
   *priority winner* of the preferred fan-in, not the first responder.

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -34,13 +34,19 @@ reaches the editor.
 
 Stop stripping client-provided tokens (selectively), route the resulting
 downstream→upstream `$/progress` and partial-result notifications, and aggregate
-them so the editor sees **one coherent lifecycle** whose data-bearing signals
-(`report`, the result, the terminal `End`) all come from the delivered server.
+them so the editor sees **one coherent lifecycle** that stays consistent with the
+result actually delivered.
 
-**Core principle.** Every *data-bearing* signal the editor sees — each `report`,
-the delivered result, and the terminal `End` — must come from the *same server
-whose result is actually delivered*, so progress and data never diverge. The
-opening `Begin` is exempt: the winner is not yet known when it must be sent, so
+**Core principle.** The data-bearing signals the editor sees — each `report`, the
+delivered result, and the terminal `End` — must stay consistent with the result
+actually delivered, so progress and data never diverge: the `End` coincides with
+the result being complete, and no `report` reflects data the editor will not
+receive. How that resolves is strategy-specific: under *preferred* the result is
+a single winner, so those signals track that one server; under *concatenated* the
+result is the merge of *all* contributors, so the bridge composes the lifecycle
+over the whole set (progress is `n/m`, the `End` fires only when the last
+contributor finishes). The opening `Begin` is exempt: the winner is not yet known
+when it must be sent, so
 it is forwarded opportunistically from whichever contributor reports first,
 purely to light the indicator promptly. `Begin` is not content-free — it carries
 a `title` (and optional `message`) — so that opening text may originate from a
@@ -124,8 +130,10 @@ bridge composes the terminal rather than relaying a downstream's.
 
 - Client-requested progress (`workDoneToken`) reaches the editor for the first
   time.
-- The data-bearing progress signals (`report`/`End`) and the delivered result
-  always share one source — no jarring swap and no freeze of shown data.
+- The data-bearing progress signals (`report`/`End`) stay consistent with the
+  delivered result — no jarring swap and no freeze of shown data (under
+  *preferred* both track the one winner; under *concatenated* both span the same
+  contributor set).
 - partialResult streaming becomes possible without mis-translated locations.
 - Failure degrades gracefully: if data was shown the editor keeps it and the
   lifecycle terminates cleanly; if not, the request falls through to the next

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -80,7 +80,7 @@ lifecycle is committed.
   locations needing the *same* injection offset and URI translation as final
   responses, applied incrementally per chunk through the existing aggregation
   path (which assumes a single final blob today and must accept incremental
-  input). Preferred streams the winner's translated chunks; concatenated
+  input). *Preferred* streams the winner's translated chunks; *concatenated*
   concatenates all contributors' translated chunks.
 
 The terminal `End` the bridge emits on failure is the same primitive

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -104,29 +104,24 @@ request just returns its result (today's behavior, minus the strip).
   rules above are instances of this invariant.)
 - **Graceful degradation on committed-server failure.** The branch turns on
   *whether the editor has already been shown data*:
-  - *preferred, anchor already streamed partials*: data is on screen, so promote
-    the accumulated partials into the delivered result and complete the request.
-    `partialResultToken` (data) and `workDoneToken` (progress) are separate
-    tokens, so close the *progress* only if a work-done `Begin` is actually
-    open — then emit a *synthetic* `End` (the downstream is gone and cannot send a
-    real one, the same primitive ls-bridge-progress-disconnect-cleanup uses); an
-    anchor that streamed only partial-result data without opening work-done
-    progress needs no `End`. Do not wait for another candidate (that would freeze
-    the shown data) and do not swap in a different server's result. The result may
-    be incomplete; accepted as graceful degradation.
-  - *preferred, anchor produced nothing* (empty or failed before any partial
-    result): it falls through to the next-priority candidate, exactly as any empty
-    result does under preferred. If the spent anchor had opened no `Begin`,
-    nothing was shown — ordinary latency, not a freeze or swap — and the new
-    anchor's own `Begin` opens the lifecycle. If it had already opened a `Begin`,
-    LSP permits only one per token, so that `Begin` stays open (its title lingers
-    — see Consequences) and the new anchor's `report`/`End` re-anchor under it;
-    should the new anchor provide no real `End` (it completes with no progress
-    phase), the bridge synthesizes one at request completion so the lingering
-    `Begin` is always closed. This recurses down the priority order; if every
-    candidate is exhausted and preferred returns no result at all, the same rule
-    applies at request completion — synthesize an `End` if a `Begin` is open,
-    otherwise emit none.
+  - *preferred, winner already streamed partials*: data is on screen, so promote
+    the winner's accumulated partials into the delivered result and complete the
+    request. Do not wait for another candidate (that would freeze the shown data)
+    and do not swap in a different server's result. The result may be incomplete;
+    accepted as graceful degradation. (Progress follows the pairing invariant:
+    `partialResultToken` data and `workDoneToken` progress are separate tokens, so
+    any open work-done `Begin` is closed by a synthetic `End`; a winner that
+    streamed only partial-result data opened none and needs no `End`.)
+  - *preferred, winner produced nothing* (empty or failed before any partial
+    result): it falls through to the next-priority candidate — down to a `Rest`
+    winner, or to no result at all — exactly as any empty result does under
+    preferred. Nothing was committed, so this is ordinary latency, not a freeze or
+    swap. Progress follows the pairing invariant: if a prior *named* anchor opened
+    a `Begin`, it stays open (its title can linger — see Consequences) and is
+    closed by the next named anchor's real `End`, or by a synthetic `End` at
+    request completion (when the next winner is a `Rest` member or emits no
+    progress, or no result is returned at all); if no `Begin` was opened, none is
+    emitted.
   - *concatenated*: a failed contributor contributes whatever it already streamed
     (possibly nothing) and is **dropped from the expected set** (the `n/m`
     denominator shrinks); the others proceed, and the aggregate `End` fires once
@@ -209,7 +204,7 @@ bridge composes the terminal rather than relaying a downstream's `End`.
   merge policy.
 - The aggregation path must move from a single final blob to incremental input to
   support partialResult merging.
-- When the anchor fails *after* streaming, the delivered result may be incomplete
+- When the winner fails *after* streaming, the delivered result may be incomplete
   (only the streamed prefix); accepted as graceful degradation over freezing or
   swapping.
 - If the anchor emits a `Begin` and then loses (returns empty) or dies, its
@@ -228,7 +223,7 @@ bridge composes the terminal rather than relaying a downstream's `End`.
 - Namespacing is unnecessary here (client tokens are already unique), so the
   `ProgressRegistry` of ls-bridge-work-done-progress is not involved; this path
   is distinct from server-declared progress.
-- Under fan-out the bridge owns the upstream terminal — relaying the winner's `End`
+- Under fan-out the bridge owns the upstream terminal — relaying the anchor's `End`
   under *preferred*, composing one under *concatenated* and on failure — so
   failure handling changes only that payload, not the mechanism.
 - A fast *concatenated* fan-out can briefly flash `Begin`→`End`; editors
@@ -246,7 +241,7 @@ are stripped before fan-out. Specific points to settle during implementation:
 - `partialResultToken` support depends on the aggregation layer accepting
   incremental input. Until that lands, `partialResultToken` may stay stripped
   while `workDoneToken` is bridged — a valid intermediate phase. Without
-  partial-result accumulation a failed anchor always looks empty and falls
+  partial-result accumulation a failed candidate always looks empty and falls
   through to the next candidate, which is acceptable.
 - Percentage composition under *concatenated* (`n/m`) is a display heuristic, not
   a contract.

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -50,7 +50,11 @@ arrival), not a pure latency race that could put the title and progress on one
 server while the delivered result comes from another. A candidate that returns
 empty — or fails before producing any data — is no **winner** (reserved for the
 source whose result, possibly a promoted partial prefix, is delivered), so the
-anchor falls through to the next candidate.
+anchor falls through to the next candidate. Within the unordered `Rest` (wildcard)
+group no member is the a-priori anchor — which one wins is a latency race, not
+knowable in advance — so the bridge never forwards a `Rest` member's own `Begin`
+as the title; that group's progress is handled as a silent anchor (a synthetic
+neutral `Begin` under *concatenated*, nothing under *preferred*).
 
 **Only the anchor's own progress is ever tracked**; other contributors influence
 the lifecycle solely by *completing* (their result arriving), never through their

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -60,13 +60,13 @@ because the two deliver differently:
   non-anchor's `Begin` as the title. (One documented edge: after a fall-through,
   an earlier anchor's title can linger; see Consequences.)
 - *concatenated* merges **all** contributors, so no single source owns the title:
-  the bridge **always composes its own synthetic neutral `Begin`** (never
-  borrowing a downstream's title; e.g. a request-derived one) and reports
-  collection progress,
-  **ignoring every downstream's own `$/progress`**. This trades per-server
-  granularity for a title
-  that stays accurate across the whole aggregate — borrowing one contributor's
-  title would go stale the moment that contributor finishes while others are
+  when progress is shown at all (see the engages-only-when-staggered rule below)
+  the bridge **composes its own synthetic neutral `Begin`** (never borrowing a
+  downstream's title; e.g. a request-derived one) and reports collection
+  progress, **ignoring every downstream's own `$/progress`**. This trades
+  per-server granularity for a title that stays accurate across the whole
+  aggregate — borrowing one contributor's title would go stale the moment that
+  contributor finishes while others are
   still pending (see Consequences).
 
 The lifecycle engages only when there is progress worth showing; otherwise the

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -48,9 +48,9 @@ receive. The anchor follows the **priority walk** (honoring explicit
 `priorities`, with the wildcard `Rest` resolved first-win by earliest non-empty
 arrival), not a pure latency race that could put the title and progress on one
 server while the delivered result comes from another. A candidate that returns
-empty or fails is no **winner** (the term is reserved for the server whose
-non-empty result is delivered), so the anchor falls through to the next
-candidate.
+empty — or fails before producing any data — is no **winner** (reserved for the
+source whose result, possibly a promoted partial prefix, is delivered), so the
+anchor falls through to the next candidate.
 
 **Only the anchor's own progress is ever tracked**; other contributors influence
 the lifecycle solely by *completing* (their result arriving), never through their

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -41,7 +41,7 @@ can only occur before any data has been shown; once data is delivered, the
 lifecycle is committed.
 
 - **Selector — priority-based.** The tracked and delivered server is the
-  *priority winner* of the preferred (`l`) fan-in, not the first responder.
+  *priority winner* of the preferred fan-in, not the first responder.
   Latency-based selection is rejected because it can make progress (the fastest
   server) and delivered data (the priority winner) come from different servers.
 - **Begin — opportunistic.** The winner is unknown when `Begin` arrives (`Begin`
@@ -49,11 +49,11 @@ lifecycle is committed.
   light the indicator immediately; gate only `report`/`End` on the
   currently-chosen server.
 - **report / End — per aggregation strategy.**
-  - *preferred (`l`)*: forward only the winner's `report`; emit `End` when the
+  - *preferred*: forward only the winner's `report`; emit `End` when the
     winner's final response is aggregated; discard other servers' progress and
     results. If the winner's first response is already complete (not partial),
     do not track other servers at all.
-  - *concatenated (`led`)*: keep progress alive until *all* contributors finish
+  - *concatenated*: keep progress alive until *all* contributors finish
     (no premature `End`); `report` may reflect `n/m` contributors done as a
     percentage; `End` on the last contributor.
 - **Graceful degradation on committed-server failure.** The branch turns on
@@ -65,8 +65,9 @@ lifecycle is committed.
     as graceful degradation.
   - *preferred, winner produced nothing* (died before any partial result): its
     result is empty, which — exactly as for any empty or absent winner result
-    under `l` — falls through to the next-priority candidate. Nothing was shown
-    yet, so this is ordinary request latency, not a freeze and not a swap. The
+    under the preferred strategy — falls through to the next-priority candidate.
+    Nothing was shown yet, so this is ordinary request latency, not a freeze and
+    not a swap. The
     opportunistic `Begin` stays open and `report`/`End` re-gate onto the new
     candidate (no new `Begin`); this recurses down the priority order.
   - *concatenated*: a failed contributor donates its accumulated partials
@@ -140,9 +141,9 @@ Not yet implemented (tracked in issue #414); today both client-provided tokens
 are stripped before fan-out. Specific points to settle during implementation:
 
 - The empty-vs-non-empty threshold that triggers fall-through must **match the
-  existing `l` empty-result behaviour**, which may be method-specific (e.g.
+  existing preferred-strategy empty-result behaviour**, which may be method-specific (e.g.
   `host.rs` treats an empty `vec![]` as a usable result that must not read as "no
-  result"). Align with `l`; do not invent a new threshold.
+  result"). Align with the preferred strategy; do not invent a new threshold.
 - `partialResultToken` support depends on the aggregation layer accepting
   incremental input. Until that lands, `partialResultToken` may stay stripped
   while `workDoneToken` is bridged — a valid intermediate phase. Without

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -45,27 +45,28 @@ receive. How that resolves is strategy-specific: under *preferred* the result is
 a single winner, so those signals track that one server; under *concatenated* the
 result is the merge of *all* contributors, so the bridge composes the lifecycle
 over the whole set (progress is `n/m`, the `End` fires only when the last
-contributor finishes). The opening `Begin` is exempt: the winner is not yet known
-when it must be sent, so
-it is forwarded opportunistically from whichever contributor reports first,
-purely to light the indicator promptly. `Begin` is not content-free — it carries
-a `title` (and optional `message`) — so that opening text may originate from a
-non-winner. LSP does not allow amending a `title` after `Begin`, so this is
+contributor finishes). The opening `Begin` is exempt: the eventual source is not
+yet known when it must be sent, so it is forwarded opportunistically from
+whichever contributor reports first, purely to light the indicator promptly.
+`Begin` is not content-free — it carries a `title` (and optional `message`) — so
+that opening text may originate from a contributor that does not end up sourcing
+the result. LSP does not allow amending a `title` after `Begin`, so this is
 accepted as a transient cosmetic detail: the data-bearing `report`/result/`End`
-that follow all come from the winner. (A bridge-owned neutral `title` could avoid
-surfacing a non-winner's; either way the data-bearing guarantee holds.) A swap of
-*delivered data* can only occur before any data has been shown; once data is
-delivered, the lifecycle is committed.
+that follow are sourced per the strategy rules below. (A bridge-owned neutral
+`title` could avoid surfacing a stray one; either way the data-bearing guarantee
+holds.) A swap of *delivered data* can only occur before any data has been shown;
+once data is delivered, the lifecycle is committed.
 
 - **Selector — priority-based.** The tracked and delivered server is the
   *priority winner* of the preferred fan-in, not the first responder.
   Latency-based selection is rejected because it can make the data-bearing
   progress (`report`/`End`, the fastest server) and the delivered result (the
   priority winner) come from different servers.
-- **Begin — opportunistic.** The winner is unknown when `Begin` arrives (`Begin`
-  precedes any result), so forward the *first* `Begin` from any contributor to
-  light the indicator immediately; gate only `report`/`End` on the
-  currently-chosen server.
+- **Begin — opportunistic.** The eventual source is unknown when `Begin` arrives
+  (`Begin` precedes any result), so forward the *first* `Begin` from any
+  contributor to light the indicator immediately; gate `report`/`End` per the
+  strategy rules below (the winner under *preferred*; the contributor set under
+  *concatenated*).
 - **report / End — per aggregation strategy.**
   - *preferred*: forward only the winner's `report`; emit `End` when the
     winner's final response is aggregated; discard other servers' progress and
@@ -114,10 +115,10 @@ bridge composes the terminal rather than relaying a downstream's.
   paint, but the data-bearing progress and the delivered result can come from
   different servers — the jarring swap this decision avoids. Rejected in favour
   of priority.
-- **Delay `Begin` until the winner is known.** Keeps progress source-consistent
-  from the first frame, but defeats the point of progress (no early "something is
-  happening" signal). Rejected in favour of an opportunistic first `Begin` with
-  source-gated `report`/`End`.
+- **Delay `Begin` until the source is known.** Keeps the opening title
+  source-consistent from the first frame, but defeats the point of progress (no
+  early "something is happening" signal). Rejected in favour of an opportunistic
+  first `Begin` with `report`/`End` gated per strategy.
 - **Wait for the next-priority candidate after partial data was shown.**
   Avoids delivering incomplete data, but freezes the already-shown
   results until the slower candidate finishes and risks a late swap. Rejected in

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -38,44 +38,40 @@ downstream→upstream `$/progress` and partial-result notifications, and aggrega
 them so the editor sees **one coherent lifecycle** that stays consistent with the
 result actually delivered.
 
-**Core principle.** The data-bearing signals the editor sees — each `report`, the
-delivered result, and the terminal `End` — must stay consistent with the result
-actually delivered, so progress and data never diverge: the `End` coincides with
-the result being complete, and no `report` reflects data the editor will not
-receive. How that resolves is strategy-specific: under *preferred* the result is
-a single winner, so those signals track that one server; under *concatenated* the
-result is the merge of *all* contributors, so the bridge composes the lifecycle
-over the whole set (progress is `n/m`, the `End` fires only when the last
-contributor finishes). The opening `Begin` is exempt: the eventual source is not
-yet known when it must be sent, so it is forwarded opportunistically from
-whichever contributor reports first, purely to light the indicator promptly.
-`Begin` is not content-free — it carries a `title` (and optional `message`) — so
-that opening text may originate from a contributor that does not end up sourcing
-the result. LSP does not allow amending a `title` after `Begin`, so this is
-accepted as a transient cosmetic detail: the data-bearing `report`/result/`End`
-that follow are sourced per the strategy rules below. (A bridge-owned neutral
-`title` could avoid surfacing a stray one; either way the data-bearing guarantee
-holds.) A swap of *delivered data* can only occur before any data has been shown;
-once data is delivered, the lifecycle is committed.
+**Core principle.** The progress narrative is **anchored on the priority
+winner** — the highest-priority contributor — and the data the editor receives
+stays consistent with the result actually delivered: the `End` coincides with the
+result being complete, and no `report` carries data the editor will not receive.
+**Only the winner's own progress is ever tracked**; other contributors influence
+the lifecycle solely by *completing* (their result arriving), never through their
+own `$/progress`. So the `Begin` title comes from the winner — or, when the winner
+emits none, from a bridge-owned synthetic — never from an arbitrary non-winner.
+The winner is chosen by **priority, not latency**: a latency anchor could put the
+title and progress on one server while the delivered result comes from another.
 
-- **Selector — priority-based.** The tracked and delivered server is the
-  *priority winner* of the preferred fan-in, not the first responder.
-  Latency-based selection is rejected because it can make the data-bearing
-  progress (`report`/`End`, the fastest server) and the delivered result (the
-  priority winner) come from different servers.
-- **Begin — opportunistic.** The eventual source is unknown when `Begin` arrives
-  (`Begin` precedes any result), so forward the *first* `Begin` from any
-  contributor to light the indicator immediately; gate `report`/`End` per the
-  strategy rules below (the winner under *preferred*; the contributor set under
-  *concatenated*).
-- **report / End — per aggregation strategy.**
-  - *preferred*: forward only the winner's `report`; emit `End` when the
-    winner's final response is aggregated; discard other servers' progress and
-    results. If the winner's first response is already complete (not partial),
-    do not track other servers at all.
-  - *concatenated*: keep progress alive until *all* contributors finish
-    (no premature `End`); `report` may reflect `n/m` contributors done as a
-    percentage; `End` on the last contributor.
+The lifecycle engages only when there is progress worth showing; otherwise the
+request just returns its result (today's behavior, minus the strip).
+
+- **Single downstream (N = 1).** Relay that server's own `Begin`/`report`/`End`
+  verbatim (token-translated). If it emits none, the editor sees no progress.
+- **preferred, N > 1.** The delivered result is one winner, and preferred
+  short-circuits (it does not wait for the losers), so there is no collection
+  count to report. If the winner emits its own progress, forward its
+  `Begin`/`report`/`End` (real title) and suppress every loser's progress; if the
+  winner returns a complete result with no progress phase, show nothing.
+- **concatenated, N > 1.** The delivered result merges *all* contributors, so the
+  bridge waits for every one and reports collection progress:
+  - if the winner emits its own `Begin`, forward it (real title) and track the
+    winner's `report`s, *interleaving* the other contributors' **result arrivals**
+    as `report`s (`n/m` collected);
+  - if the winner emits no `Begin`, synthesize a bridge-owned `Begin` (neutral,
+    e.g. a request-derived title) on the first result and report `n/m` as the
+    rest arrive;
+  - either way the `End` fires once **every** contributor's result is collected,
+    and non-winner contributors' own `$/progress` is ignored.
+
+  Accumulated `report`s may be coalesced into one notification
+  (`Begin → report → report (2, 3) → End`) to bound notification volume.
 - **Graceful degradation on committed-server failure.** The branch turns on
   *whether the editor has already been shown data*:
   - *preferred, winner already streamed partials*: data is on screen, so promote
@@ -87,15 +83,13 @@ once data is delivered, the lifecycle is committed.
     server's result. The result may be incomplete; accepted as graceful
     degradation.
   - *preferred, winner produced nothing* (died before any partial result): its
-    result is empty, which — exactly as for any empty or absent winner result
-    under the preferred strategy — falls through to the next-priority candidate.
-    Nothing was shown yet, so this is ordinary request latency, not a freeze and
-    not a swap. The opportunistic `Begin` stays open and `report`/`End` re-gate
-    onto the new candidate (no new `Begin`); this recurses down the priority
-    order.
-  - *concatenated*: a failed contributor donates its accumulated partials
-    (possibly empty) and the others concatenate as usual; nothing special is
-    needed.
+    empty result falls through to the next-priority candidate, exactly as any
+    empty result does under preferred. Nothing was shown yet, so this is ordinary
+    latency, not a freeze or swap; the progress re-anchors on the new winner (its
+    own `Begin`, if any), recursing down the priority order.
+  - *concatenated*: a failed contributor contributes whatever it already streamed
+    (possibly nothing); the collection count adjusts and the others proceed, with
+    `End` once the rest are collected.
 - **partialResultToken — translate, then merge.** Partial-result chunks carry
   locations needing the *same* injection offset and URI translation as final
   responses, applied incrementally per chunk through the existing aggregation
@@ -116,10 +110,16 @@ bridge composes the terminal rather than relaying a downstream's.
   paint, but the data-bearing progress and the delivered result can come from
   different servers — the jarring swap this decision avoids. Rejected in favor
   of priority.
-- **Delay `Begin` until the source is known.** Keeps the opening title
-  source-consistent from the first frame, but defeats the point of progress (no
-  early "something is happening" signal). Rejected in favor of an opportunistic
-  first `Begin` with `report`/`End` gated per strategy.
+- **Forward the first contributor's `Begin` opportunistically.** Lights the
+  indicator a few milliseconds sooner, but `Begin` carries a required `title`, so
+  it can surface a non-winner's label that LSP will not let the bridge amend
+  later. Rejected in favor of anchoring `Begin` on the winner (its real `Begin`,
+  or a bridge-owned synthetic when it has none).
+- **Track every contributor's progress and merge it.** Most information, but
+  collapsing N independent `Begin`/`report`/`End` streams (distinct titles,
+  percentages) into one coherent indicator is messy and rarely meaningful.
+  Rejected in favor of tracking only the winner's progress and folding the rest
+  in as result-arrival counts.
 - **Wait for the next-priority candidate after partial data was shown.**
   Avoids delivering incomplete data, but freezes the already-shown
   results until the slower candidate finishes and risks a late swap. Rejected in
@@ -137,6 +137,10 @@ bridge composes the terminal rather than relaying a downstream's.
   *preferred* both track the one winner; under *concatenated* both span the same
   contributor set).
 - partialResult streaming becomes possible without mis-translated locations.
+- Progress engages only when meaningful: a fast or single-server request with no
+  downstream progress shows nothing, so there is no spurious spinner. The `Begin`
+  title always reflects the winner (or a neutral bridge title), never an
+  arbitrary server.
 - Failure degrades gracefully: if data was shown the editor keeps it and the
   lifecycle terminates cleanly; if not, the request falls through to the next
   server like any empty result.
@@ -151,10 +155,10 @@ bridge composes the terminal rather than relaying a downstream's.
 - When a winner fails *after* streaming, the delivered result may be incomplete
   (only the streamed prefix); accepted as graceful degradation over freezing or
   swapping.
-- The opening `Begin`'s `title`/`message` may briefly reflect a non-winner
-  contributor (the winner is unknown when `Begin` must fire, and LSP forbids
-  amending a `title` afterwards). Accepted as transient and cosmetic, or avoided
-  by emitting a bridge-owned neutral `title`.
+- If the winner emits a `Begin` and then loses (returns empty) or dies, its
+  `title` lingers on the already-open progress until `End`, since LSP forbids
+  retitling. Rare (the winner both reported progress and failed) and cosmetic;
+  accepted.
 
 ### Neutral
 
@@ -164,6 +168,8 @@ bridge composes the terminal rather than relaying a downstream's.
 - Under fan-out the bridge composes the upstream terminal `End` and response (it
   aggregates the downstreams), so failure handling changes only that payload, not
   the mechanism.
+- A fast *concatenated* fan-out can briefly flash `Begin`→`End`; editors
+  typically debounce short-lived progress, so it is rarely visible.
 
 ## Decision–Implementation Gap
 
@@ -181,3 +187,5 @@ are stripped before fan-out. Specific points to settle during implementation:
   through to the next candidate, which is acceptable.
 - Percentage composition under *concatenated* (`n/m`) is a display heuristic, not
   a contract.
+- The synthetic `Begin` title used when a *concatenated* winner is silent is a
+  presentation choice (e.g. derived from the request method); not specified here.

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -14,8 +14,9 @@ motivated the `ProgressRegistry` — does not apply here.
 The problem is **fan-out**. The bridge multiplexes one editor request onto
 several downstream servers (e.g. a references request spanning several injected
 languages, fanned out per language-server-bridge-request-strategies). Each
-downstream may emit `$/progress` and partial results against the same
-client-provided token. Forwarding them verbatim duplicates the lifecycle (N
+downstream may emit work-done progress (`$/progress` against the `workDoneToken`)
+and partial results (against the `partialResultToken`). Forwarding the work-done
+stream verbatim duplicates the lifecycle (N
 `Begin`, N `End`) and corrupts the indicator; concatenating result chunks
 verbatim mis-orders data. So, under fan-out,
 **the bridge must own the upstream terminal**: it cannot blindly relay all N
@@ -100,7 +101,10 @@ request just returns its result (today's behavior, minus the strip).
     — see Consequences) and the new winner's `report`/`End` re-anchor under it;
     should the new winner provide no real `End` (it completes with no progress
     phase), the bridge synthesizes one at request completion so the lingering
-    `Begin` is always closed. This recurses down the priority order.
+    `Begin` is always closed. This recurses down the priority order; if every
+    candidate is exhausted and preferred returns no result at all, the same rule
+    applies at request completion — synthesize an `End` if a `Begin` is open,
+    otherwise emit none.
   - *concatenated*: a failed contributor contributes whatever it already streamed
     (possibly nothing) and is **dropped from the expected set** (the `n/m`
     denominator shrinks); the others proceed, and `End` fires once the remaining
@@ -125,9 +129,9 @@ bridge composes the terminal rather than relaying a downstream's.
   client-requested progress never surfaces — the gap this decision closes.
   Rejected.
 - **Latency-based selector (track the first responder).** Lower time-to-first
-  paint, but the data-bearing progress and the delivered result can come from
-  different servers — the jarring swap this decision avoids. Rejected in favor
-  of priority.
+  paint, but the tracked progress (`report`/`End`) and the delivered result can
+  come from different servers — the jarring swap this decision avoids. Rejected
+  in favor of priority.
 - **Forward the first contributor's `Begin` opportunistically.** Lights the
   indicator a few milliseconds sooner, but `Begin` carries a required `title`, so
   it can surface a non-winner's label that LSP will not let the bridge amend
@@ -150,10 +154,10 @@ bridge composes the terminal rather than relaying a downstream's.
 
 - Client-requested progress (`workDoneToken`) reaches the editor for the first
   time.
-- The data-bearing progress signals (`report`/`End`) stay consistent with the
-  delivered result — no jarring swap and no freeze of shown data (under
-  *preferred* both track the one winner; under *concatenated* both span the same
-  contributor set).
+- The progress signals (`report`/`End`) stay consistent with the delivered
+  result's source — no jarring swap and no freeze of shown data (under *preferred*
+  both track the one winner; under *concatenated* both span the same contributor
+  set).
 - partialResult streaming becomes possible without mis-translated locations.
 - Progress engages only when meaningful: a fast or single-server request with no
   downstream progress shows nothing, so there is no spurious spinner. The `Begin`

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -100,8 +100,8 @@ once data is delivered, the lifecycle is committed.
   locations needing the *same* injection offset and URI translation as final
   responses, applied incrementally per chunk through the existing aggregation
   path (which assumes a single final blob today and must accept incremental
-  input). *Preferred* streams the winner's translated chunks; *concatenated*
-  concatenates all contributors' translated chunks.
+  input). Under *preferred* the bridge streams the winner's translated chunks;
+  under *concatenated* it concatenates all contributors' translated chunks.
 
 The terminal `End` the bridge emits on failure is the same primitive
 ls-bridge-progress-disconnect-cleanup uses for server-declared tokens — the
@@ -179,5 +179,5 @@ are stripped before fan-out. Specific points to settle during implementation:
   while `workDoneToken` is bridged — a valid intermediate phase. Without
   partial-result accumulation a failed winner always looks empty and falls
   through to the next candidate, which is acceptable.
-- Percentage composition under `concatenated` (`n/m`) is a display heuristic, not
+- Percentage composition under *concatenated* (`n/m`) is a display heuristic, not
   a contract.

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -63,8 +63,9 @@ request just returns its result (today's behavior, minus the strip).
 - **concatenated, N > 1.** The delivered result merges *all* contributors, so the
   bridge waits for every one and reports collection progress:
   - if the winner emits its own `Begin`, forward it (real title) and track the
-    winner's `report`s, *interleaving* the other contributors' **result arrivals**
-    as `report`s (`n/m` collected);
+    winner's `report`s — but **suppress the winner's own `End`**, since the
+    aggregate is not done until every contributor is collected; *interleave* the
+    other contributors' **result arrivals** as `report`s (`n/m` collected);
   - if the winner emits no `Begin`, synthesize a bridge-owned `Begin` (neutral,
     e.g. a request-derived title) on the first result and report `n/m` as the
     rest arrive;

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -16,13 +16,12 @@ several downstream servers (e.g. a references request spanning several injected
 languages, fanned out per language-server-bridge-request-strategies). Each
 downstream may emit work-done progress (`$/progress` against the `workDoneToken`)
 and partial results (against the `partialResultToken`). Forwarding the work-done
-stream verbatim duplicates the lifecycle (N
-`Begin`, N `End`) and corrupts the indicator; concatenating result chunks
-verbatim mis-orders data. So, under fan-out,
-**the bridge must own the upstream terminal**: it cannot blindly relay all N
-downstreams' `End`s/responses (they collide); it forwards exactly one or composes
-one, as the Decision details. (A request that reaches a single server is just
-relayed.)
+stream verbatim duplicates the lifecycle (N `Begin`, N `End`) and corrupts the
+indicator; concatenating result chunks verbatim mis-orders data. So, under
+fan-out, **the bridge must own the upstream terminal**: it cannot blindly relay
+all N downstreams' `End`s/responses (they collide); it forwards exactly one or
+composes one, as the Decision details. (A request that reaches a single server is
+just relayed.)
 
 Today the bridge does not forward client-provided tokens to downstreams at all.
 The host raw-request path strips them (`strip_progress_tokens`,
@@ -52,7 +51,7 @@ server while the delivered result comes from another. A candidate that returns
 empty — or fails before producing any data — is no **winner** (reserved for the
 source whose result, possibly a promoted partial prefix, is delivered), so the
 anchor falls through to the next candidate. Within the unordered `Rest` (wildcard)
-group no member is the a-priori anchor — which one wins is a latency race, not
+group no member is the a priori anchor — which one wins is a latency race, not
 knowable in advance — so the bridge never forwards a `Rest` member's own `Begin`
 as the title; that group's progress is handled as a silent anchor (a synthetic
 neutral `Begin` under *concatenated*, nothing under *preferred*).
@@ -151,7 +150,7 @@ request just returns its result (today's behavior, minus the strip).
 
 The terminal `End` the bridge emits on failure is the same primitive
 ls-bridge-progress-disconnect-cleanup uses for server-declared tokens — the
-bridge composes the terminal rather than relaying a downstream's.
+bridge composes the terminal rather than relaying a downstream's `End`.
 
 ## Considered Options
 
@@ -218,7 +217,7 @@ bridge composes the terminal rather than relaying a downstream's.
 - Namespacing is unnecessary here (client tokens are already unique), so the
   `ProgressRegistry` of ls-bridge-work-done-progress is not involved; this path
   is distinct from server-declared progress.
-- Under fan-out the bridge owns the upstream terminal — relaying the winner's
+- Under fan-out the bridge owns the upstream terminal — relaying the winner's `End`
   under *preferred*, composing one under *concatenated* and on failure — so
   failure handling changes only that payload, not the mechanism.
 - A fast *concatenated* fan-out can briefly flash `Begin`→`End`; editors
@@ -249,6 +248,6 @@ are stripped before fan-out. Specific points to settle during implementation:
   order-insensitive.
 - Treating `Rest`-group members as never-anchors trades progress visibility for
   title correctness: under *preferred*, if the delivered winner is an unnamed
-  `Rest` member doing long work, its own progress is not shown (no safe a-priori
+  `Rest` member doing long work, its own progress is not shown (no safe a priori
   title). A future refinement could surface it once it is the sole active `Rest`
   member.

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -41,7 +41,8 @@ them so the editor sees **one coherent lifecycle** that stays consistent with th
 result actually delivered.
 
 **Core principle.** The progress narrative is **anchored on the priority anchor**
-— the highest-priority candidate currently tracked — and the data the editor
+— the highest-priority *named* candidate currently tracked (a `Rest`/wildcard
+member is never an anchor) — and the data the editor
 receives stays consistent with the result actually delivered: the `End` coincides
 with the result being complete, and no `report` carries data the editor will not
 receive. The anchor follows the **priority walk** (honoring explicit
@@ -130,10 +131,11 @@ request just returns its result (today's behavior, minus the strip).
   - *concatenated*: a failed contributor contributes whatever it already streamed
     (possibly nothing) and is **dropped from the expected set** (the `n/m`
     denominator shrinks); the others proceed, and `End` fires once the remaining
-    expected results are collected. If the *anchor* (highest-priority contributor)
-    is the one that fails before opening a `Begin`, the anchor role moves to the
-    next-priority survivor — its `Begin` if it has one, else the silent-anchor
-    synthesis above.
+    expected results are collected. If the *anchor* (highest-priority named
+    contributor) is the one that fails before opening a `Begin`, the anchor role
+    moves to the next named-priority survivor — its `Begin` if it has one; if only
+    `Rest`-group members remain, the group stays silent and the synthetic
+    neutral `Begin` applies.
 - **partialResultToken — translate, then merge.** Partial-result chunks carry
   locations needing the *same* injection offset and URI translation as final
   responses, applied incrementally per chunk through the existing aggregation
@@ -242,3 +244,8 @@ are stripped before fan-out. Specific points to settle during implementation:
   ones are in — trading streaming latency for ordering fidelity. An
   implementation may relax this if a method's partial results are
   order-insensitive.
+- Treating `Rest`-group members as never-anchors trades progress visibility for
+  title correctness: under *preferred*, if the delivered winner is an unnamed
+  `Rest` member doing long work, its own progress is not shown (no safe a-priori
+  title). A future refinement could surface it once it is the sole active `Rest`
+  member.

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -68,9 +68,12 @@ request just returns its result (today's behavior, minus the strip).
     winner's `report`s — but **suppress the winner's own `End`**, since the
     aggregate is not done until every contributor is collected; *interleave* the
     other contributors' **result arrivals** as `report`s (`n/m` collected);
-  - if the winner emits no `Begin`, synthesize a bridge-owned `Begin` (neutral,
-    e.g. a request-derived title) on the first result and report `n/m` as the
-    rest arrive;
+  - if the winner emits no `Begin`, the bridge synthesizes one (neutral title,
+    e.g. request-derived) once the winner is **known to be silent** — it returned
+    its result with no `Begin`. Contributors that completed earlier are counted
+    into the first `n/m` report, and the rest advance it as they arrive. (Waiting
+    for the anchor to resolve, rather than firing on the first arbitrary result,
+    keeps a real winner `Begin` from being pre-empted by a non-anchor.)
   - either way the `End` fires once **every** contributor's result is collected,
     and non-winner contributors' own `$/progress` is ignored.
 
@@ -92,8 +95,10 @@ request just returns its result (today's behavior, minus the strip).
     nothing was shown — ordinary latency, not a freeze or swap — and the new
     winner's own `Begin` opens the lifecycle. If it had already opened a `Begin`,
     LSP permits only one per token, so that `Begin` stays open (its title lingers
-    — see Consequences) and only `report`/`End` re-anchor onto the new winner.
-    This recurses down the priority order.
+    — see Consequences) and the new winner's `report`/`End` re-anchor under it;
+    should the new winner provide no real `End` (it completes with no progress
+    phase), the bridge synthesizes one at request completion so the lingering
+    `Begin` is always closed. This recurses down the priority order.
   - *concatenated*: a failed contributor contributes whatever it already streamed
     (possibly nothing) and is **dropped from the expected set** (the `n/m`
     denominator shrinks); the others proceed, and `End` fires once the remaining

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -40,9 +40,10 @@ them so the editor sees **one coherent lifecycle** that stays consistent with th
 result actually delivered.
 
 **Core principle.** Whatever the editor sees stays consistent with the result
-actually delivered: the `End` coincides with the result being complete, and no
-`report` carries data the editor will not receive. How the title-bearing `Begin`
-is produced then depends on the strategy, because the two deliver differently:
+actually delivered: the work-done `End` coincides with the result being complete,
+and no `partialResultToken` chunk is streamed that the delivered result will not
+contain. How the title-bearing `Begin` is produced then depends on the strategy,
+because the two deliver differently:
 
 - *preferred* delivers a single **winner**, and progress is **anchored** on the
   **anchor** — the highest-priority *named* candidate — whose own `Begin` is the

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -17,9 +17,9 @@ languages, fanned out per language-server-bridge-request-strategies). Each
 downstream may emit `$/progress` and partial results against the same
 client-provided token. Forwarding them verbatim duplicates the lifecycle (N
 `Begin`, N `End`) and corrupts the indicator; concatenating result chunks
-verbatim mis-orders data. Because of fan-out the bridge is **always the party
-that composes the upstream terminal `End` and the final response** — it
-aggregates N downstreams and never simply relays one downstream's terminal.
+verbatim mis-orders data. Because of fan-out,
+**the bridge always composes the upstream terminal itself** — it aggregates N
+downstreams and never simply relays one downstream's `End` or final response.
 
 Today the bridge sidesteps all of this by **stripping both tokens** before
 sending a downstream request (`strip_progress_tokens`,
@@ -32,8 +32,8 @@ never reaches the editor.
 
 Stop stripping client-provided tokens (selectively), route the resulting
 downstream→upstream `$/progress` and partial-result notifications, and aggregate
-them so the editor sees **one coherent lifecycle whose source matches the
-delivered result**.
+them so the editor sees **one coherent lifecycle** whose source matches the
+delivered result.
 
 **Core principle.** The progress the editor sees must track the *same server
 whose result is actually delivered*, so progress and data never diverge. A swap
@@ -59,17 +59,20 @@ lifecycle is committed.
 - **Graceful degradation on committed-server failure.** The branch turns on
   *whether the editor has already been shown data*:
   - *preferred, winner already streamed partials*: data is on screen, so promote
-    the accumulated partials into the winner's result and `End` immediately — do
-    not wait for another candidate (that would freeze the shown data) and do not
-    swap in a different server's result. The result may be incomplete; accepted
-    as graceful degradation.
+    the accumulated partials into the winner's result and immediately emit a
+    *synthetic* `End` — the downstream is gone and cannot send a real one, so the
+    bridge composes the terminal itself (the same primitive
+    ls-bridge-progress-disconnect-cleanup uses). Do not wait for another
+    candidate (that would freeze the shown data) and do not swap in a different
+    server's result. The result may be incomplete; accepted as graceful
+    degradation.
   - *preferred, winner produced nothing* (died before any partial result): its
     result is empty, which — exactly as for any empty or absent winner result
     under the preferred strategy — falls through to the next-priority candidate.
     Nothing was shown yet, so this is ordinary request latency, not a freeze and
-    not a swap. The
-    opportunistic `Begin` stays open and `report`/`End` re-gate onto the new
-    candidate (no new `Begin`); this recurses down the priority order.
+    not a swap. The opportunistic `Begin` stays open and `report`/`End` re-gate
+    onto the new candidate (no new `Begin`); this recurses down the priority
+    order.
   - *concatenated*: a failed contributor donates its accumulated partials
     (possibly empty) and the others concatenate as usual; nothing special is
     needed.
@@ -96,8 +99,8 @@ bridge composes the terminal rather than relaying a downstream's.
   from the first frame, but defeats the point of progress (no early "something is
   happening" signal). Rejected in favour of an opportunistic first `Begin` with
   source-gated `report`/`End`.
-- **On failure after partial data was shown, wait for the next-priority
-  candidate.** Avoids delivering incomplete data, but freezes the already-shown
+- **Wait for the next-priority candidate after partial data was shown.**
+  Avoids delivering incomplete data, but freezes the already-shown
   results until the slower candidate finishes and risks a late swap. Rejected in
   favour of promoting the streamed partials. (An empty winner that showed
   *nothing* still falls through normally — that is plain latency, not a freeze.)
@@ -140,10 +143,10 @@ bridge composes the terminal rather than relaying a downstream's.
 Not yet implemented (tracked in issue #414); today both client-provided tokens
 are stripped before fan-out. Specific points to settle during implementation:
 
-- The empty-vs-non-empty threshold that triggers fall-through must **match the
-  existing preferred-strategy empty-result behaviour**, which may be method-specific (e.g.
-  `host.rs` treats an empty `vec![]` as a usable result that must not read as "no
-  result"). Align with the preferred strategy; do not invent a new threshold.
+- The empty-vs-non-empty threshold that triggers fall-through must
+  **match the existing preferred-strategy empty-result behaviour** — a uniform
+  fall-through-on-empty across the priority walk, not a per-method exception.
+  Align with the preferred strategy; do not invent a new threshold.
 - `partialResultToken` support depends on the aggregation layer accepting
   incremental input. Until that lands, `partialResultToken` may stay stripped
   while `workDoneToken` is bridged — a valid intermediate phase. Without

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -40,77 +40,84 @@ downstream→upstream `$/progress` and partial-result notifications, and aggrega
 them so the editor sees **one coherent lifecycle** that stays consistent with the
 result actually delivered.
 
-**Core principle.** The progress narrative is
-**anchored on the priority winner** (the highest-priority contributor), and the
-data the editor receives
-stays consistent with the result actually delivered: the `End` coincides with the
-result being complete, and no `report` carries data the editor will not receive.
-**Only the winner's own progress is ever tracked**; other contributors influence
+**Core principle.** The progress narrative is **anchored on the priority anchor**
+— the highest-priority candidate currently tracked — and the data the editor
+receives stays consistent with the result actually delivered: the `End` coincides
+with the result being complete, and no `report` carries data the editor will not
+receive. The anchor follows the **priority walk** (honoring explicit
+`priorities`, with the wildcard `Rest` resolved first-win by earliest non-empty
+arrival), not a pure latency race that could put the title and progress on one
+server while the delivered result comes from another. A candidate that returns
+empty or fails is no **winner** (the term is reserved for the server whose
+non-empty result is delivered), so the anchor falls through to the next
+candidate.
+
+**Only the anchor's own progress is ever tracked**; other contributors influence
 the lifecycle solely by *completing* (their result arriving), never through their
-own `$/progress`. So the `Begin` title comes from the current priority anchor —
-normally the delivered winner, or (under *concatenated*) a bridge-owned synthetic
-when the anchor is silent — never an arbitrary non-anchor. (One documented edge:
-after a fall-through, an earlier anchor's title can linger; see Consequences.)
-The winner is chosen by **priority, not latency**: a latency anchor could put the
-title and progress on one server while the delivered result comes from another.
+own `$/progress`. So the `Begin` title comes from the current anchor — normally
+the delivered winner, or (under *concatenated*) a bridge-owned synthetic when the
+anchor is silent — never an arbitrary non-anchor. (One documented edge: after a
+fall-through, an earlier anchor's title can linger; see Consequences.)
 
 The lifecycle engages only when there is progress worth showing; otherwise the
 request just returns its result (today's behavior, minus the strip).
 
 - **Single downstream (N = 1).** Relay that server's own `Begin`/`report`/`End`
-  verbatim (token-translated). If it emits none, the editor sees no progress.
-- **preferred, N > 1.** The delivered result is one winner, and preferred
+  against the client's original token (client tokens are already unique, so no
+  remapping). If it emits none, the editor sees no progress.
+- **preferred, N > 1.** The delivered result is a single winner, and preferred
   short-circuits (it does not wait for the losers), so there is no collection
-  count to report. If the winner emits its own progress, forward its
-  `Begin`/`report`/`End` (real title) and suppress every loser's progress; if the
-  winner returns a complete result with no progress phase, show nothing.
+  count to report. If the anchor emits its own progress, forward its
+  `Begin`/`report`/`End` (real title) and suppress every other candidate's
+  progress; if the anchor returns a complete result with no progress phase, show
+  nothing.
 - **concatenated, N > 1.** The delivered result merges *all* contributors, so the
   bridge waits for every one and reports collection progress:
-  - if the winner emits its own `Begin`, forward it (real title) and track the
-    winner's `report`s — but **suppress the winner's own `End`**, since the
+  - if the anchor emits its own `Begin`, forward it (real title) and track the
+    anchor's `report`s — but **suppress the anchor's own `End`**, since the
     aggregate is not done until every contributor is collected; *interleave* the
     other contributors' **result arrivals** as `report`s (`n/m` collected);
-  - if the winner emits no `Begin`, the bridge synthesizes one (neutral title,
-    e.g. request-derived) once the winner is **known to be silent** — it returned
+  - if the anchor emits no `Begin`, the bridge synthesizes one (neutral title,
+    e.g. request-derived) once the anchor is **known to be silent** — it returned
     its result with no `Begin`. Contributors that completed earlier are counted
     into the first `n/m` report, and the rest advance it as they arrive. (Waiting
     for the anchor to resolve, rather than firing on the first arbitrary result,
-    keeps a real winner `Begin` from being pre-empted by a non-anchor.)
+    keeps a real anchor `Begin` from being pre-empted by a non-anchor.)
   - either way the `End` fires once **every** contributor's result is collected,
-    and non-winner contributors' own `$/progress` is ignored.
+    and non-anchor contributors' own `$/progress` is ignored.
 
   Accumulated `report`s may be coalesced into one notification
   (`Begin → report → report (2, 3) → End`) to bound notification volume.
 - **Begin/End pairing invariant.** An open work-done `Begin` is closed by exactly
-  one `End`, fired when the *request* terminates — normal completion, winner
+  one `End`, fired when the *request* terminates — normal completion, anchor
   failure, fall-through exhaustion, or client cancellation (the fan-in returns
   `Cancelled`). When the lifecycle tracks a single source to completion (N = 1, or
   *preferred*), that `End` is the source's real one; under *concatenated* the
-  bridge emits a single aggregate-timed `End` and suppresses the winner's own
+  bridge emits a single aggregate-timed `End` and suppresses the anchor's own
   (which fires before collection finishes). If the source cannot send one — it
   died, or the request was cancelled (the fan-in aborts the downstreams) — the
   bridge synthesizes it. A request that opened no `Begin` emits no `End`. (The
   per-branch rules below are instances of this invariant.)
 - **Graceful degradation on committed-server failure.** The branch turns on
   *whether the editor has already been shown data*:
-  - *preferred, winner already streamed partials*: data is on screen, so promote
-    the accumulated partials into the winner's result and complete the request.
+  - *preferred, anchor already streamed partials*: data is on screen, so promote
+    the accumulated partials into the delivered result and complete the request.
     `partialResultToken` (data) and `workDoneToken` (progress) are separate
     tokens, so close the *progress* only if a work-done `Begin` is actually
     open — then emit a *synthetic* `End` (the downstream is gone and cannot send a
-    real one, the same primitive ls-bridge-progress-disconnect-cleanup uses); a
-    winner that streamed only partial-result data without opening work-done
+    real one, the same primitive ls-bridge-progress-disconnect-cleanup uses); an
+    anchor that streamed only partial-result data without opening work-done
     progress needs no `End`. Do not wait for another candidate (that would freeze
     the shown data) and do not swap in a different server's result. The result may
     be incomplete; accepted as graceful degradation.
-  - *preferred, winner produced nothing* (died before any partial result): its
-    empty result falls through to the next-priority candidate, exactly as any
-    empty result does under preferred. If the dead winner had opened no `Begin`,
+  - *preferred, anchor produced nothing* (empty or failed before any partial
+    result): it falls through to the next-priority candidate, exactly as any empty
+    result does under preferred. If the spent anchor had opened no `Begin`,
     nothing was shown — ordinary latency, not a freeze or swap — and the new
-    winner's own `Begin` opens the lifecycle. If it had already opened a `Begin`,
+    anchor's own `Begin` opens the lifecycle. If it had already opened a `Begin`,
     LSP permits only one per token, so that `Begin` stays open (its title lingers
-    — see Consequences) and the new winner's `report`/`End` re-anchor under it;
-    should the new winner provide no real `End` (it completes with no progress
+    — see Consequences) and the new anchor's `report`/`End` re-anchor under it;
+    should the new anchor provide no real `End` (it completes with no progress
     phase), the bridge synthesizes one at request completion so the lingering
     `Begin` is always closed. This recurses down the priority order; if every
     candidate is exhausted and preferred returns no result at all, the same rule
@@ -148,18 +155,18 @@ bridge composes the terminal rather than relaying a downstream's.
   in favor of priority.
 - **Forward the first contributor's `Begin` opportunistically.** Lights the
   indicator a few milliseconds sooner, but `Begin` carries a required `title`, so
-  it can surface a non-winner's label that LSP will not let the bridge amend
-  later. Rejected in favor of anchoring `Begin` on the winner (its real `Begin`,
+  it can surface a non-anchor's label that LSP will not let the bridge amend
+  later. Rejected in favor of anchoring `Begin` on the anchor (its real `Begin`,
   or a bridge-owned synthetic when it has none).
 - **Track every contributor's progress and merge it.** Most information, but
   collapsing N independent `Begin`/`report`/`End` streams (distinct titles,
   percentages) into one coherent indicator is messy and rarely meaningful.
-  Rejected in favor of tracking only the winner's progress and folding the rest
+  Rejected in favor of tracking only the anchor's progress and folding the rest
   in as result-arrival counts.
 - **Wait for the next-priority candidate after partial data was shown.**
   Avoids delivering incomplete data, but freezes the already-shown
   results until the slower candidate finishes and risks a late swap. Rejected in
-  favor of promoting the streamed partials. (An empty winner that showed
+  favor of promoting the streamed partials. (An empty anchor that showed
   *nothing* still falls through normally — that is plain latency, not a freeze.)
 
 ## Consequences
@@ -189,12 +196,12 @@ bridge composes the terminal rather than relaying a downstream's.
   merge policy.
 - The aggregation path must move from a single final blob to incremental input to
   support partialResult merging.
-- When a winner fails *after* streaming, the delivered result may be incomplete
+- When the anchor fails *after* streaming, the delivered result may be incomplete
   (only the streamed prefix); accepted as graceful degradation over freezing or
   swapping.
-- If the winner emits a `Begin` and then loses (returns empty) or dies, its
+- If the anchor emits a `Begin` and then loses (returns empty) or dies, its
   `title` lingers on the already-open progress until `End`, since LSP forbids
-  retitling. Rare (the winner both reported progress and failed) and cosmetic;
+  retitling. Rare (the anchor both reported progress and failed) and cosmetic;
   accepted.
 
 ### Neutral
@@ -220,11 +227,11 @@ are stripped before fan-out. Specific points to settle during implementation:
 - `partialResultToken` support depends on the aggregation layer accepting
   incremental input. Until that lands, `partialResultToken` may stay stripped
   while `workDoneToken` is bridged — a valid intermediate phase. Without
-  partial-result accumulation a failed winner always looks empty and falls
+  partial-result accumulation a failed anchor always looks empty and falls
   through to the next candidate, which is acceptable.
 - Percentage composition under *concatenated* (`n/m`) is a display heuristic, not
   a contract.
-- The synthetic `Begin` title used when a *concatenated* winner is silent is a
+- The synthetic `Begin` title used when a *concatenated* anchor is silent is a
   presentation choice (e.g. derived from the request method); not specified here.
 - Ordering `partialResultToken` chunks to match the *concatenated* priority order
   means holding a lower-priority contributor's chunks until the higher-priority

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -38,8 +38,9 @@ downstream→upstream `$/progress` and partial-result notifications, and aggrega
 them so the editor sees **one coherent lifecycle** that stays consistent with the
 result actually delivered.
 
-**Core principle.** The progress narrative is **anchored on the priority
-winner** — the highest-priority contributor — and the data the editor receives
+**Core principle.** The progress narrative is
+**anchored on the priority winner** (the highest-priority contributor), and the
+data the editor receives
 stays consistent with the result actually delivered: the `End` coincides with the
 result being complete, and no `report` carries data the editor will not receive.
 **Only the winner's own progress is ever tracked**; other contributors influence

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -112,7 +112,7 @@ request just returns its result (today's behavior, minus the strip).
     `partialResultToken` data and `workDoneToken` progress are separate tokens, so
     any open work-done `Begin` is closed by a synthetic `End`; a winner that
     streamed only partial-result data opened none and needs no `End`.)
-  - *preferred, winner produced nothing* (empty or failed before any partial
+  - *preferred, candidate produced nothing* (empty or failed before any partial
     result): it falls through to the next-priority candidate — down to a `Rest`
     winner, or to no result at all — exactly as any empty result does under
     preferred. Nothing was committed, so this is ordinary latency, not a freeze or

--- a/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
+++ b/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
@@ -63,7 +63,8 @@ ls-bridge-client-progress relies on for client-provided tokens.
   in flight. Rejected in favor of ending on every reader exit.
 - **Synthesize a `window/workDoneProgress/cancel` instead.** Cancel is an
   editor→server signal; the terminal the editor expects for a progress it created
-  is an `End` report, not a cancel it would route back to a now-dead connection.
+  is an `end`-kind `$/progress` notification, not a cancel it would route back to
+  a now-dead connection.
   Rejected.
 
 ## Consequences

--- a/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
+++ b/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
@@ -1,6 +1,6 @@
 # LS Bridge Progress Disconnect Cleanup
 
-**Related Decisions**: [ls-bridge-work-done-progress](ls-bridge-work-done-progress.md), [ls-bridge-server-pool-coordination](ls-bridge-server-pool-coordination.md), [ls-bridge-graceful-shutdown](ls-bridge-graceful-shutdown.md)
+**Related Decisions**: [ls-bridge-work-done-progress](ls-bridge-work-done-progress.md), [ls-bridge-client-progress](ls-bridge-client-progress.md), [ls-bridge-server-pool-coordination](ls-bridge-server-pool-coordination.md), [ls-bridge-graceful-shutdown](ls-bridge-graceful-shutdown.md)
 
 ## Context
 
@@ -19,8 +19,8 @@ connection's mappings and the forwarding loop drops their admissions (the
 editor.
 
 The consequence is a **dangling progress indicator**: the editor created the
-progress on `Begin`, never receives an `End`, and leaves the spinner up
-indefinitely. Some editors offer no way to dismiss a progress they believe is
+progress token on `window/workDoneProgress/create`, the downstream started it
+with `Begin`, but no `End` ever arrives, so the spinner stays up indefinitely. Some editors offer no way to dismiss a progress they believe is
 still running. Work-done progress is a strict begin/end lifecycle, and the
 bridge currently breaks it on the disconnect path.
 
@@ -31,17 +31,19 @@ When a connection's reader task exits, the bridge
 token that connection owned and forwards it to the editor, in addition to the
 existing mapping purge and admission cleanup.
 
-- The set of tokens is exactly the live upstream tokens the registry already
-  returns when purging the connection — the same list that drives the
-  `ForgetWorkDoneProgress` admission cleanup. The synthetic `End` is emitted for
-  each before (or as) that admission is forgotten, so the editor sees one clean
-  terminal per token.
-- The synthetic `End` passes through the same `created_tokens` admission gate the
-  forwarding loop already applies to real progress: a token is ended only if the
-  editor *accepted* its `window/workDoneProgress/create` (the create was
-  admitted, not merely forwarded). A create the editor rejected or that timed out
-  is not admitted, so it never receives a spurious terminal — and the editor
-  never sees an `End` for a progress it was never asked to create.
+- The bridge ends only tokens that are **begun but not yet ended** — those whose
+  `Begin` was already forwarded to the editor with no matching `End`. A token
+  whose `window/workDoneProgress/create` the editor accepted but whose `Begin`
+  was never forwarded (the downstream died between create and begin) has no
+  visible progress to terminate, so it gets no synthetic `End` — its mapping is
+  simply purged. This keeps every emitted `End` paired with a real `Begin`, and a
+  create the editor rejected likewise never receives a terminal.
+- Tracking the begun-not-ended set is cheap: the forwarding loop already relays
+  each token's `Begin` and `End`, so it marks a token in-progress when it forwards
+  the `Begin` and clears it on the `End`. On connection teardown the bridge
+  synthesizes an `End` for each of that connection's tokens still in this set,
+  alongside the existing registry purge / `ForgetWorkDoneProgress` admission
+  cleanup.
 - The synthetic `End` carries no message; the editor needs only the terminal to
   clear the indicator.
 
@@ -93,9 +95,9 @@ ls-bridge-client-progress relies on for client-provided tokens.
 - Scope is **server-declared** tokens (the ls-bridge-work-done-progress path).
   Client-provided tokens have their own terminal handling under
   ls-bridge-client-progress.
-- Shares the synthetic-terminal-`End` primitive with ls-bridge-client-progress;
-  both rely on the bridge composing the upstream terminal rather than relaying a
-  single downstream's.
+- Shares the synthetic-terminal-`End` primitive with ls-bridge-client-progress:
+  when the source cannot send its own terminal (here a disconnected downstream;
+  there a failed winner), the bridge composes one.
 
 ## Decision–Implementation Gap
 

--- a/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
+++ b/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
@@ -4,7 +4,7 @@
 
 ## Context
 
-Under ls-bridge-work-done-progress the bridge forwards a downstream's
+Under ls-bridge-work-done-progress, the bridge forwards a downstream's
 server-declared progress to the editor: a downstream requests a token with
 `window/workDoneProgress/create`, the bridge mints a unique upstream token,
 forwards the create, and then relays each `$/progress` (begin → report → end)

--- a/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
+++ b/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
@@ -75,8 +75,9 @@ ls-bridge-client-progress relies on for client-provided tokens.
 
 - Every forwarded `Begin` reaches a matching `End`; no dangling progress
   indicators when a downstream disconnects mid-work.
-- Cleanup is driven by the live-token list the purge already produces, so it adds
-  no new tracking state.
+- Cleanup hangs off the existing connection-teardown hook; the only added state
+  is a per-token begun-not-ended flag the forwarding loop maintains as it already
+  relays each `Begin`/`End`.
 
 ### Negative
 

--- a/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
+++ b/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
@@ -20,9 +20,10 @@ editor.
 
 The consequence is a **dangling progress indicator**: the editor created the
 progress token on `window/workDoneProgress/create`, the downstream started it
-with `Begin`, but no `End` ever arrives, so the spinner stays up indefinitely. Some editors offer no way to dismiss a progress they believe is
-still running. Work-done progress is a strict begin/end lifecycle, and the
-bridge currently breaks it on the disconnect path.
+with `Begin`, but no `End` ever arrives, so the spinner stays up indefinitely.
+Some editors offer no way to dismiss a progress indicator they believe is still
+running. Work-done progress is a strict begin/end lifecycle, and the bridge
+currently breaks it on the disconnect path.
 
 ## Decision
 
@@ -36,8 +37,9 @@ existing mapping purge and admission cleanup.
   whose `window/workDoneProgress/create` the editor accepted but whose `Begin`
   was never forwarded (the downstream died between create and begin) has no
   visible progress to terminate, so it gets no synthetic `End` — its mapping is
-  simply purged. This keeps every emitted `End` paired with a real `Begin`, and a
-  create the editor rejected likewise never receives a terminal.
+  simply purged. This keeps every emitted `End` paired with a real `Begin`; a
+  `window/workDoneProgress/create` request the editor rejected likewise never
+  receives a terminal.
 - Tracking the begun-not-ended set is cheap: the forwarding loop already relays
   each token's `Begin` and `End`, so it marks a token in-progress when it forwards
   the `Begin` and clears it on the `End`. On connection teardown the bridge

--- a/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
+++ b/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
@@ -98,7 +98,7 @@ ls-bridge-client-progress relies on for client-provided tokens.
   ls-bridge-client-progress.
 - Shares the synthetic-terminal-`End` primitive with ls-bridge-client-progress:
   when the source cannot send its own terminal (here a disconnected downstream;
-  there a failed winner), the bridge composes one.
+  there a failed anchor), the bridge composes one.
 
 ## Decision–Implementation Gap
 

--- a/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
+++ b/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
@@ -1,0 +1,99 @@
+# LS Bridge Progress Disconnect Cleanup
+
+**Related Decisions**: [ls-bridge-work-done-progress](ls-bridge-work-done-progress.md), [ls-bridge-server-pool-coordination](ls-bridge-server-pool-coordination.md), [ls-bridge-graceful-shutdown](ls-bridge-graceful-shutdown.md)
+
+## Context
+
+Under ls-bridge-work-done-progress the bridge forwards a downstream's
+server-declared progress to the editor: a downstream requests a token with
+`window/workDoneProgress/create`, the bridge mints a unique upstream token,
+forwards the create, and then relays each `$/progress` (begin → report → end)
+against that token until a terminating `End` clears the mapping.
+
+A downstream can exit *between* `Begin` and `End` — it crashes, is shut down, or
+is respawned while work is in flight. Today the bridge handles that only
+*internally*: when the connection's reader task exits, the registry purges the
+connection's mappings and the forwarding loop drops their admissions (the
+`ForgetWorkDoneProgress` notification removes them from `created_tokens` in
+`src/lsp/lsp_impl/lifecycle.rs`). It never forwards a terminating `End` to the
+editor.
+
+The consequence is a **dangling progress indicator**: the editor created the
+progress on `Begin`, never receives an `End`, and leaves the spinner up
+indefinitely. Some editors offer no way to dismiss a progress they believe is
+still running. Work-done progress is a strict begin/end lifecycle, and the
+bridge currently breaks it on the disconnect path.
+
+## Decision
+
+When a connection's reader task exits, the bridge **synthesizes a terminating
+`$/progress` `End` for every still-open upstream token that connection owned**
+and forwards it to the editor, in addition to the existing mapping purge and
+admission cleanup.
+
+- The set of tokens is exactly the live upstream tokens the registry already
+  returns when purging the connection — the same list that drives the
+  `ForgetWorkDoneProgress` admission cleanup. The synthetic `End` is emitted for
+  each before (or as) that admission is forgotten, so the editor sees one clean
+  terminal per token.
+- Only tokens the bridge actually minted and forwarded a create for are ended,
+  so the editor never receives an `End` for a progress it was never asked to
+  create. The existing capability gate (the bridge only forwards a create when
+  the editor advertised `window.workDoneProgress`) already guarantees this.
+- The synthetic `End` carries no message; the editor needs only the terminal to
+  clear the indicator.
+
+This makes every `Begin` the bridge forwards reach a matching `End` even when the
+originating downstream dies mid-work. The bridge composes this terminal itself —
+the same "bridge owns the upstream terminal" primitive that
+ls-bridge-client-progress relies on for client-provided tokens.
+
+## Considered Options
+
+- **Do nothing (status quo).** Simplest, but leaves a dangling spinner whenever a
+  downstream dies mid-progress — the defect this decision exists to fix.
+  Rejected.
+- **Rely on editor-side timeouts.** Work-done progress has no timeout in the LSP
+  spec; many editors keep an un-ended progress visible forever. Not a reliable
+  cleanup. Rejected.
+- **Send the synthetic `End` only on graceful shutdown.** Misses crash and
+  respawn — precisely the cases where a downstream is most likely to abandon work
+  in flight. Rejected in favour of ending on every reader exit.
+- **Synthesize a `window/workDoneProgress/cancel` instead.** Cancel is an
+  editor→server signal; the terminal the editor expects for a progress it created
+  is an `End` report, not a cancel it would route back to a now-dead connection.
+  Rejected.
+
+## Consequences
+
+### Positive
+
+- Every forwarded `Begin` reaches a matching `End`; no dangling progress
+  indicators when a downstream disconnects mid-work.
+- Cleanup is driven by the live-token list the purge already produces, so it adds
+  no new tracking state.
+
+### Negative
+
+- The editor may see an `End` for work that did not truly complete (it ended
+  because the server died). Accepted: a clean terminal is strictly better than a
+  stuck spinner, and the editor has no way to distinguish "finished" from
+  "abandoned" regardless.
+- Couples the connection-purge path to the upstream forwarding loop slightly more
+  tightly: the purge must now feed synthetic `End`s, not just forget admissions.
+
+### Neutral
+
+- Scope is **server-declared** tokens (the ls-bridge-work-done-progress path).
+  Client-provided tokens have their own terminal handling under
+  ls-bridge-client-progress.
+- Shares the synthetic-terminal-`End` primitive with ls-bridge-client-progress;
+  both rely on the bridge composing the upstream terminal rather than relaying a
+  single downstream's.
+
+## Decision–Implementation Gap
+
+Not yet implemented (tracked in issue #413). Today the reader-exit path purges
+the registry mappings and forgets the loop admissions but forwards no terminating
+`End`, so an editor still sees a dangling indicator when a downstream dies
+mid-progress. This record captures the agreed fix ahead of the change.

--- a/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
+++ b/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
@@ -26,10 +26,10 @@ bridge currently breaks it on the disconnect path.
 
 ## Decision
 
-When a connection's reader task exits, the bridge **synthesizes a terminating
-`$/progress` `End` for every still-open upstream token that connection owned**
-and forwards it to the editor, in addition to the existing mapping purge and
-admission cleanup.
+When a connection's reader task exits, the bridge
+**synthesizes a terminating `$/progress` `End`** for every still-open upstream
+token that connection owned and forwards it to the editor, in addition to the
+existing mapping purge and admission cleanup.
 
 - The set of tokens is exactly the live upstream tokens the registry already
   returns when purging the connection — the same list that drives the
@@ -79,8 +79,11 @@ ls-bridge-client-progress relies on for client-provided tokens.
   because the server died). Accepted: a clean terminal is strictly better than a
   stuck spinner, and the editor has no way to distinguish "finished" from
   "abandoned" regardless.
-- Couples the connection-purge path to the upstream forwarding loop slightly more
-  tightly: the purge must now feed synthetic `End`s, not just forget admissions.
+- Adds an upstream synthesis step to the forwarding loop: when it processes the
+  forgotten tokens it must now emit synthetic `End`s, not just drop admissions.
+  The reader's purge path stays decoupled — it already hands the live-token list
+  to the loop (via `ForgetWorkDoneProgress`), so no new cross-task coupling is
+  introduced; only the loop's existing handler grows.
 
 ### Neutral
 

--- a/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
+++ b/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
@@ -36,10 +36,12 @@ existing mapping purge and admission cleanup.
   `ForgetWorkDoneProgress` admission cleanup. The synthetic `End` is emitted for
   each before (or as) that admission is forgotten, so the editor sees one clean
   terminal per token.
-- Only tokens the bridge actually minted and forwarded a create for are ended,
-  so the editor never receives an `End` for a progress it was never asked to
-  create. The existing capability gate (the bridge only forwards a create when
-  the editor advertised `window.workDoneProgress`) already guarantees this.
+- The synthetic `End` passes through the same `created_tokens` admission gate the
+  forwarding loop already applies to real progress: a token is ended only if the
+  editor *accepted* its `window/workDoneProgress/create` (the create was
+  admitted, not merely forwarded). A create the editor rejected or that timed out
+  is not admitted, so it never receives a spurious terminal — and the editor
+  never sees an `End` for a progress it was never asked to create.
 - The synthetic `End` carries no message; the editor needs only the terminal to
   clear the indicator.
 

--- a/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
+++ b/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
@@ -60,7 +60,7 @@ ls-bridge-client-progress relies on for client-provided tokens.
   cleanup. Rejected.
 - **Send the synthetic `End` only on graceful shutdown.** Misses crash and
   respawn — precisely the cases where a downstream is most likely to abandon work
-  in flight. Rejected in favour of ending on every reader exit.
+  in flight. Rejected in favor of ending on every reader exit.
 - **Synthesize a `window/workDoneProgress/cancel` instead.** Cancel is an
   editor→server signal; the terminal the editor expects for a progress it created
   is an `End` report, not a cancel it would route back to a now-dead connection.

--- a/docs/architecture-decisions/ls-bridge-work-done-progress.md
+++ b/docs/architecture-decisions/ls-bridge-work-done-progress.md
@@ -90,4 +90,8 @@ client-initiated request) is not remapped — those tokens are already unique
 because the client mints them — and such `$/progress` is currently **dropped**,
 not passed through, to avoid duplicates under request fan-out (one client
 request → multiple downstreams). Passing them through (deduplicated across
-fan-out) is possible future work.
+fan-out) is decided separately in ls-bridge-client-progress.
+
+Terminating a still-open server-declared progress when its downstream
+disconnects mid-work (so the editor's indicator does not dangle) is decided in
+ls-bridge-progress-disconnect-cleanup.


### PR DESCRIPTION
## Summary

Records two architecture decisions ahead of implementation, for the follow-ups split from #379 (bridged work-done progress):

- **`ls-bridge-progress-disconnect-cleanup`** (#413): when a downstream disconnects mid-progress, the bridge synthesizes a terminating `$/progress` `End` for each **server-declared** token that is *begun but not yet ended*, so the editor's indicator never dangles. (A token created but never begun gets no `End`.)
- **`ls-bridge-client-progress`** (#414): pass through **client-provided** `workDoneToken`/`partialResultToken` under request fan-out (today both are stripped). The progress lifecycle is **anchored on the priority winner**:
  - The `Begin` title comes from the highest-priority *named* anchor (its real `Begin`), or a bridge-owned synthetic title — never an arbitrary non-anchor. Only the anchor's own progress is tracked; other contributors influence the lifecycle only by completing.
  - Lifecycle by fan-out shape: **N=1** relays the single server's progress (client token unchanged); **preferred N>1** forwards the anchor's own `Begin`/`report`/`End` and short-circuits (no `n/m`); **concatenated N>1** forwards the anchor's `Begin` (or synthesizes one when the anchor is silent), folds other servers' *result arrivals* into `n/m` reports, and fires one aggregate-timed `End` once all results are collected.
  - A general **Begin/End pairing invariant** closes any open `Begin` exactly once on completion, failure, fall-through exhaustion, or cancellation — with the real `End`, or a synthetic one when the source can't send it.
  - `partialResultToken` chunks are translated (injection offsets/URIs) and, under concatenated, released in the priority order of the final result.

Also updates `ls-bridge-work-done-progress`'s Decision–Implementation Gap to point at both new records.

## Notes
- Docs-only; no source changes. Both records are forward-looking decisions and say so (tracked in #413 / #414).
- Follows the repo ADR convention (`docs/architecture-decisions/template.md`): no Status/metadata block; body-prose ADR cross-references use bare slugs, with markdown links reserved for the `Related Decisions` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)