### PR TITLE
perf(bridge): coalesce a burst of publishDiagnostics in the forwarding loop (#426 part 2)

### DIFF
--- a/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
+++ b/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
@@ -466,8 +466,11 @@ because the #380 benefit now outweighs it:
   the per-URI ordering guarantee.
 - Re-publish is unthrottled by design (the `didChange` debounce is gone): a no-op
   push is suppressed (winner content unchanged), but a chatty linter emitting
-  distinct results in quick succession re-publishes each time. A coalescing window
-  could be added later if it proves noisy; it is deliberately out of scope here.
+  distinct results in quick succession re-publishes each time. To bound the cost of
+  a push-happy/misbehaving downstream, the forwarding loop coalesces a drained burst
+  of `publishDiagnostics` by `(connection, uri)` to the latest before delivering
+  (`coalesce_upstream_batch`, #426) — at most one republish per distinct key per
+  batch — with every other notification acting as an order-preserving barrier.
 - `pullFallback` (default on) keeps a *scoped* host-event pull trigger alive for
   pull-driven servers — the per-event re-pull is removed only for push-driven
   ones, not universally. Setting it `false` drops those servers from the proactive

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -66,10 +66,12 @@ pub(crate) enum UpstreamNotification {
     /// (unresolved virtual URI; real URI not open / not `_self` / wrong server).
     ///
     /// This carries an arbitrary-size `Vec<Diagnostic>` over the **unbounded**
-    /// upstream channel, so a push-happy or misbehaving downstream paired with a
-    /// slow upstream loop could grow memory. Re-publish is unthrottled by design
-    /// (push-propagation-diagnostic-forwarding § Consequences); a bounded /
-    /// coalescing diagnostics channel is the deferred mitigation if it proves noisy.
+    /// upstream channel. To keep a push-happy or misbehaving downstream from making
+    /// the loop republish every superseded push, the forwarding loop coalesces a
+    /// drained burst by `(connection, uri)` to the latest before delivering
+    /// (`coalesce_upstream_batch`, #426), so it does at most one republish per
+    /// distinct key per batch. Re-publish is otherwise unthrottled by design
+    /// (push-propagation-diagnostic-forwarding § Consequences).
     PublishDiagnostics {
         /// The URI the downstream published for — a virtual injection URI (region
         /// push) or a real host URI (`_self` host-layer push).

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -66,12 +66,13 @@ pub(crate) enum UpstreamNotification {
     /// (unresolved virtual URI; real URI not open / not `_self` / wrong server).
     ///
     /// This carries an arbitrary-size `Vec<Diagnostic>` over the **unbounded**
-    /// upstream channel. To keep a push-happy or misbehaving downstream from making
-    /// the loop republish every superseded push, the forwarding loop coalesces a
-    /// drained burst by `(connection, uri)` to the latest before delivering
-    /// (`coalesce_upstream_batch`, #426), so it does at most one republish per
-    /// distinct key per batch. Re-publish is otherwise unthrottled by design
-    /// (push-propagation-diagnostic-forwarding § Consequences).
+    /// upstream channel. To keep a chatty downstream re-pushing the *same*
+    /// `(connection, uri)` from making the loop republish every superseded push, the
+    /// forwarding loop coalesces a drained burst by `(connection, uri)` to the latest
+    /// before delivering (`coalesce_upstream_batch`, #426): at most one republish per
+    /// distinct key per batch. This collapses same-key supersession only — a flood of
+    /// *distinct* URIs is not coalesced, and re-publish is otherwise unthrottled by
+    /// design (push-propagation-diagnostic-forwarding § Consequences).
     PublishDiagnostics {
         /// The URI the downstream published for — a virtual injection URI (region
         /// push) or a real host URI (`_self` host-layer push).

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1139,10 +1139,27 @@ mod tests {
             }
         }
 
+        /// A `PublishDiagnostics` carrying an empty list — a *clearing* push.
+        fn publish_clear(conn: u64, uri: &str) -> UpstreamNotification {
+            UpstreamNotification::PublishDiagnostics {
+                uri: uri.to_string(),
+                server: "srv".to_string(),
+                connection_id: ProgressConnectionId::for_test(conn),
+                diagnostics: vec![],
+            }
+        }
+
         fn evict(conn: u64) -> UpstreamNotification {
             UpstreamNotification::EvictConnectionDiagnostics {
                 connection_id: ProgressConnectionId::for_test(conn),
             }
+        }
+
+        fn is_empty_publish(n: &UpstreamNotification) -> bool {
+            matches!(
+                n,
+                UpstreamNotification::PublishDiagnostics { diagnostics, .. } if diagnostics.is_empty()
+            )
         }
 
         /// The latest message of `out[idx]`, which must be a `PublishDiagnostics`.
@@ -1237,6 +1254,54 @@ mod tests {
             let out = coalesce_upstream_batch(vec![UpstreamNotification::DiagnosticRefresh]);
             assert_eq!(out.len(), 1);
             assert!(matches!(out[0], UpstreamNotification::DiagnosticRefresh));
+        }
+
+        #[test]
+        fn coalesces_a_run_then_delivers_the_evict_after_it() {
+            // [P, P, Evict]: the two same-key pushes collapse to the latest, then the
+            // evict (which originally followed both) is delivered after it.
+            let out =
+                coalesce_upstream_batch(vec![publish(1, "u", "a"), publish(1, "u", "b"), evict(1)]);
+            assert_eq!(out.len(), 2);
+            assert_eq!(msg_at(&out, 0), "b");
+            assert!(matches!(
+                out[1],
+                UpstreamNotification::EvictConnectionDiagnostics { .. }
+            ));
+        }
+
+        #[test]
+        fn a_later_clear_supersedes_an_earlier_error_in_a_run() {
+            // The clear must win (latest), so the editor ends cleared — a dropped
+            // clear would leave a stale diagnostic on screen.
+            let out = coalesce_upstream_batch(vec![publish(1, "u", "err"), publish_clear(1, "u")]);
+            assert_eq!(out.len(), 1);
+            assert!(
+                is_empty_publish(&out[0]),
+                "the clearing push supersedes the earlier error"
+            );
+        }
+
+        #[test]
+        fn coalesces_each_key_independently_around_a_barrier() {
+            // Two keys before a barrier (one coalesced), the barrier, then the first
+            // key again after it (kept separate).
+            let out = coalesce_upstream_batch(vec![
+                publish(1, "u", "a1"),
+                publish(2, "v", "b"),
+                publish(1, "u", "a2"),
+                UpstreamNotification::DiagnosticRefresh,
+                publish(1, "u", "a3"),
+            ]);
+            assert_eq!(out.len(), 4);
+            assert_eq!(msg_at(&out, 0), "a2", "key (1,u) coalesces to its latest");
+            assert_eq!(msg_at(&out, 1), "b", "the distinct key (2,v) is untouched");
+            assert!(matches!(out[2], UpstreamNotification::DiagnosticRefresh));
+            assert_eq!(
+                msg_at(&out, 3),
+                "a3",
+                "the push after the barrier is separate"
+            );
         }
     }
 

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -644,8 +644,9 @@ async fn upstream_forwarding_loop(
 /// instead of draining forever (#426).
 const UPSTREAM_COALESCE_BATCH_CAP: usize = 256;
 
-/// Collapse a drained burst of upstream notifications, coalescing **consecutive**
-/// `PublishDiagnostics` for the same `(connection_id, uri)` down to the latest one
+/// Collapse a drained burst of upstream notifications, coalescing the
+/// `PublishDiagnostics` for each `(connection_id, uri)` within a barrier-delimited
+/// run (not necessarily adjacent — other keys may interleave) down to the latest one
 /// (#426). A push-happy or misbehaving downstream can pile arbitrary-size
 /// `Vec<Diagnostic>` on the unbounded upstream channel faster than the loop
 /// republishes them; since `record` already keeps only the latest per
@@ -674,9 +675,11 @@ fn coalesce_upstream_batch(
 
     // `None` entries are tombstones: a publish superseded by a later same-key one.
     let mut output: Vec<Option<UpstreamNotification>> = Vec::with_capacity(batch.len());
-    // Pending coalesced publishes since the last barrier: `(connection, uri)` key →
-    // its (live, latest) index in `output`.
-    let mut pending: HashMap<(ProgressConnectionId, String), usize> = HashMap::new();
+    // Pending coalesced publishes since the last barrier: connection → uri → its
+    // (live, latest) index in `output`. Nested (rather than a flat `(conn, uri)`
+    // tuple key) so the coalescing-repeat path looks up by `&uri` with `get_mut` and
+    // only clones the `uri` when first inserting it.
+    let mut pending: HashMap<ProgressConnectionId, HashMap<String, usize>> = HashMap::new();
 
     for notification in batch {
         match notification {
@@ -686,12 +689,15 @@ fn coalesce_upstream_batch(
                 connection_id,
                 diagnostics,
             } => {
-                let key = (connection_id, uri.clone());
                 let idx = output.len();
-                // Record this as the key's latest; tombstone the earlier occurrence
-                // (if any) so only the latest survives, at its own later position.
-                if let Some(prev) = pending.insert(key, idx) {
-                    output[prev] = None;
+                let by_uri = pending.entry(connection_id).or_default();
+                if let Some(prev) = by_uri.get_mut(&uri) {
+                    // Tombstone the earlier occurrence so only the latest survives, at
+                    // its own later position (no `uri` clone on this hot repeat path).
+                    output[*prev] = None;
+                    *prev = idx;
+                } else {
+                    by_uri.insert(uri.clone(), idx);
                 }
                 output.push(Some(UpstreamNotification::PublishDiagnostics {
                     uri,

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -487,10 +487,12 @@ async fn forward_upstream_request(
 ///   `workspace/diagnostic/refresh` — the server-declared work-done progress
 ///   notifications (`CreateWorkDoneProgress`/`Progress`/`ForgetWorkDoneProgress`,
 ///   window-work-done-progress), and `PublishDiagnostics`/`EvictConnectionDiagnostics`,
-///   none of which may be lost or reordered. Each wake-up drains a capped burst and
-///   coalesces same-`(connection, uri)` `PublishDiagnostics` to the latest
-///   (`coalesce_upstream_batch`, #426); every other notification is a barrier, so
-///   FIFO order (and create-before-progress) is preserved.
+///   which may not be lost. Each wake-up drains a capped burst and coalesces
+///   same-`(connection, uri)` `PublishDiagnostics` to the latest
+///   (`coalesce_upstream_batch`, #426); every other notification is an
+///   order-preserving barrier, so publishes never cross one — `publish`↔`evict`
+///   order and create-before-progress hold. (Distinct-key publishes within a run
+///   may be reordered, which is benign; see `coalesce_upstream_batch`.)
 /// - `upstream_request_rx` (unbounded): downstream-initiated *requests*
 ///   (`window/showMessageRequest`, `window/showDocument`) forwarded with the
 ///   editor's response relayed back; loss-intolerant (a dropped request hangs
@@ -570,6 +572,13 @@ async fn upstream_forwarding_loop(
                             }
                         }
                         for notification in coalesce_upstream_batch(batch) {
+                            // Re-check cancellation between deliveries so a shutdown
+                            // during a large batch isn't delayed by up to 256 republish
+                            // awaits (the outer `select!` only re-checks between batches);
+                            // the biased cancel arm then breaks the loop on the next turn.
+                            if cancel_token.is_cancelled() {
+                                break;
+                            }
                             deliver_upstream_notification(
                                 &client,
                                 notification,
@@ -641,11 +650,15 @@ const UPSTREAM_COALESCE_BATCH_CAP: usize = 256;
 /// `(host, source, server)`, the earlier pushes' work is wasted — coalescing skips
 /// it, so the loop does at most one republish per distinct key per batch.
 ///
-/// FIFO order is preserved exactly: every non-publish notification — including
-/// [`UpstreamNotification::EvictConnectionDiagnostics`] — is a **barrier** that
-/// first flushes the pending coalesced publishes (in arrival order) and then itself,
-/// so a publish can never be reordered across an evict for its connection (a
-/// `Publish(c)` then `Evict(c)` still nets to evicted, as in the un-coalesced FIFO).
+/// **Barrier order is exact**: every non-publish notification — including
+/// [`UpstreamNotification::EvictConnectionDiagnostics`] — is a barrier that the
+/// pending coalesced publishes stay *before*, so a publish can never be reordered
+/// across one (a `Publish(c)` then `Evict(c)` still nets to evicted, and
+/// create-before-progress holds). Within a run of consecutive publishes the order is
+/// *not* exact: a same-key push collapses onto the first occurrence's position, and
+/// distinct keys may be reordered relative to each other. That is benign because each
+/// delivery re-merges and republishes the host's *full* current slot set, so the
+/// editor's end state is independent of intra-run publish order.
 fn coalesce_upstream_batch(
     batch: Vec<crate::lsp::bridge::UpstreamNotification>,
 ) -> Vec<crate::lsp::bridge::UpstreamNotification> {
@@ -1283,6 +1296,26 @@ mod tests {
         }
 
         #[test]
+        fn within_a_run_a_later_same_key_push_takes_the_first_position() {
+            // Documents the intra-run reorder: [A1, B, A2] with A1/A2 same key and B a
+            // *different-key publish* (no barrier) coalesces A1←A2 onto A1's position,
+            // so A2's content lands before B. Benign — each delivery re-merges the full
+            // host set — but it is NOT exact FIFO, unlike barrier order.
+            let out = coalesce_upstream_batch(vec![
+                publish(1, "u", "a1"),
+                publish(2, "v", "b"),
+                publish(1, "u", "a2"),
+            ]);
+            assert_eq!(out.len(), 2);
+            assert_eq!(
+                msg_at(&out, 0),
+                "a2",
+                "same-key latest, at the first position"
+            );
+            assert_eq!(msg_at(&out, 1), "b");
+        }
+
+        #[test]
         fn coalesces_each_key_independently_around_a_barrier() {
             // Two keys before a barrier (one coalesced), the barrier, then the first
             // key again after it (kept separate).
@@ -1419,6 +1452,100 @@ mod tests {
 
         cancel.cancel();
         let _ = loop_handle.await;
+    }
+
+    /// Cancellation is re-checked *between* deliveries of a coalesced batch, so a
+    /// shutdown mid-batch is not delayed by the rest of the batch (#426). Two
+    /// `DiagnosticRefresh` are drained into one batch; cancelling during the first's
+    /// editor round-trip must make the loop skip the second and exit.
+    #[tokio::test]
+    async fn forwarding_loop_rechecks_cancellation_between_batched_deliveries() {
+        use crate::lsp::bridge::UpstreamNotification;
+        use futures::{SinkExt, StreamExt};
+        use std::sync::{Arc, Mutex};
+        use tower::{Service, ServiceExt};
+        use tower_lsp_server::jsonrpc::{Request, Response};
+        use tower_lsp_server::ls_types::{InitializeParams, InitializeResult};
+        use tower_lsp_server::{LanguageServer, LspService};
+
+        struct Dummy;
+        impl LanguageServer for Dummy {
+            async fn initialize(
+                &self,
+                _: InitializeParams,
+            ) -> tower_lsp_server::jsonrpc::Result<InitializeResult> {
+                Ok(InitializeResult::default())
+            }
+            async fn shutdown(&self) -> tower_lsp_server::jsonrpc::Result<()> {
+                Ok(())
+            }
+        }
+
+        let captured: Arc<Mutex<Option<Client>>> = Arc::new(Mutex::new(None));
+        let captured_for_init = Arc::clone(&captured);
+        let (mut service, socket) = LspService::build(move |client| {
+            *captured_for_init.lock().unwrap() = Some(client);
+            Dummy
+        })
+        .finish();
+        let client = captured.lock().unwrap().take().unwrap();
+
+        let init = Request::build("initialize")
+            .params(serde_json::json!({ "capabilities": {} }))
+            .id(1)
+            .finish();
+        let _ = service.ready().await.unwrap().call(init).await;
+
+        let (mut requests, mut responses) = socket.split();
+
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let (_window_tx, window_rx) = tokio::sync::mpsc::channel(16);
+        let (_request_tx, request_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        // Two refreshes queued before the loop runs → drained into one batch.
+        tx.send(UpstreamNotification::DiagnosticRefresh).unwrap();
+        tx.send(UpstreamNotification::DiagnosticRefresh).unwrap();
+
+        let loop_handle = tokio::spawn(upstream_forwarding_loop(
+            rx,
+            window_rx,
+            request_rx,
+            None,
+            crate::lsp::bridge::InboundRequestRegistry::default(),
+            client,
+            None,
+            cancel.clone(),
+        ));
+
+        // The loop delivers the first refresh (a request that awaits the editor).
+        let first = requests
+            .next()
+            .await
+            .expect("first refresh request emitted");
+        assert_eq!(first.method(), "workspace/diagnostic/refresh");
+        // Cancel during the first delivery's round-trip; when it completes the loop
+        // must re-check cancellation and skip the second batched refresh.
+        cancel.cancel();
+        responses
+            .send(Response::from_ok(
+                first.id().expect("refresh request id").clone(),
+                serde_json::Value::Null,
+            ))
+            .await
+            .unwrap();
+
+        // The loop must skip the second refresh and exit. Were cancellation NOT
+        // re-checked mid-batch, it would deliver the second refresh and block on its
+        // (never-sent) response — so this would hang. The timeout turns that
+        // regression into a failure instead of an infinite hang.
+        tokio::time::timeout(std::time::Duration::from_secs(5), loop_handle)
+            .await
+            .expect("loop must exit after cancellation, not block on the skipped refresh")
+            .unwrap();
+        // `requests`/`responses` intentionally dropped without asserting stream
+        // closure: `service` still holds a Client clone, so the stream stays open.
+        drop((requests, responses));
     }
 
     /// When the editor REJECTS `window/workDoneProgress/create`, the loop must

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -709,8 +709,13 @@ fn coalesce_upstream_batch(
             // Any non-publish notification is a barrier: the pending publishes are
             // already committed to `output` ahead of it (order preserved); stop
             // coalescing across it so a later same-key push is emitted separately.
+            // Clear the inner maps rather than the outer one, so a batch with several
+            // barriers reuses the per-connection allocations instead of dropping and
+            // re-allocating them each time.
             barrier => {
-                pending.clear();
+                for by_uri in pending.values_mut() {
+                    by_uri.clear();
+                }
                 output.push(Some(barrier));
             }
         }

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -484,10 +484,13 @@ async fn forward_upstream_request(
 /// Consumes from three channels (loss-tolerance split, #378) and dispatches them
 /// to the LSP client:
 /// - `upstream_rx` (unbounded): `DiagnosticRefresh` — forwarded as
-///   `workspace/diagnostic/refresh` — and the server-declared work-done
-///   progress notifications (`CreateWorkDoneProgress`/`Progress`/
-///   `ForgetWorkDoneProgress`, window-work-done-progress), which must not be
-///   lost or reordered.
+///   `workspace/diagnostic/refresh` — the server-declared work-done progress
+///   notifications (`CreateWorkDoneProgress`/`Progress`/`ForgetWorkDoneProgress`,
+///   window-work-done-progress), and `PublishDiagnostics`/`EvictConnectionDiagnostics`,
+///   none of which may be lost or reordered. Each wake-up drains a capped burst and
+///   coalesces same-`(connection, uri)` `PublishDiagnostics` to the latest
+///   (`coalesce_upstream_batch`, #426); every other notification is a barrier, so
+///   FIFO order (and create-before-progress) is preserved.
 /// - `upstream_request_rx` (unbounded): downstream-initiated *requests*
 ///   (`window/showMessageRequest`, `window/showDocument`) forwarded with the
 ///   editor's response relayed back; loss-intolerant (a dropped request hangs
@@ -552,15 +555,30 @@ async fn upstream_forwarding_loop(
 
             notification = upstream_rx.recv() => {
                 match notification {
-                    Some(notification) => {
-                        deliver_upstream_notification(
-                            &client,
-                            notification,
-                            &mut created_tokens,
-                            &mut begun_tokens,
-                            diagnostic_publisher.as_deref(),
-                        )
-                        .await
+                    Some(first) => {
+                        // Drain the rest of the currently-queued burst (capped) and
+                        // coalesce same-(connection,uri) PublishDiagnostics to the
+                        // latest, so a push-happy downstream can't make the loop
+                        // republish every superseded push off the unbounded channel
+                        // (#426). The common case (nothing else queued) is one extra
+                        // non-blocking try_recv and a single-element passthrough.
+                        let mut batch = vec![first];
+                        while batch.len() < UPSTREAM_COALESCE_BATCH_CAP {
+                            match upstream_rx.try_recv() {
+                                Ok(next) => batch.push(next),
+                                Err(_) => break, // empty or disconnected
+                            }
+                        }
+                        for notification in coalesce_upstream_batch(batch) {
+                            deliver_upstream_notification(
+                                &client,
+                                notification,
+                                &mut created_tokens,
+                                &mut begun_tokens,
+                                diagnostic_publisher.as_deref(),
+                            )
+                            .await
+                        }
                     }
                     None => break, // Channel closed
                 }
@@ -607,6 +625,71 @@ async fn upstream_forwarding_loop(
             }
         }
     }
+}
+
+/// Max notifications drained into one coalescing batch per loop wake-up. Bounds the
+/// transient batch while still collapsing a burst; under a continuous flood the loop
+/// processes the channel in capped chunks, so it keeps making publish progress
+/// instead of draining forever (#426).
+const UPSTREAM_COALESCE_BATCH_CAP: usize = 256;
+
+/// Collapse a drained burst of upstream notifications, coalescing **consecutive**
+/// `PublishDiagnostics` for the same `(connection_id, uri)` down to the latest one
+/// (#426). A push-happy or misbehaving downstream can pile arbitrary-size
+/// `Vec<Diagnostic>` on the unbounded upstream channel faster than the loop
+/// republishes them; since `record` already keeps only the latest per
+/// `(host, source, server)`, the earlier pushes' work is wasted — coalescing skips
+/// it, so the loop does at most one republish per distinct key per batch.
+///
+/// FIFO order is preserved exactly: every non-publish notification — including
+/// [`UpstreamNotification::EvictConnectionDiagnostics`] — is a **barrier** that
+/// first flushes the pending coalesced publishes (in arrival order) and then itself,
+/// so a publish can never be reordered across an evict for its connection (a
+/// `Publish(c)` then `Evict(c)` still nets to evicted, as in the un-coalesced FIFO).
+fn coalesce_upstream_batch(
+    batch: Vec<crate::lsp::bridge::UpstreamNotification>,
+) -> Vec<crate::lsp::bridge::UpstreamNotification> {
+    use crate::lsp::bridge::{ProgressConnectionId, UpstreamNotification};
+    use std::collections::HashMap;
+
+    let mut output: Vec<UpstreamNotification> = Vec::with_capacity(batch.len());
+    // Pending coalesced publishes since the last barrier: a `(connection, uri)` key
+    // → its index in `output`. The publish already sits in `output` at that index;
+    // a later same-key publish overwrites it there (latest wins, original position).
+    let mut pending: HashMap<(ProgressConnectionId, String), usize> = HashMap::new();
+
+    for notification in batch {
+        match notification {
+            UpstreamNotification::PublishDiagnostics {
+                uri,
+                server,
+                connection_id,
+                diagnostics,
+            } => {
+                let key = (connection_id, uri.clone());
+                let next = UpstreamNotification::PublishDiagnostics {
+                    uri,
+                    server,
+                    connection_id,
+                    diagnostics,
+                };
+                if let Some(&idx) = pending.get(&key) {
+                    output[idx] = next; // coalesce: replace the superseded push in place
+                } else {
+                    pending.insert(key, output.len());
+                    output.push(next);
+                }
+            }
+            // Any non-publish notification is a barrier: the pending publishes are
+            // already committed to `output` ahead of it (order preserved); just stop
+            // coalescing across it so a later same-key push is emitted separately.
+            barrier => {
+                pending.clear();
+                output.push(barrier);
+            }
+        }
+    }
+    output
 }
 
 /// Service a downstream-initiated request by forwarding it to the editor on a
@@ -1036,6 +1119,124 @@ mod tests {
             request_id: tower_lsp_server::jsonrpc::Id::Number(1),
             token: tokio_util::sync::CancellationToken::new(),
             generation: 0,
+        }
+    }
+
+    mod coalesce {
+        use super::super::coalesce_upstream_batch;
+        use crate::lsp::bridge::{ProgressConnectionId, UpstreamNotification};
+        use tower_lsp_server::ls_types::Diagnostic;
+
+        fn publish(conn: u64, uri: &str, msg: &str) -> UpstreamNotification {
+            UpstreamNotification::PublishDiagnostics {
+                uri: uri.to_string(),
+                server: "srv".to_string(),
+                connection_id: ProgressConnectionId::for_test(conn),
+                diagnostics: vec![Diagnostic {
+                    message: msg.to_string(),
+                    ..Default::default()
+                }],
+            }
+        }
+
+        fn evict(conn: u64) -> UpstreamNotification {
+            UpstreamNotification::EvictConnectionDiagnostics {
+                connection_id: ProgressConnectionId::for_test(conn),
+            }
+        }
+
+        /// The latest message of `out[idx]`, which must be a `PublishDiagnostics`.
+        fn msg_at(out: &[UpstreamNotification], idx: usize) -> &str {
+            match &out[idx] {
+                UpstreamNotification::PublishDiagnostics { diagnostics, .. } => {
+                    diagnostics[0].message.as_str()
+                }
+                other => panic!("expected PublishDiagnostics at {idx}, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn collapses_consecutive_same_key_to_latest() {
+            let out = coalesce_upstream_batch(vec![
+                publish(1, "u", "a"),
+                publish(1, "u", "b"),
+                publish(1, "u", "c"),
+            ]);
+            assert_eq!(out.len(), 1, "three pushes for one key collapse to one");
+            assert_eq!(msg_at(&out, 0), "c", "the latest push wins");
+        }
+
+        #[test]
+        fn keeps_distinct_keys() {
+            // Different uri, and different connection on the same uri, are distinct.
+            let out = coalesce_upstream_batch(vec![
+                publish(1, "u", "a"),
+                publish(1, "v", "b"),
+                publish(2, "u", "c"),
+            ]);
+            assert_eq!(out.len(), 3, "distinct (connection, uri) keys are all kept");
+        }
+
+        #[test]
+        fn does_not_coalesce_across_an_evict_barrier() {
+            // Publish, evict the same connection, publish again: the evict is a
+            // barrier, so the two same-key pushes are NOT collapsed and stay ordered.
+            let out =
+                coalesce_upstream_batch(vec![publish(1, "u", "a"), evict(1), publish(1, "u", "b")]);
+            assert_eq!(out.len(), 3);
+            assert_eq!(msg_at(&out, 0), "a");
+            assert!(matches!(
+                out[1],
+                UpstreamNotification::EvictConnectionDiagnostics { .. }
+            ));
+            assert_eq!(msg_at(&out, 2), "b");
+        }
+
+        #[test]
+        fn publish_then_evict_keeps_publish_first() {
+            // The ordering invariant: a publish for a connection is delivered before
+            // the evict for that connection (publish-then-evict nets to evicted).
+            let out = coalesce_upstream_batch(vec![publish(1, "u", "a"), evict(1)]);
+            assert_eq!(out.len(), 2);
+            assert!(matches!(
+                out[0],
+                UpstreamNotification::PublishDiagnostics { .. }
+            ));
+            assert!(matches!(
+                out[1],
+                UpstreamNotification::EvictConnectionDiagnostics { .. }
+            ));
+        }
+
+        #[test]
+        fn non_publish_notification_is_a_barrier() {
+            // A non-publish notification (DiagnosticRefresh) flushes pending pushes
+            // ahead of it and stops coalescing across it — order is preserved.
+            let out = coalesce_upstream_batch(vec![
+                publish(1, "u", "a1"),
+                publish(1, "u", "a2"),
+                UpstreamNotification::DiagnosticRefresh,
+                publish(1, "u", "a3"),
+            ]);
+            assert_eq!(out.len(), 3);
+            assert_eq!(
+                msg_at(&out, 0),
+                "a2",
+                "the run before the barrier coalesces"
+            );
+            assert!(matches!(out[1], UpstreamNotification::DiagnosticRefresh));
+            assert_eq!(
+                msg_at(&out, 2),
+                "a3",
+                "the push after the barrier is separate"
+            );
+        }
+
+        #[test]
+        fn passes_a_lone_non_publish_through_unchanged() {
+            let out = coalesce_upstream_batch(vec![UpstreamNotification::DiagnosticRefresh]);
+            assert_eq!(out.len(), 1);
+            assert!(matches!(out[0], UpstreamNotification::DiagnosticRefresh));
         }
     }
 

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -505,9 +505,12 @@ async fn forward_upstream_request(
 /// editor stalls the loop — but the `biased` select drains the two loss-intolerant
 /// channels (`upstream_rx`, then `upstream_request_rx`) before the best-effort
 /// `window_rx`, so a `window/*` burst cannot starve `DiagnosticRefresh`, progress,
-/// or request forwarding, and the bounded window queue caps memory. FIFO order is
-/// preserved within each channel (the window-notification e2e relies on
-/// window-channel FIFO; create-before-progress relies on upstream-channel FIFO).
+/// or request forwarding, and the bounded window queue caps memory. The window
+/// channel preserves strict FIFO (the window-notification e2e relies on it). The
+/// upstream channel preserves **barrier** order — every non-publish notification
+/// keeps its position, so create-before-progress holds — while coalescing collapses
+/// superseded same-`(connection, uri)` `PublishDiagnostics` within a drained burst
+/// (`coalesce_upstream_batch`, #426).
 ///
 /// Exits when:
 /// - Either channel is closed (all senders dropped — both senders live in the
@@ -650,25 +653,30 @@ const UPSTREAM_COALESCE_BATCH_CAP: usize = 256;
 /// `(host, source, server)`, the earlier pushes' work is wasted — coalescing skips
 /// it, so the loop does at most one republish per distinct key per batch.
 ///
+/// Coalescing **drops superseded earlier pushes** and keeps every survivor in its
+/// original FIFO order: a same-key push tombstones its earlier occurrence and lands
+/// at its own (later) position. This is required for correctness, not just tidiness —
+/// a restarted server pushes under a *new* `connection_id` for the *same* uri, which
+/// is a distinct coalescing key but the **same** cache slot `(host, source, server)`;
+/// keeping last-occurrence order makes the delivered sequence equivalent to FIFO with
+/// the superseded entries removed, so the slot's final writer (and any later
+/// `Evict(connection)`) behaves exactly as in the un-coalesced FIFO.
+///
 /// **Barrier order is exact**: every non-publish notification — including
 /// [`UpstreamNotification::EvictConnectionDiagnostics`] — is a barrier that the
 /// pending coalesced publishes stay *before*, so a publish can never be reordered
 /// across one (a `Publish(c)` then `Evict(c)` still nets to evicted, and
-/// create-before-progress holds). Within a run of consecutive publishes the order is
-/// *not* exact: a same-key push collapses onto the first occurrence's position, and
-/// distinct keys may be reordered relative to each other. That is benign because each
-/// delivery re-merges and republishes the host's *full* current slot set, so the
-/// editor's end state is independent of intra-run publish order.
+/// create-before-progress holds).
 fn coalesce_upstream_batch(
     batch: Vec<crate::lsp::bridge::UpstreamNotification>,
 ) -> Vec<crate::lsp::bridge::UpstreamNotification> {
     use crate::lsp::bridge::{ProgressConnectionId, UpstreamNotification};
     use std::collections::HashMap;
 
-    let mut output: Vec<UpstreamNotification> = Vec::with_capacity(batch.len());
-    // Pending coalesced publishes since the last barrier: a `(connection, uri)` key
-    // → its index in `output`. The publish already sits in `output` at that index;
-    // a later same-key publish overwrites it there (latest wins, original position).
+    // `None` entries are tombstones: a publish superseded by a later same-key one.
+    let mut output: Vec<Option<UpstreamNotification>> = Vec::with_capacity(batch.len());
+    // Pending coalesced publishes since the last barrier: `(connection, uri)` key →
+    // its (live, latest) index in `output`.
     let mut pending: HashMap<(ProgressConnectionId, String), usize> = HashMap::new();
 
     for notification in batch {
@@ -680,29 +688,29 @@ fn coalesce_upstream_batch(
                 diagnostics,
             } => {
                 let key = (connection_id, uri.clone());
-                let next = UpstreamNotification::PublishDiagnostics {
+                let idx = output.len();
+                // Record this as the key's latest; tombstone the earlier occurrence
+                // (if any) so only the latest survives, at its own later position.
+                if let Some(prev) = pending.insert(key, idx) {
+                    output[prev] = None;
+                }
+                output.push(Some(UpstreamNotification::PublishDiagnostics {
                     uri,
                     server,
                     connection_id,
                     diagnostics,
-                };
-                if let Some(&idx) = pending.get(&key) {
-                    output[idx] = next; // coalesce: replace the superseded push in place
-                } else {
-                    pending.insert(key, output.len());
-                    output.push(next);
-                }
+                }));
             }
             // Any non-publish notification is a barrier: the pending publishes are
-            // already committed to `output` ahead of it (order preserved); just stop
+            // already committed to `output` ahead of it (order preserved); stop
             // coalescing across it so a later same-key push is emitted separately.
             barrier => {
                 pending.clear();
-                output.push(barrier);
+                output.push(Some(barrier));
             }
         }
     }
-    output
+    output.into_iter().flatten().collect()
 }
 
 /// Service a downstream-initiated request by forwarding it to the editor on a
@@ -1296,29 +1304,31 @@ mod tests {
         }
 
         #[test]
-        fn within_a_run_a_later_same_key_push_takes_the_first_position() {
-            // Documents the intra-run reorder: [A1, B, A2] with A1/A2 same key and B a
-            // *different-key publish* (no barrier) coalesces A1←A2 onto A1's position,
-            // so A2's content lands before B. Benign — each delivery re-merges the full
-            // host set — but it is NOT exact FIFO, unlike barrier order.
+        fn survivors_keep_fifo_order_even_when_two_connections_share_a_slot() {
+            // A restarted server pushes for the same uri under a NEW connection id:
+            // [A1(c1,u), B(c2,u), A2(c1,u)]. (c1,u) and (c2,u) are distinct coalescing
+            // keys but the same cache slot (host, source, server). The superseded A1 is
+            // dropped and the survivors keep FIFO order — B then A2 — so the slot's last
+            // writer stays A2, matching the un-coalesced FIFO (NOT A2 then B, which would
+            // make B the last writer and mis-handle a later Evict(c1)).
             let out = coalesce_upstream_batch(vec![
                 publish(1, "u", "a1"),
-                publish(2, "v", "b"),
+                publish(2, "u", "b"),
                 publish(1, "u", "a2"),
             ]);
-            assert_eq!(out.len(), 2);
+            assert_eq!(out.len(), 2, "the superseded a1 is dropped");
             assert_eq!(
                 msg_at(&out, 0),
-                "a2",
-                "same-key latest, at the first position"
+                "b",
+                "survivors keep FIFO order: b precedes a2"
             );
-            assert_eq!(msg_at(&out, 1), "b");
+            assert_eq!(msg_at(&out, 1), "a2", "a2 stays the slot's last writer");
         }
 
         #[test]
         fn coalesces_each_key_independently_around_a_barrier() {
-            // Two keys before a barrier (one coalesced), the barrier, then the first
-            // key again after it (kept separate).
+            // Two keys before a barrier (one coalesced to its latest, last-occurrence
+            // order), the barrier, then the first key again after it (kept separate).
             let out = coalesce_upstream_batch(vec![
                 publish(1, "u", "a1"),
                 publish(2, "v", "b"),
@@ -1327,8 +1337,12 @@ mod tests {
                 publish(1, "u", "a3"),
             ]);
             assert_eq!(out.len(), 4);
-            assert_eq!(msg_at(&out, 0), "a2", "key (1,u) coalesces to its latest");
-            assert_eq!(msg_at(&out, 1), "b", "the distinct key (2,v) is untouched");
+            assert_eq!(
+                msg_at(&out, 0),
+                "b",
+                "the surviving a2 follows b in FIFO order"
+            );
+            assert_eq!(msg_at(&out, 1), "a2", "key (1,u) coalesces to its latest");
             assert!(matches!(out[2], UpstreamNotification::DiagnosticRefresh));
             assert_eq!(
                 msg_at(&out, 3),

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -673,6 +673,12 @@ fn coalesce_upstream_batch(
     use crate::lsp::bridge::{ProgressConnectionId, UpstreamNotification};
     use std::collections::HashMap;
 
+    // Common case — a lone notification (no burst queued): nothing to coalesce, so
+    // skip the `output`/`pending` allocations and the tombstone pass entirely.
+    if batch.len() <= 1 {
+        return batch;
+    }
+
     // `None` entries are tombstones: a publish superseded by a later same-key one.
     let mut output: Vec<Option<UpstreamNotification>> = Vec::with_capacity(batch.len());
     // Pending coalesced publishes since the last barrier: connection → uri → its

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -489,10 +489,9 @@ async fn forward_upstream_request(
 ///   window-work-done-progress), and `PublishDiagnostics`/`EvictConnectionDiagnostics`,
 ///   which may not be lost. Each wake-up drains a capped burst and coalesces
 ///   same-`(connection, uri)` `PublishDiagnostics` to the latest
-///   (`coalesce_upstream_batch`, #426); every other notification is an
-///   order-preserving barrier, so publishes never cross one — `publish`↔`evict`
-///   order and create-before-progress hold. (Distinct-key publishes within a run
-///   may be reordered, which is benign; see `coalesce_upstream_batch`.)
+///   (`coalesce_upstream_batch`, #426): only superseded earlier pushes are dropped,
+///   and every surviving notification — publishes and barriers alike — keeps its
+///   FIFO order, so `publish`↔`evict` order and create-before-progress hold.
 /// - `upstream_request_rx` (unbounded): downstream-initiated *requests*
 ///   (`window/showMessageRequest`, `window/showDocument`) forwarded with the
 ///   editor's response relayed back; loss-intolerant (a dropped request hangs


### PR DESCRIPTION
Closes the remaining half of #426 (part 1, the per-host republish lock, shipped in #467).

## Problem
`UpstreamNotification::PublishDiagnostics` carries an arbitrary-size `Vec<Diagnostic>` over the **unbounded** upstream channel. A push-happy/misbehaving downstream paired with a slow forwarding loop made the loop republish *every* superseded push and could grow memory.

## Fix
On each wake-up the loop drains the queued burst (capped at `UPSTREAM_COALESCE_BATCH_CAP = 256`) and coalesces same-`(connection_id, uri)` `PublishDiagnostics` to the latest via `coalesce_upstream_batch`, so it does **at most one republish per distinct key per batch**. `record` already keeps only the latest per `(host, source, server)`, so the skipped pushes' work was wasted anyway.

## Correctness
- **Last-occurrence coalescing**: a same-key push tombstones its earlier occurrence and keeps the latest at its own position, so the delivered sequence equals FIFO with superseded entries removed. This matters because a *restarted* server pushes for the same uri under a new `connection_id` (a distinct coalescing key but the **same** cache slot) — last-occurrence order keeps the slot's final writer and any later `Evict(connection)` behaving exactly as un-coalesced FIFO.
- **Barrier order is exact**: every non-publish notification (incl. `EvictConnectionDiagnostics`) is an order-preserving barrier, so a publish never crosses an evict for its connection and create-before-progress holds.
- **Cancellation** is re-checked between deliveries, so a shutdown mid-batch isn't delayed by the rest of the batch.

## Scope (honest)
This collapses same-key supersession only — a flood of **distinct** URIs is not coalesced, and re-publish is otherwise unthrottled by design.

## Tests
- 10 `coalesce::*` unit tests: same-key collapse, distinct keys, evict/non-publish barriers, clear-wins, the restart shared-slot FIFO case, multi-key-around-a-barrier.
- `forwarding_loop_rechecks_cancellation_between_batched_deliveries`: deterministic regression for mid-batch cancellation (timeout-guarded).

## Review
Converged through subagent `/review` and Codex MCP review (both SHIP; Codex caught the restart shared-slot ordering bug, now fixed). Full lib suite (2030) + `clippy --all-targets --all-features` + `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #426.
