### PR TITLE
feat(diagnostics): pullFallback/pushFallback toggles + per-server capability classification (#425)

### DIFF
--- a/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
+++ b/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
@@ -508,6 +508,19 @@ because the #380 benefit now outweighs it:
   servers, so a push-only host server (skipped by the capability-gated pull)
   re-analyzes current text. Runs at the debounce cadence (after typing settles),
   not per-keystroke; pull-capable servers fingerprint-dedup the extra sync.
+- The `pullFallback` / `pushFallback` config toggles and capability
+  classification (#425). `pullFallback` / `pushFallback` are `Option<bool>` on
+  `AggregationConfig` (camelCase serde, default `true`), merged field-by-field
+  (`merge.rs`). `pullFallback` gates the host-event pull per region/host in
+  `prepare_diagnostic_snapshot` (Path A); `pushFallback` folds push-driven
+  servers' cached pushes into the client-pull response in `diagnostic_impl`
+  (Path B). Servers are classified **live and non-creating** by
+  `LanguageServerPool::pull_driven_servers` (static initialize caps + dynamic
+  registrations). The pull/push double-count is removed by the publisher's
+  `filter_pull_driven_push_slots`, which drops a pull-driven server's push slot
+  from the publish whenever a `PullLayer` blob is present, so each server has one
+  native source while its slot stays cached (a spontaneous push from a
+  pull-driven server still publishes when no `PullLayer` exists).
 
 **Deferred** (staged follow-ups; the code documents each at its site):
 
@@ -516,7 +529,10 @@ because the #380 benefit now outweighs it:
   (lazy re-anchor still keeps *positions* current via the retained pull trigger).
 - Per-source strategy fan-in (`preferred` sticky / `concatenated` visible-walk);
   the staged merge concatenates, with HashMap-nondeterministic cross-source order.
+  This also subsumes the **interim `pullFallback` dedup limitation**: because
+  `PullLayer` is one host-wide blob with no per-server identity,
+  `filter_pull_driven_push_slots` triggers on "any `PullLayer` present" rather
+  than "this exact server was pulled", so a *mixed* per-region `pullFallback`
+  (one region's pull-driven server pulled, a sibling's not) can over-suppress.
+  Per-`(source, server)` pull slots remove it.
 - Region-invalidation and crash cache eviction.
-- The `pullFallback` / `pushFallback` config toggles and the capability
-  classification — without the latter the pull feed and a server's spontaneous
-  push can double-count that server (documented in `diagnostic_cache.rs`).

--- a/src/config.rs
+++ b/src/config.rs
@@ -223,6 +223,12 @@ fn strip_inherited_aggregation_config(
         max_fan_out: (current.max_fan_out != inherited.max_fan_out)
             .then_some(current.max_fan_out)
             .flatten(),
+        pull_fallback: (current.pull_fallback != inherited.pull_fallback)
+            .then_some(current.pull_fallback)
+            .flatten(),
+        push_fallback: (current.push_fallback != inherited.push_fallback)
+            .then_some(current.push_fallback)
+            .flatten(),
     }
 }
 
@@ -818,11 +824,13 @@ mod strip_inherited_tests {
             priorities: Some(vec!["pyright".to_string()]),
             strategy: Some(AggregationStrategy::Preferred),
             max_fan_out: Some(2),
+            ..Default::default()
         };
         let current = AggregationConfig {
             priorities: Some(vec!["pyright".to_string()]),
             strategy: Some(AggregationStrategy::Concatenated),
             max_fan_out: Some(2),
+            ..Default::default()
         };
         let result = strip_inherited_aggregation_config(&inherited, &current);
         assert_eq!(result.priorities, None, "priorities match → stripped");

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -114,6 +114,10 @@ fn default_languages() -> HashMap<String, LanguageSettings> {
                             "textDocument/diagnostic".to_string(),
                             AggregationConfig {
                                 strategy: Some(AggregationStrategy::Concatenated),
+                                // pushFallback (Path B): push-driven servers'
+                                // cached pushes fold into the client-pull
+                                // response (push-propagation-diagnostic-forwarding).
+                                push_fallback: Some(true),
                                 ..Default::default()
                             },
                         ),
@@ -121,6 +125,10 @@ fn default_languages() -> HashMap<String, LanguageSettings> {
                             "textDocument/publishDiagnostics".to_string(),
                             AggregationConfig {
                                 strategy: Some(AggregationStrategy::Concatenated),
+                                // pullFallback (Path A): pull-driven servers are
+                                // pulled on host events into the proactive cache
+                                // (push-propagation-diagnostic-forwarding).
+                                pull_fallback: Some(true),
                                 ..Default::default()
                             },
                         ),
@@ -304,6 +312,11 @@ mod tests {
             .get("textDocument/diagnostic")
             .expect("should have diagnostic aggregation");
         assert_eq!(diag_agg.strategy, Some(AggregationStrategy::Concatenated));
+        assert_eq!(
+            diag_agg.push_fallback,
+            Some(true),
+            "the template documents pushFallback's default on the client-pull method"
+        );
 
         let pub_diag_agg = agg
             .get("textDocument/publishDiagnostics")
@@ -311,6 +324,11 @@ mod tests {
         assert_eq!(
             pub_diag_agg.strategy,
             Some(AggregationStrategy::Concatenated)
+        );
+        assert_eq!(
+            pub_diag_agg.pull_fallback,
+            Some(true),
+            "the template documents pullFallback's default on the proactive-publish method"
         );
     }
 

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -217,6 +217,8 @@ pub(crate) fn merge_aggregation_configs(
             .clone()
             .or_else(|| base.priorities.clone()),
         max_fan_out: overlay.max_fan_out.or(base.max_fan_out),
+        pull_fallback: overlay.pull_fallback.or(base.pull_fallback),
+        push_fallback: overlay.push_fallback.or(base.push_fallback),
     }
 }
 
@@ -2558,5 +2560,48 @@ mod tests {
         let overlay = settings::AggregationConfig::default(); // max_fan_out: None
         let merged = merge_aggregation_configs(&base, &overlay);
         assert_eq!(merged.max_fan_out, Some(5));
+    }
+
+    #[test]
+    fn merge_aggregation_configs_fallback_toggles_overlay_wins() {
+        let base = settings::AggregationConfig {
+            pull_fallback: Some(true),
+            push_fallback: Some(true),
+            ..Default::default()
+        };
+        let overlay = settings::AggregationConfig {
+            pull_fallback: Some(false),
+            push_fallback: Some(false),
+            ..Default::default()
+        };
+        let merged = merge_aggregation_configs(&base, &overlay);
+        assert_eq!(merged.pull_fallback, Some(false));
+        assert_eq!(merged.push_fallback, Some(false));
+    }
+
+    #[test]
+    fn merge_aggregation_configs_fallback_toggles_inherit_from_base() {
+        // Each toggle merges independently: an unset overlay field inherits the
+        // base while a set one (here `push_fallback`) overrides.
+        let base = settings::AggregationConfig {
+            pull_fallback: Some(false),
+            push_fallback: Some(false),
+            ..Default::default()
+        };
+        let overlay = settings::AggregationConfig {
+            push_fallback: Some(true),
+            ..Default::default()
+        };
+        let merged = merge_aggregation_configs(&base, &overlay);
+        assert_eq!(
+            merged.pull_fallback,
+            Some(false),
+            "unset overlay inherits base"
+        );
+        assert_eq!(
+            merged.push_fallback,
+            Some(true),
+            "set overlay overrides base"
+        );
     }
 }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -219,6 +219,10 @@ pub(crate) struct ResolvedAggregationConfig {
     /// pulled on host events into the proactive cache. Only meaningful for the
     /// `textDocument/publishDiagnostics` method (Path A).
     pub(crate) pull_fallback: bool,
+    /// Resolved `pushFallback` (default `true`): whether push-driven servers'
+    /// cached pushes are folded into the client-pull response. Only meaningful
+    /// for the `textDocument/diagnostic` method (Path B).
+    pub(crate) push_fallback: bool,
 }
 
 /// The resolved default for an absent `pullFallback` / `pushFallback`: both
@@ -235,6 +239,7 @@ impl ResolvedAggregationConfig {
             priorities: default_priorities(),
             max_fan_out: None,
             pull_fallback: DEFAULT_DIAGNOSTIC_FALLBACK,
+            push_fallback: DEFAULT_DIAGNOSTIC_FALLBACK,
         }
     }
 }
@@ -295,12 +300,14 @@ impl BridgeLanguageConfig {
                 priorities: entry.priorities.unwrap_or_else(default_priorities),
                 max_fan_out: entry.max_fan_out.and_then(|raw| usize::try_from(raw).ok()),
                 pull_fallback: entry.pull_fallback.unwrap_or(DEFAULT_DIAGNOSTIC_FALLBACK),
+                push_fallback: entry.push_fallback.unwrap_or(DEFAULT_DIAGNOSTIC_FALLBACK),
             },
             None => ResolvedAggregationConfig {
                 strategy: default_aggregation_strategy_for_method(method),
                 priorities: default_priorities(),
                 max_fan_out: None,
                 pull_fallback: DEFAULT_DIAGNOSTIC_FALLBACK,
+                push_fallback: DEFAULT_DIAGNOSTIC_FALLBACK,
             },
         }
     }
@@ -2390,19 +2397,21 @@ kind = "injections""#;
     }
 
     #[test]
-    fn resolve_aggregation_pull_fallback_defaults_true_and_honors_explicit() {
-        // Absent → default true (every server contributes to the proactive path).
+    fn resolve_aggregation_fallbacks_default_true_and_honor_explicit() {
+        // Absent → both default true (every server contributes to both paths).
         let none =
             BridgeLanguageConfig::default().resolve_aggregation("textDocument/publishDiagnostics");
         assert!(none.pull_fallback, "absent pullFallback resolves to true");
+        assert!(none.push_fallback, "absent pushFallback resolves to true");
 
-        // Explicit false survives resolution.
+        // Explicit false on each toggle survives resolution independently.
         let config = BridgeLanguageConfig {
             enabled: Some(true),
             aggregation: Some(HashMap::from([(
                 "textDocument/publishDiagnostics".to_string(),
                 AggregationConfig {
                     pull_fallback: Some(false),
+                    push_fallback: Some(false),
                     ..Default::default()
                 },
             )])),
@@ -2411,6 +2420,10 @@ kind = "injections""#;
         assert!(
             !agg.pull_fallback,
             "explicit pullFallback = false is honored"
+        );
+        assert!(
+            !agg.push_fallback,
+            "explicit pushFallback = false is honored"
         );
     }
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -215,16 +215,26 @@ pub(crate) struct ResolvedAggregationConfig {
     pub(crate) strategy: AggregationStrategy,
     pub(crate) priorities: Vec<String>,
     pub(crate) max_fan_out: Option<usize>,
+    /// Resolved `pullFallback` (default `true`): whether pull-driven servers are
+    /// pulled on host events into the proactive cache. Only meaningful for the
+    /// `textDocument/publishDiagnostics` method (Path A).
+    pub(crate) pull_fallback: bool,
 }
+
+/// The resolved default for an absent `pullFallback` / `pushFallback`: both
+/// fallback channels are on, so every server contributes to both diagnostic
+/// paths regardless of which single mechanism it natively supports.
+const DEFAULT_DIAGNOSTIC_FALLBACK: bool = true;
 
 impl ResolvedAggregationConfig {
     /// Create a config with all fields at their defaults (`Preferred`
-    /// strategy, `["*"]` priorities = all servers, first-win).
+    /// strategy, `["*"]` priorities = all servers, first-win, fallbacks on).
     pub(crate) fn with_defaults() -> Self {
         Self {
             strategy: AggregationStrategy::Preferred,
             priorities: default_priorities(),
             max_fan_out: None,
+            pull_fallback: DEFAULT_DIAGNOSTIC_FALLBACK,
         }
     }
 }
@@ -284,11 +294,13 @@ impl BridgeLanguageConfig {
                 // fan-out kill switch (aggregation-priorities-wildcard).
                 priorities: entry.priorities.unwrap_or_else(default_priorities),
                 max_fan_out: entry.max_fan_out.and_then(|raw| usize::try_from(raw).ok()),
+                pull_fallback: entry.pull_fallback.unwrap_or(DEFAULT_DIAGNOSTIC_FALLBACK),
             },
             None => ResolvedAggregationConfig {
                 strategy: default_aggregation_strategy_for_method(method),
                 priorities: default_priorities(),
                 max_fan_out: None,
+                pull_fallback: DEFAULT_DIAGNOSTIC_FALLBACK,
             },
         }
     }
@@ -2375,6 +2387,31 @@ kind = "injections""#;
             "default priorities must be [\"*\"] (all servers), not [] (disabled)"
         );
         assert_eq!(agg.max_fan_out, None);
+    }
+
+    #[test]
+    fn resolve_aggregation_pull_fallback_defaults_true_and_honors_explicit() {
+        // Absent → default true (every server contributes to the proactive path).
+        let none =
+            BridgeLanguageConfig::default().resolve_aggregation("textDocument/publishDiagnostics");
+        assert!(none.pull_fallback, "absent pullFallback resolves to true");
+
+        // Explicit false survives resolution.
+        let config = BridgeLanguageConfig {
+            enabled: Some(true),
+            aggregation: Some(HashMap::from([(
+                "textDocument/publishDiagnostics".to_string(),
+                AggregationConfig {
+                    pull_fallback: Some(false),
+                    ..Default::default()
+                },
+            )])),
+        };
+        let agg = config.resolve_aggregation("textDocument/publishDiagnostics");
+        assert!(
+            !agg.pull_fallback,
+            "explicit pullFallback = false is honored"
+        );
     }
 
     #[test]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -67,6 +67,28 @@ pub struct AggregationConfig {
     /// - Negative: treated as no limit (silently ignored via `usize::try_from`)
     #[serde(default)]
     pub max_fan_out: Option<i64>,
+    /// Whether **pull-driven** servers (those advertising
+    /// `diagnosticProvider`) are pulled on host events and merged into the
+    /// proactive `publishDiagnostics` cache, so they too publish proactively
+    /// (push-propagation-diagnostic-forwarding "Per-server source and
+    /// fallback"). Belongs in the `textDocument/publishDiagnostics` (Path A)
+    /// method block.
+    ///
+    /// `None` = inherit (default `true`). `false` drops pull-driven servers
+    /// from the proactive path entirely; their *spontaneous* pushes are still
+    /// cached and published (it only stops kakehashi from pulling them).
+    #[serde(default)]
+    pub pull_fallback: Option<bool>,
+    /// Whether **push-driven** servers' (those *not* advertising
+    /// `diagnosticProvider`) cached pushes are folded into the client-pull
+    /// `textDocument/diagnostic` response (push-propagation-diagnostic-forwarding
+    /// "Per-server source and fallback"). Belongs in the
+    /// `textDocument/diagnostic` (Path B) method block.
+    ///
+    /// `None` = inherit (default `true`). `false` answers a client pull from
+    /// live pull-driven servers only, ignoring cached pushes.
+    #[serde(default)]
+    pub push_fallback: Option<bool>,
 }
 
 /// Configuration for a single bridged language within a host filetype.
@@ -2333,6 +2355,7 @@ kind = "injections""#;
                     strategy: Some(AggregationStrategy::Concatenated),
                     priorities: Some(vec!["server_a".to_string(), "server_b".to_string()]),
                     max_fan_out: Some(3),
+                    ..Default::default()
                 },
             )])),
         };
@@ -2352,6 +2375,21 @@ kind = "injections""#;
             "default priorities must be [\"*\"] (all servers), not [] (disabled)"
         );
         assert_eq!(agg.max_fan_out, None);
