### PR TITLE
feat(bridge): share one client-progress aggregator across documentSymbol regions (#450)

### DIFF
--- a/src/lsp/aggregation/server.rs
+++ b/src/lsp/aggregation/server.rs
@@ -6,7 +6,10 @@ mod host_dispatch;
 pub(crate) mod priority;
 
 pub(crate) use concatenated_pipeline::run_sequential_format_pipeline;
-pub(crate) use dispatch::{dispatch_concatenated, dispatch_preferred, effective_priorities_from};
+pub(crate) use dispatch::{
+    dispatch_concatenated, dispatch_preferred, dispatch_preferred_with_tokens,
+    effective_priorities_from, mint_region_progress_source,
+};
 pub(crate) use fan_in::FanInResult;
 pub(crate) use fan_out::FanOutTask;
 pub(crate) use host_dispatch::{

--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -18,8 +18,8 @@ use std::sync::{Arc, Mutex};
 use tower_lsp_server::ls_types::NumberOrString;
 
 use crate::lsp::bridge::{
-    ClientProgressAggregator, ClientProgressDeregisterGuard, LanguageServerPool,
-    ResolvedServerConfig,
+    ClientProgressAggregator, ClientProgressDeregisterGuard, ClientProgressRegistry,
+    LanguageServerPool, ResolvedServerConfig,
 };
 use crate::lsp::lsp_impl::bridge_context::DocumentRequestContext;
 use crate::lsp::request_id::CancelReceiver;
@@ -244,6 +244,53 @@ where
     // would have nowhere to route.
     drop(client_progress);
     result
+}
+
+/// Like [`dispatch_preferred`], but routes client progress to an
+/// externally-supplied per-server token map instead of minting its own — and owns
+/// no teardown guard (the caller does).
+///
+/// For a multi-region request (e.g. `documentSymbol`), the handler creates ONE
+/// shared aggregator + ONE teardown guard for the whole request and mints a token
+/// per region with [`mint_region_progress_source`]; each region's dispatch routes
+/// its tracked source's `$/progress` to that shared aggregator via `tokens`. The
+/// shared aggregator's winner rule then shows one coherent lifecycle across all
+/// regions (ls-bridge-client-progress).
+pub(crate) async fn dispatch_preferred_with_tokens<T, F, Fut>(
+    ctx: &DocumentRequestContext,
+    pool: Arc<LanguageServerPool>,
+    f: F,
+    is_nonempty: impl Fn(&T) -> bool,
+    cancel_rx: Option<CancelReceiver>,
+    tokens: HashMap<String, NumberOrString>,
+) -> FanInResult<T>
+where
+    T: Send + 'static,
+    F: Fn(FanOutTask) -> Fut,
+    Fut: Future<Output = io::Result<T>> + Send + 'static,
+{
+    let entries = expanded_entries(ctx);
+    let selected = select_servers(&ctx.configs, &entries);
+    let mut join_set = fan_out(ctx, pool, f, &selected, Some(&tokens));
+    preferred::preferred(&mut join_set, is_nonempty, &entries, cancel_rx).await
+}
+
+/// Mint the client-progress token for one region of a multi-region request: pick
+/// the region's tracked source (sole server / named anchor; `None` for an
+/// all-`Rest` fan-out) and register a bridge token to the request's shared
+/// `aggregator`. Returns the `server → token` map for
+/// [`dispatch_preferred_with_tokens`]. The caller must deregister the returned
+/// token via its shared teardown guard.
+pub(crate) fn mint_region_progress_source(
+    ctx: &DocumentRequestContext,
+    registry: &ClientProgressRegistry,
+    aggregator: &Arc<Mutex<ClientProgressAggregator>>,
+) -> Option<HashMap<String, NumberOrString>> {
+    let entries = expanded_entries(ctx);
+    let selected = select_servers(&ctx.configs, &entries);
+    let tracked = tracked_progress_source(&selected, &entries)?;
+    let token = registry.register(Arc::clone(aggregator));
+    Some(HashMap::from([(tracked.to_string(), token)]))
 }
 
 /// Server-level aggregation entry point using the concatenated strategy.

--- a/src/lsp/bridge/client_progress.rs
+++ b/src/lsp/bridge/client_progress.rs
@@ -137,16 +137,21 @@ impl Drop for ClientProgressDeregisterGuard {
         // notification before its response — and the response is what completes
         // fan-in and drops this guard (ls-bridge-message-ordering).
         self.registry.deregister(&self.tokens);
-        let terminal = self
+        // Enqueue the synthetic terminal `End` **while still holding the aggregator
+        // lock**, so it is ordered strictly before/after any concurrent reader's
+        // relay (which also enqueues under the lock) — never interleaved. Combined
+        // with `take_terminal_end` marking the lifecycle ended, no relay can escape
+        // after this terminal (guards the cancel race; ls-bridge-client-progress).
+        let mut aggregator = self
             .aggregator
             .lock()
-            .recover_poison("ClientProgressAggregator teardown")
-            .take_terminal_end();
-        if let Some(params) = terminal {
+            .recover_poison("ClientProgressAggregator teardown");
+        if let Some(params) = aggregator.take_terminal_end() {
             let _ = self
                 .upstream_tx
                 .send(crate::lsp::bridge::actor::UpstreamNotification::ClientProgress { params });
         }
+        drop(aggregator);
     }
 }
 
@@ -225,23 +230,28 @@ impl ClientProgressAggregator {
         })
     }
 
