### PR TITLE
fix(bridge): reject new connection spawns after shutdown begins

### DIFF
--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -194,9 +194,12 @@ pub struct LanguageServerPool {
     /// `shutdown_all_with_timeout`, and checked inside the `connections` lock in
     /// `get_or_create_connection_resolved`: holding that same lock makes the
     /// set-then-snapshot and the check-then-insert mutually exclusive, so a spawn
-    /// either lands before the snapshot (and is torn down) or is rejected. Additive
-    /// to `abort_all_eager_open` + the per-task `CancellationToken`s, which already
-    /// stop most eager spawns before they reach this point.
+    /// either lands before the snapshot (and is torn down) or is rejected. The
+    /// "lands before the snapshot ⟹ torn down" half relies on a freshly inserted
+    /// handle being `Initializing`, which `shutdown_all_with_timeout`'s snapshot
+    /// filter includes (alongside `Ready`); narrowing that filter would reopen the
+    /// window. Additive to `abort_all_eager_open` + the per-task `CancellationToken`s,
+    /// which already stop most eager spawns before they reach this point.
     shutting_down: AtomicBool,
     /// Document tracking for virtual documents (versions, host mappings, opened state)
     document_tracker: DocumentTracker,

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -39,7 +39,7 @@ pub(crate) use shutdown_timeout::GlobalShutdownTimeout;
 
 use std::collections::HashMap;
 use std::io;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
@@ -184,6 +184,20 @@ pub struct LanguageServerPool {
     /// workspace root (issue #382); documents sharing a root (or the
     /// client-root fallback) still share one process.
     connections: Mutex<HashMap<ConnectionKey, Arc<ConnectionHandle>>>,
+    /// Gate that rejects **new** connection spawns once shutdown has begun.
+    ///
+    /// `shutdown_all` snapshots the live connections and tears them down, but a
+    /// late eager spawn (an in-flight `process_injections` / eager-open task whose
+    /// body started before `abort_all_eager_open` could cancel it) could otherwise
+    /// create and insert a connection *after* that snapshot — escaping teardown and
+    /// leaking a child process past shutdown. Set true at the very start of
+    /// `shutdown_all_with_timeout`, and checked inside the `connections` lock in
+    /// `get_or_create_connection_resolved`: holding that same lock makes the
+    /// set-then-snapshot and the check-then-insert mutually exclusive, so a spawn
+    /// either lands before the snapshot (and is torn down) or is rejected. Additive
+    /// to `abort_all_eager_open` + the per-task `CancellationToken`s, which already
+    /// stop most eager spawns before they reach this point.
+    shutting_down: AtomicBool,
     /// Document tracking for virtual documents (versions, host mappings, opened state)
     document_tracker: DocumentTracker,
     /// Host-document sync state per `(uri, connection key)`
@@ -289,6 +303,7 @@ impl LanguageServerPool {
         let (upstream_request_tx, upstream_request_rx) = tokio::sync::mpsc::unbounded_channel();
         Self {
             connections: Mutex::new(HashMap::new()),
+            shutting_down: AtomicBool::new(false),
             document_tracker: DocumentTracker::new(),
             host_documents: Mutex::new(HashMap::new()),
             upstream_request_registry: std::sync::Mutex::new(HashMap::new()),
@@ -1242,6 +1257,20 @@ impl LanguageServerPool {
         timeout: Duration,
     ) -> io::Result<Arc<ConnectionHandle>> {
         let mut connections = self.connections.lock().await;
+
+        // Reject new spawns once shutdown has begun. Checked here, INSIDE the
+        // `connections` lock that `shutdown_all` also takes to snapshot: if shutdown
+        // set the flag first, this rejects (no escaping connection); if this inserts
+        // first, shutdown's later snapshot sees the connection and tears it down.
+        // Relaxed is sufficient — the lock provides the happens-before. Callers
+        // (eager open / lazy request) already degrade gracefully on a connection
+        // error, so an `Interrupted` here is a no-op at shutdown time.
+        if self.shutting_down.load(Ordering::Relaxed) {
+            return Err(io::Error::new(
+                io::ErrorKind::Interrupted,
+                "bridge pool is shutting down; rejecting new connection spawn",
+            ));
+        }
 
         // Get consecutive panic count for this connection
         let panic_count = {
@@ -3322,6 +3351,33 @@ mod tests {
     // ========================================
     // Forced Shutdown Tests
     // ========================================
+
+    /// A spawn that reaches the pool after shutdown has begun must be rejected,
+    /// not create a connection that escapes `shutdown_all`'s snapshot+teardown and
+    /// leaks a child process. Guards the narrow terminal-time eager-spawn window
+    /// (`LanguageServerPool::shutting_down`).
+    #[tokio::test]
+    async fn rejects_new_connection_spawn_after_shutdown() {
+        let pool = LanguageServerPool::new();
+        let config = devnull_config();
+
+        // Shutdown with no live connections still arms the new-spawn gate.
+        pool.shutdown_all().await;
+
+        let err = pool
+            .get_or_create_connection_with_timeout("test", &config, None, Duration::from_secs(5))
+            .await
+            .map(|_| ()) // ConnectionHandle isn't Debug; discard it for expect_err
+            .expect_err("a spawn after shutdown must be rejected");
+        assert_eq!(err.kind(), io::ErrorKind::Interrupted);
+
+        // Nothing was inserted — no connection escaped teardown.
+        let connections = pool.connections.lock().await;
+        assert!(
+            connections.is_empty(),
+            "a rejected spawn must not insert a connection"
+        );
+    }
 
     /// Test that pool.shutdown_all_with_timeout force-kills unresponsive processes.
     ///

--- a/src/lsp/bridge/pool/shutdown.rs
+++ b/src/lsp/bridge/pool/shutdown.rs
@@ -40,6 +40,13 @@ impl LanguageServerPool {
     /// ones jump straight to Closed. When `timeout` elapses, survivors are
     /// force-killed (SIGTERM→SIGKILL on Unix) and all enter Closed.
     pub(crate) async fn shutdown_all_with_timeout(&self, timeout: GlobalShutdownTimeout) {
+        // Close the new-spawn window FIRST, before snapshotting connections below:
+        // a late eager spawn that acquires the `connections` lock after this point
+        // is rejected by `get_or_create_connection_resolved`, so it cannot insert a
+        // connection that escapes this teardown. See `LanguageServerPool::shutting_down`.
+        self.shutting_down
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
         // Track connections that were skipped for logging (minimize lock duration)
         let mut failed_connections: Vec<super::ConnectionKey> = Vec::new();
         let mut already_closing: Vec<super::ConnectionKey> = Vec::new();


### PR DESCRIPTION
## Summary

Follow-up **#3** from the parse-actor effort (`__ignored/followups.md`). Independent of the parse changes, so it targets `main` directly.

Closes a narrow terminal-time race: a late "eager" bridge spawn (an in-flight `process_injections` / eager-open task whose body started before `abort_all_eager_open` could cancel it) can create and insert a downstream LS connection **after** `shutdown_all` snapshotted the live set — escaping teardown and leaking a child process past server shutdown.

## Fix

- Add `shutting_down: AtomicBool` to `LanguageServerPool`.
- Set it `true` at the **start** of `shutdown_all_with_timeout`, **before** the connections snapshot.
- Check it **inside** the `self.connections.lock()` critical section of `get_or_create_connection_resolved`, returning `io::ErrorKind::Interrupted` on rejection.

Both the shutdown snapshot and the create's check+insert contend on the same `connections` lock, making set-then-snapshot and check-then-insert mutually exclusive. A spawn therefore either **lands before the snapshot** (inserted as `Initializing`, which the snapshot includes → torn down) or is **rejected**. Additive to `abort_all_eager_open` + the per-task `CancellationToken`s (which stop most eager spawns earlier); `Ordering::Relaxed` is sound because the mutex supplies the happens-before. Callers already degrade gracefully on a connection error, so the rejection is a no-op at shutdown time.

## Tests
- New `rejects_new_connection_spawn_after_shutdown`: arms the gate via the real `shutdown_all`, asserts a subsequent spawn returns `Interrupted` and inserts nothing.
- Full `cargo test --lib` green (2160); the 188-test bridge-pool suite passes (no existing create path wrongly hits the gate).

Reviewed locally with `/review` + codex: both confirmed the race is genuinely closed (lock ordering verified, no unlock between check and insert, sole production spawn chokepoint, graceful degradation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)