### PR TITLE
fix(diagnose): treat present-but-malformed downstream payloads as exit-2 failures (#488)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -631,7 +631,9 @@ error (so it can never silently slip past the gate). Exit codes: `0` no failing
 diagnostic; `1` a failing diagnostic — any error always, plus warnings with
 `--fail-on-warning` (info/hint never fail); `2` an operational error (a file
 could not be read, a path could not be opened, or a configured downstream
-server failed) — independent of the diagnostics, so it surfaces a broken run
+server failed — including a server that answered a pull request with an error
+response or a present-but-malformed diagnostic payload, the same strictness
+`format` applies) — independent of the diagnostics, so it surfaces a broken run
 rather than looking clean to CI.
 
 > The `2` exit on a downstream failure is exact under the default

--- a/docs/README.md
+++ b/docs/README.md
@@ -631,10 +631,10 @@ error (so it can never silently slip past the gate). Exit codes: `0` no failing
 diagnostic; `1` a failing diagnostic — any error always, plus warnings with
 `--fail-on-warning` (info/hint never fail); `2` an operational error (a file
 could not be read, a path could not be opened, or a configured downstream
-server failed — including a server that answered a pull request with an error
-response or a present-but-malformed diagnostic payload, the same strictness
-`format` applies) — independent of the diagnostics, so it surfaces a broken run
-rather than looking clean to CI.
+server failed — including one that answered the `textDocument/diagnostic` pull
+with an error response or a present-but-malformed payload, matching
+`kakehashi format`'s strictness) — independent of the diagnostics, so it
+surfaces a broken run rather than looking clean to CI.
 
 > The `2` exit on a downstream failure is exact under the default
 > `concatenated` aggregation strategy. Under the non-default `preferred`

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -53,7 +53,6 @@ pub(crate) use coordinator::BridgeCoordinator;
 pub(crate) use coordinator::ResolvedServerConfig;
 pub(crate) use inbound_request_registry::InboundRequestRegistry;
 pub(crate) use pool::ConnectionKey;
-pub(crate) use pool::ConnectionReadiness;
 pub use pool::LanguageServerPool;
 pub(crate) use pool::UpstreamId;
 pub(crate) use progress_registry::{ProgressConnectionId, ProgressRegistry};

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -60,16 +60,6 @@ use super::protocol::{
 /// server that doesn't respond within this window fails with a timeout error.
 pub(crate) const INIT_TIMEOUT_SECS: u64 = 30;
 
-/// How a request obtains its pooled connection: fail fast on an
-/// `Initializing` server (interactive requests — an initializing server is
-/// just an empty contributor for this request), or wait through the
-/// handshake (diagnostics, where waiting beats returning empty results).
-#[derive(Clone, Copy, Debug)]
-pub(crate) enum ConnectionReadiness {
-    FailFast,
-    WaitReady,
-}
-
 use super::actor::{
     OUTBOUND_QUEUE_CAPACITY, OutboundMessage, ResponseRouter, ServerRequestDeps,
     UpstreamNotification, UpstreamRequest, spawn_reader_task_for_server,

--- a/src/lsp/bridge/text_document/diagnostic.rs
+++ b/src/lsp/bridge/text_document/diagnostic.rs
@@ -135,9 +135,9 @@ fn build_diagnostic_request(
 /// JSON-RPC *error* response separately (it propagates as `Err`), so this only
 /// inspects the `result`. Mirroring [`transform_formatting_response_to_host`],
 /// a present-but-malformed payload is a request **failure** (`Err`): an absent
-/// `result` member (protocol violation), an unknown report `kind`, a `full`
-/// report missing `items`, or `items` that fail to deserialize as
-/// `Diagnostic[]`. A `null` result or an `unchanged` report is the
+/// `result` member (protocol violation), a report with no `kind` or an unknown
+/// report `kind`, a `full` report missing `items`, or `items` that fail to
+/// deserialize as `Diagnostic[]`. A `null` result or an `unchanged` report is the
 /// authoritative "no diagnostics" answer and stays an empty `Vec` (`Ok`).
 /// Collapsing a malformed payload into the same empty value as "no
 /// capability" would let a broken downstream server pass as "nothing wrong" —
@@ -161,11 +161,14 @@ fn transform_diagnostic_response_to_host(
         return Ok(Vec::new());
     }
 
-    // Check report kind: `unchanged` is an authoritative empty; `full`/absent
-    // proceeds; an unknown kind is a malformed payload (request failure).
+    // Check report kind: `unchanged` is an authoritative empty; `full`
+    // proceeds; an unknown kind, or an absent/non-string `kind` (the LSP report
+    // tag is required), is a malformed payload (request failure). This matches
+    // the host parser's tagged-enum deserialize so the two paths reject the
+    // same shapes.
     match result.get("kind").and_then(|k| k.as_str()) {
         Some("unchanged") => return Ok(Vec::new()),
-        Some("full") | None => {}
+        Some("full") => {}
         Some(other) => {
             log::warn!(
                 target: "kakehashi::bridge",
@@ -175,6 +178,11 @@ fn transform_diagnostic_response_to_host(
             return Err(io::Error::other(format!(
                 "malformed diagnostic result from downstream server: unknown report kind '{other}'"
             )));
+        }
+        None => {
+            return Err(io::Error::other(
+                "malformed diagnostic result from downstream server: report has no 'kind'",
+            ));
         }
     }
 
@@ -472,6 +480,23 @@ mod tests {
             "jsonrpc": "2.0",
             "id": 42,
             "result": { "kind": "full" }
+        });
+
+        let transformed =
+            transform_diagnostic_response_to_host(response, &RegionOffset::new(5, 0), "unused");
+        assert!(transformed.is_err());
+    }
+
+    #[test]
+    fn diagnostic_response_report_without_kind_is_request_failure() {
+        // The LSP report `kind` tag is required; a present report that omits it
+        // (e.g. `{ "items": [] }`) is malformed → `Err`, matching the host
+        // parser's tagged-enum deserialize. Without this the region path would
+        // wrongly read it as an empty `full` report and miss the exit-2 failure.
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 42,
+            "result": { "items": [] }
         });
 
         let transformed =

--- a/src/lsp/bridge/text_document/diagnostic.rs
+++ b/src/lsp/bridge/text_document/diagnostic.rs
@@ -97,11 +97,10 @@ impl LanguageServerPool {
                         jsonrpc_error_summary(&response)
                     )));
                 }
