### PR TITLE
fix(diagnose): surface concatenated panic failures as exit 2 (#506)

### DIFF
--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -233,10 +233,10 @@ pub(crate) async fn dispatch_concatenated<T, F, Fut>(
     f: F,
     cancel_rx: Option<CancelReceiver>,
     log_target: Option<&str>,
-    // Counts panicking tasks (`JoinError`) even on partial-success `Done`, so a
-    // panicking server still drives CLI exit 2 (#506). The caller still counts
-    // I/O failures in-task; only panics feed this.
-    panic_sink: Option<&std::sync::Arc<std::sync::atomic::AtomicUsize>>,
+    // Counts panicking tasks even on partial-success `Done`, so a panicking
+    // server still drives CLI exit 2 (#506). The caller still counts I/O
+    // failures in-task; only panics feed this.
+    panic_sink: Option<&std::sync::atomic::AtomicUsize>,
 ) -> FanInResult<Vec<T>>
 where
     T: Send + 'static,

--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -233,6 +233,10 @@ pub(crate) async fn dispatch_concatenated<T, F, Fut>(
     f: F,
     cancel_rx: Option<CancelReceiver>,
     log_target: Option<&str>,
+    // Counts panicking tasks (`JoinError`) even on partial-success `Done`, so a
+    // panicking server still drives CLI exit 2 (#506). The caller still counts
+    // I/O failures in-task; only panics feed this.
+    panic_sink: Option<&std::sync::Arc<std::sync::atomic::AtomicUsize>>,
 ) -> FanInResult<Vec<T>>
 where
     T: Send + 'static,
@@ -245,7 +249,7 @@ where
     // Client progress under concatenated is a later stage; pass no tokens so
     // downstream `$/progress` is dropped (non-regressing).
     let mut join_set = fan_out(ctx, pool, f, &selected, None);
-    concatenated::concatenated(&mut join_set, &ordering, cancel_rx, log_target).await
+    concatenated::concatenated(&mut join_set, &ordering, cancel_rx, log_target, panic_sink).await
 }
 
 #[cfg(test)]

--- a/src/lsp/aggregation/server/fan_in.rs
+++ b/src/lsp/aggregation/server/fan_in.rs
@@ -61,4 +61,14 @@ pub(super) mod test_helpers {
             }
         });
     }
+
+    /// Spawn a task that panics, so `join_next` yields a `JoinError` — the
+    /// shape of a downstream-request task that unwound instead of returning
+    /// `Err` (the case the panic sink must surface, #506).
+    pub(super) fn spawn_panicking<T: Send + 'static>(join_set: &mut JoinSet<TaggedResult<T>>) {
+        async fn panicking_task<T>() -> TaggedResult<T> {
+            panic!("simulated bridge task panic");
+        }
+        join_set.spawn(panicking_task::<T>());
+    }
 }

--- a/src/lsp/aggregation/server/fan_in/concatenated.rs
+++ b/src/lsp/aggregation/server/fan_in/concatenated.rs
@@ -52,11 +52,20 @@ fn order_by_priority<T>(tagged: Vec<(String, T)>, priorities: &[String]) -> Vec<
 /// `NoResult{errors}` when every task fails, `Cancelled` if a cancel arrives
 /// first. Callers MUST follow up with `pool.unregister_all_for_upstream_id()`
 /// to clean up entries left behind by aborted tasks.
+///
+/// `panic_sink`, when set, is incremented once per task that **panicked**
+/// (`JoinError`). This is surfaced even on `Done` — unlike the local `errors`
+/// tally, which the partial-success `Done` arm discards — because a concatenated
+/// caller counts I/O failures in-task but a panic unwinds before that runs, so
+/// the sink is the only path that lets a panicking server drive CLI exit 2
+/// (#506). Only panics feed it: I/O `Err`s are left to the caller's in-task
+/// counting, so they are never double-counted here.
 pub(crate) async fn concatenated<T: Send + 'static>(
     join_set: &mut JoinSet<TaggedResult<T>>,
     priorities: &[String],
     cancel_rx: Option<CancelReceiver>,
     log_target: Option<&str>,
