### PR TITLE
feat(bridge): propagate downstream publishDiagnostics to the editor (#380)

### DIFF
--- a/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
+++ b/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
@@ -478,19 +478,29 @@ because the #380 benefit now outweighs it:
 
 ## Decision–Implementation Gap
 
-Not yet implemented — this decision runs ahead of the code, which still
-implements the prior pull-first synthetic push:
+**Implemented** (the core push propagation):
 
-- `src/lsp/lsp_impl/coordinator/diagnostic.rs`
-  (`spawn_synthetic_diagnostic_task`, `schedule_debounced_diagnostic`),
-  `src/lsp/debounced_diagnostics.rs`, `src/lsp/synthetic_diagnostics.rs`, and the
-  pull in `src/lsp/bridge/text_document/diagnostic.rs`.
-- `src/lsp/bridge/actor/reader.rs` still discards non-scratch
-  `publishDiagnostics` at `forward_notification`'s `_ => {}` arm (#380).
+- The per-host merge cache (`src/lsp/diagnostic_cache.rs`, `DiagnosticAggregator`)
+  and the single `DiagnosticPublisher`
+  (`src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs`).
+- The host-event pull is unified onto the cache as the `PullLayer` blob (the
+  synthetic/debounced feed in `coordinator/diagnostic.rs` /
+  `debounced_diagnostics.rs` now republishes through the publisher rather than
+  publishing directly).
+- Non-scratch `publishDiagnostics` are routed from `reader.rs` into the cache as
+  `Region` slots (virtual coordinates, transformed at publish via lazy re-anchor),
+  closing #380 for region pushes.
 
-Migration outline: route non-scratch pushes into a new aggregator backed by the
-per-host merge cache; reduce the synthetic/debounced *proactive* pull to the
-`pullFallback` scope (pull-driven servers only) instead of retiring it outright;
-keep the *client* pull handler (augmented with the push cache for push-driven
-servers); update the bare-slug code references that currently name
-the prior pull-first decision.
+**Deferred** (staged follow-ups; the code documents each at its site):
+
+- The `content_epoch` version gate and the wire-version↔epoch mapping. Until then
+  there is no stale-overwrite guard and a brief wrong-content window after edits
+  (lazy re-anchor still keeps *positions* current via the retained pull trigger).
+- Per-source strategy fan-in (`preferred` sticky / `concatenated` visible-walk);
+  the staged merge concatenates, with HashMap-nondeterministic cross-source order.
+- The `_self` host-layer push source (the host layer is still served by the pull
+  feed for now).
+- Region-invalidation and crash cache eviction.
+- The `pullFallback` / `pushFallback` config toggles and the capability
+  classification — without the latter the pull feed and a server's spontaneous
+  push can double-count that server (documented in `diagnostic_cache.rs`).

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -3,6 +3,7 @@ mod bridge;
 mod cache;
 mod client;
 mod debounced_diagnostics;
+mod diagnostic_cache;
 pub(crate) mod in_progress_set;
 mod settings_manager;
 mod synthetic_diagnostics;

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -2359,6 +2359,60 @@ mod tests {
         );
     }
 
+    /// A malformed `diagnostics` array must be dropped, not routed as an empty
+    /// (clearing) push — otherwise a parse error would silently wipe the region.
+    /// An empty array, by contrast, is a legitimate clear and is routed.
+    #[tokio::test]
+    async fn handle_message_drops_malformed_but_routes_empty_publish_diagnostics() {
+        let make_deps = || {
+            let (response_tx, _response_rx) = mpsc::channel(16);
+            let (upstream_tx, upstream_rx) = mpsc::unbounded_channel();
+            let (window_tx, _window_rx) = mpsc::channel(16);
+            let deps = ServerRequestDeps {
+                server_name: Some("luals".to_string()),
+                response_tx,
+                dynamic_capabilities: Arc::new(DynamicCapabilityRegistry::new()),
+                upstream_tx,
+                workspace_folders: WorkspaceFolderSet::new(None),
+                window_tx,
+                upstream_request_tx: mpsc::unbounded_channel().0,
+                inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
+                progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
+                progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
+            };
+            (deps, upstream_rx)
+        };
+        let uri = "file:///project/kakehashi-virtual-uri-REGION.lua";
+
+        // Malformed: `diagnostics` is not an array of Diagnostic -> dropped.
+        let (deps, mut upstream_rx) = make_deps();
+        let malformed = json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics",
+            "params": {"uri": uri, "diagnostics": [{"range": "not-a-range"}]}
+        });
+        handle_message(malformed, &ResponseRouter::new(), "", &deps).await;
+        assert!(
+            upstream_rx.try_recv().is_err(),
+            "malformed diagnostics must be dropped, not routed"
+        );
+
+        // Empty array: a legitimate clear -> routed with an empty Vec.
+        let (deps, mut upstream_rx) = make_deps();
+        let empty = json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics",
+            "params": {"uri": uri, "diagnostics": []}
+        });
+        handle_message(empty, &ResponseRouter::new(), "", &deps).await;
+        match upstream_rx.try_recv().expect("empty array should be routed") {
+            UpstreamNotification::PublishDiagnostics { diagnostics, .. } => {
+                assert!(diagnostics.is_empty(), "empty array clears");
+            }
+            _ => panic!("expected PublishDiagnostics"),
+        }
+    }
+
     #[tokio::test]
     async fn handle_message_unknown_server_request_sends_method_not_found() {
         let router = ResponseRouter::new();

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -56,6 +56,18 @@ pub(crate) enum UpstreamNotification {
     /// Request upstream to re-pull diagnostics.
     /// Sent when downstream server issues `workspace/diagnostic/refresh`.
     DiagnosticRefresh,
+    /// A downstream-initiated `textDocument/publishDiagnostics` for an injection
+    /// region's virtual document (push-propagation-diagnostic-forwarding). The
+    /// forwarding loop resolves `uri` to its host document + region, caches the
+    /// diagnostics under `server`, and republishes the merged host set.
+    PublishDiagnostics {
+        /// The virtual document URI the downstream published for.
+        uri: String,
+        /// The originating downstream server's config name (`deps.server_name`).
+        server: Option<String>,
+        /// The pushed diagnostics, in the virtual document's coordinates.
+        diagnostics: Vec<tower_lsp_server::ls_types::Diagnostic>,
+    },
     /// Forward a downstream `window/logMessage` to the editor.
     /// `message` is already prefixed with the originating server name.
     LogMessage { typ: MessageType, message: String },
@@ -739,6 +751,10 @@ async fn handle_message(
                     "{}Discarding publishDiagnostics targeting a scratch virtual document",
                     server_prefix
                 );
+            } else if message["method"].as_str() == Some("textDocument/publishDiagnostics") {
+                // Non-scratch region push: route into the diagnostics cache
+                // (push-propagation-diagnostic-forwarding) instead of dropping (#380).
+                text_document::publish_diagnostics::forward_push(&message, deps);
             } else if message["method"].as_str() == Some("$/progress") {
                 window::progress::forward(&message, server_prefix, deps);
             } else if message["method"].as_str() == Some("$/cancelRequest") {
@@ -784,9 +800,10 @@ fn handle_cancel_request(message: &serde_json::Value, deps: &ServerRequestDeps) 
 /// [`telemetry::event`]); all are forwarded unconditionally so the bridge stays
 /// transparent.
 ///
-/// `$/progress` and `$/cancelRequest` are handled earlier in `handle_message`,
-/// so they never reach here. Everything else is still silently ignored
-/// (push-based publishDiagnostics: #380).
+/// `$/progress`, `$/cancelRequest`, and non-scratch `textDocument/publishDiagnostics`
+/// (routed to the diagnostics cache — push-propagation-diagnostic-forwarding) are
+/// handled earlier in `handle_message`, so they never reach here. Everything else
+/// is still silently ignored.
 fn forward_notification(
     message: &serde_json::Value,
     server_prefix: &str,
@@ -2247,6 +2264,98 @@ mod tests {
         assert!(
             response_rx.try_recv().is_err(),
             "a notification must not trigger any downstream response"
+        );
+    }
+
+    /// A non-scratch push for an injection region's virtual document is routed
+    /// upstream as `PublishDiagnostics` (push-propagation-diagnostic-forwarding),
+    /// carrying the originating server name and the pushed diagnostics.
+    #[tokio::test]
+    async fn handle_message_routes_non_scratch_publish_diagnostics_for_virtual_uri() {
+        let router = ResponseRouter::new();
+        let (response_tx, _response_rx) = mpsc::channel(16);
+        let (upstream_tx, mut upstream_rx) = mpsc::unbounded_channel();
+        let (window_tx, _window_rx) = mpsc::channel(16);
+        let deps = ServerRequestDeps {
+            server_name: Some("luals".to_string()),
+            response_tx,
+            dynamic_capabilities: Arc::new(DynamicCapabilityRegistry::new()),
+            upstream_tx,
+            workspace_folders: WorkspaceFolderSet::new(None),
+            window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
+            progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
+            progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
+        };
+
+        let message = json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics",
+            "params": {
+                "uri": "file:///project/kakehashi-virtual-uri-REGION.lua",
+                "diagnostics": [{
+                    "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 1}},
+                    "message": "boom"
+                }]
+            }
+        });
+
+        handle_message(message, &router, "", &deps).await;
+
+        match upstream_rx
+            .try_recv()
+            .expect("virtual-uri push should be routed upstream")
+        {
+            UpstreamNotification::PublishDiagnostics {
+                uri,
+                server,
+                diagnostics,
+            } => {
+                assert!(uri.contains("kakehashi-virtual-uri-REGION"));
+                assert_eq!(server.as_deref(), Some("luals"));
+                assert_eq!(diagnostics.len(), 1);
+                assert_eq!(diagnostics[0].message, "boom");
+            }
+            _ => panic!("expected PublishDiagnostics"),
+        }
+    }
+
+    /// A push for a non-virtual URI (the downstream's own file, or the real host
+    /// URI) has no region mapping and is dropped, not routed.
+    #[tokio::test]
+    async fn handle_message_drops_publish_diagnostics_for_non_virtual_uri() {
+        let router = ResponseRouter::new();
+        let (response_tx, _response_rx) = mpsc::channel(16);
+        let (upstream_tx, mut upstream_rx) = mpsc::unbounded_channel();
+        let (window_tx, _window_rx) = mpsc::channel(16);
+        let deps = ServerRequestDeps {
+            server_name: Some("luals".to_string()),
+            response_tx,
+            dynamic_capabilities: Arc::new(DynamicCapabilityRegistry::new()),
+            upstream_tx,
+            workspace_folders: WorkspaceFolderSet::new(None),
+            window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
+            progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
+            progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
+        };
+
+        let message = json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics",
+            "params": {
+                "uri": "file:///project/real_file.lua",
+                "diagnostics": []
+            }
+        });
+
+        handle_message(message, &router, "", &deps).await;
+
+        assert!(
+            upstream_rx.try_recv().is_err(),
+            "a non-virtual-uri push must not be routed"
         );
     }
 

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -60,6 +60,12 @@ pub(crate) enum UpstreamNotification {
     /// region's virtual document (push-propagation-diagnostic-forwarding). The
     /// forwarding loop resolves `uri` to its host document + region, caches the
     /// diagnostics under `server`, and republishes the merged host set.
+    ///
+    /// This carries an arbitrary-size `Vec<Diagnostic>` over the **unbounded**
+    /// upstream channel, so a push-happy or misbehaving downstream paired with a
+    /// slow upstream loop could grow memory. Re-publish is unthrottled by design
+    /// (push-propagation-diagnostic-forwarding § Consequences); a bounded /
+    /// coalescing diagnostics channel is the deferred mitigation if it proves noisy.
     PublishDiagnostics {
         /// The virtual document URI the downstream published for.
         uri: String,

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -63,8 +63,9 @@ pub(crate) enum UpstreamNotification {
     PublishDiagnostics {
         /// The virtual document URI the downstream published for.
         uri: String,
-        /// The originating downstream server's config name (`deps.server_name`).
-        server: Option<String>,
+        /// The originating downstream server's config name (`deps.server_name`);
+        /// pushes without a name are dropped at the reader, so this is always set.
+        server: String,
         /// The pushed diagnostics, in the virtual document's coordinates.
         diagnostics: Vec<tower_lsp_server::ls_types::Diagnostic>,
     },
@@ -2315,7 +2316,7 @@ mod tests {
                 diagnostics,
             } => {
                 assert!(uri.contains("kakehashi-virtual-uri-REGION"));
-                assert_eq!(server.as_deref(), Some("luals"));
+                assert_eq!(server, "luals");
                 assert_eq!(diagnostics.len(), 1);
                 assert_eq!(diagnostics[0].message, "boom");
             }

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -754,7 +754,9 @@ async fn handle_message(
             } else if message["method"].as_str() == Some("textDocument/publishDiagnostics") {
                 // Non-scratch region push: route into the diagnostics cache
                 // (push-propagation-diagnostic-forwarding) instead of dropping (#380).
-                text_document::publish_diagnostics::forward_push(&message, deps);
+                // `message` is owned and discarded after this arm, so move it in and
+                // deserialize the diagnostics by value (no string clones).
+                text_document::publish_diagnostics::forward_push(message, deps);
             } else if message["method"].as_str() == Some("$/progress") {
                 window::progress::forward(&message, server_prefix, deps);
             } else if message["method"].as_str() == Some("$/cancelRequest") {

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -2423,6 +2423,29 @@ mod tests {
             }
             _ => panic!("expected PublishDiagnostics"),
         }
+
+        // Adversarial: `params` is not an object (string) — must not panic, drop.
+        let (deps, mut upstream_rx) = make_deps();
+        let bad_params = json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics",
+            "params": "not-an-object"
+        });
+        handle_message(bad_params, &ResponseRouter::new(), "", &deps).await;
+        assert!(
+            upstream_rx.try_recv().is_err(),
+            "a non-object params must be dropped without panicking"
+        );
+
+        // Adversarial: `params` present but missing `uri` — drop, no panic.
+        let (deps, mut upstream_rx) = make_deps();
+        let no_uri = json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics",
+            "params": {"diagnostics": []}
+        });
+        handle_message(no_uri, &ResponseRouter::new(), "", &deps).await;
+        assert!(upstream_rx.try_recv().is_err(), "missing uri is dropped");
     }
 
     #[tokio::test]

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -2405,7 +2405,10 @@ mod tests {
             "params": {"uri": uri, "diagnostics": []}
         });
         handle_message(empty, &ResponseRouter::new(), "", &deps).await;
