### PR TITLE
refactor(document): remove vestigial incremental-edit-history state (#505)

### DIFF
--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -36,10 +36,6 @@ pub struct Document {
     text: Arc<str>,
     language_id: Option<String>,
     tree: Option<Tree>,
-    /// Previous tree for changed_ranges comparison during incremental parsing
-    previous_tree: Option<Tree>,
-    /// Previous text for line delta calculation during incremental tokenization
-    previous_text: Option<Arc<str>>,
     /// Edited-but-not-yet-reparsed seed for the **off-ingress** incremental parse
     /// (per-document-parse-actor).
     ///
@@ -67,8 +63,6 @@ impl Document {
             text: Arc::from(text),
             language_id: None,
             tree: None,
-            previous_tree: None,
-            previous_text: None,
             pending_seed: None,
         }
     }
@@ -79,8 +73,6 @@ impl Document {
             text: Arc::from(text),
             language_id: Some(language_id),
             tree: None,
-            previous_tree: None,
-            previous_text: None,
             pending_seed: None,
         }
     }
@@ -91,8 +83,6 @@ impl Document {
             text: Arc::from(text),
             language_id: Some(language_id),
             tree: Some(tree),
-            previous_tree: None,
-            previous_text: None,
             pending_seed: None,
         }
     }
@@ -135,17 +125,9 @@ impl Document {
         })
     }
 
-    /// Update tree and text together for incremental tokenization support
-    ///
-    /// This preserves both previous tree and previous text for:
-    /// - changed_ranges comparison (tree)
-    /// - line delta calculation (text)
-    ///
-    /// Note: For proper `changed_ranges()` support, prefer `update_with_edited_tree`
-    /// which accepts the edited previous tree (after `tree.edit()` was called).
+    /// Install a freshly parsed tree together with its text.
     pub(crate) fn update_tree_and_text(&mut self, new_tree: Tree, new_text: String) {
-        self.previous_tree = self.tree.take();
-        self.previous_text = Some(std::mem::replace(&mut self.text, Arc::from(new_text)));
+        self.text = Arc::from(new_text);
         self.tree = Some(new_tree);
         // Any pending incremental seed is for an edit superseded by this fresh
         // tree+text; keep the invariant "visible tree present ⟹ no stale seed" so a
@@ -154,30 +136,11 @@ impl Document {
         self.pending_seed = None;
     }
 
-    /// Update tree and text with an explicit edited previous tree.
-    ///
-    /// Preferred when the previous tree was edited via `tree.edit()` before
-    /// parsing: the edited tree lets `changed_ranges()` accurately compute the
-    /// byte ranges changed between the old and new parse trees.
-    pub(crate) fn update_with_edited_tree(
-        &mut self,
-        new_tree: Tree,
-        new_text: String,
-        edited_previous_tree: Tree,
-    ) {
-        self.previous_tree = Some(edited_previous_tree);
-        self.previous_text = Some(std::mem::replace(&mut self.text, Arc::from(new_text)));
-        self.tree = Some(new_tree);
-        // See `update_tree_and_text`: a fresh visible tree consumes any pending seed.
-        self.pending_seed = None;
-    }
-
     /// Attach a parsed tree **without** touching the text.
     ///
     /// For an on-demand reader parse whose parsed text already equals the stored
-    /// text: there is no content-version transition to record, so `previous_tree`
-    /// / `previous_text` are left as-is and the text is neither re-cloned nor
-    /// replaced.
+    /// text: there is no content-version transition to record, so the text is
+    /// neither re-cloned nor replaced.
     ///
     /// Clears `pending_seed`: a present reader-visible tree means the off-ingress
     /// reparse's seed has been consumed (the tree it would have produced is now
@@ -229,8 +192,6 @@ impl Document {
         self.text = Arc::from(text);
         // Note: Tree needs to be rebuilt after text change
         self.tree = None;
-        self.previous_tree = None;
-        self.previous_text = None;
         self.pending_seed = None;
     }
 }
