### PR TITLE
docs+test(client-progress): ADR sync + deferred integration tests (#442)

### DIFF
--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -241,17 +241,22 @@ bridge composes the terminal rather than relaying a downstream's `End`.
 
 ## Decision–Implementation Gap
 
-**Implemented** (issue #414): the `workDoneToken` path for the **N = 1** relay
-and the **`preferred`** strategy with a **single fixed anchor** — the dispatch
-mints a per-server bridge token only for the tracked source (sole server at
-N = 1, highest-priority *named* anchor at N > 1; a wildcard `Rest` group that
-outranks the candidate yields no anchor), routes that downstream's `$/progress`
-onto the editor's token, and guarantees a terminal `End` on teardown. Wired for
-`textDocument/references`; #446 extends it to the goto family (under #437) and
-#448 adds the `workDoneProgress` capability advertisement (under #445; without it
-spec-compliant clients never send a token).
+**Implemented** (issue #414 and follow-ups): the `workDoneToken` path for the
+**N = 1** relay and the **`preferred`** strategy with a **single fixed anchor** —
+the dispatch mints a per-server bridge token only for the tracked source (sole
+server at N = 1, highest-priority *named* anchor at N > 1; a wildcard `Rest`
+group that outranks the candidate yields no anchor), routes that downstream's
+`$/progress` onto the editor's token, and guarantees a terminal `End` on
+teardown. Coverage spans both the **single-region** methods (`references` and the
+goto family) and the **whole-document, multi-region** methods (`documentSymbol`,
+`inlayHint`, `documentColor`, `formatting`, `rangeFormatting`, `codeLens`): the
+latter fan out over several injection regions and so share **one** request-level
+aggregator and teardown guard, joined by the **winner-token rule** (the first
+source to relay a `Begin` owns the lifecycle), instead of a per-dispatch
+aggregator. Per-method plumbing and remaining capability-advertisement gaps are
+tracked under #437/#447/#457.
 
-**Deferred** (still stripped or unhandled; tracked):
+**Deferred** (still stripped, unhandled, or inert; tracked by issue):
 
 - **`partialResultToken`** is still stripped — only `workDoneToken` is bridged so
   far (the intermediate phase this section already anticipated). #439.
@@ -260,10 +265,10 @@ spec-compliant clients never send a token).
 - **Dynamic fall-through re-anchoring** is not built: the single fixed anchor's
   open `Begin` is closed by the synthetic terminal `End` rather than handed to the
   next named anchor's real `End`. #438.
-- **Method coverage** beyond references (and the goto family added by #446) —
-  notably the whole-document, multi-region methods (`documentSymbol`, …), which
-  fan out to several regions per request and so need a request-level shared
-  aggregator, not the per-dispatch one. #437.
+- **`workDoneProgress` advertisement gaps**: a few providers carry the plumbing
+  but cannot advertise the capability until the `ls-types` typed API models the
+  field, so spec-compliant clients send no token for them — `typeDefinition` /
+  `implementation` (#447) and `codeLens` (#457).
 - **Host-layer** client progress: the host path still strips the token. #441.
 
 The remaining notes below are design-tuning points; the empty-vs-non-empty

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -247,14 +247,15 @@ the dispatch mints a per-server bridge token only for the tracked source (sole
 server at N = 1, highest-priority *named* anchor at N > 1; a wildcard `Rest`
 group that outranks the candidate yields no anchor), routes that downstream's
 `$/progress` onto the editor's token, and guarantees a terminal `End` on
-teardown. Coverage spans both the **single-region** methods (`references` and the
-goto family) and the **whole-document, multi-region** methods (`documentSymbol`,
-`inlayHint`, `documentColor`, `formatting`, `rangeFormatting`, `codeLens`): the
-latter fan out over several injection regions and so share **one** request-level
-aggregator and teardown guard, joined by the **winner-token rule** (the first
-source to relay a `Begin` owns the lifecycle), instead of a per-dispatch
-aggregator. Per-method plumbing and remaining capability-advertisement gaps are
-tracked under #437/#447/#457.
+teardown. Coverage spans the **single-region** methods (`references`, the goto
+family, `inlayHint`) and the **whole-document, multi-region** methods
+(`documentSymbol`, `formatting`, `rangeFormatting`, `codeLens`): the latter fan
+out over several injection regions and so share **one** request-level aggregator
+and teardown guard, joined by the **winner-token rule** (the first source to
+relay a `Begin` owns the lifecycle), instead of a per-dispatch aggregator.
+(`documentColor` is not yet wired — it still passes no client token.) Per-method
+plumbing and remaining capability-advertisement gaps are tracked under
+#437/#447/#457.
 
 **Deferred** (still stripped, unhandled, or inert; tracked by issue):
 

--- a/docs/architecture-decisions/ls-bridge-client-progress.md
+++ b/docs/architecture-decisions/ls-bridge-client-progress.md
@@ -248,14 +248,14 @@ server at N = 1, highest-priority *named* anchor at N > 1; a wildcard `Rest`
 group that outranks the candidate yields no anchor), routes that downstream's
 `$/progress` onto the editor's token, and guarantees a terminal `End` on
 teardown. Coverage spans the **single-region** methods (`references`, the goto
-family, `inlayHint`) and the **whole-document, multi-region** methods
-(`documentSymbol`, `formatting`, `rangeFormatting`, `codeLens`): the latter fan
-out over several injection regions and so share **one** request-level aggregator
-and teardown guard, joined by the **winner-token rule** (the first source to
-relay a `Begin` owns the lifecycle), instead of a per-dispatch aggregator.
-(`documentColor` is not yet wired — it still passes no client token.) Per-method
-plumbing and remaining capability-advertisement gaps are tracked under
-#437/#447/#457.
+family, `inlayHint`) and the **multi-region** methods (`documentSymbol`,
+`formatting`, `rangeFormatting`, `codeLens` — whole-document except
+`rangeFormatting`, which is range-scoped): the latter fan out over several
+injection regions and so share **one** request-level aggregator and teardown
+guard, joined by the **winner-token rule** (the first source to relay a `Begin`
+owns the lifecycle), instead of a per-dispatch aggregator. (`documentColor` is
+not yet wired — it still passes no client token.) Per-method plumbing and
+remaining capability-advertisement gaps are tracked under #437/#447/#457.
 
 **Deferred** (still stripped, unhandled, or inert; tracked by issue):
 

--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -357,6 +357,8 @@ mod tests {
     /// `None`, so a suppressed server reports no `$/progress` for the request.
     #[tokio::test]
     async fn setup_client_progress_tracks_only_the_anchor_and_fan_out_suppresses_the_rest() {
+        use crate::error::LockResultExt;
+
         let pool = Arc::new(LanguageServerPool::new());
         let ctx = ctx_with_token(Some(NumberOrString::String("editor-wd".to_string())));
         // N>1: named anchor `ra` ahead of a `Rest` member `typos`.
@@ -387,7 +389,7 @@ mod tests {
                 let seen = Arc::clone(&seen_for_closure);
                 async move {
                     seen.lock()
-                        .expect("seen lock")
+                        .recover_poison("suppression test seen")
                         .push((task.server_name.clone(), task.client_progress_token.clone()));
                     Ok::<(), io::Error>(())
                 }
@@ -397,7 +399,7 @@ mod tests {
         );
         while join_set.join_next().await.is_some() {}
 
-        let got = seen.lock().expect("seen lock").clone();
+        let got = seen.lock().recover_poison("suppression test seen").clone();
         let anchor = got
             .iter()
             .find(|(name, _)| name == "ra")
@@ -406,9 +408,10 @@ mod tests {
             .iter()
             .find(|(name, _)| name == "typos")
             .expect("the Rest member fanned out");
-        assert!(
-            anchor.1.is_some(),
-            "the anchor receives the bridge progress token"
+        assert_eq!(
+            anchor.1.as_ref(),
+            map.get("ra"),
+            "the anchor receives exactly the minted bridge progress token"
         );
         assert!(
             suppressed.1.is_none(),

--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -319,4 +319,100 @@ mod tests {
         let entries = [PriorityEntry::Rest(vec!["a".to_string(), "b".to_string()])];
         assert_eq!(tracked_progress_source(&selected, &entries), None);
     }
+
+    /// A `DocumentRequestContext` carrying `token`, with otherwise inert region
+    /// metadata — `setup_client_progress` reads only the token, and `fan_out`
+    /// reads the region fields but does not depend on their values here.
+    fn ctx_with_token(token: Option<NumberOrString>) -> DocumentRequestContext {
+        use crate::config::settings::AggregationStrategy;
+        use crate::language::injection::{CacheableInjectionRegion, ResolvedInjection};
+
+        DocumentRequestContext {
+            uri: url::Url::parse("file:///suppression.md").expect("valid URI"),
+            resolved: ResolvedInjection {
+                region: CacheableInjectionRegion {
+                    language: "rust".to_string(),
+                    byte_range: 0..0,
+                    line_range: 0..0,
+                    start_column: 0,
+                    region_id: "r0".to_string(),
+                    content_hash: 0,
+                },
+                injection_language: "rust".to_string(),
+                virtual_content: String::new(),
+                line_column_offsets: vec![],
+            },
+            configs: vec![],
+            upstream_request_id: None,
+            priorities: vec![],
+            strategy: AggregationStrategy::Preferred,
+            max_fan_out: None,
+            client_progress_token: token,
+        }
+    }
+
+    /// Suppression regression (#442): under *preferred*, `setup_client_progress`
+    /// mints **exactly one** bridge token — for the named anchor only — and
+    /// `fan_out` hands that token to the anchor while every other candidate gets
+    /// `None`, so a suppressed server reports no `$/progress` for the request.
+    #[tokio::test]
+    async fn setup_client_progress_tracks_only_the_anchor_and_fan_out_suppresses_the_rest() {
+        let pool = Arc::new(LanguageServerPool::new());
+        let ctx = ctx_with_token(Some(NumberOrString::String("editor-wd".to_string())));
+        // N>1: named anchor `ra` ahead of a `Rest` member `typos`.
+        let selected = [config("ra"), config("typos")];
+        let entries = [
+            PriorityEntry::Server("ra".to_string()),
+            PriorityEntry::Rest(vec!["typos".to_string()]),
+        ];
+
+        let (map, _guard) = setup_client_progress(&ctx, &pool, &selected, &entries)
+            .expect("a workDoneToken + a named anchor yields a tracked source");
+
+        assert_eq!(map.len(), 1, "exactly one bridge token is minted");
+        assert!(map.contains_key("ra"), "the named anchor is tracked");
+        assert!(!map.contains_key("typos"), "the Rest member is suppressed");
+        assert!(
+            pool.client_progress_registry().route(&map["ra"]).is_some(),
+            "the minted token is registered in the routing table"
+        );
+
+        // fan_out hands the anchor its token and every other server `None`.
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen_for_closure = Arc::clone(&seen);
+        let mut join_set = fan_out(
+            &ctx,
+            Arc::clone(&pool),
+            move |task: FanOutTask| {
+                let seen = Arc::clone(&seen_for_closure);
+                async move {
+                    seen.lock()
+                        .expect("seen lock")
+                        .push((task.server_name.clone(), task.client_progress_token.clone()));
+                    Ok::<(), io::Error>(())
+                }
+            },
+            &selected,
+            Some(&map),
+        );
+        while join_set.join_next().await.is_some() {}
+
+        let got = seen.lock().expect("seen lock").clone();
+        let anchor = got
+            .iter()
+            .find(|(name, _)| name == "ra")
+            .expect("the anchor fanned out");
+        let suppressed = got
+            .iter()
+            .find(|(name, _)| name == "typos")
+            .expect("the Rest member fanned out");
+        assert!(
+            anchor.1.is_some(),
+            "the anchor receives the bridge progress token"
+        );
+        assert!(
+            suppressed.1.is_none(),
+            "the suppressed server receives no progress token"
+        );
+    }
 }

--- a/src/lsp/bridge/client_progress.rs
+++ b/src/lsp/bridge/client_progress.rs
@@ -107,7 +107,7 @@ impl ClientProgressRegistry {
 /// Shared by the reader (`window::progress::forward`) and its integration test so
 /// both drive the exact enqueue-under-lock sequence.
 pub(crate) fn relay_to_aggregator(
-    aggregator: &std::sync::Arc<Mutex<ClientProgressAggregator>>,
+    aggregator: &Mutex<ClientProgressAggregator>,
     upstream_tx: &tokio::sync::mpsc::UnboundedSender<
         crate::lsp::bridge::actor::UpstreamNotification,
     >,

--- a/src/lsp/bridge/client_progress.rs
+++ b/src/lsp/bridge/client_progress.rs
@@ -513,8 +513,16 @@ mod tests {
     /// `$/progress` the way the reader does — resolve the bridge token through
     /// the registry, feed the resolved aggregator — then tear the request down.
     /// Asserts the relayed `Begin` and the synthetic terminal `End` both reach
-    /// the editor on the client token, exercising the full route+relay+teardown
-    /// wiring rather than mutating the aggregator directly.
+    /// the editor on the client token, exercising the route+relay+teardown wiring
+    /// rather than mutating the aggregator directly.
+    ///
+    /// The route+relay step inlines the reader's glue
+    /// (`window::progress::forward`: `route` → `on_downstream_progress` →
+    /// `upstream_tx.send`) deliberately — invoking the real `forward()` needs a
+    /// `ServerRequestDeps` reader harness that does not exist yet (the gap #442
+    /// itself notes). The concurrency invariant `forward()` adds (enqueue under
+    /// the aggregator lock) is out of a single-threaded test's reach and is
+    /// covered by `no_relay_escapes_after_teardown_even_without_a_prior_begin`.
     #[test]
     fn reader_route_relays_begin_then_teardown_synthesizes_end() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();

--- a/src/lsp/bridge/client_progress.rs
+++ b/src/lsp/bridge/client_progress.rs
@@ -509,6 +509,72 @@ mod tests {
         );
     }
 
+    /// Reader → registry-route → guard integration (#442): drive a downstream
+    /// `$/progress` the way the reader does — resolve the bridge token through
+    /// the registry, feed the resolved aggregator — then tear the request down.
+    /// Asserts the relayed `Begin` and the synthetic terminal `End` both reach
+    /// the editor on the client token, exercising the full route+relay+teardown
+    /// wiring rather than mutating the aggregator directly.
+    #[test]
+    fn reader_route_relays_begin_then_teardown_synthesizes_end() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let registry = std::sync::Arc::new(ClientProgressRegistry::new());
+        let aggregator =
+            std::sync::Arc::new(Mutex::new(ClientProgressAggregator::new(client_token())));
+        let token = registry.register(aggregator.clone());
+
+        let guard = ClientProgressDeregisterGuard::new(
+            registry.clone(),
+            vec![token.clone()],
+            aggregator,
+            tx.clone(),
+        );
+
+        // Reader step: a downstream `$/progress` Begin arrives for `token`. The
+        // reader resolves it through the registry and relays the returned params.
+        let routed = registry
+            .route(&token)
+            .expect("token routes to its aggregator");
+        let relayed = routed
+            .lock()
+            .recover_poison("test route")
+            .on_downstream_progress(&token, begin())
+            .expect("the first Begin is relayed");
+        let _ = tx.send(UpstreamNotification::ClientProgress { params: relayed });
+
+        // The editor sees the Begin on its own token.
+        match rx.try_recv().expect("Begin relayed upstream") {
+            UpstreamNotification::ClientProgress { params } => {
+                assert_eq!(params.token, client_token(), "Begin on the client token");
+                assert!(matches!(
+                    params.value,
+                    ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(_))
+                ));
+            }
+            _ => panic!("expected a ClientProgress Begin"),
+        }
+
+        // Request settles: the dispatch returns and drops the guard, which
+        // synthesizes the terminal End (the downstream's own End raced the
+        // response / never came) and deregisters the route.
+        drop(guard);
+        match rx.try_recv().expect("teardown synthesizes a terminal End") {
+            UpstreamNotification::ClientProgress { params } => {
+                assert_eq!(params.token, client_token(), "End on the client token");
+                assert!(matches!(
+                    params.value,
+                    ProgressParamsValue::WorkDone(WorkDoneProgress::End(_))
+                ));
+            }
+            _ => panic!("expected a ClientProgress End"),
+        }
+        assert!(rx.try_recv().is_err(), "exactly one Begin and one End");
+        assert!(
+            registry.route(&token).is_none(),
+            "the route is deregistered on teardown"
+        );
+    }
+
     #[test]
     fn no_relay_escapes_after_teardown_even_without_a_prior_begin() {
         // Cancel race: teardown can run before any `Begin` was relayed (a cancel

--- a/src/lsp/bridge/client_progress.rs
+++ b/src/lsp/bridge/client_progress.rs
@@ -541,12 +541,13 @@ mod tests {
     /// the editor on the client token, exercising the production route+relay+
     /// teardown path rather than mutating the aggregator directly.
     ///
-    /// The relay goes through the **same production helper**
-    /// (`relay_to_aggregator`) that `window::progress::forward` uses, so its
-    /// enqueue-under-lock ordering is real code here, not a stub. Only the trivial
-    /// `route` lookup and the reader's JSON deserialization are not driven; the
-    /// *concurrent* interleaving that the lock ordering guards is out of a
-    /// single-threaded test's reach.
+    /// Both the `route` lookup and the relay go through real code — the latter via
+    /// the **same production helper** (`relay_to_aggregator`) that
+    /// `window::progress::forward` uses, so its enqueue-under-lock ordering is
+    /// exercised, not stubbed. Only the reader's JSON deserialization and
+    /// `forward`'s token-branch selection are bypassed; the *concurrent*
+    /// interleaving that the lock ordering guards is out of a single-threaded
+    /// test's reach.
     #[test]
     fn reader_route_relays_begin_then_teardown_synthesizes_end() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();

--- a/src/lsp/bridge/client_progress.rs
+++ b/src/lsp/bridge/client_progress.rs
@@ -97,6 +97,31 @@ impl ClientProgressRegistry {
     }
 }
 
+/// Relay one downstream `$/progress` `value` (arriving for the bridge token
+/// `source`) through its request's `aggregator` onto the editor's token,
+/// enqueuing the translated lifecycle on `upstream_tx` **while still holding the
+/// aggregator lock** — so the relay is ordered strictly before/after the
+/// teardown's terminal `End` (which also enqueues under the lock), never
+/// interleaved (guards the cancel race; ls-bridge-client-progress).
+///
+/// Shared by the reader (`window::progress::forward`) and its integration test so
+/// both drive the exact enqueue-under-lock sequence.
+pub(crate) fn relay_to_aggregator(
+    aggregator: &std::sync::Arc<Mutex<ClientProgressAggregator>>,
+    upstream_tx: &tokio::sync::mpsc::UnboundedSender<
+        crate::lsp::bridge::actor::UpstreamNotification,
+    >,
+    source: &NumberOrString,
+    value: ProgressParamsValue,
+) {
+    let mut agg = aggregator.lock().recover_poison("ClientProgressAggregator");
+    if let Some(out) = agg.on_downstream_progress(source, value) {
+        let _ = upstream_tx
+            .send(crate::lsp::bridge::actor::UpstreamNotification::ClientProgress { params: out });
+    }
+    drop(agg);
+}
+
 /// Tears down a request's client-progress routing when dropped — i.e. when the
 /// dispatch call returns. It first deregisters the bridge tokens (so a late
 /// downstream `$/progress` no longer routes), then **synthesizes the terminal
@@ -513,16 +538,15 @@ mod tests {
     /// `$/progress` the way the reader does — resolve the bridge token through
     /// the registry, feed the resolved aggregator — then tear the request down.
     /// Asserts the relayed `Begin` and the synthetic terminal `End` both reach
-    /// the editor on the client token, exercising the route+relay+teardown wiring
-    /// rather than mutating the aggregator directly.
+    /// the editor on the client token, exercising the production route+relay+
+    /// teardown path rather than mutating the aggregator directly.
     ///
-    /// The route+relay step inlines the reader's glue
-    /// (`window::progress::forward`: `route` → `on_downstream_progress` →
-    /// `upstream_tx.send`) deliberately — invoking the real `forward()` needs a
-    /// `ServerRequestDeps` reader harness that does not exist yet (the gap #442
-    /// itself notes). The concurrency invariant `forward()` adds (enqueue under
-    /// the aggregator lock) is out of a single-threaded test's reach and is
-    /// covered by `no_relay_escapes_after_teardown_even_without_a_prior_begin`.
+    /// The relay goes through the **same production helper**
+    /// (`relay_to_aggregator`) that `window::progress::forward` uses, so its
+    /// enqueue-under-lock ordering is real code here, not a stub. Only the trivial
+    /// `route` lookup and the reader's JSON deserialization are not driven; the
+    /// *concurrent* interleaving that the lock ordering guards is out of a
+    /// single-threaded test's reach.
     #[test]
     fn reader_route_relays_begin_then_teardown_synthesizes_end() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
@@ -538,17 +562,12 @@ mod tests {
             tx.clone(),
         );
 
-        // Reader step: a downstream `$/progress` Begin arrives for `token`. The
-        // reader resolves it through the registry and relays the returned params.
+        // Reader step: a downstream `$/progress` Begin arrives for `token`. Resolve
+        // it through the registry and relay it via the production helper.
         let routed = registry
             .route(&token)
             .expect("token routes to its aggregator");
-        let relayed = routed
-            .lock()
-            .recover_poison("test route")
-            .on_downstream_progress(&token, begin())
-            .expect("the first Begin is relayed");
-        let _ = tx.send(UpstreamNotification::ClientProgress { params: relayed });
+        relay_to_aggregator(&routed, &tx, &token, begin());
 
         // The editor sees the Begin on its own token.
         match rx.try_recv().expect("Begin relayed upstream") {

--- a/src/lsp/bridge/window/progress.rs
+++ b/src/lsp/bridge/window/progress.rs
@@ -11,7 +11,6 @@ use log::debug;
 use serde::Deserialize;
 use tower_lsp_server::ls_types::{ProgressParams, ProgressParamsValue, WorkDoneProgress};
 
-use crate::error::LockResultExt;
 use crate::lsp::bridge::actor::{ServerRequestDeps, UpstreamNotification};
 
 /// Translate and forward a downstream `$/progress` notification to the editor.
@@ -47,17 +46,16 @@ pub(in crate::lsp::bridge) fn forward(
     // own `workDoneToken` and emits it ungated (ls-bridge-client-progress).
     if let Some(aggregator) = deps.client_progress_registry.route(&params.token) {
         // The incoming token identifies the source; the aggregator picks the first
-        // source to `Begin` as the winner and relays only its progress. Enqueue the
-        // relay **while still holding the aggregator lock**, so it is ordered
-        // strictly before/after the teardown's terminal `End` (which also enqueues
-        // under the lock) — never interleaved (guards the cancel race).
-        let mut agg = aggregator.lock().recover_poison("ClientProgressAggregator");
-        if let Some(out) = agg.on_downstream_progress(&params.token, params.value) {
-            let _ = deps
-                .upstream_tx
-                .send(UpstreamNotification::ClientProgress { params: out });
-        }
-        drop(agg);
+        // source to `Begin` as the winner and relays only its progress. The shared
+        // helper enqueues the relay under the aggregator lock so it is ordered
+        // strictly before/after the teardown's terminal `End` (guards the cancel
+        // race; ls-bridge-client-progress).
+        crate::lsp::bridge::client_progress::relay_to_aggregator(
+            &aggregator,
+            &deps.upstream_tx,
+            &params.token,
+            params.value,
+        );
         return;
     }
 


### PR DESCRIPTION
## Summary
Closes #442 — the two follow-up deliverables from the client-progress work (PRs #432/#434).

### 1. ADR sync (part 1)
The "Decision–Implementation Gap" section of `ls-bridge-client-progress.md` had drifted behind merged work (it claimed references-only coverage). Refreshed to reflect current state, **verified against the code**:
- **Single-region** (`dispatch_preferred`): `references`, the goto family, `inlayHint`.
- **Multi-region** (shared request-level aggregator + winner-token rule): `documentSymbol`, `formatting`, `rangeFormatting` (range-scoped), `codeLens`.
- `documentColor` is **not** wired (passes `client_progress_token: None`) — stated explicitly.
- Remaining gaps point at their tracking issues (#437/#447/#457/#439/#440/#441/#438) instead of a per-method snapshot that drifts as those land.

### 2. Deferred integration tests (part 2)
Two tests the reviewers on #432/#434 flagged, which previously only had direct-aggregator unit coverage:
- `reader_route_relays_begin_then_teardown_synthesizes_end` (`client_progress.rs`): resolves a downstream `$/progress` token through `ClientProgressRegistry::route()` and relays it via the **shared production helper** `relay_to_aggregator` (the same code `window::progress::forward` uses), then drops the teardown guard and asserts both the relayed `Begin` and the synthetic terminal `End` reach the editor on the client token.
- `setup_client_progress_tracks_only_the_anchor_and_fan_out_suppresses_the_rest` (`dispatch.rs`): asserts `setup_client_progress` mints exactly one bridge token (the named anchor) and `fan_out` hands every other candidate `None`.

To let the first test drive real code, the route-and-relay body of `forward()` was extracted into `client_progress::relay_to_aggregator` (a pure structural move; the existing `forwarding_loop_forwards_client_progress_ungated` test confirms `forward()`'s behavior is unchanged).

## Tests
Full `cargo test --lib` (2021 pass) + clippy clean.

## Reviews
Passed an internal multi-perspective `/review` (caught + fixed a `documentColor` overclaim in the ADR) and a codex review (converged). Note the ADR has been bot-cycle-churned before — please flag only substantive inaccuracies, not prose phrasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)