### PR TITLE
feat(bridge): preferred N>1 client progress — track the named anchor (#414)

### DIFF
--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -30,42 +30,128 @@ use super::fan_out::{FanOutTask, fan_out, select_servers};
 use super::priority::{PriorityEntry, entry_names, expand_priorities, truncate_entries};
 
 /// Set up client-progress aggregation for a fanned-out request that carries a
-/// `workDoneToken`: create the aggregator, mint+register a bridge token per
-/// selected server, and return the `server → token` map (handed to `fan_out`)
-/// plus a guard that deregisters the tokens when the dispatch returns
-/// (ls-bridge-client-progress). Returns `None` when there is no client token.
+/// `workDoneToken`: create the aggregator, mint+register a bridge token for the
+/// **tracked source** only (the sole server at N=1, or the named anchor at N>1),
+/// and return the `server → token` map (handed to `fan_out`) plus a guard that
+/// deregisters the token when the dispatch returns (ls-bridge-client-progress).
+/// Returns `None` when there is no client token or no tracked source.
 fn setup_client_progress(
     ctx: &DocumentRequestContext,
     pool: &LanguageServerPool,
     selected: &[ResolvedServerConfig],
+    entries: &[PriorityEntry],
 ) -> Option<(
     HashMap<String, NumberOrString>,
     ClientProgressDeregisterGuard,
 )> {
     let client_token = ctx.client_progress_token.clone()?;
-    // Stage 1 bridges client progress only for the single-downstream case. With
-    // more than one server we mint nothing — those downstreams get no
-    // `workDoneToken` and emit no `$/progress` — so multi-server fan-out stays
-    // exactly as today (no wasted traffic) until the preferred/concatenated
-    // stages land.
-    if selected.len() != 1 {
-        return None;
-    }
-    let aggregator = Arc::new(Mutex::new(ClientProgressAggregator::new(
-        client_token,
-        selected.len(),
-    )));
+    // Under *preferred*, only the tracked source's progress is shown; every other
+    // candidate is suppressed by handing it no `workDoneToken` (so it emits no
+    // `$/progress` — no wasted traffic). With no tracked source (an all-`Rest`
+    // N>1 fan-out) nothing is minted and the editor sees no progress.
+    let tracked = tracked_progress_source(selected, entries)?;
+    let aggregator = Arc::new(Mutex::new(ClientProgressAggregator::new(client_token)));
     let registry = Arc::clone(pool.client_progress_registry());
+    let token = registry.register(Arc::clone(&aggregator));
     let mut map = HashMap::new();
-    let mut minted = Vec::new();
-    for config in selected {
-        let token = registry.register(Arc::clone(&aggregator));
-        minted.push(token.clone());
-        map.insert(config.server_name.clone(), token);
-    }
+    map.insert(tracked, token.clone());
     let guard =
-        ClientProgressDeregisterGuard::new(registry, minted, aggregator, pool.upstream_tx());
+        ClientProgressDeregisterGuard::new(registry, vec![token], aggregator, pool.upstream_tx());
     Some((map, guard))
+}
+
+/// The server whose `$/progress` the editor sees under *preferred*
+/// (ls-bridge-client-progress):
+/// - **N = 1**: the sole selected server — its real `Begin` is safe to forward
+///   even if wildcard-selected (a single downstream has no racing contender).
+/// - **N > 1**: the **anchor** — the highest-priority *named* candidate in the
+///   priority walk. `Rest`/wildcard members are never anchors (no safe a-priori
+///   title for a latency race), so an all-`Rest` fan-out has no tracked source.
+///
+/// `None` means no progress is shown for the request.
+fn tracked_progress_source(
+    selected: &[ResolvedServerConfig],
+    entries: &[PriorityEntry],
+) -> Option<String> {
+    if let [only] = selected {
+        return Some(only.server_name.clone());
+    }
+    // The first *named* entry that actually participates (is selected). Rest
+    // entries are skipped; if no named server is selected the fan-out is
+    // all-wildcard and has no anchor.
+    entries.iter().find_map(|entry| match entry {
+        PriorityEntry::Server(name)
+            if selected.iter().any(|config| &config.server_name == name) =>
+        {
+            Some(name.clone())
+        }
+        _ => None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::settings::BridgeServerConfig;
+
+    fn config(name: &str) -> ResolvedServerConfig {
+        ResolvedServerConfig {
+            server_name: name.to_string(),
+            config: Arc::new(BridgeServerConfig {
+                cmd: vec![name.to_string()],
+                languages: vec![],
+                initialization_options: None,
+                root_markers: None,
+                on_type_formatting_triggers: None,
+                prefer_shared_instance: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn tracked_source_is_the_sole_server_at_n1() {
+        // N=1 relays the sole server even when wildcard-selected.
+        let selected = [config("rust-analyzer")];
+        let entries = [PriorityEntry::Rest(vec!["rust-analyzer".to_string()])];
+        assert_eq!(
+            tracked_progress_source(&selected, &entries),
+            Some("rust-analyzer".to_string())
+        );
+    }
+
+    #[test]
+    fn tracked_source_is_the_named_anchor_at_n_gt_1() {
+        let selected = [config("ra"), config("typos")];
+        let entries = [
+            PriorityEntry::Server("ra".to_string()),
+            PriorityEntry::Rest(vec!["typos".to_string()]),
+        ];
+        assert_eq!(
+            tracked_progress_source(&selected, &entries),
+            Some("ra".to_string())
+        );
+    }
+
+    #[test]
+    fn first_named_anchor_wins_over_a_later_named_one() {
+        let selected = [config("ra"), config("clangd")];
+        let entries = [
+            PriorityEntry::Server("ra".to_string()),
+            PriorityEntry::Server("clangd".to_string()),
+        ];
+        assert_eq!(
+            tracked_progress_source(&selected, &entries),
+            Some("ra".to_string())
+        );
+    }
+
+    #[test]
+    fn no_tracked_source_for_all_rest_at_n_gt_1() {
+        // Rest members are never anchors → no progress shown.
+        let selected = [config("a"), config("b")];
+        let entries = [PriorityEntry::Rest(vec!["a".to_string(), "b".to_string()])];
+        assert_eq!(tracked_progress_source(&selected, &entries), None);
+    }
 }
 
 /// Expand `ctx.priorities` into the priority walk for this request:
@@ -123,10 +209,10 @@ where
     // Compute the selected servers once and share it with both client-progress
     // setup and fan-out (avoids a second `select_servers` on the dispatch path).
     let selected = select_servers(&ctx.configs, &entries);
-    // Stage 1: `setup_client_progress` bridges client progress only for the
-    // single-downstream case (it returns `None` for N>1, keeping fan-out
-    // non-regressing) and only when the request carries a `workDoneToken`.
-    let client_progress = setup_client_progress(ctx, &pool, &selected);
+    // `setup_client_progress` bridges client progress for the tracked source only
+    // (sole server at N=1, named anchor at N>1) when the request carries a
+    // `workDoneToken`; every other candidate is suppressed (handed no token).
+    let client_progress = setup_client_progress(ctx, &pool, &selected, &entries);
     let cp_tokens = client_progress.as_ref().map(|(m, _guard)| m);
     let mut join_set = fan_out(ctx, pool, f, &selected, cp_tokens);
     let result = preferred::preferred(&mut join_set, is_nonempty, &entries, cancel_rx).await;

--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -46,9 +46,11 @@ fn setup_client_progress(
 )> {
     let client_token = ctx.client_progress_token.clone()?;
     // Under *preferred*, only the tracked source's progress is shown; every other
-    // candidate is suppressed by handing it no `workDoneToken` (so it emits no
-    // `$/progress` — no wasted traffic). With no tracked source (an all-`Rest`
-    // N>1 fan-out) nothing is minted and the editor sees no progress.
+    // candidate is suppressed by handing it no `workDoneToken`, so it reports no
+    // `$/progress` *for this request* (a downstream may still drive its own
+    // server-declared progress — that path is unaffected). With no tracked source
+    // (an all-`Rest` N>1 fan-out) nothing is minted and the editor sees no
+    // progress for the request.
     let tracked = tracked_progress_source(selected, entries)?;
     let aggregator = Arc::new(Mutex::new(ClientProgressAggregator::new(client_token)));
     let registry = Arc::clone(pool.client_progress_registry());

--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -68,7 +68,10 @@ fn setup_client_progress(
 ///   priority walk. `Rest`/wildcard members are never anchors (no safe a-priori
 ///   title for a latency race), so an all-`Rest` fan-out has no tracked source.
 ///
-/// `None` means no progress is shown for the request.
+/// `None` means no progress is shown for the request. This picks a **single
+/// fixed anchor**; dynamic fall-through re-anchoring (re-tracking the next named
+/// candidate when this one returns empty) is a later stage — on fall-through the
+/// open `Begin` is instead closed by the synthetic terminal `End`.
 fn tracked_progress_source(
     selected: &[ResolvedServerConfig],
     entries: &[PriorityEntry],
@@ -142,6 +145,21 @@ mod tests {
         assert_eq!(
             tracked_progress_source(&selected, &entries),
             Some("ra".to_string())
+        );
+    }
+
+    #[test]
+    fn named_anchor_wins_even_when_a_rest_group_precedes_it() {
+        // Walk order `[Rest, Server]` (the `["*", "zzz"]` config shape): the Rest
+        // group is skipped, and the later named server is the anchor.
+        let selected = [config("a"), config("zzz")];
+        let entries = [
+            PriorityEntry::Rest(vec!["a".to_string()]),
+            PriorityEntry::Server("zzz".to_string()),
+        ];
+        assert_eq!(
+            tracked_progress_source(&selected, &entries),
+            Some("zzz".to_string())
         );
     }
 

--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -56,7 +56,7 @@ fn setup_client_progress(
     let registry = Arc::clone(pool.client_progress_registry());
     let token = registry.register(Arc::clone(&aggregator));
     let mut map = HashMap::new();
-    map.insert(tracked, token.clone());
+    map.insert(tracked.to_string(), token.clone());
     let guard =
         ClientProgressDeregisterGuard::new(registry, vec![token], aggregator, pool.upstream_tx());
     Some((map, guard))
@@ -79,12 +79,12 @@ fn setup_client_progress(
 /// fixed anchor**; dynamic fall-through re-anchoring (re-tracking the next named
 /// candidate when this one returns empty) is a later stage — on fall-through the
 /// open `Begin` is instead closed by the synthetic terminal `End`.
-fn tracked_progress_source(
-    selected: &[ResolvedServerConfig],
-    entries: &[PriorityEntry],
-) -> Option<String> {
+fn tracked_progress_source<'a>(
+    selected: &'a [ResolvedServerConfig],
+    entries: &'a [PriorityEntry],
+) -> Option<&'a str> {
     if let [only] = selected {
-        return Some(only.server_name.clone());
+        return Some(&only.server_name);
     }
     let participates = |name: &str| selected.iter().any(|c| c.server_name == name);
     // Walk in priority order to the first *participating* entry: if it is a named
@@ -94,7 +94,7 @@ fn tracked_progress_source(
     // skipped.)
     for entry in entries {
         match entry {
-            PriorityEntry::Server(name) if participates(name) => return Some(name.clone()),
+            PriorityEntry::Server(name) if participates(name) => return Some(name),
             PriorityEntry::Rest(names) if names.iter().any(|n| participates(n)) => return None,
             _ => {}
         }
@@ -128,7 +128,7 @@ mod tests {
         let entries = [PriorityEntry::Rest(vec!["rust-analyzer".to_string()])];
         assert_eq!(
             tracked_progress_source(&selected, &entries),
-            Some("rust-analyzer".to_string())
+            Some("rust-analyzer")
         );
     }
 
@@ -139,10 +139,7 @@ mod tests {
             PriorityEntry::Server("ra".to_string()),
             PriorityEntry::Rest(vec!["typos".to_string()]),
         ];
-        assert_eq!(
-            tracked_progress_source(&selected, &entries),
-            Some("ra".to_string())
-        );
+        assert_eq!(tracked_progress_source(&selected, &entries), Some("ra"));
     }
 
     #[test]
@@ -152,10 +149,7 @@ mod tests {
             PriorityEntry::Server("ra".to_string()),
             PriorityEntry::Server("clangd".to_string()),
         ];
-        assert_eq!(
-            tracked_progress_source(&selected, &entries),
-            Some("ra".to_string())
-        );
+        assert_eq!(tracked_progress_source(&selected, &entries), Some("ra"));
     }
 
     #[test]

--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -64,9 +64,14 @@ fn setup_client_progress(
 /// (ls-bridge-client-progress):
 /// - **N = 1**: the sole selected server — its real `Begin` is safe to forward
 ///   even if wildcard-selected (a single downstream has no racing contender).
-/// - **N > 1**: the **anchor** — the highest-priority *named* candidate in the
-///   priority walk. `Rest`/wildcard members are never anchors (no safe a-priori
-///   title for a latency race), so an all-`Rest` fan-out has no tracked source.
+/// - **N > 1**: the **anchor** — but only when the **top-priority participating
+///   candidate is a *named* server**. `Rest`/wildcard members are never anchors
+///   (no safe a-priori title for a latency race), and the winner is *usually* the
+///   anchor — so a named server that a `Rest` group **outranks** (e.g. priorities
+///   `["*", "zzz"]`, where the wildcard wins first) is not a valid anchor:
+///   tracking it would show its progress while a wildcard member delivers the
+///   result. In that case, and for an all-`Rest` fan-out, there is no tracked
+///   source.
 ///
 /// `None` means no progress is shown for the request. This picks a **single
 /// fixed anchor**; dynamic fall-through re-anchoring (re-tracking the next named
@@ -79,17 +84,20 @@ fn tracked_progress_source(
     if let [only] = selected {
         return Some(only.server_name.clone());
     }
-    // The first *named* entry that actually participates (is selected). Rest
-    // entries are skipped; if no named server is selected the fan-out is
-    // all-wildcard and has no anchor.
-    entries.iter().find_map(|entry| match entry {
-        PriorityEntry::Server(name)
-            if selected.iter().any(|config| &config.server_name == name) =>
-        {
-            Some(name.clone())
+    let participates = |name: &str| selected.iter().any(|c| c.server_name == name);
+    // Walk in priority order to the first *participating* entry: if it is a named
+    // server, it outranks any wildcard and is the anchor; if it is a `Rest` group
+    // with a participating member, the top contender is a wildcard, so there is no
+    // a-priori anchor. (Non-participating entries — e.g. an empty `Rest` — are
+    // skipped.)
+    for entry in entries {
+        match entry {
+            PriorityEntry::Server(name) if participates(name) => return Some(name.clone()),
+            PriorityEntry::Rest(names) if names.iter().any(|n| participates(n)) => return None,
+            _ => {}
         }
-        _ => None,
-    })
+    }
+    None
 }
 
 #[cfg(test)]
@@ -149,18 +157,17 @@ mod tests {
     }
 
     #[test]
-    fn named_anchor_wins_even_when_a_rest_group_precedes_it() {
-        // Walk order `[Rest, Server]` (the `["*", "zzz"]` config shape): the Rest
-        // group is skipped, and the later named server is the anchor.
+    fn no_anchor_when_a_rest_group_outranks_the_named_candidate() {
+        // Walk order `[Rest, Server]` (the `["*", "zzz"]` config shape): the
+        // wildcard group is the top-priority contender (it wins first), so the
+        // lower-priority named server is NOT a valid anchor — tracking it would
+        // show its progress while a wildcard member delivers the result.
         let selected = [config("a"), config("zzz")];
         let entries = [
             PriorityEntry::Rest(vec!["a".to_string()]),
             PriorityEntry::Server("zzz".to_string()),
         ];
-        assert_eq!(
-            tracked_progress_source(&selected, &entries),
-            Some("zzz".to_string())
-        );
+        assert_eq!(tracked_progress_source(&selected, &entries), None);
     }
 
     #[test]

--- a/src/lsp/bridge/client_progress.rs
+++ b/src/lsp/bridge/client_progress.rs
@@ -14,10 +14,12 @@
 //!
 //! # Staging
 //!
-//! Per the non-regressing rule, the aggregator **drops any progress it does not
-//! yet handle — it never forwards raw downstream progress**. Currently only the
-//! single-downstream (`N = 1`) relay is implemented; multi-server fan-out
-//! (`preferred`/`concatenated`) is dropped until those stages land.
+//! *preferred* (incl. `N = 1`) is implemented: the dispatch path mints a bridge
+//! token solely for the **tracked source** (the sole server at `N = 1`, or the
+//! highest-priority *named* anchor at `N > 1`) and suppresses every other
+//! candidate by handing it no token, so only the tracked source's progress
+//! routes here. *concatenated* aggregation and `partialResultToken` are later
+//! stages; until then a *concatenated* request shows no client progress.
 
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -142,20 +144,19 @@ impl Drop for ClientProgressDeregisterGuard {
     }
 }
 
-/// Translates a fanned-out request's downstream `$/progress` into a single
+/// Translates the **tracked source's** downstream `$/progress` into a single
 /// lifecycle on the client's `workDoneToken`.
 ///
-/// Stage 1 implements the single-downstream (`N = 1`) relay, including a
-/// synthetic terminal `End` on teardown (so a relayed `Begin` is always closed
-/// even if the downstream's `End` races the response or never arrives).
-/// Multi-server aggregation (`preferred`/`concatenated`), which reintroduces the
-/// per-strategy anchor, arrives in later stages.
+/// Only the tracked source's bridge token routes here (under *preferred*/N=1 the
+/// dispatch path mints a token solely for that source — the sole server at N=1,
+/// or the highest-priority *named* anchor at N>1 — and suppresses every other
+/// candidate by handing it no token). So this aggregator just enforces one
+/// coherent `Begin → … → End` and guarantees a terminal `End` on teardown (even
+/// if the source's own `End` races the response or never arrives).
 #[derive(Debug)]
 pub(crate) struct ClientProgressAggregator {
     /// The editor-minted token every emitted `$/progress` is reported against.
     client_token: NumberOrString,
-    /// Number of downstream servers the request fanned out to.
-    server_count: usize,
     /// Whether a `Begin` has been relayed upstream (pairing invariant).
     begun: bool,
     /// Whether the terminal `End` has been emitted (drop anything after it; emit
@@ -164,21 +165,16 @@ pub(crate) struct ClientProgressAggregator {
 }
 
 impl ClientProgressAggregator {
-    pub(crate) fn new(client_token: NumberOrString, server_count: usize) -> Self {
+    pub(crate) fn new(client_token: NumberOrString) -> Self {
         Self {
             client_token,
-            server_count,
             begun: false,
             ended: false,
         }
     }
 
-    /// Feed one downstream `$/progress` value. Returns the upstream `$/progress`
-    /// to forward against the client token, or `None` to drop it.
-    ///
-    /// Stage 1 handles only the single-downstream case; with more than one
-    /// server the progress is dropped (never forwarded raw) until the
-    /// `preferred`/`concatenated` stages land.
+    /// Feed one tracked-source `$/progress` value. Returns the upstream
+    /// `$/progress` to forward against the client token, or `None` to drop it.
     pub(crate) fn on_downstream_progress(
         &mut self,
         value: ProgressParamsValue,
@@ -187,20 +183,15 @@ impl ClientProgressAggregator {
             &value,
             ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(_))
         );
-        if self.ended
-            || self.server_count != 1
-            || (is_begin && self.begun)
-            || (!is_begin && !self.begun)
-        {
+        if self.ended || (is_begin && self.begun) || (!is_begin && !self.begun) {
             // Drop, so the editor sees one coherent Begin → … → End lifecycle:
-            // N > 1 is not yet aggregated (never forward raw); anything after the
-            // terminal End; a duplicate `Begin`; and any out-of-order `report`/
-            // `End` before the first `Begin`.
+            // anything after the terminal End; a duplicate `Begin`; and any
+            // out-of-order `report`/`End` before the first `Begin`.
             return None;
         }
-        // N = 1: relay verbatim under the client token, tracking the lifecycle so
-        // a terminal End is guaranteed even if the downstream's own End never
-        // arrives (or arrives after teardown).
+        // Relay verbatim under the client token, tracking the lifecycle so a
+        // terminal End is guaranteed even if the source's own End never arrives
+        // (or arrives after teardown).
         if is_begin {
             self.begun = true;
         } else if matches!(
@@ -258,7 +249,7 @@ mod tests {
 
     #[test]
     fn n1_relays_begin_then_end_under_the_client_token_then_drops() {
-        let mut agg = ClientProgressAggregator::new(client_token(), 1);
+        let mut agg = ClientProgressAggregator::new(client_token());
 
         for value in [begin(), end()] {
             let out = agg
@@ -275,7 +266,7 @@ mod tests {
     }
 
     fn agg() -> std::sync::Arc<Mutex<ClientProgressAggregator>> {
-        std::sync::Arc::new(Mutex::new(ClientProgressAggregator::new(client_token(), 1)))
+        std::sync::Arc::new(Mutex::new(ClientProgressAggregator::new(client_token())))
     }
 
     #[test]
@@ -302,17 +293,8 @@ mod tests {
     }
 
     #[test]
-    fn multi_server_progress_is_dropped_until_aggregation_lands() {
-        let mut agg = ClientProgressAggregator::new(client_token(), 2);
-        assert!(
-            agg.on_downstream_progress(begin()).is_none(),
-            "N>1 must not forward raw downstream progress (would duplicate Begins)"
-        );
-    }
-
-    #[test]
     fn out_of_order_end_before_begin_is_dropped() {
-        let mut agg = ClientProgressAggregator::new(client_token(), 1);
+        let mut agg = ClientProgressAggregator::new(client_token());
         // An `End` before any `Begin` must be dropped — the editor must never see
         // a terminal for a lifecycle that never began.
         assert!(
@@ -332,7 +314,7 @@ mod tests {
 
     #[test]
     fn duplicate_begin_is_dropped() {
-        let mut agg = ClientProgressAggregator::new(client_token(), 1);
+        let mut agg = ClientProgressAggregator::new(client_token());
         assert!(
             agg.on_downstream_progress(begin()).is_some(),
             "first Begin relays"
@@ -358,7 +340,7 @@ mod tests {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let registry = std::sync::Arc::new(ClientProgressRegistry::new());
         let aggregator =
-            std::sync::Arc::new(Mutex::new(ClientProgressAggregator::new(client_token(), 1)));
+            std::sync::Arc::new(Mutex::new(ClientProgressAggregator::new(client_token())));
         let token = registry.register(aggregator.clone());
         // Downstream begins (relayed) but never ends.
         aggregator.lock().unwrap().on_downstream_progress(begin());
@@ -395,7 +377,7 @@ mod tests {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let registry = std::sync::Arc::new(ClientProgressRegistry::new());
         let aggregator =
-            std::sync::Arc::new(Mutex::new(ClientProgressAggregator::new(client_token(), 1)));
+            std::sync::Arc::new(Mutex::new(ClientProgressAggregator::new(client_token())));
         let token = registry.register(aggregator.clone());
         {
             let mut guard = aggregator.lock().unwrap();
@@ -423,7 +405,7 @@ mod tests {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let registry = std::sync::Arc::new(ClientProgressRegistry::new());
         let aggregator =
-            std::sync::Arc::new(Mutex::new(ClientProgressAggregator::new(client_token(), 1)));
+            std::sync::Arc::new(Mutex::new(ClientProgressAggregator::new(client_token())));
         let token = registry.register(aggregator.clone());
 
         drop(ClientProgressDeregisterGuard::new(

--- a/src/lsp/bridge/client_progress.rs
+++ b/src/lsp/bridge/client_progress.rs
@@ -14,12 +14,18 @@
 //!
 //! # Staging
 //!
-//! *preferred* (incl. `N = 1`) is implemented: the dispatch path mints a bridge
-//! token solely for the **tracked source** (the sole server at `N = 1`, or the
-//! highest-priority *named* anchor at `N > 1`) and suppresses every other
-//! candidate by handing it no token, so only the tracked source's progress
-//! routes here. *concatenated* aggregation and `partialResultToken` are later
-//! stages; until then a *concatenated* request shows no client progress.
+//! *preferred* is implemented with a **single fixed anchor**: the dispatch path
+//! mints a bridge token solely for the **tracked source** (the sole server at
+//! `N = 1`, or the highest-priority *named* anchor at `N > 1`) and suppresses
+//! every other candidate by handing it no token, so only the tracked source's
+//! progress routes here. If that anchor returns empty and the request falls
+//! through to a lower-priority candidate, the editor sees no *new* progress for
+//! it; the open `Begin` is closed by the synthetic terminal `End` at request
+//! completion (an ADR-sanctioned branch of the pairing invariant). Deferred to
+//! later stages: **dynamic fall-through re-anchoring** (showing the *next* named
+//! anchor's real progress/`End`), *concatenated* aggregation, and
+//! `partialResultToken`. Until then a *concatenated* request shows no client
+//! progress.
 
 use std::collections::HashMap;
 use std::sync::Mutex;


### PR DESCRIPTION
## Summary

Next stage of `ls-bridge-client-progress` (#414), **stacked on the N=1 slice ([#432](https://github.com/atusy/kakehashi/pull/432))**. Generalizes client-progress pass-through from N=1-only to the full **`preferred`** strategy.

> Base is `feat-414-client-progress` (#432); retarget to `main` once that merges.

## What changed
- **`tracked_progress_source(selected, entries)`** (`dispatch.rs`): the server whose `$/progress` the editor sees — the **sole** server at N=1, or the **anchor** at N>1. The anchor is found by walking the priority order to the first *participating* entry: a **named** server there is the anchor; a participating **`Rest`/wildcard** group there means the wildcard is the top contender (it wins first), so there is **no a-priori anchor** (`None`). Thus a named server that a `Rest` group outranks (e.g. `["*", "zzz"]` with other servers) yields `None` — tracking it would show its progress while a wildcard member delivers the result. All-`Rest` → `None`.
- **`setup_client_progress`** mints a bridge token **only for the tracked source** and suppresses every other candidate by handing it no `workDoneToken` (so it reports no `$/progress` *for this request* — server-declared progress is unaffected). Source-selection thus moves from the aggregator to dispatch.
- **`ClientProgressAggregator`** drops its `server_count` gate — only the tracked source's token routes to it now, so it just enforces one coherent `Begin → … → End` (+ duplicate / out-of-order guards + synthetic terminal `End` on teardown, unchanged).

## Scope (intentional, documented)
This slice tracks a **single fixed anchor**. **Dynamic fall-through re-anchoring** — showing the *next* named anchor's real progress/`End` when the first returns empty — is **deferred**; on fall-through the open `Begin` is closed by the synthetic terminal `End` at request completion (an ADR-sanctioned branch of the pairing invariant). `concatenated` aggregation and `partialResultToken` remain later stages.

## Tests
5 `tracked_progress_source` unit tests: sole-at-N=1 (even wildcard-selected), named-anchor-at-N>1, first-named-wins-over-later-named, **no-anchor-when-a-`Rest`-group-outranks-the-named-candidate**, all-`Rest`→none. (Suppression is transitively covered: one tracked server → one map entry → `fan_out` gives others `None`.)

Reviewed via subagent `/review` and Codex (no must-fix); Copilot caught the anchor/wildcard-precedence semantics (fixed). Part of #414 (does not close it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)