### PR TITLE
perf: kill O(n²) in semantic finalize + ~5× faster E2E suite (parallel runner)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,27 @@ inherits = "release"
 debug = true
 strip = false
 
+# Optimize the tree-sitter query engine (and the regex crate used by query
+# predicates) in dev/test builds. Tree-sitter query compilation
+# (`ts_query__perform_analysis`, bundled C in the `tree-sitter` crate) runs at
+# every server spawn; unoptimized it dominates per-spawn latency (~160ms for the
+# first semantic-tokens response in a debug build). The E2E suite spawns the
+# binary hundreds of times, so this repeated tax is large. Scoped to these
+# specific crates (not all deps) so the one-time clean-build cost stays small
+# while THIS crate stays unoptimized for fast incremental compiles. Applied to
+# both dev and test profiles so `cargo build` and `cargo test` both benefit.
+[profile.dev.package.tree-sitter]
+opt-level = 3
+
+[profile.dev.package.regex]
+opt-level = 3
+
+[profile.test.package.tree-sitter]
+opt-level = 3
+
+[profile.test.package.regex]
+opt-level = 3
+
 [dependencies]
 arc-swap = "1"
 clap = { version = "4", features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test:
 # timing-sensitive tests without cross-binary load.
 .PHONY: test_e2e
 test_e2e:
-	scripts/test_e2e_parallel.sh
+	CARGO="$(CARGO)" scripts/test_e2e_parallel.sh
 
 .PHONY: test_e2e_sequential
 test_e2e_sequential:

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,17 @@ test:
 # Run integration and E2E tests (excludes unit tests)
 # - Integration tests: tests/test_*.rs (no feature required)
 # - E2E tests: tests/e2e_*.rs (requires e2e feature)
+# Default to the parallel runner: `cargo test` runs integration binaries
+# sequentially, leaving a many-core machine idle while each binary waits on a
+# spawned server. The script runs the binaries in a bounded parallel pool (~3x
+# faster here) with identical coverage. Use test_e2e_sequential to debug
+# timing-sensitive tests without cross-binary load.
 .PHONY: test_e2e
 test_e2e:
+	scripts/test_e2e_parallel.sh
+
+.PHONY: test_e2e_sequential
+test_e2e_sequential:
 	$(CARGO) test --features e2e --test 'test_*' --test 'e2e_*'
 
 # Run all tests (unit + integration + E2E)

--- a/scripts/test_e2e_parallel.sh
+++ b/scripts/test_e2e_parallel.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Run the E2E / integration test binaries CONCURRENTLY.
+# Run the E2E / integration test binaries CONCURRENTLY, with live progress.
 #
 # `cargo test` runs integration-test binaries one at a time (it only parallelizes
 # the test functions *within* a single binary). Each of our E2E binaries spends
@@ -9,10 +9,10 @@
 # machine almost idle — the full suite takes ~95s here at ~1.2x core utilization.
 #
 # This script builds the binaries once, then runs them in a bounded parallel
-# pool. The bound matters: oversubscribing (e.g. 30 concurrent test threads on 10
-# cores) makes timing-sensitive tests and the lua-ls poll loops thrash and run
-# SLOWER than sequential. A total concurrency of ~1.5x cores is the sweet spot
-# (measured here: ~31s, a 3x speedup, with identical pass counts).
+# pool, printing each binary's result as it finishes. The bound matters:
+# oversubscribing (e.g. 30 concurrent test threads on 10 cores) makes
+# timing-sensitive tests and the lua-ls poll loops thrash and run SLOWER than
+# sequential. Total concurrency ~1.5x cores is the sweet spot (~18s, ~5x).
 #
 # Safe to run concurrently because each spawned server is isolated:
 #   - KAKEHASHI_DATA_DIR  : shared, read-only after install (parsers/queries)
@@ -22,12 +22,22 @@
 #
 # Usage:
 #   scripts/test_e2e_parallel.sh
-#   E2E_JOBS=8 E2E_INNER_THREADS=2 scripts/test_e2e_parallel.sh
+#   E2E_JOBS=8 E2E_INNER_THREADS=2 E2E_BIN_TIMEOUT=180 scripts/test_e2e_parallel.sh
 #
 # Env:
 #   E2E_JOBS           number of test BINARIES to run at once (default: ~0.75x cores)
 #   E2E_INNER_THREADS  test threads WITHIN each binary       (default: 2)
 #                      → total concurrency ≈ E2E_JOBS * E2E_INNER_THREADS
+#   E2E_BIN_TIMEOUT    per-binary timeout in seconds         (default: 600, 0=off)
+#
+# NOTE: the build step (`cargo test --no-run`) writes to the default `target/`,
+# which rust-analyzer may lock while it (re)compiles after an edit — the
+# "==> Building" line can sit for a while in that case. It is the editor's lock,
+# not a hang. Under heavy CPU load (editor + rust-analyzer compiling) the run
+# also slows and per-binary times climb; the timeout is deliberately generous so
+# a busy machine reports "slow", never a spurious failure. The pass count is
+# printed at the end — eyeball it against your sequential baseline; a much lower
+# count means binaries silently skipped, not that the run was clean.
 set -uo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
@@ -37,6 +47,15 @@ DEFAULT_JOBS=$(( (CORES * 3 + 3) / 4 ))
 [ "$DEFAULT_JOBS" -lt 2 ] && DEFAULT_JOBS=2
 JOBS="${E2E_JOBS:-$DEFAULT_JOBS}"
 INNER="${E2E_INNER_THREADS:-2}"
+BIN_TIMEOUT="${E2E_BIN_TIMEOUT:-240}"
+
+# A `timeout` command (GNU coreutils, or gtimeout via Homebrew) lets us cap each
+# binary so one stuck test can't stall the whole pool. Optional — skipped if
+# absent or disabled.
+TIMEOUT_BIN=""
+if [ "$BIN_TIMEOUT" -gt 0 ]; then
+  TIMEOUT_BIN="$(command -v timeout || command -v gtimeout || true)"
+fi
 
 echo "==> Building test binaries (cargo test --no-run)"
 # `cargo test --no-run` prints an `Executable tests/<file> (<path>)` line for
@@ -47,35 +66,67 @@ BINS=$(printf '%s\n' "$BUILD_OUT" \
        | sed -n 's/^[[:space:]]*Executable tests\/[^ ]* (\(.*\))$/\1/p' | sort -u)
 N=$(printf '%s\n' "$BINS" | grep -c .)
 [ "$N" -eq 0 ] && { echo "error: found no integration-test binaries"; exit 1; }
-echo "==> Running $N binaries  (JOBS=$JOBS, INNER=$INNER, ~$((JOBS * INNER)) concurrent on ${CORES} cores)"
 
 RESDIR="$(mktemp -d)"
-trap 'rm -rf "$RESDIR"' EXIT
-export RESDIR INNER
+# On exit OR interrupt: drop the temp dir and kill any of THIS repo's test
+# binaries still running (Ctrl-C otherwise leaves them as a pool of orphans).
+# We deliberately kill ONLY the `deps/e2e_*` / `deps/test_*` binaries, never a
+# bare `kakehashi` — a dev may run THIS repo's `target/debug/kakehashi` as their
+# editor's language server (see __ignored/kakehashi.bash), and a path-based
+# pkill cannot tell that apart from a test-spawned server. The test servers
+# instead get stdin EOF when their parent test binary dies and exit on their
+# own; their lua-language-server grandchildren may briefly orphan to PID 1 on a
+# hard Ctrl-C (pkill them by name manually if needed — but that also hits an
+# editor's lua-ls, so it's left to the user).
+REPO="$(pwd)"
+cleanup() {
+  pkill -f "$REPO/target/.*/deps/e2e_" 2>/dev/null
+  pkill -f "$REPO/target/.*/deps/test_" 2>/dev/null
+  rm -rf "$RESDIR"
+}
+trap cleanup EXIT INT TERM
 
+echo "==> Running $N binaries  (JOBS=$JOBS, INNER=$INNER, ~$((JOBS * INNER)) concurrent on ${CORES} cores${TIMEOUT_BIN:+, ${BIN_TIMEOUT}s/binary})"
+echo "    (progress streams below as each binary finishes)"
+echo
+
+export RESDIR INNER TIMEOUT_BIN BIN_TIMEOUT N
 SECONDS=0
+# Each job runs one binary, then prints a one-line progress record immediately
+# (so the user sees the suite advancing) and records its status for the summary.
 printf '%s\n' "$BINS" | xargs -P "$JOBS" -I{} sh -c '
   bin="$1"; name=$(basename "$bin" | sed "s/-[0-9a-f]*$//")
-  if "$bin" --test-threads="$INNER" > "$RESDIR/$name.log" 2>&1; then
-    echo "ok   $name"
+  t0=$(date +%s)
+  if [ -n "$TIMEOUT_BIN" ]; then
+    "$TIMEOUT_BIN" "$BIN_TIMEOUT" "$bin" --test-threads="$INNER" > "$RESDIR/$name.log" 2>&1
   else
-    echo "FAIL $name"
+    "$bin" --test-threads="$INNER" > "$RESDIR/$name.log" 2>&1
   fi
-' _ {} | sort > "$RESDIR/summary.txt"
+  ec=$?
+  dt=$(( $(date +%s) - t0 ))
+  case $ec in
+    0)   status="ok  " ;;
+    124) status="TIME" ;;   # killed by timeout
+    *)   status="FAIL" ;;
+  esac
+  echo "$ec" > "$RESDIR/$name.status"
+  done=$(ls "$RESDIR"/*.status 2>/dev/null | wc -l | tr -d " ")
+  printf "  [%2d/%2d] %s %-34s %3ds\n" "$done" "$N" "$status" "$name" "$dt"
+' _ {}
 WALL=$SECONDS
 
 PASSED=$(grep -hoE "result: ok\. [0-9]+ passed" "$RESDIR"/*.log 2>/dev/null \
          | grep -oE "[0-9]+" | paste -sd+ - | bc)
-FAILS=$(grep -c '^FAIL ' "$RESDIR/summary.txt" || true)
+FAILS=$(grep -lvx 0 "$RESDIR"/*.status 2>/dev/null | wc -l | tr -d ' ')
 
+echo
 echo "----------------------------------------------------------------"
 echo "  binaries: $N    wall: ${WALL}s    tests passed: ${PASSED:-0}    failing binaries: $FAILS"
 echo "----------------------------------------------------------------"
 if [ "$FAILS" -gt 0 ]; then
-  grep '^FAIL ' "$RESDIR/summary.txt"
-  echo "--- output of failing binaries ---"
-  for f in $(grep '^FAIL ' "$RESDIR/summary.txt" | awk '{print $2}'); do
-    echo "===== $f ====="; tail -40 "$RESDIR/$f.log"
+  echo "--- output of failing/timed-out binaries ---"
+  for s in $(grep -lvx 0 "$RESDIR"/*.status 2>/dev/null); do
+    f="${s%.status}"; echo "===== $(basename "$f") (exit $(cat "$s")) ====="; tail -40 "$f.log"
   done
   exit 1
 fi

--- a/scripts/test_e2e_parallel.sh
+++ b/scripts/test_e2e_parallel.sh
@@ -47,7 +47,7 @@ DEFAULT_JOBS=$(( (CORES * 3 + 3) / 4 ))
 [ "$DEFAULT_JOBS" -lt 2 ] && DEFAULT_JOBS=2
 JOBS="${E2E_JOBS:-$DEFAULT_JOBS}"
 INNER="${E2E_INNER_THREADS:-2}"
-BIN_TIMEOUT="${E2E_BIN_TIMEOUT:-240}"
+BIN_TIMEOUT="${E2E_BIN_TIMEOUT:-600}"
 
 # A `timeout` command (GNU coreutils, or gtimeout via Homebrew) lets us cap each
 # binary so one stuck test can't stall the whole pool. Optional — skipped if
@@ -66,6 +66,16 @@ BINS=$(printf '%s\n' "$BUILD_OUT" \
        | sed -n 's/^[[:space:]]*Executable tests\/[^ ]* (\(.*\))$/\1/p' | sort -u)
 N=$(printf '%s\n' "$BINS" | grep -c .)
 [ "$N" -eq 0 ] && { echo "error: found no integration-test binaries"; exit 1; }
+# Independent expected count: every top-level tests/*.rs is one integration
+# binary (helpers/ is a subdir module, not a binary). If the Executable-line
+# parse ever silently under-counts (a cargo output format change), N drops below
+# this and we fail loudly instead of running a smaller-but-green subset.
+EXPECTED=$(ls tests/*.rs 2>/dev/null | wc -l | tr -d ' ')
+if [ "$N" -ne "$EXPECTED" ]; then
+  echo "error: parsed $N test binaries but tests/ has $EXPECTED .rs files — the"
+  echo "       Executable-line parse may be under-counting; refusing a partial run."
+  exit 1
+fi
 
 RESDIR="$(mktemp -d)"
 # On exit OR interrupt: drop the temp dir and kill any of THIS repo's test
@@ -78,7 +88,10 @@ RESDIR="$(mktemp -d)"
 # own; their lua-language-server grandchildren may briefly orphan to PID 1 on a
 # hard Ctrl-C (pkill them by name manually if needed — but that also hits an
 # editor's lua-ls, so it's left to the user).
-REPO="$(pwd)"
+# Escape regex metacharacters in the path (it contains '.' from "github.com")
+# so `pkill -f` matches it literally — the `deps/e2e_`/`deps/test_` anchor keeps
+# this safe regardless, but a literal path avoids any accidental over-match.
+REPO="$(pwd | sed 's/[.[\*^$]/\\&/g')"
 cleanup() {
   pkill -f "$REPO/target/.*/deps/e2e_" 2>/dev/null
   pkill -f "$REPO/target/.*/deps/test_" 2>/dev/null
@@ -118,11 +131,19 @@ WALL=$SECONDS
 PASSED=$(grep -hoE "result: ok\. [0-9]+ passed" "$RESDIR"/*.log 2>/dev/null \
          | grep -oE "[0-9]+" | paste -sd+ - | bc)
 FAILS=$(grep -lvx 0 "$RESDIR"/*.status 2>/dev/null | wc -l | tr -d ' ')
+RAN=$(ls "$RESDIR"/*.status 2>/dev/null | wc -l | tr -d ' ')
 
 echo
 echo "----------------------------------------------------------------"
 echo "  binaries: $N    wall: ${WALL}s    tests passed: ${PASSED:-0}    failing binaries: $FAILS"
 echo "----------------------------------------------------------------"
+# Guard against a binary being silently dropped (e.g. a future cargo output
+# change defeating the Executable-line parse): every discovered binary must have
+# produced a status file, else coverage shrank without any binary "failing".
+if [ "$RAN" -ne "$N" ]; then
+  echo "error: only $RAN/$N binaries ran — some were dropped before execution"
+  exit 1
+fi
 if [ "$FAILS" -gt 0 ]; then
   echo "--- output of failing/timed-out binaries ---"
   for s in $(grep -lvx 0 "$RESDIR"/*.status 2>/dev/null); do

--- a/scripts/test_e2e_parallel.sh
+++ b/scripts/test_e2e_parallel.sh
@@ -84,7 +84,11 @@ if [ "$N" -ne "$EXPECTED" ]; then
   exit 1
 fi
 
-RESDIR="$(mktemp -d)"
+# Fail fast if the temp dir can't be made — otherwise an empty RESDIR would send
+# logs/status to bogus absolute paths (`/$name.log`). `mktemp -d` (no template)
+# works on GNU and modern macOS/BSD; fall back to an explicit template if not.
+RESDIR="$(mktemp -d 2>/dev/null || mktemp -d "${TMPDIR:-/tmp}/e2e-parallel.XXXXXX")"
+[ -n "$RESDIR" ] && [ -d "$RESDIR" ] || { echo "error: could not create a temp dir (mktemp -d failed)"; exit 1; }
 # On exit OR interrupt: drop the temp dir and kill any of THIS repo's test
 # binaries still running (Ctrl-C otherwise leaves them as a pool of orphans).
 # We deliberately kill ONLY the `deps/e2e_*` / `deps/test_*` binaries, never a

--- a/scripts/test_e2e_parallel.sh
+++ b/scripts/test_e2e_parallel.sh
@@ -88,18 +88,42 @@ RESDIR="$(mktemp -d)"
 # own; their lua-language-server grandchildren may briefly orphan to PID 1 on a
 # hard Ctrl-C (pkill them by name manually if needed — but that also hits an
 # editor's lua-ls, so it's left to the user).
-# Escape every ERE metacharacter in the path so `pkill -f` matches it literally.
+# Where the test binaries actually live — honor CARGO_TARGET_DIR (the README/PR
+# even suggests a separate one to dodge rust-analyzer's lock), resolving a
+# relative value against the repo root, so the cleanup below still finds them.
+TARGET_DIR="${CARGO_TARGET_DIR:-target}"
+case "$TARGET_DIR" in /*) ;; *) TARGET_DIR="$(pwd)/$TARGET_DIR" ;; esac
+# Escape every ERE metacharacter so `pkill -f` matches the path literally.
 # (Typical paths only hit '.' from "github.com", but a checkout under a path with
 # +, ?, (), {}, |, etc. would otherwise broaden the pattern.) The `deps/e2e_`/
-# `deps/test_` anchor keeps the kill scoped regardless; this just removes any
-# accidental over-match. The char class lists ']' first so it's literal.
-REPO="$(pwd | sed 's/[][(){}.^$*+?|\\]/\\&/g')"
+# `deps/test_` anchor keeps the kill scoped to THIS run's test binaries — never a
+# bare `kakehashi` a dev might run as their editor LSP. The char class lists ']'
+# first so it's literal.
+TARGET_RE="$(printf '%s' "$TARGET_DIR" | sed 's/[][(){}.^$*+?|\\]/\\&/g')"
 cleanup() {
-  pkill -f "$REPO/target/.*/deps/e2e_" 2>/dev/null
-  pkill -f "$REPO/target/.*/deps/test_" 2>/dev/null
+  pkill -f "$TARGET_RE/.*/deps/e2e_" 2>/dev/null
+  pkill -f "$TARGET_RE/.*/deps/test_" 2>/dev/null
   rm -rf "$RESDIR"
 }
 trap cleanup EXIT INT TERM
+
+# Fresh checkout: the shared parser/query install (deps/test/kakehashi) does not
+# exist yet. The test binaries create it lazily on first server spawn, so the
+# parallel pool below would have many processes race to populate one dir — one
+# reading another's half-written parser/query files (corrupt-cache flakiness, an
+# early `.installed`). Seed it ONCE, serially, with a single binary first; the
+# marker then short-circuits every later run (and the rest of this run's pool).
+# Bounded to one binary on purpose: grinding through all of them silently would
+# reintroduce the "looks hung" problem this runner exists to avoid.
+INSTALL_MARKER="deps/test/kakehashi/.installed"
+if [ ! -f "$INSTALL_MARKER" ]; then
+  echo "==> First run: seeding shared parser/query install (serial, one binary)…"
+  seed="$(printf '%s\n' "$BINS" | head -1)"
+  if [ -n "$seed" ]; then
+    "$seed" --test-threads=1 >/dev/null 2>&1 || true
+  fi
+  [ -f "$INSTALL_MARKER" ] || echo "    warning: install marker still absent; the pool may briefly race to populate it"
+fi
 
 echo "==> Running $N binaries  (JOBS=$JOBS, INNER=$INNER, ~$((JOBS * INNER)) concurrent on ${CORES} cores${TIMEOUT_BIN:+, ${BIN_TIMEOUT}s/binary})"
 echo "    (progress streams below as each binary finishes)"
@@ -130,8 +154,9 @@ printf '%s\n' "$BINS" | xargs -P "$JOBS" -I{} sh -c '
 ' _ {}
 WALL=$SECONDS
 
+# Sum with awk (no `bc` dependency — not installed on minimal environments).
 PASSED=$(grep -hoE "result: ok\. [0-9]+ passed" "$RESDIR"/*.log 2>/dev/null \
-         | grep -oE "[0-9]+" | paste -sd+ - | bc)
+         | grep -oE "[0-9]+" | awk '{s += $1} END {print s + 0}')
 FAILS=$(grep -lvx 0 "$RESDIR"/*.status 2>/dev/null | wc -l | tr -d ' ')
 RAN=$(ls "$RESDIR"/*.status 2>/dev/null | wc -l | tr -d ' ')
 

--- a/scripts/test_e2e_parallel.sh
+++ b/scripts/test_e2e_parallel.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# Run the E2E / integration test binaries CONCURRENTLY.
+#
+# `cargo test` runs integration-test binaries one at a time (it only parallelizes
+# the test functions *within* a single binary). Each of our E2E binaries spends
+# most of its wall time waiting on a spawned `kakehashi` server (and, for the
+# bridge tests, on `lua-language-server`), so a sequential run leaves a many-core
+# machine almost idle — the full suite takes ~95s here at ~1.2x core utilization.
+#
+# This script builds the binaries once, then runs them in a bounded parallel
+# pool. The bound matters: oversubscribing (e.g. 30 concurrent test threads on 10
+# cores) makes timing-sensitive tests and the lua-ls poll loops thrash and run
+# SLOWER than sequential. A total concurrency of ~1.5x cores is the sweet spot
+# (measured here: ~31s, a 3x speedup, with identical pass counts).
+#
+# Safe to run concurrently because each spawned server is isolated:
+#   - KAKEHASHI_DATA_DIR  : shared, read-only after install (parsers/queries)
+#   - XDG_CONFIG_HOME     : per-process temp dir (no user-config bleed)
+#   - KAKEHASHI_STATE_DIR : per-process temp dir (crash-recovery state, set by
+#                           the test harness so processes don't poison each other)
+#
+# Usage:
+#   scripts/test_e2e_parallel.sh
+#   E2E_JOBS=8 E2E_INNER_THREADS=2 scripts/test_e2e_parallel.sh
+#
+# Env:
+#   E2E_JOBS           number of test BINARIES to run at once (default: ~0.75x cores)
+#   E2E_INNER_THREADS  test threads WITHIN each binary       (default: 2)
+#                      → total concurrency ≈ E2E_JOBS * E2E_INNER_THREADS
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+CORES=$(sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || echo 4)
+DEFAULT_JOBS=$(( (CORES * 3 + 3) / 4 ))
+[ "$DEFAULT_JOBS" -lt 2 ] && DEFAULT_JOBS=2
+JOBS="${E2E_JOBS:-$DEFAULT_JOBS}"
+INNER="${E2E_INNER_THREADS:-2}"
+
+echo "==> Building test binaries (cargo test --no-run)"
+# `cargo test --no-run` prints an `Executable tests/<file> (<path>)` line for
+# every integration-test binary even when fully cached, so parse those paths.
+# (--message-format=json only emits artifacts when something recompiles.)
+BUILD_OUT="$(cargo test --features e2e --no-run 2>&1)" || { echo "$BUILD_OUT"; exit 1; }
+BINS=$(printf '%s\n' "$BUILD_OUT" \
+       | sed -n 's/^[[:space:]]*Executable tests\/[^ ]* (\(.*\))$/\1/p' | sort -u)
+N=$(printf '%s\n' "$BINS" | grep -c .)
+[ "$N" -eq 0 ] && { echo "error: found no integration-test binaries"; exit 1; }
+echo "==> Running $N binaries  (JOBS=$JOBS, INNER=$INNER, ~$((JOBS * INNER)) concurrent on ${CORES} cores)"
+
+RESDIR="$(mktemp -d)"
+trap 'rm -rf "$RESDIR"' EXIT
+export RESDIR INNER
+
+SECONDS=0
+printf '%s\n' "$BINS" | xargs -P "$JOBS" -I{} sh -c '
+  bin="$1"; name=$(basename "$bin" | sed "s/-[0-9a-f]*$//")
+  if "$bin" --test-threads="$INNER" > "$RESDIR/$name.log" 2>&1; then
+    echo "ok   $name"
+  else
+    echo "FAIL $name"
+  fi
+' _ {} | sort > "$RESDIR/summary.txt"
+WALL=$SECONDS
+
+PASSED=$(grep -hoE "result: ok\. [0-9]+ passed" "$RESDIR"/*.log 2>/dev/null \
+         | grep -oE "[0-9]+" | paste -sd+ - | bc)
+FAILS=$(grep -c '^FAIL ' "$RESDIR/summary.txt" || true)
+
+echo "----------------------------------------------------------------"
+echo "  binaries: $N    wall: ${WALL}s    tests passed: ${PASSED:-0}    failing binaries: $FAILS"
+echo "----------------------------------------------------------------"
+if [ "$FAILS" -gt 0 ]; then
+  grep '^FAIL ' "$RESDIR/summary.txt"
+  echo "--- output of failing binaries ---"
+  for f in $(grep '^FAIL ' "$RESDIR/summary.txt" | awk '{print $2}'); do
+    echo "===== $f ====="; tail -40 "$RESDIR/$f.log"
+  done
+  exit 1
+fi
+echo "All E2E binaries passed."

--- a/scripts/test_e2e_parallel.sh
+++ b/scripts/test_e2e_parallel.sh
@@ -58,11 +58,15 @@ if [ "$BIN_TIMEOUT" -gt 0 ]; then
   TIMEOUT_BIN="$(command -v timeout || command -v gtimeout || true)"
 fi
 
-echo "==> Building test binaries (cargo test --no-run)"
+# Honor the Makefile's `CARGO` override (toolchain selector / cargo wrapper),
+# the way the other targets do — `make test_e2e` passes it through.
+CARGO="${CARGO:-cargo}"
+
+echo "==> Building test binaries ($CARGO test --no-run)"
 # `cargo test --no-run` prints an `Executable tests/<file> (<path>)` line for
 # every integration-test binary even when fully cached, so parse those paths.
 # (--message-format=json only emits artifacts when something recompiles.)
-BUILD_OUT="$(cargo test --features e2e --no-run 2>&1)" || { echo "$BUILD_OUT"; exit 1; }
+BUILD_OUT="$("$CARGO" test --features e2e --no-run 2>&1)" || { echo "$BUILD_OUT"; exit 1; }
 BINS=$(printf '%s\n' "$BUILD_OUT" \
        | sed -n 's/^[[:space:]]*Executable tests\/[^ ]* (\(.*\))$/\1/p' | sort -u)
 N=$(printf '%s\n' "$BINS" | grep -c .)

--- a/scripts/test_e2e_parallel.sh
+++ b/scripts/test_e2e_parallel.sh
@@ -178,10 +178,15 @@ printf '%s\n' "$BINS" | xargs -P "$JOBS" -I{} sh -c '
   # corrupted [0/N] counter when stragglers outlived a previous run.
   [ -d "$RESDIR" ] || exit 0
   t0=$(date +%s)
+  # The `> "$RESDIR/$name.log"` open can still lose a race with cleanup renaming
+  # RESDIR away after the guard above. Wrap each run in a group whose stderr is
+  # /dev/null so that a redirection-open failure stays quiet (the `2>&1` on the
+  # command itself is never reached when opening stdout fails); the post-run
+  # guard below then records nothing for this aborted worker.
   if [ -n "$TIMEOUT_BIN" ]; then
-    "$TIMEOUT_BIN" "$BIN_TIMEOUT" "$bin" --test-threads="$INNER" > "$RESDIR/$name.log" 2>&1
+    { "$TIMEOUT_BIN" "$BIN_TIMEOUT" "$bin" --test-threads="$INNER" > "$RESDIR/$name.log" 2>&1; } 2>/dev/null
   else
-    "$bin" --test-threads="$INNER" > "$RESDIR/$name.log" 2>&1
+    { "$bin" --test-threads="$INNER" > "$RESDIR/$name.log" 2>&1; } 2>/dev/null
   fi
   ec=$?
   dt=$(( $(date +%s) - t0 ))

--- a/scripts/test_e2e_parallel.sh
+++ b/scripts/test_e2e_parallel.sh
@@ -30,6 +30,8 @@
 #   E2E_INNER_THREADS  test threads WITHIN each binary       (default: 2)
 #                      → total concurrency ≈ E2E_JOBS * E2E_INNER_THREADS
 #   E2E_BIN_TIMEOUT    per-binary timeout in seconds         (default: 600, 0=off)
+#   E2E_RETRIES        serial retries for a FAILED binary    (default: 1, 0=off)
+#                      → recovers load-induced timeout flakes; real failures persist
 #
 # NOTE: the build step (`cargo test --no-run`) writes to the default `target/`,
 # which rust-analyzer may lock while it (re)compiles after an edit — the
@@ -158,6 +160,38 @@ printf '%s\n' "$BINS" | xargs -P "$JOBS" -I{} sh -c '
   printf "  [%2d/%2d] %s %-34s %3ds\n" "$done" "$N" "$status" "$name" "$dt"
 ' _ {}
 WALL=$SECONDS
+
+# Retry any failed binaries ONCE, serially. Under heavy machine load (e.g. a
+# rust-analyzer compile storm) a spawned server or mock bridge can miss its
+# internal startup timeout (10–30s) and the whole binary fails spuriously; given
+# the machine to itself on retry it succeeds. A genuinely broken test still
+# fails both times. Set E2E_RETRIES=0 to disable.
+RETRY="${E2E_RETRIES:-1}"
+if [ "$RETRY" -gt 0 ]; then
+  retry_names=""
+  for s in "$RESDIR"/*.status; do
+    [ -f "$s" ] || continue
+    [ "$(cat "$s")" != 0 ] && retry_names="$retry_names $(basename "$s" .status)"
+  done
+  if [ -n "${retry_names# }" ]; then
+    echo
+    echo "==> Retrying failed binaries serially ($(printf '%s' "$retry_names" | wc -w | tr -d ' ') — load-induced flakes recover here):"
+    for name in $retry_names; do
+      bin="$(printf '%s\n' "$BINS" | grep "/deps/${name}-" | head -1)"
+      [ -n "$bin" ] || continue
+      t0=$(date +%s)
+      if [ -n "$TIMEOUT_BIN" ]; then
+        "$TIMEOUT_BIN" "$BIN_TIMEOUT" "$bin" --test-threads=1 > "$RESDIR/$name.log" 2>&1
+      else
+        "$bin" --test-threads=1 > "$RESDIR/$name.log" 2>&1
+      fi
+      ec=$?; echo "$ec" > "$RESDIR/$name.status"
+      dt=$(( $(date +%s) - t0 ))
+      if [ "$ec" = 0 ]; then printf "  retry ok   %-34s %3ds (was a flake)\n" "$name" "$dt"
+      else                   printf "  retry FAIL %-34s %3ds (real failure)\n" "$name" "$dt"; fi
+    done
+  fi
+fi
 
 # Sum with awk (no `bc` dependency — not installed on minimal environments).
 PASSED=$(grep -hoE "result: ok\. [0-9]+ passed" "$RESDIR"/*.log 2>/dev/null \

--- a/scripts/test_e2e_parallel.sh
+++ b/scripts/test_e2e_parallel.sh
@@ -112,8 +112,16 @@ case "$TARGET_DIR" in /*) ;; *) TARGET_DIR="$(pwd)/$TARGET_DIR" ;; esac
 # first so it's literal.
 TARGET_RE="$(printf '%s' "$TARGET_DIR" | sed 's/[][(){}.^$*+?|\\]/\\&/g')"
 cleanup() {
-  pkill -f "$TARGET_RE/.*/deps/e2e_" 2>/dev/null
-  pkill -f "$TARGET_RE/.*/deps/test_" 2>/dev/null
+  # Kill this run's test binaries. SIGTERM first; a binary blocked waiting on a
+  # hung child (server/lua-ls) can ignore it, so SIGKILL the survivors after a
+  # beat — otherwise a Ctrl-C'd run leaks binaries that keep running into the
+  # NEXT run (and write to this run's now-deleted RESDIR). `timeout`-wrapped
+  # invocations carry the same path, so they're matched too.
+  pkill -TERM -f "$TARGET_RE/.*/deps/(e2e_|test_)" 2>/dev/null
+  if pgrep -f "$TARGET_RE/.*/deps/(e2e_|test_)" >/dev/null 2>&1; then
+    sleep 1
+    pkill -KILL -f "$TARGET_RE/.*/deps/(e2e_|test_)" 2>/dev/null
+  fi
   rm -rf "$RESDIR"
 }
 trap cleanup EXIT INT TERM
@@ -146,6 +154,11 @@ SECONDS=0
 # (so the user sees the suite advancing) and records its status for the summary.
 printf '%s\n' "$BINS" | xargs -P "$JOBS" -I{} sh -c '
   bin="$1"; name=$(basename "$bin" | sed "s/-[0-9a-f]*$//")
+  # If the run was aborted (Ctrl-C removed RESDIR via the cleanup trap), do not
+  # start a still-queued binary or write into the deleted dir — that is what
+  # produced the "<RESDIR>/<name>.status: No such file or directory" spew and a
+  # corrupted [0/N] counter when stragglers outlived a previous run.
+  [ -d "$RESDIR" ] || exit 0
   t0=$(date +%s)
   if [ -n "$TIMEOUT_BIN" ]; then
     "$TIMEOUT_BIN" "$BIN_TIMEOUT" "$bin" --test-threads="$INNER" > "$RESDIR/$name.log" 2>&1
@@ -154,6 +167,7 @@ printf '%s\n' "$BINS" | xargs -P "$JOBS" -I{} sh -c '
   fi
   ec=$?
   dt=$(( $(date +%s) - t0 ))
+  [ -d "$RESDIR" ] || exit 0   # aborted mid-run — record nothing, print nothing
   case $ec in
     0)   status="ok  " ;;
     124) status="TIME" ;;   # killed by timeout

