### PR TITLE
chore(ci): bump GitHub Actions to latest majors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,11 +42,17 @@ jobs:
 
   # kakehashi downloads and unpacks archives from the network; audit catches
   # advisories in that supply chain (e.g. the tar extraction RUSTSECs).
+  #
+  # We run `cargo audit` directly instead of rustsec/audit-check: that action
+  # publishes results via the GitHub Check API, which the read-only default
+  # GITHUB_TOKEN cannot access (it fails on fork PRs and degrades to warnings
+  # otherwise), and it is still pinned to the now-deprecated Node 20 runtime.
+  # `cargo audit` exits nonzero only on vulnerabilities, so unmaintained-crate
+  # advisories stay non-blocking — matching the previous behavior.
   audit:
     name: Audit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: rustsec/audit-check@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - run: cargo install cargo-audit --locked
+      - run: cargo audit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,15 +40,6 @@ jobs:
       - uses: actions/checkout@v7
       - run: cargo clippy -- -D warnings
 
-  # kakehashi downloads and unpacks archives from the network; audit catches
-  # advisories in that supply chain (e.g. the tar extraction RUSTSECs).
-  #
-  # We run `cargo audit` directly instead of rustsec/audit-check: that action
-  # publishes results via the GitHub Check API, which the read-only default
-  # GITHUB_TOKEN cannot access (it fails on fork PRs and degrades to warnings
-  # otherwise), and it is still pinned to the now-deprecated Node 20 runtime.
-  # `cargo audit` exits nonzero only on vulnerabilities, so unmaintained-crate
-  # advisories stay non-blocking — matching the previous behavior.
   audit:
     name: Audit
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,14 +14,14 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: cargo check
 
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: rustup component add rust-analyzer
       - run: make deps/tree-sitter
       - run: cargo test
@@ -30,14 +30,14 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: cargo fmt --all --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: cargo clippy -- -D warnings
 
   # kakehashi downloads and unpacks archives from the network; audit catches
@@ -46,7 +46,7 @@ jobs:
     name: Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Add target
         run: rustup target add ${{ matrix.target }}
@@ -68,7 +68,7 @@ jobs:
             -DestinationPath ${{ env.BINARY_NAME }}-${{ github.ref_name }}-${{ matrix.target }}.zip
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.BINARY_NAME }}-${{ matrix.target }}
           path: ${{ env.BINARY_NAME }}-${{ github.ref_name }}-${{ matrix.target }}.*
@@ -81,11 +81,11 @@ jobs:
       contents: write
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: artifacts/**/*


### PR DESCRIPTION
## What

1. Bump the GitHub Actions used in CI and release workflows to their latest major versions.
2. Replace `rustsec/audit-check@v2` with a direct `cargo audit` invocation in the Audit job.

### Action version bumps

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v6 | v7 |
| `actions/upload-artifact` | v6 | v7 |
| `actions/download-artifact` | v7 | v8 |
| `softprops/action-gh-release` | v2 | v3 |

### Audit job

`rustsec/audit-check@v2` publishes results via the GitHub Check API, which this
repo's read-only default `GITHUB_TOKEN` cannot access. Every run logged:

- `Unable to publish audit check! Resource not accessible by integration`
- a misleading `It seems that this Action is executed from the forked repository` fallback
- `Node.js 20 is deprecated` — `audit-check@v2` is the latest release and is still Node-20-based

Running `cargo audit` directly removes the Check API dependency (so it works on
fork PRs too) and drops the Node 20 action. The pass/fail contract is preserved:
`cargo audit` exits nonzero **only on vulnerabilities**, so the two existing
unmaintained-crate advisories (RUSTSEC-2025-0141 `bincode`, RUSTSEC-2024-0320
`yaml-rust`) stay non-blocking — verified locally (0 vulnerabilities, exit 0) and
on CI (Audit job green, log free of the publish/Node 20/fork warnings).

## Why

Keeps the CI/release supply chain on supported runtimes and removes the broken,
noisy audit check while keeping its security signal intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)