+    panic_sink: Option<&std::sync::Arc<std::sync::atomic::AtomicUsize>>,
 ) -> FanInResult<Vec<T>> {
     let log_target = log_target.unwrap_or(module_path!());
     let mut results: Vec<(String, T)> = Vec::new();
@@ -80,6 +89,15 @@ pub(crate) async fn concatenated<T: Send + 'static>(
                     None => break,
                     Some(Err(join_err)) => {
                         errors += 1;
+                        // Surface the panic to the caller's sink even though a
+                        // partial-success run returns `Done` and drops `errors`.
+                        // ONLY panics feed the sink: a panicking task unwinds
+                        // before the dispatch's in-task error counting runs,
+                        // whereas an I/O `Err` is already counted in-task — so
+                        // adding I/O errors here too would double-count (#506).
+                        if let Some(sink) = panic_sink {
+                            sink.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        }
                         log::warn!(target: log_target, "bridge task panicked: {join_err}");
                     }
                     Some(Ok(tagged)) => match tagged.value {
@@ -104,9 +122,67 @@ pub(crate) async fn concatenated<T: Send + 'static>(
 #[cfg(test)]
 mod tests {
     use std::io;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::*;
     use crate::lsp::aggregation::server::fan_in::test_helpers::*;
+
+    #[tokio::test]
+    async fn concatenated_surfaces_panic_count_to_sink_even_on_partial_success() {
+        // A downstream-request task that PANICS unwinds before its in-task
+        // error counting runs, and a partial-success run returns `Done`
+        // (dropping the local `errors` tally), so without the panic sink a
+        // panicking server is invisible to CLI exit-2 accounting (#506).
+        let mut join_set: JoinSet<TaggedResult<i32>> = JoinSet::new();
+        spawn_tagged(&mut join_set, Ok(42));
+        spawn_panicking(&mut join_set);
+
+        let sink = Arc::new(AtomicUsize::new(0));
+        let result = concatenated(&mut join_set, &[], None, None, Some(&sink)).await;
+
+        // Partial success: the surviving result is still returned...
+        let values = assert_done(result);
+        assert_eq!(values, vec![42]);
+        // ...and the panic is surfaced to the sink so it can drive exit 2.
+        assert_eq!(sink.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn concatenated_panic_sink_counts_only_panics_not_io_errors() {
+        // The panic sink is fed ONLY by `JoinError` panics. I/O failures are
+        // counted in-task by the concatenated dispatch's send closure, so the
+        // fan-in must not double-count them here.
+        let mut join_set: JoinSet<TaggedResult<i32>> = JoinSet::new();
+        spawn_tagged(&mut join_set, Ok(42));
+        spawn_tagged(&mut join_set, Err(io::Error::other("io fail")));
+
+        let sink = Arc::new(AtomicUsize::new(0));
+        let result = concatenated(&mut join_set, &[], None, None, Some(&sink)).await;
+
+        assert_eq!(assert_done(result), vec![42]);
+        assert_eq!(
+            sink.load(Ordering::Relaxed),
+            0,
+            "I/O errors are counted in-task, never via the panic sink"
+        );
+    }
+
+    #[tokio::test]
+    async fn concatenated_surfaces_panic_count_to_sink_when_all_fail() {
+        // All tasks panic → `NoResult`. The concatenated dispatch does not
+        // count `NoResult.errors`, so the panic sink is the only path that
+        // surfaces an all-panic run as exit 2.
+        let mut join_set: JoinSet<TaggedResult<i32>> = JoinSet::new();
+        spawn_panicking(&mut join_set);
+        spawn_panicking(&mut join_set);
+
+        let sink = Arc::new(AtomicUsize::new(0));
+        let result = concatenated(&mut join_set, &[], None, None, Some(&sink)).await;
+
+        assert_eq!(assert_no_result(result), 2);
+        assert_eq!(sink.load(Ordering::Relaxed), 2);
+    }
 
     #[tokio::test]
     async fn concatenated_returns_all_successful_results() {
@@ -115,7 +191,7 @@ mod tests {
         spawn_tagged(&mut join_set, Ok(2));
         spawn_tagged(&mut join_set, Ok(3));
 
-        let result = concatenated(&mut join_set, &[], None, None).await;
+        let result = concatenated(&mut join_set, &[], None, None, None).await;
         let mut values = assert_done(result);
         values.sort();
         assert_eq!(values, vec![1, 2, 3]);
@@ -128,7 +204,7 @@ mod tests {
         spawn_tagged(&mut join_set, Err(io::Error::other("fail 2")));
         spawn_tagged(&mut join_set, Err(io::Error::other("fail 3")));
 
-        let result = concatenated(&mut join_set, &[], None, None).await;
+        let result = concatenated(&mut join_set, &[], None, None, None).await;
         assert_eq!(
             assert_no_result(result),
             3,
@@ -143,7 +219,7 @@ mod tests {
         spawn_tagged(&mut join_set, Err(io::Error::other("fail 1")));
         spawn_tagged(&mut join_set, Err(io::Error::other("fail 2")));
 
-        let result = concatenated(&mut join_set, &[], None, None).await;
+        let result = concatenated(&mut join_set, &[], None, None, None).await;
         let values = assert_done(result);
         assert_eq!(values, vec![42]);
     }
@@ -152,7 +228,7 @@ mod tests {
     async fn concatenated_returns_done_empty_for_empty_join_set() {
         let mut join_set: JoinSet<TaggedResult<i32>> = JoinSet::new();
 
-        let result = concatenated(&mut join_set, &[], None, None).await;
+        let result = concatenated(&mut join_set, &[], None, None, None).await;
         let values = assert_done(result);
         assert!(
             values.is_empty(),
@@ -174,7 +250,7 @@ mod tests {
 
         tx.send(()).unwrap();
 
-        let result = concatenated(&mut join_set, &[], Some(rx), None).await;
+        let result = concatenated(&mut join_set, &[], Some(rx), None, None).await;
         assert_cancelled(result);
     }
 
@@ -184,7 +260,7 @@ mod tests {
         let mut join_set: JoinSet<TaggedResult<i32>> = JoinSet::new();
         spawn_tagged(&mut join_set, Ok(42));
 
-        let result = concatenated(&mut join_set, &[], Some(rx), None).await;
+        let result = concatenated(&mut join_set, &[], Some(rx), None, None).await;
         let values = assert_done(result);
         assert_eq!(values, vec![42]);
     }
@@ -201,7 +277,7 @@ mod tests {
             "server_b".to_string(),
             "server_c".to_string(),
         ];
-        let result = concatenated(&mut join_set, &priorities, None, None).await;
+        let result = concatenated(&mut join_set, &priorities, None, None, None).await;
         let values = assert_done(result);
         assert_eq!(values, vec![1, 2, 3]);
     }
@@ -215,7 +291,7 @@ mod tests {
 
         // Only server_a and server_b are prioritized; server_x is unlisted
         let priorities = vec!["server_a".to_string(), "server_b".to_string()];
-        let result = concatenated(&mut join_set, &priorities, None, None).await;
+        let result = concatenated(&mut join_set, &priorities, None, None, None).await;
         let values = assert_done(result);
         // Prioritized servers first in order, then unlisted
         assert_eq!(&values[..2], &[1, 2]);
@@ -231,7 +307,7 @@ mod tests {
 
         // server_a is prioritized but fails; server_b succeeds; server_x is unlisted
         let priorities = vec!["server_a".to_string(), "server_b".to_string()];
-        let result = concatenated(&mut join_set, &priorities, None, None).await;
+        let result = concatenated(&mut join_set, &priorities, None, None, None).await;
         let values = assert_done(result);
         // server_b (prioritized, succeeded) first, then server_x (unlisted)
         assert_eq!(values, vec![2, 99]);
@@ -244,7 +320,7 @@ mod tests {
 
         // server_a is in priorities but has no task in the JoinSet
         let priorities = vec!["server_a".to_string(), "server_b".to_string()];
-        let result = concatenated(&mut join_set, &priorities, None, None).await;
+        let result = concatenated(&mut join_set, &priorities, None, None, None).await;
         let values = assert_done(result);
         assert_eq!(values, vec![2]);
     }

--- a/src/lsp/aggregation/server/fan_in/concatenated.rs
+++ b/src/lsp/aggregation/server/fan_in/concatenated.rs
@@ -54,18 +54,20 @@ fn order_by_priority<T>(tagged: Vec<(String, T)>, priorities: &[String]) -> Vec<
 /// to clean up entries left behind by aborted tasks.
 ///
 /// `panic_sink`, when set, is incremented once per task that **panicked**
-/// (`JoinError`). This is surfaced even on `Done` — unlike the local `errors`
-/// tally, which the partial-success `Done` arm discards — because a concatenated
-/// caller counts I/O failures in-task but a panic unwinds before that runs, so
-/// the sink is the only path that lets a panicking server drive CLI exit 2
-/// (#506). Only panics feed it: I/O `Err`s are left to the caller's in-task
-/// counting, so they are never double-counted here.
+/// (a `JoinError` with `is_panic()`). This is surfaced even on `Done` — unlike
+/// the local `errors` tally, which the partial-success `Done` arm discards —
+/// because a concatenated caller counts I/O failures in-task but a panic unwinds
+/// before that runs, so the sink is the only path that lets a panicking server
+/// drive CLI exit 2 (#506). Only panics feed it: I/O `Err`s are left to the
+/// caller's in-task counting, and a cancellation `JoinError` (`is_cancelled()`)
+/// is deliberately excluded — an aborted task was cancelled, not failed, and
+/// must not drive exit 2 (matching `RequestErrorSink`'s contract).
 pub(crate) async fn concatenated<T: Send + 'static>(
     join_set: &mut JoinSet<TaggedResult<T>>,
     priorities: &[String],
     cancel_rx: Option<CancelReceiver>,
     log_target: Option<&str>,
-    panic_sink: Option<&std::sync::Arc<std::sync::atomic::AtomicUsize>>,
+    panic_sink: Option<&std::sync::atomic::AtomicUsize>,
 ) -> FanInResult<Vec<T>> {
     let log_target = log_target.unwrap_or(module_path!());
     let mut results: Vec<(String, T)> = Vec::new();
@@ -89,16 +91,20 @@ pub(crate) async fn concatenated<T: Send + 'static>(
                     None => break,
                     Some(Err(join_err)) => {
                         errors += 1;
-                        // Surface the panic to the caller's sink even though a
+                        // Surface a PANIC to the caller's sink even though a
                         // partial-success run returns `Done` and drops `errors`.
-                        // ONLY panics feed the sink: a panicking task unwinds
+                        // Only panics feed the sink: a panicking task unwinds
                         // before the dispatch's in-task error counting runs,
                         // whereas an I/O `Err` is already counted in-task — so
-                        // adding I/O errors here too would double-count (#506).
-                        if let Some(sink) = panic_sink {
+                        // adding I/O errors here too would double-count (#506). A
+                        // cancellation `JoinError` is excluded: an aborted task
+                        // was cancelled, not failed, and must not drive exit 2.
+                        if join_err.is_panic()
+                            && let Some(sink) = panic_sink
+                        {
                             sink.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         }
-                        log::warn!(target: log_target, "bridge task panicked: {join_err}");
+                        log::warn!(target: log_target, "bridge task did not complete: {join_err}");
                     }
                     Some(Ok(tagged)) => match tagged.value {
                         Err(io_err) => {
@@ -122,7 +128,6 @@ pub(crate) async fn concatenated<T: Send + 'static>(
 #[cfg(test)]
 mod tests {
     use std::io;
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::*;
@@ -138,7 +143,7 @@ mod tests {
         spawn_tagged(&mut join_set, Ok(42));
         spawn_panicking(&mut join_set);
 
-        let sink = Arc::new(AtomicUsize::new(0));
+        let sink = AtomicUsize::new(0);
         let result = concatenated(&mut join_set, &[], None, None, Some(&sink)).await;
 
         // Partial success: the surviving result is still returned...
@@ -157,7 +162,7 @@ mod tests {
         spawn_tagged(&mut join_set, Ok(42));
         spawn_tagged(&mut join_set, Err(io::Error::other("io fail")));
 
-        let sink = Arc::new(AtomicUsize::new(0));
+        let sink = AtomicUsize::new(0);
         let result = concatenated(&mut join_set, &[], None, None, Some(&sink)).await;
 
         assert_eq!(assert_done(result), vec![42]);
@@ -177,11 +182,23 @@ mod tests {
         spawn_panicking(&mut join_set);
         spawn_panicking(&mut join_set);
 
-        let sink = Arc::new(AtomicUsize::new(0));
+        let sink = AtomicUsize::new(0);
         let result = concatenated(&mut join_set, &[], None, None, Some(&sink)).await;
 
         assert_eq!(assert_no_result(result), 2);
         assert_eq!(sink.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn concatenated_handles_panic_without_a_sink() {
+        // The `panic_sink = None` path (the configuration LSP-mode callers use)
+        // must still drain the panicking task to `NoResult` without itself
+        // panicking.
+        let mut join_set: JoinSet<TaggedResult<i32>> = JoinSet::new();
+        spawn_panicking(&mut join_set);
+
+        let result = concatenated(&mut join_set, &[], None, None, None).await;
+        assert_eq!(assert_no_result(result), 1);
     }
 
     #[tokio::test]

--- a/src/lsp/aggregation/server/fan_in/concatenated.rs
+++ b/src/lsp/aggregation/server/fan_in/concatenated.rs
@@ -190,6 +190,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn concatenated_excludes_cancelled_join_errors_from_panic_sink() {
+        // A task aborted before completion yields a *cancelled* `JoinError`
+        // (`is_panic() == false`), which must NOT feed the panic sink: an
+        // aborted task was cancelled, not failed, so it must not drive exit 2.
+        // It still counts toward the local `errors` tally (log severity only).
+        let mut join_set: JoinSet<TaggedResult<i32>> = JoinSet::new();
+        let handle = join_set.spawn(async {
+            std::future::pending::<()>().await;
+            TaggedResult {
+                server_name: "aborted".to_string(),
+                value: Ok(1),
+            }
+        });
+        handle.abort();
+
+        let sink = AtomicUsize::new(0);
+        let result = concatenated(&mut join_set, &[], None, None, Some(&sink)).await;
+
+        assert_eq!(assert_no_result(result), 1);
+        assert_eq!(
+            sink.load(Ordering::Relaxed),
+            0,
+            "a cancelled JoinError must not feed the panic sink"
+        );
+    }
+
+    #[tokio::test]
     async fn concatenated_handles_panic_without_a_sink() {
         // The `panic_sink = None` path (the configuration LSP-mode callers use)
         // must still drain the panicking task to `NoResult` without itself

--- a/src/lsp/aggregation/server/host_dispatch.rs
+++ b/src/lsp/aggregation/server/host_dispatch.rs
@@ -65,10 +65,10 @@ pub(crate) async fn dispatch_host_concatenated<T, F, Fut>(
     f: F,
     cancel_rx: Option<CancelReceiver>,
     log_target: Option<&str>,
-    // Counts panicking tasks (`JoinError`) even on partial-success `Done`, so a
-    // panicking host server still drives CLI exit 2 (#506). The caller still
-    // counts I/O failures in-task; only panics feed this.
-    panic_sink: Option<&std::sync::Arc<std::sync::atomic::AtomicUsize>>,
+    // Counts panicking tasks even on partial-success `Done`, so a panicking
+    // host server still drives CLI exit 2 (#506). The caller still counts I/O
+    // failures in-task; only panics feed this.
+    panic_sink: Option<&std::sync::atomic::AtomicUsize>,
 ) -> FanInResult<Vec<T>>
 where
     T: Send + 'static,

--- a/src/lsp/aggregation/server/host_dispatch.rs
+++ b/src/lsp/aggregation/server/host_dispatch.rs
@@ -65,6 +65,10 @@ pub(crate) async fn dispatch_host_concatenated<T, F, Fut>(
     f: F,
     cancel_rx: Option<CancelReceiver>,
     log_target: Option<&str>,
+    // Counts panicking tasks (`JoinError`) even on partial-success `Done`, so a
+    // panicking host server still drives CLI exit 2 (#506). The caller still
+    // counts I/O failures in-task; only panics feed this.
+    panic_sink: Option<&std::sync::Arc<std::sync::atomic::AtomicUsize>>,
 ) -> FanInResult<Vec<T>>
 where
     T: Send + 'static,
@@ -73,7 +77,7 @@ where
 {
     let (mut join_set, entries) = host_fan_out(ctx, pool, f);
     let ordering = entry_names(&entries);
-    concatenated::concatenated(&mut join_set, &ordering, cancel_rx, log_target).await
+    concatenated::concatenated(&mut join_set, &ordering, cancel_rx, log_target, panic_sink).await
 }
 
 /// Shared host fan-out: allowlist + `"*"` expansion against `ctx.configs`,

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -482,7 +482,7 @@ pub(crate) async fn collect_host_diagnostics(
                 Some("kakehashi::diagnostic"),
                 // Surface panic failures (the in-task `send` counts I/O errors
                 // only, and `Done` drops the fan-in's own tally) (#506).
-                request_error_sink.as_ref(),
+                request_error_sink.as_deref(),
             )
             .await
             {
@@ -604,7 +604,7 @@ async fn dispatch_concatenated_diagnostics(
         // Panics unwind before the in-task counting above runs, and a
         // partial-success `Done` discards the fan-in's own tally, so surface
         // panic failures through the sink to keep exit 2 honest (#506).
-        sink.as_ref(),
+        sink.as_deref(),
     )
     .await;
 

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -474,8 +474,17 @@ pub(crate) async fn collect_host_diagnostics(
                     result
                 }
             };
-            match dispatch_host_concatenated(ctx, pool, send, None, Some("kakehashi::diagnostic"))
-                .await
+            match dispatch_host_concatenated(
+                ctx,
+                pool,
+                send,
+                None,
+                Some("kakehashi::diagnostic"),
+                // Surface panic failures (the in-task `send` counts I/O errors
+                // only, and `Done` drops the fan-in's own tally) (#506).
+                request_error_sink.as_ref(),
+            )
+            .await
             {
                 FanInResult::Done(vecs) => vecs.into_iter().flatten().collect(),
                 FanInResult::NoResult { .. } | FanInResult::Cancelled => Vec::new(),
@@ -592,6 +601,10 @@ async fn dispatch_concatenated_diagnostics(
         |t| send_diagnostic_request_counting_errors(t, sink.clone()),
         None, // cancel handled at outer level
         None, // no custom log_target
+        // Panics unwind before the in-task counting above runs, and a
+        // partial-success `Done` discards the fan-in's own tally, so surface
+        // panic failures through the sink to keep exit 2 honest (#506).
+        sink.as_ref(),
     )
     .await;
 


### PR DESCRIPTION
Closes #506.

## What

Under the default `concatenated` strategy, `kakehashi diagnose` counts request-time failures **in-task** (`if result.is_err() { count_request_errors(...) }`). But a downstream task that **panics** unwinds before that runs, so its failure was invisible to exit-2 accounting.

The concatenated fan-in (`concatenated()`) tallies the `JoinError` into a local `errors`, but a partial-success run returns `FanInResult::Done` and **discards** that count (only `results.is_empty() && errors > 0` → `NoResult { errors }`). So a panicking server with at least one healthy peer surfaced as **exit 0/1 instead of 2**. (The all-panic `NoResult` run was also dropped, because the concatenated diagnose dispatch counts I/O failures in-task only and ignores `NoResult.errors`.)

This is defense-in-depth: production code follows the no-panic-on-request-path rule, so it only bites on a downstream-task bug — but "a broken run never looks clean to CI" should hold for the most broken kind.

## How

- Add an optional `panic_sink: Option<&AtomicUsize>` to the concatenated fan-in and the region (`dispatch_concatenated`) and host (`dispatch_host_concatenated`) dispatches.
- The fan-in increments it once per task whose `JoinError::is_panic()` is true, surfaced **even on `Done`**.
- **Invariants:** only panics feed the sink — I/O `Err`s stay counted in-task by the diagnose send closures (no double-count), and a *cancellation* `JoinError` (`is_cancelled()`) is excluded ("cancelled, not failed", matching `RequestErrorSink`'s contract).
- Both diagnose concatenated callers pass the request-error sink.

The `format` concatenated path is a separate serial pipeline (`dispatch_concatenated_formatting`), not this fan-in, and is out of scope.

## Testing

Unit-tested at the fan-in (`concatenated.rs`):
- panic on partial success → sink counted, result still `Done`;
- all-panic → `NoResult`, sink counted;
- I/O error → sink untouched (counted in-task);
- cancelled (aborted) `JoinError` → sink untouched, local tally still incremented;
- panic with `sink = None` → drains without panicking.

Lib clippy, fmt, `cargo test --lib` (2122), and `e2e_cli_diagnose` (16) all green. (The pre-commit `--all-targets` gate trips on a pre-existing unrelated `redundant_locals` lint in `did_open.rs` test code, identical to `origin/main`; not introduced here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)