### PR TITLE
feat(bridge): client-progress pass-through for the goto family (#437)

### DIFF
--- a/src/lsp/bridge/protocol/request.rs
+++ b/src/lsp/bridge/protocol/request.rs
@@ -5,7 +5,7 @@
 //! document coordinates.
 
 use tower_lsp_server::ls_types::{
-    DidOpenTextDocumentParams, Position, TextDocumentIdentifier, TextDocumentItem,
+    DidOpenTextDocumentParams, NumberOrString, Position, TextDocumentIdentifier, TextDocumentItem,
     TextDocumentPositionParams, Uri,
 };
 
@@ -13,6 +13,18 @@ use super::jsonrpc::{JsonRpcNotification, JsonRpcRequest};
 use super::request_id::RequestId;
 use super::translation::{RegionOffset, translate_host_position_to_virtual};
 use super::virtual_uri::VirtualDocumentUri;
+
+/// A position-based request's params plus an optional client-provided
+/// `workDoneToken` (ls-bridge-client-progress). `TextDocumentPositionParams` has
+/// no progress field, so we flatten it and add the token alongside; when the
+/// token is `None` this serializes byte-identically to the bare position params.
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct PositionRequestParams {
+    #[serde(flatten)]
+    position: TextDocumentPositionParams,
+    #[serde(rename = "workDoneToken", skip_serializing_if = "Option::is_none")]
+    work_done_token: Option<NumberOrString>,
+}
 
 /// Build `TextDocumentPositionParams` with host-to-virtual coordinate translation.
 ///
@@ -51,6 +63,29 @@ pub(crate) fn build_position_based_request(
 ) -> JsonRpcRequest<TextDocumentPositionParams> {
     let params = build_text_document_position_params(virtual_uri, host_position, offset);
     JsonRpcRequest::new(request_id.as_i64(), method, params)
+}
+
+/// Like [`build_position_based_request`], but carries the editor's
+/// `workDoneToken` so the downstream reports `$/progress` against it
+/// (ls-bridge-client-progress). `client_progress_token = None` is equivalent to
+/// [`build_position_based_request`] (the token field is omitted).
+pub(crate) fn build_position_based_request_with_progress(
+    virtual_uri: &VirtualDocumentUri,
+    host_position: Position,
+    offset: &RegionOffset,
+    request_id: RequestId,
+    method: &'static str,
+    client_progress_token: Option<NumberOrString>,
+) -> JsonRpcRequest<PositionRequestParams> {
+    let position = build_text_document_position_params(virtual_uri, host_position, offset);
+    JsonRpcRequest::new(
+        request_id.as_i64(),
+        method,
+        PositionRequestParams {
+            position,
+            work_done_token: client_progress_token,
+        },
+    )
 }
 
 /// Build a whole-document JSON-RPC request (documentLink, documentSymbol,

--- a/src/lsp/bridge/protocol/request.rs
+++ b/src/lsp/bridge/protocol/request.rs
@@ -213,4 +213,61 @@ mod tests {
         assert_eq!(json["params"]["position"]["line"], 0);
         assert_eq!(json["params"]["position"]["character"], 0); // saturated
     }
+
+    #[test]
+    fn progress_request_includes_work_done_token_only_when_present() {
+        use tower_lsp_server::ls_types::NumberOrString;
+        let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
+        let host_pos = Position {
+            line: 5,
+            character: 4,
+        };
+
+        // With a token: `workDoneToken` is present alongside the (flattened)
+        // position params.
+        let with = build_position_based_request_with_progress(
+            &virtual_uri,
+            host_pos,
+            &RegionOffset::new(5, 4),
+            RequestId::new(1),
+            "textDocument/definition",
+            Some(NumberOrString::String("wd-1".to_string())),
+        );
+        let json = serde_json::to_value(&with).unwrap();
+        assert_eq!(json["params"]["workDoneToken"], "wd-1");
+        assert!(
+            json["params"]["textDocument"]["uri"].is_string(),
+            "position params still present"
+        );
+        assert!(json["params"]["position"]["line"].is_number());
+
+        // Without a token: the field is omitted entirely, leaving the params
+        // byte-identical to the bare position request (non-regression).
+        let without = build_position_based_request_with_progress(
+            &virtual_uri,
+            host_pos,
+            &RegionOffset::new(5, 4),
+            RequestId::new(1),
+            "textDocument/definition",
+            None,
+        );
+        let bare = build_position_based_request(
+            &virtual_uri,
+            host_pos,
+            &RegionOffset::new(5, 4),
+            RequestId::new(1),
+            "textDocument/definition",
+        );
+        assert!(
+            serde_json::to_value(&without).unwrap()["params"]
+                .get("workDoneToken")
+                .is_none(),
+            "workDoneToken omitted when None"
+        );
+        assert_eq!(
+            serde_json::to_value(&without).unwrap(),
+            serde_json::to_value(&bare).unwrap(),
+            "None serializes identically to the bare position request"
+        );
+    }
 }

