### PR TITLE
perf(parse): re-add incremental parse seeding off-ingress

### DIFF
--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -147,6 +147,11 @@ impl Document {
         self.previous_tree = self.tree.take();
         self.previous_text = Some(std::mem::replace(&mut self.text, Arc::from(new_text)));
         self.tree = Some(new_tree);
+        // Any pending incremental seed is for an edit superseded by this fresh
+        // tree+text; keep the invariant "visible tree present ⟹ no stale seed" so a
+        // later `reparse_latest` can't seed from a tree that predates this text
+        // (the #348 contract hazard).
+        self.pending_seed = None;
     }
 
     /// Update tree and text with an explicit edited previous tree.
@@ -163,6 +168,8 @@ impl Document {
         self.previous_tree = Some(edited_previous_tree);
         self.previous_text = Some(std::mem::replace(&mut self.text, Arc::from(new_text)));
         self.tree = Some(new_tree);
+        // See `update_tree_and_text`: a fresh visible tree consumes any pending seed.
+        self.pending_seed = None;
     }
 
     /// Attach a parsed tree **without** touching the text.
@@ -436,6 +443,50 @@ mod tests {
         assert!(
             doc.pending_seed().is_none(),
             "attaching a fresh tree must consume the seed"
+        );
+    }
+
+    /// Every method that installs a fresh visible tree must clear `pending_seed`,
+    /// upholding "visible tree present ⟹ no stale seed" — else a later
+    /// `reparse_latest` could seed from a tree predating the new text (#348).
+    #[test]
+    fn fresh_tree_updates_clear_pending_seed() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let edit = InputEdit {
+            start_byte: 11,
+            old_end_byte: 11,
+            new_end_byte: 12,
+            start_position: tree_sitter::Point::new(0, 11),
+            old_end_position: tree_sitter::Point::new(0, 11),
+            new_end_position: tree_sitter::Point::new(0, 12),
+        };
+
+        // update_tree_and_text clears the seed.
+        let tree = parser.parse("fn main() {}", None).unwrap();
+        let mut doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree);
+        doc.apply_edit_and_seed("fn main() { }".to_string(), &[edit.clone()]);
+        assert!(doc.pending_seed().is_some());
+        let t2 = parser.parse("fn main() { }", None).unwrap();
+        doc.update_tree_and_text(t2, "fn main() { }".to_string());
+        assert!(
+            doc.pending_seed().is_none(),
+            "update_tree_and_text must clear the pending seed"
+        );
+
+        // update_with_edited_tree clears the seed.
+        let tree = parser.parse("fn main() {}", None).unwrap();
+        let mut doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree);
+        doc.apply_edit_and_seed("fn main() { }".to_string(), &[edit]);
+        assert!(doc.pending_seed().is_some());
+        let edited = parser.parse("fn main() {}", None).unwrap();
+        let t3 = parser.parse("fn main() { }", None).unwrap();
+        doc.update_with_edited_tree(t3, "fn main() { }".to_string(), edited);
+        assert!(
+            doc.pending_seed().is_none(),
+            "update_with_edited_tree must clear the pending seed"
         );
     }
 

--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use tree_sitter::Tree;
+use tree_sitter::{InputEdit, Tree};
 
 /// Immutable snapshot of document state for lock-free processing
 pub(crate) struct DocumentSnapshot {
@@ -40,6 +40,24 @@ pub struct Document {
     previous_tree: Option<Tree>,
     /// Previous text for line delta calculation during incremental tokenization
     previous_text: Option<Arc<str>>,
+    /// Edited-but-not-yet-reparsed seed for the **off-ingress** incremental parse
+    /// (per-document-parse-actor).
+    ///
+    /// `didChange` clears the reader-visible `tree` (so a reader never sees a tree
+    /// that predates the edit — the flip's reader-safety invariant) but stashes the
+    /// pre-edit tree here with the edit's `InputEdit`s already applied
+    /// (`tree.edit()`). The off-ingress `reparse_latest` consumes it as
+    /// `parser.parse(text, Some(seed))` to parse incrementally instead of from
+    /// scratch. Coalesced edits accumulate their `InputEdit`s onto this same seed,
+    /// so a burst still produces one correctly-edited seed for the final reparse.
+    ///
+    /// **Read by `reparse_latest` only** — never by `tree()` / `snapshot()`, which
+    /// must stay `None` until the reparse lands. Cleared the moment a fresh tree is
+    /// attached (`set_tree`) — a present tree means the seed is consumed — and on a
+    /// full-text sync (`apply_edit_and_seed` with no `InputEdit`s), where seeding an
+    /// unedited tree against wholly-replaced text would violate tree-sitter's
+    /// incremental contract and corrupt external scanners (#348).
+    pending_seed: Option<Tree>,
 }
 
 impl Document {
@@ -51,6 +69,7 @@ impl Document {
             tree: None,
             previous_tree: None,
             previous_text: None,
+            pending_seed: None,
         }
     }
 
@@ -62,6 +81,7 @@ impl Document {
             tree: None,
             previous_tree: None,
             previous_text: None,
+            pending_seed: None,
         }
     }
 
