### PR TITLE
feat(bridge): forward willSave/didSave to virt bridges (#357)

### DIFF
--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -53,18 +53,32 @@ Partially implemented:
   matches the virt path's full-content `didChange` forwarding and avoids
   hooking the concurrent upstream `didChange` stream; verbatim forwarding
   remains the target if eager sync proves necessary.
-- **Save methods are host-bridge-only** (#357): `willSave` (notification) and
-  `willSaveWaitUntil` (request) concern the document being saved — the *host*
-  document — so they bypass the layer walk and forward only to host servers,
-  never to virt bridges. `willSave` is fan-out to host servers that already
-  have the document open and advertise it (no lazy spawn for a fire-and-forget
-  notification); `willSaveWaitUntil` forwards verbatim and returns the host
-  servers' `TextEdit[]` via the `preferred` host aggregation, bounded by a 5s
-  budget so a slow server cannot hang the editor's save. Both capabilities are
-  advertised at initialize only when some language enables host bridging.
-  Virt fan-out (one save per open virtual doc) is deliberately deferred: it
-  overlaps with format-on-save semantics the concatenated formatting pipeline
-  owns, and is left for a follow-up should a concrete need appear.
+- **Save notifications fan out to both layers; `willSaveWaitUntil` stays
+  host-only** (#357). The save *notifications* concern the host save but are
+  forwarded to BOTH bridge layers:
+  - **`willSave`** goes to host servers that already have the host document
+    open *and* to every open virtual document (URI rewritten to the virtual
+    one, reason verbatim);
+  - **`didSave`** goes to every open virtual document (URI rewritten); it is
+    not forwarded to host servers today (the host `didSave` handler drives the
+    synthetic-diagnostic pull instead).
+
+  Each recipient is **gated per-server** on the relevant capability —
+  `willSave` on `textDocumentSync.willSave`, `didSave` on `textDocumentSync.save`
+  — which is also the safety valve: a virt server only hears about a fragment
+  "save" if it opted into save hooks; one that didn't never sees it. Both are
+  fire-and-forget (no lazy spawn). `willSave` is advertised whenever a runnable
+  bridge server (host or virt) is configured; `didSave` is always advertised
+  (`save.includeText = false`).
+
+  **`willSaveWaitUntil` (the request) remains host-only** and bypasses the
+  layer walk: it forwards verbatim and returns the host servers' `TextEdit[]`
+  via the `preferred` host aggregation, bounded by a 5s budget so a slow server
+  cannot hang the editor's save. It is advertised only when some language
+  enables host bridging. Fanning the *request* out to virt would need
+  virtual→host edit translation and cross-region aggregation that overlap the
+  concatenated formatting pipeline (format-on-save), so virt `willSaveWaitUntil`
+  stays deferred.
 - **Not implemented**: `publishDiagnostics` pass-through from host servers
   (downstream notifications are not forwarded upstream today on either
   path).

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -71,9 +71,13 @@ Partially implemented:
   `save.includeText = true`**: kakehashi advertises `includeText = false`
   upstream and so never receives the editor's saved bytes, so rather than send a
   contract-violating textless didSave it declines (the server still has current
-  content from didChange). Both are fire-and-forget (no lazy spawn). `willSave`
-  is advertised whenever a runnable bridge server (host or virt) is configured;
-  `didSave` is always advertised to the editor (`save.includeText = false`).
+  content from didChange). That gate reads **static** capabilities only — a
+  *dynamic* didSave registration is not honored for forwarding, since the
+  method-name-only dynamic registry cannot carry `includeText` and could
+  otherwise smuggle an `includeText = true` server past the filter. Both are
+  fire-and-forget (no lazy spawn). `willSave` is advertised whenever a runnable
+  bridge server (host or virt) is configured; `didSave` is always advertised to
+  the editor (`save.includeText = false`).
 
   **`willSaveWaitUntil` (the request) remains host-only** and bypasses the
   layer walk: it forwards verbatim and returns the host servers' `TextEdit[]`

--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -66,10 +66,14 @@ Partially implemented:
   Each recipient is **gated per-server** on the relevant capability —
   `willSave` on `textDocumentSync.willSave`, `didSave` on `textDocumentSync.save`
   — which is also the safety valve: a virt server only hears about a fragment
-  "save" if it opted into save hooks; one that didn't never sees it. Both are
-  fire-and-forget (no lazy spawn). `willSave` is advertised whenever a runnable
-  bridge server (host or virt) is configured; `didSave` is always advertised
-  (`save.includeText = false`).
+  "save" if it opted into save hooks; one that didn't never sees it. The
+  `didSave` gate additionally **excludes servers that demand
+  `save.includeText = true`**: kakehashi advertises `includeText = false`
+  upstream and so never receives the editor's saved bytes, so rather than send a
+  contract-violating textless didSave it declines (the server still has current
+  content from didChange). Both are fire-and-forget (no lazy spawn). `willSave`
+  is advertised whenever a runnable bridge server (host or virt) is configured;
+  `didSave` is always advertised to the editor (`save.includeText = false`).
 
   **`willSaveWaitUntil` (the request) remains host-only** and bypasses the
   layer walk: it forwards verbatim and returns the host servers' `TextEdit[]`

--- a/docs/architecture-decisions/language-server-bridge-virtual-document-model.md
+++ b/docs/architecture-decisions/language-server-bridge-virtual-document-model.md
@@ -158,7 +158,7 @@ For materialized documents:
 4. **Registration**: Send `textDocument/didOpen` to language server
 5. **Wait for indexing**: For materialized documents, wait for `publishDiagnostics`
 6. **Sync**: On host document change, send `textDocument/didChange` (or rewrite temp file)
-7. **Save hooks** (#357): On host `willSave`/`didSave`, fan the notification out to every open virtual document (URI rewritten to the virtual one), gated per-server on `willSave` / `save` capability — see [host-document-bridge](host-document-bridge.md). `willSaveWaitUntil` is host-only.
+7. **Save hooks** (#357): On host `willSave`/`didSave`, fan the notification out to every open virtual document (URI rewritten to the virtual one), gated per-server on `willSave` / `save` capability — see host-document-bridge. `willSaveWaitUntil` is host-only.
 8. **Cleanup**: Send `textDocument/didClose` and delete temp files when injection is removed or host closes
 
 ### Server Process Sharing

--- a/docs/architecture-decisions/language-server-bridge-virtual-document-model.md
+++ b/docs/architecture-decisions/language-server-bridge-virtual-document-model.md
@@ -158,7 +158,8 @@ For materialized documents:
 4. **Registration**: Send `textDocument/didOpen` to language server
 5. **Wait for indexing**: For materialized documents, wait for `publishDiagnostics`
 6. **Sync**: On host document change, send `textDocument/didChange` (or rewrite temp file)
-7. **Cleanup**: Send `textDocument/didClose` and delete temp files when injection is removed or host closes
+7. **Save hooks** (#357): On host `willSave`/`didSave`, fan the notification out to every open virtual document (URI rewritten to the virtual one), gated per-server on `willSave` / `save` capability — see [host-document-bridge](host-document-bridge.md). `willSaveWaitUntil` is host-only.
+8. **Cleanup**: Send `textDocument/didClose` and delete temp files when injection is removed or host closes
 
 ### Server Process Sharing
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -311,6 +311,20 @@ impl WorkspaceSettings {
             .values()
             .any(LanguageSettings::is_host_bridging_enabled)
     }
+
+    /// True if any configured language server has a runnable command. The
+    /// built-in `_` wildcard defaults entry carries an empty `cmd` and is thus
+    /// excluded, so this is false on a blank config but true once a real server
+    /// (host- or virt-capable) is configured.
+    ///
+    /// Gates willSave advertisement (#357): willSave now fans out to both host
+    /// and virt bridges, so a single runnable bridge server is a potential
+    /// consumer — but a config with only the empty defaults entry has none.
+    pub(crate) fn any_bridge_server_runnable(&self) -> bool {
+        self.language_servers
+            .values()
+            .any(|server| !server.cmd.is_empty())
+    }
 }
 
 impl From<&WorkspaceSettings> for RawWorkspaceSettings {
@@ -397,6 +411,40 @@ mod tests {
         // `resolve_host_language_settings`, so a wildcard opt-in must count.
         let settings = settings_with_host_bridge(WILDCARD_KEY, true);
         assert!(settings.any_host_bridging_enabled());
+    }
+
+    #[test]
+    fn any_bridge_server_runnable_excludes_empty_cmd_defaults() {
+        use crate::config::settings::BridgeServerConfig;
+
+        let server = |cmd: Vec<&str>| BridgeServerConfig {
+            cmd: cmd.into_iter().map(String::from).collect(),
+            languages: vec![],
+            initialization_options: None,
+            root_markers: None,
+            on_type_formatting_triggers: None,
+            prefer_shared_instance: None,
+        };
+
+        // Only the built-in `_` defaults entry (empty cmd): not runnable.
+        let settings = WorkspaceSettings {
+            language_servers: HashMap::from([(WILDCARD_KEY.to_string(), server(vec![]))]),
+            ..Default::default()
+        };
+        assert!(
+            !settings.any_bridge_server_runnable(),
+            "only the empty defaults entry → no runnable server"
+        );
+
+        // A real server with a command counts.
+        let settings = WorkspaceSettings {
+            language_servers: HashMap::from([
+                (WILDCARD_KEY.to_string(), server(vec![])),
+                ("lua_ls".to_string(), server(vec!["lua-language-server"])),
+            ]),
+            ..Default::default()
+        };
+        assert!(settings.any_bridge_server_runnable());
     }
 
     #[test]

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -543,11 +543,11 @@ impl LanguageServerPool {
     }
 
     /// Membership check for the save fan-out liveness recheck (avoids the
-    /// reverse-index `Vec<ConnectionKey>` clone): is `virtual_uri` open on
-    /// `connection_key`?
+    /// reverse-index `Vec<ConnectionKey>` clone): is the virtual document at
+    /// `virtual_uri` (its URI string) open on `connection_key`?
     pub(super) fn is_virtual_doc_open_on_connection(
         &self,
-        virtual_uri: &VirtualDocumentUri,
+        virtual_uri: &str,
         connection_key: &ConnectionKey,
     ) -> bool {
         self.document_tracker

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -542,6 +542,17 @@ impl LanguageServerPool {
             .get_all_connections_for_virtual_uri(virtual_uri)
     }
 
+    /// Zero-allocation membership check for the save fan-out liveness recheck:
+    /// is `virtual_uri` open on `connection_key`?
+    pub(super) fn is_virtual_doc_open_on_connection(
+        &self,
+        virtual_uri: &VirtualDocumentUri,
+        connection_key: &ConnectionKey,
+    ) -> bool {
+        self.document_tracker
+            .is_virtual_doc_open_on_connection(virtual_uri, connection_key)
+    }
+
     /// Register a document as successfully opened (test helper).
     ///
     /// Delegates to `DocumentTracker::register_opened_document()`.

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -455,6 +455,12 @@ impl LanguageServerPool {
     // DocumentTracker delegation methods
     // ========================================
 
+    /// Snapshot (without removing) every virtual document currently open for a
+    /// host URI. Used by the save-notification fan-out (#357).
+    pub(crate) async fn host_virtual_docs(&self, host_uri: &Url) -> Vec<OpenedVirtualDoc> {
+        self.document_tracker.host_virtual_docs(host_uri).await
+    }
+
     /// Remove and return all virtual documents for a host URI.
     ///
     /// Used by did_close module for cleanup.

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -542,8 +542,9 @@ impl LanguageServerPool {
             .get_all_connections_for_virtual_uri(virtual_uri)
     }
 
-    /// Zero-allocation membership check for the save fan-out liveness recheck:
-    /// is `virtual_uri` open on `connection_key`?
+    /// Membership check for the save fan-out liveness recheck (avoids the
+    /// reverse-index `Vec<ConnectionKey>` clone): is `virtual_uri` open on
+    /// `connection_key`?
     pub(super) fn is_virtual_doc_open_on_connection(
         &self,
         virtual_uri: &VirtualDocumentUri,

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -14,7 +14,7 @@ use tokio::sync::mpsc;
 use tower_lsp_server::ls_types::{
     ColorProviderCapability, DeclarationCapability, FoldingRangeProviderCapability,
     HoverProviderCapability, ImplementationProviderCapability,
-    LinkedEditingRangeServerCapabilities, OneOf, RenameOptions, ServerCapabilities,
+    LinkedEditingRangeServerCapabilities, OneOf, RenameOptions, SaveOptions, ServerCapabilities,
     TextDocumentSyncCapability, TextDocumentSyncOptions, TextDocumentSyncSaveOptions,
     TypeDefinitionProviderCapability,
 };
@@ -594,16 +594,23 @@ impl ConnectionHandle {
                 ))
             ),
             // didSave is opt-in via `textDocumentSync.save` (a server declares
-            // it reacts to saves). Only the `Options` form carries it;
-            // `Supported(false)` and the bare `Kind` number form correctly fall
-            // through to false. Gates save-hook forwarding to virt servers (#357).
+            // it reacts to saves). Gates save-hook forwarding to virt servers
+            // (#357). A server demanding `includeText = true` is deliberately
+            // EXCLUDED: kakehashi advertises `includeText = false` to the editor
+            // and so never receives the saved bytes to forward, and the virt doc
+            // is already current from didChange — so we cannot honor that
+            // contract and decline rather than send a contract-violating textless
+            // didSave. `Supported(false)` and the bare `Kind` number form also
+            // correctly fall through to false.
             "textDocument/didSave" => matches!(
                 caps.text_document_sync,
                 Some(TextDocumentSyncCapability::Options(
                     TextDocumentSyncOptions {
                         save: Some(
                             TextDocumentSyncSaveOptions::Supported(true)
-                                | TextDocumentSyncSaveOptions::SaveOptions(_)
+                                | TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
+                                    include_text: None | Some(false),
+                                })
                         ),
                         ..
                     }
@@ -2200,6 +2207,33 @@ mod tests {
             text_document_sync: Some(TextDocumentSyncCapability::Options(
                 TextDocumentSyncOptions {
                     save: Some(TextDocumentSyncSaveOptions::Supported(false)),
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        };
+        handle.set_server_capabilities(caps);
+
+        assert!(!handle.has_capability("textDocument/didSave"));
+    }
+
+    /// A server demanding `save.includeText = true` is excluded: kakehashi
+    /// cannot supply the saved text, so didSave must not be forwarded to it
+    /// rather than send a contract-violating textless didSave (#357).
+    #[tokio::test]
+    async fn has_capability_did_save_false_for_save_include_text_true() {
+        use tower_lsp_server::ls_types::{
+            SaveOptions, TextDocumentSyncCapability, TextDocumentSyncOptions,
+            TextDocumentSyncSaveOptions,
+        };
+
+        let handle = spawn_sink_handle().await;
+        let caps = ServerCapabilities {
+            text_document_sync: Some(TextDocumentSyncCapability::Options(
+                TextDocumentSyncOptions {
+                    save: Some(TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
+                        include_text: Some(true),
+                    })),
                     ..Default::default()
                 },
             )),

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -593,37 +593,12 @@ impl ConnectionHandle {
                     }
                 ))
             ),
-            // didSave is opt-in via `textDocumentSync.save` (a server declares
-            // it reacts to saves). Gates save-hook forwarding to virt servers
-            // (#357). A server demanding `includeText = true` is deliberately
-            // EXCLUDED: kakehashi advertises `includeText = false` to the editor
-            // and so never receives the saved bytes to forward, and the virt doc
-            // is already current from didChange — so we cannot honor that
-            // contract and decline rather than send a contract-violating textless
-            // didSave. `Supported(false)` and the bare `Kind` number form also
-            // correctly fall through to false.
-            //
-            // Caveat: this `includeText = true` exclusion only applies to STATIC
-            // (initialize) capabilities. A server that *dynamically* registers
-            // didSave with `includeText: true` is admitted by the method-name-only
-            // dynamic registry above and would receive a textless didSave. Benign
-            // in practice (the virt doc is already current via didChange) and
-            // honoring dynamic `includeText` would require the registry to parse
-            // and store registration options — deferred.
-            "textDocument/didSave" => matches!(
-                caps.text_document_sync,
-                Some(TextDocumentSyncCapability::Options(
-                    TextDocumentSyncOptions {
-                        save: Some(
-                            TextDocumentSyncSaveOptions::Supported(true)
-                                | TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
-                                    include_text: None | Some(false),
-                                })
-                        ),
-                        ..
-                    }
-                ))
-            ),
+            // NOTE: `textDocument/didSave` is intentionally NOT handled here.
+            // didSave forwarding (virt save fan-out, #357) needs an
+            // includeText-aware decision that the dynamic registry — which is
+            // method-name-only and cannot carry `save.includeText` — would
+            // bypass. It uses [`Self::accepts_textless_did_save`] (static
+            // capabilities only) instead.
             "textDocument/documentSymbol" => {
                 matches!(
                     caps.document_symbol_provider,
@@ -640,6 +615,39 @@ impl ConnectionHandle {
             ),
             _ => false,
         }
+    }
+
+    /// Whether this server accepts a **textless** `textDocument/didSave` from the
+    /// virt save fan-out (#357): it must advertise `save` in its STATIC
+    /// (initialize) `textDocumentSync` *without* demanding `includeText = true`.
+    ///
+    /// Deliberately reads only static capabilities, NOT the dynamic registry:
+    /// kakehashi advertises `includeText = false` to the editor and so never
+    /// receives the saved bytes to forward, and the method-name-only dynamic
+    /// registry cannot carry `save.includeText` — so trusting a dynamic didSave
+    /// registration could send a textless didSave to a server that registered
+    /// `includeText: true`. `includeText = true`, `Supported(false)`, the bare
+    /// `Kind` form, and an absent `save` all yield false. A server that opts in
+    /// without `includeText` already has current content from the didChange
+    /// stream, so the textless notification is sufficient.
+    pub(crate) fn accepts_textless_did_save(&self) -> bool {
+        let Some(caps) = self.server_capabilities() else {
+            return false;
+        };
+        matches!(
+            caps.text_document_sync,
+            Some(TextDocumentSyncCapability::Options(
+                TextDocumentSyncOptions {
+                    save: Some(
+                        TextDocumentSyncSaveOptions::Supported(true)
+                            | TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
+                                include_text: None | Some(false),
+                            })
+                    ),
+                    ..
+                }
+            ))
+        )
     }
 
     /// Begin graceful shutdown: transition to Closing (rejecting new requests) and
@@ -2008,36 +2016,6 @@ mod tests {
                     ));
                 }),
             ),
