### PR TITLE
chore(release): bump version to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "kakehashi"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "arc-swap",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kakehashi"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 default-run = "kakehashi"
 


### PR DESCRIPTION
Bumps the crate version from `0.6.0` to `0.7.0` in `Cargo.toml` and refreshes `Cargo.lock`.

## What's landed since v0.6.0

This release is dominated by a major build-out of the **external language-server bridge** and its **diagnostics** path, plus a new CLI subcommand and parse-pipeline groundwork.

### External language-server bridge
- **Connection pooling** per `(server, workspace root)`, with `preferSharedInstance` opt-in to route configured servers to a single shared connection (#391).
- **Workspace-root resolution** via `rootMarkers` (Neovim entry-priority order), `workspace/workspaceFolders` support, and rootless-folder name fallback.
- **Notification forwarding** to downstream/host servers: `willSave`, `didSave`, `willSaveWaitUntil`, `onTypeFormatting`, plus `window/showMessage`, `window/logMessage`, `telemetry/event`, `window/showMessageRequest`, `window/showDocument` (with virtual→host URI translation), and `$/cancelRequest`.
- Hardened save fan-out and `showDocument` paths against connection-liveness and region edit races.

### Diagnostics
- **Proactive `publishDiagnostics`** propagated to the editor through a per-host cache (#380, #421), including push-only `_self` hosts.
- **Push/pull aggregation toggles** `pullFallback` / `pushFallback` so push-driven servers' cached diagnostics can fold into client pulls, with one native source per server to fix pull/push double-counting (#423, #425).
- **Deterministic merged-diagnostic ordering**, geometry re-merge that re-anchors pushed diagnostics on position-only edits, and slot eviction on connection crash / region invalidation / edit (#422, #424, #466, #469).
- **Pull clients refreshed when a push changes the cache** (`workspace/diagnostic/refresh`), fixing diagnostics that went stale until the next edit (#496).

### Client work-done progress
- Bridges the editor's `workDoneToken` to downstream requests across goto definition / references / type-definition / implementation / declaration, rename, full + range formatting, `inlayHint`, `codeLens`, and `documentSymbol`, including a shared aggregator across regions and synthesized terminal `End` on disconnect (#414, #437, #445, #450–#459).

### CLI
- New **`kakehashi diagnose`** subcommand for CI-friendly diagnostics, with a `--fail-on-warning` flag and the default (formerly "quickfix") output format.

### Parse pipeline & install
- Parse-decoupling groundwork (parse-actor ADRs), hoisting host attach ahead of parse/install, and a non-resurrecting reader-fallback CAS (#480, #492, #494).
- **Killable parser-compile deadline** via a re-exec subprocess with a self-watchdog and atomic temp+rename install (#493).

### Performance
- Killed an O(n²) host-token filter by indexing injection regions by line; numerous injection / selection / bridge hot-path allocation and scan optimizations.
- e2e tests now run in a bounded parallel pool (`make test_e2e`).

### Breaking changes
- `config`: layers aggregation order renamed to `priorities`; layers method map nested under `layers.aggregation`.
- `bridge`: cross-layer formatting now defaults to concatenated.
- `diagnose`: dropped the `grep` output format; `--threshold` replaced by `--fail-on-warning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
