### PR TITLE
feat(bridge): client-provided progress pass-through — N=1 slice (#414)

### DIFF
--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -60,7 +60,7 @@ fn setup_client_progress(
     let mut map = HashMap::new();
     let mut minted = Vec::new();
     for config in selected {
-        let token = registry.register(Arc::clone(&aggregator), &config.server_name);
+        let token = registry.register(Arc::clone(&aggregator));
         minted.push(token.clone());
         map.insert(config.server_name, token);
     }
@@ -127,7 +127,14 @@ where
     let client_progress = setup_client_progress(ctx, &pool, &entries);
     let cp_tokens = client_progress.as_ref().map(|(m, _guard)| m);
     let mut join_set = fan_out(ctx, pool, f, &entries, cp_tokens);
-    preferred::preferred(&mut join_set, is_nonempty, &entries, cancel_rx).await
+    let result = preferred::preferred(&mut join_set, is_nonempty, &entries, cancel_rx).await;
+    // Hold the client-progress guard across the await above (it owns the routing
+    // and the synthetic-terminal-End-on-teardown); tear it down only now, after
+    // the request has settled. The explicit drop documents that the guard must
+    // outlive the fan-in — otherwise a downstream `$/progress` during the request
+    // would have nowhere to route.
+    drop(client_progress);
+    result
 }
 
 /// Server-level aggregation entry point using the concatenated strategy.

--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -37,13 +37,12 @@ use super::priority::{PriorityEntry, entry_names, expand_priorities, truncate_en
 fn setup_client_progress(
     ctx: &DocumentRequestContext,
     pool: &LanguageServerPool,
-    entries: &[PriorityEntry],
+    selected: &[ResolvedServerConfig],
 ) -> Option<(
     HashMap<String, NumberOrString>,
     ClientProgressDeregisterGuard,
 )> {
     let client_token = ctx.client_progress_token.clone()?;
-    let selected = select_servers(&ctx.configs, entries);
     // Stage 1 bridges client progress only for the single-downstream case. With
     // more than one server we mint nothing — those downstreams get no
     // `workDoneToken` and emit no `$/progress` — so multi-server fan-out stays
@@ -62,7 +61,7 @@ fn setup_client_progress(
     for config in selected {
         let token = registry.register(Arc::clone(&aggregator));
         minted.push(token.clone());
-        map.insert(config.server_name, token);
+        map.insert(config.server_name.clone(), token);
     }
     let guard =
         ClientProgressDeregisterGuard::new(registry, minted, aggregator, pool.upstream_tx());
@@ -121,12 +120,15 @@ where
     Fut: Future<Output = io::Result<T>> + Send + 'static,
 {
     let entries = expanded_entries(ctx);
+    // Compute the selected servers once and share it with both client-progress
+    // setup and fan-out (avoids a second `select_servers` on the dispatch path).
+    let selected = select_servers(&ctx.configs, &entries);
     // Stage 1: `setup_client_progress` bridges client progress only for the
     // single-downstream case (it returns `None` for N>1, keeping fan-out
     // non-regressing) and only when the request carries a `workDoneToken`.
-    let client_progress = setup_client_progress(ctx, &pool, &entries);
+    let client_progress = setup_client_progress(ctx, &pool, &selected);
     let cp_tokens = client_progress.as_ref().map(|(m, _guard)| m);
-    let mut join_set = fan_out(ctx, pool, f, &entries, cp_tokens);
+    let mut join_set = fan_out(ctx, pool, f, &selected, cp_tokens);
     let result = preferred::preferred(&mut join_set, is_nonempty, &entries, cancel_rx).await;
     // Hold the client-progress guard across the await above (it owns the routing
     // and the synthetic-terminal-End-on-teardown); tear it down only now, after
@@ -158,8 +160,9 @@ where
 {
     let entries = expanded_entries(ctx);
     let ordering = entry_names(&entries);
+    let selected = select_servers(&ctx.configs, &entries);
     // Client progress under concatenated is a later stage; pass no tokens so
     // downstream `$/progress` is dropped (non-regressing).
-    let mut join_set = fan_out(ctx, pool, f, &entries, None);
+    let mut join_set = fan_out(ctx, pool, f, &selected, None);
     concatenated::concatenated(&mut join_set, &ordering, cancel_rx, log_target).await
 }

--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -59,7 +59,9 @@ fn setup_client_progress(
         minted.push(token.clone());
         map.insert(config.server_name.clone(), token);
     }
-    Some((map, ClientProgressDeregisterGuard::new(registry, minted)))
+    let guard =
+        ClientProgressDeregisterGuard::new(registry, minted, aggregator, pool.upstream_tx());
+    Some((map, guard))
 }
 
 /// Expand `ctx.priorities` into the priority walk for this request:

--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -15,14 +15,52 @@ use std::future::Future;
 use std::io;
 use std::sync::Arc;
 
-use crate::lsp::bridge::{LanguageServerPool, ResolvedServerConfig};
+use std::collections::HashMap;
+use std::sync::{Arc as StdArc, Mutex};
+
+use tower_lsp_server::ls_types::NumberOrString;
+
+use crate::lsp::bridge::{
+    ClientProgressAggregator, ClientProgressDeregisterGuard, LanguageServerPool,
+    ResolvedServerConfig,
+};
 use crate::lsp::lsp_impl::bridge_context::DocumentRequestContext;
 use crate::lsp::request_id::CancelReceiver;
 
 use super::fan_in::FanInResult;
 use super::fan_in::{concatenated, preferred};
-use super::fan_out::{FanOutTask, fan_out};
+use super::fan_out::{FanOutTask, fan_out, select_servers};
 use super::priority::{PriorityEntry, entry_names, expand_priorities, truncate_entries};
+
+/// Set up client-progress aggregation for a fanned-out request that carries a
+/// `workDoneToken`: create the aggregator, mint+register a bridge token per
+/// selected server, and return the `server → token` map (handed to `fan_out`)
+/// plus a guard that deregisters the tokens when the dispatch returns
+/// (ls-bridge-client-progress). Returns `None` when there is no client token.
+fn setup_client_progress(
+    ctx: &DocumentRequestContext,
+    pool: &LanguageServerPool,
+    entries: &[PriorityEntry],
+) -> Option<(
+    HashMap<String, NumberOrString>,
+    ClientProgressDeregisterGuard,
+)> {
+    let client_token = ctx.client_progress_token.clone()?;
+    let selected = select_servers(&ctx.configs, entries);
+    let aggregator = StdArc::new(Mutex::new(ClientProgressAggregator::new(
+        client_token,
+        selected.len(),
+    )));
+    let registry = StdArc::clone(pool.client_progress_registry());
+    let mut map = HashMap::new();
+    let mut minted = Vec::new();
+    for config in &selected {
+        let token = registry.register(StdArc::clone(&aggregator), &config.server_name);
+        minted.push(token.clone());
+        map.insert(config.server_name.clone(), token);
+    }
+    Some((map, ClientProgressDeregisterGuard::new(registry, minted)))
+}
 
 /// Expand `ctx.priorities` into the priority walk for this request:
 /// allowlist + `"*"` expansion against the configured servers, then the
@@ -76,7 +114,11 @@ where
     Fut: Future<Output = io::Result<T>> + Send + 'static,
 {
     let entries = expanded_entries(ctx);
-    let mut join_set = fan_out(ctx, pool, f, &entries);
+    // Stage 1: aggregate only the single-downstream (N=1) case; the aggregator
+    // drops N>1 progress until the preferred/concatenated stages land.
+    let client_progress = setup_client_progress(ctx, &pool, &entries);
+    let cp_tokens = client_progress.as_ref().map(|(m, _guard)| m);
+    let mut join_set = fan_out(ctx, pool, f, &entries, cp_tokens);
     preferred::preferred(&mut join_set, is_nonempty, &entries, cancel_rx).await
 }
 
@@ -101,6 +143,8 @@ where
 {
     let entries = expanded_entries(ctx);
     let ordering = entry_names(&entries);
-    let mut join_set = fan_out(ctx, pool, f, &entries);
+    // Client progress under concatenated is a later stage; pass no tokens so
+    // downstream `$/progress` is dropped (non-regressing).
+    let mut join_set = fan_out(ctx, pool, f, &entries, None);
     concatenated::concatenated(&mut join_set, &ordering, cancel_rx, log_target).await
 }

--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -10,13 +10,10 @@
 //! feed the same expansion to fan-out (membership + spawn order) and fan-in
 //! (decision order), so the two sides can never disagree.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::io;
-use std::sync::Arc;
-
-use std::collections::HashMap;
-use std::sync::{Arc as StdArc, Mutex};
+use std::sync::{Arc, Mutex};
 
 use tower_lsp_server::ls_types::NumberOrString;
 
@@ -47,17 +44,25 @@ fn setup_client_progress(
 )> {
     let client_token = ctx.client_progress_token.clone()?;
     let selected = select_servers(&ctx.configs, entries);
-    let aggregator = StdArc::new(Mutex::new(ClientProgressAggregator::new(
+    // Stage 1 bridges client progress only for the single-downstream case. With
+    // more than one server we mint nothing — those downstreams get no
+    // `workDoneToken` and emit no `$/progress` — so multi-server fan-out stays
+    // exactly as today (no wasted traffic) until the preferred/concatenated
+    // stages land.
+    if selected.len() != 1 {
+        return None;
+    }
+    let aggregator = Arc::new(Mutex::new(ClientProgressAggregator::new(
         client_token,
         selected.len(),
     )));
-    let registry = StdArc::clone(pool.client_progress_registry());
+    let registry = Arc::clone(pool.client_progress_registry());
     let mut map = HashMap::new();
     let mut minted = Vec::new();
-    for config in &selected {
-        let token = registry.register(StdArc::clone(&aggregator), &config.server_name);
+    for config in selected {
+        let token = registry.register(Arc::clone(&aggregator), &config.server_name);
         minted.push(token.clone());
-        map.insert(config.server_name.clone(), token);
+        map.insert(config.server_name, token);
     }
     let guard =
         ClientProgressDeregisterGuard::new(registry, minted, aggregator, pool.upstream_tx());
@@ -116,8 +121,9 @@ where
     Fut: Future<Output = io::Result<T>> + Send + 'static,
 {
     let entries = expanded_entries(ctx);
-    // Stage 1: aggregate only the single-downstream (N=1) case; the aggregator
-    // drops N>1 progress until the preferred/concatenated stages land.
+    // Stage 1: `setup_client_progress` bridges client progress only for the
+    // single-downstream case (it returns `None` for N>1, keeping fan-out
+    // non-regressing) and only when the request carries a `workDoneToken`.
     let client_progress = setup_client_progress(ctx, &pool, &entries);
     let cp_tokens = client_progress.as_ref().map(|(m, _guard)| m);
     let mut join_set = fan_out(ctx, pool, f, &entries, cp_tokens);

--- a/src/lsp/aggregation/server/fan_out.rs
+++ b/src/lsp/aggregation/server/fan_out.rs
@@ -89,7 +89,7 @@ pub(crate) fn fan_out<T, F, Fut>(
     ctx: &DocumentRequestContext,
     pool: Arc<LanguageServerPool>,
     f: F,
-    entries: &[PriorityEntry],
+    selected: &[ResolvedServerConfig],
     client_progress_tokens: Option<
         &std::collections::HashMap<String, tower_lsp_server::ls_types::NumberOrString>,
     >,
@@ -100,8 +100,7 @@ where
     Fut: Future<Output = io::Result<T>> + Send + 'static,
 {
     let mut join_set = JoinSet::new();
-    let selected = select_servers(&ctx.configs, entries);
-    for config in &selected {
+    for config in selected {
         let server_name = config.server_name.clone();
         let task = FanOutTask {
             pool: Arc::clone(&pool),

--- a/src/lsp/aggregation/server/fan_out.rs
+++ b/src/lsp/aggregation/server/fan_out.rs
@@ -33,6 +33,10 @@ pub(crate) struct FanOutTask {
     pub(crate) offset: RegionOffset,
     pub(crate) virtual_content: String,
     pub(crate) upstream_id: Option<UpstreamId>,
+    /// Bridge-minted `workDoneToken` to hand this downstream so its `$/progress`
+    /// routes to the request's aggregator (ls-bridge-client-progress); `None`
+    /// when the request carries no client `workDoneToken`.
+    pub(crate) client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
 }
 
 /// Result tagged with the originating server name.
@@ -86,6 +90,9 @@ pub(crate) fn fan_out<T, F, Fut>(
     pool: Arc<LanguageServerPool>,
     f: F,
     entries: &[PriorityEntry],
+    client_progress_tokens: Option<
+        &std::collections::HashMap<String, tower_lsp_server::ls_types::NumberOrString>,
+    >,
 ) -> JoinSet<TaggedResult<T>>
 where
     T: Send + 'static,
@@ -109,6 +116,8 @@ where
             ),
             virtual_content: ctx.resolved.virtual_content.clone(),
             upstream_id: ctx.upstream_request_id.clone(),
+            client_progress_token: client_progress_tokens
+                .and_then(|m| m.get(&server_name).cloned()),
         };
         let fut = f(task);
         join_set.spawn(async move {

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -47,7 +47,7 @@ pub(crate) use actor::OutboundMessage;
 pub(crate) use actor::UpstreamNotification;
 pub(crate) use actor::UpstreamRequest;
 pub(crate) use client_progress::{
-    ClientProgressAggregator, ClientProgressRegistry, ClientProgressStrategy,
+    ClientProgressAggregator, ClientProgressDeregisterGuard, ClientProgressRegistry,
 };
 pub(crate) use coordinator::BridgeCoordinator;
 pub(crate) use coordinator::ResolvedServerConfig;

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -26,6 +26,7 @@
 
 mod actor;
 mod client;
+mod client_progress;
 mod connection;
 pub(crate) mod coordinator;
 mod inbound_request_registry;

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -46,6 +46,9 @@ pub(crate) use actor::ForwardedRequestCancel;
 pub(crate) use actor::OutboundMessage;
 pub(crate) use actor::UpstreamNotification;
 pub(crate) use actor::UpstreamRequest;
+pub(crate) use client_progress::{
+    ClientProgressAggregator, ClientProgressRegistry, ClientProgressStrategy,
+};
 pub(crate) use coordinator::BridgeCoordinator;
 pub(crate) use coordinator::ResolvedServerConfig;
 pub(crate) use inbound_request_registry::InboundRequestRegistry;

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -104,6 +104,14 @@ pub(crate) enum UpstreamNotification {
     Progress {
         params: tower_lsp_server::ls_types::ProgressParams,
     },
+    /// Forward aggregated **client-provided** work-done progress to the editor.
+    /// `params` carries the editor's own `workDoneToken` (the bridge aggregated
+    /// the fanned-out downstreams' progress onto it; ls-bridge-client-progress).
+    /// Unlike [`Progress`](Self::Progress) this is **not** admission-gated: the
+    /// editor minted the token and needs no `window/workDoneProgress/create`.
+    ClientProgress {
+        params: tower_lsp_server::ls_types::ProgressParams,
+    },
     /// Tell the forwarding loop to forget these (upstream) progress tokens
     /// without an `End` — sent when a downstream connection's reader exits with
     /// progress still in flight, so the loop's created-token set can't leak

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -233,6 +233,9 @@ pub(crate) struct ServerRequestDeps {
     pub(crate) progress_registry: Arc<crate::lsp::bridge::ProgressRegistry>,
     /// This connection's id, used to scope forward token translation.
     pub(crate) progress_connection_id: crate::lsp::bridge::ProgressConnectionId,
+    /// Routes bridge-minted client-progress tokens (`kakehashi/bridge/cprog/*`)
+    /// to their aggregator (ls-bridge-client-progress).
+    pub(crate) client_progress_registry: Arc<crate::lsp::bridge::ClientProgressRegistry>,
 }
 
 /// RAII guard that purges this connection's progress-token mappings when the
@@ -483,6 +486,7 @@ pub(crate) fn spawn_reader_task_with_liveness(
             inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             workspace_folders: WorkspaceFolderSet::new(None),
             progress_registry,
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
             progress_connection_id,
         },
     )
@@ -572,6 +576,7 @@ async fn reader_loop(
         upstream_request_tx: mpsc::unbounded_channel().0,
         inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
         progress_registry,
+        client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
         progress_connection_id,
     };
     reader_loop_with_liveness(reader, router, cancel_token, liveness, server_request_deps).await
@@ -1027,6 +1032,7 @@ mod tests {
             upstream_request_tx: mpsc::unbounded_channel().0,
             inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry,
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
             progress_connection_id,
         };
         (deps, (rx, upstream_rx, window_rx))
@@ -1139,6 +1145,7 @@ mod tests {
             upstream_request_tx: mpsc::unbounded_channel().0,
             inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry,
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
             progress_connection_id,
         };
         (deps, window_rx, (rx, upstream_rx))
@@ -1235,6 +1242,7 @@ mod tests {
             inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             workspace_folders: WorkspaceFolderSet::new(None),
             progress_registry,
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
             progress_connection_id,
         };
 
@@ -1310,6 +1318,9 @@ mod tests {
                 inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
                 workspace_folders: WorkspaceFolderSet::new(None),
                 progress_registry: Arc::clone(&progress_registry),
+                client_progress_registry: Arc::new(
+                    crate::lsp::bridge::ClientProgressRegistry::new(),
+                ),
                 progress_connection_id: conn,
             },
         );
@@ -1734,6 +1745,7 @@ mod tests {
             upstream_request_tx: mpsc::unbounded_channel().0,
             inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
 
@@ -1794,6 +1806,7 @@ mod tests {
             upstream_request_tx: mpsc::unbounded_channel().0,
             inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
 
@@ -1853,6 +1866,7 @@ mod tests {
             upstream_request_tx: mpsc::unbounded_channel().0,
             inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry: Arc::clone(&progress_registry),
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
             progress_connection_id,
         };
 
@@ -1912,6 +1926,7 @@ mod tests {
             upstream_request_tx: mpsc::unbounded_channel().0,
             inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry,
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
             progress_connection_id,
         };
 
@@ -1970,6 +1985,7 @@ mod tests {
             upstream_request_tx: mpsc::unbounded_channel().0,
             inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry,
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
             progress_connection_id,
         };
 
@@ -2025,6 +2041,7 @@ mod tests {
             upstream_request_tx: mpsc::unbounded_channel().0,
             inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry: Arc::clone(&progress_registry),
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
             progress_connection_id,
         };
 
@@ -2081,6 +2098,7 @@ mod tests {
             upstream_request_tx: mpsc::unbounded_channel().0,
             inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry,
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
             progress_connection_id,
         };
 
@@ -2119,6 +2137,7 @@ mod tests {
             upstream_request_tx: mpsc::unbounded_channel().0,
             inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
 
@@ -2174,6 +2193,7 @@ mod tests {
             inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             workspace_folders: WorkspaceFolderSet::new(Some(folders)),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
 
@@ -2217,6 +2237,7 @@ mod tests {
             inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             workspace_folders: WorkspaceFolderSet::new(None),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
 
@@ -2260,6 +2281,7 @@ mod tests {
             upstream_request_tx: mpsc::unbounded_channel().0,
             inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
 
@@ -2309,6 +2331,7 @@ mod tests {
             upstream_request_tx: mpsc::unbounded_channel().0,
             inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
 
@@ -2364,6 +2387,7 @@ mod tests {
             upstream_request_tx: mpsc::unbounded_channel().0,
             inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
 
@@ -2414,6 +2438,9 @@ mod tests {
                 upstream_request_tx: mpsc::unbounded_channel().0,
                 inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
                 progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
+                client_progress_registry: Arc::new(
+                    crate::lsp::bridge::ClientProgressRegistry::new(),
+                ),
                 progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
             };
             (deps, upstream_rx)
@@ -2492,6 +2519,7 @@ mod tests {
             upstream_request_tx: mpsc::unbounded_channel().0,
             inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
 
@@ -2531,6 +2559,7 @@ mod tests {
             upstream_request_tx: mpsc::unbounded_channel().0,
             inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
 
@@ -2585,6 +2614,7 @@ mod tests {
             upstream_request_tx: mpsc::unbounded_channel().0,
             inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
 
@@ -2650,6 +2680,7 @@ mod tests {
             upstream_request_tx: mpsc::unbounded_channel().0,
             inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
         let handle = tokio::spawn(async move {
@@ -2710,6 +2741,7 @@ mod tests {
             upstream_request_tx: mpsc::unbounded_channel().0,
             inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             progress_registry: Arc::new(crate::lsp::bridge::ProgressRegistry::new()),
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
             progress_connection_id: crate::lsp::bridge::ProgressConnectionId::for_test(0),
         };
 
@@ -3012,6 +3044,7 @@ mod tests {
             inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
             workspace_folders: WorkspaceFolderSet::new(None),
             progress_registry,
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
             progress_connection_id,
         };
         (deps, response_rx, upstream_request_rx)

--- a/src/lsp/bridge/client_progress.rs
+++ b/src/lsp/bridge/client_progress.rs
@@ -1,0 +1,190 @@
+//! Per-client-request work-done progress aggregation (ls-bridge-client-progress).
+//!
+//! When the editor attaches a `workDoneToken` to a request, the bridge fans the
+//! request out to several downstream servers. Each downstream may report
+//! `$/progress` against the bridge-minted token it was handed; forwarding those
+//! verbatim would duplicate the lifecycle (N `Begin`, N `End`) on the editor's
+//! single token. A [`ClientProgressAggregator`] translates the per-downstream
+//! progress into **one** coherent lifecycle on the client's own token.
+//!
+//! This module is the pure state machine — it decides *what* upstream
+//! `$/progress` to emit; the bridge wiring feeds it downstream events and
+//! forwards the [`ProgressParams`] it returns (ungated, since the editor minted
+//! the token and needs no `window/workDoneProgress/create`).
+//!
+//! # Staging
+//!
+//! Per the non-regressing rule, the aggregator **drops any progress it does not
+//! yet handle — it never forwards raw downstream progress**. Currently only the
+//! single-downstream (`N = 1`) relay is implemented; multi-server fan-out
+//! (`preferred`/`concatenated`) is dropped until those stages land.
+
+use tower_lsp_server::ls_types::{
+    NumberOrString, ProgressParams, ProgressParamsValue, WorkDoneProgress,
+};
+
+/// Aggregation shape for the fanned-out request, mirroring the server-level
+/// fan-in strategy (language-server-bridge-request-strategies).
+#[derive(Debug, Clone)]
+pub(crate) enum ClientProgressStrategy {
+    /// One winner is delivered; progress is anchored on the highest-priority
+    /// *named* candidate (`None` when only `Rest`/wildcard members participate).
+    Preferred { anchor: Option<String> },
+    /// All contributors are merged; the bridge composes a synthetic aggregate.
+    Concatenated,
+}
+
+/// Translates a fanned-out request's downstream `$/progress` into a single
+/// lifecycle on the client's `workDoneToken`.
+#[derive(Debug)]
+pub(crate) struct ClientProgressAggregator {
+    /// The editor-minted token every emitted `$/progress` is reported against.
+    client_token: NumberOrString,
+    strategy: ClientProgressStrategy,
+    /// Number of downstream servers the request fanned out to.
+    server_count: usize,
+    /// Whether a `Begin` has been emitted upstream (pairing invariant).
+    begun: bool,
+    /// Whether the terminal `End` has been emitted (idempotency guard).
+    ended: bool,
+}
+
+impl ClientProgressAggregator {
+    pub(crate) fn new(
+        client_token: NumberOrString,
+        strategy: ClientProgressStrategy,
+        server_count: usize,
+    ) -> Self {
+        Self {
+            client_token,
+            strategy,
+            server_count,
+            begun: false,
+            ended: false,
+        }
+    }
+
+    /// Feed one downstream `$/progress` value (from `server`). Returns the
+    /// upstream `$/progress` to forward against the client token, or `None` to
+    /// drop it.
+    ///
+    /// Stage 1 handles only the single-downstream case; with more than one
+    /// server the progress is dropped (never forwarded raw) until the
+    /// `preferred`/`concatenated` stages land.
+    pub(crate) fn on_downstream_progress(
+        &mut self,
+        _server: &str,
+        value: ProgressParamsValue,
+    ) -> Option<ProgressParams> {
+        if self.ended || self.server_count != 1 {
+            // N > 1 is not yet aggregated; never forward raw. Anything after the
+            // terminal End is also dropped.
+            let _ = &self.strategy;
+            return None;
+        }
+
+        // N = 1: relay verbatim under the client token, tracking the lifecycle so
+        // the pairing invariant holds.
+        match &value {
+            ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(_)) => self.begun = true,
+            ProgressParamsValue::WorkDone(WorkDoneProgress::End(_)) => self.ended = true,
+            _ => {}
+        }
+        Some(ProgressParams {
+            token: self.client_token.clone(),
+            value,
+        })
+    }
+
+    /// Whether a `Begin` was emitted upstream but no `End` yet — i.e. a terminal
+    /// `End` must be synthesized if the request ends without one (failure /
+    /// cancellation / disconnect; ls-bridge-progress-disconnect-cleanup).
+    pub(crate) fn needs_terminal_end(&self) -> bool {
+        self.begun && !self.ended
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower_lsp_server::ls_types::{
+        WorkDoneProgressBegin, WorkDoneProgressEnd, WorkDoneProgressReport,
+    };
+
+    fn client_token() -> NumberOrString {
+        NumberOrString::String("editor-wd-1".to_string())
+    }
+
+    fn begin() -> ProgressParamsValue {
+        ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(WorkDoneProgressBegin {
+            title: "Indexing".to_string(),
+            cancellable: None,
+            message: None,
+            percentage: None,
+        }))
+    }
+    fn report() -> ProgressParamsValue {
+        ProgressParamsValue::WorkDone(WorkDoneProgress::Report(WorkDoneProgressReport {
+            cancellable: None,
+            message: Some("50%".to_string()),
+            percentage: Some(50),
+        }))
+    }
+    fn end() -> ProgressParamsValue {
+        ProgressParamsValue::WorkDone(WorkDoneProgress::End(WorkDoneProgressEnd { message: None }))
+    }
+
+    #[test]
+    fn n1_relays_begin_report_end_under_the_client_token() {
+        let mut agg = ClientProgressAggregator::new(
+            client_token(),
+            ClientProgressStrategy::Preferred { anchor: None },
+            1,
+        );
+
+        for value in [begin(), report(), end()] {
+            let out = agg
+                .on_downstream_progress("rust-analyzer", value.clone())
+                .expect("N=1 relays the downstream progress");
+            assert_eq!(out.token, client_token(), "retargeted to the client token");
+            assert!(
+                matches!((&out.value, &value), (a, b) if std::mem::discriminant(a) == std::mem::discriminant(b)),
+                "value forwarded verbatim"
+            );
+        }
+    }
+
+    #[test]
+    fn n1_tracks_begin_then_end_for_the_pairing_invariant() {
+        let mut agg = ClientProgressAggregator::new(
+            client_token(),
+            ClientProgressStrategy::Preferred { anchor: None },
+            1,
+        );
+        assert!(!agg.needs_terminal_end(), "nothing begun yet");
+        agg.on_downstream_progress("s", begin());
+        assert!(agg.needs_terminal_end(), "begun, not ended");
+        agg.on_downstream_progress("s", end());
+        assert!(!agg.needs_terminal_end(), "ended normally");
+    }
+
+    #[test]
+    fn multi_server_progress_is_dropped_until_aggregation_lands() {
+        let mut agg = ClientProgressAggregator::new(
+            client_token(),
+            ClientProgressStrategy::Preferred {
+                anchor: Some("rust-analyzer".to_string()),
+            },
+            2,
+        );
+        assert!(
+            agg.on_downstream_progress("rust-analyzer", begin())
+                .is_none(),
+            "N>1 must not forward raw downstream progress (would duplicate Begins)"
+        );
+        assert!(
+            !agg.needs_terminal_end(),
+            "nothing emitted, nothing to terminate"
+        );
+    }
+}

--- a/src/lsp/bridge/client_progress.rs
+++ b/src/lsp/bridge/client_progress.rs
@@ -136,8 +136,11 @@ impl ClientProgressDeregisterGuard {
 
 impl Drop for ClientProgressDeregisterGuard {
     fn drop(&mut self) {
-        // Deregister first: after this no reader can feed the aggregator, so the
-        // terminal decision below cannot race a concurrent real `End`.
+        // Deregister first so a late *real* `End` cannot flip `ended` after the
+        // decision below (no double-`End`). The `Begin`-before-synthetic-`End`
+        // ordering rests on the reader loop processing the downstream's `Begin`
+        // notification before its response — and the response is what completes
+        // fan-in and drops this guard (ls-bridge-message-ordering).
         self.registry.deregister(&self.tokens);
         let terminal = self
             .aggregator

--- a/src/lsp/bridge/client_progress.rs
+++ b/src/lsp/bridge/client_progress.rs
@@ -260,10 +260,7 @@ mod tests {
                 .on_downstream_progress(value.clone())
                 .expect("N=1 relays the downstream progress");
             assert_eq!(out.token, client_token(), "retargeted to the client token");
-            assert!(
-                matches!((&out.value, &value), (a, b) if std::mem::discriminant(a) == std::mem::discriminant(b)),
-                "value forwarded verbatim"
-            );
+            assert_eq!(out.value, value, "value forwarded verbatim");
         }
         // After the terminal End, further progress is dropped.
         assert!(

--- a/src/lsp/bridge/client_progress.rs
+++ b/src/lsp/bridge/client_progress.rs
@@ -102,43 +102,74 @@ impl ClientProgressRegistry {
     }
 }
 
-/// Deregisters a request's bridge tokens from the registry when dropped — i.e.
-/// when the dispatch call returns. After this, a late downstream `$/progress`
-/// for the finished request no longer routes (it is dropped).
+/// Tears down a request's client-progress routing when dropped — i.e. when the
+/// dispatch call returns. It first deregisters the bridge tokens (so a late
+/// downstream `$/progress` no longer routes), then **synthesizes the terminal
+/// `End`** if the aggregator relayed a `Begin` but never an `End` — guaranteeing
+/// the editor's indicator is closed even when the downstream's own `End` raced
+/// the response or never came (ls-bridge-client-progress pairing invariant).
 pub(crate) struct ClientProgressDeregisterGuard {
     registry: std::sync::Arc<ClientProgressRegistry>,
     tokens: Vec<NumberOrString>,
+    aggregator: std::sync::Arc<Mutex<ClientProgressAggregator>>,
+    upstream_tx:
+        tokio::sync::mpsc::UnboundedSender<crate::lsp::bridge::actor::UpstreamNotification>,
 }
 
 impl ClientProgressDeregisterGuard {
     pub(crate) fn new(
         registry: std::sync::Arc<ClientProgressRegistry>,
         tokens: Vec<NumberOrString>,
+        aggregator: std::sync::Arc<Mutex<ClientProgressAggregator>>,
+        upstream_tx: tokio::sync::mpsc::UnboundedSender<
+            crate::lsp::bridge::actor::UpstreamNotification,
+        >,
     ) -> Self {
-        Self { registry, tokens }
+        Self {
+            registry,
+            tokens,
+            aggregator,
+            upstream_tx,
+        }
     }
 }
 
 impl Drop for ClientProgressDeregisterGuard {
     fn drop(&mut self) {
+        // Deregister first: after this no reader can feed the aggregator, so the
+        // terminal decision below cannot race a concurrent real `End`.
         self.registry.deregister(&self.tokens);
+        let terminal = self
+            .aggregator
+            .lock()
+            .recover_poison("ClientProgressAggregator teardown")
+            .take_terminal_end();
+        if let Some(params) = terminal {
+            let _ = self
+                .upstream_tx
+                .send(crate::lsp::bridge::actor::UpstreamNotification::ClientProgress { params });
+        }
     }
 }
 
 /// Translates a fanned-out request's downstream `$/progress` into a single
 /// lifecycle on the client's `workDoneToken`.
 ///
-/// Stage 1 implements the single-downstream (`N = 1`) relay only; multi-server
-/// aggregation (`preferred`/`concatenated`) and failure-path terminal synthesis
-/// arrive in later stages, where the strategy and begun-not-ended tracking are
-/// reintroduced.
+/// Stage 1 implements the single-downstream (`N = 1`) relay, including a
+/// synthetic terminal `End` on teardown (so a relayed `Begin` is always closed
+/// even if the downstream's `End` races the response or never arrives).
+/// Multi-server aggregation (`preferred`/`concatenated`), which reintroduces the
+/// per-strategy anchor, arrives in later stages.
 #[derive(Debug)]
 pub(crate) struct ClientProgressAggregator {
     /// The editor-minted token every emitted `$/progress` is reported against.
     client_token: NumberOrString,
     /// Number of downstream servers the request fanned out to.
     server_count: usize,
-    /// Whether the terminal `End` has been relayed (drop anything after it).
+    /// Whether a `Begin` has been relayed upstream (pairing invariant).
+    begun: bool,
+    /// Whether the terminal `End` has been emitted (drop anything after it; emit
+    /// the synthetic teardown `End` at most once).
     ended: bool,
 }
 
@@ -147,6 +178,7 @@ impl ClientProgressAggregator {
         Self {
             client_token,
             server_count,
+            begun: false,
             ended: false,
         }
     }
@@ -168,17 +200,37 @@ impl ClientProgressAggregator {
             // terminal End is also dropped.
             return None;
         }
-        // N = 1: relay verbatim under the client token.
-        if matches!(
-            &value,
-            ProgressParamsValue::WorkDone(WorkDoneProgress::End(_))
-        ) {
-            self.ended = true;
+        // N = 1: relay verbatim under the client token, tracking the lifecycle so
+        // a terminal End is guaranteed even if the downstream's own End never
+        // arrives (or arrives after teardown).
+        match &value {
+            ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(_)) => self.begun = true,
+            ProgressParamsValue::WorkDone(WorkDoneProgress::End(_)) => self.ended = true,
+            _ => {}
         }
         Some(ProgressParams {
             token: self.client_token.clone(),
             value,
         })
+    }
+
+    /// On request teardown, return a synthetic terminal `End` for the client token
+    /// **iff** a `Begin` was relayed but no `End` — so the editor's indicator is
+    /// always closed even when the downstream's `End` never arrives or races the
+    /// response (ls-bridge-client-progress pairing invariant). Marks the lifecycle
+    /// ended so it fires at most once and a later real `End` is ignored.
+    pub(crate) fn take_terminal_end(&mut self) -> Option<ProgressParams> {
+        if self.begun && !self.ended {
+            self.ended = true;
+            Some(ProgressParams {
+                token: self.client_token.clone(),
+                value: ProgressParamsValue::WorkDone(WorkDoneProgress::End(
+                    tower_lsp_server::ls_types::WorkDoneProgressEnd { message: None },
+                )),
+            })
+        } else {
+            None
+        }
     }
 }
 
@@ -256,6 +308,100 @@ mod tests {
             agg.on_downstream_progress("rust-analyzer", begin())
                 .is_none(),
             "N>1 must not forward raw downstream progress (would duplicate Begins)"
+        );
+    }
+
+    use crate::lsp::bridge::actor::UpstreamNotification;
+
+    /// Teardown after a relayed `Begin` with no `End` (the downstream's `End`
+    /// raced the response or never came) must synthesize a terminal `End` so the
+    /// editor's indicator does not hang.
+    #[test]
+    fn teardown_synthesizes_end_when_begun_but_not_ended() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let registry = std::sync::Arc::new(ClientProgressRegistry::new());
+        let aggregator =
+            std::sync::Arc::new(Mutex::new(ClientProgressAggregator::new(client_token(), 1)));
+        let token = registry.register(aggregator.clone(), "rust-analyzer");
+        // Downstream begins (relayed) but never ends.
+        aggregator
+            .lock()
+            .unwrap()
+            .on_downstream_progress("rust-analyzer", begin());
+
+        drop(ClientProgressDeregisterGuard::new(
+            registry.clone(),
+            vec![token.clone()],
+            aggregator,
+            tx,
+        ));
+
+        let msg = rx.try_recv().expect("teardown synthesizes a terminal End");
+        match msg {
+            UpstreamNotification::ClientProgress { params } => {
+                assert_eq!(params.token, client_token(), "End on the client token");
+                assert!(matches!(
+                    params.value,
+                    ProgressParamsValue::WorkDone(WorkDoneProgress::End(_))
+                ));
+            }
+            _ => panic!("expected a ClientProgress End"),
+        }
+        assert!(rx.try_recv().is_err(), "exactly one terminal End");
+        assert!(
+            registry.route(&token).is_none(),
+            "tokens are deregistered on teardown"
+        );
+    }
+
+    /// Teardown after a normal `Begin`→`End` must synthesize nothing (the editor
+    /// already saw the real `End`); no double-`End`.
+    #[test]
+    fn teardown_emits_nothing_when_already_ended() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let registry = std::sync::Arc::new(ClientProgressRegistry::new());
+        let aggregator =
+            std::sync::Arc::new(Mutex::new(ClientProgressAggregator::new(client_token(), 1)));
+        let token = registry.register(aggregator.clone(), "rust-analyzer");
+        {
+            let mut guard = aggregator.lock().unwrap();
+            guard.on_downstream_progress("rust-analyzer", begin());
+            guard.on_downstream_progress("rust-analyzer", end());
+        }
+
+        drop(ClientProgressDeregisterGuard::new(
+            registry,
+            vec![token],
+            aggregator,
+            tx,
+        ));
+
+        assert!(
+            rx.try_recv().is_err(),
+            "an already-ended lifecycle synthesizes no second End"
+        );
+    }
+
+    /// Teardown after no progress at all (the downstream never began) synthesizes
+    /// nothing — no spurious `End` for a token the editor never saw begin.
+    #[test]
+    fn teardown_emits_nothing_when_never_begun() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let registry = std::sync::Arc::new(ClientProgressRegistry::new());
+        let aggregator =
+            std::sync::Arc::new(Mutex::new(ClientProgressAggregator::new(client_token(), 1)));
+        let token = registry.register(aggregator.clone(), "rust-analyzer");
+
+        drop(ClientProgressDeregisterGuard::new(
+            registry,
+            vec![token],
+            aggregator,
+            tx,
+        ));
+
+        assert!(
+            rx.try_recv().is_err(),
+            "no Begin was relayed, so no terminal End is synthesized"
         );
     }
 }

--- a/src/lsp/bridge/client_progress.rs
+++ b/src/lsp/bridge/client_progress.rs
@@ -102,43 +102,51 @@ impl ClientProgressRegistry {
     }
 }
 
-/// Aggregation shape for the fanned-out request, mirroring the server-level
-/// fan-in strategy (language-server-bridge-request-strategies).
-#[derive(Debug, Clone)]
-pub(crate) enum ClientProgressStrategy {
-    /// One winner is delivered; progress is anchored on the highest-priority
-    /// *named* candidate (`None` when only `Rest`/wildcard members participate).
-    Preferred { anchor: Option<String> },
-    /// All contributors are merged; the bridge composes a synthetic aggregate.
-    Concatenated,
+/// Deregisters a request's bridge tokens from the registry when dropped — i.e.
+/// when the dispatch call returns. After this, a late downstream `$/progress`
+/// for the finished request no longer routes (it is dropped).
+pub(crate) struct ClientProgressDeregisterGuard {
+    registry: std::sync::Arc<ClientProgressRegistry>,
+    tokens: Vec<NumberOrString>,
+}
+
+impl ClientProgressDeregisterGuard {
+    pub(crate) fn new(
+        registry: std::sync::Arc<ClientProgressRegistry>,
+        tokens: Vec<NumberOrString>,
+    ) -> Self {
+        Self { registry, tokens }
+    }
+}
+
+impl Drop for ClientProgressDeregisterGuard {
+    fn drop(&mut self) {
+        self.registry.deregister(&self.tokens);
+    }
 }
 
 /// Translates a fanned-out request's downstream `$/progress` into a single
 /// lifecycle on the client's `workDoneToken`.
+///
+/// Stage 1 implements the single-downstream (`N = 1`) relay only; multi-server
+/// aggregation (`preferred`/`concatenated`) and failure-path terminal synthesis
+/// arrive in later stages, where the strategy and begun-not-ended tracking are
+/// reintroduced.
 #[derive(Debug)]
 pub(crate) struct ClientProgressAggregator {
     /// The editor-minted token every emitted `$/progress` is reported against.
     client_token: NumberOrString,
-    strategy: ClientProgressStrategy,
     /// Number of downstream servers the request fanned out to.
     server_count: usize,
-    /// Whether a `Begin` has been emitted upstream (pairing invariant).
-    begun: bool,
-    /// Whether the terminal `End` has been emitted (idempotency guard).
+    /// Whether the terminal `End` has been relayed (drop anything after it).
     ended: bool,
 }
 
 impl ClientProgressAggregator {
-    pub(crate) fn new(
-        client_token: NumberOrString,
-        strategy: ClientProgressStrategy,
-        server_count: usize,
-    ) -> Self {
+    pub(crate) fn new(client_token: NumberOrString, server_count: usize) -> Self {
         Self {
             client_token,
-            strategy,
             server_count,
-            begun: false,
             ended: false,
         }
     }
@@ -158,37 +166,26 @@ impl ClientProgressAggregator {
         if self.ended || self.server_count != 1 {
             // N > 1 is not yet aggregated; never forward raw. Anything after the
             // terminal End is also dropped.
-            let _ = &self.strategy;
             return None;
         }
-
-        // N = 1: relay verbatim under the client token, tracking the lifecycle so
-        // the pairing invariant holds.
-        match &value {
-            ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(_)) => self.begun = true,
-            ProgressParamsValue::WorkDone(WorkDoneProgress::End(_)) => self.ended = true,
-            _ => {}
+        // N = 1: relay verbatim under the client token.
+        if matches!(
+            &value,
+            ProgressParamsValue::WorkDone(WorkDoneProgress::End(_))
+        ) {
+            self.ended = true;
         }
         Some(ProgressParams {
             token: self.client_token.clone(),
             value,
         })
     }
-
-    /// Whether a `Begin` was emitted upstream but no `End` yet — i.e. a terminal
-    /// `End` must be synthesized if the request ends without one (failure /
-    /// cancellation / disconnect; ls-bridge-progress-disconnect-cleanup).
-    pub(crate) fn needs_terminal_end(&self) -> bool {
-        self.begun && !self.ended
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tower_lsp_server::ls_types::{
-        WorkDoneProgressBegin, WorkDoneProgressEnd, WorkDoneProgressReport,
-    };
+    use tower_lsp_server::ls_types::{WorkDoneProgressBegin, WorkDoneProgressEnd};
 
     fn client_token() -> NumberOrString {
         NumberOrString::String("editor-wd-1".to_string())
@@ -202,26 +199,15 @@ mod tests {
             percentage: None,
         }))
     }
-    fn report() -> ProgressParamsValue {
-        ProgressParamsValue::WorkDone(WorkDoneProgress::Report(WorkDoneProgressReport {
-            cancellable: None,
-            message: Some("50%".to_string()),
-            percentage: Some(50),
-        }))
-    }
     fn end() -> ProgressParamsValue {
         ProgressParamsValue::WorkDone(WorkDoneProgress::End(WorkDoneProgressEnd { message: None }))
     }
 
     #[test]
-    fn n1_relays_begin_report_end_under_the_client_token() {
-        let mut agg = ClientProgressAggregator::new(
-            client_token(),
-            ClientProgressStrategy::Preferred { anchor: None },
-            1,
-        );
+    fn n1_relays_begin_then_end_under_the_client_token_then_drops() {
+        let mut agg = ClientProgressAggregator::new(client_token(), 1);
 
-        for value in [begin(), report(), end()] {
+        for value in [begin(), end()] {
             let out = agg
                 .on_downstream_progress("rust-analyzer", value.clone())
                 .expect("N=1 relays the downstream progress");
@@ -231,28 +217,16 @@ mod tests {
                 "value forwarded verbatim"
             );
         }
-    }
-
-    #[test]
-    fn n1_tracks_begin_then_end_for_the_pairing_invariant() {
-        let mut agg = ClientProgressAggregator::new(
-            client_token(),
-            ClientProgressStrategy::Preferred { anchor: None },
-            1,
+        // After the terminal End, further progress is dropped.
+        assert!(
+            agg.on_downstream_progress("rust-analyzer", begin())
+                .is_none(),
+            "no progress is relayed after the End"
         );
-        assert!(!agg.needs_terminal_end(), "nothing begun yet");
-        agg.on_downstream_progress("s", begin());
-        assert!(agg.needs_terminal_end(), "begun, not ended");
-        agg.on_downstream_progress("s", end());
-        assert!(!agg.needs_terminal_end(), "ended normally");
     }
 
     fn agg() -> std::sync::Arc<Mutex<ClientProgressAggregator>> {
-        std::sync::Arc::new(Mutex::new(ClientProgressAggregator::new(
-            client_token(),
-            ClientProgressStrategy::Preferred { anchor: None },
-            1,
-        )))
+        std::sync::Arc::new(Mutex::new(ClientProgressAggregator::new(client_token(), 1)))
     }
 
     #[test]
@@ -277,21 +251,11 @@ mod tests {
 
     #[test]
     fn multi_server_progress_is_dropped_until_aggregation_lands() {
-        let mut agg = ClientProgressAggregator::new(
-            client_token(),
-            ClientProgressStrategy::Preferred {
-                anchor: Some("rust-analyzer".to_string()),
-            },
-            2,
-        );
+        let mut agg = ClientProgressAggregator::new(client_token(), 2);
         assert!(
             agg.on_downstream_progress("rust-analyzer", begin())
                 .is_none(),
             "N>1 must not forward raw downstream progress (would duplicate Begins)"
-        );
-        assert!(
-            !agg.needs_terminal_end(),
-            "nothing emitted, nothing to terminate"
         );
     }
 }

--- a/src/lsp/bridge/client_progress.rs
+++ b/src/lsp/bridge/client_progress.rs
@@ -19,9 +19,88 @@
 //! single-downstream (`N = 1`) relay is implemented; multi-server fan-out
 //! (`preferred`/`concatenated`) is dropped until those stages land.
 
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use tower_lsp_server::ls_types::{
     NumberOrString, ProgressParams, ProgressParamsValue, WorkDoneProgress,
 };
+
+use crate::error::LockResultExt;
+
+/// Routing table from a bridge-minted per-server progress token to the
+/// aggregator that owns it. The reader looks up an incoming `$/progress` token
+/// here to feed the right aggregator; `dispatch_*` registers the tokens when it
+/// fans out and deregisters them when the request completes.
+///
+/// Shared (`Arc`) between every reader task and the dispatch path.
+#[derive(Default)]
+pub(crate) struct ClientProgressRegistry {
+    inner: Mutex<HashMap<NumberOrString, ClientProgressRoute>>,
+    /// Monotonic source of unique per-server bridge tokens.
+    counter: AtomicU64,
+}
+
+struct ClientProgressRoute {
+    aggregator: std::sync::Arc<Mutex<ClientProgressAggregator>>,
+    server: String,
+}
+
+impl ClientProgressRegistry {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Mint a unique bridge token for `(aggregator, server)`, register the route,
+    /// and return the token to hand to that downstream as its `workDoneToken`.
+    pub(crate) fn register(
+        &self,
+        aggregator: std::sync::Arc<Mutex<ClientProgressAggregator>>,
+        server: &str,
+    ) -> NumberOrString {
+        let suffix = self.counter.fetch_add(1, Ordering::Relaxed);
+        let token = NumberOrString::String(format!("kakehashi/bridge/cprog/{suffix}"));
+        self.inner
+            .lock()
+            .recover_poison("ClientProgressRegistry::register")
+            .insert(
+                token.clone(),
+                ClientProgressRoute {
+                    aggregator,
+                    server: server.to_string(),
+                },
+            );
+        token
+    }
+
+    /// Resolve an incoming `$/progress` token to its aggregator and originating
+    /// server name. `None` for tokens this registry never minted (e.g. a
+    /// server-declared token, handled elsewhere).
+    pub(crate) fn route(
+        &self,
+        token: &NumberOrString,
+    ) -> Option<(std::sync::Arc<Mutex<ClientProgressAggregator>>, String)> {
+        let guard = self
+            .inner
+            .lock()
+            .recover_poison("ClientProgressRegistry::route");
+        guard
+            .get(token)
+            .map(|r| (r.aggregator.clone(), r.server.clone()))
+    }
+
+    /// Drop the routes for a finished request's bridge tokens.
+    pub(crate) fn deregister(&self, tokens: &[NumberOrString]) {
+        let mut guard = self
+            .inner
+            .lock()
+            .recover_poison("ClientProgressRegistry::deregister");
+        for token in tokens {
+            guard.remove(token);
+        }
+    }
+}
 
 /// Aggregation shape for the fanned-out request, mirroring the server-level
 /// fan-in strategy (language-server-bridge-request-strategies).
@@ -166,6 +245,34 @@ mod tests {
         assert!(agg.needs_terminal_end(), "begun, not ended");
         agg.on_downstream_progress("s", end());
         assert!(!agg.needs_terminal_end(), "ended normally");
+    }
+
+    fn agg() -> std::sync::Arc<Mutex<ClientProgressAggregator>> {
+        std::sync::Arc::new(Mutex::new(ClientProgressAggregator::new(
+            client_token(),
+            ClientProgressStrategy::Preferred { anchor: None },
+            1,
+        )))
+    }
+
+    #[test]
+    fn registry_routes_minted_tokens_and_forgets_deregistered_ones() {
+        let reg = ClientProgressRegistry::new();
+        let a = agg();
+        let t1 = reg.register(a.clone(), "rust-analyzer");
+        let t2 = reg.register(a.clone(), "pyright");
+        assert_ne!(t1, t2, "each (request, server) gets a unique bridge token");
+
+        let (_routed, server) = reg.route(&t1).expect("registered token routes");
+        assert_eq!(server, "rust-analyzer");
+        assert!(
+            reg.route(&NumberOrString::Number(99)).is_none(),
+            "unknown token does not route"
+        );
+
+        reg.deregister(&[t1.clone(), t2.clone()]);
+        assert!(reg.route(&t1).is_none(), "deregistered token is forgotten");
+        assert!(reg.route(&t2).is_none());
     }
 
     #[test]

--- a/src/lsp/bridge/client_progress.rs
+++ b/src/lsp/bridge/client_progress.rs
@@ -37,14 +37,9 @@ use crate::error::LockResultExt;
 /// Shared (`Arc`) between every reader task and the dispatch path.
 #[derive(Default)]
 pub(crate) struct ClientProgressRegistry {
-    inner: Mutex<HashMap<NumberOrString, ClientProgressRoute>>,
+    inner: Mutex<HashMap<NumberOrString, std::sync::Arc<Mutex<ClientProgressAggregator>>>>,
     /// Monotonic source of unique per-server bridge tokens.
     counter: AtomicU64,
-}
-
-struct ClientProgressRoute {
-    aggregator: std::sync::Arc<Mutex<ClientProgressAggregator>>,
-    server: String,
 }
 
 impl ClientProgressRegistry {
@@ -52,42 +47,34 @@ impl ClientProgressRegistry {
         Self::default()
     }
 
-    /// Mint a unique bridge token for `(aggregator, server)`, register the route,
-    /// and return the token to hand to that downstream as its `workDoneToken`.
+    /// Mint a unique bridge token for one downstream of `aggregator`'s request,
+    /// register the route, and return the token to hand to that downstream as its
+    /// `workDoneToken`.
     pub(crate) fn register(
         &self,
         aggregator: std::sync::Arc<Mutex<ClientProgressAggregator>>,
-        server: &str,
     ) -> NumberOrString {
         let suffix = self.counter.fetch_add(1, Ordering::Relaxed);
         let token = NumberOrString::String(format!("kakehashi/bridge/cprog/{suffix}"));
         self.inner
             .lock()
             .recover_poison("ClientProgressRegistry::register")
-            .insert(
-                token.clone(),
-                ClientProgressRoute {
-                    aggregator,
-                    server: server.to_string(),
-                },
-            );
+            .insert(token.clone(), aggregator);
         token
     }
 
-    /// Resolve an incoming `$/progress` token to its aggregator and originating
-    /// server name. `None` for tokens this registry never minted (e.g. a
-    /// server-declared token, handled elsewhere).
+    /// Resolve an incoming `$/progress` token to its aggregator. `None` for tokens
+    /// this registry never minted (e.g. a server-declared token, handled
+    /// elsewhere).
     pub(crate) fn route(
         &self,
         token: &NumberOrString,
-    ) -> Option<(std::sync::Arc<Mutex<ClientProgressAggregator>>, String)> {
-        let guard = self
-            .inner
+    ) -> Option<std::sync::Arc<Mutex<ClientProgressAggregator>>> {
+        self.inner
             .lock()
-            .recover_poison("ClientProgressRegistry::route");
-        guard
+            .recover_poison("ClientProgressRegistry::route")
             .get(token)
-            .map(|r| (r.aggregator.clone(), r.server.clone()))
+            .cloned()
     }
 
     /// Drop the routes for a finished request's bridge tokens.
@@ -186,30 +173,36 @@ impl ClientProgressAggregator {
         }
     }
 
-    /// Feed one downstream `$/progress` value (from `server`). Returns the
-    /// upstream `$/progress` to forward against the client token, or `None` to
-    /// drop it.
+    /// Feed one downstream `$/progress` value. Returns the upstream `$/progress`
+    /// to forward against the client token, or `None` to drop it.
     ///
     /// Stage 1 handles only the single-downstream case; with more than one
     /// server the progress is dropped (never forwarded raw) until the
     /// `preferred`/`concatenated` stages land.
     pub(crate) fn on_downstream_progress(
         &mut self,
-        _server: &str,
         value: ProgressParamsValue,
     ) -> Option<ProgressParams> {
-        if self.ended || self.server_count != 1 {
-            // N > 1 is not yet aggregated; never forward raw. Anything after the
-            // terminal End is also dropped.
+        let is_begin = matches!(
+            &value,
+            ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(_))
+        );
+        if self.ended || self.server_count != 1 || (!self.begun && !is_begin) {
+            // Drop: N > 1 is not yet aggregated (never forward raw); anything after
+            // the terminal End; and any out-of-order `report`/`End` before a
+            // `Begin` — the editor must see a coherent Begin → … → End lifecycle.
             return None;
         }
         // N = 1: relay verbatim under the client token, tracking the lifecycle so
         // a terminal End is guaranteed even if the downstream's own End never
         // arrives (or arrives after teardown).
-        match &value {
-            ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(_)) => self.begun = true,
-            ProgressParamsValue::WorkDone(WorkDoneProgress::End(_)) => self.ended = true,
-            _ => {}
+        if is_begin {
+            self.begun = true;
+        } else if matches!(
+            &value,
+            ProgressParamsValue::WorkDone(WorkDoneProgress::End(_))
+        ) {
+            self.ended = true;
         }
         Some(ProgressParams {
             token: self.client_token.clone(),
@@ -264,7 +257,7 @@ mod tests {
 
         for value in [begin(), end()] {
             let out = agg
-                .on_downstream_progress("rust-analyzer", value.clone())
+                .on_downstream_progress(value.clone())
                 .expect("N=1 relays the downstream progress");
             assert_eq!(out.token, client_token(), "retargeted to the client token");
             assert!(
@@ -274,8 +267,7 @@ mod tests {
         }
         // After the terminal End, further progress is dropped.
         assert!(
-            agg.on_downstream_progress("rust-analyzer", begin())
-                .is_none(),
+            agg.on_downstream_progress(begin()).is_none(),
             "no progress is relayed after the End"
         );
     }
@@ -288,12 +280,15 @@ mod tests {
     fn registry_routes_minted_tokens_and_forgets_deregistered_ones() {
         let reg = ClientProgressRegistry::new();
         let a = agg();
-        let t1 = reg.register(a.clone(), "rust-analyzer");
-        let t2 = reg.register(a.clone(), "pyright");
+        let t1 = reg.register(a.clone());
+        let t2 = reg.register(a.clone());
         assert_ne!(t1, t2, "each (request, server) gets a unique bridge token");
 
-        let (_routed, server) = reg.route(&t1).expect("registered token routes");
-        assert_eq!(server, "rust-analyzer");
+        let routed = reg.route(&t1).expect("registered token routes");
+        assert!(
+            std::sync::Arc::ptr_eq(&routed, &a),
+            "routes to the exact aggregator registered"
+        );
         assert!(
             reg.route(&NumberOrString::Number(99)).is_none(),
             "unknown token does not route"
@@ -308,9 +303,28 @@ mod tests {
     fn multi_server_progress_is_dropped_until_aggregation_lands() {
         let mut agg = ClientProgressAggregator::new(client_token(), 2);
         assert!(
-            agg.on_downstream_progress("rust-analyzer", begin())
-                .is_none(),
+            agg.on_downstream_progress(begin()).is_none(),
             "N>1 must not forward raw downstream progress (would duplicate Begins)"
+        );
+    }
+
+    #[test]
+    fn out_of_order_end_before_begin_is_dropped() {
+        let mut agg = ClientProgressAggregator::new(client_token(), 1);
+        // An `End` before any `Begin` must be dropped — the editor must never see
+        // a terminal for a lifecycle that never began.
+        assert!(
+            agg.on_downstream_progress(end()).is_none(),
+            "End before Begin is dropped"
+        );
+        // A subsequent normal Begin → End still relays.
+        assert!(
+            agg.on_downstream_progress(begin()).is_some(),
+            "Begin relays"
+        );
+        assert!(
+            agg.on_downstream_progress(end()).is_some(),
+            "then End relays"
         );
     }
 
@@ -325,12 +339,9 @@ mod tests {
         let registry = std::sync::Arc::new(ClientProgressRegistry::new());
         let aggregator =
             std::sync::Arc::new(Mutex::new(ClientProgressAggregator::new(client_token(), 1)));
-        let token = registry.register(aggregator.clone(), "rust-analyzer");
+        let token = registry.register(aggregator.clone());
         // Downstream begins (relayed) but never ends.
-        aggregator
-            .lock()
-            .unwrap()
-            .on_downstream_progress("rust-analyzer", begin());
+        aggregator.lock().unwrap().on_downstream_progress(begin());
 
         drop(ClientProgressDeregisterGuard::new(
             registry.clone(),
@@ -365,11 +376,11 @@ mod tests {
         let registry = std::sync::Arc::new(ClientProgressRegistry::new());
         let aggregator =
             std::sync::Arc::new(Mutex::new(ClientProgressAggregator::new(client_token(), 1)));
-        let token = registry.register(aggregator.clone(), "rust-analyzer");
+        let token = registry.register(aggregator.clone());
         {
             let mut guard = aggregator.lock().unwrap();
-            guard.on_downstream_progress("rust-analyzer", begin());
-            guard.on_downstream_progress("rust-analyzer", end());
+            guard.on_downstream_progress(begin());
+            guard.on_downstream_progress(end());
         }
 
         drop(ClientProgressDeregisterGuard::new(
@@ -393,7 +404,7 @@ mod tests {
         let registry = std::sync::Arc::new(ClientProgressRegistry::new());
         let aggregator =
             std::sync::Arc::new(Mutex::new(ClientProgressAggregator::new(client_token(), 1)));
-        let token = registry.register(aggregator.clone(), "rust-analyzer");
+        let token = registry.register(aggregator.clone());
 
         drop(ClientProgressDeregisterGuard::new(
             registry,

--- a/src/lsp/bridge/client_progress.rs
+++ b/src/lsp/bridge/client_progress.rs
@@ -187,10 +187,15 @@ impl ClientProgressAggregator {
             &value,
             ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(_))
         );
-        if self.ended || self.server_count != 1 || (!self.begun && !is_begin) {
-            // Drop: N > 1 is not yet aggregated (never forward raw); anything after
-            // the terminal End; and any out-of-order `report`/`End` before a
-            // `Begin` — the editor must see a coherent Begin → … → End lifecycle.
+        if self.ended
+            || self.server_count != 1
+            || (is_begin && self.begun)
+            || (!is_begin && !self.begun)
+        {
+            // Drop, so the editor sees one coherent Begin → … → End lifecycle:
+            // N > 1 is not yet aggregated (never forward raw); anything after the
+            // terminal End; a duplicate `Begin`; and any out-of-order `report`/
+            // `End` before the first `Begin`.
             return None;
         }
         // N = 1: relay verbatim under the client token, tracking the lifecycle so
@@ -322,6 +327,24 @@ mod tests {
         assert!(
             agg.on_downstream_progress(end()).is_some(),
             "then End relays"
+        );
+    }
+
+    #[test]
+    fn duplicate_begin_is_dropped() {
+        let mut agg = ClientProgressAggregator::new(client_token(), 1);
+        assert!(
+            agg.on_downstream_progress(begin()).is_some(),
+            "first Begin relays"
+        );
+        // A second Begin must be dropped — the editor must see exactly one Begin.
+        assert!(
+            agg.on_downstream_progress(begin()).is_none(),
+            "duplicate Begin is dropped"
+        );
+        assert!(
+            agg.on_downstream_progress(end()).is_some(),
+            "End still relays"
         );
     }
 

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -340,6 +340,14 @@ impl LanguageServerPool {
         &self.client_progress_registry
     }
 
+    /// A clone of the upstream-notification sender, for emitting aggregated
+    /// client progress (and its synthetic teardown `End`) to the editor.
+    pub(crate) fn upstream_tx(
+        &self,
+    ) -> tokio::sync::mpsc::UnboundedSender<super::UpstreamNotification> {
+        self.upstream_tx.clone()
+    }
+
     /// Set the workspace root URI.
     ///
     /// Called once during upstream initialize to forward the root URI to downstream servers.

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -266,6 +266,11 @@ pub struct LanguageServerPool {
     /// reader task (to register/translate) and the cancel path (to route a
     /// client `window/workDoneProgress/cancel` to the owning downstream).
     progress_registry: Arc<super::ProgressRegistry>,
+    /// Routes bridge-minted per-server client-progress tokens to their
+    /// aggregator (ls-bridge-client-progress). Shared with every reader task (to
+    /// route an incoming `$/progress`) and the dispatch path (register on
+    /// fan-out / deregister on completion).
+    client_progress_registry: Arc<super::ClientProgressRegistry>,
     /// Tracks downstream-initiated requests forwarded to the editor so a
     /// downstream `$/cancelRequest` (or connection death) can cancel the
     /// editor-bound request (#404). Shared with every reader task (to register /
@@ -309,6 +314,7 @@ impl LanguageServerPool {
             upstream_request_tx,
             upstream_request_rx: std::sync::Mutex::new(Some(upstream_request_rx)),
             progress_registry: Arc::new(super::ProgressRegistry::new()),
+            client_progress_registry: Arc::new(super::ClientProgressRegistry::new()),
             inbound_request_registry: super::InboundRequestRegistry::default(),
         }
     }
@@ -325,6 +331,13 @@ impl LanguageServerPool {
     #[cfg(test)]
     pub(crate) fn progress_registry(&self) -> &Arc<super::ProgressRegistry> {
         &self.progress_registry
+    }
+
+    /// Routes bridge-minted client-progress tokens to their aggregator
+    /// (ls-bridge-client-progress); shared with reader tasks (route incoming
+    /// `$/progress`) and the dispatch path (register/deregister).
+    pub(crate) fn client_progress_registry(&self) -> &Arc<super::ClientProgressRegistry> {
+        &self.client_progress_registry
     }
 
     /// Set the workspace root URI.
@@ -1255,6 +1268,7 @@ impl LanguageServerPool {
                 // reader (it answers workspace/workspaceFolders pulls).
                 workspace_folders: workspace_folders.clone(),
                 progress_registry: Arc::clone(&self.progress_registry),
+                client_progress_registry: Arc::clone(&self.client_progress_registry),
                 progress_connection_id: self.progress_registry.new_connection_id(),
             },
         );

--- a/src/lsp/bridge/text_document/references.rs
+++ b/src/lsp/bridge/text_document/references.rs
@@ -40,6 +40,7 @@ impl LanguageServerPool {
         virtual_content: &str,
         include_declaration: bool,
         upstream_request_id: Option<UpstreamId>,
+        client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
     ) -> io::Result<Option<Vec<Location>>> {
         let handle = self
             .get_or_create_connection(server_name, server_config, Some(host_uri))
@@ -67,7 +68,12 @@ impl LanguageServerPool {
                     context: ReferenceContext {
                         include_declaration,
                     },
-                    work_done_progress_params: Default::default(),
+                    // Hand the downstream the bridge-minted token so its
+                    // `$/progress` routes to this request's aggregator
+                    // (ls-bridge-client-progress).
+                    work_done_progress_params: tower_lsp_server::ls_types::WorkDoneProgressParams {
+                        work_done_token: client_progress_token,
+                    },
                     partial_result_params: Default::default(),
                 };
                 JsonRpcRequest::new(request_id.as_i64(), "textDocument/references", params)

--- a/src/lsp/bridge/window/progress.rs
+++ b/src/lsp/bridge/window/progress.rs
@@ -11,6 +11,7 @@ use log::debug;
 use serde::Deserialize;
 use tower_lsp_server::ls_types::{ProgressParams, ProgressParamsValue, WorkDoneProgress};
 
+use crate::error::LockResultExt;
 use crate::lsp::bridge::actor::{ServerRequestDeps, UpstreamNotification};
 
 /// Translate and forward a downstream `$/progress` notification to the editor.
@@ -40,6 +41,23 @@ pub(in crate::lsp::bridge) fn forward(
         );
         return;
     };
+
+    // Client-provided progress: if the token is one the bridge minted for a
+    // fanned-out request, route it to that request's aggregator, which composes a
+    // single lifecycle on the editor's own `workDoneToken` and emits it ungated
+    // (ls-bridge-client-progress).
+    if let Some((aggregator, server)) = deps.client_progress_registry.route(&params.token) {
+        let emitted = aggregator
+            .lock()
+            .recover_poison("ClientProgressAggregator")
+            .on_downstream_progress(&server, params.value);
+        if let Some(out) = emitted {
+            let _ = deps
+                .upstream_tx
+                .send(UpstreamNotification::ClientProgress { params: out });
+        }
+        return;
+    }
 
     let Some(upstream_token) = deps
         .progress_registry

--- a/src/lsp/bridge/window/progress.rs
+++ b/src/lsp/bridge/window/progress.rs
@@ -46,11 +46,11 @@ pub(in crate::lsp::bridge) fn forward(
     // fanned-out request, route it to that request's aggregator, which composes a
     // single lifecycle on the editor's own `workDoneToken` and emits it ungated
     // (ls-bridge-client-progress).
-    if let Some((aggregator, server)) = deps.client_progress_registry.route(&params.token) {
+    if let Some(aggregator) = deps.client_progress_registry.route(&params.token) {
         let emitted = aggregator
             .lock()
             .recover_poison("ClientProgressAggregator")
-            .on_downstream_progress(&server, params.value);
+            .on_downstream_progress(params.value);
         if let Some(out) = emitted {
             let _ = deps
                 .upstream_tx

--- a/src/lsp/bridge/window/progress.rs
+++ b/src/lsp/bridge/window/progress.rs
@@ -42,10 +42,9 @@ pub(in crate::lsp::bridge) fn forward(
         return;
     };
 
-    // Client-provided progress: if the token is one the bridge minted for a
-    // fanned-out request, route it to that request's aggregator, which composes a
-    // single lifecycle on the editor's own `workDoneToken` and emits it ungated
-    // (ls-bridge-client-progress).
+    // Client-progress routing: if the token is one the bridge minted for a fanned-out request,
+    // route it to that request's aggregator, which relays a single lifecycle onto the editor's
+    // own `workDoneToken` and emits it ungated (ls-bridge-client-progress).
     if let Some(aggregator) = deps.client_progress_registry.route(&params.token) {
         let emitted = aggregator
             .lock()

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -51,6 +51,10 @@ pub(crate) struct DocumentRequestContext {
     /// Maximum number of servers to fan out to.
     /// `None` = no limit, `Some(0)` = disable fan-out.
     pub(crate) max_fan_out: Option<usize>,
+    /// The editor's `workDoneToken` for this request, if any. When set, dispatch
+    /// aggregates the fanned-out downstreams' `$/progress` onto it
+    /// (ls-bridge-client-progress); `None` disables client-progress aggregation.
+    pub(crate) client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
 }
 
 /// All resolved context needed to send a **host** bridge request
@@ -627,6 +631,7 @@ impl Kakehashi {
             priorities: agg.priorities,
             strategy: agg.strategy,
             max_fan_out: agg.max_fan_out,
+            client_progress_token: None,
         })
     }
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -178,6 +178,7 @@ impl DiagnosticScheduler {
                                 priorities: agg.priorities,
                                 strategy: agg.strategy,
                                 max_fan_out: agg.max_fan_out,
+                                client_progress_token: None,
                             });
                         }
                         contexts

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -890,6 +890,15 @@ async fn deliver_upstream_notification(
                 .send_notification::<tower_lsp_server::ls_types::notification::Progress>(params)
                 .await;
         }
+        UpstreamNotification::ClientProgress { params } => {
+            // Aggregated client-provided progress: the editor minted the token
+            // and needs no `window/workDoneProgress/create`, so forward it
+            // ungated (ls-bridge-client-progress). The aggregator already
+            // guarantees a single coherent Begin/report/End lifecycle.
+            client
+                .send_notification::<tower_lsp_server::ls_types::notification::Progress>(params)
+                .await;
+        }
         UpstreamNotification::ForgetWorkDoneProgress(tokens) => {
             // A downstream reader exited with progress in flight; drop its
             // admissions so the set can't leak across respawns. For any token that
@@ -1712,6 +1721,98 @@ mod tests {
             ))
             .await
             .unwrap();
+
+        cancel.cancel();
+        let _ = loop_handle.await;
+    }
+
+    /// `ClientProgress` is forwarded to the editor **ungated** — without any
+    /// `window/workDoneProgress/create` admission, because the editor minted the
+    /// client `workDoneToken` itself (ls-bridge-client-progress). Contrast
+    /// `forwarding_loop_drops_progress_when_create_rejected`, where server-declared
+    /// `Progress` for an un-created token is dropped.
+    #[tokio::test]
+    async fn forwarding_loop_forwards_client_progress_ungated() {
+        use crate::lsp::bridge::UpstreamNotification;
+        use futures::StreamExt;
+        use std::sync::{Arc, Mutex};
+        use tower::{Service, ServiceExt};
+        use tower_lsp_server::jsonrpc::Request;
+        use tower_lsp_server::ls_types::{
+            InitializeParams, InitializeResult, NumberOrString, ProgressParams,
+            ProgressParamsValue, WorkDoneProgress, WorkDoneProgressBegin,
+        };
+        use tower_lsp_server::{LanguageServer, LspService};
+
+        struct Dummy;
+        impl LanguageServer for Dummy {
+            async fn initialize(
+                &self,
+                _: InitializeParams,
+            ) -> tower_lsp_server::jsonrpc::Result<InitializeResult> {
+                Ok(InitializeResult::default())
+            }
+            async fn shutdown(&self) -> tower_lsp_server::jsonrpc::Result<()> {
+                Ok(())
+            }
+        }
+
+        let captured: Arc<Mutex<Option<Client>>> = Arc::new(Mutex::new(None));
+        let captured_for_init = Arc::clone(&captured);
+        let (mut service, socket) = LspService::build(move |client| {
+            *captured_for_init.lock().unwrap() = Some(client);
+            Dummy
+        })
+        .finish();
+        let client = captured.lock().unwrap().take().unwrap();
+        let init = Request::build("initialize")
+            .params(serde_json::json!({ "capabilities": {} }))
+            .id(1)
+            .finish();
+        let _ = service.ready().await.unwrap().call(init).await;
+
+        let (mut requests, _responses) = socket.split();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let (_window_tx, window_rx) = tokio::sync::mpsc::channel(16);
+        let (_request_tx, request_rx) = tokio::sync::mpsc::unbounded_channel();
+        let loop_handle = tokio::spawn(upstream_forwarding_loop(
+            rx,
+            window_rx,
+            request_rx,
+            None,
+            crate::lsp::bridge::InboundRequestRegistry::default(),
+            client,
+            None,
+            cancel.clone(),
+        ));
+
+        // No create was ever sent for this token, yet ClientProgress must be
+        // forwarded (the editor owns the token).
+        let token = NumberOrString::String("editor-wd-1".to_string());
+        tx.send(UpstreamNotification::ClientProgress {
+            params: ProgressParams {
+                token: token.clone(),
+                value: ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(
+                    WorkDoneProgressBegin {
+                        title: "Finding references".to_string(),
+                        cancellable: None,
+                        message: None,
+                        percentage: None,
+                    },
+                )),
+            },
+        })
+        .unwrap();
+
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(2), requests.next())
+            .await
+            .expect("client progress must be forwarded ungated")
+            .expect("stream yielded a message");
+        assert_eq!(msg.method(), "$/progress");
+        let params: ProgressParams =
+            serde_json::from_value(msg.params().expect("has params").clone()).unwrap();
+        assert_eq!(params.token, token, "forwarded under the client token");
 
         cancel.cancel();
         let _ = loop_handle.await;

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -178,6 +178,7 @@ impl Kakehashi {
                     priorities: agg.priorities,
                     strategy,
                     max_fan_out: agg.max_fan_out,
+                    client_progress_token: None,
                 };
                 let pool = Arc::clone(&pool);
 

--- a/src/lsp/lsp_impl/text_document/document_color.rs
+++ b/src/lsp/lsp_impl/text_document/document_color.rs
@@ -113,6 +113,7 @@ impl Kakehashi {
                 priorities: agg.priorities,
                 strategy: agg.strategy,
                 max_fan_out: agg.max_fan_out,
+                client_progress_token: None,
             };
             let pool = Arc::clone(&pool);
 

--- a/src/lsp/lsp_impl/text_document/document_symbol.rs
+++ b/src/lsp/lsp_impl/text_document/document_symbol.rs
@@ -136,6 +136,7 @@ impl Kakehashi {
                 priorities: agg.priorities,
                 strategy: agg.strategy,
                 max_fan_out: agg.max_fan_out,
+                client_progress_token: None,
             };
             let pool = Arc::clone(&pool);
 

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -258,6 +258,7 @@ impl Kakehashi {
                 priorities: agg.priorities,
                 strategy: agg.strategy,
                 max_fan_out: agg.max_fan_out,
+                client_progress_token: None,
             };
             // Decide how this region formats — concatenated pipeline, preferred
             // fan-out, or skip — from its resolved aggregation config. See

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -203,6 +203,7 @@ impl Kakehashi {
                     priorities: agg.priorities,
                     strategy: agg.strategy,
                     max_fan_out: agg.max_fan_out,
+                    client_progress_token: None,
                 };
                 let pool = Arc::clone(&pool);
                 let options = options.clone();

--- a/src/lsp/lsp_impl/text_document/references.rs
+++ b/src/lsp/lsp_impl/text_document/references.rs
@@ -24,8 +24,10 @@ impl Kakehashi {
         let lsp_uri = params.text_document_position.text_document.uri;
         let position = params.text_document_position.position;
         let include_declaration = params.context.include_declaration;
+        let work_done_token = params.work_done_progress_params.work_done_token.clone();
 
-        let virt = self.references_virt_layer(&lsp_uri, position, include_declaration);
+        let virt =
+            self.references_virt_layer(&lsp_uri, position, include_declaration, work_done_token);
         self.walk_layers(
             &lsp_uri,
             METHOD,
@@ -44,10 +46,14 @@ impl Kakehashi {
         lsp_uri: &Uri,
         position: Position,
         include_declaration: bool,
+        client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
     ) -> Result<Option<Vec<Location>>> {
-        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
+        let Some(mut ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
             return Ok(None);
         };
+        // Aggregate the fanned-out servers' progress onto the editor's token
+        // (ls-bridge-client-progress).
+        ctx.document.client_progress_token = client_progress_token;
 
         let (cancel_rx, _cancel_guard) =
             self.subscribe_cancel(ctx.document.upstream_request_id.as_ref());
@@ -71,6 +77,7 @@ impl Kakehashi {
                         &t.virtual_content,
                         include_declaration,
                         t.upstream_id,
+                        t.client_progress_token,
                     )
                     .await
             },

--- a/src/lsp/lsp_impl/text_document/references.rs
+++ b/src/lsp/lsp_impl/text_document/references.rs
@@ -24,7 +24,7 @@ impl Kakehashi {
         let lsp_uri = params.text_document_position.text_document.uri;
         let position = params.text_document_position.position;
         let include_declaration = params.context.include_declaration;
-        let work_done_token = params.work_done_progress_params.work_done_token.clone();
+        let work_done_token = params.work_done_progress_params.work_done_token;
 
         let virt =
             self.references_virt_layer(&lsp_uri, position, include_declaration, work_done_token);

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -144,6 +144,7 @@ impl Kakehashi {
                     priorities: agg.priorities,
                     strategy: agg.strategy,
                     max_fan_out: agg.max_fan_out,
+                    client_progress_token: None,
                 };
                 let pool = Arc::clone(&pool);
                 let send = send.clone();


### PR DESCRIPTION
## Summary

First slice of `ls-bridge-client-progress` (#414): when the editor attaches a `workDoneToken` to a request, pass the downstream's `$/progress` back onto that token — but **only when the request reaches a single downstream (N=1)**. Multi-server fan-out is intentionally **dropped** (never forwarded raw, so no duplicate `Begin`s), keeping every other case non-regressing. `preferred`/`concatenated` aggregation, `partialResultToken`, and other methods are later stages.

Wired end-to-end for **`textDocument/references`** as the representative method; all other methods are unaffected (they pass `client_progress_token: None`).

## How it works
- **`ClientProgressAggregator`** (`client_progress.rs`): per-request state machine. N=1 relays `Begin`/`report`/`End` onto the editor's token; drops N>1 and anything after `End`. `take_terminal_end()` synthesizes a terminal `End` on teardown iff a `Begin` was relayed but no `End`.
- **`ClientProgressRegistry`**: maps each bridge-minted per-server token (`kakehashi/bridge/cprog/N`) to its aggregator; owned by the pool, shared with reader tasks (route) and dispatch (register/deregister).
- **`UpstreamNotification::ClientProgress`**: forwarded to the editor **ungated** (the editor minted the token; no `window/workDoneProgress/create` needed), separate from the admission-gated server-declared `Progress`.
- **`dispatch_preferred` / `setup_client_progress`**: when the request carries a `workDoneToken`, mints+registers a per-server token (threaded through `fan_out` → `FanOutTask`), and an RAII `ClientProgressDeregisterGuard` (held across the fan-in await) deregisters on return — then **synthesizes the terminal `End`** so a downstream `End` that races the response (LSP doesn't order them) can't leave a hanging spinner.
- **`window/progress.rs`**: routes a registered token to its aggregator → emits `ClientProgress`; otherwise falls through to the server-declared path.

## Correctness
- **Pairing invariant**: every relayed `Begin` is closed by exactly one `End` (real or synthetic). Guard `Drop` deregisters *before* deciding, so a late real `End` can't double-fire; `Begin`-before-`End` ordering rests on the single sequential reader loop (Begin notification precedes the response that completes fan-in).
- **Non-regression**: N>1 and `concatenated` and all non-references methods are unchanged.

## Tests
7 unit tests: N=1 relay then drop-after-End; N>1 drop; registry routing; teardown synthesizes `End` when begun-not-ended; emits nothing when already-ended / never-begun; ungated `ClientProgress` forwarding.

Reviewed via subagent `/review` (found + fixed the teardown-`End` race) and Codex (no must-fix). A full reader→dispatch→guard integration test is noted as follow-up hardening.

Part of #414 (does not close it — later stages remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)