### PR TITLE
feat(rename): bridge + advertise client-progress for textDocument/rename (#437)

### DIFF
--- a/src/lsp/bridge/text_document/rename.rs
+++ b/src/lsp/bridge/text_document/rename.rs
@@ -14,8 +14,8 @@ use std::collections::HashMap;
 
 use crate::config::settings::BridgeServerConfig;
 use tower_lsp_server::ls_types::{
-    DocumentChangeOperation, DocumentChanges, OneOf, Position, TextDocumentEdit, TextEdit, Uri,
-    WorkspaceEdit,
+    DocumentChangeOperation, DocumentChanges, NumberOrString, OneOf, Position, TextDocumentEdit,
+    TextEdit, Uri, WorkDoneProgressParams, WorkspaceEdit,
 };
 use url::Url;
 
@@ -47,6 +47,7 @@ impl LanguageServerPool {
         virtual_content: &str,
         new_name: &str,
         upstream_request_id: Option<UpstreamId>,
+        client_progress_token: Option<NumberOrString>,
     ) -> io::Result<Option<WorkspaceEdit>> {
         let handle = self
             .get_or_create_connection(server_name, server_config, Some(host_uri))
@@ -65,7 +66,14 @@ impl LanguageServerPool {
             host_position,
             "textDocument/rename",
             |virtual_uri, request_id| {
-                build_rename_request(virtual_uri, host_position, &offset, new_name, request_id)
+                build_rename_request(
+                    virtual_uri,
+                    host_position,
+                    &offset,
+                    new_name,
+                    request_id,
+                    client_progress_token,
+                )
             },
             |response, ctx| {
                 transform_workspace_edit_response_to_host(
@@ -89,6 +97,7 @@ fn build_rename_request(
     offset: &RegionOffset,
     new_name: &str,
     request_id: RequestId,
+    client_progress_token: Option<NumberOrString>,
 ) -> JsonRpcRequest<RenameParams> {
     let params = RenameParams {
         text_document_position: build_text_document_position_params(
@@ -97,7 +106,9 @@ fn build_rename_request(
             offset,
         ),
         new_name: new_name.to_string(),
-        work_done_progress_params: Default::default(),
+        work_done_progress_params: WorkDoneProgressParams {
+            work_done_token: client_progress_token,
+        },
     };
     JsonRpcRequest::new(request_id.as_i64(), "textDocument/rename", params)
 }
@@ -257,6 +268,7 @@ mod tests {
             &RegionOffset::new(3, 0),
             "newName",
             RequestId::new(1),
+            None,
         );
 
         assert_uses_virtual_uri(&request, "lua");
@@ -272,11 +284,51 @@ mod tests {
             &RegionOffset::new(3, 0),
             "renamedVariable",
             test_request_id(),
+            None,
         );
 
         assert_position_request(&request, "textDocument/rename", 2);
         let json = serde_json::to_value(&request).unwrap();
         assert_eq!(json["params"]["newName"], "renamedVariable");
+    }
+
+    #[test]
+    fn rename_request_carries_work_done_token() {
+        // Client-progress wiring (#437): the editor's workDoneToken is threaded
+        // into the downstream rename request so its `$/progress` routes back.
+        let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
+        let request = build_rename_request(
+            &virtual_uri,
+            test_position(),
+            &RegionOffset::new(3, 0),
+            "newName",
+            test_request_id(),
+            Some(NumberOrString::String("wd-1".to_string())),
+        );
+        assert_eq!(
+            serde_json::to_value(&request).unwrap()["params"]["workDoneToken"],
+            "wd-1"
+        );
+    }
+
+    #[test]
+    fn rename_request_omits_work_done_token_when_absent() {
+        // No editor token → no `workDoneToken` field (non-regressing default).
+        let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
+        let request = build_rename_request(
+            &virtual_uri,
+            test_position(),
+            &RegionOffset::new(3, 0),
+            "newName",
+            test_request_id(),
+            None,
+        );
+        assert!(
+            serde_json::to_value(&request).unwrap()["params"]
+                .get("workDoneToken")
+                .is_none(),
+            "absent token must not serialize a null workDoneToken"
+        );
     }
 
     // ==========================================================================

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -313,7 +313,12 @@ impl Kakehashi {
                 }),
                 rename_provider: Some(OneOf::Right(RenameOptions {
                     prepare_provider: Some(true),
-                    work_done_progress_options: WorkDoneProgressOptions::default(),
+                    // Advertise workDoneProgress so spec-compliant clients attach a
+                    // workDoneToken, which the bridge relays onto downstream rename
+                    // progress (#437, ls-bridge-client-progress).
+                    work_done_progress_options: WorkDoneProgressOptions {
+                        work_done_progress: Some(true),
+                    },
                 })),
                 document_formatting_provider: Some(OneOf::Right(DocumentFormattingOptions {
                     work_done_progress_options: WorkDoneProgressOptions {

--- a/src/lsp/lsp_impl/text_document/rename.rs
+++ b/src/lsp/lsp_impl/text_document/rename.rs
@@ -18,7 +18,7 @@ const METHOD: &str = "textDocument/rename";
 impl Kakehashi {
     pub(crate) async fn rename_impl(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
         let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
-        let work_done_token = params.work_done_progress_params.work_done_token.clone();
+        let work_done_token = params.work_done_progress_params.work_done_token;
         let lsp_uri = params.text_document_position.text_document.uri;
         let position = params.text_document_position.position;
         let new_name = params.new_name;

--- a/src/lsp/lsp_impl/text_document/rename.rs
+++ b/src/lsp/lsp_impl/text_document/rename.rs
@@ -7,7 +7,7 @@
 //! wins (`preferred`).
 
 use tower_lsp_server::jsonrpc::Result;
-use tower_lsp_server::ls_types::{Position, RenameParams, Uri, WorkspaceEdit};
+use tower_lsp_server::ls_types::{NumberOrString, Position, RenameParams, Uri, WorkspaceEdit};
 
 use super::super::Kakehashi;
 use crate::lsp::aggregation::server::dispatch_preferred;
@@ -18,11 +18,12 @@ const METHOD: &str = "textDocument/rename";
 impl Kakehashi {
     pub(crate) async fn rename_impl(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
         let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
+        let work_done_token = params.work_done_progress_params.work_done_token.clone();
         let lsp_uri = params.text_document_position.text_document.uri;
         let position = params.text_document_position.position;
         let new_name = params.new_name;
 
-        let virt = self.rename_virt_layer(&lsp_uri, position, &new_name);
+        let virt = self.rename_virt_layer(&lsp_uri, position, &new_name, work_done_token);
         self.walk_layers(
             &lsp_uri,
             METHOD,
@@ -41,10 +42,12 @@ impl Kakehashi {
         lsp_uri: &Uri,
         position: Position,
         new_name: &str,
+        client_progress_token: Option<NumberOrString>,
     ) -> Result<Option<WorkspaceEdit>> {
-        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
+        let Some(mut ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
             return Ok(None);
         };
+        ctx.document.client_progress_token = client_progress_token;
 
         let (cancel_rx, _cancel_guard) =
             self.subscribe_cancel(ctx.document.upstream_request_id.as_ref());
@@ -70,6 +73,7 @@ impl Kakehashi {
                             &t.virtual_content,
                             &new_name,
                             t.upstream_id,
+                            t.client_progress_token,
                         )
                         .await
                 }

--- a/tests/e2e_lsp_protocol.rs
+++ b/tests/e2e_lsp_protocol.rs
@@ -73,6 +73,7 @@ fn test_advertises_work_done_progress_independent_of_window_capability() {
         "definitionProvider",
         "referencesProvider",
         "declarationProvider",
+        "renameProvider",
     ] {
         assert_eq!(
             caps[provider]["workDoneProgress"],

--- a/tests/snapshots/e2e_lsp_protocol__initialize_capabilities.snap
+++ b/tests/snapshots/e2e_lsp_protocol__initialize_capabilities.snap
@@ -50,7 +50,8 @@ expression: capabilities
     "workDoneProgress": true
   },
   "renameProvider": {
-    "prepareProvider": true
+    "prepareProvider": true,
+    "workDoneProgress": true
   },
   "documentLinkProvider": {},
   "foldingRangeProvider": true,


### PR DESCRIPTION
## Summary
Advances #437 by wiring `textDocument/rename` into the client-progress bridge — one of the named residual methods. Previously rename dropped the editor's `workDoneToken` (`build_rename_request` used `Default::default()`), so no `$/progress` reached the editor for a bridged rename.

## Changes
1. **Plumbing** (`bridge/text_document/rename.rs`, `lsp_impl/text_document/rename.rs`): thread the editor's `workDoneToken` through `rename_impl → rename_virt_layer → ctx.document.client_progress_token → send_rename_request → build_rename_request`, exactly mirroring the goto family. `dispatch_preferred`'s `setup_client_progress` then routes the tracked source's `$/progress` onto the editor's token.
2. **Advertisement** (`lifecycle.rs`): set `workDoneProgress: true` on `rename_provider`. `RenameOptions` flattens `WorkDoneProgressOptions` (no ls-types crate gap, unlike type_def/impl in #447), so this is a real, non-inert advertisement — without it, spec-compliant clients never attach a token.

## Non-regressing
`WorkDoneProgressParams { work_done_token: None }` serializes identically to the old `Default::default()` (field skipped via `skip_serializing_if`), so the no-token path (the common case) is byte-identical. Guarded by `rename_request_omits_work_done_token_when_absent`.

## Tests
- `rename_request_carries_work_done_token` / `rename_request_omits_work_done_token_when_absent` (builder unit tests).
- `renameProvider` added to the `test_advertises_work_done_progress_independent_of_window_capability` e2e assertion; `initialize_capabilities` snapshot updated.
- Full `cargo test --lib` (2045) + clippy `--all-targets` clean.

## Scope note
`documentColor` / `colorPresentation` (the remaining #450/#437 color residuals) are blocked by the same ls-types crate gap as #447/#457 — `ColorProviderCapability` has no variant carrying `WorkDoneProgressOptions`, so their progress plumbing would be inert. Tracked separately; not included here.

## Reviews
Passed an internal multi-perspective `/review` (one `.clone()` nit, fixed) and a codex review (no actionable findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)