### PR TITLE
fix(format): count preferred failures only when no server wins (#503)

### DIFF
--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -52,7 +52,9 @@ use crate::lsp::bridge::{
     UpstreamId, VirtualDocumentUri, translate_virtual_range_to_host,
 };
 use crate::lsp::lsp_impl::bridge_context::DocumentRequestContext;
-use crate::lsp::lsp_impl::text_document::{RequestErrorSink, count_request_errors};
+use crate::lsp::lsp_impl::text_document::{
+    RequestErrorSink, count_no_winner_errors, count_request_errors,
+};
 use crate::lsp::request_id::{CancelReceiver, CancelSubscriptionGuard};
 
 use super::super::{Kakehashi, uri_to_url};
@@ -461,19 +463,18 @@ impl Kakehashi {
 
         let cancel_rx = cancel_state.derive_receiver();
         let pool = self.bridge.pool_arc();
-        // Source-level error counting, mirroring the virt preferred dispatch:
-        // `Done` discards the fan-in's error count, so counting here is what
-        // keeps a failed-but-rescued host formatter visible to CLI mode.
-        let request_error_sink = cancel_state.request_error_sink.clone();
         let result = crate::lsp::aggregation::server::dispatch_host_preferred(
             &ctx,
             pool.clone(),
+            // Non-counting send, mirroring the virt preferred dispatch: under
+            // `preferred` a non-winning host server's failure is not a CLI
+            // exit-2 (the winner is authoritative), and in-task counting is racy
+            // (the fan-in aborts losers without joining). Failures are counted
+            // only when no server won, via `count_no_winner_errors` below (#503).
             move |t| {
                 let params = params.clone();
-                let request_error_sink = request_error_sink.clone();
                 async move {
-                    let result = t
-                        .pool
+                    t.pool
                         .send_host_formatting_request(
                             &t.server_name,
                             &t.server_config,
@@ -486,11 +487,7 @@ impl Kakehashi {
                             params,
                             t.upstream_id,
                         )
-                        .await;
-                    if result.is_err() {
-                        count_request_errors(&request_error_sink, 1);
-                    }
-                    result
+                        .await
                 }
             },
             // `Some(vec![])` (and a capable server's `null`, normalized to it)
@@ -502,14 +499,17 @@ impl Kakehashi {
         )
         .await;
         pool.unregister_all_for_upstream_id(ctx.upstream_request_id.as_ref());
+        // Count failures only when no host server won (#503): `NoResult` drains
+        // every task, so its `errors` is the exhaustive, deterministic count.
+        count_no_winner_errors(&result, &cancel_state.request_error_sink);
         // Quiet on an all-empty host layer (the virt arm already emits the
         // client-visible LOG); only real host failures get surfaced —
         // mirroring `host_layer_value_with_ctx`.
         match result {
             FanInResult::Done(value) => Ok(value),
             FanInResult::NoResult { errors } => {
-                // Request errors were already counted at the source (the
-                // dispatch closure above); this arm only chooses log severity.
+                // `errors` was just recorded into the sink above; this arm only
+                // chooses log severity.
                 if errors > 0 {
                     self.client
                         .log_message(
@@ -745,15 +745,15 @@ async fn dispatch_preferred_formatting(
 ) -> Option<Vec<TextEdit>> {
     let send = move |t: crate::lsp::aggregation::server::FanOutTask| {
         let options = options.clone();
-        // Count request failures at the SOURCE, not from the fan-in
-        // verdict: `FanInResult::Done` discards the error count, so a
-        // failed higher-priority formatter rescued by a fallback server
-        // would otherwise go unreported and a CLI run would exit 0
-        // despite a broken configured formatter.
-        let request_error_sink = request_error_sink.clone();
+        // Non-counting send: under `preferred` a non-winning server's request
+        // failure is NOT a CLI exit-2 (the winner is authoritative), and
+        // counting losers in-task is racy — the preferred fan-in `abort_all`s
+        // losers without joining them, so a loser's `fetch_add` could land
+        // after the CLI read the counter. Failures are recorded only when no
+        // server won, via `count_no_winner_errors` on the fan-in result below
+        // (#503, mirroring the diagnose fix #487).
         async move {
-            let result = t
-                .pool
+            t.pool
                 .send_formatting_request(
                     &t.server_name,
                     &t.server_config,
@@ -771,11 +771,7 @@ async fn dispatch_preferred_formatting(
                     t.client_progress_token,
                     None,
                 )
-                .await;
-            if result.is_err() {
-                count_request_errors(&request_error_sink, 1);
-            }
-            result
+                .await
         }
     };
     // `Some(vec![])` is an authoritative "no edits needed" from the
@@ -800,6 +796,11 @@ async fn dispatch_preferred_formatting(
         }
         None => dispatch_preferred(region_ctx, pool, send, is_nonempty, region_cancel_rx).await,
     };
+    // Count failures only when no server won. `NoResult` drains every task, so
+    // its `errors` is the exhaustive, deterministic count (zero if the
+    // non-winners merely returned empty); `Done`/`Cancelled` count nothing
+    // (#503).
+    count_no_winner_errors(&result, &request_error_sink);
     match result {
         FanInResult::Done(edits) => edits,
         FanInResult::NoResult { .. } | FanInResult::Cancelled => None,

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -433,11 +433,14 @@ languages = ["lua"]
 }
 
 #[test]
-fn e2e_failed_formatter_rescued_by_fallback_still_exits_with_error() {
-    // Preferred fan-out: the priority server errors, the fallback formats.
-    // The file gets the fallback's output, but the broken configured
-    // formatter must still surface as exit 2 — otherwise CI never learns
-    // the primary formatter is broken.
+fn e2e_format_preferred_non_winning_failure_is_not_counted() {
+    // Preferred fan-out (the bridge-level default for formatting): the
+    // higher-priority server errors, the fallback formats and WINS. Under
+    // `preferred` the winning formatter is authoritative, so a non-winning
+    // server's request failure must NOT surface as exit 2 (#503, mirroring the
+    // diagnose fix #487). Counting losers in-task is also racy — the preferred
+    // fan-in aborts losers without joining them. The run must exit 0
+    // deterministically; the fallback's output is still written.
     let ws = workspace_with(&[("doc.md", MARKDOWN)]);
     std::fs::write(
         ws.path().join("kakehashi.toml"),
@@ -463,8 +466,9 @@ languages = ["lua"]
     let output = run_format(ws.path(), &["doc.md"]);
     assert_eq!(
         output.status.code(),
-        Some(2),
-        "a failed formatter must exit 2 even when a fallback rescued the file; stderr: {}",
+        Some(0),
+        "preferred winner is authoritative; a non-winning formatter's failure must \
+         not exit 2; stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
@@ -474,10 +478,12 @@ languages = ["lua"]
 }
 
 #[test]
-fn e2e_malformed_formatter_response_exits_with_error() {
+fn e2e_format_preferred_malformed_non_winner_is_not_counted() {
     // A protocol-invalid success (result is not TextEdit[]) is a request
-    // failure too: the fallback still formats the file, but the run must
-    // exit 2 so the broken formatter surfaces.
+    // failure, but as a non-winning candidate under `preferred` it is treated
+    // the same as any other loser failure: the fallback wins and is
+    // authoritative, so the run exits 0, not 2 (#503). The fallback still
+    // formats the file.
     let ws = workspace_with(&[("doc.md", MARKDOWN)]);
     std::fs::write(
         ws.path().join("kakehashi.toml"),
@@ -503,13 +509,50 @@ languages = ["lua"]
     let output = run_format(ws.path(), &["doc.md"]);
     assert_eq!(
         output.status.code(),
-        Some(2),
-        "a malformed formatter response must exit 2; stderr: {}",
+        Some(0),
+        "a malformed non-winning formatter must not exit 2 when a fallback wins; stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
         read(ws.path(), "doc.md").contains("LOCAL X = 1"),
         "the fallback formatter's output is still written"
+    );
+}
+
+#[test]
+fn e2e_format_preferred_all_servers_fail_exits_two() {
+    // No formatter wins under `preferred` (both error) → the fan-in drains to
+    // `NoResult` and the failure count is decisive, so the run exits 2. Guards
+    // that #503's "don't count non-winning failures" does not suppress the
+    // genuine all-failed case.
+    let ws = workspace_with(&[("doc.md", MARKDOWN)]);
+    std::fs::write(
+        ws.path().join("kakehashi.toml"),
+        format!(
+            r#"autoInstall = false
+
+[languages.markdown.bridge.lua.aggregation."textDocument/formatting"]
+priorities = ["mock-fail-a", "mock-fail-b"]
+
+[languageServers.mock-fail-a]
+cmd = ['{bin}', 'fail-request']
+languages = ["lua"]
+
+[languageServers.mock-fail-b]
+cmd = ['{bin}', 'fail-request']
+languages = ["lua"]
+"#,
+            bin = env!("CARGO_BIN_EXE_mock-lsp-formatter")
+        ),
+    )
+    .expect("write all-fail config");
+
+    let output = run_format(ws.path(), &["doc.md"]);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "all preferred formatters failing (no winner) must exit 2; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
     );
 }
 

--- a/tests/e2e_cli_format.rs
+++ b/tests/e2e_cli_format.rs
@@ -554,6 +554,16 @@ languages = ["lua"]
         "all preferred formatters failing (no winner) must exit 2; stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("operation(s) failed"),
+        "stderr should report the failed requests; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        read(ws.path(), "doc.md"),
+        MARKDOWN,
+        "no winner means no edit — the file must be left untouched"
+    );
 }
 
 #[test]
@@ -590,6 +600,54 @@ languages = ["markdown"]
         read(ws.path(), "doc.md"),
         MARKDOWN,
         "the file must be left untouched"
+    );
+}
+
+#[test]
+fn e2e_host_layer_preferred_non_winning_failure_is_not_counted() {
+    // The HOST-layer analogue of `e2e_format_preferred_non_winning_failure_
+    // is_not_counted`: two `bridge._self` host formatters race under
+    // `preferred`; the higher-priority one errors, the fallback uppercases the
+    // document and WINS. The winning host formatter is authoritative, so the
+    // loser's failure must NOT exit 2 (#503) — pinning the non-counting change
+    // in `host_format_edits`, which the single-server host failure test (no
+    // winner → exit 2) cannot exercise.
+    let ws = workspace_with(&[("doc.md", MARKDOWN)]);
+    std::fs::write(
+        ws.path().join("kakehashi.toml"),
+        format!(
+            r#"autoInstall = false
+
+[languages.markdown.bridge._self]
+enabled = true
+
+[languages.markdown.bridge._self.aggregation."textDocument/formatting"]
+priorities = ["mock-fail-host", "mock-upper-host"]
+
+[languageServers.mock-fail-host]
+cmd = ['{bin}', 'fail-request']
+languages = ["markdown"]
+
+[languageServers.mock-upper-host]
+cmd = ['{bin}', 'upper']
+languages = ["markdown"]
+"#,
+            bin = env!("CARGO_BIN_EXE_mock-lsp-formatter")
+        ),
+    )
+    .expect("write host fail+fallback config");
+
+    let output = run_format(ws.path(), &["doc.md"]);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "a winning host formatter is authoritative; the loser's failure must not \
+         exit 2; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        read(ws.path(), "doc.md").contains("LOCAL X = 1"),
+        "the winning host formatter's uppercased output is still written"
     );
 }
 


### PR DESCRIPTION
Closes #503.

## What

Mirror the diagnose fix (#487) onto the **formatting** `preferred` aggregation paths.

Under `preferred`, a non-winning formatter's request failure was counted in-task (`if result.is_err() { count_request_errors(...) }`), so a failed-but-rescued formatter surfaced as CLI **exit 2**. That is wrong — the winning formatter is authoritative, so a loser's failure is irrelevant — and racy: the preferred fan-in `abort_all`s losers without joining them, so a loser's `fetch_add` could land after the CLI read the counter.

## How

- `dispatch_preferred_formatting` (virt) and `host_format_edits` (host) now use a **non-counting send** and record failures only when no server won, via the shared `count_no_winner_errors(&result, &sink)` on the fan-in result. `NoResult` drains every task, so its `errors` is the exhaustive, deterministic count.
- The `concatenated` formatting pipeline **keeps** in-task counting (each failure is a missing contribution) — unchanged.

## Behavior change (please confirm)

Two existing e2e tests asserted the **pre-fix** behavior (a rescued-by-fallback loser failure → exit 2). They are inverted to exit 0 and renamed:
- `e2e_failed_formatter_rescued_by_fallback_still_exits_with_error` → `e2e_format_preferred_non_winning_failure_is_not_counted`
- `e2e_malformed_formatter_response_exits_with_error` → `e2e_format_preferred_malformed_non_winner_is_not_counted`

The second flip is the slightly stronger claim — a **malformed** (protocol-invalid) response that *loses* now also exits 0. It follows uniformly from #503's "winner is authoritative" logic and the issue does not carve it out, but flagging it in case you intended malformed losers to stay exit-2.

New guards added:
- `e2e_format_preferred_all_servers_fail_exits_two` — genuine no-winner case still exits 2 (+ file untouched + stderr assertion).
- `e2e_host_layer_preferred_non_winning_failure_is_not_counted` — host-layer analogue pinning the `host_format_edits` change (a single failing host server alone can't exercise a winner + loser).

## Testing

- `cargo test --features e2e --test e2e_cli_format` — 17 pass.
- Lib clippy, fmt, `cargo test --lib` (2118) green. (The pre-commit `--all-targets` gate trips on a pre-existing unrelated `redundant_locals` lint in `did_open.rs` test code, identical to `origin/main`; not introduced here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)