### PR TITLE
perf(diagnostics): per-host republish lock (#426 part 1)

### DIFF
--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -182,12 +182,17 @@ impl DiagnosticAggregator {
     /// docs). Different hosts hold different locks and so never block each other.
     pub(crate) async fn lock_republish(&self, host: &Url) -> tokio::sync::OwnedMutexGuard<()> {
         // Brief outer lock to fetch-or-create this host's lock, then await it.
+        // Clone the `Url` key only when inserting a new entry — the steady state
+        // (lock already present) avoids the allocation on this per-republish path.
         let lock = {
             let mut locks = self
                 .republish_locks
                 .lock()
                 .recover_poison("DiagnosticAggregator::republish_locks");
-            Arc::clone(locks.entry(host.clone()).or_default())
+            match locks.get(host) {
+                Some(lock) => Arc::clone(lock),
+                None => Arc::clone(locks.entry(host.clone()).or_default()),
+            }
         };
         lock.lock_owned().await
     }

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -36,7 +36,7 @@
 //! host-layer eager-open (diagnostics on open before the first request).
 
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use tower_lsp_server::ls_types::Diagnostic;
 use url::Url;
@@ -160,13 +160,16 @@ fn transform_region_diagnostic(diag: &mut Diagnostic, offset: &RegionOffset, hos
 #[derive(Default)]
 pub(crate) struct DiagnosticAggregator {
     cache: Mutex<HashMap<Url, SourceSlots>>,
-    /// Serializes the publisher's snapshot→merge→publish so two concurrent
-    /// republishes (a region push vs a host-event pull, on different tasks)
-    /// cannot interleave and emit out of order — which would let a stale snapshot
-    /// publish *after* a fresh one and permanently hide diagnostics on a quiescent
-    /// file. Global (not per-host) for simplicity; republishes are per diagnostic
-    /// event, not hot. A per-host lock is a possible follow-up.
-    republish_lock: tokio::sync::Mutex<()>,
+    /// Per-host republish locks. The publisher holds a host's lock across its
+    /// snapshot→merge→publish so two concurrent republishes for the **same** host
+    /// (a region push vs a host-event pull, on different tasks) cannot interleave
+    /// and emit out of order — which would let a stale snapshot publish *after* a
+    /// fresh one and permanently hide diagnostics on a quiescent file. Keying the
+    /// lock by host means a slow editor publish for one host no longer stalls
+    /// *every* host's republish, only that host's (#426). The outer `Mutex` is held
+    /// only briefly to fetch/insert the per-host lock; the per-host
+    /// `tokio::sync::Mutex` is the one held across the publish await.
+    republish_locks: Mutex<HashMap<Url, Arc<tokio::sync::Mutex<()>>>>,
 }
 
 impl DiagnosticAggregator {
@@ -174,10 +177,19 @@ impl DiagnosticAggregator {
         Self::default()
     }
 
-    /// Acquire the global republish lock; held by the publisher across
-    /// snapshot→merge→publish so emissions stay ordered (see field docs).
-    pub(crate) async fn lock_republish(&self) -> tokio::sync::MutexGuard<'_, ()> {
-        self.republish_lock.lock().await
+    /// Acquire the republish lock for `host`; held by the publisher across
+    /// snapshot→merge→publish so emissions for that host stay ordered (see field
+    /// docs). Different hosts hold different locks and so never block each other.
+    pub(crate) async fn lock_republish(&self, host: &Url) -> tokio::sync::OwnedMutexGuard<()> {
+        // Brief outer lock to fetch-or-create this host's lock, then await it.
+        let lock = {
+            let mut locks = self
+                .republish_locks
+                .lock()
+                .recover_poison("DiagnosticAggregator::republish_locks");
+            Arc::clone(locks.entry(host.clone()).or_default())
+        };
+        lock.lock_owned().await
     }
 
     /// Record (replacing) one server's diagnostics for a `(host, source)`.
@@ -254,6 +266,31 @@ mod tests {
 
     fn host() -> Url {
         Url::parse("file:///doc.md").unwrap()
+    }
+
+    #[tokio::test]
+    async fn per_host_republish_locks_are_independent_but_serialize_same_host() {
+        use std::time::Duration;
+        let agg = DiagnosticAggregator::new();
+        let a = Url::parse("file:///a.md").unwrap();
+        let b = Url::parse("file:///b.md").unwrap();
+
+        // Hold host A's republish lock.
+        let _guard_a = agg.lock_republish(&a).await;
+
+        // A different host's lock must acquire without blocking on A's (#426) — if
+        // it serialized globally, this would hang and the timeout would fire.
+        let _guard_b = tokio::time::timeout(Duration::from_secs(1), agg.lock_republish(&b))
+            .await
+            .expect("a different host's republish lock must not block on host A's");
+
+        // The SAME host's lock must serialize: a second acquire blocks while A's
+        // guard is held.
+        let same = tokio::time::timeout(Duration::from_millis(100), agg.lock_republish(&a)).await;
+        assert!(
+            same.is_err(),
+            "the same host's republish lock must serialize (preserving per-host order)"
+        );
     }
 
     fn messages(slots: &ServerSlots) -> Vec<String> {

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -234,7 +234,7 @@ impl DiagnosticPublisher {
         // Recompute injection offsets only when there are region push slots to
         // transform. A PullLayer-only snapshot (the common pull-driven case) needs
         // none, so skip the whole-document injection resolution — and shorten the
-        // time the global republish lock is held.
+        // time this host's republish lock is held.
         let region_offsets = if snapshot
             .keys()
             .any(|source| matches!(source, DiagnosticSource::Region(_)))

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -216,12 +216,12 @@ impl DiagnosticPublisher {
         //
         // The lock is held across the editor `publish_diagnostics` await below
         // because the ordering guarantee requires it (releasing before the send
-        // would let two publishes reorder on the wire). The cost is that a slow
-        // editor stalls *all* hosts' republishes — an accepted staging tradeoff of
-        // the global lock; the deferred per-host lock shrinks the blast radius to
-        // one host. publish_diagnostics is a fire-and-forget notification, so the
-        // stall window is the client's outbound-channel send, not a round-trip.
-        let _guard = self.aggregator.lock_republish().await;
+        // would let two publishes reorder on the wire). The lock is **per host**
+        // (#426), so a slow editor publish for one host stalls only that host's
+        // republishes, not every host's; different hosts proceed concurrently.
+        // publish_diagnostics is a fire-and-forget notification, so the stall window
+        // is the client's outbound-channel send, not a round-trip.
+        let _guard = self.aggregator.lock_republish(host).await;
 
         let mut snapshot = self.aggregator.snapshot(host);
         // Drop Host push slots whose server is no longer a configured `_self` host


### PR DESCRIPTION
## Summary

Part 1 of #426. `republish` held one **global** `republish_lock` across the editor publish await (required for ordering), so a slow editor publish for any host stalled **every** host's republish. This replaces it with a **per-host** lock.

The publisher now holds only the target host's lock across snapshot→merge→publish: different hosts proceed concurrently, while same-host republishes still serialize — preserving per-host order, which is sufficient since the cache is nested per host and hosts are independent (cross-host ordering was never required, confirmed by Codex).

- `republish_lock: tokio::sync::Mutex<()>` → `republish_locks: Mutex<HashMap<Url, Arc<tokio::sync::Mutex<()>>>>`.
- `lock_republish(host)` briefly locks the outer std `Mutex` to fetch/insert the host's lock, **drops the outer guard before** `.lock_owned().await` (no std lock held across an await).

## Scope
- **Part 2** (bounded/coalescing diagnostics channel) is deferred.
- The lock map isn't evicted (eviction with an in-flight holder would break serialization); bounded by distinct host URIs, each entry tiny. Reclamation tracked in **#466**.

## Verification
- clippy/fmt clean, `--lib` 2007 pass.
- New test `per_host_republish_locks_are_independent_but_serialize_same_host`: a different host's lock acquires without blocking on a held host's lock; the same host's lock serializes.

Reviewed via Codex (concurrency correctness confirmed — same-host serialize, cross-host independent, outer guard dropped before await, `lock_owned` correct; no must-fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)