### PR TITLE
fix(diagnose): skip the synthetic diagnostic task in CLI mode (#489)

### DIFF
--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -175,6 +175,12 @@ pub struct Kakehashi {
     /// is live (unambiguous), otherwise `null`.
     #[allow(clippy::type_complexity)]
     captures_cache: dashmap::DashMap<(Url, String), [Option<(String, Vec<serde_json::Value>)>; 2]>,
+    /// True when the process runs as a one-shot CLI (`kakehashi diagnose`/`format`)
+    /// rather than a long-lived LSP server. Set once by `cli_initialize`. No editor
+    /// consumes a proactive `publishDiagnostics` in CLI mode (the stub client pump
+    /// discards it), so `did_open_impl` skips the synthetic diagnostic task — that
+    /// avoids both the wasted downstream pull and the abort-vs-`didClose` race (#489).
+    cli_mode: std::sync::atomic::AtomicBool,
 }
 
 impl std::fmt::Debug for Kakehashi {
@@ -244,7 +250,20 @@ impl Kakehashi {
             shutdown_token: tokio_util::sync::CancellationToken::new(),
             home_dir: dirs::home_dir().map(|p| p.to_string_lossy().into_owned()),
             captures_cache: dashmap::DashMap::new(),
+            cli_mode: std::sync::atomic::AtomicBool::new(false),
         }
+    }
+
+    /// Mark this instance as running in one-shot CLI mode. Called by
+    /// `cli_initialize`; see the `cli_mode` field.
+    pub(crate) fn mark_cli_mode(&self) {
+        self.cli_mode
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Whether this instance runs as a one-shot CLI rather than an LSP server.
+    pub(crate) fn is_cli_mode(&self) -> bool {
+        self.cli_mode.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Create a `ClientNotifier` for centralized client communication.

--- a/src/lsp/lsp_impl/cli_format.rs
+++ b/src/lsp/lsp_impl/cli_format.rs
@@ -42,6 +42,9 @@ impl Kakehashi {
     /// configuration from `root` (typically the current directory) exactly
     /// like an editor session rooted there would.
     pub(crate) async fn cli_initialize(&self, root: &Path) {
+        // One-shot CLI: no editor consumes proactive publishDiagnostics, so
+        // did_open_impl skips the synthetic diagnostic task (#489).
+        self.mark_cli_mode();
         let workspace_folders = Url::from_file_path(root)
             .ok()
             .and_then(|url| url_to_uri(&url).ok())

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -117,8 +117,16 @@ impl Kakehashi {
 
         // pull-first-diagnostic-forwarding Phase 2: Trigger synthetic diagnostic push on didOpen
         // This provides proactive diagnostics for clients that don't support pull diagnostics.
-        self.diagnostic_scheduler()
-            .spawn_synthetic_diagnostic_task(uri);
+        //
+        // Skipped in one-shot CLI mode (#489): no editor consumes the proactive
+        // `publishDiagnostics` (the stub client pump discards it), so the task is
+        // pure wasted downstream work, and its abort-without-join on `didClose`
+        // races the bridge-state sweep. The CLI's reported diagnostics come from the
+        // explicit `diagnostic_impl` pull, which is unaffected.
+        if !self.is_cli_mode() {
+            self.diagnostic_scheduler()
+                .spawn_synthetic_diagnostic_task(uri);
+        }
 
         // NOTE: No semantic_tokens_refresh() on didOpen.
         // Capable LSP clients should request by themselves.
@@ -781,6 +789,80 @@ print("hello")
         assert!(
             !snapshot.host_pull_enabled,
             "pullFallback = false disables the host pull (host_pull_enabled = false)"
+        );
+    }
+
+    /// #489: in one-shot CLI mode no editor consumes a proactive
+    /// `publishDiagnostics`, so `did_open_impl` must NOT schedule the synthetic
+    /// diagnostic task — that avoids the wasted downstream pull and the
+    /// abort-vs-`didClose` race. The LSP-mode control below proves the assertion
+    /// discriminates (the task IS scheduled when not in CLI mode), so a gate that
+    /// suppressed it unconditionally would fail the control.
+    #[tokio::test]
+    async fn cli_mode_did_open_does_not_schedule_synthetic_diagnostic_task() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("markdown".to_string(), tree_sitter_md::LANGUAGE.into());
+        server.settings_manager.apply_settings(WorkspaceSettings {
+            auto_install: false,
+            ..Default::default()
+        });
+        server.mark_cli_mode();
+
+        let uri = Url::parse("file:///test/cli_no_synthetic.md").unwrap();
+        let lsp_uri = crate::lsp::lsp_impl::url_to_uri(&uri).expect("URI should convert");
+        server
+            .did_open_impl(DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: lsp_uri,
+                    language_id: "markdown".to_string(),
+                    version: 1,
+                    text: "# hi\n".to_string(),
+                },
+            })
+            .await;
+
+        assert!(
+            !server.synthetic_diagnostics.has_active_task(&uri),
+            "CLI-mode didOpen must not schedule a synthetic diagnostic task (#489)"
+        );
+    }
+
+    /// Control for the test above: in LSP mode (the default) `did_open_impl` DOES
+    /// schedule the synthetic diagnostic task. Without this, a no-op gate would let
+    /// the CLI-suppression test pass vacuously.
+    #[tokio::test]
+    async fn lsp_mode_did_open_schedules_synthetic_diagnostic_task() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("markdown".to_string(), tree_sitter_md::LANGUAGE.into());
+        server.settings_manager.apply_settings(WorkspaceSettings {
+            auto_install: false,
+            ..Default::default()
+        });
+
+        let uri = Url::parse("file:///test/lsp_synthetic.md").unwrap();
+        let lsp_uri = crate::lsp::lsp_impl::url_to_uri(&uri).expect("URI should convert");
+        server
+            .did_open_impl(DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: lsp_uri,
+                    language_id: "markdown".to_string(),
+                    version: 1,
+                    text: "# hi\n".to_string(),
+                },
+            })
+            .await;
+
+        assert!(
+            server.synthetic_diagnostics.has_active_task(&uri),
+            "LSP-mode didOpen schedules the synthetic diagnostic task"
         );
     }
 }