-                Ok(transform_diagnostic_response_to_host(
-                    response,
-                    ctx.offset,
-                    host_uri.as_str(),
-                ))
+                // A present-but-malformed payload (absent `result`, unknown
+                // report kind, missing/garbled `items`) is likewise a request
+                // failure; only `null`/`unchanged` stays an empty layer.
+                transform_diagnostic_response_to_host(response, ctx.offset, host_uri.as_str())
             },
         )
         .await?
@@ -134,24 +133,38 @@ fn build_diagnostic_request(
 ///
 /// The caller ([`LanguageServerPool::send_diagnostic_request`]) handles a
 /// JSON-RPC *error* response separately (it propagates as `Err`), so this only
-/// extracts the `result`: an empty `Vec` for a null/absent result, an unchanged
-/// report, missing items, or a deserialization failure. Only related info
-/// matching `host_uri` is transformed.
+/// inspects the `result`. Mirroring [`transform_formatting_response_to_host`],
+/// a present-but-malformed payload is a request **failure** (`Err`): an absent
+/// `result` member (protocol violation), an unknown report `kind`, a `full`
+/// report missing `items`, or `items` that fail to deserialize as
+/// `Diagnostic[]`. A `null` result or an `unchanged` report is the
+/// authoritative "no diagnostics" answer and stays an empty `Vec` (`Ok`).
+/// Collapsing a malformed payload into the same empty value as "no
+/// capability" would let a broken downstream server pass as "nothing wrong" —
+/// the fan-in counts `Err`s, which CLI mode maps onto its `2` exit code and
+/// the editor path logs at WARNING. Only related info matching `host_uri` is
+/// transformed.
 fn transform_diagnostic_response_to_host(
     mut response: serde_json::Value,
     offset: &RegionOffset,
     host_uri: &str,
-) -> Vec<Diagnostic> {
+) -> io::Result<Vec<Diagnostic>> {
+    // Absent `result` with no error (the caller already promoted an error
+    // response to `Err`) is a protocol violation — a request failure.
     let Some(mut result) = response.get_mut("result").map(serde_json::Value::take) else {
-        return Vec::new();
+        return Err(io::Error::other(
+            "diagnostic response carries neither result nor error (protocol violation)",
+        ));
     };
     if result.is_null() {
-        return Vec::new();
+        // Authoritative "no diagnostics" — a handled response, not a failure.
+        return Ok(Vec::new());
     }
 
-    // Check report kind
+    // Check report kind: `unchanged` is an authoritative empty; `full`/absent
+    // proceeds; an unknown kind is a malformed payload (request failure).
     match result.get("kind").and_then(|k| k.as_str()) {
-        Some("unchanged") => return Vec::new(),
+        Some("unchanged") => return Ok(Vec::new()),
         Some("full") | None => {}
         Some(other) => {
             log::warn!(
@@ -159,16 +172,33 @@ fn transform_diagnostic_response_to_host(
                 "Unknown diagnostic report kind: {}",
                 other
             );
-            return Vec::new();
+            return Err(io::Error::other(format!(
+                "malformed diagnostic result from downstream server: unknown report kind '{other}'"
+            )));
         }
     }
 
-    // Deserialize items, taking ownership to avoid clones
+    // A `full` report MUST carry `items`; a missing `items` member is a
+    // malformed payload (request failure).
     let Some(items) = result.get_mut("items").map(serde_json::Value::take) else {
-        return Vec::new();
+        return Err(io::Error::other(
+            "malformed diagnostic result from downstream server: full report missing 'items'",
+        ));
     };
-    let Ok(mut diagnostics) = serde_json::from_value::<Vec<Diagnostic>>(items) else {
-        return Vec::new();
+    // `items` that do not deserialize as `Diagnostic[]` (wrong shape, missing
+    // fields, etc.) is likewise a request failure; the log keeps the
+    // misbehaving downstream diagnosable.
+    let mut diagnostics: Vec<Diagnostic> = match serde_json::from_value(items) {
+        Ok(diagnostics) => diagnostics,
+        Err(err) => {
+            log::warn!(
+                target: "kakehashi::bridge",
+                "Failed to deserialize diagnostic items as Diagnostic[]: {err}"
+            );
+            return Err(io::Error::other(format!(
+                "malformed diagnostic result from downstream server: {err}"
+            )));
+        }
     };
 
     // Transform coordinates on typed structs
@@ -176,7 +206,7 @@ fn transform_diagnostic_response_to_host(
         transform_diagnostic(diag, offset, host_uri);
     }
 
-    diagnostics
+    Ok(diagnostics)
 }
 
 /// Transform a single typed Diagnostic by applying the region offset to its range.
@@ -242,7 +272,8 @@ mod tests {
         });
 
         let diagnostics =
-            transform_diagnostic_response_to_host(response, &RegionOffset::new(5, 0), "unused");
+            transform_diagnostic_response_to_host(response, &RegionOffset::new(5, 0), "unused")
+                .unwrap();
 
         assert_eq!(diagnostics.len(), 2);
 
@@ -292,7 +323,8 @@ mod tests {
             response,
             &RegionOffset::new(3, 0),
             "file:///test.md",
-        );
+        )
+        .unwrap();
 
         assert_eq!(diagnostics.len(), 1);
 
@@ -341,7 +373,8 @@ mod tests {
             response,
             &RegionOffset::new(3, 0),
             "file:///test.md",
-        );
+        )
+        .unwrap();
 
         assert_eq!(diagnostics.len(), 1);
 
@@ -368,7 +401,8 @@ mod tests {
         });
 
         let diagnostics =
-            transform_diagnostic_response_to_host(response, &RegionOffset::new(5, 0), "unused");
+            transform_diagnostic_response_to_host(response, &RegionOffset::new(5, 0), "unused")
+                .expect("unchanged is an authoritative empty result, not a failure");
         assert!(diagnostics.is_empty());
     }
 
@@ -377,21 +411,31 @@ mod tests {
         let response = json!({ "jsonrpc": "2.0", "id": 42, "result": null });
 
         let diagnostics =
-            transform_diagnostic_response_to_host(response, &RegionOffset::new(5, 0), "unused");
+            transform_diagnostic_response_to_host(response, &RegionOffset::new(5, 0), "unused")
+                .expect("null is an authoritative empty result, not a failure");
         assert!(diagnostics.is_empty());
     }
 
     #[test]