@@ -73,6 +93,7 @@ impl Document {
             tree: Some(tree),
             previous_tree: None,
             previous_text: None,
+            pending_seed: None,
         }
     }
 
@@ -150,8 +171,50 @@ impl Document {
     /// text: there is no content-version transition to record, so `previous_tree`
     /// / `previous_text` are left as-is and the text is neither re-cloned nor
     /// replaced.
+    ///
+    /// Clears `pending_seed`: a present reader-visible tree means the off-ingress
+    /// reparse's seed has been consumed (the tree it would have produced is now
+    /// here), so the next `didChange` seeds from this fresh tree, not a stale seed.
     pub(crate) fn set_tree(&mut self, tree: Tree) {
         self.tree = Some(tree);
+        self.pending_seed = None;
+    }
+
+    /// Apply an edit's new text and stash an **incremental parse seed** for the
+    /// off-ingress reparse, clearing the reader-visible tree.
+    ///
+    /// The reader-visible `tree` is cleared (a reader must never see a tree that
+    /// predates this edit). The pre-edit tree — or the seed already accumulated by
+    /// an earlier coalesced edit — has `edits` applied via `tree.edit()` and is
+    /// stashed in `pending_seed` for `reparse_latest` to parse incrementally.
+    ///
+    /// With **no** `edits` (a full-text sync) the seed is dropped to `None`: seeding
+    /// an unedited tree against wholly-replaced text violates tree-sitter's
+    /// incremental contract and corrupted external scanners in #348, so a full-text
+    /// sync must parse from scratch.
+    pub(crate) fn apply_edit_and_seed(&mut self, new_text: String, edits: &[InputEdit]) {
+        // Base the seed on the reader-visible tree if present, else the seed an
+        // earlier coalesced edit already accumulated (the visible tree is cleared
+        // on the first edit of a burst, so subsequent edits chain onto the seed).
+        let base = self.tree.take().or_else(|| self.pending_seed.take());
+        self.pending_seed = match base {
+            Some(mut tree) if !edits.is_empty() => {
+                for edit in edits {
+                    tree.edit(edit);
+                }
+                Some(tree)
+            }
+            // Full-text sync (no edits) or no base tree: parse from scratch (#348).
+            _ => None,
+        };
+        self.text = Arc::from(new_text);
+    }
+
+    /// The off-ingress incremental parse seed, if any. **Read only by
+    /// `reparse_latest`** — `tree()` / `snapshot()` deliberately ignore it so a
+    /// reader never observes a pre-reparse tree. See [`pending_seed`](Self::pending_seed).
+    pub(crate) fn pending_seed(&self) -> Option<&Tree> {
+        self.pending_seed.as_ref()
     }
 
     /// Update text and clear layers/state
@@ -161,6 +224,7 @@ impl Document {
         self.tree = None;
         self.previous_tree = None;
         self.previous_text = None;
+        self.pending_seed = None;
     }
 }
 