-    /// On request teardown, return a synthetic terminal `End` for the client token
-    /// **iff** a `Begin` was relayed but no `End` — so the editor's indicator is
-    /// always closed even when the winner's `End` never arrives or races the
-    /// response (ls-bridge-client-progress pairing invariant). Marks the lifecycle
-    /// ended so it fires at most once and a later real `End` is ignored.
+    /// On request teardown, **terminate the lifecycle** and return a synthetic
+    /// terminal `End` for the client token **iff** a `Begin` was relayed but no
+    /// `End` — so the editor's indicator is always closed even when the winner's
+    /// `End` never arrives or races the response (ls-bridge-client-progress pairing
+    /// invariant).
+    ///
+    /// `ended` is set **unconditionally**, even when no `Begin` was relayed yet:
+    /// after teardown the aggregator must relay nothing, otherwise a `$/progress`
+    /// a reader routed just before teardown (e.g. on a cancel that drops the
+    /// dispatch before the response) could relay a `Begin` *after* this terminal,
+    /// leaving a dangling indicator. The caller enqueues the returned `End` while
+    /// still holding the aggregator lock, so a concurrent relay is ordered strictly
+    /// before or after this terminal — never interleaved.
     pub(crate) fn take_terminal_end(&mut self) -> Option<ProgressParams> {
-        if self.winner.is_some() && !self.ended {
-            self.ended = true;
-            Some(ProgressParams {
-                token: self.client_token.clone(),
-                value: ProgressParamsValue::WorkDone(WorkDoneProgress::End(
-                    tower_lsp_server::ls_types::WorkDoneProgressEnd { message: None },
-                )),
-            })
-        } else {
-            None
-        }
+        let emit = self.winner.is_some() && !self.ended;
+        self.ended = true;
+        emit.then(|| ProgressParams {
+            token: self.client_token.clone(),
+            value: ProgressParamsValue::WorkDone(WorkDoneProgress::End(
+                tower_lsp_server::ls_types::WorkDoneProgressEnd { message: None },
+            )),
+        })
     }
 }
 
@@ -496,6 +506,28 @@ mod tests {
         assert!(
             rx.try_recv().is_err(),
             "no Begin was relayed, so no terminal End is synthesized"
+        );
+    }
+
+    #[test]
+    fn no_relay_escapes_after_teardown_even_without_a_prior_begin() {
+        // Cancel race: teardown can run before any `Begin` was relayed (a cancel
+        // drops the dispatch before the response). `take_terminal_end` must mark
+        // the lifecycle ended unconditionally, so a `$/progress` a reader routed
+        // just before teardown cannot relay a `Begin` afterwards — which would
+        // dangle, with no terminal to follow.
+        let mut agg = ClientProgressAggregator::new(client_token());
+        assert!(
+            agg.take_terminal_end().is_none(),
+            "no Begin yet → no terminal End"
+        );
+        assert!(
+            agg.on_downstream_progress(&src(), begin()).is_none(),
+            "after teardown, a late Begin relays nothing"
+        );
+        assert!(
+            agg.on_downstream_progress(&src(), end()).is_none(),
+            "and a late End relays nothing"
         );
     }
 }

--- a/src/lsp/bridge/protocol/request.rs
+++ b/src/lsp/bridge/protocol/request.rs
@@ -104,6 +104,38 @@ pub(crate) fn build_whole_document_request(
     JsonRpcRequest::new(request_id.as_i64(), method, params)
 }
 