--- a/src/lsp/bridge/protocol/request.rs
+++ b/src/lsp/bridge/protocol/request.rs
@@ -241,8 +241,23 @@ mod tests {
         );
         assert!(json["params"]["position"]["line"].is_number());
 
+        // The numeric ProgressToken variant serializes as a bare number, not a
+        // wrapper object (`NumberOrString` is `#[serde(untagged)]`).
+        let numeric = build_position_based_request_with_progress(
+            &virtual_uri,
+            host_pos,
+            &RegionOffset::new(5, 4),
+            RequestId::new(1),
+            "textDocument/definition",
+            Some(NumberOrString::Number(7)),
+        );
+        assert_eq!(
+            serde_json::to_value(&numeric).unwrap()["params"]["workDoneToken"],
+            7
+        );
+
         // Without a token: the field is omitted entirely, leaving the params
-        // byte-identical to the bare position request (non-regression).
+        // byte-for-byte identical to the bare position request (non-regression).
         let without = build_position_based_request_with_progress(
             &virtual_uri,
             host_pos,
@@ -264,10 +279,12 @@ mod tests {
                 .is_none(),
             "workDoneToken omitted when None"
         );
+        // Compare the serialized bytes (not just the structural Value) so field
+        // order is included in the non-regression guarantee.
         assert_eq!(
-            serde_json::to_value(&without).unwrap(),
-            serde_json::to_value(&bare).unwrap(),
-            "None serializes identically to the bare position request"
+            serde_json::to_string(&without).unwrap(),
+            serde_json::to_string(&bare).unwrap(),
+            "None serializes byte-for-byte identically to the bare position request"
         );
     }
 }

--- a/src/lsp/bridge/text_document/declaration.rs
+++ b/src/lsp/bridge/text_document/declaration.rs
@@ -16,10 +16,9 @@ use url::Url;
 
 use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::{
-    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, build_position_based_request,
-    transform_goto_response_to_host,
+    JsonRpcRequest, PositionRequestParams, RegionOffset, RequestId, VirtualDocumentUri,
+    build_position_based_request_with_progress, transform_goto_response_to_host,
 };
