### PR TITLE
feat(bridge): propagate _self host-layer push diagnostics (#421)

### DIFF
--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -87,9 +87,11 @@ Partially implemented:
   virtual→host edit translation and cross-region aggregation that overlap the
   concatenated formatting pipeline (format-on-save), so virt `willSaveWaitUntil`
   stays deferred.
-- **Not implemented**: `publishDiagnostics` pass-through from host servers
-  (downstream notifications are not forwarded upstream today on either
-  path).
+- **Diagnostics**: a `_self` host server's pushed `publishDiagnostics` for the
+  real host URI are propagated to the editor via the per-host diagnostic cache
+  (push-propagation-diagnostic-forwarding, #421) — accepted when the URI names an
+  open host-bridged document. Host-layer eager-open (on-open diagnostics before
+  the first request) is still deferred.
 
 ## Context
 

--- a/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
+++ b/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
@@ -490,6 +490,10 @@ because the #380 benefit now outweighs it:
 - Non-scratch `publishDiagnostics` are routed from `reader.rs` into the cache as
   `Region` slots (virtual coordinates, transformed at publish via lazy re-anchor),
   closing #380 for region pushes.
+- The `_self` host-layer push source (#421): a push on the real host URI that
+  names an open `_self` host-bridged document is cached as a `Host` slot (host
+  coordinates) and merged through. Classification/routing only — **eager-open**
+  (below) is still deferred.
 
 **Deferred** (staged follow-ups; the code documents each at its site):
 
@@ -498,8 +502,9 @@ because the #380 benefit now outweighs it:
   (lazy re-anchor still keeps *positions* current via the retained pull trigger).
 - Per-source strategy fan-in (`preferred` sticky / `concatenated` visible-walk);
   the staged merge concatenates, with HashMap-nondeterministic cross-source order.
-- The `_self` host-layer push source (the host layer is still served by the pull
-  feed for now).
+- Host-layer eager-open: a push-only `_self` server only pushes after the host
+  doc is opened on it (lazily, on the first host request), so on-open diagnostics
+  rely on the editor's open-time pull opening the doc.
 - Region-invalidation and crash cache eviction.
 - The `pullFallback` / `pushFallback` config toggles and the capability
   classification — without the latter the pull feed and a server's spontaneous

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -61,8 +61,9 @@ pub(crate) enum UpstreamNotification {
     /// `uri`: a virtual injection URI resolves to its host document + region (a
     /// region push, virtual coordinates); a real URI is a candidate `_self`
     /// host-layer push (host coordinates) accepted only for an open host-bridged
-    /// document. Either way the diagnostics are cached under `server` and the
-    /// merged host set is republished.
+    /// document. When the push classifies to a live target it is cached under
+    /// `server` and the merged host set is republished; otherwise it is dropped
+    /// (unresolved virtual URI; real URI not open / not `_self` / wrong server).
     ///
     /// This carries an arbitrary-size `Vec<Diagnostic>` over the **unbounded**
     /// upstream channel, so a push-happy or misbehaving downstream paired with a

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -56,10 +56,13 @@ pub(crate) enum UpstreamNotification {
     /// Request upstream to re-pull diagnostics.
     /// Sent when downstream server issues `workspace/diagnostic/refresh`.
     DiagnosticRefresh,
-    /// A downstream-initiated `textDocument/publishDiagnostics` for an injection
-    /// region's virtual document (push-propagation-diagnostic-forwarding). The
-    /// forwarding loop resolves `uri` to its host document + region, caches the
-    /// diagnostics under `server`, and republishes the merged host set.
+    /// A downstream-initiated `textDocument/publishDiagnostics`
+    /// (push-propagation-diagnostic-forwarding). The forwarding loop classifies
+    /// `uri`: a virtual injection URI resolves to its host document + region (a
+    /// region push, virtual coordinates); a real URI is a candidate `_self`
+    /// host-layer push (host coordinates) accepted only for an open host-bridged
+    /// document. Either way the diagnostics are cached under `server` and the
+    /// merged host set is republished.
     ///
     /// This carries an arbitrary-size `Vec<Diagnostic>` over the **unbounded**
     /// upstream channel, so a push-happy or misbehaving downstream paired with a
@@ -67,12 +70,14 @@ pub(crate) enum UpstreamNotification {
     /// (push-propagation-diagnostic-forwarding § Consequences); a bounded /
     /// coalescing diagnostics channel is the deferred mitigation if it proves noisy.
     PublishDiagnostics {
-        /// The virtual document URI the downstream published for.
+        /// The URI the downstream published for — a virtual injection URI (region
+        /// push) or a real host URI (`_self` host-layer push).
         uri: String,
         /// The originating downstream server's config name (`deps.server_name`);
         /// pushes without a name are dropped at the reader, so this is always set.
         server: String,
-        /// The pushed diagnostics, in the virtual document's coordinates.
+        /// The pushed diagnostics, in the published document's own coordinates
+        /// (virtual for a region push, host for a `_self` push).
         diagnostics: Vec<tower_lsp_server::ls_types::Diagnostic>,
     },
     /// Forward a downstream `window/logMessage` to the editor.

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -2330,16 +2330,18 @@ mod tests {
         }
     }
 
-    /// A push for a non-virtual URI (the downstream's own file, or the real host
-    /// URI) has no region mapping and is dropped, not routed.
+    /// A non-virtual (real host URI) push is now routed up too — the publisher
+    /// classifies it as a candidate `_self` host-layer push and decides (using
+    /// document/config state the reader lacks) whether it names an open
+    /// host-bridged doc. The reader only forwards.
     #[tokio::test]
-    async fn handle_message_drops_publish_diagnostics_for_non_virtual_uri() {
+    async fn handle_message_routes_real_uri_push_for_host_classification() {
         let router = ResponseRouter::new();
         let (response_tx, _response_rx) = mpsc::channel(16);
         let (upstream_tx, mut upstream_rx) = mpsc::unbounded_channel();
         let (window_tx, _window_rx) = mpsc::channel(16);
         let deps = ServerRequestDeps {
-            server_name: Some("luals".to_string()),
+            server_name: Some("lua_ls".to_string()),
             response_tx,
             dynamic_capabilities: Arc::new(DynamicCapabilityRegistry::new()),
             upstream_tx,
@@ -2356,16 +2358,27 @@ mod tests {
             "method": "textDocument/publishDiagnostics",
             "params": {
                 "uri": "file:///project/real_file.lua",
-                "diagnostics": []
+                "diagnostics": [{
+                    "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 1}},
+                    "message": "host diag"
+                }]
             }
         });
 
         handle_message(message, &router, "", &deps).await;
 
-        assert!(
-            upstream_rx.try_recv().is_err(),
-            "a non-virtual-uri push must not be routed"
-        );
+        match upstream_rx
+            .try_recv()
+            .expect("real-uri push should be routed for host classification")
+        {
+            UpstreamNotification::PublishDiagnostics {
+                uri, diagnostics, ..
+            } => {
+                assert_eq!(uri, "file:///project/real_file.lua");
+                assert_eq!(diagnostics.len(), 1);
+            }
+            _ => panic!("expected PublishDiagnostics"),
+        }
     }
 
     /// A malformed `diagnostics` array must be dropped, not routed as an empty

--- a/src/lsp/bridge/text_document/publish_diagnostics.rs
+++ b/src/lsp/bridge/text_document/publish_diagnostics.rs
@@ -29,14 +29,12 @@ pub(in crate::lsp::bridge) fn is_scratch_publish_diagnostics(message: &serde_jso
             .is_some_and(crate::lsp::bridge::VirtualDocumentUri::is_scratch_uri)
 }
 
-/// Route a non-scratch downstream `textDocument/publishDiagnostics` for an
-/// injection region's virtual document into the proactive diagnostics cache
-/// (push-propagation-diagnostic-forwarding). The forwarding loop resolves the
-/// virtual URI to its host + region and republishes the merged host set.
-///
-/// A push for a non-virtual URI (the downstream's own files, or the real host
-/// URI) has no region mapping and is dropped — the host layer is still served by
-/// the pull feed for now.
+/// Route a non-scratch downstream `textDocument/publishDiagnostics` into the
+/// proactive diagnostics cache (push-propagation-diagnostic-forwarding). The
+/// forwarding loop classifies the URI: a virtual injection URI becomes a region
+/// push; a real URI is a candidate `_self` host-layer push, accepted only if it
+/// names an open host-bridged document (the publisher filters the server's own
+/// workspace pushes). Either way the merged host set is republished.
 pub(in crate::lsp::bridge) fn forward_push(
     mut message: serde_json::Value,
     deps: &crate::lsp::bridge::actor::ServerRequestDeps,
@@ -65,9 +63,6 @@ pub(in crate::lsp::bridge) fn forward_push(
     let Some(serde_json::Value::String(uri)) = params.remove("uri") else {
         return;
     };
-    if !crate::lsp::bridge::VirtualDocumentUri::is_virtual_uri(&uri) {
-        return;
-    }
     // Deserialize the moved-out diagnostics value (no clone) — `from_value` moves
     // the diagnostics' owned strings. A parse failure (including an absent or
     // non-array `diagnostics`) is *dropped* (not treated as an empty/clearing push,

--- a/src/lsp/bridge/text_document/publish_diagnostics.rs
+++ b/src/lsp/bridge/text_document/publish_diagnostics.rs
@@ -32,9 +32,10 @@ pub(in crate::lsp::bridge) fn is_scratch_publish_diagnostics(message: &serde_jso
 /// Route a non-scratch downstream `textDocument/publishDiagnostics` into the
 /// proactive diagnostics cache (push-propagation-diagnostic-forwarding). The
 /// forwarding loop classifies the URI: a virtual injection URI becomes a region
-/// push; a real URI is a candidate `_self` host-layer push, accepted only if it
-/// names an open host-bridged document (the publisher filters the server's own
-/// workspace pushes). Either way the merged host set is republished.
+/// push; a real URI is a candidate `_self` host-layer push. When the push
+/// classifies to a live target the merged host set is republished; otherwise it
+/// is dropped — an unresolved virtual URI, or a real URI for a non-open or
+/// non-`_self` document, or a push from a server that isn't a host server for it.
 pub(in crate::lsp::bridge) fn forward_push(
     mut message: serde_json::Value,
     deps: &crate::lsp::bridge::actor::ServerRequestDeps,

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -49,6 +49,11 @@ pub(crate) enum DiagnosticSource {
     /// coordinates and transformed to host coordinates at publish time against
     /// the region's *current* offset (lazy re-anchor).
     Region(String),
+    /// A downstream **push** from a `_self` host-layer server for the real host
+    /// document (host-document-bridge). Held in **host** coordinates (the host
+    /// path applies no translation), so it passes through the merge unchanged.
+    /// Keyed per server, so several host servers on one host document coexist.
+    Host,
     /// The host-event pull's cross-layer-combined result, in host coordinates.
     /// A single blob (one synthetic server slot) for now — a follow-up replaces
     /// it with per-`(region, server)` slots gated by `pullFallback`.
@@ -85,7 +90,8 @@ pub(crate) type SourceSlots = HashMap<DiagnosticSource, ServerSlots>;
 ///   resolves, e.g. it was edited away) is skipped here; its now-stale slot
 ///   lingers in the cache until the whole host is dropped on `didClose`
 ///   (per-region / crash eviction is a deferred follow-up).
-/// - [`DiagnosticSource::PullLayer`] slots are already host-local and pass through.
+/// - [`DiagnosticSource::Host`] and [`DiagnosticSource::PullLayer`] slots are
+///   already host-local and pass through unchanged.
 ///
 /// Staged: results are concatenated (the default `textDocument/publishDiagnostics`
 /// strategy). Per-source strategy fan-in (`preferred` sticky / `concatenated`
@@ -113,7 +119,8 @@ pub(crate) fn merge_cached_diagnostics(
                     }
                 }
             }
-            DiagnosticSource::PullLayer => {
+            DiagnosticSource::Host | DiagnosticSource::PullLayer => {
+                // Already host-local: pass through unchanged.
                 for slot in servers.into_values() {
                     merged.extend(slot.diagnostics);
                 }
@@ -414,6 +421,39 @@ mod tests {
         let mut msgs: Vec<&str> = merged.iter().map(|d| d.message.as_str()).collect();
         msgs.sort();
         assert_eq!(msgs, vec!["pull", "push"]);
+    }
+
+    #[test]
+    fn merge_passes_host_push_slots_through_unchanged() {
+        let agg = DiagnosticAggregator::new();
+        // Two host servers push for the same host doc; both pass through in host
+        // coords (no transform), keyed per server.
+        agg.record(
+            &host(),
+            DiagnosticSource::Host,
+            "lua_ls".into(),
+            vec![diag_at("hostA", 7, 3)],
+        );
+        agg.record(
+            &host(),
+            DiagnosticSource::Host,
+            "selene".into(),
+            vec![diag_at("hostB", 8, 0)],
+        );
+        let merged = merge_cached_diagnostics(&host(), agg.snapshot(&host()), &HashMap::new());
+        let mut by_msg: Vec<(&str, Position)> = merged
+            .iter()
+            .map(|d| (d.message.as_str(), d.range.start))
+            .collect();
+        by_msg.sort();
+        assert_eq!(
+            by_msg,
+            vec![
+                ("hostA", Position::new(7, 3)),
+                ("hostB", Position::new(8, 0))
+            ],
+            "host push slots pass through in host coordinates, per server"
+        );
     }
 
     #[test]

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -12,25 +12,28 @@
 //! / server later.
 //!
 //! ## Staging
-//! Two source kinds are populated:
+//! Three source kinds are populated:
 //! - [`DiagnosticSource::PullLayer`] — the host-event pull's already
 //!   cross-layer-combined result, in host coordinates, as one blob.
 //! - [`DiagnosticSource::Region`] — a downstream push for an injection region, in
 //!   virtual coordinates, transformed to host coordinates at publish time.
+//! - [`DiagnosticSource::Host`] — a downstream `_self` host-layer push for the
+//!   real host document, in host coordinates (passes through unchanged).
 //!
 //! **Known interim overlap (deferred capability gate).** The pull feed fans out
-//! to *every* configured region server with no capability classification, so a
-//! server that both answers `textDocument/diagnostic` (landing in `PullLayer`)
-//! *and* spontaneously pushes `publishDiagnostics` (landing in a `Region` slot) is
-//! counted twice. In practice the two channels are disjoint — a pull-capable
-//! server should not also push (LSP) — so this only *duplicates*, never *hides*,
-//! and only for a misbehaving server. The deferred `pullFallback` / capability
-//! classification removes the overlap by giving each server one native source.
+//! to *every* configured server (region and host) with no capability
+//! classification, so a server that both answers `textDocument/diagnostic`
+//! (landing in `PullLayer`) *and* spontaneously pushes `publishDiagnostics`
+//! (landing in a `Region` or `Host` slot) is counted twice. In practice the two
+//! channels are disjoint — a pull-capable server should not also push (LSP) — so
+//! this only *duplicates*, never *hides*, and only for a misbehaving server. The
+//! deferred `pullFallback` / capability classification removes the overlap by
+//! giving each server one native source.
 //!
 //! Also deferred: per-source strategy fan-in (`preferred` sticky / `concatenated`
 //! visible-walk; cross-source order is HashMap-nondeterministic until then), the
-//! `_self` host-layer push source, the `content_epoch` version gate, and
-//! region-invalidation/crash eviction.
+//! `content_epoch` version gate, region-invalidation/crash eviction, and
+//! host-layer eager-open (diagnostics on open before the first request).
 
 use std::collections::HashMap;
 use std::sync::Mutex;

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -421,7 +421,11 @@ mod tests {
 
         // The push comes from a server that is NOT a configured host server for rust.
         DiagnosticPublisher::new(server)
-            .publish_host_push(uri.as_str(), "some_other_server".to_string(), vec![diag("z")])
+            .publish_host_push(
+                uri.as_str(),
+                "some_other_server".to_string(),
+                vec![diag("z")],
+            )
             .await;
 
         assert!(

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -123,24 +123,29 @@ impl DiagnosticPublisher {
         host: &Url,
         snapshot: &mut crate::lsp::diagnostic_cache::SourceSlots,
     ) {
-        let Some(host_slots) = snapshot.get_mut(&DiagnosticSource::Host) else {
+        if !snapshot.contains_key(&DiagnosticSource::Host) {
             return; // no host push slots — nothing to filter
-        };
+        }
         // If the doc is gone or its language no longer opts into `_self`, no server
         // is valid — drop the whole Host source.
-        let still_valid: Vec<String> = match self.open_document_language(host) {
-            Some(language_name) => {
-                let settings = self.settings_manager.load_settings();
-                self.bridge
-                    .get_host_configs_for_language(&settings, &language_name)
-                    .into_iter()
-                    .map(|config| config.server_name)
-                    .collect()
-            }
-            None => Vec::new(),
+        let Some(language_name) = self.open_document_language(host) else {
+            snapshot.remove(&DiagnosticSource::Host);
+            return;
         };
-        host_slots.retain(|server, _| still_valid.iter().any(|s| s == server));
-        if host_slots.is_empty() {
+        let settings = self.settings_manager.load_settings();
+        let configs = self
+            .bridge
+            .get_host_configs_for_language(&settings, &language_name);
+        // Borrowed-`&str` set: O(1) membership, no `server_name` clones.
+        let valid: std::collections::HashSet<&str> =
+            configs.iter().map(|c| c.server_name.as_str()).collect();
+        let became_empty = if let Some(host_slots) = snapshot.get_mut(&DiagnosticSource::Host) {
+            host_slots.retain(|server, _| valid.contains(server.as_str()));
+            host_slots.is_empty()
+        } else {
+            false
+        };
+        if became_empty {
             snapshot.remove(&DiagnosticSource::Host);
         }
     }

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -15,11 +15,12 @@ use url::Url;
 
 use crate::document::DocumentStore;
 use crate::language::{InjectionResolver, LanguageCoordinator};
-use crate::lsp::bridge::{BridgeCoordinator, RegionOffset};
+use crate::lsp::bridge::{BridgeCoordinator, RegionOffset, VirtualDocumentUri};
 use crate::lsp::diagnostic_cache::{
     DiagnosticAggregator, DiagnosticSource, merge_cached_diagnostics,
 };
 use crate::lsp::lsp_impl::Kakehashi;
+use crate::lsp::settings_manager::SettingsManager;
 use tower_lsp_server::Client;
 use tower_lsp_server::ls_types::Diagnostic;
 
@@ -34,6 +35,7 @@ pub(crate) struct DiagnosticPublisher {
     language: Arc<LanguageCoordinator>,
     documents: Arc<DocumentStore>,
     bridge: Arc<BridgeCoordinator>,
+    settings_manager: Arc<SettingsManager>,
     aggregator: Arc<DiagnosticAggregator>,
 }
 
@@ -44,8 +46,67 @@ impl DiagnosticPublisher {
             language: Arc::clone(&server.language),
             documents: Arc::clone(&server.documents),
             bridge: Arc::clone(&server.bridge),
+            settings_manager: Arc::clone(&server.settings_manager),
             aggregator: Arc::clone(&server.diagnostics),
         }
+    }
+
+    /// Route a downstream `publishDiagnostics` push into the cache, classifying by
+    /// its URI: a virtual injection URI becomes a region push; anything else is
+    /// treated as a candidate `_self` host-layer push for the real host document.
+    pub(crate) async fn publish_push(
+        &self,
+        uri: String,
+        server: String,
+        diagnostics: Vec<Diagnostic>,
+    ) {
+        if VirtualDocumentUri::is_virtual_uri(&uri) {
+            self.publish_region_push(&uri, server, diagnostics).await;
+        } else {
+            self.publish_host_push(&uri, server, diagnostics).await;
+        }
+    }
+
+    /// Record a `_self` host-layer push and republish the host (host-document-bridge).
+    ///
+    /// A host server pushes for the **real** host URI in host coordinates. Accept
+    /// it only when that URI is an **open** document whose language has `_self`
+    /// host bridging enabled — otherwise it is a stray push for the server's own
+    /// workspace file (not a host-bridged doc the editor has open) and is dropped.
+    /// Host diagnostics need no coordinate transform.
+    pub(crate) async fn publish_host_push(
+        &self,
+        host_uri: &str,
+        server: String,
+        diagnostics: Vec<Diagnostic>,
+    ) {
+        let Ok(host) = Url::parse(host_uri) else {
+            return;
+        };
+        let Some(language_name) = self.open_document_language(&host) else {
+            return; // not an open document
+        };
+        let settings = self.settings_manager.load_settings();
+        if self
+            .bridge
+            .get_host_configs_for_language(&settings, &language_name)
+            .is_empty()
+        {
+            // `_self` host bridging is off for this language, or no host server is
+            // configured — this real-URI push is not a host-layer contribution.
+            return;
+        }
+        self.aggregator
+            .record(&host, DiagnosticSource::Host, server, diagnostics);
+        self.republish(&host).await;
+    }
+
+    /// Detect the language of an *open* document, or `None` if it isn't open.
+    fn open_document_language(&self, uri: &Url) -> Option<String> {
+        let doc = self.documents.get(uri)?;
+        let snapshot = doc.snapshot()?;
+        self.language
+            .detect_language(uri.path(), snapshot.text(), None, doc.language_id())
     }
 
     /// Record a downstream region push and republish the host (Path A).

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -70,12 +70,11 @@ impl DiagnosticPublisher {
     /// Record a `_self` host-layer push and republish the host (host-document-bridge).
     ///
     /// A host server pushes for the **real** host URI in host coordinates. Accept
-    /// it only when that URI names an **open** document whose language opts into
-    /// `_self` host bridging — which drops the common stray case, a push for a
-    /// workspace file the editor doesn't have open. The gate does *not* verify the
-    /// pushing server is one of the configured host servers; that per-server
-    /// classification is deferred (see the cache module's staging note). Host
-    /// diagnostics need no coordinate transform.
+    /// it only when that URI names an **open** document AND the pushing `server` is
+    /// a configured `_self` host server for that document's language. This drops
+    /// both the common stray case (a push for a workspace file the editor doesn't
+    /// have open) and a real-URI push from a server that isn't a host server for
+    /// this language. Host diagnostics need no coordinate transform.
     pub(crate) async fn publish_host_push(
         &self,
         host_uri: &str,
@@ -89,13 +88,14 @@ impl DiagnosticPublisher {
             return; // not an open document
         };
         let settings = self.settings_manager.load_settings();
-        if self
+        let is_host_server = self
             .bridge
             .get_host_configs_for_language(&settings, &language_name)
-            .is_empty()
-        {
-            // `_self` host bridging is off for this language, or no host server is
-            // configured — this real-URI push is not a host-layer contribution.
+            .iter()
+            .any(|config| config.server_name == server);
+        if !is_host_server {
+            // `_self` host bridging is off for this language, or `server` is not a
+            // configured host server for it — not a host-layer contribution.
             return;
         }
         self.aggregator
@@ -400,6 +400,33 @@ mod tests {
         assert!(
             server.diagnostics.snapshot(&uri).is_empty(),
             "a push for a language without _self host bridging must be dropped"
+        );
+    }
+
+    #[tokio::test]
+    async fn host_push_dropped_for_non_host_server() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        register_rust(server);
+        // rust_ls is the configured host server; _self is enabled for rust.
+        server.settings_manager.apply_settings(rust_settings(true));
+
+        let uri = Url::parse("file:///test/host.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+
+        // The push comes from a server that is NOT a configured host server for rust.
+        DiagnosticPublisher::new(server)
+            .publish_host_push(uri.as_str(), "some_other_server".to_string(), vec![diag("z")])
+            .await;
+
+        assert!(
+            server.diagnostics.snapshot(&uri).is_empty(),
+            "a push from a server that is not a host server for the language must be dropped"
         );
     }
 }

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -70,10 +70,12 @@ impl DiagnosticPublisher {
     /// Record a `_self` host-layer push and republish the host (host-document-bridge).
     ///
     /// A host server pushes for the **real** host URI in host coordinates. Accept
-    /// it only when that URI is an **open** document whose language has `_self`
-    /// host bridging enabled — otherwise it is a stray push for the server's own
-    /// workspace file (not a host-bridged doc the editor has open) and is dropped.
-    /// Host diagnostics need no coordinate transform.
+    /// it only when that URI names an **open** document whose language opts into
+    /// `_self` host bridging — which drops the common stray case, a push for a
+    /// workspace file the editor doesn't have open. The gate does *not* verify the
+    /// pushing server is one of the configured host servers; that per-server
+    /// classification is deferred (see the cache module's staging note). Host
+    /// diagnostics need no coordinate transform.
     pub(crate) async fn publish_host_push(
         &self,
         host_uri: &str,
@@ -337,9 +339,12 @@ mod tests {
         server.settings_manager.apply_settings(rust_settings(true));
 
         let uri = Url::parse("file:///test/host.rs").unwrap();
-        server
-            .documents
-            .insert(uri.clone(), "fn main() {}".to_string(), Some("rust".to_string()), None);
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
 
         DiagnosticPublisher::new(server)
             .publish_host_push(uri.as_str(), "rust_ls".to_string(), vec![diag("boom")])
@@ -381,9 +386,12 @@ mod tests {
         server.settings_manager.apply_settings(rust_settings(false));
 
         let uri = Url::parse("file:///test/host.rs").unwrap();
-        server
-            .documents
-            .insert(uri.clone(), "fn main() {}".to_string(), Some("rust".to_string()), None);
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
 
         DiagnosticPublisher::new(server)
             .publish_host_push(uri.as_str(), "rust_ls".to_string(), vec![diag("y")])

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -123,13 +123,15 @@ impl DiagnosticPublisher {
         host: &Url,
         snapshot: &mut crate::lsp::diagnostic_cache::SourceSlots,
     ) {
-        if !snapshot.contains_key(&DiagnosticSource::Host) {
-            return; // no host push slots — nothing to filter
-        }
+        // Single map lookup via the entry API (no separate contains_key/get_mut/remove).
+        let mut entry = match snapshot.entry(DiagnosticSource::Host) {
+            std::collections::hash_map::Entry::Occupied(entry) => entry,
+            std::collections::hash_map::Entry::Vacant(_) => return, // no host push slots
+        };
         // If the doc is gone or its language no longer opts into `_self`, no server
         // is valid — drop the whole Host source.
         let Some(language_name) = self.open_document_language(host) else {
-            snapshot.remove(&DiagnosticSource::Host);
+            entry.remove();
             return;
         };
         let settings = self.settings_manager.load_settings();
@@ -139,14 +141,10 @@ impl DiagnosticPublisher {
         // Borrowed-`&str` set: O(1) membership, no `server_name` clones.
         let valid: std::collections::HashSet<&str> =
             configs.iter().map(|c| c.server_name.as_str()).collect();
-        let became_empty = if let Some(host_slots) = snapshot.get_mut(&DiagnosticSource::Host) {
-            host_slots.retain(|server, _| valid.contains(server.as_str()));
-            host_slots.is_empty()
-        } else {
-            false
-        };
-        if became_empty {
-            snapshot.remove(&DiagnosticSource::Host);
+        let slots = entry.get_mut();
+        slots.retain(|server, _| valid.contains(server.as_str()));
+        if slots.is_empty() {
+            entry.remove();
         }
     }
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -138,6 +138,12 @@ impl DiagnosticPublisher {
         let configs = self
             .bridge
             .get_host_configs_for_language(&settings, &language_name);
+        if configs.is_empty() {
+            // No host servers for this language (or `_self` disabled) — every host
+            // slot is stale. Drop the whole source without scanning the slots.
+            entry.remove();
+            return;
+        }
         let slots = entry.get_mut();
         // A language has only a handful of host servers (usually 1–2), so a linear
         // scan over `configs` is cheaper than allocating a lookup set on every

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -114,6 +114,37 @@ impl DiagnosticPublisher {
             .detect_language(uri.path(), doc.text(), None, doc.language_id())
     }
 
+    /// Remove `Host` push slots from `snapshot` whose server is no longer a
+    /// configured `_self` host server for `host`'s current language, so stale host
+    /// diagnostics are filtered out of the publish after a config change. Operates
+    /// on the snapshot clone only; the cache is untouched.
+    fn filter_stale_host_slots(
+        &self,
+        host: &Url,
+        snapshot: &mut crate::lsp::diagnostic_cache::SourceSlots,
+    ) {
+        let Some(host_slots) = snapshot.get_mut(&DiagnosticSource::Host) else {
+            return; // no host push slots — nothing to filter
+        };
+        // If the doc is gone or its language no longer opts into `_self`, no server
+        // is valid — drop the whole Host source.
+        let still_valid: Vec<String> = match self.open_document_language(host) {
+            Some(language_name) => {
+                let settings = self.settings_manager.load_settings();
+                self.bridge
+                    .get_host_configs_for_language(&settings, &language_name)
+                    .into_iter()
+                    .map(|config| config.server_name)
+                    .collect()
+            }
+            None => Vec::new(),
+        };
+        host_slots.retain(|server, _| still_valid.iter().any(|s| s == server));
+        if host_slots.is_empty() {
+            snapshot.remove(&DiagnosticSource::Host);
+        }
+    }
+
     /// Record a downstream region push and republish the host (Path A).
     ///
     /// `virtual_uri` is the URI the downstream published for; it is resolved to
@@ -183,7 +214,14 @@ impl DiagnosticPublisher {
         // stall window is the client's outbound-channel send, not a round-trip.
         let _guard = self.aggregator.lock_republish().await;
 
-        let snapshot = self.aggregator.snapshot(host);
+        let mut snapshot = self.aggregator.snapshot(host);
+        // Drop Host push slots whose server is no longer a configured `_self` host
+        // server for the document's current language — so a host server's pushed
+        // diagnostics don't linger in the editor after the user disables `_self`
+        // (or unconfigures the server) via `workspace/didChangeConfiguration`. The
+        // slots stay cached (cleared on `didClose`); they're just filtered out of
+        // this publish. (The analogous Region/config-change re-merge is deferred.)
+        self.filter_stale_host_slots(host, &mut snapshot);
         // Recompute injection offsets only when there are region push slots to
         // transform. A PullLayer-only snapshot (the common pull-driven case) needs
         // none, so skip the whole-document injection resolution — and shorten the
@@ -431,6 +469,50 @@ mod tests {
         assert!(
             server.diagnostics.snapshot(&uri).is_empty(),
             "a push from a server that is not a host server for the language must be dropped"
+        );
+    }
+
+    #[tokio::test]
+    async fn host_slots_filtered_from_publish_after_self_disabled() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        register_rust(server);
+        server.settings_manager.apply_settings(rust_settings(true));
+
+        let uri = Url::parse("file:///test/host.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        let publisher = DiagnosticPublisher::new(server);
+        publisher
+            .publish_host_push(uri.as_str(), "rust_ls".to_string(), vec![diag("e")])
+            .await;
+        assert!(
+            server
+                .diagnostics
+                .snapshot(&uri)
+                .contains_key(&DiagnosticSource::Host),
+            "host slot is recorded while _self is enabled"
+        );
+
+        // Disable _self for rust; the publish-time filter should now exclude the
+        // stale host slot, while the cache itself keeps it (cleared on didClose).
+        server.settings_manager.apply_settings(rust_settings(false));
+        let mut snapshot = server.diagnostics.snapshot(&uri);
+        publisher.filter_stale_host_slots(&uri, &mut snapshot);
+        assert!(
+            !snapshot.contains_key(&DiagnosticSource::Host),
+            "stale host slots are filtered out of the publish after _self is disabled"
+        );
+        assert!(
+            server
+                .diagnostics
+                .snapshot(&uri)
+                .contains_key(&DiagnosticSource::Host),
+            "the cache still holds the slot; only the publish snapshot is filtered"
         );
     }
 }

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -138,11 +138,11 @@ impl DiagnosticPublisher {
         let configs = self
             .bridge
             .get_host_configs_for_language(&settings, &language_name);
-        // Borrowed-`&str` set: O(1) membership, no `server_name` clones.
-        let valid: std::collections::HashSet<&str> =
-            configs.iter().map(|c| c.server_name.as_str()).collect();
         let slots = entry.get_mut();
-        slots.retain(|server, _| valid.contains(server.as_str()));
+        // A language has only a handful of host servers (usually 1–2), so a linear
+        // scan over `configs` is cheaper than allocating a lookup set on every
+        // republish (no `server_name` clones either).
+        slots.retain(|server, _| configs.iter().any(|c| &c.server_name == server));
         if slots.is_empty() {
             entry.remove();
         }

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -102,11 +102,14 @@ impl DiagnosticPublisher {
     }
 
     /// Detect the language of an *open* document, or `None` if it isn't open.
+    ///
+    /// Borrows the document text directly (no `snapshot()` clone) — detection
+    /// never touches the tree, so this also avoids spuriously dropping a push for
+    /// an open-but-not-yet-parsed document.
     fn open_document_language(&self, uri: &Url) -> Option<String> {
         let doc = self.documents.get(uri)?;
-        let snapshot = doc.snapshot()?;
         self.language
-            .detect_language(uri.path(), snapshot.text(), None, doc.language_id())
+            .detect_language(uri.path(), doc.text(), None, doc.language_id())
     }
 
     /// Record a downstream region push and republish the host (Path A).
@@ -252,5 +255,143 @@ impl DiagnosticPublisher {
             );
         }
         offsets
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::settings::{
+        BridgeLanguageConfig, BridgeServerConfig, HOST_BRIDGE_KEY, LanguageSettings,
+        WorkspaceSettings,
+    };
+    use std::collections::HashMap;
+    use tower_lsp_server::LspService;
+    use tower_lsp_server::ls_types::{Position, Range};
+
+    fn diag(message: &str) -> Diagnostic {
+        Diagnostic {
+            range: Range::new(Position::new(0, 0), Position::new(0, 1)),
+            message: message.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn rust_server_config() -> (String, BridgeServerConfig) {
+        (
+            "rust_ls".to_string(),
+            BridgeServerConfig {
+                cmd: vec!["true".to_string()],
+                languages: vec!["rust".to_string()],
+                initialization_options: None,
+                root_markers: None,
+                on_type_formatting_triggers: None,
+                prefer_shared_instance: None,
+            },
+        )
+    }
+
+    /// Settings with a configured rust host server; `_self` host bridging is set
+    /// to `enabled` for the rust language.
+    fn rust_settings(self_enabled: bool) -> WorkspaceSettings {
+        let (name, cfg) = rust_server_config();
+        let mut language_servers = HashMap::new();
+        language_servers.insert(name, cfg);
+        let mut languages = HashMap::new();
+        languages.insert(
+            "rust".to_string(),
+            LanguageSettings {
+                bridge: Some(HashMap::from([(
+                    HOST_BRIDGE_KEY.to_string(),
+                    BridgeLanguageConfig {
+                        enabled: Some(self_enabled),
+                        aggregation: None,
+                    },
+                )])),
+                ..Default::default()
+            },
+        );
+        WorkspaceSettings {
+            auto_install: false,
+            language_servers,
+            languages,
+            ..Default::default()
+        }
+    }
+
+    /// `service.inner()` borrows from `service`, so the harness is set up inline
+    /// per test; this registers the rust grammar so `detect_language` resolves a
+    /// `.rs` document to `"rust"`.
+    fn register_rust(server: &Kakehashi) {
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("rust".to_string(), tree_sitter_rust::LANGUAGE.into());
+    }
+
+    #[tokio::test]
+    async fn host_push_accepted_for_open_self_bridged_doc() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        register_rust(server);
+        server.settings_manager.apply_settings(rust_settings(true));
+
+        let uri = Url::parse("file:///test/host.rs").unwrap();
+        server
+            .documents
+            .insert(uri.clone(), "fn main() {}".to_string(), Some("rust".to_string()), None);
+
+        DiagnosticPublisher::new(server)
+            .publish_host_push(uri.as_str(), "rust_ls".to_string(), vec![diag("boom")])
+            .await;
+
+        let snap = server.diagnostics.snapshot(&uri);
+        let host_slots = snap
+            .get(&DiagnosticSource::Host)
+            .expect("a Host slot should be recorded for an open _self-bridged doc");
+        assert_eq!(host_slots["rust_ls"].diagnostics.len(), 1);
+        assert_eq!(host_slots["rust_ls"].diagnostics[0].message, "boom");
+    }
+
+    #[tokio::test]
+    async fn host_push_dropped_when_document_not_open() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        register_rust(server);
+        server.settings_manager.apply_settings(rust_settings(true));
+
+        // URI is never inserted into the document store.
+        let uri = Url::parse("file:///test/not_open.rs").unwrap();
+        DiagnosticPublisher::new(server)
+            .publish_host_push(uri.as_str(), "rust_ls".to_string(), vec![diag("x")])
+            .await;
+
+        assert!(
+            server.diagnostics.snapshot(&uri).is_empty(),
+            "a push for a non-open document must be dropped"
+        );
+    }
+
+    #[tokio::test]
+    async fn host_push_dropped_when_self_bridging_disabled() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        register_rust(server);
+        // Same rust server, but `_self` host bridging is explicitly disabled.
+        server.settings_manager.apply_settings(rust_settings(false));
+
+        let uri = Url::parse("file:///test/host.rs").unwrap();
+        server
+            .documents
+            .insert(uri.clone(), "fn main() {}".to_string(), Some("rust".to_string()), None);
+
+        DiagnosticPublisher::new(server)
+            .publish_host_push(uri.as_str(), "rust_ls".to_string(), vec![diag("y")])
+            .await;
+
+        assert!(
+            server.diagnostics.snapshot(&uri).is_empty(),
+            "a push for a language without _self host bridging must be dropped"
+        );
     }
 }

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -802,15 +802,13 @@ async fn deliver_upstream_notification(
             server,
             diagnostics,
         } => {
-            // Cache the downstream region push and republish the merged host set
-            // (push-propagation-diagnostic-forwarding). The publisher resolves the
-            // virtual URI to its host + region; a `None` publisher (test loop)
-            // drops it. (Pushes without a server name were already dropped at the
-            // reader, so `server` is always set here.)
+            // Cache the downstream push and republish the merged host set
+            // (push-propagation-diagnostic-forwarding). The publisher classifies the
+            // URI (virtual → region, real → `_self` host layer); a `None` publisher
+            // (test loop) drops it. (Pushes without a server name were already
+            // dropped at the reader, so `server` is always set here.)
             if let Some(publisher) = diagnostic_publisher {
-                publisher
-                    .publish_region_push(&uri, server, diagnostics)
-                    .await;
+                publisher.publish_push(uri, server, diagnostics).await;
             }
         }
         UpstreamNotification::LogMessage { typ, message } => {

--- a/src/lsp/lsp_impl/text_document/did_close.rs
+++ b/src/lsp/lsp_impl/text_document/did_close.rs
@@ -71,8 +71,10 @@ impl Kakehashi {
         // close_host_document tears down host_to_virtual: a region push dequeued
         // before that teardown can still resolve its virtual URI and re-create the
         // cache entry, so clearing first would leave a resurrected, never-cleared
-        // host. (A residual resolve→suspend→record micro-window remains, closed
-        // only by the deferred tombstone/epoch gate.)
+        // host. (Residual resolve→suspend→record micro-windows remain — both the
+        // region path and the host path, whose `documents.get→record` can race the
+        // `documents.remove()` above — closed only by the deferred tombstone/epoch
+        // gate.)
         super::super::coordinator::DiagnosticPublisher::new(self)
             .clear_host(&uri)
             .await;


### PR DESCRIPTION
## What

Closes #421. A push-only server bridged as the **host** (`bridge._self`) — e.g.
**lua-language-server** on a `.lua` host document — publishes `publishDiagnostics`
for the **real host URI**, not a virtual injection URI. The push-propagation work
(#380) only routed virtual-URI pushes, so the prior `is_virtual_uri` guard dropped
these and the editor saw nothing. (Confirmed from a real session log: lua-ls
pushed diagnostics for `example2.lua`; kakehashi forwarded only empty `ndiag:0`.)

- Add `DiagnosticSource::Host` (host coordinates, per-server slots); the merge
  passes `Host` through unchanged alongside `PullLayer`.
- `forward_push` routes any non-scratch push up; `DiagnosticPublisher::publish_push`
  classifies the URI — virtual → region push; real → `_self` host push.
- `publish_host_push` accepts a real-URI push only when the URI names an **open**
  document **and** the pushing `server` is a configured `_self` host server for
  that document's language (`get_host_configs_for_language(...).any(server)`);
  records a `Host` slot and republishes. Otherwise it is dropped.

## Verification

New gate tests prove the accept/drop matrix non-vacuously (accept; not-open;
`_self` disabled; non-host server). The load-bearing config resolution is
confirmed against the reporter's setup (`[languages.lua.bridge._self] enabled =
true` + `lua_ls`). **Interactive confirmation against a live lua-ls is still
recommended** (a push-path e2e is tracked in #427).

## Deferred (documented in code + ADRs)

- **Host-layer eager-open**: a push-only `_self` server only pushes after the host
  doc is opened on it (lazily, on the first host request), so on-open diagnostics
  rely on the editor's open-time diagnostic pull opening the doc. Tracked follow-up.
- **Channel pressure (#426)**: the reader now forwards real-URI pushes for the
  publisher to filter, so a push-happy host server's many workspace-file pushes are
  deserialized + sent up the unbounded channel before being dropped. CPU-side only
  (dropped fast, no unbounded memory); deferred to #426.
- Dual-mode (pull+push) host server double-count, `content_epoch` gate, per-source
  fan-in, region/crash eviction — all from #380, documented.

## Review
Passed multi-perspective subagent `/review` (2 rounds) and Codex MCP review
(2 fresh high-effort sessions to "no comments to provide").

🤖 Generated with [Claude Code](https://claude.com/claude-code)