-            (
-                "textDocument/didSave",
-                Box::new(|c| {
-                    c.text_document_sync = Some(TextDocumentSyncCapability::Options(
-                        TextDocumentSyncOptions {
-                            save: Some(tower_lsp_server::ls_types::TextDocumentSyncSaveOptions::SaveOptions(
-                                tower_lsp_server::ls_types::SaveOptions {
-                                    include_text: Some(false),
-                                },
-                            )),
-                            ..Default::default()
-                        },
-                    ));
-                }),
-            ),
-            (
-                "textDocument/didSave",
-                Box::new(|c| {
-                    c.text_document_sync = Some(TextDocumentSyncCapability::Options(
-                        TextDocumentSyncOptions {
-                            save: Some(
-                                tower_lsp_server::ls_types::TextDocumentSyncSaveOptions::Supported(
-                                    true,
-                                ),
-                            ),
-                            ..Default::default()
-                        },
-                    ));
-                }),
-            ),
         ];
 
         for (method, set_cap) in &cases {
@@ -2191,7 +2169,6 @@ mod tests {
             "textDocument/onTypeFormatting",
             "textDocument/willSave",
             "textDocument/willSaveWaitUntil",
-            "textDocument/didSave",
         ];
         for method in methods {
             assert!(
@@ -2202,54 +2179,73 @@ mod tests {
         }
     }
 
-    /// `textDocumentSync.save = Supported(false)` is an explicit opt-out, so
-    /// didSave must not be forwarded to that server (#357).
+    /// `accepts_textless_did_save` is true for a static `save` opt-in without
+    /// `includeText` — both the `Supported(true)` and `SaveOptions` forms (#357).
     #[tokio::test]
-    async fn has_capability_did_save_false_for_save_supported_false() {
-        use tower_lsp_server::ls_types::{
-            TextDocumentSyncCapability, TextDocumentSyncOptions, TextDocumentSyncSaveOptions,
-        };
-
-        let handle = spawn_sink_handle().await;
-        let caps = ServerCapabilities {
-            text_document_sync: Some(TextDocumentSyncCapability::Options(
-                TextDocumentSyncOptions {
-                    save: Some(TextDocumentSyncSaveOptions::Supported(false)),
-                    ..Default::default()
-                },
-            )),
-            ..Default::default()
-        };
-        handle.set_server_capabilities(caps);
-
-        assert!(!handle.has_capability("textDocument/didSave"));
-    }
-
-    /// A server demanding `save.includeText = true` is excluded: kakehashi
-    /// cannot supply the saved text, so didSave must not be forwarded to it
-    /// rather than send a contract-violating textless didSave (#357).
-    #[tokio::test]
-    async fn has_capability_did_save_false_for_save_include_text_true() {
+    async fn accepts_textless_did_save_true_for_save_without_include_text() {
         use tower_lsp_server::ls_types::{
             SaveOptions, TextDocumentSyncCapability, TextDocumentSyncOptions,
             TextDocumentSyncSaveOptions,
         };
 
-        let handle = spawn_sink_handle().await;
-        let caps = ServerCapabilities {
-            text_document_sync: Some(TextDocumentSyncCapability::Options(
-                TextDocumentSyncOptions {
-                    save: Some(TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
-                        include_text: Some(true),
-                    })),
-                    ..Default::default()
-                },
-            )),
-            ..Default::default()
-        };
-        handle.set_server_capabilities(caps);
+        for save in [
+            TextDocumentSyncSaveOptions::Supported(true),
+            TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
+                include_text: Some(false),
+            }),
+            TextDocumentSyncSaveOptions::SaveOptions(SaveOptions { include_text: None }),
+        ] {
+            let handle = spawn_sink_handle().await;
+            handle.set_server_capabilities(ServerCapabilities {
+                text_document_sync: Some(TextDocumentSyncCapability::Options(
+                    TextDocumentSyncOptions {
+                        save: Some(save),
+                        ..Default::default()
+                    },
+                )),
+                ..Default::default()
+            });
+            assert!(handle.accepts_textless_did_save());
+        }
+    }
 
