### PR TITLE
fix(diagnose): make preferred-strategy exit-2 accounting deterministic (#487)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -636,11 +636,11 @@ with an error response or a present-but-malformed payload, matching
 `kakehashi format`'s strictness) — independent of the diagnostics, so it
 surfaces a broken run rather than looking clean to CI.
 
-> The `2` exit on a downstream failure is exact under the default
-> `concatenated` aggregation strategy. Under the non-default `preferred`
-> strategy, a *non-winning* server's request-time failure may not surface as
-> exit `2` (the winning server's result is authoritative). See
-> [#487](https://github.com/atusy/kakehashi/issues/487).
+> Under the non-default `preferred` aggregation strategy, the winning server's
+> result is authoritative, so a *non-winning* server's request-time failure is
+> deliberately **not** counted toward exit `2` — only a failure with no winner
+> at all (every server failed) does. The default `concatenated` strategy counts
+> every server's failure.
 
 Diagnostics stream to stdout as each file is processed. Every file is always
 scanned so the exit code reflects the whole set; if stdout is closed before the

--- a/docs/README.md
+++ b/docs/README.md
@@ -638,9 +638,9 @@ surfaces a broken run rather than looking clean to CI.
 
 > Under the non-default `preferred` aggregation strategy, the winning server's
 > result is authoritative, so a *non-winning* server's request-time failure is
-> deliberately **not** counted toward exit `2` — only a failure with no winner
-> at all (every server failed) does. The default `concatenated` strategy counts
-> every server's failure.
+> deliberately **not** counted toward exit `2` — a failure surfaces only when
+> no server won (no non-empty result) *and* a contender actually failed. The
+> default `concatenated` strategy counts every server's failure.
 
 Diagnostics stream to stdout as each file is processed. Every file is always
 scanned so the exit code reflects the whole set; if stdout is closed before the

--- a/src/lsp/lsp_impl/text_document.rs
+++ b/src/lsp/lsp_impl/text_document.rs
@@ -60,4 +60,69 @@ pub(crate) fn count_request_errors(sink: &RequestErrorSink, n: usize) {
     }
 }
 
+/// Record a `preferred`-strategy fan-in's failures into `sink`, counting them
+/// **only when no server won** (`NoResult`).
+///
+/// Under `preferred`, the winning server's result is authoritative, so a
+/// non-winning server's failure is irrelevant — it must not surface as a CLI
+/// exit-2 (the same intent [`RequestErrorSink`] documents: an abandoned
+/// loser was *cancelled*, not failed). Counting losers in-task is also **racy**:
+/// the preferred fan-in `abort_all`s the losers without joining them, so a
+/// loser's in-task `fetch_add` can land after the CLI has read the counter
+/// (#487). Counting from the fan-in result instead is deterministic: only
+/// `NoResult` (every server failed → no winner) carries a decisive,
+/// fully-drained `errors` count; `Done`/`Cancelled` count nothing. Shared so
+/// the preferred diagnose and (future) formatting dispatches stay consistent.
+pub(crate) fn count_no_winner_errors<T>(
+    result: &crate::lsp::aggregation::server::FanInResult<T>,
+    sink: &RequestErrorSink,
+) {
+    if let crate::lsp::aggregation::server::FanInResult::NoResult { errors } = result {
+        count_request_errors(sink, *errors);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lsp::aggregation::server::FanInResult;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn sink_value(sink: &RequestErrorSink) -> usize {
+        sink.as_ref().unwrap().load(Ordering::Relaxed)
+    }
+
+    #[test]
+    fn count_no_winner_errors_counts_only_when_no_server_won() {
+        let sink: RequestErrorSink = Some(Arc::new(AtomicUsize::new(0)));
+
+        // No winner (every server failed) → the drained failure count is
+        // decisive and is recorded, so an all-failed `preferred` run still
+        // surfaces as exit 2.
+        count_no_winner_errors(&FanInResult::<()>::NoResult { errors: 3 }, &sink);
+        assert_eq!(sink_value(&sink), 3);
+
+        // A winner emerged → non-winning failures are irrelevant and MUST NOT
+        // be counted (the heart of #487).
+        count_no_winner_errors(&FanInResult::Done(()), &sink);
+        assert_eq!(
+            sink_value(&sink),
+            3,
+            "Done must not count non-winning failures"
+        );
+
+        // Cancelled → nothing decisive happened; count nothing.
+        count_no_winner_errors(&FanInResult::<()>::Cancelled, &sink);
+        assert_eq!(sink_value(&sink), 3, "Cancelled must not count");
+    }
+
+    #[test]
+    fn count_no_winner_errors_is_a_noop_without_a_sink() {
+        // LSP mode installs no sink; the helper must not panic.
+        let sink: RequestErrorSink = None;
+        count_no_winner_errors(&FanInResult::<()>::NoResult { errors: 5 }, &sink);
+    }
+}
+
 // Re-export the methods (they are implemented as impl blocks on Kakehashi)

--- a/src/lsp/lsp_impl/text_document.rs
+++ b/src/lsp/lsp_impl/text_document.rs
@@ -70,9 +70,12 @@ pub(crate) fn count_request_errors(sink: &RequestErrorSink, n: usize) {
 /// the preferred fan-in `abort_all`s the losers without joining them, so a
 /// loser's in-task `fetch_add` can land after the CLI has read the counter
 /// (#487). Counting from the fan-in result instead is deterministic: only
-/// `NoResult` (every server failed → no winner) carries a decisive,
-/// fully-drained `errors` count; `Done`/`Cancelled` count nothing. Shared so
-/// the preferred diagnose and (future) formatting dispatches stay consistent.
+/// `NoResult` (no server won — every contender failed or returned empty)
+/// carries a decisive, fully-drained `errors` count, and `errors` counts only
+/// the actual failures (it is `0` when the non-winners merely returned empty),
+/// so an all-empty run is not a failure. `Done`/`Cancelled` count nothing.
+/// Shared so the preferred diagnose and (future) formatting dispatches stay
+/// consistent.
 pub(crate) fn count_no_winner_errors<T>(
     result: &crate::lsp::aggregation::server::FanInResult<T>,
     sink: &RequestErrorSink,

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -31,7 +31,9 @@ use crate::lsp::diagnostic_cache::{DiagnosticSource, cached_push_diagnostics, pu
 use crate::lsp::lsp_impl::bridge_context::{
     DocumentRequestContext, HostRequestContext, resolve_aggregation_config_from_settings,
 };
-use crate::lsp::lsp_impl::text_document::{RequestErrorSink, count_request_errors};
+use crate::lsp::lsp_impl::text_document::{
+    RequestErrorSink, count_no_winner_errors, count_request_errors,
+};
 
 // ============================================================================
 // Shared diagnostic utilities (used by both pull and push diagnostics)
@@ -454,47 +456,24 @@ pub(crate) async fn collect_host_diagnostics(
     pool: Arc<LanguageServerPool>,
     request_error_sink: &RequestErrorSink,
 ) -> Vec<Diagnostic> {
-    let send = |t: HostFanOutTask| {
-        // Cloned per call so the returned future is `'static`, and so a
-        // request-time host failure (timeout, crash, error response after the
-        // server is ready, or a present-but-malformed report payload) is
-        // counted — letting CLI mode surface it as exit 2 instead of silently
-        // losing the host layer. `send_host_diagnostic_request` keeps a
-        // `null`/`unchanged`/no-capability result a lenient empty (not an
-        // error); only a malformed payload is `Err`.
-        let sink = request_error_sink.clone();
-        async move {
-            let result = tokio::time::timeout(
-                DIAGNOSTIC_REQUEST_TIMEOUT,
-                t.pool.send_host_diagnostic_request(
-                    &t.server_name,
-                    &t.server_config,
-                    &crate::lsp::bridge::HostDocument {
-                        uri: &t.uri,
-                        language_id: &t.language_id,
-                        text: &t.text,
-                    },
-                    serde_json::json!({ "textDocument": { "uri": t.uri.as_str() } }),
-                    t.upstream_id,
-                ),
-            )
-            .await
-            .unwrap_or_else(|_| {
-                Err(std::io::Error::other(format!(
-                    "host diagnostic request timed out for {}",
-                    t.server_name
-                )))
-            });
-            if result.is_err() {
-                count_request_errors(&sink, 1);
-            }
-            result
-        }
-    };
-
     // Cancellation is handled by the caller dropping this future.
     match ctx.strategy {
         AggregationStrategy::Concatenated => {
+            // Concatenated merges every layer, so a crashed/timed-out server is
+            // a missing contribution — count each failure in-task. A partial
+            // failure still yields `Done` (which discards the fan-in's own
+            // count), and the drain is exhaustive, so in-task counting is both
+            // necessary and deterministic here.
+            let send = |t: HostFanOutTask| {
+                let sink = request_error_sink.clone();
+                async move {
+                    let result = send_host_diagnostic_fan_out_request(t).await;
+                    if result.is_err() {
+                        count_request_errors(&sink, 1);
+                    }
+                    result
+                }
+            };
             match dispatch_host_concatenated(ctx, pool, send, None, Some("kakehashi::diagnostic"))
                 .await
             {
@@ -503,15 +482,21 @@ pub(crate) async fn collect_host_diagnostics(
             }
         }
         AggregationStrategy::Preferred => {
-            match dispatch_host_preferred(
+            // Preferred: the winning server is authoritative, so a non-winning
+            // server's failure is irrelevant and must NOT be counted (counting
+            // it in-task is also racy — the fan-in aborts losers without joining
+            // them). Count only when no server won, from the fan-in result
+            // (#487).
+            let result = dispatch_host_preferred(
                 ctx,
                 pool,
-                send,
+                send_host_diagnostic_fan_out_request,
                 |v: &Vec<Diagnostic>| !v.is_empty(),
                 None,
             )
-            .await
-            {
+            .await;
+            count_no_winner_errors(&result, request_error_sink);
+            match result {
                 FanInResult::Done(diagnostics) => diagnostics,
                 FanInResult::NoResult { .. } | FanInResult::Cancelled => Vec::new(),
             }
@@ -542,6 +527,36 @@ async fn send_diagnostic_fan_out_request(t: FanOutTask) -> std::io::Result<Vec<D
     .unwrap_or_else(|_| {
         Err(std::io::Error::other(format!(
             "diagnostic request timed out for region {rid}"
+        )))
+    })
+}
+
+/// Send a host diagnostic request for a single fan-out task with timeout, with
+/// **no** error counting. The caller counts per strategy: concatenated counts
+/// every failure in-task (a missing merge contribution); preferred counts only
+/// the no-winner case via [`count_no_winner_errors`] (#487).
+async fn send_host_diagnostic_fan_out_request(
+    t: HostFanOutTask,
+) -> std::io::Result<Vec<Diagnostic>> {
+    tokio::time::timeout(
+        DIAGNOSTIC_REQUEST_TIMEOUT,
+        t.pool.send_host_diagnostic_request(
+            &t.server_name,
+            &t.server_config,
+            &crate::lsp::bridge::HostDocument {
+                uri: &t.uri,
+                language_id: &t.language_id,
+                text: &t.text,
+            },
+            serde_json::json!({ "textDocument": { "uri": t.uri.as_str() } }),
+            t.upstream_id,
+        ),
+    )
+    .await
+    .unwrap_or_else(|_| {
+        Err(std::io::Error::other(format!(
+            "host diagnostic request timed out for {}",
+            t.server_name
         )))
     })
 }
@@ -588,19 +603,15 @@ async fn dispatch_concatenated_diagnostics(
 
 /// Dispatch diagnostics using the preferred strategy (first non-empty response wins).
 ///
-/// KNOWN LIMITATION (CLI exit codes, tracked in #487): when a winner is
-/// decided, the preferred fan-in (`aggregation::server::fan_in::preferred`)
-/// `abort_all()`s the losing tasks WITHOUT joining them, so a
-/// losing server that fails its request can run `count_request_errors` after
-/// this returns and after the CLI has loaded `sink`. Such a non-winning
-/// failure may therefore not surface as `kakehashi diagnose` exit 2. The
-/// default `concatenated` strategy drains every task (`join_next` to `None`)
-/// and is exact; the all-servers-fail case yields `NoResult` with no winner,
-/// hence no abort and a deterministic count. Only "preferred + a winner + a
-/// non-winning failure" is racy — and under preferred semantics the winner's
-/// result is authoritative, so whether that should be exit 2 at all is a
-/// product question. See #487 for the fix options (shared with the formatting
-/// preferred path).
+/// Under preferred the winning server's result is authoritative, so a
+/// non-winning server's request failure is **not** counted toward CLI exit 2:
+/// failures are recorded only when no server won, via [`count_no_winner_errors`]
+/// on the fan-in result. This is deterministic — `NoResult` (all servers
+/// failed) drains every task, whereas the racy in-task counting it replaces
+/// could miss or catch a loser depending on when the fan-in `abort_all`ed it
+/// (#487). The default `concatenated` strategy still counts every failure
+/// in-task (each is a missing merge contribution). The same fix applies to the
+/// formatting preferred path (tracked separately).
 async fn dispatch_preferred_diagnostics(
     region_ctx: &DocumentRequestContext,
     pool: Arc<LanguageServerPool>,
@@ -609,11 +620,12 @@ async fn dispatch_preferred_diagnostics(
     let result = dispatch_preferred(
         region_ctx,
         pool,
-        |t| send_diagnostic_request_counting_errors(t, sink.clone()),
+        send_diagnostic_fan_out_request,
         |v: &Vec<Diagnostic>| !v.is_empty(),
         None, // cancel handled at outer level
     )
     .await;
+    count_no_winner_errors(&result, sink);
 
     match result {
         FanInResult::Done(diagnostics) => diagnostics,

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -606,12 +606,13 @@ async fn dispatch_concatenated_diagnostics(
 /// Under preferred the winning server's result is authoritative, so a
 /// non-winning server's request failure is **not** counted toward CLI exit 2:
 /// failures are recorded only when no server won, via [`count_no_winner_errors`]
-/// on the fan-in result. This is deterministic — `NoResult` (all servers
-/// failed) drains every task, whereas the racy in-task counting it replaces
-/// could miss or catch a loser depending on when the fan-in `abort_all`ed it
-/// (#487). The default `concatenated` strategy still counts every failure
-/// in-task (each is a missing merge contribution). The same fix applies to the
-/// formatting preferred path (tracked separately).
+/// on the fan-in result. This is deterministic — `NoResult` (no winner emerged)
+/// drains every task, so its `errors` is the exhaustive count of the actual
+/// failures (zero if the non-winners merely returned empty), whereas the racy
+/// in-task counting it replaces could miss or catch a loser depending on when
+/// the fan-in `abort_all`ed it (#487). The default `concatenated` strategy
+/// still counts every failure in-task (each is a missing merge contribution).
+/// The same fix applies to the formatting preferred path (tracked separately).
 async fn dispatch_preferred_diagnostics(
     region_ctx: &DocumentRequestContext,
     pool: Arc<LanguageServerPool>,

--- a/tests/e2e_cli_diagnose.rs
+++ b/tests/e2e_cli_diagnose.rs
@@ -453,6 +453,81 @@ languages = ["markdown"]
 }
 
 #[test]
+fn e2e_diagnose_preferred_non_winning_failure_is_not_counted() {
+    // Under the non-default `preferred` strategy the winning server is
+    // authoritative, so a non-winning server's request failure must NOT surface
+    // as exit 2 (#487). `mock-win` (higher priority) answers with a warning for
+    // the lua region and wins; `mock-fail` errors but is a loser. The run must
+    // exit 0 deterministically (the warning is benign without --fail-on-warning,
+    // the loser's failure is ignored) — never 2.
+    let ws = workspace_with(
+        &format!(
+            r#"autoInstall = false
+
+[languages.markdown.bridge.lua.aggregation."textDocument/diagnostic"]
+strategy = "preferred"
+priorities = ["mock-win", "mock-fail"]
+
+[languageServers.mock-win]
+cmd = ['{bin}', 'diagnostics']
+languages = ["lua"]
+
+[languageServers.mock-fail]
+cmd = ['{bin}', 'diagnostics-fail']
+languages = ["lua"]
+"#,
+            bin = env!("CARGO_BIN_EXE_mock-lsp-formatter")
+        ),
+        &[("doc.md", MARKDOWN)],
+    );
+
+    let output = run_diagnose(ws.path(), &["doc.md"]);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "preferred winner is authoritative; a non-winning server's failure must \
+         not exit 2; stderr: {}",
+        stderr_of(&output)
+    );
+}
+
+#[test]
+fn e2e_diagnose_preferred_all_servers_fail_exits_two() {
+    // No server wins under `preferred` (both error) → the fan-in drains to
+    // `NoResult` and the failure count is decisive, so the run exits 2. Guards
+    // that #487's "don't count non-winning failures" does not suppress the
+    // genuine all-failed case.
+    let ws = workspace_with(
+        &format!(
+            r#"autoInstall = false
+
+[languages.markdown.bridge.lua.aggregation."textDocument/diagnostic"]
+strategy = "preferred"
+priorities = ["mock-fail-a", "mock-fail-b"]
+
+[languageServers.mock-fail-a]
+cmd = ['{bin}', 'diagnostics-fail']
+languages = ["lua"]
+
+[languageServers.mock-fail-b]
+cmd = ['{bin}', 'diagnostics-fail']
+languages = ["lua"]
+"#,
+            bin = env!("CARGO_BIN_EXE_mock-lsp-formatter")
+        ),
+        &[("doc.md", MARKDOWN)],
+    );
+
+    let output = run_diagnose(ws.path(), &["doc.md"]);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "all preferred servers failing (no winner) must exit 2; stderr: {}",
+        stderr_of(&output)
+    );
+}
+
+#[test]
 fn e2e_diagnose_directory_walk_respects_gitignore_but_explicit_path_wins() {
     let ws = workspace_with(
         &config_toml(),


### PR DESCRIPTION
> **Stacked on #501 (#488).** Base is `fix/diagnose-malformed-payload-exit2` because #487's host path builds on #488's `send_host_diagnostic_request`. GitHub will retarget this PR to `main` when #501 merges. The diff below is #487-only.

## Problem (#487)

`kakehashi diagnose`'s operational **exit 2** accounting was racy under the non-default **`preferred`** aggregation strategy. A non-winning server's request failure was counted *in-task*, but the preferred fan-in `abort_all`s the losing tasks **without joining them** (`fan_in/preferred.rs`) — so a loser's `count_request_errors` could land before *or* after the CLI read the sink: exit `0`/`1` or `2` for the same run. The default `concatenated` strategy drains every task and is exact.

## Fix (chosen approach: "don't count non-winning failures")

Under `preferred`, the winning server's result is **authoritative**, so a non-winning server's failure is irrelevant and must not surface as exit 2 — exactly the intent `RequestErrorSink` already documents ("an abandoned loser was *cancelled*, not failed"). Count failures **only when no server won**.

- New shared helper `count_no_winner_errors(&FanInResult<T>, &sink)` records the fan-in's failure count **only on `NoResult`** (no winner → the drain is exhaustive, so the count is decisive and deterministic); `Done`/`Cancelled` count nothing.
- Both preferred diagnose paths — region (`dispatch_preferred_diagnostics`) and host (`collect_host_diagnostics`) — now use a **non-counting** send + `count_no_winner_errors` on the result. The racy in-task `fetch_add` under preferred is gone.
- **`concatenated` is unchanged**: it keeps in-task counting (each failure is a missing merge contribution; a partial-success still yields `Done`, which discards the fan-in count, so in-task counting is necessary there — and exhaustive-drain makes it deterministic).
- All-servers-fail under `preferred` still yields `NoResult` → **exit 2**.

The helper is shared so the **formatting** preferred path (same in-task pattern, `formatting.rs`) can reuse it — that fix is tracked in #503 (out of #487 scope; LSP/format-only).

## Determinism

The fix removes the racy write entirely: the only sink write under preferred is `count_no_winner_errors`, run synchronously on the already-materialized `FanInResult` after the fan-in returned. No task outlives the call with a pending increment.

## Tests

- **Unit:** `count_no_winner_errors` counts on `NoResult` only; no-op without a sink.
- **E2E (deterministic):** `preferred` winner + a failing non-winner → **exit 0** (the winner is authoritative); `preferred` all-fail → **exit 2**. The winner+loser test was **verified to fail with exit 2 on the pre-fix code** — a genuine regression guard, not a vacuous pass.
- Full `cargo test --lib` green; `cargo clippy -- -D warnings` clean.

## Review

Passed a 10-perspective `/review` (verified by executing the new unit + e2e tests) and a Codex review — both found no actionable issues.

Closes #487