-        match upstream_rx.try_recv().expect("empty array should be routed") {
+        match upstream_rx
+            .try_recv()
+            .expect("empty array should be routed")
+        {
             UpstreamNotification::PublishDiagnostics { diagnostics, .. } => {
                 assert!(diagnostics.is_empty(), "empty array clears");
             }

--- a/src/lsp/bridge/text_document/publish_diagnostics.rs
+++ b/src/lsp/bridge/text_document/publish_diagnostics.rs
@@ -56,7 +56,10 @@ pub(in crate::lsp::bridge) fn forward_push(
     // than `IndexMut` (`message["params"]["uri"]`) avoids a panic on adversarial
     // input where `params` exists but is a string/number/array; `Map::remove`
     // still moves the owned values out (no clone).
-    let Some(params) = message.get_mut("params").and_then(serde_json::Value::as_object_mut) else {
+    let Some(params) = message
+        .get_mut("params")
+        .and_then(serde_json::Value::as_object_mut)
+    else {
         return;
     };
     let Some(serde_json::Value::String(uri)) = params.remove("uri") else {
@@ -70,7 +73,9 @@ pub(in crate::lsp::bridge) fn forward_push(
     // non-array `diagnostics`) is *dropped* (not treated as an empty/clearing push,
     // which would silently wipe the region's diagnostics); an empty `[]` array
     // yields an empty Vec and clears legitimately.
-    let diagnostics_value = params.remove("diagnostics").unwrap_or(serde_json::Value::Null);
+    let diagnostics_value = params
+        .remove("diagnostics")
+        .unwrap_or(serde_json::Value::Null);
     let diagnostics = match serde_json::from_value::<Vec<tower_lsp_server::ls_types::Diagnostic>>(
         diagnostics_value,
     ) {

--- a/src/lsp/bridge/text_document/publish_diagnostics.rs
+++ b/src/lsp/bridge/text_document/publish_diagnostics.rs
@@ -41,6 +41,16 @@ pub(in crate::lsp::bridge) fn forward_push(
     mut message: serde_json::Value,
     deps: &crate::lsp::bridge::actor::ServerRequestDeps,
 ) {
+    // The server name keys the cache slot; production always sets it (readers are
+    // spawned with `Some(server_name)`). Drop a push that lacks one *before* any
+    // parse/enqueue work — it would be dropped downstream anyway.
+    let Some(server) = deps.server_name.clone() else {
+        log::debug!(
+            target: "kakehashi::bridge::reader",
+            "dropping region push without a server name"
+        );
+        return;
+    };
     let Some(uri) = message["params"]["uri"].as_str().map(String::from) else {
         return;
     };
@@ -68,7 +78,7 @@ pub(in crate::lsp::bridge) fn forward_push(
     let _ = deps.upstream_tx.send(
         crate::lsp::bridge::actor::UpstreamNotification::PublishDiagnostics {
             uri,
-            server: deps.server_name.clone(),
+            server,
             diagnostics,
         },
     );

--- a/src/lsp/bridge/text_document/publish_diagnostics.rs
+++ b/src/lsp/bridge/text_document/publish_diagnostics.rs
@@ -2,10 +2,12 @@
 //!
 //! Unlike the other `text_document/*` files (outbound request senders), this one
 //! is **inbound** (downstream → bridge): a downstream server pushes diagnostics.
-//! The bridge does not forward push diagnostics in general (#380); the one case
-//! it must act on is a push targeting a concatenated-formatting *scratch*
-//! virtual document, which is discarded structurally by the dispatcher in
-//! [`actor::reader`](crate::lsp::bridge::actor) using [`is_scratch_publish_diagnostics`].
+//! A non-scratch push for an injection region's virtual document is **routed**
+//! into the proactive diagnostics cache ([`forward_push`],
+//! push-propagation-diagnostic-forwarding, closing #380); a push targeting a
+//! concatenated-formatting *scratch* virtual document is discarded structurally
+//! by the dispatcher in [`actor::reader`](crate::lsp::bridge::actor) using
+//! [`is_scratch_publish_diagnostics`].
 
 /// Whether `message` is a `textDocument/publishDiagnostics` notification
 /// targeting a concatenated-formatting *scratch* virtual document

--- a/src/lsp/bridge/text_document/publish_diagnostics.rs
+++ b/src/lsp/bridge/text_document/publish_diagnostics.rs
@@ -42,9 +42,10 @@ pub(in crate::lsp::bridge) fn forward_push(
     deps: &crate::lsp::bridge::actor::ServerRequestDeps,
 ) {
     // The server name keys the cache slot; production always sets it (readers are
-    // spawned with `Some(server_name)`). Drop a push that lacks one *before* any
-    // parse/enqueue work — it would be dropped downstream anyway.
-    let Some(server) = deps.server_name.clone() else {
+    // spawned with `Some(server_name)`). Check it by reference up front so a push
+    // that lacks one is dropped before any parse/enqueue work; the actual clone is
+    // deferred to the send below, past every early-return guard.
+    let Some(server_name) = deps.server_name.as_deref() else {
         log::debug!(
             target: "kakehashi::bridge::reader",
             "dropping region push without a server name"
@@ -79,7 +80,7 @@ pub(in crate::lsp::bridge) fn forward_push(
     let _ = deps.upstream_tx.send(
         crate::lsp::bridge::actor::UpstreamNotification::PublishDiagnostics {
             uri,
-            server,
+            server: server_name.to_owned(),
             diagnostics,
         },
     );

--- a/src/lsp/bridge/text_document/publish_diagnostics.rs
+++ b/src/lsp/bridge/text_document/publish_diagnostics.rs
@@ -27,6 +27,41 @@ pub(in crate::lsp::bridge) fn is_scratch_publish_diagnostics(message: &serde_jso
             .is_some_and(crate::lsp::bridge::VirtualDocumentUri::is_scratch_uri)
 }
 
+/// Route a non-scratch downstream `textDocument/publishDiagnostics` for an
+/// injection region's virtual document into the proactive diagnostics cache
+/// (push-propagation-diagnostic-forwarding). The forwarding loop resolves the
+/// virtual URI to its host + region and republishes the merged host set.
+///
+/// A push for a non-virtual URI (the downstream's own files, or the real host
+/// URI) has no region mapping and is dropped — the host layer is still served by
+/// the pull feed for now.
+pub(in crate::lsp::bridge) fn forward_push(
+    message: &serde_json::Value,
+    deps: &crate::lsp::bridge::actor::ServerRequestDeps,
+) {
+    let Some(uri) = message["params"]["uri"].as_str() else {
+        return;
+    };
+    if !crate::lsp::bridge::VirtualDocumentUri::is_virtual_uri(uri) {
+        return;
+    }
+    // Deserialize the diagnostics array straight from the borrowed value (no
+    // clone of the message); a malformed array yields an empty (clearing) push.
+    let diagnostics =
+        <Vec<tower_lsp_server::ls_types::Diagnostic> as serde::Deserialize>::deserialize(
+            &message["params"]["diagnostics"],
+        )
+        .unwrap_or_default();
+
+    let _ = deps.upstream_tx.send(
+        crate::lsp::bridge::actor::UpstreamNotification::PublishDiagnostics {
+            uri: uri.to_string(),
+            server: deps.server_name.clone(),
+            diagnostics,
+        },
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lsp/bridge/text_document/publish_diagnostics.rs
+++ b/src/lsp/bridge/text_document/publish_diagnostics.rs
@@ -46,12 +46,22 @@ pub(in crate::lsp::bridge) fn forward_push(
         return;
     }
     // Deserialize the diagnostics array straight from the borrowed value (no
-    // clone of the message); a malformed array yields an empty (clearing) push.
+    // clone of the message). A parse failure is *dropped* (not treated as an
+    // empty/clearing push, which would silently wipe the region's diagnostics) —
+    // an empty array still deserializes to an empty Vec and clears legitimately.
     let diagnostics =
-        <Vec<tower_lsp_server::ls_types::Diagnostic> as serde::Deserialize>::deserialize(
+        match <Vec<tower_lsp_server::ls_types::Diagnostic> as serde::Deserialize>::deserialize(
             &message["params"]["diagnostics"],
-        )
-        .unwrap_or_default();
+        ) {
+            Ok(diagnostics) => diagnostics,
+            Err(e) => {
+                log::debug!(
+                    target: "kakehashi::bridge::reader",
+                    "dropping malformed publishDiagnostics for {uri}: {e}"
+                );
+                return;
+            }
+        };
 
     let _ = deps.upstream_tx.send(
         crate::lsp::bridge::actor::UpstreamNotification::PublishDiagnostics {

--- a/src/lsp/bridge/text_document/publish_diagnostics.rs
+++ b/src/lsp/bridge/text_document/publish_diagnostics.rs
@@ -38,36 +38,36 @@ pub(in crate::lsp::bridge) fn is_scratch_publish_diagnostics(message: &serde_jso
 /// URI) has no region mapping and is dropped — the host layer is still served by
 /// the pull feed for now.
 pub(in crate::lsp::bridge) fn forward_push(
-    message: &serde_json::Value,
+    mut message: serde_json::Value,
     deps: &crate::lsp::bridge::actor::ServerRequestDeps,
 ) {
-    let Some(uri) = message["params"]["uri"].as_str() else {
+    let Some(uri) = message["params"]["uri"].as_str().map(String::from) else {
         return;
     };
-    if !crate::lsp::bridge::VirtualDocumentUri::is_virtual_uri(uri) {
+    if !crate::lsp::bridge::VirtualDocumentUri::is_virtual_uri(&uri) {
         return;
     }
-    // Deserialize the diagnostics array straight from the borrowed value (no
-    // clone of the message). A parse failure is *dropped* (not treated as an
-    // empty/clearing push, which would silently wipe the region's diagnostics) —
-    // an empty array still deserializes to an empty Vec and clears legitimately.
-    let diagnostics =
-        match <Vec<tower_lsp_server::ls_types::Diagnostic> as serde::Deserialize>::deserialize(
-            &message["params"]["diagnostics"],
-        ) {
-            Ok(diagnostics) => diagnostics,
-            Err(e) => {
-                log::debug!(
-                    target: "kakehashi::bridge::reader",
-                    "dropping malformed publishDiagnostics for {uri}: {e}"
-                );
-                return;
-            }
-        };
+    // Deserialize by value (move) out of the owned, soon-discarded message —
+    // `from_value` moves the diagnostics' owned strings instead of cloning them
+    // (which `deserialize(&value)` would). A parse failure is *dropped* (not
+    // treated as an empty/clearing push, which would silently wipe the region's
+    // diagnostics); an empty array still yields an empty Vec and clears legitimately.
+    let diagnostics = match serde_json::from_value::<Vec<tower_lsp_server::ls_types::Diagnostic>>(
+        message["params"]["diagnostics"].take(),
+    ) {
+        Ok(diagnostics) => diagnostics,
+        Err(e) => {
+            log::debug!(
+                target: "kakehashi::bridge::reader",
+                "dropping malformed publishDiagnostics for {uri}: {e}"
+            );
+            return;
+        }
+    };
 
     let _ = deps.upstream_tx.send(
         crate::lsp::bridge::actor::UpstreamNotification::PublishDiagnostics {
-            uri: uri.to_string(),
+            uri,
             server: deps.server_name.clone(),
             diagnostics,
         },

--- a/src/lsp/bridge/text_document/publish_diagnostics.rs
+++ b/src/lsp/bridge/text_document/publish_diagnostics.rs
@@ -52,20 +52,27 @@ pub(in crate::lsp::bridge) fn forward_push(
         );
         return;
     };
-    // Take the owned URI string out of the message (no clone).
-    let serde_json::Value::String(uri) = message["params"]["uri"].take() else {
+    // `params` must be a JSON object. Using `get_mut(...).as_object_mut()` rather
+    // than `IndexMut` (`message["params"]["uri"]`) avoids a panic on adversarial
+    // input where `params` exists but is a string/number/array; `Map::remove`
+    // still moves the owned values out (no clone).
+    let Some(params) = message.get_mut("params").and_then(serde_json::Value::as_object_mut) else {
+        return;
+    };
+    let Some(serde_json::Value::String(uri)) = params.remove("uri") else {
         return;
     };
     if !crate::lsp::bridge::VirtualDocumentUri::is_virtual_uri(&uri) {
         return;
     }
-    // Deserialize by value (move) out of the owned, soon-discarded message —
-    // `from_value` moves the diagnostics' owned strings instead of cloning them
-    // (which `deserialize(&value)` would). A parse failure is *dropped* (not
-    // treated as an empty/clearing push, which would silently wipe the region's
-    // diagnostics); an empty array still yields an empty Vec and clears legitimately.
+    // Deserialize the moved-out diagnostics value (no clone) — `from_value` moves
+    // the diagnostics' owned strings. A parse failure (including an absent or
+    // non-array `diagnostics`) is *dropped* (not treated as an empty/clearing push,
+    // which would silently wipe the region's diagnostics); an empty `[]` array
+    // yields an empty Vec and clears legitimately.
+    let diagnostics_value = params.remove("diagnostics").unwrap_or(serde_json::Value::Null);
     let diagnostics = match serde_json::from_value::<Vec<tower_lsp_server::ls_types::Diagnostic>>(
-        message["params"]["diagnostics"].take(),
+        diagnostics_value,
     ) {
         Ok(diagnostics) => diagnostics,
         Err(e) => {

--- a/src/lsp/bridge/text_document/publish_diagnostics.rs
+++ b/src/lsp/bridge/text_document/publish_diagnostics.rs
@@ -51,7 +51,8 @@ pub(in crate::lsp::bridge) fn forward_push(
         );
         return;
     };
-    let Some(uri) = message["params"]["uri"].as_str().map(String::from) else {
+    // Take the owned URI string out of the message (no clone).
+    let serde_json::Value::String(uri) = message["params"]["uri"].take() else {
         return;
     };
     if !crate::lsp::bridge::VirtualDocumentUri::is_virtual_uri(&uri) {

--- a/src/lsp/debounced_diagnostics.rs
+++ b/src/lsp/debounced_diagnostics.rs
@@ -17,7 +17,7 @@ use url::Url;
 
 use super::bridge::LanguageServerPool;
 
-use super::lsp_impl::coordinator::DiagnosticPublisher;
+use super::lsp_impl::DiagnosticPublisher;
 use super::lsp_impl::text_document::publish_diagnostic::{
     DiagnosticSnapshot, collect_push_diagnostics,
 };

--- a/src/lsp/debounced_diagnostics.rs
+++ b/src/lsp/debounced_diagnostics.rs
@@ -13,12 +13,11 @@ use std::time::Duration;
 
 use dashmap::DashMap;
 use tokio::task::AbortHandle;
-use tower_lsp_server::Client;
-use tower_lsp_server::ls_types::Uri;
 use url::Url;
 
 use super::bridge::LanguageServerPool;
 
+use super::lsp_impl::coordinator::DiagnosticPublisher;
 use super::lsp_impl::text_document::publish_diagnostic::{
     DiagnosticSnapshot, collect_push_diagnostics,
 };
@@ -40,16 +39,15 @@ const LOG_TARGET: &str = "kakehashi::debounced_diag";
 struct DebouncedDiagnosticData {
     /// The document URI (url::Url for internal use)
     uri: Url,
-    /// The document URI (ls_types::Uri for LSP notification)
-    lsp_uri: Uri,
-    /// LSP client for publishing diagnostics
-    client: Client,
     /// Pre-captured per-region contexts (None if document has no injections)
     snapshot_data: Option<DiagnosticSnapshot>,
     /// Bridge pool for sending diagnostic requests
     bridge_pool: Arc<LanguageServerPool>,
     /// Reference to synthetic diagnostics manager for task registration
     synthetic_diagnostics: Arc<SyntheticDiagnosticsManager>,
+    /// The single proactive publisher: feeds the pull result into the cache and
+    /// republishes the merged set (push-propagation-diagnostic-forwarding).
+    publisher: Arc<DiagnosticPublisher>,
 }
 
 /// Manager for debounced diagnostic triggers.
@@ -94,11 +92,10 @@ impl DebouncedDiagnosticsManager {
     pub(crate) fn schedule(
         &self,
         uri: Url,
-        lsp_uri: Uri,
-        client: Client,
         snapshot_data: Option<DiagnosticSnapshot>,
         bridge_pool: Arc<LanguageServerPool>,
         synthetic_diagnostics: Arc<SyntheticDiagnosticsManager>,
+        publisher: Arc<DiagnosticPublisher>,
     ) {
         // Opportunistic cleanup: remove finished timers to prevent unbounded growth.
         // This is O(n) but runs infrequently and keeps the map from accumulating
@@ -120,11 +117,10 @@ impl DebouncedDiagnosticsManager {
 
         let data = DebouncedDiagnosticData {
             uri: uri.clone(),
-            lsp_uri,
-            client,
             snapshot_data,
             bridge_pool,
             synthetic_diagnostics,
+            publisher,
         };
 
         let duration = self.debounce_duration;
@@ -201,11 +197,10 @@ impl DebouncedDiagnosticsManager {
 async fn execute_debounced_diagnostic(data: DebouncedDiagnosticData) {
     let DebouncedDiagnosticData {
         uri,
-        lsp_uri,
-        client,
         snapshot_data,
         bridge_pool,
         synthetic_diagnostics,
+        publisher,
     } = data;
 
     // Spawn the actual diagnostic task (similar to DiagnosticScheduler::spawn_synthetic_diagnostic_task)
@@ -226,13 +221,14 @@ async fn execute_debounced_diagnostic(data: DebouncedDiagnosticData) {
 
         log::debug!(
             target: LOG_TARGET,
-            "Collected {} diagnostics for {} (debounced)",
+            "Collected {} pull-layer diagnostics for {} (debounced)",
             diagnostics.len(),
             uri_clone
         );
 
-        // Publish diagnostics
-        client.publish_diagnostics(lsp_uri, diagnostics, None).await;
+        // Feed the host-event pull result into the cache and republish the merged
+        // set (push-propagation-diagnostic-forwarding) — push slots survive.
+        publisher.publish_pull_layer(&uri_clone, diagnostics).await;
     });
 
     // Register with SyntheticDiagnosticsManager for superseding

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -12,20 +12,34 @@
 //! / server later.
 //!
 //! ## Staging
-//! This commit unifies the existing host-event pull feed onto the cache without
-//! behavior change: the pull's already cross-layer-combined result is stored as
-//! the single [`DiagnosticSource::PullLayer`] blob (host coordinates) and the
-//! publisher emits it. A follow-up adds [downstream pushes] as per-`(region,
-//! server)` slots in virtual coordinates (transformed at publish time), the
-//! `_self` host-layer source, and the `content_epoch` version gate.
+//! Two source kinds are populated:
+//! - [`DiagnosticSource::PullLayer`] — the host-event pull's already
+//!   cross-layer-combined result, in host coordinates, as one blob.
+//! - [`DiagnosticSource::Region`] — a downstream push for an injection region, in
+//!   virtual coordinates, transformed to host coordinates at publish time.
+//!
+//! **Known interim overlap (deferred capability gate).** The pull feed fans out
+//! to *every* configured region server with no capability classification, so a
+//! server that both answers `textDocument/diagnostic` (landing in `PullLayer`)
+//! *and* spontaneously pushes `publishDiagnostics` (landing in a `Region` slot) is
+//! counted twice. In practice the two channels are disjoint — a pull-capable
+//! server should not also push (LSP) — so this only *duplicates*, never *hides*,
+//! and only for a misbehaving server. The deferred `pullFallback` / capability
+//! classification removes the overlap by giving each server one native source.
+//!
+//! Also deferred: per-source strategy fan-in (`preferred` sticky / `concatenated`
+//! visible-walk; cross-source order is HashMap-nondeterministic until then), the
+//! `_self` host-layer push source, the `content_epoch` version gate, and
+//! region-invalidation/crash eviction.
 
 use std::collections::HashMap;
-use std::sync::{Mutex, PoisonError};
+use std::sync::Mutex;
 
 use tower_lsp_server::ls_types::Diagnostic;
 use url::Url;
 
-use crate::lsp::bridge::{RegionOffset, translate_virtual_range_to_host};
+use crate::error::LockResultExt;
+use crate::lsp::bridge::{RegionOffset, VirtualDocumentUri, translate_virtual_range_to_host};
 
 /// Which contributor a slot belongs to under a host document.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -76,9 +90,11 @@ pub(crate) type SourceSlots = HashMap<DiagnosticSource, ServerSlots>;
 /// strategy). Per-source strategy fan-in (`preferred` sticky / `concatenated`
 /// visible-walk) and `relatedInformation` range translation are follow-ups.
 pub(crate) fn merge_cached_diagnostics(
+    host: &Url,
     snapshot: &SourceSlots,
     region_offsets: &HashMap<String, RegionOffset>,
 ) -> Vec<Diagnostic> {
+    let host_str = host.as_str();
     let mut merged = Vec::new();
     for (source, servers) in snapshot {
         match source {
@@ -90,7 +106,7 @@ pub(crate) fn merge_cached_diagnostics(
                 for slot in servers.values() {
                     for diagnostic in &slot.diagnostics {
                         let mut diagnostic = diagnostic.clone();
-                        translate_virtual_range_to_host(&mut diagnostic.range, offset);
+                        transform_region_diagnostic(&mut diagnostic, offset, host_str);
                         merged.push(diagnostic);
                     }
                 }
@@ -105,15 +121,51 @@ pub(crate) fn merge_cached_diagnostics(
     merged
 }
 
+/// Transform a pushed region diagnostic from virtual to host coordinates.
+///
+/// Mirrors the pull path's `transform_diagnostic`
+/// (`bridge::text_document::diagnostic`): the main range is shifted by the
+/// region offset, and `relatedInformation` entries referencing **virtual** URIs
+/// are dropped (clients cannot resolve them — without this they would leak to the
+/// editor); entries on the same host document are translated, others kept as-is.
+fn transform_region_diagnostic(diag: &mut Diagnostic, offset: &RegionOffset, host_uri: &str) {
+    translate_virtual_range_to_host(&mut diag.range, offset);
+    if let Some(related) = &mut diag.related_information {
+        related.retain_mut(|info| {
+            let uri_str = info.location.uri.as_str();
+            if VirtualDocumentUri::is_virtual_uri(uri_str) {
+                return false;
+            }
+            if uri_str == host_uri {
+                translate_virtual_range_to_host(&mut info.location.range, offset);
+            }
+            true
+        });
+    }
+}
+
 /// The per-host diagnostic slot cache (see module docs).
 #[derive(Default)]
 pub(crate) struct DiagnosticAggregator {
     cache: Mutex<HashMap<Url, SourceSlots>>,
+    /// Serializes the publisher's snapshot→merge→publish so two concurrent
+    /// republishes (a region push vs a host-event pull, on different tasks)
+    /// cannot interleave and emit out of order — which would let a stale snapshot
+    /// publish *after* a fresh one and permanently hide diagnostics on a quiescent
+    /// file. Global (not per-host) for simplicity; republishes are per diagnostic
+    /// event, not hot. A per-host lock is a possible follow-up.
+    republish_lock: tokio::sync::Mutex<()>,
 }
 
 impl DiagnosticAggregator {
     pub(crate) fn new() -> Self {
         Self::default()
+    }
+
+    /// Acquire the global republish lock; held by the publisher across
+    /// snapshot→merge→publish so emissions stay ordered (see field docs).
+    pub(crate) async fn lock_republish(&self) -> tokio::sync::MutexGuard<'_, ()> {
+        self.republish_lock.lock().await
     }
 
     /// Record (replacing) one server's diagnostics for a `(host, source)`.
@@ -164,7 +216,9 @@ impl DiagnosticAggregator {
         // Recover from a poisoned lock rather than propagating a panic: a
         // diagnostic cache is best-effort state, never a correctness invariant
         // worth crashing the server over.
-        self.cache.lock().unwrap_or_else(PoisonError::into_inner)
+        self.cache
+            .lock()
+            .recover_poison("DiagnosticAggregator::cache")
     }
 }
 
@@ -241,7 +295,7 @@ mod tests {
     fn merge_concatenates_pull_layer() {
         let agg = DiagnosticAggregator::new();
         agg.set_pull_layer(&host(), vec![diag("a"), diag("b")]);
-        let merged = merge_cached_diagnostics(&agg.snapshot(&host()), &HashMap::new());
+        let merged = merge_cached_diagnostics(&host(), &agg.snapshot(&host()), &HashMap::new());
         let mut msgs: Vec<&str> = merged.iter().map(|d| d.message.as_str()).collect();
         msgs.sort();
         assert_eq!(msgs, vec!["a", "b"]);
@@ -249,7 +303,7 @@ mod tests {
 
     #[test]
     fn merge_of_empty_snapshot_is_empty() {
-        assert!(merge_cached_diagnostics(&SourceSlots::new(), &HashMap::new()).is_empty());
+        assert!(merge_cached_diagnostics(&host(), &SourceSlots::new(), &HashMap::new()).is_empty());
     }
 
     #[test]
@@ -264,10 +318,63 @@ mod tests {
         let mut offsets = HashMap::new();
         // Region r1 sits at host line 5, column offset 4 on its first line.
         offsets.insert("r1".to_string(), RegionOffset::new(5, 4));
-        let merged = merge_cached_diagnostics(&agg.snapshot(&host()), &offsets);
+        let merged = merge_cached_diagnostics(&host(), &agg.snapshot(&host()), &offsets);
         assert_eq!(merged.len(), 1);
         // line 0 -> 0+5, character 2 -> 2+4
         assert_eq!(merged[0].range.start, Position::new(5, 6));
+    }
+
+    #[test]
+    fn merge_drops_virtual_related_information_and_translates_host() {
+        use std::str::FromStr;
+        use tower_lsp_server::ls_types::{DiagnosticRelatedInformation, Location, Uri as LsUri};
+
+        let host_uri = "file:///doc.md";
+        let related = |uri: &str, line: u32| DiagnosticRelatedInformation {
+            location: Location {
+                uri: LsUri::from_str(uri).unwrap(),
+                range: Range::new(Position::new(line, 0), Position::new(line, 1)),
+            },
+            message: uri.to_string(),
+        };
+        let mut d = diag_at("err", 0, 0);
+        d.related_information = Some(vec![
+            related("file:///doc.md/kakehashi-virtual-uri-R.lua", 0), // virtual -> dropped
+            related(host_uri, 0),                                     // host -> translated
+            related("file:///other.lua", 3),                          // other -> kept as-is
+        ]);
+
+        let agg = DiagnosticAggregator::new();
+        agg.record(
+            &host(),
+            DiagnosticSource::Region("r1".into()),
+            "luals".into(),
+            vec![d],
+        );
+        let mut offsets = HashMap::new();
+        offsets.insert("r1".to_string(), RegionOffset::new(5, 0));
+        let merged = merge_cached_diagnostics(&host(), &agg.snapshot(&host()), &offsets);
+
+        let related = merged[0].related_information.as_ref().unwrap();
+        assert_eq!(related.len(), 2, "virtual-URI related info is dropped");
+        let host_entry = related
+            .iter()
+            .find(|r| r.location.uri.as_str() == host_uri)
+            .unwrap();
+        assert_eq!(
+            host_entry.location.range.start,
+            Position::new(5, 0),
+            "host-document related info is translated by the offset"
+        );
+        let other = related
+            .iter()
+            .find(|r| r.location.uri.as_str() == "file:///other.lua")
+            .unwrap();
+        assert_eq!(
+            other.location.range.start,
+            Position::new(3, 0),
+            "other-document related info keeps its coordinates"
+        );
     }
 
     #[test]
@@ -280,7 +387,7 @@ mod tests {
             vec![diag("stale")],
         );
         // No offset for "gone" -> region is stale -> skipped.
-        let merged = merge_cached_diagnostics(&agg.snapshot(&host()), &HashMap::new());
+        let merged = merge_cached_diagnostics(&host(), &agg.snapshot(&host()), &HashMap::new());
         assert!(merged.is_empty());
     }
 
@@ -296,7 +403,7 @@ mod tests {
         agg.set_pull_layer(&host(), vec![diag_at("pull", 9, 0)]);
         let mut offsets = HashMap::new();
         offsets.insert("r1".to_string(), RegionOffset::new(2, 0));
-        let merged = merge_cached_diagnostics(&agg.snapshot(&host()), &offsets);
+        let merged = merge_cached_diagnostics(&host(), &agg.snapshot(&host()), &offsets);
         let mut msgs: Vec<&str> = merged.iter().map(|d| d.message.as_str()).collect();
         msgs.sort();
         assert_eq!(msgs, vec!["pull", "push"]);

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -82,8 +82,9 @@ pub(crate) type SourceSlots = HashMap<DiagnosticSource, ServerSlots>;
 /// - [`DiagnosticSource::Region`] slots hold virtual coordinates and are
 ///   transformed via `region_offsets[region_id]` (lazy re-anchor against the
 ///   region's *current* offset). A region with no current offset (it no longer
-///   resolves, e.g. it was edited away) is skipped — its slot is stale and gets
-///   evicted by the lifecycle.
+///   resolves, e.g. it was edited away) is skipped here; its now-stale slot
+///   lingers in the cache until the whole host is dropped on `didClose`
+///   (per-region / crash eviction is a deferred follow-up).
 /// - [`DiagnosticSource::PullLayer`] slots are already host-local and pass through.
 ///
 /// Staged: results are concatenated (the default `textDocument/publishDiagnostics`

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1,0 +1,220 @@
+//! Per-host diagnostic cache — the single source of truth for proactive
+//! `textDocument/publishDiagnostics` (push-propagation-diagnostic-forwarding).
+//!
+//! A client replaces *all* diagnostics for a URI on each publish, and every
+//! injection region of a host maps to the same host URI, so there can be exactly
+//! **one** proactive publisher per host. Every proactive feed writes slots here
+//! and one publisher merges every slot and emits the cumulative result — that is
+//! what keeps sibling regions intact against the clobber.
+//!
+//! The cache is **nested** `host_uri → source → server` (not a flat tuple key) so
+//! the lifecycle's evictions are O(1): a whole host on `didClose` today, a source
+//! / server later.
+//!
+//! ## Staging
+//! This commit unifies the existing host-event pull feed onto the cache without
+//! behavior change: the pull's already cross-layer-combined result is stored as
+//! the single [`DiagnosticSource::PullLayer`] blob (host coordinates) and the
+//! publisher emits it. A follow-up adds [downstream pushes] as per-`(region,
+//! server)` slots in virtual coordinates (transformed at publish time), the
+//! `_self` host-layer source, and the `content_epoch` version gate.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, PoisonError};
+
+use tower_lsp_server::ls_types::Diagnostic;
+use url::Url;
+
+/// Which contributor a slot belongs to under a host document.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum DiagnosticSource {
+    /// The host-event pull's cross-layer-combined result, in host coordinates.
+    /// A single blob (one synthetic server slot) for now — a follow-up replaces
+    /// it with per-`(region, server)` slots gated by `pullFallback`.
+    PullLayer,
+}
+
+/// The synthetic server key under which the pull-layer blob is stored. Real
+/// downstream servers can never collide (config names are validated and this
+/// contains brackets).
+pub(crate) const PULL_LAYER_SERVER: &str = "<pull-layer>";
+
+/// One server's latest diagnostics for a `(host, source)`.
+///
+/// A repeat publish from the same server replaces this slot wholesale (the
+/// within-server "latest wins" rule). An empty `diagnostics` is a kept-but-empty
+/// slot: it contributes nothing to the merge but still exists, so a server going
+/// from errors to clean clears only its own contribution.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct SlotEntry {
+    pub(crate) diagnostics: Vec<Diagnostic>,
+}
+
+/// `server name → slot`. Several servers can attach to one source.
+pub(crate) type ServerSlots = HashMap<String, SlotEntry>;
+/// `source → server slots` under one host.
+pub(crate) type SourceSlots = HashMap<DiagnosticSource, ServerSlots>;
+
+/// Merge a host's cached slots into the publishable diagnostic set, in host
+/// coordinates.
+///
+/// Staged: every current slot ([`DiagnosticSource::PullLayer`]) is already
+/// host-local and concatenated. A follow-up adds region slots (virtual
+/// coordinates, transformed against the region's current offset) and per-source
+/// strategy fan-in.
+pub(crate) fn merge_cached_diagnostics(snapshot: &SourceSlots) -> Vec<Diagnostic> {
+    let mut merged = Vec::new();
+    for servers in snapshot.values() {
+        for slot in servers.values() {
+            merged.extend(slot.diagnostics.iter().cloned());
+        }
+    }
+    merged
+}
+
+/// The per-host diagnostic slot cache (see module docs).
+#[derive(Default)]
+pub(crate) struct DiagnosticAggregator {
+    cache: Mutex<HashMap<Url, SourceSlots>>,
+}
+
+impl DiagnosticAggregator {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record (replacing) one server's diagnostics for a `(host, source)`.
+    ///
+    /// An empty `diagnostics` keeps an empty slot — the merge skips it, so the
+    /// server's prior diagnostics are cleared without dropping the slot key.
+    pub(crate) fn record(
+        &self,
+        host: &Url,
+        source: DiagnosticSource,
+        server: String,
+        diagnostics: Vec<Diagnostic>,
+    ) {
+        let mut cache = self.lock();
+        cache
+            .entry(host.clone())
+            .or_default()
+            .entry(source)
+            .or_default()
+            .insert(server, SlotEntry { diagnostics });
+    }
+
+    /// Replace the cached host-event pull blob for a host
+    /// ([`DiagnosticSource::PullLayer`]). Equivalent to a single-server `record`.
+    pub(crate) fn set_pull_layer(&self, host: &Url, diagnostics: Vec<Diagnostic>) {
+        self.record(
+            host,
+            DiagnosticSource::PullLayer,
+            PULL_LAYER_SERVER.to_string(),
+            diagnostics,
+        );
+    }
+
+    /// Snapshot every source/server slot for a host, cloned for merging off-lock.
+    /// Empty when the host has no slots.
+    pub(crate) fn snapshot(&self, host: &Url) -> SourceSlots {
+        let cache = self.lock();
+        cache.get(host).cloned().unwrap_or_default()
+    }
+
+    /// Drop everything for a host (host `didClose`). Returns whether it existed.
+    pub(crate) fn evict_host(&self, host: &Url) -> bool {
+        let mut cache = self.lock();
+        cache.remove(host).is_some()
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<Url, SourceSlots>> {
+        // Recover from a poisoned lock rather than propagating a panic: a
+        // diagnostic cache is best-effort state, never a correctness invariant
+        // worth crashing the server over.
+        self.cache.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower_lsp_server::ls_types::{Position, Range};
+
+    fn diag(message: &str) -> Diagnostic {
+        Diagnostic {
+            range: Range::new(Position::new(0, 0), Position::new(0, 1)),
+            message: message.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn host() -> Url {
+        Url::parse("file:///doc.md").unwrap()
+    }
+
+    fn messages(slots: &ServerSlots) -> Vec<String> {
+        let mut out: Vec<String> = slots
+            .values()
+            .flat_map(|s| s.diagnostics.iter().map(|d| d.message.clone()))
+            .collect();
+        out.sort();
+        out
+    }
+
+    #[test]
+    fn set_pull_layer_then_snapshot_returns_blob() {
+        let agg = DiagnosticAggregator::new();
+        agg.set_pull_layer(&host(), vec![diag("a"), diag("b")]);
+        let snap = agg.snapshot(&host());
+        let pull = &snap[&DiagnosticSource::PullLayer];
+        assert_eq!(messages(pull), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn set_pull_layer_replaces_blob() {
+        let agg = DiagnosticAggregator::new();
+        agg.set_pull_layer(&host(), vec![diag("old")]);
+        agg.set_pull_layer(&host(), vec![diag("new")]);
+        let snap = agg.snapshot(&host());
+        assert_eq!(
+            messages(&snap[&DiagnosticSource::PullLayer]),
+            vec!["new"],
+            "latest replaces, not appends"
+        );
+    }
+
+    #[test]
+    fn empty_pull_layer_keeps_an_empty_slot() {
+        let agg = DiagnosticAggregator::new();
+        agg.set_pull_layer(&host(), vec![diag("x")]);
+        agg.set_pull_layer(&host(), vec![]);
+        let snap = agg.snapshot(&host());
+        assert!(snap[&DiagnosticSource::PullLayer][PULL_LAYER_SERVER]
+            .diagnostics
+            .is_empty());
+    }
+
+    #[test]
+    fn merge_concatenates_pull_layer() {
+        let agg = DiagnosticAggregator::new();
+        agg.set_pull_layer(&host(), vec![diag("a"), diag("b")]);
+        let merged = merge_cached_diagnostics(&agg.snapshot(&host()));
+        let mut msgs: Vec<&str> = merged.iter().map(|d| d.message.as_str()).collect();
+        msgs.sort();
+        assert_eq!(msgs, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn merge_of_empty_snapshot_is_empty() {
+        assert!(merge_cached_diagnostics(&SourceSlots::new()).is_empty());
+    }
+
+    #[test]
+    fn evict_host_drops_all() {
+        let agg = DiagnosticAggregator::new();
+        agg.set_pull_layer(&host(), vec![diag("h")]);
+        assert!(agg.evict_host(&host()));
+        assert!(agg.snapshot(&host()).is_empty());
+        assert!(!agg.evict_host(&host()), "second evict is a no-op");
+    }
+}

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -180,9 +180,14 @@ impl DiagnosticAggregator {
         diagnostics: Vec<Diagnostic>,
     ) {
         let mut cache = self.lock();
-        cache
-            .entry(host.clone())
-            .or_default()
+        // Look up by `&Url` first and clone the host key only when inserting a new
+        // host entry, rather than `entry(host.clone())` cloning on every call.
+        let source_slots = if let Some(source_slots) = cache.get_mut(host) {
+            source_slots
+        } else {
+            cache.entry(host.clone()).or_default()
+        };
+        source_slots
             .entry(source)
             .or_default()
             .insert(server, SlotEntry { diagnostics });

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -25,9 +25,16 @@ use std::sync::{Mutex, PoisonError};
 use tower_lsp_server::ls_types::Diagnostic;
 use url::Url;
 
+use crate::lsp::bridge::{RegionOffset, translate_virtual_range_to_host};
+
 /// Which contributor a slot belongs to under a host document.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum DiagnosticSource {
+    /// A downstream **push** for an injection region, identified by its stable
+    /// region id (lazy-node-identity-tracking ULID). Held in **virtual**
+    /// coordinates and transformed to host coordinates at publish time against
+    /// the region's *current* offset (lazy re-anchor).
+    Region(String),
     /// The host-event pull's cross-layer-combined result, in host coordinates.
     /// A single blob (one synthetic server slot) for now — a follow-up replaces
     /// it with per-`(region, server)` slots gated by `pullFallback`.
@@ -58,15 +65,41 @@ pub(crate) type SourceSlots = HashMap<DiagnosticSource, ServerSlots>;
 /// Merge a host's cached slots into the publishable diagnostic set, in host
 /// coordinates.
 ///
-/// Staged: every current slot ([`DiagnosticSource::PullLayer`]) is already
-/// host-local and concatenated. A follow-up adds region slots (virtual
-/// coordinates, transformed against the region's current offset) and per-source
-/// strategy fan-in.
-pub(crate) fn merge_cached_diagnostics(snapshot: &SourceSlots) -> Vec<Diagnostic> {
+/// - [`DiagnosticSource::Region`] slots hold virtual coordinates and are
+///   transformed via `region_offsets[region_id]` (lazy re-anchor against the
+///   region's *current* offset). A region with no current offset (it no longer
+///   resolves, e.g. it was edited away) is skipped — its slot is stale and gets
+///   evicted by the lifecycle.
+/// - [`DiagnosticSource::PullLayer`] slots are already host-local and pass through.
+///
+/// Staged: results are concatenated (the default `textDocument/publishDiagnostics`
+/// strategy). Per-source strategy fan-in (`preferred` sticky / `concatenated`
+/// visible-walk) and `relatedInformation` range translation are follow-ups.
+pub(crate) fn merge_cached_diagnostics(
+    snapshot: &SourceSlots,
+    region_offsets: &HashMap<String, RegionOffset>,
+) -> Vec<Diagnostic> {
     let mut merged = Vec::new();
-    for servers in snapshot.values() {
-        for slot in servers.values() {
-            merged.extend(slot.diagnostics.iter().cloned());
+    for (source, servers) in snapshot {
+        match source {
+            DiagnosticSource::Region(region_id) => {
+                let Some(offset) = region_offsets.get(region_id) else {
+                    // Stale region: no current offset to anchor against.
+                    continue;
+                };
+                for slot in servers.values() {
+                    for diagnostic in &slot.diagnostics {
+                        let mut diagnostic = diagnostic.clone();
+                        translate_virtual_range_to_host(&mut diagnostic.range, offset);
+                        merged.push(diagnostic);
+                    }
+                }
+            }
+            DiagnosticSource::PullLayer => {
+                for slot in servers.values() {
+                    merged.extend(slot.diagnostics.iter().cloned());
+                }
+            }
         }
     }
     merged
@@ -189,16 +222,26 @@ mod tests {
         agg.set_pull_layer(&host(), vec![diag("x")]);
         agg.set_pull_layer(&host(), vec![]);
         let snap = agg.snapshot(&host());
-        assert!(snap[&DiagnosticSource::PullLayer][PULL_LAYER_SERVER]
-            .diagnostics
-            .is_empty());
+        assert!(
+            snap[&DiagnosticSource::PullLayer][PULL_LAYER_SERVER]
+                .diagnostics
+                .is_empty()
+        );
+    }
+
+    fn diag_at(message: &str, line: u32, col: u32) -> Diagnostic {
+        Diagnostic {
+            range: Range::new(Position::new(line, col), Position::new(line, col + 1)),
+            message: message.to_string(),
+            ..Default::default()
+        }
     }
 
     #[test]
     fn merge_concatenates_pull_layer() {
         let agg = DiagnosticAggregator::new();
         agg.set_pull_layer(&host(), vec![diag("a"), diag("b")]);
-        let merged = merge_cached_diagnostics(&agg.snapshot(&host()));
+        let merged = merge_cached_diagnostics(&agg.snapshot(&host()), &HashMap::new());
         let mut msgs: Vec<&str> = merged.iter().map(|d| d.message.as_str()).collect();
         msgs.sort();
         assert_eq!(msgs, vec!["a", "b"]);
@@ -206,7 +249,57 @@ mod tests {
 
     #[test]
     fn merge_of_empty_snapshot_is_empty() {
-        assert!(merge_cached_diagnostics(&SourceSlots::new()).is_empty());
+        assert!(merge_cached_diagnostics(&SourceSlots::new(), &HashMap::new()).is_empty());
+    }
+
+    #[test]
+    fn merge_transforms_region_slots_to_host_coords() {
+        let agg = DiagnosticAggregator::new();
+        agg.record(
+            &host(),
+            DiagnosticSource::Region("r1".into()),
+            "luals".into(),
+            vec![diag_at("err", 0, 2)],
+        );
+        let mut offsets = HashMap::new();
+        // Region r1 sits at host line 5, column offset 4 on its first line.
+        offsets.insert("r1".to_string(), RegionOffset::new(5, 4));
+        let merged = merge_cached_diagnostics(&agg.snapshot(&host()), &offsets);
+        assert_eq!(merged.len(), 1);
+        // line 0 -> 0+5, character 2 -> 2+4
+        assert_eq!(merged[0].range.start, Position::new(5, 6));
+    }
+
+    #[test]
+    fn merge_skips_region_without_current_offset() {
+        let agg = DiagnosticAggregator::new();
+        agg.record(
+            &host(),
+            DiagnosticSource::Region("gone".into()),
+            "luals".into(),
+            vec![diag("stale")],
+        );
+        // No offset for "gone" -> region is stale -> skipped.
+        let merged = merge_cached_diagnostics(&agg.snapshot(&host()), &HashMap::new());
+        assert!(merged.is_empty());
+    }
+
+    #[test]
+    fn merge_combines_region_push_and_pull_layer() {
+        let agg = DiagnosticAggregator::new();
+        agg.record(
+            &host(),
+            DiagnosticSource::Region("r1".into()),
+            "luals".into(),
+            vec![diag_at("push", 0, 0)],
+        );
+        agg.set_pull_layer(&host(), vec![diag_at("pull", 9, 0)]);
+        let mut offsets = HashMap::new();
+        offsets.insert("r1".to_string(), RegionOffset::new(2, 0));
+        let merged = merge_cached_diagnostics(&agg.snapshot(&host()), &offsets);
+        let mut msgs: Vec<&str> = merged.iter().map(|d| d.message.as_str()).collect();
+        msgs.sort();
+        assert_eq!(msgs, vec!["pull", "push"]);
     }
 
     #[test]

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -88,7 +88,7 @@ pub(crate) type SourceSlots = HashMap<DiagnosticSource, ServerSlots>;
 ///
 /// Staged: results are concatenated (the default `textDocument/publishDiagnostics`
 /// strategy). Per-source strategy fan-in (`preferred` sticky / `concatenated`
-/// visible-walk) and `relatedInformation` range translation are follow-ups.
+/// visible-walk) is a follow-up.
 pub(crate) fn merge_cached_diagnostics(
     host: &Url,
     snapshot: &SourceSlots,

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -91,29 +91,30 @@ pub(crate) type SourceSlots = HashMap<DiagnosticSource, ServerSlots>;
 /// visible-walk) is a follow-up.
 pub(crate) fn merge_cached_diagnostics(
     host: &Url,
-    snapshot: &SourceSlots,
+    snapshot: SourceSlots,
     region_offsets: &HashMap<String, RegionOffset>,
 ) -> Vec<Diagnostic> {
     let host_str = host.as_str();
     let mut merged = Vec::new();
+    // Consume the (already-cloned-from-cache) snapshot so diagnostics move into
+    // the result instead of being cloned again.
     for (source, servers) in snapshot {
         match source {
             DiagnosticSource::Region(region_id) => {
-                let Some(offset) = region_offsets.get(region_id) else {
+                let Some(offset) = region_offsets.get(&region_id) else {
                     // Stale region: no current offset to anchor against.
                     continue;
                 };
-                for slot in servers.values() {
-                    for diagnostic in &slot.diagnostics {
-                        let mut diagnostic = diagnostic.clone();
+                for slot in servers.into_values() {
+                    for mut diagnostic in slot.diagnostics {
                         transform_region_diagnostic(&mut diagnostic, offset, host_str);
                         merged.push(diagnostic);
                     }
                 }
             }
             DiagnosticSource::PullLayer => {
-                for slot in servers.values() {
-                    merged.extend(slot.diagnostics.iter().cloned());
+                for slot in servers.into_values() {
+                    merged.extend(slot.diagnostics);
                 }
             }
         }
@@ -300,7 +301,7 @@ mod tests {
     fn merge_concatenates_pull_layer() {
         let agg = DiagnosticAggregator::new();
         agg.set_pull_layer(&host(), vec![diag("a"), diag("b")]);
-        let merged = merge_cached_diagnostics(&host(), &agg.snapshot(&host()), &HashMap::new());
+        let merged = merge_cached_diagnostics(&host(), agg.snapshot(&host()), &HashMap::new());
         let mut msgs: Vec<&str> = merged.iter().map(|d| d.message.as_str()).collect();
         msgs.sort();
         assert_eq!(msgs, vec!["a", "b"]);
@@ -308,7 +309,7 @@ mod tests {
 
     #[test]
     fn merge_of_empty_snapshot_is_empty() {
-        assert!(merge_cached_diagnostics(&host(), &SourceSlots::new(), &HashMap::new()).is_empty());
+        assert!(merge_cached_diagnostics(&host(), SourceSlots::new(), &HashMap::new()).is_empty());
     }
 
     #[test]
@@ -323,7 +324,7 @@ mod tests {
         let mut offsets = HashMap::new();
         // Region r1 sits at host line 5, column offset 4 on its first line.
         offsets.insert("r1".to_string(), RegionOffset::new(5, 4));
-        let merged = merge_cached_diagnostics(&host(), &agg.snapshot(&host()), &offsets);
+        let merged = merge_cached_diagnostics(&host(), agg.snapshot(&host()), &offsets);
         assert_eq!(merged.len(), 1);
         // line 0 -> 0+5, character 2 -> 2+4
         assert_eq!(merged[0].range.start, Position::new(5, 6));
@@ -358,7 +359,7 @@ mod tests {
         );
         let mut offsets = HashMap::new();
         offsets.insert("r1".to_string(), RegionOffset::new(5, 0));
-        let merged = merge_cached_diagnostics(&host(), &agg.snapshot(&host()), &offsets);
+        let merged = merge_cached_diagnostics(&host(), agg.snapshot(&host()), &offsets);
 
         let related = merged[0].related_information.as_ref().unwrap();
         assert_eq!(related.len(), 2, "virtual-URI related info is dropped");
@@ -392,7 +393,7 @@ mod tests {
             vec![diag("stale")],
         );
         // No offset for "gone" -> region is stale -> skipped.
-        let merged = merge_cached_diagnostics(&host(), &agg.snapshot(&host()), &HashMap::new());
+        let merged = merge_cached_diagnostics(&host(), agg.snapshot(&host()), &HashMap::new());
         assert!(merged.is_empty());
     }
 
@@ -408,7 +409,7 @@ mod tests {
         agg.set_pull_layer(&host(), vec![diag_at("pull", 9, 0)]);
         let mut offsets = HashMap::new();
         offsets.insert("r1".to_string(), RegionOffset::new(2, 0));
-        let merged = merge_cached_diagnostics(&host(), &agg.snapshot(&host()), &offsets);
+        let merged = merge_cached_diagnostics(&host(), agg.snapshot(&host()), &offsets);
         let mut msgs: Vec<&str> = merged.iter().map(|d| d.message.as_str()).collect();
         msgs.sort();
         assert_eq!(msgs, vec!["pull", "push"]);

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -1,6 +1,6 @@
 pub(crate) mod bridge_context;
 mod cli_format;
-mod coordinator;
+pub(crate) mod coordinator;
 mod kakehashi;
 mod lifecycle;
 mod show_document_translation;
@@ -146,6 +146,11 @@ pub struct Kakehashi {
     synthetic_diagnostics: std::sync::Arc<SyntheticDiagnosticsManager>,
     /// Manager for debounced didChange diagnostic triggers (pull-first-diagnostic-forwarding Phase 3)
     debounced_diagnostics: std::sync::Arc<DebouncedDiagnosticsManager>,
+    /// Per-host proactive diagnostic cache — the single source of truth for
+    /// `textDocument/publishDiagnostics` (push-propagation-diagnostic-forwarding).
+    /// Both the host-event pull feed and downstream pushes write slots here; one
+    /// publisher merges and emits per host.
+    diagnostics: std::sync::Arc<crate::lsp::diagnostic_cache::DiagnosticAggregator>,
     /// Token for cancelling the upstream forwarding task on shutdown.
     ///
     /// Without this, the forwarding task only exits when all channel senders are
@@ -231,6 +236,9 @@ impl Kakehashi {
             bridge: std::sync::Arc::new(bridge),
             synthetic_diagnostics: std::sync::Arc::new(SyntheticDiagnosticsManager::new()),
             debounced_diagnostics: std::sync::Arc::new(DebouncedDiagnosticsManager::new()),
+            diagnostics: std::sync::Arc::new(
+                crate::lsp::diagnostic_cache::DiagnosticAggregator::new(),
+            ),
             shutdown_token: tokio_util::sync::CancellationToken::new(),
             home_dir: dirs::home_dir().map(|p| p.to_string_lossy().into_owned()),
             captures_cache: dashmap::DashMap::new(),

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -1,6 +1,7 @@
 pub(crate) mod bridge_context;
 mod cli_format;
-pub(crate) mod coordinator;
+mod coordinator;
+pub(crate) use coordinator::DiagnosticPublisher;
 mod kakehashi;
 mod lifecycle;
 mod show_document_translation;

--- a/src/lsp/lsp_impl/coordinator.rs
+++ b/src/lsp/lsp_impl/coordinator.rs
@@ -1,9 +1,11 @@
 mod diagnostic;
+mod diagnostic_publisher;
 mod injection;
 mod install;
 mod parse;
 
 pub(crate) use diagnostic::DiagnosticScheduler;
+pub(crate) use diagnostic_publisher::DiagnosticPublisher;
 pub(crate) use injection::InjectionCoordinator;
 pub(crate) use install::InstallCoordinator;
 pub(crate) use parse::ParseCoordinator;

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -14,28 +14,31 @@ use crate::lsp::lsp_impl::text_document::publish_diagnostic::{
 };
 use crate::lsp::settings_manager::SettingsManager;
 use crate::lsp::synthetic_diagnostics::SyntheticDiagnosticsManager;
-use tower_lsp_server::Client;
 
 pub(crate) struct DiagnosticScheduler {
-    client: Client,
     language: std::sync::Arc<LanguageCoordinator>,
     documents: std::sync::Arc<DocumentStore>,
     bridge: std::sync::Arc<BridgeCoordinator>,
     settings_manager: std::sync::Arc<SettingsManager>,
     debounced_diagnostics: std::sync::Arc<DebouncedDiagnosticsManager>,
     synthetic_diagnostics: std::sync::Arc<SyntheticDiagnosticsManager>,
+    /// The single proactive publisher: the host-event pull below feeds its
+    /// result into the cache and republishes (push-propagation-diagnostic-forwarding),
+    /// rather than calling `client.publish_diagnostics` directly, so it can never
+    /// clobber a sibling region's push.
+    publisher: std::sync::Arc<super::DiagnosticPublisher>,
 }
 
 impl DiagnosticScheduler {
     pub(crate) fn new(server: &Kakehashi) -> Self {
         Self {
-            client: server.client.clone(),
             language: std::sync::Arc::clone(&server.language),
             documents: std::sync::Arc::clone(&server.documents),
             bridge: std::sync::Arc::clone(&server.bridge),
             settings_manager: std::sync::Arc::clone(&server.settings_manager),
             debounced_diagnostics: std::sync::Arc::clone(&server.debounced_diagnostics),
             synthetic_diagnostics: std::sync::Arc::clone(&server.synthetic_diagnostics),
+            publisher: std::sync::Arc::new(super::DiagnosticPublisher::new(server)),
         }
     }
 
@@ -44,16 +47,15 @@ impl DiagnosticScheduler {
     /// A later change cancels and replaces the pending timer. The snapshot is
     /// captured now, at schedule time, so diagnostics stay consistent with the
     /// document state that triggered the change.
-    pub(crate) fn schedule_debounced_diagnostic(&self, uri: Url, lsp_uri: Uri) {
+    pub(crate) fn schedule_debounced_diagnostic(&self, uri: Url, _lsp_uri: Uri) {
         let snapshot_data = self.prepare_diagnostic_snapshot(&uri);
 
         self.debounced_diagnostics.schedule(
             uri,
-            lsp_uri,
-            self.client.clone(),
             snapshot_data,
             self.bridge.pool_arc(),
             std::sync::Arc::clone(&self.synthetic_diagnostics),
+            std::sync::Arc::clone(&self.publisher),
         );
     }
 
@@ -63,10 +65,10 @@ impl DiagnosticScheduler {
     /// with `SyntheticDiagnosticsManager` (superseding any previous task), then
     /// fans out to downstream servers and publishes via
     /// `textDocument/publishDiagnostics`.
-    pub(crate) fn spawn_synthetic_diagnostic_task(&self, uri: Url, lsp_uri: Uri) {
-        let client = self.client.clone();
+    pub(crate) fn spawn_synthetic_diagnostic_task(&self, uri: Url, _lsp_uri: Uri) {
         let snapshot_data = self.prepare_diagnostic_snapshot(&uri);
         let bridge_pool = self.bridge.pool_arc();
+        let publisher = std::sync::Arc::clone(&self.publisher);
         let uri_clone = uri.clone();
 
         let task = tokio::spawn(async move {
@@ -79,12 +81,15 @@ impl DiagnosticScheduler {
 
             log::debug!(
                 target: LOG_TARGET,
-                "Collected {} diagnostics for {}",
+                "Collected {} pull-layer diagnostics for {}",
                 diagnostics.len(),
                 uri_clone
             );
 
-            client.publish_diagnostics(lsp_uri, diagnostics, None).await;
+            // Feed the host-event pull result into the cache and republish the
+            // merged set (push-propagation-diagnostic-forwarding) instead of
+            // publishing directly — push slots for the same host survive.
+            publisher.publish_pull_layer(&uri_clone, diagnostics).await;
         });
 
         self.synthetic_diagnostics

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -5,7 +5,6 @@ use crate::lsp::bridge::BridgeCoordinator;
 use crate::lsp::debounced_diagnostics::DebouncedDiagnosticsManager;
 use crate::lsp::lsp_impl::bridge_context::resolve_aggregation_config_from_settings;
 use crate::lsp::lsp_impl::bridge_context::{DocumentRequestContext, HostRequestContext};
-use tower_lsp_server::ls_types::Uri;
 use url::Url;
 
 use crate::lsp::lsp_impl::Kakehashi;
@@ -47,7 +46,7 @@ impl DiagnosticScheduler {
     /// A later change cancels and replaces the pending timer. The snapshot is
     /// captured now, at schedule time, so diagnostics stay consistent with the
     /// document state that triggered the change.
-    pub(crate) fn schedule_debounced_diagnostic(&self, uri: Url, _lsp_uri: Uri) {
+    pub(crate) fn schedule_debounced_diagnostic(&self, uri: Url) {
         let snapshot_data = self.prepare_diagnostic_snapshot(&uri);
 
         self.debounced_diagnostics.schedule(
@@ -65,7 +64,7 @@ impl DiagnosticScheduler {
     /// with `SyntheticDiagnosticsManager` (superseding any previous task), then
     /// fans out to downstream servers and publishes via
     /// `textDocument/publishDiagnostics`.
-    pub(crate) fn spawn_synthetic_diagnostic_task(&self, uri: Url, _lsp_uri: Uri) {
+    pub(crate) fn spawn_synthetic_diagnostic_task(&self, uri: Url) {
         let snapshot_data = self.prepare_diagnostic_snapshot(&uri);
         let bridge_pool = self.bridge.pool_arc();
         let publisher = std::sync::Arc::clone(&self.publisher);

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -3,31 +3,37 @@
 //!
 //! Every proactive diagnostic feed writes slots into the [`DiagnosticAggregator`]
 //! and then asks this publisher to **republish** the host: it snapshots the
-//! cache, merges every slot, and emits one `publishDiagnostics`. Routing every
-//! feed through one publisher is what keeps sibling regions intact against the
-//! client's URI-level clobber.
-//!
-//! Staged: this commit handles the host-event pull blob
-//! ([`DiagnosticSource::PullLayer`](crate::lsp::diagnostic_cache::DiagnosticSource)).
-//! A follow-up adds downstream region pushes, which need the host document's live
-//! injection offsets to transform virtual coordinates — the publisher gains
-//! `documents`/`language`/`bridge` then.
+//! cache, transforms region push slots to host coordinates against the region's
+//! *current* offset (lazy re-anchor), merges with the host-event pull blob, and
+//! emits one `publishDiagnostics`. Routing every feed through one publisher is
+//! what keeps sibling regions intact against the client's URI-level clobber.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use url::Url;
 
-use crate::lsp::diagnostic_cache::{DiagnosticAggregator, merge_cached_diagnostics};
+use crate::document::DocumentStore;
+use crate::language::{InjectionResolver, LanguageCoordinator};
+use crate::lsp::bridge::{BridgeCoordinator, RegionOffset};
+use crate::lsp::diagnostic_cache::{
+    DiagnosticAggregator, DiagnosticSource, merge_cached_diagnostics,
+};
 use crate::lsp::lsp_impl::Kakehashi;
 use tower_lsp_server::Client;
+use tower_lsp_server::ls_types::Diagnostic;
 
 /// Logging target for proactive push diagnostics.
 const LOG_TARGET: &str = "kakehashi::push_diag";
 
 /// Bundles the state needed to merge the cache and publish for a host, so the
-/// notification feeds can trigger a republish without each holding `Kakehashi`.
+/// notification feeds (reader push, host-event pull) can trigger a republish
+/// without each holding `Kakehashi`.
 pub(crate) struct DiagnosticPublisher {
     client: Client,
+    language: Arc<LanguageCoordinator>,
+    documents: Arc<DocumentStore>,
+    bridge: Arc<BridgeCoordinator>,
     aggregator: Arc<DiagnosticAggregator>,
 }
 
@@ -35,20 +41,47 @@ impl DiagnosticPublisher {
     pub(crate) fn new(server: &Kakehashi) -> Self {
         Self {
             client: server.client.clone(),
+            language: Arc::clone(&server.language),
+            documents: Arc::clone(&server.documents),
+            bridge: Arc::clone(&server.bridge),
             aggregator: Arc::clone(&server.diagnostics),
         }
+    }
+
+    /// Record a downstream region push and republish the host (Path A).
+    ///
+    /// `virtual_uri` is the URI the downstream published for; it is resolved to
+    /// its host document + region id. A push for a URI that resolves to no live
+    /// region (a closed/edited-away region, or a non-bridged document) is dropped.
+    /// Diagnostics are stored in virtual coordinates and transformed at publish.
+    pub(crate) async fn publish_region_push(
+        &self,
+        virtual_uri: &str,
+        server: String,
+        diagnostics: Vec<Diagnostic>,
+    ) {
+        let Some((host, region_id)) = self.bridge.resolve_virtual_uri(virtual_uri).await else {
+            log::debug!(
+                target: LOG_TARGET,
+                "push for unresolved virtual uri {virtual_uri}, dropping"
+            );
+            return;
+        };
+        self.aggregator.record(
+            &host,
+            DiagnosticSource::Region(region_id),
+            server,
+            diagnostics,
+        );
+        self.republish(&host).await;
     }
 
     /// Feed the host-event pull's combined result into the cache and republish.
     ///
     /// The pull blob is already host-local; it replaces the
-    /// [`DiagnosticSource::PullLayer`](crate::lsp::diagnostic_cache::DiagnosticSource)
-    /// slot, then the merge folds in every other slot for the host.
-    pub(crate) async fn publish_pull_layer(
-        &self,
-        host: &Url,
-        diagnostics: Vec<tower_lsp_server::ls_types::Diagnostic>,
-    ) {
+    /// [`DiagnosticSource::PullLayer`] slot, then the merge folds in region push
+    /// slots.
+    pub(crate) async fn publish_pull_layer(&self, host: &Url, diagnostics: Vec<Diagnostic>) {
         self.aggregator.set_pull_layer(host, diagnostics);
         self.republish(host).await;
     }
@@ -59,11 +92,13 @@ impl DiagnosticPublisher {
         self.republish(host).await;
     }
 
-    /// Merge the host's cached slots and publish the cumulative result. An empty
-    /// merge clears the editor's diagnostics for the host.
+    /// Merge the host's cached slots and publish the cumulative result. Region
+    /// slots are transformed against the host document's *current* injection
+    /// offsets; an empty merge clears the editor's diagnostics for the host.
     pub(crate) async fn republish(&self, host: &Url) {
         let snapshot = self.aggregator.snapshot(host);
-        let diagnostics = merge_cached_diagnostics(&snapshot);
+        let region_offsets = self.current_region_offsets(host);
+        let diagnostics = merge_cached_diagnostics(&snapshot, &region_offsets);
 
         let lsp_uri = match crate::lsp::lsp_impl::url_to_uri(host) {
             Ok(uri) => uri,
@@ -82,5 +117,47 @@ impl DiagnosticPublisher {
         self.client
             .publish_diagnostics(lsp_uri, diagnostics, None)
             .await;
+    }
+
+    /// Map each currently-resolvable injection region of the host document to its
+    /// offset, recomputed from the live document so region push slots re-anchor
+    /// after edits above them. Empty when the document is missing or has no
+    /// injections.
+    fn current_region_offsets(&self, host: &Url) -> HashMap<String, RegionOffset> {
+        let mut offsets = HashMap::new();
+
+        let Some(doc) = self.documents.get(host) else {
+            return offsets;
+        };
+        let Some(snapshot) = doc.snapshot() else {
+            return offsets;
+        };
+        let Some(language_name) =
+            self.language
+                .detect_language(host.path(), snapshot.text(), None, doc.language_id())
+        else {
+            return offsets;
+        };
+        let Some(injection_query) = self.language.injection_query(&language_name) else {
+            return offsets;
+        };
+
+        for resolved in InjectionResolver::resolve_all(
+            &self.language,
+            self.bridge.node_tracker(),
+            host,
+            snapshot.tree(),
+            snapshot.text(),
+            injection_query.as_ref(),
+        ) {
+            offsets.insert(
+                resolved.region.region_id.clone(),
+                RegionOffset::with_per_line_offsets(
+                    resolved.region.line_range.start,
+                    resolved.line_column_offsets.clone(),
+                ),
+            );
+        }
+        offsets
     }
 }

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -110,7 +110,18 @@ impl DiagnosticPublisher {
         let _guard = self.aggregator.lock_republish().await;
 
         let snapshot = self.aggregator.snapshot(host);
-        let region_offsets = self.current_region_offsets(host);
+        // Recompute injection offsets only when there are region push slots to
+        // transform. A PullLayer-only snapshot (the common pull-driven case) needs
+        // none, so skip the whole-document injection resolution — and shorten the
+        // time the global republish lock is held.
+        let region_offsets = if snapshot
+            .keys()
+            .any(|source| matches!(source, DiagnosticSource::Region(_)))
+        {
+            self.current_region_offsets(host)
+        } else {
+            HashMap::new()
+        };
         let diagnostics = merge_cached_diagnostics(host, snapshot, &region_offsets);
 
         let lsp_uri = match crate::lsp::lsp_impl::url_to_uri(host) {

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -81,6 +81,14 @@ impl DiagnosticPublisher {
     /// The pull blob is already host-local; it replaces the
     /// [`DiagnosticSource::PullLayer`] slot, then the merge folds in region push
     /// slots.
+    ///
+    /// Staged limitation: `SyntheticDiagnosticsManager` aborts a superseded pull
+    /// task, but the abort cannot preempt the synchronous `set_pull_layer` write
+    /// below — so a superseded task can leave a slightly stale `PullLayer` that a
+    /// later republish includes until the next pull completes. This is the same
+    /// staleness class the deferred `content_epoch` version gate
+    /// (push-propagation-diagnostic-forwarding) handles generally; until then it
+    /// self-heals on the next completed pull.
     pub(crate) async fn publish_pull_layer(&self, host: &Url, diagnostics: Vec<Diagnostic>) {
         self.aggregator.set_pull_layer(host, diagnostics);
         self.republish(host).await;

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -111,7 +111,7 @@ impl DiagnosticPublisher {
 
         let snapshot = self.aggregator.snapshot(host);
         let region_offsets = self.current_region_offsets(host);
-        let diagnostics = merge_cached_diagnostics(host, &snapshot, &region_offsets);
+        let diagnostics = merge_cached_diagnostics(host, snapshot, &region_offsets);
 
         let lsp_uri = match crate::lsp::lsp_impl::url_to_uri(host) {
             Ok(uri) => uri,

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -107,6 +107,14 @@ impl DiagnosticPublisher {
         // Serialize the whole snapshot→merge→publish so concurrent republishes
         // (region push vs host-event pull) emit in order and a stale snapshot can
         // never publish after a fresh one (push-propagation-diagnostic-forwarding).
+        //
+        // The lock is held across the editor `publish_diagnostics` await below
+        // because the ordering guarantee requires it (releasing before the send
+        // would let two publishes reorder on the wire). The cost is that a slow
+        // editor stalls *all* hosts' republishes — an accepted staging tradeoff of
+        // the global lock; the deferred per-host lock shrinks the blast radius to
+        // one host. publish_diagnostics is a fire-and-forget notification, so the
+        // stall window is the client's outbound-channel send, not a round-trip.
         let _guard = self.aggregator.lock_republish().await;
 
         let snapshot = self.aggregator.snapshot(host);

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -96,9 +96,14 @@ impl DiagnosticPublisher {
     /// slots are transformed against the host document's *current* injection
     /// offsets; an empty merge clears the editor's diagnostics for the host.
     pub(crate) async fn republish(&self, host: &Url) {
+        // Serialize the whole snapshot→merge→publish so concurrent republishes
+        // (region push vs host-event pull) emit in order and a stale snapshot can
+        // never publish after a fresh one (push-propagation-diagnostic-forwarding).
+        let _guard = self.aggregator.lock_republish().await;
+
         let snapshot = self.aggregator.snapshot(host);
         let region_offsets = self.current_region_offsets(host);
-        let diagnostics = merge_cached_diagnostics(&snapshot, &region_offsets);
+        let diagnostics = merge_cached_diagnostics(host, &snapshot, &region_offsets);
 
         let lsp_uri = match crate::lsp::lsp_impl::url_to_uri(host) {
             Ok(uri) => uri,

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1,0 +1,86 @@
+//! The single proactive `textDocument/publishDiagnostics` publisher
+//! (push-propagation-diagnostic-forwarding).
+//!
+//! Every proactive diagnostic feed writes slots into the [`DiagnosticAggregator`]
+//! and then asks this publisher to **republish** the host: it snapshots the
+//! cache, merges every slot, and emits one `publishDiagnostics`. Routing every
+//! feed through one publisher is what keeps sibling regions intact against the
+//! client's URI-level clobber.
+//!
+//! Staged: this commit handles the host-event pull blob
+//! ([`DiagnosticSource::PullLayer`](crate::lsp::diagnostic_cache::DiagnosticSource)).
+//! A follow-up adds downstream region pushes, which need the host document's live
+//! injection offsets to transform virtual coordinates — the publisher gains
+//! `documents`/`language`/`bridge` then.
+
+use std::sync::Arc;
+
+use url::Url;
+
+use crate::lsp::diagnostic_cache::{DiagnosticAggregator, merge_cached_diagnostics};
+use crate::lsp::lsp_impl::Kakehashi;
+use tower_lsp_server::Client;
+
+/// Logging target for proactive push diagnostics.
+const LOG_TARGET: &str = "kakehashi::push_diag";
+
+/// Bundles the state needed to merge the cache and publish for a host, so the
+/// notification feeds can trigger a republish without each holding `Kakehashi`.
+pub(crate) struct DiagnosticPublisher {
+    client: Client,
+    aggregator: Arc<DiagnosticAggregator>,
+}
+
+impl DiagnosticPublisher {
+    pub(crate) fn new(server: &Kakehashi) -> Self {
+        Self {
+            client: server.client.clone(),
+            aggregator: Arc::clone(&server.diagnostics),
+        }
+    }
+
+    /// Feed the host-event pull's combined result into the cache and republish.
+    ///
+    /// The pull blob is already host-local; it replaces the
+    /// [`DiagnosticSource::PullLayer`](crate::lsp::diagnostic_cache::DiagnosticSource)
+    /// slot, then the merge folds in every other slot for the host.
+    pub(crate) async fn publish_pull_layer(
+        &self,
+        host: &Url,
+        diagnostics: Vec<tower_lsp_server::ls_types::Diagnostic>,
+    ) {
+        self.aggregator.set_pull_layer(host, diagnostics);
+        self.republish(host).await;
+    }
+
+    /// Drop the host's cache entry and publish the now-empty set (host `didClose`).
+    pub(crate) async fn clear_host(&self, host: &Url) {
+        self.aggregator.evict_host(host);
+        self.republish(host).await;
+    }
+
+    /// Merge the host's cached slots and publish the cumulative result. An empty
+    /// merge clears the editor's diagnostics for the host.
+    pub(crate) async fn republish(&self, host: &Url) {
+        let snapshot = self.aggregator.snapshot(host);
+        let diagnostics = merge_cached_diagnostics(&snapshot);
+
+        let lsp_uri = match crate::lsp::lsp_impl::url_to_uri(host) {
+            Ok(uri) => uri,
+            Err(e) => {
+                log::warn!(target: LOG_TARGET, "skip publish, bad host URI {host}: {e}");
+                return;
+            }
+        };
+
+        log::debug!(
+            target: LOG_TARGET,
+            "publishing {} merged diagnostics for {}",
+            diagnostics.len(),
+            host
+        );
+        self.client
+            .publish_diagnostics(lsp_uri, diagnostics, None)
+            .await;
+    }
+}

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -802,13 +802,24 @@ async fn deliver_upstream_notification(
             server,
             diagnostics,
         } => {
+            // The server name keys the cache slot; production always sets it
+            // (pool.rs spawns readers with `Some(server_name)`). Drop a push that
+            // lacks one rather than collapse it to an empty-string key that could
+            // collide with another unnamed pusher.
+            let Some(server) = server else {
+                log::debug!(
+                    target: "kakehashi::bridge",
+                    "dropping region push without a server name for {uri}"
+                );
+                return;
+            };
             // Cache the downstream region push and republish the merged host set
             // (push-propagation-diagnostic-forwarding). The publisher resolves the
             // virtual URI to its host + region; a `None` publisher (test loop)
             // drops it.
             if let Some(publisher) = diagnostic_publisher {
                 publisher
-                    .publish_region_push(&uri, server.unwrap_or_default(), diagnostics)
+                    .publish_region_push(&uri, server, diagnostics)
                     .await;
             }
         }

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -802,21 +802,11 @@ async fn deliver_upstream_notification(
             server,
             diagnostics,
         } => {
-            // The server name keys the cache slot; production always sets it
-            // (pool.rs spawns readers with `Some(server_name)`). Drop a push that
-            // lacks one rather than collapse it to an empty-string key that could
-            // collide with another unnamed pusher.
-            let Some(server) = server else {
-                log::debug!(
-                    target: "kakehashi::bridge",
-                    "dropping region push without a server name for {uri}"
-                );
-                return;
-            };
             // Cache the downstream region push and republish the merged host set
             // (push-propagation-diagnostic-forwarding). The publisher resolves the
             // virtual URI to its host + region; a `None` publisher (test loop)
-            // drops it.
+            // drops it. (Pushes without a server name were already dropped at the
+            // reader, so `server` is always set here.)
             if let Some(publisher) = diagnostic_publisher {
                 publisher
                     .publish_region_push(&uri, server, diagnostics)

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -336,6 +336,12 @@ impl Kakehashi {
                 Arc::clone(&self.bridge),
             )));
             let inbound_request_registry = self.bridge.pool().inbound_request_registry();
+            // The single proactive diagnostics publisher: region pushes routed up
+            // by the reader resolve to a host + region and republish the merged
+            // host set (push-propagation-diagnostic-forwarding).
+            let diagnostic_publisher = Some(Arc::new(
+                crate::lsp::lsp_impl::coordinator::DiagnosticPublisher::new(self),
+            ));
             tokio::spawn(upstream_forwarding_loop(
                 upstream_rx,
                 window_rx,
@@ -343,6 +349,7 @@ impl Kakehashi {
                 show_document_translator,
                 inbound_request_registry,
                 client,
+                diagnostic_publisher,
                 token,
             ));
         }
@@ -446,6 +453,9 @@ async fn forward_upstream_request(
 /// - Either channel is closed (all senders dropped — both senders live in the
 ///   pool, so they close together at shutdown), OR
 /// - The `cancel_token` is cancelled (deterministic shutdown)
+// Heterogeneous channels + collaborators threaded into one long-lived loop task;
+// bundling them into a struct would just move the list, not shorten it.
+#[allow(clippy::too_many_arguments)]
 async fn upstream_forwarding_loop(
     mut upstream_rx: tokio::sync::mpsc::UnboundedReceiver<crate::lsp::bridge::UpstreamNotification>,
     mut window_rx: tokio::sync::mpsc::Receiver<crate::lsp::bridge::UpstreamNotification>,
@@ -455,6 +465,7 @@ async fn upstream_forwarding_loop(
     show_document_translator: Option<Arc<ShowDocumentTranslator>>,
     inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry,
     client: Client,
+    diagnostic_publisher: Option<Arc<crate::lsp::lsp_impl::coordinator::DiagnosticPublisher>>,
     cancel_token: tokio_util::sync::CancellationToken,
 ) {
     // Tokens the editor successfully created. `$/progress` is forwarded only for
@@ -480,8 +491,13 @@ async fn upstream_forwarding_loop(
             notification = upstream_rx.recv() => {
                 match notification {
                     Some(notification) => {
-                        deliver_upstream_notification(&client, notification, &mut created_tokens)
-                            .await
+                        deliver_upstream_notification(
+                            &client,
+                            notification,
+                            &mut created_tokens,
+                            diagnostic_publisher.as_deref(),
+                        )
+                        .await
                     }
                     None => break, // Channel closed
                 }
@@ -514,8 +530,13 @@ async fn upstream_forwarding_loop(
             notification = window_rx.recv() => {
                 match notification {
                     Some(notification) => {
-                        deliver_upstream_notification(&client, notification, &mut created_tokens)
-                            .await
+                        deliver_upstream_notification(
+                            &client,
+                            notification,
+                            &mut created_tokens,
+                            diagnostic_publisher.as_deref(),
+                        )
+                        .await
                     }
                     None => break, // Channel closed
                 }
@@ -762,6 +783,7 @@ async fn deliver_upstream_notification(
     client: &Client,
     notification: crate::lsp::bridge::UpstreamNotification,
     created_tokens: &mut std::collections::HashSet<tower_lsp_server::ls_types::NumberOrString>,
+    diagnostic_publisher: Option<&crate::lsp::lsp_impl::coordinator::DiagnosticPublisher>,
 ) {
     use crate::lsp::bridge::UpstreamNotification;
     use tower_lsp_server::ls_types::{ProgressParamsValue, WorkDoneProgress};
@@ -773,6 +795,21 @@ async fn deliver_upstream_notification(
                     "workspace/diagnostic/refresh forwarding failed: {}",
                     e
                 );
+            }
+        }
+        UpstreamNotification::PublishDiagnostics {
+            uri,
+            server,
+            diagnostics,
+        } => {
+            // Cache the downstream region push and republish the merged host set
+            // (push-propagation-diagnostic-forwarding). The publisher resolves the
+            // virtual URI to its host + region; a `None` publisher (test loop)
+            // drops it.
+            if let Some(publisher) = diagnostic_publisher {
+                publisher
+                    .publish_region_push(&uri, server.unwrap_or_default(), diagnostics)
+                    .await;
             }
         }
         UpstreamNotification::LogMessage { typ, message } => {
@@ -953,6 +990,7 @@ mod tests {
             None,
             crate::lsp::bridge::InboundRequestRegistry::default(),
             client,
+            None,
             cancel.clone(),
         ));
 
@@ -1062,6 +1100,7 @@ mod tests {
             None,
             crate::lsp::bridge::InboundRequestRegistry::default(),
             client,
+            None,
             cancel.clone(),
         ));
 
@@ -1174,6 +1213,7 @@ mod tests {
             None,
             crate::lsp::bridge::InboundRequestRegistry::default(),
             client,
+            None,
             cancel.clone(),
         ));
 
@@ -1348,6 +1388,7 @@ mod tests {
             None,
             crate::lsp::bridge::InboundRequestRegistry::default(),
             client,
+            None,
             cancel.clone(),
         ));
 
@@ -1403,6 +1444,7 @@ mod tests {
             None,
             crate::lsp::bridge::InboundRequestRegistry::default(),
             client,
+            None,
             cancel.clone(),
         ));
 
@@ -1456,6 +1498,7 @@ mod tests {
             None,
             InboundRequestRegistry::default(),
             client,
+            None,
             loop_cancel.clone(),
         ));
 
@@ -1532,6 +1575,7 @@ mod tests {
             None,
             crate::lsp::bridge::InboundRequestRegistry::default(),
             client,
+            None,
             cancel.clone(),
         ));
 

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -109,7 +109,7 @@ impl Kakehashi {
         // After 500ms of no changes, diagnostics will be collected and published.
         // This provides near-real-time feedback while avoiding excessive requests during typing.
         self.diagnostic_scheduler()
-            .schedule_debounced_diagnostic(uri, lsp_uri);
+            .schedule_debounced_diagnostic(uri);
 
         // NOTE: We intentionally do NOT call semantic_tokens_refresh() here.
         // LSP clients already request new tokens after didChange (via semanticTokens/full/delta).

--- a/src/lsp/lsp_impl/text_document/did_close.rs
+++ b/src/lsp/lsp_impl/text_document/did_close.rs
@@ -51,13 +51,6 @@ impl Kakehashi {
         // Cancel any pending debounced diagnostic for this document (pull-first-diagnostic-forwarding Phase 3)
         self.debounced_diagnostics.cancel(&uri);
 
-        // Drop the proactive diagnostic cache for this host and clear the editor's
-        // diagnostics (push-propagation-diagnostic-forwarding). Runs after the
-        // synthetic/debounced tasks are aborted above, so no late task re-fills it.
-        super::super::coordinator::DiagnosticPublisher::new(self)
-            .clear_host(&uri)
-            .await;
-
         // Cancel any eager-open tasks for this document (prevents orphaned didOpen)
         self.bridge.cancel_eager_open(&uri);
 
@@ -72,6 +65,17 @@ impl Kakehashi {
                 uri
             );
         }
+
+        // Drop the proactive diagnostic cache for this host and clear the editor's
+        // diagnostics (push-propagation-diagnostic-forwarding). MUST run AFTER
+        // close_host_document tears down host_to_virtual: a region push dequeued
+        // before that teardown can still resolve its virtual URI and re-create the
+        // cache entry, so clearing first would leave a resurrected, never-cleared
+        // host. (A residual resolve→suspend→record micro-window remains, closed
+        // only by the deferred tombstone/epoch gate.)
+        super::super::coordinator::DiagnosticPublisher::new(self)
+            .clear_host(&uri)
+            .await;
 
         // Close the host document itself on any servers it was opened on via
         // the host bridge (host-document-bridge).

--- a/src/lsp/lsp_impl/text_document/did_close.rs
+++ b/src/lsp/lsp_impl/text_document/did_close.rs
@@ -51,6 +51,13 @@ impl Kakehashi {
         // Cancel any pending debounced diagnostic for this document (pull-first-diagnostic-forwarding Phase 3)
         self.debounced_diagnostics.cancel(&uri);
 
+        // Drop the proactive diagnostic cache for this host and clear the editor's
+        // diagnostics (push-propagation-diagnostic-forwarding). Runs after the
+        // synthetic/debounced tasks are aborted above, so no late task re-fills it.
+        super::super::coordinator::DiagnosticPublisher::new(self)
+            .clear_host(&uri)
+            .await;
+
         // Cancel any eager-open tasks for this document (prevents orphaned didOpen)
         self.bridge.cancel_eager_open(&uri);
 

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -98,9 +98,8 @@ impl Kakehashi {
 
         // pull-first-diagnostic-forwarding Phase 2: Trigger synthetic diagnostic push on didOpen
         // This provides proactive diagnostics for clients that don't support pull diagnostics.
-        // Note: We use the already-cloned lsp_uri here (it was cloned at the start of the method).
         self.diagnostic_scheduler()
-            .spawn_synthetic_diagnostic_task(uri, lsp_uri);
+            .spawn_synthetic_diagnostic_task(uri);
 
         // NOTE: No semantic_tokens_refresh() on didOpen.
         // Capable LSP clients should request by themselves.

--- a/src/lsp/lsp_impl/text_document/did_save.rs
+++ b/src/lsp/lsp_impl/text_document/did_save.rs
@@ -35,7 +35,7 @@ impl Kakehashi {
 
         // Spawn background task for synthetic diagnostic collection
         self.diagnostic_scheduler()
-            .spawn_synthetic_diagnostic_task(uri, lsp_uri);
+            .spawn_synthetic_diagnostic_task(uri);
 
         self.notifier().log_info("file saved!").await;
     }

--- a/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
@@ -1,7 +1,10 @@
-//! Shared fan-out/aggregation for proactive `textDocument/publishDiagnostics`
-//! pushes (pull-first-diagnostic-forwarding Phase 2). `DiagnosticScheduler` schedules and handles
-//! superseding (via `SyntheticDiagnosticsManager` / `DebouncedDiagnosticsManager`);
-//! this module just collects per-layer diagnostics from a prepared snapshot.
+//! Shared fan-out/aggregation for the host-event diagnostic pull
+//! (push-propagation-diagnostic-forwarding): on `didOpen`/`didSave`/`didChange`,
+//! `DiagnosticScheduler` pulls every layer's diagnostics from a prepared snapshot
+//! and the result is fed into the cache as the `PullLayer` blob, then republished.
+//! `DiagnosticScheduler` handles superseding (via `SyntheticDiagnosticsManager` /
+//! `DebouncedDiagnosticsManager`); this module just collects the per-layer
+//! diagnostics.
 
 use std::sync::Arc;
 


### PR DESCRIPTION
## What

First implementation of the `push-propagation-diagnostic-forwarding` ADR: downstream-pushed `textDocument/publishDiagnostics` now reach the editor, closing **#380**.

- A per-host nested cache (`DiagnosticAggregator`, `host → source → server`) + a single `DiagnosticPublisher` become the one proactive publisher per host (the client clobbers all diagnostics for a URI on each publish, so push and pull must share one cache).
- The existing host-event pull is unified onto the cache as the `PullLayer` blob (behaviour-preserving) instead of publishing directly.
- The reader routes a non-scratch `publishDiagnostics` for an injection region's virtual document into the cache as a `Region` slot (virtual coordinates, transformed to host coordinates at publish via lazy re-anchor), so diagnostics a downstream emits on its own timeline (slow linters, build-triggered) reach the editor without a host edit.

## Staged — deliberately deferred (documented in code + the ADR's Decision–Implementation Gap)

- `content_epoch` version gate (stale-overwrite guard); until then a brief wrong-content window after edits, lazy re-anchor keeps *positions* current.
- Per-source strategy fan-in (`preferred` sticky / `concatenated` visible-walk); the staged merge concatenates.
- `_self` host-layer push source (host layer still served by the pull feed).
- Region-invalidation / crash cache eviction.
- `pullFallback` / `pushFallback` config toggles + capability classification (without the latter the pull feed and a server's spontaneous push can double-count that server — documented).

## Correctness notes

- **Lost-update race**: the publisher serializes snapshot→merge→publish through a shared `republish_lock`, so a stale snapshot can't publish after a fresh one.
- **Resurrection race**: `didClose` clears the cache *after* `close_host_document` tears down `host_to_virtual`, so a late push resolves to `None`.
- Virtual-URI `relatedInformation` is filtered (parity with the pull path); malformed push arrays are dropped (not treated as a clear).

## Review

Passed multi-perspective subagent `/review` (2 rounds to convergence) and a Codex MCP review (2 fresh high-effort sessions to "no comments to provide"). A push-specific e2e is a tracked follow-up; the existing `e2e_synthetic_push_diagnostic` already exercises the unified publisher path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)