### PR TITLE
feat(bridge): client work-done progress for rangeFormatting (#437)

### DIFF
--- a/src/lsp/bridge/text_document/formatting.rs
+++ b/src/lsp/bridge/text_document/formatting.rs
@@ -23,7 +23,8 @@ use log::warn;
 
 use crate::config::settings::BridgeServerConfig;
 use tower_lsp_server::ls_types::{
-    DocumentFormattingParams, FormattingOptions, TextDocumentIdentifier, TextEdit,
+    DocumentFormattingParams, FormattingOptions, NumberOrString, TextDocumentIdentifier, TextEdit,
+    WorkDoneProgressParams,
 };
 use url::Url;
 
@@ -59,6 +60,7 @@ impl LanguageServerPool {
         virtual_content: &str,
         options: FormattingOptions,
         upstream_request_id: Option<UpstreamId>,
+        client_progress_token: Option<NumberOrString>,
         downstream_id_probe: Option<&std::sync::OnceLock<RequestId>>,
     ) -> io::Result<Option<Vec<TextEdit>>> {
         let handle = self
@@ -76,7 +78,9 @@ impl LanguageServerPool {
             &offset,
             virtual_content,
             upstream_request_id,
-            |virtual_uri, request_id| build_formatting_request(virtual_uri, options, request_id),
+            |virtual_uri, request_id| {
+                build_formatting_request(virtual_uri, options, request_id, client_progress_token)
+            },
             // The transform promotes error responses, missing results, and
             // malformed payloads to `Err` (request failure) — only the
             // no-capability early return above yields `Ok(None)`.
@@ -133,13 +137,18 @@ fn build_formatting_request(
     virtual_uri: &VirtualDocumentUri,
     options: FormattingOptions,
     request_id: RequestId,
+    client_progress_token: Option<NumberOrString>,
 ) -> JsonRpcRequest<DocumentFormattingParams> {
     let params = DocumentFormattingParams {
         text_document: TextDocumentIdentifier {
             uri: virtual_uri.to_lsp_uri(),
         },
         options,
-        work_done_progress_params: Default::default(),
+        // Forward the bridge-minted token so the downstream reports `$/progress`
+        // against this request's shared aggregator (ls-bridge-client-progress).
+        work_done_progress_params: WorkDoneProgressParams {
+            work_done_token: client_progress_token,
+        },
     };
     JsonRpcRequest::new(request_id.as_i64(), "textDocument/formatting", params)
 }
@@ -268,7 +277,8 @@ mod tests {
     #[test]
     fn formatting_request_uses_virtual_uri() {
         let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
-        let request = build_formatting_request(&virtual_uri, default_options(), test_request_id());
+        let request =
+            build_formatting_request(&virtual_uri, default_options(), test_request_id(), None);
 
         assert_uses_virtual_uri(&request, "lua");
     }
@@ -276,7 +286,8 @@ mod tests {
     #[test]
     fn formatting_request_has_correct_method_and_no_position() {
         let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
-        let request = build_formatting_request(&virtual_uri, default_options(), RequestId::new(7));
+        let request =
+            build_formatting_request(&virtual_uri, default_options(), RequestId::new(7), None);
 
         let json = serde_json::to_value(&request).unwrap();
         assert_eq!(json["jsonrpc"], "2.0");
@@ -300,7 +311,7 @@ mod tests {
             ..Default::default()
         };
 
-        let request = build_formatting_request(&virtual_uri, options, RequestId::new(1));
+        let request = build_formatting_request(&virtual_uri, options, RequestId::new(1), None);
 
         let json = serde_json::to_value(&request).unwrap();
         assert_eq!(json["params"]["options"]["tabSize"], 2);

--- a/src/lsp/bridge/text_document/formatting.rs
+++ b/src/lsp/bridge/text_document/formatting.rs
@@ -284,6 +284,31 @@ mod tests {
     }
 
     #[test]
+    fn formatting_request_carries_work_done_token_only_when_present() {
+        let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
+
+        let with = build_formatting_request(
+            &virtual_uri,
+            default_options(),
+            test_request_id(),
+            Some(NumberOrString::String("cprog-1".to_string())),
+        );
+        assert_eq!(
+            serde_json::to_value(&with).unwrap()["params"]["workDoneToken"],
+            "cprog-1"
+        );
+
+        let without =
+            build_formatting_request(&virtual_uri, default_options(), test_request_id(), None);
+        assert!(
+            serde_json::to_value(&without).unwrap()["params"]
+                .get("workDoneToken")
+                .is_none(),
+            "None omits the token"
+        );
+    }
+
+    #[test]
     fn formatting_request_has_correct_method_and_no_position() {
         let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
         let request =

--- a/src/lsp/bridge/text_document/range_formatting.rs
+++ b/src/lsp/bridge/text_document/range_formatting.rs
@@ -22,7 +22,8 @@ use std::io;
 
 use crate::config::settings::BridgeServerConfig;
 use tower_lsp_server::ls_types::{
-    DocumentRangeFormattingParams, FormattingOptions, Range, TextDocumentIdentifier, TextEdit,
+    DocumentRangeFormattingParams, FormattingOptions, NumberOrString, Range,
+    TextDocumentIdentifier, TextEdit, WorkDoneProgressParams,
 };
 use url::Url;
 
@@ -59,6 +60,7 @@ impl LanguageServerPool {
         host_range: Range,
         options: FormattingOptions,
         upstream_request_id: Option<UpstreamId>,
+        client_progress_token: Option<NumberOrString>,
         downstream_id_probe: Option<&std::sync::OnceLock<RequestId>>,
     ) -> io::Result<Option<Vec<TextEdit>>> {
         let handle = self
@@ -84,6 +86,7 @@ impl LanguageServerPool {
                     &offset_for_request,
                     options,
                     request_id,
+                    client_progress_token,
                 )
             },
             // The transform promotes error responses, missing results, and
@@ -113,6 +116,7 @@ fn build_range_formatting_request(
     offset: &RegionOffset,
     options: FormattingOptions,
     request_id: RequestId,
+    client_progress_token: Option<NumberOrString>,
 ) -> JsonRpcRequest<DocumentRangeFormattingParams> {
     let mut virtual_range = host_range;
     translate_host_range_to_virtual(&mut virtual_range, offset);
@@ -123,7 +127,11 @@ fn build_range_formatting_request(
         },
         range: virtual_range,
         options,
-        work_done_progress_params: Default::default(),
+        // Forward the bridge-minted token so the downstream reports `$/progress`
+        // against this request's shared aggregator (ls-bridge-client-progress).
+        work_done_progress_params: WorkDoneProgressParams {
+            work_done_token: client_progress_token,
+        },
     };
     JsonRpcRequest::new(request_id.as_i64(), "textDocument/rangeFormatting", params)
 }
@@ -164,9 +172,43 @@ mod tests {
             &RegionOffset::new(5, 0),
             default_options(),
             test_request_id(),
+            None,
         );
 
         assert_uses_virtual_uri(&request, "lua");
+    }
+
+    #[test]
+    fn range_formatting_request_carries_work_done_token_only_when_present() {
+        let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
+
+        let with = build_range_formatting_request(
+            &virtual_uri,
+            range(5, 0, 8, 0),
+            &RegionOffset::new(5, 0),
+            default_options(),
+            test_request_id(),
+            Some(NumberOrString::String("cprog-1".to_string())),
+        );
+        assert_eq!(
+            serde_json::to_value(&with).unwrap()["params"]["workDoneToken"],
+            "cprog-1"
+        );
+
+        let without = build_range_formatting_request(
+            &virtual_uri,
+            range(5, 0, 8, 0),
+            &RegionOffset::new(5, 0),
+            default_options(),
+            test_request_id(),
+            None,
+        );
+        assert!(
+            serde_json::to_value(&without).unwrap()["params"]
+                .get("workDoneToken")
+                .is_none(),
+            "None omits the token"
+        );
     }
 
     #[test]
@@ -180,6 +222,7 @@ mod tests {
             &RegionOffset::new(8, 0),
             default_options(),
             RequestId::new(42),
+            None,
         );
 
         let json = serde_json::to_value(&request).unwrap();
@@ -203,6 +246,7 @@ mod tests {
             &RegionOffset::new(5, 4),
             default_options(),
             RequestId::new(1),
+            None,
         );
 
         let json = serde_json::to_value(&request).unwrap();
@@ -232,6 +276,7 @@ mod tests {
             &RegionOffset::new(0, 0),
             options,
             RequestId::new(1),
+            None,
         );
 
         let json = serde_json::to_value(&request).unwrap();
@@ -253,6 +298,7 @@ mod tests {
             &RegionOffset::new(10, 0),
             default_options(),
             RequestId::new(1),
+            None,
         );
 
         let json = serde_json::to_value(&request).unwrap();

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -9,12 +9,12 @@ use tower_lsp_server::ls_types::ColorProviderCapability;
 use tower_lsp_server::ls_types::{
     CodeLensOptions, CompletionOptions, DeclarationCapability, DeclarationOptions,
     DefinitionOptions, DiagnosticOptions, DiagnosticServerCapabilities, DocumentLinkOptions,
-    DocumentOnTypeFormattingOptions, DocumentSymbolOptions, FoldingRangeProviderCapability,
-    HoverProviderCapability, ImplementationProviderCapability, InitializeParams, InitializeResult,
-    InitializedParams, InlayHintOptions, InlayHintServerCapabilities,
-    LinkedEditingRangeServerCapabilities, OneOf, ReferenceOptions, RenameOptions, SaveOptions,
-    SelectionRangeProviderCapability, SemanticTokenModifier, SemanticTokenType,
-    SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
+    DocumentOnTypeFormattingOptions, DocumentRangeFormattingOptions, DocumentSymbolOptions,
+    FoldingRangeProviderCapability, HoverProviderCapability, ImplementationProviderCapability,
+    InitializeParams, InitializeResult, InitializedParams, InlayHintOptions,
+    InlayHintServerCapabilities, LinkedEditingRangeServerCapabilities, OneOf, ReferenceOptions,
+    RenameOptions, SaveOptions, SelectionRangeProviderCapability, SemanticTokenModifier,
+    SemanticTokenType, SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
     SemanticTokensServerCapabilities, ServerCapabilities, ServerInfo, SignatureHelpOptions,
     TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
     TextDocumentSyncSaveOptions, TypeDefinitionProviderCapability, Uri, WorkDoneProgressOptions,
@@ -315,7 +315,13 @@ impl Kakehashi {
                     work_done_progress_options: WorkDoneProgressOptions::default(),
                 })),
                 document_formatting_provider: Some(OneOf::Left(true)),
-                document_range_formatting_provider: Some(OneOf::Left(true)),
+                document_range_formatting_provider: Some(OneOf::Right(
+                    DocumentRangeFormattingOptions {
+                        work_done_progress_options: WorkDoneProgressOptions {
+                            work_done_progress: Some(true),
+                        },
+                    },
+                )),
                 document_on_type_formatting_provider: on_type_formatting_triggers.map(
                     |(first, more)| DocumentOnTypeFormattingOptions {
                         first_trigger_character: first,

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -730,6 +730,9 @@ async fn dispatch_preferred_formatting(
                         &t.virtual_content,
                         options,
                         t.upstream_id,
+                        // Full-formatting client progress is out of scope for #459
+                        // (range formatting only); pass no token here.
+                        None,
                         None,
                     )
                     .await;
@@ -1075,6 +1078,9 @@ async fn dispatch_concatenated_formatting(
                             &current_text,
                             options,
                             upstream_id,
+                            // OnTypeFormatting pipeline: no client progress here
+                            // (#459 covers rangeFormatting's region fan-out only).
+                            None,
                             Some(&step_downstream_id),
                         )
                         .await
@@ -1098,6 +1104,9 @@ async fn dispatch_concatenated_formatting(
                                     whole_region,
                                     options,
                                     upstream_id,
+                                    // OnTypeFormatting pipeline: no client progress
+                                    // here (#459 covers rangeFormatting only).
+                                    None,
                                     Some(&step_downstream_id),
                                 )
                                 .await

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -730,8 +730,8 @@ async fn dispatch_preferred_formatting(
                         &t.virtual_content,
                         options,
                         t.upstream_id,
-                        // Full-formatting client progress is out of scope for #459
-                        // (range formatting only); pass no token here.
+                        // Full-formatting client progress is out of scope here
+                        // (this PR wires rangeFormatting); tracked in #459.
                         None,
                         None,
                     )
@@ -1078,8 +1078,9 @@ async fn dispatch_concatenated_formatting(
                             &current_text,
                             options,
                             upstream_id,
-                            // OnTypeFormatting pipeline: no client progress here
-                            // (#459 covers rangeFormatting's region fan-out only).
+                            // Concatenated formatting pipeline (serial over scratch
+                            // docs): no client progress here — concatenated progress
+                            // is deferred (#440). Pass no token.
                             None,
                             Some(&step_downstream_id),
                         )
@@ -1104,8 +1105,9 @@ async fn dispatch_concatenated_formatting(
                                     whole_region,
                                     options,
                                     upstream_id,
-                                    // OnTypeFormatting pipeline: no client progress
-                                    // here (#459 covers rangeFormatting only).
+                                    // Concatenated formatting pipeline (serial over
+                                    // scratch docs): no client progress here —
+                                    // concatenated progress is deferred (#440).
                                     None,
                                     Some(&step_downstream_id),
                                 )

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -20,16 +20,19 @@
 //! formatting returns no result), it falls back to `rangeFormatting` so
 //! range-only servers still format.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use tokio::task::JoinSet;
 use tower_lsp_server::jsonrpc::Result;
-use tower_lsp_server::ls_types::{DocumentRangeFormattingParams, Range, TextEdit};
+use tower_lsp_server::ls_types::{DocumentRangeFormattingParams, NumberOrString, Range, TextEdit};
 
 use crate::language::InjectionResolver;
 use crate::lsp::aggregation::server::FanInResult;
-use crate::lsp::aggregation::server::dispatch_preferred;
+use crate::lsp::aggregation::server::{
+    dispatch_preferred, dispatch_preferred_with_tokens, mint_region_progress_source,
+};
+use crate::lsp::bridge::{ClientProgressAggregator, ClientProgressDeregisterGuard};
 use crate::lsp::lsp_impl::bridge_context::{DocumentRequestContext, parse_host_verbatim};
 use crate::text::PositionMapper;
 
@@ -43,6 +46,7 @@ impl Kakehashi {
     ) -> Result<Option<Vec<TextEdit>>> {
         let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
         let lsp_uri = params.text_document.uri.clone();
+        let work_done_token = params.work_done_progress_params.work_done_token.clone();
         let virt = async {
             let lsp_uri = params.text_document.uri;
             let options = params.options;
@@ -143,6 +147,20 @@ impl Kakehashi {
 
             let mut outer_join_set: JoinSet<Option<Vec<TextEdit>>> = JoinSet::new();
 
+            // Shared client progress: a range-formatting request fans out over
+            // several injection regions (one `dispatch_preferred` each), so they
+            // share ONE aggregator + ONE teardown guard. The aggregator's winner
+            // rule shows the first region to begin as one coherent
+            // `Begin → … → End` on the editor's token (ls-bridge-client-progress).
+            // `None` when no `workDoneToken`.
+            let shared_cp = work_done_token.map(|client_token| {
+                (
+                    Arc::new(Mutex::new(ClientProgressAggregator::new(client_token))),
+                    Arc::clone(pool.client_progress_registry()),
+                )
+            });
+            let mut cp_minted: Vec<NumberOrString> = Vec::new();
+
             for resolved in all_regions {
                 // A covering request (its byte span encloses the whole region)
                 // prefers full formatting; a partial request range-formats the
@@ -205,77 +223,123 @@ impl Kakehashi {
                     max_fan_out: agg.max_fan_out,
                     client_progress_token: None,
                 };
+
+                // Mint this region's tracked-source token into the shared
+                // aggregator (the per-region map dispatch hands to its winning
+                // downstream).
+                let region_cp_tokens = shared_cp.as_ref().and_then(|(aggregator, registry)| {
+                    mint_region_progress_source(&region_ctx, registry, aggregator)
+                });
+                if let Some(map) = &region_cp_tokens {
+                    cp_minted.extend(map.values().cloned());
+                }
+
                 let pool = Arc::clone(&pool);
                 let options = options.clone();
                 let region_cancel_rx = cancel_state.derive_receiver();
 
                 outer_join_set.spawn(async move {
-                    let result = dispatch_preferred(
-                        &region_ctx,
-                        pool.clone(),
-                        move |t| {
-                            let options = options.clone();
-                            async move {
-                                // Covering request: prefer full formatting, but fall
-                                // back to rangeFormatting over the whole region when
-                                // the server has no `documentFormattingProvider`
-                                // (`Ok(None)`) — otherwise a range-only server would
-                                // format nothing. Errors propagate (no fallback);
-                                // `Ok(Some(_))` (incl. an empty edit list) is an
-                                // authoritative result.
-                                if is_covering {
-                                    match t
-                                        .pool
-                                        .send_formatting_request(
-                                            &t.server_name,
-                                            &t.server_config,
-                                            &t.uri,
-                                            &t.injection_language,
-                                            &t.region_id,
-                                            t.offset.clone(),
-                                            &t.virtual_content,
-                                            options.clone(),
-                                            t.upstream_id.clone(),
-                                            None,
-                                        )
-                                        .await
-                                    {
-                                        Ok(None) => {} // fall through to rangeFormatting
-                                        other => return other,
-                                    }
-                                }
-                                t.pool
-                                    .send_range_formatting_request(
+                    let send = move |t: crate::lsp::aggregation::server::FanOutTask| {
+                        let options = options.clone();
+                        async move {
+                            // The covering path may issue BOTH a formatting and
+                            // a rangeFormatting request; capture the per-task
+                            // client-progress token once and hand it to whichever
+                            // call actually goes on the wire.
+                            let cp_token = t.client_progress_token;
+                            // Covering request: prefer full formatting, but fall
+                            // back to rangeFormatting over the whole region when
+                            // the server has no `documentFormattingProvider`
+                            // (`Ok(None)`) — otherwise a range-only server would
+                            // format nothing. Errors propagate (no fallback);
+                            // `Ok(Some(_))` (incl. an empty edit list) is an
+                            // authoritative result.
+                            if is_covering {
+                                match t
+                                    .pool
+                                    .send_formatting_request(
                                         &t.server_name,
                                         &t.server_config,
                                         &t.uri,
                                         &t.injection_language,
                                         &t.region_id,
-                                        t.offset,
+                                        t.offset.clone(),
                                         &t.virtual_content,
-                                        clipped_host_range,
-                                        options,
-                                        t.upstream_id,
+                                        options.clone(),
+                                        t.upstream_id.clone(),
+                                        cp_token.clone(),
                                         None,
                                     )
                                     .await
+                                {
+                                    Ok(None) => {} // fall through to rangeFormatting
+                                    other => return other,
+                                }
                             }
-                        },
-                        // Same semantics as full formatting: `Some(vec![])` is
-                        // an authoritative "no edits needed" (e.g., the range is
-                        // already perfectly formatted) — keep it and stop. `None`
-                        // means "no response" and falls through to lower-priority
-                        // servers.
-                        |opt| opt.is_some(),
-                        region_cancel_rx,
-                    )
-                    .await;
+                            t.pool
+                                .send_range_formatting_request(
+                                    &t.server_name,
+                                    &t.server_config,
+                                    &t.uri,
+                                    &t.injection_language,
+                                    &t.region_id,
+                                    t.offset,
+                                    &t.virtual_content,
+                                    clipped_host_range,
+                                    options,
+                                    t.upstream_id,
+                                    cp_token,
+                                    None,
+                                )
+                                .await
+                        }
+                    };
+                    // Same semantics as full formatting: `Some(vec![])` is an
+                    // authoritative "no edits needed" (e.g., the range is already
+                    // perfectly formatted) — keep it and stop. `None` means "no
+                    // response" and falls through to lower-priority servers.
+                    let is_nonempty = |opt: &Option<Vec<TextEdit>>| opt.is_some();
+                    let result = match region_cp_tokens {
+                        Some(tokens) => {
+                            dispatch_preferred_with_tokens(
+                                &region_ctx,
+                                pool.clone(),
+                                send,
+                                is_nonempty,
+                                region_cancel_rx,
+                                tokens,
+                            )
+                            .await
+                        }
+                        None => {
+                            dispatch_preferred(
+                                &region_ctx,
+                                pool.clone(),
+                                send,
+                                is_nonempty,
+                                region_cancel_rx,
+                            )
+                            .await
+                        }
+                    };
                     match result {
                         FanInResult::Done(edits) => edits,
                         FanInResult::NoResult { .. } | FanInResult::Cancelled => None,
                     }
                 });
             }
+
+            // One teardown guard for the whole request, held across the edit
+            // collection so the synthetic terminal `End` fires once, after every
+            // region settles (or on cancel). Dropped at the end of this block.
+            let _cp_guard = shared_cp.map(|(aggregator, registry)| {
+                ClientProgressDeregisterGuard::new(
+                    registry,
+                    cp_minted,
+                    aggregator,
+                    pool.upstream_tx(),
+                )
+            });
 
             let response =
                 finalize_formatting_edits(outer_join_set, cancel_state.token.clone()).await;

--- a/tests/snapshots/e2e_lsp_protocol__initialize_capabilities.snap
+++ b/tests/snapshots/e2e_lsp_protocol__initialize_capabilities.snap
@@ -44,7 +44,9 @@ expression: capabilities
     "resolveProvider": true
   },
   "documentFormattingProvider": true,
-  "documentRangeFormattingProvider": true,
+  "documentRangeFormattingProvider": {
+    "workDoneProgress": true
+  },
   "renameProvider": {
     "prepareProvider": true
   },


### PR DESCRIPTION
## Summary

Part of #437. Wires client work-done progress for `textDocument/rangeFormatting` — the last of the slow/list-returning bridged methods.

rangeFormatting fans out over injection regions (**preferred-only**, no concatenated path), so it uses the merged `documentSymbol` multi-region shared-aggregator pattern: the handler creates **one** shared aggregator + **one** teardown guard, mints a per-region token, dispatches via `dispatch_preferred_with_tokens`; the winner rule shows the first region to begin as one coherent `Begin → … → End`. Advertises `documentRangeFormattingProvider` with `workDoneProgress` (`DocumentRangeFormattingOptions` flattens `WorkDoneProgressOptions`).

## Scope expansion (necessary)
The downstream `formatting`/`rangeFormatting` request builders gained a `client_progress_token` param (threaded into `work_done_progress_params`). The existing trailing `None` slot was `downstream_id_probe`, **not** the token — so the token needed a real new param. The **covering path** may issue both a `formatting` and a `rangeFormatting` request for one region, so the per-task token is reused across them (same source token → one coherent lifecycle; the two are sequential). Full-formatting and on-type-formatting callers pass `None` — byte-identical prior behavior.

## Proven vs. asserted
- **Proven**: builder serde (unit), and **non-regression** across all formatting variants — e2e `rangeFormatting`/`formatting`/`concatenated`/`on-type` (27 each) + `protocol` (31); clippy/fmt clean, `--lib` 2005 pass; snapshot diff is exactly `documentRangeFormattingProvider` → `{ workDoneProgress: true }`.
- **Asserted, not integration-tested**: the end-to-end multi-region progress path (reader→dispatch harness deferred, #442).

## Follow-up
- https://github.com/atusy/kakehashi/issues/459: full `textDocument/formatting` is now plumbed (builder accepts the token) but not wired — its handler passes `None`.

Reviewed via subagent (implementation), advisor, and Codex (focused on the guard scope, covering-fallback token reuse, and the shared-builder/on-type call sites — all confirmed). Part of #437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)