### PR TITLE
feat(parse): run the didChange parse off the ingress ticket (per-document parse actor)

### DIFF
--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -280,6 +280,40 @@ impl DocumentStore {
         stored
     }
 
+    /// Like [`update_tree_if_text_unchanged`], but additionally requires the
+    /// document's `language_id` to still equal `expected_language_id`.
+    ///
+    /// For the off-ingress edit reparse (`reparse_latest`), whose tree was parsed
+    /// with a grammar chosen from the language detected at read time. A
+    /// `didClose` + reopen of the same URI with **identical text but a different
+    /// `language_id`** while the parse is in flight would, under the text-only CAS,
+    /// attach a tree parsed by the *old* grammar to the reopened document — wrong
+    /// tokens. Folding the language check into the same `get_mut` shard lock as the
+    /// text check rejects that atomically. (Same-language identical-text reopen
+    /// stays benign: the tree is a correct parse of the identical text.)
+    pub(crate) fn update_tree_if_text_and_language_unchanged(
+        &self,
+        uri: &Url,
+        expected_text: &str,
+        expected_language_id: Option<&str>,
+        new_tree: Tree,
+    ) -> bool {
+        let stored = if let Some(mut doc) = self.documents.get_mut(uri) {
+            if doc.text() == expected_text && doc.language_id() == expected_language_id {
+                doc.set_tree(new_tree);
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+        if stored {
+            self.mark_tree_available_if_tracked(uri);
+        }
+        stored
+    }
+
     /// Like [`update_tree_if_text_unchanged`], but additionally stores the tree
     /// only if the document currently has **no** tree. For the off-ingress install
     /// reparse (`reparse_installed_document`), whose "don't clobber a concurrent
@@ -635,6 +669,44 @@ mod tests {
             first,
             "an existing tree must be preserved, not overwritten"
         );
+    }
+
+    #[test]
+    fn update_tree_if_text_and_language_unchanged_rejects_a_changed_language() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///relabelled.rs").unwrap();
+        // Document was reopened with the same text but a different language_id
+        // while an old-grammar parse was in flight.
+        store.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("ruby".to_string()),
+            None,
+        );
+
+        let stored = store.update_tree_if_text_and_language_unchanged(
+            &uri,
+            "fn main() {}",
+            Some("rust"),
+            parse_rust("fn main() {}"),
+        );
+        assert!(
+            !stored,
+            "a tree parsed for a different language must be rejected"
+        );
+        assert!(
+            store.get(&uri).unwrap().tree().is_none(),
+            "the relabelled document keeps no wrong-grammar tree"
+        );
+
+        // Same language → stores.
+        assert!(store.update_tree_if_text_and_language_unchanged(
+            &uri,
+            "fn main() {}",
+            Some("ruby"),
+            parse_rust("fn main() {}"),
+        ));
+        assert!(store.get(&uri).unwrap().tree().is_some());
     }
 
     #[test]

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -377,6 +377,7 @@ impl Kakehashi {
         let parse = self.parse_coordinator();
         let injection = self.injection_coordinator();
         let publisher = DiagnosticPublisher::new(self);
+        let diagnostic_scheduler = self.diagnostic_scheduler();
         let diagnostics = std::sync::Arc::clone(&self.diagnostics);
         let scheduler = std::sync::Arc::clone(&self.parse_scheduler);
         let shutdown = self.shutdown_token.clone();
@@ -423,6 +424,16 @@ impl Kakehashi {
                 if diagnostics.has_region_slots(&uri) {
                     publisher.republish(&uri).await;
                 }
+
+                // Schedule the debounced diagnostic HERE, after the reparse restored
+                // the tree — NOT in the did_change handler, where the tree has just
+                // been cleared. `prepare_diagnostic_snapshot` returns `None` without
+                // a tree (`Document::snapshot()` requires one), and a `None` snapshot
+                // makes the debounce a no-op — skipping the on-edit host re-sync
+                // (#431) that keeps a push-only `_self` host server's diagnostics
+                // following edits. Running it post-parse captures a snapshot with the
+                // fresh tree; the debounce coalesces across loop iterations.
+                diagnostic_scheduler.schedule_debounced_diagnostic(uri.clone());
 
                 if !scheduler.finish(&uri) {
                     // Normal exit: finish() removed the entry.

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -379,6 +379,7 @@ impl Kakehashi {
         let publisher = DiagnosticPublisher::new(self);
         let diagnostics = std::sync::Arc::clone(&self.diagnostics);
         let scheduler = std::sync::Arc::clone(&self.parse_scheduler);
+        let shutdown = self.shutdown_token.clone();
 
         tokio::spawn(async move {
             // If the loop panics in its glue (the blocking parse is already
@@ -394,6 +395,12 @@ impl Kakehashi {
             // ticket between this spawn and the first parse).
             let mut ticket = scheduler.latest_ticket(&uri);
             loop {
+                // Stop promptly on server shutdown rather than running another
+                // parse + injection/bridge round into a tearing-down bridge.
+                if shutdown.is_cancelled() {
+                    guard.disarm();
+                    break;
+                }
                 parse.reparse_latest(&uri, ticket).await;
 
                 // Tree-dependent downstream, in the order did_change ran it inline:

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -379,6 +379,7 @@ impl Kakehashi {
         let publisher = DiagnosticPublisher::new(self);
         let diagnostic_scheduler = self.diagnostic_scheduler();
         let diagnostics = std::sync::Arc::clone(&self.diagnostics);
+        let documents = std::sync::Arc::clone(&self.documents);
         let scheduler = std::sync::Arc::clone(&self.parse_scheduler);
         let shutdown = self.shutdown_token.clone();
 
@@ -392,11 +393,21 @@ impl Kakehashi {
                 uri.clone(),
             );
 
+            // Stop the loop and clear the scheduler entry so a later edit re-spawns
+            // (leaving the entry at `parsing: true` would wedge the URI — the same
+            // failure the panic guard prevents). Used by the shutdown and
+            // closed-document early exits, which bypass the normal `finish()`.
+            let stop = |scheduler: &parse_scheduler::ParseScheduler,
+                        guard: &mut parse_scheduler::ParseLoopGuard| {
+                scheduler.clear(&uri);
+                guard.disarm();
+            };
+
             loop {
                 // Stop promptly on server shutdown rather than running another
                 // parse + injection/bridge round into a tearing-down bridge.
                 if shutdown.is_cancelled() {
-                    guard.disarm();
+                    stop(&scheduler, &mut guard);
                     break;
                 }
 
@@ -407,12 +418,21 @@ impl Kakehashi {
                 let ticket = scheduler.start_pass(&uri).flatten();
                 parse.reparse_latest(&uri, ticket).await;
 
+                // If the document was closed during the parse, skip ALL downstream
+                // work: process_injections / republish on a gone URI could re-publish
+                // diagnostics that `didClose` just cleared (resurrecting them in the
+                // editor) and act on removed state.
+                if documents.get(&uri).is_none() {
+                    stop(&scheduler, &mut guard);
+                    break;
+                }
+
                 // Re-check shutdown after the (awaited) parse and BEFORE the
                 // downstream work: shutdown could have been requested while parsing,
                 // and process_injections can spawn fresh eager bridge connections
                 // that would escape `shutdown_all`'s snapshot.
                 if shutdown.is_cancelled() {
-                    guard.disarm();
+                    stop(&scheduler, &mut guard);
                     break;
                 }
 

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -403,6 +403,15 @@ impl Kakehashi {
                 }
                 parse.reparse_latest(&uri, ticket).await;
 
+                // Re-check shutdown after the (awaited) parse and BEFORE the
+                // downstream work: shutdown could have been requested while parsing,
+                // and process_injections can spawn fresh eager bridge connections
+                // that would escape `shutdown_all`'s snapshot.
+                if shutdown.is_cancelled() {
+                    guard.disarm();
+                    break;
+                }
+
                 // Tree-dependent downstream, in the order did_change ran it inline:
                 // injected-language processing + forwarding, then geometry re-merge
                 // (which re-anchors region push slots against the now-current

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -4,6 +4,7 @@ mod coordinator;
 pub(crate) use coordinator::DiagnosticPublisher;
 mod kakehashi;
 mod lifecycle;
+mod parse_scheduler;
 mod show_document_translation;
 pub(crate) mod text_document;
 mod whole_document;
@@ -180,6 +181,12 @@ pub struct Kakehashi {
     /// discards it), so `did_open_impl` skips the synthetic diagnostic task — that
     /// avoids both the wasted downstream pull and the abort-vs-`didClose` race (#489).
     cli_mode: std::sync::atomic::AtomicBool,
+    /// Per-document coalescing scheduler for the off-ingress parse
+    /// (per-document-parse-actor ADR): `did_change` applies the edit and clears the
+    /// tree synchronously, then schedules the (re)parse here so the parse runs off
+    /// the ingress writer ticket, coalescing bursts to one reparse over the latest
+    /// text. Shared (`Arc`) with the spawned parse loops.
+    parse_scheduler: std::sync::Arc<parse_scheduler::ParseScheduler>,
 }
 
 impl std::fmt::Debug for Kakehashi {
@@ -250,6 +257,7 @@ impl Kakehashi {
             home_dir: dirs::home_dir().map(|p| p.to_string_lossy().into_owned()),
             captures_cache: dashmap::DashMap::new(),
             cli_mode: std::sync::atomic::AtomicBool::new(false),
+            parse_scheduler: std::sync::Arc::new(parse_scheduler::ParseScheduler::default()),
         }
     }
 
@@ -345,6 +353,55 @@ impl Kakehashi {
 
     pub(super) fn diagnostic_scheduler(&self) -> coordinator::DiagnosticScheduler {
         coordinator::DiagnosticScheduler::new(self)
+    }
+
+    /// Schedule the **off-ingress** (re)parse of `uri` after a `did_change` applied
+    /// the edit and cleared the tree (per-document-parse-actor ADR). The parse runs
+    /// in a spawned loop off the writer ticket, so `did_change` returns without
+    /// waiting on it; the [`ParseScheduler`](parse_scheduler::ParseScheduler)
+    /// coalesces a burst of edits into a single follow-up reparse over the latest
+    /// text. The loop reparses, then runs the tree-dependent downstream work
+    /// (injected-language processing + bridge `didChange` forwarding, then the
+    /// diagnostic geometry re-merge), then loops if another edit arrived.
+    ///
+    /// Resurrection-safe with no teardown: the parse's non-inserting CAS no-ops
+    /// once a `didClose` removed the document, so a `Close` needs no actor
+    /// coordination.
+    pub(crate) fn schedule_reparse(&self, uri: Url, ticket: Option<u64>) {
+        if !self.parse_scheduler.schedule(&uri, ticket) {
+            // A parse loop is already running for this document; it has been
+            // marked dirty and will reparse the latest text when it finishes.
+            return;
+        }
+
+        let parse = self.parse_coordinator();
+        let injection = self.injection_coordinator();
+        let publisher = DiagnosticPublisher::new(self);
+        let diagnostics = std::sync::Arc::clone(&self.diagnostics);
+        let scheduler = std::sync::Arc::clone(&self.parse_scheduler);
+
+        tokio::spawn(async move {
+            // Cover the latest edit on the first pass too (an edit can raise the
+            // ticket between this spawn and the first parse).
+            let mut ticket = scheduler.latest_ticket(&uri);
+            loop {
+                parse.reparse_latest(&uri, ticket).await;
+
+                // Tree-dependent downstream, in the order did_change ran it inline:
+                // injected-language processing + forwarding, then geometry re-merge
+                // (which re-anchors region push slots against the now-current
+                // injection geometry).
+                injection.process_injections(&uri, true).await;
+                if diagnostics.has_region_slots(&uri) {
+                    publisher.republish(&uri).await;
+                }
+
+                match scheduler.next(&uri) {
+                    Some(next_ticket) => ticket = next_ticket,
+                    None => break,
+                }
+            }
+        });
     }
 }
 

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -381,6 +381,15 @@ impl Kakehashi {
         let scheduler = std::sync::Arc::clone(&self.parse_scheduler);
 
         tokio::spawn(async move {
+            // If the loop panics in its glue (the blocking parse is already
+            // panic-isolated by spawn_blocking), this guard clears the stuck
+            // `parsing` entry on unwind so the next edit re-spawns rather than the
+            // document wedging tree-less forever.
+            let mut guard = parse_scheduler::ParseLoopGuard::new(
+                std::sync::Arc::clone(&scheduler),
+                uri.clone(),
+            );
+
             // Cover the latest edit on the first pass too (an edit can raise the
             // ticket between this spawn and the first parse).
             let mut ticket = scheduler.latest_ticket(&uri);
@@ -398,7 +407,11 @@ impl Kakehashi {
 
                 match scheduler.next(&uri) {
                     Some(next_ticket) => ticket = next_ticket,
-                    None => break,
+                    None => {
+                        // Normal exit: next() already removed the entry.
+                        guard.disarm();
+                        break;
+                    }
                 }
             }
         });

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -391,9 +391,6 @@ impl Kakehashi {
                 uri.clone(),
             );
 
-            // Cover the latest edit on the first pass too (an edit can raise the
-            // ticket between this spawn and the first parse).
-            let mut ticket = scheduler.latest_ticket(&uri);
             loop {
                 // Stop promptly on server shutdown rather than running another
                 // parse + injection/bridge round into a tearing-down bridge.
@@ -401,6 +398,12 @@ impl Kakehashi {
                     guard.disarm();
                     break;
                 }
+
+                // Start the pass: clear `dirty` and take the latest ticket, so an
+                // edit folded into this text doesn't trigger a redundant reparse and
+                // a later edit still loops. (`flatten`: outer = entry present, inner
+                // = the ticket.)
+                let ticket = scheduler.start_pass(&uri).flatten();
                 parse.reparse_latest(&uri, ticket).await;
 
                 // Re-check shutdown after the (awaited) parse and BEFORE the
@@ -421,13 +424,10 @@ impl Kakehashi {
                     publisher.republish(&uri).await;
                 }
 
-                match scheduler.next(&uri) {
-                    Some(next_ticket) => ticket = next_ticket,
-                    None => {
-                        // Normal exit: next() already removed the entry.
-                        guard.disarm();
-                        break;
-                    }
+                if !scheduler.finish(&uri) {
+                    // Normal exit: finish() removed the entry.
+                    guard.disarm();
+                    break;
                 }
             }
         });

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -667,7 +667,14 @@ impl Kakehashi {
         method_name: &str,
     ) -> Option<HostRequestContext> {
         let uri = uri_to_url(lsp_uri).ok()?;
-        let snapshot = self.documents.get(&uri)?.snapshot()?;
+        // Host tier needs only the text, never the parse tree
+        // (parse-decoupled-document-lifecycle ADR): read `text_arc()` directly
+        // rather than `snapshot()?`, which requires a tree. Otherwise — now that
+        // `didChange` clears the tree and reparses off-ingress — every host-bridged
+        // request (hover / definition / formatting / will-save / diagnostics) would
+        // bail to `None` for the whole reparse window after each edit, even though
+        // it forwards the real URI + text verbatim and depends on no tree.
+        let text = self.documents.get(&uri)?.text_arc();
         let language_name = self.document_language(&uri)?;
 
         let settings = self.settings_manager.load_settings();
@@ -697,7 +704,7 @@ impl Kakehashi {
 
         Some(HostRequestContext {
             uri,
-            text: snapshot.text_arc(),
+            text,
             language_id: language_name,
             configs,
             priorities: agg.priorities,
@@ -849,28 +856,42 @@ impl Kakehashi {
     ///
     /// Delegates to the shared preamble, then looks up ALL bridge server configs
     /// for the injection language. Returns `None` if no configs found.
-    pub(crate) fn resolve_bridge_contexts(
+    pub(crate) async fn resolve_bridge_contexts(
         &self,
         lsp_uri: &Uri,
         position: Position,
         method_name: &str,
     ) -> Option<PositionRequestContext> {
+        // Ensure a fresh tree before the (sync) preamble snapshots it: `didChange`
+        // now clears the tree and reparses off-ingress, so without this an injection
+        // request (hover / definition / completion / …) issued in the reparse window
+        // would find `snapshot()` empty and return null after every edit.
+        self.ensure_fresh_tree_for_bridge(lsp_uri).await;
         let preamble = self.resolve_bridge_preamble(lsp_uri, position, method_name)?;
         let document = self.preamble_to_document_context(preamble, method_name)?;
 
         Some(PositionRequestContext { document, position })
     }
 
+    /// Wait for / on-demand the document's tree before a sync bridge-preamble
+    /// snapshot (shared by the position and range resolvers).
+    async fn ensure_fresh_tree_for_bridge(&self, lsp_uri: &Uri) {
+        if let Ok(uri) = uri_to_url(lsp_uri) {
+            self.ensure_document_parsed(&uri).await;
+        }
+    }
+
     /// Resolve injection context for a range-based bridge endpoint request.
     ///
     /// Uses `range.start` to find the injection region, then returns a
     /// [`RangeRequestContext`] with the full range for the handler to use.
-    pub(crate) fn resolve_bridge_contexts_for_range(
+    pub(crate) async fn resolve_bridge_contexts_for_range(
         &self,
         lsp_uri: &Uri,
         range: Range,
         method_name: &str,
     ) -> Option<RangeRequestContext> {
+        self.ensure_fresh_tree_for_bridge(lsp_uri).await;
         let preamble = self.resolve_bridge_preamble(lsp_uri, range.start, method_name)?;
         let document = self.preamble_to_document_context(preamble, method_name)?;
 

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -404,17 +404,19 @@ impl ParseCoordinator {
 
         // Re-read the latest text + detect the language under one read guard. A
         // missing document means a `didClose` ran — resolve the watermark and stop
-        // (no resurrection).
-        let (language_name, text) = {
+        // (no resurrection). `language_id` is captured so the tree write can reject
+        // a reopen that changed the language while this parse was in flight.
+        let (language_name, language_id, text) = {
             let Some(doc) = self.documents.get(uri) else {
                 advance_watermark();
                 return;
             };
             let text = doc.text().to_string();
+            let language_id = doc.language_id().map(str::to_string);
             let language_name =
                 self.language
-                    .detect_language(uri.path(), &text, None, doc.language_id());
-            (language_name, text)
+                    .detect_language(uri.path(), &text, None, language_id.as_deref());
+            (language_name, language_id, text)
         };
 
         let Some(language_name) = language_name else {
@@ -442,17 +444,21 @@ impl ParseCoordinator {
             .await;
 
         if let Some((tree, text)) = parsed {
-            // Text-CAS, not the full `(incarnation, ticket)` epoch CAS. The
-            // incarnation half is deferred (see #508): a close→reopen with
-            // *identical* text while this parse is in flight can let the CAS attach
-            // this tree to the reopened lifetime. That is benign — the text is
-            // identical, so the tree is a correct parse of it — only the watermark
-            // ticket is from the old lifetime; reads stay correct because the tree
-            // matches the text. The strict epoch CAS (incarnation stored on the
-            // Document so the check is atomic with the write) is the follow-up.
-            let stored = self
-                .documents
-                .update_tree_if_text_unchanged(uri, &text, tree.clone());
+            // Text + language CAS (non-inserting). Rejecting on a changed
+            // `language_id` closes the close→reopen-with-different-language race
+            // (a tree parsed by the old grammar must not attach to a relabelled
+            // document). The remaining residual — a same-language reopen with
+            // *identical* text — is benign (the tree is a correct parse of that
+            // text); only the watermark ticket is from the old lifetime, and reads
+            // stay correct. The strict `(incarnation, ticket)` epoch CAS
+            // (incarnation stored on the Document, atomic with the write) is the
+            // follow-up that closes even that.
+            let stored = self.documents.update_tree_if_text_and_language_unchanged(
+                uri,
+                &text,
+                language_id.as_deref(),
+                tree.clone(),
+            );
             if stored {
                 self.cache.populate_injections(
                     uri,

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -273,7 +273,7 @@ impl ParseCoordinator {
     ///
     /// - re-reads the **latest** store text rather than the open-time text (a
     ///   `didChange` may have landed while the install ran), and
-    /// - persists through the **non-inserting** `update_tree_if_text_unchanged`
+    /// - persists through the **non-inserting**, tree-absent `attach_tree_if_absent`
     ///   CAS, so a `didClose` during the install leaves the document gone instead
     ///   of resurrecting it (the install/parse resurrection vector the actor ADR
     ///   calls out), and a `didChange` between the read and the write drops the
@@ -384,10 +384,12 @@ impl ParseCoordinator {
     /// `did_change` clears the tree synchronously and schedules this; it runs in a
     /// spawned loop, *not* on the writer ticket. A **full** parse (no incremental
     /// seed — the tree was cleared, which also keeps #348 closed). The tree write
-    /// is the non-inserting text CAS [`update_tree_if_text_unchanged`]: a closed
-    /// (Vacant) document is left gone (resurrection-safe), and a text that moved on
-    /// (a `didChange` landed while parsing) is dropped — the scheduler's `dirty`
-    /// loop then reparses the newer text. On **every** resolution path the parse
+    /// is the non-inserting text **and language** CAS
+    /// [`update_tree_if_text_and_language_unchanged`]: a closed (Vacant) document is
+    /// left gone (resurrection-safe), a text that moved on (a `didChange` landed
+    /// while parsing) is dropped — the scheduler's `dirty` loop then reparses the
+    /// newer text — and a reopen that changed the language is rejected (no
+    /// wrong-grammar tree). On **every** resolution path the parse
     /// advances the store watermark to `ticket`, so a virt/native reader gated
     /// behind the originating edit is released once its parse resolved.
     ///

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -378,6 +378,91 @@ impl ParseCoordinator {
         self.notifier().log_language_events(&events).await;
     }
 
+    /// Re-parse `uri`'s **latest** store text off the ingress path, for the
+    /// per-document parse scheduler (`Kakehashi::schedule_reparse`).
+    ///
+    /// `did_change` clears the tree synchronously and schedules this; it runs in a
+    /// spawned loop, *not* on the writer ticket. A **full** parse (no incremental
+    /// seed — the tree was cleared, which also keeps #348 closed). The tree write
+    /// is the non-inserting text CAS [`update_tree_if_text_unchanged`]: a closed
+    /// (Vacant) document is left gone (resurrection-safe), and a text that moved on
+    /// (a `didChange` landed while parsing) is dropped — the scheduler's `dirty`
+    /// loop then reparses the newer text. On **every** resolution path the parse
+    /// advances the store watermark to `ticket`, so a virt/native reader gated
+    /// behind the originating edit is released once its parse resolved.
+    ///
+    /// Incremental parse and semantic-token delta are intentionally not preserved
+    /// here (the cleared tree forces a full parse); coalescing recovers the burst
+    /// case, and incrementality is a perf optimization, never correctness. Re-adding
+    /// it is a follow-up.
+    pub(crate) async fn reparse_latest(&self, uri: &Url, ticket: Option<u64>) {
+        let advance_watermark = || {
+            if let Some(ticket) = ticket {
+                self.documents.advance_watermark(uri, ticket);
+            }
+        };
+
+        // Re-read the latest text + detect the language under one read guard. A
+        // missing document means a `didClose` ran — resolve the watermark and stop
+        // (no resurrection).
+        let (language_name, text) = {
+            let Some(doc) = self.documents.get(uri) else {
+                advance_watermark();
+                return;
+            };
+            let text = doc.text().to_string();
+            let language_name =
+                self.language
+                    .detect_language(uri.path(), &text, None, doc.language_id());
+            (language_name, text)
+        };
+
+        let Some(language_name) = language_name else {
+            advance_watermark();
+            return;
+        };
+        if self.auto_install.is_parser_failed(&language_name) {
+            advance_watermark();
+            return;
+        }
+        let load_result = self.language.ensure_language_loaded(&language_name);
+
+        let text_len = text.len();
+        let auto_install = self.auto_install.clone();
+        let language_name_clone = language_name.clone();
+        // Move the owned `text` into the blocking closure and hand it back with the
+        // tree, so the document text is never cloned.
+        let parsed = self
+            .parse_with_pool(&language_name, uri, text_len, move |mut parser| {
+                let _ = auto_install.begin_parsing(&language_name_clone);
+                let result = parser.parse(&text, None);
+                let _ = auto_install.end_parsing(&language_name_clone);
+                (parser, result.map(|tree| (tree, text)))
+            })
+            .await;
+
+        if let Some((tree, text)) = parsed {
+            let stored = self
+                .documents
+                .update_tree_if_text_unchanged(uri, &text, tree.clone());
+            if stored {
+                self.cache.populate_injections(
+                    uri,
+                    &text,
+                    &tree,
+                    &language_name,
+                    &self.language,
+                    self.bridge.node_tracker(),
+                );
+            }
+        }
+
+        advance_watermark();
+        self.notifier()
+            .log_language_events(&load_result.events)
+            .await;
+    }
+
     fn notifier(&self) -> ClientNotifier<'_> {
         build_notifier(&self.client, &self.settings_manager)
     }

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -413,8 +413,10 @@ impl ParseCoordinator {
                 advance_watermark();
                 return;
             };
-            let text = doc.text().to_string();
-            let language_id = doc.language_id().map(str::to_string);
+            // `text_arc()` is a refcount bump, not a full copy of the document text
+            // (#498) — cheap on this reparse hot path.
+            let text = doc.text_arc();
+            let language_id = doc.language_id().map(|s| s.to_string());
             let language_name =
                 self.language
                     .detect_language(uri.path(), &text, None, language_id.as_deref());
@@ -434,18 +436,19 @@ impl ParseCoordinator {
         let text_len = text.len();
         let auto_install = self.auto_install.clone();
         let language_name_clone = language_name.clone();
-        // Move the owned `text` into the blocking closure and hand it back with the
-        // tree, so the document text is never cloned.
+        // Hand a cheap `Arc<str>` clone (refcount bump) to the blocking closure; the
+        // original stays here for the CAS + injection populate below.
+        let text_for_parse = text.clone();
         let parsed = self
             .parse_with_pool(&language_name, uri, text_len, move |mut parser| {
                 let _ = auto_install.begin_parsing(&language_name_clone);
-                let result = parser.parse(&text, None);
+                let result = parser.parse(&*text_for_parse, None);
                 let _ = auto_install.end_parsing(&language_name_clone);
-                (parser, result.map(|tree| (tree, text)))
+                (parser, result)
             })
             .await;
 
-        if let Some((tree, text)) = parsed {
+        if let Some(tree) = parsed {
             // Text + language CAS (non-inserting). Rejecting on a changed
             // `language_id` closes the close→reopen-with-different-language race
             // (a tree parsed by the old grammar must not attach to a relabelled

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -442,6 +442,14 @@ impl ParseCoordinator {
             .await;
 
         if let Some((tree, text)) = parsed {
+            // Text-CAS, not the full `(incarnation, ticket)` epoch CAS. The
+            // incarnation half is deferred (see #508): a close→reopen with
+            // *identical* text while this parse is in flight can let the CAS attach
+            // this tree to the reopened lifetime. That is benign — the text is
+            // identical, so the tree is a correct parse of it — only the watermark
+            // ticket is from the old lifetime; reads stay correct because the tree
+            // matches the text. The strict epoch CAS (incarnation stored on the
+            // Document so the check is atomic with the write) is the follow-up.
             let stored = self
                 .documents
                 .update_tree_if_text_unchanged(uri, &text, tree.clone());

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -490,7 +490,7 @@ impl Kakehashi {
         };
 
         // Same didOpen→async-parse race the node handlers guard against.
-        self.ensure_parsed_for_node_lookup(&uri).await;
+        self.ensure_document_parsed(&uri).await;
 
         let Some(language_id) = self.document_language(&uri) else {
             log::debug!(target: "kakehashi::captures", "no host language detected for {uri}");
@@ -515,7 +515,7 @@ impl Kakehashi {
             // a reparse; wait for it like the initial prelude does, so the
             // snapshot below is the settled (text, tree) pair and never a
             // mid-parse combination.
-            self.ensure_parsed_for_node_lookup(&uri).await;
+            self.ensure_document_parsed(&uri).await;
         }
 
         // Fetch the open generation BEFORE snapshotting: if a close+reopen

--- a/src/lsp/lsp_impl/kakehashi/node/children.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/children.rs
@@ -72,7 +72,7 @@ impl Kakehashi {
         // `Document::tree()` populated with a stale tree while NodeTracker has
         // already been adjusted. The helper waits on the parse-state watch
         // channel and re-parses on demand so the snapshot below is consistent.
-        self.ensure_parsed_for_node_lookup(&uri).await;
+        self.ensure_document_parsed(&uri).await;
 
         // Snapshot the document so we operate on a consistent (text, tree) pair.
         let Some(snapshot) = self.documents.get(&uri).and_then(|doc| doc.snapshot()) else {

--- a/src/lsp/lsp_impl/kakehashi/node/common.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/common.rs
@@ -200,7 +200,7 @@ impl Kakehashi {
 
         // Same race as the other handlers: didOpen schedules an async parse, so
         // a request issued immediately after must not see `tree: None`.
-        self.ensure_parsed_for_node_lookup(&uri).await;
+        self.ensure_document_parsed(&uri).await;
 
         // Snapshot so we operate on a consistent (text, tree) pair.
         let snapshot = self.documents.get(&uri).and_then(|doc| doc.snapshot())?;
@@ -351,7 +351,7 @@ impl Kakehashi {
         }
 
         // Same didOpen race guard as the single-id prelude.
-        self.ensure_parsed_for_node_lookup(&uri).await;
+        self.ensure_document_parsed(&uri).await;
         let Some(snapshot) = self.documents.get(&uri).and_then(|doc| doc.snapshot()) else {
             return Value::Null;
         };

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -228,6 +228,11 @@ impl Kakehashi {
         self.ensure_injection_languages_loaded(&uri, &host_language, text, tree, byte)
             .await;
 
+        // Re-ensure freshness before the re-snapshot: a `didChange` processed
+        // during the (awaited) grammar load clears the tree off-ingress, so
+        // without this the re-snapshot below would spuriously return `Null`.
+        self.ensure_document_parsed(&uri).await;
+
         // Re-snapshot after the await and recompute the position mapping. From
         // here on we operate strictly on the post-await document state.
         let snapshot = match self.documents.get(&uri).and_then(|doc| doc.snapshot()) {

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -166,7 +166,7 @@ impl Kakehashi {
         // Ensure the document is parsed before snapshotting. `didOpen` inserts the
         // document with `tree: None` and schedules an async parse; a client that
         // calls `kakehashi/node` quickly afterwards must not race with that parse.
-        self.ensure_parsed_for_node_lookup(&uri).await;
+        self.ensure_document_parsed(&uri).await;
 
         // Snapshot the document so we hold the read lock for as short as possible.
         let snapshot = match self.documents.get(&uri).and_then(|doc| doc.snapshot()) {
@@ -388,7 +388,18 @@ impl Kakehashi {
         }
     }
 
-    /// Parse the document on-demand if its tree has not been built yet.
+    /// Ensure the store holds a **fresh** parse tree for `uri`, parsing on demand
+    /// if needed. The shared post-edit freshness helper for every request handler
+    /// that snapshots the document tree.
+    ///
+    /// Since the per-document parse actor flip, `didChange` clears the tree and
+    /// reparses **off-ingress**, so a request arriving in the reparse window finds
+    /// `Document::snapshot()` returning `None`. Any tree-reading handler must call
+    /// this first: it waits the bounded `wait_for_parse_completion` for the
+    /// off-ingress reparse to land and, failing that, parses on demand and writes
+    /// the tree through the non-inserting CAS — so the caller's subsequent
+    /// `snapshot()` sees a current `(text, tree)` pair instead of empty/stale.
+    /// Without it the handler degrades to empty results after every edit.
     ///
     /// `didOpen` inserts the document immediately with `tree: None` and
     /// schedules an asynchronous parse. `kakehashi/node` requests issued
@@ -404,10 +415,7 @@ impl Kakehashi {
     /// not a stale combination produced mid-parse. The timeout matches the
     /// `semantic_tokens` budget so this helper stays responsive even if the
     /// parser hangs on a pathological input.
-    pub(in crate::lsp::lsp_impl::kakehashi) async fn ensure_parsed_for_node_lookup(
-        &self,
-        uri: &Url,
-    ) {
+    pub(crate) async fn ensure_document_parsed(&self, uri: &Url) {
         self.documents
             .wait_for_parse_completion(uri, std::time::Duration::from_millis(200))
             .await;

--- a/src/lsp/lsp_impl/kakehashi/node/parent.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/parent.rs
@@ -70,7 +70,7 @@ impl Kakehashi {
         // Ensure the document is parsed before snapshotting — same race as in
         // `kakehashi/node`: didOpen schedules an async parse, a client that
         // immediately follows up with `parent` must not see `tree: None`.
-        self.ensure_parsed_for_node_lookup(&uri).await;
+        self.ensure_document_parsed(&uri).await;
 
         // Snapshot the document so we operate on a consistent (text, tree) pair.
         let Some(snapshot) = self.documents.get(&uri).and_then(|doc| doc.snapshot()) else {

--- a/src/lsp/lsp_impl/parse_scheduler.rs
+++ b/src/lsp/lsp_impl/parse_scheduler.rs
@@ -1,0 +1,162 @@
+//! Per-document coalescing scheduler for the **off-ingress parse**
+//! (per-document-parse-actor ADR).
+//!
+//! `did_change` applies the edit to the store and clears the tree synchronously
+//! (under the edit lock), then asks this scheduler to (re)parse off the ingress
+//! ticket. The scheduler guarantees **one** in-flight parse loop per document:
+//! edits arriving while a parse runs only set a `dirty` bit, so a burst collapses
+//! to a single follow-up reparse over the latest text rather than one parse per
+//! edit — the coalescing the cost table makes worthwhile. The parse loop itself
+//! lives in `Kakehashi::schedule_reparse`; this type owns only the
+//! spawn-or-mark-dirty decision and is the one piece that must be race-tight.
+
+use dashmap::DashMap;
+use dashmap::mapref::entry::Entry;
+use url::Url;
+
+/// Per-document scheduling state.
+#[derive(Default)]
+struct SchedState {
+    /// A parse loop is currently running for this document.
+    parsing: bool,
+    /// An edit landed while the loop was parsing; it must reparse again.
+    dirty: bool,
+    /// The highest ingress writer ticket the next parse must cover (for the
+    /// watermark). The latest scheduled edit wins; a single coalesced parse
+    /// covers the whole contiguous run up to here.
+    ticket: Option<u64>,
+}
+
+/// Coalescing scheduler: at most one parse loop runs per document at a time.
+#[derive(Default)]
+pub(crate) struct ParseScheduler {
+    states: DashMap<Url, SchedState>,
+}
+
+impl ParseScheduler {
+    /// Record a pending reparse for `uri` at `ticket`. Returns `true` when the
+    /// caller should **spawn** the parse loop (none was running); `false` when a
+    /// loop is already running — it has now been marked `dirty` so it reparses the
+    /// latest text once its current parse finishes.
+    ///
+    /// `entry` holds the shard write lock across the whole decision, so two racing
+    /// `did_change`s can never both spawn nor drop the `dirty` bit.
+    pub(crate) fn schedule(&self, uri: &Url, ticket: Option<u64>) -> bool {
+        match self.states.entry(uri.clone()) {
+            Entry::Occupied(mut entry) => {
+                let state = entry.get_mut();
+                state.ticket = ticket;
+                if state.parsing {
+                    state.dirty = true;
+                    false
+                } else {
+                    state.parsing = true;
+                    state.dirty = false;
+                    true
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(SchedState {
+                    parsing: true,
+                    dirty: false,
+                    ticket,
+                });
+                true
+            }
+        }
+    }
+
+    /// Peek the highest ticket scheduled for `uri` so the loop's *first* reparse
+    /// covers the latest edit (an edit can land between the spawn and the first
+    /// parse, raising the ticket past the one the spawn was created with). `None`
+    /// if there is no pending entry.
+    pub(crate) fn latest_ticket(&self, uri: &Url) -> Option<u64> {
+        self.states.get(uri).and_then(|state| state.ticket)
+    }
+
+    /// Called by the parse loop after one parse completes, to decide whether to
+    /// loop again. Returns `Some(ticket)` when an edit landed during the parse
+    /// (`dirty`) — the loop keeps running and reparses the latest text at `ticket`
+    /// (itself `Option<u64>`, since a reparse may carry no ingress ticket); `None`
+    /// when nothing is pending — the entry is removed and the loop exits. The outer
+    /// `Option` is the continue/stop signal, distinct from the inner ticket, so a
+    /// pending reparse whose ticket is `None` still continues the loop. Atomic
+    /// under the shard write lock so it cannot race a concurrent `schedule`: a
+    /// `schedule` arriving just before this either set `dirty` (we continue) or
+    /// finds no entry afterward and spawns a fresh loop.
+    pub(crate) fn next(&self, uri: &Url) -> Option<Option<u64>> {
+        match self.states.entry(uri.clone()) {
+            Entry::Occupied(mut entry) => {
+                if entry.get().dirty {
+                    let state = entry.get_mut();
+                    state.dirty = false;
+                    Some(state.ticket)
+                } else {
+                    entry.remove();
+                    None
+                }
+            }
+            Entry::Vacant(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn uri() -> Url {
+        Url::parse("file:///s.rs").unwrap()
+    }
+
+    #[test]
+    fn first_schedule_spawns_and_second_marks_dirty() {
+        let s = ParseScheduler::default();
+        let u = uri();
+        assert!(s.schedule(&u, Some(1)), "first schedule spawns the loop");
+        assert!(
+            !s.schedule(&u, Some(2)),
+            "a second schedule while parsing only marks dirty"
+        );
+    }
+
+    #[test]
+    fn next_continues_when_dirty_with_latest_ticket_then_exits() {
+        let s = ParseScheduler::default();
+        let u = uri();
+        assert!(s.schedule(&u, Some(1)));
+        assert!(
+            !s.schedule(&u, Some(5)),
+            "edit during parse marks dirty, ticket=5"
+        );
+
+        // Loop finishes its first parse: dirty was set → continue at the latest ticket.
+        assert_eq!(s.next(&u), Some(Some(5)));
+        // Nothing more pending → loop exits and the entry is cleared.
+        assert_eq!(s.next(&u), None);
+    }
+
+    #[test]
+    fn after_exit_a_new_schedule_spawns_again() {
+        let s = ParseScheduler::default();
+        let u = uri();
+        assert!(s.schedule(&u, Some(1)));
+        assert_eq!(s.next(&u), None, "no dirty → exit");
+        assert!(
+            s.schedule(&u, Some(2)),
+            "a fresh edit after the loop exited spawns a new loop"
+        );
+    }
+
+    #[test]
+    fn documents_are_independent() {
+        let s = ParseScheduler::default();
+        let a = Url::parse("file:///a.rs").unwrap();
+        let b = Url::parse("file:///b.rs").unwrap();
+        assert!(s.schedule(&a, Some(1)));
+        assert!(
+            s.schedule(&b, Some(1)),
+            "a different document spawns its own loop"
+        );
+    }
+}

--- a/src/lsp/lsp_impl/parse_scheduler.rs
+++ b/src/lsp/lsp_impl/parse_scheduler.rs
@@ -111,22 +111,34 @@ impl ParseScheduler {
     /// continue) or after the removal (entry re-created → it spawns a fresh loop).
     /// A `get_mut`-then-`remove` split would instead let `schedule` set `dirty`
     /// between the two and then be deleted — a lost wakeup. `remove_if` also borrows
-    /// the key (no `Url` clone). The loop's entry is always present when this runs
-    /// (nothing else removes scheduler entries), so a non-removal means it was kept
-    /// for `dirty` → continue.
+    /// the key (no `Url` clone).
+    ///
+    /// `continue_loop` is set **inside** the predicate so it distinguishes
+    /// kept-because-dirty (continue) from a missing entry (stop). A bare
+    /// `remove_if(...).is_none()` would return `true` for a missing entry too,
+    /// trapping the loop in an infinite, CPU-burning cycle.
     pub(crate) fn finish(&self, uri: &Url) -> bool {
-        // `Some` = removed because it was clean → stop; `None` = kept (dirty) → loop.
-        self.states
-            .remove_if(uri, |_, state| !state.dirty)
-            .is_none()
+        let mut continue_loop = false;
+        self.states.remove_if(uri, |_, state| {
+            if state.dirty {
+                // Keep the entry and loop again; the next `start_pass` clears dirty.
+                continue_loop = true;
+                false
+            } else {
+                // Nothing pending — remove the entry and stop.
+                true
+            }
+        });
+        continue_loop
     }
 
-    /// Clear `uri`'s scheduling entry unconditionally. Used by [`ParseLoopGuard`]
-    /// when the spawned parse loop exits **abnormally** (a panic): the entry is
-    /// stuck at `parsing: true`, and without clearing it every later `did_change`
-    /// would only mark it `dirty` and never re-spawn, wedging the document
-    /// tree-less forever. Clearing lets the next edit spawn a fresh loop.
-    fn abort(&self, uri: &Url) {
+    /// Clear `uri`'s scheduling entry unconditionally, leaving the next
+    /// `did_change` free to spawn a fresh loop. Used when a parse loop stops
+    /// **without** the normal `finish()` removal — a panic (via [`ParseLoopGuard`]),
+    /// a server shutdown, or the document being closed mid-parse — all of which
+    /// would otherwise leave the entry stuck at `parsing: true` and wedge the URI
+    /// (every later edit only marks it `dirty`, never re-spawning).
+    pub(crate) fn clear(&self, uri: &Url) {
         self.states.remove(uri);
     }
 }
@@ -162,7 +174,7 @@ impl ParseLoopGuard {
 impl Drop for ParseLoopGuard {
     fn drop(&mut self) {
         if self.armed {
-            self.scheduler.abort(&self.uri);
+            self.scheduler.clear(&self.uri);
             log::warn!(
                 target: "kakehashi::parse_actor",
                 "parse loop for {} aborted abnormally; cleared its schedule so the next edit re-spawns",
@@ -276,6 +288,33 @@ mod tests {
         assert!(
             !scheduler.schedule(&u, Some(3)),
             "the fresh entry survived the disarmed guard's drop (still parsing)"
+        );
+    }
+
+    #[test]
+    fn finish_on_a_missing_entry_stops_the_loop() {
+        let s = ParseScheduler::default();
+        let u = uri();
+        // No entry present (e.g. it was already removed). `finish` must return
+        // false (stop) — a `true` here would spin the parse loop forever.
+        assert!(
+            !s.finish(&u),
+            "finish on a missing entry must stop the loop, not continue"
+        );
+    }
+
+    #[test]
+    fn schedule_keeps_the_highest_ticket() {
+        let s = ParseScheduler::default();
+        let u = uri();
+        assert!(s.schedule(&u, Some(5)));
+        // A later schedule with no ticket (or a lower one) must not regress it.
+        assert!(!s.schedule(&u, None));
+        assert!(!s.schedule(&u, Some(2)));
+        assert_eq!(
+            s.start_pass(&u),
+            Some(Some(5)),
+            "the highest ticket is kept"
         );
     }
 

--- a/src/lsp/lsp_impl/parse_scheduler.rs
+++ b/src/lsp/lsp_impl/parse_scheduler.rs
@@ -10,6 +10,8 @@
 //! lives in `Kakehashi::schedule_reparse`; this type owns only the
 //! spawn-or-mark-dirty decision and is the one piece that must be race-tight.
 
+use std::sync::Arc;
+
 use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;
 use url::Url;
@@ -99,6 +101,56 @@ impl ParseScheduler {
             Entry::Vacant(_) => None,
         }
     }
+
+    /// Clear `uri`'s scheduling entry unconditionally. Used by [`ParseLoopGuard`]
+    /// when the spawned parse loop exits **abnormally** (a panic): the entry is
+    /// stuck at `parsing: true`, and without clearing it every later `did_change`
+    /// would only mark it `dirty` and never re-spawn, wedging the document
+    /// tree-less forever. Clearing lets the next edit spawn a fresh loop.
+    fn abort(&self, uri: &Url) {
+        self.states.remove(uri);
+    }
+}
+
+/// Re-arms the scheduler if the spawned parse loop is torn down without finishing
+/// normally — i.e. a panic in the loop glue (`reparse_latest` / `process_injections`
+/// / `republish`; the blocking parse itself is already panic-isolated by
+/// `spawn_blocking`). On a clean exit the loop calls [`disarm`](Self::disarm) (its
+/// `next()` already removed the entry); on a panic the guard's `Drop` runs during
+/// unwind and clears the stuck entry so the next `did_change` re-spawns.
+pub(crate) struct ParseLoopGuard {
+    scheduler: Arc<ParseScheduler>,
+    uri: Url,
+    armed: bool,
+}
+
+impl ParseLoopGuard {
+    pub(crate) fn new(scheduler: Arc<ParseScheduler>, uri: Url) -> Self {
+        Self {
+            scheduler,
+            uri,
+            armed: true,
+        }
+    }
+
+    /// Mark a normal loop exit so `Drop` does not clear the entry (the loop's
+    /// final `next()` already removed it, and a fresh loop may have been spawned).
+    pub(crate) fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ParseLoopGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            self.scheduler.abort(&self.uri);
+            log::warn!(
+                target: "kakehashi::parse_actor",
+                "parse loop for {} aborted abnormally; cleared its schedule so the next edit re-spawns",
+                self.uri
+            );
+        }
+    }
 }
 
 #[cfg(test)]
@@ -145,6 +197,43 @@ mod tests {
         assert!(
             s.schedule(&u, Some(2)),
             "a fresh edit after the loop exited spawns a new loop"
+        );
+    }
+
+    #[test]
+    fn guard_clears_a_stuck_entry_on_abnormal_drop() {
+        let scheduler = Arc::new(ParseScheduler::default());
+        let u = uri();
+        assert!(scheduler.schedule(&u, Some(1)), "spawned: entry is parsing");
+
+        // Loop panicked: the guard was never disarmed. Its Drop must clear the
+        // stuck `parsing` entry so the next edit re-spawns.
+        {
+            let _guard = ParseLoopGuard::new(Arc::clone(&scheduler), u.clone());
+            // dropped here without disarm() → abnormal-exit path
+        }
+        assert!(
+            scheduler.schedule(&u, Some(2)),
+            "after an aborted loop, the next edit must spawn a fresh loop (not just mark dirty)"
+        );
+    }
+
+    #[test]
+    fn disarmed_guard_leaves_a_freshly_spawned_entry_alone() {
+        let scheduler = Arc::new(ParseScheduler::default());
+        let u = uri();
+        assert!(scheduler.schedule(&u, Some(1)));
+
+        // Normal exit: next() removed the entry, guard disarmed. A new loop may
+        // have been spawned meanwhile; the disarmed guard's Drop must NOT clear it.
+        let mut guard = ParseLoopGuard::new(Arc::clone(&scheduler), u.clone());
+        assert_eq!(scheduler.next(&u), None, "no dirty → entry removed");
+        guard.disarm();
+        assert!(scheduler.schedule(&u, Some(2)), "a fresh loop is spawned");
+        drop(guard); // disarmed → must not abort the fresh entry
+        assert!(
+            !scheduler.schedule(&u, Some(3)),
+            "the fresh entry survived the disarmed guard's drop (still parsing)"
         );
     }
 

--- a/src/lsp/lsp_impl/parse_scheduler.rs
+++ b/src/lsp/lsp_impl/parse_scheduler.rs
@@ -47,7 +47,11 @@ impl ParseScheduler {
         // Hot path (a live document being edited): `get_mut` borrows the key, so no
         // `Url` clone; only a first-edit miss pays for the owned key via `entry`.
         if let Some(mut state) = self.states.get_mut(uri) {
-            state.ticket = ticket;
+            // Keep the highest ticket: writer tickets are monotonic, and a later
+            // schedule carrying `None` (or, defensively, an out-of-order lower one)
+            // must not regress the watermark target. `None < Some(_)` in `Option`'s
+            // ordering, so `max` keeps any real ticket.
+            state.ticket = state.ticket.max(ticket);
             return if state.parsing {
                 state.dirty = true;
                 false
@@ -62,7 +66,7 @@ impl ParseScheduler {
             // `get_mut` miss and here.
             Entry::Occupied(mut entry) => {
                 let state = entry.get_mut();
-                state.ticket = ticket;
+                state.ticket = state.ticket.max(ticket);
                 if state.parsing {
                     state.dirty = true;
                     false

--- a/src/lsp/lsp_impl/parse_scheduler.rs
+++ b/src/lsp/lsp_impl/parse_scheduler.rs
@@ -44,7 +44,22 @@ impl ParseScheduler {
     /// `entry` holds the shard write lock across the whole decision, so two racing
     /// `did_change`s can never both spawn nor drop the `dirty` bit.
     pub(crate) fn schedule(&self, uri: &Url, ticket: Option<u64>) -> bool {
+        // Hot path (a live document being edited): `get_mut` borrows the key, so no
+        // `Url` clone; only a first-edit miss pays for the owned key via `entry`.
+        if let Some(mut state) = self.states.get_mut(uri) {
+            state.ticket = ticket;
+            return if state.parsing {
+                state.dirty = true;
+                false
+            } else {
+                state.parsing = true;
+                state.dirty = false;
+                true
+            };
+        }
         match self.states.entry(uri.clone()) {
+            // Re-check: a concurrent `schedule` may have inserted between the
+            // `get_mut` miss and here.
             Entry::Occupied(mut entry) => {
                 let state = entry.get_mut();
                 state.ticket = ticket;
@@ -68,37 +83,40 @@ impl ParseScheduler {
         }
     }
 
-    /// Peek the highest ticket scheduled for `uri` so the loop's *first* reparse
-    /// covers the latest edit (an edit can land between the spawn and the first
-    /// parse, raising the ticket past the one the spawn was created with). `None`
-    /// if there is no pending entry.
-    pub(crate) fn latest_ticket(&self, uri: &Url) -> Option<u64> {
-        self.states.get(uri).and_then(|state| state.ticket)
+    /// Start a parse pass: **clear `dirty`** and return the latest ticket. Called
+    /// at the top of each loop iteration, *before* reading the document text, so an
+    /// edit arriving after this re-sets `dirty` and [`finish`](Self::finish) loops
+    /// again — while an edit already folded into this pass's text does **not**
+    /// trigger a redundant reparse of the same text. The outer `Option` is `None`
+    /// only if the entry is somehow gone (defensive); the inner is the ticket.
+    pub(crate) fn start_pass(&self, uri: &Url) -> Option<Option<u64>> {
+        self.states.get_mut(uri).map(|mut state| {
+            state.dirty = false;
+            state.ticket
+        })
     }
 
-    /// Called by the parse loop after one parse completes, to decide whether to
-    /// loop again. Returns `Some(ticket)` when an edit landed during the parse
-    /// (`dirty`) — the loop keeps running and reparses the latest text at `ticket`
-    /// (itself `Option<u64>`, since a reparse may carry no ingress ticket); `None`
-    /// when nothing is pending — the entry is removed and the loop exits. The outer
-    /// `Option` is the continue/stop signal, distinct from the inner ticket, so a
-    /// pending reparse whose ticket is `None` still continues the loop. Atomic
-    /// under the shard write lock so it cannot race a concurrent `schedule`: a
-    /// `schedule` arriving just before this either set `dirty` (we continue) or
-    /// finds no entry afterward and spawns a fresh loop.
-    pub(crate) fn next(&self, uri: &Url) -> Option<Option<u64>> {
+    /// Called by the parse loop after one pass (parse + downstream) completes, to
+    /// decide whether to loop again. Returns `true` when an edit landed during the
+    /// pass (`dirty`) — keep the entry and loop (the next [`start_pass`] clears it);
+    /// `false` when nothing is pending — the entry is removed and the loop exits.
+    ///
+    /// **Atomic via `entry`** (the whole check-and-remove under one shard write
+    /// lock): a `get_mut`-then-`remove` split would let a concurrent `schedule` set
+    /// `dirty` between the check and the removal and then be deleted — a lost
+    /// wakeup that wedges the document until the next edit. So this is deliberately
+    /// not micro-optimized to avoid the `Url` clone.
+    pub(crate) fn finish(&self, uri: &Url) -> bool {
         match self.states.entry(uri.clone()) {
-            Entry::Occupied(mut entry) => {
+            Entry::Occupied(entry) => {
                 if entry.get().dirty {
-                    let state = entry.get_mut();
-                    state.dirty = false;
-                    Some(state.ticket)
+                    true
                 } else {
                     entry.remove();
-                    None
+                    false
                 }
             }
-            Entry::Vacant(_) => None,
+            Entry::Vacant(_) => false,
         }
     }
 
@@ -116,7 +134,7 @@ impl ParseScheduler {
 /// normally — i.e. a panic in the loop glue (`reparse_latest` / `process_injections`
 /// / `republish`; the blocking parse itself is already panic-isolated by
 /// `spawn_blocking`). On a clean exit the loop calls [`disarm`](Self::disarm) (its
-/// `next()` already removed the entry); on a panic the guard's `Drop` runs during
+/// `finish()` already removed the entry); on a panic the guard's `Drop` runs during
 /// unwind and clears the stuck entry so the next `did_change` re-spawns.
 pub(crate) struct ParseLoopGuard {
     scheduler: Arc<ParseScheduler>,
@@ -134,7 +152,7 @@ impl ParseLoopGuard {
     }
 
     /// Mark a normal loop exit so `Drop` does not clear the entry (the loop's
-    /// final `next()` already removed it, and a fresh loop may have been spawned).
+    /// final `finish()` already removed it, and a fresh loop may have been spawned).
     pub(crate) fn disarm(&mut self) {
         self.armed = false;
     }
@@ -173,19 +191,40 @@ mod tests {
     }
 
     #[test]
-    fn next_continues_when_dirty_with_latest_ticket_then_exits() {
+    fn start_pass_clears_dirty_and_finish_continues_then_exits() {
         let s = ParseScheduler::default();
         let u = uri();
         assert!(s.schedule(&u, Some(1)));
-        assert!(
-            !s.schedule(&u, Some(5)),
-            "edit during parse marks dirty, ticket=5"
-        );
 
-        // Loop finishes its first parse: dirty was set → continue at the latest ticket.
-        assert_eq!(s.next(&u), Some(Some(5)));
-        // Nothing more pending → loop exits and the entry is cleared.
-        assert_eq!(s.next(&u), None);
+        // Pass 1 starts: clears dirty, takes the latest ticket (1).
+        assert_eq!(s.start_pass(&u), Some(Some(1)));
+        // An edit lands during the pass → dirty, ticket=5.
+        assert!(!s.schedule(&u, Some(5)), "edit during parse marks dirty");
+        // finish() sees dirty → continue (entry kept).
+        assert!(s.finish(&u), "dirty during the pass → loop continues");
+
+        // Pass 2 starts: clears dirty, takes the latest ticket (5).
+        assert_eq!(s.start_pass(&u), Some(Some(5)));
+        // No edit during pass 2 → finish() removes the entry and stops.
+        assert!(!s.finish(&u), "no dirty → loop exits and entry removed");
+        assert_eq!(s.start_pass(&u), None, "entry removed after exit");
+    }
+
+    #[test]
+    fn no_redundant_pass_when_edit_arrived_before_the_first_start_pass() {
+        let s = ParseScheduler::default();
+        let u = uri();
+        // Edit 1 spawns; edit 2 lands before the loop's first start_pass (marks
+        // dirty). The first start_pass clears that dirty (its text already covers
+        // edit 2), so finish() does NOT trigger a redundant same-text pass.
+        assert!(s.schedule(&u, Some(1)));
+        assert!(!s.schedule(&u, Some(2)));
+
+        assert_eq!(s.start_pass(&u), Some(Some(2)), "first pass covers edit 2");
+        assert!(
+            !s.finish(&u),
+            "dirty was cleared by start_pass → no redundant pass"
+        );
     }
 
     #[test]
@@ -193,7 +232,8 @@ mod tests {
         let s = ParseScheduler::default();
         let u = uri();
         assert!(s.schedule(&u, Some(1)));
-        assert_eq!(s.next(&u), None, "no dirty → exit");
+        let _ = s.start_pass(&u);
+        assert!(!s.finish(&u), "no dirty → exit");
         assert!(
             s.schedule(&u, Some(2)),
             "a fresh edit after the loop exited spawns a new loop"
@@ -224,10 +264,11 @@ mod tests {
         let u = uri();
         assert!(scheduler.schedule(&u, Some(1)));
 
-        // Normal exit: next() removed the entry, guard disarmed. A new loop may
+        // Normal exit: finish() removed the entry, guard disarmed. A new loop may
         // have been spawned meanwhile; the disarmed guard's Drop must NOT clear it.
         let mut guard = ParseLoopGuard::new(Arc::clone(&scheduler), u.clone());
-        assert_eq!(scheduler.next(&u), None, "no dirty → entry removed");
+        let _ = scheduler.start_pass(&u);
+        assert!(!scheduler.finish(&u), "no dirty → entry removed");
         guard.disarm();
         assert!(scheduler.schedule(&u, Some(2)), "a fresh loop is spawned");
         drop(guard); // disarmed → must not abort the fresh entry

--- a/src/lsp/lsp_impl/parse_scheduler.rs
+++ b/src/lsp/lsp_impl/parse_scheduler.rs
@@ -105,23 +105,20 @@ impl ParseScheduler {
     /// pass (`dirty`) — keep the entry and loop (the next [`start_pass`] clears it);
     /// `false` when nothing is pending — the entry is removed and the loop exits.
     ///
-    /// **Atomic via `entry`** (the whole check-and-remove under one shard write
-    /// lock): a `get_mut`-then-`remove` split would let a concurrent `schedule` set
-    /// `dirty` between the check and the removal and then be deleted — a lost
-    /// wakeup that wedges the document until the next edit. So this is deliberately
-    /// not micro-optimized to avoid the `Url` clone.
+    /// Uses `remove_if`, which holds the shard write lock across the predicate
+    /// **and** the removal, so it is atomic against a concurrent `schedule`: that
+    /// `schedule` either sets `dirty` before the predicate runs (entry kept → we
+    /// continue) or after the removal (entry re-created → it spawns a fresh loop).
+    /// A `get_mut`-then-`remove` split would instead let `schedule` set `dirty`
+    /// between the two and then be deleted — a lost wakeup. `remove_if` also borrows
+    /// the key (no `Url` clone). The loop's entry is always present when this runs
+    /// (nothing else removes scheduler entries), so a non-removal means it was kept
+    /// for `dirty` → continue.
     pub(crate) fn finish(&self, uri: &Url) -> bool {
-        match self.states.entry(uri.clone()) {
-            Entry::Occupied(entry) => {
-                if entry.get().dirty {
-                    true
-                } else {
-                    entry.remove();
-                    false
-                }
-            }
-            Entry::Vacant(_) => false,
-        }
+        // `Some` = removed because it was clean → stop; `None` = kept (dirty) → loop.
+        self.states
+            .remove_if(uri, |_, state| !state.dirty)
+            .is_none()
     }
 
     /// Clear `uri`'s scheduling entry unconditionally. Used by [`ParseLoopGuard`]

--- a/src/lsp/lsp_impl/text_document/color_presentation.rs
+++ b/src/lsp/lsp_impl/text_document/color_presentation.rs
@@ -15,11 +15,10 @@ impl Kakehashi {
         let range = params.range;
         let color = params.color;
 
-        let Some(ctx) = self.resolve_bridge_contexts_for_range(
-            &lsp_uri,
-            range,
-            "textDocument/colorPresentation",
-        ) else {
+        let Some(ctx) = self
+            .resolve_bridge_contexts_for_range(&lsp_uri, range, "textDocument/colorPresentation")
+            .await
+        else {
             return Ok(Vec::new());
         };
 

--- a/src/lsp/lsp_impl/text_document/completion.rs
+++ b/src/lsp/lsp_impl/text_document/completion.rs
@@ -47,7 +47,10 @@ impl Kakehashi {
         position: Position,
     ) -> Result<Option<CompletionResponse>> {
         // Use shared preamble to resolve injection context with ALL matching servers
-        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
+        let Some(ctx) = self
+            .resolve_bridge_contexts(lsp_uri, position, METHOD)
+            .await
+        else {
             return Ok(None);
         };
 

--- a/src/lsp/lsp_impl/text_document/declaration.rs
+++ b/src/lsp/lsp_impl/text_document/declaration.rs
@@ -49,7 +49,10 @@ impl Kakehashi {
         position: Position,
         client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
     ) -> Result<Option<Vec<LocationLink>>> {
-        let Some(mut ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
+        let Some(mut ctx) = self
+            .resolve_bridge_contexts(lsp_uri, position, METHOD)
+            .await
+        else {
             return Ok(None);
         };
         // Aggregate the fanned-out servers' progress onto the editor's token

--- a/src/lsp/lsp_impl/text_document/definition.rs
+++ b/src/lsp/lsp_impl/text_document/definition.rs
@@ -50,7 +50,10 @@ impl Kakehashi {
         position: Position,
         client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
     ) -> Result<Option<Vec<LocationLink>>> {
-        let Some(mut ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
+        let Some(mut ctx) = self
+            .resolve_bridge_contexts(lsp_uri, position, METHOD)
+            .await
+        else {
             return Ok(None);
         };
         // Aggregate the fanned-out servers' progress onto the editor's token

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -103,22 +103,23 @@ impl Kakehashi {
 
         log::trace!("textDocument/diagnostic called for {}", uri);
 
-        // Get document snapshot (minimizes lock duration)
+        // Ensure a fresh tree before snapshotting for the VIRT layer: `didChange`
+        // clears the tree and reparses off-ingress, so without this the virt
+        // injection regions would be empty for the reparse window after each edit.
+        // The HOST layer needs no tree (it forwards the real URI + text), so it
+        // must survive even when the tree never lands — hence the snapshot below is
+        // optional, not an early bail.
+        self.ensure_document_parsed(&uri).await;
+
+        // A missing document means a `didClose` removed it — nothing to report. A
+        // present document whose tree isn't ready (parse pending/failed even after
+        // the wait) yields `None` here; the host layer still runs, only virt skips.
         let snapshot = match self.documents.get(&uri) {
             None => {
                 log::debug!("textDocument/diagnostic: No document found for {}", uri);
                 return Ok(empty_diagnostic_report());
             }
-            Some(doc) => match doc.snapshot() {
-                None => {
-                    log::debug!(
-                        "textDocument/diagnostic: Document not fully initialized for {}",
-                        uri
-                    );
-                    return Ok(empty_diagnostic_report());
-                }
-                Some(snapshot) => snapshot,
-            },
+            Some(doc) => doc.snapshot(),
             // doc automatically dropped here, lock released
         };
 
@@ -159,8 +160,9 @@ impl Kakehashi {
 
         // Resolve injection regions once: the live virt pull below and the
         // pushFallback fold (#425) after the join share them.
-        let virt_regions = if virt_enabled {
-            self.language
+        let virt_regions = match (virt_enabled, snapshot.as_ref()) {
+            (true, Some(snapshot)) => self
+                .language
                 .injection_query(&language_name)
                 .map(|injection_query| {
                     InjectionResolver::resolve_all(
@@ -172,9 +174,11 @@ impl Kakehashi {
                         injection_query.as_ref(),
                     )
                 })
-                .unwrap_or_default()
-        } else {
-            Vec::new()
+                .unwrap_or_default(),
+            // Virt gated off, or no tree yet (the host layer still pulls). The
+            // wait+on-demand above already tried, so a missing tree here is the
+            // rare parse-failure case, self-healing on the next pull.
+            _ => Vec::new(),
         };
         // Lightweight per-region metadata `(region_id, injection_language,
         // current offset)` for the pushFallback fold; the live pull below moves

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -103,25 +103,11 @@ impl Kakehashi {
 
         log::trace!("textDocument/diagnostic called for {}", uri);
 
-        // Ensure a fresh tree before snapshotting for the VIRT layer: `didChange`
-        // clears the tree and reparses off-ingress, so without this the virt
-        // injection regions would be empty for the reparse window after each edit.
-        // The HOST layer needs no tree (it forwards the real URI + text), so it
-        // must survive even when the tree never lands — hence the snapshot below is
-        // optional, not an early bail.
-        self.ensure_document_parsed(&uri).await;
-
-        // A missing document means a `didClose` removed it — nothing to report. A
-        // present document whose tree isn't ready (parse pending/failed even after
-        // the wait) yields `None` here; the host layer still runs, only virt skips.
-        let snapshot = match self.documents.get(&uri) {
-            None => {
-                log::debug!("textDocument/diagnostic: No document found for {}", uri);
-                return Ok(empty_diagnostic_report());
-            }
-            Some(doc) => doc.snapshot(),
-            // doc automatically dropped here, lock released
-        };
+        // A missing document means a `didClose` removed it — nothing to report.
+        if self.documents.get(&uri).is_none() {
+            log::debug!("textDocument/diagnostic: No document found for {}", uri);
+            return Ok(empty_diagnostic_report());
+        }
 
         // Get the language for this document
         let Some(language_name) = self.document_language(&uri) else {
@@ -148,6 +134,19 @@ impl Kakehashi {
             );
             return Ok(empty_diagnostic_report());
         }
+
+        // Snapshot for the VIRT layer ONLY, and ONLY ensure a fresh tree when virt
+        // actually participates: `didChange` clears the tree and reparses
+        // off-ingress, so the virt injection regions would otherwise be empty for
+        // the reparse window after each edit. The HOST layer needs no tree, so a
+        // host-only document must not pay the freshness wait. A still-missing tree
+        // (parse pending/failed) yields `None` — host still pulls, virt skips.
+        let snapshot = if virt_enabled {
+            self.ensure_document_parsed(&uri).await;
+            self.documents.get(&uri).and_then(|doc| doc.snapshot())
+        } else {
+            None
+        };
 
         // Get upstream request ID from task-local storage (set by RequestIdCapture middleware)
         let upstream_request_id = crate::lsp::current_upstream_id();

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -62,8 +62,9 @@ impl Kakehashi {
         // Use InputEdits directly for precise invalidation when available,
         // fall back to diff-based approach for full document sync.
         //
-        // This must be called AFTER content changes are applied (so we have new text)
-        // but BEFORE parse_document (so position sync happens before new tree is built).
+        // This must be called AFTER content changes are applied (so we have new
+        // text) but BEFORE the tree is cleared and the off-ingress reparse is
+        // scheduled (so node-position sync happens against the pre-edit state).
         let invalidated_ulids = if edits.is_empty() {
             // Full document sync: no InputEdits available, reconstruct from diff
             self.bridge.apply_text_diff(&uri, &old_text, &text)
@@ -73,8 +74,9 @@ impl Kakehashi {
             self.bridge.apply_input_edits(&uri, &edit_infos)
         };
 
-        // Invalidate injection caches for regions overlapping with edits.
-        // Must be called BEFORE parse_document which updates the injection_map.
+        // Invalidate injection caches for regions overlapping with edits. Must run
+        // here (pre-edit invalidation) before the off-ingress reparse loop
+        // repopulates the injection map from the freshly parsed tree.
         self.cache.invalidate_for_edits(&uri, &edits);
 
         // Apply the edit to the store and CLEAR the tree synchronously, here under

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -99,8 +99,11 @@ impl Kakehashi {
 
         // lazy-node-identity-tracking: Close invalidated virtual documents.
         // Send didClose notifications to downstream LSs for orphaned docs. Stays in
-        // the handler (text-derived) and runs BEFORE the scheduler's forward, so the
-        // close-then-forward wire order is preserved.
+        // the handler (text-derived). It closes the **invalidated** (old) region
+        // ulids, whereas the scheduler loop's forward targets the **current** region
+        // ulids — disjoint virtual documents — so even though the off-ingress loop
+        // can forward a later edit's content before an earlier edit's close
+        // completes, the two never act on the same downstream document.
         self.injection_coordinator()
             .close_invalidated_virtual_docs(&uri, &invalidated_ulids)
             .await;

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -112,17 +112,17 @@ impl Kakehashi {
 
         // Schedule the OFF-INGRESS reparse: this replaces the inline parse_document,
         // the post-parse process_injections (didChange forwarding + injected-language
-        // processing + eager bridge spawn), and the geometry re-merge republish —
-        // all of which need the fresh tree and so run in the spawned, coalescing
-        // parse loop instead of holding the writer ticket. The handler returns
-        // without waiting on the parse.
+        // processing + eager bridge spawn), the geometry re-merge republish, AND the
+        // debounced diagnostic — all of which need the fresh tree and so run in the
+        // spawned, coalescing parse loop instead of holding the writer ticket.
+        //
+        // The debounced diagnostic in particular MUST run post-parse, not here: this
+        // handler just cleared the tree, and `prepare_diagnostic_snapshot` returns
+        // `None` without one (`Document::snapshot()` requires a tree). A `None`
+        // snapshot makes the debounce a no-op, skipping the on-edit host re-sync
+        // (#431) that keeps a push-only `_self` host server's diagnostics following
+        // edits. The handler returns without waiting on the parse.
         self.schedule_reparse(uri.clone(), ticket);
-
-        // pull-first-diagnostic-forwarding Phase 3: Schedule debounced diagnostic push on didChange.
-        // After 500ms of no changes, diagnostics will be collected and published.
-        // This provides near-real-time feedback while avoiding excessive requests during typing.
-        self.diagnostic_scheduler()
-            .schedule_debounced_diagnostic(uri);
 
         // NOTE: We intentionally do NOT call semantic_tokens_refresh() here.
         // LSP clients already request new tokens after didChange (via semanticTokens/full/delta).

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -41,7 +41,9 @@ impl Kakehashi {
         let old_text = {
             let doc = self.documents.get(&uri);
             match doc {
-                Some(d) => d.text().to_string(),
+                // `text_arc()` is a refcount bump, not a full copy of the pre-edit
+                // text — cheap on every keystroke (#498).
+                Some(d) => d.text_arc(),
                 None => {
                     self.notifier()
                         .log_warning("Document not found for change event")
@@ -122,7 +124,7 @@ impl Kakehashi {
         // snapshot makes the debounce a no-op, skipping the on-edit host re-sync
         // (#431) that keeps a push-only `_self` host server's diagnostics following
         // edits. The handler returns without waiting on the parse.
-        self.schedule_reparse(uri.clone(), ticket);
+        self.schedule_reparse(uri, ticket);
 
         // NOTE: We intentionally do NOT call semantic_tokens_refresh() here.
         // LSP clients already request new tokens after didChange (via semanticTokens/full/delta).

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -35,11 +35,13 @@ impl Kakehashi {
             .log_trace(format!("[DID_CHANGE] START uri={}", uri))
             .await;
 
-        // Retrieve the stored document info
-        let (language_id, old_text) = {
+        // Retrieve the stored document's current text (the base for the diff). The
+        // language is re-detected by the off-ingress reparse from the stored
+        // `language_id`, so it is not needed here.
+        let old_text = {
             let doc = self.documents.get(&uri);
             match doc {
-                Some(d) => (d.language_id().map(|s| s.to_string()), d.text().to_string()),
+                Some(d) => d.text().to_string(),
                 None => {
                     self.notifier()
                         .log_warning("Document not found for change event")
@@ -75,17 +77,16 @@ impl Kakehashi {
         // Must be called BEFORE parse_document which updates the injection_map.
         self.cache.invalidate_for_edits(&uri, &edits);
 
-        // Parse the updated document with edit information. The parse stamps the
-        // store watermark with this didChange's ingress ticket on resolution.
-        self.parse_coordinator()
-            .parse_document(
-                uri.clone(),
-                text,
-                language_id.as_deref(),
-                edits,
-                crate::lsp::current_writer_ticket(),
-            )
-            .await;
+        // Apply the edit to the store and CLEAR the tree synchronously, here under
+        // the edit lock (per-document-parse-actor ADR). Clearing the tree (rather
+        // than leaving the pre-edit one) is what keeps readers safe once the parse
+        // is off-ingress: a virt/native reader now sees *no* tree until the reparse
+        // lands (empty / on-demand fallback) instead of a stale tree that predates
+        // this edit — turning the #342/#374 stale-tree race into benign emptiness.
+        // The document exists (checked above) and the edit lock serializes didClose,
+        // so this update is in-place, not a resurrection.
+        let ticket = crate::lsp::current_writer_ticket();
+        self.documents.update_document(uri.clone(), text, None);
 
         // NOTE: We intentionally do NOT invalidate the semantic token cache here.
         // The cached tokens (with their result_id) are needed for delta calculations.
@@ -97,33 +98,20 @@ impl Kakehashi {
         // tokens won't be returned for mismatched result_ids.
 
         // lazy-node-identity-tracking: Close invalidated virtual documents.
-        // Send didClose notifications to downstream LSs for orphaned docs.
+        // Send didClose notifications to downstream LSs for orphaned docs. Stays in
+        // the handler (text-derived) and runs BEFORE the scheduler's forward, so the
+        // close-then-forward wire order is preserved.
         self.injection_coordinator()
             .close_invalidated_virtual_docs(&uri, &invalidated_ulids)
             .await;
 
-        // Forward didChange to opened virtual documents + process injected languages.
-        // Injection data is resolved once and reused for:
-        // 1. didChange forwarding to already-opened virtual documents
-        // 2. Auto-install missing parsers
-        // 3. Eager server spawn + didOpen for virtual documents
-        // Must be called AFTER parse_document so we have access to the updated AST.
-        self.injection_coordinator()
-            .process_injections(&uri, true)
-            .await;
-
-        // Geometry re-merge (#422): a host edit can shift a region's position without
-        // changing its extracted content — the fingerprint guard then skips re-syncing
-        // it, so no downstream re-push will re-anchor its cached diagnostics. Republish
-        // (off the debounce) so the cached region push slots re-anchor to their new
-        // host coordinates via lazy re-anchor. Gated on actually having region push
-        // slots so a quiet/diagnostic-free file pays nothing; the no-op-publish
-        // suppression then emits only when the re-anchored coordinates really changed.
-        if self.diagnostics.has_region_slots(&uri) {
-            crate::lsp::lsp_impl::coordinator::DiagnosticPublisher::new(self)
-                .republish(&uri)
-                .await;
-        }
+        // Schedule the OFF-INGRESS reparse: this replaces the inline parse_document,
+        // the post-parse process_injections (didChange forwarding + injected-language
+        // processing + eager bridge spawn), and the geometry re-merge republish —
+        // all of which need the fresh tree and so run in the spawned, coalescing
+        // parse loop instead of holding the writer ticket. The handler returns
+        // without waiting on the parse.
+        self.schedule_reparse(uri.clone(), ticket);
 
         // pull-first-diagnostic-forwarding Phase 3: Schedule debounced diagnostic push on didChange.
         // After 500ms of no changes, diagnostics will be collected and published.

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -764,6 +764,69 @@ print("hello")
         );
     }
 
+    /// Off-ingress edit reparse (per-document-parse-actor flip): `reparse_latest`
+    /// parses the latest store text and advances the watermark, but must NOT
+    /// resurrect a document a `didClose` removed mid-parse.
+    #[tokio::test]
+    async fn reparse_latest_does_not_resurrect_closed_document() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        configure_rust_self_host(server);
+
+        let uri = Url::parse("file:///test/closed_during_reparse.rs").unwrap();
+        // Document already closed (removed) — models a didClose racing the
+        // scheduled reparse. The watermark ticket still resolves.
+        server
+            .parse_coordinator()
+            .reparse_latest(&uri, Some(7))
+            .await;
+
+        assert!(
+            server.documents.get(&uri).is_none(),
+            "the off-ingress reparse must not resurrect a closed document"
+        );
+    }
+
+    /// `reparse_latest` attaches a fresh tree to the open document (whose tree was
+    /// cleared by the edit) and advances the watermark to the edit's ticket.
+    #[tokio::test]
+    async fn reparse_latest_parses_and_advances_watermark() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        configure_rust_self_host(server);
+
+        let uri = Url::parse("file:///test/edited.rs").unwrap();
+        // The edit applied new text and cleared the tree (tree = None), exactly as
+        // did_change does before scheduling the reparse.
+        server.documents.insert(
+            uri.clone(),
+            "fn edited() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        assert!(server.documents.get(&uri).unwrap().tree().is_none());
+
+        server
+            .parse_coordinator()
+            .reparse_latest(&uri, Some(3))
+            .await;
+
+        assert!(
+            server.documents.get(&uri).unwrap().tree().is_some(),
+            "the off-ingress reparse attaches a tree to the edited document"
+        );
+        // The watermark reached the edit's ticket, so a reader gated behind it is
+        // released (wait_for_epoch returns immediately for target <= 3).
+        timeout(
+            Duration::from_millis(100),
+            server
+                .documents
+                .wait_for_epoch(&uri, 3, Duration::from_secs(5)),
+        )
+        .await
+        .expect("watermark must have advanced to the reparse ticket");
+    }
+
     /// If a concurrent `didChange` already parsed the document (a tree is
     /// present), the install reparse must short-circuit and not redundantly
     /// reparse / clobber it.

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -712,6 +712,74 @@ print("hello")
         );
     }
 
+    /// Regression (parse-actor flip): the debounced diagnostic — which drives the
+    /// on-edit host re-sync (#431) that keeps a push host's diagnostics following
+    /// edits — must be scheduled AFTER the off-ingress reparse, not in the
+    /// `did_change` handler. The handler clears the tree, and
+    /// `prepare_diagnostic_snapshot` returns `None` without a tree, so scheduling
+    /// the debounce there would capture a `None` snapshot and silently skip the
+    /// re-sync (the diagnostics-don't-follow-edits bug). This pins the mechanism:
+    /// the snapshot is `None` with the tree cleared and valid again once the
+    /// reparse restores it.
+    #[tokio::test]
+    async fn diagnostic_snapshot_needs_the_reparsed_tree_not_the_cleared_one() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        configure_rust_self_host(server);
+
+        let uri = Url::parse("file:///test/diag_follow.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        server
+            .parse_coordinator()
+            .parse_document(
+                uri.clone(),
+                "fn main() {}".to_string(),
+                Some("rust"),
+                vec![],
+                None,
+            )
+            .await;
+        assert!(
+            server
+                .diagnostic_scheduler()
+                .prepare_diagnostic_snapshot(&uri)
+                .is_some(),
+            "a parsed self-host doc yields a diagnostic snapshot"
+        );
+
+        // What did_change does synchronously: apply the edit and CLEAR the tree.
+        server
+            .documents
+            .update_document(uri.clone(), "fn changed() {}".to_string(), None);
+        assert!(
+            server
+                .diagnostic_scheduler()
+                .prepare_diagnostic_snapshot(&uri)
+                .is_none(),
+            "with the tree cleared, the snapshot is None — scheduling the debounce \
+             here (as the handler used to) would skip the on-edit host re-sync"
+        );
+
+        // The off-ingress reparse restores the tree → the snapshot is valid again,
+        // which is exactly why the debounce is scheduled from the reparse loop.
+        server
+            .parse_coordinator()
+            .reparse_latest(&uri, Some(1))
+            .await;
+        assert!(
+            server
+                .diagnostic_scheduler()
+                .prepare_diagnostic_snapshot(&uri)
+                .is_some(),
+            "after the reparse the snapshot is valid again (the debounce is scheduled here)"
+        );
+    }
+
     /// Resurrection safety (#480 off-ingress install): a `didClose` landing while
     /// the spawned auto-install runs removes the document; the late
     /// `reparse_installed_document` must NOT recreate it.

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -86,6 +86,7 @@ impl Kakehashi {
                     // watermark so a gated reader is not stranded.
                     let install = self.install_coordinator();
                     let injection = self.injection_coordinator();
+                    let diagnostic_scheduler = self.diagnostic_scheduler();
                     let documents = std::sync::Arc::clone(&self.documents);
                     let lang = lang.clone();
                     let install_uri = uri.clone();
@@ -109,6 +110,12 @@ impl Kakehashi {
                             .is_some_and(|doc| doc.tree().is_some());
                         if has_tree {
                             injection.process_injections(&install_uri, false).await;
+                            // Re-fire the proactive synthetic diagnostic now that a
+                            // tree exists: the handler's spawn (below) ran in the
+                            // skip-parse path with no tree, so its snapshot was None
+                            // and the pull-layer diagnostics were skipped on this
+                            // first open of a just-installed parser.
+                            diagnostic_scheduler.spawn_synthetic_diagnostic_task(install_uri);
                         }
                     });
                     skip_parse = true;
@@ -709,6 +716,105 @@ print("hello")
         assert!(
             host.configs.iter().any(|c| c.server_name == "rust_ls"),
             "the push-only rust_ls must be in the host context so the debounce re-sync reaches it"
+        );
+    }
+
+    /// Regression (parse-actor flip): the host bridge context needs only the
+    /// document text, never the parse tree (parse-decoupled ADR), so it must keep
+    /// resolving after `did_change` clears the tree — otherwise every host-bridged
+    /// request (hover / definition / formatting / diagnostics) would bail for the
+    /// whole reparse window after each edit.
+    #[tokio::test]
+    async fn resolve_host_bridge_context_survives_a_cleared_tree() {
+        use std::str::FromStr;
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        configure_rust_self_host(server);
+
+        let uri = Url::parse("file:///test/host_cleared.rs").unwrap();
+        let lsp_uri = tower_lsp_server::ls_types::Uri::from_str(uri.as_str()).unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        server
+            .parse_coordinator()
+            .parse_document(
+                uri.clone(),
+                "fn main() {}".to_string(),
+                Some("rust"),
+                vec![],
+                None,
+            )
+            .await;
+        assert!(
+            server
+                .resolve_host_bridge_context(&lsp_uri, "textDocument/diagnostic")
+                .is_some(),
+            "sanity: host context resolves with a tree present"
+        );
+
+        // did_change clears the tree synchronously.
+        server
+            .documents
+            .update_document(uri.clone(), "fn changed() {}".to_string(), None);
+        assert!(
+            server.documents.get(&uri).unwrap().tree().is_none(),
+            "precondition: the tree is cleared"
+        );
+        assert!(
+            server
+                .resolve_host_bridge_context(&lsp_uri, "textDocument/diagnostic")
+                .is_some(),
+            "host context must survive a cleared tree (it needs only text, not the tree)"
+        );
+    }
+
+    /// Regression (parse-actor flip): `ensure_document_parsed` — the shared
+    /// post-edit freshness helper that every snapshot-reading handler (pull
+    /// diagnostics, the position/range bridge preamble, formatting, node/captures)
+    /// now calls — must restore a tree that `did_change` cleared, so those handlers
+    /// don't return empty/null after every edit while the off-ingress reparse is
+    /// still pending. (Without it, a request racing the reparse sees
+    /// `snapshot() == None`.)
+    #[tokio::test]
+    async fn ensure_document_parsed_restores_a_cleared_tree() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        configure_rust_self_host(server);
+
+        let uri = Url::parse("file:///test/ensure_fresh.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        server
+            .parse_coordinator()
+            .parse_document(
+                uri.clone(),
+                "fn main() {}".to_string(),
+                Some("rust"),
+                vec![],
+                None,
+            )
+            .await;
+
+        // did_change applies the edit and CLEARS the tree synchronously.
+        server
+            .documents
+            .update_document(uri.clone(), "fn changed() {}".to_string(), None);
+        assert!(server.documents.get(&uri).unwrap().tree().is_none());
+
+        // A reader's freshness call restores the tree (here via on-demand parse,
+        // since no off-ingress reparse is running in this unit test).
+        server.ensure_document_parsed(&uri).await;
+        assert!(
+            server.documents.get(&uri).unwrap().tree().is_some(),
+            "the freshness helper must restore the tree so post-edit readers aren't empty"
         );
     }
 

--- a/src/lsp/lsp_impl/text_document/did_save.rs
+++ b/src/lsp/lsp_impl/text_document/did_save.rs
@@ -33,6 +33,13 @@ impl Kakehashi {
             .forward_did_save_to_virtual_docs(&uri)
             .await;
 
+        // Ensure a fresh tree before the synthetic task snapshots it: a save
+        // batched right after an edit (autosave / format-on-save) races the
+        // off-ingress reparse, and `prepare_diagnostic_snapshot` returns `None`
+        // without a tree — making the synthetic diagnostic a no-op for the virt
+        // layer.
+        self.ensure_document_parsed(&uri).await;
+
         // Spawn background task for synthetic diagnostic collection
         self.diagnostic_scheduler()
             .spawn_synthetic_diagnostic_task(uri);

--- a/src/lsp/lsp_impl/text_document/document_color.rs
+++ b/src/lsp/lsp_impl/text_document/document_color.rs
@@ -28,6 +28,11 @@ impl Kakehashi {
 
         log::debug!("documentColor called for {}", uri);
 
+        // Ensure a fresh tree before snapshotting: `didChange` clears the tree and
+        // reparses off-ingress, so without this documentColor (virt-only) returns
+        // empty for the whole reparse window after every edit.
+        self.ensure_document_parsed(&uri).await;
+
         // Get document snapshot (minimizes lock duration)
         let snapshot = match self.documents.get(&uri) {
             None => {

--- a/src/lsp/lsp_impl/text_document/document_highlight.rs
+++ b/src/lsp/lsp_impl/text_document/document_highlight.rs
@@ -43,7 +43,10 @@ impl Kakehashi {
         lsp_uri: &Uri,
         position: Position,
     ) -> Result<Option<Vec<DocumentHighlight>>> {
-        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
+        let Some(ctx) = self
+            .resolve_bridge_contexts(lsp_uri, position, METHOD)
+            .await
+        else {
             return Ok(None);
         };
 

--- a/src/lsp/lsp_impl/text_document/document_symbol.rs
+++ b/src/lsp/lsp_impl/text_document/document_symbol.rs
@@ -66,6 +66,12 @@ impl Kakehashi {
 
         log::debug!("documentSymbol called for {}", uri);
 
+        // Ensure a fresh tree before snapshotting: `didChange` clears the tree and
+        // reparses off-ingress, so without this the virt layer drops injection-region
+        // symbols for the whole reparse window after every edit (the host layer is
+        // unaffected — it needs no tree).
+        self.ensure_document_parsed(&uri).await;
+
         // Get document snapshot (minimizes lock duration)
         let snapshot = match self.documents.get(&uri) {
             None => {

--- a/src/lsp/lsp_impl/text_document/document_symbol.rs
+++ b/src/lsp/lsp_impl/text_document/document_symbol.rs
@@ -67,9 +67,8 @@ impl Kakehashi {
         log::debug!("documentSymbol called for {}", uri);
 
         // Ensure a fresh tree before snapshotting: `didChange` clears the tree and
-        // reparses off-ingress, so without this the virt layer drops injection-region
-        // symbols for the whole reparse window after every edit (the host layer is
-        // unaffected — it needs no tree).
+        // reparses off-ingress, so without this the (tree-driven) virt layer drops
+        // injection-region symbols for the whole reparse window after every edit.
         self.ensure_document_parsed(&uri).await;
 
         // Get document snapshot (minimizes lock duration)

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -93,6 +93,12 @@ impl Kakehashi {
 
         log::debug!("formatting called for {}", uri);
 
+        // Ensure a fresh tree before snapshotting: `didChange` clears the tree and
+        // reparses off-ingress, so a format-on-save batched right after an edit
+        // would otherwise snapshot `None` and return no edits. (range_formatting
+        // uses the same helper — keep them from drifting.)
+        self.ensure_document_parsed(&uri).await;
+
         let snapshot = match self.documents.get(&uri) {
             None => {
                 log::debug!("formatting: No document found for {}", uri);

--- a/src/lsp/lsp_impl/text_document/hover.rs
+++ b/src/lsp/lsp_impl/text_document/hover.rs
@@ -36,7 +36,10 @@ impl Kakehashi {
 
     /// Virt layer: bridge the injection region under the cursor.
     async fn hover_virt_layer(&self, lsp_uri: &Uri, position: Position) -> Result<Option<Hover>> {
-        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
+        let Some(ctx) = self
+            .resolve_bridge_contexts(lsp_uri, position, METHOD)
+            .await
+        else {
             return Ok(None);
         };
 

--- a/src/lsp/lsp_impl/text_document/implementation.rs
+++ b/src/lsp/lsp_impl/text_document/implementation.rs
@@ -49,7 +49,10 @@ impl Kakehashi {
         position: Position,
         client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
     ) -> Result<Option<Vec<LocationLink>>> {
-        let Some(mut ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
+        let Some(mut ctx) = self
+            .resolve_bridge_contexts(lsp_uri, position, METHOD)
+            .await
+        else {
             return Ok(None);
         };
         // Aggregate the fanned-out servers' progress onto the editor's token

--- a/src/lsp/lsp_impl/text_document/inlay_hint.rs
+++ b/src/lsp/lsp_impl/text_document/inlay_hint.rs
@@ -46,7 +46,10 @@ impl Kakehashi {
         range: Range,
         client_progress_token: Option<NumberOrString>,
     ) -> Result<Option<Vec<InlayHint>>> {
-        let Some(mut ctx) = self.resolve_bridge_contexts_for_range(lsp_uri, range, METHOD) else {
+        let Some(mut ctx) = self
+            .resolve_bridge_contexts_for_range(lsp_uri, range, METHOD)
+            .await
+        else {
             return Ok(None);
         };
         ctx.document.client_progress_token = client_progress_token;

--- a/src/lsp/lsp_impl/text_document/linked_editing_range.rs
+++ b/src/lsp/lsp_impl/text_document/linked_editing_range.rs
@@ -43,7 +43,10 @@ impl Kakehashi {
         lsp_uri: &Uri,
         position: Position,
     ) -> Result<Option<LinkedEditingRanges>> {
-        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
+        let Some(ctx) = self
+            .resolve_bridge_contexts(lsp_uri, position, METHOD)
+            .await
+        else {
             return Ok(None);
         };
 

--- a/src/lsp/lsp_impl/text_document/moniker.rs
+++ b/src/lsp/lsp_impl/text_document/moniker.rs
@@ -40,7 +40,10 @@ impl Kakehashi {
         lsp_uri: &Uri,
         position: Position,
     ) -> Result<Option<Vec<Moniker>>> {
-        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
+        let Some(ctx) = self
+            .resolve_bridge_contexts(lsp_uri, position, METHOD)
+            .await
+        else {
             return Ok(None);
         };
 

--- a/src/lsp/lsp_impl/text_document/on_type_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/on_type_formatting.rs
@@ -48,7 +48,10 @@ impl Kakehashi {
         ch: &str,
         options: FormattingOptions,
     ) -> Result<Option<Vec<TextEdit>>> {
-        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
+        let Some(ctx) = self
+            .resolve_bridge_contexts(lsp_uri, position, METHOD)
+            .await
+        else {
             return Ok(None);
         };
 

--- a/src/lsp/lsp_impl/text_document/prepare_rename.rs
+++ b/src/lsp/lsp_impl/text_document/prepare_rename.rs
@@ -45,7 +45,10 @@ impl Kakehashi {
         lsp_uri: &Uri,
         position: Position,
     ) -> Result<Option<PrepareRenameResponse>> {
-        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
+        let Some(ctx) = self
+            .resolve_bridge_contexts(lsp_uri, position, METHOD)
+            .await
+        else {
             return Ok(None);
         };
 

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -21,7 +21,6 @@
 //! range-only servers still format.
 
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 use tokio::task::JoinSet;
 use tower_lsp_server::jsonrpc::Result;
@@ -59,15 +58,12 @@ impl Kakehashi {
 
             log::debug!("rangeFormatting called for {} range {:?}", uri, host_range);
 
-            // Tower-LSP runs requests concurrently, so a rangeFormatting call can
-            // arrive before didOpen/didChange has finished parsing. Wait briefly
-            // for any in-flight parse to land a tree before snapshotting, matching
-            // the read-handler pattern (semantic tokens, node lookups); otherwise
-            // an otherwise-valid request would degrade to `Ok(None)` purely due to
-            // a parse race.
-            self.documents
-                .wait_for_parse_completion(&uri, Duration::from_millis(200))
-                .await;
+            // Tower-LSP runs requests concurrently, and `didChange` now reparses
+            // off-ingress, so a rangeFormatting call can arrive before a tree
+            // exists. Wait for the reparse (and parse on demand if needed) before
+            // snapshotting — the shared post-edit freshness helper — so an
+            // otherwise-valid request doesn't degrade to `Ok(None)` on a parse race.
+            self.ensure_document_parsed(&uri).await;
 
             let snapshot = match self.documents.get(&uri) {
                 None => {

--- a/src/lsp/lsp_impl/text_document/references.rs
+++ b/src/lsp/lsp_impl/text_document/references.rs
@@ -48,7 +48,10 @@ impl Kakehashi {
         include_declaration: bool,
         client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
     ) -> Result<Option<Vec<Location>>> {
-        let Some(mut ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
+        let Some(mut ctx) = self
+            .resolve_bridge_contexts(lsp_uri, position, METHOD)
+            .await
+        else {
             return Ok(None);
         };
         // Aggregate the fanned-out servers' progress onto the editor's token

--- a/src/lsp/lsp_impl/text_document/rename.rs
+++ b/src/lsp/lsp_impl/text_document/rename.rs
@@ -44,7 +44,10 @@ impl Kakehashi {
         new_name: &str,
         client_progress_token: Option<NumberOrString>,
     ) -> Result<Option<WorkspaceEdit>> {
-        let Some(mut ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
+        let Some(mut ctx) = self
+            .resolve_bridge_contexts(lsp_uri, position, METHOD)
+            .await
+        else {
             return Ok(None);
         };
         ctx.document.client_progress_token = client_progress_token;

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -735,6 +735,12 @@ impl Kakehashi {
             })));
         };
 
+        // Ensure a fresh tree before snapshotting: `didChange` clears the tree and
+        // reparses off-ingress, so without this the visible-range tokens go blank
+        // for the reparse window after every edit. (The full/delta paths get this
+        // via `get_tree_with_wait`; the range path reads the store directly.)
+        self.ensure_document_parsed(&uri).await;
+
         let Some(doc) = self.documents.get(&uri) else {
             return Ok(Some(SemanticTokensRangeResult::Tokens(SemanticTokens {
                 result_id: None,

--- a/src/lsp/lsp_impl/text_document/signature_help.rs
+++ b/src/lsp/lsp_impl/text_document/signature_help.rs
@@ -47,7 +47,10 @@ impl Kakehashi {
         position: Position,
     ) -> Result<Option<SignatureHelp>> {
         // Use shared preamble to resolve injection context with ALL matching servers
-        let Some(ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
+        let Some(ctx) = self
+            .resolve_bridge_contexts(lsp_uri, position, METHOD)
+            .await
+        else {
             return Ok(None);
         };
 

--- a/src/lsp/lsp_impl/text_document/type_definition.rs
+++ b/src/lsp/lsp_impl/text_document/type_definition.rs
@@ -49,7 +49,10 @@ impl Kakehashi {
         position: Position,
         client_progress_token: Option<tower_lsp_server::ls_types::NumberOrString>,
     ) -> Result<Option<Vec<LocationLink>>> {
-        let Some(mut ctx) = self.resolve_bridge_contexts(lsp_uri, position, METHOD) else {
+        let Some(mut ctx) = self
+            .resolve_bridge_contexts(lsp_uri, position, METHOD)
+            .await
+        else {
             return Ok(None);
         };
         // Aggregate the fanned-out servers' progress onto the editor's token

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -65,14 +65,13 @@ impl Kakehashi {
             log::debug!("{} called for {}", method_name, uri);
 
             // Tower-LSP runs requests concurrently, so a whole-document request can
-            // arrive before didOpen/didChange has finished parsing. Wait briefly
-            // for any in-flight parse to land a tree before snapshotting, matching
-            // the read-handler pattern (semantic tokens, rangeFormatting, node
-            // lookups); otherwise an otherwise-valid request would degrade to
-            // `Ok(None)` purely due to a parse race.
-            self.documents
-                .wait_for_parse_completion(&uri, std::time::Duration::from_millis(200))
-                .await;
+            // arrive before didOpen/didChange has finished parsing, and didChange
+            // now reparses off-ingress. Use the shared post-edit freshness helper
+            // (wait for the reparse, then parse on demand) before snapshotting —
+            // matching the other read handlers (semantic tokens, formatting, node
+            // lookups) — so an otherwise-valid request doesn't degrade to `Ok(None)`
+            // on a parse race or a reparse slower than the bounded wait.
+            self.ensure_document_parsed(&uri).await;
 
             // Get document snapshot (minimizes lock duration)
             let snapshot = match self.documents.get(&uri) {


### PR DESCRIPTION
**Stacked on #511** (which stacks on #508). The core of the **per-document parse actor** (`docs/architecture-decisions/per-document-parse-actor.md`): `didChange` no longer parses inline on its ingress writer ticket.

## What
`didChange` now applies the edit to the store and **clears the tree** synchronously (under the edit lock), then schedules an off-ingress reparse and returns — so a slow parse on a large / injection-heavy document no longer holds the writer ticket and stalls the next edit or any host forward sequenced behind it.

- **`ParseScheduler`** (new) — per-document coalescing: one parse loop per document; edits arriving mid-parse only set a `dirty` bit, so a burst collapses to a single follow-up reparse over the latest text. Race-tight via DashMap `entry`. `ParseLoopGuard` re-arms the scheduler if the spawned loop panics (so a panic can't wedge the document tree-less forever).
- **`Kakehashi::schedule_reparse`** — spawns the loop (owns the Parse/Injection coordinators + DiagnosticPublisher): `reparse_latest` → `process_injections` → geometry re-merge `republish` → loop if dirty. Shutdown-gated (before and after the parse). No teardown: the parse's non-inserting CAS no-ops once a `didClose` removed the document.
- **`ParseCoordinator::reparse_latest`** — re-reads the latest text, **full** parse (the cleared tree also keeps #348 closed), non-inserting **text + language** CAS, and advances the #508 watermark to the edit's ticket on every resolution path — making the watermark **load-bearing** (a virt/native reader gated behind the edit now waits on the watermark for the off-ingress parse).

## Why it's safe
Clearing the tree turns the #342/#374 stale-tree race into **benign emptiness**: a reader sees *no* tree (empty / on-demand fallback), never a tree predating its edit. `didClose` during a scheduled parse → the CAS no-ops (resurrection-safe). The text+language CAS also rejects a wrong-language reopen-ABA.

## Known follow-ups (deferred, documented)
- **Incremental parse + semantic-token delta** are dropped here (the cleared tree forces a full parse; coalescing recovers the burst case — incrementality is a perf optimization, never correctness). Re-adding it is a follow-up.
- **Strict `(incarnation, ticket)` epoch CAS** — the same-language identical-text reopen residual is benign (correct tree); incarnation-on-the-Document is the follow-up.
- **Bridge-side shutdown gate** — a narrow, pre-existing, terminal-time window where a late eager bridge spawn escapes `shutdown_all`'s snapshot (the parse loop itself is shutdown-gated). Owned by bridge connection creation.
- `didOpen`'s present-parser parse stays inline (host attach was already hoisted in #492); the **edit path** is the flip.

## Tests
- `ParseScheduler`: spawn-vs-dirty, coalescing/`next`, re-spawn-after-exit, guard re-arm (panic) + disarm-leaves-fresh-entry-alone.
- `reparse_latest`: resurrection-safe (closed → no resurrect), parses + advances watermark, skips when a tree already present.
- store: text+language CAS rejects a changed language.
- **e2e validated**: `e2e_semantic` (54), `e2e_semantic_blockquote` (32), `e2e_kakehashi_node` (41), `e2e_incremental_sync` (26), `e2e_didchange_forwarding` (27) all pass under the async timing.

Reviewed via `/review` (HIGH loop-panic-wedge → drop-guard) and codex (HIGH wrong-language ABA → text+language CAS; MED shutdown → gated; both converged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)