### PR TITLE
test(e2e): isolate XDG_CONFIG_HOME for the spawned LSP server

### DIFF
--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -63,14 +63,18 @@ fn test_data_dir() -> &'static Path {
 ///
 /// The directory is left empty: the server's `$XDG_CONFIG_HOME/kakehashi`
 /// lookup simply finds nothing and falls back to built-in defaults.
+///
+/// Uses a unique per-process [`tempfile::TempDir`] rather than a fixed path so
+/// the isolation is deterministic: a fixed shared path could already hold stale
+/// contents from a prior or concurrent run (re-introducing the very pollution
+/// this guards against) or collide on permissions across users. The `TempDir`
+/// is parked in a `static` so it outlives every spawned server for the whole
+/// test process; it is intentionally never dropped (statics aren't), so no
+/// cleanup can race a still-running server.
 fn isolated_config_dir() -> &'static Path {
-    static DIR: OnceLock<PathBuf> = OnceLock::new();
-    DIR.get_or_init(|| {
-        let dir = std::env::temp_dir().join("kakehashi-e2e-empty-xdg-config");
-        let _ = std::fs::create_dir_all(&dir);
-        dir
-    })
-    .as_path()
+    static DIR: OnceLock<tempfile::TempDir> = OnceLock::new();
+    DIR.get_or_init(|| tempfile::tempdir().expect("create temp dir for XDG_CONFIG_HOME isolation"))
+        .path()
 }
 
 /// LSP client for communicating with kakehashi binary.

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -52,6 +52,27 @@ fn test_data_dir() -> &'static Path {
     dir.as_path()
 }
 
+/// Empty `XDG_CONFIG_HOME` for the spawned server, so it never reads the
+/// developer's real `~/.config/kakehashi`. Inherited user config changes the
+/// server's behavior under test — e.g. a host-bridging entry flips the
+/// willSave/willSaveWaitUntil capability gate and breaks the
+/// `initialize_capabilities` snapshot — so isolation must hold regardless of
+/// how the test is invoked (`make test_e2e`, a bare `cargo test`, or the
+/// pre-commit gate). Doing it here, rather than in the Makefile, is the only
+/// place that covers all three.
+///
+/// The directory is left empty: the server's `$XDG_CONFIG_HOME/kakehashi`
+/// lookup simply finds nothing and falls back to built-in defaults.
+fn isolated_config_dir() -> &'static Path {
+    static DIR: OnceLock<PathBuf> = OnceLock::new();
+    DIR.get_or_init(|| {
+        let dir = std::env::temp_dir().join("kakehashi-e2e-empty-xdg-config");
+        let _ = std::fs::create_dir_all(&dir);
+        dir
+    })
+    .as_path()
+}
+
 /// LSP client for communicating with kakehashi binary.
 ///
 /// Handles JSON-RPC 2.0 message framing with Content-Length headers,
@@ -165,6 +186,7 @@ impl LspClientBuilder {
             cmd.env_remove(key);
         }
         cmd.env("KAKEHASHI_DATA_DIR", test_data_dir());
+        cmd.env("XDG_CONFIG_HOME", isolated_config_dir());
         for (key, value) in &self.envs {
             cmd.env(key, value);
         }
@@ -307,6 +329,7 @@ impl LspClient {
         // and points to the built `kakehashi` binary, so we don't hardcode its path here.
         let mut cmd = Command::new(env!("CARGO_BIN_EXE_kakehashi"));
         cmd.env("KAKEHASHI_DATA_DIR", test_data_dir())
+            .env("XDG_CONFIG_HOME", isolated_config_dir())
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());


### PR DESCRIPTION
## Problem

`make test_e2e` (and a bare `cargo test --features e2e`) fails on any machine that has a real `~/.config/kakehashi`. The e2e LSP tests spawn the kakehashi binary, which discovers user config under `$XDG_CONFIG_HOME/kakehashi`. A host-bridging entry in that config flips the `willSave`/`willSaveWaitUntil` capability gate (`#357`), which changes the advertised capabilities and breaks the `initialize_capabilities` snapshot:

```
    "change": 2,
+   "willSave": true,
+   "willSaveWaitUntil": true,
    "save": { ... }
```

This is config pollution, not a real change — the committed snapshot is correct.

## Fix

Isolate `XDG_CONFIG_HOME` in the spawn helper (`tests/helpers/lsp_client.rs`), next to the existing `KAKEHASHI_DATA_DIR` isolation, rather than in the Makefile. This way isolation holds for **every** invocation path:

- `make test_e2e` / `make test_all`
- a bare `cargo test` of a single case (e.g. when debugging one test)
- the pre-commit gate

The server is pointed at an empty, dedicated `XDG_CONFIG_HOME` as an **overridable default** (set before per-test envs), so:

- the implicit user-config discovery path is neutralized, and
- tests that inject config via `--config-file` (e.g. `e2e_host_bridge.rs`, which asserts `willSave` *is* advertised when host-bridging is enabled) keep working unchanged.

## Verification

- `cargo test --features e2e --test e2e_lsp_protocol test_initialize_returns_capabilities` passes with a real `~/.config/kakehashi` present (previously failed).
- Full `cargo test --features e2e --test 'e2e_*'` passes (0 failures), including all `e2e_host_bridge` capability assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)