### PR TITLE
feat(bridge): client progress for codeLens via the shared whole-document helper (#455)

### DIFF
--- a/src/lsp/bridge/text_document/code_lens.rs
+++ b/src/lsp/bridge/text_document/code_lens.rs
@@ -25,14 +25,14 @@ use std::sync::Arc;
 use log::warn;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tower_lsp_server::ls_types::CodeLens;
+use tower_lsp_server::ls_types::{CodeLens, NumberOrString};
 use url::Url;
 
 use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::{
-    DocumentParams, JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri,
-    build_whole_document_request, response_has_jsonrpc_error, translate_host_range_to_virtual,
-    translate_virtual_range_to_host,
+    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, WholeDocumentRequestParams,
+    build_whole_document_request_with_progress, response_has_jsonrpc_error,
+    translate_host_range_to_virtual, translate_virtual_range_to_host,
 };
 use super::completion::EnvelopeOffset;
 use crate::config::settings::{BridgeServerConfig, WorkspaceSettings};
@@ -132,6 +132,7 @@ impl LanguageServerPool {
         offset: RegionOffset,
         virtual_content: &str,
         upstream_request_id: Option<UpstreamId>,
+        client_progress_token: Option<NumberOrString>,
     ) -> io::Result<Option<Vec<CodeLens>>> {
         let handle = self
             .get_or_create_connection(server_name, server_config, Some(host_uri))
@@ -148,7 +149,9 @@ impl LanguageServerPool {
             &offset,
             virtual_content,
             upstream_request_id,
-            build_code_lens_request,
+            |virtual_uri, request_id| {
+                build_code_lens_request(virtual_uri, request_id, client_progress_token)
+            },
             |response, ctx| {
                 let envelope_ctx = CodeLensEnvelopeContext {
                     server_name,
@@ -329,8 +332,14 @@ impl LanguageServerPool {
 fn build_code_lens_request(
     virtual_uri: &VirtualDocumentUri,
     request_id: RequestId,
-) -> JsonRpcRequest<DocumentParams> {
-    build_whole_document_request(virtual_uri, request_id, "textDocument/codeLens")
+    client_progress_token: Option<NumberOrString>,
+) -> JsonRpcRequest<WholeDocumentRequestParams> {
+    build_whole_document_request_with_progress(
+        virtual_uri,
+        request_id,
+        "textDocument/codeLens",
+        client_progress_token,
+    )
 }
 
 /// Build a JSON-RPC `codeLens/resolve` request.
@@ -411,15 +420,38 @@ mod tests {
     #[test]
     fn code_lens_request_uses_virtual_uri() {
         let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
-        let request = build_code_lens_request(&virtual_uri, RequestId::new(42));
+        let request = build_code_lens_request(&virtual_uri, RequestId::new(42), None);
 
         assert_uses_virtual_uri(&request, "lua");
     }
 
     #[test]
+    fn code_lens_request_carries_work_done_token_only_when_present() {
+        let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
+
+        let with = build_code_lens_request(
+            &virtual_uri,
+            RequestId::new(1),
+            Some(NumberOrString::String("cprog-1".to_string())),
+        );
+        assert_eq!(
+            serde_json::to_value(&with).unwrap()["params"]["workDoneToken"],
+            "cprog-1"
+        );
+
+        let without = build_code_lens_request(&virtual_uri, RequestId::new(1), None);
+        assert!(
+            serde_json::to_value(&without).unwrap()["params"]
+                .get("workDoneToken")
+                .is_none(),
+            "None omits the token"
+        );
+    }
+
+    #[test]
     fn code_lens_request_has_correct_method_and_no_position() {
         let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
-        let request = build_code_lens_request(&virtual_uri, RequestId::new(123));
+        let request = build_code_lens_request(&virtual_uri, RequestId::new(123), None);
 
         let json = serde_json::to_value(&request).unwrap();
         assert_eq!(json["jsonrpc"], "2.0");

--- a/src/lsp/lsp_impl/text_document/code_lens.rs
+++ b/src/lsp/lsp_impl/text_document/code_lens.rs
@@ -16,10 +16,12 @@ impl Kakehashi {
         params: CodeLensParams,
     ) -> Result<Option<Vec<CodeLens>>> {
         let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
+        let work_done_token = params.work_done_progress_params.work_done_token;
         self.whole_document_preferred_fan_out(
             &params.text_document.uri,
             "textDocument/codeLens",
             raw_params,
+            work_done_token,
             |t| async move {
                 t.pool
                     .send_code_lens_request(
@@ -31,6 +33,7 @@ impl Kakehashi {
                         t.offset,
                         &t.virtual_content,
                         t.upstream_id,
+                        t.client_progress_token,
                     )
                     .await
             },

--- a/src/lsp/lsp_impl/text_document/document_link.rs
+++ b/src/lsp/lsp_impl/text_document/document_link.rs
@@ -15,6 +15,9 @@ impl Kakehashi {
             &params.text_document.uri,
             "textDocument/documentLink",
             raw_params,
+            // documentLink is fast; not advertised for client progress (#437), so
+            // no token is carried.
+            None,
             |t| async move {
                 t.pool
                     .send_document_link_request(

--- a/src/lsp/lsp_impl/text_document/folding_range.rs
+++ b/src/lsp/lsp_impl/text_document/folding_range.rs
@@ -15,6 +15,9 @@ impl Kakehashi {
             &params.text_document.uri,
             "textDocument/foldingRange",
             raw_params,
+            // foldingRange is fast; not advertised for client progress (#437), so
+            // no token is carried.
+            None,
             |t| async move {
                 t.pool
                     .send_folding_range_request(

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -13,14 +13,18 @@
 
 use std::future::Future;
 use std::io;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use tokio::task::JoinSet;
 use tower_lsp_server::jsonrpc::Result;
-use tower_lsp_server::ls_types::Uri;
+use tower_lsp_server::ls_types::{NumberOrString, Uri};
 
 use crate::language::InjectionResolver;
-use crate::lsp::aggregation::server::{FanInResult, FanOutTask, dispatch_preferred};
+use crate::lsp::aggregation::server::{
+    FanInResult, FanOutTask, dispatch_preferred, dispatch_preferred_with_tokens,
+    mint_region_progress_source,
+};
+use crate::lsp::bridge::{ClientProgressAggregator, ClientProgressDeregisterGuard};
 
 use super::bridge_context::{DocumentRequestContext, parse_host_verbatim};
 use super::{Kakehashi, uri_to_url};
@@ -38,6 +42,7 @@ impl Kakehashi {
         lsp_uri: &Uri,
         method_name: &'static str,
         raw_params: serde_json::Value,
+        client_progress_token: Option<NumberOrString>,
         send: F,
     ) -> Result<Option<Vec<T>>>
     where
@@ -121,6 +126,20 @@ impl Kakehashi {
             // Outer JoinSet: one task per injection region, all in parallel
             let mut outer_join_set: JoinSet<Option<Vec<T>>> = JoinSet::new();
 
+            // Shared client progress across all regions: one aggregator + one
+            // teardown guard for the whole request. The winner rule shows the first
+            // region to begin as one coherent Begin → … → End on the editor's token
+            // (ls-bridge-client-progress, #455). `None` (no advertised token) keeps
+            // the prior behavior — used by the fast helper methods that don't
+            // advertise `workDoneProgress`.
+            let shared_cp = client_progress_token.map(|client_token| {
+                (
+                    Arc::new(Mutex::new(ClientProgressAggregator::new(client_token))),
+                    Arc::clone(pool.client_progress_registry()),
+                )
+            });
+            let mut cp_minted: Vec<NumberOrString> = Vec::new();
+
             for resolved in all_regions {
                 // Get ALL bridge server configs for this injection language
                 let configs = self.bridge_configs_for_injection_language(
@@ -146,24 +165,56 @@ impl Kakehashi {
                     max_fan_out: agg.max_fan_out,
                     client_progress_token: None,
                 };
+                // Mint this region's tracked-source token into the shared
+                // aggregator (no-op when there's no client token).
+                let region_cp_tokens = shared_cp.as_ref().and_then(|(aggregator, registry)| {
+                    mint_region_progress_source(&region_ctx, registry, aggregator)
+                });
+                if let Some(map) = &region_cp_tokens {
+                    cp_minted.extend(map.values().cloned());
+                }
+
                 let pool = Arc::clone(&pool);
                 let send = send.clone();
 
                 outer_join_set.spawn(async move {
-                    let result = dispatch_preferred(
-                        &region_ctx,
-                        pool.clone(),
-                        send,
-                        |opt| matches!(opt, Some(v) if !v.is_empty()),
-                        None,
-                    )
-                    .await;
+                    let is_nonempty =
+                        |opt: &Option<Vec<T>>| matches!(opt, Some(v) if !v.is_empty());
+                    let result = match region_cp_tokens {
+                        Some(tokens) => {
+                            dispatch_preferred_with_tokens(
+                                &region_ctx,
+                                pool.clone(),
+                                send,
+                                is_nonempty,
+                                None,
+                                tokens,
+                            )
+                            .await
+                        }
+                        None => {
+                            dispatch_preferred(&region_ctx, pool.clone(), send, is_nonempty, None)
+                                .await
+                        }
+                    };
                     match result {
                         FanInResult::Done(items) => items,
                         FanInResult::NoResult { .. } | FanInResult::Cancelled => None,
                     }
                 });
             }
+
+            // One teardown guard for the whole request, held across the region
+            // collection so the synthetic terminal End fires once, after every
+            // region settles (or on cancel).
+            let _cp_guard = shared_cp.map(|(aggregator, registry)| {
+                ClientProgressDeregisterGuard::new(
+                    registry,
+                    cp_minted,
+                    aggregator,
+                    pool.upstream_tx(),
+                )
+            });
 
             // Collect results, aborting early if $/cancelRequest arrives.
             let all_items = crate::lsp::aggregation::region::collect_region_results_with_cancel(

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -37,6 +37,11 @@ impl Kakehashi {
     /// is safe for any item kind). Returns `None` when the document has no
     /// injection regions, no configured servers, or every region came back
     /// empty — mirroring the per-method handlers this was extracted from.
+    ///
+    /// `client_progress_token` is the editor's `workDoneToken`, if any: when
+    /// `Some`, one shared aggregator relays the first region to begin as a single
+    /// `Begin → … → End` on that token (ls-bridge-client-progress); `None` (the
+    /// fast methods that don't advertise `workDoneProgress`) keeps prior behavior.
     pub(super) async fn whole_document_preferred_fan_out<T, F, Fut>(
         &self,
         lsp_uri: &Uri,


### PR DESCRIPTION
## Summary

Part of #437. Makes the shared `whole_document_preferred_fan_out` helper (used by `codeLens`, `foldingRange`, `documentLink`) client-progress-capable, and wires `codeLens`.

When given the editor's `workDoneToken`, the helper creates **one** shared `ClientProgressAggregator` + **one** teardown guard across the per-region dispatches (same pattern as `documentSymbol` #453, including the cancel-race fix), and the winner rule shows the first region to begin as one coherent `Begin → … → End`. When `None`, prior behavior — zero overhead.

- **`codeLens`** (slow, list-returning): extracts its `workDoneToken` and threads it to `send_code_lens_request` → `build_code_lens_request` (`build_whole_document_request_with_progress`); relays the region's `$/progress` onto the editor's token.
- **`foldingRange`/`documentLink`** (fast): pass `None` — not advertised, per #437's "prioritize slow methods" guidance. Byte-identical prior behavior.

## codeLens advertisement is crate-blocked
`CodeLensOptions` in ls-types 0.0.6 has only `resolve_provider` — it does **not** flatten `WorkDoneProgressOptions`, so `codeLens` can't advertise `workDoneProgress` (a crate gap like #447, tracked in **#457**). So the path is plumbed (works for lenient clients that send a token opportunistically, and future-proofs the shared helper) but unadvertised — mirroring the #446/#447 precedent.

## Verification
- clippy/fmt clean, `--lib` 2004 pass.
- e2e `e2e_code_lens_resolve` (26), `e2e_lsp_lua_folding_range` (27), `e2e_lsp_lua_document_link` (27) — all three helper methods **non-regressing**.
- Unit: `code_lens_request_carries_work_done_token_only_when_present`.

Reviewed via subagent `/review` + Codex (both converged, incl. verifying the host-layer interaction: a host server's progress on the verbatim client token is dropped by the `$/progress` reader, so no duplicate lifecycle). Part of #437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)