### PR TITLE
fix(diagnostics): refresh pull clients on push-driven cache change (#422)

### DIFF
--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -62,7 +62,7 @@ pub(crate) use protocol::RequestId;
 pub(crate) use protocol::VirtualDocumentUri;
 pub(crate) use protocol::location_link_to_location;
 pub(crate) use protocol::translate_virtual_range_to_host;
-pub(crate) use text_document::host::{HostDocument, normalize_host_goto_result};
+pub(crate) use text_document::host::{HostDocument, HostTextReader, normalize_host_goto_result};
 pub(crate) use text_document::{CodeLensEnvelope, extract_code_lens_envelope};
 pub(crate) use workspace::WorkspaceFolderSet;
 

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -572,7 +572,15 @@ impl BridgeCoordinator {
         text: &str,
     ) {
         let configs = self.get_host_configs_for_language(settings, host_language);
-        self.eager_sync_host_document_on_servers(host_uri, host_language, Arc::from(text), configs);
+        // Initial open: the snapshot text is current and there is no concurrent
+        // re-sync to race, so no live reader is needed.
+        self.eager_sync_host_document_on_servers(
+            host_uri,
+            host_language,
+            Arc::from(text),
+            configs,
+            None,
+        );
     }
 
     /// Sync the real host document to a resolved set of `_self` host servers
@@ -595,6 +603,7 @@ impl BridgeCoordinator {
         language_id: &str,
         text: Arc<str>,
         configs: Vec<ResolvedServerConfig>,
+        live_text_reader: Option<crate::lsp::bridge::HostTextReader>,
     ) {
         if configs.is_empty() {
             // Host bridging off / no host server for this language — drop any
@@ -614,18 +623,15 @@ impl BridgeCoordinator {
         // cancel it.
         //
         // On-edit re-sync carries *different* text per fire, so a superseded task
-        // emitting after a newer one could in principle roll the host server back to
-        // older text (a higher version with stale content). The supersede above
-        // closes the common case: each task's only blocking point before the sync is
-        // `get_or_create_connection_wait_ready` (an `.await` on `wait_for_ready`), so
-        // `abort()` cancels a parked older task *there*, before it reaches
-        // `sync_host_document`; and debounce fires are ≥500ms apart, far wider than
-        // the µs spawn→register window, so the prior fire's handle is already
-        // registered (hence abortable) when the next fire supersedes. The only
-        // residual is a µs alignment — an older task unblocking from wait-ready at
-        // the exact instant a newer fire's task reaches the (await-free) sync — which
-        // is the deferred `content_epoch` stale-overwrite window (#422), not a new
-        // bug class; it self-heals on the next edit.
+        // emitting after a newer one could otherwise roll the host server back to
+        // older text. The supersede above aborts a task still parked at
+        // `get_or_create_connection_wait_ready`, closing the common case; the µs
+        // residual — an older task unblocking from wait-ready at the instant a newer
+        // task reaches the (await-free) sync — is closed by `live_text_reader`:
+        // `sync_host_document` reads the document's *current* text under the
+        // `host_documents` lock, so whichever task syncs last sends the latest text,
+        // not the snapshot it was spawned with (#422). The `text` snapshot remains
+        // the fallback when no reader is supplied (initial open) or it yields `None`.
         let (generation, cancel) = self.supersede_host_eager_open(host_uri);
 
         // Share the text + languageId across per-server tasks via `Arc<str>` rather
@@ -641,6 +647,10 @@ impl BridgeCoordinator {
             let server_name = config.server_name.clone();
             let server_config = config.config.clone();
             let cancel = cancel.clone();
+            // Each task shares the same live reader (cheap `Arc` clone) — it is
+            // evaluated inside `sync_host_document`'s lock, so the last task to sync
+            // sends the latest text regardless of which snapshot it was spawned with.
+            let live_text_reader = live_text_reader.clone();
             let task = tokio::spawn(async move {
                 tokio::select! {
                     biased;
@@ -653,6 +663,7 @@ impl BridgeCoordinator {
                         &host_uri_owned,
                         &language_id,
                         &text,
+                        live_text_reader.as_ref(),
                     ) => {}
                 }
             });

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -663,7 +663,7 @@ impl BridgeCoordinator {
                         &host_uri_owned,
                         &language_id,
                         &text,
-                        live_text_reader.as_ref(),
+                        live_text_reader.as_deref(),
                     ) => {}
                 }
             });

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -113,6 +113,7 @@ impl LanguageServerPool {
         host_uri: &url::Url,
         language_id: &str,
         text: &str,
+        live_text_reader: Option<&super::host::HostTextReader>,
     ) {
         let handle = match self
             .get_or_create_connection_wait_ready(
@@ -159,9 +160,14 @@ impl LanguageServerPool {
             language_id,
             text,
         };
-        if let Err(e) =
-            super::host::sync_host_document(&mut sender, &mut docs, &doc, None, connection_key)
-                .await
+        if let Err(e) = super::host::sync_host_document(
+            &mut sender,
+            &mut docs,
+            &doc,
+            live_text_reader.map(|reader| reader.as_ref()),
+            connection_key,
+        )
+        .await
         {
             log::debug!(
                 target: "kakehashi::bridge",

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -113,7 +113,7 @@ impl LanguageServerPool {
         host_uri: &url::Url,
         language_id: &str,
         text: &str,
-        live_text_reader: Option<&super::host::HostTextReader>,
+        live_text_reader: Option<&(dyn Fn() -> Option<Arc<str>> + Send + Sync)>,
     ) {
         let handle = match self
             .get_or_create_connection_wait_ready(
@@ -164,7 +164,7 @@ impl LanguageServerPool {
             &mut sender,
             &mut docs,
             &doc,
-            live_text_reader.map(|reader| reader.as_ref()),
+            live_text_reader,
             connection_key,
         )
         .await

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -160,7 +160,8 @@ impl LanguageServerPool {
             text,
         };
         if let Err(e) =
-            super::host::sync_host_document(&mut sender, &mut docs, &doc, connection_key).await
+            super::host::sync_host_document(&mut sender, &mut docs, &doc, None, connection_key)
+                .await
         {
             log::debug!(
                 target: "kakehashi::bridge",

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -86,12 +86,19 @@ pub(super) async fn sync_host_document<S: MessageSender>(
     sender: &mut S,
     docs: &mut std::collections::HashMap<(String, ConnectionKey), HostDocSyncState>,
     doc: &HostDocument<'_>,
-    _live_text_reader: Option<&(dyn Fn() -> Option<Arc<str>> + Send + Sync)>,
+    live_text_reader: Option<&(dyn Fn() -> Option<Arc<str>> + Send + Sync)>,
     connection_key: &ConnectionKey,
 ) -> io::Result<()> {
     let uri_lsp = host_url_to_lsp_uri(doc.uri)?;
     let key = (doc.uri.to_string(), connection_key.clone());
-    let fp = fingerprint(doc.text);
+    // With a live reader, read the document's CURRENT text under this lock so a
+    // late-unparking eager re-sync sends the latest text, not the snapshot it was
+    // spawned with (#422); a `None` read (closed mid-sync) falls back to the
+    // snapshot. The effective text drives both the fingerprint dedup and the sent
+    // content, so re-syncing the same current text stays a no-op.
+    let live = live_text_reader.and_then(|read| read());
+    let text: &str = live.as_deref().unwrap_or(doc.text);
+    let fp = fingerprint(text);
 
     match docs.entry(key) {
         Entry::Vacant(entry) => {
@@ -102,7 +109,7 @@ pub(super) async fn sync_host_document<S: MessageSender>(
                         uri_lsp,
                         doc.language_id.to_string(),
                         1,
-                        doc.text.to_string(),
+                        text.to_string(),
                     ),
                 },
             );
@@ -122,7 +129,7 @@ pub(super) async fn sync_host_document<S: MessageSender>(
                         content_changes: vec![TextDocumentContentChangeEvent {
                             range: None,
                             range_length: None,
-                            text: doc.text.to_string(),
+                            text: text.to_string(),
                         }],
                     },
                 );

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -54,6 +54,13 @@ fn fingerprint(text: &str) -> u64 {
     hasher.finish()
 }
 
+/// Owned reader of a host document's current text, shared across the eager
+/// re-sync's per-server tasks. The eager on-edit re-sync builds one (capturing
+/// the document store + URI) and hands a clone to each task; the task passes it
+/// to [`sync_host_document`], which evaluates it under the `host_documents` lock
+/// so a late task sends the latest text rather than a stale snapshot (#422).
+pub(crate) type HostTextReader = Arc<dyn Fn() -> Option<Arc<str>> + Send + Sync>;
+
 /// Open or re-sync the host document on a downstream server, mutating the
 /// pool's sync-state map in place.
 ///

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -70,10 +70,23 @@ fn fingerprint(text: &str) -> u64 {
 /// (ls-bridge-message-ordering) guarantees wire order matches enqueue order.
 /// Generic over [`MessageSender`] so tests can observe the notifications via
 /// a channel.
+///
+/// `live_text_reader`, when `Some`, supplies the document's **current** text,
+/// read here under the `host_documents` lock instead of trusting `doc.text`.
+/// The eager on-edit re-sync passes it so a sync task that unparked late sends
+/// the *latest* text rather than the schedule-time snapshot it was spawned with
+/// — a snapshot a newer edit may have superseded (host-sync-stale-overwrite,
+/// #422). Reading under the same lock that gates the fingerprint compare and the
+/// send means the last task to take the lock observes the newest text, so
+/// concurrent re-syncs can no longer roll a host server back to stale content; a
+/// `None` return (document closed mid-sync) falls back to `doc.text`. Interactive
+/// requests, the formatting pipeline's speculative scratch text, and the initial
+/// `didOpen` pass `None` and are synced verbatim.
 pub(super) async fn sync_host_document<S: MessageSender>(
     sender: &mut S,
     docs: &mut std::collections::HashMap<(String, ConnectionKey), HostDocSyncState>,
     doc: &HostDocument<'_>,
+    _live_text_reader: Option<&(dyn Fn() -> Option<Arc<str>> + Send + Sync)>,
     connection_key: &ConnectionKey,
 ) -> io::Result<()> {
     let uri_lsp = host_url_to_lsp_uri(doc.uri)?;
@@ -387,7 +400,9 @@ impl LanguageServerPool {
 
             let mut docs = self.host_documents().await;
             let mut sender = ConnectionHandleSender(&handle);
-            if let Err(e) = sync_host_document(&mut sender, &mut docs, doc, connection_key).await {
+            if let Err(e) =
+                sync_host_document(&mut sender, &mut docs, doc, None, connection_key).await
+            {
                 drop(docs);
                 drop(connections);
                 if let Some(ref id) = upstream_request_id {
@@ -720,6 +735,7 @@ mod tests {
             &mut sender,
             &mut docs,
             &host_doc(&uri, "v1"),
+            None,
             &ConnectionKey::for_server("srv"),
         )
         .await
@@ -737,6 +753,7 @@ mod tests {
             &mut sender,
             &mut docs,
             &host_doc(&uri, "v1"),
+            None,
             &ConnectionKey::for_server("srv"),
         )
         .await
@@ -748,6 +765,7 @@ mod tests {
             &mut sender,
             &mut docs,
             &host_doc(&uri, "v2"),
+            None,
             &ConnectionKey::for_server("srv"),
         )
         .await
@@ -765,6 +783,7 @@ mod tests {
             &mut sender,
             &mut docs,
             &host_doc(&uri, "v3"),
+            None,
             &ConnectionKey::for_server("srv"),
         )
         .await

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -796,6 +796,83 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn sync_with_live_reader_sends_current_text_not_stale_snapshot() {
+        use crate::lsp::bridge::actor::OutboundMessage;
+
+        // The eager on-edit re-sync passes a live reader. sync_host_document must
+        // send the reader's CURRENT text, not the (possibly superseded) snapshot
+        // the task was spawned with — otherwise a late-unparking task rolls the
+        // host server back to stale content (host-sync-stale-overwrite, #422).
+        let mut docs = std::collections::HashMap::new();
+        let (mut sender, mut rx) = tokio::sync::mpsc::channel::<OutboundMessage>(16);
+        let uri = Url::parse("file:///test/host.md").unwrap();
+
+        let reader = || Some(Arc::<str>::from("fresh"));
+        sync_host_document(
+            &mut sender,
+            &mut docs,
+            &host_doc(&uri, "stale-snapshot"),
+            Some(&reader),
+            &ConnectionKey::for_server("srv"),
+        )
+        .await
+        .unwrap();
+
+        let OutboundMessage::Untracked(payload) = rx.try_recv().expect("didOpen must be queued")
+        else {
+            panic!("expected a notification");
+        };
+        assert_eq!(payload["method"], "textDocument/didOpen");
+        assert_eq!(
+            payload["params"]["textDocument"]["text"], "fresh",
+            "the live reader's current text must win over the stale snapshot"
+        );
+    }
+
+    #[tokio::test]
+    async fn sync_with_live_reader_dedups_unchanged_current_text() {
+        use crate::lsp::bridge::actor::OutboundMessage;
+
+        // Two re-syncs whose live reader returns the SAME current text: only the
+        // first sends; the second is a fingerprint no-op. This is the user's
+        // concern — multiple debounce fires must not each re-send the latest text.
+        let mut docs = std::collections::HashMap::new();
+        let (mut sender, mut rx) = tokio::sync::mpsc::channel::<OutboundMessage>(16);
+        let uri = Url::parse("file:///test/host.md").unwrap();
+        let reader = || Some(Arc::<str>::from("current"));
+
+        sync_host_document(
+            &mut sender,
+            &mut docs,
+            &host_doc(&uri, "ignored"),
+            Some(&reader),
+            &ConnectionKey::for_server("srv"),
+        )
+        .await
+        .unwrap();
+        let OutboundMessage::Untracked(payload) = rx.try_recv().expect("first sync must didOpen")
+        else {
+            panic!("expected a notification");
+        };
+        assert_eq!(payload["params"]["textDocument"]["text"], "current");
+
+        // Second sync, same current text from the reader: fingerprint no-op.
+        sync_host_document(
+            &mut sender,
+            &mut docs,
+            &host_doc(&uri, "ignored"),
+            Some(&reader),
+            &ConnectionKey::for_server("srv"),
+        )
+        .await
+        .unwrap();
+        assert!(
+            rx.try_recv().is_err(),
+            "re-sync of the same current text must be a no-op (no redundant send)"
+        );
+    }
+
+    #[tokio::test]
     async fn close_host_bridge_document_drops_only_that_uri() {
         let pool = LanguageServerPool::new();
         let uri_a = Url::parse("file:///test/a.md").unwrap();

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -30,6 +30,20 @@ pub(crate) fn check_semantic_tokens_refresh_support(caps: &ClientCapabilities) -
         .unwrap_or(false)
 }
 
+/// Whether the client advertises `workspace.diagnostics.refreshSupport`
+/// (LSP @since 3.17.0): it will honor a `workspace/diagnostic/refresh` by
+/// re-pulling. Returns `false` for any missing/null capability in the chain, so
+/// we never send a refresh a client would silently ignore — which would leak a
+/// tower-lsp pending-request entry plus a parked task (the same hazard the
+/// [`check_semantic_tokens_refresh_support`] gate guards against).
+pub(crate) fn check_diagnostic_refresh_support(caps: &ClientCapabilities) -> bool {
+    caps.workspace
+        .as_ref()
+        .and_then(|w| w.diagnostics.as_ref())
+        .and_then(|d| d.refresh_support)
+        .unwrap_or(false)
+}
+
 /// Server→client notifier: logging, progress, semantic-token refresh. `Clone`
 /// and thread-safe (the underlying `Client` synchronizes internally, and
 /// `client_capabilities` is a shared `OnceLock`).
@@ -202,7 +216,8 @@ mod tests {
     use super::*;
     use rstest::rstest;
     use tower_lsp_server::ls_types::{
-        SemanticTokensWorkspaceClientCapabilities, WorkspaceClientCapabilities,
+        DiagnosticWorkspaceClientCapabilities, SemanticTokensWorkspaceClientCapabilities,
+        WorkspaceClientCapabilities,
     };
 
     /// Tests for check_semantic_tokens_refresh_support pure function.
@@ -250,5 +265,40 @@ mod tests {
         // Keep as separate test to explicitly document Default behavior
         let caps = ClientCapabilities::default();
         assert!(!check_semantic_tokens_refresh_support(&caps));
+    }
+
+    /// Tests for `check_diagnostic_refresh_support` — same shape as the
+    /// semantic-tokens gate, but against `workspace.diagnostics.refreshSupport`.
+    /// This is the gate `request_pull_diagnostic_refresh` uses, so a missing
+    /// capability anywhere in the chain must read as `false` (don't send a refresh
+    /// the client would silently ignore).
+    #[rstest]
+    #[case::refresh_support_true(true, true, Some(true), true)]
+    #[case::refresh_support_false(true, true, Some(false), false)]
+    #[case::refresh_support_none(true, true, None, false)]
+    #[case::diagnostics_none(true, false, None, false)]
+    #[case::workspace_none(false, false, None, false)]
+    fn test_check_diagnostic_refresh_support(
+        #[case] workspace: bool,
+        #[case] diagnostics: bool,
+        #[case] refresh_support: Option<bool>,
+        #[case] expected: bool,
+    ) {
+        let caps = ClientCapabilities {
+            workspace: if workspace {
+                Some(WorkspaceClientCapabilities {
+                    diagnostics: if diagnostics {
+                        Some(DiagnosticWorkspaceClientCapabilities { refresh_support })
+                    } else {
+                        None
+                    },
+                    ..Default::default()
+                })
+            } else {
+                None
+            },
+            ..Default::default()
+        };
+        assert_eq!(check_diagnostic_refresh_support(&caps), expected);
     }
 }

--- a/src/lsp/debounced_diagnostics.rs
+++ b/src/lsp/debounced_diagnostics.rs
@@ -46,6 +46,10 @@ struct DebouncedDiagnosticData {
     /// Bridge coordinator — used to eager re-sync the host document to `_self`
     /// host servers at the debounced cadence (#431).
     bridge: Arc<BridgeCoordinator>,
+    /// Document store — lets the eager re-sync read the host document's *current*
+    /// text at sync time (under the bridge's `host_documents` lock) so a late
+    /// re-sync sends the latest text rather than this fire's snapshot (#422).
+    documents: Arc<crate::document::DocumentStore>,
     /// Reference to synthetic diagnostics manager for task registration
     synthetic_diagnostics: Arc<SyntheticDiagnosticsManager>,
     /// The single proactive publisher: feeds the pull result into the cache and
@@ -100,6 +104,7 @@ impl DebouncedDiagnosticsManager {
         bridge: Arc<BridgeCoordinator>,
         synthetic_diagnostics: Arc<SyntheticDiagnosticsManager>,
         publisher: Arc<DiagnosticPublisher>,
+        documents: Arc<crate::document::DocumentStore>,
     ) {
         // Opportunistic cleanup: remove finished timers to prevent unbounded growth.
         // This is O(n) but runs infrequently and keeps the map from accumulating
@@ -126,6 +131,7 @@ impl DebouncedDiagnosticsManager {
             bridge,
             synthetic_diagnostics,
             publisher,
+            documents,
         };
 
         let duration = self.debounce_duration;
@@ -207,6 +213,7 @@ async fn execute_debounced_diagnostic(data: DebouncedDiagnosticData) {
         bridge,
         synthetic_diagnostics,
         publisher,
+        documents,
     } = data;
 
     // #431: re-sync the host document to its `_self` host servers at this debounced
@@ -220,11 +227,27 @@ async fn execute_debounced_diagnostic(data: DebouncedDiagnosticData) {
         // outer scheduled `uri` — they're equal today, but keying off the host
         // context keeps the sync correct if a scheduled URI ever differs from its
         // host document.
+        //
+        // The live reader lets the sync read the document's *current* text under
+        // the bridge's `host_documents` lock, so when several debounce fires race
+        // (rapid edits with pauses), the task that syncs last sends the latest
+        // text — not this fire's `host.text` snapshot, which a newer edit may have
+        // superseded. That closes the eager-sync stale-overwrite that left a
+        // push-only host server analyzing rolled-back text (#422). `host.text`
+        // stays the fallback if the document is closed mid-sync.
+        let host_uri = host.uri.clone();
+        let documents = Arc::clone(&documents);
+        let live_text_reader: crate::lsp::bridge::HostTextReader = Arc::new(move || {
+            documents
+                .get(&host_uri)
+                .map(|doc| Arc::<str>::from(doc.text()))
+        });
         bridge.eager_sync_host_document_on_servers(
             &host.uri,
             &host.language_id,
             host.text.clone(),
             host.configs.clone(),
+            Some(live_text_reader),
         );
     }
 

--- a/src/lsp/debounced_diagnostics.rs
+++ b/src/lsp/debounced_diagnostics.rs
@@ -237,6 +237,15 @@ async fn execute_debounced_diagnostic(data: DebouncedDiagnosticData) {
         // stays the fallback if the document is closed mid-sync.
         let host_uri = host.uri.clone();
         let documents = Arc::clone(&documents);
+        // Lock-ordering: this runs inside `sync_host_document`, i.e. under the
+        // bridge `host_documents` lock — so the `DocumentStore` shard read below is
+        // taken in the order `host_documents -> DocumentStore`. That is deadlock-free
+        // because the *inverse* order never occurs: every host-request path
+        // (`resolve_host_bridge_context`, formatting, the diagnostic pull, `did_change`)
+        // resolves an OWNED snapshot/text and drops its `DocumentStore` ref BEFORE
+        // calling any bridge method that acquires `host_documents`. The `Ref` taken
+        // here is dropped within the closure (`doc.text()` is copied into an owned
+        // `Arc<str>`), so it never crosses an `.await`.
         let live_text_reader: crate::lsp::bridge::HostTextReader = Arc::new(move || {
             documents
                 .get(&host_uri)

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -85,6 +85,7 @@ impl DiagnosticScheduler {
             std::sync::Arc::clone(&self.bridge),
             std::sync::Arc::clone(&self.synthetic_diagnostics),
             std::sync::Arc::clone(&self.publisher),
+            std::sync::Arc::clone(&self.documents),
         );
     }
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -405,17 +405,35 @@ impl DiagnosticPublisher {
     ///
     /// Emitted **off** the per-host republish lock and **only** from the
     /// push-origin paths ([`Self::publish_host_push`], [`Self::publish_region_push`]),
-    /// never from the pull-origin republish ([`Self::publish_pull_layer`]) — a
-    /// refresh triggers a pull, which would re-enter the pull-origin republish, so
-    /// refreshing there too could ping-pong.
+    /// never from the pull-origin republish ([`Self::publish_pull_layer`]) nor the
+    /// edit-origin re-merge (`did_change`): those carry no *new* result the editor
+    /// is unaware of — a pull-origin set is already the answer to a pull the editor
+    /// made, and an edit-origin re-merge is covered by the editor's own `didChange`
+    /// re-pull — so a refresh there would be redundant. (No tight loop forms: a
+    /// refresh-induced pull is answered inline by `diagnostic_impl`, which never
+    /// republishes, so a refresh cannot directly beget another; the indirect
+    /// push→refresh→re-pull→downstream-re-push→here path is bounded by
+    /// `published_set_changed`, converging once the re-pushed set stabilizes.)
     ///
     /// **Spawned, not awaited:** `workspace/diagnostic/refresh` is a request whose
     /// future resolves only when the editor answers, so awaiting it inline would
     /// block the push path on the client round-trip (and never resolve in a test
     /// that doesn't answer). Detaching it keeps the push path non-blocking and
-    /// avoids the upstream-notification loop's inline-await head-of-line block. A
-    /// client without refresh support just errors (logged).
+    /// avoids the upstream-notification loop's inline-await head-of-line block.
+    ///
+    /// Gated on the client advertising `workspace.diagnostics.refreshSupport`: a
+    /// client that supports pull but not refresh would silently ignore the request,
+    /// leaking a tower-lsp pending-request entry plus a parked task — the same gate
+    /// the `semantic_tokens_refresh` path uses.
     fn request_pull_diagnostic_refresh(&self) {
+        let supported = self
+            .settings_manager
+            .client_capabilities_lock()
+            .get()
+            .is_some_and(crate::lsp::client::check_diagnostic_refresh_support);
+        if !supported {
+            return;
+        }
         let client = self.client.clone();
         tokio::spawn(async move {
             if let Err(e) = client.workspace_diagnostic_refresh().await {

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -111,7 +111,12 @@ impl DiagnosticPublisher {
             Some(connection_id),
             diagnostics,
         );
-        self.republish(&host).await;
+        // A host `_self` push is spontaneous and asynchronous; a pull-mode client
+        // won't know to re-pull, so nudge it when the merged set actually changed
+        // (push/pull-divergence, #422).
+        if self.republish(&host).await {
+            self.request_pull_diagnostic_refresh();
+        }
     }
 
     /// Detect the language of an *open* document, or `None` if it isn't open.
@@ -234,7 +239,12 @@ impl DiagnosticPublisher {
             Some(connection_id),
             diagnostics,
         );
-        self.republish(&host).await;
+        // A region push is spontaneous and asynchronous (a push-only injected-
+        // language server); like the host push, nudge a pull-mode client to
+        // re-pull when the merged set actually changed (push/pull-divergence, #422).
+        if self.republish(&host).await {
+            self.request_pull_diagnostic_refresh();
+        }
     }
 
     /// Feed the host-event pull's combined result into the cache and republish.
@@ -299,7 +309,13 @@ impl DiagnosticPublisher {
     /// Merge the host's cached slots and publish the cumulative result. Region
     /// slots are transformed against the host document's *current* injection
     /// offsets; an empty merge clears the editor's diagnostics for the host.
-    pub(crate) async fn republish(&self, host: &Url) {
+    ///
+    /// Returns `true` when a *changed* set was published to the editor, `false`
+    /// when nothing was sent (bad URI, or the merged set was identical to the
+    /// last publish). Push-origin callers ([`Self::publish_host_push`],
+    /// [`Self::publish_region_push`]) use this to decide whether to also nudge
+    /// pull-mode clients with [`Self::request_pull_diagnostic_refresh`].
+    pub(crate) async fn republish(&self, host: &Url) -> bool {
         // Serialize the whole snapshot→merge→publish so concurrent republishes
         // (region push vs host-event pull) emit in order and a stale snapshot can
         // never publish after a fresh one (push-propagation-diagnostic-forwarding).
@@ -345,7 +361,7 @@ impl DiagnosticPublisher {
             Ok(uri) => uri,
             Err(e) => {
                 log::warn!(target: LOG_TARGET, "skip publish, bad host URI {host}: {e}");
-                return;
+                return false;
             }
         };
 
@@ -359,7 +375,7 @@ impl DiagnosticPublisher {
                 "skip republish for {host}: merged set unchanged ({} diagnostics)",
                 diagnostics.len()
             );
-            return;
+            return false;
         }
 
         log::debug!(
@@ -371,6 +387,44 @@ impl DiagnosticPublisher {
         self.client
             .publish_diagnostics(lsp_uri, diagnostics, None)
             .await;
+        true
+    }
+
+    /// Ask pull-mode clients to re-pull diagnostics (`workspace/diagnostic/refresh`)
+    /// after a **spontaneous downstream push** changed the merged set.
+    ///
+    /// kakehashi advertises `diagnosticProvider`, so a pull-mode editor (e.g.
+    /// Neovim) displays the diagnostics it *pulled* and ignores our
+    /// `publishDiagnostics`. A push-only `_self` host server (e.g. panache)
+    /// analyzes the latest text **asynchronously**, lands its push after the
+    /// editor's last pull, and updates our cache — but the editor never re-pulls,
+    /// so its displayed (pull-namespace) diagnostics rot until the next
+    /// edit-triggered pull (the "stays stale until you edit another line"
+    /// symptom). This refresh closes that gap: it tells the client to re-pull,
+    /// which returns the now-current merged set.
+    ///
+    /// Emitted **off** the per-host republish lock and **only** from the
+    /// push-origin paths ([`Self::publish_host_push`], [`Self::publish_region_push`]),
+    /// never from the pull-origin republish ([`Self::publish_pull_layer`]) — a
+    /// refresh triggers a pull, which would re-enter the pull-origin republish, so
+    /// refreshing there too could ping-pong.
+    ///
+    /// **Spawned, not awaited:** `workspace/diagnostic/refresh` is a request whose
+    /// future resolves only when the editor answers, so awaiting it inline would
+    /// block the push path on the client round-trip (and never resolve in a test
+    /// that doesn't answer). Detaching it keeps the push path non-blocking and
+    /// avoids the upstream-notification loop's inline-await head-of-line block. A
+    /// client without refresh support just errors (logged).
+    fn request_pull_diagnostic_refresh(&self) {
+        let client = self.client.clone();
+        tokio::spawn(async move {
+            if let Err(e) = client.workspace_diagnostic_refresh().await {
+                log::debug!(
+                    target: LOG_TARGET,
+                    "workspace/diagnostic/refresh after push failed: {e}"
+                );
+            }
+        });
     }
 
     /// Map each currently-resolvable injection region of the host document to its
@@ -538,6 +592,45 @@ mod tests {
             .expect("a Host slot should be recorded for an open _self-bridged doc");
         assert_eq!(host_slots["rust_ls"].diagnostics.len(), 1);
         assert_eq!(host_slots["rust_ls"].diagnostics[0].message, "boom");
+    }
+
+    #[tokio::test]
+    async fn republish_reports_whether_the_published_set_changed() {
+        // `republish` returns whether it published a *changed* set — the gate the
+        // push-origin paths use to decide whether to also emit
+        // `workspace/diagnostic/refresh` (so a pull-mode editor re-pulls and sees an
+        // async host push; push/pull-divergence, #422). A non-empty first publish is
+        // a change; re-publishing the identical cache is not (so a no-op push won't
+        // spam refreshes). Driven directly (no socket/init) so it stays fast.
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        register_rust(server);
+        server.settings_manager.apply_settings(rust_settings(true));
+
+        let uri = Url::parse("file:///test/host_changed.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+
+        let publisher = DiagnosticPublisher::new(server);
+        server.diagnostics.record(
+            &uri,
+            DiagnosticSource::Host,
+            "rust_ls".to_string(),
+            Some(ProgressConnectionId::for_test(1)),
+            vec![diag("boom")],
+        );
+        assert!(
+            publisher.republish(&uri).await,
+            "first publish of a non-empty host set must report a change (drives the refresh)"
+        );
+        assert!(
+            !publisher.republish(&uri).await,
+            "re-publishing the identical set must report unchanged (no redundant refresh)"
+        );
     }
 
     #[tokio::test]

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -417,6 +417,85 @@ print("hello")
         .expect("re-sync with changed text should send a didChange advancing to version 2");
     }
 
+    /// Live-reader wiring (#422): the on-edit eager re-sync syncs the reader's
+    /// CURRENT text, not its `text` snapshot. With the snapshot held *constant*
+    /// across two re-syncs but the reader returning different text, the host
+    /// server still advances to version 2 — so a stale snapshot can neither
+    /// suppress a real update nor roll the server back, which is what closes the
+    /// eager-sync stale-overwrite.
+    #[tokio::test]
+    async fn eager_sync_syncs_live_reader_text_not_the_snapshot() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+
+        configure_rust_self_host(server);
+        server.bridge.insert_ready_test_connection("rust_ls").await;
+
+        let uri = Url::parse("file:///test/host_reader.rs").unwrap();
+        let settings = server.settings_manager.load_settings();
+        let configs = server
+            .bridge
+            .get_host_configs_for_language(&settings, "rust");
+
+        // The snapshot is the SAME both times; only the live reader changes.
+        let snapshot: std::sync::Arc<str> = std::sync::Arc::from("fn snapshot() {}");
+        let reader_v1: crate::lsp::bridge::HostTextReader =
+            std::sync::Arc::new(|| Some(std::sync::Arc::from("fn live_v1() {}")));
+        let reader_v2: crate::lsp::bridge::HostTextReader =
+            std::sync::Arc::new(|| Some(std::sync::Arc::from("fn live_v2() {}")));
+
+        server.bridge.eager_sync_host_document_on_servers(
+            &uri,
+            "rust",
+            std::sync::Arc::clone(&snapshot),
+            configs.clone(),
+            Some(reader_v1),
+        );
+        timeout(Duration::from_secs(1), async {
+            loop {
+                if server
+                    .bridge
+                    .pool()
+                    .host_document_version(&uri, "rust_ls")
+                    .await
+                    == Some(1)
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("first eager-sync should didOpen at version 1 using the reader's text");
+
+        // Same snapshot, different reader text: must advance to version 2. If the
+        // sync trusted the (unchanged) snapshot it would fingerprint-dedup and stay
+        // at version 1 — so reaching version 2 proves the reader drove the sync.
+        server.bridge.eager_sync_host_document_on_servers(
+            &uri,
+            "rust",
+            snapshot,
+            configs,
+            Some(reader_v2),
+        );
+        timeout(Duration::from_secs(1), async {
+            loop {
+                if server
+                    .bridge
+                    .pool()
+                    .host_document_version(&uri, "rust_ls")
+                    .await
+                    == Some(2)
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("changed reader text (constant snapshot) should advance to version 2");
+    }
+
     /// On-edit re-sync wiring (#431): when the debounced diagnostic *fires*,
     /// `execute_debounced_diagnostic` re-syncs the host doc to its `_self` servers
     /// via the coordinator. Drives `DebouncedDiagnosticsManager::schedule` with a

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -372,6 +372,7 @@ print("hello")
             "rust",
             std::sync::Arc::from("fn main() {}"),
             configs.clone(),
+            None,
         );
         timeout(Duration::from_secs(1), async {
             loop {
@@ -396,6 +397,7 @@ print("hello")
             "rust",
             std::sync::Arc::from("fn other() {}"),
             configs,
+            None,
         );
         timeout(Duration::from_secs(1), async {
             loop {
@@ -469,6 +471,7 @@ print("hello")
             std::sync::Arc::clone(&server.bridge),
             std::sync::Arc::new(SyntheticDiagnosticsManager::new()),
             std::sync::Arc::new(DiagnosticPublisher::new(server)),
+            std::sync::Arc::clone(&server.documents),
         );
 
         timeout(Duration::from_secs(1), async {

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -498,13 +498,18 @@ print("hello")
 
     /// On-edit re-sync wiring (#431): when the debounced diagnostic *fires*,
     /// `execute_debounced_diagnostic` re-syncs the host doc to its `_self` servers
-    /// via the coordinator. Drives `DebouncedDiagnosticsManager::schedule` with a
-    /// zero debounce and a host snapshot, then asserts the host doc gets synced.
-    /// The test `rust_ls` connection advertises no `diagnosticProvider`, so the
-    /// capability-gated pull skips it — only the eager-sync hook can sync it, which
-    /// isolates the wiring (removing the hook would fail this test).
+    /// via the coordinator. The test `rust_ls` connection advertises no
+    /// `diagnosticProvider`, so the capability-gated pull skips it — only the
+    /// eager-sync hook can sync it, which isolates the wiring (removing the hook
+    /// would fail this test).
+    ///
+    /// It also locks the #422 live reader: the debounce carries a CONSTANT snapshot
+    /// text while the document's live text in the store changes between fires. Only
+    /// reading the store (the live reader the debounce builds) makes the second fire
+    /// send new text and advance the host version — a snapshot-only / `None`-reader
+    /// sync would fingerprint-dedup and stay at version 1.
     #[tokio::test]
-    async fn debounced_fire_resyncs_host_document() {
+    async fn debounced_fire_resyncs_host_document_from_live_store_text() {
         use crate::config::settings::{AggregationStrategy, LayerSource, ResolvedLayerConfig};
         use crate::lsp::debounced_diagnostics::DebouncedDiagnosticsManager;
         use crate::lsp::lsp_impl::DiagnosticPublisher;
@@ -523,14 +528,15 @@ print("hello")
             .bridge
             .get_host_configs_for_language(&settings, "rust");
 
-        let snapshot = DiagnosticSnapshot {
+        // Snapshot text is CONSTANT across both fires; only the store text changes.
+        let snapshot = || DiagnosticSnapshot {
             virt_contexts: vec![],
             host_pull_enabled: true,
             host: Some(HostRequestContext {
                 uri: uri.clone(),
                 language_id: "rust".to_string(),
-                text: std::sync::Arc::from("fn main() {}"),
-                configs,
+                text: std::sync::Arc::from("fn debounce_snapshot() {}"),
+                configs: configs.clone(),
                 priorities: vec![],
                 strategy: AggregationStrategy::Concatenated,
                 max_fan_out: None,
@@ -541,34 +547,71 @@ print("hello")
                 strategy: AggregationStrategy::Concatenated,
             },
         };
+        let manager = DebouncedDiagnosticsManager::with_duration(Duration::ZERO);
 
-        // Fire immediately (zero debounce) and assert the host doc was synced.
-        DebouncedDiagnosticsManager::with_duration(Duration::ZERO).schedule(
+        let wait_version = |want: i32| {
+            let server = server;
+            let uri = &uri;
+            async move {
+                timeout(Duration::from_secs(1), async {
+                    loop {
+                        if server
+                            .bridge
+                            .pool()
+                            .host_document_version(uri, "rust_ls")
+                            .await
+                            == Some(want)
+                        {
+                            break;
+                        }
+                        tokio::time::sleep(Duration::from_millis(10)).await;
+                    }
+                })
+                .await
+            }
+        };
+
+        // Live text v1 (≠ snapshot) — first fire opens the doc at version 1.
+        server.documents.insert(
             uri.clone(),
-            Some(snapshot),
+            "fn live_v1() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        manager.schedule(
+            uri.clone(),
+            Some(snapshot()),
             server.bridge.pool_arc(),
             std::sync::Arc::clone(&server.bridge),
             std::sync::Arc::new(SyntheticDiagnosticsManager::new()),
             std::sync::Arc::new(DiagnosticPublisher::new(server)),
             std::sync::Arc::clone(&server.documents),
         );
+        wait_version(1)
+            .await
+            .expect("first debounce fire should re-sync the host doc at version 1");
 
-        timeout(Duration::from_secs(1), async {
-            loop {
-                if server
-                    .bridge
-                    .pool()
-                    .host_document_version(&uri, "rust_ls")
-                    .await
-                    .is_some()
-                {
-                    break;
-                }
-                tokio::time::sleep(Duration::from_millis(10)).await;
-            }
-        })
-        .await
-        .expect("debounce fire should re-sync the host document to the _self server");
+        // Change ONLY the store; the debounce snapshot text stays constant. A live
+        // read advances to version 2; a snapshot/None sync would dedup at version 1.
+        server.documents.insert(
+            uri.clone(),
+            "fn live_v2() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        manager.schedule(
+            uri.clone(),
+            Some(snapshot()),
+            server.bridge.pool_arc(),
+            std::sync::Arc::clone(&server.bridge),
+            std::sync::Arc::new(SyntheticDiagnosticsManager::new()),
+            std::sync::Arc::new(DiagnosticPublisher::new(server)),
+            std::sync::Arc::clone(&server.documents),
+        );
+        wait_version(2).await.expect(
+            "second debounce fire must re-read the updated store text and advance to version 2 \
+             (a snapshot-only sync would dedup at version 1)",
+        );
     }
 
     /// Locks the load-bearing property behind #431: `prepare_diagnostic_snapshot`

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -152,7 +152,7 @@ mod tests {
                 if condition() {
                     break;
                 }
-                tokio::time::sleep(Duration::from_millis(10)).await;
+                tokio::task::yield_now().await;
             }
         })
         .await
@@ -341,7 +341,7 @@ print("hello")
                 {
                     break;
                 }
-                tokio::time::sleep(Duration::from_millis(10)).await;
+                tokio::task::yield_now().await;
             }
         })
         .await
@@ -385,7 +385,7 @@ print("hello")
                 {
                     break;
                 }
-                tokio::time::sleep(Duration::from_millis(10)).await;
+                tokio::task::yield_now().await;
             }
         })
         .await
@@ -410,7 +410,7 @@ print("hello")
                 {
                     break;
                 }
-                tokio::time::sleep(Duration::from_millis(10)).await;
+                tokio::task::yield_now().await;
             }
         })
         .await
@@ -462,7 +462,7 @@ print("hello")
                 {
                     break;
                 }
-                tokio::time::sleep(Duration::from_millis(10)).await;
+                tokio::task::yield_now().await;
             }
         })
         .await
@@ -489,7 +489,7 @@ print("hello")
                 {
                     break;
                 }
-                tokio::time::sleep(Duration::from_millis(10)).await;
+                tokio::task::yield_now().await;
             }
         })
         .await
@@ -564,7 +564,7 @@ print("hello")
                         {
                             break;
                         }
-                        tokio::time::sleep(Duration::from_millis(10)).await;
+                        tokio::task::yield_now().await;
                     }
                 })
                 .await
@@ -710,7 +710,7 @@ print("hello")
                     {
                         break;
                     }
-                    tokio::time::sleep(Duration::from_millis(10)).await;
+                    tokio::task::yield_now().await;
                 }
             }) => {
                 result.expect(


### PR DESCRIPTION
## Problem (#422)

Markdown diagnostics didn't follow edits: after renaming a reference label
(`[univ]` → `[uni]`), a stale panache diagnostic stuck **until you edited another
line** — it never cleared on its own, even minutes later.

## Root cause — push/pull divergence (confirmed by a stuck-state Neovim capture)

kakehashi advertises `diagnosticProvider`, so a pull-mode editor (Neovim)
**displays the diagnostics it pulled** (namespace `nvim.lsp.kakehashi.N.nil`) and
**ignores our `publishDiagnostics`** (its push namespace stays empty). A push-only
`_self` host server (panache) analyzes the latest text **asynchronously** and
lands its push *after* the editor's last pull. `republish()` only sent
`publishDiagnostics` — ignored by the pull-mode client — and **never told the
client to re-pull**, so the displayed (pulled) diagnostics rotted until the next
edit-triggered pull. (basedpyright avoids this precisely because it emits
`workspace/diagnostic/refresh`; panache didn't.)

The stuck-state capture nailed it: buffer `[uni]`/`[uni]: foo` (matching → no
diagnostic expected), yet `vim.diagnostic.get(0)` held the old `[uni] not found` /
`[unia] never used` in the **pull** namespace, with the **push** namespace empty.

## Fix A — refresh pull clients on a push-driven cache change (the actual fix)

When a spontaneous downstream **push** changes kakehashi's merged set, emit
`workspace/diagnostic/refresh` so pull-mode clients re-pull and pick it up.

- `republish()` now returns whether it published a *changed* set.
- The push-origin paths (`publish_host_push` / `publish_region_push`) emit the
  refresh on a change; the **pull-origin** (`publish_pull_layer`) and
  **edit-origin** (`did_change`) republishes deliberately do **not** — that's the
  loop guard (a refresh→re-pull→republish ping-pong can't form; a refresh-induced
  pull is answered inline by `diagnostic_impl` without republishing).
- The refresh is **spawned** (fire-and-forget) so it never blocks the push path on
  the client round-trip nor routes through the upstream-loop's inline await.
- Gated on the client advertising `workspace.diagnostics.refreshSupport` (mirrors
  the `semantic_tokens_refresh` gate) so a non-refresh client can't leak a
  tower-lsp pending entry + parked task.

## Fix B — re-read live host text on the eager re-sync (a related latent race)

Found during the investigation, orthogonal to the display bug: the #431 debounced
on-edit re-sync carried a *schedule-time text snapshot*; concurrent re-syncs could
land out of order and roll a push-only host server back to stale text. Now
`sync_host_document` re-reads the document's **current** text under the
`host_documents` lock (via a `live_text_reader` the debounce builds from the
DocumentStore), so the last sync sends the latest text. Fingerprint dedup keeps
re-syncing the same text a no-op. This helps panache *produce* the correct set;
Fix A gets that set to the displayed namespace.

## Validation

- End-to-end: confirmed in the reporter's real Neovim+panache session — the stale
  clears **without editing another line**.
- Tests: `republish` change-gate; `check_diagnostic_refresh_support` (rstest); a
  discriminating debounce test (constant snapshot + store-only change → host
  version advances only via the live read); the eager-sync live-reader test. Full
  `cargo test --lib` green (2104).
- A socket-observation unit test for the refresh emission is infeasible
  (`Kakehashi::initialize` hangs in-process; client sends don't reach the test
  socket without it) — covered by the gate test + the end-to-end confirmation.

## Deferred (per review, measure-first)

- Coalescing/debouncing the refresh (every set-changing push currently triggers a
  workspace-wide re-pull; harmless during editing since the editor re-pulls on
  `didChange` anyway, but worth measuring under push-only region servers).
- Storing `Document.text` as `Arc<str>` to make the live read a cheap clone
  instead of a full copy.
- Refreshing pull clients on **eviction-origin** changes too (a downstream server
  crash drops its diagnostics via `republish` but doesn't nudge a pull client) —
  pre-existing, same bug class, out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
