### PR TITLE
refactor(parse): per-document parse watermark (publish + first reader consumer)

### DIFF
--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -363,6 +363,39 @@ impl DocumentStore {
         });
     }
 
+    /// Wait until the parse watermark for `uri` reaches `target` — the tail
+    /// ingress ticket a virt/native reader must observe — bounded by `timeout`.
+    ///
+    /// Returns early (proceed into the empty/`null` reader fallback) when the
+    /// watermark already covers `target`, when there is no watermark entry
+    /// (nothing has been published, or a `didClose` removed it — so there is
+    /// nothing to wait for), or when the entry is dropped while waiting (a
+    /// concurrent `didClose`). Non-inserting on the missing-entry path so it never
+    /// resurrects a watermark for a closed URI.
+    pub(crate) async fn wait_for_epoch(
+        &self,
+        uri: &Url,
+        target: u64,
+        timeout: std::time::Duration,
+    ) {
+        // Subscribe under the shard read lock, then drop the `Ref` *before*
+        // awaiting — never hold a DashMap guard across `.await`.
+        let mut receiver = {
+            let Some(sender) = self.watermarks.get(uri) else {
+                return;
+            };
+            sender.subscribe()
+        };
+
+        let wait_future = async {
+            // Err => the sender was dropped (entry removed after a close): every
+            // parse that will ever run for this lifetime has, so proceed.
+            let _ = receiver.wait_for(|watermark| *watermark >= target).await;
+        };
+
+        let _ = tokio::time::timeout(timeout, wait_future).await;
+    }
+
     // Lock safety: Single remove() call - no read lock held before or during write
     pub(crate) fn remove(&self, uri: &Url) -> Option<Document> {
         self.parse_states.remove(uri);
@@ -591,6 +624,109 @@ mod tests {
             None,
             "closing the document drops its watermark so a reopen starts fresh"
         );
+    }
+
+    #[tokio::test]
+    async fn wait_for_epoch_returns_immediately_when_already_reached() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///wm.rs").unwrap();
+        store.advance_watermark(&uri, 5);
+
+        // target below the watermark resolves without blocking.
+        timeout(
+            Duration::from_millis(100),
+            store.wait_for_epoch(&uri, 3, Duration::from_secs(10)),
+        )
+        .await
+        .expect("a watermark already past the target must not block");
+    }
+
+    #[tokio::test]
+    async fn wait_for_epoch_returns_immediately_when_no_entry() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///absent.rs").unwrap();
+        // No publish has happened: nothing is pending, so the reader proceeds.
+        timeout(
+            Duration::from_millis(100),
+            store.wait_for_epoch(&uri, 1, Duration::from_secs(10)),
+        )
+        .await
+        .expect("a missing watermark entry means nothing to wait for");
+    }
+
+    #[tokio::test]
+    async fn wait_for_epoch_blocks_until_watermark_reaches_target() {
+        let store = Arc::new(DocumentStore::new());
+        let uri = Url::parse("file:///wm.rs").unwrap();
+        // Entry exists at ticket 1, below the reader's target of 3.
+        store.advance_watermark(&uri, 1);
+
+        let waiter = {
+            let store = Arc::clone(&store);
+            let uri = uri.clone();
+            tokio::spawn(async move {
+                store.wait_for_epoch(&uri, 3, Duration::from_secs(10)).await;
+            })
+        };
+
+        // The intermediate ticket 2 must not release a reader waiting for 3.
+        store.advance_watermark(&uri, 2);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            !waiter.is_finished(),
+            "reader must keep waiting until the watermark covers its target ticket"
+        );
+
+        store.advance_watermark(&uri, 3);
+        timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("reaching the target must wake the reader")
+            .expect("waiter task panicked");
+    }
+
+    #[tokio::test]
+    async fn wait_for_epoch_proceeds_when_entry_removed_mid_wait() {
+        let store = Arc::new(DocumentStore::new());
+        let uri = Url::parse("file:///wm.rs").unwrap();
+        store.advance_watermark(&uri, 1);
+
+        let waiter = {
+            let store = Arc::clone(&store);
+            let uri = uri.clone();
+            tokio::spawn(async move {
+                store.wait_for_epoch(&uri, 9, Duration::from_secs(10)).await;
+            })
+        };
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            !waiter.is_finished(),
+            "reader is waiting for an unreached target"
+        );
+
+        // A didClose drops the watermark entry: the blocked reader must proceed
+        // (into the empty fallback) rather than stall to the timeout.
+        store.remove(&uri);
+        timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("dropping the watermark sender must wake the reader")
+            .expect("waiter task panicked");
+    }
+
+    #[tokio::test]
+    async fn wait_for_epoch_times_out_when_target_unreached() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///wm.rs").unwrap();
+        store.advance_watermark(&uri, 1);
+
+        // The watermark never reaches 9; the bounded wait returns after the
+        // timeout rather than hanging.
+        timeout(
+            Duration::from_secs(5),
+            store.wait_for_epoch(&uri, 9, Duration::from_millis(80)),
+        )
+        .await
+        .expect("wait_for_epoch must return after its own timeout even if unreached");
     }
 
     #[test]

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -347,9 +347,14 @@ impl DocumentStore {
     /// document's — it exists exactly while the document is open and is dropped by
     /// [`remove`](Self::remove) on close.
     fn ensure_watermark_entry(&self, uri: &Url) {
-        self.watermarks
-            .entry(uri.clone())
-            .or_insert_with(|| watch::channel(0).0);
+        // `insert()` runs on every didChange; the entry almost always already
+        // exists. Probe with a borrowed `get` first so the common hit path takes
+        // no `Url` clone, paying the clone only on the (rare) first registration.
+        if self.watermarks.get(uri).is_none() {
+            self.watermarks
+                .entry(uri.clone())
+                .or_insert_with(|| watch::channel(0).0);
+        }
     }
 
     /// Publish that the parse covering ingress writer `ticket` for `uri` has
@@ -384,11 +389,12 @@ impl DocumentStore {
     /// ingress ticket a virt/native reader must observe — bounded by `timeout`.
     ///
     /// Returns early (proceed into the empty/`null` reader fallback) when the
-    /// watermark already covers `target`, when there is no watermark entry
-    /// (nothing has been published, or a `didClose` removed it — so there is
-    /// nothing to wait for), or when the entry is dropped while waiting (a
-    /// concurrent `didClose`). Non-inserting on the missing-entry path so it never
-    /// resurrects a watermark for a closed URI.
+    /// watermark already covers `target`, when there is no watermark entry — the
+    /// document is not registered (never opened, or a `didClose` removed it), as
+    /// `insert` seeds the entry at 0 for every live document, so there is nothing
+    /// to wait for — or when the entry is dropped while waiting (a concurrent
+    /// `didClose`). Non-inserting on the missing-entry path so it never resurrects
+    /// a watermark for a closed URI.
     pub(crate) async fn wait_for_epoch(
         &self,
         uri: &Url,
@@ -729,7 +735,9 @@ mod tests {
 
         // The intermediate ticket 2 must not release a reader waiting for 3.
         store.advance_watermark(&uri, 2);
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        // Let the spawned waiter run to its park point (deterministic on the
+        // current-thread test runtime — no wall-clock dependency).
+        tokio::task::yield_now().await;
         assert!(
             !waiter.is_finished(),
             "reader must keep waiting until the watermark covers its target ticket"
@@ -757,7 +765,7 @@ mod tests {
             })
         };
 
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        tokio::task::yield_now().await;
         assert!(
             !waiter.is_finished(),
             "reader is waiting for an unreached target"

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -615,7 +615,11 @@ mod tests {
     fn insert_seeds_a_watermark_entry_at_zero() {
         let store = DocumentStore::new();
         let uri = Url::parse("file:///wm.rs").unwrap();
-        assert_eq!(watermark_of(&store, &uri), None, "no entry before registration");
+        assert_eq!(
+            watermark_of(&store, &uri),
+            None,
+            "no entry before registration"
+        );
 
         seed_document(&store, &uri);
         assert_eq!(
@@ -632,7 +636,11 @@ mod tests {
         seed_document(&store, &uri);
 
         store.advance_watermark(&uri, 7);
-        assert_eq!(watermark_of(&store, &uri), Some(7), "publish records the ticket");
+        assert_eq!(
+            watermark_of(&store, &uri),
+            Some(7),
+            "publish records the ticket"
+        );
     }
 
     #[test]
@@ -650,7 +658,11 @@ mod tests {
         );
 
         store.advance_watermark(&uri, 8);
-        assert_eq!(watermark_of(&store, &uri), Some(8), "a higher ticket advances it");
+        assert_eq!(
+            watermark_of(&store, &uri),
+            Some(8),
+            "a higher ticket advances it"
+        );
     }
 
     #[test]

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -229,6 +229,11 @@ impl DocumentStore {
             }
         };
         self.update_tree_availability(&uri, has_tree);
+        // Keep the "live document ⟺ watermark entry" invariant: `update_document`
+        // can insert on its `Vacant` branch, and a present document with no
+        // watermark entry would make `wait_for_epoch` treat it as unregistered.
+        // Idempotent on the (common) update-in-place path.
+        self.ensure_watermark_entry(&uri);
     }
 
     /// Store `new_tree` for an **existing** document, but only if its current text
@@ -626,6 +631,20 @@ mod tests {
             watermark_of(&store, &uri),
             Some(0),
             "registering the document seeds a watermark at 0"
+        );
+    }
+
+    #[test]
+    fn update_document_seeds_a_watermark_entry_when_it_inserts() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///wm.rs").unwrap();
+        // `update_document` (a reader on-demand fallback) inserts on its vacant
+        // branch; the watermark invariant must hold for the resulting document.
+        store.update_document(uri.clone(), "x".to_string(), None);
+        assert_eq!(
+            watermark_of(&store, &uri),
+            Some(0),
+            "a document created via update_document must still get a watermark entry"
         );
     }
 

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -187,6 +187,9 @@ impl DocumentStore {
 
         self.documents.insert(uri.clone(), document);
         self.update_tree_availability(&uri, has_tree);
+        // Seed the watermark so its lifetime tracks the document's; `advance_watermark`
+        // is non-inserting and relies on this entry being present.
+        self.ensure_watermark_entry(&uri);
     }
 
     // Lock safety: Returns DocumentHandle wrapping Ref - caller holds read lock until drop
@@ -338,20 +341,34 @@ impl DocumentStore {
         self.edit_locks.remove(uri);
     }
 
+    /// Ensure a watermark entry exists for `uri`, created at ticket 0. Idempotent:
+    /// an already-advanced watermark is left untouched. Called when a document is
+    /// registered ([`insert`](Self::insert)) so the watermark's lifetime tracks the
+    /// document's — it exists exactly while the document is open and is dropped by
+    /// [`remove`](Self::remove) on close.
+    fn ensure_watermark_entry(&self, uri: &Url) {
+        self.watermarks
+            .entry(uri.clone())
+            .or_insert_with(|| watch::channel(0).0);
+    }
+
     /// Publish that the parse covering ingress writer `ticket` for `uri` has
     /// reached a terminal outcome. The watermark only ever advances — a later
     /// resolution for an earlier ticket (a parse superseded then completed out of
-    /// order) cannot regress it — so a reader's `>= target` wait is stable. The
-    /// entry is created on first publish (a live document always parses before any
-    /// reader needs it) and dropped by [`remove`](Self::remove) on close.
+    /// order) cannot regress it — so a reader's `>= target` wait is stable.
+    ///
+    /// **Non-inserting**: it advances an existing entry but never creates one. The
+    /// entry is seeded by [`insert`](Self::insert) when the document is registered
+    /// and dropped on close, so a straggler parse that resolves *after* a
+    /// `didClose` (its epoch now stale) finds no entry and no-ops, rather than
+    /// resurrecting a ghost watermark for a closed URI. Every live mutation that
+    /// schedules a parse has registered the document first, so the entry is always
+    /// present when a legitimate publish runs.
     pub(crate) fn advance_watermark(&self, uri: &Url, ticket: u64) {
-        let sender = match self.watermarks.entry(uri.clone()) {
-            Entry::Occupied(entry) => entry.get().clone(),
-            Entry::Vacant(entry) => {
-                let (sender, _receiver) = watch::channel(0);
-                entry.insert(sender.clone());
-                sender
-            }
+        // Clone the sender out of the `Ref` (so the DashMap guard is dropped
+        // before `send_if_modified`); a missing entry means a closed document.
+        let Some(sender) = self.watermarks.get(uri).map(|sender| sender.clone()) else {
+            return;
         };
         sender.send_if_modified(|watermark| {
             if ticket > *watermark {
@@ -583,11 +600,30 @@ mod tests {
         store.watermarks.get(uri).map(|s| *s.borrow())
     }
 
+    /// Register a document so its watermark entry is seeded (mirrors a didOpen).
+    fn seed_document(store: &DocumentStore, uri: &Url) {
+        store.insert(uri.clone(), "x".to_string(), Some("rust".to_string()), None);
+    }
+
+    #[test]
+    fn insert_seeds_a_watermark_entry_at_zero() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///wm.rs").unwrap();
+        assert_eq!(watermark_of(&store, &uri), None, "no entry before registration");
+
+        seed_document(&store, &uri);
+        assert_eq!(
+            watermark_of(&store, &uri),
+            Some(0),
+            "registering the document seeds a watermark at 0"
+        );
+    }
+
     #[test]
     fn advance_watermark_publishes_the_ticket() {
         let store = DocumentStore::new();
         let uri = Url::parse("file:///wm.rs").unwrap();
-        assert_eq!(watermark_of(&store, &uri), None, "no entry before any publish");
+        seed_document(&store, &uri);
 
         store.advance_watermark(&uri, 7);
         assert_eq!(watermark_of(&store, &uri), Some(7), "publish records the ticket");
@@ -597,6 +633,7 @@ mod tests {
     fn advance_watermark_is_monotonic() {
         let store = DocumentStore::new();
         let uri = Url::parse("file:///wm.rs").unwrap();
+        seed_document(&store, &uri);
         store.advance_watermark(&uri, 5);
         // An out-of-order resolution for an earlier ticket must not regress it.
         store.advance_watermark(&uri, 3);
@@ -611,10 +648,29 @@ mod tests {
     }
 
     #[test]
+    fn advance_watermark_does_not_resurrect_a_closed_document() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///wm.rs").unwrap();
+        seed_document(&store, &uri);
+        store.advance_watermark(&uri, 2);
+
+        // didClose drops the entry; a straggler parse for a now-stale ticket then
+        // resolves and tries to publish. Being non-inserting, it must NOT recreate
+        // a ghost watermark for the closed URI.
+        store.remove(&uri);
+        store.advance_watermark(&uri, 3);
+        assert_eq!(
+            watermark_of(&store, &uri),
+            None,
+            "a publish after close must not resurrect a watermark entry"
+        );
+    }
+
+    #[test]
     fn remove_drops_the_watermark_entry() {
         let store = DocumentStore::new();
         let uri = Url::parse("file:///wm.rs").unwrap();
-        store.insert(uri.clone(), "x".to_string(), Some("rust".to_string()), None);
+        seed_document(&store, &uri);
         store.advance_watermark(&uri, 4);
         assert_eq!(watermark_of(&store, &uri), Some(4));
 
@@ -630,6 +686,7 @@ mod tests {
     async fn wait_for_epoch_returns_immediately_when_already_reached() {
         let store = DocumentStore::new();
         let uri = Url::parse("file:///wm.rs").unwrap();
+        seed_document(&store, &uri);
         store.advance_watermark(&uri, 5);
 
         // target below the watermark resolves without blocking.
@@ -658,7 +715,8 @@ mod tests {
     async fn wait_for_epoch_blocks_until_watermark_reaches_target() {
         let store = Arc::new(DocumentStore::new());
         let uri = Url::parse("file:///wm.rs").unwrap();
-        // Entry exists at ticket 1, below the reader's target of 3.
+        // Entry seeded at 0, advanced to ticket 1, below the reader's target of 3.
+        seed_document(&store, &uri);
         store.advance_watermark(&uri, 1);
 
         let waiter = {
@@ -688,6 +746,7 @@ mod tests {
     async fn wait_for_epoch_proceeds_when_entry_removed_mid_wait() {
         let store = Arc::new(DocumentStore::new());
         let uri = Url::parse("file:///wm.rs").unwrap();
+        seed_document(&store, &uri);
         store.advance_watermark(&uri, 1);
 
         let waiter = {
@@ -717,6 +776,7 @@ mod tests {
     async fn wait_for_epoch_times_out_when_target_unreached() {
         let store = DocumentStore::new();
         let uri = Url::parse("file:///wm.rs").unwrap();
+        seed_document(&store, &uri);
         store.advance_watermark(&uri, 1);
 
         // The watermark never reaches 9; the bounded wait returns after the

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -35,6 +35,21 @@ pub struct DocumentStore {
     /// `Kakehashi::store_lineage` (captures-protocol §"Delta semantics").
     open_generations: DashMap<Url, u64>,
     open_counter: std::sync::atomic::AtomicU64,
+    /// Per-document **parse watermark**: the highest ingress writer ticket whose
+    /// parse has reached a terminal outcome (a tree, or parsed-to-nothing). It is
+    /// monotonic per document and published by the parse path on resolution.
+    ///
+    /// This is deliberately a signal **distinct** from the `IngressOrderGate`
+    /// completion channel. Today the parse resolves *inline*, before its writer
+    /// ticket completes, so the watermark and ticket-completion move in lockstep;
+    /// a reader gated behind the ticket already observes a fresh tree. The
+    /// per-document parse actor (see `per-document-parse-actor` ADR) will run the
+    /// parse *off* the ingress ticket, at which point ticket-completion no longer
+    /// implies a fresh tree and this watermark — not the completion channel — is
+    /// what tells a virt/native reader the store reflects its tail edit. Keyed on
+    /// the ticket (the intra-lifetime wire order); the incarnation half of the
+    /// eventual `(incarnation, ticket)` epoch is not folded in yet.
+    watermarks: DashMap<Url, watch::Sender<u64>>,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -70,6 +85,7 @@ impl Default for DocumentStore {
             edit_locks: DashMap::new(),
             open_generations: DashMap::new(),
             open_counter: std::sync::atomic::AtomicU64::new(0),
+            watermarks: DashMap::new(),
         }
     }
 }
@@ -322,11 +338,40 @@ impl DocumentStore {
         self.edit_locks.remove(uri);
     }
 
+    /// Publish that the parse covering ingress writer `ticket` for `uri` has
+    /// reached a terminal outcome. The watermark only ever advances — a later
+    /// resolution for an earlier ticket (a parse superseded then completed out of
+    /// order) cannot regress it — so a reader's `>= target` wait is stable. The
+    /// entry is created on first publish (a live document always parses before any
+    /// reader needs it) and dropped by [`remove`](Self::remove) on close.
+    pub(crate) fn advance_watermark(&self, uri: &Url, ticket: u64) {
+        let sender = match self.watermarks.entry(uri.clone()) {
+            Entry::Occupied(entry) => entry.get().clone(),
+            Entry::Vacant(entry) => {
+                let (sender, _receiver) = watch::channel(0);
+                entry.insert(sender.clone());
+                sender
+            }
+        };
+        sender.send_if_modified(|watermark| {
+            if ticket > *watermark {
+                *watermark = ticket;
+                true
+            } else {
+                false
+            }
+        });
+    }
+
     // Lock safety: Single remove() call - no read lock held before or during write
     pub(crate) fn remove(&self, uri: &Url) -> Option<Document> {
         self.parse_states.remove(uri);
         self.edit_locks.remove(uri);
         self.open_generations.remove(uri);
+        // Dropping the watermark sender wakes any reader still blocked on
+        // `wait_for_epoch` for this document, so a reader racing the close
+        // proceeds into the empty fallback instead of stalling to the timeout.
+        self.watermarks.remove(uri);
         self.documents.remove(uri).map(|(_, doc)| doc)
     }
 
@@ -497,6 +542,54 @@ mod tests {
             store.parse_states.get(&uri).is_none(),
             "the availability update must not recreate a parse-state for a URI whose \
              parse-state a concurrent close already removed"
+        );
+    }
+
+    /// Read the published watermark for a URI (test-only; the field is private).
+    fn watermark_of(store: &DocumentStore, uri: &Url) -> Option<u64> {
+        store.watermarks.get(uri).map(|s| *s.borrow())
+    }
+
+    #[test]
+    fn advance_watermark_publishes_the_ticket() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///wm.rs").unwrap();
+        assert_eq!(watermark_of(&store, &uri), None, "no entry before any publish");
+
+        store.advance_watermark(&uri, 7);
+        assert_eq!(watermark_of(&store, &uri), Some(7), "publish records the ticket");
+    }
+
+    #[test]
+    fn advance_watermark_is_monotonic() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///wm.rs").unwrap();
+        store.advance_watermark(&uri, 5);
+        // An out-of-order resolution for an earlier ticket must not regress it.
+        store.advance_watermark(&uri, 3);
+        assert_eq!(
+            watermark_of(&store, &uri),
+            Some(5),
+            "a later-but-lower publish must not regress the watermark"
+        );
+
+        store.advance_watermark(&uri, 8);
+        assert_eq!(watermark_of(&store, &uri), Some(8), "a higher ticket advances it");
+    }
+
+    #[test]
+    fn remove_drops_the_watermark_entry() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///wm.rs").unwrap();
+        store.insert(uri.clone(), "x".to_string(), Some("rust".to_string()), None);
+        store.advance_watermark(&uri, 4);
+        assert_eq!(watermark_of(&store, &uri), Some(4));
+
+        store.remove(&uri);
+        assert_eq!(
+            watermark_of(&store, &uri),
+            None,
+            "closing the document drops its watermark so a reopen starts fresh"
         );
     }
 

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -18,6 +18,7 @@ mod semantic_request_tracker;
 mod settings;
 
 pub use bridge::LanguageServerPool;
+pub(crate) use ingress_order::current_writer_ticket;
 pub use ingress_order::IngressOrderGate;
 pub use lsp_impl::Kakehashi;
 pub(crate) use request_id::current_upstream_id;

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -18,7 +18,7 @@ mod semantic_request_tracker;
 mod settings;
 
 pub use bridge::LanguageServerPool;
-pub(crate) use ingress_order::current_writer_ticket;
+pub(crate) use ingress_order::{current_reader_tail, current_writer_ticket};
 pub use ingress_order::IngressOrderGate;
 pub use lsp_impl::Kakehashi;
 pub(crate) use request_id::current_upstream_id;

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -18,8 +18,8 @@ mod semantic_request_tracker;
 mod settings;
 
 pub use bridge::LanguageServerPool;
-pub(crate) use ingress_order::{current_reader_tail, current_writer_ticket};
 pub use ingress_order::IngressOrderGate;
+pub(crate) use ingress_order::{current_reader_tail, current_writer_ticket};
 pub use lsp_impl::Kakehashi;
 pub(crate) use request_id::current_upstream_id;
 pub use request_id::{CancelForwarder, RequestIdCapture};

--- a/src/lsp/ingress_order.rs
+++ b/src/lsp/ingress_order.rs
@@ -192,17 +192,21 @@ impl DocumentSequencer {
         let Some(entry) = self.docs.get(uri) else {
             return (None, None);
         };
-        let barrier = if *entry.completion.done.borrow() < entry.tail {
-            let rx = entry.completion.done.subscribe();
+        let done = *entry.completion.done.borrow();
+        let tail = entry.tail;
+        let barrier = if done < tail {
             Some(ReaderBarrier {
-                target: entry.tail,
-                rx,
+                target: tail,
+                rx: entry.completion.done.subscribe(),
             })
         } else {
             None
         };
-        let tail = (entry.tail > 0).then_some(entry.tail);
-        (barrier, tail)
+        // Release the `docs` read-lock shard before the cheap tail check: this is
+        // the reader hot path, and holding it would needlessly contend with
+        // writers taking the shard's write lock (issue_writer_ticket / finish_close).
+        drop(entry);
+        (barrier, (tail > 0).then_some(tail))
     }
 
     /// Drop `uri`'s sequencing state after a close completed, unless later

--- a/src/lsp/ingress_order.rs
+++ b/src/lsp/ingress_order.rs
@@ -53,6 +53,25 @@ use tower_lsp_server::jsonrpc::{Request, Response};
 
 use crate::error::LockResultExt;
 
+tokio::task_local! {
+    /// The current writer's ingress ticket, scoped around the gated handler
+    /// future so the `didOpen` / `didChange` handler can stamp the parse it
+    /// schedules with the wire-order ticket. Read via [`current_writer_ticket`].
+    ///
+    /// Deliberately bridges gate→handler only: the handler reads it and threads
+    /// the ticket down to `parse_document` as an explicit value, so the parse can
+    /// publish the watermark from inside the per-document actor task later, where
+    /// this task-local is no longer in scope.
+    static WRITER_TICKET: u64;
+}
+
+/// The ingress writer ticket of the currently-running gated writer handler, or
+/// `None` when called outside a gated writer (e.g. a unit test invoking a
+/// handler directly without the middleware).
+pub(crate) fn current_writer_ticket() -> Option<u64> {
+    WRITER_TICKET.try_with(|ticket| *ticket).ok()
+}
+
 /// Per-document sequencing state.
 struct DocSeq {
     /// Last issued writer ticket (tickets start at 1; 0 = none issued).
@@ -339,10 +358,12 @@ where
             Some(Role::Writer { uri, close }) => {
                 let sequencer = Arc::clone(&self.sequencer);
                 let mut gate = sequencer.issue_writer_ticket(&uri);
+                let ticket = gate.ticket();
                 Box::pin(async move {
                     gate.wait_turn().await;
-                    let result = inner_fut.await;
-                    let ticket = gate.ticket();
+                    // Scope the ticket around the handler so it can stamp its
+                    // scheduled parse with this wire-order ticket.
+                    let result = WRITER_TICKET.scope(ticket, inner_fut).await;
                     // Mark done before any cleanup decision.
                     drop(gate);
                     if close {

--- a/src/lsp/ingress_order.rs
+++ b/src/lsp/ingress_order.rs
@@ -137,7 +137,7 @@ impl DocCompletion {
 
 /// Issues per-document writer tickets and reader barriers in wire order.
 ///
-/// `issue_writer_ticket` / `reader_barrier` are synchronous so they can run
+/// `issue_writer_ticket` / `reader_barrier_and_tail` are synchronous so they run
 /// inside `Service::call`, which tower-lsp-server invokes in wire order; the
 /// returned values are awaited later, inside the buffered handler future.
 #[derive(Default)]
@@ -178,30 +178,31 @@ impl DocumentSequencer {
         }
     }
 
-    /// Snapshot the barrier a reader of `uri` must wait behind: the writer
-    /// ticket tail at call time. Returns `None` when no writer is pending
-    /// (no entry, or every issued ticket already completed).
-    pub(crate) fn reader_barrier(&self, uri: &str) -> Option<ReaderBarrier> {
-        let entry = self.docs.get(uri)?;
-        if *entry.completion.done.borrow() >= entry.tail {
-            return None;
-        }
-        let target = entry.tail;
-        let rx = entry.completion.done.subscribe();
-        drop(entry);
-        Some(ReaderBarrier { target, rx })
-    }
-
-    /// The tail writer ticket a reader of `uri` must observe: the highest ticket
-    /// issued at call time, regardless of completion. `None` when no writer was
-    /// ever ticketed for the document (so there is nothing for the reader to wait
-    /// on). Unlike [`reader_barrier`](Self::reader_barrier) this reports the tail
-    /// even when every writer has already completed, because the reader waits on
-    /// the parse **watermark** (which a completed ticket has already advanced),
-    /// not on ticket completion.
-    pub(crate) fn reader_tail(&self, uri: &str) -> Option<u64> {
-        let entry = self.docs.get(uri)?;
-        (entry.tail > 0).then_some(entry.tail)
+    /// Snapshot, in a **single** `docs` lookup (the reader hot path), both of the
+    /// things a reader of `uri` needs at call time:
+    ///
+    /// - the **barrier** it must wait behind — the writer tail ticket — or `None`
+    ///   when no writer is pending (no entry, or every issued ticket completed);
+    /// - the **tail** writer ticket it must observe via the parse watermark, or
+    ///   `None` when no writer was ever ticketed. Unlike the barrier, this is
+    ///   reported even when every writer has already completed, because the reader
+    ///   waits on the watermark (which a completed ticket has already advanced),
+    ///   not on ticket completion.
+    pub(crate) fn reader_barrier_and_tail(&self, uri: &str) -> (Option<ReaderBarrier>, Option<u64>) {
+        let Some(entry) = self.docs.get(uri) else {
+            return (None, None);
+        };
+        let barrier = if *entry.completion.done.borrow() < entry.tail {
+            let rx = entry.completion.done.subscribe();
+            Some(ReaderBarrier {
+                target: entry.tail,
+                rx,
+            })
+        } else {
+            None
+        };
+        let tail = (entry.tail > 0).then_some(entry.tail);
+        (barrier, tail)
     }
 
     /// Drop `uri`'s sequencing state after a close completed, unless later
@@ -398,13 +399,13 @@ where
                 })
             }
             Some(Role::Reader { uri }) => {
-                let barrier = self.sequencer.reader_barrier(&uri);
-                // Snapshot the tail ticket at `call` time (wire order), exposing
-                // it to the handler so a virt/native reader can wait for the parse
-                // watermark to reach it. `reader_barrier` only reports a pending
-                // writer; the tail is needed even when all writers completed,
-                // because the watermark — not ticket completion — gates the read.
-                let tail = self.sequencer.reader_tail(&uri);
+                // Snapshot the barrier and the tail ticket at `call` time (wire
+                // order) in one lookup, exposing the tail to the handler so a
+                // virt/native reader can wait for the parse watermark to reach it.
+                // The barrier only reports a pending writer; the tail is needed
+                // even when all writers completed, because the watermark — not
+                // ticket completion — gates the read.
+                let (barrier, tail) = self.sequencer.reader_barrier_and_tail(&uri);
                 Box::pin(async move {
                     if let Some(barrier) = barrier {
                         barrier.wait().await;
@@ -458,7 +459,10 @@ mod tests {
         let seq = DocumentSequencer::default();
         let first = seq.issue_writer_ticket(URI);
 
-        let barrier = seq.reader_barrier(URI).expect("writer pending");
+        let barrier = seq
+            .reader_barrier_and_tail(URI)
+            .0
+            .expect("writer pending");
 
         // A writer arriving AFTER the reader must not extend its wait.
         let second = seq.issue_writer_ticket(URI);
@@ -476,14 +480,14 @@ mod tests {
     async fn reader_with_no_pending_writers_does_not_wait() {
         let seq = DocumentSequencer::default();
         assert!(
-            seq.reader_barrier(URI).is_none(),
+            seq.reader_barrier_and_tail(URI).0.is_none(),
             "no entry means no waiting"
         );
 
         let first = seq.issue_writer_ticket(URI);
         drop(first);
         assert!(
-            seq.reader_barrier(URI).is_none(),
+            seq.reader_barrier_and_tail(URI).0.is_none(),
             "all tickets done means no waiting"
         );
     }
@@ -491,23 +495,29 @@ mod tests {
     #[tokio::test]
     async fn reader_tail_reports_highest_ticket_even_after_completion() {
         let seq = DocumentSequencer::default();
-        assert_eq!(seq.reader_tail(URI), None, "no writer issued → nothing to wait on");
+        assert_eq!(
+            seq.reader_barrier_and_tail(URI).1,
+            None,
+            "no writer issued → nothing to wait on"
+        );
 
         let first = seq.issue_writer_ticket(URI);
         let second = seq.issue_writer_ticket(URI);
-        assert_eq!(seq.reader_tail(URI), Some(2), "tail is the highest issued ticket");
+        assert_eq!(
+            seq.reader_barrier_and_tail(URI).1,
+            Some(2),
+            "tail is the highest issued ticket"
+        );
 
-        // Unlike `reader_barrier`, the tail is still reported once every writer
-        // has completed — the reader waits on the parse watermark, which a
-        // completed ticket has already advanced.
+        // Unlike the barrier, the tail is still reported once every writer has
+        // completed — the reader waits on the parse watermark, which a completed
+        // ticket has already advanced.
         drop(first);
         drop(second);
-        assert!(
-            seq.reader_barrier(URI).is_none(),
-            "all writers done → no barrier"
-        );
+        let (barrier, tail) = seq.reader_barrier_and_tail(URI);
+        assert!(barrier.is_none(), "all writers done → no barrier");
         assert_eq!(
-            seq.reader_tail(URI),
+            tail,
             Some(2),
             "but the tail is still observable for the watermark wait"
         );
@@ -567,7 +577,10 @@ mod tests {
     async fn finish_close_removes_state_and_wakes_stragglers() {
         let seq = DocumentSequencer::default();
         let close = seq.issue_writer_ticket(URI);
-        let barrier = seq.reader_barrier(URI).expect("close pending");
+        let barrier = seq
+            .reader_barrier_and_tail(URI)
+            .0
+            .expect("close pending");
 
         let ticket = close.ticket();
         drop(close);

--- a/src/lsp/ingress_order.rs
+++ b/src/lsp/ingress_order.rs
@@ -188,7 +188,10 @@ impl DocumentSequencer {
     ///   reported even when every writer has already completed, because the reader
     ///   waits on the watermark (which a completed ticket has already advanced),
     ///   not on ticket completion.
-    pub(crate) fn reader_barrier_and_tail(&self, uri: &str) -> (Option<ReaderBarrier>, Option<u64>) {
+    pub(crate) fn reader_barrier_and_tail(
+        &self,
+        uri: &str,
+    ) -> (Option<ReaderBarrier>, Option<u64>) {
         let Some(entry) = self.docs.get(uri) else {
             return (None, None);
         };
@@ -463,10 +466,7 @@ mod tests {
         let seq = DocumentSequencer::default();
         let first = seq.issue_writer_ticket(URI);
 
-        let barrier = seq
-            .reader_barrier_and_tail(URI)
-            .0
-            .expect("writer pending");
+        let barrier = seq.reader_barrier_and_tail(URI).0.expect("writer pending");
 
         // A writer arriving AFTER the reader must not extend its wait.
         let second = seq.issue_writer_ticket(URI);
@@ -581,10 +581,7 @@ mod tests {
     async fn finish_close_removes_state_and_wakes_stragglers() {
         let seq = DocumentSequencer::default();
         let close = seq.issue_writer_ticket(URI);
-        let barrier = seq
-            .reader_barrier_and_tail(URI)
-            .0
-            .expect("close pending");
+        let barrier = seq.reader_barrier_and_tail(URI).0.expect("close pending");
 
         let ticket = close.ticket();
         drop(close);
@@ -911,8 +908,7 @@ mod tests {
         });
 
         // The first writer for the document is ticket 1; the handler must see it.
-        gate
-            .call(notification("textDocument/didChange", URI))
+        gate.call(notification("textDocument/didChange", URI))
             .await
             .unwrap();
 
@@ -939,12 +935,10 @@ mod tests {
 
         // A writer issues ticket 1, then a reader follows on the wire: the reader
         // handler must observe tail ticket 1 (so it can wait the watermark to it).
-        gate
-            .call(notification("textDocument/didChange", URI))
+        gate.call(notification("textDocument/didChange", URI))
             .await
             .unwrap();
-        gate
-            .call(notification("textDocument/semanticTokens/full", URI))
+        gate.call(notification("textDocument/semanticTokens/full", URI))
             .await
             .unwrap();
 

--- a/src/lsp/ingress_order.rs
+++ b/src/lsp/ingress_order.rs
@@ -63,6 +63,12 @@ tokio::task_local! {
     /// publish the watermark from inside the per-document actor task later, where
     /// this task-local is no longer in scope.
     static WRITER_TICKET: u64;
+
+    /// The tail writer ticket a reader must observe — the highest ticket issued
+    /// for the document at the reader's `call` time. Scoped around the gated
+    /// reader handler so it can wait for the parse watermark to reach this ticket.
+    /// Read via [`current_reader_tail`].
+    static READER_TAIL: u64;
 }
 
 /// The ingress writer ticket of the currently-running gated writer handler, or
@@ -70,6 +76,13 @@ tokio::task_local! {
 /// handler directly without the middleware).
 pub(crate) fn current_writer_ticket() -> Option<u64> {
     WRITER_TICKET.try_with(|ticket| *ticket).ok()
+}
+
+/// The tail writer ticket the currently-running gated reader handler must
+/// observe, or `None` outside a gated reader or when no writer has been issued
+/// for the document (nothing to wait for).
+pub(crate) fn current_reader_tail() -> Option<u64> {
+    READER_TAIL.try_with(|ticket| *ticket).ok()
 }
 
 /// Per-document sequencing state.
@@ -177,6 +190,18 @@ impl DocumentSequencer {
         let rx = entry.completion.done.subscribe();
         drop(entry);
         Some(ReaderBarrier { target, rx })
+    }
+
+    /// The tail writer ticket a reader of `uri` must observe: the highest ticket
+    /// issued at call time, regardless of completion. `None` when no writer was
+    /// ever ticketed for the document (so there is nothing for the reader to wait
+    /// on). Unlike [`reader_barrier`](Self::reader_barrier) this reports the tail
+    /// even when every writer has already completed, because the reader waits on
+    /// the parse **watermark** (which a completed ticket has already advanced),
+    /// not on ticket completion.
+    pub(crate) fn reader_tail(&self, uri: &str) -> Option<u64> {
+        let entry = self.docs.get(uri)?;
+        (entry.tail > 0).then_some(entry.tail)
     }
 
     /// Drop `uri`'s sequencing state after a close completed, unless later
@@ -374,11 +399,20 @@ where
             }
             Some(Role::Reader { uri }) => {
                 let barrier = self.sequencer.reader_barrier(&uri);
+                // Snapshot the tail ticket at `call` time (wire order), exposing
+                // it to the handler so a virt/native reader can wait for the parse
+                // watermark to reach it. `reader_barrier` only reports a pending
+                // writer; the tail is needed even when all writers completed,
+                // because the watermark — not ticket completion — gates the read.
+                let tail = self.sequencer.reader_tail(&uri);
                 Box::pin(async move {
                     if let Some(barrier) = barrier {
                         barrier.wait().await;
                     }
-                    inner_fut.await
+                    match tail {
+                        Some(tail) => READER_TAIL.scope(tail, inner_fut).await,
+                        None => inner_fut.await,
+                    }
                 })
             }
         }
@@ -451,6 +485,31 @@ mod tests {
         assert!(
             seq.reader_barrier(URI).is_none(),
             "all tickets done means no waiting"
+        );
+    }
+
+    #[tokio::test]
+    async fn reader_tail_reports_highest_ticket_even_after_completion() {
+        let seq = DocumentSequencer::default();
+        assert_eq!(seq.reader_tail(URI), None, "no writer issued → nothing to wait on");
+
+        let first = seq.issue_writer_ticket(URI);
+        let second = seq.issue_writer_ticket(URI);
+        assert_eq!(seq.reader_tail(URI), Some(2), "tail is the highest issued ticket");
+
+        // Unlike `reader_barrier`, the tail is still reported once every writer
+        // has completed — the reader waits on the parse watermark, which a
+        // completed ticket has already advanced.
+        drop(first);
+        drop(second);
+        assert!(
+            seq.reader_barrier(URI).is_none(),
+            "all writers done → no barrier"
+        );
+        assert_eq!(
+            seq.reader_tail(URI),
+            Some(2),
+            "but the tail is still observable for the watermark wait"
         );
     }
 
@@ -787,6 +846,100 @@ mod tests {
         assert_eq!(
             *log.lock().recover_poison("ingress_order::tests"),
             vec!["close", "open"]
+        );
+    }
+
+    /// Inner mock that records the ingress task-locals **as observed inside the
+    /// gated handler future** — the only place they are in scope. This is the
+    /// discriminator the behavior-preservation tests cannot give: because the
+    /// watermark wait is instantly satisfied in the sync world, an inert
+    /// plumbing (task-local never propagating, so the handlers read `None` and
+    /// silently skip publish/consume) produces identical observable behavior. A
+    /// direct assertion that the handler sees `Some(expected)` is what proves the
+    /// plumbing is effective rather than dead scaffolding.
+    struct TaskLocalProbe {
+        writer_ticket: Arc<std::sync::Mutex<Option<u64>>>,
+        reader_tail: Arc<std::sync::Mutex<Option<u64>>>,
+    }
+
+    impl Service<Request> for TaskLocalProbe {
+        type Response = Option<Response>;
+        type Error = std::convert::Infallible;
+        type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _req: Request) -> Self::Future {
+            let writer_ticket = Arc::clone(&self.writer_ticket);
+            let reader_tail = Arc::clone(&self.reader_tail);
+            // Read the task-locals *inside* the returned future: the gate scopes
+            // them around this future when it is awaited, not around `call`.
+            Box::pin(async move {
+                *writer_ticket.lock().recover_poison("TaskLocalProbe") = current_writer_ticket();
+                *reader_tail.lock().recover_poison("TaskLocalProbe") = current_reader_tail();
+                Ok(None)
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn gate_propagates_writer_ticket_into_the_handler() {
+        let writer_ticket = Arc::new(std::sync::Mutex::new(None));
+        let reader_tail = Arc::new(std::sync::Mutex::new(None));
+        let mut gate = IngressOrderGate::new(TaskLocalProbe {
+            writer_ticket: Arc::clone(&writer_ticket),
+            reader_tail: Arc::clone(&reader_tail),
+        });
+
+        // The first writer for the document is ticket 1; the handler must see it.
+        gate
+            .call(notification("textDocument/didChange", URI))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            *writer_ticket.lock().recover_poison("ingress_order::tests"),
+            Some(1),
+            "the writer handler must observe its ingress ticket, not None (inert plumbing)"
+        );
+        assert_eq!(
+            *reader_tail.lock().recover_poison("ingress_order::tests"),
+            None,
+            "a writer handler is not a reader and sees no reader tail"
+        );
+    }
+
+    #[tokio::test]
+    async fn gate_propagates_reader_tail_into_the_handler() {
+        let writer_ticket = Arc::new(std::sync::Mutex::new(None));
+        let reader_tail = Arc::new(std::sync::Mutex::new(None));
+        let mut gate = IngressOrderGate::new(TaskLocalProbe {
+            writer_ticket: Arc::clone(&writer_ticket),
+            reader_tail: Arc::clone(&reader_tail),
+        });
+
+        // A writer issues ticket 1, then a reader follows on the wire: the reader
+        // handler must observe tail ticket 1 (so it can wait the watermark to it).
+        gate
+            .call(notification("textDocument/didChange", URI))
+            .await
+            .unwrap();
+        gate
+            .call(notification("textDocument/semanticTokens/full", URI))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            *reader_tail.lock().recover_poison("ingress_order::tests"),
+            Some(1),
+            "the reader handler must observe the tail ticket, not None (inert plumbing)"
+        );
+        assert_eq!(
+            *writer_ticket.lock().recover_poison("ingress_order::tests"),
+            None,
+            "a reader handler is not a writer and sees no writer ticket"
         );
     }
 }

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -198,7 +198,11 @@ impl InstallCoordinator {
             let lang_for_parse = host_language.as_deref();
             let parse_coordinator = self.parse_coordinator();
             parse_coordinator
-                .parse_document(uri.clone(), text, lang_for_parse, vec![])
+                // No ingress ticket: this post-install reparse runs off the
+                // ingress sequence (the original didOpen's ticket already
+                // advanced the watermark on its skip-parse path), so it does not
+                // re-stamp the watermark.
+                .parse_document(uri.clone(), text, lang_for_parse, vec![], None)
                 .await;
         }
     }

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -139,15 +139,35 @@ impl ParseCoordinator {
         }
     }
 
+    /// Parse `uri`'s text and publish the result into the store.
+    ///
+    /// `ticket` is the ingress writer ticket of the mutation that scheduled this
+    /// parse (plumbed from `IngressOrderGate` via the handler), or `None` for a
+    /// caller outside the ingress sequence (a post-install reparse, or a test
+    /// driving the coordinator directly). On every resolution path — a tree, a
+    /// parsed-to-nothing, a previously-crashed parser, or no detectable language —
+    /// the parse advances the store's per-document **watermark** to `ticket`, so a
+    /// virt/native reader waiting on the watermark is released once the parse
+    /// covering its tail edit has resolved. Threading the ticket as an explicit
+    /// value (rather than reading a task-local here) keeps this signature stable
+    /// when the per-document parse actor later runs this off the ingress task.
     pub(crate) async fn parse_document(
         &self,
         uri: Url,
         text: String,
         language_id: Option<&str>,
         edits: Vec<InputEdit>,
+        ticket: Option<u64>,
     ) {
         let parse_generation = self.documents.mark_parse_started(&uri);
         let mut events = Vec::new();
+
+        // Publish the watermark on whichever path resolves the parse below.
+        let advance_watermark = || {
+            if let Some(ticket) = ticket {
+                self.documents.advance_watermark(&uri, ticket);
+            }
+        };
 
         let language_name = self
             .language
@@ -164,6 +184,7 @@ impl ParseCoordinator {
                     .insert(uri.clone(), text, Some(language_name), None);
                 self.documents
                     .mark_parse_finished(&uri, parse_generation, false);
+                advance_watermark();
                 self.notifier().log_language_events(&events).await;
                 return;
             }
@@ -230,6 +251,7 @@ impl ParseCoordinator {
 
                 self.documents
                     .mark_parse_finished(&uri, parse_generation, true);
+                advance_watermark();
                 self.notifier().log_language_events(&events).await;
                 return;
             }
@@ -238,6 +260,7 @@ impl ParseCoordinator {
         self.documents.insert(uri.clone(), text, None, None);
         self.documents
             .mark_parse_finished(&uri, parse_generation, false);
+        advance_watermark();
         self.notifier().log_language_events(&events).await;
     }
 

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -75,9 +75,16 @@ impl Kakehashi {
         // Must be called BEFORE parse_document which updates the injection_map.
         self.cache.invalidate_for_edits(&uri, &edits);
 
-        // Parse the updated document with edit information
+        // Parse the updated document with edit information. The parse stamps the
+        // store watermark with this didChange's ingress ticket on resolution.
         self.parse_coordinator()
-            .parse_document(uri.clone(), text, language_id.as_deref(), edits)
+            .parse_document(
+                uri.clone(),
+                text,
+                language_id.as_deref(),
+                edits,
+                crate::lsp::current_writer_ticket(),
+            )
             .await;
 
         // NOTE: We intentionally do NOT invalidate the semantic token cache here.

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -90,6 +90,12 @@ impl Kakehashi {
             }
         }
 
+        // This didOpen's ingress writer ticket (plumbed from IngressOrderGate),
+        // used to stamp the store watermark so a reader gated behind this open is
+        // released once its parse — or the decision to defer parsing to install —
+        // has resolved.
+        let ticket = crate::lsp::current_writer_ticket();
+
         // Only parse if auto-install was NOT triggered
         // If auto-install was triggered, reload_language_after_install will call parse_document
         // after the parser file is completely written, preventing race condition
@@ -100,8 +106,17 @@ impl Kakehashi {
                     params.text_document.text,
                     Some(&language_id),
                     vec![], // No edits for initial document open
+                    ticket,
                 )
                 .await;
+        } else if let Some(ticket) = ticket {
+            // Parsing is deferred to reload_language_after_install. Advance the
+            // watermark now so a reader gated behind this open does not stall to
+            // its timeout waiting for a parse that won't run on the ingress path;
+            // it proceeds and observes the (still tree-less) install-pending
+            // document via its existing has-tree wait, exactly as before this
+            // signal existed.
+            self.documents.advance_watermark(&uri, ticket);
         }
 
         // Now handle deferred SemanticTokensRefresh events after document is parsed
@@ -642,7 +657,7 @@ print("hello")
             .insert(uri.clone(), text.clone(), Some("rust".to_string()), None);
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), text, Some("rust"), vec![])
+            .parse_document(uri.clone(), text, Some("rust"), vec![], None)
             .await;
 
         let snapshot = server
@@ -775,7 +790,7 @@ print("hello")
             .insert(uri.clone(), text.clone(), Some("rust".to_string()), None);
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), text, Some("rust"), vec![])
+            .parse_document(uri.clone(), text, Some("rust"), vec![], None)
             .await;
 
         let snapshot = server

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -102,6 +102,22 @@ impl Kakehashi {
             return None;
         }
 
+        // Wait for the parse covering this reader's tail edit to resolve, keyed
+        // on the ingress parse **watermark** (per-document-parse-actor ADR). Today
+        // the parse runs inline within the writer's gated critical section, so by
+        // the time the gate releases this reader the watermark has already reached
+        // the tail ticket and this returns immediately — behavior-preserving. Once
+        // the per-document parse actor runs the parse off the ingress ticket, a
+        // bare `has_tree` check would pass while the store still holds the *old*
+        // tree (the #342/#374 stale-tree race); this watermark wait is what closes
+        // that, the first reader migrated to it. Bounded by the same 200ms as the
+        // has-tree wait below, which still backstops the empty fallback.
+        if let Some(tail) = crate::lsp::current_reader_tail() {
+            self.documents
+                .wait_for_epoch(uri, tail, Duration::from_millis(200))
+                .await;
+        }
+
         // Wait for any in-flight parse to complete
         self.documents
             .wait_for_parse_completion(uri, Duration::from_millis(200))

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -103,17 +103,19 @@ impl Kakehashi {
         }
 
         // Wait for the parse covering this reader's tail edit to resolve, keyed
-        // on the ingress parse **watermark** (per-document-parse-actor ADR). Today
-        // the parse runs inline within the writer's gated critical section, so by
-        // the time the gate releases this reader the watermark has already reached
-        // the tail ticket and this returns immediately — behavior-preserving (it
-        // adds no latency to the existing has-tree wait below, which keeps its
-        // full budget). It cannot stall here: the document is present (checked
-        // above), and every present document's writer advances its ticket's
-        // watermark. Once the per-document parse actor runs the parse off the
-        // ingress ticket, a bare `has_tree` check would instead pass while the
-        // store still holds the *old* tree (the #342/#374 stale-tree race); this
-        // watermark wait is what closes that — the first reader migrated to it.
+        // on the ingress parse **watermark** (per-document-parse-actor ADR),
+        // bounded by 200ms. In the current inline-parse world this returns
+        // effectively immediately: the parse runs within the writer's gated
+        // critical section, so by the time the gate releases this reader the
+        // watermark has already reached the tail ticket — so today it adds no
+        // measurable latency over the existing has-tree wait below. (The
+        // document is present — checked above — and every present document's
+        // writer advances its ticket's watermark, so the wait isn't expected to
+        // approach the 200ms bound under the inline model.) Once the per-document
+        // parse actor runs the parse off the ingress ticket this genuinely waits
+        // — that is the point: a bare `has_tree` check would instead pass while
+        // the store still holds the *old* tree (the #342/#374 stale-tree race),
+        // and this watermark wait is what closes it (the first reader migrated).
         if let Some(tail) = crate::lsp::current_reader_tail() {
             self.documents
                 .wait_for_epoch(uri, tail, Duration::from_millis(200))

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -106,12 +106,14 @@ impl Kakehashi {
         // on the ingress parse **watermark** (per-document-parse-actor ADR). Today
         // the parse runs inline within the writer's gated critical section, so by
         // the time the gate releases this reader the watermark has already reached
-        // the tail ticket and this returns immediately — behavior-preserving. Once
-        // the per-document parse actor runs the parse off the ingress ticket, a
-        // bare `has_tree` check would pass while the store still holds the *old*
-        // tree (the #342/#374 stale-tree race); this watermark wait is what closes
-        // that, the first reader migrated to it. Bounded by the same 200ms as the
-        // has-tree wait below, which still backstops the empty fallback.
+        // the tail ticket and this returns immediately — behavior-preserving (it
+        // adds no latency to the existing has-tree wait below, which keeps its
+        // full budget). It cannot stall here: the document is present (checked
+        // above), and every present document's writer advances its ticket's
+        // watermark. Once the per-document parse actor runs the parse off the
+        // ingress ticket, a bare `has_tree` check would instead pass while the
+        // store still holds the *old* tree (the #342/#374 stale-tree race); this
+        // watermark wait is what closes that — the first reader migrated to it.
         if let Some(tail) = crate::lsp::current_reader_tail() {
             self.documents
                 .wait_for_epoch(uri, tail, Duration::from_millis(200))

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -102,29 +102,33 @@ impl Kakehashi {
             return None;
         }
 
-        // Wait for the parse covering this reader's tail edit to resolve, keyed
-        // on the ingress parse **watermark** (per-document-parse-actor ADR),
-        // bounded by 200ms. In the current inline-parse world this returns
-        // effectively immediately: the parse runs within the writer's gated
-        // critical section, so by the time the gate releases this reader the
-        // watermark has already reached the tail ticket — so today it adds no
-        // measurable latency over the existing has-tree wait below. (The
-        // document is present — checked above — and every present document's
-        // writer advances its ticket's watermark, so the wait isn't expected to
-        // approach the 200ms bound under the inline model.) Once the per-document
-        // parse actor runs the parse off the ingress ticket this genuinely waits
-        // — that is the point: a bare `has_tree` check would instead pass while
-        // the store still holds the *old* tree (the #342/#374 stale-tree race),
-        // and this watermark wait is what closes it (the first reader migrated).
+        // Settle the in-flight parse before snapshotting, under a SINGLE 200ms
+        // budget shared across both waits so the `edit_lock` held here is never
+        // pinned longer than the pre-existing has-tree budget (the two waits do
+        // not stack to ~400ms).
+        //
+        // First wait on the parse **watermark** for this reader's tail edit
+        // (per-document-parse-actor ADR). In the current inline-parse world this
+        // returns effectively immediately — the parse runs within the writer's
+        // gated critical section, so by the time the gate releases this reader the
+        // watermark already covers the tail ticket — leaving the full budget for
+        // the has-tree wait below (so today this adds no measurable latency). Once
+        // the per-document parse actor runs the parse off the ingress ticket this
+        // genuinely waits — that is the point: a bare `has_tree` check would
+        // instead pass while the store still holds the *old* tree (the #342/#374
+        // stale-tree race), and this watermark wait is what closes it.
+        let settle_budget = Duration::from_millis(200);
+        let settle_start = std::time::Instant::now();
         if let Some(tail) = crate::lsp::current_reader_tail() {
             self.documents
-                .wait_for_epoch(uri, tail, Duration::from_millis(200))
+                .wait_for_epoch(uri, tail, settle_budget)
                 .await;
         }
 
-        // Wait for any in-flight parse to complete
+        // Wait for any in-flight parse to complete with whatever budget remains.
+        let remaining = settle_budget.saturating_sub(settle_start.elapsed());
         self.documents
-            .wait_for_parse_completion(uri, Duration::from_millis(200))
+            .wait_for_parse_completion(uri, remaining)
             .await;
 
         // First, try to use the tree from the document store.


### PR DESCRIPTION
First staged PR toward the **per-document parse actor** (`docs/architecture-decisions/per-document-parse-actor.md`). Adds the reader **watermark** mechanism the actor needs, wired end-to-end and behavior-preserving today.

## What

- **`DocumentStore` watermark** — a per-document signal (`watch::Sender<u64>`) holding the highest ingress writer ticket whose parse has reached a terminal outcome.
  - `advance_watermark(uri, ticket)`: monotonic, **non-inserting** (no-op for a closed URI → no resurrection).
  - `wait_for_epoch(uri, target, timeout)`: bounded wait until the watermark covers `target`; returns early on already-reached / missing-entry / sender-dropped (drops the DashMap `Ref` before awaiting).
  - The entry's lifetime tracks the document: seeded in `insert()`, dropped in `remove()`.
- **Ticket plumbing** — `IngressOrderGate` exposes the writer ticket (`current_writer_ticket`) and the reader tail ticket (`current_reader_tail`) via task-locals scoped around the gated handler future. `parse_document` takes the ticket as an explicit **value** (not a task-local) and advances the watermark on every resolution path, so the signature survives the parse moving off-ingress in the actor PR.
- **First consumer** — the semantic-tokens reader waits on the watermark for its tail ticket.

## Why it's behavior-preserving

Today the parse runs inline within the writer's gated critical section, so `advance_watermark` runs strictly before the writer ticket completes, and the reader's `wait_for_epoch` runs strictly *after* the `ReaderBarrier` releases it — so the watermark already covers the tail ticket and the wait returns immediately. It becomes **load-bearing** only once the per-document parse actor runs the parse off the ingress ticket, where a bare `has_tree` check would pass against the *old* tree (the #342/#374 stale-tree race). The signal is deliberately distinct from the gate completion channel.

Incarnation (the high half of the eventual `(incarnation, ticket)` epoch) is intentionally deferred; the entry's per-lifetime seeding/drop on open/close gives a fresh watermark on reopen for now.

## Tests

- Store: monotonicity, seed-on-insert, non-resurrection after close, drop-on-remove, and the full `wait_for_epoch` matrix (already-reached / no-entry / blocks-until-target / proceeds-on-close-mid-wait / times-out).
- Ingress: `reader_tail` reports the tail even after completion; **task-local propagation** tests assert the handler actually observes `Some(ticket)` / `Some(tail)` — the discriminator that the plumbing is effective rather than inert scaffolding.

Reviewed via `/review` (2 rounds) and codex; both converged clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)