### PR TITLE
fix(node): close the on-demand-parse resurrection vector (ADR)

### DIFF
--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -124,6 +124,16 @@ impl Document {
         self.tree = Some(new_tree);
     }
 
+    /// Attach a parsed tree **without** touching the text.
+    ///
+    /// For an on-demand reader parse whose parsed text already equals the stored
+    /// text: there is no content-version transition to record, so `previous_tree`
+    /// / `previous_text` are left as-is and the text is neither re-cloned nor
+    /// replaced.
+    pub(crate) fn set_tree(&mut self, tree: Tree) {
+        self.tree = Some(tree);
+    }
+
     /// Update text and clear layers/state
     pub(crate) fn update_text(&mut self, text: String) {
         self.text = text;

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -212,19 +212,22 @@ impl DocumentStore {
         expected_text: &str,
         new_tree: Tree,
     ) -> bool {
-        let stored = match self.documents.entry(uri.clone()) {
-            Entry::Occupied(mut entry) => {
-                let doc = entry.get_mut();
-                if doc.text() == expected_text {
-                    doc.update_tree_and_text(new_tree, expected_text.to_string());
-                    true
-                } else {
-                    false
-                }
+        // `get_mut` (non-inserting, borrowed key) rather than `entry(uri.clone())`:
+        // a missing document — a concurrent didClose removed it — yields `None` and
+        // is left untouched, so the parse can't resurrect it, and we avoid cloning
+        // the `Url`. The `RefMut` holds the shard write lock for the whole arm, so
+        // the text check and the tree write are atomic against didChange/didClose.
+        // Text already equals `expected_text`, so only the tree is attached — no
+        // text re-clone, no `previous_text` churn.
+        let stored = if let Some(mut doc) = self.documents.get_mut(uri) {
+            if doc.text() == expected_text {
+                doc.set_tree(new_tree);
+                true
+            } else {
+                false
             }
-            // Closed (or never opened): do NOT insert — that would resurrect a
-            // document a concurrent didClose just removed.
-            Entry::Vacant(_) => false,
+        } else {
+            false
         };
         if stored {
             self.update_tree_availability(uri, true);

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -195,6 +195,43 @@ impl DocumentStore {
         self.update_tree_availability(&uri, has_tree);
     }
 
+    /// Store `new_tree` for an **existing** document, but only if its current text
+    /// still equals `expected_text`. Returns `true` iff the tree was stored.
+    ///
+    /// This is the safe persistence path for an **on-demand reader parse** (e.g.
+    /// `kakehashi/node`'s parse fallback). Unlike [`update_document`] it is
+    /// **non-inserting**: a `Vacant` entry — the document was closed while the
+    /// parse ran — is left untouched, so a parse completing after a `didClose`
+    /// cannot **resurrect** the document. Folding the text-equality check into the
+    /// same atomic `entry()` operation also closes the check-then-write window
+    /// against a concurrent `didChange`: a tree parsed from now-stale text is
+    /// dropped rather than associated with the newer text.
+    pub fn update_tree_if_text_unchanged(
+        &self,
+        uri: &Url,
+        expected_text: &str,
+        new_tree: Tree,
+    ) -> bool {
+        let stored = match self.documents.entry(uri.clone()) {
+            Entry::Occupied(mut entry) => {
+                let doc = entry.get_mut();
+                if doc.text() == expected_text {
+                    doc.update_tree_and_text(new_tree, expected_text.to_string());
+                    true
+                } else {
+                    false
+                }
+            }
+            // Closed (or never opened): do NOT insert — that would resurrect a
+            // document a concurrent didClose just removed.
+            Entry::Vacant(_) => false,
+        };
+        if stored {
+            self.update_tree_availability(uri, true);
+        }
+        stored
+    }
+
     /// Update document with an edited previous tree for proper changed_ranges() support.
     ///
     /// Call when parsing used an edited old tree (via `tree.edit()`): the
@@ -343,6 +380,74 @@ mod tests {
             store.open_generation(&uri),
             stale,
             "a closed URI's entry must be dropped so a reopen draws a fresh generation"
+        );
+    }
+
+    fn parse_rust(text: &str) -> Tree {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        parser.parse(text, None).unwrap()
+    }
+
+    #[test]
+    fn update_tree_if_text_unchanged_does_not_resurrect_closed_document() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///closed.rs").unwrap();
+        // No document inserted: models a didClose that removed the entry while an
+        // on-demand reader parse was still running.
+        let stored =
+            store.update_tree_if_text_unchanged(&uri, "fn main() {}", parse_rust("fn main() {}"));
+        assert!(
+            !stored,
+            "must not store a tree for a vacant (closed) document"
+        );
+        assert!(
+            store.get(&uri).is_none(),
+            "the closed document must not be resurrected by the reader parse"
+        );
+    }
+
+    #[test]
+    fn update_tree_if_text_unchanged_stores_when_text_matches() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///live.rs").unwrap();
+        store.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+
+        let stored =
+            store.update_tree_if_text_unchanged(&uri, "fn main() {}", parse_rust("fn main() {}"));
+        assert!(stored, "a live document with unchanged text gets the tree");
+        assert!(
+            store.get(&uri).unwrap().tree().is_some(),
+            "the parsed tree must be visible after the CAS write"
+        );
+    }
+
+    #[test]
+    fn update_tree_if_text_unchanged_drops_stale_text_parse() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///edited.rs").unwrap();
+        // The document moved on (a didChange landed) while the parse for the old
+        // text was in flight.
+        store.insert(
+            uri.clone(),
+            "fn newer() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+
+        let stored =
+            store.update_tree_if_text_unchanged(&uri, "fn main() {}", parse_rust("fn main() {}"));
+        assert!(!stored, "a tree parsed from now-stale text must be dropped");
+        assert!(
+            store.get(&uri).unwrap().tree().is_none(),
+            "the stale tree must not overwrite the current text's (still-absent) tree"
         );
     }
 

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -88,6 +88,23 @@ impl DocumentStore {
         sender.send_replace(state);
     }
 
+    /// Set `has_tree = true` only if a parse-state entry already exists.
+    ///
+    /// Unlike [`update_tree_availability`] this does **not** create the entry
+    /// (`get`, not `parse_sender`'s get-or-insert). For a live document the entry
+    /// always exists (created on insert), so this is equivalent; but for the
+    /// non-inserting reader CAS it avoids resurrecting a parse-state for a URI that
+    /// a concurrent `didClose` removed — `remove` drops `parse_states` first, so a
+    /// get-or-insert here would recreate a ghost `has_tree = true` for a closed
+    /// document. Holding the `Ref` serializes against that `remove`.
+    fn mark_tree_available_if_tracked(&self, uri: &Url) {
+        if let Some(sender) = self.parse_states.get(uri) {
+            let mut state = *sender.borrow();
+            state.has_tree = true;
+            sender.send_replace(state);
+        }
+    }
+
     fn parse_sender(&self, uri: &Url) -> watch::Sender<ParseState> {
         match self.parse_states.entry(uri.clone()) {
             Entry::Occupied(entry) => entry.get().clone(),
@@ -203,9 +220,11 @@ impl DocumentStore {
     /// **non-inserting**: a `Vacant` entry — the document was closed while the
     /// parse ran — is left untouched, so a parse completing after a `didClose`
     /// cannot **resurrect** the document. Folding the text-equality check into the
-    /// same atomic `entry()` operation also closes the check-then-write window
-    /// against a concurrent `didChange`: a tree parsed from now-stale text is
-    /// dropped rather than associated with the newer text.
+    /// same atomic `get_mut` lock also closes the check-then-write window against a
+    /// concurrent `didChange`: a tree parsed from now-stale text is dropped rather
+    /// than associated with the newer text. The availability update is likewise
+    /// non-inserting (see `mark_tree_available_if_tracked`), so the parse-state
+    /// isn't resurrected either.
     pub(crate) fn update_tree_if_text_unchanged(
         &self,
         uri: &Url,
@@ -230,7 +249,9 @@ impl DocumentStore {
             false
         };
         if stored {
-            self.update_tree_availability(uri, true);
+            // Non-inserting too: don't recreate a parse-state for a URI a
+            // concurrent didClose may have just dropped.
+            self.mark_tree_available_if_tracked(uri);
         }
         stored
     }
@@ -451,6 +472,31 @@ mod tests {
         assert!(
             store.get(&uri).unwrap().tree().is_none(),
             "the stale tree must not overwrite the current text's (still-absent) tree"
+        );
+    }
+
+    #[test]
+    fn update_tree_if_text_unchanged_does_not_recreate_parse_state_after_close() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///race.rs").unwrap();
+        store.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        // `remove` (didClose) drops `parse_states` before `documents`; model the
+        // window where the parse-state is already gone but our in-flight CAS still
+        // sees the document.
+        store.parse_states.remove(&uri);
+
+        let stored =
+            store.update_tree_if_text_unchanged(&uri, "fn main() {}", parse_rust("fn main() {}"));
+        assert!(stored, "the still-present document gets the tree");
+        assert!(
+            store.parse_states.get(&uri).is_none(),
+            "the availability update must not recreate a parse-state for a URI whose \
+             parse-state a concurrent close already removed"
         );
     }
 

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -206,7 +206,7 @@ impl DocumentStore {
     /// same atomic `entry()` operation also closes the check-then-write window
     /// against a concurrent `didChange`: a tree parsed from now-stale text is
     /// dropped rather than associated with the newer text.
-    pub fn update_tree_if_text_unchanged(
+    pub(crate) fn update_tree_if_text_unchanged(
         &self,
         uri: &Url,
         expected_text: &str,

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -446,24 +446,20 @@ impl Kakehashi {
             .await;
 
         if let Some(tree) = parsed {
-            // Race guard: between the text snapshot above and parse completion,
-            // a didChange may have updated the document. Storing our tree would
-            // associate it with stale text, breaking the (text, tree) consistency
-            // invariant. Compare against the current text and discard if it has
-            // moved; the next request will re-trigger the parse against the
-            // newer text.
-            let text_unchanged = self
+            // Persist atomically and non-insertingly: store the tree only if the
+            // document still exists with the text we parsed. Between the snapshot
+            // above and now, a didChange may have moved the text (storing our tree
+            // would break the (text, tree) consistency invariant) or a didClose may
+            // have removed the document (re-inserting it would resurrect a closed
+            // doc — #342/#374). The single atomic CAS closes both at the write
+            // itself; the next request re-triggers the parse against newer text.
+            if !self
                 .documents
-                .get(uri)
-                .map(|doc| doc.text() == text)
-                .unwrap_or(false);
-            if text_unchanged {
-                self.documents
-                    .update_document(uri.clone(), text, Some(tree));
-            } else {
+                .update_tree_if_text_unchanged(uri, &text, tree)
+            {
                 log::debug!(
                     target: "kakehashi::node",
-                    "discarding on-demand parse for {} — text changed during parse",
+                    "discarding on-demand parse for {} — text changed or document closed during parse",
                     uri
                 );
             }


### PR DESCRIPTION
Lands the **reader-fallback CAS** from the per-document-parse-actor ADR as a
standalone fix (with the existing generation counters; the actor later upgrades
the same check to the composite `(incarnation, ticket)` epoch).

## Problem

`ensure_parsed_for_node_lookup` (the `kakehashi/node` on-demand parse fallback)
checked text-unchanged via a `get`, then persisted via `DocumentStore::update_document`,
which **inserts on vacancy**. A `didClose` landing between the check and the write
re-inserts — **resurrects** — the closed document (#342/#374 class). This site is
the one *unguarded* reader fallback; `semanticTokens` and `selectionRange` run the
same pattern but under the per-URI `edit_lock` that `didClose` also takes, so they
can't resurrect today (deferred to the actor work, verified safe).

## Fix

`DocumentStore::update_tree_if_text_unchanged`: a **non-inserting**, atomic
`entry()`-based write that stores the tree only when the document still exists
**and** its current text equals the parsed text. `Vacant` → no-op (no
resurrection); text moved on (a `didChange` landed) → drop the stale tree. The
check and the write share one DashMap key-lock, so it also closes the
check-then-write window against a concurrent `didChange`.

## Tests

Unit tests for the three branches: vacant → not stored + not resurrected;
occupied + matching text → stored; occupied + stale text → dropped, current text's
(absent) tree untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)