--- a/scripts/test_e2e_parallel.sh
+++ b/scripts/test_e2e_parallel.sh
@@ -88,10 +88,12 @@ RESDIR="$(mktemp -d)"
 # own; their lua-language-server grandchildren may briefly orphan to PID 1 on a
 # hard Ctrl-C (pkill them by name manually if needed — but that also hits an
 # editor's lua-ls, so it's left to the user).
-# Escape regex metacharacters in the path (it contains '.' from "github.com")
-# so `pkill -f` matches it literally — the `deps/e2e_`/`deps/test_` anchor keeps
-# this safe regardless, but a literal path avoids any accidental over-match.
-REPO="$(pwd | sed 's/[.[\*^$]/\\&/g')"
+# Escape every ERE metacharacter in the path so `pkill -f` matches it literally.
+# (Typical paths only hit '.' from "github.com", but a checkout under a path with
+# +, ?, (), {}, |, etc. would otherwise broaden the pattern.) The `deps/e2e_`/
+# `deps/test_` anchor keeps the kill scoped regardless; this just removes any
+# accidental over-match. The char class lists ']' first so it's literal.
+REPO="$(pwd | sed 's/[][(){}.^$*+?|\\]/\\&/g')"
 cleanup() {
   pkill -f "$REPO/target/.*/deps/e2e_" 2>/dev/null
   pkill -f "$REPO/target/.*/deps/test_" 2>/dev/null

--- a/scripts/test_e2e_parallel.sh
+++ b/scripts/test_e2e_parallel.sh
@@ -112,19 +112,37 @@ case "$TARGET_DIR" in /*) ;; *) TARGET_DIR="$(pwd)/$TARGET_DIR" ;; esac
 # first so it's literal.
 TARGET_RE="$(printf '%s' "$TARGET_DIR" | sed 's/[][(){}.^$*+?|\\]/\\&/g')"
 cleanup() {
-  # Kill this run's test binaries. SIGTERM first; a binary blocked waiting on a
-  # hung child (server/lua-ls) can ignore it, so SIGKILL the survivors after a
-  # beat — otherwise a Ctrl-C'd run leaks binaries that keep running into the
-  # NEXT run (and write to this run's now-deleted RESDIR). `timeout`-wrapped
-  # invocations carry the same path, so they're matched too.
+  # Mark the run aborted FIRST by making the RESDIR path vanish: every queued/
+  # in-flight worker guards on `[ -d "$RESDIR" ]`, so once it's gone xargs can no
+  # longer launch a fresh test binary — closing the window where a job spawned
+  # between the kill and the removal would escape the pkill below. Use rename(2)
+  # (mv), not `rm -rf`: `rm -rf` deletes the directory LAST, after walking it, so
+  # a worker writing a status file mid-walk could leave the dir (and the guard)
+  # alive; a rename makes the guarded path disappear atomically with no window.
+  aborting="$RESDIR"
+  if [ -n "$RESDIR" ] && [ -d "$RESDIR" ]; then
+    aborting="${RESDIR}.aborting.$$"
+    mv "$RESDIR" "$aborting" 2>/dev/null || aborting="$RESDIR"
+  fi
+  # Then kill this run's test binaries. SIGTERM first; a binary blocked waiting
+  # on a hung child (server/lua-ls) can ignore it, so SIGKILL the survivors after
+  # a beat — otherwise a Ctrl-C'd run leaks binaries that keep running into the
+  # NEXT run. `timeout`-wrapped invocations carry the same path, so they match.
   pkill -TERM -f "$TARGET_RE/.*/deps/(e2e_|test_)" 2>/dev/null
   if pgrep -f "$TARGET_RE/.*/deps/(e2e_|test_)" >/dev/null 2>&1; then
     sleep 1
     pkill -KILL -f "$TARGET_RE/.*/deps/(e2e_|test_)" 2>/dev/null
   fi
-  rm -rf "$RESDIR"
+  # Now that workers are dead, remove the moved dir (no one races us for it).
+  [ -n "$aborting" ] && rm -rf "$aborting"
 }
