### PR TITLE
feat(lsp): advertise workDoneProgress on client-progress providers (#445)

### DIFF
--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -110,6 +110,16 @@ impl Kakehashi {
         self.bridge
             .pool()
             .set_workspace_folders(workspace_folders_for_bridge);
+        // Only advertise `workDoneProgress` on our providers when the client
+        // signals work-done-progress support — otherwise the bridged `$/progress`
+        // on a client token would have nowhere to land (ls-bridge-client-progress,
+        // #445). Read before `params.capabilities` is moved below.
+        let client_supports_work_done_progress = params
+            .capabilities
+            .window
+            .as_ref()
+            .and_then(|w| w.work_done_progress)
+            .unwrap_or(false);
         self.bridge
             .pool()
             .set_client_capabilities(params.capabilities);
@@ -248,25 +258,34 @@ impl Kakehashi {
                     ),
                 ),
                 selection_range_provider: Some(SelectionRangeProviderCapability::Simple(true)),
-                // Advertise `workDoneProgress` so spec-compliant clients attach a
-                // `workDoneToken` we can bridge (ls-bridge-client-progress, #445).
-                // NOTE: `type_definition`/`implementation` also have the plumbing,
-                // but cannot advertise it via this crate's typed API — in
-                // ls-types 0.0.6 their only `Options` variant wraps
+                // Advertise `workDoneProgress` (so the client attaches a
+                // `workDoneToken` we can bridge, ls-bridge-client-progress #445)
+                // ONLY when the client supports work-done progress — otherwise keep
+                // the bare `true` form. NOTE: `type_definition`/`implementation`
+                // also have the plumbing, but cannot advertise it via this crate's
+                // typed API — in ls-types 0.0.6 their only `Options` variant wraps
                 // `StaticTextDocumentRegistrationOptions`, which has no
                 // `workDoneProgress` field (the LSP spec *does* define it). They
                 // stay `Simple(true)`, so their client-progress plumbing is inert
                 // for spec-compliant clients until that crate gap is closed (#447).
-                declaration_provider: Some(DeclarationCapability::Options(DeclarationOptions {
-                    work_done_progress_options: WorkDoneProgressOptions {
-                        work_done_progress: Some(true),
-                    },
-                })),
-                definition_provider: Some(OneOf::Right(DefinitionOptions {
-                    work_done_progress_options: WorkDoneProgressOptions {
-                        work_done_progress: Some(true),
-                    },
-                })),
+                declaration_provider: Some(if client_supports_work_done_progress {
+                    DeclarationCapability::Options(DeclarationOptions {
+                        work_done_progress_options: WorkDoneProgressOptions {
+                            work_done_progress: Some(true),
+                        },
+                    })
+                } else {
+                    DeclarationCapability::Simple(true)
+                }),
+                definition_provider: Some(if client_supports_work_done_progress {
+                    OneOf::Right(DefinitionOptions {
+                        work_done_progress_options: WorkDoneProgressOptions {
+                            work_done_progress: Some(true),
+                        },
+                    })
+                } else {
+                    OneOf::Left(true)
+                }),
                 type_definition_provider: Some(TypeDefinitionProviderCapability::Simple(true)),
                 implementation_provider: Some(ImplementationProviderCapability::Simple(true)),
                 hover_provider: Some(HoverProviderCapability::Simple(true)),
@@ -280,11 +299,15 @@ impl Kakehashi {
                     retrigger_characters: Some(vec![",".to_string()]),
                     ..Default::default()
                 }),