+    }
+
+    #[test]
+    fn aggregation_config_deserializes_fallback_toggles_as_camel_case() {
+        // The wire form is camelCase (push-propagation-diagnostic-forwarding):
+        // `pullFallback` / `pushFallback`, both optional.
+        let cfg: AggregationConfig =
+            serde_json::from_str(r#"{ "pullFallback": false, "pushFallback": true }"#).unwrap();
+        assert_eq!(cfg.pull_fallback, Some(false));
+        assert_eq!(cfg.push_fallback, Some(true));
+
+        // Absent toggles stay `None` (inherit), distinct from an explicit value.
+        let absent: AggregationConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(absent.pull_fallback, None);
+        assert_eq!(absent.push_fallback, None);
     }
 
     #[test]

--- a/src/lsp/aggregation/server.rs
+++ b/src/lsp/aggregation/server.rs
@@ -11,7 +11,8 @@ pub(crate) use dispatch::{
     effective_priorities_from, mint_region_progress_source,
 };
 pub(crate) use fan_in::FanInResult;
-pub(crate) use fan_out::FanOutTask;
+pub(crate) use fan_out::{FanOutTask, select_servers};
 pub(crate) use host_dispatch::{
     HostFanOutTask, dispatch_host_concatenated, dispatch_host_preferred,
 };
+pub(crate) use priority::{expand_priorities, truncate_entries};

--- a/src/lsp/aggregation/server.rs
+++ b/src/lsp/aggregation/server.rs
@@ -11,7 +11,7 @@ pub(crate) use dispatch::{
     effective_priorities_from, mint_region_progress_source,
 };
 pub(crate) use fan_in::FanInResult;
-pub(crate) use fan_out::{FanOutTask, select_servers};
+pub(crate) use fan_out::FanOutTask;
 pub(crate) use host_dispatch::{
     HostFanOutTask, dispatch_host_concatenated, dispatch_host_preferred,
 };

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -452,6 +452,38 @@ impl LanguageServerPool {
         self.connections.lock().await
     }
 
+    /// Among `candidates`, the server names that have a **live connection
+    /// advertising pull diagnostics** — `textDocument/diagnostic`, via static
+    /// initialize caps or a dynamic registration — checked WITHOUT creating a
+    /// connection (push-propagation-diagnostic-forwarding "Per-server source and
+    /// fallback", #425). Classification is therefore *live*: a server that
+    /// registers/unregisters pull support mid-session is reclassified by the
+    /// next call.
+    ///
+    /// The proactive publisher uses this to classify which cached push slots
+    /// come from a pull-driven server, so the host-event pull (`PullLayer`) and
+    /// that server's spontaneous push don't double-count it.
+    pub(crate) async fn pull_driven_servers(
+        &self,
+        candidates: &std::collections::HashSet<String>,
+    ) -> std::collections::HashSet<String> {
+        if candidates.is_empty() {
+            return std::collections::HashSet::new();
+        }
+        let connections = self.connections.lock().await;
+        let mut pull_driven = std::collections::HashSet::new();
+        for handle in connections.values() {
+            let server = handle.key().server();
+            if candidates.contains(server)
+                && !pull_driven.contains(server)
+                && handle.has_capability("textDocument/diagnostic")
+            {
+                pull_driven.insert(server.to_string());
+            }
+        }
+        pull_driven
+    }
+
     /// Host-document sync state (host-document-bridge). Used by the host
     /// request path in `text_document/host.rs`.
     pub(super) async fn host_documents(
@@ -4904,5 +4936,58 @@ mod tests {
             Some(2),
             "init_server: opened=1, no didChange, test-increment=2"
         );
+    }
+
+    /// `pull_driven_servers` classifies among `candidates` exactly the servers
+    /// with a live connection advertising `textDocument/diagnostic` (#425):
+    /// a pull-capable server is returned, a push-only one is not, and a name
+    /// with no live connection is dropped — all without creating a connection.
+    #[tokio::test]
+    async fn pull_driven_servers_classifies_by_live_capability() {
+        use std::collections::HashSet;
+        use tower_lsp_server::ls_types::{
+            DiagnosticOptions, DiagnosticServerCapabilities, ServerCapabilities,
+        };
+
+        let pool = LanguageServerPool::new();
+
+        // "ra" advertises pull diagnostics (static capability) → pull-driven.
+        let ra =
+            create_handle_with_key(ConnectionState::Ready, ConnectionKey::for_server("ra")).await;
+        ra.set_server_capabilities(ServerCapabilities {
+            diagnostic_provider: Some(DiagnosticServerCapabilities::Options(
+                DiagnosticOptions::default(),
+            )),
+            ..Default::default()
+        });
+        pool.insert_connection(ra).await;
+
+        // "linter" has no diagnostic capability → push-driven.
+        let linter =
+            create_handle_with_key(ConnectionState::Ready, ConnectionKey::for_server("linter"))
+                .await;
+        linter.set_server_capabilities(ServerCapabilities::default());
+        pool.insert_connection(linter).await;
+
+        let candidates = HashSet::from([
+            "ra".to_string(),
+            "linter".to_string(),
+            "ghost".to_string(), // no live connection
+        ]);
+        let pull_driven = pool.pull_driven_servers(&candidates).await;
+
+        assert_eq!(
+            pull_driven,
+            HashSet::from(["ra".to_string()]),
+            "only the pull-capable server with a live connection is pull-driven"
+        );
+    }
+
+    /// An empty candidate set short-circuits to empty without touching the pool.
+    #[tokio::test]
+    async fn pull_driven_servers_empty_candidates_returns_empty() {
+        use std::collections::HashSet;
+        let pool = LanguageServerPool::new();
+        assert!(pool.pull_driven_servers(&HashSet::new()).await.is_empty());
     }
 }

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -488,6 +488,12 @@ impl LanguageServerPool {
                 && handle.has_capability("textDocument/diagnostic")
             {
                 pull_driven.insert(server.to_string());
+                // `pull_driven` only ever holds names from `candidates`, so once
+                // every candidate has matched there is nothing left to find —
+                // stop scanning the remaining connections.
+                if pull_driven.len() == candidates.len() {
+                    break;
+                }
             }
         }
         pull_driven

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -463,6 +463,15 @@ impl LanguageServerPool {
     /// The proactive publisher uses this to classify which cached push slots
     /// come from a pull-driven server, so the host-event pull (`PullLayer`) and
     /// that server's spontaneous push don't double-count it.
+    ///
+    /// Classification is **by server name, not by the producing connection**: a
+    /// server with several `(server, root)` connections counts as pull-driven if
+    /// *any* of them advertises the capability. Static initialize caps are
+    /// identical across instances of one binary, so this only diverges if two
+    /// instances hold *different dynamic* diagnostic registrations — an exotic
+    /// case that could misclassify the non-registering instance's push. A precise
+    /// per-`connection_id` classification belongs to the deferred per-source
+    /// fan-in (push-propagation-diagnostic-forwarding); accepted and documented.
     pub(crate) async fn pull_driven_servers(
         &self,
         candidates: &std::collections::HashSet<String>,

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -474,7 +474,7 @@ impl LanguageServerPool {
     /// fan-in (push-propagation-diagnostic-forwarding); accepted and documented.
     pub(crate) async fn pull_driven_servers(
         &self,
-        candidates: &std::collections::HashSet<String>,
+        candidates: &std::collections::HashSet<&str>,
     ) -> std::collections::HashSet<String> {
         if candidates.is_empty() {
             return std::collections::HashSet::new();
@@ -4979,9 +4979,7 @@ mod tests {
         pool.insert_connection(linter).await;
 
         let candidates = HashSet::from([
-            "ra".to_string(),
-            "linter".to_string(),
-            "ghost".to_string(), // no live connection
+            "ra", "linter", "ghost", // no live connection
         ]);
         let pull_driven = pool.pull_driven_servers(&candidates).await;
 
@@ -4997,6 +4995,10 @@ mod tests {
     async fn pull_driven_servers_empty_candidates_returns_empty() {
         use std::collections::HashSet;
         let pool = LanguageServerPool::new();
-        assert!(pool.pull_driven_servers(&HashSet::new()).await.is_empty());
+        assert!(
+            pool.pull_driven_servers(&HashSet::<&str>::new())
+                .await
+                .is_empty()
+        );
     }
 }

--- a/src/lsp/bridge/pool/connection_key.rs
+++ b/src/lsp/bridge/pool/connection_key.rs
@@ -86,7 +86,6 @@ impl ConnectionKey {
     }
 
     /// The config server name (the `language_servers` map key).
-    #[cfg(test)]
     pub(crate) fn server(&self) -> &str {
         &self.server
     }

--- a/src/lsp/debounced_diagnostics.rs
+++ b/src/lsp/debounced_diagnostics.rs
@@ -19,7 +19,7 @@ use super::bridge::{BridgeCoordinator, LanguageServerPool};
 
 use super::lsp_impl::DiagnosticPublisher;
 use super::lsp_impl::text_document::publish_diagnostic::{
-    DiagnosticSnapshot, collect_push_diagnostics,
+    DiagnosticSnapshot, PullLayerOutcome, collect_push_diagnostics,
 };
 use super::synthetic_diagnostics::SyntheticDiagnosticsManager;
 
@@ -235,25 +235,27 @@ async fn execute_debounced_diagnostic(data: DebouncedDiagnosticData) {
         let diagnostics =
             collect_push_diagnostics(snapshot_data, &bridge_pool, &uri_clone, LOG_TARGET).await;
 
-        let Some(diagnostics) = diagnostics else {
-            log::debug!(
-                target: LOG_TARGET,
-                "No diagnostics to collect for {} (no snapshot data)",
-                uri_clone
-            );
-            return;
-        };
-
-        log::debug!(
-            target: LOG_TARGET,
-            "Collected {} pull-layer diagnostics for {} (debounced)",
-            diagnostics.len(),
-            uri_clone
-        );
-
-        // Feed the host-event pull result into the cache and republish the merged
+        // Feed the host-event pull outcome into the cache and republish the merged
         // set (push-propagation-diagnostic-forwarding) — push slots survive.
-        publisher.publish_pull_layer(&uri_clone, diagnostics).await;
+        match diagnostics {
+            PullLayerOutcome::Skip => {
+                log::debug!(
+                    target: LOG_TARGET,
+                    "No diagnostics to collect for {} (no snapshot data)",
+                    uri_clone
+                );
+            }
+            PullLayerOutcome::Clear => publisher.clear_pull_layer(&uri_clone).await,
+            PullLayerOutcome::Publish(diagnostics) => {
+                log::debug!(
+                    target: LOG_TARGET,
+                    "Collected {} pull-layer diagnostics for {} (debounced)",
+                    diagnostics.len(),
+                    uri_clone
+                );
+                publisher.publish_pull_layer(&uri_clone, diagnostics).await;
+            }
+        }
     });
 
     // Register with SyntheticDiagnosticsManager for superseding

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -22,15 +22,18 @@
 //! - [`DiagnosticSource::Host`] — a downstream `_self` host-layer push for the
 //!   real host document, in host coordinates (passes through unchanged).
 //!
-//! **Known interim overlap (deferred capability gate).** The pull feed fans out
-//! to *every* configured server (region and host) with no capability
-//! classification, so a server that both answers `textDocument/diagnostic`
-//! (landing in `PullLayer`) *and* spontaneously pushes `publishDiagnostics`
-//! (landing in a `Region` or `Host` slot) is counted twice. In practice the two
-//! channels are disjoint — a pull-capable server should not also push (LSP) — so
-//! this only *duplicates*, never *hides*, and only for a misbehaving server. The
-//! deferred `pullFallback` / capability classification removes the overlap by
-//! giving each server one native source.
+//! **One native source per server (#425).** A server that both answers
+//! `textDocument/diagnostic` (landing in `PullLayer`) *and* spontaneously pushes
+//! `publishDiagnostics` (landing in a `Region` or `Host` slot) would be counted
+//! twice. The proactive publisher's
+//! [`filter_pull_driven_push_slots`](crate::lsp::lsp_impl::coordinator) drops a
+//! **pull-driven** server's push slots from the publish whenever a `PullLayer`
+//! blob is present (classification is live via
+//! [`LanguageServerPool::pull_driven_servers`](crate::lsp::bridge::LanguageServerPool)),
+//! so the pull contribution wins and the push is kept only as the proactive
+//! source for genuinely **push-driven** servers. The slot stays cached either
+//! way (so a pull-driven server's spontaneous push still closes #380 when
+//! `pullFallback` is off and no `PullLayer` exists).
 //!
 //! Region-invalidation eviction is implemented (`evict_source`, wired into the
 //! edit path that orphans a region — #424) and crash/server eviction too

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -192,6 +192,73 @@ pub(crate) fn merge_cached_diagnostics(
     merged
 }
 
+/// Every distinct server name with a **push** slot (`Region`/`Host`, never
+/// `PullLayer`) in `snapshot`. Path B's `pushFallback` fold uses this to
+/// classify which cached pushers are push-driven (#425). Takes the snapshot the
+/// caller already holds so the candidate set and the folded slots come from the
+/// **same** read (no TOCTOU window across the classifying `await`).
+pub(crate) fn push_slot_servers(snapshot: &SourceSlots) -> std::collections::HashSet<String> {
+    let mut servers = std::collections::HashSet::new();
+    for (source, slots) in snapshot {
+        if matches!(source, DiagnosticSource::PullLayer) {
+            continue;
+        }
+        servers.extend(slots.keys().cloned());
+    }
+    servers
+}
+
+/// Cached **push** diagnostics from `snapshot`, partitioned by layer, for every
+/// `(source, server)` the `include` predicate accepts — Path B's `pushFallback`
+/// fold (#425). `Region` slots are transformed to host coordinates via
+/// `region_offsets` (a region with no current offset is skipped, like the
+/// proactive merge); `Host` slots are already host-local. The `PullLayer` blob
+/// is never returned — Path B live-pulls pull-driven servers, so folding the
+/// blob would double-count them.
+///
+/// The caller passes the snapshot (rather than re-reading the cache) so the
+/// folded slots match the snapshot its candidate classification was derived
+/// from. Returns `(virt_layer_items, host_layer_items)` so the caller can extend
+/// each layer's live-pull result before the cross-layer combine.
+pub(crate) fn cached_push_diagnostics(
+    host: &Url,
+    snapshot: SourceSlots,
+    region_offsets: &HashMap<String, RegionOffset>,
+    include: impl Fn(&DiagnosticSource, &str) -> bool,
+) -> (Vec<Diagnostic>, Vec<Diagnostic>) {
+    let host_str = host.as_str();
+    let mut region_items = Vec::new();
+    let mut host_items = Vec::new();
+    for (source, servers) in snapshot {
+        match &source {
+            DiagnosticSource::PullLayer => {}
+            DiagnosticSource::Region(region_id) => {
+                let Some(offset) = region_offsets.get(region_id) else {
+                    continue;
+                };
+                for (server, slot) in servers {
+                    if !include(&source, &server) {
+                        continue;
+                    }
+                    for mut diagnostic in slot.diagnostics {
+                        transform_region_diagnostic(&mut diagnostic, offset, host_str);
+                        region_items.push(diagnostic);
+                    }
+                }
+            }
+            DiagnosticSource::Host => {
+                for (server, slot) in servers {
+                    if !include(&source, &server) {
+                        continue;
+                    }
+                    host_items.extend(slot.diagnostics);
+                }
+            }
+        }
+    }
+    (region_items, host_items)
+}
+
 /// Largest set for which the serialization-free O(n²) match is used; above this, a
 /// noisy server's payload would make the quadratic compare a republish bottleneck,
 /// so we switch to the O(n) serialized-count path.
@@ -427,72 +494,6 @@ impl DiagnosticAggregator {
                     && servers.values().any(|slot| !slot.diagnostics.is_empty())
             })
         })
-    }
-
-    /// Every distinct server name with a cached **push** slot (`Region`/`Host`,
-    /// never `PullLayer`) for `host`. Path B's `pushFallback` fold uses this to
-    /// classify which cached pushers are push-driven (#425).
-    pub(crate) fn push_slot_servers(&self, host: &Url) -> std::collections::HashSet<String> {
-        let cache = self.lock();
-        let mut servers = std::collections::HashSet::new();
-        if let Some(sources) = cache.get(host) {
-            for (source, slots) in sources {
-                if matches!(source, DiagnosticSource::PullLayer) {
-                    continue;
-                }
-                servers.extend(slots.keys().cloned());
-            }
-        }
-        servers
-    }
-
-    /// Cached **push** diagnostics for `host`, partitioned by layer, for every
-    /// `(source, server)` the `include` predicate accepts — Path B's
-    /// `pushFallback` fold (#425). `Region` slots are transformed to host
-    /// coordinates via `region_offsets` (a region with no current offset is
-    /// skipped, like the proactive merge); `Host` slots are already host-local.
-    /// The `PullLayer` blob is never returned — Path B live-pulls pull-driven
-    /// servers, so folding the blob would double-count them.
-    ///
-    /// Returns `(virt_layer_items, host_layer_items)` so the caller can extend
-    /// each layer's live-pull result before the cross-layer combine.
-    pub(crate) fn cached_push_diagnostics(
-        &self,
-        host: &Url,
-        region_offsets: &HashMap<String, RegionOffset>,
-        include: impl Fn(&DiagnosticSource, &str) -> bool,
-    ) -> (Vec<Diagnostic>, Vec<Diagnostic>) {
-        let host_str = host.as_str();
-        let mut region_items = Vec::new();
-        let mut host_items = Vec::new();
-        for (source, servers) in self.snapshot(host) {
-            match &source {
-                DiagnosticSource::PullLayer => {}
-                DiagnosticSource::Region(region_id) => {
-                    let Some(offset) = region_offsets.get(region_id) else {
-                        continue;
-                    };
-                    for (server, slot) in servers {
-                        if !include(&source, &server) {
-                            continue;
-                        }
-                        for mut diagnostic in slot.diagnostics {
-                            transform_region_diagnostic(&mut diagnostic, offset, host_str);
-                            region_items.push(diagnostic);
-                        }
-                    }
-                }
-                DiagnosticSource::Host => {
-                    for (server, slot) in servers {
-                        if !include(&source, &server) {
-                            continue;
-                        }
-                        host_items.extend(slot.diagnostics);
-                    }
-                }
-            }
-        }
-        (region_items, host_items)
     }
 
     /// Drop everything for a host (host `didClose`). Returns whether it existed.
@@ -1004,7 +1005,7 @@ mod tests {
         );
         agg.set_pull_layer(&host(), vec![diag("p")]);
 
-        let servers = agg.push_slot_servers(&host());
+        let servers = push_slot_servers(&agg.snapshot(&host()));
         assert_eq!(
             servers,
             std::collections::HashSet::from(["linter".to_string(), "hostlint".to_string()]),
@@ -1035,8 +1036,12 @@ mod tests {
         let mut offsets = HashMap::new();
         offsets.insert("r1".to_string(), RegionOffset::new(5, 0));
 
-        let (region_items, host_items) =
-            agg.cached_push_diagnostics(&host(), &offsets, |_source, _server| true);
+        let (region_items, host_items) = cached_push_diagnostics(
+            &host(),
+            agg.snapshot(&host()),
+            &offsets,
+            |_source, _server| true,
+        );
 
         assert_eq!(region_items.len(), 1);
         assert_eq!(region_items[0].message, "region");
@@ -1084,8 +1089,12 @@ mod tests {
         let mut offsets = HashMap::new();
         offsets.insert("r1".to_string(), RegionOffset::new(0, 0));
 
-        let (region_items, host_items) =
-            agg.cached_push_diagnostics(&host(), &offsets, |_source, server| server == "linter");
+        let (region_items, host_items) = cached_push_diagnostics(
+            &host(),
+            agg.snapshot(&host()),
+            &offsets,
+            |_source, server| server == "linter",
+        );
 
         assert_eq!(
             region_items

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -429,6 +429,72 @@ impl DiagnosticAggregator {
         })
     }
 
+    /// Every distinct server name with a cached **push** slot (`Region`/`Host`,
+    /// never `PullLayer`) for `host`. Path B's `pushFallback` fold uses this to
+    /// classify which cached pushers are push-driven (#425).
+    pub(crate) fn push_slot_servers(&self, host: &Url) -> std::collections::HashSet<String> {
+        let cache = self.lock();
+        let mut servers = std::collections::HashSet::new();
+        if let Some(sources) = cache.get(host) {
+            for (source, slots) in sources {
+                if matches!(source, DiagnosticSource::PullLayer) {
+                    continue;
+                }
+                servers.extend(slots.keys().cloned());
+            }
+        }
+        servers
+    }
+
+    /// Cached **push** diagnostics for `host`, partitioned by layer, for every
+    /// `(source, server)` the `include` predicate accepts — Path B's
+    /// `pushFallback` fold (#425). `Region` slots are transformed to host
+    /// coordinates via `region_offsets` (a region with no current offset is
+    /// skipped, like the proactive merge); `Host` slots are already host-local.
+    /// The `PullLayer` blob is never returned — Path B live-pulls pull-driven
+    /// servers, so folding the blob would double-count them.
+    ///
+    /// Returns `(virt_layer_items, host_layer_items)` so the caller can extend
+    /// each layer's live-pull result before the cross-layer combine.
+    pub(crate) fn cached_push_diagnostics(
+        &self,
+        host: &Url,
+        region_offsets: &HashMap<String, RegionOffset>,
+        include: impl Fn(&DiagnosticSource, &str) -> bool,
+    ) -> (Vec<Diagnostic>, Vec<Diagnostic>) {
+        let host_str = host.as_str();
+        let mut region_items = Vec::new();
+        let mut host_items = Vec::new();
+        for (source, servers) in self.snapshot(host) {
+            match &source {
+                DiagnosticSource::PullLayer => {}
+                DiagnosticSource::Region(region_id) => {
+                    let Some(offset) = region_offsets.get(region_id) else {
+                        continue;
+                    };
+                    for (server, slot) in servers {
+                        if !include(&source, &server) {
+                            continue;
+                        }
+                        for mut diagnostic in slot.diagnostics {
+                            transform_region_diagnostic(&mut diagnostic, offset, host_str);
+                            region_items.push(diagnostic);
+                        }
+                    }
+                }
+                DiagnosticSource::Host => {
+                    for (server, slot) in servers {
+                        if !include(&source, &server) {
+                            continue;
+                        }
+                        host_items.extend(slot.diagnostics);
+                    }
+                }
+            }
+        }
+        (region_items, host_items)
+    }
+
     /// Drop everything for a host (host `didClose`). Returns whether it existed.
     pub(crate) fn evict_host(&self, host: &Url) -> bool {
         let mut cache = self.lock();
@@ -917,6 +983,119 @@ mod tests {
             ],
             "host push slots pass through in host coordinates, per server"
         );
+    }
+
+    #[test]
+    fn push_slot_servers_lists_push_servers_excluding_pull_layer() {
+        let agg = DiagnosticAggregator::new();
+        agg.record(
+            &host(),
+            DiagnosticSource::Region("r1".into()),
+            "linter".into(),
+            Some(ProgressConnectionId::for_test(1)),
+            vec![diag("x")],
+        );
+        agg.record(
+            &host(),
+            DiagnosticSource::Host,
+            "hostlint".into(),
+            Some(ProgressConnectionId::for_test(2)),
+            vec![diag("y")],
+        );
+        agg.set_pull_layer(&host(), vec![diag("p")]);
+
+        let servers = agg.push_slot_servers(&host());
+        assert_eq!(
+            servers,
+            std::collections::HashSet::from(["linter".to_string(), "hostlint".to_string()]),
+            "the synthetic pull-layer server is never reported as a pusher"
+        );
+    }
+
+    #[test]
+    fn cached_push_diagnostics_partitions_by_layer_and_transforms_regions() {
+        let agg = DiagnosticAggregator::new();
+        agg.record(
+            &host(),
+            DiagnosticSource::Region("r1".into()),
+            "linter".into(),
+            Some(ProgressConnectionId::for_test(1)),
+            vec![diag_at("region", 0, 0)],
+        );
+        agg.record(
+            &host(),
+            DiagnosticSource::Host,
+            "hostlint".into(),
+            Some(ProgressConnectionId::for_test(2)),
+            vec![diag_at("host", 8, 0)],
+        );
+        // The pull blob must never be folded into the client-pull response.
+        agg.set_pull_layer(&host(), vec![diag_at("pull", 9, 0)]);
+
+        let mut offsets = HashMap::new();
+        offsets.insert("r1".to_string(), RegionOffset::new(5, 0));
+
+        let (region_items, host_items) =
+            agg.cached_push_diagnostics(&host(), &offsets, |_source, _server| true);
+
+        assert_eq!(region_items.len(), 1);
+        assert_eq!(region_items[0].message, "region");
+        assert_eq!(
+            region_items[0].range.start.line, 5,
+            "region push is transformed to host coordinates (base line 5)"
+        );
+        assert_eq!(
+            host_items
+                .iter()
+                .map(|d| d.message.as_str())
+                .collect::<Vec<_>>(),
+            vec!["host"],
+            "host push passes through; the pull blob is excluded"
+        );
+    }
+
+    #[test]
+    fn cached_push_diagnostics_respects_include_predicate_and_missing_offset() {
+        let agg = DiagnosticAggregator::new();
+        // Two region servers; only "linter" is included by the predicate.
+        agg.record(
+            &host(),
+            DiagnosticSource::Region("r1".into()),
+            "linter".into(),
+            Some(ProgressConnectionId::for_test(1)),
+            vec![diag_at("kept", 0, 0)],
+        );
+        agg.record(
+            &host(),
+            DiagnosticSource::Region("r1".into()),
+            "ra".into(),
+            Some(ProgressConnectionId::for_test(2)),
+            vec![diag_at("excluded", 0, 0)],
+        );
+        // A region with no current offset is skipped entirely.
+        agg.record(
+            &host(),
+            DiagnosticSource::Region("gone".into()),
+            "linter".into(),
+            Some(ProgressConnectionId::for_test(3)),
+            vec![diag_at("stale", 0, 0)],
+        );
+
+        let mut offsets = HashMap::new();
+        offsets.insert("r1".to_string(), RegionOffset::new(0, 0));
+
+        let (region_items, host_items) =
+            agg.cached_push_diagnostics(&host(), &offsets, |_source, server| server == "linter");
+
+        assert_eq!(
+            region_items
+                .iter()
+                .map(|d| d.message.as_str())
+                .collect::<Vec<_>>(),
+            vec!["kept"],
+            "only the included server's slot in a region with a live offset is returned"
+        );
+        assert!(host_items.is_empty());
     }
 
     #[test]

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -25,8 +25,8 @@
 //! **One native source per server (#425).** A server that both answers
 //! `textDocument/diagnostic` (landing in `PullLayer`) *and* spontaneously pushes
 //! `publishDiagnostics` (landing in a `Region` or `Host` slot) would be counted
-//! twice. The proactive publisher's
-//! [`filter_pull_driven_push_slots`](crate::lsp::lsp_impl::coordinator) drops a
+//! twice. The proactive [`DiagnosticPublisher`](crate::lsp::lsp_impl::coordinator)'s
+//! `filter_pull_driven_push_slots` drops a
 //! **pull-driven** server's push slots from the publish whenever a `PullLayer`
 //! blob is present (classification is live via
 //! [`LanguageServerPool::pull_driven_servers`](crate::lsp::bridge::LanguageServerPool)),
@@ -197,13 +197,13 @@ pub(crate) fn merge_cached_diagnostics(
 /// classify which cached pushers are push-driven (#425). Takes the snapshot the
 /// caller already holds so the candidate set and the folded slots come from the
 /// **same** read (no TOCTOU window across the classifying `await`).
-pub(crate) fn push_slot_servers(snapshot: &SourceSlots) -> std::collections::HashSet<String> {
+pub(crate) fn push_slot_servers(snapshot: &SourceSlots) -> std::collections::HashSet<&str> {
     let mut servers = std::collections::HashSet::new();
     for (source, slots) in snapshot {
         if matches!(source, DiagnosticSource::PullLayer) {
             continue;
         }
-        servers.extend(slots.keys().cloned());
+        servers.extend(slots.keys().map(String::as_str));
     }
     servers
 }
@@ -1005,10 +1005,11 @@ mod tests {
         );
         agg.set_pull_layer(&host(), vec![diag("p")]);
 
-        let servers = push_slot_servers(&agg.snapshot(&host()));
+        let snapshot = agg.snapshot(&host());
+        let servers = push_slot_servers(&snapshot);
         assert_eq!(
             servers,
-            std::collections::HashSet::from(["linter".to_string(), "hostlint".to_string()]),
+            std::collections::HashSet::from(["linter", "hostlint"]),
             "the synthetic pull-layer server is never reported as a pusher"
         );
     }

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -25,7 +25,8 @@
 //! **One native source per server (#425).** A server that both answers
 //! `textDocument/diagnostic` (landing in `PullLayer`) *and* spontaneously pushes
 //! `publishDiagnostics` (landing in a `Region` or `Host` slot) would be counted
-//! twice. The proactive [`DiagnosticPublisher`](crate::lsp::lsp_impl::coordinator)'s
+//! twice. The proactive
+//! [`DiagnosticPublisher`](crate::lsp::lsp_impl::coordinator::DiagnosticPublisher)'s
 //! `filter_pull_driven_push_slots` drops a
 //! **pull-driven** server's push slots from the publish whenever a `PullLayer`
 //! blob is present (classification is live via

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -965,6 +965,7 @@ mod tests {
                 priorities: None,
                 strategy: Some(strategy),
                 max_fan_out: None,
+                ..Default::default()
             },
         );
         BridgeLanguageConfig {
@@ -1243,6 +1244,7 @@ mod tests {
                 priorities: None,
                 strategy: Some(AggregationStrategy::Concatenated),
                 max_fan_out: None,
+                ..Default::default()
             },
         );
         agg.insert(
@@ -1251,6 +1253,7 @@ mod tests {
                 priorities: None,
                 strategy: Some(AggregationStrategy::Preferred),
                 max_fan_out: None,
+                ..Default::default()
             },
         );
         let mut bridge = HashMap::new();
@@ -1284,6 +1287,7 @@ mod tests {
                 priorities: Some(vec!["black".to_string(), "isort".to_string()]),
                 strategy: Some(AggregationStrategy::Concatenated),
                 max_fan_out: None,
+                ..Default::default()
             },
         );
         let mut bridge = HashMap::new();
@@ -1318,6 +1322,7 @@ mod tests {
                 priorities: None,
                 strategy: Some(AggregationStrategy::Concatenated),
                 max_fan_out: None,
+                ..Default::default()
             },
         );
         agg.insert(
@@ -1326,6 +1331,7 @@ mod tests {
                 priorities: Some(vec!["black".to_string()]),
                 strategy: None,
                 max_fan_out: None,
+                ..Default::default()
             },
         );
         let mut bridge = HashMap::new();
