### PR TITLE
feat(bridge): forward willSave/willSaveWaitUntil to host bridge (#357)

### DIFF
--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -53,6 +53,18 @@ Partially implemented:
   matches the virt path's full-content `didChange` forwarding and avoids
   hooking the concurrent upstream `didChange` stream; verbatim forwarding
   remains the target if eager sync proves necessary.
+- **Save methods are host-bridge-only** (#357): `willSave` (notification) and
+  `willSaveWaitUntil` (request) concern the document being saved — the *host*
+  document — so they bypass the layer walk and forward only to host servers,
+  never to virt bridges. `willSave` is fan-out to host servers that already
+  have the document open and advertise it (no lazy spawn for a fire-and-forget
+  notification); `willSaveWaitUntil` forwards verbatim and returns the host
+  servers' `TextEdit[]` via the `preferred` host aggregation, bounded by a 5s
+  budget so a slow server cannot hang the editor's save. Both capabilities are
+  advertised at initialize only when some language enables host bridging.
+  Virt fan-out (one save per open virtual doc) is deliberately deferred: it
+  overlaps with format-on-save semantics the concatenated formatting pipeline
+  owns, and is left for a follow-up should a concrete need appear.
 - **Not implemented**: `publishDiagnostics` pass-through from host servers
   (downstream notifications are not forwarded upstream today on either
   path).

--- a/src/config.rs
+++ b/src/config.rs
@@ -295,6 +295,22 @@ impl WorkspaceSettings {
             .get(host_language)
             .or_else(|| self.languages.get(WILDCARD_KEY))
     }
+
+    /// True if any configured language opts into host bridging
+    /// (`bridge._self.enabled = true`), including the `"_"` wildcard entry —
+    /// an unconfigured document falls back to it wholesale via
+    /// [`Self::resolve_host_language_settings`], so a wildcard opt-in really
+    /// does enable host forwarding for those documents.
+    ///
+    /// Gates the willSave/willSaveWaitUntil capabilities at initialize (#357):
+    /// those methods forward only to host-bridge servers, so advertising them
+    /// when no language enables host bridging would make every save block on a
+    /// no-op round trip that can only ever return "no edits".
+    pub(crate) fn any_host_bridging_enabled(&self) -> bool {
+        self.languages
+            .values()
+            .any(LanguageSettings::is_host_bridging_enabled)
+    }
 }
 
 impl From<&WorkspaceSettings> for RawWorkspaceSettings {
@@ -337,6 +353,51 @@ impl From<WorkspaceSettings> for RawWorkspaceSettings {
 mod tests {
     use super::*;
     use rstest::rstest;
+
+    /// Build a [`WorkspaceSettings`] whose `languages` map binds `key` to a
+    /// language whose host bridging is `enabled`.
+    fn settings_with_host_bridge(key: &str, enabled: bool) -> WorkspaceSettings {
+        use crate::config::settings::{BridgeLanguageConfig, HOST_BRIDGE_KEY};
+        let lang = LanguageSettings {
+            bridge: Some(HashMap::from([(
+                HOST_BRIDGE_KEY.to_string(),
+                BridgeLanguageConfig {
+                    enabled: Some(enabled),
+                    aggregation: None,
+                },
+            )])),
+            ..Default::default()
+        };
+        WorkspaceSettings {
+            languages: HashMap::from([(key.to_string(), lang)]),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn any_host_bridging_enabled_is_false_for_default_settings() {
+        assert!(!WorkspaceSettings::default().any_host_bridging_enabled());
+    }
+
+    #[test]
+    fn any_host_bridging_enabled_true_for_explicit_language() {
+        let settings = settings_with_host_bridge("markdown", true);
+        assert!(settings.any_host_bridging_enabled());
+    }
+
+    #[test]
+    fn any_host_bridging_enabled_false_when_explicitly_disabled() {
+        let settings = settings_with_host_bridge("markdown", false);
+        assert!(!settings.any_host_bridging_enabled());
+    }
+
+    #[test]
+    fn any_host_bridging_enabled_true_for_wildcard_language() {
+        // An unconfigured document falls back wholesale to the `"_"` entry via
+        // `resolve_host_language_settings`, so a wildcard opt-in must count.
+        let settings = settings_with_host_bridge(WILDCARD_KEY, true);
+        assert!(settings.any_host_bridging_enabled());
+    }
 
     #[test]
     fn test_capture_mapping_handles_at_prefix() {

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -15,7 +15,7 @@ use tower_lsp_server::ls_types::{
     ColorProviderCapability, DeclarationCapability, FoldingRangeProviderCapability,
     HoverProviderCapability, ImplementationProviderCapability,
     LinkedEditingRangeServerCapabilities, OneOf, RenameOptions, ServerCapabilities,
-    TypeDefinitionProviderCapability,
+    TextDocumentSyncCapability, TextDocumentSyncOptions, TypeDefinitionProviderCapability,
 };
 
 use super::connection_action::BridgeError;
@@ -570,6 +570,28 @@ impl ConnectionHandle {
                 )
             }
             "textDocument/onTypeFormatting" => caps.document_on_type_formatting_provider.is_some(),
+            // willSave/willSaveWaitUntil live in `textDocumentSync`, and only its
+            // `Options` form carries the flags — the bare `Kind` number form
+            // advertises neither, so it correctly falls through to false. These
+            // gate host-bridge save forwarding (#357).
+            "textDocument/willSave" => matches!(
+                caps.text_document_sync,
+                Some(TextDocumentSyncCapability::Options(
+                    TextDocumentSyncOptions {
+                        will_save: Some(true),
+                        ..
+                    }
+                ))
+            ),
+            "textDocument/willSaveWaitUntil" => matches!(
+                caps.text_document_sync,
+                Some(TextDocumentSyncCapability::Options(
+                    TextDocumentSyncOptions {
+                        will_save_wait_until: Some(true),
+                        ..
+                    }
+                ))
+            ),
             "textDocument/documentSymbol" => {
                 matches!(
                     caps.document_symbol_provider,
@@ -1750,7 +1772,8 @@ mod tests {
             DeclarationCapability, DeclarationOptions, DeclarationRegistrationOptions,
             DocumentLinkOptions, HoverProviderCapability, ImplementationProviderCapability, OneOf,
             SignatureHelpOptions, StaticTextDocumentColorProviderOptions,
-            TextDocumentRegistrationOptions, TypeDefinitionProviderCapability,
+            TextDocumentRegistrationOptions, TextDocumentSyncCapability, TextDocumentSyncOptions,
+            TypeDefinitionProviderCapability,
         };
 
         type CapCase = (&'static str, Box<dyn Fn(&mut ServerCapabilities)>);
@@ -1931,6 +1954,28 @@ mod tests {
                     );
                 }),
             ),
+            (
+                "textDocument/willSave",
+                Box::new(|c| {
+                    c.text_document_sync = Some(TextDocumentSyncCapability::Options(
+                        TextDocumentSyncOptions {
+                            will_save: Some(true),
+                            ..Default::default()
+                        },
+                    ));
+                }),
+            ),
+            (
+                "textDocument/willSaveWaitUntil",
+                Box::new(|c| {
+                    c.text_document_sync = Some(TextDocumentSyncCapability::Options(
+                        TextDocumentSyncOptions {
+                            will_save_wait_until: Some(true),
+                            ..Default::default()
+                        },
+                    ));
+                }),
+            ),
         ];
 
         for (method, set_cap) in &cases {
@@ -2082,6 +2127,8 @@ mod tests {
             "textDocument/codeLens",
             "codeLens/resolve",
             "textDocument/onTypeFormatting",
+            "textDocument/willSave",
+            "textDocument/willSaveWaitUntil",
         ];
         for method in methods {
             assert!(
@@ -2090,6 +2137,46 @@ mod tests {
                 method
             );
         }
+    }
+
+    /// The bare `Kind` form of `textDocumentSync` (a sync-kind number) carries
+    /// no willSave/willSaveWaitUntil flags, so a server advertising only it must
+    /// not be treated as save-capable (#357).
+    #[tokio::test]
+    async fn has_capability_will_save_false_for_kind_only_sync() {
+        use tower_lsp_server::ls_types::{TextDocumentSyncCapability, TextDocumentSyncKind};
+
+        let handle = spawn_sink_handle().await;
+        let caps = ServerCapabilities {
+            text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL)),
+            ..Default::default()
+        };
+        handle.set_server_capabilities(caps);
+
+        assert!(!handle.has_capability("textDocument/willSave"));
+        assert!(!handle.has_capability("textDocument/willSaveWaitUntil"));
+    }
+
+    /// The two save flags are independent: advertising `willSave` alone must not
+    /// imply `willSaveWaitUntil` (the request half), and vice versa (#357).
+    #[tokio::test]
+    async fn has_capability_will_save_flags_are_independent() {
+        use tower_lsp_server::ls_types::{TextDocumentSyncCapability, TextDocumentSyncOptions};
+
+        let handle = spawn_sink_handle().await;
+        let caps = ServerCapabilities {
+            text_document_sync: Some(TextDocumentSyncCapability::Options(
+                TextDocumentSyncOptions {
+                    will_save: Some(true),
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        };
+        handle.set_server_capabilities(caps);
+
+        assert!(handle.has_capability("textDocument/willSave"));
+        assert!(!handle.has_capability("textDocument/willSaveWaitUntil"));
     }
 
     // ========================================

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -194,7 +194,9 @@ impl LanguageServerPool {
         uri: &Url,
         params: &tower_lsp_server::ls_types::WillSaveTextDocumentParams,
     ) {
-        let uri_string = uri.to_string();
+        // `as_str()` is the already-serialized form; `.to_owned()` clones it in
+        // one allocation, skipping the `Display`/`to_string` formatting path.
+        let uri_string = uri.as_str().to_owned();
 
         let handles: Vec<(ConnectionKey, Arc<ConnectionHandle>)> = {
             let connections = self.connections().await;

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -184,11 +184,16 @@ impl LanguageServerPool {
     /// fire-and-forget notification it must not lazily spawn a connection just
     /// to announce a save (issue Q3, latency).
     ///
-    /// Lock discipline matches [`Self::close_host_bridge_document`]: connection
-    /// handles are pre-fetched before the `host_documents` lock (consistent
-    /// `connections` → `host_documents` ordering with the respawn purge), and
-    /// the notifications are queued while the lock is held so a concurrent
-    /// open/close cannot interleave inconsistently.
+    /// Lock discipline follows the host **request** path
+    /// ([`Self::execute_host_request`]), stricter than the pre-snapshot in
+    /// [`Self::close_host_bridge_document`]: `connections` is held across the
+    /// `host_documents` iteration (consistent `connections` → `host_documents`
+    /// ordering with the respawn purge in `pool.rs`), and willSave is queued
+    /// only onto the **live** handle for each key. A pre-snapshot would leave a
+    /// window where a respawn between the snapshot and the send could queue
+    /// willSave onto a replaced/dead connection; holding `connections`
+    /// excludes the purge from interleaving, closing it (#357 review). The
+    /// sends are non-yielding queue writes, so holding both locks is cheap.
     pub(crate) async fn notify_host_will_save(
         &self,
         uri: &Url,
@@ -198,16 +203,9 @@ impl LanguageServerPool {
         // one allocation, skipping the `Display`/`to_string` formatting path.
         let uri_string = uri.as_str().to_owned();
 
-        let handles: Vec<(ConnectionKey, Arc<ConnectionHandle>)> = {
-            let connections = self.connections().await;
-            connections
-                .iter()
-                .map(|(key, handle)| (key.clone(), Arc::clone(handle)))
-                .collect()
-        };
-
+        let connections = self.connections().await;
         let docs = self.host_documents().await;
-        for (connection_key, handle) in &handles {
+        for (connection_key, handle) in connections.iter() {
             if !docs.contains_key(&(uri_string.clone(), connection_key.clone())) {
                 continue;
             }

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -171,6 +171,52 @@ impl LanguageServerPool {
         docs.retain(|(doc_uri, _), _| *doc_uri != uri_string);
     }
 
+    /// Forward a `textDocument/willSave` notification (#357) to every host
+    /// bridge server that **already has this host document open** and that
+    /// advertises `willSave`.
+    ///
+    /// willSave concerns the host document the editor is about to save, so it
+    /// is a verbatim passthrough (real URI, real `reason`) — no per-virtual-doc
+    /// fan-out and no coordinate translation. Restricting to servers with the
+    /// document already open mirrors the lazy host-document lifecycle: a server
+    /// that never received a request never opened the document, so a willSave
+    /// referencing an unknown document would be a protocol nuisance — and as a
+    /// fire-and-forget notification it must not lazily spawn a connection just
+    /// to announce a save (issue Q3, latency).
+    ///
+    /// Lock discipline matches [`Self::close_host_bridge_document`]: connection
+    /// handles are pre-fetched before the `host_documents` lock (consistent
+    /// `connections` → `host_documents` ordering with the respawn purge), and
+    /// the notifications are queued while the lock is held so a concurrent
+    /// open/close cannot interleave inconsistently.
+    pub(crate) async fn notify_host_will_save(
+        &self,
+        uri: &Url,
+        params: &tower_lsp_server::ls_types::WillSaveTextDocumentParams,
+    ) {
+        let uri_string = uri.to_string();
+
+        let handles: Vec<(ConnectionKey, Arc<ConnectionHandle>)> = {
+            let connections = self.connections().await;
+            connections
+                .iter()
+                .map(|(key, handle)| (key.clone(), Arc::clone(handle)))
+                .collect()
+        };
+
+        let docs = self.host_documents().await;
+        for (connection_key, handle) in &handles {
+            if !docs.contains_key(&(uri_string.clone(), connection_key.clone())) {
+                continue;
+            }
+            if !handle.has_capability("textDocument/willSave") {
+                continue;
+            }
+            let notification = JsonRpcNotification::new("textDocument/willSave", params);
+            handle.send_notification(notification);
+        }
+    }
+
     /// Send a host bridge request with the upstream params forwarded
     /// **verbatim** (host-document-bridge): the params already reference the
     /// real URI and real coordinates, so no per-method request shaping is

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -26,7 +26,8 @@ use tower_lsp_server::ls_types::{
     PrepareRenameResponse, ReferenceParams, RenameParams, SelectionRange, SelectionRangeParams,
     SemanticTokensDeltaParams, SemanticTokensFullDeltaResult, SemanticTokensParams,
     SemanticTokensRangeParams, SemanticTokensRangeResult, SemanticTokensResult, SignatureHelp,
-    SignatureHelpParams, TextDocumentPositionParams, TextEdit, Uri, WorkspaceEdit,
+    SignatureHelpParams, TextDocumentPositionParams, TextEdit, Uri, WillSaveTextDocumentParams,
+    WorkspaceEdit,
 };
 #[cfg(feature = "experimental")]
 use tower_lsp_server::ls_types::{
@@ -342,6 +343,10 @@ impl LanguageServer for Kakehashi {
 
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
         self.did_change_impl(params).await
+    }
+
+    async fn will_save(&self, params: WillSaveTextDocumentParams) {
+        self.will_save_impl(params).await
     }
 
     async fn did_save(&self, params: DidSaveTextDocumentParams) {

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -349,6 +349,13 @@ impl LanguageServer for Kakehashi {
         self.will_save_impl(params).await
     }
 
+    async fn will_save_wait_until(
+        &self,
+        params: WillSaveTextDocumentParams,
+    ) -> Result<Option<Vec<TextEdit>>> {
+        self.will_save_wait_until_impl(params).await
+    }
+
     async fn did_save(&self, params: DidSaveTextDocumentParams) {
         self.did_save_impl(params).await
     }

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -198,6 +198,13 @@ impl Kakehashi {
         // capability not advertised, matching previous behavior.
         let on_type_formatting_triggers =
             crate::config::settings::on_type_formatting_trigger_union(&settings.language_servers);
+        // Gate the willSave capability on host bridging being configured (#357):
+        // willSave forwards only to host-bridge servers, so advertising it when
+        // no language opts in would make the editor send a notification nothing
+        // consumes. Computed before `settings` moves into apply_raw_settings,
+        // like the trigger union above. willSaveWaitUntil shares this gate but
+        // is wired in a later change.
+        let host_bridging_enabled = settings.any_host_bridging_enabled();
         self.apply_raw_settings(raw_settings, settings).await;
 
         self.notifier().log_info("server initialized!").await;
@@ -212,7 +219,9 @@ impl Kakehashi {
                     TextDocumentSyncOptions {
                         open_close: Some(true),
                         change: Some(TextDocumentSyncKind::INCREMENTAL),
-                        will_save: None,
+                        // Advertised only when a host bridge is configured (#357);
+                        // forwarded verbatim to host-bridge servers.
+                        will_save: host_bridging_enabled.then_some(true),
                         will_save_wait_until: None,
                         save: Some(TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
                             include_text: Some(false),

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -198,12 +198,12 @@ impl Kakehashi {
         // capability not advertised, matching previous behavior.
         let on_type_formatting_triggers =
             crate::config::settings::on_type_formatting_trigger_union(&settings.language_servers);
-        // Gate the willSave capability on host bridging being configured (#357):
-        // willSave forwards only to host-bridge servers, so advertising it when
-        // no language opts in would make the editor send a notification nothing
-        // consumes. Computed before `settings` moves into apply_raw_settings,
-        // like the trigger union above. willSaveWaitUntil shares this gate but
-        // is wired in a later change.
+        // Gate the willSave/willSaveWaitUntil capabilities on host bridging
+        // being configured (#357): both forward only to host-bridge servers, so
+        // advertising them when no language opts in would make the editor send a
+        // willSave nothing consumes and block every save on a willSaveWaitUntil
+        // round trip that can only ever return "no edits". Computed before
+        // `settings` moves into apply_raw_settings, like the trigger union above.
         let host_bridging_enabled = settings.any_host_bridging_enabled();
         self.apply_raw_settings(raw_settings, settings).await;
 
@@ -222,7 +222,7 @@ impl Kakehashi {
                         // Advertised only when a host bridge is configured (#357);
                         // forwarded verbatim to host-bridge servers.
                         will_save: host_bridging_enabled.then_some(true),
-                        will_save_wait_until: None,
+                        will_save_wait_until: host_bridging_enabled.then_some(true),
                         save: Some(TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
                             include_text: Some(false),
                         })),

--- a/src/lsp/lsp_impl/text_document.rs
+++ b/src/lsp/lsp_impl/text_document.rs
@@ -35,5 +35,6 @@ mod semantic_tokens;
 mod signature_help;
 mod type_definition;
 mod will_save;
+mod will_save_wait_until;
 
 // Re-export the methods (they are implemented as impl blocks on Kakehashi)

--- a/src/lsp/lsp_impl/text_document.rs
+++ b/src/lsp/lsp_impl/text_document.rs
@@ -34,5 +34,6 @@ mod selection_range;
 mod semantic_tokens;
 mod signature_help;
 mod type_definition;
+mod will_save;
 
 // Re-export the methods (they are implemented as impl blocks on Kakehashi)

--- a/src/lsp/lsp_impl/text_document/will_save.rs
+++ b/src/lsp/lsp_impl/text_document/will_save.rs
@@ -1,0 +1,32 @@
+//! willSave notification handler for Kakehashi (#357).
+
+use tower_lsp_server::ls_types::WillSaveTextDocumentParams;
+
+use super::super::{Kakehashi, uri_to_url};
+
+impl Kakehashi {
+    /// Handle `textDocument/willSave`.
+    ///
+    /// Forwards the notification verbatim to host-bridge servers that already
+    /// have the host document open (host-document-bridge, #357). willSave
+    /// concerns the host document being saved, so only the host layer is
+    /// notified — virtual-document servers learn of saves through the existing
+    /// didSave forwarding, and propagating save edits from virtual regions
+    /// overlaps with the concatenated formatting pipeline (deferred to a
+    /// follow-up should a concrete need appear). Fire-and-forget: no response
+    /// is awaited and no connection is lazily spawned.
+    pub(crate) async fn will_save_impl(&self, params: WillSaveTextDocumentParams) {
+        let Ok(uri) = uri_to_url(&params.text_document.uri) else {
+            log::warn!(
+                "Invalid URI in willSave: {}",
+                params.text_document.uri.as_str()
+            );
+            return;
+        };
+
+        self.bridge
+            .pool_arc()
+            .notify_host_will_save(&uri, &params)
+            .await;
+    }
+}

--- a/src/lsp/lsp_impl/text_document/will_save_wait_until.rs
+++ b/src/lsp/lsp_impl/text_document/will_save_wait_until.rs
@@ -1,0 +1,131 @@
+//! willSaveWaitUntil request handler for Kakehashi (#357).
+
+use std::time::Duration;
+
+use tower_lsp_server::jsonrpc::Result;
+use tower_lsp_server::ls_types::{TextEdit, WillSaveTextDocumentParams};
+
+use super::super::Kakehashi;
+
+/// Upper bound on a willSaveWaitUntil round-trip to host-bridge servers before
+/// kakehashi gives up and lets the editor save with no save-time edits.
+///
+/// The LSP spec warns clients drop slow willSaveWaitUntil results to keep saves
+/// fast and reliable (issue #357 Q3). The underlying per-request wait is bounded
+/// at 30s — far longer than a save should ever block — so this caps it to the
+/// same 5s budget the concatenated formatting pipeline uses for explicit user
+/// actions, rather than introducing a new knob.
+const WILL_SAVE_WAIT_UNTIL_BUDGET: Duration = Duration::from_secs(5);
+
+impl Kakehashi {
+    /// Handle `textDocument/willSaveWaitUntil`.
+    ///
+    /// Forwards the request verbatim (real URI, real `reason`) to host-bridge
+    /// servers and returns their save-time `TextEdit[]` (host-document-bridge,
+    /// #357). Host-only: the host document is the one being saved, so the edits
+    /// need no virtual→host translation, and per-virtual-doc fan-out (which
+    /// overlaps with format-on-save semantics the concatenated pipeline owns) is
+    /// deferred to a follow-up should a concrete need appear.
+    ///
+    /// Aggregation reuses the `preferred` host layer (first non-empty wins,
+    /// falling through to lower-priority host servers). This is deliberately
+    /// **not** the formatting path: formatting treats a capable server's `null`
+    /// as the authoritative "already formatted" and stops fall-through, but a
+    /// save hook returning no edits should let the next host server contribute —
+    /// exactly the semantics `host_layer_value_with_ctx` gives via
+    /// `is_empty_layer_value`.
+    pub(crate) async fn will_save_wait_until_impl(
+        &self,
+        params: WillSaveTextDocumentParams,
+    ) -> Result<Option<Vec<TextEdit>>> {
+        let lsp_uri = &params.text_document.uri;
+        let Some(ctx) = self.resolve_host_bridge_context(lsp_uri, "textDocument/willSaveWaitUntil")
+        else {
+            return Ok(None);
+        };
+
+        let raw_params = match serde_json::to_value(&params) {
+            Ok(value) => value,
+            Err(e) => {
+                log::warn!("willSaveWaitUntil: failed to serialize params: {e}");
+                return Ok(None);
+            }
+        };
+
+        let fut =
+            self.host_layer_value_with_ctx(&ctx, "textDocument/willSaveWaitUntil", raw_params);
+        let value = match tokio::time::timeout(WILL_SAVE_WAIT_UNTIL_BUDGET, fut).await {
+            Ok(result) => result?,
+            Err(_) => {
+                // Bounded save latency (#357 Q3): abandon the in-flight host
+                // request and let the editor save without save-time edits.
+                // Dropping `fut` skips its trailing upstream-registry sweep, so
+                // run it here to avoid leaking the cancel mapping.
+                log::warn!(
+                    "willSaveWaitUntil timed out after {WILL_SAVE_WAIT_UNTIL_BUDGET:?}; \
+                     saving without host save-time edits"
+                );
+                self.bridge
+                    .pool_arc()
+                    .unregister_all_for_upstream_id(ctx.upstream_request_id.as_ref());
+                return Ok(None);
+            }
+        };
+
+        Ok(parse_will_save_wait_until_edits(value))
+    }
+}
+
+/// Convert the raw host-layer result into the editor-facing `TextEdit[]`.
+///
+/// `None` (no host response, an empty list, or a malformed payload) means "let
+/// the save proceed with no save-time edits". The dispatch already filters
+/// empty/`null` results, but the empty guard is kept so a stray `[]` can never
+/// reach the editor as "apply these (zero) edits".
+fn parse_will_save_wait_until_edits(value: Option<serde_json::Value>) -> Option<Vec<TextEdit>> {
+    let value = value?;
+    match serde_json::from_value::<Vec<TextEdit>>(value) {
+        Ok(edits) if edits.is_empty() => None,
+        Ok(edits) => Some(edits),
+        Err(e) => {
+            log::warn!("willSaveWaitUntil: malformed TextEdit[] from host server: {e}");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_none_is_no_edits() {
+        assert!(parse_will_save_wait_until_edits(None).is_none());
+    }
+
+    #[test]
+    fn parse_empty_list_is_no_edits() {
+        assert!(parse_will_save_wait_until_edits(Some(json!([]))).is_none());
+    }
+
+    #[test]
+    fn parse_malformed_payload_is_no_edits() {
+        // A host server answering with the wrong shape must not abort the save.
+        assert!(parse_will_save_wait_until_edits(Some(json!({"unexpected": true}))).is_none());
+    }
+
+    #[test]
+    fn parse_edits_pass_through_verbatim() {
+        let value = json!([{
+            "range": { "start": { "line": 2, "character": 0 },
+                       "end": { "line": 2, "character": 4 } },
+            "newText": "fixed"
+        }]);
+        let edits = parse_will_save_wait_until_edits(Some(value)).expect("edits expected");
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].new_text, "fixed");
+        // Host coordinates are forwarded untranslated.
+        assert_eq!(edits[0].range.start.line, 2);
+    }
+}

--- a/src/lsp/lsp_impl/text_document/will_save_wait_until.rs
+++ b/src/lsp/lsp_impl/text_document/will_save_wait_until.rs
@@ -59,8 +59,12 @@ impl Kakehashi {
             Err(_) => {
                 // Bounded save latency (#357 Q3): abandon the in-flight host
                 // request and let the editor save without save-time edits.
-                // Dropping `fut` skips its trailing upstream-registry sweep, so
-                // run it here to avoid leaking the cancel mapping.
+                // The per-server requests run as spawned tasks; dropping `fut`
+                // aborts them, and an aborted task may not reach its own
+                // upstream-registry unregister, so sweep the id here to avoid
+                // leaking the cancel mapping. (The abort does not send a
+                // downstream $/cancelRequest — the host server keeps computing,
+                // which the 5s budget accepts in exchange for a fast save.)
                 log::warn!(
                     "willSaveWaitUntil timed out after {WILL_SAVE_WAIT_UNTIL_BUDGET:?}; \
                      saving without host save-time edits"

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -48,6 +48,14 @@
 //!   `;` as triggers; answers `textDocument/onTypeFormatting` with the
 //!   uppercasing whole-document edit for ANY typed character (bridge-side
 //!   trigger filtering is what `tests/e2e_on_type_formatting.rs` proves).
+//! - `will-save` — advertises `hoverProvider` + a `textDocumentSync` Options
+//!   block with `willSave` and `willSaveWaitUntil` true. Records every
+//!   `textDocument/willSave` notification (count + last reason) and answers
+//!   `textDocument/willSaveWaitUntil` with a save-time edit echoing the
+//!   requested URI (only for documents synced via `didOpen`). `hover` reports
+//!   the recorded willSave count and last reason, so the test can prove the
+//!   notification reached the host server. Used by `tests/e2e_host_bridge.rs`
+//!   to prove host-bridge willSave/willSaveWaitUntil forwarding (#357).
 //! - `notify` — right after answering `initialize`, emits a
 //!   `window/showMessage` followed by a `window/logMessage` notification.
 //!   Used by `tests/e2e_window_notifications.rs` to prove the bridge forwards
@@ -83,6 +91,10 @@ fn main() {
     // `workspace-folders` mode: every folder URI this server has been told
     // about, via `initialize` params and `workspace/didChangeWorkspaceFolders`.
     let mut workspace_folders: Vec<String> = Vec::new();
+    // `will-save` mode: how many `textDocument/willSave` notifications arrived
+    // and the reason carried by the most recent one (#357).
+    let mut will_save_count: usize = 0;
+    let mut last_will_save_reason: i64 = 0;
 
     while let Some(message) = read_message(&mut reader) {
         let method = message
@@ -120,6 +132,15 @@ fn main() {
                             "moreTriggerCharacter": [";"]
                         },
                         "textDocumentSync": 1
+                    }),
+                    "will-save" => json!({
+                        "hoverProvider": true,
+                        "textDocumentSync": {
+                            "openClose": true,
+                            "change": 1,
+                            "willSave": true,
+                            "willSaveWaitUntil": true
+                        }
                     }),
                     "workspace-folders" => json!({
                         "hoverProvider": true,
@@ -229,6 +250,35 @@ fn main() {
                     .unwrap_or(Value::Null);
                 respond(&mut writer, id, result);
             }
+            "textDocument/willSave" => {
+                // Notification (no id): record receipt + reason so a later
+                // hover can prove the host bridge forwarded it (#357).
+                will_save_count += 1;
+                if let Some(reason) = message.pointer("/params/reason").and_then(Value::as_i64) {
+                    last_will_save_reason = reason;
+                }
+            }
+            "textDocument/willSaveWaitUntil" => {
+                // Answer with a save-time edit echoing the requested URI — but
+                // only for documents synced via didOpen, so a successful edit
+                // proves the host document was opened and the REAL URI was
+                // forwarded verbatim (#357).
+                let result = message
+                    .pointer("/params/textDocument/uri")
+                    .and_then(Value::as_str)
+                    .filter(|uri| documents.contains_key(*uri))
+                    .map(|uri| {
+                        json!([{
+                            "range": {
+                                "start": { "line": 0, "character": 0 },
+                                "end": { "line": 0, "character": 0 }
+                            },
+                            "newText": format!("willsave-edit:{uri}\n")
+                        }])
+                    })
+                    .unwrap_or(Value::Null);
+                respond(&mut writer, id, result);
+            }
             "workspace/didChangeWorkspaceFolders" => {
                 // Notification (no id): record every added folder URI so a
                 // later hover can prove the bridge announced the new root.
@@ -244,7 +294,15 @@ fn main() {
                 }
             }
             "textDocument/hover" => {
-                let result = if mode.starts_with("workspace-folders") {
+                let result = if mode == "will-save" {
+                    // Report the recorded willSave count + last reason so the
+                    // test can prove the notification reached this server (#357).
+                    json!({
+                        "contents": format!(
+                            "willsave-count:{will_save_count}:reason:{last_will_save_reason}"
+                        )
+                    })
+                } else if mode.starts_with("workspace-folders") {
                     // Echo the sorted, de-duplicated set of folder URIs this
                     // single process currently knows. Not gated on didOpen: the
                     // folder set is the subject under test, and it is populated

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -56,6 +56,10 @@
 //!   the recorded willSave count and last reason, so the test can prove the
 //!   notification reached the host server. Used by `tests/e2e_host_bridge.rs`
 //!   to prove host-bridge willSave/willSaveWaitUntil forwarding (#357).
+//! - `will-save-slow` — like `will-save`, but sleeps 8s before answering
+//!   `willSaveWaitUntil`, past kakehashi's 5s save budget. Lets the test prove
+//!   the bridge times out and returns null near 5s instead of hanging the save
+//!   on the 30s request timeout (#357 Q3).
 //! - `notify` — right after answering `initialize`, emits a
 //!   `window/showMessage` followed by a `window/logMessage` notification.
 //!   Used by `tests/e2e_window_notifications.rs` to prove the bridge forwards
@@ -133,7 +137,7 @@ fn main() {
                         },
                         "textDocumentSync": 1
                     }),
-                    "will-save" => json!({
+                    "will-save" | "will-save-slow" => json!({
                         "hoverProvider": true,
                         "textDocumentSync": {
                             "openClose": true,
@@ -259,6 +263,12 @@ fn main() {
                 }
             }
             "textDocument/willSaveWaitUntil" => {
+                // `will-save-slow` stalls past kakehashi's 5s save budget so the
+                // test can exercise the bridge's timeout-drop path: kakehashi
+                // must return null near 5s (not wait the 30s request timeout).
+                if mode == "will-save-slow" {
+                    std::thread::sleep(std::time::Duration::from_secs(8));
+                }
                 // Answer with a save-time edit echoing the requested URI — but
                 // only for documents synced via didOpen, so a successful edit
                 // proves the host document was opened and the REAL URI was
@@ -294,7 +304,7 @@ fn main() {
                 }
             }
             "textDocument/hover" => {
-                let result = if mode == "will-save" {
+                let result = if mode.starts_with("will-save") {
                     // Report the recorded willSave count + last reason so the
                     // test can prove the notification reached this server (#357).
                     json!({

--- a/tests/e2e_host_bridge.rs
+++ b/tests/e2e_host_bridge.rs
@@ -412,6 +412,206 @@ strategy = "concatenated"
     shutdown(&mut client);
 }
 
+// ==========================================================================
+// Host-bridge willSave / willSaveWaitUntil (host-document-bridge, #357)
+// ==========================================================================
+
+const SAVE_URI: &str = "file:///test_host_will_save.md";
+
+/// Initialize a client whose markdown host server runs the mock's `will-save`
+/// mode, opening [`SAVE_URI`]. Returns the raw `initialize` response so the
+/// capability-gate tests can inspect the advertised `textDocumentSync`.
+fn init_will_save_client(config_toml: &str) -> (LspClient, tempfile::TempDir, Value) {
+    let config_dir = tempfile::TempDir::new().expect("config dir");
+    let config_path = config_dir.path().join("will_save.toml");
+    std::fs::write(&config_path, config_toml).expect("write config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("temp path should be UTF-8"))
+        .build();
+
+    let init = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": {
+                "languageServers": {
+                    "mock-host": {
+                        "cmd": [mock_bin(), "will-save"],
+                        "languages": ["markdown"]
+                    }
+                }
+            }
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": SAVE_URI,
+                "languageId": "markdown",
+                "version": 1,
+                "text": MARKDOWN
+            }
+        }),
+    );
+    (client, config_dir, init)
+}
+
+/// Hover the host document, returning the `will-save` mock's `contents`
+/// (`willsave-count:<n>:reason:<r>`) once the host bridge is warm, else `None`.
+fn host_save_hover(client: &mut LspClient) -> Option<String> {
+    let response = client.send_request(
+        "textDocument/hover",
+        json!({
+            "textDocument": { "uri": SAVE_URI },
+            "position": { "line": 0, "character": 0 },
+        }),
+    );
+    assert!(response.get("error").is_none(), "hover must not error");
+    response
+        .pointer("/result/contents")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+#[test]
+fn e2e_host_bridge_advertises_save_capabilities_when_enabled() {
+    let (mut client, _config_dir, init) =
+        init_will_save_client("[languages.markdown.bridge._self]\nenabled = true\n");
+
+    let sync = init
+        .pointer("/result/capabilities/textDocumentSync")
+        .expect("textDocumentSync must be present");
+    assert_eq!(
+        sync.get("willSave").and_then(Value::as_bool),
+        Some(true),
+        "willSave must be advertised when a host bridge is configured; got {sync}"
+    );
+    assert_eq!(
+        sync.get("willSaveWaitUntil").and_then(Value::as_bool),
+        Some(true),
+        "willSaveWaitUntil must be advertised when a host bridge is configured; got {sync}"
+    );
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_host_bridge_hides_save_capabilities_when_disabled() {
+    // No `bridge._self.enabled` anywhere: the save methods forward only to host
+    // bridges, so kakehashi must keep advertising neither (today's behavior).
+    let (mut client, _config_dir, init) = init_will_save_client("");
+
+    let sync = init
+        .pointer("/result/capabilities/textDocumentSync")
+        .expect("textDocumentSync must be present");
+    assert!(
+        sync.get("willSave").is_none_or(Value::is_null),
+        "willSave must NOT be advertised without a host bridge; got {sync}"
+    );
+    assert!(
+        sync.get("willSaveWaitUntil").is_none_or(Value::is_null),
+        "willSaveWaitUntil must NOT be advertised without a host bridge; got {sync}"
+    );
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_host_will_save_wait_until_returns_host_edits() {
+    let (mut client, _config_dir, _init) =
+        init_will_save_client("[languages.markdown.bridge._self]\nenabled = true\n");
+
+    let mut hit = None;
+    for _ in 0..300 {
+        let response = client.send_request(
+            "textDocument/willSaveWaitUntil",
+            json!({
+                "textDocument": { "uri": SAVE_URI },
+                "reason": 1
+            }),
+        );
+        assert!(
+            response.get("error").is_none(),
+            "willSaveWaitUntil must not surface a top-level error; got: {:?}",
+            response.get("error")
+        );
+        let result = response["result"].clone();
+        if !result.is_null() {
+            hit = Some(result);
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let result = hit.expect("host willSaveWaitUntil must produce edits");
+
+    let new_text = result[0]["newText"].as_str().expect("edit newText");
+    assert_eq!(
+        new_text,
+        format!("willsave-edit:{SAVE_URI}\n"),
+        "willSaveWaitUntil edit must echo the real host URI and return verbatim"
+    );
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_host_will_save_notification_reaches_host() {
+    let (mut client, _config_dir, _init) =
+        init_will_save_client("[languages.markdown.bridge._self]\nenabled = true\n");
+
+    // Warm up: a hover opens the host document downstream (the host bridge syncs
+    // lazily on the first request) and reports the willSave count — zero before
+    // any willSave is forwarded.
+    let mut warmed = false;
+    for _ in 0..300 {
+        if let Some(contents) = host_save_hover(&mut client) {
+            assert!(
+                contents.starts_with("willsave-count:0:"),
+                "before any willSave the host server must report zero; got {contents}"
+            );
+            warmed = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(
+        warmed,
+        "host hover must answer (document synced) before the willSave"
+    );
+
+    // Forward one willSave (reason 2 = AfterDelay).
+    client.send_notification(
+        "textDocument/willSave",
+        json!({ "textDocument": { "uri": SAVE_URI }, "reason": 2 }),
+    );
+
+    // Subsequent hovers must reflect the recorded willSave: count 1, reason 2.
+    let mut seen = None;
+    for _ in 0..300 {
+        if let Some(contents) = host_save_hover(&mut client)
+            && !contents.starts_with("willsave-count:0:")
+        {
+            seen = Some(contents);
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let contents = seen.expect("the forwarded willSave must reach the host server");
+    assert_eq!(
+        contents, "willsave-count:1:reason:2",
+        "the host server must record the forwarded willSave and its reason"
+    );
+
+    shutdown(&mut client);
+}
+
 /// The generic raw-forward path serves the other methods too: hover on the
 /// host document round-trips verbatim (the mock echoes the requested URI in
 /// its hover contents — a virtual URI would betray a translation).

--- a/tests/e2e_host_bridge.rs
+++ b/tests/e2e_host_bridge.rs
@@ -422,6 +422,15 @@ const SAVE_URI: &str = "file:///test_host_will_save.md";
 /// mode, opening [`SAVE_URI`]. Returns the raw `initialize` response so the
 /// capability-gate tests can inspect the advertised `textDocumentSync`.
 fn init_will_save_client(config_toml: &str) -> (LspClient, tempfile::TempDir, Value) {
+    init_will_save_client_with_mode(config_toml, "will-save")
+}
+
+/// As [`init_will_save_client`] but selects the mock server `mode` — used by
+/// the timeout test to run the `will-save-slow` mock.
+fn init_will_save_client_with_mode(
+    config_toml: &str,
+    mode: &str,
+) -> (LspClient, tempfile::TempDir, Value) {
     let config_dir = tempfile::TempDir::new().expect("config dir");
     let config_path = config_dir.path().join("will_save.toml");
     std::fs::write(&config_path, config_toml).expect("write config");
@@ -441,7 +450,7 @@ fn init_will_save_client(config_toml: &str) -> (LspClient, tempfile::TempDir, Va
             "initializationOptions": {
                 "languageServers": {
                     "mock-host": {
-                        "cmd": [mock_bin(), "will-save"],
+                        "cmd": [mock_bin(), mode],
                         "languages": ["markdown"]
                     }
                 }
@@ -607,6 +616,63 @@ fn e2e_host_will_save_notification_reaches_host() {
     assert_eq!(
         contents, "willsave-count:1:reason:2",
         "the host server must record the forwarded willSave and its reason"
+    );
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_host_will_save_wait_until_times_out_without_hanging_save() {
+    // The host server stalls 8s on willSaveWaitUntil; kakehashi's 5s save budget
+    // must abandon the request and return null near 5s — NOT wait the 30s
+    // request timeout (#357 Q3). Without the budget this test would block ~30s.
+    let (mut client, _config_dir, _init) = init_will_save_client_with_mode(
+        "[languages.markdown.bridge._self]\nenabled = true\n",
+        "will-save-slow",
+    );
+
+    // Warm up so the connection is Ready before the timed request: a cold
+    // FailFast request returns null instantly (no wait), which would not
+    // exercise the timeout path.
+    let mut warmed = false;
+    for _ in 0..300 {
+        if host_save_hover(&mut client).is_some() {
+            warmed = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(warmed, "host bridge must be warm before the timed request");
+
+    let start = std::time::Instant::now();
+    let response = client.send_request(
+        "textDocument/willSaveWaitUntil",
+        json!({
+            "textDocument": { "uri": SAVE_URI },
+            "reason": 1
+        }),
+    );
+    let elapsed = start.elapsed();
+
+    assert!(
+        response.get("error").is_none(),
+        "a timed-out willSaveWaitUntil must return a result, not an error; got: {:?}",
+        response.get("error")
+    );
+    assert!(
+        response["result"].is_null(),
+        "a timed-out willSaveWaitUntil must return null (save proceeds editless); got: {}",
+        response["result"]
+    );
+    // The 5s budget — not an instant cold null (< 1s) and not the 30s request
+    // timeout. Generous bounds keep this robust under CI load.
+    assert!(
+        elapsed >= std::time::Duration::from_secs(3),
+        "must wait for the budget, not return an instant cold null; elapsed {elapsed:?}"
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(20),
+        "must time out on the 5s budget, not the 30s request timeout; elapsed {elapsed:?}"
     );
 
     shutdown(&mut client);


### PR DESCRIPTION
Closes #357.

## What

Forward `textDocument/willSave` (notification) and `textDocument/willSaveWaitUntil` (request) to **host-bridge servers only** (host-document-bridge), never to virt bridges. This is the phase-1 design the issue author concluded on #357: save-time methods concern the document being saved — the host document — so host servers see the real URI and real text and forwarding is a verbatim passthrough with no per-virtual-doc fan-out and no coordinate translation.

## How (incremental commits)

1. **Capability recognition** — `has_capability` arms for `textDocument/willSave` / `willSaveWaitUntil`, reading the flags from the downstream server's `textDocumentSync` Options (the bare sync-`Kind` number form carries no flags → false).
2. **willSave** — `notify_host_will_save` fans the notification (verbatim: real URI + reason) only to host servers that already have the document open *and* advertise willSave. No lazy spawn for a fire-and-forget notification (issue Q1/Q3). Lock discipline mirrors `close_host_bridge_document`.
3. **willSaveWaitUntil** — forwards verbatim and returns the host servers' `TextEdit[]` via the `preferred` host aggregation (first non-empty wins, falling through to lower-priority servers) — deliberately **not** the formatting path's authoritative-null semantics. Bounded by a 5s budget: on timeout it abandons the request, sweeps the upstream-cancel registry, and lets the editor save edit-less rather than hang on the 30s request timeout (issue Q3).
4. **Capability gating** — `textDocumentSync.willSave`/`willSaveWaitUntil` advertised at initialize only when some language enables host bridging (`any_host_bridging_enabled`), else `None` (today's behavior) (issue Q4).

Virt fan-out is deliberately deferred — tracked in #417.

## Tests

- Unit: capability arms (incl. Kind-only + flag independence), `any_host_bridging_enabled` (default/explicit/wildcard), willSaveWaitUntil response parsing.
- E2E (`will-save` / `will-save-slow` mock modes): capability advertised-when-enabled / hidden-when-disabled, willSaveWaitUntil returns host edits with the real URI verbatim, willSave notification reaches the host server with its reason, and the 5s-budget timeout returns null near 5s instead of hanging on the 30s request timeout.

## Docs

Recorded the host-bridge-only decision, the willSave already-open/no-lazy-spawn rule, the willSaveWaitUntil aggregation + 5s budget, and the deferred virt fan-out in the host-document-bridge ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)