### PR TITLE
feat(diagnostics): evict a region's diagnostic slots when an edit invalidates it (#424)

### DIFF
--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -252,13 +252,15 @@ impl DiagnosticAggregator {
     /// The host entry is removed if it becomes empty.
     pub(crate) fn evict_source(&self, host: &Url, source: &DiagnosticSource) -> bool {
         let mut cache = self.lock();
-        let std::collections::hash_map::Entry::Occupied(mut host_entry) = cache.entry(host.clone())
-        else {
+        // Borrow by `&Url` (no key clone) — the common case (host present, other
+        // sources remain) is a single lookup. The host entry is removed only when
+        // this was its last source, which costs a second lookup but is rare.
+        let Some(slots) = cache.get_mut(host) else {
             return false;
         };
-        let removed = host_entry.get_mut().remove(source).is_some();
-        if host_entry.get().is_empty() {
-            host_entry.remove();
+        let removed = slots.remove(source).is_some();
+        if slots.is_empty() {
+            cache.remove(host);
         }
         removed
     }
@@ -554,8 +556,8 @@ mod tests {
         agg.record(&host(), region.clone(), "srv".to_string(), vec![diag("r")]);
         assert!(agg.evict_source(&host(), &region));
         assert!(
-            agg.snapshot(&host()).is_empty(),
-            "the host entry is dropped once its last source is evicted"
+            !agg.lock().contains_key(&host()),
+            "the host entry itself is dropped (not left present-but-empty) once its last source is evicted"
         );
         assert!(
             !agg.evict_source(&host(), &region),

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -246,6 +246,23 @@ impl DiagnosticAggregator {
         cache.remove(host).is_some()
     }
 
+    /// Drop one `source`'s slots (every server) under `host` — e.g. a region
+    /// invalidated by an edit, whose stale `Region` slots would otherwise linger
+    /// until the whole host is closed (#424). Returns whether the source existed.
+    /// The host entry is removed if it becomes empty.
+    pub(crate) fn evict_source(&self, host: &Url, source: &DiagnosticSource) -> bool {
+        let mut cache = self.lock();
+        let std::collections::hash_map::Entry::Occupied(mut host_entry) = cache.entry(host.clone())
+        else {
+            return false;
+        };
+        let removed = host_entry.get_mut().remove(source).is_some();
+        if host_entry.get().is_empty() {
+            host_entry.remove();
+        }
+        removed
+    }
+
     fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<Url, SourceSlots>> {
         // Recover from a poisoned lock rather than propagating a panic: a
         // diagnostic cache is best-effort state, never a correctness invariant
@@ -508,5 +525,41 @@ mod tests {
         assert!(agg.evict_host(&host()));
         assert!(agg.snapshot(&host()).is_empty());
         assert!(!agg.evict_host(&host()), "second evict is a no-op");
+    }
+
+    #[test]
+    fn evict_source_drops_only_that_source() {
+        let agg = DiagnosticAggregator::new();
+        let region = DiagnosticSource::Region("R1".to_string());
+        agg.record(&host(), region.clone(), "srv".to_string(), vec![diag("r")]);
+        agg.set_pull_layer(&host(), vec![diag("p")]);
+
+        assert!(agg.evict_source(&host(), &region));
+        let snap = agg.snapshot(&host());
+        assert!(!snap.contains_key(&region), "the region source is evicted");
+        assert!(
+            snap.contains_key(&DiagnosticSource::PullLayer),
+            "other sources for the host are untouched"
+        );
+        assert!(
+            !agg.evict_source(&host(), &region),
+            "a second evict of the same source is a no-op"
+        );
+    }
+
+    #[test]
+    fn evict_source_removes_the_host_when_its_last_source_goes() {
+        let agg = DiagnosticAggregator::new();
+        let region = DiagnosticSource::Region("R1".to_string());
+        agg.record(&host(), region.clone(), "srv".to_string(), vec![diag("r")]);
+        assert!(agg.evict_source(&host(), &region));
+        assert!(
+            agg.snapshot(&host()).is_empty(),
+            "the host entry is dropped once its last source is evicted"
+        );
+        assert!(
+            !agg.evict_source(&host(), &region),
+            "evicting a source from an absent host is a no-op"
+        );
     }
 }

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -30,9 +30,11 @@
 //! deferred `pullFallback` / capability classification removes the overlap by
 //! giving each server one native source.
 //!
-//! Also deferred: per-source strategy fan-in (`preferred` sticky / `concatenated`
-//! visible-walk; cross-source order is HashMap-nondeterministic until then), the
-//! `content_epoch` version gate, region-invalidation/crash eviction, and
+//! Region-invalidation eviction is implemented (`evict_source`, wired into the
+//! edit path that orphans a region — #424). Still deferred: per-source strategy
+//! fan-in (`preferred` sticky / `concatenated` visible-walk; cross-source order is
+//! HashMap-nondeterministic until then), the `content_epoch` version gate,
+//! **crash/server** eviction (needs connection-generation identity, #469), and
 //! host-layer eager-open (diagnostics on open before the first request).
 
 use std::collections::HashMap;
@@ -90,9 +92,9 @@ pub(crate) type SourceSlots = HashMap<DiagnosticSource, ServerSlots>;
 /// - [`DiagnosticSource::Region`] slots hold virtual coordinates and are
 ///   transformed via `region_offsets[region_id]` (lazy re-anchor against the
 ///   region's *current* offset). A region with no current offset (it no longer
-///   resolves, e.g. it was edited away) is skipped here; its now-stale slot
-///   lingers in the cache until the whole host is dropped on `didClose`
-///   (per-region / crash eviction is a deferred follow-up).
+///   resolves, e.g. it was edited away) is skipped here; the edit that orphaned it
+///   also evicts its now-stale slot (`evict_source`, #424), so it no longer lingers
+///   until the host's `didClose`. (Crash/server eviction is still deferred — #469.)
 /// - [`DiagnosticSource::Host`] and [`DiagnosticSource::PullLayer`] slots are
 ///   already host-local and pass through unchanged.
 ///

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -64,18 +64,20 @@ impl InjectionCoordinator {
         self.cache
             .remove_injection_tokens_for_ulids(host_uri, invalidated_ulids);
 
-        // Evict each invalidated region's diagnostic slots from the cache (#424).
-        // The merge already *skips* a region with no current offset, so the editor
-        // never sees stale diagnostics, but the slot would otherwise linger until
-        // the whole host is closed — this reclaims it on the edit that orphaned it.
+        self.bridge
+            .close_invalidated_docs(host_uri, invalidated_ulids)
+            .await;
+
+        // Evict each invalidated region's diagnostic slots from the cache (#424) —
+        // AFTER `close_invalidated_docs` removed the virtual-doc tracking, so a
+        // racing queued push can no longer resolve the orphaned region's URI and
+        // recreate the slot we just evicted. The merge already *skips* a region with
+        // no current offset, so the editor never sees stale diagnostics; this
+        // reclaims the lingering slot on the edit that orphaned it.
         for ulid in invalidated_ulids {
             self.diagnostics
                 .evict_source(host_uri, &DiagnosticSource::Region(ulid.to_string()));
         }
-
-        self.bridge
-            .close_invalidated_docs(host_uri, invalidated_ulids)
-            .await;
     }
 
     /// Resolve all injection regions for a document, with stable region IDs from

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -9,6 +9,7 @@ use crate::lsp::auto_install::AutoInstallManager;
 use crate::lsp::bridge::BridgeCoordinator;
 use crate::lsp::bridge::coordinator::BridgeInjection;
 use crate::lsp::cache::CacheCoordinator;
+use crate::lsp::diagnostic_cache::{DiagnosticAggregator, DiagnosticSource};
 use crate::lsp::lsp_impl::Kakehashi;
 use crate::lsp::settings_manager::SettingsManager;
 use tower_lsp_server::Client;
@@ -27,6 +28,7 @@ pub(crate) struct InjectionCoordinator {
     settings_manager: std::sync::Arc<SettingsManager>,
     auto_install: AutoInstallManager,
     bridge: std::sync::Arc<BridgeCoordinator>,
+    diagnostics: std::sync::Arc<DiagnosticAggregator>,
 }
 
 impl InjectionCoordinator {
@@ -40,6 +42,7 @@ impl InjectionCoordinator {
             settings_manager: std::sync::Arc::clone(&server.settings_manager),
             auto_install: server.auto_install.clone(),
             bridge: std::sync::Arc::clone(&server.bridge),
+            diagnostics: std::sync::Arc::clone(&server.diagnostics),
         }
     }
 
@@ -60,6 +63,15 @@ impl InjectionCoordinator {
 
         self.cache
             .remove_injection_tokens_for_ulids(host_uri, invalidated_ulids);
+
+        // Evict each invalidated region's diagnostic slots from the cache (#424).
+        // The merge already *skips* a region with no current offset, so the editor
+        // never sees stale diagnostics, but the slot would otherwise linger until
+        // the whole host is closed — this reclaims it on the edit that orphaned it.
+        for ulid in invalidated_ulids {
+            self.diagnostics
+                .evict_source(host_uri, &DiagnosticSource::Region(ulid.to_string()));
+        }
 
         self.bridge
             .close_invalidated_docs(host_uri, invalidated_ulids)


### PR DESCRIPTION
## Summary

First half of #424. Adds `DiagnosticAggregator::evict_source(host, source)` and wires it into `close_invalidated_virtual_docs`: when an edit orphans an injection region, its `Region(ulid)` slots are evicted from the diagnostic cache.

The merge **already skips** a region with no current offset, so the editor never saw stale diagnostics — this reclaims the lingering cache slot on the edit that orphaned it, rather than holding it until the host's `didClose`. The eviction key matches the stored slot key (`region_id` is the region ULID's string form per discovery.rs).

## Ordering (Codex-caught)
The eviction runs **after** `close_invalidated_docs` removes the virtual-doc tracking, so a racing queued push can no longer resolve the orphaned URI and recreate the slot in that window.

## Known residual (non-regressing; tracked)
A push that *resolved* before invalidation can still `record` after eviction, recreating the slot. This is **harmless and non-regressing**: the recreated slot is skipped at merge (no current offset), the ULID isn't reused, and it's cleared on `didClose` — exactly the pre-existing lingering behavior this otherwise improves on. Full resolve→record gating is the deferred `content_epoch` version gate, **#422**. Codex reviewed and agreed this is a #422 dependency, not a blocker.

## Scope
- **Crash/restart eviction** (`evict_server` at the reader-exit hook) is the harder half → **#469**.

## Verification
- clippy/fmt clean, `--lib` 2010 pass.
- Tests: `evict_source_drops_only_that_source`, `evict_source_removes_the_host_when_its_last_source_goes`.

Reviewed via Codex (ordering race fixed; residual reconciled to #422).

🤖 Generated with [Claude Code](https://claude.com/claude-code)