@@ -1386,6 +1392,7 @@ mod tests {
                 priorities: None,
                 strategy: Some(AggregationStrategy::Concatenated),
                 max_fan_out: None,
+                ..Default::default()
             },
         );
         let mut wildcard_agg = HashMap::new();
@@ -1395,6 +1402,7 @@ mod tests {
                 priorities: Some(vec!["black".to_string()]),
                 strategy: None,
                 max_fan_out: None,
+                ..Default::default()
             },
         );
         let mut bridge = HashMap::new();
@@ -1436,6 +1444,7 @@ mod tests {
                 priorities: Some(vec![]),
                 strategy: Some(AggregationStrategy::Concatenated),
                 max_fan_out: None,
+                ..Default::default()
             },
         );
         let mut bridge = HashMap::new();
@@ -1471,6 +1480,7 @@ mod tests {
                 ]),
                 strategy: Some(AggregationStrategy::Concatenated),
                 max_fan_out: None,
+                ..Default::default()
             },
         );
         let mut bridge = HashMap::new();

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -15,13 +15,23 @@ use crate::lsp::lsp_impl::text_document::publish_diagnostic::{
 use crate::lsp::settings_manager::SettingsManager;
 use crate::lsp::synthetic_diagnostics::SyntheticDiagnosticsManager;
 
-/// Whether the proactive pull would dispatch to **at least one** server for a
-/// method, resolving the visible walk exactly as dispatch does (expand
+/// Whether the proactive pull's **config-level** server selection for a method
+/// is non-empty — the visible walk resolved exactly as dispatch does (expand
 /// `priorities`, truncate by `maxFanOut`, then the allowlist select). An empty
-/// result (`priorities = []`, `maxFanOut = 0`, or names only unconfigured
-/// servers) means no pull runs, so the caller skips the context — keeping the
-/// invariant "a `PullLayer` is present only when a pull actually dispatched"
-/// (#425), so an empty pull layer never falsely suppresses a spontaneous push.
+/// selection (`priorities = []`, `maxFanOut = 0`, or names only unconfigured
+/// servers) means the pull would fan out to nobody, so the caller skips the
+/// context entirely.
+///
+/// This is a *selection* check, not a contribution prediction: a non-empty
+/// selection still builds a context and runs the pull even if every selected
+/// server is capability-gated at runtime (`send_diagnostic_request` /
+/// `send_host_raw_request` return empty when a server lacks
+/// `textDocument/diagnostic`), leaving a present-but-**empty** `PullLayer`. That
+/// is harmless for the pull/push dedup (#425): a capability-gated server is, by
+/// definition, *push*-driven, so `filter_pull_driven_push_slots` never
+/// suppresses its spontaneous push against that empty blob. The skip here only
+/// stops a *config*-empty selection from minting an empty `PullLayer` that would
+/// falsely suppress a genuinely pull-driven server's push.
 fn dispatches_to_any_server(
     priorities: &[String],
     configs: &[ResolvedServerConfig],

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -2,7 +2,7 @@ use crate::config::settings::ResolvedAggregationConfig;
 use crate::document::DocumentStore;
 use crate::language::InjectionResolver;
 use crate::language::LanguageCoordinator;
-use crate::lsp::aggregation::server::{expand_priorities, select_servers, truncate_entries};
+use crate::lsp::aggregation::server::{expand_priorities, truncate_entries};
 use crate::lsp::bridge::{BridgeCoordinator, ResolvedServerConfig};
 use crate::lsp::debounced_diagnostics::DebouncedDiagnosticsManager;
 use crate::lsp::lsp_impl::bridge_context::resolve_aggregation_config_from_settings;
@@ -18,10 +18,12 @@ use crate::lsp::synthetic_diagnostics::SyntheticDiagnosticsManager;
 
 /// Whether the proactive pull's **config-level** server selection for a method
 /// is non-empty — the visible walk resolved exactly as dispatch does (expand
-/// `priorities`, truncate by `maxFanOut`, then the allowlist select). An empty
-/// selection (`priorities = []`, `maxFanOut = 0`, or names only unconfigured
-/// servers) means the pull would fan out to nobody, so the caller skips the
-/// context entirely.
+/// `priorities`, then truncate by `maxFanOut`). The walk already drops
+/// unconfigured names and empty `Rest` groups, so a non-empty walk is exactly a
+/// non-empty selection; checking `is_empty()` avoids `select_servers`' config
+/// map + `ResolvedServerConfig` clones. An empty selection (`priorities = []`,
+/// `maxFanOut = 0`, or names only unconfigured servers) means the pull would fan
+/// out to nobody, so the caller skips the context entirely.
 ///
 /// This is a *selection* check, not a contribution prediction: a non-empty
 /// selection still builds a context and runs the pull even if every selected
@@ -38,8 +40,7 @@ fn dispatches_to_any_server(
     configs: &[ResolvedServerConfig],
     max_fan_out: Option<usize>,
 ) -> bool {
-    let entries = truncate_entries(expand_priorities(priorities, configs), max_fan_out);
-    !select_servers(configs, &entries).is_empty()
+    !truncate_entries(expand_priorities(priorities, configs), max_fan_out).is_empty()
 }
 
 pub(crate) struct DiagnosticScheduler {

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -1,3 +1,4 @@
+use crate::config::settings::ResolvedAggregationConfig;
 use crate::document::DocumentStore;
 use crate::language::InjectionResolver;
 use crate::language::LanguageCoordinator;
@@ -161,46 +162,51 @@ impl DiagnosticScheduler {
         // Virt layer: `None` = the document can never have virt diagnostics
         // (no injection query), distinct from `Some(vec![])` = gated off or
         // currently no regions (publish-empty-to-clear).
-        let virt_contexts: Option<Vec<DocumentRequestContext>> =
-            if !layer_cfg.allows(crate::config::settings::LayerSource::Virt) {
-                log::debug!(
-                    target: LOG_TARGET,
-                    "virt layer disabled for {} via layers.aggregation priorities",
-                    language_name
-                );
-                Some(Vec::new())
-            } else {
-                self.language
-                    .injection_query(&language_name)
-                    .map(|injection_query| {
-                        let all_regions = InjectionResolver::resolve_all(
-                            &self.language,
-                            self.bridge.node_tracker(),
-                            uri,
-                            snapshot.tree(),
-                            snapshot.text(),
-                            injection_query.as_ref(),
-                        );
+        let virt_contexts: Option<Vec<DocumentRequestContext>> = if !layer_cfg
+            .allows(crate::config::settings::LayerSource::Virt)
+        {
+            log::debug!(
+                target: LOG_TARGET,
+                "virt layer disabled for {} via layers.aggregation priorities",
+                language_name
+            );
+            Some(Vec::new())
+        } else {
+            self.language
+                .injection_query(&language_name)
+                .map(|injection_query| {
+                    let all_regions = InjectionResolver::resolve_all(
+                        &self.language,
+                        self.bridge.node_tracker(),
+                        uri,
+                        snapshot.tree(),
+                        snapshot.text(),
+                        injection_query.as_ref(),
+                    );
 
-                        let mut contexts = Vec::new();
-                        // Configs + aggregation are keyed by injection language, so
-                        // resolve them once per distinct language (a document can
-                        // hold many regions of one language). `None` caches a skipped
-                        // language: no configured server, OR the pull would dispatch
-                        // to none.
-                        let mut resolved_by_lang = std::collections::HashMap::new();
-                        for resolved in all_regions {
-                            let entry = resolved_by_lang
-                                .entry(resolved.injection_language.clone())
-                                .or_insert_with_key(|lang| {
-                                    let configs = self.bridge.get_all_configs_for_language(
-                                        &settings,
-                                        &language_name,
-                                        lang,
-                                    );
-                                    if configs.is_empty() {
-                                        return None;
-                                    }
+                    let mut contexts = Vec::new();
+                    // Configs + aggregation are keyed by injection language, so
+                    // resolve them once per distinct language (a document can
+                    // hold many regions of one language). `None` caches a skipped
+                    // language: no configured server, OR the pull would dispatch
+                    // to none. The key is cloned only on the resolving miss, not
+                    // on every region.
+                    type ResolvedLang =
+                        Option<(Vec<ResolvedServerConfig>, ResolvedAggregationConfig)>;
+                    let mut resolved_by_lang: std::collections::HashMap<String, ResolvedLang> =
+                        std::collections::HashMap::new();
+                    for resolved in all_regions {
+                        if !resolved_by_lang.contains_key(&resolved.injection_language) {
+                            let lang = &resolved.injection_language;
+                            let computed: ResolvedLang = {
+                                let configs = self.bridge.get_all_configs_for_language(
+                                    &settings,
+                                    &language_name,
+                                    lang,
+                                );
+                                if configs.is_empty() {
+                                    None
+                                } else {
                                     let agg = resolve_aggregation_config_from_settings(
                                         &settings,
                                         &language_name,
@@ -224,28 +230,33 @@ impl DiagnosticScheduler {
                                             agg.max_fan_out,
                                         )
                                     {
-                                        return None;
+                                        None
+                                    } else {
+                                        Some((configs, agg))
                                     }
-                                    Some((configs, agg))
-                                });
-                            let Some((configs, agg)) = entry.as_ref() else {
-                                continue;
+                                }
                             };
-
-                            contexts.push(DocumentRequestContext {
-                                uri: uri.clone(),
-                                resolved,
-                                configs: configs.clone(),
-                                upstream_request_id: None,
-                                priorities: agg.priorities.clone(),
-                                strategy: agg.strategy,
-                                max_fan_out: agg.max_fan_out,
-                                client_progress_token: None,
-                            });
+                            resolved_by_lang.insert(resolved.injection_language.clone(), computed);
                         }
-                        contexts
-                    })
-            };
+                        let Some((configs, agg)) = &resolved_by_lang[&resolved.injection_language]
+                        else {
+                            continue;
+                        };
+
+                        contexts.push(DocumentRequestContext {
+                            uri: uri.clone(),
+                            resolved,
+                            configs: configs.clone(),
+                            upstream_request_id: None,
+                            priorities: agg.priorities.clone(),
+                            strategy: agg.strategy,
+                            max_fan_out: agg.max_fan_out,
+                            client_progress_token: None,
+                        });
+                    }
+                    contexts
+                })
+        };
 
         // Host layer (host-document-bridge): participates when listed in the
         // layer priorities AND opted in via bridge._self.enabled with a

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -9,7 +9,7 @@ use url::Url;
 
 use crate::lsp::lsp_impl::Kakehashi;
 use crate::lsp::lsp_impl::text_document::publish_diagnostic::{
-    DiagnosticSnapshot, collect_push_diagnostics,
+    DiagnosticSnapshot, PullLayerOutcome, collect_push_diagnostics,
 };
 use crate::lsp::settings_manager::SettingsManager;
 use crate::lsp::synthetic_diagnostics::SyntheticDiagnosticsManager;
@@ -75,21 +75,22 @@ impl DiagnosticScheduler {
             let diagnostics =
                 collect_push_diagnostics(snapshot_data, &bridge_pool, &uri_clone, LOG_TARGET).await;
 
-            let Some(diagnostics) = diagnostics else {
-                return;
-            };
-
-            log::debug!(
-                target: LOG_TARGET,
-                "Collected {} pull-layer diagnostics for {}",
-                diagnostics.len(),
-                uri_clone
-            );
-
-            // Feed the host-event pull result into the cache and republish the
+            // Feed the host-event pull outcome into the cache and republish the
             // merged set (push-propagation-diagnostic-forwarding) instead of
             // publishing directly — push slots for the same host survive.
-            publisher.publish_pull_layer(&uri_clone, diagnostics).await;
+            match diagnostics {
+                PullLayerOutcome::Skip => {}
+                PullLayerOutcome::Clear => publisher.clear_pull_layer(&uri_clone).await,
+                PullLayerOutcome::Publish(diagnostics) => {
+                    log::debug!(
+                        target: LOG_TARGET,
+                        "Collected {} pull-layer diagnostics for {}",
+                        diagnostics.len(),
+                        uri_clone
+                    );
+                    publisher.publish_pull_layer(&uri_clone, diagnostics).await;
+                }
+            }
         });
 
         self.synthetic_diagnostics
@@ -201,45 +202,55 @@ impl DiagnosticScheduler {
         // layer priorities AND opted in via bridge._self.enabled with a
         // host-capable server. No upstream request id — push tasks are not
         // tied to a client request.
-        let host = if layer_cfg.allows(crate::config::settings::LayerSource::Host) {
+        //
+        // `host_bridging_configured` is that participation *independent of*
+        // `pullFallback`; `host` is the pull context, which `pullFallback` can
+        // gate to `None` while the layer stays configured. The split matters so
+        // an all-gated host still yields a snapshot whose Clear outcome evicts a
+        // stale `PullLayer` (#425) rather than skipping and leaving it to linger.
+        let host_lang_settings = if layer_cfg.allows(crate::config::settings::LayerSource::Host) {
             settings
                 .resolve_host_language_settings(&language_name)
                 .filter(|lang_settings| lang_settings.is_host_bridging_enabled())
-                .and_then(|lang_settings| {
-                    let configs = self
-                        .bridge
-                        .get_host_configs_for_language(&settings, &language_name);
-                    if configs.is_empty() {
-                        return None;
-                    }
-                    let agg =
-                        lang_settings.resolve_host_aggregation("textDocument/publishDiagnostics");
-                    // `pullFallback = false` skips the host-layer pull (Path A,
-                    // #425); a push-driven `_self` server still publishes via its
-                    // cached pushes, and a pull-only `_self` server simply stops
-                    // being pulled on host events.
-                    if !agg.pull_fallback {
-                        return None;
-                    }
-                    Some(HostRequestContext {
-                        uri: uri.clone(),
-                        language_id: language_name.clone(),
-                        text: std::sync::Arc::from(snapshot.text()),
-                        configs,
-                        priorities: agg.priorities,
-                        strategy: agg.strategy,
-                        max_fan_out: agg.max_fan_out,
-                        upstream_request_id: None,
-                    })
-                })
         } else {
             None
         };
+        let mut host_bridging_configured = false;
+        let host = host_lang_settings.and_then(|lang_settings| {
+            let configs = self
+                .bridge
+                .get_host_configs_for_language(&settings, &language_name);
+            if configs.is_empty() {
+                return None;
+            }
+            host_bridging_configured = true;
+            let agg = lang_settings.resolve_host_aggregation("textDocument/publishDiagnostics");
+            // `pullFallback = false` skips the host-layer pull (Path A, #425); a
+            // push-driven `_self` server still publishes via its cached pushes,
+            // and a pull-only `_self` server simply stops being pulled on host
+            // events. The layer stays configured (above), so the snapshot is
+            // still produced and its Clear outcome evicts any stale pull blob.
+            if !agg.pull_fallback {
+                return None;
+            }
+            Some(HostRequestContext {
+                uri: uri.clone(),
+                language_id: language_name.clone(),
+                text: std::sync::Arc::from(snapshot.text()),
+                configs,
+                priorities: agg.priorities,
+                strategy: agg.strategy,
+                max_fan_out: agg.max_fan_out,
+                upstream_request_id: None,
+            })
+        });
 
-        // A document that can never contribute (no injection query, no host
-        // participation) keeps the old skip-publishing behavior.
-        let virt_contexts = match (virt_contexts, &host) {
-            (None, None) => return None,
+        // A document that can never contribute (no injection query AND no
+        // configured host layer) keeps the old skip-publishing behavior. A
+        // configured-but-pull-gated host still produces a snapshot so its stale
+        // `PullLayer` is cleared on this event.
+        let virt_contexts = match (virt_contexts, host.is_some() || host_bridging_configured) {
+            (None, false) => return None,
             (virt, _) => virt.unwrap_or_default(),
         };
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -163,101 +163,107 @@ impl DiagnosticScheduler {
         // Virt layer: `None` = the document can never have virt diagnostics
         // (no injection query), distinct from `Some(vec![])` = gated off or
         // currently no regions (publish-empty-to-clear).
-        let virt_contexts: Option<Vec<DocumentRequestContext>> = if !layer_cfg
-            .allows(crate::config::settings::LayerSource::Virt)
-        {
-            log::debug!(
-                target: LOG_TARGET,
-                "virt layer disabled for {} via layers.aggregation priorities",
-                language_name
-            );
-            Some(Vec::new())
-        } else {
-            self.language
-                .injection_query(&language_name)
-                .map(|injection_query| {
-                    let all_regions = InjectionResolver::resolve_all(
-                        &self.language,
-                        self.bridge.node_tracker(),
-                        uri,
-                        snapshot.tree(),
-                        snapshot.text(),
-                        injection_query.as_ref(),
-                    );
+        let virt_contexts: Option<Vec<DocumentRequestContext>> =
+            if !layer_cfg.allows(crate::config::settings::LayerSource::Virt) {
+                log::debug!(
+                    target: LOG_TARGET,
+                    "virt layer disabled for {} via layers.aggregation priorities",
+                    language_name
+                );
+                Some(Vec::new())
+            } else {
+                self.language
+                    .injection_query(&language_name)
+                    .map(|injection_query| {
+                        let all_regions = InjectionResolver::resolve_all(
+                            &self.language,
+                            self.bridge.node_tracker(),
+                            uri,
+                            snapshot.tree(),
+                            snapshot.text(),
+                            injection_query.as_ref(),
+                        );
 
-                    let mut contexts = Vec::new();
-                    // Configs + aggregation are keyed by injection language, so
-                    // resolve them once per distinct language (a document can
-                    // hold many regions of one language). `None` caches a skipped
-                    // language: no configured server, OR the pull would dispatch
-                    // to none. The key is cloned only on the resolving miss, not
-                    // on every region.
-                    type ResolvedLang =
-                        Option<(Vec<ResolvedServerConfig>, ResolvedAggregationConfig)>;
-                    let mut resolved_by_lang: std::collections::HashMap<String, ResolvedLang> =
-                        std::collections::HashMap::new();
-                    for resolved in all_regions {
-                        if !resolved_by_lang.contains_key(&resolved.injection_language) {
-                            let lang = &resolved.injection_language;
-                            let computed: ResolvedLang = {
-                                let configs = self.bridge.get_all_configs_for_language(
-                                    &settings,
-                                    &language_name,
-                                    lang,
-                                );
-                                if configs.is_empty() {
-                                    None
-                                } else {
-                                    let agg = resolve_aggregation_config_from_settings(
-                                        &settings,
-                                        &language_name,
-                                        lang,
-                                        "textDocument/publishDiagnostics",
-                                    );
-                                    // Only keep a language the pull will actually
-                                    // dispatch (#425): drop it when `pullFallback =
-                                    // false` OR its effective server selection is
-                                    // empty (`priorities = []`, `maxFanOut = 0`, or
-                                    // names only unconfigured servers). This keeps
-                                    // the invariant "PullLayer present ⟺ a pull
-                                    // dispatched to ≥1 server", so an absent/Clear
-                                    // pull layer never falsely suppresses a server's
-                                    // spontaneous push. The push path is untouched —
-                                    // only kakehashi's pulling stops.
-                                    if !agg.pull_fallback
-                                        || !dispatches_to_any_server(
-                                            &agg.priorities,
-                                            &configs,
-                                            agg.max_fan_out,
-                                        )
-                                    {
-                                        None
-                                    } else {
-                                        Some((configs, agg))
-                                    }
+                        let mut contexts = Vec::new();
+                        // Configs + aggregation are keyed by injection language, so
+                        // resolve them once per distinct language (a document can
+                        // hold many regions of one language). `None` caches a skipped
+                        // language: no configured server, OR the pull would dispatch
+                        // to none. The key is cloned only on the resolving miss, not
+                        // on every region.
+                        type ResolvedLang =
+                            Option<(Vec<ResolvedServerConfig>, ResolvedAggregationConfig)>;
+                        let mut resolved_by_lang: std::collections::HashMap<String, ResolvedLang> =
+                            std::collections::HashMap::new();
+                        for resolved in all_regions {
+                            // `get` on the common (cache-hit) path is a single lookup;
+                            // only the resolving miss touches the map again, cloning
+                            // the language key just for that insert.
+                            let entry = match resolved_by_lang.get(&resolved.injection_language) {
+                                Some(entry) => entry,
+                                None => {
+                                    let lang = &resolved.injection_language;
+                                    let computed: ResolvedLang = {
+                                        let configs = self.bridge.get_all_configs_for_language(
+                                            &settings,
+                                            &language_name,
+                                            lang,
+                                        );
+                                        if configs.is_empty() {
+                                            None
+                                        } else {
+                                            let agg = resolve_aggregation_config_from_settings(
+                                                &settings,
+                                                &language_name,
+                                                lang,
+                                                "textDocument/publishDiagnostics",
+                                            );
+                                            // Only keep a language the pull will actually
+                                            // dispatch (#425): drop it when `pullFallback =
+                                            // false` OR its effective server selection is
+                                            // empty (`priorities = []`, `maxFanOut = 0`, or
+                                            // names only unconfigured servers). This keeps
+                                            // the invariant "PullLayer present ⟺ a pull
+                                            // dispatched to ≥1 server", so an absent/Clear
+                                            // pull layer never falsely suppresses a
+                                            // server's spontaneous push. The push path is
+                                            // untouched — only kakehashi's pulling stops.
+                                            if !agg.pull_fallback
+                                                || !dispatches_to_any_server(
+                                                    &agg.priorities,
+                                                    &configs,
+                                                    agg.max_fan_out,
+                                                )
+                                            {
+                                                None
+                                            } else {
+                                                Some((configs, agg))
+                                            }
+                                        }
+                                    };
+                                    resolved_by_lang
+                                        .entry(resolved.injection_language.clone())
+                                        .or_insert(computed)
                                 }
                             };
-                            resolved_by_lang.insert(resolved.injection_language.clone(), computed);
-                        }
-                        let Some((configs, agg)) = &resolved_by_lang[&resolved.injection_language]
-                        else {
-                            continue;
-                        };
+                            let Some((configs, agg)) = entry else {
+                                continue;
+                            };
 
-                        contexts.push(DocumentRequestContext {
-                            uri: uri.clone(),
-                            resolved,
-                            configs: configs.clone(),
-                            upstream_request_id: None,
-                            priorities: agg.priorities.clone(),
-                            strategy: agg.strategy,
-                            max_fan_out: agg.max_fan_out,
-                            client_progress_token: None,
-                        });
-                    }
-                    contexts
-                })
-        };
+                            contexts.push(DocumentRequestContext {
+                                uri: uri.clone(),
+                                resolved,
+                                configs: configs.clone(),
+                                upstream_request_id: None,
+                                priorities: agg.priorities.clone(),
+                                strategy: agg.strategy,
+                                max_fan_out: agg.max_fan_out,
+                                client_progress_token: None,
+                            });
+                        }
+                        contexts
+                    })
+            };
 
         // Host layer (host-document-bridge): participates when listed in the
         // layer priorities AND opted in via bridge._self.enabled with a

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -1,7 +1,8 @@
 use crate::document::DocumentStore;
 use crate::language::InjectionResolver;
 use crate::language::LanguageCoordinator;
-use crate::lsp::bridge::BridgeCoordinator;
+use crate::lsp::aggregation::server::{expand_priorities, select_servers, truncate_entries};
+use crate::lsp::bridge::{BridgeCoordinator, ResolvedServerConfig};
 use crate::lsp::debounced_diagnostics::DebouncedDiagnosticsManager;
 use crate::lsp::lsp_impl::bridge_context::resolve_aggregation_config_from_settings;
 use crate::lsp::lsp_impl::bridge_context::{DocumentRequestContext, HostRequestContext};
@@ -13,6 +14,22 @@ use crate::lsp::lsp_impl::text_document::publish_diagnostic::{
 };
 use crate::lsp::settings_manager::SettingsManager;
 use crate::lsp::synthetic_diagnostics::SyntheticDiagnosticsManager;
+
+/// Whether the proactive pull would dispatch to **at least one** server for a
+/// method, resolving the visible walk exactly as dispatch does (expand
+/// `priorities`, truncate by `maxFanOut`, then the allowlist select). An empty
+/// result (`priorities = []`, `maxFanOut = 0`, or names only unconfigured
+/// servers) means no pull runs, so the caller skips the context — keeping the
+/// invariant "a `PullLayer` is present only when a pull actually dispatched"
+/// (#425), so an empty pull layer never falsely suppresses a spontaneous push.
+fn dispatches_to_any_server(
+    priorities: &[String],
+    configs: &[ResolvedServerConfig],
+    max_fan_out: Option<usize>,
+) -> bool {
+    let entries = truncate_entries(expand_priorities(priorities, configs), max_fan_out);
+    !select_servers(configs, &entries).is_empty()
+}
 
 pub(crate) struct DiagnosticScheduler {
     language: std::sync::Arc<LanguageCoordinator>,
@@ -103,9 +120,10 @@ impl DiagnosticScheduler {
     /// Extracts all data synchronously before spawning to avoid lifetime issues
     /// with `self` references in async tasks. Return states: `None` (document
     /// missing, no snapshot, no language, or nothing that could ever
-    /// contribute — skip publishing), `Some(snapshot)` with no contributors
-    /// (caller publishes empty to clear), and `Some(snapshot)` with
-    /// virt regions and/or a host context ready for requests.
+    /// contribute — skip), `Some(snapshot)` with no pull contributors (the
+    /// collection returns `Clear`, evicting any stale `PullLayer`; a
+    /// configured-but-pull-gated host still lands here so its re-sync runs), and
+    /// `Some(snapshot)` with virt regions and/or a pullable host context.
     pub(crate) fn prepare_diagnostic_snapshot(&self, uri: &Url) -> Option<DiagnosticSnapshot> {
         let (snapshot, language_name) = {
             let doc = self.documents.get(uri)?;
@@ -133,81 +151,92 @@ impl DiagnosticScheduler {
         // Virt layer: `None` = the document can never have virt diagnostics
         // (no injection query), distinct from `Some(vec![])` = gated off or
         // currently no regions (publish-empty-to-clear).
-        let virt_contexts: Option<Vec<DocumentRequestContext>> =
-            if !layer_cfg.allows(crate::config::settings::LayerSource::Virt) {
-                log::debug!(
-                    target: LOG_TARGET,
-                    "virt layer disabled for {} via layers.aggregation priorities",
-                    language_name
-                );
-                Some(Vec::new())
-            } else {
-                self.language
-                    .injection_query(&language_name)
-                    .map(|injection_query| {
-                        let all_regions = InjectionResolver::resolve_all(
-                            &self.language,
-                            self.bridge.node_tracker(),
-                            uri,
-                            snapshot.tree(),
-                            snapshot.text(),
-                            injection_query.as_ref(),
+        let virt_contexts: Option<Vec<DocumentRequestContext>> = if !layer_cfg
+            .allows(crate::config::settings::LayerSource::Virt)
+        {
+            log::debug!(
+                target: LOG_TARGET,
+                "virt layer disabled for {} via layers.aggregation priorities",
+                language_name
+            );
+            Some(Vec::new())
+        } else {
+            self.language
+                .injection_query(&language_name)
+                .map(|injection_query| {
+                    let all_regions = InjectionResolver::resolve_all(
+                        &self.language,
+                        self.bridge.node_tracker(),
+                        uri,
+                        snapshot.tree(),
+                        snapshot.text(),
+                        injection_query.as_ref(),
+                    );
+
+                    let mut contexts = Vec::new();
+                    for resolved in all_regions {
+                        let configs = self.bridge.get_all_configs_for_language(
+                            &settings,
+                            &language_name,
+                            &resolved.injection_language,
+                        );
+                        if configs.is_empty() {
+                            continue;
+                        }
+
+                        let agg = resolve_aggregation_config_from_settings(
+                            &settings,
+                            &language_name,
+                            &resolved.injection_language,
+                            "textDocument/publishDiagnostics",
                         );
 
-                        let mut contexts = Vec::new();
-                        for resolved in all_regions {
-                            let configs = self.bridge.get_all_configs_for_language(
-                                &settings,
-                                &language_name,
-                                &resolved.injection_language,
-                            );
-                            if configs.is_empty() {
-                                continue;
-                            }
-
-                            let agg = resolve_aggregation_config_from_settings(
-                                &settings,
-                                &language_name,
-                                &resolved.injection_language,
-                                "textDocument/publishDiagnostics",
-                            );
-
-                            // `pullFallback = false` drops this region's
-                            // pull-driven servers from the proactive path: the
-                            // host-event pull does not fan out to them (Path A,
-                            // #425). Their spontaneous pushes are still cached and
-                            // published; only kakehashi's pulling stops. An empty
-                            // contexts list still publishes-empty to clear any
-                            // stale pull contribution.
-                            if !agg.pull_fallback {
-                                continue;
-                            }
-
-                            contexts.push(DocumentRequestContext {
-                                uri: uri.clone(),
-                                resolved,
-                                configs,
-                                upstream_request_id: None,
-                                priorities: agg.priorities,
-                                strategy: agg.strategy,
-                                max_fan_out: agg.max_fan_out,
-                                client_progress_token: None,
-                            });
+                        // Only build a context for a region the pull will
+                        // actually dispatch (#425): drop it when `pullFallback
+                        // = false` OR its effective server selection is empty
+                        // (`priorities = []`, `maxFanOut = 0`, or names only
+                        // unconfigured servers). This keeps the invariant
+                        // "PullLayer present ⟺ a pull dispatched to ≥1
+                        // server": an absent/Clear pull layer (not an empty
+                        // one) then never falsely suppresses a server's
+                        // spontaneous push. The push path is untouched — only
+                        // kakehashi's pulling stops.
+                        if !agg.pull_fallback
+                            || !dispatches_to_any_server(&agg.priorities, &configs, agg.max_fan_out)
+                        {
+                            continue;
                         }
-                        contexts
-                    })
-            };
+
+                        contexts.push(DocumentRequestContext {
+                            uri: uri.clone(),
+                            resolved,
+                            configs,
+                            upstream_request_id: None,
+                            priorities: agg.priorities,
+                            strategy: agg.strategy,
+                            max_fan_out: agg.max_fan_out,
+                            client_progress_token: None,
+                        });
+                    }
+                    contexts
+                })
+        };
 
         // Host layer (host-document-bridge): participates when listed in the
         // layer priorities AND opted in via bridge._self.enabled with a
         // host-capable server. No upstream request id — push tasks are not
         // tied to a client request.
         //
-        // `host_bridging_configured` is that participation *independent of*
-        // `pullFallback`; `host` is the pull context, which `pullFallback` can
-        // gate to `None` while the layer stays configured. The split matters so
-        // an all-gated host still yields a snapshot whose Clear outcome evicts a
-        // stale `PullLayer` (#425) rather than skipping and leaving it to linger.
+        // The host context is built whenever the layer is **configured** (in the
+        // priorities AND `_self` opted in with servers), *independent of*
+        // `pullFallback`: it carries the text the #431 debounced re-sync pushes
+        // to push-only `_self` servers (the host analogue of the virtual-doc
+        // didChange forward), which must keep flowing even when the pull is off.
+        // `host_pull_enabled` separately gates the Path A pull — false when
+        // `pullFallback = false` or the host's effective selection is empty —
+        // mirroring the per-region gate above. Building the context (rather than
+        // `None`-ing it) also keeps the snapshot non-`None` so an all-gated host's
+        // stale `PullLayer` is cleared on this event.
         let host_lang_settings = if layer_cfg.allows(crate::config::settings::LayerSource::Host) {
             settings
                 .resolve_host_language_settings(&language_name)
@@ -215,7 +244,7 @@ impl DiagnosticScheduler {
         } else {
             None
         };
-        let mut host_bridging_configured = false;
+        let mut host_pull_enabled = false;
         let host = host_lang_settings.and_then(|lang_settings| {
             let configs = self
                 .bridge
@@ -223,16 +252,9 @@ impl DiagnosticScheduler {
             if configs.is_empty() {
                 return None;
             }
-            host_bridging_configured = true;
             let agg = lang_settings.resolve_host_aggregation("textDocument/publishDiagnostics");
-            // `pullFallback = false` skips the host-layer pull (Path A, #425); a
-            // push-driven `_self` server still publishes via its cached pushes,
-            // and a pull-only `_self` server simply stops being pulled on host
-            // events. The layer stays configured (above), so the snapshot is
-            // still produced and its Clear outcome evicts any stale pull blob.
-            if !agg.pull_fallback {
-                return None;
-            }
+            host_pull_enabled = agg.pull_fallback
+                && dispatches_to_any_server(&agg.priorities, &configs, agg.max_fan_out);
             Some(HostRequestContext {
                 uri: uri.clone(),
                 language_id: language_name.clone(),
@@ -248,14 +270,15 @@ impl DiagnosticScheduler {
         // A document that can never contribute (no injection query AND no
         // configured host layer) keeps the old skip-publishing behavior. A
         // configured-but-pull-gated host still produces a snapshot so its stale
-        // `PullLayer` is cleared on this event.
-        let virt_contexts = match (virt_contexts, host.is_some() || host_bridging_configured) {
+        // `PullLayer` is cleared on this event and its re-sync still runs.
+        let virt_contexts = match (virt_contexts, host.is_some()) {
             (None, false) => return None,
             (virt, _) => virt.unwrap_or_default(),
         };
 
         Some(DiagnosticSnapshot {
             virt_contexts,
+            host_pull_enabled,
             host,
             layer_cfg,
         })

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -171,6 +171,17 @@ impl DiagnosticScheduler {
                                 "textDocument/publishDiagnostics",
                             );
 
+                            // `pullFallback = false` drops this region's
+                            // pull-driven servers from the proactive path: the
+                            // host-event pull does not fan out to them (Path A,
+                            // #425). Their spontaneous pushes are still cached and
+                            // published; only kakehashi's pulling stops. An empty
+                            // contexts list still publishes-empty to clear any
+                            // stale pull contribution.
+                            if !agg.pull_fallback {
+                                continue;
+                            }
+
                             contexts.push(DocumentRequestContext {
                                 uri: uri.clone(),
                                 resolved,
@@ -203,6 +214,13 @@ impl DiagnosticScheduler {
                     }
                     let agg =
                         lang_settings.resolve_host_aggregation("textDocument/publishDiagnostics");
+                    // `pullFallback = false` skips the host-layer pull (Path A,
+                    // #425); a push-driven `_self` server still publishes via its
+                    // cached pushes, and a pull-only `_self` server simply stops
+                    // being pulled on host events.
+                    if !agg.pull_fallback {
+                        return None;
+                    }
                     Some(HostRequestContext {
                         uri: uri.clone(),
                         language_id: language_name.clone(),

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -151,76 +151,91 @@ impl DiagnosticScheduler {
         // Virt layer: `None` = the document can never have virt diagnostics
         // (no injection query), distinct from `Some(vec![])` = gated off or
         // currently no regions (publish-empty-to-clear).
-        let virt_contexts: Option<Vec<DocumentRequestContext>> = if !layer_cfg
-            .allows(crate::config::settings::LayerSource::Virt)
-        {
-            log::debug!(
-                target: LOG_TARGET,
-                "virt layer disabled for {} via layers.aggregation priorities",
-                language_name
-            );
-            Some(Vec::new())
-        } else {
-            self.language
-                .injection_query(&language_name)
-                .map(|injection_query| {
-                    let all_regions = InjectionResolver::resolve_all(
-                        &self.language,
-                        self.bridge.node_tracker(),
-                        uri,
-                        snapshot.tree(),
-                        snapshot.text(),
-                        injection_query.as_ref(),
-                    );
-
-                    let mut contexts = Vec::new();
-                    for resolved in all_regions {
-                        let configs = self.bridge.get_all_configs_for_language(
-                            &settings,
-                            &language_name,
-                            &resolved.injection_language,
-                        );
-                        if configs.is_empty() {
-                            continue;
-                        }
-
-                        let agg = resolve_aggregation_config_from_settings(
-                            &settings,
-                            &language_name,
-                            &resolved.injection_language,
-                            "textDocument/publishDiagnostics",
+        let virt_contexts: Option<Vec<DocumentRequestContext>> =
+            if !layer_cfg.allows(crate::config::settings::LayerSource::Virt) {
+                log::debug!(
+                    target: LOG_TARGET,
+                    "virt layer disabled for {} via layers.aggregation priorities",
+                    language_name
+                );
+                Some(Vec::new())
+            } else {
+                self.language
+                    .injection_query(&language_name)
+                    .map(|injection_query| {
+                        let all_regions = InjectionResolver::resolve_all(
+                            &self.language,
+                            self.bridge.node_tracker(),
+                            uri,
+                            snapshot.tree(),
+                            snapshot.text(),
+                            injection_query.as_ref(),
                         );
 
-                        // Only build a context for a region the pull will
-                        // actually dispatch (#425): drop it when `pullFallback
-                        // = false` OR its effective server selection is empty
-                        // (`priorities = []`, `maxFanOut = 0`, or names only
-                        // unconfigured servers). This keeps the invariant
-                        // "PullLayer present ⟺ a pull dispatched to ≥1
-                        // server": an absent/Clear pull layer (not an empty
-                        // one) then never falsely suppresses a server's
-                        // spontaneous push. The push path is untouched — only
-                        // kakehashi's pulling stops.
-                        if !agg.pull_fallback
-                            || !dispatches_to_any_server(&agg.priorities, &configs, agg.max_fan_out)
-                        {
-                            continue;
-                        }
+                        let mut contexts = Vec::new();
+                        // Configs + aggregation are keyed by injection language, so
+                        // resolve them once per distinct language (a document can
+                        // hold many regions of one language). `None` caches a skipped
+                        // language: no configured server, OR the pull would dispatch
+                        // to none.
+                        let mut resolved_by_lang = std::collections::HashMap::new();
+                        for resolved in all_regions {
+                            let entry = resolved_by_lang
+                                .entry(resolved.injection_language.clone())
+                                .or_insert_with_key(|lang| {
+                                    let configs = self.bridge.get_all_configs_for_language(
+                                        &settings,
+                                        &language_name,
+                                        lang,
+                                    );
+                                    if configs.is_empty() {
+                                        return None;
+                                    }
+                                    let agg = resolve_aggregation_config_from_settings(
+                                        &settings,
+                                        &language_name,
+                                        lang,
+                                        "textDocument/publishDiagnostics",
+                                    );
+                                    // Only keep a language the pull will actually
+                                    // dispatch (#425): drop it when `pullFallback =
+                                    // false` OR its effective server selection is
+                                    // empty (`priorities = []`, `maxFanOut = 0`, or
+                                    // names only unconfigured servers). This keeps
+                                    // the invariant "PullLayer present ⟺ a pull
+                                    // dispatched to ≥1 server", so an absent/Clear
+                                    // pull layer never falsely suppresses a server's
+                                    // spontaneous push. The push path is untouched —
+                                    // only kakehashi's pulling stops.
+                                    if !agg.pull_fallback
+                                        || !dispatches_to_any_server(
+                                            &agg.priorities,
+                                            &configs,
+                                            agg.max_fan_out,
+                                        )
+                                    {
+                                        return None;
+                                    }
+                                    Some((configs, agg))
+                                });
+                            let Some((configs, agg)) = entry.as_ref() else {
+                                continue;
+                            };
 
-                        contexts.push(DocumentRequestContext {
-                            uri: uri.clone(),
-                            resolved,
-                            configs,
-                            upstream_request_id: None,
-                            priorities: agg.priorities,
-                            strategy: agg.strategy,
-                            max_fan_out: agg.max_fan_out,
-                            client_progress_token: None,
-                        });
-                    }
-                    contexts
-                })
-        };
+                            contexts.push(DocumentRequestContext {
+                                uri: uri.clone(),
+                                resolved,
+                                configs: configs.clone(),
+                                upstream_request_id: None,
+                                priorities: agg.priorities.clone(),
+                                strategy: agg.strategy,
+                                max_fan_out: agg.max_fan_out,
+                                client_progress_token: None,
+                            });
+                        }
+                        contexts
+                    })
+            };
 
         // Host layer (host-document-bridge): participates when listed in the
         // layer priorities AND opted in via bridge._self.enabled with a

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -195,14 +195,9 @@ impl DiagnosticPublisher {
             return;
         }
         // Distinct push-server names across the Region/Host sources, borrowed
-        // from the snapshot (no key clones on this republish hot path).
-        let mut push_servers = std::collections::HashSet::new();
-        for (source, servers) in snapshot.iter() {
-            if matches!(source, DiagnosticSource::PullLayer) {
-                continue;
-            }
-            push_servers.extend(servers.keys().map(String::as_str));
-        }
+        // from the snapshot (no key clones on this republish hot path) — the same
+        // set Path B's fold derives, so share the helper.
+        let push_servers = crate::lsp::diagnostic_cache::push_slot_servers(snapshot);
         if push_servers.is_empty() {
             return; // PullLayer-only snapshot (the common pull-driven case).
         }

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -194,18 +194,21 @@ impl DiagnosticPublisher {
             // No pull blob to double-count against.
             return;
         }
-        // Distinct push-server names across the Region/Host sources.
+        // Distinct push-server names across the Region/Host sources, borrowed
+        // from the snapshot (no key clones on this republish hot path).
         let mut push_servers = std::collections::HashSet::new();
         for (source, servers) in snapshot.iter() {
             if matches!(source, DiagnosticSource::PullLayer) {
                 continue;
             }
-            push_servers.extend(servers.keys().cloned());
+            push_servers.extend(servers.keys().map(String::as_str));
         }
         if push_servers.is_empty() {
             return; // PullLayer-only snapshot (the common pull-driven case).
         }
         let pull_driven = self.bridge.pool().pull_driven_servers(&push_servers).await;
+        // Drop the borrow of `snapshot` before the mutable retain below.
+        drop(push_servers);
         retain_non_pull_driven_push_slots(snapshot, &pull_driven);
     }
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -257,6 +257,22 @@ impl DiagnosticPublisher {
         self.republish(host).await;
     }
 
+    /// Evict the host's `PullLayer` blob and republish — the host-event pull had
+    /// no contributors this event (every layer `pullFallback`-gated, or none).
+    ///
+    /// Eviction (vs publishing an empty blob) is deliberate: an **absent**
+    /// `PullLayer` both clears any stale pull result and stops
+    /// [`Self::filter_pull_driven_push_slots`] from treating "no pull ran" as
+    /// "pull present", which would otherwise suppress a pull-driven server's
+    /// spontaneous push under `pullFallback = false` (#425). A pull that ran and
+    /// returned clean keeps its empty `PullLayer` (via [`Self::publish_pull_layer`]),
+    /// so that path still suppresses a stale push — the two empties differ.
+    pub(crate) async fn clear_pull_layer(&self, host: &Url) {
+        self.aggregator
+            .evict_source(host, &DiagnosticSource::PullLayer);
+        self.republish(host).await;
+    }
+
     /// Evict every diagnostic slot a now-exited downstream connection produced and
     /// republish the affected hosts (#469). Called when a connection's reader exits
     /// (crash/respawn); a restart's slots carry a fresh connection id and survive,

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -165,6 +165,50 @@ impl DiagnosticPublisher {
         }
     }
 
+    /// Remove cached **push** slots (`Region`/`Host`) whose server is
+    /// **pull-driven** when a `PullLayer` blob is present, so a pull-driven
+    /// server that both answers the host-event pull (landing in `PullLayer`)
+    /// AND spontaneously pushes `publishDiagnostics` is not counted twice —
+    /// each server has exactly one native source
+    /// (push-propagation-diagnostic-forwarding "Per-server source and
+    /// fallback", #425).
+    ///
+    /// Classification is live (static initialize caps + dynamic registrations,
+    /// `LanguageServerPool::pull_driven_servers`) and non-creating. The push
+    /// slots stay cached — this filters only the publish snapshot clone, like
+    /// [`Self::filter_stale_host_slots`] — so the pull contribution wins while a
+    /// later crash/edit eviction still clears the push slot.
+    ///
+    /// Interim limitation: `PullLayer` is one host-wide blob with no per-server
+    /// identity, so the trigger is "any PullLayer present", not "this exact
+    /// server was pulled". With a *mixed* per-region `pullFallback` (one
+    /// region's pull-driven server pulled, a sibling's not), a pull-driven
+    /// server whose region set `pullFallback = false` can still have its push
+    /// suppressed while the blob carries the sibling region. The deferred
+    /// per-source fan-in (per-`(source, server)` pull slots) removes this.
+    async fn filter_pull_driven_push_slots(
+        &self,
+        snapshot: &mut crate::lsp::diagnostic_cache::SourceSlots,
+    ) {
+        if !snapshot.contains_key(&DiagnosticSource::PullLayer) {
+            // No pull blob to double-count against.
+            return;
+        }
+        // Distinct push-server names across the Region/Host sources.
+        let mut push_servers = std::collections::HashSet::new();
+        for (source, servers) in snapshot.iter() {
+            if matches!(source, DiagnosticSource::PullLayer) {
+                continue;
+            }
+            push_servers.extend(servers.keys().cloned());
+        }
+        if push_servers.is_empty() {
+            return; // PullLayer-only snapshot (the common pull-driven case).
+        }
+        let pull_driven = self.bridge.pool().pull_driven_servers(&push_servers).await;
+        retain_non_pull_driven_push_slots(snapshot, &pull_driven);
+    }
+
     /// Record a downstream region push and republish the host (Path A).
     ///
     /// `virtual_uri` is the URI the downstream published for; it is resolved to
@@ -263,6 +307,12 @@ impl DiagnosticPublisher {
         // slots stay cached (cleared on `didClose`); they're just filtered out of
         // this publish. (The analogous Region/config-change re-merge is deferred.)
         self.filter_stale_host_slots(host, &mut snapshot);
+        // Drop a pull-driven server's push slots when the host-event pull blob
+        // (`PullLayer`) is present: that server already contributes via the
+        // pull, so keeping its spontaneous push too would double-count it
+        // (#425). The cache keeps the slot; only this publish snapshot is
+        // filtered.
+        self.filter_pull_driven_push_slots(&mut snapshot).await;
         // Recompute injection offsets only when there are region push slots to
         // transform. A PullLayer-only snapshot (the common pull-driven case) needs
         // none, so skip the whole-document injection resolution — and shorten the
@@ -350,6 +400,27 @@ impl DiagnosticPublisher {
         }
         offsets
     }
+}
+
+/// Remove `Region`/`Host` push slots whose server is in `pull_driven` when a
+/// `PullLayer` blob is present in `snapshot`, dropping any source left empty.
+/// The pure core of [`DiagnosticPublisher::filter_pull_driven_push_slots`],
+/// split out so the dedup rule is testable without a live pool. A no-op when
+/// `pull_driven` is empty or there is no `PullLayer` to double-count against.
+fn retain_non_pull_driven_push_slots(
+    snapshot: &mut crate::lsp::diagnostic_cache::SourceSlots,
+    pull_driven: &std::collections::HashSet<String>,
+) {
+    if pull_driven.is_empty() || !snapshot.contains_key(&DiagnosticSource::PullLayer) {
+        return;
+    }
+    snapshot.retain(|source, servers| {
+        if matches!(source, DiagnosticSource::PullLayer) {
+            return true;
+        }
+        servers.retain(|server, _| !pull_driven.contains(server));
+        !servers.is_empty()
+    });
 }
 
 #[cfg(test)]
@@ -632,5 +703,113 @@ mod tests {
             host.contains_key("live_ls"),
             "the live connection's slot survives the eviction"
         );
+    }
+
+    use crate::lsp::diagnostic_cache::SourceSlots;
+    use std::collections::HashSet;
+
+    /// Build a snapshot for `host` with a `PullLayer` blob plus two `Host` push
+    /// slots: `ra` (a pull-driven server that also pushed) and `linter` (a
+    /// push-driven server).
+    fn snapshot_with_pull_layer_and_two_host_pushes(host: &Url) -> SourceSlots {
+        let agg = DiagnosticAggregator::new();
+        agg.set_pull_layer(host, vec![diag("pulled")]);
+        agg.record(
+            host,
+            DiagnosticSource::Host,
+            "ra".to_string(),
+            Some(ProgressConnectionId::for_test(1)),
+            vec![diag("ra-push")],
+        );
+        agg.record(
+            host,
+            DiagnosticSource::Host,
+            "linter".to_string(),
+            Some(ProgressConnectionId::for_test(2)),
+            vec![diag("linter-push")],
+        );
+        agg.snapshot(host)
+    }
+
+    #[test]
+    fn retain_drops_pull_driven_push_slot_but_keeps_push_driven_and_pull_blob() {
+        let host = Url::parse("file:///test/host.rs").unwrap();
+        let mut snap = snapshot_with_pull_layer_and_two_host_pushes(&host);
+
+        retain_non_pull_driven_push_slots(&mut snap, &HashSet::from(["ra".to_string()]));
+
+        let host_slots = snap
+            .get(&DiagnosticSource::Host)
+            .expect("the Host source survives because the push-driven slot remains");
+        assert!(
+            !host_slots.contains_key("ra"),
+            "a pull-driven server's push slot is dropped (the pull covers it)"
+        );
+        assert!(
+            host_slots.contains_key("linter"),
+            "a push-driven server's slot is kept (the pull never covered it)"
+        );
+        assert!(
+            snap.contains_key(&DiagnosticSource::PullLayer),
+            "the pull blob itself is never filtered"
+        );
+    }
+
+    #[test]
+    fn retain_is_a_noop_without_a_pull_layer() {
+        // pullFallback-off / no-pull-yet path: with no PullLayer there is nothing
+        // to double-count against, so even a pull-driven server's spontaneous
+        // push is published (keeps #380 closed).
+        let host = Url::parse("file:///test/host.rs").unwrap();
+        let agg = DiagnosticAggregator::new();
+        agg.record(
+            &host,
+            DiagnosticSource::Host,
+            "ra".to_string(),
+            Some(ProgressConnectionId::for_test(1)),
+            vec![diag("ra-push")],
+        );
+        let mut snap = agg.snapshot(&host);
+
+        retain_non_pull_driven_push_slots(&mut snap, &HashSet::from(["ra".to_string()]));
+
+        assert!(
+            snap[&DiagnosticSource::Host].contains_key("ra"),
+            "no PullLayer present → no suppression"
+        );
+    }
+
+    #[test]
+    fn retain_drops_a_source_left_empty_after_filtering() {
+        let host = Url::parse("file:///test/host.rs").unwrap();
+        let agg = DiagnosticAggregator::new();
+        agg.set_pull_layer(&host, vec![diag("pulled")]);
+        agg.record(
+            &host,
+            DiagnosticSource::Host,
+            "ra".to_string(),
+            Some(ProgressConnectionId::for_test(1)),
+            vec![diag("ra-push")],
+        );
+        let mut snap = agg.snapshot(&host);
+
+        retain_non_pull_driven_push_slots(&mut snap, &HashSet::from(["ra".to_string()]));
+
+        assert!(
+            !snap.contains_key(&DiagnosticSource::Host),
+            "a source whose every server was pull-driven is removed entirely"
+        );
+        assert!(snap.contains_key(&DiagnosticSource::PullLayer));
+    }
+
+    #[test]
+    fn retain_with_empty_pull_driven_set_keeps_everything() {
+        let host = Url::parse("file:///test/host.rs").unwrap();
+        let mut snap = snapshot_with_pull_layer_and_two_host_pushes(&host);
+
+        retain_non_pull_driven_push_slots(&mut snap, &HashSet::new());
+
+        let host_slots = &snap[&DiagnosticSource::Host];
+        assert!(host_slots.contains_key("ra") && host_slots.contains_key("linter"));
     }
 }

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -28,7 +28,9 @@ use crate::lsp::aggregation::server::{
 };
 use crate::lsp::bridge::{LanguageServerPool, RegionOffset};
 use crate::lsp::diagnostic_cache::DiagnosticSource;
-use crate::lsp::lsp_impl::bridge_context::{DocumentRequestContext, HostRequestContext};
+use crate::lsp::lsp_impl::bridge_context::{
+    DocumentRequestContext, HostRequestContext, resolve_aggregation_config_from_settings,
+};
 use crate::lsp::lsp_impl::text_document::{RequestErrorSink, count_request_errors};
 
 // ============================================================================
@@ -329,17 +331,23 @@ impl Kakehashi {
         // push-driven ones so a pull-driven server is not double-counted.
         let pull_driven = self.bridge.pool().pull_driven_servers(&candidates).await;
 
+        // Load settings once: resolving per-region pushFallback in the loop and
+        // the host gate below otherwise re-reads it N+1 times and could resolve
+        // different regions against different snapshots if config is swapped
+        // mid-request.
+        let settings = self.settings_manager.load_settings();
+
         // Per-region `pushFallback` gate + current offsets for the transform.
         let mut region_offsets = HashMap::new();
         let mut region_push_enabled = HashSet::new();
         for (region_id, injection_language, offset) in region_meta {
-            if self
-                .resolve_aggregation_config(
-                    language_name,
-                    injection_language,
-                    "textDocument/diagnostic",
-                )
-                .push_fallback
+            if resolve_aggregation_config_from_settings(
+                &settings,
+                language_name,
+                injection_language,
+                "textDocument/diagnostic",
+            )
+            .push_fallback
             {
                 region_push_enabled.insert(region_id.clone());
             }
@@ -348,18 +356,24 @@ impl Kakehashi {
 
         // Host `pushFallback` gate: the host layer participates AND pushFallback
         // is on for the host's diagnostic method.
-        let host_push_enabled = host_layer_participates && {
-            let settings = self.settings_manager.load_settings();
-            settings
+        let host_push_enabled = host_layer_participates
+            && settings
                 .resolve_host_language_settings(language_name)
                 .map(|s| {
                     s.resolve_host_aggregation("textDocument/diagnostic")
                         .push_fallback
                 })
-                .unwrap_or(false)
-        };
+                .unwrap_or(false);
 
         let include = |source: &DiagnosticSource, server: &str| {
+            // Pull-driven servers are excluded unconditionally: their native
+            // source is the live pull above, which already gates on the same
+            // capability AND on this method's `priorities`/`maxFanOut`. A
+            // pull-driven server that `priorities` drops from the live fan-out is
+            // therefore also dropped here — config-consistent, not a leak. (The
+            // only lossy corner is a pull-driven server whose live pull times out
+            // this cycle while holding a stale cached push; transient, and it
+            // never hides a current diagnostic.)
             if pull_driven.contains(server) {
                 return false; // covered by the live pull
             }

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -354,17 +354,23 @@ impl Kakehashi {
         let mut region_offsets = HashMap::new();
         let mut push_fallback_by_lang: HashMap<String, bool> = HashMap::new();
         for (region_id, injection_language, offset) in region_meta {
-            let push_fallback = *push_fallback_by_lang
-                .entry(injection_language)
-                .or_insert_with_key(|lang| {
-                    resolve_aggregation_config_from_settings(
+            // `get` on the common (cache-hit) path is a single lookup; only the
+            // resolving miss touches the map again, moving the owned language key
+            // in (no clone).
+            let push_fallback = match push_fallback_by_lang.get(&injection_language) {
+                Some(&fallback) => fallback,
+                None => {
+                    let fallback = resolve_aggregation_config_from_settings(
                         &settings,
                         language_name,
-                        lang,
+                        &injection_language,
                         "textDocument/diagnostic",
                     )
-                    .push_fallback
-                });
+                    .push_fallback;
+                    push_fallback_by_lang.insert(injection_language, fallback);
+                    fallback
+                }
+            };
             if push_fallback {
                 region_offsets.insert(region_id, offset);
             }

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -27,7 +27,7 @@ use crate::lsp::aggregation::server::{
     dispatch_host_preferred, dispatch_preferred,
 };
 use crate::lsp::bridge::{LanguageServerPool, RegionOffset};
-use crate::lsp::diagnostic_cache::DiagnosticSource;
+use crate::lsp::diagnostic_cache::{DiagnosticSource, cached_push_diagnostics, push_slot_servers};
 use crate::lsp::lsp_impl::bridge_context::{
     DocumentRequestContext, HostRequestContext, resolve_aggregation_config_from_settings,
 };
@@ -313,7 +313,11 @@ impl Kakehashi {
     /// *appended* after the region's live election rather than competing in it —
     /// consistent with Path A's concatenate-everything merge and the deferred
     /// per-source strategy fan-in (push-propagation-diagnostic-forwarding), not an
-    /// election bug.
+    /// election bug. For the same reason the fold honors only `pushFallback`, not
+    /// the visible walk: it does not re-apply `priorities`/`maxFanOut`, so a
+    /// push-driven server outside the walk is still folded — exactly what Path A's
+    /// proactive merge already publishes, until the deferred fan-in resolves the
+    /// walk for both paths together.
     async fn fold_push_fallback_diagnostics(
         &self,
         host: &Url,
@@ -323,7 +327,11 @@ impl Kakehashi {
         virt_items: &mut Vec<Diagnostic>,
         host_items: &mut Vec<Diagnostic>,
     ) {
-        let candidates = self.diagnostics.push_slot_servers(host);
+        // One snapshot drives both the candidate classification and the fold, so
+        // a push arriving across the classifying `await` below cannot land in the
+        // folded set while skipping classification (no TOCTOU double-count).
+        let snapshot = self.diagnostics.snapshot(host);
+        let candidates = push_slot_servers(&snapshot);
         if candidates.is_empty() {
             return; // no cached pushes for this host
         }
@@ -384,8 +392,7 @@ impl Kakehashi {
             }
         };
         let (region_push, host_push) =
-            self.diagnostics
-                .cached_push_diagnostics(host, &region_offsets, include);
+            cached_push_diagnostics(host, snapshot, &region_offsets, include);
         virt_items.extend(region_push);
         host_items.extend(host_push);
     }

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -346,17 +346,25 @@ impl Kakehashi {
         let settings = self.settings_manager.load_settings();
 
         // Per-region `pushFallback` gate + current offsets for the transform.
+        // `pushFallback` is keyed by injection language, so resolve it once per
+        // distinct language rather than per region (a document can hold many
+        // regions of one language).
         let mut region_offsets = HashMap::new();
         let mut region_push_enabled = HashSet::new();
+        let mut push_fallback_by_lang: HashMap<String, bool> = HashMap::new();
         for (region_id, injection_language, offset) in region_meta {
-            if resolve_aggregation_config_from_settings(
-                &settings,
-                language_name,
-                &injection_language,
-                "textDocument/diagnostic",
-            )
-            .push_fallback
-            {
+            let push_fallback = *push_fallback_by_lang
+                .entry(injection_language)
+                .or_insert_with_key(|lang| {
+                    resolve_aggregation_config_from_settings(
+                        &settings,
+                        language_name,
+                        lang,
+                        "textDocument/diagnostic",
+                    )
+                    .push_fallback
+                });
+            if push_fallback {
                 region_push_enabled.insert(region_id.clone());
             }
             // `region_meta` is consumed: move the id + offset (a heap `Vec`) in

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -306,6 +306,12 @@ impl Kakehashi {
     /// the method's priorities AND `bridge._self` is opted in with configured
     /// servers (capability is *not* required: a push-only `_self` server yields a
     /// host context whose live pull returns empty, and this fold supplies it).
+    ///
+    /// Under a per-region `strategy = preferred`, the folded push-driven slots are
+    /// *appended* after the region's live election rather than competing in it —
+    /// consistent with Path A's concatenate-everything merge and the deferred
+    /// per-source strategy fan-in (push-propagation-diagnostic-forwarding), not an
+    /// election bug.
     async fn fold_push_fallback_diagnostics(
         &self,
         host: &Url,

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -7,7 +7,7 @@
 //! `JoinSet` aborts all downstream tasks, and cancels are also forwarded
 //! downstream fire-and-forget via middleware.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -345,12 +345,13 @@ impl Kakehashi {
         // mid-request.
         let settings = self.settings_manager.load_settings();
 
-        // Per-region `pushFallback` gate + current offsets for the transform.
-        // `pushFallback` is keyed by injection language, so resolve it once per
-        // distinct language rather than per region (a document can hold many
-        // regions of one language).
+        // Current offsets for the transform, keyed by region — built ONLY for
+        // regions whose `pushFallback` is on (resolved once per distinct
+        // injection language, since a document can hold many regions of one
+        // language). A region without an offset is skipped by
+        // `cached_push_diagnostics`, so this map doubles as the per-region
+        // pushFallback gate — no separate set, no `region_id` clone.
         let mut region_offsets = HashMap::new();
-        let mut region_push_enabled = HashSet::new();
         let mut push_fallback_by_lang: HashMap<String, bool> = HashMap::new();
         for (region_id, injection_language, offset) in region_meta {
             let push_fallback = *push_fallback_by_lang
@@ -365,11 +366,8 @@ impl Kakehashi {
                     .push_fallback
                 });
             if push_fallback {
-                region_push_enabled.insert(region_id.clone());
+                region_offsets.insert(region_id, offset);
             }
-            // `region_meta` is consumed: move the id + offset (a heap `Vec`) in
-            // rather than cloning per region.
-            region_offsets.insert(region_id, offset);
         }
 
         // Host `pushFallback` gate: the host layer participates AND pushFallback
@@ -396,7 +394,10 @@ impl Kakehashi {
                 return false; // covered by the live pull
             }
             match source {
-                DiagnosticSource::Region(id) => region_push_enabled.contains(id),
+                // A `Region` slot only reaches `include` when `region_offsets`
+                // has its offset, i.e. its `pushFallback` is on — so the gate is
+                // already applied; nothing more to check beyond `pull_driven`.
+                DiagnosticSource::Region(_) => true,
                 DiagnosticSource::Host => host_push_enabled,
                 DiagnosticSource::PullLayer => false,
             }

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -7,6 +7,7 @@
 //! `JoinSet` aborts all downstream tasks, and cancels are also forwarded
 //! downstream fire-and-forget via middleware.
 
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -16,6 +17,7 @@ use tower_lsp_server::ls_types::{
     Diagnostic, DocumentDiagnosticParams, DocumentDiagnosticReport, DocumentDiagnosticReportResult,
     FullDocumentDiagnosticReport, RelatedFullDocumentDiagnosticReport,
 };
+use url::Url;
 
 use super::super::{Kakehashi, uri_to_url};
 use crate::config::settings::{AggregationStrategy, LayerSource, ResolvedLayerConfig};
@@ -24,7 +26,8 @@ use crate::lsp::aggregation::server::{
     FanInResult, FanOutTask, HostFanOutTask, dispatch_concatenated, dispatch_host_concatenated,
     dispatch_host_preferred, dispatch_preferred,
 };
-use crate::lsp::bridge::LanguageServerPool;
+use crate::lsp::bridge::{LanguageServerPool, RegionOffset};
+use crate::lsp::diagnostic_cache::DiagnosticSource;
 use crate::lsp::lsp_impl::bridge_context::{DocumentRequestContext, HostRequestContext};
 use crate::lsp::lsp_impl::text_document::{RequestErrorSink, count_request_errors};
 
@@ -150,30 +153,48 @@ impl Kakehashi {
 
         let pool = self.bridge.pool_arc();
 
+        // Resolve injection regions once: the live virt pull below and the
+        // pushFallback fold (#425) after the join share them.
+        let virt_regions = if virt_enabled {
+            self.language
+                .injection_query(&language_name)
+                .map(|injection_query| {
+                    InjectionResolver::resolve_all(
+                        &self.language,
+                        self.bridge.node_tracker(),
+                        &uri,
+                        snapshot.tree(),
+                        snapshot.text(),
+                        injection_query.as_ref(),
+                    )
+                })
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+        // Lightweight per-region metadata `(region_id, injection_language,
+        // current offset)` for the pushFallback fold; the live pull below moves
+        // the regions themselves.
+        let region_meta: Vec<(String, String, RegionOffset)> = virt_regions
+            .iter()
+            .map(|r| {
+                (
+                    r.region.region_id.clone(),
+                    r.injection_language.clone(),
+                    RegionOffset::with_per_line_offsets(
+                        r.region.line_range.start,
+                        r.line_column_offsets.clone(),
+                    ),
+                )
+            })
+            .collect();
+
         // Virt layer: 2-level aggregation —
         //   Inner: dispatch per region (fans out to all servers for that region)
         //   Outer: collect across regions
         let virt_fut = async {
-            if !virt_enabled {
-                return Vec::new();
-            }
-            let Some(injection_query) = self.language.injection_query(&language_name) else {
-                return Vec::new();
-            };
-            let all_regions = InjectionResolver::resolve_all(
-                &self.language,
-                self.bridge.node_tracker(),
-                &uri,
-                snapshot.tree(),
-                snapshot.text(),
-                injection_query.as_ref(),
-            );
-            if all_regions.is_empty() {
-                return Vec::new();
-            }
-
             let mut outer_join_set: JoinSet<Vec<Diagnostic>> = JoinSet::new();
-            for resolved in all_regions {
+            for resolved in virt_regions {
                 let configs = self.bridge_configs_for_injection_language(
                     &language_name,
                     &resolved.injection_language,
@@ -234,7 +255,7 @@ impl Kakehashi {
         // Both layers fan out concurrently; the layer strategy decides the
         // combine. Cancel drops both in-flight layer futures.
         let combined = async { tokio::join!(virt_fut, host_fut) };
-        let (virt_items, host_items) = match cancel_rx {
+        let (mut virt_items, mut host_items) = match cancel_rx {
             Some(mut cancel_rx) => {
                 tokio::select! {
                     biased;
@@ -256,9 +277,97 @@ impl Kakehashi {
         // _upstream_id_with_notify).
         pool.unregister_all_for_upstream_id(upstream_request_id.as_ref());
 
+        // pushFallback (Path B, #425): the live pulls above cover only
+        // pull-driven servers (capability-gated). Fold in push-driven servers'
+        // cached pushes so they also answer the client pull.
+        self.fold_push_fallback_diagnostics(
+            &uri,
+            &language_name,
+            &region_meta,
+            host_ctx.is_some(),
+            &mut virt_items,
+            &mut host_items,
+        )
+        .await;
+
         Ok(make_diagnostic_report(combine_layer_diagnostics(
             &layer_cfg, virt_items, host_items,
         )))
+    }
+
+    /// pushFallback fold (Path B, #425): append push-driven servers' cached
+    /// pushes to the per-layer pull results. The live pull already covers
+    /// pull-driven servers (their native source), so only servers that do **not**
+    /// advertise `diagnosticProvider` are folded — their cached pushes are their
+    /// native source. Region pushes are transformed to host coordinates against
+    /// the region's current offset; host pushes are already host-local.
+    ///
+    /// `host_layer_participates` is `host_ctx.is_some()` — the host layer is in
+    /// the method's priorities AND `bridge._self` is opted in with configured
+    /// servers (capability is *not* required: a push-only `_self` server yields a
+    /// host context whose live pull returns empty, and this fold supplies it).
+    async fn fold_push_fallback_diagnostics(
+        &self,
+        host: &Url,
+        language_name: &str,
+        region_meta: &[(String, String, RegionOffset)],
+        host_layer_participates: bool,
+        virt_items: &mut Vec<Diagnostic>,
+        host_items: &mut Vec<Diagnostic>,
+    ) {
+        let candidates = self.diagnostics.push_slot_servers(host);
+        if candidates.is_empty() {
+            return; // no cached pushes for this host
+        }
+        // Classify live (static caps + dynamic registrations); fold only the
+        // push-driven ones so a pull-driven server is not double-counted.
+        let pull_driven = self.bridge.pool().pull_driven_servers(&candidates).await;
+
+        // Per-region `pushFallback` gate + current offsets for the transform.
+        let mut region_offsets = HashMap::new();
+        let mut region_push_enabled = HashSet::new();
+        for (region_id, injection_language, offset) in region_meta {
+            if self
+                .resolve_aggregation_config(
+                    language_name,
+                    injection_language,
+                    "textDocument/diagnostic",
+                )
+                .push_fallback
+            {
+                region_push_enabled.insert(region_id.clone());
+            }
+            region_offsets.insert(region_id.clone(), offset.clone());
+        }
+
+        // Host `pushFallback` gate: the host layer participates AND pushFallback
+        // is on for the host's diagnostic method.
+        let host_push_enabled = host_layer_participates && {
+            let settings = self.settings_manager.load_settings();
+            settings
+                .resolve_host_language_settings(language_name)
+                .map(|s| {
+                    s.resolve_host_aggregation("textDocument/diagnostic")
+                        .push_fallback
+                })
+                .unwrap_or(false)
+        };
+
+        let include = |source: &DiagnosticSource, server: &str| {
+            if pull_driven.contains(server) {
+                return false; // covered by the live pull
+            }
+            match source {
+                DiagnosticSource::Region(id) => region_push_enabled.contains(id),
+                DiagnosticSource::Host => host_push_enabled,
+                DiagnosticSource::PullLayer => false,
+            }
+        };
+        let (region_push, host_push) =
+            self.diagnostics
+                .cached_push_diagnostics(host, &region_offsets, include);
+        virt_items.extend(region_push);
+        host_items.extend(host_push);
     }
 }
 

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -285,7 +285,7 @@ impl Kakehashi {
         self.fold_push_fallback_diagnostics(
             &uri,
             &language_name,
-            &region_meta,
+            region_meta,
             host_ctx.is_some(),
             &mut virt_items,
             &mut host_items,
@@ -322,7 +322,7 @@ impl Kakehashi {
         &self,
         host: &Url,
         language_name: &str,
-        region_meta: &[(String, String, RegionOffset)],
+        region_meta: Vec<(String, String, RegionOffset)>,
         host_layer_participates: bool,
         virt_items: &mut Vec<Diagnostic>,
         host_items: &mut Vec<Diagnostic>,
@@ -352,14 +352,16 @@ impl Kakehashi {
             if resolve_aggregation_config_from_settings(
                 &settings,
                 language_name,
-                injection_language,
+                &injection_language,
                 "textDocument/diagnostic",
             )
             .push_fallback
             {
                 region_push_enabled.insert(region_id.clone());
             }
-            region_offsets.insert(region_id.clone(), offset.clone());
+            // `region_meta` is consumed: move the id + offset (a heap `Vec`) in
+            // rather than cloning per region.
+            region_offsets.insert(region_id, offset);
         }
 
         // Host `pushFallback` gate: the host layer participates AND pushFallback

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -128,7 +128,8 @@ mod tests {
     use super::*;
     use crate::config::WorkspaceSettings;
     use crate::config::settings::{
-        BridgeLanguageConfig, BridgeServerConfig, HOST_BRIDGE_KEY, LanguageSettings,
+        AggregationConfig, BridgeLanguageConfig, BridgeServerConfig, HOST_BRIDGE_KEY,
+        LanguageSettings,
     };
     use crate::lsp::bridge::VirtualDocumentUri;
     use tokio::time::{Duration, timeout};
@@ -435,6 +436,7 @@ print("hello")
 
         let snapshot = DiagnosticSnapshot {
             virt_contexts: vec![],
+            host_pull_enabled: true,
             host: Some(HostRequestContext {
                 uri: uri.clone(),
                 language_id: "rust".to_string(),
@@ -512,6 +514,65 @@ print("hello")
         assert!(
             host.configs.iter().any(|c| c.server_name == "rust_ls"),
             "the push-only rust_ls must be in the host context so the debounce re-sync reaches it"
+        );
+    }
+
+    /// #425 regression guard: host `pullFallback = false` gates the host **pull**
+    /// (`host_pull_enabled = false`) but must NOT drop the host context — the
+    /// #431 debounced re-sync still needs it to push current text to a push-only
+    /// `_self` server. If the gate dropped the context, that server would analyze
+    /// stale text (re-opening #380 for the host).
+    #[tokio::test]
+    async fn prepare_diagnostic_snapshot_keeps_host_for_resync_when_pull_gated() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        configure_rust_self_host(server);
+
+        // Override the `_self` aggregation: pullFallback = false for the
+        // proactive-publish method.
+        let mut settings = (*server.settings_manager.load_settings()).clone();
+        if let Some(bridge) = settings
+            .languages
+            .get_mut("rust")
+            .and_then(|lang| lang.bridge.as_mut())
+        {
+            bridge.insert(
+                HOST_BRIDGE_KEY.to_string(),
+                BridgeLanguageConfig {
+                    enabled: Some(true),
+                    aggregation: Some(HashMap::from([(
+                        "textDocument/publishDiagnostics".to_string(),
+                        AggregationConfig {
+                            pull_fallback: Some(false),
+                            ..Default::default()
+                        },
+                    )])),
+                },
+            );
+        }
+        server.settings_manager.apply_settings(settings);
+
+        let uri = Url::parse("file:///test/host_pull_gated.rs").unwrap();
+        let text = "fn main() {}".to_string();
+        server
+            .documents
+            .insert(uri.clone(), text.clone(), Some("rust".to_string()), None);
+        server
+            .parse_coordinator()
+            .parse_document(uri.clone(), text, Some("rust"), vec![])
+            .await;
+
+        let snapshot = server
+            .diagnostic_scheduler()
+            .prepare_diagnostic_snapshot(&uri)
+            .expect("a parsed _self-bridged doc still yields a snapshot when the pull is gated");
+        assert!(
+            snapshot.host.is_some(),
+            "the host context is kept for the re-sync even when the pull is gated off"
+        );
+        assert!(
+            !snapshot.host_pull_enabled,
+            "pullFallback = false disables the host pull (host_pull_enabled = false)"
         );
     }
 }

--- a/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
@@ -27,18 +27,28 @@ pub(crate) struct DiagnosticSnapshot {
     /// Per-region virt contexts; empty when the virt layer is gated off or
     /// the document has no bridgeable injection regions.
     pub(crate) virt_contexts: Vec<DocumentRequestContext>,
-    /// Host-layer context (host-document-bridge); `None` unless the host
-    /// layer is in `layers.aggregation` priorities AND `bridge._self` is
-    /// opted in with a capable server.
+    /// Host-layer context (host-document-bridge); `None` unless the host layer
+    /// is in `layers.aggregation` priorities AND `bridge._self` is opted in with
+    /// a configured server. Present even when the host **pull** is gated off
+    /// (see `host_pull_enabled`) because it also carries the text the #431
+    /// debounced re-sync pushes to push-only `_self` servers.
     pub(crate) host: Option<HostRequestContext>,
+    /// Whether the host context should be **pulled** on this event (Path A).
+    /// `false` when host `pullFallback = false` or the host's effective server
+    /// selection is empty; the context still drives the re-sync. Always `false`
+    /// when `host` is `None`.
+    pub(crate) host_pull_enabled: bool,
     /// Cross-layer combine config for `textDocument/publishDiagnostics`.
     pub(crate) layer_cfg: ResolvedLayerConfig,
 }
 
 impl DiagnosticSnapshot {
-    /// Whether any layer can contribute diagnostics.
+    /// Whether any layer can contribute to the **pull** this event — the
+    /// Publish-vs-Clear decision for the `PullLayer`. The host counts only when
+    /// it will actually be pulled (`host_pull_enabled`); a configured-but-gated
+    /// host context is for the re-sync, not the pull.
     pub(crate) fn has_contributors(&self) -> bool {
-        !self.virt_contexts.is_empty() || self.host.is_some()
+        !self.virt_contexts.is_empty() || (self.host.is_some() && self.host_pull_enabled)
     }
 }
 
@@ -96,6 +106,7 @@ pub(crate) async fn collect_push_diagnostics(
     let DiagnosticSnapshot {
         virt_contexts,
         host,
+        host_pull_enabled,
         layer_cfg,
     } = snapshot;
 
@@ -127,9 +138,13 @@ pub(crate) async fn collect_push_diagnostics(
 
     let host_fut = async {
         match &host {
-            // Push diagnostics are LSP-mode-only; failures are log-only.
-            Some(ctx) => collect_host_diagnostics(ctx, Arc::clone(pool), &None).await,
-            None => Vec::new(),
+            // Pull only when enabled; a configured-but-gated host context exists
+            // for the re-sync (above), not the pull. Push diagnostics are
+            // LSP-mode-only, so failures are log-only (`&None` error sink).
+            Some(ctx) if host_pull_enabled => {
+                collect_host_diagnostics(ctx, Arc::clone(pool), &None).await
+            }
+            _ => Vec::new(),
         }
     };
 

--- a/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
@@ -42,28 +42,52 @@ impl DiagnosticSnapshot {
     }
 }
 
+/// What the host-event pull collection wants done to the host's `PullLayer`
+/// slot (push-propagation-diagnostic-forwarding). The three states are
+/// distinct: `Skip` ≠ `Clear` (do nothing vs evict).
+pub(crate) enum PullLayerOutcome {
+    /// No snapshot (document gone / can never contribute): do nothing, leave the
+    /// cache untouched.
+    Skip,
+    /// Contributors exist but none can pull this event (every layer is
+    /// `pullFallback`-gated, or there are genuinely none): **evict** the host's
+    /// `PullLayer` so a stale pull blob does not linger AND an absent (not
+    /// merely empty) `PullLayer` lets a pull-driven server's spontaneous push
+    /// publish — the `pullFallback = false` guarantee (#425). Distinct from a
+    /// pull that ran and returned clean (that keeps an empty `PullLayer` present
+    /// so the clean result still suppresses a pull-driven server's stale push).
+    Clear,
+    /// A pull ran; publish its (possibly empty) result as the `PullLayer` blob.
+    Publish(Vec<tower_lsp_server::ls_types::Diagnostic>),
+}
+
 /// Collect diagnostics from every participating layer using priority-aware
 /// aggregation (cross-layer-aggregation).
 ///
 /// Shared logic for both immediate (didSave/didOpen) and debounced (didChange)
-/// push diagnostics. Returns `None` if there's no snapshot data, or
-/// `Some(diagnostics)` (possibly empty to clear previous diagnostics).
+/// push diagnostics. Returns a [`PullLayerOutcome`]: `Skip` when there is no
+/// snapshot, `Clear` when nothing can pull this event (evict a stale pull blob),
+/// or `Publish` with the pull's combined result.
 pub(crate) async fn collect_push_diagnostics(
     snapshot_data: Option<DiagnosticSnapshot>,
     pool: &Arc<LanguageServerPool>,
     uri: &Url,
     log_target: &'static str,
-) -> Option<Vec<tower_lsp_server::ls_types::Diagnostic>> {
-    let snapshot = snapshot_data?;
+) -> PullLayerOutcome {
+    let Some(snapshot) = snapshot_data else {
+        return PullLayerOutcome::Skip;
+    };
 
     if !snapshot.has_contributors() {
         log::debug!(
             target: log_target,
-            "No diagnostic contributors (regions or host servers) for {}",
+            "No diagnostic contributors (regions or host servers) for {}; clearing pull layer",
             uri
         );
-        // Return empty to signal caller should clear diagnostics
-        return Some(Vec::new());
+        // Evict (not publish-empty): an absent PullLayer both clears any stale
+        // pull result and avoids falsely triggering the pull/push double-count
+        // filter against a pull-driven server's spontaneous push (#425).
+        return PullLayerOutcome::Clear;
     }
 
     // Destructure so each future owns exactly the field it needs (the
@@ -111,7 +135,7 @@ pub(crate) async fn collect_push_diagnostics(
 
     let (virt_items, host_items) = tokio::join!(virt_fut, host_fut);
 
-    Some(combine_layer_diagnostics(
+    PullLayerOutcome::Publish(combine_layer_diagnostics(
         &layer_cfg, virt_items, host_items,
     ))
 }

--- a/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
@@ -91,7 +91,8 @@ pub(crate) async fn collect_push_diagnostics(
     if !snapshot.has_contributors() {
         log::debug!(
             target: log_target,
-            "No diagnostic contributors (regions or host servers) for {}; clearing pull layer",
+            "No pull contributors for {} (no pullable regions, and any host layer is \
+             pullFallback-gated or empty-selection); clearing pull layer",
             uri
         );
         // Evict (not publish-empty): an absent PullLayer both clears any stale

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -49,6 +49,10 @@
 //!   `didChange`. Used by `tests/e2e_push_diagnostics.rs` to prove a downstream's
 //!   spontaneous push reaches the editor in host coordinates and that an empty push
 //!   clears it (#427).
+//! - `diagnostics-push-pullcap` — advertises `diagnosticProvider` (pull-driven)
+//!   AND spontaneously pushes one diagnostic on `didOpen`. Used by
+//!   `tests/e2e_push_diagnostics.rs` to prove `pullFallback = false` still
+//!   publishes a pull-driven server's spontaneous push (#425).
 //! - `diagnostics-push-crash` — pushes the same diagnostic on `didOpen`, then exits
 //!   the process on the next `didChange` to simulate a downstream crash while the
 //!   host stays open. Used to prove the bridge evicts the dead connection's slots
@@ -143,7 +147,11 @@ fn main() {
                         "codeLensProvider": { "resolveProvider": true },
                         "textDocumentSync": 1
                     }),
-                    "diagnostics" | "diagnostics-fail" => json!({
+                    // `diagnostics-push-pullcap` is BOTH: it advertises
+                    // `diagnosticProvider` (pull-driven) AND pushes on didOpen
+                    // (below). Used to prove `pullFallback = false` still
+                    // publishes a pull-driven server's spontaneous push (#425).
+                    "diagnostics" | "diagnostics-fail" | "diagnostics-push-pullcap" => json!({
                         "diagnosticProvider": {
                             "interFileDependencies": false,
                             "workspaceDiagnostics": false
@@ -240,7 +248,10 @@ fn main() {
                     // coordinates and publishes it to the editor (#427).
                     // `diagnostics-push-crash` pushes the same diagnostic, then exits
                     // the process on the next `didChange` to simulate a crash (#469).
-                    if mode == "diagnostics-push" || mode == "diagnostics-push-crash" {
+                    if mode == "diagnostics-push"
+                        || mode == "diagnostics-push-crash"
+                        || mode == "diagnostics-push-pullcap"
+                    {
                         notify(
                             &mut writer,
                             "textDocument/publishDiagnostics",

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -211,6 +211,78 @@ fn e2e_pushfallback_folds_push_driven_server_into_client_pull() {
     client.send_notification("exit", json!(null));
 }
 
+#[test]
+fn e2e_pullfallback_false_still_publishes_a_pull_driven_servers_spontaneous_push() {
+    // #425 guarantee: `pullFallback = false` stops kakehashi from PULLING a
+    // pull-driven server, but its spontaneous publishDiagnostics push must still
+    // reach the editor (#380 stays closed). Regression guard for the
+    // empty-PullLayer-suppresses-the-push bug: with no pull contributors the
+    // host's PullLayer is EVICTED (not stored empty), so the merge's pull/push
+    // dedup does not suppress the pull-driven server's cached push.
+    let config_dir = tempfile::TempDir::new().expect("temp dir");
+    let config_path = config_dir.path().join("pullfallback.toml");
+    std::fs::write(&config_path, "").expect("write config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("utf8 path"))
+        .build();
+
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": {
+                "languageServers": {
+                    "mock-pullcap": {
+                        "cmd": [mock_bin(), "diagnostics-push-pullcap"],
+                        "languages": ["lua"]
+                    }
+                },
+                "languages": {
+                    "markdown": {
+                        "bridge": {
+                            "lua": {
+                                "aggregation": {
+                                    "textDocument/publishDiagnostics": { "pullFallback": false }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": { "uri": MD_URI, "languageId": "markdown", "version": 1, "text": MD_TEXT }
+        }),
+    );
+
+    // The pull-driven mock pushes on didOpen. pullFallback = false means the
+    // bridge never pulls it, so the only way its diagnostic reaches the editor is
+    // the spontaneous push surviving the merge — at host line 3.
+    let got = client.wait_for_notification_where(
+        &["textDocument/publishDiagnostics"],
+        Duration::from_secs(15),
+        pushed_diag_at_line(HOST_LINE),
+    );
+    assert!(
+        got.is_some(),
+        "pullFallback = false must still publish a pull-driven server's spontaneous push \
+         (an empty PullLayer must not suppress it)"
+    );
+
+    client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
 /// True if the host publish carries the mock's pushed diagnostic at host `line`.
 fn pushed_diag_at_line(line: i64) -> impl Fn(&Value) -> bool {
     move |params: &Value| {

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -212,7 +212,7 @@ fn e2e_pushfallback_folds_push_driven_server_into_client_pull() {
 }
 
 #[test]
-fn e2e_pullfallback_false_still_publishes_a_pull_driven_servers_spontaneous_push() {
+fn e2e_pullfallback_false_still_publishes_a_pull_driven_server_spontaneous_push() {
     // #425 guarantee: `pullFallback = false` stops kakehashi from PULLING a
     // pull-driven server, but its spontaneous publishDiagnostics push must still
     // reach the editor (#380 stays closed). Regression guard for the

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -164,6 +164,53 @@ fn e2e_push_diagnostic_reaches_editor_in_host_coords_then_clears() {
     client.send_notification("exit", json!(null));
 }
 
+#[test]
+fn e2e_pushfallback_folds_push_driven_server_into_client_pull() {
+    // pushFallback (Path B, #425): a push-driven downstream (the `diagnostics-push`
+    // mock advertises NO `diagnosticProvider`) contributes nothing to a live
+    // `textDocument/diagnostic` fan-out — the capability gate skips it. Its cached
+    // spontaneous push is instead folded into the client-pull response, in host
+    // coordinates. Default `pushFallback = true`.
+    let (mut client, _config_dir) = init_client();
+
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": { "uri": MD_URI, "languageId": "markdown", "version": 1, "text": MD_TEXT }
+        }),
+    );
+
+    // Wait for the spontaneous push so the slot is cached (it also reaches the editor).
+    client
+        .wait_for_notification_where(
+            &["textDocument/publishDiagnostics"],
+            Duration::from_secs(15),
+            has_pushed_diag,
+        )
+        .expect("the push-driven mock should push on didOpen");
+
+    // A client pull: the live fan-out skips the push-only mock (no
+    // `diagnosticProvider`), so only `pushFallback` can surface its diagnostic.
+    let response = client.send_request(
+        "textDocument/diagnostic",
+        json!({ "textDocument": { "uri": MD_URI } }),
+    );
+    let items = response["result"]["items"]
+        .as_array()
+        .expect("the pull answer is a full diagnostic report with an items array");
+    let folded = items.iter().find(|d| is_mock_push(d)).expect(
+        "pushFallback must fold the push-driven server's cached push into the client-pull response",
+    );
+    assert_eq!(
+        folded["range"]["start"]["line"],
+        json!(HOST_LINE),
+        "the folded push must be transformed to host coordinates (host line {HOST_LINE})"
+    );
+
+    client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
 /// True if the host publish carries the mock's pushed diagnostic at host `line`.
 fn pushed_diag_at_line(line: i64) -> impl Fn(&Value) -> bool {
     move |params: &Value| {


### PR DESCRIPTION
Closes #425.

Implements the deferred symmetric diagnostic fallback toggles and per-server
capability classification from the push-propagation ADR, and removes the
documented pull/push double-count.

## What

- **Config**: `pullFallback` / `pushFallback` are `Option<bool>` on
  `AggregationConfig` (camelCase serde, default `true`), merged field-by-field,
  stripped against inherited values, and spelled out in the generated config
  template.
- **Classification** (live, non-creating): `LanguageServerPool::pull_driven_servers`
  scans the connections map — a server advertising `diagnosticProvider` (static
  initialize caps or dynamic registration) is *pull-driven*, else *push-driven*.
- **Double-count fix**: the proactive publisher's `filter_pull_driven_push_slots`
  drops a pull-driven server's push slot from the publish when a `PullLayer`
  blob is present, so each server has exactly one native source (the slot stays
  cached).
- **Path A (`pullFallback`)**: `prepare_diagnostic_snapshot` gates the host-event
  pull per region/host. The collection returns `Skip` / `Clear` / `Publish`:
  with no pull contributors the `PullLayer` is **evicted** (absent, not empty),
  so it neither lingers nor falsely suppresses a pull-driven server's spontaneous
  push — `pullFallback = false` keeps #380 closed. The host context is kept for
  the #431 re-sync even when the pull is gated (`host_pull_enabled`).
- **Path B (`pushFallback`)**: `diagnostic_impl`'s `fold_push_fallback_diagnostics`
  folds push-driven servers' cached pushes into the client-pull response (region
  pushes transformed to host coords, host pushes pass through; the `PullLayer` is
  never folded). One cache snapshot drives both classification and fold (no
  TOCTOU).
- **Invariant**: a `PullLayer` is present only when a pull actually dispatched to
  ≥1 server (skips `pullFallback=false`, `priorities=[]`, `maxFanOut=0`, and
  only-unconfigured-names contexts).

## Tests

Unit coverage for classification, the merge-time dedup, the push fold/transform,
config merge/resolve/serde, and the host-pull gate; e2e
`e2e_pushfallback_folds_push_driven_server_into_client_pull` and
`e2e_pullfallback_false_still_publishes_a_pull_driven_servers_spontaneous_push`
(new push-and-pull-capable mock mode) lock the two paths end-to-end.

## Deferred (documented at each site)

Per-source strategy fan-in (visible-walk eligibility / `preferred` sticky
election) — which also subsumes the mixed-per-region `pullFallback`
over-suppression and the by-server-name classification edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)