-    fn diagnostic_response_missing_result_returns_empty() {
-        let response = json!({ "jsonrpc": "2.0", "id": 42, "error": { "code": -32603, "message": "internal error" } });
+    fn diagnostic_response_missing_result_is_request_failure() {
+        // Neither `result` nor `error` member — a protocol violation. (An
+        // *error* response is promoted to `Err` by the caller before transform
+        // runs, so transform only ever sees the no-result-no-error shape here.)
+        let response = json!({ "jsonrpc": "2.0", "id": 42 });
 
-        let diagnostics =
+        let transformed =
             transform_diagnostic_response_to_host(response, &RegionOffset::new(5, 0), "unused");
-        assert!(diagnostics.is_empty());
+        assert!(
+            transformed.is_err(),
+            "a response with neither result nor error must be a request failure"
+        );
     }
 
     #[test]
-    fn diagnostic_response_malformed_items_returns_empty() {
+    fn diagnostic_response_malformed_items_is_request_failure() {
+        // A non-`Diagnostic[]` `items` is a malformed payload — must be `Err`
+        // (request failure), not the lenient empty, so CLI mode can exit 2 for
+        // a broken downstream server.
         let response = json!({
             "jsonrpc": "2.0",
             "id": 42,
@@ -401,9 +445,38 @@ mod tests {
             }
         });
 
-        let diagnostics =
+        let transformed =
             transform_diagnostic_response_to_host(response, &RegionOffset::new(5, 0), "unused");
-        assert!(diagnostics.is_empty());
+        assert!(transformed.is_err());
+    }
+
+    #[test]
+    fn diagnostic_response_unknown_kind_is_request_failure() {
+        // An unrecognized report `kind` is a malformed payload — `Err`, not the
+        // lenient empty.
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 42,
+            "result": { "kind": "partial", "items": [] }
+        });
+
+        let transformed =
+            transform_diagnostic_response_to_host(response, &RegionOffset::new(5, 0), "unused");
+        assert!(transformed.is_err());
+    }
+
+    #[test]
+    fn diagnostic_response_full_report_missing_items_is_request_failure() {
+        // A `full` report MUST carry `items`; its absence is malformed → `Err`.
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 42,
+            "result": { "kind": "full" }
+        });
+
+        let transformed =
+            transform_diagnostic_response_to_host(response, &RegionOffset::new(5, 0), "unused");
+        assert!(transformed.is_err());
     }
 
     #[test]
@@ -418,7 +491,8 @@ mod tests {
         });
 
         let diagnostics =
-            transform_diagnostic_response_to_host(response, &RegionOffset::new(5, 0), "unused");
+            transform_diagnostic_response_to_host(response, &RegionOffset::new(5, 0), "unused")
+                .expect("an empty items array is an authoritative empty result, not a failure");
         assert!(diagnostics.is_empty());
     }
 
@@ -464,7 +538,8 @@ mod tests {
         });
 
         let diagnostics =
-            transform_diagnostic_response_to_host(response, &RegionOffset::new(3, 0), "unused");
+            transform_diagnostic_response_to_host(response, &RegionOffset::new(3, 0), "unused")
+                .unwrap();
 
         assert_eq!(diagnostics.len(), 1);
         let related = diagnostics[0].related_information.as_ref().unwrap();
@@ -518,7 +593,8 @@ mod tests {
         });
 
         let diagnostics =
-            transform_diagnostic_response_to_host(response, &RegionOffset::new(3, 0), "unused");
+            transform_diagnostic_response_to_host(response, &RegionOffset::new(3, 0), "unused")
+                .unwrap();
 
         assert_eq!(diagnostics.len(), 1);
         let related = diagnostics[0].related_information.as_ref().unwrap();