@@ -248,6 +312,131 @@ mod tests {
         assert_eq!(doc.text(), "fn main() { let x = 1; }");
         // Previous tree should also exist
         assert!(doc.previous_tree.is_some());
+    }
+
+    /// A non-empty edit stashes an incremental parse seed and clears the
+    /// reader-visible tree (readers must not see a pre-reparse tree).
+    #[test]
+    fn apply_edit_and_seed_stashes_seed_and_clears_tree() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let tree = parser.parse("fn main() {}", None).unwrap();
+        let mut doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree);
+
+        // Insert a space at byte 11 (before the closing brace): "fn main() { }".
+        let edit = InputEdit {
+            start_byte: 11,
+            old_end_byte: 11,
+            new_end_byte: 12,
+            start_position: tree_sitter::Point::new(0, 11),
+            old_end_position: tree_sitter::Point::new(0, 11),
+            new_end_position: tree_sitter::Point::new(0, 12),
+        };
+        doc.apply_edit_and_seed("fn main() { }".to_string(), &[edit]);
+
+        assert!(doc.tree().is_none(), "reader-visible tree must be cleared");
+        assert!(
+            doc.pending_seed().is_some(),
+            "incremental seed must be stashed"
+        );
+        assert_eq!(doc.text(), "fn main() { }");
+    }
+
+    /// A full-text sync (no `InputEdit`s) must drop the seed: seeding an unedited
+    /// tree against wholly-replaced text is the tree-sitter contract violation that
+    /// caused the #348 heap corruption.
+    #[test]
+    fn apply_edit_and_seed_drops_seed_on_full_text_sync() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let tree = parser.parse("fn main() {}", None).unwrap();
+        let mut doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree);
+
+        // Full-text sync carries no InputEdits.
+        doc.apply_edit_and_seed("totally different content".to_string(), &[]);
+
+        assert!(doc.tree().is_none());
+        assert!(
+            doc.pending_seed().is_none(),
+            "full-text sync must not leave a stale seed (#348)"
+        );
+    }
+
+    /// Coalesced edits accumulate onto the same seed: after a first edit clears the
+    /// visible tree, a second edit chains its `InputEdit` onto the stashed seed.
+    #[test]
+    fn apply_edit_and_seed_coalesces_across_edits() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let tree = parser.parse("fn main() {}", None).unwrap();
+        let mut doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree);
+
+        let edit1 = InputEdit {
+            start_byte: 11,
+            old_end_byte: 11,
+            new_end_byte: 12,
+            start_position: tree_sitter::Point::new(0, 11),
+            old_end_position: tree_sitter::Point::new(0, 11),
+            new_end_position: tree_sitter::Point::new(0, 12),
+        };
+        doc.apply_edit_and_seed("fn main() { }".to_string(), &[edit1]);
+        assert!(doc.tree().is_none());
+
+        // Second edit lands while the visible tree is still cleared: it must chain
+        // onto the accumulated seed, not silently drop incrementality.
+        let edit2 = InputEdit {
+            start_byte: 12,
+            old_end_byte: 12,
+            new_end_byte: 13,
+            start_position: tree_sitter::Point::new(0, 12),
+            old_end_position: tree_sitter::Point::new(0, 12),
+            new_end_position: tree_sitter::Point::new(0, 13),
+        };
+        doc.apply_edit_and_seed("fn main() {  }".to_string(), &[edit2]);
+
+        assert!(doc.tree().is_none());
+        assert!(
+            doc.pending_seed().is_some(),
+            "coalesced edit must keep the accumulated seed"
+        );
+        assert_eq!(doc.text(), "fn main() {  }");
+    }
+
+    /// Attaching a fresh tree consumes (clears) the pending seed.
+    #[test]
+    fn set_tree_clears_pending_seed() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let tree = parser.parse("fn main() {}", None).unwrap();
+        let mut doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree);
+
+        let edit = InputEdit {
+            start_byte: 11,
+            old_end_byte: 11,
+            new_end_byte: 12,
+            start_position: tree_sitter::Point::new(0, 11),
+            old_end_position: tree_sitter::Point::new(0, 11),
+            new_end_position: tree_sitter::Point::new(0, 12),
+        };
+        doc.apply_edit_and_seed("fn main() { }".to_string(), &[edit]);
+        assert!(doc.pending_seed().is_some());
+
+        let reparsed = parser.parse("fn main() { }", None).unwrap();
+        doc.set_tree(reparsed);
+
+        assert!(doc.tree().is_some());
+        assert!(
+            doc.pending_seed().is_none(),
+            "attaching a fresh tree must consume the seed"
+        );
     }
 
     #[test]

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -236,6 +236,35 @@ impl DocumentStore {
         self.ensure_watermark_entry(&uri);
     }
 