+/// A whole-document request's params plus an optional client-provided
+/// `workDoneToken` (ls-bridge-client-progress). `DocumentParams` has no progress
+/// field, so we flatten it and add the token alongside; when the token is `None`
+/// this serializes byte-identically to the bare `DocumentParams`.
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct WholeDocumentRequestParams {
+    #[serde(flatten)]
+    document: DocumentParams,
+    #[serde(rename = "workDoneToken", skip_serializing_if = "Option::is_none")]
+    work_done_token: Option<NumberOrString>,
+}
+
+/// Like [`build_whole_document_request`], but carries the editor's `workDoneToken`
+/// so the downstream reports `$/progress` against it (ls-bridge-client-progress).
+/// `client_progress_token = None` is equivalent to [`build_whole_document_request`].
+pub(crate) fn build_whole_document_request_with_progress(
+    virtual_uri: &VirtualDocumentUri,
+    request_id: RequestId,
+    method: &'static str,
+    client_progress_token: Option<NumberOrString>,
+) -> JsonRpcRequest<WholeDocumentRequestParams> {
+    let params = WholeDocumentRequestParams {
+        document: DocumentParams {
+            text_document: TextDocumentIdentifier {
+                uri: virtual_uri_to_lsp_uri(virtual_uri),
+            },
+        },
+        work_done_token: client_progress_token,
+    };
+    JsonRpcRequest::new(request_id.as_i64(), method, params)
+}
+
 /// Build a JSON-RPC didOpen notification carrying a virtual document's initial
 /// content to a downstream language server.
 pub(crate) fn build_didopen_notification(
@@ -146,6 +178,53 @@ mod tests {
     use super::super::super::text_document::test_helpers::test_host_uri;
     use super::*;
     use tower_lsp_server::ls_types::Position;
+
+    #[test]
+    fn whole_document_request_carries_work_done_token_only_when_present() {
+        let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
+
+        // With a token: present in params.
+        let with = build_whole_document_request_with_progress(
+            &virtual_uri,
+            RequestId::new(1),
+            "textDocument/documentSymbol",
+            Some(NumberOrString::String("cprog-1".to_string())),
+        );
+        let json = serde_json::to_value(&with).unwrap();
+        assert_eq!(json["params"]["workDoneToken"], "cprog-1");
+        assert!(json["params"]["textDocument"].is_object());
+
+        // Number token variant round-trips too.
+        let with_num = build_whole_document_request_with_progress(
+            &virtual_uri,
+            RequestId::new(2),
+            "textDocument/documentSymbol",
+            Some(NumberOrString::Number(7)),
+        );
+        assert_eq!(
+            serde_json::to_value(&with_num).unwrap()["params"]["workDoneToken"],
+            7
+        );
+
+        // Without a token: byte-identical to the bare whole-document params
+        // (the field is skipped), so this is non-regressing.
+        let without = build_whole_document_request_with_progress(
+            &virtual_uri,
+            RequestId::new(1),
+            "textDocument/documentSymbol",
+            None,
+        );
+        let bare = build_whole_document_request(
+            &virtual_uri,
+            RequestId::new(1),
+            "textDocument/documentSymbol",
+        );
+        assert_eq!(
+            serde_json::to_string(&without).unwrap(),
+            serde_json::to_string(&bare).unwrap(),
+            "None token serializes identically to the bare request"
+        );
+    }
 
     #[test]
     fn position_request_first_line_applies_column_offset() {

--- a/src/lsp/bridge/text_document/document_symbol.rs
+++ b/src/lsp/bridge/text_document/document_symbol.rs
@@ -77,10 +77,14 @@ impl LanguageServerPool {
     }
 }
 
-/// Build a JSON-RPC document symbol request for a downstream language server.
+/// Build a JSON-RPC `textDocument/documentSymbol` request for a downstream server.
 ///
-/// Like DocumentLinkParams, DocumentSymbolParams only has a textDocument field -
-/// no position. The request asks for all symbols in the entire document.
+/// The request is whole-document (no position). The bridge serializes only the
+/// `textDocument` field plus — when `client_progress_token` is `Some` — a
+/// `workDoneToken`, so the downstream reports `$/progress` against this request's
+/// shared aggregator (ls-bridge-client-progress). `None` omits the token, yielding
+/// the bare whole-document params. (The editor's other `DocumentSymbolParams`
+/// fields, e.g. `partialResultToken`, are not forwarded.)
 fn build_document_symbol_request(
     virtual_uri: &VirtualDocumentUri,
     request_id: RequestId,

--- a/src/lsp/bridge/text_document/document_symbol.rs
+++ b/src/lsp/bridge/text_document/document_symbol.rs
@@ -13,14 +13,14 @@
 use std::io;
 
 use crate::config::settings::BridgeServerConfig;
-use tower_lsp_server::ls_types::{DocumentSymbol, SymbolInformation};
+use tower_lsp_server::ls_types::{DocumentSymbol, NumberOrString, SymbolInformation};
 use url::Url;
 
 use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::translate_virtual_range_to_host;
 use super::super::protocol::{
-    DocumentParams, JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri,
-    build_whole_document_request, response_has_jsonrpc_error,
+    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, WholeDocumentRequestParams,
+    build_whole_document_request_with_progress, response_has_jsonrpc_error,
 };
 
 impl LanguageServerPool {
@@ -44,6 +44,7 @@ impl LanguageServerPool {
         offset: RegionOffset,
         virtual_content: &str,
         upstream_request_id: Option<UpstreamId>,
+        client_progress_token: Option<NumberOrString>,
     ) -> io::Result<Option<Vec<DocumentSymbol>>> {
         let handle = self
             .get_or_create_connection(server_name, server_config, Some(host_uri))
@@ -59,7 +60,11 @@ impl LanguageServerPool {
             &offset,
             virtual_content,
             upstream_request_id,
-            build_document_symbol_request,
+            // Hand the downstream the bridge-minted token so its `$/progress`
+            // routes to this request's shared aggregator (ls-bridge-client-progress).
+            |virtual_uri, request_id| {
+                build_document_symbol_request(virtual_uri, request_id, client_progress_token)
+            },
             |response, ctx| {
                 transform_document_symbol_response_to_host(
                     response,
@@ -79,8 +84,14 @@ impl LanguageServerPool {
 fn build_document_symbol_request(
     virtual_uri: &VirtualDocumentUri,
     request_id: RequestId,
-) -> JsonRpcRequest<DocumentParams> {
-    build_whole_document_request(virtual_uri, request_id, "textDocument/documentSymbol")
+    client_progress_token: Option<NumberOrString>,
+) -> JsonRpcRequest<WholeDocumentRequestParams> {
+    build_whole_document_request_with_progress(
+        virtual_uri,
+        request_id,
+        "textDocument/documentSymbol",
+        client_progress_token,
+    )
 }
 
 /// Translate a documentSymbol response from virtual to host coordinates and
@@ -227,7 +238,7 @@ mod tests {
     #[test]
     fn document_symbol_request_uses_virtual_uri() {
         let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
-        let request = build_document_symbol_request(&virtual_uri, RequestId::new(42));
+        let request = build_document_symbol_request(&virtual_uri, RequestId::new(42), None);
 
         assert_uses_virtual_uri(&request, "lua");
     }
@@ -235,7 +246,7 @@ mod tests {
     #[test]
     fn document_symbol_request_has_correct_method_and_no_position() {
         let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
-        let request = build_document_symbol_request(&virtual_uri, RequestId::new(123));
+        let request = build_document_symbol_request(&virtual_uri, RequestId::new(123), None);
 
         let json = serde_json::to_value(&request).unwrap();
         assert_eq!(json["jsonrpc"], "2.0");

--- a/src/lsp/bridge/window/progress.rs
+++ b/src/lsp/bridge/window/progress.rs
@@ -47,16 +47,17 @@ pub(in crate::lsp::bridge) fn forward(
     // own `workDoneToken` and emits it ungated (ls-bridge-client-progress).
     if let Some(aggregator) = deps.client_progress_registry.route(&params.token) {
         // The incoming token identifies the source; the aggregator picks the first
-        // source to `Begin` as the winner and relays only its progress.
-        let emitted = aggregator
-            .lock()
-            .recover_poison("ClientProgressAggregator")
-            .on_downstream_progress(&params.token, params.value);
-        if let Some(out) = emitted {
+        // source to `Begin` as the winner and relays only its progress. Enqueue the
+        // relay **while still holding the aggregator lock**, so it is ordered
+        // strictly before/after the teardown's terminal `End` (which also enqueues
+        // under the lock) — never interleaved (guards the cancel race).
+        let mut agg = aggregator.lock().recover_poison("ClientProgressAggregator");
+        if let Some(out) = agg.on_downstream_progress(&params.token, params.value) {
             let _ = deps
                 .upstream_tx
                 .send(UpstreamNotification::ClientProgress { params: out });
         }
+        drop(agg);
         return;
     }
 

--- a/src/lsp/lsp_impl/text_document/document_symbol.rs
+++ b/src/lsp/lsp_impl/text_document/document_symbol.rs
@@ -6,17 +6,21 @@
 //! with the real URI and the response verbatim. The first layer producing a
 //! non-empty result wins (`preferred`).
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use tokio::task::JoinSet;
 use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::{
-    DocumentSymbol, DocumentSymbolParams, DocumentSymbolResponse, Location, SymbolInformation, Uri,
+    DocumentSymbol, DocumentSymbolParams, DocumentSymbolResponse, Location, NumberOrString,
+    SymbolInformation, Uri,
 };
 
 use crate::language::InjectionResolver;
-use crate::lsp::aggregation::server::FanInResult;
-use crate::lsp::aggregation::server::dispatch_preferred;
+use crate::lsp::aggregation::server::{
+    FanInResult, FanOutTask, dispatch_preferred, dispatch_preferred_with_tokens,
+    mint_region_progress_source,
+};
+use crate::lsp::bridge::{ClientProgressAggregator, ClientProgressDeregisterGuard};
 use crate::lsp::lsp_impl::bridge_context::{DocumentRequestContext, parse_host_verbatim};
 
 use super::super::{Kakehashi, uri_to_url};
@@ -29,9 +33,10 @@ impl Kakehashi {
         params: DocumentSymbolParams,
     ) -> Result<Option<DocumentSymbolResponse>> {
         let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
+        let work_done_token = params.work_done_progress_params.work_done_token.clone();
         let lsp_uri = params.text_document.uri;
 
-        let virt = self.document_symbol_virt_layer(&lsp_uri);
+        let virt = self.document_symbol_virt_layer(&lsp_uri, work_done_token);
         self.walk_layers(
             &lsp_uri,
             METHOD,
@@ -51,6 +56,7 @@ impl Kakehashi {
     async fn document_symbol_virt_layer(
         &self,
         lsp_uri: &Uri,
+        work_done_token: Option<NumberOrString>,
     ) -> Result<Option<DocumentSymbolResponse>> {
         // Convert ls_types::Uri to url::Url for internal use
         let Ok(uri) = uri_to_url(lsp_uri) else {
@@ -113,6 +119,19 @@ impl Kakehashi {
         // Outer JoinSet: one task per injection region, all in parallel
         let mut outer_join_set: JoinSet<Vec<DocumentSymbol>> = JoinSet::new();
 
+        // Shared client progress: a whole-document request fans out over several
+        // injection regions (one `dispatch_preferred` each), so they share ONE
+        // aggregator + ONE teardown guard. The aggregator's winner rule shows the
+        // first region to begin as one coherent `Begin → … → End` on the editor's
+        // token (ls-bridge-client-progress). `None` when no `workDoneToken`.
+        let shared_cp = work_done_token.map(|client_token| {
+            (
+                Arc::new(Mutex::new(ClientProgressAggregator::new(client_token))),
+                Arc::clone(pool.client_progress_registry()),
+            )
+        });
+        let mut cp_minted: Vec<NumberOrString> = Vec::new();
+
         for resolved in all_regions {
             // Get ALL bridge server configs for this injection language
             let configs = self.bridge_configs_for_injection_language(
@@ -138,36 +157,65 @@ impl Kakehashi {
                 max_fan_out: agg.max_fan_out,
                 client_progress_token: None,
             };
+
+            // Mint this region's tracked-source token into the shared aggregator
+            // (the per-region map dispatch hands to its winning downstream).
+            let region_cp_tokens = shared_cp.as_ref().and_then(|(aggregator, registry)| {
+                mint_region_progress_source(&region_ctx, registry, aggregator)
+            });
+            if let Some(map) = &region_cp_tokens {
+                cp_minted.extend(map.values().cloned());
+            }
+
             let pool = Arc::clone(&pool);
 
             outer_join_set.spawn(async move {
-                let result = dispatch_preferred(
-                    &region_ctx,
-                    pool.clone(),
-                    |t| async move {
-                        t.pool
-                            .send_document_symbol_request(
-                                &t.server_name,
-                                &t.server_config,
-                                &t.uri,
-                                &t.injection_language,
-                                &t.region_id,
-                                t.offset,
-                                &t.virtual_content,
-                                t.upstream_id,
-                            )
-                            .await
-                    },
-                    |opt| matches!(opt, Some(v) if !v.is_empty()),
-                    None,
-                )
-                .await;
+                let send = |t: FanOutTask| async move {
+                    t.pool
+                        .send_document_symbol_request(
+                            &t.server_name,
+                            &t.server_config,
+                            &t.uri,
+                            &t.injection_language,
+                            &t.region_id,
+                            t.offset,
+                            &t.virtual_content,
+                            t.upstream_id,
+                            t.client_progress_token,
+                        )
+                        .await
+                };
+                let is_nonempty =
+                    |opt: &Option<Vec<DocumentSymbol>>| matches!(opt, Some(v) if !v.is_empty());
+                let result = match region_cp_tokens {
+                    Some(tokens) => {
+                        dispatch_preferred_with_tokens(
+                            &region_ctx,
+                            pool.clone(),
+                            send,
+                            is_nonempty,
+                            None,
+                            tokens,
+                        )
+                        .await
+                    }
+                    None => {
+                        dispatch_preferred(&region_ctx, pool.clone(), send, is_nonempty, None).await
+                    }
+                };
                 match result {
                     FanInResult::Done(symbols) => symbols.unwrap_or_default(),
                     FanInResult::NoResult { .. } | FanInResult::Cancelled => Vec::new(),
                 }
             });
         }
+
+        // One teardown guard for the whole request, held across the region
+        // collection so the synthetic terminal `End` fires once, after every
+        // region settles (or on cancel, when `collect` drops the JoinSet).
+        let _cp_guard = shared_cp.map(|(aggregator, registry)| {
+            ClientProgressDeregisterGuard::new(registry, cp_minted, aggregator, pool.upstream_tx())
+        });
 
         // Collect results, aborting early if $/cancelRequest arrives.
         let result = crate::lsp::aggregation::region::collect_region_results_with_cancel(


### PR DESCRIPTION
## Summary

Behavioral half of #437 for **whole-document, multi-region** methods (#450), building on the merged winner-token aggregator (#451). `documentSymbol` fans out over several injection regions (one `dispatch_preferred` each); previously each region would mint its own aggregator, duplicating the lifecycle on the editor's token.

Now the handler creates **one** shared `ClientProgressAggregator` + **one** teardown guard for the whole request and mints a per-region token into it; each region dispatches via `dispatch_preferred_with_tokens`, routing its tracked source's `$/progress` to the shared aggregator. The winner rule shows the **first region to begin** as a single coherent `Begin → … → End`, and the one guard fires the terminal `End` after every region settles (or on cancel).

## Pieces
- `request.rs`: `WholeDocumentRequestParams` (flatten `DocumentParams` + skip-if-none `workDoneToken`) + `build_whole_document_request_with_progress`; `None` is byte-identical to the bare params.
- `dispatch.rs`: `dispatch_preferred_with_tokens` (pre-built token map, no own setup/guard) + `mint_region_progress_source`.
- `send_document_symbol_request` carries the bridge-minted token to the downstream.
- handler: shared-aggregator orchestration across the region tasks.
- **Cancel-race fix** (Codex): `take_terminal_end` now terminates unconditionally, and both enqueue sites send while holding the aggregator lock, so a relay and the teardown `End` are strictly ordered (no `End → Begin`). This also hardens the single-region path.

## Proven vs. asserted
- **Proven**: winner rule + serde byte-identity + cancel-ordering (unit); the **no-token path is non-regressing** (e2e `e2e_lsp_lua_document_symbol` 27 pass; `initialize_capabilities` snapshot unchanged). clippy/fmt clean, `--lib` 2003 pass.
- **Asserted, not yet integration-tested**: the end-to-end "editor sends `documentSymbol`+`workDoneToken` over a multi-region doc → exactly one `Begin → End`". The reader→dispatch integration harness is deferred (#442).

## Semantics note
The multi-region winner is a **latency race across regions** — which region's named-anchor title the editor sees depends on timing (extends the ADR's "no a-priori title for a latency race" rule).

## Follow-ups
- #452: advertise `workDoneProgress` on `documentSymbol` so strict clients send the token (today only lenient clients exercise the path — the whole-document analog of #448).
- `inlayHint`/`documentColor`/`rangeFormatting` can reuse this scaffolding.

Reviewed via subagent `/review` + Codex (cancel-race fix added; both converged). Part of #437 / completes the wiring tracked in #450.

🤖 Generated with [Claude Code](https://claude.com/claude-code)