@@ -268,57 +229,6 @@ mod tests {
         doc.update_text("updated".to_string());
         assert_eq!(doc.text(), "updated");
         assert!(doc.tree().is_none());
-    }
-
-    #[test]
-    fn test_document_preserves_previous_tree() {
-        let mut parser = tree_sitter::Parser::new();
-        parser
-            .set_language(&tree_sitter_rust::LANGUAGE.into())
-            .unwrap();
-        let tree1 = parser.parse("fn main() {}", None).unwrap();
-
-        let mut doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree1);
-
-        // Initially no previous tree
-        assert!(doc.previous_tree.is_none());
-
-        // Update tree and text - old should become previous
-        let tree2 = parser.parse("fn main() { let x = 1; }", None).unwrap();
-        doc.update_tree_and_text(tree2, "fn main() { let x = 1; }".to_string());
-
-        // Now previous tree should exist
-        assert!(doc.previous_tree.is_some());
-        // Current tree should be the new one
-        assert!(doc.tree().is_some());
-    }
-
-    #[test]
-    fn test_document_preserves_previous_text() {
-        let mut parser = tree_sitter::Parser::new();
-        parser
-            .set_language(&tree_sitter_rust::LANGUAGE.into())
-            .unwrap();
-
-        let old_text = "fn main() {}".to_string();
-        let new_text = "fn main() { let x = 1; }".to_string();
-
-        let tree1 = parser.parse(&old_text, None).unwrap();
-        let mut doc = Document::with_tree(old_text.clone(), "rust".to_string(), tree1);
-
-        // Initially no previous text
-        assert!(doc.previous_text.is_none());
-
-        // Update tree and text together
-        let tree2 = parser.parse(&new_text, None).unwrap();
-        doc.update_tree_and_text(tree2, new_text.clone());
-
-        // Now previous text should exist and match old text
-        assert_eq!(doc.previous_text.as_deref(), Some("fn main() {}"));
-        // Current text should be new text
-        assert_eq!(doc.text(), "fn main() { let x = 1; }");
-        // Previous tree should also exist
-        assert!(doc.previous_tree.is_some());
     }
 
     /// A non-empty edit stashes an incremental parse seed and clears the
@@ -467,26 +377,13 @@ mod tests {
         // update_tree_and_text clears the seed.
         let tree = parser.parse("fn main() {}", None).unwrap();
         let mut doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree);