@@ -586,7 +662,8 @@ mod tests {
 
         // This should not panic due to overflow
         let diagnostics =
-            transform_diagnostic_response_to_host(response, &RegionOffset::new(100, 0), "unused");
+            transform_diagnostic_response_to_host(response, &RegionOffset::new(100, 0), "unused")
+                .unwrap();
 
         // Values should saturate at u32::MAX
         assert_eq!(diagnostics.len(), 1);

--- a/src/lsp/bridge/text_document/diagnostic.rs
+++ b/src/lsp/bridge/text_document/diagnostic.rs
@@ -17,7 +17,7 @@ use std::io;
 use std::time::Duration;
 
 use crate::config::settings::BridgeServerConfig;
-use tower_lsp_server::ls_types::Diagnostic;
+use tower_lsp_server::ls_types::{Diagnostic, DocumentDiagnosticReport};
 use url::Url;
 
 use super::super::pool::{INIT_TIMEOUT_SECS, LanguageServerPool, UpstreamId};
@@ -135,9 +135,11 @@ fn build_diagnostic_request(
 /// JSON-RPC *error* response separately (it propagates as `Err`), so this only
 /// inspects the `result`. Mirroring [`transform_formatting_response_to_host`],
 /// a present-but-malformed payload is a request **failure** (`Err`): an absent
-/// `result` member (protocol violation), a report with no `kind` or an unknown
-/// report `kind`, a `full` report missing `items`, or `items` that fail to
-/// deserialize as `Diagnostic[]`. A `null` result or an `unchanged` report is the
+/// `result` member (protocol violation), or a non-null `result` that does not
+/// deserialize as a `DocumentDiagnosticReport` (no/unknown `kind`, a `full`
+/// report missing `items`, a malformed `unchanged` report, or `items` that
+/// aren't `Diagnostic[]`) — validated by the same typed deserialize the host
+/// parser uses. A `null` result or a valid `unchanged` report is the
 /// authoritative "no diagnostics" answer and stays an empty `Vec` (`Ok`).
 /// Collapsing a malformed payload into the same empty value as "no
 /// capability" would let a broken downstream server pass as "nothing wrong" —
@@ -151,7 +153,7 @@ fn transform_diagnostic_response_to_host(
 ) -> io::Result<Vec<Diagnostic>> {
     // Absent `result` with no error (the caller already promoted an error
     // response to `Err`) is a protocol violation — a request failure.
-    let Some(mut result) = response.get_mut("result").map(serde_json::Value::take) else {
+    let Some(result) = response.get_mut("result").map(serde_json::Value::take) else {
         return Err(io::Error::other(
             "diagnostic response carries neither result nor error (protocol violation)",
         ));
@@ -161,47 +163,21 @@ fn transform_diagnostic_response_to_host(
         return Ok(Vec::new());
     }
 
-    // Check report kind: `unchanged` is an authoritative empty; `full`
-    // proceeds; an unknown kind, or an absent/non-string `kind` (the LSP report
-    // tag is required), is a malformed payload (request failure). This matches
-    // the host parser's tagged-enum deserialize so the two paths reject the
-    // same shapes.
-    match result.get("kind").and_then(|k| k.as_str()) {
-        Some("unchanged") => return Ok(Vec::new()),
-        Some("full") => {}
-        Some(other) => {
-            log::warn!(
-                target: "kakehashi::bridge",
-                "Unknown diagnostic report kind: {}",
-                other
-            );
-            return Err(io::Error::other(format!(
-                "malformed diagnostic result from downstream server: unknown report kind '{other}'"
-            )));
-        }
-        None => {
-            return Err(io::Error::other(
-                "malformed diagnostic result from downstream server: report has no 'kind'",
-            ));
-        }
-    }
-
-    // A `full` report MUST carry `items`; a missing `items` member is a
-    // malformed payload (request failure).
-    let Some(items) = result.get_mut("items").map(serde_json::Value::take) else {
-        return Err(io::Error::other(
-            "malformed diagnostic result from downstream server: full report missing 'items'",
-        ));
-    };
-    // `items` that do not deserialize as `Diagnostic[]` (wrong shape, missing
-    // fields, etc.) is likewise a request failure; the log keeps the
-    // misbehaving downstream diagnosable.
-    let mut diagnostics: Vec<Diagnostic> = match serde_json::from_value(items) {
-        Ok(diagnostics) => diagnostics,
+    // Validate the whole report via the typed `DocumentDiagnosticReport`
+    // (identical to the host parser, `parse_host_diagnostic_response`, so the
+    // two paths reject the same shapes): an absent/unknown `kind`, a `full`
+    // report missing `items`, a malformed `unchanged` report or
+    // `relatedDocuments`, or `items` that don't deserialize as `Diagnostic[]`
+    // is a malformed payload (request failure). A valid `unchanged` report is
+    // the authoritative empty. `relatedDocuments` (diagnostics for OTHER
+    // documents) are dropped — they have no place in this region's report.
+    let mut diagnostics = match serde_json::from_value::<DocumentDiagnosticReport>(result) {
+        Ok(DocumentDiagnosticReport::Full(report)) => report.full_document_diagnostic_report.items,
+        Ok(DocumentDiagnosticReport::Unchanged(_)) => return Ok(Vec::new()),
         Err(err) => {
             log::warn!(
                 target: "kakehashi::bridge",
-                "Failed to deserialize diagnostic items as Diagnostic[]: {err}"
+                "Failed to deserialize diagnostic report: {err}"
             );
             return Err(io::Error::other(format!(
                 "malformed diagnostic result from downstream server: {err}"
@@ -497,6 +473,23 @@ mod tests {
             "jsonrpc": "2.0",
             "id": 42,
             "result": { "items": [] }
+        });
+
+        let transformed =
+            transform_diagnostic_response_to_host(response, &RegionOffset::new(5, 0), "unused");
+        assert!(transformed.is_err());
+    }
+
+    #[test]
+    fn diagnostic_response_unchanged_without_result_id_is_request_failure() {
+        // An `unchanged` report MUST carry a `resultId`; its absence is
+        // malformed. The whole-report typed deserialize rejects it, keeping the
+        // region path's strictness identical to the host parser (a hand-rolled
+        // `kind`-only check would have wrongly accepted it as an empty result).
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 42,
+            "result": { "kind": "unchanged" }
         });
 
         let transformed =

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -23,9 +23,9 @@ use std::io;
 use std::sync::Arc;
 
 use tower_lsp_server::ls_types::{
-    DidChangeTextDocumentParams, DidOpenTextDocumentParams, Location, LocationLink,
-    TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem, TextEdit, Uri,
-    VersionedTextDocumentIdentifier,
+    Diagnostic, DidChangeTextDocumentParams, DidOpenTextDocumentParams, DocumentDiagnosticReport,
+    Location, LocationLink, TextDocumentContentChangeEvent, TextDocumentIdentifier,
+    TextDocumentItem, TextEdit, Uri, VersionedTextDocumentIdentifier,
 };
 use url::Url;
 
@@ -345,6 +345,65 @@ impl LanguageServerPool {
         .await?
     }
 
+    /// Send a host `textDocument/diagnostic` request with diagnostics' strict
+    /// semantics. Unlike [`Self::send_host_raw_request`] (which collapses an
+    /// absent `result`, a `null` result, and a missing capability into the same
+    /// `Ok(None)`), this distinguishes them: a present-but-malformed report
+    /// (error response, absent `result` member, unknown `kind`, a `full` report
+    /// missing `items`, or items that fail to deserialize) is a counted request
+    /// failure (`Err`), mirroring [`Self::send_host_formatting_request`]; a
+    /// `null`/`unchanged` result is the authoritative empty `Ok(vec![])`; and a
+    /// server that does not advertise the capability stays the lenient empty
+    /// `Ok(vec![])`. The dedicated method keeps that strictness out of the
+    /// shared raw path that other host methods rely on.
+    ///
+    /// `readiness` matches [`Self::send_host_raw_request`]: the diagnostic
+    /// caller passes `WaitReady` so the request waits through server
+    /// initialization (the caller's request timeout bounds the wait) —
+    /// returning empty while a server initializes would silently lose the host
+    /// layer on the first pull.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn send_host_diagnostic_request(
+        &self,
+        server_name: &str,
+        server_config: &BridgeServerConfig,
+        doc: &HostDocument<'_>,
+        method: &'static str,
+        params: serde_json::Value,
+        upstream_request_id: Option<UpstreamId>,
+        readiness: super::super::pool::ConnectionReadiness,
+    ) -> io::Result<Vec<Diagnostic>> {
+        let handle = match readiness {
+            super::super::pool::ConnectionReadiness::FailFast => {
+                self.get_or_create_connection(server_name, server_config, Some(doc.uri))
+                    .await?
+            }
+            super::super::pool::ConnectionReadiness::WaitReady => {
+                self.get_or_create_connection_wait_ready(
+                    server_name,
+                    server_config,
+                    Some(doc.uri),
+                    std::time::Duration::from_secs(super::super::pool::INIT_TIMEOUT_SECS),
+                )
+                .await?
+            }
+        };
+        if !handle.has_capability(method) {
+            // No capability — the lenient empty layer (kept, unlike a malformed
+            // payload), so a host server that simply does not pull contributes
+            // nothing without looking like a failure.
+            return Ok(Vec::new());
+        }
+        self.execute_host_request(
+            handle,
+            doc,
+            upstream_request_id,
+            |request_id| JsonRpcRequest::new(request_id.as_i64(), method, params),
+            move |response| parse_host_diagnostic_response(response, method),
+        )
+        .await?
+    }
+
     /// Drive a host bridge request end-to-end: register for cancel
     /// forwarding, sync the host document, send, await, transform.
     ///
@@ -537,6 +596,51 @@ fn parse_host_formatting_response(
     }
 }
 
+/// Parse a host `textDocument/diagnostic` response with diagnostics' strict
+/// semantics, mirroring [`parse_host_formatting_response`]. An error response,
+/// a success without a `result` member (protocol violation), or a present-but-
+/// malformed report (an unknown `kind`, a `full` report missing `items`, or
+/// `items` that fail to deserialize) is a request failure (`Err`) — collapsing
+/// it into the empty layer would let a broken host server pass as "nothing
+/// wrong". A `null` result or an `unchanged` report (a server should not send
+/// `unchanged` — we never supply `previousResultId` — but honor it) is the
+/// authoritative empty `Ok(vec![])`. `relatedDocuments` entries are dropped:
+/// diagnostics for OTHER documents have no place in this document's report.
+fn parse_host_diagnostic_response(
+    mut response: serde_json::Value,
+    method: &'static str,
+) -> io::Result<Vec<Diagnostic>> {
+    if response_has_jsonrpc_error(&response, method) {
+        return Err(io::Error::other(format!(
+            "downstream server answered {method} with an error response: {}",
+            jsonrpc_error_summary(&response)
+        )));
+    }
+    let Some(result) = response.get_mut("result").map(serde_json::Value::take) else {
+        return Err(io::Error::other(format!(
+            "{method} response carries neither result nor error (protocol violation)"
+        )));
+    };
+    if result.is_null() {
+        return Ok(Vec::new());
+    }
+    match serde_json::from_value::<DocumentDiagnosticReport>(result) {
+        Ok(DocumentDiagnosticReport::Full(report)) => {
+            Ok(report.full_document_diagnostic_report.items)
+        }
+        Ok(DocumentDiagnosticReport::Unchanged(_)) => Ok(Vec::new()),
+        Err(e) => {
+            log::warn!(
+                target: "kakehashi::bridge",
+                "host diagnostic report failed to deserialize: {e}"
+            );
+            Err(io::Error::other(format!(
+                "malformed {method} result from downstream server: {e}"
+            )))
+        }
+    }
+}
+
 /// Normalize a goto result (`Location | Location[] | LocationLink[]`) to
 /// `Vec<LocationLink>` **without** any URI or range rewriting — host
 /// responses already speak real-document coordinates.
@@ -711,6 +815,101 @@ mod tests {
             parse_host_formatting_response(response, "textDocument/formatting").is_err(),
             "errors must be a counted request failure, unlike null"
         );
+    }
+
+    #[test]
+    fn host_diagnostic_full_report_yields_items() {
+        let response = serde_json::json!({
+            "jsonrpc": "2.0", "id": 1,
+            "result": {
+                "kind": "full",
+                "items": [{
+                    "range": { "start": { "line": 2, "character": 0 },
+                               "end": { "line": 2, "character": 5 } },
+                    "message": "host says hi"
+                }]
+            }
+        });
+        let items = parse_host_diagnostic_response(response, "textDocument/diagnostic")
+            .expect("a full report is a valid response");
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].message, "host says hi");
+        assert_eq!(
+            items[0].range.start.line, 2,
+            "no translation on the host path"
+        );
+    }
+
+    #[test]
+    fn host_diagnostic_null_and_unchanged_are_authoritative_empty() {
+        // `null` and an `unchanged` report are handled responses meaning "no
+        // diagnostics" — `Ok(vec![])`, not a failure. (We never send a
+        // `previousResultId`, but honor `unchanged` if a server volunteers it.)
+        let null = serde_json::json!({ "jsonrpc": "2.0", "id": 1, "result": null });
+        assert!(
+            parse_host_diagnostic_response(null, "textDocument/diagnostic")
+                .expect("null is authoritative empty")
+                .is_empty()
+        );
+
+        let unchanged = serde_json::json!({
+            "jsonrpc": "2.0", "id": 1,
+            "result": { "kind": "unchanged", "resultId": "x" }
+        });
+        assert!(
+            parse_host_diagnostic_response(unchanged, "textDocument/diagnostic")
+                .expect("unchanged is authoritative empty")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn host_diagnostic_error_response_is_a_request_failure() {
+        let response = serde_json::json!({
+            "jsonrpc": "2.0", "id": 1,
+            "error": { "code": -32603, "message": "boom" }
+        });
+        assert!(
+            parse_host_diagnostic_response(response, "textDocument/diagnostic").is_err(),
+            "an error response must be a counted request failure, unlike null"
+        );
+    }
+
+    #[test]
+    fn host_diagnostic_missing_result_is_a_request_failure() {
+        // Neither `result` nor `error` — a protocol violation, not the lenient
+        // empty that the shared raw path keeps for non-diagnostic methods.
+        let response = serde_json::json!({ "jsonrpc": "2.0", "id": 1 });
+        assert!(parse_host_diagnostic_response(response, "textDocument/diagnostic").is_err());
+    }
+
+    #[test]
+    fn host_diagnostic_malformed_payload_is_a_request_failure() {
+        // A present, non-null `result` that is not a diagnostic report at all.
+        let response = serde_json::json!({ "jsonrpc": "2.0", "id": 1, "result": "nonsense" });
+        assert!(parse_host_diagnostic_response(response, "textDocument/diagnostic").is_err());
+    }
+
+    #[test]
+    fn host_diagnostic_unknown_kind_is_a_request_failure() {
+        // The exit-2 behavior hinges on the tagged-enum deserialize REJECTING
+        // an unrecognized report `kind` — assert it rather than infer it.
+        let response = serde_json::json!({
+            "jsonrpc": "2.0", "id": 1,
+            "result": { "kind": "partial", "items": [] }
+        });
+        assert!(parse_host_diagnostic_response(response, "textDocument/diagnostic").is_err());
+    }
+
+    #[test]
+    fn host_diagnostic_full_report_missing_items_is_a_request_failure() {
+        // Likewise, a `full` report MUST carry `items`; the deserialize must
+        // reject its absence.
+        let response = serde_json::json!({
+            "jsonrpc": "2.0", "id": 1,
+            "result": { "kind": "full" }
+        });
+        assert!(parse_host_diagnostic_response(response, "textDocument/diagnostic").is_err());
     }
 
     #[test]

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -258,7 +258,11 @@ impl LanguageServerPool {
     /// `partialResultToken` would stream its results into the void and could
     /// legally return an empty final result; `workDoneToken` would likewise
     /// report progress nowhere.
-    #[allow(clippy::too_many_arguments)]
+    ///
+    /// Fails fast on an initializing server (an empty layer for this request;
+    /// the next request gets it) — the policy every interactive host-bridged
+    /// method wants. The diagnostic path, which must instead wait through
+    /// initialization, uses the dedicated [`Self::send_host_diagnostic_request`].
     pub(crate) async fn send_host_raw_request(
         &self,
         server_name: &str,
@@ -267,29 +271,11 @@ impl LanguageServerPool {
         method: &'static str,
         mut params: serde_json::Value,
         upstream_request_id: Option<UpstreamId>,
-        readiness: super::super::pool::ConnectionReadiness,
     ) -> io::Result<Option<serde_json::Value>> {
         strip_progress_tokens(&mut params);
-        let handle = match readiness {
-            // Fail-fast (interactive requests): an Initializing server is an
-            // empty layer for this request; the next request gets it.
-            super::super::pool::ConnectionReadiness::FailFast => {
-                self.get_or_create_connection(server_name, server_config, Some(doc.uri))
-                    .await?
-            }
-            // Diagnostics wait through initialization — same policy as the
-            // virt diagnostic path (waiting beats returning empty results);
-            // the caller's request timeout bounds the wait.
-            super::super::pool::ConnectionReadiness::WaitReady => {
-                self.get_or_create_connection_wait_ready(
-                    server_name,
-                    server_config,
-                    Some(doc.uri),
-                    std::time::Duration::from_secs(super::super::pool::INIT_TIMEOUT_SECS),
-                )
-                .await?
-            }
-        };
+        let handle = self
+            .get_or_create_connection(server_name, server_config, Some(doc.uri))
+            .await?;
         if !handle.has_capability(method) {
             return Ok(None);
         }
@@ -357,12 +343,9 @@ impl LanguageServerPool {
     /// `Ok(vec![])`. The dedicated method keeps that strictness out of the
     /// shared raw path that other host methods rely on.
     ///
-    /// `readiness` matches [`Self::send_host_raw_request`]: the diagnostic
-    /// caller passes `WaitReady` so the request waits through server
-    /// initialization (the caller's request timeout bounds the wait) —
-    /// returning empty while a server initializes would silently lose the host
-    /// layer on the first pull.
-    #[allow(clippy::too_many_arguments)]
+    /// Waits through server initialization (the caller's request timeout bounds
+    /// the wait) — returning empty while a server initializes would silently
+    /// lose the host layer on the first pull, like the virt diagnostic path.
     pub(crate) async fn send_host_diagnostic_request(
         &self,
         server_name: &str,
@@ -371,23 +354,15 @@ impl LanguageServerPool {
         method: &'static str,
         params: serde_json::Value,
         upstream_request_id: Option<UpstreamId>,
-        readiness: super::super::pool::ConnectionReadiness,
     ) -> io::Result<Vec<Diagnostic>> {
-        let handle = match readiness {
-            super::super::pool::ConnectionReadiness::FailFast => {
-                self.get_or_create_connection(server_name, server_config, Some(doc.uri))
-                    .await?
-            }
-            super::super::pool::ConnectionReadiness::WaitReady => {
-                self.get_or_create_connection_wait_ready(
-                    server_name,
-                    server_config,
-                    Some(doc.uri),
-                    std::time::Duration::from_secs(super::super::pool::INIT_TIMEOUT_SECS),
-                )
-                .await?
-            }
-        };
+        let handle = self
+            .get_or_create_connection_wait_ready(
+                server_name,
+                server_config,
+                Some(doc.uri),
+                std::time::Duration::from_secs(super::super::pool::INIT_TIMEOUT_SECS),
+            )
+            .await?;
         if !handle.has_capability(method) {
             // No capability — the lenient empty layer (kept, unlike a malformed
             // payload), so a host server that simply does not pull contributes

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -346,15 +346,20 @@ impl LanguageServerPool {
     /// Waits through server initialization (the caller's request timeout bounds
     /// the wait) — returning empty while a server initializes would silently
     /// lose the host layer on the first pull, like the virt diagnostic path.
+    ///
+    /// The method is fixed to `textDocument/diagnostic`: this path is dedicated
+    /// to the diagnostic-only parser and capability check, so it takes no
+    /// `method` argument — a caller cannot accidentally route another method
+    /// through it (the generic [`Self::send_host_raw_request`] is for that).
     pub(crate) async fn send_host_diagnostic_request(
         &self,
         server_name: &str,
         server_config: &BridgeServerConfig,
         doc: &HostDocument<'_>,
-        method: &'static str,
         params: serde_json::Value,
         upstream_request_id: Option<UpstreamId>,
     ) -> io::Result<Vec<Diagnostic>> {
+        let method = "textDocument/diagnostic";
         let handle = self
             .get_or_create_connection_wait_ready(
                 server_name,

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -736,7 +736,6 @@ impl Kakehashi {
                             request_method,
                             params,
                             t.upstream_id,
-                            crate::lsp::bridge::ConnectionReadiness::FailFast,
                         )
                         .await
                 }

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -477,11 +477,6 @@ pub(crate) async fn collect_host_diagnostics(
                     "textDocument/diagnostic",
                     serde_json::json!({ "textDocument": { "uri": t.uri.as_str() } }),
                     t.upstream_id,
-                    // Wait through server initialization — the first
-                    // didOpen-triggered pull would otherwise hit an Initializing
-                    // server and silently lose the host layer. The outer timeout
-                    // bounds the wait.
-                    crate::lsp::bridge::ConnectionReadiness::WaitReady,
                 ),
             )
             .await

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -457,13 +457,16 @@ pub(crate) async fn collect_host_diagnostics(
     let send = |t: HostFanOutTask| {
         // Cloned per call so the returned future is `'static`, and so a
         // request-time host failure (timeout, crash, error response after the
-        // server is ready) is counted — letting CLI mode surface it as exit 2
-        // instead of silently losing the host layer.
+        // server is ready, or a present-but-malformed report payload) is
+        // counted — letting CLI mode surface it as exit 2 instead of silently
+        // losing the host layer. `send_host_diagnostic_request` keeps a
+        // `null`/`unchanged`/no-capability result a lenient empty (not an
+        // error); only a malformed payload is `Err`.
         let sink = request_error_sink.clone();
         async move {
             let result = tokio::time::timeout(
                 DIAGNOSTIC_REQUEST_TIMEOUT,
-                t.pool.send_host_raw_request(
+                t.pool.send_host_diagnostic_request(
                     &t.server_name,
                     &t.server_config,
                     &crate::lsp::bridge::HostDocument {
@@ -474,10 +477,10 @@ pub(crate) async fn collect_host_diagnostics(
                     "textDocument/diagnostic",
                     serde_json::json!({ "textDocument": { "uri": t.uri.as_str() } }),
                     t.upstream_id,
-                    // Same policy as the virt diagnostic path: wait through
-                    // server initialization — the first didOpen-triggered pull
-                    // would otherwise hit an Initializing server and silently
-                    // lose the host layer. The outer timeout bounds the wait.
+                    // Wait through server initialization — the first
+                    // didOpen-triggered pull would otherwise hit an Initializing
+                    // server and silently lose the host layer. The outer timeout
+                    // bounds the wait.
                     crate::lsp::bridge::ConnectionReadiness::WaitReady,
                 ),
             )
@@ -488,13 +491,10 @@ pub(crate) async fn collect_host_diagnostics(
                     t.server_name
                 )))
             });
-            match result {
-                Ok(value) => Ok(parse_host_diagnostic_report(value)),
-                Err(e) => {
-                    count_request_errors(&sink, 1);
-                    Err(e)
-                }
+            if result.is_err() {
+                count_request_errors(&sink, 1);
             }
+            result
         }
     };
 
@@ -521,30 +521,6 @@ pub(crate) async fn collect_host_diagnostics(
                 FanInResult::Done(diagnostics) => diagnostics,
                 FanInResult::NoResult { .. } | FanInResult::Cancelled => Vec::new(),
             }
-        }
-    }
-}
-
-/// Parse a raw `textDocument/diagnostic` result from a host server into its
-/// diagnostic items: a `full` report yields its items (`relatedDocuments`
-/// entries are dropped — diagnostics for OTHER documents have no place in
-/// this document's report); `unchanged` (which a server should not send —
-/// we never supply `previousResultId`) and `null` / unparsable results
-/// yield nothing.
-fn parse_host_diagnostic_report(result: Option<serde_json::Value>) -> Vec<Diagnostic> {
-    let Some(value) = result else {
-        return Vec::new();
-    };
-    match serde_json::from_value::<DocumentDiagnosticReport>(value) {
-        Ok(DocumentDiagnosticReport::Full(report)) => report.full_document_diagnostic_report.items,
-        Ok(DocumentDiagnosticReport::Unchanged(_)) => Vec::new(),
-        Err(e) => {
-            log::debug!(
-                target: "kakehashi::diagnostic",
-                "host diagnostic report did not parse: {}",
-                e
-            );
-            Vec::new()
         }
     }
 }
@@ -680,7 +656,6 @@ fn empty_diagnostic_report() -> DocumentDiagnosticReportResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
     use tower_lsp_server::ls_types::{Position, Range};
 
     fn diag(message: &str) -> Diagnostic {
@@ -746,30 +721,5 @@ mod tests {
     fn combine_empty_priorities_yields_nothing() {
         let cfg = layer_cfg(vec![], AggregationStrategy::Concatenated);
         assert!(combine_layer_diagnostics(&cfg, vec![diag("virt")], vec![diag("host")]).is_empty());
-    }
-
-    #[test]
-    fn parse_host_report_full_yields_items() {
-        let value = json!({
-            "kind": "full",
-            "items": [{
-                "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 1}},
-                "message": "host says hi"
-            }]
-        });
-        let items = parse_host_diagnostic_report(Some(value));
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].message, "host says hi");
-    }
-
-    #[test]
-    fn parse_host_report_unchanged_none_and_garbage_yield_nothing() {
-        assert!(parse_host_diagnostic_report(None).is_empty());
-        assert!(
-            parse_host_diagnostic_report(Some(json!({"kind": "unchanged", "resultId": "x"})))
-                .is_empty()
-        );
-        assert!(parse_host_diagnostic_report(Some(json!("nonsense"))).is_empty());
-        assert!(parse_host_diagnostic_report(Some(serde_json::Value::Null)).is_empty());
     }
 }

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -474,7 +474,6 @@ pub(crate) async fn collect_host_diagnostics(
                         language_id: &t.language_id,
                         text: &t.text,
                     },
-                    "textDocument/diagnostic",
                     serde_json::json!({ "textDocument": { "uri": t.uri.as_str() } }),
                     t.upstream_id,
                 ),

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -44,6 +44,11 @@
 //!   that echoes the requested URI, but only for documents it received via
 //!   `didOpen`. Used to prove cross-layer diagnostic aggregation merges the
 //!   host layer in (cross-layer-aggregation).
+//! - `diagnostics-malformed` — advertises `diagnosticProvider`; answers
+//!   `textDocument/diagnostic` with a successful response whose `result` is a
+//!   present, non-null but unparsable report (unknown `kind`). Exercises the
+//!   present-but-malformed-payload path (#488): CLI mode must count it as a
+//!   request failure (exit 2), not read it as "no diagnostics".
 //! - `diagnostics-push` — spontaneously **pushes** `textDocument/publishDiagnostics`
 //!   on `didOpen` (one diagnostic on virtual line 0, no pull) and an empty list on
 //!   `didChange`. Used by `tests/e2e_push_diagnostics.rs` to prove a downstream's
@@ -151,7 +156,10 @@ fn main() {
                     // `diagnosticProvider` (pull-driven) AND pushes on didOpen
                     // (below). Used to prove `pullFallback = false` still
                     // publishes a pull-driven server's spontaneous push (#425).
-                    "diagnostics" | "diagnostics-fail" | "diagnostics-push-pullcap" => json!({
+                    "diagnostics"
+                    | "diagnostics-fail"
+                    | "diagnostics-malformed"
+                    | "diagnostics-push-pullcap" => json!({
                         "diagnosticProvider": {
                             "interFileDependencies": false,
                             "workspaceDiagnostics": false
@@ -444,6 +452,15 @@ fn main() {
                     // path (vs. a server that never starts), which CLI mode
                     // must not read as "no diagnostics".
                     respond_error(&mut writer, id, -32603, "mock diagnostic request failure");
+                    continue;
+                }
+                if mode == "diagnostics-malformed" {
+                    // Healthy handshake, successful response, but a present,
+                    // non-null `result` that is not a valid diagnostic report
+                    // (unknown report `kind`). Exercises the present-but-
+                    // malformed-payload path (#488): CLI mode must count it as a
+                    // request failure (exit 2), NOT read it as "no diagnostics".
+                    respond(&mut writer, id, json!({ "kind": "borked" }));
                     continue;
                 }
                 // One deterministic diagnostic echoing the requested URI —

--- a/tests/e2e_cli_diagnose.rs
+++ b/tests/e2e_cli_diagnose.rs
@@ -388,6 +388,71 @@ languages = ["markdown"]
 }
 
 #[test]
+fn e2e_diagnose_malformed_payload_exits_two() {
+    // The server handshakes fine and answers the diagnostic request with a
+    // SUCCESS response whose `result` is present, non-null, but unparsable
+    // (unknown report `kind`) — distinct from an error response and from a
+    // `null`/no-capability "no diagnostics". The region (virt) parser must
+    // count it as a request failure so the CLI exits 2, mirroring `format`
+    // (#488); collapsing it into an empty report would look clean to CI.
+    let ws = workspace_with(
+        &format!(
+            r#"autoInstall = false
+
+[languageServers.mock-diag-malformed]
+cmd = ['{}', 'diagnostics-malformed']
+languages = ["lua"]
+"#,
+            env!("CARGO_BIN_EXE_mock-lsp-formatter")
+        ),
+        &[("doc.md", MARKDOWN)],
+    );
+
+    let output = run_diagnose(ws.path(), &["doc.md"]);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "a present-but-malformed diagnostic payload must exit 2; stderr: {}",
+        stderr_of(&output)
+    );
+    assert!(
+        stderr_of(&output).contains("operation(s) failed"),
+        "stderr should report the failed request; stderr: {}",
+        stderr_of(&output)
+    );
+}
+
+#[test]
+fn e2e_diagnose_host_layer_malformed_payload_exits_two() {
+    // Same present-but-malformed payload through the HOST layer
+    // (bridge._self.enabled): the dedicated host diagnostic parser must also
+    // count it so the CLI exits 2 rather than silently losing the host layer.
+    let ws = workspace_with(
+        &format!(
+            r#"autoInstall = false
+
+[languages.markdown.bridge._self]
+enabled = true
+
+[languageServers.mock-host-malformed]
+cmd = ['{}', 'diagnostics-malformed']
+languages = ["markdown"]
+"#,
+            env!("CARGO_BIN_EXE_mock-lsp-formatter")
+        ),
+        &[("doc.md", MARKDOWN)],
+    );
+
+    let output = run_diagnose(ws.path(), &["doc.md"]);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "a host-layer malformed payload must exit 2; stderr: {}",
+        stderr_of(&output)
+    );
+}
+
+#[test]
 fn e2e_diagnose_directory_walk_respects_gitignore_but_explicit_path_wins() {
     let ws = workspace_with(
         &config_toml(),


### PR DESCRIPTION
## Problem (#488)

`kakehashi diagnose` exited **0** on a downstream pull-diagnostic response that was *present but malformed*, unlike `kakehashi format`, which counts such payloads as request failures (**exit 2**). Both run the same in-process bridge, so this was a diagnose↔format inconsistency: a broken downstream server could look clean to CI.

The leniency lived on both diagnose paths:
- **region (injection)** — `transform_diagnostic_response_to_host` turned a missing `result`, unknown report `kind`, missing `items`, or a deserialization failure into an empty `Vec`.
- **host (`_self`)** — went through `send_host_raw_request`, whose `parse_host_raw_response` collapses an absent `result`, a `null` result, and a missing capability into the same `Ok(None)`; `parse_host_diagnostic_report` then made a deserialize failure empty too.

## Fix — mirror `format`'s strictness on both paths

A **present-but-malformed** payload is now a counted request failure (`Err` → CLI exit 2; the editor path logs at WARNING and the layer stays empty). A `null` result, a valid `unchanged` report, or a server without the capability stays the lenient authoritative empty.

- **Region** (`transform_diagnostic_response_to_host`) now returns `io::Result<Vec<Diagnostic>>` and validates the whole non-null `result` via `serde_json::from_value::<DocumentDiagnosticReport>` — the *same typed deserialize the host parser uses*, so the two paths reject identical shapes (no/unknown `kind`, `full` missing `items`, `unchanged` missing `resultId`, malformed `relatedDocuments`, non-`Diagnostic[]` items).
- **Host** gets a dedicated `send_host_diagnostic_request` + `parse_host_diagnostic_response` (mirroring `send_host_formatting_request` / `parse_host_formatting_response`) that see the raw JSON-RPC envelope to distinguish absent vs `null` `result` **without** touching the shared `parse_host_raw_response` that goto/hover/etc. rely on — sidestepping the cross-cutting change the issue flagged as the reason for deferral. The old lenient `parse_host_diagnostic_report` is removed.

## Editor behavior is unchanged

The concatenated fan-in **drops and counts** a per-server `Err`, so a malformed server contributes nothing to the merged set either way — only the CLI exit code and the WARNING log differ. The `preferred` strategy routes both the old empty and the new `Err` to `failed_servers`, so winner selection is identical. Verified across `fan_in/concatenated.rs` + `preferred.rs`.

## Tests

- Unit: strict decision tree on **both** parsers — absent/`null`/`unchanged`/valid-`full`/unknown-`kind`/missing-`items`/`unchanged`-without-`resultId`/malformed-items; the host tests prove serde rejects unknown `kind` and missing `items` (the exit-2 behavior hinges on that).
- E2E: a new `diagnostics-malformed` mock mode + two `e2e_cli_diagnose` tests assert **exit 2** through the region parser and the host parser end-to-end.
- Re-ran the editor-path e2e the issue named (`e2e_lsp_lua_diagnostic`, `e2e_push_diagnostics`, `e2e_host_bridge`) — all green; no editor regression.
- Full `cargo test --lib` (2113) green; `cargo clippy -- -D warnings` clean.

## Review

Passed a 10-perspective `/review` (no Critical/High) and a Codex review that converged to "no remaining actionable issues" — the Codex cycle is what drove the region path onto the shared typed deserialize for full region/host symmetry.


## Review follow-ups (addressed in-PR)

- **Codex** drove the region path onto the same typed `DocumentDiagnosticReport` deserialize the host parser uses, so the two paths now reject identical malformed shapes (including `unchanged` missing `resultId`).
- **Gemini** flagged the now single-valued `ConnectionReadiness` param: collapsed both host methods to their single readiness mode, deleted the enum + re-export, and dropped two `#[allow(too_many_arguments)]` (behavior-preserving refactor).
- **Copilot** flagged ambiguous exit-code wording in `docs/README.md`; reworded.
Closes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)