-        assert!(!handle.has_capability("textDocument/didSave"));
+    /// `accepts_textless_did_save` is false with no capabilities, for
+    /// `Supported(false)`, the bare `Kind` form, and — crucially — a server
+    /// demanding `save.includeText = true` (kakehashi cannot supply the text)
+    /// (#357).
+    #[tokio::test]
+    async fn accepts_textless_did_save_false_cases() {
+        use tower_lsp_server::ls_types::{
+            SaveOptions, TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
+            TextDocumentSyncSaveOptions,
+        };
+
+        // No capabilities at all.
+        let handle = spawn_sink_handle().await;
+        handle.set_server_capabilities(ServerCapabilities::default());
+        assert!(!handle.accepts_textless_did_save());
+
+        let sync_cases = [
+            TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL),
+            TextDocumentSyncCapability::Options(TextDocumentSyncOptions {
+                save: Some(TextDocumentSyncSaveOptions::Supported(false)),
+                ..Default::default()
+            }),
+            TextDocumentSyncCapability::Options(TextDocumentSyncOptions {
+                save: Some(TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
+                    include_text: Some(true),
+                })),
+                ..Default::default()
+            }),
+        ];
+        for sync in sync_cases {
+            let handle = spawn_sink_handle().await;
+            handle.set_server_capabilities(ServerCapabilities {
+                text_document_sync: Some(sync),
+                ..Default::default()
+            });
+            assert!(!handle.accepts_textless_did_save());
+        }
     }
 
     /// The bare `Kind` form of `textDocumentSync` (a sync-kind number) carries

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -15,7 +15,8 @@ use tower_lsp_server::ls_types::{
     ColorProviderCapability, DeclarationCapability, FoldingRangeProviderCapability,
     HoverProviderCapability, ImplementationProviderCapability,
     LinkedEditingRangeServerCapabilities, OneOf, RenameOptions, ServerCapabilities,
-    TextDocumentSyncCapability, TextDocumentSyncOptions, TypeDefinitionProviderCapability,
+    TextDocumentSyncCapability, TextDocumentSyncOptions, TextDocumentSyncSaveOptions,
+    TypeDefinitionProviderCapability,
 };
 
 use super::connection_action::BridgeError;
@@ -588,6 +589,22 @@ impl ConnectionHandle {
                 Some(TextDocumentSyncCapability::Options(
                     TextDocumentSyncOptions {
                         will_save_wait_until: Some(true),
+                        ..
+                    }
+                ))
+            ),
+            // didSave is opt-in via `textDocumentSync.save` (a server declares
+            // it reacts to saves). Only the `Options` form carries it;
+            // `Supported(false)` and the bare `Kind` number form correctly fall
+            // through to false. Gates save-hook forwarding to virt servers (#357).
+            "textDocument/didSave" => matches!(
+                caps.text_document_sync,
+                Some(TextDocumentSyncCapability::Options(
+                    TextDocumentSyncOptions {
+                        save: Some(
+                            TextDocumentSyncSaveOptions::Supported(true)
+                                | TextDocumentSyncSaveOptions::SaveOptions(_)
+                        ),
                         ..
                     }
                 ))
@@ -1976,6 +1993,36 @@ mod tests {
                     ));
                 }),
             ),