-                references_provider: Some(OneOf::Right(ReferenceOptions {
-                    work_done_progress_options: WorkDoneProgressOptions {
-                        work_done_progress: Some(true),
-                    },
-                })),
+                references_provider: Some(if client_supports_work_done_progress {
+                    OneOf::Right(ReferenceOptions {
+                        work_done_progress_options: WorkDoneProgressOptions {
+                            work_done_progress: Some(true),
+                        },
+                    })
+                } else {
+                    OneOf::Left(true)
+                }),
                 document_highlight_provider: Some(OneOf::Left(true)),
                 document_link_provider: Some(DocumentLinkOptions {
                     resolve_provider: None,

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -110,16 +110,6 @@ impl Kakehashi {
         self.bridge
             .pool()
             .set_workspace_folders(workspace_folders_for_bridge);
-        // Only advertise `workDoneProgress` on our providers when the client
-        // signals work-done-progress support — otherwise the bridged `$/progress`
-        // on a client token would have nowhere to land (ls-bridge-client-progress,
-        // #445). Read before `params.capabilities` is moved below.
-        let client_supports_work_done_progress = params
-            .capabilities
-            .window
-            .as_ref()
-            .and_then(|w| w.work_done_progress)
-            .unwrap_or(false);
         self.bridge
             .pool()
             .set_client_capabilities(params.capabilities);
@@ -258,34 +248,28 @@ impl Kakehashi {
                     ),
                 ),
                 selection_range_provider: Some(SelectionRangeProviderCapability::Simple(true)),
-                // Advertise `workDoneProgress` (so the client attaches a
-                // `workDoneToken` we can bridge, ls-bridge-client-progress #445)
-                // ONLY when the client supports work-done progress — otherwise keep
-                // the bare `true` form. NOTE: `type_definition`/`implementation`
+                // Advertise `workDoneProgress` so clients attach a `workDoneToken`
+                // we can bridge (ls-bridge-client-progress, #445). Per LSP this is
+                // unconditional — client-initiated progress has no client
+                // capability; the provider's advertisement alone prompts the token
+                // (`window.workDoneProgress` governs *server*-initiated progress, a
+                // different mechanism). NOTE: `type_definition`/`implementation`
                 // also have the plumbing, but cannot advertise it via this crate's
                 // typed API — in ls-types 0.0.6 their only `Options` variant wraps
                 // `StaticTextDocumentRegistrationOptions`, which has no
                 // `workDoneProgress` field (the LSP spec *does* define it). They
                 // stay `Simple(true)`, so their client-progress plumbing is inert
                 // for spec-compliant clients until that crate gap is closed (#447).
-                declaration_provider: Some(if client_supports_work_done_progress {
-                    DeclarationCapability::Options(DeclarationOptions {
-                        work_done_progress_options: WorkDoneProgressOptions {
-                            work_done_progress: Some(true),
-                        },
-                    })
-                } else {
-                    DeclarationCapability::Simple(true)
-                }),
-                definition_provider: Some(if client_supports_work_done_progress {
-                    OneOf::Right(DefinitionOptions {
-                        work_done_progress_options: WorkDoneProgressOptions {
-                            work_done_progress: Some(true),
-                        },
-                    })
-                } else {
-                    OneOf::Left(true)
-                }),
+                declaration_provider: Some(DeclarationCapability::Options(DeclarationOptions {
+                    work_done_progress_options: WorkDoneProgressOptions {
+                        work_done_progress: Some(true),
+                    },
+                })),
+                definition_provider: Some(OneOf::Right(DefinitionOptions {
+                    work_done_progress_options: WorkDoneProgressOptions {
+                        work_done_progress: Some(true),
+                    },
+                })),
                 type_definition_provider: Some(TypeDefinitionProviderCapability::Simple(true)),
                 implementation_provider: Some(ImplementationProviderCapability::Simple(true)),
                 hover_provider: Some(HoverProviderCapability::Simple(true)),
@@ -299,15 +283,11 @@ impl Kakehashi {
                     retrigger_characters: Some(vec![",".to_string()]),
                     ..Default::default()
                 }),
-                references_provider: Some(if client_supports_work_done_progress {
-                    OneOf::Right(ReferenceOptions {
-                        work_done_progress_options: WorkDoneProgressOptions {
-                            work_done_progress: Some(true),
-                        },
-                    })
-                } else {
-                    OneOf::Left(true)
-                }),
+                references_provider: Some(OneOf::Right(ReferenceOptions {
+                    work_done_progress_options: WorkDoneProgressOptions {
+                        work_done_progress: Some(true),
+                    },
+                })),
                 document_highlight_provider: Some(OneOf::Left(true)),
                 document_link_provider: Some(DocumentLinkOptions {
                     resolve_provider: None,

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -250,10 +250,13 @@ impl Kakehashi {
                 selection_range_provider: Some(SelectionRangeProviderCapability::Simple(true)),
                 // Advertise `workDoneProgress` so spec-compliant clients attach a
                 // `workDoneToken` we can bridge (ls-bridge-client-progress, #445).
-                // NOTE: `type_definition`/`implementation` cannot advertise it here
-                // — in ls-types 0.0.6 their only `Options` variant is
+                // NOTE: `type_definition`/`implementation` also have the plumbing,
+                // but cannot advertise it via this crate's typed API — in
+                // ls-types 0.0.6 their only `Options` variant wraps
                 // `StaticTextDocumentRegistrationOptions`, which has no
-                // `workDoneProgress` field. Tracked as a known limitation.
+                // `workDoneProgress` field (the LSP spec *does* define it). They
+                // stay `Simple(true)`, so their client-progress plumbing is inert
+                // for spec-compliant clients until that crate gap is closed (#447).
                 declaration_provider: Some(DeclarationCapability::Options(DeclarationOptions {
                     work_done_progress_options: WorkDoneProgressOptions {
                         work_done_progress: Some(true),

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -7,12 +7,13 @@ use tower_lsp_server::jsonrpc::Result;
 #[cfg(feature = "experimental")]
 use tower_lsp_server::ls_types::ColorProviderCapability;
 use tower_lsp_server::ls_types::{
-    CodeLensOptions, CompletionOptions, DeclarationCapability, DiagnosticOptions,
-    DiagnosticServerCapabilities, DocumentLinkOptions, DocumentOnTypeFormattingOptions,
-    FoldingRangeProviderCapability, HoverProviderCapability, ImplementationProviderCapability,
-    InitializeParams, InitializeResult, InitializedParams, LinkedEditingRangeServerCapabilities,
-    OneOf, RenameOptions, SaveOptions, SelectionRangeProviderCapability, SemanticTokenModifier,
-    SemanticTokenType, SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
+    CodeLensOptions, CompletionOptions, DeclarationCapability, DeclarationOptions,
+    DefinitionOptions, DiagnosticOptions, DiagnosticServerCapabilities, DocumentLinkOptions,
+    DocumentOnTypeFormattingOptions, FoldingRangeProviderCapability, HoverProviderCapability,
+    ImplementationProviderCapability, InitializeParams, InitializeResult, InitializedParams,
+    LinkedEditingRangeServerCapabilities, OneOf, ReferenceOptions, RenameOptions, SaveOptions,
+    SelectionRangeProviderCapability, SemanticTokenModifier, SemanticTokenType,
+    SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
     SemanticTokensServerCapabilities, ServerCapabilities, ServerInfo, SignatureHelpOptions,
     TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
     TextDocumentSyncSaveOptions, TypeDefinitionProviderCapability, Uri, WorkDoneProgressOptions,
@@ -247,8 +248,22 @@ impl Kakehashi {
                     ),
                 ),
                 selection_range_provider: Some(SelectionRangeProviderCapability::Simple(true)),
-                declaration_provider: Some(DeclarationCapability::Simple(true)),
-                definition_provider: Some(OneOf::Left(true)),
+                // Advertise `workDoneProgress` so spec-compliant clients attach a
+                // `workDoneToken` we can bridge (ls-bridge-client-progress, #445).
+                // NOTE: `type_definition`/`implementation` cannot advertise it here
+                // — in ls-types 0.0.6 their only `Options` variant is
+                // `StaticTextDocumentRegistrationOptions`, which has no
+                // `workDoneProgress` field. Tracked as a known limitation.
+                declaration_provider: Some(DeclarationCapability::Options(DeclarationOptions {
+                    work_done_progress_options: WorkDoneProgressOptions {
+                        work_done_progress: Some(true),
+                    },
+                })),
+                definition_provider: Some(OneOf::Right(DefinitionOptions {
+                    work_done_progress_options: WorkDoneProgressOptions {
+                        work_done_progress: Some(true),
+                    },
+                })),
                 type_definition_provider: Some(TypeDefinitionProviderCapability::Simple(true)),
                 implementation_provider: Some(ImplementationProviderCapability::Simple(true)),
                 hover_provider: Some(HoverProviderCapability::Simple(true)),
@@ -262,7 +277,11 @@ impl Kakehashi {
                     retrigger_characters: Some(vec![",".to_string()]),
                     ..Default::default()
                 }),
-                references_provider: Some(OneOf::Left(true)),
+                references_provider: Some(OneOf::Right(ReferenceOptions {
+                    work_done_progress_options: WorkDoneProgressOptions {
+                        work_done_progress: Some(true),
+                    },
+                })),
                 document_highlight_provider: Some(OneOf::Left(true)),
                 document_link_provider: Some(DocumentLinkOptions {
                     resolve_provider: None,

--- a/tests/e2e_lsp_protocol.rs
+++ b/tests/e2e_lsp_protocol.rs
@@ -47,11 +47,12 @@ fn test_initialize_returns_capabilities() {
 }
 
 #[test]
-fn test_initialize_advertises_work_done_progress_when_client_supports_it() {
-    // When the client signals work-done-progress support, the client-progress
-    // providers advertise `workDoneProgress` (so the client attaches a
-    // workDoneToken we can bridge); without it they stay bare `true`
-    // (ls-bridge-client-progress, #445).
+fn test_advertises_work_done_progress_independent_of_window_capability() {
+    // Client-initiated progress has NO client capability — the provider's
+    // `workDoneProgress` advertisement alone prompts the token. So we advertise it
+    // unconditionally, even when the client explicitly sets `window.workDoneProgress`
+    // to false (that capability governs *server*-initiated progress, a different
+    // mechanism) (ls-bridge-client-progress, #445).
     let mut client = LspClient::new();
 
     let response = client.send_request(
@@ -59,7 +60,7 @@ fn test_initialize_advertises_work_done_progress_when_client_supports_it() {
         json!({
             "processId": std::process::id(),
             "rootUri": null,
-            "capabilities": { "window": { "workDoneProgress": true } }
+            "capabilities": { "window": { "workDoneProgress": false } }
         }),
     );
 
@@ -76,7 +77,7 @@ fn test_initialize_advertises_work_done_progress_when_client_supports_it() {
         assert_eq!(
             caps[provider]["workDoneProgress"],
             json!(true),
-            "{provider} should advertise workDoneProgress when the client supports it"
+            "{provider} must advertise workDoneProgress regardless of window.workDoneProgress"
         );
     }
     // type_definition/implementation cannot advertise it via the current types

--- a/tests/e2e_lsp_protocol.rs
+++ b/tests/e2e_lsp_protocol.rs
@@ -47,6 +47,45 @@ fn test_initialize_returns_capabilities() {
 }
 
 #[test]
+fn test_initialize_advertises_work_done_progress_when_client_supports_it() {
+    // When the client signals work-done-progress support, the client-progress
+    // providers advertise `workDoneProgress` (so the client attaches a
+    // workDoneToken we can bridge); without it they stay bare `true`
+    // (ls-bridge-client-progress, #445).
+    let mut client = LspClient::new();
+
+    let response = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": { "window": { "workDoneProgress": true } }
+        }),
+    );
+
+    let caps = response
+        .get("result")
+        .and_then(|r| r.get("capabilities"))
+        .expect("InitializeResult should have capabilities");
+
+    for provider in [
+        "definitionProvider",
+        "referencesProvider",
+        "declarationProvider",
+    ] {
+        assert_eq!(
+            caps[provider]["workDoneProgress"],
+            json!(true),
+            "{provider} should advertise workDoneProgress when the client supports it"
+        );
+    }
+    // type_definition/implementation cannot advertise it via the current types
+    // crate (#447), so they remain bare `true`.
+    assert_eq!(caps["typeDefinitionProvider"], json!(true));
+    assert_eq!(caps["implementationProvider"], json!(true));
+}
+
+#[test]
 fn test_effective_configuration_returns_settings() {
     let mut client = LspClient::new();
 

--- a/tests/snapshots/e2e_lsp_protocol__initialize_capabilities.snap
+++ b/tests/snapshots/e2e_lsp_protocol__initialize_capabilities.snap
@@ -28,10 +28,14 @@ expression: capabilities
       ","
     ]
   },
-  "definitionProvider": true,
+  "definitionProvider": {
+    "workDoneProgress": true
+  },
   "typeDefinitionProvider": true,
   "implementationProvider": true,
-  "referencesProvider": true,
+  "referencesProvider": {
+    "workDoneProgress": true
+  },
   "documentHighlightProvider": true,
   "documentSymbolProvider": true,
   "codeLensProvider": {
@@ -44,7 +48,9 @@ expression: capabilities
   },
   "documentLinkProvider": {},
   "foldingRangeProvider": true,
-  "declarationProvider": true,
+  "declarationProvider": {
+    "workDoneProgress": true
+  },
   "semanticTokensProvider": {
     "legend": {
       "tokenTypes": [

--- a/tests/snapshots/e2e_lsp_protocol__initialize_capabilities.snap
+++ b/tests/snapshots/e2e_lsp_protocol__initialize_capabilities.snap
@@ -28,14 +28,10 @@ expression: capabilities
       ","
     ]
   },
-  "definitionProvider": {
-    "workDoneProgress": true
-  },
+  "definitionProvider": true,
   "typeDefinitionProvider": true,
   "implementationProvider": true,
-  "referencesProvider": {
-    "workDoneProgress": true
-  },
+  "referencesProvider": true,
   "documentHighlightProvider": true,
   "documentSymbolProvider": true,
   "codeLensProvider": {
@@ -48,9 +44,7 @@ expression: capabilities
   },
   "documentLinkProvider": {},
   "foldingRangeProvider": true,
-  "declarationProvider": {
-    "workDoneProgress": true
-  },
+  "declarationProvider": true,
   "semanticTokensProvider": {
     "legend": {
       "tokenTypes": [


### PR DESCRIPTION
## Summary

Resolves the #445 must-fix surfaced by review of #437: the client-progress pass-through (`references` #432, goto #437) was **inert** because the providers were advertised as bare `true`, without `workDoneProgress`. This advertises it so clients attach a `workDoneToken` we can bridge.

> **Stacked on `feat-414-goto-progress` (#446)** — retarget to `main` once that merges. Merge order: #446 → #445.

## What changed (`lifecycle.rs` + capability snapshot)
- `definition`, `references`, `declaration` providers: bare `Simple(true)`/`OneOf::Left(true)` → the `Options` form with `WorkDoneProgressOptions { work_done_progress: Some(true) }`.
- **Unconditional** — per LSP 3.17 (Client Initiated Progress), client-initiated request tokens have **no** client capability; the provider's `workDoneProgress` advertisement alone prompts them. (`window.workDoneProgress` governs *server*-initiated progress — a different mechanism — so it does **not** gate this.)
- `type_definition`/`implementation` **cannot** advertise it via the current types crate: in `ls-types 0.0.6` their only `Options` variant wraps `StaticTextDocumentRegistrationOptions`, which has no `workDoneProgress` field. They stay `Simple(true)`; their plumbing is inert until that gap closes — **tracked in #447**.

## Tests
- Updated the `initialize_capabilities` snapshot (the 3 providers now `{ "workDoneProgress": true }`); verified by the e2e protocol test.
- New e2e test asserting the providers advertise `workDoneProgress` even when the client sends `window.workDoneProgress: false` (proves the advertisement is independent of that capability).

Reviewed via subagent `/review` and Codex (no must-fix — Codex initially asked to gate on `window.workDoneProgress`, then corrected itself; the spec confirms unconditional). Resolves #445; #447 tracks type_def/impl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)