### PR TITLE
docs(adr): reconcile progress ADRs with merged implementation (#442)

### DIFF
--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -262,9 +262,8 @@ spec-compliant clients never send a token).
   next named anchor's real `End`. #438.
 - **Method coverage** beyond references (and the goto family added by #446) —
   notably the whole-document, multi-region methods (`documentSymbol`, …), which
-  fan out to
-  several regions per request and so need a request-level shared aggregator, not
-  the per-dispatch one. #437.
+  fan out to several regions per request and so need a request-level shared
+  aggregator, not the per-dispatch one. #437.
 - **Host-layer** client progress: the host path still strips the token. #441.
 
 The remaining notes below are design-tuning points; the empty-vs-non-empty

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -234,8 +234,36 @@ bridge composes the terminal rather than relaying a downstream's `End`.
 
 ## Decision–Implementation Gap
 
-Not yet implemented (tracked in issue #414); today both client-provided tokens
-are stripped before fan-out. Specific points to settle during implementation:
+**Implemented** (issue #414): the `workDoneToken` path for the **N = 1** relay
+and the **`preferred`** strategy with a **single fixed anchor** — the dispatch
+mints a per-server bridge token only for the tracked source (sole server at
+N = 1, highest-priority *named* anchor at N > 1; a wildcard `Rest` group that
+outranks the candidate yields no anchor), routes that downstream's `$/progress`
+onto the editor's token, and guarantees a terminal `End` on teardown. Wired for
+`textDocument/references`; the goto family and the `workDoneProgress` capability
+advertisement (without which spec-compliant clients never send a token) are in
+flight under #437 / #445.
+
+**Deferred** (still stripped or unhandled; tracked):
+
+- **`partialResultToken`** is still stripped — only `workDoneToken` is bridged so
+  far (the intermediate phase this section already anticipated). #439.
+- **`concatenated`** client progress is not built; a concatenated request shows
+  no client progress (cost/benefit go/no-go pending). #440.
+- **Dynamic fall-through re-anchoring** is not built: the single fixed anchor's
+  open `Begin` is closed by the synthetic terminal `End` rather than handed to the
+  next named anchor's real `End`. #438.
+- **Method coverage** beyond references/goto — notably the whole-document,
+  multi-region methods (`documentSymbol`, …), which fan out to several regions per
+  request and so need a request-level shared aggregator, not the per-dispatch one.
+  #437.
+- **Host-layer** client progress: the host path still strips the token. #441.
+
+The remaining notes below are design-tuning points; the empty-vs-non-empty
+fall-through threshold and the `Rest`-never-anchor rule are now **decided** as
+described above.
+
+Specific points to settle during the remaining implementation:
 
 - The empty-vs-non-empty threshold that triggers fall-through must
   **match the existing preferred-strategy empty-result behavior** — a uniform

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -84,8 +84,7 @@ request just returns its result (today's behavior, minus the strip).
   onto the client token.) If it emits none, the editor sees no progress. This
   holds even when the sole server was selected via the wildcard: the
   `Rest`-never-anchor rule disambiguates among *racing* contenders, and a single
-  downstream has none — so
-  its real `Begin` is safe to forward.
+  downstream has none — so its real `Begin` is safe to forward.
 - **preferred, N > 1.** This strategy short-circuits (it does not wait for the
   losers), so there is no collection count to report. If the anchor emits its own
   progress, forward its `Begin`/`report`/`End` (real title) and suppress every

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -242,7 +242,8 @@ outranks the candidate yields no anchor), routes that downstream's `$/progress`
 onto the editor's token, and guarantees a terminal `End` on teardown. Wired for
 `textDocument/references`; the goto family and the `workDoneProgress` capability
 advertisement (without which spec-compliant clients never send a token) are in
-flight under #437 / #445.
+flight (#446 for the goto family under #437; #448 for the advertisement under
+#445).
 
 **Deferred** (still stripped or unhandled; tracked):
 
@@ -253,10 +254,10 @@ flight under #437 / #445.
 - **Dynamic fall-through re-anchoring** is not built: the single fixed anchor's
   open `Begin` is closed by the synthetic terminal `End` rather than handed to the
   next named anchor's real `End`. #438.
-- **Method coverage** beyond references/goto — notably the whole-document,
-  multi-region methods (`documentSymbol`, …), which fan out to several regions per
-  request and so need a request-level shared aggregator, not the per-dispatch one.
-  #437.
+- **Method coverage** beyond references (and the in-flight goto family) — notably
+  the whole-document, multi-region methods (`documentSymbol`, …), which fan out to
+  several regions per request and so need a request-level shared aggregator, not
+  the per-dispatch one. #437.
 - **Host-layer** client progress: the host path still strips the token. #441.
 
 The remaining notes below are design-tuning points; the empty-vs-non-empty

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -29,11 +29,12 @@ The host raw-request path strips them (`strip_progress_tokens`,
 builders constructed fresh params with default (empty) progress fields, so no
 token was carried either way. (The host path still strips, and
 `partialResultToken` is still dropped; wired methods now carry a bridge-minted
-`workDoneToken` — see the Decision–Implementation Gap.) A downstream honoring a
-stripped token would stream into the void, since the bridge discards downstream
-notifications, and could legally return an empty final result — so client-requested
-progress did not reach the editor. (It now does on the wired paths; this motivated
-the decision below.)
+`workDoneToken` — see the Decision–Implementation Gap.) With the token stripped
+the downstream had none to report against, and the bridge discarded downstream
+notifications regardless — so client-requested progress did not reach the editor
+(and a server that did emit `$/progress` could legally still return an empty final
+result). This is what the decision below set out to fix; it now reaches the editor
+on the wired paths.
 
 ## Decision
 

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -29,11 +29,11 @@ The host raw-request path strips them (`strip_progress_tokens`,
 builders constructed fresh params with default (empty) progress fields, so no
 token was carried either way. (The host path still strips, and
 `partialResultToken` is still dropped; wired methods now carry a bridge-minted
-`workDoneToken` — see the Decision–Implementation Gap.) A downstream honoring
-them would stream into the
-void, since the bridge discards downstream notifications, and could legally
-return an empty final result. The cost is that client-requested progress never
-reaches the editor.
+`workDoneToken` — see the Decision–Implementation Gap.) A downstream honoring a
+stripped token would stream into the void, since the bridge discards downstream
+notifications, and could legally return an empty final result — so client-requested
+progress did not reach the editor. (It now does on the wired paths; this motivated
+the decision below.)
 
 ## Decision
 

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -247,10 +247,9 @@ mints a per-server bridge token only for the tracked source (sole server at
 N = 1, highest-priority *named* anchor at N > 1; a wildcard `Rest` group that
 outranks the candidate yields no anchor), routes that downstream's `$/progress`
 onto the editor's token, and guarantees a terminal `End` on teardown. Wired for
-`textDocument/references`; the goto family and the `workDoneProgress` capability
-advertisement (without which spec-compliant clients never send a token) are in
-flight (#446 for the goto family under #437; #448 for the advertisement under
-#445).
+`textDocument/references`; #446 extends it to the goto family (under #437) and
+#448 adds the `workDoneProgress` capability advertisement (under #445; without it
+spec-compliant clients never send a token).
 
 **Deferred** (still stripped or unhandled; tracked):
 
@@ -261,8 +260,9 @@ flight (#446 for the goto family under #437; #448 for the advertisement under
 - **Dynamic fall-through re-anchoring** is not built: the single fixed anchor's
   open `Begin` is closed by the synthetic terminal `End` rather than handed to the
   next named anchor's real `End`. #438.
-- **Method coverage** beyond references (and the in-flight goto family) — notably
-  the whole-document, multi-region methods (`documentSymbol`, …), which fan out to
+- **Method coverage** beyond references (and the goto family added by #446) —
+  notably the whole-document, multi-region methods (`documentSymbol`, …), which
+  fan out to
   several regions per request and so need a request-level shared aggregator, not
   the per-dispatch one. #437.
 - **Host-layer** client progress: the host path still strips the token. #441.

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -271,12 +271,9 @@ The remaining notes below are design-tuning points; the empty-vs-non-empty
 fall-through threshold and the `Rest`-never-anchor rule are now **decided** as
 described above.
 
-Specific points to settle during the remaining implementation:
+Points still open for the deferred work above (`partialResultToken`,
+*concatenated*, and the `Rest`-member refinement):
 
-- The empty-vs-non-empty threshold that triggers fall-through must
-  **match the existing preferred-strategy empty-result behavior** — a uniform
-  fall-through-on-empty across the priority walk, not a per-method exception.
-  Align with the preferred strategy; do not invent a new threshold.
 - `partialResultToken` support depends on the aggregation layer accepting
   incremental input. Until that lands, `partialResultToken` may stay stripped
   while `workDoneToken` is bridged — a valid intermediate phase. Without
@@ -295,8 +292,7 @@ Specific points to settle during the remaining implementation:
   ones are in — trading streaming latency for ordering fidelity. An
   implementation may relax this if a method's partial results are
   order-insensitive.
-- Treating `Rest`-group members as never-anchors trades progress visibility for
-  title correctness: under *preferred*, if the delivered winner is an unnamed
-  `Rest` member doing long work, its own progress is not shown (no safe a priori
-  title). A future refinement could surface it once it is the sole active `Rest`
-  member.
+- The decided `Rest`-never-anchor rule trades progress visibility for title
+  correctness: under *preferred*, if the delivered winner is an unnamed `Rest`
+  member doing long work, its own progress is not shown (no safe a priori title).
+  A future refinement could surface it once it is the sole active `Rest` member.

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -81,9 +81,10 @@ request just returns its result (today's behavior, minus the strip).
   already unique, so the server-declared `ProgressRegistry` namespacing is not
   involved; internally the bridge mints a per-server token so the reader can route
   the downstream's `$/progress` to the request's aggregator, which retargets it
-  onto the client token.) If it emits none, the editor sees no progress. This holds even when
-  the sole server was selected via the wildcard: the `Rest`-never-anchor rule
-  disambiguates among *racing* contenders, and a single downstream has none — so
+  onto the client token.) If it emits none, the editor sees no progress. This
+  holds even when the sole server was selected via the wildcard: the
+  `Rest`-never-anchor rule disambiguates among *racing* contenders, and a single
+  downstream has none — so
   its real `Begin` is safe to forward.
 - **preferred, N > 1.** This strategy short-circuits (it does not wait for the
   losers), so there is no collection count to report. If the anchor emits its own

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -23,11 +23,14 @@ all N downstreams' `End`s/responses (they collide); it forwards exactly one or
 composes one, as the Decision details. (A request that reaches a single server is
 just relayed.)
 
-Today the bridge does not forward client-provided tokens to downstreams at all.
+Originally the bridge forwarded no client-provided tokens to downstreams at all.
 The host raw-request path strips them (`strip_progress_tokens`,
 `src/lsp/bridge/text_document/host.rs`), and the per-method virtual request
-builders construct fresh params with default (empty) progress fields, so no
-token is carried either way. A downstream honoring them would stream into the
+builders constructed fresh params with default (empty) progress fields, so no
+token was carried either way. (The host path still strips, and
+`partialResultToken` is still dropped; wired methods now carry a bridge-minted
+`workDoneToken` — see the Decision–Implementation Gap.) A downstream honoring
+them would stream into the
 void, since the bridge discards downstream notifications, and could legally
 return an empty final result. The cost is that client-requested progress never
 reaches the editor.
@@ -73,8 +76,11 @@ The lifecycle engages only when there is progress worth showing; otherwise the
 request just returns its result (today's behavior, minus the strip).
 
 - **Single downstream (N = 1).** Relay that server's own `Begin`/`report`/`End`
-  against the client's original token (client tokens are already unique, so no
-  remapping). If it emits none, the editor sees no progress. This holds even when
+  onto the client's original token — what the editor sees. (Client tokens are
+  already unique, so the server-declared `ProgressRegistry` namespacing is not
+  involved; internally the bridge mints a per-server token so the reader can route
+  the downstream's `$/progress` to the request's aggregator, which retargets it
+  onto the client token.) If it emits none, the editor sees no progress. This holds even when
   the sole server was selected via the wildcard: the `Rest`-never-anchor rule
   disambiguates among *racing* contenders, and a single downstream has none — so
   its real `Begin` is safe to forward.

--- a/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
+++ b/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
@@ -12,9 +12,9 @@ against that token until a terminating `End` clears the mapping.
 
 A downstream can exit *between* `Begin` and `End` — it crashes, is shut down, or
 is respawned while work is in flight. Before #413 was implemented the bridge
-handled that
-only *internally*: when the connection's reader task exited, the registry purged
-the connection's mappings and the forwarding loop dropped their admissions (the
+handled that only *internally*: when the connection's reader task exited, the
+registry purged the connection's mappings and the forwarding loop dropped their
+admissions (the
 `ForgetWorkDoneProgress` notification removes them from `created_tokens` in
 `src/lsp/lsp_impl/lifecycle.rs`). It forwarded no terminating `End` to the editor.
 

--- a/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
+++ b/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
@@ -11,7 +11,8 @@ forwards the create, and then relays each `$/progress` (begin → report → end
 against that token until a terminating `End` clears the mapping.
 
 A downstream can exit *between* `Begin` and `End` — it crashes, is shut down, or
-is respawned while work is in flight. Before this change the bridge handled that
+is respawned while work is in flight. Before #413 was implemented the bridge
+handled that
 only *internally*: when the connection's reader task exited, the registry purged
 the connection's mappings and the forwarding loop dropped their admissions (the
 `ForgetWorkDoneProgress` notification removes them from `created_tokens` in

--- a/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
+++ b/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
@@ -104,7 +104,10 @@ ls-bridge-client-progress relies on for client-provided tokens.
 
 ## Decision–Implementation Gap
 
-Not yet implemented (tracked in issue #413). Today the reader-exit path purges
-the registry mappings and forgets the loop admissions but forwards no terminating
-`End`, so an editor still sees a dangling indicator when a downstream dies
-mid-progress. This record captures the agreed fix ahead of the change.
+**Implemented** (issue #413). On `ForgetWorkDoneProgress` the forwarding loop now
+synthesizes a terminating `$/progress` `End` for every begun-not-ended
+server-declared token, so a downstream that dies mid-progress no longer leaves a
+dangling indicator. A token created but never begun gets no `End`; a token that
+already ended is not ended again (the real `End` and the forget share the FIFO
+upstream channel, so the loop's begun-not-ended set is cleared before any later
+forget).

--- a/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
+++ b/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
@@ -11,19 +11,18 @@ forwards the create, and then relays each `$/progress` (begin → report → end
 against that token until a terminating `End` clears the mapping.
 
 A downstream can exit *between* `Begin` and `End` — it crashes, is shut down, or
-is respawned while work is in flight. Today the bridge handles that only
-*internally*: when the connection's reader task exits, the registry purges the
-connection's mappings and the forwarding loop drops their admissions (the
+is respawned while work is in flight. Before this change the bridge handled that
+only *internally*: when the connection's reader task exited, the registry purged
+the connection's mappings and the forwarding loop dropped their admissions (the
 `ForgetWorkDoneProgress` notification removes them from `created_tokens` in
-`src/lsp/lsp_impl/lifecycle.rs`). It never forwards a terminating `End` to the
-editor.
+`src/lsp/lsp_impl/lifecycle.rs`). It forwarded no terminating `End` to the editor.
 
-The consequence is a **dangling progress indicator**: the editor created the
+The consequence was a **dangling progress indicator**: the editor created the
 progress token on `window/workDoneProgress/create`, the downstream started it
-with `Begin`, but no `End` ever arrives, so the spinner stays up indefinitely.
+with `Begin`, but no `End` ever arrived, so the spinner stayed up indefinitely.
 Some editors offer no way to dismiss a progress indicator they believe is still
-running. Work-done progress is a strict begin/end lifecycle, and the bridge
-currently breaks it on the disconnect path.
+running. Work-done progress is a strict begin/end lifecycle, and the bridge broke
+it on the disconnect path (now fixed — see the Decision–Implementation Gap).
 
 ## Decision
 


### PR DESCRIPTION
## Summary

Part of #442. The two progress ADRs ran ahead of the code (they're aspirational). Reconcile their **Decision–Implementation Gap** sections — and the now-stale present-tense Context/Decision prose — with what's actually merged.

## Changes
- **`ls-bridge-client-progress`**: the gap section now records that the **N=1 relay** and **`preferred` single-anchor** path are implemented (wired for `references`; goto + `workDoneProgress` advertisement in flight via #446/#448), and that the empty-threshold and `Rest`-never-anchor rules are decided. Deferred items re-pointed to their tracking issues — `partialResultToken` #439, `concatenated` #440, dynamic re-anchoring #438, whole-document/method coverage #437, host-layer #441. Past-tensed the Context prose ("no client tokens forwarded", "streams into the void") and clarified the N=1 token routing (editor sees its own token; the bridge mints a per-server token internally to route `$/progress` to the aggregator).
- **`ls-bridge-progress-disconnect-cleanup`**: marked implemented (#413) and past-tensed the "never forwards a terminal `End` / currently breaks the lifecycle" problem statement.

Docs only — every implemented/deferred claim verified against the merged code (subagent `/review` + Codex, both converged; Codex's accuracy pass caught the stale Context prose).

The deferred client-progress **integration tests** part of #442 (needs a reader→dispatch harness) is not in this PR; #442 stays open for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)