### PR TITLE
test(e2e): downstream crash evicts its pushed diagnostics (#469)

### DIFF
--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -49,6 +49,10 @@
 //!   `didChange`. Used by `tests/e2e_push_diagnostics.rs` to prove a downstream's
 //!   spontaneous push reaches the editor in host coordinates and that an empty push
 //!   clears it (#427).
+//! - `diagnostics-push-crash` — pushes the same diagnostic on `didOpen`, then exits
+//!   the process on the next `didChange` to simulate a downstream crash while the
+//!   host stays open. Used to prove the bridge evicts the dead connection's slots
+//!   and republishes the host cleared (#469).
 //! - `on-type` — advertises `documentOnTypeFormattingProvider` with `}` and
 //!   `;` as triggers; answers `textDocument/onTypeFormatting` with the
 //!   uppercasing whole-document edit for ANY typed character (bridge-side
@@ -234,7 +238,9 @@ fn main() {
                     // `diagnostics-push` mode: spontaneously push one diagnostic on
                     // the virtual line 0 (no pull). The bridge translates it to host
                     // coordinates and publishes it to the editor (#427).
-                    if mode == "diagnostics-push" {
+                    // `diagnostics-push-crash` pushes the same diagnostic, then exits
+                    // the process on the next `didChange` to simulate a crash (#469).
+                    if mode == "diagnostics-push" || mode == "diagnostics-push-crash" {
                         notify(
                             &mut writer,
                             "textDocument/publishDiagnostics",
@@ -266,6 +272,13 @@ fn main() {
                             "textDocument/publishDiagnostics",
                             push_diagnostics(uri, false),
                         );
+                    }
+                    // `diagnostics-push-crash`: exit the process now (the diagnostic
+                    // pushed on didOpen is still live in the editor). The bridge's
+                    // reader sees EOF, evicts this connection's slots, and republishes
+                    // the host cleared (#469).
+                    if mode == "diagnostics-push-crash" {
+                        std::process::exit(0);
                     }
                 }
             }

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -13,6 +13,10 @@
 //! No-resurrection-after-close (a late push dropped once the editor closed the doc)
 //! is covered by the `#421` push-accept-guard unit tests; an e2e for it would be a
 //! flaky negative-timeout assertion, so it is intentionally left out here.
+//!
+//! A second test (`diagnostics-push-crash` mode) proves crash eviction (#469): the
+//! downstream pushes a diagnostic, then exits; the bridge evicts that connection's
+//! slots and republishes the host **cleared** — a positive (non-flaky) assertion.
 
 #![cfg(feature = "e2e")]
 
@@ -37,6 +41,10 @@ const MD_TEXT: &str = "# Test\n\n```lua\nlocal x = 1\n```\n";
 const HOST_LINE: i64 = 3;
 
 fn init_client() -> (LspClient, tempfile::TempDir) {
+    init_client_with_mode("diagnostics-push")
+}
+
+fn init_client_with_mode(mode: &str) -> (LspClient, tempfile::TempDir) {
     let config_dir = tempfile::TempDir::new().expect("temp dir");
     let config_path = config_dir.path().join("push_diagnostics.toml");
     std::fs::write(&config_path, "").expect("write config");
@@ -55,7 +63,7 @@ fn init_client() -> (LspClient, tempfile::TempDir) {
             "workspaceFolders": null,
             "initializationOptions": {
                 "languageServers": {
-                    "mock-push": { "cmd": [mock_bin(), "diagnostics-push"], "languages": ["lua"] }
+                    "mock-push": { "cmd": [mock_bin(), mode], "languages": ["lua"] }
                 }
             }
         }),
@@ -144,6 +152,57 @@ fn e2e_push_diagnostic_reaches_editor_in_host_coords_then_clears() {
     assert!(
         cleared.is_some(),
         "an empty push should clear the source's diagnostic for the host doc"
+    );
+
+    client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
+fn e2e_downstream_crash_evicts_its_pushed_diagnostics() {
+    let (mut client, _config_dir) = init_client_with_mode("diagnostics-push-crash");
+
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": MD_URI,
+                "languageId": "markdown",
+                "version": 1,
+                "text": MD_TEXT
+            }
+        }),
+    );
+
+    // The crash mock pushes one diagnostic on didOpen; the editor receives it.
+    client
+        .wait_for_notification_where(
+            &["textDocument/publishDiagnostics"],
+            Duration::from_secs(15),
+            has_pushed_diag,
+        )
+        .expect("editor should receive the pushed diagnostic before the crash");
+
+    // didChange drives the mock to exit (crash) while the host stays open. The
+    // bridge's reader sees EOF, evicts that connection's slots, and republishes the
+    // host cleared — a positive assertion (no negative timeout): we wait for the
+    // publish that no longer carries the dead server's diagnostic (#469).
+    client.send_notification(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": MD_URI, "version": 2 },
+            "contentChanges": [{ "text": MD_TEXT }]
+        }),
+    );
+
+    let cleared = client.wait_for_notification_where(
+        &["textDocument/publishDiagnostics"],
+        Duration::from_secs(15),
+        cleared_host_diag,
+    );
+    assert!(
+        cleared.is_some(),
+        "a crashed downstream's pushed diagnostics must be evicted and the host republished cleared"
     );
 
     client.send_request("shutdown", json!(null));


### PR DESCRIPTION
Stacked on #477 (base: `feat-469-evict-server`).

Adds the end-to-end crash-eviction seam both reviewers of #469 flagged as the one untested path — as a **positive, non-flaky** assertion (no negative timeout).

## What it proves
A downstream connection pushes a diagnostic, then dies while the host document stays open. The bridge's reader sees EOF → `ProgressPurgeGuard` emits `EvictConnectionDiagnostics` → the forwarding loop evicts that connection's cache slots and republishes the host **cleared**. The test waits for the publish that no longer carries the dead server's diagnostic.

## Changes
- `mock_formatter.rs`: new `diagnostics-push-crash` mode — pushes one diagnostic on `didOpen`, then `std::process::exit(0)` on the next `didChange` to simulate a crash with the host still open.
- `e2e_push_diagnostics.rs`: `e2e_downstream_crash_evicts_its_pushed_diagnostics` (refactored `init_client` to take a mode).

Complements #469's cache/guard/publisher unit + seam tests with the full editor-output path. (Issue #427's a/b/c push cases were already covered — #463 e2e + #421 guard units — and that issue is now closed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)