### PR TITLE
feat(install): killable parser-compile deadline via re-exec subprocess (ADR)

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -69,6 +69,18 @@ enum Commands {
         #[arg(long, default_value_t = true, action = clap::ArgAction::Set, num_args = 1)]
         insert_spaces: bool,
     },
+    /// Internal: compile a parser grammar in a killable subprocess.
+    ///
+    /// Re-exec target of `install::parser::compile_parser`, which runs this inside
+    /// a process group it can kill on a deadline (the loader shells out to `cc`
+    /// with no surfaced child). Not for direct use; hidden from `--help`.
+    #[command(name = "__compile-parser", hide = true)]
+    CompileParser {
+        /// Grammar source directory (contains src/parser.c)
+        grammar_dir: PathBuf,
+        /// Output path for the compiled shared library
+        output_path: PathBuf,
+    },
     /// Report diagnostics for files via the configured downstream language servers
     ///
     /// Only pull diagnostics (textDocument/diagnostic) are collected. Push
@@ -321,6 +333,10 @@ fn main() -> ExitCode {
             output_format,
             fail_on_warning,
         }),
+        Some(Commands::CompileParser {
+            grammar_dir,
+            output_path,
+        }) => run_compile_parser(&grammar_dir, &output_path),
         None => {
             // Start LSP server (backward compatible default behavior)
             // Only LSP mode needs a tokio runtime; CLI subcommands are synchronous
@@ -715,6 +731,23 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
     } else {
         eprintln!("\nPartially installed '{}' language support.", language);
         Err(ExitCode::FAILURE)
+    }
+}
+
+/// Run the hidden `__compile-parser` subprocess entry: compile one grammar
+/// in-process and exit (success → 0, failure → non-zero). Invoked by
+/// `install::parser::compile_parser`, which runs this binary as a killable
+/// subprocess so a hung `cc` can be deadline-killed.
+fn run_compile_parser(
+    grammar_dir: &std::path::Path,
+    output_path: &std::path::Path,
+) -> Result<(), ExitCode> {
+    match parser::compile_parser_inprocess(grammar_dir, output_path) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            eprintln!("parser compile failed: {e}");
+            Err(ExitCode::FAILURE)
+        }
     }
 }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -745,6 +745,10 @@ fn run_compile_parser(
     grammar_dir: &std::path::Path,
     output_path: &std::path::Path,
 ) -> Result<(), ExitCode> {
+    // Self-bound the compile so a parent crash mid-compile can't leave us (and a
+    // hung cc) running as an orphan; the parent's deadline is still the usual
+    // trigger.
+    parser::arm_compile_watchdog();
     match parser::compile_parser_inprocess(grammar_dir, output_path) {
         Ok(()) => Ok(()),
         Err(e) => {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -690,6 +690,9 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
         force,
         verbose,
         no_cache,
+        // The CLI runs from the kakehashi binary, so the killable subprocess path
+        // is available and a hung cc is deadline-bounded.
+        compile: parser::ParserCompile::KillableSubprocess,
     };
 
     match parser::install_parser(language, &options) {

--- a/src/install.rs
+++ b/src/install.rs
@@ -157,6 +157,9 @@ pub mod test_support {
             force: false,
             verbose: false,
             no_cache: false,
+            // Test setup runs from a test-harness binary, whose `current_exe()` has
+            // no `__compile-parser` subcommand — compile in-process.
+            compile: parser::ParserCompile::InProcess,
         };
         let mut all_ok = true;
         for lang in TEST_LANGUAGES {
@@ -259,6 +262,9 @@ fn install_language_blocking(
         force,
         verbose: false,
         no_cache: false,
+        // Auto-install runs inside the LSP server (current_exe is kakehashi); a
+        // hung cc must be deadline-killable so it can't wedge the install.
+        compile: parser::ParserCompile::KillableSubprocess,
     };
 
     // AlreadyExists means the artifact is present and usable — success,

--- a/src/install.rs
+++ b/src/install.rs
@@ -237,6 +237,7 @@ fn install_language_blocking(
     data_dir: &std::path::Path,
     force: bool,
     queries_base_url: &str,
+    compile: parser::ParserCompile,
 ) -> InstallResult {
     let mut result = InstallResult {
         parser_path: None,
@@ -262,9 +263,11 @@ fn install_language_blocking(
         force,
         verbose: false,
         no_cache: false,
-        // Auto-install runs inside the LSP server (current_exe is kakehashi); a
-        // hung cc must be deadline-killable so it can't wedge the install.
-        compile: parser::ParserCompile::KillableSubprocess,
+        // Caller-chosen: the killable subprocess re-execs this binary's
+        // `__compile-parser`, so it is valid only when `current_exe()` is the
+        // kakehashi binary. The production caller (LSP auto-install) is, and asks
+        // for it; test/embedder callers pass InProcess.
+        compile,
     };
 
     // AlreadyExists means the artifact is present and usable — success,
@@ -312,6 +315,7 @@ pub(crate) async fn install_language_async(
     language: String,
     data_dir: PathBuf,
     force: bool,
+    compile: parser::ParserCompile,
 ) -> InstallResult {
     // Run blocking install operations in a separate thread pool
     tokio::task::spawn_blocking(move || {
@@ -320,6 +324,7 @@ pub(crate) async fn install_language_async(
             &data_dir,
             force,
             queries::NVIM_TREESITTER_QUERIES_URL,
+            compile,
         )
     })
     .await
@@ -460,7 +465,13 @@ mod tests {
             ("/parent_lang/highlights.scm", "(comment) @comment\n"),
         ]);
 
-        let result = install_language_blocking("child_lang", data_dir, false, &base_url);
+        let result = install_language_blocking(
+            "child_lang",
+            data_dir,
+            false,
+            &base_url,
+            parser::ParserCompile::InProcess,
+        );
 
         assert!(
             result.queries_error.is_none(),
@@ -535,8 +546,13 @@ mod tests {
         let data_dir = temp.path().join("nest").join("data");
         std::fs::create_dir_all(&data_dir).unwrap();
 
-        let result =
-            install_language_blocking("../../evil", &data_dir, false, "http://127.0.0.1:1");
+        let result = install_language_blocking(
+            "../../evil",
+            &data_dir,
+            false,
+            "http://127.0.0.1:1",
+            parser::ParserCompile::InProcess,
+        );
 
         assert!(!result.is_success(), "unsafe name must not install");
         assert!(
@@ -583,8 +599,13 @@ mod tests {
 
         // Everything exists, so no download may happen — point the base URL
         // at a closed port to fail loudly if one is attempted anyway.
-        let result =
-            install_language_blocking("exists_lang", data_dir, false, "http://127.0.0.1:1");
+        let result = install_language_blocking(
+            "exists_lang",
+            data_dir,
+            false,
+            "http://127.0.0.1:1",
+            parser::ParserCompile::InProcess,
+        );
 
         assert!(
             result.is_success(),

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -449,6 +449,51 @@ fn run_with_timeout(
     }
 }
 
+/// Run a subprocess under a hard deadline, killing it on expiry.
+///
+/// Unlike [`run_with_timeout`], this is for a child that itself spawns children
+/// (the parser compile re-execs this binary, which shells out to `cc` as a
+/// *grandchild*). A bare `child.kill()` reaches only the direct child and leaves
+/// the `cc` grandchild running — the very hang this deadline exists to bound. So
+/// the child is spawned as its own **process-group leader** and the deadline kill
+/// targets the whole **group**, reaping grandchildren too.
+fn run_killable_subprocess(
+    mut cmd: Command,
+    timeout: Duration,
+    context: &str,
+) -> Result<std::process::ExitStatus, ParserInstallError> {
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| ParserInstallError::CompileError(format!("{}: {}", context, e)))?;
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Ok(status),
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    // BUG (closed in the GREEN commit): a bare child kill orphans
+                    // the `cc` grandchild.
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(ParserInstallError::CompileError(format!(
+                        "{} timed out after {:?}",
+                        context, timeout
+                    )));
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(e) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(ParserInstallError::CompileError(format!(
+                    "{}: {}",
+                    context, e
+                )));
+            }
+        }
+    }
+}
+
 /// Clone a git repository at a specific revision.
 fn clone_repo(url: &str, revision: &str, dest: &Path) -> Result<(), ParserInstallError> {
     // First, clone with depth 1 (we'll fetch the specific revision)
@@ -538,6 +583,54 @@ mod tests {
         assert!(
             started.elapsed() < Duration::from_secs(5),
             "stuck child must be killed promptly, not waited out"
+        );
+    }
+
+    /// A deadline kill must reap the whole process **group**, not just the direct
+    /// child. The parser compiler shells out to `cc` as a *grandchild*; a bare
+    /// `child.kill()` would leave it running — the hang this deadline exists to
+    /// bound. We model it with `sh` (the group leader) backgrounding a long-lived
+    /// grandchild, and assert the grandchild dies when the deadline fires.
+    #[cfg(unix)]
+    #[test]
+    fn run_killable_subprocess_reaps_grandchildren_on_deadline() {
+        use nix::sys::signal::Signal;
+
+        let tmp = tempdir().expect("temp dir");
+        let pidfile = tmp.path().join("grandchild.pid");
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg(format!(
+            "sleep 60 & printf %s \"$!\" > '{}'; wait",
+            pidfile.display()
+        ));
+
+        let result = run_killable_subprocess(cmd, Duration::from_millis(300), "test compile");
+        assert!(
+            result.is_err(),
+            "a subprocess that outlives the deadline must error out"
+        );
+
+        let pid_raw: i32 = std::fs::read_to_string(&pidfile)
+            .expect("grandchild recorded its pid")
+            .trim()
+            .parse()
+            .expect("valid pid");
+        let pid = nix::unistd::Pid::from_raw(pid_raw);
+
+        // Poll for the group kill to land (and the grandchild to be reaped by init).
+        let mut alive = true;
+        for _ in 0..100 {
+            match nix::sys::signal::kill(pid, None::<Signal>) {
+                Err(nix::errno::Errno::ESRCH) => {
+                    alive = false;
+                    break;
+                }
+                _ => std::thread::sleep(Duration::from_millis(20)),
+            }
+        }
+        assert!(
+            !alive,
+            "the backgrounded grandchild must be killed with the process group, not orphaned"
         );
     }
 

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -69,6 +69,7 @@ impl From<MetadataError> for ParserInstallError {
 }
 
 /// Result of installing a parser.
+#[derive(Debug)]
 pub struct ParserInstallResult {
     /// The language that was installed.
     pub language: String,
@@ -167,14 +168,20 @@ pub fn compile_parser_inprocess(
 /// On Linux, prefer `/proc/self/exe`: if the running `kakehashi` binary is
 /// replaced (a package upgrade while the LSP server runs), `current_exe()`
 /// resolves to a stale `".../kakehashi (deleted)"` path that no longer spawns,
-/// whereas `/proc/self/exe` still execs the original image. Elsewhere
+/// whereas `execve("/proc/self/exe")` still runs the original image. Elsewhere
 /// `current_exe()` is the portable answer.
 fn self_exe_for_reexec() -> Result<PathBuf, ParserInstallError> {
     #[cfg(target_os = "linux")]
     {
-        let proc_self = PathBuf::from("/proc/self/exe");
-        if proc_self.exists() {
-            return Ok(proc_self);
+        // Check the symlink with `symlink_metadata` (lstat), NOT `exists()`:
+        // `exists()` follows the link to the target and returns false exactly when
+        // the binary was deleted/replaced — the case this branch exists to handle.
+        // `symlink_metadata` confirms the `/proc/self/exe` link itself is present
+        // (so we fall back to `current_exe()` when `/proc` isn't mounted) without
+        // requiring the target to still exist.
+        let proc_self = Path::new("/proc/self/exe");
+        if std::fs::symlink_metadata(proc_self).is_ok() {
+            return Ok(proc_self.to_path_buf());
         }
     }
     std::env::current_exe().map_err(|e| {
@@ -218,6 +225,18 @@ pub fn install_parser(
     language: &str,
     options: &InstallOptions,
 ) -> Result<ParserInstallResult, ParserInstallError> {
+    // `language` becomes path segments (`parser/<language>.<ext>` and the temp
+    // file) and a URL/metadata key, so reject traversal-capable names before
+    // touching the filesystem. Higher-level callers (auto-install) already gate
+    // this, but `install_parser` is a public entry point and must be safe on its
+    // own — a name like `../../evil` would otherwise write outside the data dir.
+    if !super::queries::is_safe_language_name(language) {
+        return Err(ParserInstallError::IoError(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("unsafe language name '{}'", language.escape_default()),
+        )));
+    }
+
     let parser_dir = options.data_dir.join("parser");
     let parser_file = parser_dir.join(format!("{}.{}", language, std::env::consts::DLL_EXTENSION));
 
@@ -738,6 +757,26 @@ mod tests {
 
     const TREE_SITTER_JSON_URL: &str =
         "https://github.com/tree-sitter/tree-sitter-json/archive/v0.24.8.tar.gz";
+
+    #[test]
+    fn install_parser_rejects_unsafe_language_name() {
+        let temp = tempdir().expect("temp dir");
+        let options = InstallOptions {
+            data_dir: temp.path().to_path_buf(),
+            force: false,
+            verbose: false,
+            no_cache: false,
+            compile: ParserCompile::InProcess,
+        };
+        // A traversal-capable name must be rejected before any filesystem or
+        // network work — `install_parser` is a public entry point.
+        match install_parser("../../evil", &options) {
+            Err(ParserInstallError::IoError(e)) => {
+                assert_eq!(e.kind(), std::io::ErrorKind::InvalidInput);
+            }
+            other => panic!("expected an InvalidInput IoError, got {other:?}"),
+        }
+    }
 
     #[test]
     fn test_dll_extension_is_valid() {

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -163,6 +163,37 @@ pub fn compile_parser_inprocess(
         .map_err(|e| ParserInstallError::CompileError(e.to_string()))
 }
 
+/// Arm a self-deadline inside the `__compile-parser` subprocess.
+///
+/// The parent's [`run_killable_subprocess`] normally enforces the deadline and
+/// kills the compile's process group. But if the *parent* (`kakehashi`) dies
+/// mid-compile — editor crash, `SIGTERM`, cancellation — this subprocess is
+/// orphaned and the loader's synchronous `cc` would keep running forever. This
+/// backstop closes that: become our own process-group leader (so the group kill
+/// can only reach us and our `cc`, never a shell that launched us directly), then
+/// spawn a watchdog that group-kills us shortly after [`PARSER_COMPILE_TIMEOUT`].
+///
+/// On a normal/quick compile the process exits first and the watchdog thread is
+/// torn down with it; the grace margin keeps the parent's deadline the usual
+/// trigger. Unix-only (process groups); a no-op elsewhere. The subcommand entry
+/// (`src/bin/main.rs`) calls this before compiling.
+pub fn arm_compile_watchdog() {
+    #[cfg(unix)]
+    {
+        use nix::sys::signal::{Signal, killpg};
+        use nix::unistd::{Pid, setpgid};
+        // Own group leader. When spawned by run_killable_subprocess the parent
+        // already did this via process_group(0) (a harmless repeat); when run
+        // directly it makes the group-kill below safe. Ignore EPERM-if-already.
+        let _ = setpgid(Pid::from_raw(0), Pid::from_raw(0));
+        std::thread::spawn(|| {
+            std::thread::sleep(PARSER_COMPILE_TIMEOUT + Duration::from_secs(30));
+            // pgid 0 = our own process group (us + the cc we shelled out).
+            let _ = killpg(Pid::from_raw(0), Signal::SIGKILL);
+        });
+    }
+}
+
 /// Resolve the path to re-exec for the `__compile-parser` subprocess.
 ///
 /// On Linux, prefer `/proc/self/exe`: if the running `kakehashi` binary is
@@ -295,7 +326,7 @@ pub fn install_parser(
     // by this process still fails at the rename — a loaded DLL can't be removed — a
     // pre-existing platform limitation this scheme doesn't change.)
     fs::create_dir_all(&parser_dir)?;
-    static TMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    static TMP_COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let tmp_file = parser_dir.join(format!(
         ".{}.{}.{}.{}.tmp",
         language,

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -266,6 +266,13 @@ pub fn install_parser(
     };
     match compiled {
         Ok(()) => {
+            // On unix `rename` atomically replaces an existing parser. Windows
+            // `rename` instead fails if the destination exists, which would make a
+            // `force` reinstall fail after a good compile — remove the old file
+            // first there (a small non-atomic window, acceptable on the
+            // non-primary platform).
+            #[cfg(windows)]
+            let _ = fs::remove_file(&parser_file);
             if let Err(e) = fs::rename(&tmp_file, &parser_file) {
                 let _ = fs::remove_file(&tmp_file);
                 return Err(ParserInstallError::IoError(e));
@@ -761,12 +768,14 @@ mod tests {
         // Background a grandchild that touches `survived` 2s out; `spawned` is
         // touched right after launching it (proving the descendant was actually
         // started, so an absent `survived` can't be a vacuous pass from sh dying
-        // before it forked the child).
-        cmd.arg("-c").arg(format!(
-            "( sleep 2; touch '{}' ) & touch '{}'; wait",
-            survived.display(),
-            spawned.display()
-        ));
+        // before it forked the child). Paths are passed as positional params
+        // ($1/$2), not interpolated, so a temp dir containing a quote can't break
+        // the script.
+        cmd.arg("-c")
+            .arg(r#"( sleep 2; touch "$1" ) & touch "$2"; wait"#)
+            .arg("sh")
+            .arg(&survived)
+            .arg(&spawned);
 
         let started = std::time::Instant::now();
         let result = run_killable_subprocess(cmd, Duration::from_millis(700), "test compile");

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -162,6 +162,26 @@ pub fn compile_parser_inprocess(
         .map_err(|e| ParserInstallError::CompileError(e.to_string()))
 }
 
+/// Resolve the path to re-exec for the `__compile-parser` subprocess.
+///
+/// On Linux, prefer `/proc/self/exe`: if the running `kakehashi` binary is
+/// replaced (a package upgrade while the LSP server runs), `current_exe()`
+/// resolves to a stale `".../kakehashi (deleted)"` path that no longer spawns,
+/// whereas `/proc/self/exe` still execs the original image. Elsewhere
+/// `current_exe()` is the portable answer.
+fn self_exe_for_reexec() -> Result<PathBuf, ParserInstallError> {
+    #[cfg(target_os = "linux")]
+    {
+        let proc_self = PathBuf::from("/proc/self/exe");
+        if proc_self.exists() {
+            return Ok(proc_self);
+        }
+    }
+    std::env::current_exe().map_err(|e| {
+        ParserInstallError::CompileError(format!("locating the kakehashi binary: {e}"))
+    })
+}
+
 /// Compile a Tree-sitter parser under a hard, killable deadline.
 ///
 /// The loader's `compile_parser_at_path` shells out to `cc` without surfacing the
@@ -173,10 +193,7 @@ pub fn compile_parser_inprocess(
 /// `fork`: forking a multithreaded process is unsafe past the child's first
 /// non-async-signal-safe call.
 fn compile_parser(grammar_path: &Path, output_path: &Path) -> Result<(), ParserInstallError> {
-    let exe = std::env::current_exe().map_err(|e| {
-        ParserInstallError::CompileError(format!("locating the kakehashi binary: {e}"))
-    })?;
-    let mut cmd = Command::new(exe);
+    let mut cmd = Command::new(self_exe_for_reexec()?);
     cmd.arg("__compile-parser")
         .arg(grammar_path)
         .arg(output_path)
@@ -251,13 +268,20 @@ pub fn install_parser(
     // would make later runs skip reinstall and load a broken parser); writing to a
     // temp and renaming only on success means a failure never clobbers a
     // previously-working parser (e.g. a `force` reinstall that fails) and concurrent
-    // readers never observe a half-written file. `std::process::id()` keeps the temp
-    // unique even though the per-language install dedup already serializes installs.
+    // readers never observe a half-written file.
+    //
+    // The temp name combines the pid with a process-local counter so two installs
+    // in the same process never collide on it, independent of the per-language
+    // install dedup. (Windows caveat: replacing a parser that is *currently loaded*
+    // by this process still fails at the rename — a loaded DLL can't be removed — a
+    // pre-existing platform limitation this scheme doesn't change.)
     fs::create_dir_all(&parser_dir)?;
+    static TMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let tmp_file = parser_dir.join(format!(
-        ".{}.{}.{}.tmp",
+        ".{}.{}.{}.{}.tmp",
         language,
         std::process::id(),
+        TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
         std::env::consts::DLL_EXTENSION
     ));
     let compiled = match options.compile {

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -557,8 +557,10 @@ fn run_killable_subprocess(
 
 /// Kill the child **and** any grandchildren it spawned. The child was started as
 /// its own process-group leader, so its pgid equals its pid and a group-wide
-/// signal reaches the whole tree (`cc`, linkers, etc.). Falls back to a direct
-/// kill on non-unix, where the process-group model differs.
+/// signal reaches the whole tree (`cc`, linkers, etc.). On non-unix this falls
+/// back to a direct `child.kill()`, which does **not** reap grandchildren — the
+/// orphaned-`cc` hazard is unmitigated there (kakehashi targets unix in practice;
+/// a Job Object would be the Windows equivalent).
 fn kill_process_group(child: &mut std::process::Child) {
     #[cfg(unix)]
     {
@@ -682,7 +684,10 @@ mod tests {
             pidfile.display()
         ));
 
-        let result = run_killable_subprocess(cmd, Duration::from_millis(300), "test compile");
+        // 1s (not a tight 300ms) so a loaded CI box still records the grandchild
+        // pid via `printf` before the group is killed — otherwise the pidfile read
+        // below could panic instead of failing cleanly.
+        let result = run_killable_subprocess(cmd, Duration::from_millis(1000), "test compile");
         assert!(
             result.is_err(),
             "a subprocess that outlives the deadline must error out"

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -105,8 +105,28 @@ pub fn parser_file_exists(language: &str, data_dir: &Path) -> Option<PathBuf> {
     }
 }
 
-/// Compile a Tree-sitter parser from source using tree-sitter-loader.
-fn compile_parser(grammar_path: &Path, output_path: &Path) -> Result<(), ParserInstallError> {
+/// Upper bound for a single parser compile.
+///
+/// The loader shells out to `cc` with no timeout of its own; a pathological
+/// toolchain (a hung or wedged compiler) would otherwise block the install — and,
+/// in the LSP server, the in-progress install marker and process exit — forever.
+/// Generous enough not to false-kill a legitimately slow grammar (e.g. a cold
+/// TypeScript build) while still bounding a true hang.
+const PARSER_COMPILE_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Compile a Tree-sitter parser from source using tree-sitter-loader, **in
+/// process**.
+///
+/// This is the raw loader call: it shells out to `cc` and, on a pathological
+/// toolchain, can hang with no surfaced child to kill. Production install does
+/// **not** call this directly — it goes through [`compile_parser`], which runs it
+/// inside a killable subprocess. This is `pub` only as the entry point for that
+/// subprocess: the hidden `__compile-parser` subcommand (`src/bin/main.rs`) calls
+/// here.
+pub fn compile_parser_inprocess(
+    grammar_path: &Path,
+    output_path: &Path,
+) -> Result<(), ParserInstallError> {
     let parent_dir = output_path.parent().ok_or_else(|| {
         ParserInstallError::IoError(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
@@ -120,6 +140,40 @@ fn compile_parser(grammar_path: &Path, output_path: &Path) -> Result<(), ParserI
     loader
         .compile_parser_at_path(grammar_path, output_path.to_path_buf(), &[])
         .map_err(|e| ParserInstallError::CompileError(e.to_string()))
+}
+
+/// Compile a Tree-sitter parser under a hard, killable deadline.
+///
+/// The loader's `compile_parser_at_path` shells out to `cc` without surfacing the
+/// child, so a `tokio::time::timeout` cannot kill a hung compiler (the blocking
+/// thread and its `cc` would keep running). Instead we **re-exec** this binary's
+/// hidden `__compile-parser` subcommand inside a killable process group (see the
+/// per-document-parse-actor ADR, "a real install deadline via a killable
+/// subprocess") and bound it with [`PARSER_COMPILE_TIMEOUT`]. Re-exec rather than
+/// `fork`: forking a multithreaded process is unsafe past the child's first
+/// non-async-signal-safe call.
+fn compile_parser(grammar_path: &Path, output_path: &Path) -> Result<(), ParserInstallError> {
+    let exe = std::env::current_exe().map_err(|e| {
+        ParserInstallError::CompileError(format!("locating the kakehashi binary: {e}"))
+    })?;
+    let mut cmd = Command::new(exe);
+    cmd.arg("__compile-parser")
+        .arg(grammar_path)
+        .arg(output_path)
+        // Null stdin/stdout: when the parent is the LSP server, stdout is the
+        // JSON-RPC channel and no child output may reach it. stderr stays
+        // inherited so `cc` diagnostics land in the logs.
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null());
+    let status = run_killable_subprocess(cmd, PARSER_COMPILE_TIMEOUT, "parser compile")?;
+    if !status.success() {
+        return Err(ParserInstallError::CompileError(format!(
+            "parser compile subprocess for '{}' exited with {}",
+            grammar_path.display(),
+            status
+        )));
+    }
+    Ok(())
 }
 
 /// Install a Tree-sitter parser for a language.
@@ -462,6 +516,15 @@ fn run_killable_subprocess(
     timeout: Duration,
     context: &str,
 ) -> Result<std::process::ExitStatus, ParserInstallError> {
+    // Spawn the child as its own process-group leader (pgid == child pid), so a
+    // deadline kill can target the whole group and reap grandchildren (the `cc`
+    // the compile shells out to) rather than orphaning them.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
+
     let mut child = cmd
         .spawn()
         .map_err(|e| ParserInstallError::CompileError(format!("{}: {}", context, e)))?;
@@ -471,9 +534,7 @@ fn run_killable_subprocess(
             Ok(Some(status)) => return Ok(status),
             Ok(None) => {
                 if std::time::Instant::now() >= deadline {
-                    // BUG (closed in the GREEN commit): a bare child kill orphans
-                    // the `cc` grandchild.
-                    let _ = child.kill();
+                    kill_process_group(&mut child);
                     let _ = child.wait();
                     return Err(ParserInstallError::CompileError(format!(
                         "{} timed out after {:?}",
@@ -483,7 +544,7 @@ fn run_killable_subprocess(
                 std::thread::sleep(Duration::from_millis(50));
             }
             Err(e) => {
-                let _ = child.kill();
+                kill_process_group(&mut child);
                 let _ = child.wait();
                 return Err(ParserInstallError::CompileError(format!(
                     "{}: {}",
@@ -491,6 +552,23 @@ fn run_killable_subprocess(
                 )));
             }
         }
+    }
+}
+
+/// Kill the child **and** any grandchildren it spawned. The child was started as
+/// its own process-group leader, so its pgid equals its pid and a group-wide
+/// signal reaches the whole tree (`cc`, linkers, etc.). Falls back to a direct
+/// kill on non-unix, where the process-group model differs.
+fn kill_process_group(child: &mut std::process::Child) {
+    #[cfg(unix)]
+    {
+        use nix::sys::signal::{Signal, killpg};
+        use nix::unistd::Pid;
+        let _ = killpg(Pid::from_raw(child.id() as i32), Signal::SIGKILL);
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = child.kill();
     }
 }
 
@@ -853,7 +931,12 @@ mod tests {
             .path()
             .join(format!("json.{}", std::env::consts::DLL_EXTENSION));
 
-        compile_parser(&clone_dir, &output_path).expect("compile should succeed");
+        // Exercise the in-process loader call directly: the killable subprocess
+        // path (`compile_parser`) re-execs the kakehashi binary's
+        // `__compile-parser` subcommand, which is not present in the unit-test
+        // harness binary. End-to-end subprocess wiring is covered by
+        // `tests/test_compile_parser_subprocess.rs`.
+        compile_parser_inprocess(&clone_dir, &output_path).expect("compile should succeed");
 
         assert!(
             output_path.exists(),

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -78,6 +78,24 @@ pub struct ParserInstallResult {
     pub revision: String,
 }
 
+/// How the parser source is compiled.
+///
+/// The killable path re-execs **this** binary's `__compile-parser` subcommand, so
+/// it is only valid when the running executable is the `kakehashi` binary (the LSP
+/// server and the `language install` CLI). A caller whose `current_exe()` is
+/// something else — a test harness binary, an external embedder — must compile
+/// in-process, since that other binary has no `__compile-parser` subcommand.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ParserCompile {
+    /// Compile inside a killable subprocess (re-exec `__compile-parser`) so a hung
+    /// `cc` can be deadline-killed. The production default.
+    #[default]
+    KillableSubprocess,
+    /// Compile in-process — no killable deadline. For callers whose `current_exe()`
+    /// is not the `kakehashi` binary (e.g. test setup).
+    InProcess,
+}
+
 /// Options for parser installation.
 pub struct InstallOptions {
     /// Base data directory.
@@ -88,6 +106,8 @@ pub struct InstallOptions {
     pub verbose: bool,
     /// Whether to bypass the metadata cache.
     pub no_cache: bool,
+    /// How to compile the parser source (see [`ParserCompile`]).
+    pub compile: ParserCompile,
 }
 
 /// Check if a parser file exists for the given language.
@@ -227,7 +247,10 @@ pub fn install_parser(
 
     // Compile the parser directly to the install path
     fs::create_dir_all(&parser_dir)?;
-    compile_parser(&source_dir, &parser_file)?;
+    match options.compile {
+        ParserCompile::KillableSubprocess => compile_parser(&source_dir, &parser_file)?,
+        ParserCompile::InProcess => compile_parser_inprocess(&source_dir, &parser_file)?,
+    }
 
     if options.verbose {
         eprintln!("Installed to: {}", parser_file.display());
@@ -666,54 +689,40 @@ mod tests {
         );
     }
 
-    /// A deadline kill must reap the whole process **group**, not just the direct
-    /// child. The parser compiler shells out to `cc` as a *grandchild*; a bare
-    /// `child.kill()` would leave it running — the hang this deadline exists to
-    /// bound. We model it with `sh` (the group leader) backgrounding a long-lived
-    /// grandchild, and assert the grandchild dies when the deadline fires.
+    /// A deadline kill must terminate the whole process **group**, not just the
+    /// direct child. The parser compiler shells out to `cc` as a *grandchild*; a
+    /// bare `child.kill()` would leave it running — the hang this deadline exists
+    /// to bound. We model it with `sh` (the group leader) backgrounding a
+    /// grandchild that, *if it survives*, creates a marker file 2s out. The
+    /// deadline fires at 700ms, so a group kill must stop the grandchild before it
+    /// can touch the marker. Observing a side effect only a survivor produces is
+    /// robust against orphan-reaping timing and PID reuse (a bare child.kill()
+    /// would orphan the grandchild, which then creates the marker → RED).
     #[cfg(unix)]
     #[test]
-    fn run_killable_subprocess_reaps_grandchildren_on_deadline() {
-        use nix::sys::signal::Signal;
-
+    fn run_killable_subprocess_terminates_descendants_on_deadline() {
         let tmp = tempdir().expect("temp dir");
-        let pidfile = tmp.path().join("grandchild.pid");
+        let marker = tmp.path().join("grandchild-survived");
         let mut cmd = Command::new("sh");
-        cmd.arg("-c").arg(format!(
-            "sleep 60 & printf %s \"$!\" > '{}'; wait",
-            pidfile.display()
-        ));
+        cmd.arg("-c")
+            .arg(format!("( sleep 2; touch '{}' ) & wait", marker.display()));
 
-        // 1s (not a tight 300ms) so a loaded CI box still records the grandchild
-        // pid via `printf` before the group is killed — otherwise the pidfile read
-        // below could panic instead of failing cleanly.
-        let result = run_killable_subprocess(cmd, Duration::from_millis(1000), "test compile");
+        let started = std::time::Instant::now();
+        let result = run_killable_subprocess(cmd, Duration::from_millis(700), "test compile");
         assert!(
             result.is_err(),
             "a subprocess that outlives the deadline must error out"
         );
 
-        let pid_raw: i32 = std::fs::read_to_string(&pidfile)
-            .expect("grandchild recorded its pid")
-            .trim()
-            .parse()
-            .expect("valid pid");
-        let pid = nix::unistd::Pid::from_raw(pid_raw);
-
-        // Poll for the group kill to land (and the grandchild to be reaped by init).
-        let mut alive = true;
-        for _ in 0..100 {
-            match nix::sys::signal::kill(pid, None::<Signal>) {
-                Err(nix::errno::Errno::ESRCH) => {
-                    alive = false;
-                    break;
-                }
-                _ => std::thread::sleep(Duration::from_millis(20)),
-            }
+        // Wait past the grandchild's would-be touch time (2s), then assert it
+        // never ran — its group was killed at 700ms.
+        while started.elapsed() < Duration::from_millis(2500) {
+            std::thread::sleep(Duration::from_millis(50));
         }
         assert!(
-            !alive,
-            "the backgrounded grandchild must be killed with the process group, not orphaned"
+            !marker.exists(),
+            "the backgrounded grandchild created its marker, so it survived the \
+             deadline — it must be terminated with the process group, not orphaned"
         );
     }
 

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -533,15 +533,16 @@ fn run_with_timeout(
 /// *grandchild*). A bare `child.kill()` reaches only the direct child and leaves
 /// the `cc` grandchild running — the very hang this deadline exists to bound. So
 /// the child is spawned as its own **process-group leader** and the deadline kill
-/// targets the whole **group**, reaping grandchildren too.
+/// targets the whole **group**, terminating grandchildren too (the direct child is
+/// reaped here; the terminated descendants are reaped by init after reparenting).
 fn run_killable_subprocess(
     mut cmd: Command,
     timeout: Duration,
     context: &str,
 ) -> Result<std::process::ExitStatus, ParserInstallError> {
     // Spawn the child as its own process-group leader (pgid == child pid), so a
-    // deadline kill can target the whole group and reap grandchildren (the `cc`
-    // the compile shells out to) rather than orphaning them.
+    // deadline kill can terminate the whole group (the `cc` the compile shells out
+    // to) rather than orphaning grandchildren.
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
@@ -578,12 +579,14 @@ fn run_killable_subprocess(
     }
 }
 
-/// Kill the child **and** any grandchildren it spawned. The child was started as
-/// its own process-group leader, so its pgid equals its pid and a group-wide
-/// signal reaches the whole tree (`cc`, linkers, etc.). On non-unix this falls
-/// back to a direct `child.kill()`, which does **not** reap grandchildren — the
-/// orphaned-`cc` hazard is unmitigated there (kakehashi targets unix in practice;
-/// a Job Object would be the Windows equivalent).
+/// Terminate the child **and** every descendant it spawned. The child was started
+/// as its own process-group leader, so its pgid equals its pid and a group-wide
+/// `SIGKILL` reaches the whole tree (`cc`, linkers, etc.). This only *terminates*
+/// descendants; the caller reaps the direct child via `child.wait()`, and the
+/// terminated descendants are reparented to init and reaped there. On non-unix this
+/// falls back to a direct `child.kill()`, which does **not** reach descendants —
+/// the orphaned-`cc` hazard is unmitigated there (kakehashi targets unix in
+/// practice; a Job Object would be the Windows equivalent).
 fn kill_process_group(child: &mut std::process::Child) {
     #[cfg(unix)]
     {
@@ -702,16 +705,28 @@ mod tests {
     #[test]
     fn run_killable_subprocess_terminates_descendants_on_deadline() {
         let tmp = tempdir().expect("temp dir");
-        let marker = tmp.path().join("grandchild-survived");
+        let survived = tmp.path().join("grandchild-survived");
+        let spawned = tmp.path().join("grandchild-spawned");
         let mut cmd = Command::new("sh");
-        cmd.arg("-c")
-            .arg(format!("( sleep 2; touch '{}' ) & wait", marker.display()));
+        // Background a grandchild that touches `survived` 2s out; `spawned` is
+        // touched right after launching it (proving the descendant was actually
+        // started, so an absent `survived` can't be a vacuous pass from sh dying
+        // before it forked the child).
+        cmd.arg("-c").arg(format!(
+            "( sleep 2; touch '{}' ) & touch '{}'; wait",
+            survived.display(),
+            spawned.display()
+        ));
 
         let started = std::time::Instant::now();
         let result = run_killable_subprocess(cmd, Duration::from_millis(700), "test compile");
         assert!(
             result.is_err(),
             "a subprocess that outlives the deadline must error out"
+        );
+        assert!(
+            spawned.exists(),
+            "the grandchild must have been spawned (else the test would pass vacuously)"
         );
 
         // Wait past the grandchild's would-be touch time (2s), then assert it
@@ -720,7 +735,7 @@ mod tests {
             std::thread::sleep(Duration::from_millis(50));
         }
         assert!(
-            !marker.exists(),
+            !survived.exists(),
             "the backgrounded grandchild created its marker, so it survived the \
              deadline — it must be terminated with the process group, not orphaned"
         );

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -245,19 +245,36 @@ pub fn install_parser(
         eprintln!("Building parser in: {}", source_dir.display());
     }
 
-    // Compile the parser directly to the install path
+    // Compile to a temp path in the install dir, then atomically rename into place
+    // on success. A failed or deadline-killed compile can leave a partial/corrupt
+    // library behind (`parser_file_exists` only checks existence, so a leftover
+    // would make later runs skip reinstall and load a broken parser); writing to a
+    // temp and renaming only on success means a failure never clobbers a
+    // previously-working parser (e.g. a `force` reinstall that fails) and concurrent
+    // readers never observe a half-written file. `std::process::id()` keeps the temp
+    // unique even though the per-language install dedup already serializes installs.
     fs::create_dir_all(&parser_dir)?;
+    let tmp_file = parser_dir.join(format!(
+        ".{}.{}.{}.tmp",
+        language,
+        std::process::id(),
+        std::env::consts::DLL_EXTENSION
+    ));
     let compiled = match options.compile {
-        ParserCompile::KillableSubprocess => compile_parser(&source_dir, &parser_file),
-        ParserCompile::InProcess => compile_parser_inprocess(&source_dir, &parser_file),
+        ParserCompile::KillableSubprocess => compile_parser(&source_dir, &tmp_file),
+        ParserCompile::InProcess => compile_parser_inprocess(&source_dir, &tmp_file),
     };
-    if let Err(e) = compiled {
-        // A failed or deadline-killed compile can leave a partial/corrupt shared
-        // library at `parser_file`. `parser_file_exists` only checks existence, so
-        // a leftover artifact would make every later run skip reinstall and load a
-        // broken parser. Remove it before surfacing the error.
-        let _ = fs::remove_file(&parser_file);
-        return Err(e);
+    match compiled {
+        Ok(()) => {
+            if let Err(e) = fs::rename(&tmp_file, &parser_file) {
+                let _ = fs::remove_file(&tmp_file);
+                return Err(ParserInstallError::IoError(e));
+            }
+        }
+        Err(e) => {
+            let _ = fs::remove_file(&tmp_file);
+            return Err(e);
+        }
     }
 
     if options.verbose {

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -247,9 +247,17 @@ pub fn install_parser(
 
     // Compile the parser directly to the install path
     fs::create_dir_all(&parser_dir)?;
-    match options.compile {
-        ParserCompile::KillableSubprocess => compile_parser(&source_dir, &parser_file)?,
-        ParserCompile::InProcess => compile_parser_inprocess(&source_dir, &parser_file)?,
+    let compiled = match options.compile {
+        ParserCompile::KillableSubprocess => compile_parser(&source_dir, &parser_file),
+        ParserCompile::InProcess => compile_parser_inprocess(&source_dir, &parser_file),
+    };
+    if let Err(e) = compiled {
+        // A failed or deadline-killed compile can leave a partial/corrupt shared
+        // library at `parser_file`. `parser_file_exists` only checks existence, so
+        // a leftover artifact would make every later run skip reinstall and load a
+        // broken parser. Remove it before surfacing the error.
+        let _ = fs::remove_file(&parser_file);
+        return Err(e);
     }
 
     if options.verbose {
@@ -592,7 +600,11 @@ fn kill_process_group(child: &mut std::process::Child) {
     {
         use nix::sys::signal::{Signal, killpg};
         use nix::unistd::Pid;
-        let _ = killpg(Pid::from_raw(child.id() as i32), Signal::SIGKILL);
+        // If the group signal can't be delivered (sandbox/OS limits), still make a
+        // best effort to kill the direct child so it isn't left running.
+        if killpg(Pid::from_raw(child.id() as i32), Signal::SIGKILL).is_err() {
+            let _ = child.kill();
+        }
     }
     #[cfg(not(unix))]
     {

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -567,7 +567,7 @@ fn run_killable_subprocess(
             Ok(None) => {
                 if std::time::Instant::now() >= deadline {
                     kill_process_group(&mut child);
-                    let _ = child.wait();
+                    reap_bounded(&mut child);
                     return Err(ParserInstallError::CompileError(format!(
                         "{} timed out after {:?}",
                         context, timeout
@@ -577,11 +577,32 @@ fn run_killable_subprocess(
             }
             Err(e) => {
                 kill_process_group(&mut child);
-                let _ = child.wait();
+                reap_bounded(&mut child);
                 return Err(ParserInstallError::CompileError(format!(
                     "{}: {}",
                     context, e
                 )));
+            }
+        }
+    }
+}
+
+/// Reap the (already-killed) child, but only for a bounded time. After `SIGKILL`
+/// a child dies at once, so this returns immediately in practice. The bound
+/// matters only in the pathological case where the child can't be killed
+/// (uninterruptible D-state, blocked signals, sandbox limits): rather than
+/// `child.wait()` blocking forever — reintroducing the very unbounded wait this
+/// deadline exists to prevent — we give up after the bound and leave a zombie.
+fn reap_bounded(child: &mut std::process::Child) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) | Err(_) => return,
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(20));
             }
         }
     }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -181,11 +181,20 @@ pub fn arm_compile_watchdog() {
     #[cfg(unix)]
     {
         use nix::sys::signal::{Signal, killpg};
-        use nix::unistd::{Pid, setpgid};
-        // Own group leader. When spawned by run_killable_subprocess the parent
-        // already did this via process_group(0) (a harmless repeat); when run
-        // directly it makes the group-kill below safe. Ignore EPERM-if-already.
+        use nix::unistd::{Pid, getpgrp, getpid, setpgid};
+        // Become our own group leader. When spawned by run_killable_subprocess the
+        // parent already did this via process_group(0) (a harmless repeat); when run
+        // directly it isolates us from the launching shell's group.
         let _ = setpgid(Pid::from_raw(0), Pid::from_raw(0));
+        // CRITICAL: only arm the group-kill if we are *confirmed* our own group
+        // leader (pgid == pid). If setpgid failed (sandbox, already a session
+        // leader), we're still in the parent's/shell's group, and killpg(0) would
+        // SIGKILL *that* group — terminating the parent (or an interactive shell)
+        // along with us. In that case skip the watchdog: the parent-side deadline
+        // still bounds the compile; we only forgo the orphan backstop.
+        if getpgrp() != getpid() {
+            return;
+        }
         std::thread::spawn(|| {
             std::thread::sleep(PARSER_COMPILE_TIMEOUT + Duration::from_secs(30));
             // pgid 0 = our own process group (us + the cc we shelled out).

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -323,7 +323,16 @@ impl AutoInstallManager {
         let task_data_dir = data_dir.clone();
         let install_task = tokio::spawn(async move {
             let _marker = install_marker;
-            crate::install::install_language_async(task_lang, task_data_dir, false).await
+            // Auto-install runs inside the LSP server, whose `current_exe()` is the
+            // kakehashi binary — so the killable subprocess (re-exec
+            // `__compile-parser`) is valid and bounds a hung `cc`.
+            crate::install::install_language_async(
+                task_lang,
+                task_data_dir,
+                false,
+                crate::install::parser::ParserCompile::KillableSubprocess,
+            )
+            .await
         });
         let result = match install_task.await {
             Ok(result) => result,

--- a/tests/test_compile_parser_subprocess.rs
+++ b/tests/test_compile_parser_subprocess.rs
@@ -13,16 +13,16 @@ fn kakehashi() -> Command {
 }
 
 #[test]
-fn compile_parser_subcommand_exits_nonzero_on_bad_grammar() {
+fn compile_parser_subcommand_exits_nonzero_on_nonexistent_grammar() {
     let tmp = tempfile::tempdir().expect("temp dir");
-    let missing_grammar = tmp.path().join("no-such-grammar");
+    let nonexistent_grammar = tmp.path().join("no-such-grammar");
     let out = tmp
         .path()
         .join(format!("out.{}", std::env::consts::DLL_EXTENSION));
 
     let output = kakehashi()
         .arg("__compile-parser")
-        .arg(&missing_grammar)
+        .arg(&nonexistent_grammar)
         .arg(&out)
         .output()
         .expect("spawn kakehashi __compile-parser");
@@ -34,7 +34,7 @@ fn compile_parser_subcommand_exits_nonzero_on_bad_grammar() {
     );
     assert!(
         !out.exists(),
-        "no shared library should be produced for a bad grammar"
+        "no shared library should be produced for a nonexistent grammar"
     );
 }
 

--- a/tests/test_compile_parser_subprocess.rs
+++ b/tests/test_compile_parser_subprocess.rs
@@ -45,6 +45,11 @@ fn compile_parser_subcommand_is_hidden_from_help() {
         .output()
         .expect("spawn kakehashi --help");
 
+    assert!(
+        output.status.success(),
+        "--help must succeed (else the hidden-check below is vacuous); stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
     let help = String::from_utf8_lossy(&output.stdout);
     assert!(
         !help.contains("__compile-parser"),

--- a/tests/test_compile_parser_subprocess.rs
+++ b/tests/test_compile_parser_subprocess.rs
@@ -1,0 +1,53 @@
+//! Integration coverage for the hidden `__compile-parser` subcommand — the
+//! re-exec target of the killable parser-compile deadline (see the
+//! per-document-parse-actor ADR). A *successful* in-process compile is unit-tested
+//! in `install::parser` (`test_compile_parser_with_loader`); here we lock the
+//! subcommand's contract through the real binary: it exists, is hidden from
+//! `--help`, and maps a failed compile to a non-zero exit without producing an
+//! output artifact.
+
+use std::process::Command;
+
+fn kakehashi() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+}
+
+#[test]
+fn compile_parser_subcommand_exits_nonzero_on_bad_grammar() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let missing_grammar = tmp.path().join("no-such-grammar");
+    let out = tmp
+        .path()
+        .join(format!("out.{}", std::env::consts::DLL_EXTENSION));
+
+    let output = kakehashi()
+        .arg("__compile-parser")
+        .arg(&missing_grammar)
+        .arg(&out)
+        .output()
+        .expect("spawn kakehashi __compile-parser");
+
+    assert!(
+        !output.status.success(),
+        "compiling a nonexistent grammar must exit non-zero (stderr: {})",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !out.exists(),
+        "no shared library should be produced for a bad grammar"
+    );
+}
+
+#[test]
+fn compile_parser_subcommand_is_hidden_from_help() {
+    let output = kakehashi()
+        .arg("--help")
+        .output()
+        .expect("spawn kakehashi --help");
+
+    let help = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !help.contains("__compile-parser"),
+        "the internal subcommand must be hidden from --help, got:\n{help}"
+    );
+}


### PR DESCRIPTION
Implements the **killable subprocess install deadline** from the
per-document-parse-actor ADR (complementary to, not a substitute for, the actor).

## Problem

A hung parser compile can wedge install forever: the tree-sitter loader shells
out to `cc` with **no surfaced child**, so neither a `tokio::time::timeout` (the
blocking thread keeps running) nor a bare `child.kill()` (orphans the `cc`
grandchild) can stop it. In the LSP server this holds the in-progress marker and
blocks process exit indefinitely.

## Fix

- `run_killable_subprocess` spawns the child as its own **process-group leader**
  (`process_group(0)`) and, on deadline, terminates the whole group via `killpg`
  so the `cc` grandchild dies too (non-unix falls back to `child.kill()`). The
  direct child is reaped; terminated descendants are reaped by init.
- `compile_parser` **re-execs** this binary's hidden `__compile-parser` subcommand
  (re-exec, not `fork` — forking a multithreaded process is unsafe) under
  `PARSER_COMPILE_TIMEOUT` (300 s). The raw loader call is split out as
  `compile_parser_inprocess`, the subcommand's entry point.
- `InstallOptions.compile: ParserCompile` makes the compile mode **caller-chosen**:
  the LSP auto-install and CLI (whose `current_exe()` is the kakehashi binary) use
  `KillableSubprocess`; test setup (a test-harness binary with no `__compile-parser`)
  uses `InProcess`.

## Tests

- Unit (`run_killable_subprocess_terminates_descendants_on_deadline`): a
  group-leader `sh` backgrounds a grandchild that touches a marker only if it
  outlives the deadline; the deadline fires first, so the marker stays absent —
  proving the whole group is killed, not just the direct child. A "spawned" marker
  guards against a vacuous pass.
- Integration (`tests/test_compile_parser_subprocess.rs`): the `__compile-parser`
  subcommand exists, is hidden from `--help`, and maps a failed compile to a
  non-zero exit with no artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