### PR DESCRIPTION
Closes #489.

## Problem

`kakehashi diagnose`/`format` drive `did_open_impl` per file, which schedules a **synthetic diagnostic pull** whose only purpose is to proactively push `textDocument/publishDiagnostics` to an editor. In one-shot CLI mode there is no editor:

- the push goes to the stub client pump and is **discarded** → the downstream pull is pure wasted work (and double-pulls downstream, since the authoritative result already comes from the explicit `diagnostic_impl` pull);
- `didClose` `AbortHandle::abort()`s the task **without awaiting it**, then sweeps virtual/host doc state → a still-executing synthetic task can register/send after the sweep (the lifecycle race #489 reports).

## Fix

Add a `cli_mode` flag to `Kakehashi`, set once by `cli_initialize` (the entry both CLI paths await before opening any file), and gate the synthetic-task spawn in `did_open_impl` on `!is_cli_mode()`. CLI opens skip the task entirely — **no waste, no race**. LSP behavior is unchanged (the flag defaults `false`; only `cli_initialize` sets it).

This is the issue's option (a) — *suppress in CLI* — rather than (b) *join the handle before cleanup*. (a) is strictly better for CLI: (b) would make `didClose` **wait** for a downstream pull whose result is discarded (slowing CLI shutdown and double-loading downstream), whereas (a) removes the work entirely. The CLI's reported diagnostics are unaffected — they come from the explicit `diagnostic_impl` pull, not the synthetic task.

Scope: this fixes #489's CLI concern. The LSP-mode `abort()`-without-join remains, which #489 documents as benign (bridge state is URI-keyed; no cross-file corruption).

## Tests

- `cli_mode_did_open_does_not_schedule_synthetic_diagnostic_task` — CLI-mode didOpen registers no synthetic task.
- `lsp_mode_did_open_schedules_synthetic_diagnostic_task` — control proving the assertion discriminates (LSP mode still schedules it).

Full lib suite green (2125 passed). Reviewed by a `/review` subagent and the codex MCP reviewer (no actionable findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)