-trap cleanup EXIT INT TERM
+# On a signal, clean up and exit NON-ZERO (130/143) — never fall through to the
+# summary, which could otherwise print "All E2E binaries passed" if the signal
+# landed after the pass counts were computed. `trap - EXIT` first so the EXIT
+# handler doesn't re-run cleanup (it's idempotent, but this keeps it tidy).
+trap 'cleanup' EXIT
+trap 'trap - EXIT; cleanup; exit 130' INT
+trap 'trap - EXIT; cleanup; exit 143' TERM
 
 # Fresh checkout: the shared parser/query install (deps/test/kakehashi) does not
 # exist yet. The test binaries create it lazily on first server spawn, so the
@@ -173,7 +191,11 @@ printf '%s\n' "$BINS" | xargs -P "$JOBS" -I{} sh -c '
     124) status="TIME" ;;   # killed by timeout
     *)   status="FAIL" ;;
   esac
-  echo "$ec" > "$RESDIR/$name.status"
+  # The -d recheck above leaves a microsecond TOCTOU window: cleanup() can still
+  # delete RESDIR between it and this write on a hard abort. Swallow that stray
+  # error so the abort stays silent (the write no-ops; the drop-guard reports the
+  # abort via the missing status files).
+  echo "$ec" > "$RESDIR/$name.status" 2>/dev/null || exit 0
   done=$(ls "$RESDIR"/*.status 2>/dev/null | wc -l | tr -d " ")
   printf "  [%2d/%2d] %s %-34s %3ds\n" "$done" "$N" "$status" "$name" "$dt"
 ' _ {}

--- a/scripts/test_e2e_parallel.sh
+++ b/scripts/test_e2e_parallel.sh
@@ -17,8 +17,9 @@
 # Safe to run concurrently because each spawned server is isolated:
 #   - KAKEHASHI_DATA_DIR  : shared, read-only after install (parsers/queries)
 #   - XDG_CONFIG_HOME     : per-process temp dir (no user-config bleed)
-#   - KAKEHASHI_STATE_DIR : per-process temp dir (crash-recovery state, set by
-#                           the test harness so processes don't poison each other)
+#   - KAKEHASHI_STATE_DIR : per-SPAWN temp dir (crash-recovery state, set by the
+#                           test harness so no two concurrent servers — threads
+#                           or processes — ever share/poison those files)
 #
 # Usage:
 #   scripts/test_e2e_parallel.sh

--- a/src/analysis/semantic/finalize.rs
+++ b/src/analysis/semantic/finalize.rs
@@ -475,6 +475,13 @@ fn filter_by_injection_regions(
 /// regions in `map[L]`, turning the per-token region checks in
 /// [`filter_by_injection_regions`] from O(regions) into O(regions-on-line)
 /// — amortized O(1) for the common case of few regions per line.
+// NOTE (vs `build_region_intervals_map`'s `line_idx >= lines.len()` guard):
+// this map is keyed purely by line NUMBER and never indexes the `lines` slice,
+// so it must index EVERY line a region spans regardless of `lines.len()`. Tokens
+// are matched by line number here; clamping to `lines.len()` would drop region
+// lines that tokens still fall on (a finalize test exercises exactly this with
+// an empty `lines` slice). Active regions are document-bounded in practice, so
+// the range is not actually unbounded.
 fn build_regions_by_line(regions: &[ActiveInjectionBounds]) -> HashMap<usize, Vec<usize>> {
     let mut map: HashMap<usize, Vec<usize>> = HashMap::new();
     for (i, r) in regions.iter().enumerate() {

--- a/src/analysis/semantic/finalize.rs
+++ b/src/analysis/semantic/finalize.rs
@@ -186,39 +186,29 @@ fn merge_adjacent_fragments(tokens: &mut Vec<RawToken>) {
     tokens.truncate(write + 1);
 }
 
-/// Check whether a single-line token is fully inside any active injection region.
+/// Check whether a single-line token is fully inside one active injection region.
 ///
 /// Uses lexicographic tuple comparison: `(line, col) >= (start_line, start_col)`
 /// covers all four cases (middle line, start line, end line, single-line region).
-fn is_fully_in_active_injection_region(
-    token: &RawToken,
-    regions: &[ActiveInjectionBounds],
-) -> bool {
+fn token_fully_in_region(token: &RawToken, r: &ActiveInjectionBounds) -> bool {
     let token_end = token.column + token.length;
-    regions.iter().any(|r| {
-        (token.line, token.column) >= (r.start_line, r.start_col)
-            && (token.line, token_end) <= (r.end_line, r.end_col)
-    })
+    (token.line, token.column) >= (r.start_line, r.start_col)
+        && (token.line, token_end) <= (r.end_line, r.end_col)
 }
 
-/// Check whether a token exactly matches any active injection region's bounds.
+/// Check whether a token exactly matches one active injection region's bounds.
 ///
 /// This mirrors the exact-match exception in `is_in_exclusion_range()`: when
 /// a host capture sits on the same tree-sitter node as `@injection.content`
 /// (e.g., fish `(comment) @comment` + `(comment) @injection.content`), the
 /// host token should survive to the sweep-line algorithm, which splits it
 /// around injection tokens and preserves the host type in uncovered gaps.
-fn is_exact_match_active_injection_region(
-    token: &RawToken,
-    regions: &[ActiveInjectionBounds],
-) -> bool {
+fn token_exact_matches_region(token: &RawToken, r: &ActiveInjectionBounds) -> bool {
     let token_end = token.column + token.length;
-    regions.iter().any(|r| {
-        token.line == r.start_line
-            && token.line == r.end_line
-            && token.column == r.start_col
-            && token_end == r.end_col
-    })
+    token.line == r.start_line
+        && token.line == r.end_line
+        && token.column == r.start_col
+        && token_end == r.end_col
 }
 
 /// Collect the injection region intervals that overlap a host token's line.
@@ -416,6 +406,13 @@ fn filter_by_injection_regions(
     if regions.is_empty() {
         return tokens;
     }
+    // Index regions by every host line they span, so each host token only
+    // examines the regions on its own line. Without this index the three
+    // per-token region checks below each scan ALL regions, making the pass
+    // O(tokens × regions); when the region count grows with document size
+    // (e.g. one injection per comment/macro in Rust), that is quadratic on
+    // the hot path — the dominant cost found by profiling.
+    let regions_by_line = build_regions_by_line(regions);
     let region_map = build_region_intervals_map(regions, lines);
     let mut filtered = Vec::with_capacity(tokens.len());
     for token in tokens {
@@ -423,11 +420,21 @@ fn filter_by_injection_regions(
             filtered.push(token);
             continue;
         }
-        if is_exact_match_active_injection_region(&token, regions) {
+        let line_regions = regions_by_line
+            .get(&token.line)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[]);
+        if line_regions
+            .iter()
+            .any(|&i| token_exact_matches_region(&token, &regions[i]))
+        {
             filtered.push(token);
             continue;
         }
-        if is_fully_in_active_injection_region(&token, regions) {
+        if line_regions
+            .iter()
+            .any(|&i| token_fully_in_region(&token, &regions[i]))
+        {
             continue;
         }
         // Partial overlap: check if any overlapping region is single-line.
@@ -441,7 +448,8 @@ fn filter_by_injection_regions(
         // injection architecture processes each depth level separately,
         // so a given depth's active regions are homogeneous in nature.
         let token_end = token.column + token.length;
-        let overlaps_single_line_region = regions.iter().any(|r| {
+        let overlaps_single_line_region = line_regions.iter().any(|&i| {
+            let r = &regions[i];
             r.start_line == r.end_line
                 && r.start_line == token.line
                 && r.start_col < token_end
@@ -458,6 +466,23 @@ fn filter_by_injection_regions(
         }
     }
     filtered
+}
+
+/// Index active injection regions by every host line they span.
+///
+/// Returns a map from line number to the indices (into `regions`) of the
+/// regions that touch that line. A token on line L only needs to consider
+/// regions in `map[L]`, turning the per-token region checks in
+/// [`filter_by_injection_regions`] from O(regions) into O(regions-on-line)
+/// — amortized O(1) for the common case of few regions per line.
+fn build_regions_by_line(regions: &[ActiveInjectionBounds]) -> HashMap<usize, Vec<usize>> {
+    let mut map: HashMap<usize, Vec<usize>> = HashMap::new();
+    for (i, r) in regions.iter().enumerate() {
+        for line in r.start_line..=r.end_line {
+            map.entry(line).or_default().push(i);
+        }
+    }
+    map
 }
 
 /// Post-process and delta-encode raw tokens into SemanticTokensResult.

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -150,11 +150,20 @@ impl AutoInstallManager {
 
     /// Initialize the failed parser registry with crash detection.
     ///
-    /// Uses the default data directory for state storage.
+    /// State storage location: `KAKEHASHI_STATE_DIR` if set, else the default
+    /// data directory. Crash-recovery state (`parsing_in_progress`,
+    /// `failed_parsers`) is ephemeral and conceptually distinct from the
+    /// persistent parser/query install assets in the data dir; the override
+    /// lets it live elsewhere — e.g. so concurrent test processes that share one
+    /// read-only install dir can isolate their crash state and not poison each
+    /// other (a leftover `parsing_in_progress` from another process is otherwise
+    /// read as a crash and marks that parser failed).
     /// If initialization fails, returns an empty registry.
     pub fn init_failed_parser_registry() -> FailedParserRegistry {
-        let state_dir =
-            crate::install::default_data_dir().unwrap_or_else(|| PathBuf::from("/tmp/kakehashi"));
+        let state_dir = std::env::var_os("KAKEHASHI_STATE_DIR")
+            .map(PathBuf::from)
+            .or_else(crate::install::default_data_dir)
+            .unwrap_or_else(|| PathBuf::from("/tmp/kakehashi"));
 
         let registry = FailedParserRegistry::new(&state_dir);
 

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -162,6 +162,10 @@ impl AutoInstallManager {
     /// If initialization fails, returns an empty registry.
     pub fn init_failed_parser_registry() -> FailedParserRegistry {
         let state_dir = std::env::var_os("KAKEHASHI_STATE_DIR")
+            // An empty value resolves to the process cwd (writing crash files
+            // wherever it was started), so treat it as unset — matching how
+            // `resolve_data_dir` handles an empty `KAKEHASHI_DATA_DIR`.
+            .filter(|v| !v.is_empty())
             .map(PathBuf::from)
             .or_else(crate::install::default_data_dir)
             .unwrap_or_else(|| PathBuf::from("/tmp/kakehashi"));

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -151,8 +151,8 @@ impl AutoInstallManager {
     /// Initialize the failed parser registry with crash detection.
     ///
     /// State storage location: `KAKEHASHI_STATE_DIR` if set, else the default
-    /// data directory, falling back to `/tmp/kakehashi` if neither resolves.
-    /// Crash-recovery state (`parsing_in_progress`,
+    /// data directory, falling back to a `kakehashi` dir under the OS temp dir
+    /// if neither resolves. Crash-recovery state (`parsing_in_progress`,
     /// `failed_parsers`) is ephemeral and conceptually distinct from the
     /// persistent parser/query install assets in the data dir; the override
     /// lets it live elsewhere — e.g. so concurrent test processes that share one
@@ -168,7 +168,9 @@ impl AutoInstallManager {
             .filter(|v| !v.is_empty())
             .map(PathBuf::from)
             .or_else(crate::install::default_data_dir)
-            .unwrap_or_else(|| PathBuf::from("/tmp/kakehashi"));
+            // Platform-aware last resort (not a hard-coded `/tmp`, which doesn't
+            // exist on Windows); only reached if the data dir can't resolve.
+            .unwrap_or_else(|| std::env::temp_dir().join("kakehashi"));
 
         let registry = FailedParserRegistry::new(&state_dir);
 

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -151,7 +151,8 @@ impl AutoInstallManager {
     /// Initialize the failed parser registry with crash detection.
     ///
     /// State storage location: `KAKEHASHI_STATE_DIR` if set, else the default
-    /// data directory. Crash-recovery state (`parsing_in_progress`,
+    /// data directory, falling back to `/tmp/kakehashi` if neither resolves.
+    /// Crash-recovery state (`parsing_in_progress`,
     /// `failed_parsers`) is ephemeral and conceptually distinct from the
     /// persistent parser/query install assets in the data dir; the override
     /// lets it live elsewhere — e.g. so concurrent test processes that share one

--- a/tests/e2e_cli_diagnose.rs
+++ b/tests/e2e_cli_diagnose.rs
@@ -29,20 +29,24 @@ fn data_dir() -> &'static Path {
     .as_path()
 }
 
-/// Per-process dir for the spawned server's crash-recovery state, passed via
-/// `KAKEHASHI_STATE_DIR`. `kakehashi diagnose` builds the in-process LSP service
-/// (`Kakehashi::new` -> `FailedParserRegistry`), so without this it would read
-/// and write `parsing_in_progress`/`failed_parsers` in the SHARED `data_dir()`,
-/// which the parallel test runner makes a cross-process poisoning hazard. Keep
-/// it out of the shared install (read-only) and clear the transient files on
-/// each spawn for the intra-process case — mirrors `lsp_client.rs`.
-fn state_dir() -> &'static Path {
-    static DIR: OnceLock<tempfile::TempDir> = OnceLock::new();
-    let dir = DIR
-        .get_or_init(|| tempfile::tempdir().expect("create temp KAKEHASHI_STATE_DIR"))
+/// A fresh, unique dir per spawn for the spawned server's crash-recovery state,
+/// passed via `KAKEHASHI_STATE_DIR`. `kakehashi diagnose` builds the in-process
+/// LSP service (`Kakehashi::new` -> `FailedParserRegistry`), so without this it
+/// would read/write `parsing_in_progress`/`failed_parsers` in the SHARED
+/// `data_dir()`. A per-SPAWN dir means concurrent invocations (parallel test
+/// threads here, or other test processes) never share those files, so none can
+/// poison another. All per-spawn dirs live under one base `TempDir` parked in a
+/// `static` (never dropped, so the small tree is left in the OS temp dir at
+/// process exit) — mirrors `lsp_client.rs`.
+fn state_dir() -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static BASE: OnceLock<tempfile::TempDir> = OnceLock::new();
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let base = BASE
+        .get_or_init(|| tempfile::tempdir().expect("create base KAKEHASHI_STATE_DIR"))
         .path();
-    let _ = std::fs::remove_file(dir.join("parsing_in_progress"));
-    let _ = std::fs::remove_file(dir.join("failed_parsers"));
+    let dir = base.join(format!("spawn-{}", SEQ.fetch_add(1, Ordering::Relaxed)));
+    std::fs::create_dir_all(&dir).expect("create per-spawn KAKEHASHI_STATE_DIR");
     dir
 }
 

--- a/tests/e2e_cli_diagnose.rs
+++ b/tests/e2e_cli_diagnose.rs
@@ -15,19 +15,35 @@ use std::process::{Command, Output, Stdio};
 use std::sync::OnceLock;
 
 /// Shared persistent data dir with markdown/lua parsers preinstalled (same one
-/// the rest of the e2e suite uses).
+/// the rest of the e2e suite uses). Treated as read-only after install so
+/// concurrent test processes can share it.
 fn data_dir() -> &'static Path {
     static DIR: OnceLock<PathBuf> = OnceLock::new();
-    let dir = DIR.get_or_init(|| {
+    DIR.get_or_init(|| {
         let dir = kakehashi::install::test_support::test_data_dir_path();
         std::fs::create_dir_all(&dir).expect("create shared test data dir");
         kakehashi::install::test_support::ensure_test_languages_installed(&dir)
             .expect("install test parsers into the shared data dir");
         dir
-    });
+    })
+    .as_path()
+}
+
+/// Per-process dir for the spawned server's crash-recovery state, passed via
+/// `KAKEHASHI_STATE_DIR`. `kakehashi diagnose` builds the in-process LSP service
+/// (`Kakehashi::new` -> `FailedParserRegistry`), so without this it would read
+/// and write `parsing_in_progress`/`failed_parsers` in the SHARED `data_dir()`,
+/// which the parallel test runner makes a cross-process poisoning hazard. Keep
+/// it out of the shared install (read-only) and clear the transient files on
+/// each spawn for the intra-process case — mirrors `lsp_client.rs`.
+fn state_dir() -> &'static Path {
+    static DIR: OnceLock<tempfile::TempDir> = OnceLock::new();
+    let dir = DIR
+        .get_or_init(|| tempfile::tempdir().expect("create temp KAKEHASHI_STATE_DIR"))
+        .path();
     let _ = std::fs::remove_file(dir.join("parsing_in_progress"));
     let _ = std::fs::remove_file(dir.join("failed_parsers"));
-    dir.as_path()
+    dir
 }
 
 /// Workspace config bridging lua injections to the mock diagnostics server.
@@ -74,6 +90,7 @@ fn run_diagnose(workspace: &Path, args: &[&str]) -> Output {
         .args(args)
         .current_dir(workspace)
         .env("KAKEHASHI_DATA_DIR", data_dir())
+        .env("KAKEHASHI_STATE_DIR", state_dir())
         .env("RUST_LOG", "kakehashi=debug")
         .output()
         .expect("spawn kakehashi diagnose")
@@ -248,6 +265,7 @@ fn e2e_diagnose_stdin_mode_prints_diagnostics() {
         ])
         .current_dir(ws.path())
         .env("KAKEHASHI_DATA_DIR", data_dir())
+        .env("KAKEHASHI_STATE_DIR", state_dir())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -28,20 +28,24 @@ fn data_dir() -> &'static Path {
     .as_path()
 }
 
-/// Per-process dir for the spawned server's crash-recovery state, passed via
-/// `KAKEHASHI_STATE_DIR`. `kakehashi format` builds the in-process LSP service
-/// (`Kakehashi::new` -> `FailedParserRegistry`), so without this it would read
-/// and write `parsing_in_progress`/`failed_parsers` in the SHARED `data_dir()`,
-/// which the parallel test runner makes a cross-process poisoning hazard. Keep
-/// it out of the shared install (read-only) and clear the transient files on
-/// each spawn for the intra-process case — mirrors `lsp_client.rs`.
-fn state_dir() -> &'static Path {
-    static DIR: OnceLock<tempfile::TempDir> = OnceLock::new();
-    let dir = DIR
-        .get_or_init(|| tempfile::tempdir().expect("create temp KAKEHASHI_STATE_DIR"))
+/// A fresh, unique dir per spawn for the spawned server's crash-recovery state,
+/// passed via `KAKEHASHI_STATE_DIR`. `kakehashi format` builds the in-process
+/// LSP service (`Kakehashi::new` -> `FailedParserRegistry`), so without this it
+/// would read/write `parsing_in_progress`/`failed_parsers` in the SHARED
+/// `data_dir()`. A per-SPAWN dir means concurrent invocations (parallel test
+/// threads here, or other test processes) never share those files, so none can
+/// poison another. All per-spawn dirs live under one base `TempDir` parked in a
+/// `static` (never dropped, so the small tree is left in the OS temp dir at
+/// process exit) — mirrors `lsp_client.rs`.
+fn state_dir() -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static BASE: OnceLock<tempfile::TempDir> = OnceLock::new();
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let base = BASE
+        .get_or_init(|| tempfile::tempdir().expect("create base KAKEHASHI_STATE_DIR"))
         .path();
-    let _ = std::fs::remove_file(dir.join("parsing_in_progress"));
-    let _ = std::fs::remove_file(dir.join("failed_parsers"));
+    let dir = base.join(format!("spawn-{}", SEQ.fetch_add(1, Ordering::Relaxed)));
+    std::fs::create_dir_all(&dir).expect("create per-spawn KAKEHASHI_STATE_DIR");
     dir
 }
 

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -14,21 +14,35 @@ use std::process::{Command, Output, Stdio};
 use std::sync::OnceLock;
 
 /// Shared persistent data dir with markdown/lua parsers preinstalled (same
-/// one the LSP e2e suite uses; see `tests/helpers/lsp_client.rs`).
+/// one the LSP e2e suite uses; see `tests/helpers/lsp_client.rs`). Treated as
+/// read-only after install so concurrent test processes can share it.
 fn data_dir() -> &'static Path {
     static DIR: OnceLock<PathBuf> = OnceLock::new();
-    let dir = DIR.get_or_init(|| {
+    DIR.get_or_init(|| {
         let dir = kakehashi::install::test_support::test_data_dir_path();
         std::fs::create_dir_all(&dir).expect("create shared test data dir");
         kakehashi::install::test_support::ensure_test_languages_installed(&dir)
             .expect("install test parsers into the shared data dir");
         dir
-    });
-    // Clear crash-recovery state before every spawn so an earlier test's
-    // mid-parse shutdown can't poison this one.
+    })
+    .as_path()
+}
+
+/// Per-process dir for the spawned server's crash-recovery state, passed via
+/// `KAKEHASHI_STATE_DIR`. `kakehashi format` builds the in-process LSP service
+/// (`Kakehashi::new` -> `FailedParserRegistry`), so without this it would read
+/// and write `parsing_in_progress`/`failed_parsers` in the SHARED `data_dir()`,
+/// which the parallel test runner makes a cross-process poisoning hazard. Keep
+/// it out of the shared install (read-only) and clear the transient files on
+/// each spawn for the intra-process case — mirrors `lsp_client.rs`.
+fn state_dir() -> &'static Path {
+    static DIR: OnceLock<tempfile::TempDir> = OnceLock::new();
+    let dir = DIR
+        .get_or_init(|| tempfile::tempdir().expect("create temp KAKEHASHI_STATE_DIR"))
+        .path();
     let _ = std::fs::remove_file(dir.join("parsing_in_progress"));
     let _ = std::fs::remove_file(dir.join("failed_parsers"));
-    dir.as_path()
+    dir
 }
 
 /// Workspace config bridging lua injections to the uppercasing mock server.
@@ -72,6 +86,7 @@ fn run_format(workspace: &Path, args: &[&str]) -> Output {
         .args(args)
         .current_dir(workspace)
         .env("KAKEHASHI_DATA_DIR", data_dir())
+        .env("KAKEHASHI_STATE_DIR", state_dir())
         .env("RUST_LOG", "kakehashi=debug")
         .output()
         .expect("spawn kakehashi format")
@@ -178,6 +193,7 @@ fn run_format_stdin(workspace: &Path, extra_args: &[&str]) -> Output {
         .args(extra_args)
         .current_dir(workspace)
         .env("KAKEHASHI_DATA_DIR", data_dir())
+        .env("KAKEHASHI_STATE_DIR", state_dir())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/tests/e2e_synthetic_push_diagnostic.rs
+++ b/tests/e2e_synthetic_push_diagnostic.rs
@@ -332,9 +332,14 @@ print(((
     // Wait for lua-ls to be ready
     wait_for_server_ready(&mut client, markdown_uri, 5, 100);
 
-    // Wait for publishDiagnostics
+    // Unlike the optional-push tests above, this one's POINT is the
+    // position-transform assertion below, which only runs when diagnostics
+    // actually arrive (invalid Lua => lua-ls reports an error, so they do).
+    // Keep a generous timeout: it returns as soon as the push arrives (no wall
+    // cost in the common case) but still exercises the assertion under load,
+    // rather than degrading to the "tested in unit tests" no-op branch.
     let notification =
-        client.wait_for_notification("textDocument/publishDiagnostics", OPTIONAL_PUSH_WAIT);
+        client.wait_for_notification("textDocument/publishDiagnostics", Duration::from_secs(10));
 
     if let Some(params) = notification {
         println!(

--- a/tests/e2e_synthetic_push_diagnostic.rs
+++ b/tests/e2e_synthetic_push_diagnostic.rs
@@ -16,6 +16,17 @@ use helpers::lua_bridge::{create_lua_configured_client, shutdown_client};
 use serde_json::json;
 use std::time::Duration;
 
+/// Bounded wait for an *optional* `publishDiagnostics` push.
+///
+/// Several tests below accept the notification's absence (the server only has to
+/// not crash) — e.g. valid Lua produces no diagnostics, so no push may ever
+/// arrive. A long timeout there just burns wall time waiting for something that
+/// will not come, which is especially costly under parallel test execution. Kept
+/// short: a push that *is* coming arrives well within this window after the
+/// server is ready. Tests that *require* a deterministic push keep their own
+/// longer, explicit timeout.
+const OPTIONAL_PUSH_WAIT: Duration = Duration::from_secs(3);
+
 /// E2E test: publishDiagnostics is sent on didOpen
 ///
 /// When a document is opened, kakehashi should automatically collect
@@ -55,7 +66,7 @@ print(x)
     // Wait for publishDiagnostics notification
     // The synthetic push happens after initialization, so we need to wait a bit
     let notification =
-        client.wait_for_notification("textDocument/publishDiagnostics", Duration::from_secs(10));
+        client.wait_for_notification("textDocument/publishDiagnostics", OPTIONAL_PUSH_WAIT);
 
     if let Some(params) = notification {
         println!(
@@ -142,7 +153,7 @@ local x = 1
 
     // Wait for publishDiagnostics notification from didSave
     let notification =
-        client.wait_for_notification("textDocument/publishDiagnostics", Duration::from_secs(10));
+        client.wait_for_notification("textDocument/publishDiagnostics", OPTIONAL_PUSH_WAIT);
 
     if let Some(params) = notification {
         println!(
@@ -239,7 +250,7 @@ local x = 1
 
     // First, wait a reasonable time for the first notification
     if let Some(params) =
-        client.wait_for_notification("textDocument/publishDiagnostics", Duration::from_secs(10))
+        client.wait_for_notification("textDocument/publishDiagnostics", OPTIONAL_PUSH_WAIT)
     {
         notification_count += 1;
         println!(
@@ -323,7 +334,7 @@ print(((
 
     // Wait for publishDiagnostics
     let notification =
-        client.wait_for_notification("textDocument/publishDiagnostics", Duration::from_secs(10));
+        client.wait_for_notification("textDocument/publishDiagnostics", OPTIONAL_PUSH_WAIT);
 
     if let Some(params) = notification {
         println!(
@@ -419,6 +430,8 @@ fn e2e_synthetic_push_respects_layers_gate() {
         }),
     );
 
+    // Required, deterministic push (no downstream dependency) — keep a generous
+    // timeout so a busy/parallel machine can't spuriously miss it.
     let notification =
         client.wait_for_notification("textDocument/publishDiagnostics", Duration::from_secs(10));
 

--- a/tests/e2e_synthetic_push_diagnostic.rs
+++ b/tests/e2e_synthetic_push_diagnostic.rs
@@ -1,7 +1,11 @@
 //! End-to-end test for synthetic push diagnostics (pull-first-diagnostic-forwarding Phase 2).
 //!
-//! This test verifies that `textDocument/publishDiagnostics` notifications
-//! are sent automatically on `didSave` and `didOpen` events.
+//! This test verifies the `textDocument/publishDiagnostics` push path on
+//! `didSave`/`didOpen`. Note the two flavours below: tests gated by a real
+//! downstream (lua-ls) treat the push as OPTIONAL — they only assert structure
+//! IF one arrives within `OPTIONAL_PUSH_WAIT` (valid Lua may produce none), and
+//! otherwise just require the server not to crash. The layers-gate test, whose
+//! empty publish is deterministic (no downstream), DOES require the push.
 //!
 //! Run with: `cargo test --test e2e_synthetic_push_diagnostic --features e2e`
 //!

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -28,8 +28,7 @@ use std::time::{Duration, Instant};
 /// cached once per process via `OnceLock`. The directory is treated as
 /// read-only after install so independent test processes can share it; the
 /// transient crash-recovery files that the server would otherwise write here
-/// are redirected to a per-process [`isolated_state_dir`] (see
-/// [`clear_crash_recovery_state`]).
+/// are redirected to a per-spawn [`isolated_state_dir`].
 ///
 /// We always set `KAKEHASHI_DATA_DIR` on the spawned binary to this
 /// path — the binary itself runs without `cfg(test)`, so it cannot
@@ -48,36 +47,33 @@ fn test_data_dir() -> &'static Path {
     .as_path()
 }
 
-/// Per-process directory for the spawned server's crash-recovery state
+/// A fresh, unique directory for ONE spawned server's crash-recovery state
 /// (`parsing_in_progress`, `failed_parsers`), passed via `KAKEHASHI_STATE_DIR`.
 ///
-/// Kept OUT of the shared [`test_data_dir`] so independent test *processes* can
-/// run concurrently without poisoning each other: the server's
-/// `FailedParserRegistry::init()` reads a leftover `parsing_in_progress` as a
-/// crash and marks that parser failed, which would flake every later server in
-/// any process sharing the dir. The expensive parser/query install stays shared
-/// (read-only) in `test_data_dir`; only this ephemeral state is isolated.
+/// Kept OUT of the shared [`test_data_dir`] so servers never poison each other:
+/// the server's `FailedParserRegistry::init()` reads a leftover
+/// `parsing_in_progress` as a crash and marks that parser failed. A per-SPAWN
+/// (not per-process) dir is what makes the test suite safe under both
+/// cross-process AND intra-process concurrency (parallel test threads in one
+/// binary): no two concurrently-running servers ever share these files, so a
+/// server that persists state on a shutdown-while-parsing can't be read as a
+/// crash by another — and no pre-spawn clearing is needed. The expensive
+/// parser/query install stays shared (read-only) in `test_data_dir`.
 ///
-/// Like [`isolated_config_dir`], a per-process [`tempfile::TempDir`] parked in a
-/// `static` that outlives every spawned server and is never dropped.
-fn isolated_state_dir() -> &'static Path {
-    static DIR: OnceLock<tempfile::TempDir> = OnceLock::new();
-    DIR.get_or_init(|| {
-        tempfile::tempdir().expect("create temp dir for KAKEHASHI_STATE_DIR isolation")
-    })
-    .path()
-}
-
-/// Clear the transient crash-recovery files before a spawn.
-///
-/// Cross-process poisoning is already prevented by the per-process
-/// [`isolated_state_dir`]; this guards the INTRA-process case the way the old
-/// code did — a client that shut down mid-parse leaves these files behind, which
-/// would otherwise poison later clients spawned by the same E2E binary.
-fn clear_crash_recovery_state() {
-    let dir = isolated_state_dir();
-    let _ = std::fs::remove_file(dir.join("parsing_in_progress"));
-    let _ = std::fs::remove_file(dir.join("failed_parsers"));
+/// All per-spawn dirs live under one base [`tempfile::TempDir`] parked in a
+/// `static` and — like [`isolated_config_dir`] — intentionally never dropped
+/// (statics aren't), so the small tree is left in the OS temp dir when the
+/// process exits (one tree per test process; the same accepted leak).
+fn isolated_state_dir() -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static BASE: OnceLock<tempfile::TempDir> = OnceLock::new();
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let base = BASE
+        .get_or_init(|| tempfile::tempdir().expect("create base dir for KAKEHASHI_STATE_DIR"))
+        .path();
+    let dir = base.join(format!("spawn-{}", SEQ.fetch_add(1, Ordering::Relaxed)));
+    std::fs::create_dir_all(&dir).expect("create per-spawn KAKEHASHI_STATE_DIR");
+    dir
 }
 
 /// Empty `XDG_CONFIG_HOME` for the spawned server, so it never reads the
@@ -224,7 +220,6 @@ impl LspClientBuilder {
             cmd.env(key, value);
         }
 
-        clear_crash_recovery_state();
         let child = cmd.spawn().expect("Failed to spawn kakehashi binary");
         LspClient::from_child(child)
     }
@@ -373,7 +368,6 @@ impl LspClient {
             cmd.env("RUST_LOG", "debug");
         }
 
-        clear_crash_recovery_state();
         let child = cmd.spawn().expect("Failed to spawn kakehashi binary");
         Self::from_child(child)
     }

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -40,8 +40,12 @@ fn test_data_dir() -> &'static Path {
         // `kakehashi::install::test_data_dir` so unit tests and
         // E2E-spawned binaries reuse one cached parser/query install.
         let dir = kakehashi::install::test_support::test_data_dir_path();
-        let _ = std::fs::create_dir_all(&dir);
-        let _ = kakehashi::install::test_support::ensure_test_languages_installed(&dir);
+        // Fail fast with a clear message on a broken setup (permissions, disk
+        // full, corrupt cache) rather than letting every later test fail with a
+        // murky downstream error. Matches the CLI helpers' `data_dir()`.
+        std::fs::create_dir_all(&dir).expect("create shared test data dir");
+        kakehashi::install::test_support::ensure_test_languages_installed(&dir)
+            .expect("install test parsers/queries into the shared data dir");
         dir
     })
     .as_path()

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -25,19 +25,18 @@ use std::time::{Duration, Instant};
 /// avoid re-downloading.
 ///
 /// The expensive, idempotent setup (dir creation + parser/query install) is
-/// cached once per process via `OnceLock`. The transient crash-recovery files
-/// (`parsing_in_progress`, `failed_parsers`), however, are cleared on **every**
-/// call — i.e. before every client spawn — not just the first: an E2E binary
-/// spawns several clients in one process, and a client that shuts down
-/// mid-parse leaves those files behind, which would otherwise poison later
-/// clients in the same binary.
+/// cached once per process via `OnceLock`. The directory is treated as
+/// read-only after install so independent test processes can share it; the
+/// transient crash-recovery files that the server would otherwise write here
+/// are redirected to a per-process [`isolated_state_dir`] (see
+/// [`clear_crash_recovery_state`]).
 ///
 /// We always set `KAKEHASHI_DATA_DIR` on the spawned binary to this
 /// path — the binary itself runs without `cfg(test)`, so it cannot
 /// auto-redirect like lib unit tests do.
 fn test_data_dir() -> &'static Path {
     static DIR: OnceLock<PathBuf> = OnceLock::new();
-    let dir = DIR.get_or_init(|| {
+    DIR.get_or_init(|| {
         // Shares the same path and install logic as the lib-side
         // `kakehashi::install::test_data_dir` so unit tests and
         // E2E-spawned binaries reuse one cached parser/query install.
@@ -45,11 +44,40 @@ fn test_data_dir() -> &'static Path {
         let _ = std::fs::create_dir_all(&dir);
         let _ = kakehashi::install::test_support::ensure_test_languages_installed(&dir);
         dir
-    });
-    // Clear crash-recovery state before every spawn, not just the first.
+    })
+    .as_path()
+}
+
+/// Per-process directory for the spawned server's crash-recovery state
+/// (`parsing_in_progress`, `failed_parsers`), passed via `KAKEHASHI_STATE_DIR`.
+///
+/// Kept OUT of the shared [`test_data_dir`] so independent test *processes* can
+/// run concurrently without poisoning each other: the server's
+/// `FailedParserRegistry::init()` reads a leftover `parsing_in_progress` as a
+/// crash and marks that parser failed, which would flake every later server in
+/// any process sharing the dir. The expensive parser/query install stays shared
+/// (read-only) in `test_data_dir`; only this ephemeral state is isolated.
+///
+/// Like [`isolated_config_dir`], a per-process [`tempfile::TempDir`] parked in a
+/// `static` that outlives every spawned server and is never dropped.
+fn isolated_state_dir() -> &'static Path {
+    static DIR: OnceLock<tempfile::TempDir> = OnceLock::new();
+    DIR.get_or_init(|| {
+        tempfile::tempdir().expect("create temp dir for KAKEHASHI_STATE_DIR isolation")
+    })
+    .path()
+}
+
+/// Clear the transient crash-recovery files before a spawn.
+///
+/// Cross-process poisoning is already prevented by the per-process
+/// [`isolated_state_dir`]; this guards the INTRA-process case the way the old
+/// code did — a client that shut down mid-parse leaves these files behind, which
+/// would otherwise poison later clients spawned by the same E2E binary.
+fn clear_crash_recovery_state() {
+    let dir = isolated_state_dir();
     let _ = std::fs::remove_file(dir.join("parsing_in_progress"));
     let _ = std::fs::remove_file(dir.join("failed_parsers"));
-    dir.as_path()
 }
 
 /// Empty `XDG_CONFIG_HOME` for the spawned server, so it never reads the
@@ -191,10 +219,12 @@ impl LspClientBuilder {
         }
         cmd.env("KAKEHASHI_DATA_DIR", test_data_dir());
         cmd.env("XDG_CONFIG_HOME", isolated_config_dir());
+        cmd.env("KAKEHASHI_STATE_DIR", isolated_state_dir());
         for (key, value) in &self.envs {
             cmd.env(key, value);
         }
 
+        clear_crash_recovery_state();
         let child = cmd.spawn().expect("Failed to spawn kakehashi binary");
         LspClient::from_child(child)
     }
@@ -334,6 +364,7 @@ impl LspClient {
         let mut cmd = Command::new(env!("CARGO_BIN_EXE_kakehashi"));
         cmd.env("KAKEHASHI_DATA_DIR", test_data_dir())
             .env("XDG_CONFIG_HOME", isolated_config_dir())
+            .env("KAKEHASHI_STATE_DIR", isolated_state_dir())
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
@@ -342,6 +373,7 @@ impl LspClient {
             cmd.env("RUST_LOG", "debug");
         }
 
+        clear_crash_recovery_state();
         let child = cmd.spawn().expect("Failed to spawn kakehashi binary");
         Self::from_child(child)
     }


### PR DESCRIPTION
## Summary

Two related performance efforts on the semantic-token / E2E hot paths, found via flamegraph profiling and validated by measurement.

### 1. Kill an O(n²) in the semantic-token finalize path
`finalize::filter_by_injection_regions` ran **three** `regions.iter().any(...)` full scans per host token (exact-match, fully-contained, single-line-overlap). When the injection-region count scales with document size — every Rust comment and `format!`/`println!` macro is its own injection region — that is **O(tokens × regions) = O(n²)**.

Two-size flamegraph attribution (sub-fns marked `#[inline(never)]`) pinned it: the function's self-time grew **17.5% → 55.4%** from a 4× larger document (~13ms → ~286ms, ~21× for 4× input). Fix: index regions by the host lines they span and scan only `regions_by_line[token.line]` — all three predicates can only match a region touching the token's line, so it's exactly equivalent → **O(tokens + regions)**.

**Result (drive.py, rust):** 600-function doc **545ms → 128ms/req (4.25×)**; scaling cut from 6.45× to 2.04× for 4× tokens (O(n²) → ~linear). `filter_by_injection_regions` vanished from the profile.

### 2. Speed up the E2E suite (~95s → ~18s on an unloaded machine, ~5×)
`cargo test` runs integration-test binaries sequentially, so the suite ran ~95s at ~1.2× core utilization on 10 cores — each binary mostly idle-waiting on a spawned server. Four levers:

- **Parallel runner** `scripts/test_e2e_parallel.sh` (now the default for `make test_e2e`; `test_e2e_sequential` keeps the old path). Builds once, runs binaries in a bounded `xargs -P` pool with live progress, per-binary `timeout`, and an editor-safe cleanup trap. Concurrency capped at ~1.5× cores — oversubscribing thrashes (30 concurrent ran *slower* than sequential).
- **State-dir isolation** (`KAKEHASHI_STATE_DIR`, falls back to the data dir so production is unchanged): the crash-recovery files (`parsing_in_progress`/`failed_parsers`) lived in the shared install dir, so concurrent processes poisoned each other (a leftover `parsing_in_progress` is read as a crash → marks the parser failed). Isolating that ephemeral state per test process unblocks safe cross-binary parallelism.
- **Dep opt-level** for `tree-sitter` + `regex` in dev/test: each spawn's first semantic-tokens response is dominated by tree-sitter query compilation (C); at debug `opt-level 0` that's ~160ms/spawn. Optimizing just those crates cuts it to ~83ms. (Scoped, not `"*"`, to keep the clean-build cost ~1.5min.)
- **Bounded optional-push timeouts** (10s → 3s) in `e2e_synthetic_push_diagnostic` for notifications the tests already treat as optional.

Validated: 1461 tests passed, 0 failures, stable across runs (identical pass count = identical coverage).

## Notes / trade-offs
- The `~18s` E2E figure is on an unloaded machine. `make test_e2e` shares the default `target/` with the editor's rust-analyzer — its build step can block on RA's lock and a concurrent RA compile starves the tests (the same run measured ~18s RA-idle vs 365s mid-recompile). Run when RA is idle, or use a separate `CARGO_TARGET_DIR`.
- The dep opt-level change adds clean-build time to CI's `cargo test` (no target cache; CI does not run E2E). Its E2E contribution was not isolated. Easy to drop that one commit if the CI cost outweighs the local-dev benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