+            (
+                "textDocument/didSave",
+                Box::new(|c| {
+                    c.text_document_sync = Some(TextDocumentSyncCapability::Options(
+                        TextDocumentSyncOptions {
+                            save: Some(tower_lsp_server::ls_types::TextDocumentSyncSaveOptions::SaveOptions(
+                                tower_lsp_server::ls_types::SaveOptions {
+                                    include_text: Some(false),
+                                },
+                            )),
+                            ..Default::default()
+                        },
+                    ));
+                }),
+            ),
+            (
+                "textDocument/didSave",
+                Box::new(|c| {
+                    c.text_document_sync = Some(TextDocumentSyncCapability::Options(
+                        TextDocumentSyncOptions {
+                            save: Some(
+                                tower_lsp_server::ls_types::TextDocumentSyncSaveOptions::Supported(
+                                    true,
+                                ),
+                            ),
+                            ..Default::default()
+                        },
+                    ));
+                }),
+            ),
         ];
 
         for (method, set_cap) in &cases {
@@ -2129,6 +2176,7 @@ mod tests {
             "textDocument/onTypeFormatting",
             "textDocument/willSave",
             "textDocument/willSaveWaitUntil",
+            "textDocument/didSave",
         ];
         for method in methods {
             assert!(
@@ -2137,6 +2185,29 @@ mod tests {
                 method
             );
         }
+    }
+
+    /// `textDocumentSync.save = Supported(false)` is an explicit opt-out, so
+    /// didSave must not be forwarded to that server (#357).
+    #[tokio::test]
+    async fn has_capability_did_save_false_for_save_supported_false() {
+        use tower_lsp_server::ls_types::{
+            TextDocumentSyncCapability, TextDocumentSyncOptions, TextDocumentSyncSaveOptions,
+        };
+
+        let handle = spawn_sink_handle().await;
+        let caps = ServerCapabilities {
+            text_document_sync: Some(TextDocumentSyncCapability::Options(
+                TextDocumentSyncOptions {
+                    save: Some(TextDocumentSyncSaveOptions::Supported(false)),
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        };
+        handle.set_server_capabilities(caps);
+
+        assert!(!handle.has_capability("textDocument/didSave"));
     }
 
     /// The bare `Kind` form of `textDocumentSync` (a sync-kind number) carries

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -602,6 +602,14 @@ impl ConnectionHandle {
             // contract and decline rather than send a contract-violating textless
             // didSave. `Supported(false)` and the bare `Kind` number form also
             // correctly fall through to false.
+            //
+            // Caveat: this `includeText = true` exclusion only applies to STATIC
+            // (initialize) capabilities. A server that *dynamically* registers
+            // didSave with `includeText: true` is admitted by the method-name-only
+            // dynamic registry above and would receive a textless didSave. Benign
+            // in practice (the virt doc is already current via didChange) and
+            // honoring dynamic `includeText` would require the registry to parse
+            // and store registration options — deferred.
             "textDocument/didSave" => matches!(
                 caps.text_document_sync,
                 Some(TextDocumentSyncCapability::Options(

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -439,10 +439,11 @@ impl DocumentTracker {
             .unwrap_or_default()
     }
 
-    /// Zero-allocation membership check: is `virtual_uri` open on
-    /// `connection_key`? Reads the same `virtual_to_servers` reverse index as
-    /// [`Self::get_all_connections_for_virtual_uri`] but avoids cloning the
-    /// `Vec<ConnectionKey>` — used by the per-doc save fan-out liveness recheck.
+    /// Membership check: is `virtual_uri` open on `connection_key`? Reads the
+    /// same `virtual_to_servers` reverse index as
+    /// [`Self::get_all_connections_for_virtual_uri`] but only tests membership,
+    /// avoiding that method's `Vec<ConnectionKey>` clone (the `to_uri_string()`
+    /// key allocation remains) — used by the per-doc save fan-out liveness recheck.
     pub(super) fn is_virtual_doc_open_on_connection(
         &self,
         virtual_uri: &VirtualDocumentUri,

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -439,6 +439,20 @@ impl DocumentTracker {
             .unwrap_or_default()
     }
 
+    /// Zero-allocation membership check: is `virtual_uri` open on
+    /// `connection_key`? Reads the same `virtual_to_servers` reverse index as
+    /// [`Self::get_all_connections_for_virtual_uri`] but avoids cloning the
+    /// `Vec<ConnectionKey>` — used by the per-doc save fan-out liveness recheck.
+    pub(super) fn is_virtual_doc_open_on_connection(
+        &self,
+        virtual_uri: &VirtualDocumentUri,
+        connection_key: &ConnectionKey,
+    ) -> bool {
+        self.virtual_to_servers
+            .get(&virtual_uri.to_uri_string())
+            .is_some_and(|entry| entry.value().contains(connection_key))
+    }
+
     /// Resolve a virtual-document URI string back to its `(host_url, region_id)`.
     ///
     /// Used by the inbound `window/showDocument` translation to recover which

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -439,18 +439,20 @@ impl DocumentTracker {
             .unwrap_or_default()
     }
 
-    /// Membership check: is `virtual_uri` open on `connection_key`? Reads the
-    /// same `virtual_to_servers` reverse index as
-    /// [`Self::get_all_connections_for_virtual_uri`] but only tests membership,
-    /// avoiding that method's `Vec<ConnectionKey>` clone (the `to_uri_string()`
-    /// key allocation remains) — used by the per-doc save fan-out liveness recheck.
+    /// Membership check: is the virtual document at `virtual_uri` (its URI
+    /// string) open on `connection_key`? Reads the same `virtual_to_servers`
+    /// reverse index as [`Self::get_all_connections_for_virtual_uri`] but only
+    /// tests membership, avoiding that method's `Vec<ConnectionKey>` clone — and
+    /// takes `&str` so the caller (which already has the URI string for the
+    /// notification params) need not allocate it twice. Used by the per-doc save
+    /// fan-out liveness recheck.
     pub(super) fn is_virtual_doc_open_on_connection(
         &self,
-        virtual_uri: &VirtualDocumentUri,
+        virtual_uri: &str,
         connection_key: &ConnectionKey,
     ) -> bool {
         self.virtual_to_servers
-            .get(&virtual_uri.to_uri_string())
+            .get(virtual_uri)
             .is_some_and(|entry| entry.value().contains(connection_key))
     }
 

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -328,6 +328,18 @@ impl DocumentTracker {
         }
     }
 
+    /// Snapshot (without removing) every virtual document currently open for a
+    /// host URI. Used by the save-notification fan-out (#357), which forwards
+    /// willSave/didSave to the host's open virtual docs but must keep them open.
+    pub(super) async fn host_virtual_docs(&self, host_uri: &Url) -> Vec<OpenedVirtualDoc> {
+        self.host_to_virtual
+            .lock()
+            .await
+            .get(host_uri)
+            .cloned()
+            .unwrap_or_default()
+    }
+
     /// Remove and return all virtual documents for a host URI.
     ///
     /// Used by did_close module for cleanup.

--- a/src/lsp/bridge/text_document.rs
+++ b/src/lsp/bridge/text_document.rs
@@ -37,6 +37,7 @@ pub(in crate::lsp::bridge) mod publish_diagnostics;
 mod range_formatting;
 mod references;
 mod rename;
+mod save;
 mod signature_help;
 #[cfg(test)]
 pub(in crate::lsp::bridge) mod test_helpers;

--- a/src/lsp/bridge/text_document/save.rs
+++ b/src/lsp/bridge/text_document/save.rs
@@ -45,9 +45,11 @@ impl LanguageServerPool {
     /// Forward `textDocument/didSave` to every open virtual document of
     /// `host_uri`, on each live server that advertises `save` (#357).
     ///
-    /// The notification carries no `text`: kakehashi advertises
-    /// `save.includeText = false`, and the virt server's document is already
-    /// current from the didChange stream, so the bare identifier is enough.
+    /// The notification carries no `text` even if the downstream server
+    /// requested `save.includeText = true`: the virtual document is already
+    /// current from the didChange stream, so the saved text would be redundant.
+    /// `text` is optional in `DidSaveTextDocumentParams`, and re-deriving each
+    /// region's content here is not worth it for a fire-and-forget save hook.
     pub(crate) async fn forward_did_save_to_virtual_docs(&self, host_uri: &Url) {
         self.forward_save_notification_to_virtual_docs(
             host_uri,
@@ -63,12 +65,20 @@ impl LanguageServerPool {
     /// params built per virtual document by `build_params` (the virtual URI is
     /// the document the downstream server actually knows).
     ///
-    /// Locking mirrors [`Self::forward_didchange_to_opened_docs`]: the doc list
-    /// is snapshotted once, then the live handle is re-fetched per iteration
-    /// under the `connections` lock and checked for `Ready` — so a connection
-    /// that respawned after the snapshot can never be sent to via a stale
-    /// handle. `send_notification` is a non-blocking queue write (FIFO
-    /// single-writer loop, ls-bridge-message-ordering).
+    /// Mirrors [`Self::forward_didchange_to_opened_docs`]'s two-stage liveness
+    /// guard so the (necessarily lock-free) snapshot can't send to a stale
+    /// target:
+    /// 1. the `(virtual_uri, connection)` pair is re-checked against the **live**
+    ///    reverse index ([`Self::get_all_connections_for_virtual_uri`]) — a
+    ///    concurrent `didClose`/respawn that closed or purged the doc drops it
+    ///    here (didChange gets the same gate from `increment_document_version`
+    ///    returning `None`);
+    /// 2. the handle is re-fetched per iteration under the `connections` lock
+    ///    and must be `Ready`, so a respawned connection is never sent to via a
+    ///    stale handle.
+    ///
+    /// `send_notification` is a non-blocking queue write (FIFO single-writer
+    /// loop, ls-bridge-message-ordering).
     async fn forward_save_notification_to_virtual_docs(
         &self,
         host_uri: &Url,
@@ -78,6 +88,15 @@ impl LanguageServerPool {
     ) {
         let docs = self.host_virtual_docs(host_uri).await;
         for doc in docs {
+            // Stage 1: the snapshot can go stale — only send if this connection
+            // STILL has this virtual document open per the live reverse index.
+            if !self
+                .get_all_connections_for_virtual_uri(&doc.virtual_uri)
+                .contains(&doc.connection_key)
+            {
+                continue;
+            }
+            // Stage 2: re-fetch the live handle and require Ready.
             let handle = {
                 let connections = self.connections().await;
                 match connections.get(&doc.connection_key) {

--- a/src/lsp/bridge/text_document/save.rs
+++ b/src/lsp/bridge/text_document/save.rs
@@ -67,10 +67,12 @@ impl LanguageServerPool {
     /// send is guarded against a stale target by holding `connections` across
     /// the liveness recheck AND the send (order `connections` → tracker,
     /// matching the respawn purge in `pool.rs`):
-    /// - while `connections` is held a respawn purge cannot interleave, so a
-    ///   replacement process can never be installed between the recheck and the
-    ///   send (a pre-handle reverse-index check alone would NOT close this — the
-    ///   purge could swap in a fresh Ready handle that never opened the doc);
+    /// - `connections` is taken once after the snapshot and held across the
+    ///   whole loop — no `.await` happens inside it. While it is held a respawn
+    ///   purge cannot interleave, so a replacement process can never be installed
+    ///   between the recheck and the send (a pre-handle reverse-index check
+    ///   alone would NOT close this — the purge could swap in a fresh Ready
+    ///   handle that never opened the doc);
     /// - the `(virtual_uri, connection)` pair is then re-checked against the
     ///   **live** reverse index ([`Self::get_all_connections_for_virtual_uri`]),
     ///   dropping a doc a concurrent `didClose` removed (best-effort, the same
@@ -78,8 +80,8 @@ impl LanguageServerPool {
     /// - the handle must be the current `Ready` one.
     ///
     /// `send_notification` is a non-blocking queue write (FIFO single-writer
-    /// loop, ls-bridge-message-ordering), so holding `connections` across it is
-    /// cheap — the same discipline as `notify_host_will_save`.
+    /// loop, ls-bridge-message-ordering), so holding `connections` across the
+    /// batch is cheap — the same discipline as `notify_host_will_save`.
     async fn forward_save_notification_to_virtual_docs(
         &self,
         host_uri: &Url,
@@ -88,8 +90,8 @@ impl LanguageServerPool {
         build_params: impl Fn(&str) -> serde_json::Value,
     ) {
         let docs = self.host_virtual_docs(host_uri).await;
+        let connections = self.connections().await;
         for doc in docs {
-            let connections = self.connections().await;
             // Under the `connections` lock (purge excluded): only send if this
             // connection STILL has this virtual doc open and is the current
             // Ready handle.

--- a/src/lsp/bridge/text_document/save.rs
+++ b/src/lsp/bridge/text_document/save.rs
@@ -16,7 +16,7 @@
 use tower_lsp_server::ls_types::TextDocumentSaveReason;
 use url::Url;
 
-use super::super::pool::{ConnectionState, LanguageServerPool};
+use super::super::pool::{ConnectionHandle, ConnectionState, LanguageServerPool};
 use super::super::protocol::JsonRpcNotification;
 
 impl LanguageServerPool {
@@ -32,7 +32,7 @@ impl LanguageServerPool {
         self.forward_save_notification_to_virtual_docs(
             host_uri,
             "textDocument/willSave",
-            "textDocument/willSave",
+            |handle| handle.has_capability("textDocument/willSave"),
             |virtual_uri| {
                 serde_json::json!({ "textDocument": { "uri": virtual_uri }, "reason": reason })
             },
@@ -41,46 +41,50 @@ impl LanguageServerPool {
     }
 
     /// Forward `textDocument/didSave` to every open virtual document of
-    /// `host_uri`, on each live server that advertises `save` (#357).
+    /// `host_uri`, on each live server that accepts a textless didSave (#357).
     ///
     /// The notification carries no `text`. Servers that demand
-    /// `save.includeText = true` are filtered out by the capability gate
-    /// (`has_capability("textDocument/didSave")`) rather than served a textless
-    /// didSave: kakehashi advertises `includeText = false` upstream and so never
-    /// receives the editor's saved bytes to forward. Servers that accept
+    /// `save.includeText = true` are filtered out by
+    /// [`ConnectionHandle::accepts_textless_did_save`] rather than served a
+    /// textless didSave: kakehashi advertises `includeText = false` upstream and
+    /// so never receives the editor's saved bytes to forward. Servers that accept
     /// textless didSave already have current content from the didChange stream.
+    /// That gate reads STATIC capabilities only, so a dynamic didSave
+    /// registration (whose options the method-name-only dynamic registry can't
+    /// carry) cannot smuggle an `includeText = true` server past the filter.
     pub(crate) async fn forward_did_save_to_virtual_docs(&self, host_uri: &Url) {
         self.forward_save_notification_to_virtual_docs(
             host_uri,
             "textDocument/didSave",
-            "textDocument/didSave",
+            ConnectionHandle::accepts_textless_did_save,
             |virtual_uri| serde_json::json!({ "textDocument": { "uri": virtual_uri } }),
         )
         .await;
     }
 
     /// Shared fan-out: snapshot the host's open virtual docs and send `method`
-    /// to each live/Ready connection that advertises `capability`, with the
-    /// params built per virtual document by `build_params` (the virtual URI is
-    /// the document the downstream server actually knows).
+    /// to each live/Ready connection accepted by `supports`, with the params
+    /// built per virtual document by `build_params` (the virtual URI is the
+    /// document the downstream server actually knows).
     ///
-    /// The `host_to_virtual` list is necessarily snapshotted lock-free, so each
-    /// send is guarded against a stale target by holding `connections` across
-    /// the liveness recheck AND the send (order `connections` → tracker,
-    /// matching the respawn purge in `pool.rs`):
+    /// The `host_to_virtual` list is snapshotted under its own lock, which is
+    /// released before `connections` is taken — so each send is guarded against
+    /// a stale target by holding `connections` across the liveness recheck AND
+    /// the send (order `connections` → tracker, matching the respawn purge in
+    /// `pool.rs`):
     /// - `connections` is taken once after the snapshot and held across the
     ///   whole loop — no `.await` happens inside it. While it is held a respawn
     ///   purge cannot interleave, so a replacement process can never be installed
     ///   between the recheck and the send (a reverse-index check alone would NOT
     ///   close this — the purge could swap in a fresh Ready handle that never
     ///   opened the doc);
-    /// - the handle must be the current `Ready` one and advertise the capability
-    ///   (cheap checks, done first);
+    /// - the handle must be the current `Ready` one and pass `supports` (cheap
+    ///   checks, done first);
     /// - the `(virtual_uri, connection)` pair must STILL be in the **live**
     ///   reverse index ([`Self::is_virtual_doc_open_on_connection`]) — dropping a
     ///   doc a concurrent `didClose` removed (best-effort, the same accepted
     ///   TOCTOU `forward_didchange_to_opened_docs` has). This (cheap, but a
-    ///   tracker lookup) runs last so it is skipped for un-Ready/incapable docs.
+    ///   tracker lookup) runs last so it is skipped for un-Ready/unsupported docs.
     ///
     /// `send_notification` is a non-blocking queue write (FIFO single-writer
     /// loop, ls-bridge-message-ordering), so holding `connections` across the
@@ -89,18 +93,23 @@ impl LanguageServerPool {
         &self,
         host_uri: &Url,
         method: &'static str,
-        capability: &'static str,
+        supports: impl Fn(&ConnectionHandle) -> bool,
         build_params: impl Fn(&str) -> serde_json::Value,
     ) {
         let docs = self.host_virtual_docs(host_uri).await;
+        // Common path (saving a file with no open injections): skip the
+        // `connections` lock entirely.
+        if docs.is_empty() {
+            return;
+        }
         let connections = self.connections().await;
         for doc in docs {
-            // Cheap checks first: the current Ready handle that advertises the
-            // capability (all under the held `connections` lock, purge excluded).
+            // Cheap checks first: the current Ready handle that supports this
+            // notification (all under the held `connections` lock, purge excluded).
             let Some(handle) = connections.get(&doc.connection_key) else {
                 continue;
             };
-            if handle.state() != ConnectionState::Ready || !handle.has_capability(capability) {
+            if handle.state() != ConnectionState::Ready || !supports(handle) {
                 continue;
             }
             // Compute the virtual URI string once and reuse it for both the

--- a/src/lsp/bridge/text_document/save.rs
+++ b/src/lsp/bridge/text_document/save.rs
@@ -43,11 +43,12 @@ impl LanguageServerPool {
     /// Forward `textDocument/didSave` to every open virtual document of
     /// `host_uri`, on each live server that advertises `save` (#357).
     ///
-    /// The notification carries no `text` even if the downstream server
-    /// requested `save.includeText = true`: the virtual document is already
-    /// current from the didChange stream, so the saved text would be redundant.
-    /// `text` is optional in `DidSaveTextDocumentParams`, and re-deriving each
-    /// region's content here is not worth it for a fire-and-forget save hook.
+    /// The notification carries no `text`. Servers that demand
+    /// `save.includeText = true` are filtered out by the capability gate
+    /// (`has_capability("textDocument/didSave")`) rather than served a textless
+    /// didSave: kakehashi advertises `includeText = false` upstream and so never
+    /// receives the editor's saved bytes to forward. Servers that accept
+    /// textless didSave already have current content from the didChange stream.
     pub(crate) async fn forward_did_save_to_virtual_docs(&self, host_uri: &Url) {
         self.forward_save_notification_to_virtual_docs(
             host_uri,

--- a/src/lsp/bridge/text_document/save.rs
+++ b/src/lsp/bridge/text_document/save.rs
@@ -13,8 +13,6 @@
 //! Fire-and-forget: only servers that already have the virtual document open and
 //! that advertise the capability are notified; no lazy spawn.
 
-use std::sync::Arc;
-
 use tower_lsp_server::ls_types::TextDocumentSaveReason;
 use url::Url;
 
@@ -65,20 +63,23 @@ impl LanguageServerPool {
     /// params built per virtual document by `build_params` (the virtual URI is
     /// the document the downstream server actually knows).
     ///
-    /// Mirrors [`Self::forward_didchange_to_opened_docs`]'s two-stage liveness
-    /// guard so the (necessarily lock-free) snapshot can't send to a stale
-    /// target:
-    /// 1. the `(virtual_uri, connection)` pair is re-checked against the **live**
-    ///    reverse index ([`Self::get_all_connections_for_virtual_uri`]) — a
-    ///    concurrent `didClose`/respawn that closed or purged the doc drops it
-    ///    here (didChange gets the same gate from `increment_document_version`
-    ///    returning `None`);
-    /// 2. the handle is re-fetched per iteration under the `connections` lock
-    ///    and must be `Ready`, so a respawned connection is never sent to via a
-    ///    stale handle.
+    /// The `host_to_virtual` list is necessarily snapshotted lock-free, so each
+    /// send is guarded against a stale target by holding `connections` across
+    /// the liveness recheck AND the send (order `connections` → tracker,
+    /// matching the respawn purge in `pool.rs`):
+    /// - while `connections` is held a respawn purge cannot interleave, so a
+    ///   replacement process can never be installed between the recheck and the
+    ///   send (a pre-handle reverse-index check alone would NOT close this — the
+    ///   purge could swap in a fresh Ready handle that never opened the doc);
+    /// - the `(virtual_uri, connection)` pair is then re-checked against the
+    ///   **live** reverse index ([`Self::get_all_connections_for_virtual_uri`]),
+    ///   dropping a doc a concurrent `didClose` removed (best-effort, the same
+    ///   accepted TOCTOU `forward_didchange_to_opened_docs` has);
+    /// - the handle must be the current `Ready` one.
     ///
     /// `send_notification` is a non-blocking queue write (FIFO single-writer
-    /// loop, ls-bridge-message-ordering).
+    /// loop, ls-bridge-message-ordering), so holding `connections` across it is
+    /// cheap — the same discipline as `notify_host_will_save`.
     async fn forward_save_notification_to_virtual_docs(
         &self,
         host_uri: &Url,
@@ -88,23 +89,20 @@ impl LanguageServerPool {
     ) {
         let docs = self.host_virtual_docs(host_uri).await;
         for doc in docs {
-            // Stage 1: the snapshot can go stale — only send if this connection
-            // STILL has this virtual document open per the live reverse index.
+            let connections = self.connections().await;
+            // Under the `connections` lock (purge excluded): only send if this
+            // connection STILL has this virtual doc open and is the current
+            // Ready handle.
             if !self
                 .get_all_connections_for_virtual_uri(&doc.virtual_uri)
                 .contains(&doc.connection_key)
             {
                 continue;
             }
-            // Stage 2: re-fetch the live handle and require Ready.
-            let handle = {
-                let connections = self.connections().await;
-                match connections.get(&doc.connection_key) {
-                    Some(handle) if handle.state() == ConnectionState::Ready => Arc::clone(handle),
-                    _ => continue,
-                }
+            let Some(handle) = connections.get(&doc.connection_key) else {
+                continue;
             };
-            if !handle.has_capability(capability) {
+            if handle.state() != ConnectionState::Ready || !handle.has_capability(capability) {
                 continue;
             }
             let virtual_uri = doc.virtual_uri.to_uri_string();

--- a/src/lsp/bridge/text_document/save.rs
+++ b/src/lsp/bridge/text_document/save.rs
@@ -71,14 +71,16 @@ impl LanguageServerPool {
     /// - `connections` is taken once after the snapshot and held across the
     ///   whole loop — no `.await` happens inside it. While it is held a respawn
     ///   purge cannot interleave, so a replacement process can never be installed
-    ///   between the recheck and the send (a pre-handle reverse-index check
-    ///   alone would NOT close this — the purge could swap in a fresh Ready
-    ///   handle that never opened the doc);
-    /// - the `(virtual_uri, connection)` pair is then re-checked against the
-    ///   **live** reverse index ([`Self::get_all_connections_for_virtual_uri`]),
-    ///   dropping a doc a concurrent `didClose` removed (best-effort, the same
-    ///   accepted TOCTOU `forward_didchange_to_opened_docs` has);
-    /// - the handle must be the current `Ready` one.
+    ///   between the recheck and the send (a reverse-index check alone would NOT
+    ///   close this — the purge could swap in a fresh Ready handle that never
+    ///   opened the doc);
+    /// - the handle must be the current `Ready` one and advertise the capability
+    ///   (cheap checks, done first);
+    /// - the `(virtual_uri, connection)` pair must STILL be in the **live**
+    ///   reverse index ([`Self::is_virtual_doc_open_on_connection`]) — dropping a
+    ///   doc a concurrent `didClose` removed (best-effort, the same accepted
+    ///   TOCTOU `forward_didchange_to_opened_docs` has). This (cheap, but a
+    ///   tracker lookup) runs last so it is skipped for un-Ready/incapable docs.
     ///
     /// `send_notification` is a non-blocking queue write (FIFO single-writer
     /// loop, ls-bridge-message-ordering), so holding `connections` across the
@@ -93,19 +95,17 @@ impl LanguageServerPool {
         let docs = self.host_virtual_docs(host_uri).await;
         let connections = self.connections().await;
         for doc in docs {
-            // Under the `connections` lock (purge excluded): only send if this
-            // connection STILL has this virtual doc open and is the current
-            // Ready handle.
-            if !self
-                .get_all_connections_for_virtual_uri(&doc.virtual_uri)
-                .contains(&doc.connection_key)
-            {
-                continue;
-            }
+            // Cheap checks first: the current Ready handle that advertises the
+            // capability (all under the held `connections` lock, purge excluded).
             let Some(handle) = connections.get(&doc.connection_key) else {
                 continue;
             };
             if handle.state() != ConnectionState::Ready || !handle.has_capability(capability) {
+                continue;
+            }
+            // Then the liveness recheck: only send if this connection STILL has
+            // this virtual doc open (zero-alloc membership check).
+            if !self.is_virtual_doc_open_on_connection(&doc.virtual_uri, &doc.connection_key) {
                 continue;
             }
             let virtual_uri = doc.virtual_uri.to_uri_string();

--- a/src/lsp/bridge/text_document/save.rs
+++ b/src/lsp/bridge/text_document/save.rs
@@ -103,12 +103,14 @@ impl LanguageServerPool {
             if handle.state() != ConnectionState::Ready || !handle.has_capability(capability) {
                 continue;
             }
+            // Compute the virtual URI string once and reuse it for both the
+            // liveness recheck and the notification params.
+            let virtual_uri = doc.virtual_uri.to_uri_string();
             // Then the liveness recheck: only send if this connection STILL has
             // this virtual doc open (membership test, no reverse-index Vec clone).
-            if !self.is_virtual_doc_open_on_connection(&doc.virtual_uri, &doc.connection_key) {
+            if !self.is_virtual_doc_open_on_connection(&virtual_uri, &doc.connection_key) {
                 continue;
             }
-            let virtual_uri = doc.virtual_uri.to_uri_string();
             let notification = JsonRpcNotification::new(method, build_params(&virtual_uri));
             handle.send_notification(notification);
         }

--- a/src/lsp/bridge/text_document/save.rs
+++ b/src/lsp/bridge/text_document/save.rs
@@ -104,7 +104,7 @@ impl LanguageServerPool {
                 continue;
             }
             // Then the liveness recheck: only send if this connection STILL has
-            // this virtual doc open (zero-alloc membership check).
+            // this virtual doc open (membership test, no reverse-index Vec clone).
             if !self.is_virtual_doc_open_on_connection(&doc.virtual_uri, &doc.connection_key) {
                 continue;
             }

--- a/src/lsp/bridge/text_document/save.rs
+++ b/src/lsp/bridge/text_document/save.rs
@@ -15,12 +15,33 @@
 
 use std::sync::Arc;
 
+use tower_lsp_server::ls_types::TextDocumentSaveReason;
 use url::Url;
 
 use super::super::pool::{ConnectionState, LanguageServerPool};
 use super::super::protocol::JsonRpcNotification;
 
 impl LanguageServerPool {
+    /// Forward `textDocument/willSave` to every open virtual document of
+    /// `host_uri`, on each live server that advertises `willSave` (#357). The
+    /// host `reason` is forwarded verbatim; only the URI is rewritten to the
+    /// virtual document the downstream server knows.
+    pub(crate) async fn forward_will_save_to_virtual_docs(
+        &self,
+        host_uri: &Url,
+        reason: TextDocumentSaveReason,
+    ) {
+        self.forward_save_notification_to_virtual_docs(
+            host_uri,
+            "textDocument/willSave",
+            "textDocument/willSave",
+            |virtual_uri| {
+                serde_json::json!({ "textDocument": { "uri": virtual_uri }, "reason": reason })
+            },
+        )
+        .await;
+    }
+
     /// Forward `textDocument/didSave` to every open virtual document of
     /// `host_uri`, on each live server that advertises `save` (#357).
     ///

--- a/src/lsp/bridge/text_document/save.rs
+++ b/src/lsp/bridge/text_document/save.rs
@@ -1,0 +1,75 @@
+//! willSave / didSave notification fan-out to virtual-document servers (#357).
+//!
+//! willSave and didSave concern the *host* document, but virt-bridge servers
+//! only know the per-injection virtual documents projected from it. We forward
+//! these save-time notifications to every virtual document currently open for
+//! the host, rewriting the URI to the **virtual** one, so a virt server that
+//! opts into save hooks can react to the host save.
+//!
+//! Notifications only — `willSaveWaitUntil` stays host-only: its returned edits
+//! would need virtual→host translation and cross-region aggregation that overlap
+//! the concatenated formatting pipeline (see host-document-bridge).
+//!
+//! Fire-and-forget: only servers that already have the virtual document open and
+//! that advertise the capability are notified; no lazy spawn.
+
+use std::sync::Arc;
+
+use url::Url;
+
+use super::super::pool::{ConnectionState, LanguageServerPool};
+use super::super::protocol::JsonRpcNotification;
+
+impl LanguageServerPool {
+    /// Forward `textDocument/didSave` to every open virtual document of
+    /// `host_uri`, on each live server that advertises `save` (#357).
+    ///
+    /// The notification carries no `text`: kakehashi advertises
+    /// `save.includeText = false`, and the virt server's document is already
+    /// current from the didChange stream, so the bare identifier is enough.
+    pub(crate) async fn forward_did_save_to_virtual_docs(&self, host_uri: &Url) {
+        self.forward_save_notification_to_virtual_docs(
+            host_uri,
+            "textDocument/didSave",
+            "textDocument/didSave",
+            |virtual_uri| serde_json::json!({ "textDocument": { "uri": virtual_uri } }),
+        )
+        .await;
+    }
+
+    /// Shared fan-out: snapshot the host's open virtual docs and send `method`
+    /// to each live/Ready connection that advertises `capability`, with the
+    /// params built per virtual document by `build_params` (the virtual URI is
+    /// the document the downstream server actually knows).
+    ///
+    /// Locking mirrors [`Self::forward_didchange_to_opened_docs`]: the doc list
+    /// is snapshotted once, then the live handle is re-fetched per iteration
+    /// under the `connections` lock and checked for `Ready` — so a connection
+    /// that respawned after the snapshot can never be sent to via a stale
+    /// handle. `send_notification` is a non-blocking queue write (FIFO
+    /// single-writer loop, ls-bridge-message-ordering).
+    async fn forward_save_notification_to_virtual_docs(
+        &self,
+        host_uri: &Url,
+        method: &'static str,
+        capability: &'static str,
+        build_params: impl Fn(&str) -> serde_json::Value,
+    ) {
+        let docs = self.host_virtual_docs(host_uri).await;
+        for doc in docs {
+            let handle = {
+                let connections = self.connections().await;
+                match connections.get(&doc.connection_key) {
+                    Some(handle) if handle.state() == ConnectionState::Ready => Arc::clone(handle),
+                    _ => continue,
+                }
+            };
+            if !handle.has_capability(capability) {
+                continue;
+            }
+            let virtual_uri = doc.virtual_uri.to_uri_string();
+            let notification = JsonRpcNotification::new(method, build_params(&virtual_uri));
+            handle.send_notification(notification);
+        }
+    }
+}

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -198,13 +198,18 @@ impl Kakehashi {
         // capability not advertised, matching previous behavior.
         let on_type_formatting_triggers =
             crate::config::settings::on_type_formatting_trigger_union(&settings.language_servers);
-        // Gate the willSave/willSaveWaitUntil capabilities on host bridging
-        // being configured (#357): both forward only to host-bridge servers, so
-        // advertising them when no language opts in would make the editor send a
-        // willSave nothing consumes and block every save on a willSaveWaitUntil
-        // round trip that can only ever return "no edits". Computed before
-        // `settings` moves into apply_raw_settings, like the trigger union above.
+        // Gate the save capabilities (#357), computed before `settings` moves
+        // into apply_raw_settings (like the trigger union above):
+        // - willSave now fans out to BOTH host AND virt bridges, so advertise it
+        //   whenever any runnable bridge server is configured (the built-in `_`
+        //   defaults entry has an empty cmd and doesn't count) — otherwise the
+        //   editor never sends a willSave for virt servers to react to.
+        // - willSaveWaitUntil stays host-only (its edits would need virtual→host
+        //   translation + cross-region aggregation), so it keeps the stricter
+        //   host-bridging gate; advertising it without a host bridge would block
+        //   every save on a round trip that can only return "no edits".
         let host_bridging_enabled = settings.any_host_bridging_enabled();
+        let will_save_advertised = host_bridging_enabled || settings.any_bridge_server_runnable();
         self.apply_raw_settings(raw_settings, settings).await;
 
         self.notifier().log_info("server initialized!").await;
@@ -219,9 +224,9 @@ impl Kakehashi {
                     TextDocumentSyncOptions {
                         open_close: Some(true),
                         change: Some(TextDocumentSyncKind::INCREMENTAL),
-                        // Advertised only when a host bridge is configured (#357);
-                        // forwarded verbatim to host-bridge servers.
-                        will_save: host_bridging_enabled.then_some(true),
+                        // willSave: any bridge (host or virt) may consume it.
+                        // willSaveWaitUntil: host-only (#357).
+                        will_save: will_save_advertised.then_some(true),
                         will_save_wait_until: host_bridging_enabled.then_some(true),
                         save: Some(TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
                             include_text: Some(false),

--- a/src/lsp/lsp_impl/text_document/did_save.rs
+++ b/src/lsp/lsp_impl/text_document/did_save.rs
@@ -24,6 +24,15 @@ impl Kakehashi {
             uri
         );
 
+        // Forward didSave to virt-bridge servers that have a virtual document
+        // open for this host and advertise `save` (#357). A save hook on a
+        // fenced language (e.g. a server caching dirty state) reacts here;
+        // willSaveWaitUntil stays host-only.
+        self.bridge
+            .pool_arc()
+            .forward_did_save_to_virtual_docs(&uri)
+            .await;
+
         // Spawn background task for synthetic diagnostic collection
         self.diagnostic_scheduler()
             .spawn_synthetic_diagnostic_task(uri, lsp_uri);

--- a/src/lsp/lsp_impl/text_document/will_save.rs
+++ b/src/lsp/lsp_impl/text_document/will_save.rs
@@ -7,14 +7,20 @@ use super::super::{Kakehashi, uri_to_url};
 impl Kakehashi {
     /// Handle `textDocument/willSave`.
     ///
-    /// Forwards the notification verbatim to host-bridge servers that already
-    /// have the host document open (host-document-bridge, #357). willSave
-    /// concerns the host document being saved, so only the host layer is
-    /// notified — virtual-document servers learn of saves through the existing
-    /// didSave forwarding, and propagating save edits from virtual regions
-    /// overlaps with the concatenated formatting pipeline (deferred to a
-    /// follow-up should a concrete need appear). Fire-and-forget: no response
-    /// is awaited and no connection is lazily spawned.
+    /// Forwards the notification to **both** bridge layers (#357):
+    /// - **host-bridge** servers that already have the host document open
+    ///   (verbatim: real URI + reason);
+    /// - **virt-bridge** servers that have a virtual document open for this
+    ///   host, with the URI rewritten to the virtual document and the reason
+    ///   forwarded verbatim.
+    ///
+    /// Each layer notifies only servers that already have the document open and
+    /// advertise `willSave` — the per-server opt-in is what keeps a virt server
+    /// from being told about a fragment "save" it never asked to hear about.
+    /// `willSaveWaitUntil` stays host-only: its returned edits would need
+    /// virtual→host translation and cross-region aggregation overlapping the
+    /// concatenated formatting pipeline. Fire-and-forget: no response is awaited
+    /// and no connection is lazily spawned.
     pub(crate) async fn will_save_impl(&self, params: WillSaveTextDocumentParams) {
         let Ok(uri) = uri_to_url(&params.text_document.uri) else {
             log::warn!(
@@ -24,9 +30,9 @@ impl Kakehashi {
             return;
         };
 
-        self.bridge
-            .pool_arc()
-            .notify_host_will_save(&uri, &params)
+        let pool = self.bridge.pool_arc();
+        pool.notify_host_will_save(&uri, &params).await;
+        pool.forward_will_save_to_virtual_docs(&uri, params.reason)
             .await;
     }
 }

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -49,13 +49,16 @@
 //!   uppercasing whole-document edit for ANY typed character (bridge-side
 //!   trigger filtering is what `tests/e2e_on_type_formatting.rs` proves).
 //! - `will-save` — advertises `hoverProvider` + a `textDocumentSync` Options
-//!   block with `willSave` and `willSaveWaitUntil` true. Records every
-//!   `textDocument/willSave` notification (count + last reason) and answers
+//!   block with `willSave`, `willSaveWaitUntil`, and `save` true. Records every
+//!   `textDocument/willSave` (count + last reason + last URI) and
+//!   `textDocument/didSave` (count + last URI), and answers
 //!   `textDocument/willSaveWaitUntil` with a save-time edit echoing the
-//!   requested URI (only for documents synced via `didOpen`). `hover` reports
-//!   the recorded willSave count and last reason, so the test can prove the
-//!   notification reached the host server. Used by `tests/e2e_host_bridge.rs`
-//!   to prove host-bridge willSave/willSaveWaitUntil forwarding (#357).
+//!   requested URI (only for documents synced via `didOpen`). `hover` returns
+//!   the recorded state as a JSON string (`{will,reason,willUri,did,didUri}`),
+//!   so a test can prove the notifications reached this server carrying the URI
+//!   it knows — the host URI for a host server, the *virtual* URI for a virt
+//!   server. Used by `tests/e2e_host_bridge.rs` to prove host- AND virt-bridge
+//!   willSave/didSave forwarding (#357).
 //! - `will-save-slow` — like `will-save`, but sleeps 8s before answering
 //!   `willSaveWaitUntil`, past kakehashi's 5s save budget. Lets the test prove
 //!   the bridge times out and returns null near 5s instead of hanging the save
@@ -95,10 +98,15 @@ fn main() {
     // `workspace-folders` mode: every folder URI this server has been told
     // about, via `initialize` params and `workspace/didChangeWorkspaceFolders`.
     let mut workspace_folders: Vec<String> = Vec::new();
-    // `will-save` mode: how many `textDocument/willSave` notifications arrived
-    // and the reason carried by the most recent one (#357).
+    // `will-save` mode: counts + last-seen URI for the willSave/didSave
+    // notifications, reported back via hover so the test can prove they arrived
+    // and carried the right document URI (the virtual URI for a virt server,
+    // the host URI for a host server) (#357).
     let mut will_save_count: usize = 0;
     let mut last_will_save_reason: i64 = 0;
+    let mut last_will_save_uri: Option<String> = None;
+    let mut did_save_count: usize = 0;
+    let mut last_did_save_uri: Option<String> = None;
 
     while let Some(message) = read_message(&mut reader) {
         let method = message
@@ -143,7 +151,8 @@ fn main() {
                             "openClose": true,
                             "change": 1,
                             "willSave": true,
-                            "willSaveWaitUntil": true
+                            "willSaveWaitUntil": true,
+                            "save": { "includeText": false }
                         }
                     }),
                     "workspace-folders" => json!({
@@ -255,12 +264,27 @@ fn main() {
                 respond(&mut writer, id, result);
             }
             "textDocument/willSave" => {
-                // Notification (no id): record receipt + reason so a later
-                // hover can prove the host bridge forwarded it (#357).
+                // Notification (no id): record receipt + reason + URI so a later
+                // hover can prove the bridge forwarded it carrying the document
+                // URI this server knows (host or virtual) (#357).
                 will_save_count += 1;
                 if let Some(reason) = message.pointer("/params/reason").and_then(Value::as_i64) {
                     last_will_save_reason = reason;
                 }
+                last_will_save_uri = message
+                    .pointer("/params/textDocument/uri")
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+            }
+            "textDocument/didSave" => {
+                // Notification (no id): record receipt + URI for the hover probe
+                // (#357). didSave carries no text (includeText:false), so just
+                // accepting it is the property under test.
+                did_save_count += 1;
+                last_did_save_uri = message
+                    .pointer("/params/textDocument/uri")
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
             }
             "textDocument/willSaveWaitUntil" => {
                 // `will-save-slow` stalls past kakehashi's 5s save budget so the
@@ -305,13 +329,17 @@ fn main() {
             }
             "textDocument/hover" => {
                 let result = if mode.starts_with("will-save") {
-                    // Report the recorded willSave count + last reason so the
-                    // test can prove the notification reached this server (#357).
-                    json!({
-                        "contents": format!(
-                            "willsave-count:{will_save_count}:reason:{last_will_save_reason}"
-                        )
-                    })
+                    // Report the recorded willSave/didSave state as a JSON string
+                    // so the test can prove the notifications reached this server
+                    // and carried the document URI it knows (#357).
+                    let state = json!({
+                        "will": will_save_count,
+                        "reason": last_will_save_reason,
+                        "willUri": last_will_save_uri,
+                        "did": did_save_count,
+                        "didUri": last_did_save_uri,
+                    });
+                    json!({ "contents": state.to_string() })
                 } else if mode.starts_with("workspace-folders") {
                     // Echo the sorted, de-duplicated set of folder URIs this
                     // single process currently knows. Not gated on didOpen: the

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -63,6 +63,9 @@
 //!   `willSaveWaitUntil`, past kakehashi's 5s save budget. Lets the test prove
 //!   the bridge times out and returns null near 5s instead of hanging the save
 //!   on the 30s request timeout (#357 Q3).
+//! - `will-save-incapable` — like `will-save` (records + reports save state via
+//!   hover) but advertises NEITHER `willSave` nor `save`, so the bridge's
+//!   per-server capability gate must skip it and its counts stay zero (#357).
 //! - `notify` — right after answering `initialize`, emits a
 //!   `window/showMessage` followed by a `window/logMessage` notification.
 //!   Used by `tests/e2e_window_notifications.rs` to prove the bridge forwards
@@ -154,6 +157,13 @@ fn main() {
                             "willSaveWaitUntil": true,
                             "save": { "includeText": false }
                         }
+                    }),
+                    // Records willSave/didSave like `will-save`, but advertises
+                    // NEITHER save flag — so the bridge's per-server capability
+                    // gate must skip it (its hover state stays at zero) (#357).
+                    "will-save-incapable" => json!({
+                        "hoverProvider": true,
+                        "textDocumentSync": 1
                     }),
                     "workspace-folders" => json!({
                         "hoverProvider": true,

--- a/tests/e2e_host_bridge.rs
+++ b/tests/e2e_host_bridge.rs
@@ -738,6 +738,10 @@ const VIRT_SAVE_MARKDOWN: &str = "# Title\n\n```lua\nprint(1)\n```\n";
 /// `will-save` mode (a virt bridge, no host bridging), and open a markdown host
 /// with a lua fence.
 fn init_virt_save_client() -> (LspClient, tempfile::TempDir) {
+    init_virt_save_client_with_mode("will-save")
+}
+
+fn init_virt_save_client_with_mode(mode: &str) -> (LspClient, tempfile::TempDir) {
     let config_dir = tempfile::TempDir::new().expect("config dir");
     let config_path = config_dir.path().join("virt_save.toml");
     std::fs::write(&config_path, "").expect("write config");
@@ -755,7 +759,7 @@ fn init_virt_save_client() -> (LspClient, tempfile::TempDir) {
             "workspaceFolders": null,
             "initializationOptions": {
                 "languageServers": {
-                    "lua-save": { "cmd": [mock_bin(), "will-save"], "languages": ["lua"] }
+                    "lua-save": { "cmd": [mock_bin(), mode], "languages": ["lua"] }
                 }
             }
         }),
@@ -838,6 +842,54 @@ fn e2e_virt_will_save_and_did_save_reach_virtual_doc() {
             "{key} must be the VIRTUAL document URI; got {uri}"
         );
         assert_ne!(uri, VIRT_SAVE_URI, "{key} must NOT be the host URI");
+    }
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_virt_save_skips_server_without_save_capability() {
+    // The per-server capability gate is the phantom-save mitigation: a virt
+    // server that advertises neither `willSave` nor `save` must NOT be told
+    // about the host save, even with its virtual doc open (#357).
+    let (mut client, _config_dir) = init_virt_save_client_with_mode("will-save-incapable");
+
+    // Warm up: open the virtual doc (hover still works — the mode advertises it)
+    // and confirm zero saves recorded.
+    let mut warmed = false;
+    for _ in 0..300 {
+        if let Some(state) = virt_save_hover(&mut client) {
+            assert_eq!(state["will"], 0);
+            assert_eq!(state["did"], 0);
+            warmed = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(warmed, "incapable virt server must still answer hover");
+
+    client.send_notification(
+        "textDocument/willSave",
+        json!({ "textDocument": { "uri": VIRT_SAVE_URI }, "reason": 1 }),
+    );
+    client.send_notification(
+        "textDocument/didSave",
+        json!({ "textDocument": { "uri": VIRT_SAVE_URI } }),
+    );
+
+    // Give the (incorrect) fan-out time to land, then confirm the gate held:
+    // counts stay zero. Poll a handful of times so a late delivery would fail.
+    for _ in 0..10 {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        let state = virt_save_hover(&mut client).expect("hover must answer");
+        assert_eq!(
+            state["will"], 0,
+            "willSave must NOT reach a server lacking the willSave capability; got {state}"
+        );
+        assert_eq!(
+            state["did"], 0,
+            "didSave must NOT reach a server lacking the save capability; got {state}"
+        );
     }
 
     shutdown(&mut client);

--- a/tests/e2e_host_bridge.rs
+++ b/tests/e2e_host_bridge.rs
@@ -512,21 +512,60 @@ fn e2e_host_bridge_advertises_save_capabilities_when_enabled() {
 }
 
 #[test]
-fn e2e_host_bridge_hides_save_capabilities_when_disabled() {
-    // No `bridge._self.enabled` anywhere: the save methods forward only to host
-    // bridges, so kakehashi must keep advertising neither (today's behavior).
+fn e2e_host_bridge_save_capabilities_decouple_willsave_from_waituntil() {
+    // A server IS configured (so virt bridging can consume willSave) but host
+    // bridging is OFF. willSave now fans out to virt too, so it must be
+    // advertised; willSaveWaitUntil is host-only, so it must stay hidden (#357).
     let (mut client, _config_dir, init) = init_will_save_client("");
+
+    let sync = init
+        .pointer("/result/capabilities/textDocumentSync")
+        .expect("textDocumentSync must be present");
+    assert_eq!(
+        sync.get("willSave").and_then(Value::as_bool),
+        Some(true),
+        "willSave must be advertised when any bridge server is configured; got {sync}"
+    );
+    assert!(
+        sync.get("willSaveWaitUntil").is_none_or(Value::is_null),
+        "willSaveWaitUntil must stay host-only (hidden without host bridging); got {sync}"
+    );
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn e2e_host_bridge_hides_save_capabilities_without_any_server() {
+    // With no language servers configured at all, neither save method has a
+    // possible consumer, so kakehashi advertises neither (today's behavior).
+    // Use an explicit empty config file and omit initializationOptions so no
+    // default/user config can leak servers or host bridging in.
+    let config_dir = tempfile::TempDir::new().expect("config dir");
+    let config_path = config_dir.path().join("empty.toml");
+    std::fs::write(&config_path, "").expect("write config");
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("temp path should be UTF-8"))
+        .build();
+    let init = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+        }),
+    );
 
     let sync = init
         .pointer("/result/capabilities/textDocumentSync")
         .expect("textDocumentSync must be present");
     assert!(
         sync.get("willSave").is_none_or(Value::is_null),
-        "willSave must NOT be advertised without a host bridge; got {sync}"
+        "willSave must NOT be advertised with no servers configured; got {sync}"
     );
     assert!(
         sync.get("willSaveWaitUntil").is_none_or(Value::is_null),
-        "willSaveWaitUntil must NOT be advertised without a host bridge; got {sync}"
+        "willSaveWaitUntil must NOT be advertised with no servers configured; got {sync}"
     );
 
     shutdown(&mut client);

--- a/tests/e2e_host_bridge.rs
+++ b/tests/e2e_host_bridge.rs
@@ -542,8 +542,9 @@ fn e2e_host_bridge_save_capabilities_decouple_willsave_from_waituntil() {
 
 #[test]
 fn e2e_host_bridge_hides_save_capabilities_without_any_server() {
-    // With no language servers configured at all, neither save method has a
-    // possible consumer, so kakehashi advertises neither (today's behavior).
+    // With no RUNNABLE bridge servers configured (only the built-in `_`
+    // wildcard defaults entry, which has an empty cmd), neither save method has
+    // a possible consumer, so kakehashi advertises neither (today's behavior).
     // Use an explicit empty config file and omit initializationOptions so no
     // default/user config can leak servers or host bridging in.
     let config_dir = tempfile::TempDir::new().expect("config dir");

--- a/tests/e2e_host_bridge.rs
+++ b/tests/e2e_host_bridge.rs
@@ -472,21 +472,27 @@ fn init_will_save_client_with_mode(
     (client, config_dir, init)
 }
 
-/// Hover the host document, returning the `will-save` mock's `contents`
-/// (`willsave-count:<n>:reason:<r>`) once the host bridge is warm, else `None`.
-fn host_save_hover(client: &mut LspClient) -> Option<String> {
+/// Hover `uri` at `(line, character)` and parse the `will-save` mock's JSON
+/// state (`{will,reason,willUri,did,didUri}`) from the hover contents, or `None`
+/// while the bridge is still warming up.
+fn save_state_hover(client: &mut LspClient, uri: &str, line: u64, character: u64) -> Option<Value> {
     let response = client.send_request(
         "textDocument/hover",
         json!({
-            "textDocument": { "uri": SAVE_URI },
-            "position": { "line": 0, "character": 0 },
+            "textDocument": { "uri": uri },
+            "position": { "line": line, "character": character },
         }),
     );
     assert!(response.get("error").is_none(), "hover must not error");
     response
         .pointer("/result/contents")
         .and_then(Value::as_str)
-        .map(str::to_string)
+        .and_then(|s| serde_json::from_str::<Value>(s).ok())
+}
+
+/// Hover the host document itself (host-bridge `will-save` server).
+fn host_save_hover(client: &mut LspClient) -> Option<Value> {
+    save_state_hover(client, SAVE_URI, 0, 0)
 }
 
 #[test]
@@ -619,10 +625,10 @@ fn e2e_host_will_save_notification_reaches_host() {
     // any willSave is forwarded.
     let mut warmed = false;
     for _ in 0..300 {
-        if let Some(contents) = host_save_hover(&mut client) {
-            assert!(
-                contents.starts_with("willsave-count:0:"),
-                "before any willSave the host server must report zero; got {contents}"
+        if let Some(state) = host_save_hover(&mut client) {
+            assert_eq!(
+                state["will"], 0,
+                "before any willSave the host server must report zero; got {state}"
             );
             warmed = true;
             break;
@@ -640,21 +646,24 @@ fn e2e_host_will_save_notification_reaches_host() {
         json!({ "textDocument": { "uri": SAVE_URI }, "reason": 2 }),
     );
 
-    // Subsequent hovers must reflect the recorded willSave: count 1, reason 2.
+    // Subsequent hovers must reflect the recorded willSave: count 1, reason 2,
+    // and the REAL host URI (the host path forwards verbatim).
     let mut seen = None;
     for _ in 0..300 {
-        if let Some(contents) = host_save_hover(&mut client)
-            && !contents.starts_with("willsave-count:0:")
+        if let Some(state) = host_save_hover(&mut client)
+            && state["will"] != 0
         {
-            seen = Some(contents);
+            seen = Some(state);
             break;
         }
         std::thread::sleep(std::time::Duration::from_millis(50));
     }
-    let contents = seen.expect("the forwarded willSave must reach the host server");
+    let state = seen.expect("the forwarded willSave must reach the host server");
+    assert_eq!(state["will"], 1, "host server must record one willSave");
+    assert_eq!(state["reason"], 2, "host server must record the reason");
     assert_eq!(
-        contents, "willsave-count:1:reason:2",
-        "the host server must record the forwarded willSave and its reason"
+        state["willUri"], SAVE_URI,
+        "host willSave must carry the real host URI verbatim"
     );
 
     shutdown(&mut client);
@@ -713,6 +722,123 @@ fn e2e_host_will_save_wait_until_times_out_without_hanging_save() {
         elapsed < std::time::Duration::from_secs(20),
         "must time out on the 5s budget, not the 30s request timeout; elapsed {elapsed:?}"
     );
+
+    shutdown(&mut client);
+}
+
+// ==========================================================================
+// Virt-bridge willSave / didSave (notifications fan out to virtual docs, #357)
+// ==========================================================================
+
+const VIRT_SAVE_URI: &str = "file:///test_virt_save.md";
+/// A markdown host whose lua fence content sits on LSP line 3 (`print(1)`).
+const VIRT_SAVE_MARKDOWN: &str = "# Title\n\n```lua\nprint(1)\n```\n";
+
+/// Initialize a client whose **lua** injections are served by the mock's
+/// `will-save` mode (a virt bridge, no host bridging), and open a markdown host
+/// with a lua fence.
+fn init_virt_save_client() -> (LspClient, tempfile::TempDir) {
+    let config_dir = tempfile::TempDir::new().expect("config dir");
+    let config_path = config_dir.path().join("virt_save.toml");
+    std::fs::write(&config_path, "").expect("write config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("temp path should be UTF-8"))
+        .build();
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": {
+                "languageServers": {
+                    "lua-save": { "cmd": [mock_bin(), "will-save"], "languages": ["lua"] }
+                }
+            }
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": VIRT_SAVE_URI,
+                "languageId": "markdown",
+                "version": 1,
+                "text": VIRT_SAVE_MARKDOWN
+            }
+        }),
+    );
+    (client, config_dir)
+}
+
+/// Hover inside the lua fence content (LSP line 3 = `print(1)`), which routes to
+/// the lua virt server and opens its virtual document.
+fn virt_save_hover(client: &mut LspClient) -> Option<Value> {
+    save_state_hover(client, VIRT_SAVE_URI, 3, 2)
+}
+
+#[test]
+fn e2e_virt_will_save_and_did_save_reach_virtual_doc() {
+    let (mut client, _config_dir) = init_virt_save_client();
+
+    // Warm up: a hover inside the lua fence opens the virtual document on the
+    // virt server (lazy didOpen). Zero saves recorded yet.
+    let mut warmed = false;
+    for _ in 0..300 {
+        if let Some(state) = virt_save_hover(&mut client) {
+            assert_eq!(state["will"], 0, "no willSave yet; got {state}");
+            assert_eq!(state["did"], 0, "no didSave yet; got {state}");
+            warmed = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(
+        warmed,
+        "virt lua server must answer hover (virtual doc opened) before the saves"
+    );
+
+    // Forward willSave (reason 1) and didSave on the HOST document.
+    client.send_notification(
+        "textDocument/willSave",
+        json!({ "textDocument": { "uri": VIRT_SAVE_URI }, "reason": 1 }),
+    );
+    client.send_notification(
+        "textDocument/didSave",
+        json!({ "textDocument": { "uri": VIRT_SAVE_URI } }),
+    );
+
+    // The virt server must receive BOTH, carrying the VIRTUAL document URI — a
+    // host URI here would betray a routing bug.
+    let mut seen = None;
+    for _ in 0..300 {
+        if let Some(state) = virt_save_hover(&mut client)
+            && state["will"] != 0
+            && state["did"] != 0
+        {
+            seen = Some(state);
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let state = seen.expect("willSave + didSave must reach the virt server");
+    assert_eq!(
+        state["reason"], 1,
+        "willSave reason must be forwarded verbatim"
+    );
+
+    for key in ["willUri", "didUri"] {
+        let uri = state[key].as_str().unwrap_or_default();
+        assert!(
+            uri.contains("kakehashi-virtual-uri"),
+            "{key} must be the VIRTUAL document URI; got {uri}"
+        );
+        assert_ne!(uri, VIRT_SAVE_URI, "{key} must NOT be the host URI");
+    }
 
     shutdown(&mut client);
 }


### PR DESCRIPTION
Follow-up to #418, landing the **notification** half of #417: `textDocument/willSave` and `textDocument/didSave` now fan out to **virt-bridge** servers, not just host.

## What

Save *notifications* concern the host save but virt-bridge servers only know the per-injection virtual documents. So willSave and didSave are fanned out to every virtual document currently open for the host, with the URI rewritten to the virtual one (reason forwarded verbatim). `willSaveWaitUntil` (the request) deliberately **stays host-only** — its returned edits would need virtual→host translation + cross-region aggregation overlapping the concatenated formatting pipeline.

## How (incremental commits)

1. **didSave → virt** — new `has_capability("textDocument/didSave")` arm (reads `textDocumentSync.save`); `forward_did_save_to_virtual_docs` fans didSave out to open virtual docs gated per-server on `save`. `did_save_impl` now forwards in addition to the existing synthetic-diagnostic trigger.
2. **willSave → virt + advertisement** — `forward_will_save_to_virtual_docs` (gated on `willSave`); `will_save_impl` now notifies host **and** virt. Broaden the `willSave` capability advertisement to "any runnable bridge server configured" (`any_bridge_server_runnable`, excluding the empty-cmd `_` defaults); `willSaveWaitUntil` keeps the host-bridging gate — the two capabilities **decouple**.
3. **e2e** — extend the mock `will-save` mode (record didSave + URIs, JSON hover state) + a `will-save-incapable` mode; tests prove willSave + didSave reach a lua virt server carrying the **virtual** URI, that an incapable server is **skipped** by the per-server gate, and the decoupled capability advertisement.
4. **docs** — host-document-bridge + virtual-document-model ADRs.

## Safety

The per-server capability gate is the phantom-save mitigation: a virt server only hears about a fragment "save" if it advertised save hooks. The fan-out holds `connections` across the live reverse-index recheck + send (order `connections` → tracker, matching the respawn purge), so a concurrent respawn/didClose can never deliver a save notification to a process that never opened (or has closed) the virtual document.

Updates #417 (request-side virt willSaveWaitUntil still deferred there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)