+    /// Apply a `didChange`'s new text and stash an **incremental parse seed**,
+    /// clearing the reader-visible tree — the per-document-parse-actor flip's edit
+    /// path.
+    ///
+    /// Replaces the prior `update_document(uri, text, None)`: it still clears the
+    /// reader-visible tree (so a reader never sees a tree predating this edit) and
+    /// keeps the same side effects (tree-availability → false, watermark entry
+    /// ensured), but additionally stashes the pre-edit tree — with `edits` applied —
+    /// as the seed for the off-ingress `reparse_latest`'s incremental parse. With no
+    /// `edits` (full-text sync) no seed is kept (#348). Coalesced edits accumulate
+    /// onto the seed (see [`Document::apply_edit_and_seed`]).
+    ///
+    /// Called under the per-URI edit lock with the document known to exist; the
+    /// `Vacant` branch (a reordered notification for an unopened URI) inserts a
+    /// tree-less document to mirror the prior `update_document` behavior.
+    pub(crate) fn apply_edit_clearing_tree(&self, uri: Url, text: String, edits: &[InputEdit]) {
+        match self.documents.entry(uri.clone()) {
+            Entry::Occupied(mut entry) => {
+                entry.get_mut().apply_edit_and_seed(text, edits);
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(Document::new(text));
+            }
+        }
+        self.update_tree_availability(&uri, false);
+        // Keep the "live document ⟺ watermark entry" invariant (see `update_document`).
+        self.ensure_watermark_entry(&uri);
+    }
+
     /// Store `new_tree` for an **existing** document, but only if its current text
     /// still equals `expected_text`. Returns `true` iff the tree was stored.
     ///

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -251,18 +251,27 @@ impl DocumentStore {
     /// Called under the per-URI edit lock with the document known to exist; the
     /// `Vacant` branch (a reordered notification for an unopened URI) inserts a
     /// tree-less document to mirror the prior `update_document` behavior.
-    pub(crate) fn apply_edit_clearing_tree(&self, uri: Url, text: String, edits: &[InputEdit]) {
-        match self.documents.entry(uri.clone()) {
-            Entry::Occupied(mut entry) => {
-                entry.get_mut().apply_edit_and_seed(text, edits);
-            }
-            Entry::Vacant(entry) => {
-                entry.insert(Document::new(text));
+    pub(crate) fn apply_edit_clearing_tree(&self, uri: &Url, text: String, edits: &[InputEdit]) {
+        // Hot path (a live document being edited): `get_mut` borrows the key, so no
+        // `Url` clone per keystroke. Only a miss falls back to `entry` (owned key),
+        // which also re-checks for a document a concurrent open inserted between the
+        // `get_mut` and here — mirroring `ParseScheduler::schedule` and the atomicity
+        // of the prior `update_document`. The `RefMut` / entry is dropped before the
+        // parse-state and watermark updates below (separate maps), keeping the
+        // `documents` shard lock held no longer than `update_document` did.
+        if let Some(mut doc) = self.documents.get_mut(uri) {
+            doc.apply_edit_and_seed(text, edits);
+        } else {
+            match self.documents.entry(uri.clone()) {
+                Entry::Occupied(mut entry) => entry.get_mut().apply_edit_and_seed(text, edits),
+                Entry::Vacant(entry) => {
+                    entry.insert(Document::new(text));
+                }
             }
         }
-        self.update_tree_availability(&uri, false);
+        self.update_tree_availability(uri, false);
         // Keep the "live document ⟺ watermark entry" invariant (see `update_document`).
-        self.ensure_watermark_entry(&uri);
+        self.ensure_watermark_entry(uri);
     }
 
     /// Store `new_tree` for an **existing** document, but only if its current text

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -381,9 +381,11 @@ impl ParseCoordinator {
     /// Re-parse `uri`'s **latest** store text off the ingress path, for the
     /// per-document parse scheduler (`Kakehashi::schedule_reparse`).
     ///
-    /// `did_change` clears the tree synchronously and schedules this; it runs in a
-    /// spawned loop, *not* on the writer ticket. A **full** parse (no incremental
-    /// seed — the tree was cleared, which also keeps #348 closed). The tree write
+    /// `did_change` clears the reader-visible tree synchronously and schedules this;
+    /// it runs in a spawned loop, *not* on the writer ticket. When the edit stashed a
+    /// `pending_seed` (the pre-edit tree with this edit's `InputEdit`s applied) the
+    /// parse is **incremental**, seeded from it; a full-text sync stashes no seed and
+    /// parses from scratch (which keeps #348 closed). The tree write
     /// is the non-inserting text **and language** CAS
     /// [`update_tree_if_text_and_language_unchanged`]: a closed (Vacant) document is
     /// left gone (resurrection-safe), a text that moved on (a `didChange` landed
@@ -393,10 +395,9 @@ impl ParseCoordinator {
     /// advances the store watermark to `ticket`, so a virt/native reader gated
     /// behind the originating edit is released once its parse resolved.
     ///
-    /// Incremental parse and semantic-token delta are intentionally not preserved
-    /// here (the cleared tree forces a full parse); coalescing recovers the burst
-    /// case, and incrementality is a perf optimization, never correctness. Re-adding
-    /// it is a follow-up.
+    /// The semantic-token `full/delta` path is unaffected by the off-ingress move:
+    /// it diffs cached token arrays by `result_id` (never `changed_ranges`), so as
+    /// long as the seed keeps this reparse cheap the delta stays cheap too.
     pub(crate) async fn reparse_latest(&self, uri: &Url, ticket: Option<u64>) {
         let advance_watermark = || {
             if let Some(ticket) = ticket {
@@ -407,8 +408,11 @@ impl ParseCoordinator {
         // Re-read the latest text + detect the language under one read guard. A
         // missing document means a `didClose` ran — resolve the watermark and stop
         // (no resurrection). `language_id` is captured so the tree write can reject
-        // a reopen that changed the language while this parse was in flight.
-        let (language_name, language_id, text) = {
+        // a reopen that changed the language while this parse was in flight. The
+        // `pending_seed` (a cheap `Tree` refcount-clone) is the edit's incremental
+        // parse seed stashed by `didChange`; `None` for a full-text sync / freshly
+        // installed parse, in which case we parse from scratch.
+        let (language_name, language_id, text, seed) = {
             let Some(doc) = self.documents.get(uri) else {
                 advance_watermark();
                 return;
@@ -417,10 +421,11 @@ impl ParseCoordinator {
             // (#498) — cheap on this reparse hot path.
             let text = doc.text_arc();
             let language_id = doc.language_id().map(|s| s.to_string());
+            let seed = doc.pending_seed().cloned();
             let language_name =
                 self.language
                     .detect_language(uri.path(), &text, None, language_id.as_deref());
-            (language_name, language_id, text)
+            (language_name, language_id, text, seed)
         };
 
         let Some(language_name) = language_name else {
@@ -437,12 +442,17 @@ impl ParseCoordinator {
         let auto_install = self.auto_install.clone();
         let language_name_clone = language_name.clone();
         // Hand a cheap `Arc<str>` clone (refcount bump) to the blocking closure; the
-        // original stays here for the CAS + injection populate below.
+        // original stays here for the CAS + injection populate below. The seed (also
+        // a cheap `Tree` refcount-clone) makes this an **incremental** parse when an
+        // edit stashed one: tree-sitter reuses the unchanged subtrees and reparses
+        // only the edited region. `None` (full-text sync / install) parses from
+        // scratch. The seed already has this edit's `InputEdit`s applied
+        // (`didChange` → `apply_edit_and_seed`), satisfying tree-sitter's contract.
         let text_for_parse = text.clone();
         let parsed = self
             .parse_with_pool(&language_name, uri, text_len, move |mut parser| {
                 let _ = auto_install.begin_parsing(&language_name_clone);
-                let result = parser.parse(&*text_for_parse, None);
+                let result = parser.parse(&*text_for_parse, seed.as_ref());
                 let _ = auto_install.end_parsing(&language_name_clone);
                 (parser, result)
             })

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -97,8 +97,7 @@ impl Kakehashi {
         // incrementally rather than from scratch. A full-text sync (`edits` empty)
         // keeps no seed and parses from scratch (#348).
         let ticket = crate::lsp::current_writer_ticket();
-        self.documents
-            .apply_edit_clearing_tree(uri.clone(), text, &edits);
+        self.documents.apply_edit_clearing_tree(&uri, text, &edits);
 
         // NOTE: We intentionally do NOT invalidate the semantic token cache here.
         // The cached tokens (with their result_id) are needed for delta calculations.

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -81,16 +81,24 @@ impl Kakehashi {
         // repopulates the injection map from the freshly parsed tree.
         self.cache.invalidate_for_edits(&uri, &edits);
 
-        // Apply the edit to the store and CLEAR the tree synchronously, here under
-        // the edit lock (per-document-parse-actor ADR). Clearing the tree (rather
-        // than leaving the pre-edit one) is what keeps readers safe once the parse
-        // is off-ingress: a virt/native reader now sees *no* tree until the reparse
-        // lands (empty / on-demand fallback) instead of a stale tree that predates
-        // this edit — turning the #342/#374 stale-tree race into benign emptiness.
-        // The document exists (checked above) and the edit lock serializes didClose,
-        // so this update is in-place, not a resurrection.
+        // Apply the edit to the store and CLEAR the reader-visible tree
+        // synchronously, here under the edit lock (per-document-parse-actor ADR).
+        // Clearing the visible tree (rather than leaving the pre-edit one) is what
+        // keeps readers safe once the parse is off-ingress: a virt/native reader now
+        // sees *no* tree until the reparse lands (empty / on-demand fallback) instead
+        // of a stale tree that predates this edit — turning the #342/#374 stale-tree
+        // race into benign emptiness. The document exists (checked above) and the
+        // edit lock serializes didClose, so this update is in-place, not a
+        // resurrection.
+        //
+        // The pre-edit tree is NOT discarded: with `edits` applied it is stashed as
+        // the off-ingress reparse's incremental seed (`pending_seed`, read only by
+        // `reparse_latest`, never by readers), so a single edit reparses
+        // incrementally rather than from scratch. A full-text sync (`edits` empty)
+        // keeps no seed and parses from scratch (#348).
         let ticket = crate::lsp::current_writer_ticket();
-        self.documents.update_document(uri.clone(), text, None);
+        self.documents
+            .apply_edit_clearing_tree(uri.clone(), text, &edits);
 
         // NOTE: We intentionally do NOT invalidate the semantic token cache here.
         // The cached tokens (with their result_id) are needed for delta calculations.

--- a/src/lsp/text_sync.rs
+++ b/src/lsp/text_sync.rs
@@ -23,12 +23,24 @@ use crate::text::PositionMapper;
 ///
 /// An empty returned edits vec is the caller's signal to do a full re-parse
 /// (`apply_text_change`); a non-empty vec means incremental (`apply_edits`).
+///
+/// **If any rangeless (full-replacement) change occurs anywhere in the batch the
+/// returned edits are empty**, even if ranged changes follow it. The returned
+/// `InputEdit`s describe a transform of `old_text`, but a full replacement severs
+/// that relationship: edits emitted *after* it are relative to the replacement
+/// text, not `old_text`, so they can neither diff against `old_text` nor seed a
+/// tree parsed from `old_text` (the #348 incremental-contract hazard). The whole
+/// batch is therefore a full sync.
 pub(crate) fn apply_content_changes_with_edits(
     old_text: &str,
     content_changes: Vec<TextDocumentContentChangeEvent>,
 ) -> (String, Vec<InputEdit>) {
     let mut text = old_text.to_string();
     let mut edits = Vec::new();
+    // Once a full replacement lands, no `InputEdit` in this batch can describe
+    // `old_text → final` incrementally, so the batch is a full sync regardless of
+    // any ranged changes that follow.
+    let mut saw_full_replacement = false;
 
     for change in content_changes {
         if let Some(range) = change.range {
@@ -86,7 +98,16 @@ pub(crate) fn apply_content_changes_with_edits(
             // Full document change - no incremental parsing
             text = change.text;
             edits.clear(); // Clear any previous edits since it's a full replacement
+            saw_full_replacement = true;
         }
+    }
+
+    // A ranged change after a full replacement would otherwise leave a non-empty
+    // edits vec whose `InputEdit`s are relative to the replacement text, not
+    // `old_text` — unusable for both the `old_text` diff and the incremental seed.
+    // Drop them so the caller takes the full-reparse path.
+    if saw_full_replacement {
+        edits.clear();
     }
 
     (text, edits)
@@ -287,6 +308,51 @@ mod tests {
         assert!(
             edits.is_empty(),
             "Full document sync should clear previous incremental edits"
+        );
+    }
+
+    #[test]
+    fn test_apply_content_changes_full_then_incremental_yields_empty_edits() {
+        // Regression: a full replacement FOLLOWED by a ranged change must still
+        // signal a full sync (empty edits). The ranged edit is relative to the
+        // replacement text, not `old_text`; returning it as a non-empty edit would
+        // make the incremental seed apply it to the (old_text) tree — the #348
+        // contract violation. Order matters: unlike the [incremental, full] case,
+        // the full replacement is NOT the last change here.
+        let old_text = "hello world";
+        let changes = vec![
+            // First: full document replacement (clears relationship to old_text)
+            TextDocumentContentChangeEvent {
+                range: None,
+                range_length: None,
+                text: "brand new body".to_string(),
+            },
+            // Second: incremental edit on the replacement text ("brand" -> "BRAND")
+            TextDocumentContentChangeEvent {
+                range: Some(Range {
+                    start: Position {
+                        line: 0,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 0,
+                        character: 5,
+                    },
+                }),
+                range_length: Some(5),
+                text: "BRAND".to_string(),
+            },
+        ];
+
+        let (new_text, edits) = apply_content_changes_with_edits(old_text, changes);
+
+        // Text reflects both changes applied in order.
+        assert_eq!(new_text, "BRAND new body");
+        // But edits MUST be empty so the caller does a full reparse — the edits
+        // cannot incrementally describe old_text -> new_text.
+        assert!(
+            edits.is_empty(),
+            "a full replacement anywhere in the batch must force the full-sync path"
         );
     }
 

--- a/src/lsp/text_sync.rs
+++ b/src/lsp/text_sync.rs
@@ -58,39 +58,46 @@ pub(crate) fn apply_content_changes_with_edits(
             let mapper = PositionMapper::new(&text);
             let start_offset = mapper.position_to_byte_clamped(range.start);
             let end_offset = mapper.position_to_byte_clamped(range.end).max(start_offset);
-            let new_end_offset = start_offset + change.text.len();
 
-            // Calculate the new end position for tree-sitter (using byte columns)
-            let lines: Vec<&str> = change.text.split('\n').collect();
-            let line_count = lines.len();
-            // last_line_len is in BYTES (not UTF-16) because .len() on &str returns byte count
-            let last_line_len = lines.last().map(|l| l.len()).unwrap_or(0);
+            // Once a full replacement has landed in this batch the edits will be
+            // discarded at the end (the batch is a full sync), so skip building the
+            // `InputEdit` — its `split('\n')` allocation and `byte_to_point` searches
+            // would be pure waste. Still apply the splice so `text` ends correct.
+            if !saw_full_replacement {
+                let new_end_offset = start_offset + change.text.len();
 
-            // Points are derived from the (clamped) byte offsets via the same
-            // `LineIndex` (O(log n)), not the raw LSP positions, so they stay
-            // consistent with start_byte/old_end_byte for incremental parsing.
-            let start_point = mapper.byte_to_point(start_offset);
-            let old_end_point = mapper.byte_to_point(end_offset);
+                // Calculate the new end position for tree-sitter (using byte columns)
+                let lines: Vec<&str> = change.text.split('\n').collect();
+                let line_count = lines.len();
+                // last_line_len is in BYTES (not UTF-16) because .len() on &str returns byte count
+                let last_line_len = lines.last().map(|l| l.len()).unwrap_or(0);
 
-            // Calculate new end Point (tree-sitter uses byte columns)
-            let new_end_point = if line_count > 1 {
-                // New content spans multiple lines
-                Point::new(start_point.row + line_count - 1, last_line_len)
-            } else {
-                // New content is on same line as start
-                Point::new(start_point.row, start_point.column + last_line_len)
-            };
+                // Points are derived from the (clamped) byte offsets via the same
+                // `LineIndex` (O(log n)), not the raw LSP positions, so they stay
+                // consistent with start_byte/old_end_byte for incremental parsing.
+                let start_point = mapper.byte_to_point(start_offset);
+                let old_end_point = mapper.byte_to_point(end_offset);
 
-            // Create InputEdit for incremental parsing
-            let edit = InputEdit {
-                start_byte: start_offset,
-                old_end_byte: end_offset,
-                new_end_byte: new_end_offset,
-                start_position: start_point,
-                old_end_position: old_end_point,
-                new_end_position: new_end_point,
-            };
-            edits.push(edit);
+                // Calculate new end Point (tree-sitter uses byte columns)
+                let new_end_point = if line_count > 1 {
+                    // New content spans multiple lines
+                    Point::new(start_point.row + line_count - 1, last_line_len)
+                } else {
+                    // New content is on same line as start
+                    Point::new(start_point.row, start_point.column + last_line_len)
+                };
+
+                // Create InputEdit for incremental parsing
+                let edit = InputEdit {
+                    start_byte: start_offset,
+                    old_end_byte: end_offset,
+                    new_end_byte: new_end_offset,
+                    start_position: start_point,
+                    old_end_position: old_end_point,
+                    new_end_position: new_end_point,
+                };
+                edits.push(edit);
+            }
 
             // Replace the range with new text
             text.replace_range(start_offset..end_offset, &change.text);
@@ -102,10 +109,13 @@ pub(crate) fn apply_content_changes_with_edits(
         }
     }
 
-    // A ranged change after a full replacement would otherwise leave a non-empty
-    // edits vec whose `InputEdit`s are relative to the replacement text, not
-    // `old_text` — unusable for both the `old_text` diff and the incremental seed.
-    // Drop them so the caller takes the full-reparse path.
+    // Authoritative guarantee: any batch containing a full replacement returns
+    // empty edits (the full-reparse path). The skip above already prevents pushing
+    // post-replacement edits, so this is normally a no-op — but keeping it as the
+    // correctness mechanism means that optimization is *only* an optimization: a
+    // future change to the loop can't silently leak a `replacement`-relative edit
+    // (which would be unusable for both the `old_text` diff and the incremental
+    // seed) into the returned vec.
     if saw_full_replacement {
         edits.clear();
     }

--- a/src/lsp/text_sync.rs
+++ b/src/lsp/text_sync.rs
@@ -66,11 +66,18 @@ pub(crate) fn apply_content_changes_with_edits(
             if !saw_full_replacement {
                 let new_end_offset = start_offset + change.text.len();
 
-                // Calculate the new end position for tree-sitter (using byte columns)
-                let lines: Vec<&str> = change.text.split('\n').collect();
-                let line_count = lines.len();
-                // last_line_len is in BYTES (not UTF-16) because .len() on &str returns byte count
-                let last_line_len = lines.last().map(|l| l.len()).unwrap_or(0);
+                // Calculate the new end position for tree-sitter (using byte columns).
+                // Iterate the split directly rather than `.collect()`-ing a `Vec` — this
+                // runs on every keystroke's ranged edit, so the allocation is pure
+                // overhead. `split('\n')` always yields at least one segment, so
+                // `line_count >= 1` and `last_line_len` ends as the last segment's BYTE
+                // length (bytes, not UTF-16, since `str::len` is byte count).
+                let mut line_count = 0usize;
+                let mut last_line_len = 0usize;
+                for line in change.text.split('\n') {
+                    line_count += 1;
+                    last_line_len = line.len();
+                }
 
                 // Points are derived from the (clamped) byte offsets via the same
                 // `LineIndex` (O(log n)), not the raw LSP positions, so they stay


### PR DESCRIPTION
## Summary

Follow-up **P1 #1** from the parse-actor effort (`__ignored/followups.md`): restore incremental parsing on the off-ingress reparse path, the one perf regression the per-document-parse-actor flip (#512) introduced.

The flip cleared the parse tree on every `didChange` and reparsed **from scratch** off-ingress, so a single edit on a large / injection-heavy doc paid a full parse instead of an incremental one. It also added latency to `semanticTokens/full/delta`, which blocks on that reparse via `get_tree_with_wait`. (The delta *encoding* is unaffected — it diffs cached token arrays by `result_id`, never `changed_ranges`; this is purely the parse-cost latency.)

## Approach

Restore incrementality **without** reintroducing the stale-tree race the flip closed:

- `didChange` still clears the **reader-visible** tree (readers never see a tree predating the edit — the flip's reader-safety invariant), but instead of discarding the pre-edit tree it stashes it — with this edit's `InputEdit`s applied (`tree.edit()`) — as a new `Document::pending_seed`.
- `pending_seed` is read **only** by the off-ingress `reparse_latest` (which seeds `parser.parse(text, Some(seed))`), never by `tree()` / `snapshot()`.
- Coalesced edits accumulate their `InputEdit`s onto the same seed, so a burst still yields one correctly-edited seed for the final reparse.
- A full-text sync (no `InputEdit`s) keeps **no** seed and parses from scratch — preserving the #348 fix (seeding an unedited tree against wholly-replaced text corrupted tree-sitter's external scanners).
- `set_tree` clears `pending_seed` (a fresh visible tree means the seed is consumed).

The existing text+language CAS (`update_tree_if_text_and_language_unchanged`) still guards the write: a concurrent `didChange` that moved the text makes the CAS reject the stale parse, and the scheduler's `dirty` loop reparses with the newer accumulated seed.

## Second commit — a real correctness fix found in review

`apply_content_changes_with_edits` cleared accumulated edits on a full-replacement change but kept building `InputEdit`s for **ranged changes that followed it in the same batch**, leaving a non-empty edits vec whose edits are relative to the *replacement* text, not `old_text`. With incremental seeding restored, that would seed the reparse with the pre-batch (old-text) tree and apply only the post-replacement edits — exactly the #348 contract violation. Now any rangeless change in a batch forces the full-reparse path. (Latent pre-flip too, in `get_edited_tree`; re-exposed by restoring seeding.)

## Validation

A/B benchmark (`benches/compare_head_vs_main.sh` vs `origin/main`, iters=60) on the edit→reparse→delta path this change targets:

| scenario | baseline (main) | HEAD | Δ |
|---|---|---|---|
| `rust_large/edit_delta` | 49.4ms | 36.7ms | **−25.7%** |
| `markdown_injections/edit_delta` | 13.4ms | 9.0ms | **−32.9%** |

The non-edit `_full` scenarios are unchanged code (didOpen still full-parses) and showed only noise (contradictory ±, machine under concurrent build load).

## Tests
- 4 new `Document::apply_edit_and_seed` unit tests (seed stash, **#348 full-text-sync drops seed**, coalescing accumulation, `set_tree` clears seed).
- 1 new `text_sync` regression test (full-replacement-then-ranged → empty edits).
- Full `cargo test --lib` green (2164).

Reviewed locally with `/review` + codex; the codex-found mixed-batch bug is fixed here, and a pre-existing `populate_injections` CAS→populate TOCTOU was triaged as out-of-scope (deferred to the epoch-CAS follow-up #2/#4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)