-        doc.apply_edit_and_seed("fn main() { }".to_string(), &[edit.clone()]);
+        doc.apply_edit_and_seed("fn main() { }".to_string(), &[edit]);
         assert!(doc.pending_seed().is_some());
         let t2 = parser.parse("fn main() { }", None).unwrap();
         doc.update_tree_and_text(t2, "fn main() { }".to_string());
         assert!(
             doc.pending_seed().is_none(),
             "update_tree_and_text must clear the pending seed"
-        );
-
-        // update_with_edited_tree clears the seed.
-        let tree = parser.parse("fn main() {}", None).unwrap();
-        let mut doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree);
-        doc.apply_edit_and_seed("fn main() { }".to_string(), &[edit]);
-        assert!(doc.pending_seed().is_some());
-        let edited = parser.parse("fn main() {}", None).unwrap();
-        let t3 = parser.parse("fn main() { }", None).unwrap();
-        doc.update_with_edited_tree(t3, "fn main() { }".to_string(), edited);
-        assert!(
-            doc.pending_seed().is_none(),
-            "update_with_edited_tree must clear the pending seed"
         );
     }
 

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -205,7 +205,7 @@ impl DocumentStore {
         // between checking if document exists and inserting/updating.
         let has_tree = match self.documents.entry(uri.clone()) {
             Entry::Occupied(mut entry) => {
-                // Document exists - update in place to preserve previous_tree and previous_text
+                // Document exists - update in place
                 let doc = entry.get_mut();
                 if let Some(tree) = new_tree {
                     doc.update_tree_and_text(tree, text);
@@ -299,7 +299,7 @@ impl DocumentStore {
         // the `Url`. The `RefMut` holds the shard write lock for the whole arm, so
         // the text check and the tree write are atomic against didChange/didClose.
         // Text already equals `expected_text`, so only the tree is attached — no
-        // text re-clone, no `previous_text` churn.
+        // text re-clone.
         let stored = if let Some(mut doc) = self.documents.get_mut(uri) {
             if doc.text() == expected_text {
                 doc.set_tree(new_tree);
@@ -357,10 +357,8 @@ impl DocumentStore {
     /// reparse (`reparse_installed_document`), whose "don't clobber a concurrent
     /// parse" guard is a `tree.is_some()` pre-check: a parse attaching a tree for
     /// the same text *between* that pre-check and this write would otherwise be
-    /// overwritten — discarding its incremental-edit linkage (`previous_tree` /
-    /// `previous_text`) and corrupting the next `changed_ranges()`. Folding the
-    /// `tree.is_none()` check into the same `get_mut` shard lock as the text
-    /// comparison makes the guard atomic.
+    /// overwritten. Folding the `tree.is_none()` check into the same `get_mut` shard
+    /// lock as the text comparison makes the guard atomic.
     pub(crate) fn attach_tree_if_absent(
         &self,
         uri: &Url,
@@ -381,49 +379,6 @@ impl DocumentStore {
             self.mark_tree_available_if_tracked(uri);
         }
         stored
-    }
-
-    /// Update document with an edited previous tree for proper changed_ranges() support.
-    ///
-    /// Call when parsing used an edited old tree (via `tree.edit()`): the
-    /// `edited_previous_tree` lets tree-sitter's `changed_ranges()` accurately
-    /// compute the byte ranges that changed between versions.
-    pub fn update_document_with_edited_tree(
-        &self,
-        uri: Url,
-        text: String,
-        new_tree: Tree,
-        edited_previous_tree: Tree,
-    ) {
-        match self.documents.entry(uri.clone()) {
-            Entry::Occupied(mut entry) => {
-                // Document exists - update with edited tree to preserve change history
-                entry
-                    .get_mut()
-                    .update_with_edited_tree(new_tree, text, edited_previous_tree);
-            }
-            Entry::Vacant(entry) => {
-                // Document doesn't exist - create new one (edited_previous_tree is lost,
-                // but this is expected for newly created documents)
-                entry.insert(Document::with_tree(text, "unknown".to_string(), new_tree));
-            }
-        }
-        self.update_tree_availability(&uri, true);
-    }
-
-    /// Get the existing tree and apply edits for incremental parsing
-    /// Returns the edited tree without updating the document store
-    // Lock safety: and_then() consumes Ref, returning owned Tree clone - no read lock held after return
-    pub fn get_edited_tree(&self, uri: &Url, edits: &[InputEdit]) -> Option<Tree> {
-        self.documents.get(uri).and_then(|doc| {
-            doc.tree().map(|tree| {
-                let mut tree = tree.clone();
-                for edit in edits {
-                    tree.edit(edit);
-                }
-                tree
-            })
-        })
     }
 
     /// Return the per-document `didChange` serialization lock, creating it on

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -69,9 +69,10 @@ impl CacheCoordinator {
 
     /// Invalidate injection caches for regions that overlap with edits.
     ///
-    /// Called BEFORE parse_document to use pre-edit byte offsets against pre-edit
-    /// injection regions: edits outside injections preserve caches, edits inside
-    /// invalidate only affected regions.
+    /// Called by `did_change` BEFORE the tree is cleared and the off-ingress reparse
+    /// is scheduled, so it uses pre-edit byte offsets against pre-edit injection
+    /// regions: edits outside injections preserve caches, edits inside invalidate
+    /// only affected regions.
     ///
     /// Uses an O(log n) interval tree query.
     pub(crate) fn invalidate_for_edits(&self, uri: &Url, edits: &[InputEdit]) {

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -5,7 +5,6 @@ use crate::lsp::bridge::BridgeCoordinator;
 use crate::lsp::cache::CacheCoordinator;
 use crate::lsp::client::ClientNotifier;
 use tower_lsp_server::Client;
-use tree_sitter::InputEdit;
 use url::Url;
 
 use crate::lsp::lsp_impl::{Kakehashi, build_notifier};
@@ -156,7 +155,6 @@ impl ParseCoordinator {
         uri: Url,
         text: String,
         language_id: Option<&str>,
-        edits: Vec<InputEdit>,
         ticket: Option<u64>,
     ) {
         let parse_generation = self.documents.mark_parse_started(&uri);
@@ -192,24 +190,13 @@ impl ParseCoordinator {
             let load_result = self.language.ensure_language_loaded(&language_name);
             events.extend(load_result.events);
 
-            let (base_tree, pre_edit_tree) = if !edits.is_empty() {
-                let edited = self.documents.get_edited_tree(&uri, &edits);
-                let for_store = edited.clone();
-                (edited, for_store)
-            } else {
-                // Full-text sync (and any other no-edits reparse): do NOT seed
-                // the parse with the stored tree. tree-sitter's incremental
-                // contract requires every text change to be applied to the old
-                // tree via ts_tree_edit first; reusing an unedited tree against
-                // different text makes external scanners deserialize state at
-                // wrong positions and (for the markdown grammar) overflow in
-                // scanner serialize — heap corruption that killed the whole
-                // server (#348). A full parse is the correct cost of full-text
-                // sync: without InputEdits there is nothing to be incremental
-                // about.
-                (None, None)
-            };
-
+            // This is the document-open parse: there is no prior tree to seed an
+            // incremental parse from, so it is always a full parse. (The off-ingress
+            // edit reparse — `reparse_latest` — is the incremental path, seeded from
+            // `Document::pending_seed`.) A full parse is also the only safe option
+            // without an edited old tree: reusing an unedited tree against different
+            // text violates tree-sitter's incremental contract and corrupts external
+            // scanners (#348).
             let text_clone = text.clone();
             let auto_install = self.auto_install.clone();
             let language_name_clone = language_name.clone();
@@ -217,13 +204,13 @@ impl ParseCoordinator {
             let parsed_tree = self
                 .parse_with_pool(&language_name, &uri, text.len(), move |mut parser| {
                     let _ = auto_install.begin_parsing(&language_name_clone);
-                    let parse_result = parser.parse(&text_clone, base_tree.as_ref());
+                    let parse_result = parser.parse(&text_clone, None);
                     let _ = auto_install.end_parsing(&language_name_clone);
-                    (parser, parse_result.map(|tree| (tree, pre_edit_tree)))
+                    (parser, parse_result)
                 })
                 .await;
 
-            if let Some((tree, pre_edit_tree)) = parsed_tree {
+            if let Some(tree) = parsed_tree {
                 self.cache.populate_injections(
                     &uri,
                     &text,
@@ -233,21 +220,8 @@ impl ParseCoordinator {
                     self.bridge.node_tracker(),
                 );
 
-                if let Some(edited_tree) = pre_edit_tree {
-                    self.documents.update_document_with_edited_tree(
-                        uri.clone(),
-                        text,
-                        tree,
-                        edited_tree,
-                    );
-                } else {
-                    self.documents.insert(
-                        uri.clone(),
-                        text,
-                        Some(language_name.clone()),
-                        Some(tree),
-                    );
-                }
+                self.documents
+                    .insert(uri.clone(), text, Some(language_name.clone()), Some(tree));
 
                 self.documents
                     .mark_parse_finished(&uri, parse_generation, true);

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -144,7 +144,6 @@ impl Kakehashi {
                     uri.clone(),
                     params.text_document.text,
                     Some(&language_id),
-                    vec![], // No edits for initial document open
                     ticket,
                 )
                 .await;
@@ -703,7 +702,7 @@ print("hello")
             .insert(uri.clone(), text.clone(), Some("rust".to_string()), None);
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), text, Some("rust"), vec![], None)
+            .parse_document(uri.clone(), text, Some("rust"), None)
             .await;
 
         let snapshot = server
@@ -741,13 +740,7 @@ print("hello")
         );
         server
             .parse_coordinator()
-            .parse_document(
-                uri.clone(),
-                "fn main() {}".to_string(),
-                Some("rust"),
-                vec![],
-                None,
-            )
+            .parse_document(uri.clone(), "fn main() {}".to_string(), Some("rust"), None)
             .await;
         assert!(
             server
@@ -794,13 +787,7 @@ print("hello")
         );
         server
             .parse_coordinator()
-            .parse_document(
-                uri.clone(),
-                "fn main() {}".to_string(),
-                Some("rust"),
-                vec![],
-                None,
-            )
+            .parse_document(uri.clone(), "fn main() {}".to_string(), Some("rust"), None)
             .await;
 
         // did_change applies the edit and CLEARS the tree synchronously.
@@ -842,13 +829,7 @@ print("hello")
         );
         server
             .parse_coordinator()
-            .parse_document(
-                uri.clone(),
-                "fn main() {}".to_string(),
-                Some("rust"),
-                vec![],
-                None,
-            )
+            .parse_document(uri.clone(), "fn main() {}".to_string(), Some("rust"), None)
             .await;
         assert!(
             server
@@ -1154,7 +1135,7 @@ print("hello")
             .insert(uri.clone(), text.clone(), Some("rust".to_string()), None);
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), text, Some("rust"), vec![], None)
+            .parse_document(uri.clone(), text, Some("rust"), None)
             .await;
 
         let snapshot = server

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -131,11 +131,9 @@ impl Kakehashi {
             .wait_for_parse_completion(uri, remaining)
             .await;
 
-        // First, try to use the tree from the document store.
-        // This is preferred because:
-        // 1. The tree was parsed with the old tree reference (via tree.edit())
-        // 2. Tree-sitter can accurately compute changed_ranges() for incremental tokenization
-        // 3. Avoids redundant parsing
+        // First, try to use the tree already in the document store, to avoid a
+        // redundant parse here: the store's tree is kept current by didOpen's parse
+        // and the off-ingress edit reparse.
         if let Some(doc) = self.documents.get(uri) {
             let text = doc.text().to_string();
             if let Some(tree) = doc.tree().cloned() {


### PR DESCRIPTION
## Summary

Follow-up **#8 / closes #505** from the parse-actor effort. A Tidy-First, behavior-preserving cleanup enabled by PR #515's finding that the incremental-edit history is dead.

**Stacked on #515** (`feat/parse-incremental-seed`) — review/merge that first.

## Why it's dead

The parse-actor flip moved `didChange` off `ParseCoordinator::parse_document`: didChange now clears the reader-visible tree and reparses off-ingress (`reparse_latest`), seeded from `Document::pending_seed` (added in #515). So `parse_document` is now called **only by `didOpen`** (and tests), **always with empty edits**. That made an entire chain unreachable:

- `parse_document`'s `!edits.is_empty()` branch
- `DocumentStore::get_edited_tree`
- `DocumentStore::update_document_with_edited_tree`
- `Document::update_with_edited_tree`

…all of which existed to maintain `Document::previous_tree` / `previous_text` — which exist **solely** for tree-sitter's `changed_ranges()`, and `changed_ranges()` is **never called anywhere** (semantic-token `full/delta` diffs cached token arrays by `result_id`, not the tree).

## Changes

- `parse_document` drops its `edits` parameter and always full-parses + `insert`s — **identical to the only branch `didOpen` ever took**.
- Delete `get_edited_tree`, `update_document_with_edited_tree`, `update_with_edited_tree`, and the `previous_tree` / `previous_text` fields.
- Simplify `update_tree_and_text` / `update_text`; update the 6 `didOpen` call sites.
- Fix three stale comments (`semantic_tokens.rs`, `cache.rs`, `store.rs`) that referenced the removed machinery.

## Behavior

Pure structural change — **no LSP-observable behavior change**. `/review` + codex both confirmed the new `parse_document` body is behaviorally identical to the old empty-edits path (every side effect preserved: `mark_parse_started/finished`, `is_parser_failed` early-return, `populate_injections`, `advance_watermark`, the no-language fallthrough insert), the removed methods had zero remaining callers, and the fields were write-only.

## Tests
- Removed two obsolete unit tests (`test_document_preserves_previous_tree`/`_text`).
- Full `cargo test --lib` green (2163).

🤖 Generated with [Claude Code](https://claude.com/claude-code)