### PR TITLE
feat(diagnostics): evict a crashed connection's diagnostic slots (#469)

### DIFF
--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -279,8 +279,9 @@ impl Drop for ProgressPurgeGuard {
         }
         // Evict this connection's pushed diagnostics so a dead server's stale
         // diagnostics don't linger until the host's `didClose` (#469). Sent
-        // unconditionally — the loop's eviction is a cheap no-op when the
-        // connection never pushed (no slots match its id).
+        // unconditionally — when the connection never pushed, the loop's eviction
+        // scans the cache, matches no slot, and republishes nothing (a semantic
+        // no-op on this rare exit path).
         let _ = self
             .upstream_tx
             .send(UpstreamNotification::EvictConnectionDiagnostics {

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -1366,17 +1366,25 @@ mod tests {
 
         // The same guard also asks the forwarding loop to evict this connection's
         // diagnostic slots, so a dead server's diagnostics don't linger (#469).
-        let mut saw_eviction = false;
-        while let Ok(notification) = upstream_rx.try_recv() {
-            if let UpstreamNotification::EvictConnectionDiagnostics { connection_id } = notification
-            {
-                assert_eq!(
-                    connection_id, conn,
-                    "eviction must target the exited connection"
-                );
-                saw_eviction = true;
+        // `Drop` runs `purge_connection` *then* the sends, so the purge above can be
+        // observed before the eviction send lands — `recv().await` (not a single
+        // `try_recv`) so we wait for it rather than racing the guard's Drop.
+        let saw_eviction = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while let Some(notification) = upstream_rx.recv().await {
+                if let UpstreamNotification::EvictConnectionDiagnostics { connection_id } =
+                    notification
+                {
+                    assert_eq!(
+                        connection_id, conn,
+                        "eviction must target the exited connection"
+                    );
+                    return true;
+                }
             }
-        }
+            false // channel closed (all senders dropped) without an eviction
+        })
+        .await
+        .expect("EvictConnectionDiagnostics must arrive after reader exit");
         assert!(
             saw_eviction,
             "reader exit must emit EvictConnectionDiagnostics for its connection"

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -77,6 +77,10 @@ pub(crate) enum UpstreamNotification {
         /// The originating downstream server's config name (`deps.server_name`);
         /// pushes without a name are dropped at the reader, so this is always set.
         server: String,
+        /// The originating connection's id (`deps.progress_connection_id`). Tags the
+        /// cached slot so a later reader exit can evict only this connection's slots,
+        /// never a restarted connection's (which gets a fresh id) (#469).
+        connection_id: crate::lsp::bridge::ProgressConnectionId,
         /// The pushed diagnostics, in the published document's own coordinates
         /// (virtual for a region push, host for a `_self` push).
         diagnostics: Vec<tower_lsp_server::ls_types::Diagnostic>,
@@ -117,6 +121,14 @@ pub(crate) enum UpstreamNotification {
     /// progress still in flight, so the loop's created-token set can't leak
     /// entries across crashes/respawns (window-work-done-progress bridging).
     ForgetWorkDoneProgress(Vec<tower_lsp_server::ls_types::NumberOrString>),
+    /// Evict the diagnostic-cache slots a now-exited connection produced and
+    /// republish the affected hosts — sent when a downstream connection's reader
+    /// exits (crash/respawn), so a dead server's pushed diagnostics don't linger
+    /// until the host's `didClose` (#469). A restart's slots carry a fresh
+    /// connection id and so survive.
+    EvictConnectionDiagnostics {
+        connection_id: crate::lsp::bridge::ProgressConnectionId,
+    },
 }
 
 /// A downstream-initiated **request** the bridge forwards to the editor and
@@ -265,6 +277,15 @@ impl Drop for ProgressPurgeGuard {
                 .upstream_tx
                 .send(UpstreamNotification::ForgetWorkDoneProgress(tokens));
         }
+        // Evict this connection's pushed diagnostics so a dead server's stale
+        // diagnostics don't linger until the host's `didClose` (#469). Sent
+        // unconditionally — the loop's eviction is a cheap no-op when the
+        // connection never pushed (no slots match its id).
+        let _ = self
+            .upstream_tx
+            .send(UpstreamNotification::EvictConnectionDiagnostics {
+                connection_id: self.connection_id,
+            });
     }
 }
 
@@ -2356,8 +2377,10 @@ mod tests {
             UpstreamNotification::PublishDiagnostics {
                 uri,
                 server,
+                connection_id,
                 diagnostics,
             } => {
+                assert_eq!(connection_id, deps.progress_connection_id);
                 assert!(uri.contains("kakehashi-virtual-uri-REGION"));
                 assert_eq!(server, "luals");
                 assert_eq!(diagnostics.len(), 1);

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -1317,7 +1317,7 @@ mod tests {
 
         let router = Arc::new(ResponseRouter::new());
         let (response_tx, _response_rx) = mpsc::channel(16);
-        let (upstream_tx, _upstream_rx) = mpsc::unbounded_channel();
+        let (upstream_tx, mut upstream_rx) = mpsc::unbounded_channel();
         let (window_tx, _window_rx) = mpsc::channel(16);
         let progress_registry = Arc::new(crate::lsp::bridge::ProgressRegistry::new());
         let conn = progress_registry.new_connection_id();
@@ -1362,6 +1362,24 @@ mod tests {
             "reader exit must purge the connection's progress mappings"
         );
         assert_eq!(progress_registry.translate(conn, &downstream_token), None);
+
+        // The same guard also asks the forwarding loop to evict this connection's
+        // diagnostic slots, so a dead server's diagnostics don't linger (#469).
+        let mut saw_eviction = false;
+        while let Ok(notification) = upstream_rx.try_recv() {
+            if let UpstreamNotification::EvictConnectionDiagnostics { connection_id } = notification
+            {
+                assert_eq!(
+                    connection_id, conn,
+                    "eviction must target the exited connection"
+                );
+                saw_eviction = true;
+            }
+        }
+        assert!(
+            saw_eviction,
+            "reader exit must emit EvictConnectionDiagnostics for its connection"
+        );
     }
 
     #[tokio::test]

--- a/src/lsp/bridge/text_document/publish_diagnostics.rs
+++ b/src/lsp/bridge/text_document/publish_diagnostics.rs
@@ -89,6 +89,7 @@ pub(in crate::lsp::bridge) fn forward_push(
         crate::lsp::bridge::actor::UpstreamNotification::PublishDiagnostics {
             uri,
             server: server_name.to_owned(),
+            connection_id: deps.progress_connection_id,
             diagnostics,
         },
     );

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -44,7 +44,9 @@ use tower_lsp_server::ls_types::Diagnostic;
 use url::Url;
 
 use crate::error::LockResultExt;
-use crate::lsp::bridge::{RegionOffset, VirtualDocumentUri, translate_virtual_range_to_host};
+use crate::lsp::bridge::{
+    ProgressConnectionId, RegionOffset, VirtualDocumentUri, translate_virtual_range_to_host,
+};
 
 /// Which contributor a slot belongs to under a host document.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -79,6 +81,13 @@ pub(crate) const PULL_LAYER_SERVER: &str = "<pull-layer>";
 #[derive(Debug, Clone, Default)]
 pub(crate) struct SlotEntry {
     pub(crate) diagnostics: Vec<Diagnostic>,
+    /// The downstream connection that produced this slot, or `None` for the
+    /// synthetic pull-layer blob (not tied to one connection's lifetime). A server
+    /// restart mints a *new* connection id, so a later push from the restart
+    /// replaces this slot and re-tags it — letting crash eviction
+    /// ([`DiagnosticAggregator::evict_connection`]) drop only the dead connection's
+    /// slots, never a live restart's (#469).
+    pub(crate) connection_id: Option<ProgressConnectionId>,
 }
 
 /// `server name → slot`. Several servers can attach to one source.
@@ -239,11 +248,17 @@ impl DiagnosticAggregator {
     ///
     /// An empty `diagnostics` keeps an empty slot — the merge skips it, so the
     /// server's prior diagnostics are cleared without dropping the slot key.
+    ///
+    /// `connection_id` tags the slot with the downstream connection that produced
+    /// it (`None` for the synthetic pull-layer), so a later crash can evict only
+    /// that connection's slots (#469). A restart re-pushes with a new id, replacing
+    /// and re-tagging the slot.
     pub(crate) fn record(
         &self,
         host: &Url,
         source: DiagnosticSource,
         server: String,
+        connection_id: Option<ProgressConnectionId>,
         diagnostics: Vec<Diagnostic>,
     ) {
         let mut cache = self.lock();
@@ -254,19 +269,26 @@ impl DiagnosticAggregator {
         } else {
             cache.entry(host.clone()).or_default()
         };
-        source_slots
-            .entry(source)
-            .or_default()
-            .insert(server, SlotEntry { diagnostics });
+        source_slots.entry(source).or_default().insert(
+            server,
+            SlotEntry {
+                diagnostics,
+                connection_id,
+            },
+        );
     }
 
     /// Replace the cached host-event pull blob for a host
     /// ([`DiagnosticSource::PullLayer`]). Equivalent to a single-server `record`.
+    ///
+    /// The pull-layer is a cross-connection aggregate, not a single connection's
+    /// push, so its slot is tagged `None` and is never touched by crash eviction.
     pub(crate) fn set_pull_layer(&self, host: &Url, diagnostics: Vec<Diagnostic>) {
         self.record(
             host,
             DiagnosticSource::PullLayer,
             PULL_LAYER_SERVER.to_string(),
+            None,
             diagnostics,
         );
     }
@@ -324,6 +346,31 @@ impl DiagnosticAggregator {
             .recover_poison("DiagnosticAggregator::republish_locks")
             .get(host)
             .map_or(0, Arc::strong_count)
+    }
+
+    /// Drop every push slot produced by `connection_id` — a downstream connection
+    /// whose reader exited (crash/respawn, #469) — returning the host URIs that
+    /// lost at least one slot, so the caller can re-merge and republish them. The
+    /// synthetic pull-layer (tagged `None`) is never touched, and a restart's
+    /// re-push lands under a *new* connection id, so its slots survive this sweep.
+    /// O(total slots); called only on the rare connection-exit path.
+    pub(crate) fn evict_connection(&self, connection_id: ProgressConnectionId) -> Vec<Url> {
+        let mut cache = self.lock();
+        let mut affected = Vec::new();
+        cache.retain(|host, sources| {
+            let mut host_changed = false;
+            sources.retain(|_source, servers| {
+                let before = servers.len();
+                servers.retain(|_server, slot| slot.connection_id != Some(connection_id));
+                host_changed |= servers.len() != before;
+                !servers.is_empty()
+            });
+            if host_changed {
+                affected.push(host.clone());
+            }
+            !sources.is_empty()
+        });
+        affected
     }
 
     fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<Url, SourceSlots>> {
@@ -563,6 +610,7 @@ mod tests {
             &host(),
             DiagnosticSource::Region("r1".into()),
             "luals".into(),
+            None,
             vec![diag_at("err", 0, 2)],
         );
         let mut offsets = HashMap::new();
@@ -599,6 +647,7 @@ mod tests {
             &host(),
             DiagnosticSource::Region("r1".into()),
             "luals".into(),
+            None,
             vec![d],
         );
         let mut offsets = HashMap::new();
@@ -634,6 +683,7 @@ mod tests {
             &host(),
             DiagnosticSource::Region("gone".into()),
             "luals".into(),
+            None,
             vec![diag("stale")],
         );
         // No offset for "gone" -> region is stale -> skipped.
@@ -648,6 +698,7 @@ mod tests {
             &host(),
             DiagnosticSource::Region("r1".into()),
             "luals".into(),
+            None,
             vec![diag_at("push", 0, 0)],
         );
         agg.set_pull_layer(&host(), vec![diag_at("pull", 9, 0)]);
@@ -668,12 +719,14 @@ mod tests {
             &host(),
             DiagnosticSource::Host,
             "lua_ls".into(),
+            None,
             vec![diag_at("hostA", 7, 3)],
         );
         agg.record(
             &host(),
             DiagnosticSource::Host,
             "selene".into(),
+            None,
             vec![diag_at("hostB", 8, 0)],
         );
         let merged = merge_cached_diagnostics(&host(), agg.snapshot(&host()), &HashMap::new());
@@ -705,7 +758,13 @@ mod tests {
     fn evict_source_drops_only_that_source() {
         let agg = DiagnosticAggregator::new();
         let region = DiagnosticSource::Region("R1".to_string());
-        agg.record(&host(), region.clone(), "srv".to_string(), vec![diag("r")]);
+        agg.record(
+            &host(),
+            region.clone(),
+            "srv".to_string(),
+            None,
+            vec![diag("r")],
+        );
         agg.set_pull_layer(&host(), vec![diag("p")]);
 
         assert!(agg.evict_source(&host(), &region));
@@ -725,7 +784,13 @@ mod tests {
     fn evict_source_removes_the_host_when_its_last_source_goes() {
         let agg = DiagnosticAggregator::new();
         let region = DiagnosticSource::Region("R1".to_string());
-        agg.record(&host(), region.clone(), "srv".to_string(), vec![diag("r")]);
+        agg.record(
+            &host(),
+            region.clone(),
+            "srv".to_string(),
+            None,
+            vec![diag("r")],
+        );
         assert!(agg.evict_source(&host(), &region));
         assert!(
             !agg.lock().contains_key(&host()),
@@ -734,6 +799,110 @@ mod tests {
         assert!(
             !agg.evict_source(&host(), &region),
             "evicting a source from an absent host is a no-op"
+        );
+    }
+
+    #[test]
+    fn evict_connection_drops_only_that_connections_slots() {
+        let agg = DiagnosticAggregator::new();
+        let conn_a = ProgressConnectionId::for_test(1);
+        let conn_b = ProgressConnectionId::for_test(2);
+        // conn_a pushed a region slot; conn_b a host slot; plus a pull-layer (None).
+        agg.record(
+            &host(),
+            DiagnosticSource::Region("r".into()),
+            "luals".into(),
+            Some(conn_a),
+            vec![diag("a")],
+        );
+        agg.record(
+            &host(),
+            DiagnosticSource::Host,
+            "selene".into(),
+            Some(conn_b),
+            vec![diag("b")],
+        );
+        agg.set_pull_layer(&host(), vec![diag("pull")]);
+
+        let affected = agg.evict_connection(conn_a);
+        assert_eq!(
+            affected,
+            vec![host()],
+            "the host that lost a slot is reported"
+        );
+        let snap = agg.snapshot(&host());
+        assert!(
+            !snap.contains_key(&DiagnosticSource::Region("r".into())),
+            "conn_a's region slot is evicted"
+        );
+        assert!(
+            snap.contains_key(&DiagnosticSource::Host),
+            "conn_b's host slot survives"
+        );
+        assert!(
+            snap.contains_key(&DiagnosticSource::PullLayer),
+            "the pull-layer (tagged None) is never touched by connection eviction"
+        );
+    }
+
+    #[test]
+    fn evict_connection_spares_a_restarts_replaced_slot() {
+        let agg = DiagnosticAggregator::new();
+        let dead = ProgressConnectionId::for_test(1);
+        let restart = ProgressConnectionId::for_test(2);
+        // The dead connection pushed, then a restart re-pushed for the *same*
+        // (host, source, server) — `record` replaced and re-tagged the slot.
+        agg.record(
+            &host(),
+            DiagnosticSource::Region("r".into()),
+            "luals".into(),
+            Some(dead),
+            vec![diag("old")],
+        );
+        agg.record(
+            &host(),
+            DiagnosticSource::Region("r".into()),
+            "luals".into(),
+            Some(restart),
+            vec![diag("new")],
+        );
+
+        let affected = agg.evict_connection(dead);
+        assert!(
+            affected.is_empty(),
+            "nothing tagged with the dead id remains, so no host is republished"
+        );
+        let snap = agg.snapshot(&host());
+        let slot = &snap[&DiagnosticSource::Region("r".into())]["luals"];
+        assert_eq!(slot.connection_id, Some(restart));
+        assert_eq!(
+            slot.diagnostics[0].message, "new",
+            "the restart's slot is intact"
+        );
+    }
+
+    #[test]
+    fn evict_connection_removes_emptied_host_and_ignores_unknown() {
+        let agg = DiagnosticAggregator::new();
+        let conn = ProgressConnectionId::for_test(1);
+        agg.record(
+            &host(),
+            DiagnosticSource::Region("r".into()),
+            "luals".into(),
+            Some(conn),
+            vec![diag("x")],
+        );
+        // Unknown connection: no slot matches, so no host is affected.
+        assert!(
+            agg.evict_connection(ProgressConnectionId::for_test(99))
+                .is_empty(),
+            "evicting an unknown connection is a no-op"
+        );
+        // The real connection: its only slot goes, emptying and dropping the host.
+        assert_eq!(agg.evict_connection(conn), vec![host()]);
+        assert!(
+            !agg.lock().contains_key(&host()),
+            "the now-empty host entry is removed, not left present-but-empty"
         );
     }
 }

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -8,8 +8,10 @@
 //! what keeps sibling regions intact against the clobber.
 //!
 //! The cache is **nested** `host_uri → source → server` (not a flat tuple key) so
-//! the lifecycle's evictions are O(1): a whole host on `didClose` today, a source
-//! / server later.
+//! the targeted lifecycle evictions are O(1): a whole host on `didClose`
+//! (`evict_host`) and a single source on an edit (`evict_source`). Per-connection
+//! crash eviction (`evict_connection`) is the exception — it scans every slot to
+//! find the dead connection's, which is fine on that rare path.
 //!
 //! ## Staging
 //! Three source kinds are populated:
@@ -31,11 +33,13 @@
 //! giving each server one native source.
 //!
 //! Region-invalidation eviction is implemented (`evict_source`, wired into the
-//! edit path that orphans a region — #424). Still deferred: per-source strategy
-//! fan-in (`preferred` sticky / `concatenated` visible-walk; cross-source order is
-//! HashMap-nondeterministic until then), the `content_epoch` version gate,
-//! **crash/server** eviction (needs connection-generation identity, #469), and
-//! host-layer eager-open (diagnostics on open before the first request).
+//! edit path that orphans a region — #424) and crash/server eviction too
+//! (`evict_connection`, wired into the reader-exit path — #469; slots are tagged
+//! with the producing connection's id so a restart's slots survive). Still
+//! deferred: per-source strategy fan-in (`preferred` sticky / `concatenated`
+//! visible-walk; cross-source order is HashMap-nondeterministic until then), the
+//! `content_epoch` version gate, and host-layer eager-open (diagnostics on open
+//! before the first request).
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -106,7 +110,8 @@ pub(crate) type SourceSlots = HashMap<DiagnosticSource, ServerSlots>;
 ///   region's *current* offset). A region with no current offset (it no longer
 ///   resolves, e.g. it was edited away) is skipped here; the edit that orphaned it
 ///   also evicts its now-stale slot (`evict_source`, #424), so it no longer lingers
-///   until the host's `didClose`. (Crash/server eviction is still deferred — #469.)
+///   until the host's `didClose`. (A crashed connection's slots are likewise
+///   dropped on reader exit — `evict_connection`, #469.)
 /// - [`DiagnosticSource::Host`] and [`DiagnosticSource::PullLayer`] slots are
 ///   already host-local and pass through unchanged.
 ///

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -78,7 +78,10 @@ pub(crate) const PULL_LAYER_SERVER: &str = "<pull-layer>";
 /// within-server "latest wins" rule). An empty `diagnostics` is a kept-but-empty
 /// slot: it contributes nothing to the merge but still exists, so a server going
 /// from errors to clean clears only its own contribution.
-#[derive(Debug, Clone, Default)]
+// No `Default`: a `SlotEntry` is only ever built by `record` with an explicit
+// `connection_id` tag, and a defaulted (untagged) slot would silently break crash
+// eviction (#469), so the derive is deliberately omitted.
+#[derive(Debug, Clone)]
 pub(crate) struct SlotEntry {
     pub(crate) diagnostics: Vec<Diagnostic>,
     /// The downstream connection that produced this slot, or `None` for the
@@ -354,6 +357,11 @@ impl DiagnosticAggregator {
     /// synthetic pull-layer (tagged `None`) is never touched, and a restart's
     /// re-push lands under a *new* connection id, so its slots survive this sweep.
     /// O(total slots); called only on the rare connection-exit path.
+    ///
+    /// This evicts only **pushed** slots. A pull-driven server that dies leaves its
+    /// contribution in the cross-connection `PullLayer` blob until the next
+    /// host-event pull recomputes it — an intentional asymmetry (#469 targets the
+    /// push path; the pull layer self-refreshes on the next pull).
     pub(crate) fn evict_connection(&self, connection_id: ProgressConnectionId) -> Vec<Url> {
         let mut cache = self.lock();
         let mut affected = Vec::new();
@@ -879,6 +887,41 @@ mod tests {
             slot.diagnostics[0].message, "new",
             "the restart's slot is intact"
         );
+    }
+
+    #[test]
+    fn evict_connection_then_restart_repush_repopulates() {
+        // The reverse ordering: the dead connection is evicted *before* the restart
+        // re-pushes (evict-before-repush). The slot is cleared, then the restart's
+        // push under a new id re-adds it — no slot is ever wrongly retained or lost.
+        let agg = DiagnosticAggregator::new();
+        let dead = ProgressConnectionId::for_test(1);
+        let restart = ProgressConnectionId::for_test(2);
+        let region = DiagnosticSource::Region("r".into());
+        agg.record(
+            &host(),
+            region.clone(),
+            "luals".into(),
+            Some(dead),
+            vec![diag("old")],
+        );
+
+        assert_eq!(agg.evict_connection(dead), vec![host()]);
+        assert!(agg.snapshot(&host()).is_empty(), "the dead slot is cleared");
+
+        agg.record(
+            &host(),
+            region.clone(),
+            "luals".into(),
+            Some(restart),
+            vec![diag("new")],
+        );
+        let snap = agg.snapshot(&host());
+        let slot = &snap[&region]["luals"];
+        assert_eq!(slot.connection_id, Some(restart));
+        assert_eq!(slot.diagnostics[0].message, "new");
+        // A late eviction for the already-dead id now finds nothing.
+        assert!(agg.evict_connection(dead).is_empty());
     }
 
     #[test]

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -623,7 +623,7 @@ mod tests {
             &host(),
             DiagnosticSource::Region("r1".into()),
             "luals".into(),
-            None,
+            Some(ProgressConnectionId::for_test(1)),
             vec![diag_at("err", 0, 2)],
         );
         let mut offsets = HashMap::new();
@@ -660,7 +660,7 @@ mod tests {
             &host(),
             DiagnosticSource::Region("r1".into()),
             "luals".into(),
-            None,
+            Some(ProgressConnectionId::for_test(1)),
             vec![d],
         );
         let mut offsets = HashMap::new();
@@ -696,7 +696,7 @@ mod tests {
             &host(),
             DiagnosticSource::Region("gone".into()),
             "luals".into(),
-            None,
+            Some(ProgressConnectionId::for_test(1)),
             vec![diag("stale")],
         );
         // No offset for "gone" -> region is stale -> skipped.
@@ -711,7 +711,7 @@ mod tests {
             &host(),
             DiagnosticSource::Region("r1".into()),
             "luals".into(),
-            None,
+            Some(ProgressConnectionId::for_test(1)),
             vec![diag_at("push", 0, 0)],
         );
         agg.set_pull_layer(&host(), vec![diag_at("pull", 9, 0)]);
@@ -732,14 +732,14 @@ mod tests {
             &host(),
             DiagnosticSource::Host,
             "lua_ls".into(),
-            None,
+            Some(ProgressConnectionId::for_test(1)),
             vec![diag_at("hostA", 7, 3)],
         );
         agg.record(
             &host(),
             DiagnosticSource::Host,
             "selene".into(),
-            None,
+            Some(ProgressConnectionId::for_test(1)),
             vec![diag_at("hostB", 8, 0)],
         );
         let merged = merge_cached_diagnostics(&host(), agg.snapshot(&host()), &HashMap::new());
@@ -775,7 +775,7 @@ mod tests {
             &host(),
             region.clone(),
             "srv".to_string(),
-            None,
+            Some(ProgressConnectionId::for_test(1)),
             vec![diag("r")],
         );
         agg.set_pull_layer(&host(), vec![diag("p")]);
@@ -801,7 +801,7 @@ mod tests {
             &host(),
             region.clone(),
             "srv".to_string(),
-            None,
+            Some(ProgressConnectionId::for_test(1)),
             vec![diag("r")],
         );
         assert!(agg.evict_source(&host(), &region));

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -573,4 +573,47 @@ mod tests {
             "the cache still holds the slot; only the publish snapshot is filtered"
         );
     }
+
+    #[tokio::test]
+    async fn evict_connection_diagnostics_drops_only_the_dead_connection() {
+        // The seam the forwarding loop's EvictConnectionDiagnostics arm invokes:
+        // the publisher evicts the dead connection's slots (and republishes the
+        // affected host) while the live connection's slots survive (#469).
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let uri = Url::parse("file:///test/host.rs").unwrap();
+        let dead = ProgressConnectionId::for_test(1);
+        let live = ProgressConnectionId::for_test(2);
+        server.diagnostics.record(
+            &uri,
+            DiagnosticSource::Host,
+            "dead_ls".to_string(),
+            Some(dead),
+            vec![diag("from dead")],
+        );
+        server.diagnostics.record(
+            &uri,
+            DiagnosticSource::Host,
+            "live_ls".to_string(),
+            Some(live),
+            vec![diag("from live")],
+        );
+
+        DiagnosticPublisher::new(server)
+            .evict_connection_diagnostics(dead)
+            .await;
+
+        let snap = server.diagnostics.snapshot(&uri);
+        let host = snap
+            .get(&DiagnosticSource::Host)
+            .expect("the surviving host slot keeps the source alive");
+        assert!(
+            !host.contains_key("dead_ls"),
+            "the dead connection's slot is evicted"
+        );
+        assert!(
+            host.contains_key("live_ls"),
+            "the live connection's slot survives the eviction"
+        );
+    }
 }

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -15,7 +15,9 @@ use url::Url;
 
 use crate::document::DocumentStore;
 use crate::language::{InjectionResolver, LanguageCoordinator};
-use crate::lsp::bridge::{BridgeCoordinator, RegionOffset, VirtualDocumentUri};
+use crate::lsp::bridge::{
+    BridgeCoordinator, ProgressConnectionId, RegionOffset, VirtualDocumentUri,
+};
 use crate::lsp::diagnostic_cache::{
     DiagnosticAggregator, DiagnosticSource, merge_cached_diagnostics,
 };
@@ -58,12 +60,15 @@ impl DiagnosticPublisher {
         &self,
         uri: String,
         server: String,
+        connection_id: ProgressConnectionId,
         diagnostics: Vec<Diagnostic>,
     ) {
         if VirtualDocumentUri::is_virtual_uri(&uri) {
-            self.publish_region_push(&uri, server, diagnostics).await;
+            self.publish_region_push(&uri, server, connection_id, diagnostics)
+                .await;
         } else {
-            self.publish_host_push(&uri, server, diagnostics).await;
+            self.publish_host_push(&uri, server, connection_id, diagnostics)
+                .await;
         }
     }
 
@@ -79,6 +84,7 @@ impl DiagnosticPublisher {
         &self,
         host_uri: &str,
         server: String,
+        connection_id: ProgressConnectionId,
         diagnostics: Vec<Diagnostic>,
     ) {
         let Ok(host) = Url::parse(host_uri) else {
@@ -98,8 +104,13 @@ impl DiagnosticPublisher {
             // configured host server for it — not a host-layer contribution.
             return;
         }
-        self.aggregator
-            .record(&host, DiagnosticSource::Host, server, diagnostics);
+        self.aggregator.record(
+            &host,
+            DiagnosticSource::Host,
+            server,
+            Some(connection_id),
+            diagnostics,
+        );
         self.republish(&host).await;
     }
 
@@ -164,6 +175,7 @@ impl DiagnosticPublisher {
         &self,
         virtual_uri: &str,
         server: String,
+        connection_id: ProgressConnectionId,
         diagnostics: Vec<Diagnostic>,
     ) {
         let Some((host, region_id)) = self.bridge.resolve_virtual_uri(virtual_uri).await else {
@@ -177,6 +189,7 @@ impl DiagnosticPublisher {
             &host,
             DiagnosticSource::Region(region_id),
             server,
+            Some(connection_id),
             diagnostics,
         );
         self.republish(&host).await;
@@ -198,6 +211,17 @@ impl DiagnosticPublisher {
     pub(crate) async fn publish_pull_layer(&self, host: &Url, diagnostics: Vec<Diagnostic>) {
         self.aggregator.set_pull_layer(host, diagnostics);
         self.republish(host).await;
+    }
+
+    /// Evict every diagnostic slot a now-exited downstream connection produced and
+    /// republish the affected hosts (#469). Called when a connection's reader exits
+    /// (crash/respawn); a restart's slots carry a fresh connection id and survive,
+    /// so this clears only the dead server's contribution.
+    pub(crate) async fn evict_connection_diagnostics(&self, connection_id: ProgressConnectionId) {
+        let affected = self.aggregator.evict_connection(connection_id);
+        for host in affected {
+            self.republish(&host).await;
+        }
     }
 
     /// Drop the host's cache entry and publish the now-empty set (host `didClose`).
@@ -398,7 +422,12 @@ mod tests {
         );
 
         DiagnosticPublisher::new(server)
-            .publish_host_push(uri.as_str(), "rust_ls".to_string(), vec![diag("boom")])
+            .publish_host_push(
+                uri.as_str(),
+                "rust_ls".to_string(),
+                ProgressConnectionId::for_test(1),
+                vec![diag("boom")],
+            )
             .await;
 
         let snap = server.diagnostics.snapshot(&uri);
@@ -419,7 +448,12 @@ mod tests {
         // URI is never inserted into the document store.
         let uri = Url::parse("file:///test/not_open.rs").unwrap();
         DiagnosticPublisher::new(server)
-            .publish_host_push(uri.as_str(), "rust_ls".to_string(), vec![diag("x")])
+            .publish_host_push(
+                uri.as_str(),
+                "rust_ls".to_string(),
+                ProgressConnectionId::for_test(1),
+                vec![diag("x")],
+            )
             .await;
 
         assert!(
@@ -445,7 +479,12 @@ mod tests {
         );
 
         DiagnosticPublisher::new(server)
-            .publish_host_push(uri.as_str(), "rust_ls".to_string(), vec![diag("y")])
+            .publish_host_push(
+                uri.as_str(),
+                "rust_ls".to_string(),
+                ProgressConnectionId::for_test(1),
+                vec![diag("y")],
+            )
             .await;
 
         assert!(
@@ -475,6 +514,7 @@ mod tests {
             .publish_host_push(
                 uri.as_str(),
                 "some_other_server".to_string(),
+                ProgressConnectionId::for_test(1),
                 vec![diag("z")],
             )
             .await;
@@ -501,7 +541,12 @@ mod tests {
         );
         let publisher = DiagnosticPublisher::new(server);
         publisher
-            .publish_host_push(uri.as_str(), "rust_ls".to_string(), vec![diag("e")])
+            .publish_host_push(
+                uri.as_str(),
+                "rust_ls".to_string(),
+                ProgressConnectionId::for_test(1),
+                vec![diag("e")],
+            )
             .await;
         assert!(
             server

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -865,15 +865,19 @@ async fn deliver_upstream_notification(
         UpstreamNotification::PublishDiagnostics {
             uri,
             server,
+            connection_id,
             diagnostics,
         } => {
             // Cache the downstream push and republish the merged host set
             // (push-propagation-diagnostic-forwarding). The publisher classifies the
             // URI (virtual → region, real → `_self` host layer); a `None` publisher
             // (test loop) drops it. (Pushes without a server name were already
-            // dropped at the reader, so `server` is always set here.)
+            // dropped at the reader, so `server` is always set here.) The
+            // `connection_id` tags the cached slot so a later crash can evict it (#469).
             if let Some(publisher) = diagnostic_publisher {
-                publisher.publish_push(uri, server, diagnostics).await;
+                publisher
+                    .publish_push(uri, server, connection_id, diagnostics)
+                    .await;
             }
         }
         UpstreamNotification::LogMessage { typ, message } => {
@@ -975,6 +979,15 @@ async fn deliver_upstream_notification(
                         )
                         .await;
                 }
+            }
+        }
+        UpstreamNotification::EvictConnectionDiagnostics { connection_id } => {
+            // A downstream connection's reader exited (crash/respawn): drop the
+            // diagnostic slots it produced and republish the affected hosts so a
+            // dead server's diagnostics don't linger until didClose (#469). A
+            // `None` publisher (test loop) has no cache to evict.
+            if let Some(publisher) = diagnostic_publisher {
+                publisher.evict_connection_diagnostics(connection_id).await;
             }
         }
     }


### PR DESCRIPTION
Closes #469 (the crash/restart half of #424).

## Problem
Region-invalidation eviction (`evict_source` on edit) landed in #470, but a **crashed/restarted** downstream server's pushed diagnostics still lingered in the cache until the host document's `didClose` — stale diagnostics from a server that no longer exists.

## Fix
Tag each push slot with the producing connection's identity and evict on reader exit:

- `SlotEntry` gains `connection_id: Option<ProgressConnectionId>` (`None` for the synthetic pull-layer). Every push records the producing connection's id (threaded from `deps.progress_connection_id` via `forward_push` → `UpstreamNotification::PublishDiagnostics` → `publish_push` → `record`).
- A restart mints a **new** `ProgressConnectionId`; its re-push replaces and re-tags the `(host, source, server)` slot. So `evict_connection(dead_id)` removes only the dead connection's slots and never a live restart's.
- `DiagnosticAggregator::evict_connection(id) -> Vec<Url>` drops slots tagged `Some(id)`, cleans emptied sources/hosts, and returns the affected host URIs.
- On reader exit, `ProgressPurgeGuard::drop` sends `UpstreamNotification::EvictConnectionDiagnostics { connection_id }`; the single forwarding loop calls `publisher.evict_connection_diagnostics(id)`, which evicts and republishes each affected host (clearing the dead server's contribution).

## Why it's safe
All connections multiplex **one** ordered upstream channel drained by **one** single-threaded forwarding loop, so `record` and `evict_connection` never run concurrently and are processed in send order. The id-tag makes eviction restart-safe under both orderings (evict-before-repush clears then re-adds; repush-before-evict spares the slot by tag mismatch). The pull-layer (a cross-connection aggregate, tagged `None`) is never touched; a dead pull-driven server's contribution self-refreshes on the next host-event pull (documented asymmetry).

## Behavior
On a real crash + lazy respawn the dead server's diagnostics clear immediately (rather than lingering to `didClose`) and reappear when the next request re-drives the restarted server. This does not fire on host `didClose` (which doesn't tear down shared connections); server-wide shutdown cancels the loop first, so its sends are harmless no-ops.

## Tests
- `evict_connection_*` (cache): drops only the dead connection's slots, spares a restart's replaced slot (both orderings), removes emptied hosts, ignores unknown ids.
- `reader_exit_purges_progress_mappings`: asserts the guard emits `EvictConnectionDiagnostics` for its connection on exit.
- `evict_connection_diagnostics_drops_only_the_dead_connection` (publisher): the forwarding-loop delegate evicts the dead connection and keeps the live one.
- Full editor-output crash-eviction e2e is folded into the push-diagnostics e2e work (#427).

## Review
Converged through subagent `/review` and Codex MCP review (both SHIP). Full lib suite (2016) + `clippy --all-targets --all-features` + `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)