### PR TITLE
fix(install): move auto-install off the ingress writer ticket (#480)

### DIFF
--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -280,6 +280,37 @@ impl DocumentStore {
         stored
     }
 
+    /// Like [`update_tree_if_text_unchanged`], but additionally stores the tree
+    /// only if the document currently has **no** tree. For the off-ingress install
+    /// reparse (`reparse_installed_document`), whose "don't clobber a concurrent
+    /// parse" guard is a `tree.is_some()` pre-check: a parse attaching a tree for
+    /// the same text *between* that pre-check and this write would otherwise be
+    /// overwritten — discarding its incremental-edit linkage (`previous_tree` /
+    /// `previous_text`) and corrupting the next `changed_ranges()`. Folding the
+    /// `tree.is_none()` check into the same `get_mut` shard lock as the text
+    /// comparison makes the guard atomic.
+    pub(crate) fn attach_tree_if_absent(
+        &self,
+        uri: &Url,
+        expected_text: &str,
+        new_tree: Tree,
+    ) -> bool {
+        let stored = if let Some(mut doc) = self.documents.get_mut(uri) {
+            if doc.tree().is_none() && doc.text() == expected_text {
+                doc.set_tree(new_tree);
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+        if stored {
+            self.mark_tree_available_if_tracked(uri);
+        }
+        stored
+    }
+
     /// Update document with an edited previous tree for proper changed_ranges() support.
     ///
     /// Call when parsing used an edited old tree (via `tree.edit()`): the
@@ -578,6 +609,42 @@ mod tests {
         assert!(
             store.get(&uri).unwrap().tree().is_none(),
             "the stale tree must not overwrite the current text's (still-absent) tree"
+        );
+    }
+
+    #[test]
+    fn attach_tree_if_absent_stores_only_when_no_tree_present() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///absent.rs").unwrap();
+        store.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+
+        // No tree yet → stores.
+        assert!(store.attach_tree_if_absent(&uri, "fn main() {}", parse_rust("fn main() {}")));
+        let first = store.get(&uri).unwrap().tree().unwrap().root_node().id();
+
+        // A tree is now present → a second attach must NOT clobber it (the guard
+        // is atomic with the write, unlike a separate tree.is_some() pre-check).
+        assert!(!store.attach_tree_if_absent(&uri, "fn main() {}", parse_rust("fn main() {}")));
+        assert_eq!(
+            store.get(&uri).unwrap().tree().unwrap().root_node().id(),
+            first,
+            "an existing tree must be preserved, not overwritten"
+        );
+    }
+
+    #[test]
+    fn attach_tree_if_absent_does_not_resurrect_closed_document() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///closed.rs").unwrap();
+        assert!(!store.attach_tree_if_absent(&uri, "fn main() {}", parse_rust("fn main() {}")));
+        assert!(
+            store.get(&uri).is_none(),
+            "must not resurrect a closed document"
         );
     }
 

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -180,13 +180,10 @@ impl InjectionCoordinator {
         let install = self.install_coordinator();
         let auto_install_enabled = self.settings_manager.is_auto_install_enabled();
 
-        let (text, reason) = if auto_install_enabled {
-            (
-                self.documents.get(uri).map(|doc| doc.text().to_string()),
-                String::new(),
-            )
+        let reason = if auto_install_enabled {
+            String::new()
         } else {
-            (None, install.auto_install_disabled_reason())
+            install.auto_install_disabled_reason()
         };
 
         for lang in languages {
@@ -208,9 +205,12 @@ impl InjectionCoordinator {
                 continue;
             }
 
-            if let Some(ref text) = text {
+            // Only attempt the (injected-language) install while the host document
+            // is still open. `maybe_auto_install_language` re-reads the latest text
+            // itself, so no text is threaded here.
+            if self.documents.get(uri).is_some() {
                 let _ = install
-                    .maybe_auto_install_language(&resolved_lang, uri.clone(), text.clone(), true)
+                    .maybe_auto_install_language(&resolved_lang, uri.clone(), true)
                     .await;
             }
         }

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -206,8 +206,8 @@ impl InjectionCoordinator {
             }
 
             // Only attempt the (injected-language) install while the host document
-            // is still open. `maybe_auto_install_language` re-reads the latest text
-            // itself, so no text is threaded here.
+            // is still open. The injected-language install does not reparse the
+            // host document (is_injection=true), so no host text is needed here.
             if self.documents.get(uri).is_some() {
                 let _ = install
                     .maybe_auto_install_language(&resolved_lang, uri.clone(), true)

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -153,7 +153,6 @@ impl InstallCoordinator {
         &self,
         language: &str,
         uri: Url,
-        text: String,
         is_injection: bool,
     ) -> bool {
         let result = self.auto_install.try_install(language).await;
@@ -161,7 +160,7 @@ impl InstallCoordinator {
         self.dispatch_install_events(language, &result.events).await;
 
         if let Some(data_dir) = result.outcome.data_dir() {
-            self.reload_language_after_install(language, data_dir, uri, text, is_injection)
+            self.reload_language_after_install(language, data_dir, uri, is_injection)
                 .await;
             return true;
         }
@@ -170,12 +169,15 @@ impl InstallCoordinator {
     }
 
     /// Reload a language after installation and optionally re-parse the document.
+    ///
+    /// The re-parse re-reads the latest store text itself
+    /// ([`reparse_installed_document`](ParseCoordinator::reparse_installed_document)),
+    /// so no open-time text is threaded here.
     pub(crate) async fn reload_language_after_install(
         &self,
         language: &str,
         data_dir: &std::path::Path,
         uri: Url,
-        text: String,
         is_injection: bool,
     ) {
         let settings_snapshot = self.settings_manager.load_settings_pair();
@@ -195,14 +197,13 @@ impl InstallCoordinator {
 
         if !is_injection {
             let host_language = self.get_language_for_document(&uri);
-            let lang_for_parse = host_language.as_deref();
-            let parse_coordinator = self.parse_coordinator();
-            parse_coordinator
-                // No ingress ticket: this post-install reparse runs off the
-                // ingress sequence (the original didOpen's ticket already
-                // advanced the watermark on its skip-parse path), so it does not
-                // re-stamp the watermark.
-                .parse_document(uri.clone(), text, lang_for_parse, vec![], None)
+            // Resurrection-safe, off-ingress reparse: re-reads the latest store
+            // text and persists through a non-inserting CAS, so a didClose during
+            // the install can't be resurrected. (The original didOpen's ticket
+            // already advanced the watermark on its skip-parse path, so this
+            // carries no ticket.)
+            self.parse_coordinator()
+                .reparse_installed_document(uri.clone(), host_language)
                 .await;
         }
     }

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -296,17 +296,22 @@ impl ParseCoordinator {
         /// the install completes); past this the reader on-demand parse covers it.
         const MAX_REPARSE_ATTEMPTS: usize = 8;
 
-        // Resolve the language once from the current text; a missing document means
-        // a `didClose` ran during the install — do not resurrect it. Detect while
-        // borrowing the stored text (a synchronous call, no `.await` and no
-        // document write under the `Ref`) rather than cloning it.
-        let Some(language_name) = ({
+        // Resolve the language under one read guard, short-circuiting if the
+        // document is gone (a `didClose` ran during the install — do not
+        // resurrect it) or already parsed (a concurrent parse won — nothing to do,
+        // and skip the `ensure_language_loaded` work). Detection borrows the stored
+        // text (synchronous, no `.await` and no document write under the `Ref`).
+        let language_name = {
             let Some(doc) = self.documents.get(&uri) else {
                 return;
             };
+            if doc.tree().is_some() {
+                return;
+            }
             self.language
                 .detect_language(uri.path(), doc.text(), None, language_id.as_deref())
-        }) else {
+        };
+        let Some(language_name) = language_name else {
             return;
         };
         if self.auto_install.is_parser_failed(&language_name) {
@@ -328,19 +333,21 @@ impl ParseCoordinator {
                 doc.text().to_string()
             };
 
-            let text_clone = text.clone();
+            let text_len = text.len();
             let auto_install = self.auto_install.clone();
             let language_name_clone = language_name.clone();
-            let parsed_tree = self
-                .parse_with_pool(&language_name, &uri, text.len(), move |mut parser| {
+            // Move the owned `text` into the blocking closure and hand it back with
+            // the tree, so the (potentially large) document text is never cloned.
+            let parsed = self
+                .parse_with_pool(&language_name, &uri, text_len, move |mut parser| {
                     let _ = auto_install.begin_parsing(&language_name_clone);
-                    let result = parser.parse(&text_clone, None);
+                    let result = parser.parse(&text, None);
                     let _ = auto_install.end_parsing(&language_name_clone);
-                    (parser, result)
+                    (parser, result.map(|tree| (tree, text)))
                 })
                 .await;
 
-            let Some(tree) = parsed_tree else { break };
+            let Some((tree, text)) = parsed else { break };
 
             // Persist FIRST through the non-inserting CAS: a closed (Vacant)
             // document or one whose text moved on (a concurrent `didChange`) drops

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -315,18 +315,25 @@ impl ParseCoordinator {
             .await;
 
         if let Some(tree) = parsed_tree {
-            self.cache.populate_injections(
-                &uri,
-                &text,
-                &tree,
-                &language_name,
-                &self.language,
-                self.bridge.node_tracker(),
-            );
-            // Non-inserting CAS: a closed (Vacant) document or one whose text moved
-            // on (a concurrent `didChange`) drops the tree rather than writing it.
-            self.documents
-                .update_tree_if_text_unchanged(&uri, &text, tree);
+            // Persist FIRST through the non-inserting CAS: a closed (Vacant)
+            // document or one whose text moved on (a concurrent `didChange`) drops
+            // the tree rather than writing it. Only populate the injection caches
+            // when the tree actually landed, so a `didClose` racing this reparse
+            // can't leave stale injection entries for a gone document. (`Tree`
+            // clone is a cheap refcount bump.)
+            let stored = self
+                .documents
+                .update_tree_if_text_unchanged(&uri, &text, tree.clone());
+            if stored {
+                self.cache.populate_injections(
+                    &uri,
+                    &text,
+                    &tree,
+                    &language_name,
+                    &self.language,
+                    self.bridge.node_tracker(),
+                );
+            }
         }
 
         self.notifier().log_language_events(&events).await;

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -349,15 +349,17 @@ impl ParseCoordinator {
 
             let Some((tree, text)) = parsed else { break };
 
-            // Persist FIRST through the non-inserting CAS: a closed (Vacant)
-            // document or one whose text moved on (a concurrent `didChange`) drops
-            // the tree. Only populate the injection caches when the tree actually
-            // landed, so a `didClose` racing this reparse can't leave stale
-            // injection entries for a gone document. (`Tree` clone is a cheap
-            // refcount bump.)
+            // Persist FIRST through the non-inserting, tree-absent CAS: a closed
+            // (Vacant) document, one whose text moved (a concurrent `didChange`),
+            // or one a concurrent parse already gave a tree all drop this tree —
+            // the tree-absent check makes the "don't clobber a concurrent parse"
+            // guard atomic with the write. Only populate the injection caches when
+            // the tree actually landed, so a `didClose` racing this reparse can't
+            // leave stale injection entries for a gone document. (`Tree` clone is a
+            // cheap refcount bump.)
             let stored = self
                 .documents
-                .update_tree_if_text_unchanged(&uri, &text, tree.clone());
+                .attach_tree_if_absent(&uri, &text, tree.clone());
             if stored {
                 self.cache.populate_injections(
                     &uri,

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -281,46 +281,71 @@ impl ParseCoordinator {
     ///
     /// No watermark advance: the originating `didOpen`'s skip-parse branch already
     /// resolved that ticket's watermark, and this reparse carries no ticket.
+    ///
+    /// Because the install is now off-ingress, a `didChange` can run *concurrently*
+    /// with this reparse (it is no longer gated behind the install). A `didChange`
+    /// that lands while the parser is still loading stores its new text with **no
+    /// tree** (the parser wasn't available), and would then CAS-reject this
+    /// reparse's now-stale tree — leaving the document tree-less. To converge, this
+    /// re-reads the latest text and retries a bounded number of times until the
+    /// tree lands (or another parse wins). Sustained editing falls back to the
+    /// reader's on-demand parse; the parse actor replaces this with a proper
+    /// coalescing loop.
     pub(crate) async fn reparse_installed_document(&self, uri: Url, language_id: Option<String>) {
-        // Snapshot the latest text. A missing document means a `didClose` ran
-        // during the install — do not resurrect it.
-        let Some(text) = self.documents.get(&uri).map(|doc| doc.text().to_string()) else {
+        /// Bound on the convergence retries (a burst of edits landing exactly as
+        /// the install completes); past this the reader on-demand parse covers it.
+        const MAX_REPARSE_ATTEMPTS: usize = 8;
+
+        // Resolve the language once from the current text; a missing document means
+        // a `didClose` ran during the install — do not resurrect it.
+        let Some(first_text) = self.documents.get(&uri).map(|doc| doc.text().to_string()) else {
             return;
         };
-
         let Some(language_name) =
             self.language
-                .detect_language(uri.path(), &text, None, language_id.as_deref())
+                .detect_language(uri.path(), &first_text, None, language_id.as_deref())
         else {
             return;
         };
-
         if self.auto_install.is_parser_failed(&language_name) {
             return;
         }
-
         let load_result = self.language.ensure_language_loaded(&language_name);
         let events = load_result.events;
 
-        let text_clone = text.clone();
-        let auto_install = self.auto_install.clone();
-        let language_name_clone = language_name.clone();
-        let parsed_tree = self
-            .parse_with_pool(&language_name, &uri, text.len(), move |mut parser| {
-                let _ = auto_install.begin_parsing(&language_name_clone);
-                let result = parser.parse(&text_clone, None);
-                let _ = auto_install.end_parsing(&language_name_clone);
-                (parser, result)
-            })
-            .await;
+        for _ in 0..MAX_REPARSE_ATTEMPTS {
+            // Re-read the latest text each attempt. Gone => closed (no resurrect);
+            // already has a tree => a concurrent parse won, nothing to do.
+            let text = {
+                let Some(doc) = self.documents.get(&uri) else {
+                    break;
+                };
+                if doc.tree().is_some() {
+                    break;
+                }
+                doc.text().to_string()
+            };
 
-        if let Some(tree) = parsed_tree {
+            let text_clone = text.clone();
+            let auto_install = self.auto_install.clone();
+            let language_name_clone = language_name.clone();
+            let parsed_tree = self
+                .parse_with_pool(&language_name, &uri, text.len(), move |mut parser| {
+                    let _ = auto_install.begin_parsing(&language_name_clone);
+                    let result = parser.parse(&text_clone, None);
+                    let _ = auto_install.end_parsing(&language_name_clone);
+                    (parser, result)
+                })
+                .await;
+
+            let Some(tree) = parsed_tree else { break };
+
             // Persist FIRST through the non-inserting CAS: a closed (Vacant)
             // document or one whose text moved on (a concurrent `didChange`) drops
-            // the tree rather than writing it. Only populate the injection caches
-            // when the tree actually landed, so a `didClose` racing this reparse
-            // can't leave stale injection entries for a gone document. (`Tree`
-            // clone is a cheap refcount bump.)
+            // the tree. Only populate the injection caches when the tree actually
+            // landed, so a `didClose` racing this reparse can't leave stale
+            // injection entries for a gone document. (`Tree` clone is a cheap
+            // refcount bump.)
             let stored = self
                 .documents
                 .update_tree_if_text_unchanged(&uri, &text, tree.clone());
@@ -333,7 +358,10 @@ impl ParseCoordinator {
                     &self.language,
                     self.bridge.node_tracker(),
                 );
+                break;
             }
+            // CAS rejected: the text moved under us (a concurrent `didChange`).
+            // Loop to re-read the latest text and try again.
         }
 
         self.notifier().log_language_events(&events).await;

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -297,14 +297,16 @@ impl ParseCoordinator {
         const MAX_REPARSE_ATTEMPTS: usize = 8;
 
         // Resolve the language once from the current text; a missing document means
-        // a `didClose` ran during the install — do not resurrect it.
-        let Some(first_text) = self.documents.get(&uri).map(|doc| doc.text().to_string()) else {
-            return;
-        };
-        let Some(language_name) =
+        // a `didClose` ran during the install — do not resurrect it. Detect while
+        // borrowing the stored text (a synchronous call, no `.await` and no
+        // document write under the `Ref`) rather than cloning it.
+        let Some(language_name) = ({
+            let Some(doc) = self.documents.get(&uri) else {
+                return;
+            };
             self.language
-                .detect_language(uri.path(), &first_text, None, language_id.as_deref())
-        else {
+                .detect_language(uri.path(), doc.text(), None, language_id.as_deref())
+        }) else {
             return;
         };
         if self.auto_install.is_parser_failed(&language_name) {

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -264,6 +264,74 @@ impl ParseCoordinator {
         self.notifier().log_language_events(&events).await;
     }
 
+    /// Re-parse a document after its parser finished installing, **off the
+    /// ingress path** and **resurrection-safely**.
+    ///
+    /// Called from the spawned auto-install task (see `did_open`), so by the time
+    /// it runs the originating `didOpen` writer ticket has already completed.
+    /// Unlike [`parse_document`](Self::parse_document) it:
+    ///
+    /// - re-reads the **latest** store text rather than the open-time text (a
+    ///   `didChange` may have landed while the install ran), and
+    /// - persists through the **non-inserting** `update_tree_if_text_unchanged`
+    ///   CAS, so a `didClose` during the install leaves the document gone instead
+    ///   of resurrecting it (the install/parse resurrection vector the actor ADR
+    ///   calls out), and a `didChange` between the read and the write drops the
+    ///   now-stale tree.
+    ///
+    /// No watermark advance: the originating `didOpen`'s skip-parse branch already
+    /// resolved that ticket's watermark, and this reparse carries no ticket.
+    pub(crate) async fn reparse_installed_document(&self, uri: Url, language_id: Option<String>) {
+        // Snapshot the latest text. A missing document means a `didClose` ran
+        // during the install — do not resurrect it.
+        let Some(text) = self.documents.get(&uri).map(|doc| doc.text().to_string()) else {
+            return;
+        };
+
+        let Some(language_name) =
+            self.language
+                .detect_language(uri.path(), &text, None, language_id.as_deref())
+        else {
+            return;
+        };
+
+        if self.auto_install.is_parser_failed(&language_name) {
+            return;
+        }
+
+        let load_result = self.language.ensure_language_loaded(&language_name);
+        let events = load_result.events;
+
+        let text_clone = text.clone();
+        let auto_install = self.auto_install.clone();
+        let language_name_clone = language_name.clone();
+        let parsed_tree = self
+            .parse_with_pool(&language_name, &uri, text.len(), move |mut parser| {
+                let _ = auto_install.begin_parsing(&language_name_clone);
+                let result = parser.parse(&text_clone, None);
+                let _ = auto_install.end_parsing(&language_name_clone);
+                (parser, result)
+            })
+            .await;
+
+        if let Some(tree) = parsed_tree {
+            self.cache.populate_injections(
+                &uri,
+                &text,
+                &tree,
+                &language_name,
+                &self.language,
+                self.bridge.node_tracker(),
+            );
+            // Non-inserting CAS: a closed (Vacant) document or one whose text moved
+            // on (a concurrent `didChange`) drops the tree rather than writing it.
+            self.documents
+                .update_tree_if_text_unchanged(&uri, &text, tree);
+        }
+
+        self.notifier().log_language_events(&events).await;
+    }
+
     fn notifier(&self) -> ClientNotifier<'_> {
         build_notifier(&self.client, &self.settings_manager)
     }

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -86,6 +86,7 @@ impl Kakehashi {
                     // watermark so a gated reader is not stranded.
                     let install = self.install_coordinator();
                     let injection = self.injection_coordinator();
+                    let documents = std::sync::Arc::clone(&self.documents);
                     let lang = lang.clone();
                     let install_uri = uri.clone();
                     tokio::spawn(async move {
@@ -94,11 +95,21 @@ impl Kakehashi {
                             .await;
                         // The skipped inline parse meant the handler's
                         // process_injections (below) ran with no tree. Now that the
-                        // off-ingress reparse has produced one, run the normal
+                        // off-ingress reparse may have produced one, run the normal
                         // post-parse injection workflow — injected-language install
                         // and eager bridge spawn — which also keeps that injected
                         // install off the ingress ticket. forward=false: open path.
-                        injection.process_injections(&install_uri, false).await;
+                        //
+                        // Gate on the document actually having a tree: install can
+                        // fail or be deduped (AlreadyInstalling) with no reparse, and
+                        // process_injections would otherwise cancel the eager-open
+                        // for a still-tree-less document.
+                        let has_tree = documents
+                            .get(&install_uri)
+                            .is_some_and(|doc| doc.tree().is_some());
+                        if has_tree {
+                            injection.process_injections(&install_uri, false).await;
+                        }
                     });
                     skip_parse = true;
                 } else {

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -73,13 +73,26 @@ impl Kakehashi {
 
             if !load_result.success {
                 if self.settings_manager.is_auto_install_enabled() {
-                    // Language failed to load and auto-install is enabled
-                    // is_injection=false: This is the document's main language
-                    // If install is triggered, skip parse_document here - reload_language_after_install will handle it
-                    skip_parse = self
-                        .install_coordinator()
-                        .maybe_auto_install_language(lang, uri.clone(), text.clone(), false)
-                        .await;
+                    // Language failed to load and auto-install is enabled.
+                    //
+                    // Move auto-install OFF the ingress writer ticket (#480
+                    // liveness): a slow or hung parser *compile* must not hold the
+                    // didOpen ticket and wedge later same-URI readers/writers. The
+                    // spawned task installs, reloads, and resurrection-safely
+                    // reparses the latest store text; this handler returns
+                    // immediately. We skip the inline parse unconditionally — the
+                    // parser is not loaded yet, so an inline parse would yield no
+                    // tree anyway — and the skip-parse branch below advances the
+                    // watermark so a gated reader is not stranded.
+                    let install = self.install_coordinator();
+                    let lang = lang.clone();
+                    let install_uri = uri.clone();
+                    tokio::spawn(async move {
+                        install
+                            .maybe_auto_install_language(&lang, install_uri, false)
+                            .await;
+                    });
+                    skip_parse = true;
                 } else {
                     // Notify user that parser is missing and needs manual installation
                     let reason = self.install_coordinator().auto_install_disabled_reason();
@@ -96,9 +109,9 @@ impl Kakehashi {
         // has resolved.
         let ticket = crate::lsp::current_writer_ticket();
 
-        // Only parse if auto-install was NOT triggered
-        // If auto-install was triggered, reload_language_after_install will call parse_document
-        // after the parser file is completely written, preventing race condition
+        // Only parse if auto-install was NOT triggered. If it was, the spawned
+        // install task reparses off-ingress once the parser is written
+        // (reparse_installed_document), so we must not parse inline here.
         if !skip_parse {
             self.parse_coordinator()
                 .parse_document(
@@ -110,9 +123,10 @@ impl Kakehashi {
                 )
                 .await;
         } else if let Some(ticket) = ticket {
-            // Parsing is deferred to reload_language_after_install. Advance the
-            // watermark now so a reader gated behind this open does not stall to
-            // its timeout waiting for a parse that won't run on the ingress path;
+            // Parsing is deferred to the spawned off-ingress install reparse.
+            // Advance the watermark now so a reader gated behind this open does not
+            // stall to its timeout waiting for a parse that won't run on the
+            // ingress path;
             // it proceeds and observes the (still tree-less) install-pending
             // document via its existing has-tree wait, exactly as before this
             // signal existed.
@@ -670,6 +684,58 @@ print("hello")
         assert!(
             host.configs.iter().any(|c| c.server_name == "rust_ls"),
             "the push-only rust_ls must be in the host context so the debounce re-sync reaches it"
+        );
+    }
+
+    /// Resurrection safety (#480 off-ingress install): a `didClose` landing while
+    /// the spawned auto-install runs removes the document; the late
+    /// `reparse_installed_document` must NOT recreate it.
+    #[tokio::test]
+    async fn reparse_installed_document_does_not_resurrect_closed_document() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        configure_rust_self_host(server);
+
+        let uri = Url::parse("file:///test/closed_during_install.rs").unwrap();
+        // The document was closed during the install: nothing is in the store.
+        server
+            .parse_coordinator()
+            .reparse_installed_document(uri.clone(), Some("rust".to_string()))
+            .await;
+
+        assert!(
+            server.documents.get(&uri).is_none(),
+            "a reparse after the document was closed must not resurrect it"
+        );
+    }
+
+    /// The off-ingress install reparse re-reads the latest store text and attaches
+    /// a tree to the still-open document.
+    #[tokio::test]
+    async fn reparse_installed_document_parses_the_open_document() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        configure_rust_self_host(server);
+
+        let uri = Url::parse("file:///test/installed.rs").unwrap();
+        // Registered (as on didOpen) but not yet parsed — the parser had just
+        // finished installing.
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        assert!(server.documents.get(&uri).unwrap().tree().is_none());
+
+        server
+            .parse_coordinator()
+            .reparse_installed_document(uri.clone(), Some("rust".to_string()))
+            .await;
+
+        assert!(
+            server.documents.get(&uri).unwrap().tree().is_some(),
+            "the reparse must attach a tree to the open document"
         );
     }
 

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -85,12 +85,20 @@ impl Kakehashi {
                     // tree anyway — and the skip-parse branch below advances the
                     // watermark so a gated reader is not stranded.
                     let install = self.install_coordinator();
+                    let injection = self.injection_coordinator();
                     let lang = lang.clone();
                     let install_uri = uri.clone();
                     tokio::spawn(async move {
                         install
-                            .maybe_auto_install_language(&lang, install_uri, false)
+                            .maybe_auto_install_language(&lang, install_uri.clone(), false)
                             .await;
+                        // The skipped inline parse meant the handler's
+                        // process_injections (below) ran with no tree. Now that the
+                        // off-ingress reparse has produced one, run the normal
+                        // post-parse injection workflow — injected-language install
+                        // and eager bridge spawn — which also keeps that injected
+                        // install off the ingress ticket. forward=false: open path.
+                        injection.process_injections(&install_uri, false).await;
                     });
                     skip_parse = true;
                 } else {
@@ -140,9 +148,15 @@ impl Kakehashi {
 
         // Process injected languages: auto-install missing parsers and spawn bridge servers.
         // This must be called AFTER parse_document so we have access to the AST.
-        self.injection_coordinator()
-            .process_injections(&uri, false)
-            .await;
+        // In the skip-parse (auto-install) path there is no tree yet and the
+        // spawned install task runs this itself once its reparse produces one, so
+        // skip it here to avoid a redundant no-op that would cancel the eager-open
+        // the spawn is about to start.
+        if !skip_parse {
+            self.injection_coordinator()
+                .process_injections(&uri, false)
+                .await;
+        }
 
         // pull-first-diagnostic-forwarding Phase 2: Trigger synthetic diagnostic push on didOpen
         // This provides proactive diagnostics for clients that don't support pull diagnostics.
@@ -736,6 +750,42 @@ print("hello")
         assert!(
             server.documents.get(&uri).unwrap().tree().is_some(),
             "the reparse must attach a tree to the open document"
+        );
+    }
+
+    /// If a concurrent `didChange` already parsed the document (a tree is
+    /// present), the install reparse must short-circuit and not redundantly
+    /// reparse / clobber it.
+    #[tokio::test]
+    async fn reparse_installed_document_skips_when_a_tree_is_already_present() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        configure_rust_self_host(server);
+
+        let uri = Url::parse("file:///test/already_parsed.rs").unwrap();
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let tree = parser.parse("fn already() {}", None).unwrap();
+        let tree_id = tree.root_node().id();
+        server.documents.insert(
+            uri.clone(),
+            "fn already() {}".to_string(),
+            Some("rust".to_string()),
+            Some(tree),
+        );
+
+        server
+            .parse_coordinator()
+            .reparse_installed_document(uri.clone(), Some("rust".to_string()))
+            .await;
+
+        let doc = server.documents.get(&uri).unwrap();
+        assert_eq!(
+            doc.tree().unwrap().root_node().id(),
+            tree_id,
+            "the existing tree must be left untouched (no redundant reparse)"
         );
     }
 


### PR DESCRIPTION
**Stacked on #508** (`feat/parse-watermark`). Second step toward the per-document parse actor (`docs/architecture-decisions/per-document-parse-actor.md`) — the **#480 liveness fix**: auto-install no longer holds the ingress writer ticket.

## Problem
`didOpen` awaited auto-install **inside its writer-ticketed critical section**, so a slow/hung parser *compile* (untimed C compiler — even with #493's killable subprocess) held the ticket and wedged every later same-URI reader/writer.

## Change
- **`didOpen` spawns the install off-ingress** and returns immediately (ticket completes), skipping the inline parse (the parser isn't loaded yet; the skip-parse branch already advances the watermark so a gated reader isn't stranded).
- **New `ParseCoordinator::reparse_installed_document`** — the post-install reparse, made resurrection-safe:
  - re-reads the **latest** store text (a `didChange` may have landed during install),
  - persists through the non-inserting `update_tree_if_text_unchanged` CAS, so a `didClose` during install leaves the doc gone (closes the install/parse resurrection vector),
  - **bounded retry loop**: with the install now off-ingress a `didChange` runs concurrently; one landing while the parser still loads stores text with no tree and would CAS-reject the reparse's stale tree — so it re-reads + retries until the tree lands (or another parse wins / the doc closes),
  - populates injection caches only after the CAS stored the tree.
- **The spawned task runs `process_injections` after the reparse**, so an auto-installed host doc still gets its injected-language install + eager bridge spawn (the skipped inline parse couldn't — no tree yet), and that injected install rides off-ingress too.
- Drops the now-unused open-time `text` threaded through `maybe_auto_install_language` / `reload_language_after_install`.

## Explicitly out of scope (deferred, tracked)
- **Normal-path injected-language install** (a host doc *with* its parser but a missing *injected* language) is still awaited inline in `did_open`/`did_change`'s `process_injections`. This is the ADR's separate **injection re-homing** workstream → a follow-up PR (ordered bridge forwarding must be preserved). Pre-existing; not a regression.
- **populate-injections vs didClose TOCTOU** (a close between the tree CAS and `populate_injections` can recreate stale cache) — same pre-existing pattern as `parse_document`; closed by the planned **epoch-CAS for caches**. Does not regress resurrection safety.

## Tests
- `reparse_installed_document_does_not_resurrect_closed_document` (closed → no resurrect)
- `reparse_installed_document_parses_the_open_document` (happy path)
- `reparse_installed_document_skips_when_a_tree_is_already_present` (concurrent parse won → no clobber)

e2e tests pre-install parsers, so they don't exercise the spawn; the auto-install path is the real missing-parser case.

Reviewed via `/review` and codex (2 rounds); both converged (remaining items explicitly deferred to the workstreams above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)