### PR TITLE
feat(bridge): client work-done progress for inlayHint (#455)

### DIFF
--- a/src/lsp/bridge/text_document/inlay_hint.rs
+++ b/src/lsp/bridge/text_document/inlay_hint.rs
@@ -251,6 +251,50 @@ mod tests {
     }
 
     #[test]
+    fn inlay_hint_request_carries_work_done_token_only_when_present() {
+        let host_uri = test_host_uri();
+        let host_range = Range {
+            start: tower_lsp_server::ls_types::Position {
+                line: 1,
+                character: 0,
+            },
+            end: tower_lsp_server::ls_types::Position {
+                line: 2,
+                character: 0,
+            },
+        };
+        let virtual_uri = VirtualDocumentUri::new(&host_uri, "lua", "region-0");
+
+        // With a token: present in params.
+        let with = build_inlay_hint_request(
+            &virtual_uri,
+            host_range,
+            &RegionOffset::new(0, 0),
+            RequestId::new(1),
+            Some(NumberOrString::String("cprog-1".to_string())),
+        );
+        assert_eq!(
+            serde_json::to_value(&with).unwrap()["params"]["workDoneToken"],
+            "cprog-1"
+        );
+
+        // Without a token: the field is omitted (non-regressing).
+        let without = build_inlay_hint_request(
+            &virtual_uri,
+            host_range,
+            &RegionOffset::new(0, 0),
+            RequestId::new(1),
+            None,
+        );
+        assert!(
+            serde_json::to_value(&without).unwrap()["params"]
+                .get("workDoneToken")
+                .is_none(),
+            "None omits the token"
+        );
+    }
+
+    #[test]
     fn inlay_hint_request_first_line_applies_column_offset() {
         let host_uri = test_host_uri();
         // Host range starts on first line of region (line 5), region starts at col 4

--- a/src/lsp/bridge/text_document/inlay_hint.rs
+++ b/src/lsp/bridge/text_document/inlay_hint.rs
@@ -19,7 +19,9 @@ use tower_lsp_server::ls_types::{InlayHint, InlayHintLabel, Range, Uri};
 use url::Url;
 
 use super::super::pool::{LanguageServerPool, UpstreamId};
-use tower_lsp_server::ls_types::{InlayHintParams, TextDocumentIdentifier};
+use tower_lsp_server::ls_types::{
+    InlayHintParams, NumberOrString, TextDocumentIdentifier, WorkDoneProgressParams,
+};
 
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, response_has_jsonrpc_error,
@@ -45,6 +47,7 @@ impl LanguageServerPool {
         offset: RegionOffset,
         virtual_content: &str,
         upstream_request_id: Option<UpstreamId>,
+        client_progress_token: Option<NumberOrString>,
     ) -> io::Result<Option<Vec<InlayHint>>> {
         let handle = self
             .get_or_create_connection(server_name, server_config, Some(host_uri))
@@ -61,7 +64,13 @@ impl LanguageServerPool {
             virtual_content,
             upstream_request_id,
             |virtual_uri, request_id| {
-                build_inlay_hint_request(virtual_uri, host_range, &offset, request_id)
+                build_inlay_hint_request(
+                    virtual_uri,
+                    host_range,
+                    &offset,
+                    request_id,
+                    client_progress_token,
+                )
             },
             |response, ctx| {
                 transform_inlay_hint_response_to_host(
@@ -87,6 +96,7 @@ fn build_inlay_hint_request(
     host_range: Range,
     offset: &RegionOffset,
     request_id: RequestId,
+    client_progress_token: Option<NumberOrString>,
 ) -> JsonRpcRequest<InlayHintParams> {
     // Translate range from host to virtual coordinates
     let mut virtual_range = host_range;
@@ -97,7 +107,11 @@ fn build_inlay_hint_request(
             uri: virtual_uri_to_lsp_uri(virtual_uri),
         },
         range: virtual_range,
-        work_done_progress_params: Default::default(),
+        // Carry the bridge-minted token so the downstream's `$/progress` routes to
+        // this request's aggregator (ls-bridge-client-progress).
+        work_done_progress_params: WorkDoneProgressParams {
+            work_done_token: client_progress_token,
+        },
     };
     JsonRpcRequest::new(request_id.as_i64(), "textDocument/inlayHint", params)
 }
@@ -196,6 +210,7 @@ mod tests {
             host_range,
             &RegionOffset::new(5, 0),
             RequestId::new(1),
+            None,
         );
 
         assert_uses_virtual_uri(&request, "lua");
@@ -221,6 +236,7 @@ mod tests {
             host_range,
             &RegionOffset::new(region_start_line, 0),
             RequestId::new(42),
+            None,
         );
 
         let json = serde_json::to_value(&request).unwrap();
@@ -254,6 +270,7 @@ mod tests {
             host_range,
             &RegionOffset::new(5, 4),
             RequestId::new(1),
+            None,
         );
 
         let json = serde_json::to_value(&request).unwrap();
@@ -285,6 +302,7 @@ mod tests {
             host_range,
             &RegionOffset::new(5, 4),
             RequestId::new(1),
+            None,
         );
 
         let json = serde_json::to_value(&request).unwrap();
@@ -316,6 +334,7 @@ mod tests {
             host_range,
             &RegionOffset::new(10, 0),
             RequestId::new(1),
+            None,
         );
 
         let json = serde_json::to_value(&request).unwrap();

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -11,9 +11,10 @@ use tower_lsp_server::ls_types::{
     DefinitionOptions, DiagnosticOptions, DiagnosticServerCapabilities, DocumentLinkOptions,
     DocumentOnTypeFormattingOptions, DocumentSymbolOptions, FoldingRangeProviderCapability,
     HoverProviderCapability, ImplementationProviderCapability, InitializeParams, InitializeResult,
-    InitializedParams, LinkedEditingRangeServerCapabilities, OneOf, ReferenceOptions,
-    RenameOptions, SaveOptions, SelectionRangeProviderCapability, SemanticTokenModifier,
-    SemanticTokenType, SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
+    InitializedParams, InlayHintOptions, InlayHintServerCapabilities,
+    LinkedEditingRangeServerCapabilities, OneOf, ReferenceOptions, RenameOptions, SaveOptions,
+    SelectionRangeProviderCapability, SemanticTokenModifier, SemanticTokenType,
+    SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
     SemanticTokensServerCapabilities, ServerCapabilities, ServerInfo, SignatureHelpOptions,
     TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
     TextDocumentSyncSaveOptions, TypeDefinitionProviderCapability, Uri, WorkDoneProgressOptions,
@@ -321,7 +322,17 @@ impl Kakehashi {
                         more_trigger_character: (!more.is_empty()).then_some(more),
                     },
                 ),
-                inlay_hint_provider: Some(OneOf::Left(true)),
+                // Advertise workDoneProgress so spec-compliant clients attach a
+                // `workDoneToken`; the bridge relays the region's `$/progress` onto
+                // it (ls-bridge-client-progress, #455).
+                inlay_hint_provider: Some(OneOf::Right(InlayHintServerCapabilities::Options(
+                    InlayHintOptions {
+                        work_done_progress_options: WorkDoneProgressOptions {
+                            work_done_progress: Some(true),
+                        },
+                        resolve_provider: None,
+                    },
+                ))),
                 linked_editing_range_provider: Some(LinkedEditingRangeServerCapabilities::Simple(
                     true,
                 )),

--- a/src/lsp/lsp_impl/text_document/inlay_hint.rs
+++ b/src/lsp/lsp_impl/text_document/inlay_hint.rs
@@ -7,7 +7,7 @@
 //! wins (`preferred`).
 
 use tower_lsp_server::jsonrpc::Result;
-use tower_lsp_server::ls_types::{InlayHint, InlayHintParams, Range, Uri};
+use tower_lsp_server::ls_types::{InlayHint, InlayHintParams, NumberOrString, Range, Uri};
 
 use super::super::Kakehashi;
 use crate::lsp::aggregation::server::dispatch_preferred;
@@ -21,10 +21,11 @@ impl Kakehashi {
         params: InlayHintParams,
     ) -> Result<Option<Vec<InlayHint>>> {
         let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
+        let work_done_token = params.work_done_progress_params.work_done_token.clone();
         let lsp_uri = params.text_document.uri;
         let range = params.range;
 
-        let virt = self.inlay_hint_virt_layer(&lsp_uri, range);
+        let virt = self.inlay_hint_virt_layer(&lsp_uri, range, work_done_token);
         self.walk_layers(
             &lsp_uri,
             METHOD,
@@ -42,10 +43,12 @@ impl Kakehashi {
         &self,
         lsp_uri: &Uri,
         range: Range,
+        client_progress_token: Option<NumberOrString>,
     ) -> Result<Option<Vec<InlayHint>>> {
-        let Some(ctx) = self.resolve_bridge_contexts_for_range(lsp_uri, range, METHOD) else {
+        let Some(mut ctx) = self.resolve_bridge_contexts_for_range(lsp_uri, range, METHOD) else {
             return Ok(None);
         };
+        ctx.document.client_progress_token = client_progress_token;
 
         let (cancel_rx, _cancel_guard) =
             self.subscribe_cancel(ctx.document.upstream_request_id.as_ref());
@@ -68,6 +71,7 @@ impl Kakehashi {
                         t.offset,
                         &t.virtual_content,
                         t.upstream_id,
+                        t.client_progress_token,
                     )
                     .await
             },

--- a/src/lsp/lsp_impl/text_document/inlay_hint.rs
+++ b/src/lsp/lsp_impl/text_document/inlay_hint.rs
@@ -21,7 +21,8 @@ impl Kakehashi {
         params: InlayHintParams,
     ) -> Result<Option<Vec<InlayHint>>> {
         let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
-        let work_done_token = params.work_done_progress_params.work_done_token.clone();
+        // Move (not clone) the token out — `params` is consumed below.
+        let work_done_token = params.work_done_progress_params.work_done_token;
         let lsp_uri = params.text_document.uri;
         let range = params.range;
 

--- a/tests/snapshots/e2e_lsp_protocol__initialize_capabilities.snap
+++ b/tests/snapshots/e2e_lsp_protocol__initialize_capabilities.snap
@@ -100,7 +100,9 @@ expression: capabilities
   },
   "monikerProvider": true,
   "linkedEditingRangeProvider": true,
-  "inlayHintProvider": true,
+  "inlayHintProvider": {
+    "workDoneProgress": true
+  },
   "diagnosticProvider": {
     "interFileDependencies": false,
     "workspaceDiagnostics": false


### PR DESCRIPTION
## Summary

Closes #455 (part of #437). Extends client work-done progress to `textDocument/inlayHint`.

`inlayHint` resolves a **single** bridge context (the region at `range.start`), so it uses the **single-region** pattern (like references/goto, #446) — not the multi-region shared aggregator (#450). The handler threads the editor's `workDoneToken` to `ctx.client_progress_token`; `dispatch_preferred` mints a token for the tracked source and the closure carries it to `send_inlay_hint_request`, which sets it on the downstream `InlayHintParams.work_done_progress_params` (the LSP type carries the field natively — no wrapper struct needed). The bridge then relays the region's `$/progress` onto the editor's token.

Also advertises `inlayHint` with `InlayHintOptions { workDoneProgress: true }` so spec-compliant clients send the token (`InlayHintOptions` flattens `WorkDoneProgressOptions` in ls-types 0.0.6). Wiring + advertisement are in one PR since the feature is small and self-contained (no sequencing concern).

## Verification
- clippy/fmt clean, `--lib` 2001 pass.
- e2e `e2e_lsp_lua_inlay_hint` (26) pass — the **no-token path is non-regressing**.
- e2e `e2e_lsp_protocol` (31) pass — snapshot updated (`inlayHintProvider` → `{ workDoneProgress: true }`), advertise-independent-of-window test passes.

`resolve_provider: None` preserves prior behavior (was bare `true` = no resolve).

Reviewed via Codex (clean). Part of #437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)