### PR TITLE
feat(bridge): re-sync host doc to push-only _self servers on edit (#431)

### DIFF
--- a/docs/architecture-decisions/host-document-bridge.md
+++ b/docs/architecture-decisions/host-document-bridge.md
@@ -92,9 +92,10 @@ Partially implemented:
   (push-propagation-diagnostic-forwarding, #421) — accepted when the URI names an
   open host-bridged document. The host document is opened eagerly on each `_self`
   host server at host `didOpen` (#429), so a push-only host server pushes on open
-  rather than only after the first request. On-edit re-sync to push-only host
-  servers without a host request (as-you-type) is still deferred — they see edits
-  via the lazy request-path sync (save / hover).
+  rather than only after the first request; and it is re-synced on edit at the
+  debounced diagnostic cadence (#431), so a push-only host server (skipped by the
+  capability-gated pull) re-analyzes current text rather than stale text after a
+  change.
 
 ## Context
 

--- a/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
+++ b/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
@@ -244,12 +244,12 @@ policy clean:
   correct positions; this supplies the missing trigger.
 - **Host layer**: the `_self` host source uses the identical model keyed on the
   *host document's* content epoch. Push-driven `_self` servers are eagerly opened
-  on host `didOpen` (#429, implemented; see Lifecycle). Eager **re-sync** on a
-  content-changing host `didChange` — so a push-only host server re-analyzes
-  as-you-type without a host request — is deferred (#431); until then it sees
-  edits only via the lazy request-path sync (save / hover). When that lands (the
-  host path's fingerprint already gates the didChange), the gate and re-merge
-  rules above apply unchanged.
+  on host `didOpen` (#429) and eagerly **re-synced** on edit at the debounced
+  diagnostic cadence (#431) — `eager_sync_host_document_on_servers` runs when the
+  debounce fires, so a push-only host server (skipped by the capability-gated
+  pull) re-analyzes current text rather than stale text. The host path's
+  fingerprint gates the actual didChange; the gate and re-merge rules above apply
+  unchanged.
 
 ### `preferred` as a push stream
 
@@ -499,9 +499,12 @@ because the #380 benefit now outweighs it:
 - Host-layer eager-open (#429): on host `didOpen`, the host document is opened
   eagerly on each `_self` host server (`eager_open_host_document_on_servers`), so
   a push-only host server analyzes + pushes on open rather than only after the
-  first host-bridged request lazily opens it. On-edit re-sync to push-only host
-  servers (as-you-type, without a host request) is still deferred — they see
-  edits via the lazy request-path sync (save / hover), not per-keystroke.
+  first host-bridged request lazily opens it.
+- Host-layer on-edit re-sync (#431): when the debounced diagnostic fires after an
+  edit, `eager_sync_host_document_on_servers` re-syncs the host doc to its `_self`
+  servers, so a push-only host server (skipped by the capability-gated pull)
+  re-analyzes current text. Runs at the debounce cadence (after typing settles),
+  not per-keystroke; pull-capable servers fingerprint-dedup the extra sync.
 
 **Deferred** (staged follow-ups; the code documents each at its site):
 
@@ -510,9 +513,6 @@ because the #380 benefit now outweighs it:
   (lazy re-anchor still keeps *positions* current via the retained pull trigger).
 - Per-source strategy fan-in (`preferred` sticky / `concatenated` visible-walk);
   the staged merge concatenates, with HashMap-nondeterministic cross-source order.
-- On-edit eager re-sync of the host doc to push-only `_self` servers (so they
-  re-analyze as-you-type without a host request); gated on capability
-  classification so pull-capable host servers aren't sent redundant didChanges.
 - Region-invalidation and crash cache eviction.
 - The `pullFallback` / `pushFallback` config toggles and the capability
   classification — without the latter the pull feed and a server's spontaneous

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -545,10 +545,8 @@ impl BridgeCoordinator {
     /// Eagerly open the real host document on every `_self` host-bridge server for
     /// `host_language` (host-document-bridge, #429), so a push-only host server
     /// starts analyzing and pushing diagnostics on `didOpen` instead of only after
-    /// the first host-bridged request. Spawns one fire-and-forget task per server;
-    /// no-op (and cancels any prior batch) when host bridging is off for the
-    /// language. Re-syncing on `didChange` is deferred (push-only servers still see
-    /// edits via the lazy request-path sync — save/hover — not as-you-type).
+    /// the first host-bridged request. No-op (and cancels any prior batch) when
+    /// host bridging is off for the language.
     pub(crate) fn eager_open_host_document_on_servers(
         &self,
         settings: &WorkspaceSettings,
@@ -557,9 +555,30 @@ impl BridgeCoordinator {
         text: &str,
     ) {
         let configs = self.get_host_configs_for_language(settings, host_language);
+        self.eager_sync_host_document_on_servers(host_uri, host_language, text, configs);
+    }
+
+    /// Sync the real host document to a resolved set of `_self` host servers
+    /// (host-document-bridge). `sync_host_document` sends `didOpen` the first time
+    /// and a versioned `didChange` when the text changed, so this is used both for
+    /// the eager open on `didOpen` (#429) and the eager **re-sync on edit** at the
+    /// debounced diagnostic cadence (#431) — the latter is what keeps a push-only
+    /// host server (skipped by the capability-gated pull) analyzing current text
+    /// rather than stale text. Spawns one fire-and-forget task per server; no-op
+    /// (and cancels any prior batch) when `configs` is empty.
+    ///
+    /// `language_id` is the downstream `languageId` — for a `_self` bridge that is
+    /// the host language itself (consistent with `HostRequestContext.language_id`).
+    pub(crate) fn eager_sync_host_document_on_servers(
+        &self,
+        host_uri: &Url,
+        language_id: &str,
+        text: &str,
+        configs: Vec<ResolvedServerConfig>,
+    ) {
         if configs.is_empty() {
             // Host bridging off / no host server for this language — drop any
-            // prior batch so a stale open can't fire.
+            // prior batch so a stale sync can't fire.
             self.cancel_host_eager_open(host_uri);
             return;
         }
@@ -570,18 +589,14 @@ impl BridgeCoordinator {
         // (didClose) or `abort_all_eager_open` (shutdown) removed the entry, a
         // handle registered afterwards is aborted on the spot. It does NOT prevent
         // a task whose body already started on another worker before registration
-        // from sending its didOpen — that residual is identical to the region path
-        // (see the field doc), bounded and benign; left open for parity.
+        // from sending its didOpen/didChange — that residual is identical to the
+        // region path (see the field doc), bounded and benign; left open for parity.
         let generation = self.supersede_host_eager_open(host_uri);
 
         // Share the text + languageId across per-server tasks via `Arc<str>` rather
         // than cloning the (potentially large) document text once per host server.
-        // For a `_self` bridge the downstream `languageId` is the host language
-        // itself (consistent with the lazy request path's
-        // `HostRequestContext.language_id`), so derive it rather than taking a
-        // separate arg that a caller could transpose with `text`.
         let text: Arc<str> = Arc::from(text);
-        let language_id: Arc<str> = Arc::from(host_language);
+        let language_id: Arc<str> = Arc::from(language_id);
         for config in configs {
             let pool = self.pool_arc();
             let host_uri_owned = host_uri.clone();

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -555,7 +555,7 @@ impl BridgeCoordinator {
         text: &str,
     ) {
         let configs = self.get_host_configs_for_language(settings, host_language);
-        self.eager_sync_host_document_on_servers(host_uri, host_language, text, configs);
+        self.eager_sync_host_document_on_servers(host_uri, host_language, Arc::from(text), configs);
     }
 
     /// Sync the real host document to a resolved set of `_self` host servers
@@ -569,11 +569,14 @@ impl BridgeCoordinator {
     ///
     /// `language_id` is the downstream `languageId` — for a `_self` bridge that is
     /// the host language itself (consistent with `HostRequestContext.language_id`).
+    /// `text` is taken as `Arc<str>` so the debounced re-sync path can hand over its
+    /// existing `HostRequestContext.text` allocation (a cheap clone) rather than
+    /// copying the full document on every fire.
     pub(crate) fn eager_sync_host_document_on_servers(
         &self,
         host_uri: &Url,
         language_id: &str,
-        text: &str,
+        text: Arc<str>,
         configs: Vec<ResolvedServerConfig>,
     ) {
         if configs.is_empty() {
@@ -609,7 +612,8 @@ impl BridgeCoordinator {
 
         // Share the text + languageId across per-server tasks via `Arc<str>` rather
         // than cloning the (potentially large) document text once per host server.
-        let text: Arc<str> = Arc::from(text);
+        // `text` already arrives as `Arc<str>` (the debounce path hands over its
+        // `HostRequestContext.text` without copying).
         let language_id: Arc<str> = Arc::from(language_id);
         for config in configs {
             let pool = self.pool_arc();

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -591,6 +591,20 @@ impl BridgeCoordinator {
         // a task whose body already started on another worker before registration
         // from sending its didOpen/didChange — that residual is identical to the
         // region path (see the field doc), bounded and benign; left open for parity.
+        //
+        // On-edit re-sync carries *different* text per fire, so a superseded task
+        // emitting after a newer one could in principle roll the host server back to
+        // older text (a higher version with stale content). The supersede above
+        // closes the common case: each task's only blocking point before the sync is
+        // `get_or_create_connection_wait_ready` (an `.await` on `wait_for_ready`), so
+        // `abort()` cancels a parked older task *there*, before it reaches
+        // `sync_host_document`; and debounce fires are ≥500ms apart, far wider than
+        // the µs spawn→register window, so the prior fire's handle is already
+        // registered (hence abortable) when the next fire supersedes. The only
+        // residual is a µs alignment — an older task unblocking from wait-ready at
+        // the exact instant a newer fire's task reaches the (await-free) sync — which
+        // is the deferred `content_epoch` stale-overwrite window (#422), not a new
+        // bug class; it self-heals on the next edit.
         let generation = self.supersede_host_eager_open(host_uri);
 
         // Share the text + languageId across per-server tasks via `Arc<str>` rather

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -536,6 +536,26 @@ impl LanguageServerPool {
             .any(|(uri, connection_key)| uri == &key && connection_key.server() == server_name)
     }
 
+    /// The current sync version of the host document at `host_uri` on `server_name`,
+    /// or `None` if not synced. `sync_host_document` sets v1 on the didOpen and
+    /// bumps it on each content-changing didChange — so a value > 1 proves a re-sync
+    /// happened. Used to verify on-edit host re-sync (#431).
+    #[cfg(test)]
+    pub(crate) async fn host_document_version(
+        &self,
+        host_uri: &Url,
+        server_name: &str,
+    ) -> Option<i32> {
+        let key = host_uri.to_string();
+        self.host_documents()
+            .await
+            .iter()
+            .find(|((uri, connection_key), _)| {
+                uri == &key && connection_key.server() == server_name
+            })
+            .map(|(_, state)| state.version)
+    }
+
     /// Resolve a virtual-document URI string to its `(host_url, region_id)`
     /// (used by `window/showDocument` translation). See
     /// [`DocumentTracker::resolve_virtual_uri`].

--- a/src/lsp/debounced_diagnostics.rs
+++ b/src/lsp/debounced_diagnostics.rs
@@ -216,8 +216,12 @@ async fn execute_debounced_diagnostic(data: DebouncedDiagnosticData) {
     // tasks and returns) so it never head-of-line-blocks the pull on a slow
     // server's readiness; pull-capable servers fingerprint-dedup the extra sync.
     if let Some(host) = snapshot_data.as_ref().and_then(|s| s.host.as_ref()) {
+        // Sync target comes from the host context itself (`host.uri`), not the
+        // outer scheduled `uri` — they're equal today, but keying off the host
+        // context keeps the sync correct if a scheduled URI ever differs from its
+        // host document.
         bridge.eager_sync_host_document_on_servers(
-            &uri,
+            &host.uri,
             &host.language_id,
             &host.text,
             host.configs.clone(),

--- a/src/lsp/debounced_diagnostics.rs
+++ b/src/lsp/debounced_diagnostics.rs
@@ -223,7 +223,7 @@ async fn execute_debounced_diagnostic(data: DebouncedDiagnosticData) {
         bridge.eager_sync_host_document_on_servers(
             &host.uri,
             &host.language_id,
-            &host.text,
+            host.text.clone(),
             host.configs.clone(),
         );
     }

--- a/src/lsp/debounced_diagnostics.rs
+++ b/src/lsp/debounced_diagnostics.rs
@@ -15,7 +15,7 @@ use dashmap::DashMap;
 use tokio::task::AbortHandle;
 use url::Url;
 
-use super::bridge::LanguageServerPool;
+use super::bridge::{BridgeCoordinator, LanguageServerPool};
 
 use super::lsp_impl::DiagnosticPublisher;
 use super::lsp_impl::text_document::publish_diagnostic::{
@@ -43,6 +43,9 @@ struct DebouncedDiagnosticData {
     snapshot_data: Option<DiagnosticSnapshot>,
     /// Bridge pool for sending diagnostic requests
     bridge_pool: Arc<LanguageServerPool>,
+    /// Bridge coordinator — used to eager re-sync the host document to `_self`
+    /// host servers at the debounced cadence (#431).
+    bridge: Arc<BridgeCoordinator>,
     /// Reference to synthetic diagnostics manager for task registration
     synthetic_diagnostics: Arc<SyntheticDiagnosticsManager>,
     /// The single proactive publisher: feeds the pull result into the cache and
@@ -94,6 +97,7 @@ impl DebouncedDiagnosticsManager {
         uri: Url,
         snapshot_data: Option<DiagnosticSnapshot>,
         bridge_pool: Arc<LanguageServerPool>,
+        bridge: Arc<BridgeCoordinator>,
         synthetic_diagnostics: Arc<SyntheticDiagnosticsManager>,
         publisher: Arc<DiagnosticPublisher>,
     ) {
@@ -119,6 +123,7 @@ impl DebouncedDiagnosticsManager {
             uri: uri.clone(),
             snapshot_data,
             bridge_pool,
+            bridge,
             synthetic_diagnostics,
             publisher,
         };
@@ -199,9 +204,25 @@ async fn execute_debounced_diagnostic(data: DebouncedDiagnosticData) {
         uri,
         snapshot_data,
         bridge_pool,
+        bridge,
         synthetic_diagnostics,
         publisher,
     } = data;
+
+    // #431: re-sync the host document to its `_self` host servers at this debounced
+    // cadence (after the user stops typing), so a push-only host server — which the
+    // capability-gated pull below skips — re-analyzes the current text and pushes
+    // fresh diagnostics instead of stale ones. Fire-and-forget (spawns per-server
+    // tasks and returns) so it never head-of-line-blocks the pull on a slow
+    // server's readiness; pull-capable servers fingerprint-dedup the extra sync.
+    if let Some(host) = snapshot_data.as_ref().and_then(|s| s.host.as_ref()) {
+        bridge.eager_sync_host_document_on_servers(
+            &uri,
+            &host.language_id,
+            &host.text,
+            host.configs.clone(),
+        );
+    }
 
     // Spawn the actual diagnostic task (similar to DiagnosticScheduler::spawn_synthetic_diagnostic_task)
     // This task is registered with SyntheticDiagnosticsManager for superseding

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -53,6 +53,7 @@ impl DiagnosticScheduler {
             uri,
             snapshot_data,
             self.bridge.pool_arc(),
+            std::sync::Arc::clone(&self.bridge),
             std::sync::Arc::clone(&self.synthetic_diagnostics),
             std::sync::Arc::clone(&self.publisher),
         );

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -402,4 +402,77 @@ print("hello")
         .await
         .expect("re-sync with changed text should send a didChange advancing to version 2");
     }
+
+    /// On-edit re-sync wiring (#431): when the debounced diagnostic *fires*,
+    /// `execute_debounced_diagnostic` re-syncs the host doc to its `_self` servers
+    /// via the coordinator. Drives `DebouncedDiagnosticsManager::schedule` with a
+    /// zero debounce and a host snapshot, then asserts the host doc gets synced.
+    /// The test `rust_ls` connection advertises no `diagnosticProvider`, so the
+    /// capability-gated pull skips it — only the eager-sync hook can sync it, which
+    /// isolates the wiring (removing the hook would fail this test).
+    #[tokio::test]
+    async fn debounced_fire_resyncs_host_document() {
+        use crate::config::settings::{AggregationStrategy, LayerSource, ResolvedLayerConfig};
+        use crate::lsp::debounced_diagnostics::DebouncedDiagnosticsManager;
+        use crate::lsp::lsp_impl::DiagnosticPublisher;
+        use crate::lsp::lsp_impl::bridge_context::HostRequestContext;
+        use crate::lsp::lsp_impl::text_document::publish_diagnostic::DiagnosticSnapshot;
+        use crate::lsp::synthetic_diagnostics::SyntheticDiagnosticsManager;
+
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        configure_rust_self_host(server);
+        server.bridge.insert_ready_test_connection("rust_ls").await;
+
+        let uri = Url::parse("file:///test/host_debounce.rs").unwrap();
+        let settings = server.settings_manager.load_settings();
+        let configs = server
+            .bridge
+            .get_host_configs_for_language(&settings, "rust");
+
+        let snapshot = DiagnosticSnapshot {
+            virt_contexts: vec![],
+            host: Some(HostRequestContext {
+                uri: uri.clone(),
+                language_id: "rust".to_string(),
+                text: std::sync::Arc::from("fn main() {}"),
+                configs,
+                priorities: vec![],
+                strategy: AggregationStrategy::Concatenated,
+                max_fan_out: None,
+                upstream_request_id: None,
+            }),
+            layer_cfg: ResolvedLayerConfig {
+                priorities: vec![LayerSource::Host],
+                strategy: AggregationStrategy::Concatenated,
+            },
+        };
+
+        // Fire immediately (zero debounce) and assert the host doc was synced.
+        DebouncedDiagnosticsManager::with_duration(Duration::ZERO).schedule(
+            uri.clone(),
+            Some(snapshot),
+            server.bridge.pool_arc(),
+            std::sync::Arc::clone(&server.bridge),
+            std::sync::Arc::new(SyntheticDiagnosticsManager::new()),
+            std::sync::Arc::new(DiagnosticPublisher::new(server)),
+        );
+
+        timeout(Duration::from_secs(1), async {
+            loop {
+                if server
+                    .bridge
+                    .pool()
+                    .host_document_version(&uri, "rust_ls")
+                    .await
+                    .is_some()
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("debounce fire should re-sync the host document to the _self server");
+    }
 }

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -254,16 +254,10 @@ print("hello")
         );
     }
 
-    /// Host-layer eager-open (#429): the host document is opened (didOpen sent) on
-    /// a `_self` host server directly by the eager-open path. Exercised in
-    /// isolation via `eager_open_host_document_on_servers` (not `did_open_impl`)
-    /// so the host-event synthetic diagnostic pull — which would also open the doc
-    /// — can't mask whether eager-open itself works.
-    #[tokio::test]
-    async fn eager_open_sends_didopen_to_self_host_server() {
-        let (service, _socket) = LspService::new(Kakehashi::new);
-        let server = service.inner();
-
+    /// Register the rust grammar and apply settings with a single `rust_ls` `_self`
+    /// host server (host bridging on for rust). Caller then inserts a ready test
+    /// connection for `rust_ls`.
+    fn configure_rust_self_host(server: &Kakehashi) {
         server
             .language
             .language_registry_for_parallel()
@@ -273,8 +267,8 @@ print("hello")
         language_servers.insert(
             "rust_ls".to_string(),
             BridgeServerConfig {
-                // Inert: `insert_ready_test_connection` below pre-inserts a Ready
-                // handle, so this cmd is never actually spawned.
+                // Inert: the caller pre-inserts a Ready handle via
+                // `insert_ready_test_connection`, so this cmd is never spawned.
                 cmd: vec![
                     "sh".to_string(),
                     "-c".to_string(),
@@ -307,7 +301,19 @@ print("hello")
             languages,
             ..Default::default()
         });
+    }
 
+    /// Host-layer eager-open (#429): the host document is opened (didOpen sent) on
+    /// a `_self` host server directly by the eager-open path. Exercised in
+    /// isolation via `eager_open_host_document_on_servers` (not `did_open_impl`)
+    /// so the host-event synthetic diagnostic pull — which would also open the doc
+    /// — can't mask whether eager-open itself works.
+    #[tokio::test]
+    async fn eager_open_sends_didopen_to_self_host_server() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+
+        configure_rust_self_host(server);
         server.bridge.insert_ready_test_connection("rust_ls").await;
 
         let uri = Url::parse("file:///test/host_eager.rs").unwrap();
@@ -331,5 +337,69 @@ print("hello")
         })
         .await
         .expect("eager-open should send didOpen for the host document to the _self host server");
+    }
+
+    /// On-edit host re-sync (#431): a second `eager_sync_host_document_on_servers`
+    /// with changed text sends a versioned `didChange` (version advances to 2), so
+    /// a push-only host server re-analyzes current text instead of stale text. The
+    /// debounced diagnostic path routes through the same method at its cadence.
+    #[tokio::test]
+    async fn eager_sync_resyncs_host_document_on_changed_text() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+
+        configure_rust_self_host(server);
+        server.bridge.insert_ready_test_connection("rust_ls").await;
+
+        let uri = Url::parse("file:///test/host_resync.rs").unwrap();
+        let settings = server.settings_manager.load_settings();
+        let configs = server
+            .bridge
+            .get_host_configs_for_language(&settings, "rust");
+
+        // First sync opens the doc at version 1.
+        server.bridge.eager_sync_host_document_on_servers(
+            &uri,
+            "rust",
+            "fn main() {}",
+            configs.clone(),
+        );
+        timeout(Duration::from_secs(1), async {
+            loop {
+                if server
+                    .bridge
+                    .pool()
+                    .host_document_version(&uri, "rust_ls")
+                    .await
+                    == Some(1)
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("first eager-sync should didOpen the host document at version 1");
+
+        // A re-sync with changed text must send a didChange, advancing to version 2.
+        server
+            .bridge
+            .eager_sync_host_document_on_servers(&uri, "rust", "fn other() {}", configs);
+        timeout(Duration::from_secs(1), async {
+            loop {
+                if server
+                    .bridge
+                    .pool()
+                    .host_document_version(&uri, "rust_ls")
+                    .await
+                    == Some(2)
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("re-sync with changed text should send a didChange advancing to version 2");
     }
 }

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -361,7 +361,7 @@ print("hello")
         server.bridge.eager_sync_host_document_on_servers(
             &uri,
             "rust",
-            "fn main() {}",
+            std::sync::Arc::from("fn main() {}"),
             configs.clone(),
         );
         timeout(Duration::from_secs(1), async {
@@ -382,9 +382,12 @@ print("hello")
         .expect("first eager-sync should didOpen the host document at version 1");
 
         // A re-sync with changed text must send a didChange, advancing to version 2.
-        server
-            .bridge
-            .eager_sync_host_document_on_servers(&uri, "rust", "fn other() {}", configs);
+        server.bridge.eager_sync_host_document_on_servers(
+            &uri,
+            "rust",
+            std::sync::Arc::from("fn other() {}"),
+            configs,
+        );
         timeout(Duration::from_secs(1), async {
             loop {
                 if server

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -475,4 +475,40 @@ print("hello")
         .await
         .expect("debounce fire should re-sync the host document to the _self server");
     }
+
+    /// Locks the load-bearing property behind #431: `prepare_diagnostic_snapshot`
+    /// builds the host context for a `_self`-bridged doc WITHOUT gating on the
+    /// server advertising `diagnosticProvider`. A push-only `rust_ls` (no
+    /// diagnosticProvider, like marksman) is therefore in `snapshot.host.configs`,
+    /// so the debounce-fire re-sync reaches it. If the snapshot were
+    /// capability-gated, the whole on-edit re-sync would be a no-op for exactly the
+    /// push-only servers it exists to serve.
+    #[tokio::test]
+    async fn prepare_diagnostic_snapshot_includes_push_only_host_server() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        configure_rust_self_host(server);
+
+        let uri = Url::parse("file:///test/host_snapshot.rs").unwrap();
+        let text = "fn main() {}".to_string();
+        server
+            .documents
+            .insert(uri.clone(), text.clone(), Some("rust".to_string()), None);
+        server
+            .parse_coordinator()
+            .parse_document(uri.clone(), text, Some("rust"), vec![])
+            .await;
+
+        let snapshot = server
+            .diagnostic_scheduler()
+            .prepare_diagnostic_snapshot(&uri)
+            .expect("a parsed _self-bridged doc yields a diagnostic snapshot");
+        let host = snapshot.host.expect(
+            "host context is built for a _self-bridged doc, not gated on diagnosticProvider",
+        );
+        assert!(
+            host.configs.iter().any(|c| c.server_name == "rust_ls"),
+            "the push-only rust_ls must be in the host context so the debounce re-sync reaches it"
+        );
+    }
 }


### PR DESCRIPTION
## What

Closes #431. A push-only `_self` host server (e.g. **marksman** for markdown —
no `diagnosticProvider`) bridges the real host document. On a plain edit it was
never re-synced, so it kept analyzing **stale text** and pushed stale diagnostics
(a user saw reference-label diagnostics linger after fixing the buffer). Root
cause: the host diagnostic pull (`send_host_raw_request`) gates on
`has_capability("textDocument/diagnostic")` and returns early **before**
`sync_host_document` runs — so push-only servers are never synced by the pull.

Builds on merged #421 (host push propagation) + #429 (host-layer eager-open).

- `BridgeCoordinator::eager_sync_host_document_on_servers(host_uri, language_id,
  text, configs)`: the configs-taking core extracted from #429's
  `eager_open_host_document_on_servers` (which now resolves configs then
  delegates). Reuses #429's batch lifecycle (supersede / cancel-on-didClose /
  shutdown-drain). `sync_host_document` sends a versioned `didChange` on changed
  text.
- `execute_debounced_diagnostic`: when the debounce fires, re-sync the host doc to
  its `_self` servers (fire-and-forget, before the pull). `DebouncedDiagnosticData`
  carries `Arc<BridgeCoordinator>`.

## Behavior

Re-sync happens **at the debounced diagnostic cadence (after typing settles), not
per-keystroke** — so a push-only host server re-analyzes current text within the
debounce window of an edit, instead of only on a save/hover that happens to land
after the edit.

## Design notes

- Re-syncs **all** host servers: pull-capable ones fingerprint-dedup the extra
  sync (the pull also syncs them in the same fire, under the `host_documents`
  lock → one didChange per server). Dual-mode push+pull double-count is the
  pre-existing #425 concern, not worsened.
- Fire-and-forget so it never head-of-line-blocks the pull on a slow server's
  readiness.
- **Not** gated on capability classification (#425): an eager didChange to a
  pull-capable host is just an earlier sync the later pull dedups.
- The spawn→register task-body window is the pre-existing #435 residual (shared
  with the region + #429 host eager paths).

## Tests

- `eager_sync_resyncs_host_document_on_changed_text` — a re-sync with changed text
  advances the host doc to version 2 (didChange sent).
- `debounced_fire_resyncs_host_document` — drives `schedule()` with a zero debounce
  + host snapshot; the test server has no `diagnosticProvider` so the pull skips
  it and **only the eager-sync hook** can sync (ablation-confirmed non-vacuous).
- `prepare_diagnostic_snapshot_includes_push_only_host_server` — locks that the
  host context is built for a push-only server (not `diagnosticProvider`-gated).

## Review
Passed multi-perspective subagent `/review` (2 rounds, wiring test ablation-proven)
and Codex MCP review (fresh high-effort session → "no comments to provide").

🤖 Generated with [Claude Code](https://claude.com/claude-code)