### PR TITLE
docs: ADRs for capability-tier parse decoupling + per-document parse actor (#480)

### DIFF
--- a/docs/architecture-decisions/capability-tier-parse-decoupling.md
+++ b/docs/architecture-decisions/capability-tier-parse-decoupling.md
@@ -1,0 +1,205 @@
+# Capability Tier Parse Decoupling
+
+**Related Decisions**: [per-document-parse-actor](per-document-parse-actor.md),
+[host-document-bridge](host-document-bridge.md),
+[push-propagation-diagnostic-forwarding](push-propagation-diagnostic-forwarding.md),
+[ls-bridge-message-ordering](ls-bridge-message-ordering.md)
+
+## Context
+
+Opening a document should make it *usable* as fast as possible. But today the
+`didOpen` and `didChange` handlers couple a document's host-language usability to
+work it does not actually depend on: the tree-sitter parse and, worse,
+auto-install.
+
+**Most capabilities don't need our tree.** Kakehashi's features split into three
+tiers by their dependence on kakehashi's own tree-sitter parse:
+
+- **Host tier** — host-language `definition`/`hover`/`completion`/`references`/
+  `rename`/`formatting`/`diagnostics`, and the act of *attaching* the host
+  document to its external language server (the `_self` host bridge; see
+  host-document-bridge). These forward to an external server keyed by the host
+  language. They need the document **text and a language name only** — never the
+  tree. `eager_open_host_document_on_servers`
+  (`src/lsp/bridge/coordinator.rs`) takes `(settings, language: &str, uri,
+  text)`; no tree, no loaded parser. The language name it needs is
+  `language_for_path(path).or(language_id)`, a **path-based** resolution computed
+  in `did_open_impl` *before* `ensure_language_loaded` — so it is available ahead
+  of the parser-load attempt, not only ahead of the parse.
+- **Virt tier** — the same features over *injected* regions. These need the tree
+  **only to locate the region** under the cursor
+  (`InjectionResolver::resolve_at_byte_offset(..., snapshot.tree(), ...)`); the
+  forwarded request itself does not use the tree. Region location is an
+  intrinsic tree dependency — you cannot know where the embedded Python is
+  without parsing the Markdown.
+- **Native tier** — `semanticTokens`, `selectionRange`, and the `kakehashi/node`
+  / `kakehashi/captures` protocols. These are tree-derived and need a parsed
+  tree fully.
+
+**The coupling is incidental, not essential.** In `did_open_impl`
+(`src/lsp/lsp_impl/text_document/did_open.rs`) the host attach is reached only
+*after* three awaited steps that it does not depend on:
+
+1. `maybe_auto_install_language` (when the main parser is missing and
+   auto-install is on) — network/git plus an **unbounded** C-compiler step (see
+   per-document-parse-actor for the liveness analysis);
+2. `parse_document` — measured at **~120–700 ms** for a 50–2000-block
+   injection-heavy Markdown (10 KB–435 KB), and bounded only by a 10 s
+   parse timeout;
+3. `process_injections` — which itself needs the tree.
+
+The host attach is the *next* statement after those, even though
+`eager_open_host_document_on_servers` consumes neither their results nor the
+tree. So a user opening a 400 KB Markdown waits ~300 ms for host-language
+diagnostics/hover that needed none of it; a user whose parser is auto-installing
+(seconds, or a hung compiler forever) gets **no** host-language functionality
+until the install resolves. That is pure ordering, not a data dependency.
+
+On the edit path (`did_change_impl`) the analogous coupling is *text freshness*:
+the post-delta text is persisted to the store by `parse_document`, so a host
+forward that reads store text sees the new text only after the parse completes.
+
+### Measured parse cost (release build, real parsers, injection-heavy Markdown)
+
+| blocks | doc size | cold parse + injection | per-edit reparse + injection |
+| -----: | -------: | ---------------------: | ---------------------------: |
+|     50 |    10 KB |                ~120 ms |                            — |
+|    500 |   107 KB |                ~146 ms |                       ~56 ms |
+|   1000 |   215 KB |                ~186 ms |                       ~73 ms |
+|   2000 |   435 KB |                ~308 ms |                      ~183 ms |
+
+These are the latencies the host tier pays today for nothing (parse + injection
+isolated from token computation; see per-document-parse-actor for method).
+
+## Decision
+
+**Classify every capability by tier, and gate each tier only on what it
+intrinsically needs.** Concretely: hoist all host-tier work to the *front* of the
+mutation handlers, ahead of parser load, parse, and install, so host-language
+usability never waits on the tree.
+
+### Host tier is hoisted ahead of parse and install
+
+In `did_open_impl`, attach the host document to its external server(s)
+**immediately after the document is registered** — before `ensure_language_loaded`,
+before `parse_document`, before `maybe_auto_install_language`. The attach is
+already fire-and-forget (it spawns per-server tasks); only its *position* moves.
+Because it needs only the path-resolved language name (computed before the
+parser-load attempt) and the text, nothing blocks it.
+
+Consequence: a document whose parser is missing, installing, or hung still gets
+full host-language-server functionality — attach, diagnostics, hover,
+completion — at once. The unbounded install can delay only the **virt** and
+**native** tiers, which is correct: those genuinely need the tree.
+
+### Edit path keeps host text fresh without waiting for the parse
+
+On `didChange`, persist the post-delta text to the store **before** scheduling
+the parse, and let host forwards read that text. Applying a delta to the text is
+a cheap string operation; the parse (incremental tree-sitter plus injection
+reprocessing) is the expensive part the host tier must not wait on. The store's
+existing per-URI `edit_lock` continues to serialize the read-old-text →
+apply-delta → persist cycle against a concurrent `didClose` (the resurrection
+guard), exactly as today.
+
+### Ordering invariant: open-before-change survives hoisting
+
+Hoisting must not let a host `didChange` overtake the host `didOpen` at the
+external server. It cannot, for two independent reasons grounded in the current
+bridge:
+
+- **Single emitter, state-machine discriminated.** All host forwards flow
+  through `sync_host_document` (`src/lsp/bridge/text_document/host.rs`), whose
+  per-`(uri, connection)` map entry decides the message: a *vacant* entry emits
+  `didOpen`, an *occupied* entry emits `didChange`. A bare change before any open
+  is structurally impossible — the first sync always emits `didOpen`.
+- **Lock-order equals wire order.** The enqueue happens under the
+  `host_documents` mutex via a non-blocking `try_send` onto the per-connection
+  FIFO, with no `await` between lock acquisition and enqueue. The first caller to
+  take the lock enqueues first and the single writer task drains in FIFO order,
+  so wire order matches caller order.
+
+Hoisting the open *earlier* only strengthens open-before-change on the open path.
+This invariant is stated explicitly here because it is what makes the
+reordering safe; see ls-bridge-message-ordering for the connection-level
+contract.
+
+### Virt and native tiers stay parse-gated
+
+Virt-tier requests still wait on the parse, because region location needs the
+tree; native-tier requests still wait, because they are the tree. Both keep their
+existing bounded-wait-plus-fallback reader contract. While the parser is still
+installing, these tiers return their empty fallback — the intended
+"install-pending" behavior — while the host tier is fully live.
+
+## Considered Options
+
+### 1. Status quo — host attach after parse/install (rejected)
+
+Leave the handler ordering as is. Rejected: it makes host-language UX hostage to
+tree work it does not need, up to and including an unbounded compiler hold. The
+measured 120–700 ms parse and the unbounded install are paid by every host-tier
+feature for nothing.
+
+### 2. Fold this into the parse-actor refactor only (rejected as the *first* step)
+
+Wait for the full per-document parse actor (per-document-parse-actor) to land,
+and let the actor's "non-parse side effects run first" structure deliver the
+decoupling.
+
+Rejected as the *sequencing*, not as the end state. The tier decoupling is a
+small, self-contained reordering with the single largest UX payoff, and it does
+not require the actor, the epoch unification, or the off-ingress parse. Tying it
+to an ADR-sized refactor needlessly delays the win. It is recorded as its own
+decision so it can ship first.
+
+### 3. Tier decoupling, host hoisted to the front (chosen)
+
+Reorder the handlers so host-tier work precedes everything it does not depend on,
+with the open-before-change invariant made explicit. Independently shippable;
+complementary to the parse actor, which later moves the virt/native parse itself
+off the ingress path.
+
+## Consequences
+
+### Positive
+
+- **Host-language UX is immediate** — attach, diagnostics, hover, completion are
+  available as soon as the document is registered, regardless of parse latency or
+  an installing/hung parser. This is the direct user-visible win.
+- **The unbounded install is de-risked for the common case** even before the
+  parse actor lands: a missing/installing main parser no longer blocks host-tier
+  features (it still blocks virt/native, which the actor addresses separately).
+- **A clear, documented contract** for which tier needs the tree, so future
+  handlers are placed correctly by construction.
+
+### Negative
+
+- **A push-only host server may emit diagnostics against text whose parser never
+  installs.** This is correct for the host tier (it is parser-independent), but
+  it makes explicit an invariant the codebase must not violate: **nothing
+  downstream may assume "host document opened ⟹ a parse exists."** Any code
+  reached from the host attach must not read the tree.
+- **Two code paths now run concurrently from one handler** (host-tier
+  fire-and-forget vs. the parse and its dependents), so the handler's internal
+  ordering — what must precede the parse vs. what may run after — has to be kept
+  honest as handlers evolve.
+
+### Neutral
+
+- Virt and native tiers are unchanged in latency: they still wait for the parse,
+  because they intrinsically depend on it. The decoupling does not make tree
+  features faster; it stops non-tree features from waiting on them.
+- The edit-path text-freshness change (persist text before parse) is a small
+  structural reordering within `did_change_impl`; the per-document parse actor
+  later generalizes it into full single-owner text application with parse
+  coalescing.
+
+## Decision–Implementation Gap
+
+Not yet implemented. As of writing, `did_open_impl` attaches the host document
+only after awaiting auto-install, `parse_document`, and `process_injections`, and
+`did_change_impl` persists the post-delta text via `parse_document` (so host
+forwards see new text only after the parse). The tier taxonomy is described here;
+the handler reordering and the explicit open-before-change assertion are unbuilt.
+This decision can land independently of, and before, the per-document parse actor.

--- a/docs/architecture-decisions/capability-tier-parse-decoupling.md
+++ b/docs/architecture-decisions/capability-tier-parse-decoupling.md
@@ -20,12 +20,12 @@ tiers by their dependence on kakehashi's own tree-sitter parse:
   document to its external language server (the `_self` host bridge; see
   host-document-bridge). These forward to an external server keyed by the host
   language. They need the document **text and a language name only** — never the
-  tree. `eager_open_host_document_on_servers`
-  (`src/lsp/bridge/coordinator.rs`) takes `(settings, language: &str, uri,
-  text)`; no tree, no loaded parser. The language name it needs is
-  `language_for_path(path).or(language_id)`, a **path-based** resolution computed
-  in `did_open_impl` *before* `ensure_language_loaded` — so it is available ahead
-  of the parser-load attempt, not only ahead of the parse.
+  tree. `eager_open_host_document_on_servers` (`src/lsp/bridge/coordinator.rs`)
+  takes `(settings, language: &str, uri, text)`; no tree, no loaded parser. The
+  language name it needs is `language_for_path(path).or(language_id)`, a
+  **path-based** resolution computed in `did_open_impl` *before*
+  `ensure_language_loaded` — so it is available ahead of the parser-load attempt,
+  not only ahead of the parse.
 - **Virt tier** — the same features over *injected* regions. These need the tree
   **only to locate the region** under the cursor
   (`InjectionResolver::resolve_at_byte_offset(..., snapshot.tree(), ...)`); the
@@ -116,9 +116,13 @@ bridge:
   sync of a pair always finds the entry vacant and emits `didOpen`, *regardless* of
   which spawned task reaches the lock first. This carries the invariant on its own.
 - **FIFO enqueue under the lock.** Within the locked region the message goes onto
-  the per-connection FIFO via a non-blocking `try_send` with no `await` between
-  lock and enqueue, and the single writer task drains in FIFO order — so the
-  `didOpen`/`didChange` decided by the entry state cannot then be reordered on the
+  the per-connection FIFO. The enqueue itself is a synchronous `try_send`: the
+  `send_notification` call `sync_host_document` awaits is `async` in signature but
+  completes **without yielding** in the current `MessageSender`, so the lock is
+  not released between deciding the message and enqueuing it (this is an
+  implementation property of the current sender, not a hard structural guarantee
+  about `await` placement). The single writer task then drains in FIFO order — so
+  the `didOpen`/`didChange` decided by the entry state cannot be reordered on the
   wire. (Which task acquires the lock first is task-schedule order, not handler
   order; the entry-state discrimination is what makes that irrelevant.)
 

--- a/docs/architecture-decisions/capability-tier-parse-decoupling.md
+++ b/docs/architecture-decisions/capability-tier-parse-decoupling.md
@@ -43,9 +43,9 @@ tiers by their dependence on kakehashi's own tree-sitter parse:
 1. `maybe_auto_install_language` (when the main parser is missing and
    auto-install is on) — network/git plus an **unbounded** C-compiler step (see
    per-document-parse-actor for the liveness analysis);
-2. `parse_document` — measured at **~120–700 ms** for a 50–2000-block
-   injection-heavy Markdown (10 KB–435 KB), and bounded only by a 10 s
-   parse timeout;
+2. `parse_document` plus the injection processing it feeds — measured together
+   at **~120–310 ms** for a 50–2000-block injection-heavy Markdown
+   (10 KB–435 KB), and bounded only by a 10 s parse timeout;
 3. `process_injections` — which itself needs the tree.
 
 The host attach is the *next* statement after those, even though
@@ -108,16 +108,19 @@ Hoisting must not let a host `didChange` overtake the host `didOpen` at the
 external server. It cannot, for two independent reasons grounded in the current
 bridge:
 
-- **Single emitter, state-machine discriminated.** All host forwards flow
-  through `sync_host_document` (`src/lsp/bridge/text_document/host.rs`), whose
-  per-`(uri, connection)` map entry decides the message: a *vacant* entry emits
-  `didOpen`, an *occupied* entry emits `didChange`. A bare change before any open
-  is structurally impossible — the first sync always emits `didOpen`.
-- **Lock-order equals wire order.** The enqueue happens under the
-  `host_documents` mutex via a non-blocking `try_send` onto the per-connection
-  FIFO, with no `await` between lock acquisition and enqueue. The first caller to
-  take the lock enqueues first and the single writer task drains in FIFO order,
-  so wire order matches caller order.
+- **Single emitter, state-machine discriminated (the load-bearing reason).** All
+  host forwards flow through `sync_host_document`
+  (`src/lsp/bridge/text_document/host.rs`), whose per-`(uri, connection)` map entry
+  decides the message: a *vacant* entry emits `didOpen`, an *occupied* entry emits
+  `didChange`. A bare change before any open is structurally impossible — the first
+  sync of a pair always finds the entry vacant and emits `didOpen`, *regardless* of
+  which spawned task reaches the lock first. This carries the invariant on its own.
+- **FIFO enqueue under the lock.** Within the locked region the message goes onto
+  the per-connection FIFO via a non-blocking `try_send` with no `await` between
+  lock and enqueue, and the single writer task drains in FIFO order — so the
+  `didOpen`/`didChange` decided by the entry state cannot then be reordered on the
+  wire. (Which task acquires the lock first is task-schedule order, not handler
+  order; the entry-state discrimination is what makes that irrelevant.)
 
 Hoisting the open *earlier* only strengthens open-before-change on the open path.
 This invariant is stated explicitly here because it is what makes the
@@ -138,7 +141,7 @@ installing, these tiers return their empty fallback — the intended
 
 Leave the handler ordering as is. Rejected: it makes host-language UX hostage to
 tree work it does not need, up to and including an unbounded compiler hold. The
-measured 120–700 ms parse and the unbounded install are paid by every host-tier
+measured 120–310 ms parse and the unbounded install are paid by every host-tier
 feature for nothing.
 
 ### 2. Fold this into the parse-actor refactor only (rejected as the *first* step)

--- a/docs/architecture-decisions/capability-tier-parse-decoupling.md
+++ b/docs/architecture-decisions/capability-tier-parse-decoupling.md
@@ -127,6 +127,17 @@ This invariant is stated explicitly here because it is what makes the
 reordering safe; see ls-bridge-message-ordering for the connection-level
 contract.
 
+The invariant is about message **type** ordering (an open always precedes a
+change for the same document), not text-**version** ordering. Whether a later
+sync can carry *older* text than an earlier one — e.g. a delayed open-time task
+emitting `didChange` with stale text after a newer sync already opened the
+document — is a separate, **already-unresolved** concern: the content-version /
+`content_epoch` stale-overwrite window (push-propagation-diagnostic-forwarding,
+the #422 race). The `sync_host_document` fingerprint check only suppresses a
+re-sync when the text is *unchanged*; it does not reject text that differs but is
+older, so it does not close this race. Hoisting neither introduces nor fixes it;
+this ADR's reordering is orthogonal to it.
+
 ### Virt and native tiers stay parse-gated
 
 Virt-tier requests still wait on the parse, because region location needs the

--- a/docs/architecture-decisions/parse-decoupled-document-lifecycle.md
+++ b/docs/architecture-decisions/parse-decoupled-document-lifecycle.md
@@ -1,4 +1,4 @@
-# Capability Tier Parse Decoupling
+# Parse-Decoupled Document Lifecycle
 
 **Related Decisions**: [per-document-parse-actor](per-document-parse-actor.md),
 [host-document-bridge](host-document-bridge.md),

--- a/docs/architecture-decisions/per-document-parse-actor.md
+++ b/docs/architecture-decisions/per-document-parse-actor.md
@@ -269,8 +269,8 @@ since the last completed parse:
 
 ```text
 on SetText(delta):  latest = apply(latest, delta); pending_edits += delta.edits;
-                    if parsing { dirty = true } else { start_parse(latest, take(pending_edits)) }
-on parse_done:      if dirty { dirty = false; start_parse(latest, take(pending_edits)) }
+                    if parsing { dirty = true } else { parsing = true; start_parse(latest, take(pending_edits)) }
+on parse_done:      if dirty { dirty = false; start_parse(latest, take(pending_edits)) } else { parsing = false }
 ```
 
 A parse is incremental when a base tree exists, feeding tree-sitter the

--- a/docs/architecture-decisions/per-document-parse-actor.md
+++ b/docs/architecture-decisions/per-document-parse-actor.md
@@ -1,64 +1,102 @@
 # Per-Document Parse Actor
 
+**Related Decisions**:
+[capability-tier-parse-decoupling](capability-tier-parse-decoupling.md),
+[replace-tree-sitter-cli-with-loader](replace-tree-sitter-cli-with-loader.md),
+[push-propagation-diagnostic-forwarding](push-propagation-diagnostic-forwarding.md),
+[lazy-node-identity-tracking](lazy-node-identity-tracking.md)
+
 ## Context
 
-The document-mutation path (`didOpen`, `didChange`, `didClose`) currently
-spreads a single document's parse lifecycle across several handlers, a per-URI
-lock, and an install coordinator that re-enters the parse path on completion.
-Three forces collide here.
+This decision covers the **virt and native tiers** — the work that
+intrinsically needs kakehashi's tree-sitter parse (region location for injected
+languages, and the tree-derived `semanticTokens` / `selectionRange` /
+`kakehashi/node` / `kakehashi/captures` features). The host tier needs no tree
+and is decoupled separately; see capability-tier-parse-decoupling. With the host
+tier hoisted ahead of the parse, what remains is to get the parse itself off the
+latency-critical ingress path and give a document's parse lifecycle a single
+owner.
 
-**Ingress ordering (#342, #374).** `IngressOrderGate`
-(`src/lsp/ingress_order.rs`) assigns per-URI sequence tickets at `call` time so
-that writers (`didOpen`/`didChange`/`didClose`) apply in strict wire order and
-readers observe every edit that preceded them. `didOpen` was gated in #374 to
-close the open→edit and close→reopen first-poll races. The gate holds a
-document's writer ticket for the **whole handler future**.
+Three forces motivate that.
 
-**The slow, unbounded tail (#480).** Most of `did_open_impl`
-(`src/lsp/lsp_impl/text_document/did_open.rs`) is fast or fire-and-forget, but
-one branch is not: when the main language's parser is missing and auto-install
-is enabled, the handler `await`s `maybe_auto_install_language` → `try_install`
-**inside the writer-ticketed critical section**. Auto-install's network/git
-stages are timeout-bounded, but parser *compilation* (`compile_parser` →
-`tree-sitter-loader` `compile_parser_at_path`, `src/install/parser.rs`) shells
-out to a C compiler with **no timeout**. A pathologically hung compiler holds
-the `didOpen` writer ticket indefinitely, wedging every later same-URI reader
-and writer. This is a *liveness* problem, not merely latency.
+**Liveness — the unbounded install tail (#480).** When the main parser is missing
+and auto-install is enabled, `did_open_impl`
+(`src/lsp/lsp_impl/text_document/did_open.rs`) `await`s
+`maybe_auto_install_language` → `try_install` **inside the writer-ticketed
+critical section**. Auto-install's network/git stages are timeout-bounded
+(`run_with_timeout`, 120 s, killable), but parser *compilation*
+(`compile_parser` → `tree-sitter-loader`'s `compile_parser_at_path`,
+`src/install/parser.rs`) shells out to a C compiler **with no timeout and no
+surfaced child process** — the `cc` subprocess lives inside the loader library
+(see replace-tree-sitter-cli-with-loader). A hung compiler holds the `didOpen`
+writer ticket indefinitely, wedging every later same-URI reader and writer.
 
-**Scattered parse lifecycle.** The current shape couples several concerns that
-are hard to reason about independently:
+**Cost — the parse is not cheap on injection-heavy documents.** It is tempting to
+treat the parse as a few milliseconds, but for Markdown — where every inline span
+is a `markdown_inline` injection and every fenced block is its own
+injected-language parse — it is not. Measured on a release build against real
+parsers:
+
+| blocks | doc size | cold parse + injection | per-edit reparse + injection |
+| -----: | -------: | ---------------------: | ---------------------------: |
+|     50 |    10 KB |                ~120 ms |                            — |
+|    500 |   107 KB |                ~146 ms |                       ~56 ms |
+|   1000 |   215 KB |                ~186 ms |                       ~73 ms |
+|   2000 |   435 KB |                ~308 ms |                      ~183 ms |
+
+Method: each figure is the document-ready latency (didOpen→first response, or
+didChange→response) with the warm-median token-compute time subtracted, isolating
+parse + injection from token computation; driven synchronously one request at a
+time, so these are per-operation costs, not a concurrent burst. A burst of edits
+therefore costs real time per edit. Coalescing a burst into a single parse over
+the accumulated text is a genuine optimization, not a speculative one.
+
+**Change-path host immediacy requires the parse to be off-ingress.** Per
+capability-tier-parse-decoupling, host-tier forwards must be immediate on the
+*change* path too. If the parse runs inline in the change handler — holding the
+writer ticket for the tens-to-hundreds of milliseconds above — the next
+`didChange`, and any host forward sequenced behind it, waits on the parse. The
+only way host-tier immediacy survives sustained editing is for the handler to
+return before the parse runs: **parse off the ingress ticket.**
+
+**Scattered parse lifecycle, and four names for one idea.** The current shape
+couples concerns that are hard to reason about independently:
 
 - `did_open_impl` carries a `skip_parse` flag: when main-language auto-install
   fires, the handler skips `parse_document` because
   `reload_language_after_install` (`src/lsp/lsp_impl/coordinator/install.rs`)
-  re-parses *after* the parser file is written. The install path therefore
-  re-enters parsing from a different call site.
+  re-parses *after* the parser file is written — a second entry point into the
+  parse path.
 - `did_change_impl` serializes the non-atomic read-old-text → reparse → persist
-  cycle with a per-URI `edit_lock` (`src/document/store.rs`), acquired as the
-  handler's first `.await`. This is a practical mitigation layered on top of the
-  ingress gate, not a structural guarantee.
-- `reload_language_after_install` re-inserts and re-parses a document after a
-  network/compile delay. If the document was closed in the meantime, that
-  late re-parse can resurrect a closed document. #480 proposes to "reuse the
-  existing eager-open supersede machinery" to cancel it — i.e. bolt a second
-  lifecycle mechanism onto the parse path.
-- Readers already tolerate insert-without-tree: they snapshot the shared
-  `DocumentStore` and call `wait_for_parse_completion(200ms)` (a *bounded* wait
-  with a fallback) before computing — see `semantic_tokens.rs`,
-  `whole_document.rs`, `range_formatting.rs`.
+  cycle with a per-URI `edit_lock` (`src/document/store.rs`).
+- `reload_language_after_install` can re-insert and re-parse a document after a
+  network/compile delay; if the document was closed meanwhile, that late
+  re-parse resurrects a closed document.
+- Reader handlers carry an on-demand parse fallback
+  (`try_parse_and_update_document` and analogues) that *writes the store*, and
+  `update_document` **inserts on vacancy** — a second resurrection vector.
+
+Underneath, the store already keeps **two** monotonic counters that are really
+the same idea pulled in different directions: `open_generations` (used by the
+captures lineage to detect close-then-reopen) and `ParseState.generation` (whose
+`mark_parse_finished` stale-check already refuses to record a superseded parse).
+Neither gates the tree write itself. The ingress writer ticket
+(`IngressOrderGate`, `src/lsp/ingress_order.rs`) is a *third* per-document
+sequence, and the reader-ordering watermark this design needs would be a
+*fourth*. They are four implementations of one concept: a per-document logical
+version.
 
 The common root is that a document's text, parser readiness, and parse
-scheduling have **no single owner**. Each handler mutates pieces of that state
-under a shared lock, and the unbounded install runs on the latency-critical
-ingress thread.
+scheduling have **no single owner**.
 
 ## Decision
 
 Introduce a **per-document parse actor**: one actor task per open document that
 exclusively owns that document's text, parser-readiness state, and parse
-scheduling. The actor is the single consumer of a per-document mailbox, so
-mutations to one document are serialized *by construction* rather than by a
-shared lock.
+scheduling, and a **single per-document epoch** that is the one source of truth
+for ordering, resurrection-safety, and parse-staleness — subsuming
+`open_generations`, `ParseState.generation`, the reader watermark, and the
+`edit_lock`'s resurrection-guard duty.
 
 ### Writes are messages; the loop never blocks on the slow op
 
@@ -90,55 +128,86 @@ mailbox while either runs, a `Close` (and a queued `SetText`) is processed
 is the liveness fix: no ingress ticket and no mailbox is ever held hostage by
 compilation.
 
-The mailbox is **unbounded**, which is what makes the sends non-blocking. The
-queue itself is *not* inherently bounded by document size — under sustained input
-it holds one message per un-drained `SetText`, and a full-document sync — a
-rangeless content change, which yields an empty derived `InputEdit` list — carries
-the entire text, not a small delta.
-
-Deltas are **never dropped** — dropping one corrupts the text, and standard LSP
+The mailbox is **unbounded**, which is what makes the sends non-blocking. Deltas
+are **never dropped** — dropping one corrupts the text, and standard LSP
 incremental sync offers no server-initiated full-text resynchronization to
-recover from a drop — so coalescing-by-discarding is not an option and the
-mailbox cannot be capped by shedding messages. What keeps memory in check is the
-actor's per-message cost: applying a delta to the owned text is a cheap string op
-(parse and install are offloaded off the loop), so the actor drains the mailbox
-far faster than an editor produces edits, and the backlog stays transient even
-while a parse or an unbounded install is outstanding. The actor further **drains
-all currently-ready `SetText`s and applies them before scheduling a single
-parse**, collapsing a burst into one parse rather than one per message. The
-deliberate tradeoff: the only lever that could hard-cap the queue is transport
-backpressure, which would push the stall back onto the ingress thread and
-re-create exactly what this design removes — so unboundedness is accepted, relied
-on staying transient by the drain-rate argument, not by a drop policy.
+recover from a drop — so the mailbox cannot be capped by shedding messages. What
+keeps memory in check is the actor's per-message cost: applying a delta to the
+owned text is a cheap string op (parse and install are offloaded off the loop),
+so the actor drains the mailbox far faster than an editor produces edits, and the
+backlog stays transient even while a parse or an unbounded install is
+outstanding. The actor further **drains all currently-ready `SetText`s and
+applies them before scheduling a single parse**, collapsing a burst into one
+parse rather than one per message — the coalescing the cost table makes
+worthwhile. The deliberate tradeoff: the only lever that could hard-cap the queue
+is transport backpressure, which would push the stall back onto the ingress
+thread and re-create exactly what this design removes — so unboundedness is
+accepted, relied on staying transient by the drain-rate argument, not by a drop
+policy.
+
+### One epoch for ordering, resurrection, and staleness
+
+A single monotonic per-document **epoch** — the ingress writer-ticket sequence,
+made authoritative — replaces the four ad-hoc sequences. The unification is of
+the *source*, not of a single scalar: two derived quantities read off the same
+ticket sequence. The actor publishes a **processed-through watermark** (the
+highest ticket whose state has fully resolved) that readers wait on, and stamps
+each store write with the **epoch at which it was scheduled** that the CAS write
+compares before committing. Everything keys on that one sequence:
+
+- **Wire order / readiness (reader watermark).** Each mutation handler stamps its
+  enqueued message with the ingress writer ticket plumbed to it from the gate.
+  When the actor brings the document's state through ticket *N* to a **terminal
+  outcome** — `Parsed` (tree written), `NoTree` (parsed to nothing), or
+  `InstallFailed` — it advances the *published* epoch to *N*. The watermark must
+  advance on **resolution**, not only on a successful tree write, or a
+  parse/install failure would never advance it and readers would burn the full
+  timeout. A virt/native reader waits — bounded by the existing 200 ms — until
+  the epoch reaches the tail ticket that preceded it, then reads whatever the
+  store holds (a tree, or empty), instead of waiting on `has_tree`. This is
+  required because, with the handler returning at *enqueue*, a bare `has_tree`
+  check would be satisfied while the store still holds the **old** tree —
+  reintroducing the #342/#374 stale-tree race.
+- **Resurrection-safety (generation-checked CAS writes).** Every tree write
+  becomes an **atomic, non-inserting, epoch-checked** store update: it no-ops if
+  the document is gone (`Vacant`) or the epoch has moved. This generalizes the
+  existing `mark_parse_finished` stale-check from the parse-state to the tree
+  itself. The actor's own parse is one writer; the reader on-demand fallback is
+  the other (see below). The unguarded site today is
+  `kakehashi/node`'s `ensure_parsed_for_node_lookup` (`entry.rs`); the
+  `semanticTokens` and `selectionRange` fallbacks are already `edit_lock`-guarded
+  but switch to the same CAS write.
+- **Close-then-reopen detection** (today `open_generations`) is the same epoch:
+  a reopen draws a fresh epoch, so a stale lineage insert or a late parse
+  naturally fails its epoch check.
+
+This requires new plumbing in `IngressOrderGate`: today the ticket is
+middleware-private — a writer handler does not receive `gate.ticket()`, and a
+reader handler does not receive the tail ticket the `ReaderBarrier` snapshots at
+`call` time. Both must be exposed (via a task-local, a request extension, or by
+moving the enqueue into the middleware) so the writer can stamp its message and
+the reader can name the epoch it waits on. The ingress middleware is part of the
+refactor surface.
 
 ### Install is shared and global; only the parse is the actor's child
 
-Install is **not** a per-document operation the actor owns. `try_install`
-dedupes per language: the second document of the same uninstalled language gets
-an `AlreadyInstalling` outcome and skips its parse, while only the install
-"winner" re-parses (via `reload_language_after_install`, which mutates **global**
-state — pushing the data dir into `search_paths`, re-applying settings, and
-calling `ensure_language_loaded` on the shared registry — *before* the
-per-document `parse_document`). So install is already a shared, globally-mutating
-operation today; what the actor design *adds* is that every waiting document
-subscribes to its completion and parses on its own, rather than only the winner
-re-parsing.
-
-So the two operations are separated deliberately:
+Install is **not** a per-document operation the actor owns. `try_install` dedupes
+per language: the second document of the same uninstalled language gets an
+`AlreadyInstalling` outcome, while the install "winner" mutates **global** state
+(pushing the data dir into `search_paths`, re-applying settings, calling
+`ensure_language_loaded`). So the two operations are separated deliberately:
 
 - **Global install** — shared, deduplicated, deadline-bounded (see below), owned
   by a process-wide installer. An actor in `Installing` *subscribes* to its
   completion; it does not own or abort it.
-- **Per-document parse** — owned by the actor, the **authoritative** writer of
-  the document's tree into the store (the reader on-demand fallback is the one
-  other writer, which must be made private or atomically guarded — see "Reads
-  bypass the mailbox"), and the only child aborted on `Close`.
+- **Per-document parse** — owned by the actor, the **authoritative** epoch-checked
+  writer of the document's tree into the store, and the only child aborted on
+  `Close`.
 
 This split is what lets both the liveness fix and the resurrection guarantee
 hold: aborting the per-document parse on `Close` never kills an install a
 *sibling* actor still needs, and a global install completing after a `Close` is
-harmless because the store-writing parse — the abortable per-actor child — is
-already gone.
+harmless because the store-writing parse is already gone and its epoch is stale.
 
 ### State machine folds `skip_parse`
 
@@ -152,22 +221,17 @@ install path's re-entry:
 
 On install completion the actor transitions `Installing → Ready` and parses the
 **latest** text (not the open-time text). There is no separate
-`reload_language_after_install` re-entry: re-parse is simply the actor's normal
-`Ready` behavior applied to current state.
+`reload_language_after_install` re-entry: re-parse is the actor's normal `Ready`
+behavior applied to current state.
 
 ### The actor owns the text; only the *parse* coalesces
 
-LSP incremental `didChange` sends **deltas** (ranges + replacement), not full
-text. `did_change_impl` reads `old_text` from the store and calls
-`apply_content_changes_with_edits(&old_text, content_changes)` to derive both
-the new text and the tree-sitter `InputEdits`. Deltas therefore **cannot be
-coalesced by keeping only the latest** — dropping an intermediate delta
-corrupts the text.
-
-So the split is: the actor **applies every delta in order to the text it owns**
-(a cheap string op, never dropped); only the **parse** coalesces. It keeps a
-`latest_text` cell, a `dirty` flag, and the accumulated `InputEdits` since the
-last completed parse:
+LSP incremental `didChange` sends **deltas**, not full text, so deltas **cannot
+be coalesced by keeping only the latest** — dropping an intermediate delta
+corrupts the text. The split is: the actor **applies every delta in order to the
+text it owns** (a cheap string op, never dropped); only the **parse** coalesces.
+It keeps a `latest_text` cell, a `dirty` flag, and the accumulated `InputEdits`
+since the last completed parse:
 
 ```text
 on SetText(delta):  latest = apply(latest, delta); pending_edits += delta.edits;
@@ -175,303 +239,227 @@ on SetText(delta):  latest = apply(latest, delta); pending_edits += delta.edits;
 on parse_done:      if dirty { dirty = false; start_parse(latest, take(pending_edits)) }
 ```
 
-If several `SetText`s land while a parse runs, every delta is applied to `latest`
-in order, and the next parse runs once over the accumulated state — stale texts
-never accumulate in the mailbox. A parse is incremental when a base tree exists,
-feeding tree-sitter the **accumulated** `InputEdits` since the last parse; with
-no base tree (e.g. just after install) it degrades cleanly to a full parse.
-Incrementality is a performance optimization, never a correctness requirement.
+A parse is incremental when a base tree exists, feeding tree-sitter the
+**accumulated** `InputEdits` since the last parse; with no base tree (e.g. just
+after install) it degrades cleanly to a full parse. Incrementality is a
+performance optimization, never a correctness requirement.
 
-This removes the `edit_lock` **from the parse / edit-application path**. The lock
-exists today partly because the read-old-text → resolve-deltas → persist cycle
-runs in concurrently-dispatched handlers against a shared store snapshot. Moving
-delta application *into* the single-consumer actor — the actor, not the handler,
-owns and mutates the text — is what makes that cycle non-interleavable. (A design
-where the handler resolved deltas to text from a store snapshot *before* sending
-would still race the snapshot and still need the lock.)
-
-But the `edit_lock` carries a *second* duty the actor does **not** subsume:
+This removes the `edit_lock` **from the parse / edit-application path**: moving
+delta application into the single-consumer actor makes the read-old-text →
+resolve-deltas → persist cycle non-interleavable by construction. But the
+`edit_lock` carries a *second* duty the actor does **not** subsume:
 `did_close_impl` holds it to serialize the captures-lineage clear
 (`captures_cache.retain`) against a concurrent captures `full` reader's
-`store_lineage`, which inserts under the same lock (captures-protocol). Because
-readers bypass the actor, this reader-vs-close ordering is not covered by mailbox
-serialization and needs a named replacement — either keep a dedicated lock for
-the captures lineage, or fold the lineage write into the watermark contract.
-This is a path the actor would otherwise silently orphan, so it is called out in
-the Negative consequences.
+`store_lineage` insert. Because readers bypass the actor, this reader-vs-close
+ordering needs a named replacement — either a dedicated lock for the captures
+lineage, or folding the lineage write into the epoch check (a stale lineage
+insert fails its epoch check, the same mechanism that guards tree writes).
 
 ### Reads bypass the mailbox
 
 Read requests do **not** query the actor's mailbox. The actor *publishes* parse
 results into the shared `DocumentStore`; readers snapshot the store directly,
-exactly as today, using the existing `wait_for_parse_completion(200ms)` bounded
-wait plus an empty/`null` fallback.
+using the existing bounded wait — now keyed to the **epoch** rather than
+`has_tree` — plus an empty/`null` fallback. Having reads queue behind in-flight
+parses and buffered `SetText`s in the same mailbox would reintroduce exactly the
+blocking this design removes; the write-only-mailbox / shared-store-read split is
+load-bearing.
 
-One wrinkle: the actor is **not** the only writer of the store's tree today.
-Reader handlers carry an on-demand parsing fallback for the race where a request
-arrives before parsing finishes — `try_parse_and_update_document`
-(`semantic_tokens.rs`), and the analogous paths in `selection_range.rs` and the
-node-lookup `entry.rs` — which parse and then *update the store*. The existing
-"document still present and text unchanged" guard is **not** sufficient on its
-own: it is check-then-write, so a `didClose` can land between the check and the
-write, and the store's `update_document` *inserts on vacancy* — re-creating the
-closed document. With the actor owning parsing, the robust fix is to make these
-fallbacks return a **private** tree without writing the store at all, or to route
-their persistence through an **atomic, non-inserting, generation-checked** store
-update (one that no-ops when the document is gone or its generation moved). This
-matters for the resurrection guarantee below: the reader-fallback write is the
-one remaining way a closed document could be re-inserted, so it must be closed at
-the write itself, not by a check that a concurrent close can slip past.
+The reader on-demand parse fallbacks must stop being **unguarded store writers**:
+they either return a **private** tree without writing the store, or persist
+through the epoch-checked CAS write above. The present-and-text-unchanged guard
+they use today is check-then-write over a store that inserts on vacancy, so a
+concurrent `didClose` can slip between the check and the write and resurrect the
+document; the CAS write closes that at the write itself.
 
-Optionally, the actor publishes an
-*install-pending* signal into the store (the store carries no such field today —
-only `has_tree`/`in_progress`); a reader seeing it returns empty immediately
-without waiting, since the parse cannot complete until an unbounded install
-does. The existing `semantic_tokens_refresh` event — already emitted on language
-load/reload — then prompts capable clients to re-request once the actor reaches
-`Ready`. This saves only the 200ms bounded wait, so it is optional scope; the
-load-bearing property is simply that the mailbox stays write-only, which keeps
-the blocking problem from migrating to the read path.
-
-### Reader-vs-writer ordering needs a published watermark
-
-This is the subtle part, and it changes the writer-ticket timing, so it must be
-designed explicitly rather than assumed.
-
-Today `IngressOrderGate` completes a writer's ticket only *after* the whole
-handler future resolves (`drop(gate)` follows `inner_fut.await` in
-`ingress_order.rs`), and the `didChange` handler `await`s `parse_document`
-*inside* that window. So a `semanticTokens` reader ticketed right after a
-`didChange` is guaranteed to observe the **parsed** tree — locked down by
-`gate_runs_reader_only_after_preceding_writer`. A reader's
-`wait_for_parse_completion` then sees `has_tree == true` for the *current* tree.
-
-Under the actor, the handler returns at **enqueue**, so the writer ticket
-completes *before* the actor applies the delta or calls `mark_parse_started`. A
-reader's gate barrier is then satisfied while `has_tree` is still true for the
-**old** tree, and `wait_for_parse_completion` returns the stale tree
-immediately. That reintroduces exactly the #342/#374 race. A bare `has_tree`
-check is therefore insufficient.
-
-The replacement: the actor publishes a per-URI **monotonic processed-through
-watermark** keyed to the ingress writer sequence. Each mutation handler stamps
-its enqueued message with the writer ticket **plumbed to it from the gate**; when
-the state through ticket *N* reaches a **terminal outcome** — `Parsed` (tree
-written), `NoTree` (parsed to nothing), or `InstallFailed` — the actor advances
-the published watermark to *N*. The watermark must advance on *resolution*, not
-only on a successful tree write, or a parse/install failure would never advance
-it and readers would always burn the full timeout. A reader waits — bounded by
-the existing 200ms — until the watermark reaches the tail ticket that preceded
-it, then reads whatever the store holds (a tree, or empty), instead of waiting on
-`has_tree`. While an install is genuinely still pending, the watermark has not yet
-resolved, so the reader times out into the empty fallback, which is the intended
-install-pending behavior. This
-preserves the #374 reader-observes-preceding-writes guarantee without re-coupling
-the handler to parse latency or to the unbounded install.
-
-This requires new plumbing in `IngressOrderGate` (`src/lsp/ingress_order.rs`):
-today the ticket is middleware-private — a writer handler does not receive
-`gate.ticket()`, and a reader handler does not receive the tail ticket the gate's
-`ReaderBarrier` snapshots at `call` time. Both must be exposed (via a task-local,
-a request extension, or by moving the enqueue into the middleware) so the writer
-can stamp its message and the reader can name the watermark it waits on. The
-ingress middleware is therefore part of the refactor surface, not untouched.
-
-The reader-side `edit_lock` acquisitions that act as settle guards today
-(`semantic_tokens.rs`, `selection_range.rs`) become uncontended once the
-writer side no longer takes the lock; the watermark is their functional
-replacement, so they are removed rather than left as dead synchronization.
+Optionally, the actor publishes an *install-pending* signal into the store so a
+virt/native reader returns empty immediately rather than burning the 200 ms wait,
+with the existing `semantic_tokens_refresh` event prompting capable clients to
+re-request once the actor reaches `Ready`. This is optional scope; the
+load-bearing property is that the mailbox stays write-only.
 
 ### Lifetime equals document lifetime
 
 The actor's lifetime is exactly the open document's lifetime. `Close` aborts the
 in-flight **parse** (the store-writing child), unsubscribes from the shared
-install, and terminates the actor; the store entry is removed. The shared
-install itself is *not* aborted — a sibling may still need it. A late install
-completing afterward has no actor to hand off to, so the abortable per-actor
-parse can no longer re-insert the closed document — **the install/parse
-resurrection path is structurally closed**, with no separate supersede machinery.
-This holds *provided* the reader-fallback store write noted above is made
-resurrection-safe; that on-demand path is the only other writer that could
-re-insert a closed document, and — because its present-and-unchanged check is
-check-then-write over a store that inserts on vacancy — it must either stop
-writing the store entirely (return a private tree) or persist through an atomic,
-non-inserting, generation-checked update. A reopen creates a fresh actor.
+install, advances the epoch, and terminates the actor; the store entry is
+removed. The shared install itself is *not* aborted. A late install completing
+afterward has no actor to hand off to, and any straggler write fails its epoch
+check, so **the install/parse resurrection path is structurally closed** with no
+separate supersede machinery — *provided* every store-writing path, including the
+reader on-demand fallback, goes through the epoch-checked CAS write below; that
+fallback is the one residual vector, and it is closed at the write, not by a
+check a concurrent close can slip past. A reopen creates a fresh actor at a fresh
+epoch.
 
-Teardown must also wake any reader blocked on a watermark ticket that will now
-never be processed: dropping the watermark channel on actor termination signals
-those waiters to proceed (into the empty fallback), mirroring how the gate's
-`finish_close` drops its `done` sender and waiters treat the error as "nothing
-left to wait for." Without it a reader racing the close would stall to the 200ms
+Teardown must also wake any reader blocked on an epoch that will now never be
+reached: dropping the epoch channel on actor termination signals those waiters to
+proceed (into the empty fallback), mirroring how the gate's `finish_close` drops
+its `done` sender. Without it a reader racing the close would stall to the 200 ms
 timeout — bounded, but needless.
 
-### Complementary: install-wide deadline
+### Complementary: a real install deadline via a killable subprocess
 
 Moving install off the ingress path stops it from wedging requests, but a hung
 compiler should still not leak forever. A deadline here is **not** achievable by
-wrapping the current future in `tokio::time::timeout`: installation runs in
-`spawn_blocking` (`install_language_async`, `src/install.rs`), and compilation
-calls `Loader::compile_parser_at_path` (`src/install/parser.rs`), which shells
-out to `cc` *without surfacing the child process* to the caller. A timeout would
-let the `await` return while the blocking thread and its `cc` child keep running
-— the leak the deadline was meant to prevent. A real deadline therefore requires
-running compilation as a **controllable subprocess/process group** that the
-installer can kill (and reap) when the deadline fires, publishing failure only
-after termination. This is complementary to the actor, not a substitute for it.
+wrapping the current future in `tokio::time::timeout`: compilation runs in
+`spawn_blocking`, and `compile_parser_at_path` shells out to `cc` **without
+surfacing the child** (see replace-tree-sitter-cli-with-loader), so a timeout
+would let the `await` return while the blocking thread and its `cc` child keep
+running. A real deadline requires running the loader's compile step inside a
+**controllable subprocess / process group** that the installer can kill (and
+reap) when the deadline fires, publishing failure only after termination. This
+**reconciles with, and does not supersede,** replace-tree-sitter-cli-with-loader:
+the loader still owns header/scanner/platform handling; we only wrap its call in
+a killable boundary instead of reaching into the `cc` invocation. Complementary
+to the actor, not a substitute.
 
 ### Injection orchestration stays downstream
 
 `process_injections` runs as a consequence of a completed main parse, not inside
 the actor loop, so injection work never stalls main-document parsing. It is not
-uniformly fire-and-forget, though, and it hides a **second instance of the very
-liveness hazard this ADR exists to fix**: `process_injections` is awaited inside
-the gated `didOpen`/`didChange` handlers (`did_open.rs`, `did_change.rs`), and it
-in turn awaits `check_injected_languages_auto_install` →
-`maybe_auto_install_language(is_injection=true)` (`injection.rs`) — the same
-untimed C compiler, now for an *injected* language's parser, still inside the
-writer ticket. So re-homing `process_injections` has three distinct parts:
+uniformly fire-and-forget, and it hides a **second instance of the liveness
+hazard**: it awaits `check_injected_languages_auto_install` →
+`maybe_auto_install_language(is_injection=true)` — the same untimed C compiler,
+for an *injected* language. Re-homing it has three parts:
 
 - **Injected-language auto-install** — must route through the *same* shared,
   deadline-bounded installer as the main language and be subscribed to, never
-  awaited in a gated handler or the actor loop. This is a liveness requirement,
-  not just tidiness.
+  awaited in a gated handler or the actor loop. A liveness requirement.
 - **External bridge-server spawn** — genuinely fire-and-forget.
 - **`didChange` forwarding to already-opened virtual documents** — wire-order
-  sensitive; sequenced **after** the parse it depends on (it needs the fresh
-  tree) and in writer order — i.e. it must stay ordered, not be turned into an
-  unordered fire-and-forget task.
-
-All three splits must be preserved when re-homing this step.
+  sensitive; sequenced **after** the parse it depends on and in writer order, not
+  turned into an unordered fire-and-forget task.
 
 ## Considered Options
 
 ### 1. Minimal spawn of the slow tail (the literal #480 scope)
 
 Keep the existing handlers and locks; only move auto-install (and optionally
-`process_injections`) into a spawned task, and cancel that task on `didClose` by
-reusing the eager-open supersede machinery.
+`process_injections`) into a spawned task, and cancel it on `didClose` by reusing
+the eager-open supersede machinery.
 
 Rejected as the end state. It fixes the immediate liveness exposure with a small
-diff, but leaves `skip_parse`, the `edit_lock`, and the install re-entry in
-place, and adds a *second* spawn/cancel lifecycle bolted onto the parse path —
-more moving parts guarding the same invariant, not fewer. It remains a
-reasonable interim step if the full actor is staged.
+diff, but leaves `skip_parse`, the `edit_lock`, the install re-entry, and the
+four ad-hoc sequences in place, and adds a *second* spawn/cancel lifecycle bolted
+onto the parse path. It remains a reasonable interim step if the full actor is
+staged.
 
 ### 2. Install-wide deadline only
 
-Add a timeout around the whole install (including compilation) so the writer
-ticket is released after at most the deadline.
+Add a timeout around the whole install so the writer ticket is released after at
+most the deadline.
 
-Rejected as insufficient. It bounds the worst case but still holds the ticket
-for the deadline's duration, does nothing for ordinary latency, and leaves the
+Rejected as insufficient. It bounds the worst case but still holds the ticket for
+the deadline's duration, does nothing for ordinary parse latency, and leaves the
 scattered lifecycle untouched. It is also harder than it looks — compilation runs
-in non-cancellable `spawn_blocking` with no exposed child process, so a real
-deadline needs a killable subprocess (see the install-wide deadline subsection),
-not a `timeout` wrapper. Retained as a *complementary* mitigation (see Decision),
-not an alternative.
+in non-cancellable `spawn_blocking` with no exposed child, so a real deadline
+needs a killable subprocess, not a `timeout` wrapper. Retained as a
+*complementary* mitigation, not an alternative.
 
-### 3. Per-document parse actor (chosen)
+### 3. Decompose without an actor (generation-checked store + killable installer)
 
-Serializes by construction, folds `skip_parse` into state, closes the
-install/parse resurrection path (with the reader-fallback write made private or
-atomically generation-guarded), and keeps install/parse off the ingress path — at
-the cost of an ADR-sized refactor.
+Keep the concurrent handlers, but (a) make every tree write epoch-checked CAS so
+resurrection is closed without an owner, (b) move install off-ingress as a
+subscribe/notify, and (c) add the killable installer. This delivers liveness and
+resurrection-safety with no mailbox and no watermark.
 
-### 4. Actor answers read requests directly (mailbox-query reads)
+Rejected, narrowly, on the **cost** and **change-path** forces. It distributes
+the epoch-check and edit-application discipline across more call sites (each
+`didChange`, the install-completion parse, every reader fallback), and — crucially
+— it has no natural place to **coalesce a burst into one parse**, which the cost
+table shows is worth tens-to-hundreds of milliseconds per superseded edit on
+injection-heavy documents. The single-consumer actor gets coalescing for free;
+the decomposed design would have to bolt on a per-URI debounce that re-creates an
+ad-hoc owner. The epoch unification (the largest simplification) is adopted from
+this option regardless of the actor.
 
-Have read handlers send a request message to the actor and await its reply,
-instead of reading a published store snapshot.
+### 4. Per-document parse actor with a unified epoch (chosen)
 
-Rejected. It reintroduces the blocking it set out to remove: a read would queue
-behind in-flight parses and buffered `SetText`s in the same mailbox. The
+Serializes by construction, folds `skip_parse` into state, unifies the four
+sequences into one epoch, closes the resurrection path with CAS writes, coalesces
+bursts, and keeps install/parse off the ingress path — at the cost of an
+ADR-sized refactor.
+
+### 5. Actor answers read requests directly (mailbox-query reads)
+
+Have read handlers send a request message to the actor and await its reply.
+
+Rejected. A read would queue behind in-flight parses and buffered `SetText`s in
+the same mailbox, reintroducing the blocking the design removes. The
 write-only-mailbox / shared-store-read split is load-bearing.
 
 ## Consequences
 
 ### Positive
 
-- **Liveness.** An unbounded/hung install can no longer wedge same-URI readers
-  or writers; the actor loop stays responsive and `Close` always lands.
-- **Serialization by construction.** A single mailbox consumer removes the parse
-  / edit-application path's reliance on the per-URI `edit_lock`; the
-  read-old-text → reparse → persist cycle is no longer interleavable. (The
-  lock's *other* duty — reader-vs-close captures-lineage ordering — is not
-  subsumed; see Negative.)
+- **Liveness.** An unbounded/hung install can no longer wedge same-URI readers or
+  writers; the actor loop stays responsive and `Close` always lands.
+- **Burst coalescing.** A run of edits collapses to one parse over the
+  accumulated text, saving the measured per-edit reparse cost on injection-heavy
+  documents.
+- **One epoch, not four.** Wire-order readiness, resurrection-safety, and
+  parse-staleness key on a single per-document counter, subsuming
+  `open_generations`, `ParseState.generation`, the reader watermark, and the
+  `edit_lock`'s resurrection-guard duty.
 - **`skip_parse` disappears**, folded into the `Uninstalled/Installing/Ready`
   state machine; the install path stops re-entering parsing from a second call
   site.
-- **The install/parse resurrection path is structurally closed** — closing
-  aborts the actor's store-writing parse, so a later shared-install completion
-  has no actor to write through — without adding supersede machinery to the parse
-  path. (The reader-fallback store write is the one residual resurrection vector;
-  it must stay lifetime-guarded — see Negative.)
-- **One owner** for a document's text, its parse-readiness state, and parse
-  scheduling (global install stays shared), which is easier to reason about than
-  lock-guarded shared state.
+- **The install/parse resurrection path is structurally closed** — `Close` aborts
+  the actor's store-writing parse and advances the epoch, so a later
+  shared-install completion has no actor and a stale epoch — without adding
+  supersede machinery. This holds *provided* the reader on-demand fallback also
+  writes through the epoch-checked CAS path (the one residual vector; see
+  Negative), not as an unconditional property of `Close` alone.
+- **One owner** for a document's text, parse-readiness, and parse scheduling
+  (global install stays shared).
 
 ### Negative
 
 - **ADR-sized refactor** touching `did_open`, `did_change`, `did_close`, the
   install coordinator, the store, the `IngressOrderGate` middleware (to plumb the
-  writer ticket and tail ticket out to the handlers), and every reader's wait
-  path.
+  ticket and tail ticket to handlers), and every virt/native reader's wait path.
 - **Lifecycle and cancellation must be exact.** Child-task abort on `Close`,
-  completion plumbed back as messages, and mailbox backpressure are all new
-  surface area to get right.
-- **Carefully tuned races must be preserved**, not regressed: the captures
-  lineage close ordering (captures-protocol) — which today rides the `edit_lock`
-  the parse path sheds, so it needs an explicit replacement (a dedicated lock or
-  the watermark contract); the geometry re-merge / no-op suppression on
-  `didChange` (#422); and the diagnostic teardown ordering in `didClose`.
-- **A new read-path coupling** is introduced: readers must wait on the actor's
-  per-URI processed-through watermark instead of `has_tree`. Getting this watermark
-  wrong silently reintroduces the #342/#374 stale-tree race.
-- **Reader on-demand parse fallbacks must stop being unguarded store writers.**
-  `try_parse_and_update_document` and its analogues persist a tree to the store;
-  the current present-and-unchanged guard is check-then-write and the store
-  inserts on vacancy, so a concurrent `didClose` resurrects the document. They
-  must return a private tree, or persist through an atomic non-inserting
-  generation-checked update, or they reopen the resurrection vector the actor
-  otherwise closes.
-- **Injection orchestration must be re-homed** carefully: the heavy external
-  bridge-server spawn is fire-and-forget, but the bridge `didChange` forwarding
-  to already-opened virtual documents is wire-order-sensitive and must stay
-  ordered after the parse it depends on (or remain in the gated handler), not
-  be turned into an unordered fire-and-forget task.
+  completion plumbed back as messages, and the unbounded mailbox are new surface
+  area.
+- **Carefully tuned races must be preserved**: the captures-lineage close
+  ordering (it rides the `edit_lock` the parse path sheds, so it needs the
+  dedicated-lock-or-epoch-check replacement); the geometry re-merge / no-op
+  suppression on `didChange` (push-propagation-diagnostic-forwarding); and the
+  diagnostic teardown ordering in `didClose`.
+- **A new read-path coupling**: virt/native readers wait on the epoch instead of
+  `has_tree`. Getting it wrong silently reintroduces the #342/#374 stale-tree
+  race.
+- **Reader on-demand parse fallbacks must stop being unguarded store writers**
+  (`ensure_parsed_for_node_lookup` and analogues): return a private tree or
+  persist through the epoch-checked CAS write, or the resurrection vector reopens.
+- **Injection orchestration must be re-homed** carefully: injected-language
+  auto-install through the shared deadline-bounded installer, bridge-server spawn
+  fire-and-forget, and bridge `didChange` forwarding kept ordered after the parse.
 
 ### Neutral
 
 - `IngressOrderGate` still issues per-URI tickets, but the writer ticket now
-  completes at **enqueue** rather than after parse (see the watermark section),
-  so its old reader-observes-preceding-writes guarantee is no longer carried by
-  the ticket alone — it is carried by the actor's published watermark. Handlers
-  **enqueue to the mailbox from within the gated critical section**, so mailbox
-  FIFO still equals wire order and `Open`/`SetText`/`Close` reach the actor in
-  the order #374 established. Non-parse side effects that must stay wire-ordered
-  (diagnostic scheduling, the bridge `didChange` forwarding in
-  `process_injections`) either remain in the gated handler or are sequenced by
-  the actor *after* the parse they depend on; this re-homing is the
-  highest-risk part of the change.
-- Readers keep their existing bounded-wait + fallback contract, but the signal
-  they wait on changes from `has_tree` to the per-URI processed-through
-  watermark. That is the one read-path change the design requires; without it
-  the new writer-ticket timing would let a reader observe a stale tree.
+  completes at **enqueue** rather than after parse; its old
+  reader-observes-preceding-writes guarantee is carried by the published epoch
+  instead. Handlers **enqueue from within the gated critical section**, so mailbox
+  FIFO still equals wire order.
+- Host-tier work is out of scope here — it neither needs the tree nor waits on the
+  parse; see capability-tier-parse-decoupling.
 
 ## Decision–Implementation Gap
 
 Not yet implemented. This ADR records the target design; it runs ahead of the
-code. As of writing, `did_open_impl` still awaits auto-install inline, still
-carries the `skip_parse` flag, `did_change_impl` still serializes via
-`edit_lock`, and `reload_language_after_install` still re-enters the parse path
-on install completion, and readers still wait on `has_tree` (there is no
-processed-through watermark, and no install-pending signal in the store). The
-`IngressOrderGate` ticket is still middleware-private — no handler receives it —
-so the watermark plumbing does not exist yet either. Injected-language
-auto-install is also still awaited inline in the gated handlers (via
-`process_injections`), reader fallbacks still write the store
-(`try_parse_and_update_document`), and compilation still runs in non-cancellable
-`spawn_blocking`. The actor, its state machine, the child-task model, the reader
-watermark and its ingress plumbing, the injected-install re-homing, the
-private/guarded reader fallback, and the killable-subprocess install deadline are
-all unbuilt. A staged rollout may land Option 1 (minimal spawn) first as an
-interim liveness fix before the full actor.
+code. As of writing, `did_open_impl` still awaits auto-install inline and carries
+`skip_parse`, `did_change_impl` still serializes via `edit_lock`,
+`reload_language_after_install` still re-enters the parse path, and readers still
+wait on `has_tree` (no epoch watermark, no install-pending signal). The store
+still keeps `open_generations` and `ParseState.generation` as separate counters,
+and `update_document` still inserts on vacancy. The `IngressOrderGate` ticket is
+still middleware-private. Injected-language auto-install is still awaited inline,
+reader fallbacks still write the store, and compilation still runs in
+non-cancellable `spawn_blocking`. The actor, the unified epoch, the CAS writes,
+the child-task model, the ingress plumbing, the injected-install re-homing, and
+the killable-subprocess install deadline are all unbuilt. A staged rollout may
+land Option 1 (minimal spawn) and capability-tier-parse-decoupling first as
+interim steps before the full actor.

--- a/docs/architecture-decisions/per-document-parse-actor.md
+++ b/docs/architecture-decisions/per-document-parse-actor.md
@@ -93,16 +93,20 @@ compilation.
 The mailbox is **unbounded**, which is what makes the sends non-blocking. The
 queue itself is *not* inherently bounded by document size — under sustained input
 it holds one message per un-drained `SetText`, and a full-document sync (an empty
-edit list) carries the entire text, not a small delta. What keeps memory in check
-is the actor's per-message cost: applying a delta to the owned text is a cheap
-string op (parse and install are offloaded), so the actor drains far faster than
-an editor produces edits, and the backlog stays transient. The actor further
-**drains all currently-ready `SetText`s and applies them before scheduling a
-single parse**, collapsing a burst into one parse rather than one per message. A
-bounded mailbox would instead push backpressure onto the ingress thread,
-re-creating the stall the design removes; it is therefore rejected, with the
-caveat that a pathological producer is handled by a hard queued-bytes ceiling
-that drops to a full-text resynchronization rather than growing without limit.
+edit list) carries the entire text, not a small delta. Deltas are **never dropped** — dropping one corrupts the text, and standard LSP
+incremental sync offers no server-initiated full-text resynchronization to
+recover from a drop — so coalescing-by-discarding is not an option and the
+mailbox cannot be capped by shedding messages. What keeps memory in check is the
+actor's per-message cost: applying a delta to the owned text is a cheap string op
+(parse and install are offloaded off the loop), so the actor drains the mailbox
+far faster than an editor produces edits, and the backlog stays transient even
+while a parse or an unbounded install is outstanding. The actor further **drains
+all currently-ready `SetText`s and applies them before scheduling a single
+parse**, collapsing a burst into one parse rather than one per message. The
+deliberate tradeoff: the only lever that could hard-cap the queue is transport
+backpressure, which would push the stall back onto the ingress thread and
+re-create exactly what this design removes — so unboundedness is accepted, relied
+on staying transient by the drain-rate argument, not by a drop policy.
 
 ### Install is shared and global; only the parse is the actor's child
 
@@ -122,8 +126,10 @@ So the two operations are separated deliberately:
 - **Global install** — shared, deduplicated, deadline-bounded (see below), owned
   by a process-wide installer. An actor in `Installing` *subscribes* to its
   completion; it does not own or abort it.
-- **Per-document parse** — owned by the actor, the **only** step that writes the
-  document's tree into the store, and the only child aborted on `Close`.
+- **Per-document parse** — owned by the actor, the **authoritative** writer of
+  the document's tree into the store (the reader on-demand fallback is the one
+  other writer, which must be made private or atomically guarded — see "Reads
+  bypass the mailbox"), and the only child aborted on `Close`.
 
 This split is what lets both the liveness fix and the resurrection guarantee
 hold: aborting the per-document parse on `Close` never kills an install a
@@ -202,13 +208,17 @@ One wrinkle: the actor is **not** the only writer of the store's tree today.
 Reader handlers carry an on-demand parsing fallback for the race where a request
 arrives before parsing finishes — `try_parse_and_update_document`
 (`semantic_tokens.rs`), and the analogous paths in `selection_range.rs` and the
-node-lookup `entry.rs` — which parse and then *update the store*. With the actor
-owning parsing, these fallbacks should either return a **private** tree without
-writing the store, or write only through a lifetime/generation check (they
-already guard on "document still present and text unchanged"). This matters for
-the resurrection guarantee below: an unguarded reader-fallback write is the one
-remaining way a closed document could be re-inserted, so it must be closed, not
-just the install/parse child path. Optionally, the actor publishes an
+node-lookup `entry.rs` — which parse and then *update the store*. The existing
+"document still present and text unchanged" guard is **not** sufficient on its
+own: it is check-then-write, so a `didClose` can land between the check and the
+write, and the store's `update_document` *inserts on vacancy* — re-creating the
+closed document. With the actor owning parsing, the robust fix is to make these
+fallbacks return a **private** tree without writing the store at all, or to route
+their persistence through an **atomic, non-inserting, generation-checked** store
+update (one that no-ops when the document is gone or its generation moved). This
+matters for the resurrection guarantee below: the reader-fallback write is the
+one remaining way a closed document could be re-inserted, so it must be closed at
+the write itself, not by a check that a concurrent close can slip past. Optionally, the actor publishes an
 *install-pending* signal into the store (the store carries no such field today —
 only `has_tree`/`in_progress`); a reader seeing it returns empty immediately
 without waiting, since the parse cannot complete until an unbounded install
@@ -241,12 +251,16 @@ check is therefore insufficient.
 The replacement: the actor publishes a per-URI **monotonic processed-through
 watermark** keyed to the ingress writer sequence. Each mutation handler stamps
 its enqueued message with the writer ticket **plumbed to it from the gate**; when
-the actor finishes applying-and-parsing the state through ticket *N* (and has
-written the resulting tree into the store), it advances the published watermark
-to *N*. A reader waits — bounded by the existing 200ms — until the watermark
-reaches the tail ticket that preceded it, instead of waiting on `has_tree`. If an
-install is pending the watermark cannot advance, so the reader simply times out
-into the empty fallback, which is the intended install-pending behaviour. This
+the state through ticket *N* reaches a **terminal outcome** — `Parsed` (tree
+written), `NoTree` (parsed to nothing), or `InstallFailed` — the actor advances
+the published watermark to *N*. The watermark must advance on *resolution*, not
+only on a successful tree write, or a parse/install failure would never advance
+it and readers would always burn the full timeout. A reader waits — bounded by
+the existing 200ms — until the watermark reaches the tail ticket that preceded
+it, then reads whatever the store holds (a tree, or empty), instead of waiting on
+`has_tree`. While an install is genuinely still pending the watermark has not yet
+resolved, so the reader times out into the empty fallback, which is the intended
+install-pending behaviour. This
 preserves the #374 reader-observes-preceding-writes guarantee without re-coupling
 the handler to parse latency or to the unbounded install.
 
@@ -405,9 +419,11 @@ write-only-mailbox / shared-store-read split is load-bearing.
   wrong silently reintroduces the #342/#374 stale-tree race.
 - **Reader on-demand parse fallbacks must stop being unguarded store writers.**
   `try_parse_and_update_document` and its analogues persist a tree to the store;
-  with the actor owning parsing they must return a private tree or write only
-  behind the lifetime/text-unchanged guard, or they reopen the resurrection
-  vector the actor otherwise closes.
+  the current present-and-unchanged guard is check-then-write and the store
+  inserts on vacancy, so a concurrent `didClose` resurrects the document. They
+  must return a private tree, or persist through an atomic non-inserting
+  generation-checked update, or they reopen the resurrection vector the actor
+  otherwise closes.
 - **Injection orchestration must be re-homed** carefully: the heavy external
   bridge-server spawn is fire-and-forget, but the bridge `didChange` forwarding
   to already-opened virtual documents is wire-order-sensitive and must stay

--- a/docs/architecture-decisions/per-document-parse-actor.md
+++ b/docs/architecture-decisions/per-document-parse-actor.md
@@ -1,0 +1,305 @@
+# Per-Document Parse Actor
+
+## Context
+
+The document-mutation path (`didOpen`, `didChange`, `didClose`) currently
+spreads a single document's parse lifecycle across several handlers, a per-URI
+lock, and an install coordinator that re-enters the parse path on completion.
+Three forces collide here.
+
+**Ingress ordering (#342, #374).** `IngressOrderGate`
+(`src/lsp/ingress_order.rs`) assigns per-URI sequence tickets at `call` time so
+that writers (`didOpen`/`didChange`/`didClose`) apply in strict wire order and
+readers observe every edit that preceded them. `didOpen` was gated in #374 to
+close the open→edit and close→reopen first-poll races. The gate holds a
+document's writer ticket for the **whole handler future**.
+
+**The slow, unbounded tail (#480).** Most of `did_open_impl`
+(`src/lsp/lsp_impl/text_document/did_open.rs`) is fast or fire-and-forget, but
+one branch is not: when the main language's parser is missing and auto-install
+is enabled, the handler `await`s `maybe_auto_install_language` → `try_install`
+**inside the writer-ticketed critical section**. Auto-install's network/git
+stages are timeout-bounded, but parser *compilation* (`compile_parser` →
+`tree-sitter-loader` `compile_parser_at_path`, `src/install/parser.rs`) shells
+out to a C compiler with **no timeout**. A pathologically hung compiler holds
+the `didOpen` writer ticket indefinitely, wedging every later same-URI reader
+and writer. This is a *liveness* problem, not merely latency.
+
+**Scattered parse lifecycle.** The current shape couples several concerns that
+are hard to reason about independently:
+
+- `did_open_impl` carries a `skip_parse` flag: when main-language auto-install
+  fires, the handler skips `parse_document` because
+  `reload_language_after_install` (`src/lsp/lsp_impl/coordinator/install.rs`)
+  re-parses *after* the parser file is written. The install path therefore
+  re-enters parsing from a different call site.
+- `did_change_impl` serializes the non-atomic read-old-text → reparse → persist
+  cycle with a per-URI `edit_lock` (`src/document/store.rs`), acquired as the
+  handler's first `.await`. This is a practical mitigation layered on top of the
+  ingress gate, not a structural guarantee.
+- `reload_language_after_install` re-inserts and re-parses a document after a
+  network/compile delay. If the document was closed in the meantime, that
+  late re-parse can resurrect a closed document. #480 proposes to "reuse the
+  existing eager-open supersede machinery" to cancel it — i.e. bolt a second
+  lifecycle mechanism onto the parse path.
+- Readers already tolerate insert-without-tree: they snapshot the shared
+  `DocumentStore` and call `wait_for_parse_completion(200ms)` (a *bounded* wait
+  with a fallback) before computing — see `semantic_tokens.rs`,
+  `whole_document.rs`, `range_formatting.rs`.
+
+The common root is that a document's text, parser readiness, and parse
+scheduling have **no single owner**. Each handler mutates pieces of that state
+under a shared lock, and the unbounded install runs on the latency-critical
+ingress thread.
+
+## Decision
+
+Introduce a **per-document parse actor**: one actor task per open document that
+exclusively owns that document's text, parser-readiness state, and parse
+scheduling. The actor is the single consumer of a per-document mailbox, so
+mutations to one document are serialized *by construction* rather than by a
+shared lock.
+
+### Writes are messages; the loop never blocks on the slow op
+
+`didOpen`, `didChange`, and `didClose` become non-blocking sends to the actor's
+mailbox and return immediately:
+
+- `didOpen` → `Open { text, language }`
+- `didChange` → `SetText { content_changes }` (LSP deltas, applied in order)
+- `didClose` → `Close`
+
+The actor's run loop `select!`s over the mailbox **and** the completion signals
+for the install it is waiting on and the parse it owns. It **never `.await`s a
+long operation inline**:
+
+```text
+loop {
+  select! {
+    msg       = mailbox.recv()      => handle(msg),       // Open / SetText / Close
+    installed = install_done.recv() => on_installed(),    // shared install completed
+    parsed    = parse_done.recv()   => on_parsed(),       // this doc's parse completed
+  }
+}
+```
+
+Both the install and the parse run **off** the actor loop, their completion
+arriving as just another message. Because the loop stays responsive to the
+mailbox while either runs, a `Close` (and a queued `SetText`) is processed
+*during* an in-flight install — even an unbounded, hung-compiler install. This
+is the liveness fix: no ingress ticket and no mailbox is ever held hostage by
+compilation.
+
+### Install is shared and global; only the parse is the actor's child
+
+Install is **not** a per-document operation the actor owns. `try_install`
+dedupes per language ("if not already being installed"), and
+`reload_language_after_install` mutates **global** state — it pushes the data
+dir into `search_paths`, re-applies settings, and calls `ensure_language_loaded`
+on the shared registry — *before* the per-document `parse_document`. Two
+documents of the same uninstalled language opening together share one install.
+
+So the two operations are separated deliberately:
+
+- **Global install** — shared, deduplicated, deadline-bounded (see below), owned
+  by a process-wide installer. An actor in `Installing` *subscribes* to its
+  completion; it does not own or abort it.
+- **Per-document parse** — owned by the actor, the **only** step that writes the
+  document's tree into the store, and the only child aborted on `Close`.
+
+This split is what lets both the liveness fix and the resurrection guarantee
+hold: aborting the per-document parse on `Close` never kills an install a
+*sibling* actor still needs, and a global install completing after a `Close` is
+harmless because the store-writing parse — the abortable per-actor child — is
+already gone.
+
+### State machine folds `skip_parse`
+
+The actor holds an explicit state, which subsumes the `skip_parse` flag and the
+install path's re-entry:
+
+- `Uninstalled` → parser missing; the actor has subscribed to a shared install.
+- `Installing` → same; `SetText` only applies the delta to the owned text (no
+  parse).
+- `Ready` → parser available; `SetText` schedules a parse.
+
+On install completion the actor transitions `Installing → Ready` and parses the
+**latest** text (not the open-time text). There is no separate
+`reload_language_after_install` re-entry: re-parse is simply the actor's normal
+`Ready` behaviour applied to current state.
+
+### The actor owns the text; only the *parse* coalesces
+
+LSP incremental `didChange` sends **deltas** (ranges + replacement), not full
+text. `did_change_impl` reads `old_text` from the store and calls
+`apply_content_changes_with_edits(&old_text, content_changes)` to derive both
+the new text and the tree-sitter `InputEdits`. Deltas therefore **cannot be
+coalesced by keeping only the latest** — dropping an intermediate delta
+corrupts the text.
+
+So the split is: the actor **applies every delta in order to the text it owns**
+(a cheap string op, never dropped); only the **parse** coalesces. It keeps a
+`latest_text` cell, a `dirty` flag, and the accumulated `InputEdits` since the
+last completed parse:
+
+```text
+on SetText(delta):  latest = apply(latest, delta); pending_edits += delta.edits;
+                    if parsing { dirty = true } else { start_parse(latest, take(pending_edits)) }
+on parse_done:      if dirty { dirty = false; start_parse(latest, take(pending_edits)) }
+```
+
+If several `SetText`s land while a parse runs, every delta is applied to `latest`
+in order, and the next parse runs once over the accumulated state — stale texts
+never accumulate in the mailbox. A parse is incremental when a base tree exists,
+feeding tree-sitter the **accumulated** `InputEdits` since the last parse; with
+no base tree (e.g. just after install) it degrades cleanly to a full parse.
+Incrementality is a performance optimization, never a correctness requirement.
+
+This is what actually removes the `edit_lock`. The lock exists today because the
+read-old-text → resolve-deltas → persist cycle runs in concurrently-dispatched
+handlers against a shared store snapshot. Moving delta application *into* the
+single-consumer actor — the actor, not the handler, owns and mutates the text —
+is what makes that cycle non-interleavable. (A design where the handler resolved
+deltas to text from a store snapshot *before* sending would still race the
+snapshot and still need the lock.)
+
+### Reads bypass the mailbox
+
+Read requests do **not** query the actor's mailbox. The actor *publishes* parse
+results into the shared `DocumentStore`; readers snapshot the store directly,
+exactly as today, using the existing `wait_for_parse_completion(200ms)` bounded
+wait plus an empty/`null` fallback. Optionally, the actor publishes an
+*install-pending* signal into the store (the store carries no such field today —
+only `has_tree`/`in_progress`); a reader seeing it returns empty immediately
+without waiting, since the parse cannot complete until an unbounded install
+does. The existing `semantic_tokens_refresh` event — already emitted on language
+load/reload — then prompts capable clients to re-request once the actor reaches
+`Ready`. This saves only the 200ms bounded wait, so it is optional scope; the
+load-bearing property is simply that the mailbox stays write-only, which keeps
+the blocking problem from migrating to the read path.
+
+### Lifetime equals document lifetime
+
+The actor's lifetime is exactly the open document's lifetime. `Close` aborts the
+in-flight **parse** (the store-writing child), unsubscribes from the shared
+install, and terminates the actor; the store entry is removed. The shared
+install itself is *not* aborted — a sibling may still need it. Because the only
+step that writes this document's tree into the store is the aborted per-actor
+parse, a late install completing afterward has no actor to hand off to and
+cannot re-insert the closed document — **resurrection is structurally
+impossible**, with no separate supersede machinery. A reopen creates a fresh
+actor.
+
+### Complementary: install-wide deadline
+
+Moving install off the ingress path stops it from wedging requests, but a hung
+compiler should still not leak forever. An install-wide deadline (covering
+`compile_parser`) bounds the shared installer itself, so a stuck compilation
+eventually fails every subscribing actor instead of pinning a task forever. This
+is complementary to the actor, not a substitute for it.
+
+### Injection orchestration stays downstream
+
+`process_injections` (which can spawn external bridge servers) is kicked off as
+a fire-and-forget consequence of a completed main parse, not awaited inside the
+actor loop, so injection work never stalls main-document parsing.
+
+## Considered Options
+
+### 1. Minimal spawn of the slow tail (the literal #480 scope)
+
+Keep the existing handlers and locks; only move auto-install (and optionally
+`process_injections`) into a spawned task, and cancel that task on `didClose` by
+reusing the eager-open supersede machinery.
+
+Rejected as the end state. It fixes the immediate liveness exposure with a small
+diff, but leaves `skip_parse`, the `edit_lock`, and the install re-entry in
+place, and adds a *second* spawn/cancel lifecycle bolted onto the parse path —
+more moving parts guarding the same invariant, not fewer. It remains a
+reasonable interim step if the full actor is staged.
+
+### 2. Install-wide deadline only
+
+Add a timeout around the whole install (including compilation) so the writer
+ticket is released after at most the deadline.
+
+Rejected as insufficient. It bounds the worst case but still holds the ticket
+for the deadline's duration, does nothing for ordinary latency, and leaves the
+scattered lifecycle untouched. Retained as a *complementary* mitigation (see
+Decision), not an alternative.
+
+### 3. Per-document parse actor (chosen)
+
+Serializes by construction, folds `skip_parse` into state, makes resurrection
+impossible, and keeps install/parse off the ingress path — at the cost of an
+ADR-sized refactor.
+
+### 4. Actor answers read requests directly (mailbox-query reads)
+
+Have read handlers send a request message to the actor and await its reply,
+instead of reading a published store snapshot.
+
+Rejected. It reintroduces the blocking it set out to remove: a read would queue
+behind in-flight parses and buffered `SetText`s in the same mailbox. The
+write-only-mailbox / shared-store-read split is load-bearing.
+
+## Consequences
+
+### Positive
+
+- **Liveness.** An unbounded/hung install can no longer wedge same-URI readers
+  or writers; the actor loop stays responsive and `Close` always lands.
+- **Serialization by construction.** A single mailbox consumer removes the parse
+  path's reliance on the per-URI `edit_lock`; the read-old-text → reparse →
+  persist cycle is no longer interleavable.
+- **`skip_parse` disappears**, folded into the `Uninstalled/Installing/Ready`
+  state machine; the install path stops re-entering parsing from a second call
+  site.
+- **Resurrection is structurally impossible** — closing aborts the actor's
+  store-writing parse, so a later shared-install completion has no actor to write
+  through — without adding supersede machinery to the parse path.
+- **One owner** for a document's text, its parse-readiness state, and parse
+  scheduling (global install stays shared), which is easier to reason about than
+  lock-guarded shared state.
+
+### Negative
+
+- **ADR-sized refactor** touching `did_open`, `did_change`, `did_close`, the
+  install coordinator, the store, and every reader's wait path.
+- **Lifecycle and cancellation must be exact.** Child-task abort on `Close`,
+  completion plumbed back as messages, and mailbox backpressure are all new
+  surface area to get right.
+- **Carefully tuned races must be preserved**, not regressed: the captures
+  lineage close ordering (captures-protocol), the geometry re-merge / no-op
+  suppression on `didChange` (#422), and the diagnostic teardown ordering in
+  `didClose`.
+- **Injection orchestration must be re-homed** as a downstream consequence of
+  the main parse rather than an inline handler step.
+
+### Neutral
+
+- `IngressOrderGate`'s writer tickets become partly redundant for the *parse*
+  path (the actor already serializes it), but still govern wire-order for the
+  non-parse side effects that live in the mutation handlers today —
+  diagnostic scheduling, bridge `didChange` forwarding, `process_injections`.
+  The intended relationship (to be confirmed in implementation): handlers
+  **enqueue to the mailbox from within the gated critical section**, so mailbox
+  FIFO equals wire order and `Open`/`SetText`/`Close` reach the actor in the
+  order #374 established. Side effects that must stay wire-ordered either remain
+  in the gated handler (kept as the lightweight, non-blocking part of the
+  handler) or are sequenced by the actor *after* the parse they depend on
+  (e.g. injection orchestration, which needs the fresh tree). Only the
+  parse-state serialization moves into the actor; the gate's per-URI ordering
+  for the rest is retained.
+- Readers keep their existing `wait_for_parse_completion` + fallback contract;
+  the change is *who writes* the tree they read, not how they read it.
+
+## Decision–Implementation Gap
+
+Not yet implemented. This ADR records the target design; it runs ahead of the
+code. As of writing, `did_open_impl` still awaits auto-install inline, still
+carries the `skip_parse` flag, `did_change_impl` still serializes via
+`edit_lock`, and `reload_language_after_install` still re-enters the parse path
+on install completion. The actor, its state machine, the child-task model, and
+the install-wide deadline are all unbuilt. A staged rollout may land Option 1
+(minimal spawn) first as an interim liveness fix before the full actor.

--- a/docs/architecture-decisions/per-document-parse-actor.md
+++ b/docs/architecture-decisions/per-document-parse-actor.md
@@ -185,12 +185,11 @@ Two derived quantities read off this one pair; the unification is of the
   terminal completion, but no bound is claimed on how quickly a *given* ticket is
   covered under sustained editing — continuous edits can keep the watermark behind
   a reader's target ticket indefinitely. The **hard** guarantee is the reader
-  side:
-  the existing 200 ms bound plus the empty fallback caps any wait, so sustained
-  editing degrades a reader to the empty fallback rather than starving it. A
-  virt/native reader
-  waits — bounded by that 200 ms — until the watermark reaches the tail ticket
-  that preceded it, then reads whatever the store holds (a tree, or empty),
+  side: the existing 200 ms bound plus the empty fallback caps any wait, so
+  sustained editing degrades a reader to the empty fallback rather than starving
+  it. A virt/native reader waits — bounded by that 200 ms — until the watermark
+  reaches the tail ticket that preceded it, then reads whatever the store holds
+  (a tree, or empty),
   instead of waiting on `has_tree`. This is required because, with the handler
   returning at *enqueue*, a bare `has_tree` check would be satisfied while the
   store still holds the **old** tree — reintroducing the #342/#374 stale-tree
@@ -323,7 +322,7 @@ afterward has no actor to hand off to, and any straggler write fails its epoch
 check (the incarnation no longer matches), so **the install/parse resurrection
 path is structurally closed** with no separate supersede machinery — *provided*
 every store-writing path, including the reader on-demand fallback, goes through the
-epoch-checked CAS write below; that fallback is the one residual vector, and it is
+epoch-checked CAS write above; that fallback is the one residual vector, and it is
 closed at the write, not by a check a concurrent close can slip past. A reopen
 creates a fresh actor at a fresh incarnation.
 

--- a/docs/architecture-decisions/per-document-parse-actor.md
+++ b/docs/architecture-decisions/per-document-parse-actor.md
@@ -159,9 +159,9 @@ within one open document). The design makes the per-document **epoch** the pair
 
 - the **incarnation** is the retained process-wide open generation
   (`open_counter` / `open_generations`), drawn fresh on every `didOpen`. It is
-  deliberately **not** the ingress ticket: `IngressOrderGate::finish_close`
-  removes a URI's sequencing state on close, so the ticket **restarts at 1 on
-  reopen** and is not monotonic across lifetimes. Were the epoch the ticket
+  deliberately **not** the ingress ticket: `DocumentSequencer::finish_close`
+  (behind `IngressOrderGate`) removes a URI's sequencing state on close, so the
+  ticket **restarts at 1 on reopen** and is not monotonic across lifetimes. Were the epoch the ticket
   alone, a straggler write from a previous lifetime could match the reopened
   document's ticket. The incarnation is the high half precisely to close that
   gap.
@@ -329,9 +329,9 @@ creates a fresh actor at a fresh incarnation.
 
 Teardown must also wake any reader blocked on an epoch that will now never be
 reached: dropping the epoch channel on actor termination signals those waiters to
-proceed (into the empty fallback), mirroring how the gate's `finish_close` drops
-its `done` sender. Without it a reader racing the close would stall to the 200 ms
-timeout — bounded, but needless.
+proceed (into the empty fallback), mirroring how the sequencer's
+`DocumentSequencer::finish_close` drops its `done` sender. Without it a reader
+racing the close would stall to the 200 ms timeout — bounded, but needless.
 
 ### Complementary: a real install deadline via a killable subprocess
 

--- a/docs/architecture-decisions/per-document-parse-actor.md
+++ b/docs/architecture-decisions/per-document-parse-actor.md
@@ -93,10 +93,12 @@ scheduling have **no single owner**.
 
 Introduce a **per-document parse actor**: one actor task per open document that
 exclusively owns that document's text, parser-readiness state, and parse
-scheduling, and a **single per-document epoch** that is the one source of truth
-for ordering, resurrection-safety, and parse-staleness — subsuming
-`open_generations`, `ParseState.generation`, the reader watermark, and the
-`edit_lock`'s resurrection-guard duty.
+scheduling, and a **single per-document epoch** — the ingress writer ticket made
+authoritative — that is the one source of truth for ordering, resurrection-safety,
+and parse-staleness. It absorbs the three other per-document version-sequences
+(`open_generations`, `ParseState.generation`, and the otherwise-new reader
+watermark), and its per-write check additionally takes over the `edit_lock`'s
+resurrection-guard duty.
 
 ### Writes are messages; the loop never blocks on the slow op
 
@@ -148,9 +150,9 @@ policy.
 ### One epoch for ordering, resurrection, and staleness
 
 A single monotonic per-document **epoch** — the ingress writer-ticket sequence,
-made authoritative — replaces the four ad-hoc sequences. The unification is of
-the *source*, not of a single scalar: two derived quantities read off the same
-ticket sequence. The actor publishes a **processed-through watermark** (the
+made authoritative — becomes the one version-sequence the other three collapse
+into. The unification is of the *source*, not of a single scalar: two derived
+quantities read off the same ticket sequence. The actor publishes a **processed-through watermark** (the
 highest ticket whose state has fully resolved) that readers wait on, and stamps
 each store write with the **epoch at which it was scheduled** that the CAS write
 compares before committing. Everything keys on that one sequence:
@@ -399,9 +401,10 @@ write-only-mailbox / shared-store-read split is load-bearing.
   accumulated text, saving the measured per-edit reparse cost on injection-heavy
   documents.
 - **One epoch, not four.** Wire-order readiness, resurrection-safety, and
-  parse-staleness key on a single per-document counter, subsuming
-  `open_generations`, `ParseState.generation`, the reader watermark, and the
-  `edit_lock`'s resurrection-guard duty.
+  parse-staleness key on a single per-document counter — the ingress ticket made
+  authoritative — into which the other three version-sequences
+  (`open_generations`, `ParseState.generation`, the reader watermark) collapse,
+  and which additionally takes over the `edit_lock`'s resurrection-guard duty.
 - **`skip_parse` disappears**, folded into the `Uninstalled/Installing/Ready`
   state machine; the install path stops re-entering parsing from a second call
   site.

--- a/docs/architecture-decisions/per-document-parse-actor.md
+++ b/docs/architecture-decisions/per-document-parse-actor.md
@@ -92,8 +92,11 @@ compilation.
 
 The mailbox is **unbounded**, which is what makes the sends non-blocking. The
 queue itself is *not* inherently bounded by document size — under sustained input
-it holds one message per un-drained `SetText`, and a full-document sync (an empty
-edit list) carries the entire text, not a small delta. Deltas are **never dropped** — dropping one corrupts the text, and standard LSP
+it holds one message per un-drained `SetText`, and a full-document sync — a
+rangeless content change, which yields an empty derived `InputEdit` list — carries
+the entire text, not a small delta.
+
+Deltas are **never dropped** — dropping one corrupts the text, and standard LSP
 incremental sync offers no server-initiated full-text resynchronization to
 recover from a drop — so coalescing-by-discarding is not an option and the
 mailbox cannot be capped by shedding messages. What keeps memory in check is the
@@ -150,7 +153,7 @@ install path's re-entry:
 On install completion the actor transitions `Installing → Ready` and parses the
 **latest** text (not the open-time text). There is no separate
 `reload_language_after_install` re-entry: re-parse is simply the actor's normal
-`Ready` behaviour applied to current state.
+`Ready` behavior applied to current state.
 
 ### The actor owns the text; only the *parse* coalesces
 
@@ -218,7 +221,9 @@ their persistence through an **atomic, non-inserting, generation-checked** store
 update (one that no-ops when the document is gone or its generation moved). This
 matters for the resurrection guarantee below: the reader-fallback write is the
 one remaining way a closed document could be re-inserted, so it must be closed at
-the write itself, not by a check that a concurrent close can slip past. Optionally, the actor publishes an
+the write itself, not by a check that a concurrent close can slip past.
+
+Optionally, the actor publishes an
 *install-pending* signal into the store (the store carries no such field today —
 only `has_tree`/`in_progress`); a reader seeing it returns empty immediately
 without waiting, since the parse cannot complete until an unbounded install
@@ -258,9 +263,9 @@ only on a successful tree write, or a parse/install failure would never advance
 it and readers would always burn the full timeout. A reader waits — bounded by
 the existing 200ms — until the watermark reaches the tail ticket that preceded
 it, then reads whatever the store holds (a tree, or empty), instead of waiting on
-`has_tree`. While an install is genuinely still pending the watermark has not yet
+`has_tree`. While an install is genuinely still pending, the watermark has not yet
 resolved, so the reader times out into the empty fallback, which is the intended
-install-pending behaviour. This
+install-pending behavior. This
 preserves the #374 reader-observes-preceding-writes guarantee without re-coupling
 the handler to parse latency or to the unbounded install.
 
@@ -333,7 +338,8 @@ writer ticket. So re-homing `process_injections` has three distinct parts:
 - **External bridge-server spawn** — genuinely fire-and-forget.
 - **`didChange` forwarding to already-opened virtual documents** — wire-order
   sensitive; sequenced **after** the parse it depends on (it needs the fresh
-  tree) and in writer order, so it is ordered, not loosed.
+  tree) and in writer order — i.e. it must stay ordered, not be turned into an
+  unordered fire-and-forget task.
 
 All three splits must be preserved when re-homing this step.
 
@@ -431,7 +437,7 @@ write-only-mailbox / shared-store-read split is load-bearing.
   bridge-server spawn is fire-and-forget, but the bridge `didChange` forwarding
   to already-opened virtual documents is wire-order-sensitive and must stay
   ordered after the parse it depends on (or remain in the gated handler), not
-  be loosed as unordered fire-and-forget.
+  be turned into an unordered fire-and-forget task.
 
 ### Neutral
 

--- a/docs/architecture-decisions/per-document-parse-actor.md
+++ b/docs/architecture-decisions/per-document-parse-actor.md
@@ -1,7 +1,7 @@
 # Per-Document Parse Actor
 
 **Related Decisions**:
-[capability-tier-parse-decoupling](capability-tier-parse-decoupling.md),
+[parse-decoupled-document-lifecycle](parse-decoupled-document-lifecycle.md),
 [replace-tree-sitter-cli-with-loader](replace-tree-sitter-cli-with-loader.md),
 [push-propagation-diagnostic-forwarding](push-propagation-diagnostic-forwarding.md),
 [lazy-node-identity-tracking](lazy-node-identity-tracking.md)
@@ -12,7 +12,7 @@ This decision covers the **virt and native tiers** — the work that
 intrinsically needs kakehashi's tree-sitter parse (region location for injected
 languages, and the tree-derived `semanticTokens` / `selectionRange` /
 `kakehashi/node` / `kakehashi/captures` features). The host tier needs no tree
-and is decoupled separately; see capability-tier-parse-decoupling. With the host
+and is decoupled separately; see parse-decoupled-document-lifecycle. With the host
 tier hoisted ahead of the parse, what remains is to get the parse itself off the
 latency-critical ingress path and give a document's parse lifecycle a single
 owner.
@@ -52,7 +52,7 @@ therefore costs real time per edit. Coalescing a burst into a single parse over
 the accumulated text is a genuine optimization, not a speculative one.
 
 **Change-path host immediacy requires the parse to be off-ingress.** Per
-capability-tier-parse-decoupling, host-tier forwards must be immediate on the
+parse-decoupled-document-lifecycle, host-tier forwards must be immediate on the
 *change* path too. If the parse runs inline in the change handler — holding the
 writer ticket for the tens-to-hundreds of milliseconds above — the next
 `didChange`, and any host forward sequenced behind it, waits on the parse. The
@@ -482,7 +482,7 @@ write-only-mailbox / shared-store-read split is load-bearing.
   instead. Handlers **enqueue from within the gated critical section**, so mailbox
   FIFO still equals wire order.
 - Host-tier work is out of scope here — it neither needs the tree nor waits on the
-  parse; see capability-tier-parse-decoupling.
+  parse; see parse-decoupled-document-lifecycle.
 
 ## Decision–Implementation Gap
 
@@ -498,5 +498,5 @@ reader fallbacks still write the store, and compilation still runs in
 non-cancellable `spawn_blocking`. The actor, the unified epoch, the CAS writes,
 the child-task model, the ingress plumbing, the injected-install re-homing, and
 the killable-subprocess install deadline are all unbuilt. A staged rollout may
-land Option 1 (minimal spawn) and capability-tier-parse-decoupling first as
+land Option 1 (minimal spawn) and parse-decoupled-document-lifecycle first as
 interim steps before the full actor.

--- a/docs/architecture-decisions/per-document-parse-actor.md
+++ b/docs/architecture-decisions/per-document-parse-actor.md
@@ -91,13 +91,18 @@ is the liveness fix: no ingress ticket and no mailbox is ever held hostage by
 compilation.
 
 The mailbox is **unbounded**, which is what makes the sends non-blocking. The
-risk that normally argues against unbounded channels — memory growth under fast
-input — does not apply here: `SetText` carries only a small delta, the actor
-applies it to the owned text and drops it, and parse coalescing keeps at most one
-parse in flight regardless of how many `SetText`s queue. So the queued state is
-bounded by the document size, not by edit history. A bounded mailbox would
-instead push backpressure onto the ingress thread, re-creating the stall the
-design removes; it is therefore rejected.
+queue itself is *not* inherently bounded by document size — under sustained input
+it holds one message per un-drained `SetText`, and a full-document sync (an empty
+edit list) carries the entire text, not a small delta. What keeps memory in check
+is the actor's per-message cost: applying a delta to the owned text is a cheap
+string op (parse and install are offloaded), so the actor drains far faster than
+an editor produces edits, and the backlog stays transient. The actor further
+**drains all currently-ready `SetText`s and applies them before scheduling a
+single parse**, collapsing a burst into one parse rather than one per message. A
+bounded mailbox would instead push backpressure onto the ingress thread,
+re-creating the stall the design removes; it is therefore rejected, with the
+caveat that a pathological producer is handled by a hard queued-bytes ceiling
+that drops to a full-text resynchronization rather than growing without limit.
 
 ### Install is shared and global; only the parse is the actor's child
 
@@ -191,7 +196,19 @@ the Negative consequences.
 Read requests do **not** query the actor's mailbox. The actor *publishes* parse
 results into the shared `DocumentStore`; readers snapshot the store directly,
 exactly as today, using the existing `wait_for_parse_completion(200ms)` bounded
-wait plus an empty/`null` fallback. Optionally, the actor publishes an
+wait plus an empty/`null` fallback.
+
+One wrinkle: the actor is **not** the only writer of the store's tree today.
+Reader handlers carry an on-demand parsing fallback for the race where a request
+arrives before parsing finishes — `try_parse_and_update_document`
+(`semantic_tokens.rs`), and the analogous paths in `selection_range.rs` and the
+node-lookup `entry.rs` — which parse and then *update the store*. With the actor
+owning parsing, these fallbacks should either return a **private** tree without
+writing the store, or write only through a lifetime/generation check (they
+already guard on "document still present and text unchanged"). This matters for
+the resurrection guarantee below: an unguarded reader-fallback write is the one
+remaining way a closed document could be re-inserted, so it must be closed, not
+just the install/parse child path. Optionally, the actor publishes an
 *install-pending* signal into the store (the store carries no such field today —
 only `has_tree`/`in_progress`); a reader seeing it returns empty immediately
 without waiting, since the parse cannot complete until an unbounded install
@@ -251,12 +268,14 @@ replacement, so they are removed rather than left as dead synchronization.
 The actor's lifetime is exactly the open document's lifetime. `Close` aborts the
 in-flight **parse** (the store-writing child), unsubscribes from the shared
 install, and terminates the actor; the store entry is removed. The shared
-install itself is *not* aborted — a sibling may still need it. Because the only
-step that writes this document's tree into the store is the aborted per-actor
-parse, a late install completing afterward has no actor to hand off to and
-cannot re-insert the closed document — **resurrection is structurally
-impossible**, with no separate supersede machinery. A reopen creates a fresh
-actor.
+install itself is *not* aborted — a sibling may still need it. A late install
+completing afterward has no actor to hand off to, so the abortable per-actor
+parse can no longer re-insert the closed document — **the install/parse
+resurrection path is structurally closed**, with no separate supersede machinery.
+This holds *provided* the reader-fallback store write noted above is also
+lifetime-guarded; that on-demand path is the only other writer that could
+resurrect a closed document, and it must keep its "document still present"
+guard (or stop writing the store entirely). A reopen creates a fresh actor.
 
 Teardown must also wake any reader blocked on a watermark ticket that will now
 never be processed: dropping the watermark channel on actor termination signals
@@ -268,21 +287,39 @@ timeout — bounded, but needless.
 ### Complementary: install-wide deadline
 
 Moving install off the ingress path stops it from wedging requests, but a hung
-compiler should still not leak forever. An install-wide deadline (covering
-`compile_parser`) bounds the shared installer itself, so a stuck compilation
-eventually fails every subscribing actor instead of pinning a task forever. This
-is complementary to the actor, not a substitute for it.
+compiler should still not leak forever. A deadline here is **not** achievable by
+wrapping the current future in `tokio::time::timeout`: installation runs in
+`spawn_blocking` (`install_language_async`, `src/install.rs`), and compilation
+calls `Loader::compile_parser_at_path` (`src/install/parser.rs`), which shells
+out to `cc` *without surfacing the child process* to the caller. A timeout would
+let the `await` return while the blocking thread and its `cc` child keep running
+— the leak the deadline was meant to prevent. A real deadline therefore requires
+running compilation as a **controllable subprocess/process group** that the
+installer can kill (and reap) when the deadline fires, publishing failure only
+after termination. This is complementary to the actor, not a substitute for it.
 
 ### Injection orchestration stays downstream
 
 `process_injections` runs as a consequence of a completed main parse, not inside
 the actor loop, so injection work never stalls main-document parsing. It is not
-uniformly fire-and-forget, though: spawning external bridge servers is genuinely
-fire-and-forget, but the `didChange` forwarding to already-opened virtual
-documents is wire-order-sensitive and must be sequenced **after** the parse it
-depends on (it needs the fresh tree) and in writer order — so it is ordered, not
-loosed. The split between the fire-and-forget spawn and the ordered forwarding
-must be preserved when re-homing this step.
+uniformly fire-and-forget, though, and it hides a **second instance of the very
+liveness hazard this ADR exists to fix**: `process_injections` is awaited inside
+the gated `didOpen`/`didChange` handlers (`did_open.rs`, `did_change.rs`), and it
+in turn awaits `check_injected_languages_auto_install` →
+`maybe_auto_install_language(is_injection=true)` (`injection.rs`) — the same
+untimed C compiler, now for an *injected* language's parser, still inside the
+writer ticket. So re-homing `process_injections` has three distinct parts:
+
+- **Injected-language auto-install** — must route through the *same* shared,
+  deadline-bounded installer as the main language and be subscribed to, never
+  awaited in a gated handler or the actor loop. This is a liveness requirement,
+  not just tidiness.
+- **External bridge-server spawn** — genuinely fire-and-forget.
+- **`didChange` forwarding to already-opened virtual documents** — wire-order
+  sensitive; sequenced **after** the parse it depends on (it needs the fresh
+  tree) and in writer order, so it is ordered, not loosed.
+
+All three splits must be preserved when re-homing this step.
 
 ## Considered Options
 
@@ -305,8 +342,11 @@ ticket is released after at most the deadline.
 
 Rejected as insufficient. It bounds the worst case but still holds the ticket
 for the deadline's duration, does nothing for ordinary latency, and leaves the
-scattered lifecycle untouched. Retained as a *complementary* mitigation (see
-Decision), not an alternative.
+scattered lifecycle untouched. It is also harder than it looks — compilation runs
+in non-cancellable `spawn_blocking` with no exposed child process, so a real
+deadline needs a killable subprocess (see the install-wide deadline subsection),
+not a `timeout` wrapper. Retained as a *complementary* mitigation (see Decision),
+not an alternative.
 
 ### 3. Per-document parse actor (chosen)
 
@@ -337,9 +377,11 @@ write-only-mailbox / shared-store-read split is load-bearing.
 - **`skip_parse` disappears**, folded into the `Uninstalled/Installing/Ready`
   state machine; the install path stops re-entering parsing from a second call
   site.
-- **Resurrection is structurally impossible** — closing aborts the actor's
-  store-writing parse, so a later shared-install completion has no actor to write
-  through — without adding supersede machinery to the parse path.
+- **The install/parse resurrection path is structurally closed** — closing
+  aborts the actor's store-writing parse, so a later shared-install completion
+  has no actor to write through — without adding supersede machinery to the parse
+  path. (The reader-fallback store write is the one residual resurrection vector;
+  it must stay lifetime-guarded — see Negative.)
 - **One owner** for a document's text, its parse-readiness state, and parse
   scheduling (global install stays shared), which is easier to reason about than
   lock-guarded shared state.
@@ -361,6 +403,11 @@ write-only-mailbox / shared-store-read split is load-bearing.
 - **A new read-path coupling** is introduced: readers must wait on the actor's
   per-URI processed-through watermark instead of `has_tree`. Getting this watermark
   wrong silently reintroduces the #342/#374 stale-tree race.
+- **Reader on-demand parse fallbacks must stop being unguarded store writers.**
+  `try_parse_and_update_document` and its analogues persist a tree to the store;
+  with the actor owning parsing they must return a private tree or write only
+  behind the lifetime/text-unchanged guard, or they reopen the resurrection
+  vector the actor otherwise closes.
 - **Injection orchestration must be re-homed** carefully: the heavy external
   bridge-server spawn is fire-and-forget, but the bridge `didChange` forwarding
   to already-opened virtual documents is wire-order-sensitive and must stay
@@ -394,7 +441,12 @@ carries the `skip_parse` flag, `did_change_impl` still serializes via
 on install completion, and readers still wait on `has_tree` (there is no
 processed-through watermark, and no install-pending signal in the store). The
 `IngressOrderGate` ticket is still middleware-private — no handler receives it —
-so the watermark plumbing does not exist yet either. The actor, its state
-machine, the child-task model, the reader watermark and its ingress plumbing, and
-the install-wide deadline are all unbuilt. A staged rollout may land Option 1
-(minimal spawn) first as an interim liveness fix before the full actor.
+so the watermark plumbing does not exist yet either. Injected-language
+auto-install is also still awaited inline in the gated handlers (via
+`process_injections`), reader fallbacks still write the store
+(`try_parse_and_update_document`), and compilation still runs in non-cancellable
+`spawn_blocking`. The actor, its state machine, the child-task model, the reader
+watermark and its ingress plumbing, the injected-install re-homing, the
+private/guarded reader fallback, and the killable-subprocess install deadline are
+all unbuilt. A staged rollout may land Option 1 (minimal spawn) first as an
+interim liveness fix before the full actor.

--- a/docs/architecture-decisions/per-document-parse-actor.md
+++ b/docs/architecture-decisions/per-document-parse-actor.md
@@ -286,10 +286,12 @@ install itself is *not* aborted — a sibling may still need it. A late install
 completing afterward has no actor to hand off to, so the abortable per-actor
 parse can no longer re-insert the closed document — **the install/parse
 resurrection path is structurally closed**, with no separate supersede machinery.
-This holds *provided* the reader-fallback store write noted above is also
-lifetime-guarded; that on-demand path is the only other writer that could
-resurrect a closed document, and it must keep its "document still present"
-guard (or stop writing the store entirely). A reopen creates a fresh actor.
+This holds *provided* the reader-fallback store write noted above is made
+resurrection-safe; that on-demand path is the only other writer that could
+re-insert a closed document, and — because its present-and-unchanged check is
+check-then-write over a store that inserts on vacancy — it must either stop
+writing the store entirely (return a private tree) or persist through an atomic,
+non-inserting, generation-checked update. A reopen creates a fresh actor.
 
 Teardown must also wake any reader blocked on a watermark ticket that will now
 never be processed: dropping the watermark channel on actor termination signals
@@ -364,9 +366,10 @@ not an alternative.
 
 ### 3. Per-document parse actor (chosen)
 
-Serializes by construction, folds `skip_parse` into state, makes resurrection
-impossible, and keeps install/parse off the ingress path — at the cost of an
-ADR-sized refactor.
+Serializes by construction, folds `skip_parse` into state, closes the
+install/parse resurrection path (with the reader-fallback write made private or
+atomically generation-guarded), and keeps install/parse off the ingress path — at
+the cost of an ADR-sized refactor.
 
 ### 4. Actor answers read requests directly (mailbox-query reads)
 

--- a/docs/architecture-decisions/per-document-parse-actor.md
+++ b/docs/architecture-decisions/per-document-parse-actor.md
@@ -90,14 +90,27 @@ mailbox while either runs, a `Close` (and a queued `SetText`) is processed
 is the liveness fix: no ingress ticket and no mailbox is ever held hostage by
 compilation.
 
+The mailbox is **unbounded**, which is what makes the sends non-blocking. The
+risk that normally argues against unbounded channels — memory growth under fast
+input — does not apply here: `SetText` carries only a small delta, the actor
+applies it to the owned text and drops it, and parse coalescing keeps at most one
+parse in flight regardless of how many `SetText`s queue. So the queued state is
+bounded by the document size, not by edit history. A bounded mailbox would
+instead push backpressure onto the ingress thread, re-creating the stall the
+design removes; it is therefore rejected.
+
 ### Install is shared and global; only the parse is the actor's child
 
 Install is **not** a per-document operation the actor owns. `try_install`
-dedupes per language ("if not already being installed"), and
-`reload_language_after_install` mutates **global** state — it pushes the data
-dir into `search_paths`, re-applies settings, and calls `ensure_language_loaded`
-on the shared registry — *before* the per-document `parse_document`. Two
-documents of the same uninstalled language opening together share one install.
+dedupes per language: the second document of the same uninstalled language gets
+an `AlreadyInstalling` outcome and skips its parse, while only the install
+"winner" re-parses (via `reload_language_after_install`, which mutates **global**
+state — pushing the data dir into `search_paths`, re-applying settings, and
+calling `ensure_language_loaded` on the shared registry — *before* the
+per-document `parse_document`). So install is already a shared, globally-mutating
+operation today; what the actor design *adds* is that every waiting document
+subscribes to its completion and parses on its own, rather than only the winner
+re-parsing.
 
 So the two operations are separated deliberately:
 
@@ -155,13 +168,23 @@ feeding tree-sitter the **accumulated** `InputEdits` since the last parse; with
 no base tree (e.g. just after install) it degrades cleanly to a full parse.
 Incrementality is a performance optimization, never a correctness requirement.
 
-This is what actually removes the `edit_lock`. The lock exists today because the
-read-old-text → resolve-deltas → persist cycle runs in concurrently-dispatched
-handlers against a shared store snapshot. Moving delta application *into* the
-single-consumer actor — the actor, not the handler, owns and mutates the text —
-is what makes that cycle non-interleavable. (A design where the handler resolved
-deltas to text from a store snapshot *before* sending would still race the
-snapshot and still need the lock.)
+This removes the `edit_lock` **from the parse / edit-application path**. The lock
+exists today partly because the read-old-text → resolve-deltas → persist cycle
+runs in concurrently-dispatched handlers against a shared store snapshot. Moving
+delta application *into* the single-consumer actor — the actor, not the handler,
+owns and mutates the text — is what makes that cycle non-interleavable. (A design
+where the handler resolved deltas to text from a store snapshot *before* sending
+would still race the snapshot and still need the lock.)
+
+But the `edit_lock` carries a *second* duty the actor does **not** subsume:
+`did_close_impl` holds it to serialize the captures-lineage clear
+(`captures_cache.retain`) against a concurrent captures `full` reader's
+`store_lineage`, which inserts under the same lock (captures-protocol). Because
+readers bypass the actor, this reader-vs-close ordering is not covered by mailbox
+serialization and needs a named replacement — either keep a dedicated lock for
+the captures lineage, or fold the lineage write into the watermark contract.
+This is a path the actor would otherwise silently orphan, so it is called out in
+the Negative consequences.
 
 ### Reads bypass the mailbox
 
@@ -177,6 +200,39 @@ load/reload — then prompts capable clients to re-request once the actor reache
 `Ready`. This saves only the 200ms bounded wait, so it is optional scope; the
 load-bearing property is simply that the mailbox stays write-only, which keeps
 the blocking problem from migrating to the read path.
+
+### Reader-vs-writer ordering needs a published watermark
+
+This is the subtle part, and it changes the writer-ticket timing, so it must be
+designed explicitly rather than assumed.
+
+Today `IngressOrderGate` completes a writer's ticket only *after* the whole
+handler future resolves (`drop(gate)` follows `inner_fut.await` in
+`ingress_order.rs`), and the `didChange` handler `await`s `parse_document`
+*inside* that window. So a `semanticTokens` reader ticketed right after a
+`didChange` is guaranteed to observe the **parsed** tree — locked down by
+`gate_runs_reader_only_after_preceding_writer`. A reader's
+`wait_for_parse_completion` then sees `has_tree == true` for the *current* tree.
+
+Under the actor, the handler returns at **enqueue**, so the writer ticket
+completes *before* the actor applies the delta or calls `mark_parse_started`. A
+reader's gate barrier is then satisfied while `has_tree` is still true for the
+**old** tree, and `wait_for_parse_completion` returns the stale tree
+immediately. That reintroduces exactly the #342/#374 race. A bare `has_tree`
+check is therefore insufficient.
+
+The replacement: the actor publishes a per-URI **monotonic processed-through
+watermark** keyed to the ingress writer sequence. Each mutation handler stamps
+its enqueued message with the writer ticket it holds; when the actor finishes
+applying-and-parsing the state through ticket *N* (and has written the resulting
+tree into the store), it advances the published watermark to *N*. A reader
+captures the current tail ticket at gate `call` time (it already does, for the
+reader barrier) and waits — bounded by the existing 200ms — until the watermark
+reaches that ticket, instead of waiting on `has_tree`. If an install is pending
+the watermark cannot advance, so the reader simply times out into the empty
+fallback, which is the intended install-pending behaviour. This preserves the
+#374 reader-observes-preceding-writes guarantee without re-coupling the handler
+to parse latency or to the unbounded install.
 
 ### Lifetime equals document lifetime
 
@@ -200,9 +256,14 @@ is complementary to the actor, not a substitute for it.
 
 ### Injection orchestration stays downstream
 
-`process_injections` (which can spawn external bridge servers) is kicked off as
-a fire-and-forget consequence of a completed main parse, not awaited inside the
-actor loop, so injection work never stalls main-document parsing.
+`process_injections` runs as a consequence of a completed main parse, not inside
+the actor loop, so injection work never stalls main-document parsing. It is not
+uniformly fire-and-forget, though: spawning external bridge servers is genuinely
+fire-and-forget, but the `didChange` forwarding to already-opened virtual
+documents is wire-order-sensitive and must be sequenced **after** the parse it
+depends on (it needs the fresh tree) and in writer order — so it is ordered, not
+loosed. The split between the fire-and-forget spawn and the ordered forwarding
+must be preserved when re-homing this step.
 
 ## Considered Options
 
@@ -250,8 +311,10 @@ write-only-mailbox / shared-store-read split is load-bearing.
 - **Liveness.** An unbounded/hung install can no longer wedge same-URI readers
   or writers; the actor loop stays responsive and `Close` always lands.
 - **Serialization by construction.** A single mailbox consumer removes the parse
-  path's reliance on the per-URI `edit_lock`; the read-old-text → reparse →
-  persist cycle is no longer interleavable.
+  / edit-application path's reliance on the per-URI `edit_lock`; the
+  read-old-text → reparse → persist cycle is no longer interleavable. (The
+  lock's *other* duty — reader-vs-close captures-lineage ordering — is not
+  subsumed; see Negative.)
 - **`skip_parse` disappears**, folded into the `Uninstalled/Installing/Ready`
   state machine; the install path stops re-entering parsing from a second call
   site.
@@ -270,29 +333,36 @@ write-only-mailbox / shared-store-read split is load-bearing.
   completion plumbed back as messages, and mailbox backpressure are all new
   surface area to get right.
 - **Carefully tuned races must be preserved**, not regressed: the captures
-  lineage close ordering (captures-protocol), the geometry re-merge / no-op
-  suppression on `didChange` (#422), and the diagnostic teardown ordering in
-  `didClose`.
-- **Injection orchestration must be re-homed** as a downstream consequence of
-  the main parse rather than an inline handler step.
+  lineage close ordering (captures-protocol) — which today rides the `edit_lock`
+  the parse path sheds, so it needs an explicit replacement (a dedicated lock or
+  the watermark contract); the geometry re-merge / no-op suppression on
+  `didChange` (#422); and the diagnostic teardown ordering in `didClose`.
+- **A new read-path coupling** is introduced: readers must wait on the actor's
+  per-URI processed-through watermark instead of `has_tree`. Getting this watermark
+  wrong silently reintroduces the #342/#374 stale-tree race.
+- **Injection orchestration must be re-homed** carefully: the heavy external
+  bridge-server spawn is fire-and-forget, but the bridge `didChange` forwarding
+  to already-opened virtual documents is wire-order-sensitive and must stay
+  ordered after the parse it depends on (or remain in the gated handler), not
+  be loosed as unordered fire-and-forget.
 
 ### Neutral
 
-- `IngressOrderGate`'s writer tickets become partly redundant for the *parse*
-  path (the actor already serializes it), but still govern wire-order for the
-  non-parse side effects that live in the mutation handlers today —
-  diagnostic scheduling, bridge `didChange` forwarding, `process_injections`.
-  The intended relationship (to be confirmed in implementation): handlers
+- `IngressOrderGate` still issues per-URI tickets, but the writer ticket now
+  completes at **enqueue** rather than after parse (see the watermark section),
+  so its old reader-observes-preceding-writes guarantee is no longer carried by
+  the ticket alone — it is carried by the actor's published watermark. Handlers
   **enqueue to the mailbox from within the gated critical section**, so mailbox
-  FIFO equals wire order and `Open`/`SetText`/`Close` reach the actor in the
-  order #374 established. Side effects that must stay wire-ordered either remain
-  in the gated handler (kept as the lightweight, non-blocking part of the
-  handler) or are sequenced by the actor *after* the parse they depend on
-  (e.g. injection orchestration, which needs the fresh tree). Only the
-  parse-state serialization moves into the actor; the gate's per-URI ordering
-  for the rest is retained.
-- Readers keep their existing `wait_for_parse_completion` + fallback contract;
-  the change is *who writes* the tree they read, not how they read it.
+  FIFO still equals wire order and `Open`/`SetText`/`Close` reach the actor in
+  the order #374 established. Non-parse side effects that must stay wire-ordered
+  (diagnostic scheduling, the bridge `didChange` forwarding in
+  `process_injections`) either remain in the gated handler or are sequenced by
+  the actor *after* the parse they depend on; this re-homing is the
+  highest-risk part of the change.
+- Readers keep their existing bounded-wait + fallback contract, but the signal
+  they wait on changes from `has_tree` to the per-URI processed-through
+  watermark. That is the one read-path change the design requires; without it
+  the new writer-ticket timing would let a reader observe a stale tree.
 
 ## Decision–Implementation Gap
 
@@ -300,6 +370,8 @@ Not yet implemented. This ADR records the target design; it runs ahead of the
 code. As of writing, `did_open_impl` still awaits auto-install inline, still
 carries the `skip_parse` flag, `did_change_impl` still serializes via
 `edit_lock`, and `reload_language_after_install` still re-enters the parse path
-on install completion. The actor, its state machine, the child-task model, and
-the install-wide deadline are all unbuilt. A staged rollout may land Option 1
+on install completion, and readers still wait on `has_tree` (there is no
+processed-through watermark, and no install-pending signal in the store). The
+actor, its state machine, the child-task model, the reader watermark, and the
+install-wide deadline are all unbuilt. A staged rollout may land Option 1
 (minimal spawn) first as an interim liveness fix before the full actor.

--- a/docs/architecture-decisions/per-document-parse-actor.md
+++ b/docs/architecture-decisions/per-document-parse-actor.md
@@ -76,15 +76,17 @@ couples concerns that are hard to reason about independently:
   (`try_parse_and_update_document` and analogues) that *writes the store*, and
   `update_document` **inserts on vacancy** — a second resurrection vector.
 
-Underneath, the store already keeps **two** monotonic counters that are really
-the same idea pulled in different directions: `open_generations` (used by the
-captures lineage to detect close-then-reopen) and `ParseState.generation` (whose
-`mark_parse_finished` stale-check already refuses to record a superseded parse).
-Neither gates the tree write itself. The ingress writer ticket
-(`IngressOrderGate`, `src/lsp/ingress_order.rs`) is a *third* per-document
-sequence, and the reader-ordering watermark this design needs would be a
-*fourth*. They are four implementations of one concept: a per-document logical
-version.
+Underneath, the store already keeps **two** monotonic counters that are two
+**axes** of one idea: `open_generations` (process-wide, used by the captures
+lineage to detect close-then-reopen — an *incarnation* counter) and
+`ParseState.generation` (per-lifetime, whose `mark_parse_finished` stale-check
+already refuses to record a superseded parse). Neither gates the tree write
+itself. The ingress writer ticket (`IngressOrderGate`,
+`src/lsp/ingress_order.rs`) is a *third* per-document sequence — intra-lifetime
+wire order, which restarts on reopen — and the reader-ordering watermark this
+design needs would be a *fourth*. They are four implementations of two axes:
+*which lifetime* (incarnation) and *where in that lifetime's wire order*
+(ticket).
 
 The common root is that a document's text, parser readiness, and parse
 scheduling have **no single owner**.
@@ -93,12 +95,13 @@ scheduling have **no single owner**.
 
 Introduce a **per-document parse actor**: one actor task per open document that
 exclusively owns that document's text, parser-readiness state, and parse
-scheduling, and a **single per-document epoch** — the ingress writer ticket made
-authoritative — that is the one source of truth for ordering, resurrection-safety,
-and parse-staleness. It absorbs the three other per-document version-sequences
-(`open_generations`, `ParseState.generation`, and the otherwise-new reader
-watermark), and its per-write check additionally takes over the `edit_lock`'s
-resurrection-guard duty.
+scheduling, and a **single per-document epoch** — the pair
+`(incarnation, ticket)` — that is the one source of truth for ordering,
+resurrection-safety, and parse-staleness. It pairs the retained process-wide open
+generation (the incarnation, monotonic across reopen) with the ingress writer
+ticket (intra-lifetime wire order), folds `ParseState.generation` and the
+otherwise-new reader watermark into those two axes, and its per-write check
+additionally takes over the `edit_lock`'s resurrection-guard duty.
 
 ### Writes are messages; the loop never blocks on the slow op
 
@@ -149,46 +152,76 @@ policy.
 
 ### One epoch for ordering, resurrection, and staleness
 
-A single monotonic per-document **epoch** — the ingress writer-ticket sequence,
-made authoritative — becomes the one version-sequence the other three collapse
-into. The unification is of the *source*, not of a single scalar: two derived
-quantities read off the same ticket sequence. The actor publishes a **processed-through watermark** (the
-highest ticket whose state has fully resolved) that readers wait on, and stamps
-each store write with the **epoch at which it was scheduled** that the CAS write
-compares before committing. Everything keys on that one sequence:
+The four ad-hoc sequences are really **two axes** of one idea: an *incarnation*
+(which open→close lifetime this is) and an *intra-lifetime ticket* (wire order
+within one open document). The design makes the per-document **epoch** the pair
+`(incarnation, ticket)`:
+
+- the **incarnation** is the retained process-wide open generation
+  (`open_counter` / `open_generations`), drawn fresh on every `didOpen`. It is
+  deliberately **not** the ingress ticket: `IngressOrderGate::finish_close`
+  removes a URI's sequencing state on close, so the ticket **restarts at 1 on
+  reopen** and is not monotonic across lifetimes. Were the epoch the ticket
+  alone, a straggler write from a previous lifetime could match the reopened
+  document's ticket. The incarnation is the high half precisely to close that
+  gap.
+- the **ticket** is the ingress writer sequence within the current lifetime,
+  plumbed to the handler from the gate.
+
+Two derived quantities read off this one pair; the unification is of the
+*source*, not of a single scalar:
 
 - **Wire order / readiness (reader watermark).** Each mutation handler stamps its
-  enqueued message with the ingress writer ticket plumbed to it from the gate.
-  When the actor brings the document's state through ticket *N* to a **terminal
-  outcome** — `Parsed` (tree written), `NoTree` (parsed to nothing), or
-  `InstallFailed` — it advances the *published* epoch to *N*. The watermark must
-  advance on **resolution**, not only on a successful tree write, or a
-  parse/install failure would never advance it and readers would burn the full
-  timeout. A virt/native reader waits — bounded by the existing 200 ms — until
-  the epoch reaches the tail ticket that preceded it, then reads whatever the
-  store holds (a tree, or empty), instead of waiting on `has_tree`. This is
-  required because, with the handler returning at *enqueue*, a bare `has_tree`
-  check would be satisfied while the store still holds the **old** tree —
-  reintroducing the #342/#374 stale-tree race.
-- **Resurrection-safety (generation-checked CAS writes).** Every tree write
-  becomes an **atomic, non-inserting, epoch-checked** store update: it no-ops if
-  the document is gone (`Vacant`) or the epoch has moved. This generalizes the
-  existing `mark_parse_finished` stale-check from the parse-state to the tree
-  itself. The actor's own parse is one writer; the reader on-demand fallback is
-  the other (see below). The unguarded site today is
-  `kakehashi/node`'s `ensure_parsed_for_node_lookup` (`entry.rs`); the
-  `semanticTokens` and `selectionRange` fallbacks are already `edit_lock`-guarded
-  but switch to the same CAS write.
-- **Close-then-reopen detection** (today `open_generations`) is the same epoch:
-  a reopen draws a fresh epoch, so a stale lineage insert or a late parse
-  naturally fails its epoch check.
+  enqueued message with `(incarnation, ticket)`. The actor publishes a
+  **processed-through watermark**: the highest ticket (within the current
+  incarnation) whose state has reached a terminal outcome — `Parsed`, `NoTree`
+  (parsed to nothing), or `InstallFailed`. It advances on **resolution**, not
+  only on a successful tree write, or a parse/install failure would never advance
+  it and readers would burn the full timeout. Because the actor **coalesces**, a
+  single parse covers a contiguous run of tickets; the watermark advances to the
+  highest ticket that parse **covered**, and a parse superseded by a newer edit
+  before it completes does not strand its tickets — they are carried into the
+  next (covering) parse. The watermark never regresses and advances on a covering
+  terminal completion, but no bound is claimed on how quickly a *given* ticket is
+  covered under sustained editing — continuous edits can keep the watermark behind
+  a reader's target ticket indefinitely. The **hard** guarantee is the reader
+  side:
+  the existing 200 ms bound plus the empty fallback caps any wait, so sustained
+  editing degrades a reader to the empty fallback rather than starving it. A
+  virt/native reader
+  waits — bounded by that 200 ms — until the watermark reaches the tail ticket
+  that preceded it, then reads whatever the store holds (a tree, or empty),
+  instead of waiting on `has_tree`. This is required because, with the handler
+  returning at *enqueue*, a bare `has_tree` check would be satisfied while the
+  store still holds the **old** tree — reintroducing the #342/#374 stale-tree
+  race.
+- **Resurrection-safety (epoch-checked CAS writes).** Every tree write becomes an
+  **atomic, non-inserting** store update checked against the full
+  `(incarnation, ticket)` pair: it no-ops if the document is gone (`Vacant`), the
+  incarnation differs (a reopen happened), or the ticket moved. This folds both
+  `open_generations` (incarnation mismatch) and `ParseState.generation` (ticket
+  mismatch) into one comparison, generalizing the existing `mark_parse_finished`
+  stale-check from the parse-state to the tree itself. The actor's own parse is
+  one writer; the reader on-demand fallback is the other (see below). The
+  unguarded site today is `kakehashi/node`'s `ensure_parsed_for_node_lookup`
+  (`entry.rs`); the `semanticTokens` and `selectionRange` fallbacks are already
+  `edit_lock`-guarded but switch to the same CAS write.
+- **Close-then-reopen detection** is the incarnation half: a reopen draws a fresh
+  incarnation, so a stale lineage insert or a late parse from the previous
+  lifetime fails the incarnation check even though the reopened lifetime's
+  tickets restart at 1.
 
 This requires new plumbing in `IngressOrderGate`: today the ticket is
 middleware-private — a writer handler does not receive `gate.ticket()`, and a
 reader handler does not receive the tail ticket the `ReaderBarrier` snapshots at
 `call` time. Both must be exposed (via a task-local, a request extension, or by
-moving the enqueue into the middleware) so the writer can stamp its message and
-the reader can name the epoch it waits on. The ingress middleware is part of the
+moving the enqueue into the middleware). Crucially, because the epoch is the pair
+`(incarnation, ticket)` and tickets restart on reopen, the **incarnation must be
+plumbed alongside the ticket** — to both the writer (so its stamped message names
+the right lifetime) and the reader (so the tail it waits on names
+`(incarnation, ticket)`, not a bare ticket that a reopen's restarted sequence
+could ambiguate). Equivalently, the reader can hold an incarnation-bound watermark
+handle that is invalidated on close. The ingress middleware is part of the
 refactor surface.
 
 ### Install is shared and global; only the parse is the actor's child
@@ -287,12 +320,12 @@ in-flight **parse** (the store-writing child), unsubscribes from the shared
 install, advances the epoch, and terminates the actor; the store entry is
 removed. The shared install itself is *not* aborted. A late install completing
 afterward has no actor to hand off to, and any straggler write fails its epoch
-check, so **the install/parse resurrection path is structurally closed** with no
-separate supersede machinery — *provided* every store-writing path, including the
-reader on-demand fallback, goes through the epoch-checked CAS write below; that
-fallback is the one residual vector, and it is closed at the write, not by a
-check a concurrent close can slip past. A reopen creates a fresh actor at a fresh
-epoch.
+check (the incarnation no longer matches), so **the install/parse resurrection
+path is structurally closed** with no separate supersede machinery — *provided*
+every store-writing path, including the reader on-demand fallback, goes through the
+epoch-checked CAS write below; that fallback is the one residual vector, and it is
+closed at the write, not by a check a concurrent close can slip past. A reopen
+creates a fresh actor at a fresh incarnation.
 
 Teardown must also wake any reader blocked on an epoch that will now never be
 reached: dropping the epoch channel on actor termination signals those waiters to
@@ -400,11 +433,13 @@ write-only-mailbox / shared-store-read split is load-bearing.
 - **Burst coalescing.** A run of edits collapses to one parse over the
   accumulated text, saving the measured per-edit reparse cost on injection-heavy
   documents.
-- **One epoch, not four.** Wire-order readiness, resurrection-safety, and
-  parse-staleness key on a single per-document counter — the ingress ticket made
-  authoritative — into which the other three version-sequences
-  (`open_generations`, `ParseState.generation`, the reader watermark) collapse,
-  and which additionally takes over the `edit_lock`'s resurrection-guard duty.
+- **One epoch, two axes, not four sequences.** Wire-order readiness,
+  resurrection-safety, and parse-staleness key on a single composite epoch
+  `(incarnation, ticket)` — the retained process-wide open generation paired with
+  the ingress ticket — into which `ParseState.generation` and the reader watermark
+  fold, and whose per-write check additionally takes over the `edit_lock`'s
+  resurrection-guard duty. The incarnation half keeps the epoch monotonic across a
+  reopen even though tickets restart.
 - **`skip_parse` disappears**, folded into the `Uninstalled/Installing/Ready`
   state machine; the install path stops re-entering parsing from a second call
   site.

--- a/docs/architecture-decisions/per-document-parse-actor.md
+++ b/docs/architecture-decisions/per-document-parse-actor.md
@@ -223,16 +223,28 @@ check is therefore insufficient.
 
 The replacement: the actor publishes a per-URI **monotonic processed-through
 watermark** keyed to the ingress writer sequence. Each mutation handler stamps
-its enqueued message with the writer ticket it holds; when the actor finishes
-applying-and-parsing the state through ticket *N* (and has written the resulting
-tree into the store), it advances the published watermark to *N*. A reader
-captures the current tail ticket at gate `call` time (it already does, for the
-reader barrier) and waits — bounded by the existing 200ms — until the watermark
-reaches that ticket, instead of waiting on `has_tree`. If an install is pending
-the watermark cannot advance, so the reader simply times out into the empty
-fallback, which is the intended install-pending behaviour. This preserves the
-#374 reader-observes-preceding-writes guarantee without re-coupling the handler
-to parse latency or to the unbounded install.
+its enqueued message with the writer ticket **plumbed to it from the gate**; when
+the actor finishes applying-and-parsing the state through ticket *N* (and has
+written the resulting tree into the store), it advances the published watermark
+to *N*. A reader waits — bounded by the existing 200ms — until the watermark
+reaches the tail ticket that preceded it, instead of waiting on `has_tree`. If an
+install is pending the watermark cannot advance, so the reader simply times out
+into the empty fallback, which is the intended install-pending behaviour. This
+preserves the #374 reader-observes-preceding-writes guarantee without re-coupling
+the handler to parse latency or to the unbounded install.
+
+This requires new plumbing in `IngressOrderGate` (`src/lsp/ingress_order.rs`):
+today the ticket is middleware-private — a writer handler does not receive
+`gate.ticket()`, and a reader handler does not receive the tail ticket the gate's
+`ReaderBarrier` snapshots at `call` time. Both must be exposed (via a task-local,
+a request extension, or by moving the enqueue into the middleware) so the writer
+can stamp its message and the reader can name the watermark it waits on. The
+ingress middleware is therefore part of the refactor surface, not untouched.
+
+The reader-side `edit_lock` acquisitions that act as settle guards today
+(`semantic_tokens.rs`, `selection_range.rs`) become uncontended once the
+writer side no longer takes the lock; the watermark is their functional
+replacement, so they are removed rather than left as dead synchronization.
 
 ### Lifetime equals document lifetime
 
@@ -245,6 +257,13 @@ parse, a late install completing afterward has no actor to hand off to and
 cannot re-insert the closed document — **resurrection is structurally
 impossible**, with no separate supersede machinery. A reopen creates a fresh
 actor.
+
+Teardown must also wake any reader blocked on a watermark ticket that will now
+never be processed: dropping the watermark channel on actor termination signals
+those waiters to proceed (into the empty fallback), mirroring how the gate's
+`finish_close` drops its `done` sender and waiters treat the error as "nothing
+left to wait for." Without it a reader racing the close would stall to the 200ms
+timeout — bounded, but needless.
 
 ### Complementary: install-wide deadline
 
@@ -328,7 +347,9 @@ write-only-mailbox / shared-store-read split is load-bearing.
 ### Negative
 
 - **ADR-sized refactor** touching `did_open`, `did_change`, `did_close`, the
-  install coordinator, the store, and every reader's wait path.
+  install coordinator, the store, the `IngressOrderGate` middleware (to plumb the
+  writer ticket and tail ticket out to the handlers), and every reader's wait
+  path.
 - **Lifecycle and cancellation must be exact.** Child-task abort on `Close`,
   completion plumbed back as messages, and mailbox backpressure are all new
   surface area to get right.
@@ -372,6 +393,8 @@ carries the `skip_parse` flag, `did_change_impl` still serializes via
 `edit_lock`, and `reload_language_after_install` still re-enters the parse path
 on install completion, and readers still wait on `has_tree` (there is no
 processed-through watermark, and no install-pending signal in the store). The
-actor, its state machine, the child-task model, the reader watermark, and the
-install-wide deadline are all unbuilt. A staged rollout may land Option 1
+`IngressOrderGate` ticket is still middleware-private — no handler receives it —
+so the watermark plumbing does not exist yet either. The actor, its state
+machine, the child-task model, the reader watermark and its ingress plumbing, and
+the install-wide deadline are all unbuilt. A staged rollout may land Option 1
 (minimal spawn) first as an interim liveness fix before the full actor.


### PR DESCRIPTION
## What

Adds **two** Architecture Decision Records for the document-mutation path:

1. **`parse-decoupled-document-lifecycle.md`** (independently shippable) — classifies capabilities into **Host / Virt / Native** tiers by tree-sitter-parse dependence, and hoists host-tier work (host-server attach + forwards) to the *front* of `didOpen`/`didChange`, ahead of parse and install. Host-language UX (attach, diagnostics, hover, completion) then never waits on the tree.
2. **`per-document-parse-actor.md`** — for the tree-dependent (virt/native) tiers: one actor per open document owning text + parser-readiness + parse scheduling, with the parse moved off the ingress path.

## Why

`didOpen` holds the per-URI **writer ticket** (#374) for the whole handler, which awaits auto-install — whose tail is an **untimed C compiler** (`compile_parser_at_path`); a hung compile wedges every later same-URI request. And the host-server attach sits *after* parse+install by pure statement ordering, even though it needs neither the tree nor the parser — so host-language UX is needlessly blocked behind a measured ~120–310 ms parse (injection-heavy Markdown) or an unbounded install.

## Key decisions

- **Tier decoupling (ADR 1):** host attach/forwards hoisted ahead of parse/install; open-before-change preserved structurally by `sync_host_document`'s vacant→didOpen / occupied→didChange state machine. Ships without the actor.
- **Parse actor (ADR 2):** `didOpen`/`didChange`/`didClose` become non-blocking mailbox sends; the loop `select!`s and never awaits the slow op inline (install/parse run off-loop, so `Close` lands even during a hung install). Install is shared/global (the actor subscribes); only the per-document parse is the abortable child.
- **One composite epoch `(incarnation, ticket)`:** the retained process-wide open generation (monotonic across reopen) paired with the ingress ticket (intra-lifetime order), folding in `ParseState.generation` and the reader watermark, with epoch-checked non-inserting CAS writes closing the resurrection vectors.
- **Killable-subprocess install deadline** reconciles with (doesn't supersede) `replace-tree-sitter-cli-with-loader`.

## Review

Hardened through advisor passes, a `/review` subagent pass, multi-round codex review, and Copilot + Gemini PR review (all converged). Doc-only change; no code touched. Decision–Implementation Gap sections note nothing here is built yet.