-use tower_lsp_server::ls_types::TextDocumentPositionParams;
 
 impl LanguageServerPool {
     /// Send a declaration request and wait for the response.
@@ -39,6 +38,7 @@ impl LanguageServerPool {
         offset: RegionOffset,
         virtual_content: &str,
         upstream_request_id: Option<UpstreamId>,
+        client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
     ) -> io::Result<Option<Vec<LocationLink>>> {
         let handle = self
             .get_or_create_connection(server_name, server_config, Some(host_uri))
@@ -57,7 +57,13 @@ impl LanguageServerPool {
             host_position,
             "textDocument/declaration",
             |virtual_uri, request_id| {
-                build_declaration_request(virtual_uri, host_position, &offset, request_id)
+                build_declaration_request(
+                    virtual_uri,
+                    host_position,
+                    &offset,
+                    request_id,
+                    client_progress_token,
+                )
             },
             |response, ctx| {
                 transform_goto_response_to_host(
@@ -78,13 +84,15 @@ fn build_declaration_request(
     host_position: tower_lsp_server::ls_types::Position,
     offset: &RegionOffset,
     request_id: RequestId,
-) -> JsonRpcRequest<TextDocumentPositionParams> {
-    build_position_based_request(
+    client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
+) -> JsonRpcRequest<PositionRequestParams> {
+    build_position_based_request_with_progress(
         virtual_uri,
         host_position,
         offset,
         request_id,
         "textDocument/declaration",
+        client_progress_token,
     )
 }
 
@@ -101,6 +109,7 @@ mod tests {
             test_position(),
             &RegionOffset::new(3, 0),
             test_request_id(),
+            None,
         );
 
         assert_uses_virtual_uri(&request, "lua");
@@ -115,6 +124,7 @@ mod tests {
             test_position(),
             &RegionOffset::new(3, 0),
             test_request_id(),
+            None,
         );
 
         assert_position_request(&request, "textDocument/declaration", 2);

--- a/src/lsp/bridge/text_document/declaration.rs
+++ b/src/lsp/bridge/text_document/declaration.rs
@@ -129,4 +129,22 @@ mod tests {
 
         assert_position_request(&request, "textDocument/declaration", 2);
     }
+
+    #[test]
+    fn declaration_request_carries_work_done_token() {
+        let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
+        let request = build_declaration_request(
+            &virtual_uri,
+            test_position(),
+            &RegionOffset::new(3, 0),
+            test_request_id(),
+            Some(tower_lsp_server::ls_types::NumberOrString::String(
+                "wd-1".to_string(),
+            )),
+        );
+        assert_eq!(
+            serde_json::to_value(&request).unwrap()["params"]["workDoneToken"],
+            "wd-1"
+        );
+    }
 }

--- a/src/lsp/bridge/text_document/definition.rs
+++ b/src/lsp/bridge/text_document/definition.rs
@@ -135,6 +135,24 @@ mod tests {
         assert_position_request(&request, "textDocument/definition", 2);
     }
 
+    #[test]
+    fn definition_request_carries_work_done_token() {
+        let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
+        let request = build_definition_request(
+            &virtual_uri,
+            test_position(),
+            &RegionOffset::new(3, 0),
+            test_request_id(),
+            Some(tower_lsp_server::ls_types::NumberOrString::String(
+                "wd-1".to_string(),
+            )),
+        );
+        assert_eq!(
+            serde_json::to_value(&request).unwrap()["params"]["workDoneToken"],
+            "wd-1"
+        );
+    }
+
     // ==========================================================================
     // Definition response transformation tests
     // ==========================================================================

--- a/src/lsp/bridge/text_document/definition.rs
+++ b/src/lsp/bridge/text_document/definition.rs
@@ -16,10 +16,9 @@ use url::Url;
 
 use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::{
-    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, build_position_based_request,
-    transform_goto_response_to_host,
+    JsonRpcRequest, PositionRequestParams, RegionOffset, RequestId, VirtualDocumentUri,
+    build_position_based_request_with_progress, transform_goto_response_to_host,
 };
-use tower_lsp_server::ls_types::TextDocumentPositionParams;
 
 impl LanguageServerPool {
     /// Send a definition request and wait for the response.
@@ -39,6 +38,7 @@ impl LanguageServerPool {
         offset: RegionOffset,
         virtual_content: &str,
         upstream_request_id: Option<UpstreamId>,
+        client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
     ) -> io::Result<Option<Vec<LocationLink>>> {
         let handle = self
             .get_or_create_connection(server_name, server_config, Some(host_uri))
@@ -57,7 +57,13 @@ impl LanguageServerPool {
             host_position,
             "textDocument/definition",
             |virtual_uri, request_id| {
-                build_definition_request(virtual_uri, host_position, &offset, request_id)
+                build_definition_request(
+                    virtual_uri,
+                    host_position,
+                    &offset,
+                    request_id,
+                    client_progress_token,
+                )
             },
             |response, ctx| {
                 transform_goto_response_to_host(
@@ -78,13 +84,15 @@ fn build_definition_request(
     host_position: tower_lsp_server::ls_types::Position,
     offset: &RegionOffset,
     request_id: RequestId,
-) -> JsonRpcRequest<TextDocumentPositionParams> {
-    build_position_based_request(
+    client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
+) -> JsonRpcRequest<PositionRequestParams> {
+    build_position_based_request_with_progress(
         virtual_uri,
         host_position,
         offset,
         request_id,
         "textDocument/definition",
+        client_progress_token,
     )
 }
 
@@ -106,6 +114,7 @@ mod tests {
             test_position(),
             &RegionOffset::new(3, 0),
             test_request_id(),
+            None,
         );
 
         assert_uses_virtual_uri(&request, "lua");
@@ -120,6 +129,7 @@ mod tests {
             test_position(),
             &RegionOffset::new(3, 0),
             test_request_id(),
+            None,
         );
 
         assert_position_request(&request, "textDocument/definition", 2);

--- a/src/lsp/bridge/text_document/implementation.rs
+++ b/src/lsp/bridge/text_document/implementation.rs
@@ -129,4 +129,22 @@ mod tests {
 
         assert_position_request(&request, "textDocument/implementation", 2);
     }
+
+    #[test]
+    fn implementation_request_carries_work_done_token() {
+        let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
+        let request = build_implementation_request(
+            &virtual_uri,
+            test_position(),
+            &RegionOffset::new(3, 0),
+            test_request_id(),
+            Some(tower_lsp_server::ls_types::NumberOrString::String(
+                "wd-1".to_string(),
+            )),
+        );
+        assert_eq!(
+            serde_json::to_value(&request).unwrap()["params"]["workDoneToken"],
+            "wd-1"
+        );
+    }
 }

--- a/src/lsp/bridge/text_document/implementation.rs
+++ b/src/lsp/bridge/text_document/implementation.rs
@@ -16,10 +16,9 @@ use url::Url;
 
 use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::{
-    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, build_position_based_request,
-    transform_goto_response_to_host,
+    JsonRpcRequest, PositionRequestParams, RegionOffset, RequestId, VirtualDocumentUri,
+    build_position_based_request_with_progress, transform_goto_response_to_host,
 };
-use tower_lsp_server::ls_types::TextDocumentPositionParams;
 
 impl LanguageServerPool {
     /// Send an implementation request and wait for the response.
@@ -39,6 +38,7 @@ impl LanguageServerPool {
         offset: RegionOffset,
         virtual_content: &str,
         upstream_request_id: Option<UpstreamId>,
+        client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
     ) -> io::Result<Option<Vec<LocationLink>>> {
         let handle = self
             .get_or_create_connection(server_name, server_config, Some(host_uri))
@@ -57,7 +57,13 @@ impl LanguageServerPool {
             host_position,
             "textDocument/implementation",
             |virtual_uri, request_id| {
-                build_implementation_request(virtual_uri, host_position, &offset, request_id)
+                build_implementation_request(
+                    virtual_uri,
+                    host_position,
+                    &offset,
+                    request_id,
+                    client_progress_token,
+                )
             },
             |response, ctx| {
                 transform_goto_response_to_host(
@@ -78,13 +84,15 @@ fn build_implementation_request(
     host_position: tower_lsp_server::ls_types::Position,
     offset: &RegionOffset,
     request_id: RequestId,
-) -> JsonRpcRequest<TextDocumentPositionParams> {
-    build_position_based_request(
+    client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
+) -> JsonRpcRequest<PositionRequestParams> {
+    build_position_based_request_with_progress(
         virtual_uri,
         host_position,
         offset,
         request_id,
         "textDocument/implementation",
+        client_progress_token,
     )
 }
 
@@ -101,6 +109,7 @@ mod tests {
             test_position(),
             &RegionOffset::new(3, 0),
             test_request_id(),
+            None,
         );
 
         assert_uses_virtual_uri(&request, "lua");
@@ -115,6 +124,7 @@ mod tests {
             test_position(),
             &RegionOffset::new(3, 0),
             test_request_id(),
+            None,
         );
 
         assert_position_request(&request, "textDocument/implementation", 2);

--- a/src/lsp/bridge/text_document/type_definition.rs
+++ b/src/lsp/bridge/text_document/type_definition.rs
@@ -129,4 +129,22 @@ mod tests {
 
         assert_position_request(&request, "textDocument/typeDefinition", 2);
     }
+
+    #[test]
+    fn type_definition_request_carries_work_done_token() {
+        let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
+        let request = build_type_definition_request(
+            &virtual_uri,
+            test_position(),
+            &RegionOffset::new(3, 0),
+            test_request_id(),
+            Some(tower_lsp_server::ls_types::NumberOrString::String(
+                "wd-1".to_string(),
+            )),
+        );
+        assert_eq!(
+            serde_json::to_value(&request).unwrap()["params"]["workDoneToken"],
+            "wd-1"
+        );
+    }
 }

--- a/src/lsp/bridge/text_document/type_definition.rs
+++ b/src/lsp/bridge/text_document/type_definition.rs
@@ -16,10 +16,9 @@ use url::Url;
 
 use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::{
-    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, build_position_based_request,
-    transform_goto_response_to_host,
+    JsonRpcRequest, PositionRequestParams, RegionOffset, RequestId, VirtualDocumentUri,
+    build_position_based_request_with_progress, transform_goto_response_to_host,
 };
-use tower_lsp_server::ls_types::TextDocumentPositionParams;
 
 impl LanguageServerPool {
     /// Send a type definition request and wait for the response.
@@ -39,6 +38,7 @@ impl LanguageServerPool {
         offset: RegionOffset,
         virtual_content: &str,
         upstream_request_id: Option<UpstreamId>,
+        client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
     ) -> io::Result<Option<Vec<LocationLink>>> {
         let handle = self
             .get_or_create_connection(server_name, server_config, Some(host_uri))
@@ -57,7 +57,13 @@ impl LanguageServerPool {
             host_position,
             "textDocument/typeDefinition",
             |virtual_uri, request_id| {
-                build_type_definition_request(virtual_uri, host_position, &offset, request_id)
+                build_type_definition_request(
+                    virtual_uri,
+                    host_position,
+                    &offset,
+                    request_id,
+                    client_progress_token,
+                )
             },
             |response, ctx| {
                 transform_goto_response_to_host(
@@ -78,13 +84,15 @@ fn build_type_definition_request(
     host_position: tower_lsp_server::ls_types::Position,
     offset: &RegionOffset,
     request_id: RequestId,
-) -> JsonRpcRequest<TextDocumentPositionParams> {
-    build_position_based_request(
+    client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
+) -> JsonRpcRequest<PositionRequestParams> {
+    build_position_based_request_with_progress(
         virtual_uri,
         host_position,
         offset,
         request_id,
         "textDocument/typeDefinition",
+        client_progress_token,
     )
 }
 
@@ -101,6 +109,7 @@ mod tests {
             test_position(),
             &RegionOffset::new(3, 0),
             test_request_id(),
+            None,
         );
 
         assert_uses_virtual_uri(&request, "lua");
@@ -115,6 +124,7 @@ mod tests {
             test_position(),
             &RegionOffset::new(3, 0),
             test_request_id(),
+            None,
         );
 
         assert_position_request(&request, "textDocument/typeDefinition", 2);

--- a/src/lsp/lsp_impl/text_document/declaration.rs
+++ b/src/lsp/lsp_impl/text_document/declaration.rs
@@ -25,8 +25,9 @@ impl Kakehashi {
         let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
         let lsp_uri = params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
+        let work_done_token = params.work_done_progress_params.work_done_token;
 
-        let virt = self.declaration_virt_layer(&lsp_uri, position);
+        let virt = self.declaration_virt_layer(&lsp_uri, position, work_done_token);
         let links = self
             .walk_layers(
                 &lsp_uri,
@@ -46,10 +47,14 @@ impl Kakehashi {
         &self,
         lsp_uri: &Uri,
         position: Position,
+        client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
     ) -> Result<Option<Vec<LocationLink>>> {
-        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
+        let Some(mut ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
             return Ok(None);
         };
+        // Aggregate the fanned-out servers' progress onto the editor's token
+        // (ls-bridge-client-progress).
+        ctx.document.client_progress_token = client_progress_token;
 
         let (cancel_rx, _cancel_guard) =
             self.subscribe_cancel(ctx.document.upstream_request_id.as_ref());
@@ -72,6 +77,7 @@ impl Kakehashi {
                         t.offset,
                         &t.virtual_content,
                         t.upstream_id,
+                        t.client_progress_token,
                     )
                     .await
             },

--- a/src/lsp/lsp_impl/text_document/definition.rs
+++ b/src/lsp/lsp_impl/text_document/definition.rs
@@ -26,8 +26,9 @@ impl Kakehashi {
         let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
         let lsp_uri = params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
+        let work_done_token = params.work_done_progress_params.work_done_token;
 
-        let virt = self.definition_virt_layer(&lsp_uri, position);
+        let virt = self.definition_virt_layer(&lsp_uri, position, work_done_token);
         let links = self
             .walk_layers(
                 &lsp_uri,
@@ -47,10 +48,14 @@ impl Kakehashi {
         &self,
         lsp_uri: &Uri,
         position: Position,
+        client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
     ) -> Result<Option<Vec<LocationLink>>> {
-        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
+        let Some(mut ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
             return Ok(None);
         };
+        // Aggregate the fanned-out servers' progress onto the editor's token
+        // (ls-bridge-client-progress).
+        ctx.document.client_progress_token = client_progress_token;
 
         let (cancel_rx, _cancel_guard) =
             self.subscribe_cancel(ctx.document.upstream_request_id.as_ref());
@@ -72,6 +77,7 @@ impl Kakehashi {
                         t.offset,
                         &t.virtual_content,
                         t.upstream_id,
+                        t.client_progress_token,
                     )
                     .await
             },

--- a/src/lsp/lsp_impl/text_document/implementation.rs
+++ b/src/lsp/lsp_impl/text_document/implementation.rs
@@ -25,8 +25,9 @@ impl Kakehashi {
         let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
         let lsp_uri = params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
+        let work_done_token = params.work_done_progress_params.work_done_token;
 
-        let virt = self.implementation_virt_layer(&lsp_uri, position);
+        let virt = self.implementation_virt_layer(&lsp_uri, position, work_done_token);
         let links = self
             .walk_layers(
                 &lsp_uri,
@@ -46,10 +47,14 @@ impl Kakehashi {
         &self,
         lsp_uri: &Uri,
         position: Position,
+        client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
     ) -> Result<Option<Vec<LocationLink>>> {
-        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
+        let Some(mut ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
             return Ok(None);
         };
+        // Aggregate the fanned-out servers' progress onto the editor's token
+        // (ls-bridge-client-progress).
+        ctx.document.client_progress_token = client_progress_token;
 
         let (cancel_rx, _cancel_guard) =
             self.subscribe_cancel(ctx.document.upstream_request_id.as_ref());
@@ -72,6 +77,7 @@ impl Kakehashi {
                         t.offset,
                         &t.virtual_content,
                         t.upstream_id,
+                        t.client_progress_token,
                     )
                     .await
             },

--- a/src/lsp/lsp_impl/text_document/type_definition.rs
+++ b/src/lsp/lsp_impl/text_document/type_definition.rs
@@ -25,8 +25,9 @@ impl Kakehashi {
         let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
         let lsp_uri = params.text_document_position_params.text_document.uri;
         let position = params.text_document_position_params.position;
+        let work_done_token = params.work_done_progress_params.work_done_token;
 
-        let virt = self.type_definition_virt_layer(&lsp_uri, position);
+        let virt = self.type_definition_virt_layer(&lsp_uri, position, work_done_token);
         let links = self
             .walk_layers(
                 &lsp_uri,
@@ -46,10 +47,14 @@ impl Kakehashi {
         &self,
         lsp_uri: &Uri,
         position: Position,
+        client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
     ) -> Result<Option<Vec<LocationLink>>> {
-        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
+        let Some(mut ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
             return Ok(None);
         };
+        // Aggregate the fanned-out servers' progress onto the editor's token
+        // (ls-bridge-client-progress).
+        ctx.document.client_progress_token = client_progress_token;
 
         let (cancel_rx, _cancel_guard) =
             self.subscribe_cancel(ctx.document.upstream_request_id.as_ref());
@@ -72,6 +77,7 @@ impl Kakehashi {
                         t.offset,
                         &t.virtual_content,
                         t.upstream_id,
+                        t.client_progress_token,
                     )
                     .await
             },


### PR DESCRIPTION
## Summary

Extends the client-provided `workDoneToken` `$/progress` pass-through (merged for `references`) to the **goto family**: `textDocument/{definition, typeDefinition, implementation, declaration}`. Part of #437.

## What changed
- **Reusable infra** (`src/lsp/bridge/protocol/request.rs`): `PositionRequestParams` — a serde-`flatten`ed `TextDocumentPositionParams` plus `#[serde(rename="workDoneToken", skip_serializing_if="Option::is_none")] work_done_token` — and `build_position_based_request_with_progress(...)`. Position requests are sent as bare `TextDocumentPositionParams` (no progress field), so this carries the token; when `None` it serializes **byte-for-byte identically** to the bare request (non-regression).
- **Per method**: the handler extracts `params.work_done_progress_params.work_done_token` → `ctx.document.client_progress_token`; the `dispatch_preferred` closure passes `t.client_progress_token` to `send_*_request` → `build_*_request` → the new builder. The existing `preferred` aggregation (anchor selection, synthetic terminal `End`) then applies unchanged.

These are **position-based, single-region, single-dispatch** requests (cursor at one region), so the per-request aggregator stays coherent (one `Begin` per token). Whole-document/multi-region methods (`document_symbol`, etc.) need a request-level shared aggregator and are deferred.

## Tests
- `request.rs`: token present → `params.workDoneToken` emitted; numeric token → bare number; `None` → omitted and byte-identical to the bare request.
- Per-method builder test (×4) asserting a supplied token reaches the serialized request (guards half-wiring).

## Scope / follow-up
This is the per-method **plumbing**. The providers are currently advertised without `workDoneProgress` (shared with merged `references`), so spec-compliant clients won't send a token until that's fixed — tracked as a **required follow-up in #445** (advertise `workDoneProgress` across all client-progress-capable providers).

Reviewed via subagent `/review` and Codex (no must-fix after scoping). Part of #437 (does not close it — more methods + #445 remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)