### PR TITLE
fix(diagnostics): #422 Slice A — kill diagnostic flicker on position-only edits

### DIFF
--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -705,6 +705,20 @@ impl LanguageServerPool {
             .await
     }
 
+    /// Record `content`'s fingerprint as sent to this connection — call only after a
+    /// confirmed-enqueued didChange (#422). Delegates to
+    /// [`DocumentTracker::record_sent_content_fingerprint`].
+    pub(super) async fn record_sent_content_fingerprint(
+        &self,
+        virtual_uri: &VirtualDocumentUri,
+        connection_key: &ConnectionKey,
+        content: &str,
+    ) {
+        self.document_tracker
+            .record_sent_content_fingerprint(virtual_uri, connection_key, content)
+            .await
+    }
+
     /// Get or create a connection for the specified server, spawning the server
     /// and running the LSP handshake with the default timeout on a miss.
     ///

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -669,6 +669,15 @@ impl LanguageServerPool {
                 .await;
             return Err(e);
         }
+        // The didOpen was confirmed enqueued (the `MessageSender` maps `Queued` →
+        // `Ok`), so seed the content fingerprint with the opened content. Without
+        // this, the FIRST position-only host edit — which leaves this region's
+        // content unchanged — would still re-send a didChange (and, for a server that
+        // clears on didChange, flicker the diagnostics) because no fingerprint existed
+        // to compare against (#422).
+        self.document_tracker
+            .record_sent_content_fingerprint(virtual_uri, connection_key, virtual_content)
+            .await;
         Ok(())
     }
 

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -674,6 +674,11 @@ impl LanguageServerPool {
 
     /// Increment the version of a virtual document and return the new version,
     /// or `None` if the document has not been opened.
+    ///
+    /// Test-only: production sends always go through
+    /// [`Self::increment_version_if_content_changed`] (the content-guarded path,
+    /// #422); this bare delegation is retained for the version-tracking unit tests.
+    #[cfg(test)]
     pub(super) async fn increment_document_version(
         &self,
         virtual_uri: &VirtualDocumentUri,
@@ -681,6 +686,22 @@ impl LanguageServerPool {
     ) -> Option<i32> {
         self.document_tracker
             .increment_document_version(virtual_uri, connection_key)
+            .await
+    }
+
+    /// Increment the version only when `content` differs from the last `didChange`
+    /// sent to this connection for this virtual document; `None` skips the re-send
+    /// (content unchanged, or the doc isn't registered for this connection). The
+    /// content guard keeps a position-only host edit from re-analyzing every region
+    /// (#422). Delegates to [`DocumentTracker::increment_version_if_content_changed`].
+    pub(super) async fn increment_version_if_content_changed(
+        &self,
+        virtual_uri: &VirtualDocumentUri,
+        connection_key: &ConnectionKey,
+        content: &str,
+    ) -> Option<i32> {
+        self.document_tracker
+            .increment_version_if_content_changed(virtual_uri, connection_key, content)
             .await
     }
 

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -257,6 +257,11 @@ impl DocumentTracker {
     /// Increment the version of a virtual document and return the new version.
     ///
     /// Returns `None` if the document has not been opened.
+    ///
+    /// Test-only: production goes through `increment_version_if_content_changed`
+    /// (which bumps the version inline, reusing its `uri_string`, #422); this bare
+    /// version of the bump is retained for the version-tracking unit tests.
+    #[cfg(test)]
     pub(super) async fn increment_document_version(
         &self,
         virtual_uri: &VirtualDocumentUri,
@@ -277,10 +282,12 @@ impl DocumentTracker {
     /// Like [`Self::increment_document_version`], but a no-op (`None`) when
     /// `content` is unchanged since the last `didChange` sent to this connection
     /// for this virtual document — so a host edit that doesn't alter a region's
-    /// extracted content doesn't re-sync and re-analyze it (#422). The fingerprint
-    /// is recorded only after the version bump succeeds (i.e. a `didChange` will be
-    /// sent), keeping "fingerprint set ⟺ content sent". `None` is also returned when
-    /// the document isn't registered for this connection (as for `increment`).
+    /// extracted content doesn't re-sync and re-analyze it (#422). This method does
+    /// **not** record the fingerprint; the caller records it via
+    /// [`Self::record_sent_content_fingerprint`] only after the `didChange` is
+    /// confirmed enqueued, keeping "fingerprint set ⟺ content sent". `None` is also
+    /// returned when the document isn't registered for this connection (as for
+    /// `increment`).
     pub(super) async fn increment_version_if_content_changed(
         &self,
         virtual_uri: &VirtualDocumentUri,
@@ -291,11 +298,10 @@ impl DocumentTracker {
         let fp = content_fingerprint(content);
 
         // Unchanged content (vs the last fingerprint **recorded as sent**) → skip the
-        // re-send and the version bump. The fingerprint is NOT updated here: the caller
-        // records it via `record_sent_content_fingerprint` only after the didChange is
-        // confirmed enqueued, so a dropped send (full/closed writer queue) leaves the
-        // old fingerprint and the next edit re-sends (self-healing). Held briefly and
-        // released before the version lock (the two maps are never locked together).
+        // re-send and the version bump. The fingerprint is NOT updated here (see the
+        // doc): a dropped send leaves the old fingerprint so the next edit re-sends
+        // (self-healing). Held briefly and released before the version lock (the two
+        // maps are never locked together).
         {
             let fingerprints = self.document_fingerprints.lock().await;
             if fingerprints
@@ -307,10 +313,13 @@ impl DocumentTracker {
             }
         }
 
-        // Content changed (or first didChange / unknown): bump the version. `None`
-        // means the doc isn't registered for this connection.
-        self.increment_document_version(virtual_uri, connection_key)
-            .await
+        // Content changed (or first didChange / unknown): bump the version inline,
+        // reusing `uri_string` (rather than delegating to `increment_document_version`,
+        // which would recompute it). `None` means the doc isn't registered here.
+        let mut versions = self.document_versions.lock().await;
+        let version = versions.get_mut(connection_key)?.get_mut(&uri_string)?;
+        *version += 1;
+        Some(*version)
     }
 
     /// Record the fingerprint of the content just **successfully enqueued** as a
@@ -324,12 +333,19 @@ impl DocumentTracker {
         connection_key: &ConnectionKey,
         content: &str,
     ) {
-        self.document_fingerprints
-            .lock()
-            .await
-            .entry(connection_key.clone())
-            .or_default()
-            .insert(virtual_uri.to_uri_string(), content_fingerprint(content));
+        let uri_string = virtual_uri.to_uri_string();
+        let fp = content_fingerprint(content);
+        let mut fingerprints = self.document_fingerprints.lock().await;
+        // Clone the connection key only when first inserting it (common path: the
+        // connection is already present, so look up by borrow).
+        if let Some(docs) = fingerprints.get_mut(connection_key) {
+            docs.insert(uri_string, fp);
+        } else {
+            fingerprints
+                .entry(connection_key.clone())
+                .or_default()
+                .insert(uri_string, fp);
+        }
     }
 
     /// Remove a document from `document_versions` and `opened_documents`.

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -180,6 +180,17 @@ impl DocumentTracker {
                 docs.remove(&uri_string);
             }
         }
+        // Drop any fingerprint symmetrically with the version (#422) — benign today
+        // (unclaim runs right after a failed didOpen, before any didChange recorded a
+        // fingerprint) but keeps the two maps consistent if that ever changes.
+        if let Some(docs) = self
+            .document_fingerprints
+            .lock()
+            .await
+            .get_mut(connection_key)
+        {
+            docs.remove(&uri_string);
+        }
 
         // Then decrement the opened refcount and clean reverse index
         self.decrement_opened(&uri_string);
@@ -279,9 +290,12 @@ impl DocumentTracker {
         let uri_string = virtual_uri.to_uri_string();
         let fp = content_fingerprint(content);
 
-        // Unchanged content for this connection → skip the re-send (and the version
-        // bump). Held briefly and released before the version lock (the two maps are
-        // never locked simultaneously, matching the rest of this type).
+        // Unchanged content (vs the last fingerprint **recorded as sent**) → skip the
+        // re-send and the version bump. The fingerprint is NOT updated here: the caller
+        // records it via `record_sent_content_fingerprint` only after the didChange is
+        // confirmed enqueued, so a dropped send (full/closed writer queue) leaves the
+        // old fingerprint and the next edit re-sends (self-healing). Held briefly and
+        // released before the version lock (the two maps are never locked together).
         {
             let fingerprints = self.document_fingerprints.lock().await;
             if fingerprints
@@ -294,19 +308,28 @@ impl DocumentTracker {
         }
 
         // Content changed (or first didChange / unknown): bump the version. `None`
-        // here means the doc isn't registered for this connection, so don't record a
-        // fingerprint (nothing was sent).
-        let version = self
-            .increment_document_version(virtual_uri, connection_key)
-            .await?;
+        // means the doc isn't registered for this connection.
+        self.increment_document_version(virtual_uri, connection_key)
+            .await
+    }
 
+    /// Record the fingerprint of the content just **successfully enqueued** as a
+    /// `didChange` to this connection, so a later edit leaving the region's content
+    /// identical is skipped (#422). Call this only after the send returns `Queued` —
+    /// recording before the send (or on a dropped send) would mark content the server
+    /// never received, defeating the self-heal on the next edit.
+    pub(super) async fn record_sent_content_fingerprint(
+        &self,
+        virtual_uri: &VirtualDocumentUri,
+        connection_key: &ConnectionKey,
+        content: &str,
+    ) {
         self.document_fingerprints
             .lock()
             .await
             .entry(connection_key.clone())
             .or_default()
-            .insert(uri_string, fp);
-        Some(version)
+            .insert(virtual_uri.to_uri_string(), content_fingerprint(content));
     }
 
     /// Remove a document from `document_versions` and `opened_documents`.
@@ -928,7 +951,8 @@ mod tests {
             .register_opened_document(&host_uri, &virtual_uri, &conn)
             .await;
 
-        // First call records the fingerprint and bumps (1 -> 2).
+        // First call bumps (1 -> 2). The caller records the fingerprint only after a
+        // confirmed send.
         assert_eq!(
             tracker
                 .increment_version_if_content_changed(&virtual_uri, &conn, "local x = 1")
@@ -936,13 +960,16 @@ mod tests {
             Some(2),
             "first didChange sends and bumps the version"
         );
-        // Same content → skip (no bump, no re-send).
+        tracker
+            .record_sent_content_fingerprint(&virtual_uri, &conn, "local x = 1")
+            .await;
+        // Same content now recorded-as-sent → skip (no bump, no re-send).
         assert_eq!(
             tracker
                 .increment_version_if_content_changed(&virtual_uri, &conn, "local x = 1")
                 .await,
             None,
-            "unchanged content must skip the re-send"
+            "unchanged content must skip the re-send once recorded as sent"
         );
         // Changed content → bump again (2 -> 3).
         assert_eq!(
@@ -951,6 +978,36 @@ mod tests {
                 .await,
             Some(3),
             "changed content sends and bumps"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_dropped_didchange_self_heals_because_the_fingerprint_is_not_recorded() {
+        // The fingerprint is recorded only on a confirmed send. If a send is dropped
+        // (caller skips record_sent_content_fingerprint), the same content must still
+        // re-send on the next edit — otherwise the server keeps stale content (#422).
+        let tracker = DocumentTracker::new();
+        let host_uri = Url::parse("file:///test/doc.md").unwrap();
+        let virtual_uri = VirtualDocumentUri::new(&url_to_uri(&host_uri), "lua", TEST_ULID_LUA_0);
+        let conn = ConnectionKey::for_server("lua");
+        tracker
+            .register_opened_document(&host_uri, &virtual_uri, &conn)
+            .await;
+
+        // Send bumps (1 -> 2) but we do NOT record it (the send was dropped).
+        assert_eq!(
+            tracker
+                .increment_version_if_content_changed(&virtual_uri, &conn, "local x = 1")
+                .await,
+            Some(2),
+        );
+        // Same content re-sends (bumps again) because no fingerprint was recorded.
+        assert_eq!(
+            tracker
+                .increment_version_if_content_changed(&virtual_uri, &conn, "local x = 1")
+                .await,
+            Some(3),
+            "a dropped send must self-heal: identical content re-sends, not skips"
         );
     }
 

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -16,6 +16,17 @@ use url::Url;
 use super::ConnectionKey;
 use crate::lsp::bridge::protocol::VirtualDocumentUri;
 
+/// Hash of a virtual document's extracted content, used to skip re-sending an
+/// unchanged `didChange` (#422). Mirrors the host path's fingerprint
+/// (`text_document/host.rs`); collisions only risk a missed re-send, which the
+/// next genuine content change corrects.
+fn content_fingerprint(content: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    content.hash(&mut hasher);
+    hasher.finish()
+}
+
 /// Represents an opened virtual document for tracking.
 ///
 /// Used for didClose propagation when host document closes.
@@ -49,6 +60,14 @@ pub(crate) struct DocumentTracker {
     /// Keyed by connection (not language) to enable process sharing while
     /// keeping per-root connections distinct.
     document_versions: Mutex<HashMap<ConnectionKey, HashMap<String, i32>>>,
+    /// Map of connection key → (virtual document URI → fingerprint of the content
+    /// last sent to that connection). Lets the virt sync skip re-sending `didChange`
+    /// when a host edit didn't change a region's extracted content (mirrors the
+    /// host path's fingerprint guard in `text_document/host.rs`), so a position-only
+    /// edit doesn't re-analyze every region and flicker (#422). An entry is recorded
+    /// only when a `didChange` is actually sent, keeping "fingerprint set ⟺ content
+    /// sent" — never bumping the gate without a corresponding sync.
+    document_fingerprints: Mutex<HashMap<ConnectionKey, HashMap<String, u64>>>,
     /// Tracks which virtual documents were opened for each host document.
     ///
     /// Each OpenedVirtualDoc stores its connection key for reverse lookup during didClose.
@@ -74,6 +93,7 @@ impl DocumentTracker {
     pub(crate) fn new() -> Self {
         Self {
             document_versions: Mutex::new(HashMap::new()),
+            document_fingerprints: Mutex::new(HashMap::new()),
             host_to_virtual: Mutex::new(HashMap::new()),
             opened_documents: DashMap::new(),
             virtual_to_servers: DashMap::new(),
@@ -243,6 +263,52 @@ impl DocumentTracker {
         None
     }
 
+    /// Like [`Self::increment_document_version`], but a no-op (`None`) when
+    /// `content` is unchanged since the last `didChange` sent to this connection
+    /// for this virtual document — so a host edit that doesn't alter a region's
+    /// extracted content doesn't re-sync and re-analyze it (#422). The fingerprint
+    /// is recorded only after the version bump succeeds (i.e. a `didChange` will be
+    /// sent), keeping "fingerprint set ⟺ content sent". `None` is also returned when
+    /// the document isn't registered for this connection (as for `increment`).
+    pub(super) async fn increment_version_if_content_changed(
+        &self,
+        virtual_uri: &VirtualDocumentUri,
+        connection_key: &ConnectionKey,
+        content: &str,
+    ) -> Option<i32> {
+        let uri_string = virtual_uri.to_uri_string();
+        let fp = content_fingerprint(content);
+
+        // Unchanged content for this connection → skip the re-send (and the version
+        // bump). Held briefly and released before the version lock (the two maps are
+        // never locked simultaneously, matching the rest of this type).
+        {
+            let fingerprints = self.document_fingerprints.lock().await;
+            if fingerprints
+                .get(connection_key)
+                .and_then(|docs| docs.get(&uri_string))
+                == Some(&fp)
+            {
+                return None;
+            }
+        }
+
+        // Content changed (or first didChange / unknown): bump the version. `None`
+        // here means the doc isn't registered for this connection, so don't record a
+        // fingerprint (nothing was sent).
+        let version = self
+            .increment_document_version(virtual_uri, connection_key)
+            .await?;
+
+        self.document_fingerprints
+            .lock()
+            .await
+            .entry(connection_key.clone())
+            .or_default()
+            .insert(uri_string, fp);
+        Some(version)
+    }
+
     /// Remove a document from `document_versions` and `opened_documents`.
     ///
     /// Does NOT remove from `host_to_virtual` — that cleanup is handled
@@ -257,6 +323,15 @@ impl DocumentTracker {
 
         let mut versions = self.document_versions.lock().await;
         if let Some(docs) = versions.get_mut(connection_key) {
+            docs.remove(&uri_string);
+        }
+        drop(versions);
+        if let Some(docs) = self
+            .document_fingerprints
+            .lock()
+            .await
+            .get_mut(connection_key)
+        {
             docs.remove(&uri_string);
         }
 
@@ -286,6 +361,12 @@ impl DocumentTracker {
                 .map(|docs| docs.into_keys().collect())
                 .unwrap_or_default()
         };
+        // Drop this connection's fingerprints too, so a respawn under the same key
+        // re-syncs from scratch rather than skipping on a stale fingerprint (#422).
+        self.document_fingerprints
+            .lock()
+            .await
+            .remove(connection_key);
         for uri in &uris {
             self.decrement_opened(uri);
             self.remove_from_reverse_index(uri, connection_key);
@@ -835,6 +916,75 @@ mod tests {
             .increment_document_version(&virtual_uri, &ConnectionKey::for_server("lua"))
             .await;
         assert_eq!(version, Some(3), "Second increment should return 3");
+    }
+
+    #[tokio::test]
+    async fn increment_version_if_content_changed_skips_unchanged_content() {
+        let tracker = DocumentTracker::new();
+        let host_uri = Url::parse("file:///test/doc.md").unwrap();
+        let virtual_uri = VirtualDocumentUri::new(&url_to_uri(&host_uri), "lua", TEST_ULID_LUA_0);
+        let conn = ConnectionKey::for_server("lua");
+        tracker
+            .register_opened_document(&host_uri, &virtual_uri, &conn)
+            .await;
+
+        // First call records the fingerprint and bumps (1 -> 2).
+        assert_eq!(
+            tracker
+                .increment_version_if_content_changed(&virtual_uri, &conn, "local x = 1")
+                .await,
+            Some(2),
+            "first didChange sends and bumps the version"
+        );
+        // Same content → skip (no bump, no re-send).
+        assert_eq!(
+            tracker
+                .increment_version_if_content_changed(&virtual_uri, &conn, "local x = 1")
+                .await,
+            None,
+            "unchanged content must skip the re-send"
+        );
+        // Changed content → bump again (2 -> 3).
+        assert_eq!(
+            tracker
+                .increment_version_if_content_changed(&virtual_uri, &conn, "local x = 2")
+                .await,
+            Some(3),
+            "changed content sends and bumps"
+        );
+    }
+
+    #[tokio::test]
+    async fn increment_version_if_content_changed_returns_none_for_unregistered() {
+        let tracker = DocumentTracker::new();
+        let host_uri = Url::parse("file:///test/doc.md").unwrap();
+        let virtual_uri = VirtualDocumentUri::new(&url_to_uri(&host_uri), "lua", TEST_ULID_LUA_0);
+        // Never opened for this connection: no version registered, so no send — and
+        // no fingerprint recorded (so a later open + same content still sends once).
+        assert_eq!(
+            tracker
+                .increment_version_if_content_changed(
+                    &virtual_uri,
+                    &ConnectionKey::for_server("lua"),
+                    "local x = 1",
+                )
+                .await,
+            None,
+        );
+        tracker
+            .register_opened_document(&host_uri, &virtual_uri, &ConnectionKey::for_server("lua"))
+            .await;
+        assert_eq!(
+            tracker
+                .increment_version_if_content_changed(
+                    &virtual_uri,
+                    &ConnectionKey::for_server("lua"),
+                    "local x = 1",
+                )
+                .await,
+            Some(2),
+            "after registration the first send goes through even with the same content"
+        );
     }
 
     // ========================================

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -11,6 +11,8 @@ use std::collections::HashMap;
 use dashmap::DashMap;
 use tokio::sync::Mutex;
 
+use crate::error::LockResultExt;
+
 use url::Url;
 
 use super::ConnectionKey;
@@ -67,7 +69,12 @@ pub(crate) struct DocumentTracker {
     /// edit doesn't re-analyze every region and flicker (#422). An entry is recorded
     /// only when a `didChange` is actually sent, keeping "fingerprint set ⟺ content
     /// sent" — never bumping the gate without a corresponding sync.
-    document_fingerprints: Mutex<HashMap<ConnectionKey, HashMap<String, u64>>>,
+    ///
+    /// A `std::sync::Mutex` (not tokio's): only ever held for a brief synchronous map
+    /// op, never across an `.await`, so the async mutex's overhead is unwanted (mirrors
+    /// `DiagnosticAggregator::last_published`). Poisoning is recovered via
+    /// `LockResultExt::recover_poison`.
+    document_fingerprints: std::sync::Mutex<HashMap<ConnectionKey, HashMap<String, u64>>>,
     /// Tracks which virtual documents were opened for each host document.
     ///
     /// Each OpenedVirtualDoc stores its connection key for reverse lookup during didClose.
@@ -93,7 +100,7 @@ impl DocumentTracker {
     pub(crate) fn new() -> Self {
         Self {
             document_versions: Mutex::new(HashMap::new()),
-            document_fingerprints: Mutex::new(HashMap::new()),
+            document_fingerprints: std::sync::Mutex::new(HashMap::new()),
             host_to_virtual: Mutex::new(HashMap::new()),
             opened_documents: DashMap::new(),
             virtual_to_servers: DashMap::new(),
@@ -186,7 +193,7 @@ impl DocumentTracker {
         if let Some(docs) = self
             .document_fingerprints
             .lock()
-            .await
+            .recover_poison("DocumentTracker::document_fingerprints")
             .get_mut(connection_key)
         {
             docs.remove(&uri_string);
@@ -303,7 +310,10 @@ impl DocumentTracker {
         // (self-healing). Held briefly and released before the version lock (the two
         // maps are never locked together).
         {
-            let fingerprints = self.document_fingerprints.lock().await;
+            let fingerprints = self
+                .document_fingerprints
+                .lock()
+                .recover_poison("DocumentTracker::document_fingerprints");
             if fingerprints
                 .get(connection_key)
                 .and_then(|docs| docs.get(&uri_string))
@@ -335,7 +345,10 @@ impl DocumentTracker {
     ) {
         let uri_string = virtual_uri.to_uri_string();
         let fp = content_fingerprint(content);
-        let mut fingerprints = self.document_fingerprints.lock().await;
+        let mut fingerprints = self
+            .document_fingerprints
+            .lock()
+            .recover_poison("DocumentTracker::document_fingerprints");
         // Clone the connection key only when first inserting it (common path: the
         // connection is already present, so look up by borrow).
         if let Some(docs) = fingerprints.get_mut(connection_key) {
@@ -368,7 +381,7 @@ impl DocumentTracker {
         if let Some(docs) = self
             .document_fingerprints
             .lock()
-            .await
+            .recover_poison("DocumentTracker::document_fingerprints")
             .get_mut(connection_key)
         {
             docs.remove(&uri_string);
@@ -404,7 +417,7 @@ impl DocumentTracker {
         // re-syncs from scratch rather than skipping on a stale fingerprint (#422).
         self.document_fingerprints
             .lock()
-            .await
+            .recover_poison("DocumentTracker::document_fingerprints")
             .remove(connection_key);
         for uri in &uris {
             self.decrement_opened(uri);

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -20,8 +20,13 @@ use crate::lsp::bridge::protocol::VirtualDocumentUri;
 
 /// Hash of a virtual document's extracted content, used to skip re-sending an
 /// unchanged `didChange` (#422). Mirrors the host path's fingerprint
-/// (`text_document/host.rs`); collisions only risk a missed re-send, which the
-/// next genuine content change corrects.
+/// (`text_document/host.rs`).
+///
+/// A 64-bit hash collision (two *different* contents hashing equal — astronomically
+/// unlikely for `DefaultHasher`) would make a genuinely changed region look unchanged
+/// and skip its re-sync: the downstream then analyzes stale content until a *later*
+/// edit happens to hash differently, and if no further edit occurs it stays stale.
+/// This is the standard fingerprint-guard tradeoff, accepted for the collision odds.
 fn content_fingerprint(content: &str) -> u64 {
     use std::hash::{Hash, Hasher};
     let mut hasher = std::collections::hash_map::DefaultHasher::new();

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -72,8 +72,12 @@ pub(crate) struct DocumentTracker {
     /// when a host edit didn't change a region's extracted content (mirrors the
     /// host path's fingerprint guard in `text_document/host.rs`), so a position-only
     /// edit doesn't re-analyze every region and flicker (#422). An entry is recorded
-    /// only when a `didChange` is actually sent, keeping "fingerprint set ⟺ content
-    /// sent" — never bumping the gate without a corresponding sync.
+    /// only after a content sync is **confirmed enqueued** — seeded by the initial
+    /// `didOpen` (`LanguageServerPool::ensure_document_opened`) and updated on each
+    /// `didChange` (`record_sent_content_fingerprint`, called only on a `Queued`
+    /// send) — keeping "fingerprint set ⟺ content sent" so the gate is never bumped
+    /// without a corresponding sync (a dropped send leaves the old fingerprint, and
+    /// the next edit re-syncs).
     ///
     /// A `std::sync::Mutex` (not tokio's): only ever held for a brief synchronous map
     /// op, never across an `.await`, so the async mutex's overhead is unwanted (mirrors

--- a/src/lsp/bridge/text_document/did_change.rs
+++ b/src/lsp/bridge/text_document/did_change.rs
@@ -18,7 +18,9 @@ use tower_lsp_server::ls_types::{
 };
 use url::Url;
 
-use super::super::pool::{ConnectionHandle, ConnectionState, LanguageServerPool};
+use super::super::pool::{
+    ConnectionHandle, ConnectionState, LanguageServerPool, NotificationSendResult,
+};
 use super::super::protocol::{JsonRpcNotification, VirtualDocumentUri};
 
 impl LanguageServerPool {
@@ -107,26 +109,40 @@ impl LanguageServerPool {
 
                 // Send didChange notification via single-writer loop (ls-bridge-message-ordering).
                 // This is non-blocking and maintains FIFO ordering.
-                Self::send_didchange_for_virtual_doc(
+                let send_result = Self::send_didchange_for_virtual_doc(
                     &handle,
                     &virtual_uri.to_uri_string(),
                     &injection.content,
                     version,
                 );
+                // Record the fingerprint ONLY on a confirmed enqueue (#422): a dropped
+                // send (full/closed queue) must leave the old fingerprint so the next
+                // edit re-sends, rather than marking content the server never received.
+                if matches!(send_result, NotificationSendResult::Queued) {
+                    self.record_sent_content_fingerprint(
+                        &virtual_uri,
+                        &connection_key,
+                        &injection.content,
+                    )
+                    .await;
+                }
             }
         }
     }
 
-    /// Send a didChange notification for a virtual document.
+    /// Send a didChange notification for a virtual document, returning the
+    /// enqueue outcome.
     ///
     /// Uses the channel-based single-writer loop (ls-bridge-message-ordering): non-blocking, and
-    /// if the queue is full the notification is dropped with a warning log.
+    /// if the queue is full the notification is dropped with a warning log. The
+    /// returned [`NotificationSendResult`] lets the caller record the content
+    /// fingerprint only on a confirmed `Queued` enqueue (#422).
     fn send_didchange_for_virtual_doc(
         handle: &Arc<ConnectionHandle>,
         virtual_uri: &str,
         content: &str,
         version: i32,
-    ) {
+    ) -> NotificationSendResult {
         let uri = match Uri::from_str(virtual_uri) {
             Ok(u) => u,
             Err(e) => {
@@ -134,7 +150,9 @@ impl LanguageServerPool {
                     target: "kakehashi::bridge",
                     "Skipping didChange for invalid URI '{}': {}", virtual_uri, e
                 );
-                return;
+                // Nothing was enqueued; treat as a non-`Queued` outcome so the caller
+                // does not record a fingerprint for content the server never received.
+                return NotificationSendResult::SerializationFailed;
             }
         };
 
@@ -149,7 +167,7 @@ impl LanguageServerPool {
 
         let notification = JsonRpcNotification::new("textDocument/didChange", params);
 
-        // Send via the single-writer loop (non-blocking, fire-and-forget)
-        handle.send_notification(notification);
+        // Send via the single-writer loop (non-blocking, fire-and-forget).
+        handle.send_notification(notification)
     }
 }

--- a/src/lsp/bridge/text_document/did_change.rs
+++ b/src/lsp/bridge/text_document/did_change.rs
@@ -89,10 +89,17 @@ impl LanguageServerPool {
                     Arc::clone(handle)
                 };
 
-                // increment_document_version acts as per-connection filter:
-                // returns None if this connection hasn't registered the doc.
+                // Per-connection filter (returns None if this connection hasn't
+                // registered the doc) AND content guard: skip the re-send when this
+                // region's extracted content is unchanged since the last didChange to
+                // this connection, so a position-only host edit doesn't re-analyze
+                // every region (#422). Mirrors the host path's fingerprint guard.
                 let Some(version) = self
-                    .increment_document_version(&virtual_uri, &connection_key)
+                    .increment_version_if_content_changed(
+                        &virtual_uri,
+                        &connection_key,
+                        &injection.content,
+                    )
                     .await
                 else {
                     continue;

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -188,16 +188,23 @@ fn same_diagnostic_multiset(a: &[Diagnostic], b: &[Diagnostic]) -> bool {
     // Large set: O(n) signed-count multiset compare. `+1` for each `a`, `-1` for each
     // `b`; equal multisets net to all-zero (the length check above means a non-empty
     // residual implies a real difference, not just a count imbalance).
+    //
+    // A serialization failure (effectively impossible for `Diagnostic`) must not
+    // collapse distinct diagnostics onto an empty key — that could read two different
+    // sets as equal and wrongly suppress a needed publish. So on any `Err`, bail out
+    // reporting "not equal" (the caller then publishes — safe, never hides).
     let mut counts: HashMap<String, isize> = HashMap::new();
     for d in a {
-        *counts
-            .entry(serde_json::to_string(d).unwrap_or_default())
-            .or_default() += 1;
+        let Ok(key) = serde_json::to_string(d) else {
+            return false;
+        };
+        *counts.entry(key).or_default() += 1;
     }
     for d in b {
-        *counts
-            .entry(serde_json::to_string(d).unwrap_or_default())
-            .or_default() -= 1;
+        let Ok(key) = serde_json::to_string(d) else {
+            return false;
+        };
+        *counts.entry(key).or_default() -= 1;
     }
     counts.values().all(|&c| c == 0)
 }

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -152,27 +152,54 @@ pub(crate) fn merge_cached_diagnostics(
     merged
 }
 
+/// Largest set for which the allocation-free O(n²) match is used; above this, a
+/// noisy server's payload would make the quadratic compare a republish bottleneck,
+/// so we switch to the O(n) serialized-count path.
+const MULTISET_QUADRATIC_CAP: usize = 64;
+
 /// Whether two diagnostic slices are equal as **multisets** (same elements with the
 /// same multiplicity, order-independent) — used by no-op-publish suppression to
-/// ignore the merge's `HashMap` ordering (#422). An O(n²) greedy match: for each `a`
-/// element, consume the first unused equal `b` element. The per-host diagnostic count
-/// is small, so this beats serializing/sorting and never collapses distinct sets.
+/// ignore the merge's `HashMap` ordering (#422).
+///
+/// For the common small set (`<= MULTISET_QUADRATIC_CAP`) an O(n²) greedy match: for
+/// each `a` element, consume the first unused equal `b` element — no allocation or
+/// serialization. For a large set (a noisy server) that would be a republish
+/// bottleneck, so fall back to an O(n) multiset compare keyed by each diagnostic's
+/// serialized form (a total, order-independent key). Neither path collapses distinct
+/// sets.
 fn same_diagnostic_multiset(a: &[Diagnostic], b: &[Diagnostic]) -> bool {
     if a.len() != b.len() {
         return false;
     }
-    let mut matched = vec![false; b.len()];
-    for da in a {
-        let found = b
-            .iter()
-            .enumerate()
-            .find(|(i, db)| !matched[*i] && *db == da);
-        match found {
-            Some((i, _)) => matched[i] = true,
-            None => return false,
+    if a.len() <= MULTISET_QUADRATIC_CAP {
+        let mut matched = vec![false; b.len()];
+        for da in a {
+            let found = b
+                .iter()
+                .enumerate()
+                .find(|(i, db)| !matched[*i] && *db == da);
+            match found {
+                Some((i, _)) => matched[i] = true,
+                None => return false,
+            }
         }
+        return true;
     }
-    true
+    // Large set: O(n) signed-count multiset compare. `+1` for each `a`, `-1` for each
+    // `b`; equal multisets net to all-zero (the length check above means a non-empty
+    // residual implies a real difference, not just a count imbalance).
+    let mut counts: HashMap<String, isize> = HashMap::new();
+    for d in a {
+        *counts
+            .entry(serde_json::to_string(d).unwrap_or_default())
+            .or_default() += 1;
+    }
+    for d in b {
+        *counts
+            .entry(serde_json::to_string(d).unwrap_or_default())
+            .or_default() -= 1;
+    }
+    counts.values().all(|&c| c == 0)
 }
 
 /// Transform a pushed region diagnostic from virtual to host coordinates.
@@ -1079,6 +1106,27 @@ mod tests {
         assert!(
             !agg.published_set_changed(&host(), &[b, a]),
             "suppression must be order-independent for multi-source/server hosts"
+        );
+    }
+
+    #[test]
+    fn published_set_changed_large_set_is_order_independent_and_exact() {
+        // > MULTISET_QUADRATIC_CAP diagnostics → exercises the O(n) serialized-count
+        // path. It must stay order-independent and still detect a real change.
+        let agg = DiagnosticAggregator::new();
+        let big: Vec<Diagnostic> = (0..100u32).map(|i| diag_at("m", i, 0)).collect();
+        assert!(agg.published_set_changed(&host(), &big));
+        let mut shuffled = big.clone();
+        shuffled.reverse();
+        assert!(
+            !agg.published_set_changed(&host(), &shuffled),
+            "large set: a mere reorder is not a change"
+        );
+        let mut changed = big.clone();
+        changed[50] = diag_at("DIFFERENT", 50, 0);
+        assert!(
+            agg.published_set_changed(&host(), &changed),
+            "large set: a single differing diagnostic is a change"
         );
     }
 

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -337,17 +337,21 @@ impl DiagnosticAggregator {
         cache.get(host).cloned().unwrap_or_default()
     }
 
-    /// Whether `host` has any cached `Region` push slot — i.e. a downstream
-    /// diagnostic held in *virtual* coordinates that re-anchors against the region's
-    /// current offset at publish time. Used to decide whether a host edit that moved
-    /// regions needs a geometry re-merge (#422); `Host`/`PullLayer` slots are already
-    /// host-local and don't move with a region edit.
+    /// Whether `host` has a cached `Region` push slot with **non-empty** diagnostics
+    /// — i.e. a downstream diagnostic held in *virtual* coordinates that re-anchors
+    /// against the region's current offset at publish time. Used to decide whether a
+    /// host edit that moved regions needs a geometry re-merge (#422); `Host`/`PullLayer`
+    /// slots are already host-local and don't move with a region edit. A *kept-but-empty*
+    /// Region slot (a server cleared its diagnostics) has nothing to re-anchor, so it is
+    /// ignored — otherwise a quiet/diagnostic-free file would keep paying the offset
+    /// recompute on every edit.
     pub(crate) fn has_region_slots(&self, host: &Url) -> bool {
         let cache = self.lock();
         cache.get(host).is_some_and(|sources| {
-            sources
-                .keys()
-                .any(|source| matches!(source, DiagnosticSource::Region(_)))
+            sources.iter().any(|(source, servers)| {
+                matches!(source, DiagnosticSource::Region(_))
+                    && servers.values().any(|slot| !slot.diagnostics.is_empty())
+            })
         })
     }
 
@@ -1096,7 +1100,21 @@ mod tests {
             "a Host slot is host-local and does not need geometry re-anchoring"
         );
 
-        // A Region push slot does.
+        // A kept-but-EMPTY Region slot (a server cleared its diagnostics) has nothing
+        // to re-anchor, so it must NOT trigger the geometry re-merge.
+        agg.record(
+            &host(),
+            DiagnosticSource::Region("r".into()),
+            "luals".into(),
+            Some(ProgressConnectionId::for_test(1)),
+            vec![],
+        );
+        assert!(
+            !agg.has_region_slots(&host()),
+            "an empty Region slot has no diagnostics to re-anchor"
+        );
+
+        // A NON-EMPTY Region push slot does.
         agg.record(
             &host(),
             DiagnosticSource::Region("r".into()),

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -199,6 +199,12 @@ pub(crate) struct DiagnosticAggregator {
     /// removed — reclamation cannot race a republish into minting a second lock for
     /// the same host.
     republish_locks: Mutex<HashMap<Url, Arc<tokio::sync::Mutex<()>>>>,
+    /// The last diagnostic set published to the editor per host, so a republish
+    /// that would re-send an identical set is suppressed — the editor already has
+    /// it, and a redundant `publishDiagnostics` is a needless flicker/noise source
+    /// (#422). Updated under the host's republish lock (same-host republishes are
+    /// serialized), and forgotten on `didClose` ([`Self::forget_published`]).
+    last_published: Mutex<HashMap<Url, Vec<Diagnostic>>>,
 }
 
 impl DiagnosticAggregator {
@@ -312,6 +318,33 @@ impl DiagnosticAggregator {
     pub(crate) fn evict_host(&self, host: &Url) -> bool {
         let mut cache = self.lock();
         cache.remove(host).is_some()
+    }
+
+    /// Whether `diagnostics` differs from the set last published for `host`,
+    /// recording it as the new last when it does. Returns `false` when identical,
+    /// so the caller skips a redundant `publishDiagnostics` the editor already has
+    /// (#422). Called under the host's republish lock, so same-host calls serialize.
+    pub(crate) fn published_set_changed(&self, host: &Url, diagnostics: &[Diagnostic]) -> bool {
+        let mut last = self
+            .last_published
+            .lock()
+            .recover_poison("DiagnosticAggregator::last_published");
+        match last.get(host) {
+            Some(prev) if prev.as_slice() == diagnostics => false,
+            _ => {
+                last.insert(host.clone(), diagnostics.to_vec());
+                true
+            }
+        }
+    }
+
+    /// Forget the last-published set for `host` (host `didClose`), so its entry
+    /// does not linger and a later re-open publishes afresh.
+    pub(crate) fn forget_published(&self, host: &Url) {
+        self.last_published
+            .lock()
+            .recover_poison("DiagnosticAggregator::last_published")
+            .remove(host);
     }
 
     /// Drop one `source`'s slots (every server) under `host` — e.g. a region
@@ -951,6 +984,34 @@ mod tests {
         assert!(
             !agg.lock().contains_key(&host()),
             "the now-empty host entry is removed, not left present-but-empty"
+        );
+    }
+
+    #[test]
+    fn published_set_changed_suppresses_an_identical_republish() {
+        let agg = DiagnosticAggregator::new();
+        // First publish always counts as changed (nothing published before).
+        assert!(agg.published_set_changed(&host(), &[diag("a")]));
+        // An identical set is suppressed.
+        assert!(!agg.published_set_changed(&host(), &[diag("a")]));
+        // A different set publishes again.
+        assert!(agg.published_set_changed(&host(), &[diag("a"), diag("b")]));
+        assert!(!agg.published_set_changed(&host(), &[diag("a"), diag("b")]));
+        // Going back to empty is a change (clears the editor).
+        assert!(agg.published_set_changed(&host(), &[]));
+        assert!(!agg.published_set_changed(&host(), &[]));
+    }
+
+    #[test]
+    fn forget_published_lets_the_next_identical_set_publish_again() {
+        let agg = DiagnosticAggregator::new();
+        assert!(agg.published_set_changed(&host(), &[diag("a")]));
+        assert!(!agg.published_set_changed(&host(), &[diag("a")]));
+        // After didClose forgets the host, a re-open's identical first set publishes.
+        agg.forget_published(&host());
+        assert!(
+            agg.published_set_changed(&host(), &[diag("a")]),
+            "a re-opened host must publish its first set even if it matches the pre-close one"
         );
     }
 }

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -152,6 +152,29 @@ pub(crate) fn merge_cached_diagnostics(
     merged
 }
 
+/// Whether two diagnostic slices are equal as **multisets** (same elements with the
+/// same multiplicity, order-independent) — used by no-op-publish suppression to
+/// ignore the merge's `HashMap` ordering (#422). An O(n²) greedy match: for each `a`
+/// element, consume the first unused equal `b` element. The per-host diagnostic count
+/// is small, so this beats serializing/sorting and never collapses distinct sets.
+fn same_diagnostic_multiset(a: &[Diagnostic], b: &[Diagnostic]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut matched = vec![false; b.len()];
+    for da in a {
+        let found = b
+            .iter()
+            .enumerate()
+            .find(|(i, db)| !matched[*i] && *db == da);
+        match found {
+            Some((i, _)) => matched[i] = true,
+            None => return false,
+        }
+    }
+    true
+}
+
 /// Transform a pushed region diagnostic from virtual to host coordinates.
 ///
 /// Mirrors the pull path's `transform_diagnostic`
@@ -341,28 +364,25 @@ impl DiagnosticAggregator {
     ///
     /// The comparison is **order-independent**: `merge_cached_diagnostics` walks
     /// `HashMap`-keyed sources/servers, so the same logical set can serialize in a
-    /// different order between republishes. Both the incoming set and the stored one
-    /// are sorted by each diagnostic's full serialized form (a total order over every
-    /// field) first, so a multi-source/multi-server host is not wrongly seen as
-    /// "changed" merely because the merge order shuffled — while a genuine change in
-    /// any field is still detected.
+    /// different order between republishes. The two sets are compared as **multisets**
+    /// of full `Diagnostic` values ([`same_diagnostic_multiset`]), so a
+    /// multi-source/multi-server host is not wrongly seen as "changed" merely because
+    /// the merge order shuffled — while a genuine change in any field is still
+    /// detected. The per-host diagnostic count is small, so the O(n²) match is cheap
+    /// and avoids serializing every diagnostic.
     pub(crate) fn published_set_changed(&self, host: &Url, diagnostics: &[Diagnostic]) -> bool {
-        let mut sorted = diagnostics.to_vec();
-        // `sort_by_cached_key` serializes each diagnostic once (O(n)), not per
-        // comparison; the small per-host diagnostic count makes this cheap.
-        sorted.sort_by_cached_key(|d| serde_json::to_string(d).unwrap_or_default());
-
         let mut last = self
             .last_published
             .lock()
             .recover_poison("DiagnosticAggregator::last_published");
-        match last.get(host) {
-            Some(prev) if *prev == sorted => false,
-            _ => {
-                last.insert(host.clone(), sorted);
-                true
-            }
+        if last
+            .get(host)
+            .is_some_and(|prev| same_diagnostic_multiset(prev, diagnostics))
+        {
+            return false;
         }
+        last.insert(host.clone(), diagnostics.to_vec());
+        true
     }
 
     /// Forget the last-published set for `host` (host `didClose`), so its entry

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -152,20 +152,6 @@ pub(crate) fn merge_cached_diagnostics(
     merged
 }
 
-/// A stable ordering key for a diagnostic — by range then message — used to compare
-/// two merged sets order-independently for no-op-publish suppression (#422). Two
-/// fully-identical diagnostics tie, so the sort is total enough for an equality
-/// compare; it does not change what is published.
-fn diagnostic_order_key(d: &Diagnostic) -> (u32, u32, u32, u32, &str) {
-    (
-        d.range.start.line,
-        d.range.start.character,
-        d.range.end.line,
-        d.range.end.character,
-        d.message.as_str(),
-    )
-}
-
 /// Transform a pushed region diagnostic from virtual to host coordinates.
 ///
 /// Mirrors the pull path's `transform_diagnostic`
@@ -356,11 +342,15 @@ impl DiagnosticAggregator {
     /// The comparison is **order-independent**: `merge_cached_diagnostics` walks
     /// `HashMap`-keyed sources/servers, so the same logical set can serialize in a
     /// different order between republishes. Both the incoming set and the stored one
-    /// are sorted by position+message first, so a multi-source/multi-server host is
-    /// not wrongly seen as "changed" merely because the merge order shuffled.
+    /// are sorted by each diagnostic's full serialized form (a total order over every
+    /// field) first, so a multi-source/multi-server host is not wrongly seen as
+    /// "changed" merely because the merge order shuffled — while a genuine change in
+    /// any field is still detected.
     pub(crate) fn published_set_changed(&self, host: &Url, diagnostics: &[Diagnostic]) -> bool {
         let mut sorted = diagnostics.to_vec();
-        sorted.sort_by(|a, b| diagnostic_order_key(a).cmp(&diagnostic_order_key(b)));
+        // `sort_by_cached_key` serializes each diagnostic once (O(n)), not per
+        // comparison; the small per-host diagnostic count makes this cheap.
+        sorted.sort_by_cached_key(|d| serde_json::to_string(d).unwrap_or_default());
 
         let mut last = self
             .last_published

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -375,11 +375,14 @@ impl DiagnosticAggregator {
             .last_published
             .lock()
             .recover_poison("DiagnosticAggregator::last_published");
-        if last
-            .get(host)
-            .is_some_and(|prev| same_diagnostic_multiset(prev, diagnostics))
-        {
-            return false;
+        // Single lookup via `get_mut`: update in place when the host is already
+        // present (the common path), cloning the `host` key only on first insert.
+        if let Some(prev) = last.get_mut(host) {
+            if same_diagnostic_multiset(prev, diagnostics) {
+                return false;
+            }
+            *prev = diagnostics.to_vec();
+            return true;
         }
         last.insert(host.clone(), diagnostics.to_vec());
         true

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -314,6 +314,20 @@ impl DiagnosticAggregator {
         cache.get(host).cloned().unwrap_or_default()
     }
 
+    /// Whether `host` has any cached `Region` push slot — i.e. a downstream
+    /// diagnostic held in *virtual* coordinates that re-anchors against the region's
+    /// current offset at publish time. Used to decide whether a host edit that moved
+    /// regions needs a geometry re-merge (#422); `Host`/`PullLayer` slots are already
+    /// host-local and don't move with a region edit.
+    pub(crate) fn has_region_slots(&self, host: &Url) -> bool {
+        let cache = self.lock();
+        cache.get(host).is_some_and(|sources| {
+            sources
+                .keys()
+                .any(|source| matches!(source, DiagnosticSource::Region(_)))
+        })
+    }
+
     /// Drop everything for a host (host `didClose`). Returns whether it existed.
     pub(crate) fn evict_host(&self, host: &Url) -> bool {
         let mut cache = self.lock();
@@ -1013,5 +1027,34 @@ mod tests {
             agg.published_set_changed(&host(), &[diag("a")]),
             "a re-opened host must publish its first set even if it matches the pre-close one"
         );
+    }
+
+    #[test]
+    fn has_region_slots_only_true_for_region_sources() {
+        let agg = DiagnosticAggregator::new();
+        assert!(!agg.has_region_slots(&host()), "empty host has none");
+
+        // A Host push slot is host-local — it does not count as a region slot.
+        agg.record(
+            &host(),
+            DiagnosticSource::Host,
+            "selene".into(),
+            Some(ProgressConnectionId::for_test(1)),
+            vec![diag("h")],
+        );
+        assert!(
+            !agg.has_region_slots(&host()),
+            "a Host slot is host-local and does not need geometry re-anchoring"
+        );
+
+        // A Region push slot does.
+        agg.record(
+            &host(),
+            DiagnosticSource::Region("r".into()),
+            "luals".into(),
+            Some(ProgressConnectionId::for_test(1)),
+            vec![diag("r")],
+        );
+        assert!(agg.has_region_slots(&host()));
     }
 }

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -152,7 +152,7 @@ pub(crate) fn merge_cached_diagnostics(
     merged
 }
 
-/// Largest set for which the allocation-free O(n²) match is used; above this, a
+/// Largest set for which the serialization-free O(n²) match is used; above this, a
 /// noisy server's payload would make the quadratic compare a republish bottleneck,
 /// so we switch to the O(n) serialized-count path.
 const MULTISET_QUADRATIC_CAP: usize = 64;
@@ -162,11 +162,11 @@ const MULTISET_QUADRATIC_CAP: usize = 64;
 /// ignore the merge's `HashMap` ordering (#422).
 ///
 /// For the common small set (`<= MULTISET_QUADRATIC_CAP`) an O(n²) greedy match: for
-/// each `a` element, consume the first unused equal `b` element — no allocation or
-/// serialization. For a large set (a noisy server) that would be a republish
-/// bottleneck, so fall back to an O(n) multiset compare keyed by each diagnostic's
-/// serialized form (a total, order-independent key). Neither path collapses distinct
-/// sets.
+/// each `a` element, consume the first unused equal `b` element — no serialization
+/// (just a small `bool` match-mask). For a large set (a noisy server) that would be a
+/// republish bottleneck, so fall back to an O(n) multiset compare keyed by each
+/// diagnostic's serialized form (a total, order-independent key). Neither path
+/// collapses distinct sets.
 fn same_diagnostic_multiset(a: &[Diagnostic], b: &[Diagnostic]) -> bool {
     if a.len() != b.len() {
         return false;

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -152,6 +152,20 @@ pub(crate) fn merge_cached_diagnostics(
     merged
 }
 
+/// A stable ordering key for a diagnostic — by range then message — used to compare
+/// two merged sets order-independently for no-op-publish suppression (#422). Two
+/// fully-identical diagnostics tie, so the sort is total enough for an equality
+/// compare; it does not change what is published.
+fn diagnostic_order_key(d: &Diagnostic) -> (u32, u32, u32, u32, &str) {
+    (
+        d.range.start.line,
+        d.range.start.character,
+        d.range.end.line,
+        d.range.end.character,
+        d.message.as_str(),
+    )
+}
+
 /// Transform a pushed region diagnostic from virtual to host coordinates.
 ///
 /// Mirrors the pull path's `transform_diagnostic`
@@ -338,15 +352,24 @@ impl DiagnosticAggregator {
     /// recording it as the new last when it does. Returns `false` when identical,
     /// so the caller skips a redundant `publishDiagnostics` the editor already has
     /// (#422). Called under the host's republish lock, so same-host calls serialize.
+    ///
+    /// The comparison is **order-independent**: `merge_cached_diagnostics` walks
+    /// `HashMap`-keyed sources/servers, so the same logical set can serialize in a
+    /// different order between republishes. Both the incoming set and the stored one
+    /// are sorted by position+message first, so a multi-source/multi-server host is
+    /// not wrongly seen as "changed" merely because the merge order shuffled.
     pub(crate) fn published_set_changed(&self, host: &Url, diagnostics: &[Diagnostic]) -> bool {
+        let mut sorted = diagnostics.to_vec();
+        sorted.sort_by(|a, b| diagnostic_order_key(a).cmp(&diagnostic_order_key(b)));
+
         let mut last = self
             .last_published
             .lock()
             .recover_poison("DiagnosticAggregator::last_published");
         match last.get(host) {
-            Some(prev) if prev.as_slice() == diagnostics => false,
+            Some(prev) if *prev == sorted => false,
             _ => {
-                last.insert(host.clone(), diagnostics.to_vec());
+                last.insert(host.clone(), sorted);
                 true
             }
         }
@@ -1026,6 +1049,19 @@ mod tests {
         assert!(
             agg.published_set_changed(&host(), &[diag("a")]),
             "a re-opened host must publish its first set even if it matches the pre-close one"
+        );
+    }
+
+    #[test]
+    fn published_set_changed_ignores_merge_order() {
+        let agg = DiagnosticAggregator::new();
+        let a = diag_at("a", 0, 0);
+        let b = diag_at("b", 1, 0);
+        assert!(agg.published_set_changed(&host(), &[a.clone(), b.clone()]));
+        // The same logical set in a different (HashMap-shuffled) order is NOT a change.
+        assert!(
+            !agg.published_set_changed(&host(), &[b, a]),
+            "suppression must be order-independent for multi-source/server hosts"
         );
     }
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -228,6 +228,10 @@ impl DiagnosticPublisher {
     pub(crate) async fn clear_host(&self, host: &Url) {
         self.aggregator.evict_host(host);
         self.republish(host).await;
+        // The host is closed: forget its last-published set so the entry does not
+        // linger and a later re-open publishes afresh (#422). Done after the
+        // clear-republish above so that publish still sees the prior set.
+        self.aggregator.forget_published(host);
         // didClose is off the hot path: reclaim republish-lock entries whose lock
         // now has no live holder — this host's, once the clear-republish above
         // released it, plus any earlier-closed hosts that have since drained (#466).
@@ -280,6 +284,19 @@ impl DiagnosticPublisher {
                 return;
             }
         };
+
+        // Suppress a republish that would re-send the exact set the editor already
+        // has — a redundant publishDiagnostics is needless flicker/noise (#422).
+        // Done under the per-host republish lock (held above), so the compare-and-set
+        // is serialized with other republishes for this host.
+        if !self.aggregator.published_set_changed(host, &diagnostics) {
+            log::debug!(
+                target: LOG_TARGET,
+                "skip republish for {host}: merged set unchanged ({} diagnostics)",
+                diagnostics.len()
+            );
+            return;
+        }
 
         log::debug!(
             target: LOG_TARGET,

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -105,6 +105,19 @@ impl Kakehashi {
             .process_injections(&uri, true)
             .await;
 
+        // Geometry re-merge (#422): a host edit can shift a region's position without
+        // changing its extracted content — the fingerprint guard then skips re-syncing
+        // it, so no downstream re-push will re-anchor its cached diagnostics. Republish
+        // (off the debounce) so the cached region push slots re-anchor to their new
+        // host coordinates via lazy re-anchor. Gated on actually having region push
+        // slots so a quiet/diagnostic-free file pays nothing; the no-op-publish
+        // suppression then emits only when the re-anchored coordinates really changed.
+        if self.diagnostics.has_region_slots(&uri) {
+            crate::lsp::lsp_impl::coordinator::DiagnosticPublisher::new(self)
+                .republish(&uri)
+                .await;
+        }
+
         // pull-first-diagnostic-forwarding Phase 3: Schedule debounced diagnostic push on didChange.
         // After 500ms of no changes, diagnostics will be collected and published.
         // This provides near-real-time feedback while avoiding excessive requests during typing.

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -38,6 +38,10 @@ const MD_URI: &str = "file:///test_push_diagnostics.md";
 /// `0:"# Test"  1:""  2:"```lua"  3:"local x = 1"  4:"```"`. So the injected
 /// virtual document's line 0 maps to host line 3.
 const MD_TEXT: &str = "# Test\n\n```lua\nlocal x = 1\n```\n";
+/// Same shape as `MD_TEXT` but the lua region's *content* differs (`local x = 2`),
+/// so a `didChange` carrying it is NOT skipped by the content-fingerprint guard
+/// (#422) and reaches the downstream mock.
+const MD_TEXT_EDITED: &str = "# Test\n\n```lua\nlocal x = 2\n```\n";
 const HOST_LINE: i64 = 3;
 
 fn init_client() -> (LspClient, tempfile::TempDir) {
@@ -134,13 +138,15 @@ fn e2e_push_diagnostic_reaches_editor_in_host_coords_then_clears() {
         "virtual line 0 must be translated to host line {HOST_LINE} (the lua fence content line)"
     );
 
-    // A follow-up empty push (the mock pushes `[]` on didChange) clears this
+    // A follow-up edit that CHANGES the lua region's content (`local x = 1` →
+    // `local x = 2`) reaches the mock (the content-fingerprint guard only skips
+    // *unchanged* content, #422); the mock pushes `[]` on didChange, clearing this
     // source's contribution for the host doc.
     client.send_notification(
         "textDocument/didChange",
         json!({
             "textDocument": { "uri": MD_URI, "version": 2 },
-            "contentChanges": [{ "text": MD_TEXT }]
+            "contentChanges": [{ "text": MD_TEXT_EDITED }]
         }),
     );
 
@@ -219,11 +225,13 @@ fn e2e_position_only_edit_reanchors_pushed_diagnostic_without_a_repush() {
         "a position-only host edit must re-anchor the pushed diagnostic to its new host line without a re-push"
     );
 
-    // A SECOND position-only edit shifts the region to line 5. This proves the
+    // A SECOND position-only edit shifts the region to line 5. This checks the
     // diagnostic *persisted* (was not cleared by the first edit): the content guard
     // must keep the first edit's didChange from reaching the mock — otherwise the
-    // mock's empty-on-didChange push would have cleared the slot, `has_region_slots`
-    // would be false, and no re-anchor to line 5 would ever come.
+    // mock's empty-on-didChange push would empty this region's slot, and the
+    // re-anchor would carry no diagnostic to line 5. (Not a hermetic proof that no
+    // didChange was sent — a late empty push could still race — but a strong guard
+    // that the steady state is the diagnostic re-anchored, not cleared.)
     let shifted_text_2 = format!("\n\n{MD_TEXT}");
     client.send_notification(
         "textDocument/didChange",
@@ -271,15 +279,17 @@ fn e2e_downstream_crash_evicts_its_pushed_diagnostics() {
         )
         .expect("editor should receive the pushed diagnostic before the crash");
 
-    // didChange drives the mock to exit (crash) while the host stays open. The
-    // bridge's reader sees EOF, evicts that connection's slots, and republishes the
-    // host cleared — a positive assertion (no negative timeout): we wait for the
-    // publish that no longer carries the dead server's diagnostic (#469).
+    // A content-changing edit (`local x = 1` → `local x = 2`) reaches the mock — the
+    // fingerprint guard only skips *unchanged* content (#422) — driving it to exit
+    // (crash) while the host stays open. The bridge's reader sees EOF, evicts that
+    // connection's slots, and republishes the host cleared — a positive assertion (no
+    // negative timeout): we wait for the publish that no longer carries the dead
+    // server's diagnostic (#469).
     client.send_notification(
         "textDocument/didChange",
         json!({
             "textDocument": { "uri": MD_URI, "version": 2 },
-            "contentChanges": [{ "text": MD_TEXT }]
+            "contentChanges": [{ "text": MD_TEXT_EDITED }]
         }),
     );
 

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -219,6 +219,29 @@ fn e2e_position_only_edit_reanchors_pushed_diagnostic_without_a_repush() {
         "a position-only host edit must re-anchor the pushed diagnostic to its new host line without a re-push"
     );
 
+    // A SECOND position-only edit shifts the region to line 5. This proves the
+    // diagnostic *persisted* (was not cleared by the first edit): the content guard
+    // must keep the first edit's didChange from reaching the mock — otherwise the
+    // mock's empty-on-didChange push would have cleared the slot, `has_region_slots`
+    // would be false, and no re-anchor to line 5 would ever come.
+    let shifted_text_2 = format!("\n\n{MD_TEXT}");
+    client.send_notification(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": MD_URI, "version": 3 },
+            "contentChanges": [{ "text": shifted_text_2 }]
+        }),
+    );
+    let reanchored_again = client.wait_for_notification_where(
+        &["textDocument/publishDiagnostics"],
+        Duration::from_secs(15),
+        pushed_diag_at_line(HOST_LINE + 2),
+    );
+    assert!(
+        reanchored_again.is_some(),
+        "the diagnostic must survive the first edit and re-anchor again — proving it was not cleared"
+    );
+
     client.send_request("shutdown", json!(null));
     client.send_notification("exit", json!(null));
 }

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -158,6 +158,71 @@ fn e2e_push_diagnostic_reaches_editor_in_host_coords_then_clears() {
     client.send_notification("exit", json!(null));
 }
 
+/// True if the host publish carries the mock's pushed diagnostic at host `line`.
+fn pushed_diag_at_line(line: i64) -> impl Fn(&Value) -> bool {
+    move |params: &Value| {
+        params["uri"] == json!(MD_URI)
+            && params["diagnostics"].as_array().is_some_and(|ds| {
+                ds.iter()
+                    .any(|d| is_mock_push(d) && d["range"]["start"]["line"] == json!(line))
+            })
+    }
+}
+
+#[test]
+fn e2e_position_only_edit_reanchors_pushed_diagnostic_without_a_repush() {
+    // The headline #422 flicker case: a host edit that moves a region without
+    // changing its content must re-position the region's pushed diagnostic WITHOUT
+    // re-analyzing it. The content-fingerprint guard skips the didChange to the mock
+    // (so it never re-pushes — and never clears via its didChange "empty" push), and
+    // the geometry re-merge re-anchors the cached slot to the new host line.
+    let (mut client, _config_dir) = init_client_with_mode("diagnostics-push");
+
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": { "uri": MD_URI, "languageId": "markdown", "version": 1, "text": MD_TEXT }
+        }),
+    );
+
+    // The mock pushes one diagnostic on virtual line 0 → host line 3.
+    client
+        .wait_for_notification_where(
+            &["textDocument/publishDiagnostics"],
+            Duration::from_secs(15),
+            pushed_diag_at_line(HOST_LINE),
+        )
+        .expect("editor should receive the pushed diagnostic at the original host line");
+
+    // Insert a blank line ABOVE the fence: the lua region shifts from host line 3 to
+    // 4, but its content (`local x = 1`) is unchanged. The mock is NOT driven (its
+    // empty-on-didChange push never fires) because the region content didn't change.
+    let shifted_text = format!("\n{MD_TEXT}");
+    client.send_notification(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": MD_URI, "version": 2 },
+            "contentChanges": [{ "text": shifted_text }]
+        }),
+    );
+
+    // The cached diagnostic must reappear at the NEW host line (4) via geometry
+    // re-merge — re-anchored, not re-pushed (a positive assertion; the diagnostic is
+    // never lost, proving the region kept its identity across the position shift).
+    let reanchored = client.wait_for_notification_where(
+        &["textDocument/publishDiagnostics"],
+        Duration::from_secs(15),
+        pushed_diag_at_line(HOST_LINE + 1),
+    );
+    assert!(
+        reanchored.is_some(),
+        "a position-only host edit must re-anchor the pushed diagnostic to its new host line without a re-push"
+    );
+
+    client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
 #[test]
 fn e2e_downstream_crash_evicts_its_pushed_diagnostics() {
     let (mut client, _config_dir) = init_client_with_mode("diagnostics-push-crash");


### PR DESCRIPTION
Stacked on #479 (base: `feat-426-coalescing-diagnostics`). This is **Slice A** of #422 — the lower-risk flicker fix. The higher-risk `content_epoch` version gate (stale-overwrite) follows as Slice B.

## Problem
Every host `didChange` re-sent a full-text `didChange` to every opened injection region, so a **position-only** edit (e.g. a line inserted above a region) re-analyzed every region downstream — churning and flickering diagnostics. Redundant identical republishes added more noise.

## Slice A (three parts)
1. **No-op republish suppression** — skip a `publishDiagnostics` when the freshly merged set equals what the editor already has (compared order-independently via a full serialized total order, since the merge walks `HashMap`-keyed sources); forget on `didClose`.
2. **Virt content-fingerprint guard** — `DocumentTracker` records the fingerprint of the content last *sent* to each `(connection, virtual_uri)`; `increment_version_if_content_changed` skips the re-send when a region's extracted content is unchanged. The fingerprint is recorded **only after a confirmed enqueue** (didOpen and didChange both record on `Queued`), so a dropped send self-heals on the next edit — never leaving the server on stale content. Seeded at `didOpen` so the *first* edit is guarded too.
3. **Geometry re-merge** — after a host edit, republish when the host has cached `Region` slots, re-anchoring them to their new host coordinates (lazy re-anchor) without a downstream round-trip; the no-op suppression emits only if the coordinates actually changed.

## Why it's safe (no hidden diagnostics)
The load-bearing invariant is **"fingerprint recorded ⟺ content actually enqueued"** — verified against the `try_send` drop path (records only on `NotificationSendResult::Queued`). Region eviction (`evict_source`) runs *before* the geometry re-merge, so it only re-anchors surviving slots. A position-only edit preserves the region's ULID (lazy-node-identity-tracking), so the cached slot survives and re-anchors.

## Tests
- Unit: suppression (identical / order-independent / forget-on-close), fingerprint guard (skip-unchanged, **dropped-send self-heal**, unregistered), `has_region_slots`.
- e2e `e2e_position_only_edit_reanchors_pushed_diagnostic_without_a_repush`: two position-only edits shift a lua region 3→4→5; the diagnostic re-anchors each time **without a re-push and is never cleared** (proving persistence, not a transient).

## Review
Converged through subagent `/review` and Codex MCP review — both caught real bugs (fingerprint recorded before a droppable send; fingerprint not seeded at didOpen → first edit flickered) which are fixed and validated. Full lib suite (2037) + 28 e2e + `clippy --all-targets --all-features` + `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)