### PR TITLE
feat(bridge): eager-open host document on _self servers at didOpen (#429)

### DIFF
--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -90,8 +90,11 @@ Partially implemented:
 - **Diagnostics**: a `_self` host server's pushed `publishDiagnostics` for the
   real host URI are propagated to the editor via the per-host diagnostic cache
   (push-propagation-diagnostic-forwarding, #421) — accepted when the URI names an
-  open host-bridged document. Host-layer eager-open (on-open diagnostics before
-  the first request) is still deferred.
+  open host-bridged document. The host document is opened eagerly on each `_self`
+  host server at host `didOpen` (#429), so a push-only host server pushes on open
+  rather than only after the first request. On-edit re-sync to push-only host
+  servers without a host request (as-you-type) is still deferred — they see edits
+  via the lazy request-path sync (save / hover).
 
 ## Context
 

--- a/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
+++ b/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
@@ -243,10 +243,13 @@ policy clean:
   if the re-anchored host coordinates actually changed. Lazy re-anchor supplies the
   correct positions; this supplies the missing trigger.
 - **Host layer**: the `_self` host source uses the identical model keyed on the
-  *host document's* content epoch — push-driven `_self` servers are eagerly opened
-  (see Lifecycle) and eagerly re-synced on a content-changing host `didChange`
-  (the host path's fingerprint already gates this), so the gate and re-merge rules
-  above apply unchanged.
+  *host document's* content epoch. Push-driven `_self` servers are eagerly opened
+  on host `didOpen` (#429, implemented; see Lifecycle). Eager **re-sync** on a
+  content-changing host `didChange` — so a push-only host server re-analyzes
+  as-you-type without a host request — is deferred (#431); until then it sees
+  edits only via the lazy request-path sync (save / hover). When that lands (the
+  host path's fingerprint already gates the didChange), the gate and re-merge
+  rules above apply unchanged.
 
 ### `preferred` as a push stream
 

--- a/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
+++ b/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
@@ -492,8 +492,13 @@ because the #380 benefit now outweighs it:
   closing #380 for region pushes.
 - The `_self` host-layer push source (#421): a push on the real host URI that
   names an open `_self` host-bridged document is cached as a `Host` slot (host
-  coordinates) and merged through. Classification/routing only — **eager-open**
-  (below) is still deferred.
+  coordinates) and merged through.
+- Host-layer eager-open (#429): on host `didOpen`, the host document is opened
+  eagerly on each `_self` host server (`eager_open_host_document_on_servers`), so
+  a push-only host server analyzes + pushes on open rather than only after the
+  first host-bridged request lazily opens it. On-edit re-sync to push-only host
+  servers (as-you-type, without a host request) is still deferred — they see
+  edits via the lazy request-path sync (save / hover), not per-keystroke.
 
 **Deferred** (staged follow-ups; the code documents each at its site):
 
@@ -502,9 +507,9 @@ because the #380 benefit now outweighs it:
   (lazy re-anchor still keeps *positions* current via the retained pull trigger).
 - Per-source strategy fan-in (`preferred` sticky / `concatenated` visible-walk);
   the staged merge concatenates, with HashMap-nondeterministic cross-source order.
-- Host-layer eager-open: a push-only `_self` server only pushes after the host
-  doc is opened on it (lazily, on the first host request), so on-open diagnostics
-  rely on the editor's open-time pull opening the doc.
+- On-edit eager re-sync of the host doc to push-only `_self` servers (so they
+  re-analyze as-you-type without a host request); gated on capability
+  classification so pull-capable host servers aren't sent redundant didChanges.
 - Region-invalidation and crash cache eviction.
 - The `pullFallback` / `pushFallback` config toggles and the capability
   classification — without the latter the pull feed and a server's spontaneous

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -574,15 +574,19 @@ impl BridgeCoordinator {
         // (see the field doc), bounded and benign; left open for parity.
         let generation = self.supersede_host_eager_open(host_uri);
 
+        // Share the text + languageId across per-server tasks via `Arc<str>` rather
+        // than cloning the (potentially large) document text once per host server.
+        // For a `_self` bridge the downstream `languageId` is the host language
+        // itself (consistent with the lazy request path's
+        // `HostRequestContext.language_id`), so derive it rather than taking a
+        // separate arg that a caller could transpose with `text`.
+        let text: Arc<str> = Arc::from(text);
+        let language_id: Arc<str> = Arc::from(host_language);
         for config in configs {
             let pool = self.pool_arc();
             let host_uri_owned = host_uri.clone();
-            // For a `_self` bridge the downstream `languageId` is the host language
-            // itself (consistent with the lazy request path's
-            // `HostRequestContext.language_id`), so derive it rather than taking a
-            // separate arg that a caller could transpose with `text`.
-            let language_id = host_language.to_string();
-            let text = text.to_string();
+            let language_id = Arc::clone(&language_id);
+            let text = Arc::clone(&text);
             let server_name = config.server_name.clone();
             let server_config = config.config.clone();
             let task = tokio::spawn(async move {

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -98,10 +98,16 @@ pub(crate) struct BridgeCoordinator {
     /// Host-layer eager-open tasks, keyed by host document URI (#429). Separate
     /// from `eager_open_tasks` because the host path fires on `didOpen` for the
     /// real host doc (no injections). Uses the same generation/placeholder shape
-    /// as the virt path so the spawn→register window is closed: a concurrent
-    /// `cancel_host_eager_open` (didClose) or `abort_all_eager_open` (shutdown)
-    /// removes the entry, and any handle registered afterwards is aborted on the
-    /// spot instead of leaking a task that could open a connection post-cancel.
+    /// as the virt path: `supersede` resets to an empty placeholder before
+    /// spawning, so a handle *registered* after a concurrent
+    /// `cancel_host_eager_open` (didClose) / `abort_all_eager_open` (shutdown) is
+    /// aborted on the spot (the registration leak is closed). It does NOT stop a
+    /// task whose body already started on another worker thread before its handle
+    /// registers from sending its didOpen — identical to the region path, bounded
+    /// and benign (the #421 push-accept guard reads the editor `DocumentStore`, so
+    /// no phantom diagnostics; an orphan connection / `host_documents` entry clears
+    /// on reopen / respawn). Left open deliberately to stay parallel with the
+    /// region eager-open rather than diverging (tracked cross-path follow-up).
     host_eager_open_tasks: DashMap<Url, EagerOpenBatch>,
 }
 
@@ -560,11 +566,12 @@ impl BridgeCoordinator {
 
         // Supersede the previous batch (abort + reset to an empty placeholder)
         // BEFORE spawning, then register each handle against this generation. This
-        // closes the spawn→register window: a concurrent `cancel_host_eager_open`
-        // (didClose) or `abort_all_eager_open` (shutdown) removes the entry, so a
-        // handle registered afterwards is aborted on the spot rather than leaking a
-        // task that could open a connection post-cancel — the same shape the region
-        // path uses.
+        // closes the *registration* leak: if a concurrent `cancel_host_eager_open`
+        // (didClose) or `abort_all_eager_open` (shutdown) removed the entry, a
+        // handle registered afterwards is aborted on the spot. It does NOT prevent
+        // a task whose body already started on another worker before registration
+        // from sending its didOpen — that residual is identical to the region path
+        // (see the field doc), bounded and benign; left open for parity.
         let generation = self.supersede_host_eager_open(host_uri);
 
         for config in configs {

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -92,12 +92,17 @@ pub(crate) struct BridgeCoordinator {
     /// - Host document is closed while tasks wait for server readiness
     /// - Rapid did_change events spawn many overlapping batches
     eager_open_tasks: DashMap<Url, EagerOpenBatch>,
+    /// Generation counter for host-layer eager-open batches (#429); separate from
+    /// `eager_open_generation` so the two paths never alias.
+    host_eager_open_generation: std::sync::atomic::AtomicU64,
     /// Host-layer eager-open tasks, keyed by host document URI (#429). Separate
     /// from `eager_open_tasks` because the host path fires on `didOpen` for the
-    /// real host doc (no injections, no per-`didChange` superseding), so a plain
-    /// abort-old-on-new per URI suffices. Cancelled on `didClose` (before the host
-    /// doc is closed) to avoid orphan-opening a doc whose `didClose` already ran.
-    host_eager_open_tasks: DashMap<Url, Vec<tokio::task::AbortHandle>>,
+    /// real host doc (no injections). Uses the same generation/placeholder shape
+    /// as the virt path so the spawn→register window is closed: a concurrent
+    /// `cancel_host_eager_open` (didClose) or `abort_all_eager_open` (shutdown)
+    /// removes the entry, and any handle registered afterwards is aborted on the
+    /// spot instead of leaking a task that could open a connection post-cancel.
+    host_eager_open_tasks: DashMap<Url, EagerOpenBatch>,
 }
 
 impl BridgeCoordinator {
@@ -111,6 +116,7 @@ impl BridgeCoordinator {
             cancel_forwarder,
             eager_open_generation: std::sync::atomic::AtomicU64::new(0),
             eager_open_tasks: DashMap::new(),
+            host_eager_open_generation: std::sync::atomic::AtomicU64::new(0),
             host_eager_open_tasks: DashMap::new(),
         }
     }
@@ -132,6 +138,7 @@ impl BridgeCoordinator {
             cancel_forwarder,
             eager_open_generation: std::sync::atomic::AtomicU64::new(0),
             eager_open_tasks: DashMap::new(),
+            host_eager_open_generation: std::sync::atomic::AtomicU64::new(0),
             host_eager_open_tasks: DashMap::new(),
         }
     }
@@ -551,7 +558,15 @@ impl BridgeCoordinator {
             return;
         }
 
-        let mut handles = Vec::with_capacity(configs.len());
+        // Supersede the previous batch (abort + reset to an empty placeholder)
+        // BEFORE spawning, then register each handle against this generation. This
+        // closes the spawn→register window: a concurrent `cancel_host_eager_open`
+        // (didClose) or `abort_all_eager_open` (shutdown) removes the entry, so a
+        // handle registered afterwards is aborted on the spot rather than leaking a
+        // task that could open a connection post-cancel — the same shape the region
+        // path uses.
+        let generation = self.supersede_host_eager_open(host_uri);
+
         for config in configs {
             let pool = self.pool_arc();
             let host_uri_owned = host_uri.clone();
@@ -573,25 +588,53 @@ impl BridgeCoordinator {
                 )
                 .await;
             });
-            handles.push(task.abort_handle());
+            self.push_or_abort_host_eager_open_handle(host_uri, task.abort_handle(), generation);
         }
+    }
 
-        // Replace + abort the previous batch (rare: a second didOpen without a
-        // didClose). NOTE: unlike the region path — which inserts a placeholder
-        // under `supersede_eager_open_tasks` BEFORE spawning to close it — the host
-        // path leaves the spawn→insert window open: a concurrent didClose's
-        // `cancel_host_eager_open` between the spawns above and this insert finds no
-        // entry, so those tasks aren't aborted and one may `didOpen` after the doc's
-        // didClose. That residue is benign: the #421 push-accept guard checks the
-        // editor `DocumentStore` (not `host_documents`), so a closed doc can't show
-        // phantom diagnostics; the stale `host_documents` entry self-heals on
-        // reopen (same-fingerprint no-op) or on connection respawn (retain purge).
-        if let Some(previous) = self.host_eager_open_tasks.insert(host_uri.clone(), handles) {
-            for handle in previous {
-                if !handle.is_finished() {
-                    handle.abort();
+    /// Supersede the host eager-open batch for `uri` (abort old handles + reset to
+    /// an empty placeholder under one shard lock), returning the new generation.
+    /// Mirrors `supersede_eager_open_tasks` for the host path.
+    fn supersede_host_eager_open(&self, uri: &Url) -> u64 {
+        let generation = self
+            .host_eager_open_generation
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        use dashmap::mapref::entry::Entry;
+        match self.host_eager_open_tasks.entry(uri.clone()) {
+            Entry::Occupied(mut entry) => {
+                let batch = entry.get_mut();
+                let prev = std::mem::take(&mut batch.handles);
+                batch.generation = generation;
+                for handle in prev {
+                    if !handle.is_finished() {
+                        handle.abort();
+                    }
                 }
             }
+            Entry::Vacant(entry) => {
+                entry.insert(EagerOpenBatch {
+                    generation,
+                    handles: Vec::new(),
+                });
+            }
+        }
+        generation
+    }
+
+    /// Push a host eager-open abort handle into its batch, or abort it if the entry
+    /// was removed (cancel/shutdown) or its generation is stale (a newer batch
+    /// superseded it). Mirrors `push_or_abort_eager_open_handle`.
+    fn push_or_abort_host_eager_open_handle(
+        &self,
+        uri: &Url,
+        handle: tokio::task::AbortHandle,
+        expected_generation: u64,
+    ) {
+        match self.host_eager_open_tasks.get_mut(uri) {
+            Some(mut entry) if entry.value().generation == expected_generation => {
+                entry.value_mut().handles.push(handle);
+            }
+            _ => handle.abort(),
         }
     }
 
@@ -600,8 +643,8 @@ impl BridgeCoordinator {
     /// task still waiting for server readiness can't open a doc whose `didClose`
     /// already ran.
     pub(crate) fn cancel_host_eager_open(&self, host_uri: &Url) {
-        if let Some((_, handles)) = self.host_eager_open_tasks.remove(host_uri) {
-            for handle in handles {
+        if let Some((_, batch)) = self.host_eager_open_tasks.remove(host_uri) {
+            for handle in batch.handles {
                 if !handle.is_finished() {
                     handle.abort();
                 }
@@ -759,6 +802,19 @@ impl BridgeCoordinator {
             }
             false // remove entry
         });
+        // Drain the host-layer eager-open batch too (#429): otherwise a host
+        // eager-open still waiting for server readiness could spawn a connection
+        // or queue a didOpen during shutdown. `retain` aborts + removes under the
+        // shard lock, so a handle being registered concurrently (spawn→register
+        // window) either lands before this drain and is aborted here, or finds the
+        // entry already gone and is aborted by `push_or_abort_host_eager_open_handle`.
+        self.host_eager_open_tasks.retain(|_uri, batch| {
+            for handle in batch.handles.iter() {
+                handle.abort();
+                count += 1;
+            }
+            false // remove entry
+        });
         if count > 0 {
             log::debug!(
                 target: "kakehashi::bridge",
@@ -796,6 +852,34 @@ mod tests {
     use super::*;
     use crate::config::LanguageSettings;
     use crate::config::settings::BridgeLanguageConfig;
+
+    /// Shutdown's `abort_all_eager_open` must drain the host-layer eager-open
+    /// batch too (#429), not only the virt `eager_open_tasks`.
+    #[tokio::test]
+    async fn abort_all_eager_open_drains_host_batch() {
+        let coordinator = BridgeCoordinator::new();
+        let uri = Url::parse("file:///host_shutdown.lua").unwrap();
+        // A never-completing task stands in for a host eager-open still waiting on
+        // server readiness at shutdown.
+        let task = tokio::spawn(std::future::pending::<()>());
+        coordinator.host_eager_open_tasks.insert(
+            uri.clone(),
+            EagerOpenBatch {
+                generation: 0,
+                handles: vec![task.abort_handle()],
+            },
+        );
+        assert!(coordinator.host_eager_open_tasks.contains_key(&uri));
+
+        coordinator.abort_all_eager_open();
+
+        assert!(
+            coordinator.host_eager_open_tasks.is_empty(),
+            "host eager-open batch must be drained on shutdown"
+        );
+        tokio::task::yield_now().await;
+        assert!(task.is_finished(), "the host eager-open task was aborted");
+    }
 
     #[test]
     fn test_get_config_respects_bridge_filter() {

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -541,7 +541,6 @@ impl BridgeCoordinator {
         settings: &WorkspaceSettings,
         host_language: &str,
         host_uri: &Url,
-        language_id: &str,
         text: &str,
     ) {
         let configs = self.get_host_configs_for_language(settings, host_language);
@@ -556,7 +555,11 @@ impl BridgeCoordinator {
         for config in configs {
             let pool = self.pool_arc();
             let host_uri_owned = host_uri.clone();
-            let language_id = language_id.to_string();
+            // For a `_self` bridge the downstream `languageId` is the host language
+            // itself (consistent with the lazy request path's
+            // `HostRequestContext.language_id`), so derive it rather than taking a
+            // separate arg that a caller could transpose with `text`.
+            let language_id = host_language.to_string();
             let text = text.to_string();
             let server_name = config.server_name.clone();
             let server_config = config.config.clone();
@@ -573,11 +576,16 @@ impl BridgeCoordinator {
             handles.push(task.abort_handle());
         }
 
-        // Replace the previous batch (rare: a second didOpen without a didClose)
-        // and abort it. There's a residual window between the spawns above and this
-        // insert in which a concurrent didClose's cancel sees no entry — the same
-        // documented micro-window class as the region path, closed only by the
-        // deferred tombstone/epoch gate.
+        // Replace + abort the previous batch (rare: a second didOpen without a
+        // didClose). NOTE: unlike the region path — which inserts a placeholder
+        // under `supersede_eager_open_tasks` BEFORE spawning to close it — the host
+        // path leaves the spawn→insert window open: a concurrent didClose's
+        // `cancel_host_eager_open` between the spawns above and this insert finds no
+        // entry, so those tasks aren't aborted and one may `didOpen` after the doc's
+        // didClose. That residue is benign: the #421 push-accept guard checks the
+        // editor `DocumentStore` (not `host_documents`), so a closed doc can't show
+        // phantom diagnostics; the stale `host_documents` entry self-heals on
+        // reopen (same-fingerprint no-op) or on connection respawn (retain purge).
         if let Some(previous) = self.host_eager_open_tasks.insert(host_uri.clone(), handles) {
             for handle in previous {
                 if !handle.is_finished() {

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -92,6 +92,12 @@ pub(crate) struct BridgeCoordinator {
     /// - Host document is closed while tasks wait for server readiness
     /// - Rapid did_change events spawn many overlapping batches
     eager_open_tasks: DashMap<Url, EagerOpenBatch>,
+    /// Host-layer eager-open tasks, keyed by host document URI (#429). Separate
+    /// from `eager_open_tasks` because the host path fires on `didOpen` for the
+    /// real host doc (no injections, no per-`didChange` superseding), so a plain
+    /// abort-old-on-new per URI suffices. Cancelled on `didClose` (before the host
+    /// doc is closed) to avoid orphan-opening a doc whose `didClose` already ran.
+    host_eager_open_tasks: DashMap<Url, Vec<tokio::task::AbortHandle>>,
 }
 
 impl BridgeCoordinator {
@@ -105,6 +111,7 @@ impl BridgeCoordinator {
             cancel_forwarder,
             eager_open_generation: std::sync::atomic::AtomicU64::new(0),
             eager_open_tasks: DashMap::new(),
+            host_eager_open_tasks: DashMap::new(),
         }
     }
 
@@ -125,6 +132,7 @@ impl BridgeCoordinator {
             cancel_forwarder,
             eager_open_generation: std::sync::atomic::AtomicU64::new(0),
             eager_open_tasks: DashMap::new(),
+            host_eager_open_tasks: DashMap::new(),
         }
     }
 
@@ -518,6 +526,78 @@ impl BridgeCoordinator {
             // Register immediately — if concurrent cancel removed the entry
             // or the generation is stale, the handle is aborted instead of leaked.
             self.push_or_abort_eager_open_handle(host_uri, task.abort_handle(), generation);
+        }
+    }
+
+    /// Eagerly open the real host document on every `_self` host-bridge server for
+    /// `host_language` (host-document-bridge, #429), so a push-only host server
+    /// starts analyzing and pushing diagnostics on `didOpen` instead of only after
+    /// the first host-bridged request. Spawns one fire-and-forget task per server;
+    /// no-op (and cancels any prior batch) when host bridging is off for the
+    /// language. Re-syncing on `didChange` is deferred (push-only servers still see
+    /// edits via the lazy request-path sync — save/hover — not as-you-type).
+    pub(crate) fn eager_open_host_document_on_servers(
+        &self,
+        settings: &WorkspaceSettings,
+        host_language: &str,
+        host_uri: &Url,
+        language_id: &str,
+        text: &str,
+    ) {
+        let configs = self.get_host_configs_for_language(settings, host_language);
+        if configs.is_empty() {
+            // Host bridging off / no host server for this language — drop any
+            // prior batch so a stale open can't fire.
+            self.cancel_host_eager_open(host_uri);
+            return;
+        }
+
+        let mut handles = Vec::with_capacity(configs.len());
+        for config in configs {
+            let pool = self.pool_arc();
+            let host_uri_owned = host_uri.clone();
+            let language_id = language_id.to_string();
+            let text = text.to_string();
+            let server_name = config.server_name.clone();
+            let server_config = config.config.clone();
+            let task = tokio::spawn(async move {
+                pool.eager_open_host_document(
+                    &server_name,
+                    &server_config,
+                    &host_uri_owned,
+                    &language_id,
+                    &text,
+                )
+                .await;
+            });
+            handles.push(task.abort_handle());
+        }
+
+        // Replace the previous batch (rare: a second didOpen without a didClose)
+        // and abort it. There's a residual window between the spawns above and this
+        // insert in which a concurrent didClose's cancel sees no entry — the same
+        // documented micro-window class as the region path, closed only by the
+        // deferred tombstone/epoch gate.
+        if let Some(previous) = self.host_eager_open_tasks.insert(host_uri.clone(), handles) {
+            for handle in previous {
+                if !handle.is_finished() {
+                    handle.abort();
+                }
+            }
+        }
+    }
+
+    /// Abort and forget the host-layer eager-open tasks for `host_uri` (host
+    /// `didClose`). MUST run before the host document is closed so an in-flight
+    /// task still waiting for server readiness can't open a doc whose `didClose`
+    /// already ran.
+    pub(crate) fn cancel_host_eager_open(&self, host_uri: &Url) {
+        if let Some((_, handles)) = self.host_eager_open_tasks.remove(host_uri) {
+            for handle in handles {
+                if !handle.is_finished() {
+                    handle.abort();
+                }
+            }
         }
     }
 

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -527,7 +527,9 @@ impl LanguageServerPool {
     /// entry exists for that `(uri, server)`. Used to verify host-layer eager open.
     #[cfg(test)]
     pub(crate) async fn is_host_document_opened(&self, host_uri: &Url, server_name: &str) -> bool {
-        let key = host_uri.as_str().to_owned();
+        // Key exactly as `sync_host_document` does (`doc.uri.to_string()`) so the
+        // lookup can never diverge from the map's key construction.
+        let key = host_uri.to_string();
         self.host_documents()
             .await
             .keys()

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -522,6 +522,18 @@ impl LanguageServerPool {
         self.document_tracker.is_document_opened(virtual_uri)
     }
 
+    /// Whether the host document at `host_uri` has been synced (didOpen sent) to a
+    /// `_self` host server named `server_name` — i.e. a `host_documents` sync-state
+    /// entry exists for that `(uri, server)`. Used to verify host-layer eager open.
+    #[cfg(test)]
+    pub(crate) async fn is_host_document_opened(&self, host_uri: &Url, server_name: &str) -> bool {
+        let key = host_uri.to_string();
+        self.host_documents()
+            .await
+            .keys()
+            .any(|(uri, connection_key)| uri == &key && connection_key.server() == server_name)
+    }
+
     /// Resolve a virtual-document URI string to its `(host_url, region_id)`
     /// (used by `window/showDocument` translation). See
     /// [`DocumentTracker::resolve_virtual_uri`].

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -527,7 +527,7 @@ impl LanguageServerPool {
     /// entry exists for that `(uri, server)`. Used to verify host-layer eager open.
     #[cfg(test)]
     pub(crate) async fn is_host_document_opened(&self, host_uri: &Url, server_name: &str) -> bool {
-        let key = host_uri.to_string();
+        let key = host_uri.as_str().to_owned();
         self.host_documents()
             .await
             .keys()

--- a/src/lsp/bridge/pool/connection_key.rs
+++ b/src/lsp/bridge/pool/connection_key.rs
@@ -84,6 +84,12 @@ impl ConnectionKey {
     pub(crate) fn for_server(server: impl Into<String>) -> Self {
         Self::new(server, None)
     }
+
+    /// The config server name (the `language_servers` map key).
+    #[cfg(test)]
+    pub(crate) fn server(&self) -> &str {
+        &self.server
+    }
 }
 
 impl fmt::Display for ConnectionKey {

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -100,6 +100,74 @@ impl LanguageServerPool {
             }
         }
     }
+
+    /// Fire `didOpen` for the real host document on a `_self` host-bridge server
+    /// (host-document-bridge), so a push-only host server (no `textDocument/diagnostic`
+    /// support) starts analyzing and pushing diagnostics immediately, instead of
+    /// only after the first host-bridged request lazily opens it. Fire-and-forget:
+    /// failures are logged at debug and never propagated.
+    pub(crate) async fn eager_open_host_document(
+        &self,
+        server_name: &str,
+        server_config: &crate::config::settings::BridgeServerConfig,
+        host_uri: &url::Url,
+        language_id: &str,
+        text: &str,
+    ) {
+        let handle = match self
+            .get_or_create_connection_wait_ready(
+                server_name,
+                server_config,
+                Some(host_uri),
+                Duration::from_secs(INIT_TIMEOUT_SECS),
+            )
+            .await
+        {
+            Ok(h) => h,
+            Err(e) => {
+                log::debug!(
+                    target: "kakehashi::bridge",
+                    "Eager host open: server {} not ready for {}: {}",
+                    server_name,
+                    host_uri,
+                    e
+                );
+                return;
+            }
+        };
+
+        let connection_key = handle.key().clone();
+        // Sync (sends didOpen) under the `connections` + `host_documents` locks in
+        // that order, with the live-handle `Arc::ptr_eq` check — identical to
+        // `execute_host_request`, so a concurrent respawn purge cannot interleave
+        // and leave sync state the replacement never saw.
+        let connections = self.connections().await;
+        if !connections
+            .get(&connection_key)
+            .is_some_and(|current| Arc::ptr_eq(current, &handle))
+        {
+            // Replaced by a respawn between wait-ready and here; the new connection
+            // will sync lazily on its first request.
+            return;
+        }
+        let mut docs = self.host_documents().await;
+        let mut sender = ConnectionHandleSender(&handle);
+        let doc = super::host::HostDocument {
+            uri: host_uri,
+            language_id,
+            text,
+        };
+        if let Err(e) = super::host::sync_host_document(&mut sender, &mut docs, &doc, &connection_key).await
+        {
+            log::debug!(
+                target: "kakehashi::bridge",
+                "Eager host open: didOpen failed for {} on {}: {}",
+                host_uri,
+                server_name,
+                e
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -157,7 +157,8 @@ impl LanguageServerPool {
             language_id,
             text,
         };
-        if let Err(e) = super::host::sync_host_document(&mut sender, &mut docs, &doc, &connection_key).await
+        if let Err(e) =
+            super::host::sync_host_document(&mut sender, &mut docs, &doc, &connection_key).await
         {
             log::debug!(
                 target: "kakehashi::bridge",

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -136,14 +136,16 @@ impl LanguageServerPool {
             }
         };
 
-        let connection_key = handle.key().clone();
+        // Borrow the key (no clone) — both `connections.get` and `sync_host_document`
+        // take it by reference, like `execute_host_request`.
+        let connection_key = handle.key();
         // Sync (sends didOpen) under the `connections` + `host_documents` locks in
         // that order, with the live-handle `Arc::ptr_eq` check — identical to
         // `execute_host_request`, so a concurrent respawn purge cannot interleave
         // and leave sync state the replacement never saw.
         let connections = self.connections().await;
         if !connections
-            .get(&connection_key)
+            .get(connection_key)
             .is_some_and(|current| Arc::ptr_eq(current, &handle))
         {
             // Replaced by a respawn between wait-ready and here; the new connection
@@ -158,7 +160,7 @@ impl LanguageServerPool {
             text,
         };
         if let Err(e) =
-            super::host::sync_host_document(&mut sender, &mut docs, &doc, &connection_key).await
+            super::host::sync_host_document(&mut sender, &mut docs, &doc, connection_key).await
         {
             log::debug!(
                 target: "kakehashi::bridge",

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -69,7 +69,7 @@ fn fingerprint(text: &str) -> u64 {
 /// (ls-bridge-message-ordering) guarantees wire order matches enqueue order.
 /// Generic over [`MessageSender`] so tests can observe the notifications via
 /// a channel.
-async fn sync_host_document<S: MessageSender>(
+pub(super) async fn sync_host_document<S: MessageSender>(
     sender: &mut S,
     docs: &mut std::collections::HashMap<(String, ConnectionKey), HostDocSyncState>,
     doc: &HostDocument<'_>,

--- a/src/lsp/lsp_impl/text_document/did_close.rs
+++ b/src/lsp/lsp_impl/text_document/did_close.rs
@@ -51,8 +51,12 @@ impl Kakehashi {
         // Cancel any pending debounced diagnostic for this document (pull-first-diagnostic-forwarding Phase 3)
         self.debounced_diagnostics.cancel(&uri);
 
-        // Cancel any eager-open tasks for this document (prevents orphaned didOpen)
+        // Cancel any eager-open tasks for this document (prevents orphaned didOpen).
+        // Host-layer eager-open is cancelled here too — BEFORE close_host_bridge_document
+        // below — so an in-flight host eager-open still waiting for server readiness
+        // can't open a host doc whose didClose already ran (#429).
         self.bridge.cancel_eager_open(&uri);
+        self.bridge.cancel_host_eager_open(&uri);
 
         // Close all virtual documents associated with this host document
         // This sends didClose notifications to downstream language servers

--- a/src/lsp/lsp_impl/text_document/did_close.rs
+++ b/src/lsp/lsp_impl/text_document/did_close.rs
@@ -52,9 +52,10 @@ impl Kakehashi {
         self.debounced_diagnostics.cancel(&uri);
 
         // Cancel any eager-open tasks for this document (prevents orphaned didOpen).
-        // Host-layer eager-open is cancelled here too — BEFORE close_host_bridge_document
-        // below — so an in-flight host eager-open still waiting for server readiness
-        // can't open a host doc whose didClose already ran (#429).
+        // Host-layer eager-open is cancelled here too — before `close_host_bridge_document`
+        // (the host-server didClose, further below) — so an in-flight host eager-open
+        // still waiting for server readiness can't open a host doc whose didClose
+        // already ran (#429).
         self.bridge.cancel_eager_open(&uri);
         self.bridge.cancel_host_eager_open(&uri);
 

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -104,7 +104,7 @@ impl Kakehashi {
         if let Some(ref lang) = language_name {
             let settings = self.settings_manager.load_settings();
             self.bridge
-                .eager_open_host_document_on_servers(&settings, lang, &uri, lang, &text);
+                .eager_open_host_document_on_servers(&settings, lang, &uri, &text);
         }
 
         // pull-first-diagnostic-forwarding Phase 2: Trigger synthetic diagnostic push on didOpen
@@ -273,6 +273,8 @@ print("hello")
         language_servers.insert(
             "rust_ls".to_string(),
             BridgeServerConfig {
+                // Inert: `insert_ready_test_connection` below pre-inserts a Ready
+                // handle, so this cmd is never actually spawned.
                 cmd: vec![
                     "sh".to_string(),
                     "-c".to_string(),
@@ -306,20 +308,13 @@ print("hello")
             ..Default::default()
         });
 
-        server
-            .bridge
-            .insert_ready_test_connection("rust_ls")
-            .await;
+        server.bridge.insert_ready_test_connection("rust_ls").await;
 
         let uri = Url::parse("file:///test/host_eager.rs").unwrap();
         let settings = server.settings_manager.load_settings();
-        server.bridge.eager_open_host_document_on_servers(
-            &settings,
-            "rust",
-            &uri,
-            "rust",
-            "fn main() {}",
-        );
+        server
+            .bridge
+            .eager_open_host_document_on_servers(&settings, "rust", &uri, "fn main() {}");
 
         timeout(Duration::from_secs(1), async {
             loop {

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -96,6 +96,17 @@ impl Kakehashi {
             .process_injections(&uri, false)
             .await;
 
+        // Host-layer eager-open (#429): open the real host document on any `_self`
+        // host-bridge server so a push-only host server (e.g. lua-language-server)
+        // starts analyzing and pushing diagnostics on open, instead of only after
+        // the first host-bridged request lazily opens it. No-op when host bridging
+        // is off for the language; spawns fire-and-forget tasks (non-blocking).
+        if let Some(ref lang) = language_name {
+            let settings = self.settings_manager.load_settings();
+            self.bridge
+                .eager_open_host_document_on_servers(&settings, lang, &uri, lang, &text);
+        }
+
         // pull-first-diagnostic-forwarding Phase 2: Trigger synthetic diagnostic push on didOpen
         // This provides proactive diagnostics for clients that don't support pull diagnostics.
         self.diagnostic_scheduler()
@@ -116,7 +127,9 @@ mod tests {
 
     use super::*;
     use crate::config::WorkspaceSettings;
-    use crate::config::settings::BridgeServerConfig;
+    use crate::config::settings::{
+        BridgeLanguageConfig, BridgeServerConfig, HOST_BRIDGE_KEY, LanguageSettings,
+    };
     use crate::lsp::bridge::VirtualDocumentUri;
     use tokio::time::{Duration, timeout};
     use tower_lsp_server::LspService;
@@ -239,5 +252,89 @@ print("hello")
             server.bridge.pool().is_document_opened(&virtual_uri),
             "did_open should eagerly open the parsed injection as a virtual document"
         );
+    }
+
+    /// Host-layer eager-open (#429): the host document is opened (didOpen sent) on
+    /// a `_self` host server directly by the eager-open path. Exercised in
+    /// isolation via `eager_open_host_document_on_servers` (not `did_open_impl`)
+    /// so the host-event synthetic diagnostic pull — which would also open the doc
+    /// — can't mask whether eager-open itself works.
+    #[tokio::test]
+    async fn eager_open_sends_didopen_to_self_host_server() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("rust".to_string(), tree_sitter_rust::LANGUAGE.into());
+
+        let mut language_servers = HashMap::new();
+        language_servers.insert(
+            "rust_ls".to_string(),
+            BridgeServerConfig {
+                cmd: vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    "cat > /dev/null".to_string(),
+                ],
+                languages: vec!["rust".to_string()],
+                initialization_options: None,
+                root_markers: None,
+                on_type_formatting_triggers: None,
+                prefer_shared_instance: None,
+            },
+        );
+        let mut languages = HashMap::new();
+        languages.insert(
+            "rust".to_string(),
+            LanguageSettings {
+                bridge: Some(HashMap::from([(
+                    HOST_BRIDGE_KEY.to_string(),
+                    BridgeLanguageConfig {
+                        enabled: Some(true),
+                        aggregation: None,
+                    },
+                )])),
+                ..Default::default()
+            },
+        );
+        server.settings_manager.apply_settings(WorkspaceSettings {
+            auto_install: false,
+            language_servers,
+            languages,
+            ..Default::default()
+        });
+
+        server
+            .bridge
+            .insert_ready_test_connection("rust_ls")
+            .await;
+
+        let uri = Url::parse("file:///test/host_eager.rs").unwrap();
+        let settings = server.settings_manager.load_settings();
+        server.bridge.eager_open_host_document_on_servers(
+            &settings,
+            "rust",
+            &uri,
+            "rust",
+            "fn main() {}",
+        );
+
+        timeout(Duration::from_secs(1), async {
+            loop {
+                if server
+                    .bridge
+                    .pool()
+                    .is_host_document_opened(&uri, "rust_ls")
+                    .await
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("eager-open should send didOpen for the host document to the _self host server");
     }
 }


### PR DESCRIPTION
## What

Closes #429. A push-only `_self` host-bridge server (e.g. **lua-language-server**,
no `textDocument/diagnostic`) only pushes diagnostics once the host document is
open on it — but host sync was lazy (the doc opened on the first host-bridged
request). So opening a `.lua` file showed no host diagnostics until the first
hover/completion/diagnostic-pull. Builds on the merged #421 host-layer push.

- `LanguageServerPool::eager_open_host_document`: waits for the server ready, then
  sends `didOpen` via `sync_host_document` under the `connections` + `host_documents`
  locks with the live-handle `Arc::ptr_eq` check (mirrors `execute_host_request`).
- `BridgeCoordinator::eager_open_host_document_on_servers`: spawns one task per
  `_self` host server using the region path's generation/placeholder batch shape
  (`host_eager_open_tasks` + `host_eager_open_generation`); `cancel_host_eager_open`
  (didClose) and `abort_all_eager_open` (shutdown) both drain it.
- `did_open_impl`: after `process_injections`, eager-open the host doc on `_self`
  servers (no-op when host bridging is off; non-blocking).
- `did_close_impl`: `cancel_host_eager_open` before `close_host_bridge_document`.

## Verification

`eager_open_sends_didopen_to_self_host_server` exercises the eager-open in
isolation (calls the coordinator method directly, not `did_open_impl`, so the
synthetic diagnostic pull — which would also open the doc — can't mask it).
`abort_all_eager_open_drains_host_batch` covers shutdown draining the host batch.

## Deferred (documented in code + ADRs, tracked)

- **On-edit eager re-sync** to push-only host servers (as-you-type) — **#431**,
  gated on capability classification (#425). Push-only host servers currently see
  edits via the lazy request-path sync (save/hover), not per-keystroke.
- **Eager-open task-body-before-registration window** (#435): the generation/
  placeholder shape closes the *registration* leak, but a task whose body starts
  on another worker before its handle registers can still send a didOpen after a
  concurrent cancel/shutdown. Identical to the merged region eager-open path,
  bounded and benign (the #421 push-accept guard reads the editor DocumentStore →
  no phantom diagnostics; orphan connection/host_documents clears on reopen/
  respawn). Left parallel to region; to be closed for both paths together.

## Note

This spawns a host language server on every host-bridged `didOpen` (intended —
that's what makes on-open diagnostics work for push-only servers).

## Review
Passed multi-perspective subagent `/review` (2 rounds) and Codex MCP review
(found + fixed a shutdown-abort gap and a spawn→register leak; converged to
"no comments to provide").

🤖 Generated with [Claude Code](https://claude.com/claude-code)