### PR TITLE
feat(lsp): advertise workDoneProgress on documentSymbol (#452)

### DIFF
--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -9,11 +9,11 @@ use tower_lsp_server::ls_types::ColorProviderCapability;
 use tower_lsp_server::ls_types::{
     CodeLensOptions, CompletionOptions, DeclarationCapability, DeclarationOptions,
     DefinitionOptions, DiagnosticOptions, DiagnosticServerCapabilities, DocumentLinkOptions,
-    DocumentOnTypeFormattingOptions, FoldingRangeProviderCapability, HoverProviderCapability,
-    ImplementationProviderCapability, InitializeParams, InitializeResult, InitializedParams,
-    LinkedEditingRangeServerCapabilities, OneOf, ReferenceOptions, RenameOptions, SaveOptions,
-    SelectionRangeProviderCapability, SemanticTokenModifier, SemanticTokenType,
-    SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
+    DocumentOnTypeFormattingOptions, DocumentSymbolOptions, FoldingRangeProviderCapability,
+    HoverProviderCapability, ImplementationProviderCapability, InitializeParams, InitializeResult,
+    InitializedParams, LinkedEditingRangeServerCapabilities, OneOf, ReferenceOptions,
+    RenameOptions, SaveOptions, SelectionRangeProviderCapability, SemanticTokenModifier,
+    SemanticTokenType, SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
     SemanticTokensServerCapabilities, ServerCapabilities, ServerInfo, SignatureHelpOptions,
     TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
     TextDocumentSyncSaveOptions, TypeDefinitionProviderCapability, Uri, WorkDoneProgressOptions,
@@ -293,7 +293,15 @@ impl Kakehashi {
                     resolve_provider: None,
                     work_done_progress_options: WorkDoneProgressOptions::default(),
                 }),
-                document_symbol_provider: Some(OneOf::Left(true)),
+                // Advertise workDoneProgress so spec-compliant clients attach a
+                // `workDoneToken` — the bridge relays the fanned-out regions'
+                // `$/progress` onto it (ls-bridge-client-progress, #450).
+                document_symbol_provider: Some(OneOf::Right(DocumentSymbolOptions {
+                    label: None,
+                    work_done_progress_options: WorkDoneProgressOptions {
+                        work_done_progress: Some(true),
+                    },
+                })),
                 folding_range_provider: Some(FoldingRangeProviderCapability::Simple(true)),
                 // codeLens/resolve is routed to the origin downstream server
                 // via the envelope in lens.data (#355, see

--- a/tests/snapshots/e2e_lsp_protocol__initialize_capabilities.snap
+++ b/tests/snapshots/e2e_lsp_protocol__initialize_capabilities.snap
@@ -37,7 +37,9 @@ expression: capabilities
     "workDoneProgress": true
   },
   "documentHighlightProvider": true,
-  "documentSymbolProvider": true,
+  "documentSymbolProvider": {
+    "workDoneProgress": true
+  },
   "codeLensProvider": {
     "resolveProvider": true
   },


### PR DESCRIPTION
## Summary

Closes #452. `documentSymbol` now advertises `DocumentSymbolOptions { workDoneProgress: true }` instead of bare `true`, so spec-compliant clients attach a `workDoneToken` to the request — which the bridge relays across the fanned-out injection regions' `$/progress` via the shared aggregator (the multi-region wiring in #450 / PR #453).

The whole-document analog of #448 (which did this for the goto family / references); mirrors the same `OneOf::Right(...Options { work_done_progress_options: { work_done_progress: Some(true) } })` form already used by `references_provider`/`definition_provider` in the same file.

`DocumentSymbolOptions` flattens `WorkDoneProgressOptions` in ls-types 0.0.6, so this is advertisable (unlike the type_def/impl crate gap, #447).

## Verification
- `initialize_capabilities` snapshot updated: `documentSymbolProvider` → `{ "workDoneProgress": true }` (nothing else changed).
- e2e `e2e_lsp_protocol` 31 pass (incl. the snapshot + the advertise-independent-of-window-capability test). clippy/fmt clean.

The Options form is spec-equivalent to bare `true` plus the added capability, so no client behavior is dropped.

**Sequencing**: best merged after #453 (the plumbing that uses the token); harmless if merged before (clients send a token the bridge currently strips).

Reviewed via Codex (clean). Part of #437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)