### PR TITLE
fix(injection): re-home normal-path injected-language install off-ingress (#480)

### DIFF
--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -19,6 +19,10 @@ use crate::lsp::lsp_impl::detect_document_language;
 use super::InstallCoordinator;
 use super::install::InstallCoordinatorDeps;
 
+/// `Clone` is a cheap refcount bump of the shared coordinators (every field is a
+/// `Client` / `Arc<_>` / `AutoInstallManager`, all `Clone`); it lets
+/// `process_injections` hand an owned handle to a spawned off-ingress install task.
+#[derive(Clone)]
 pub(crate) struct InjectionCoordinator {
     client: Client,
     language: std::sync::Arc<LanguageCoordinator>,
@@ -161,8 +165,34 @@ impl InjectionCoordinator {
         let languages: HashSet<String> =
             injections.iter().map(|inj| inj.language.clone()).collect();
 
-        self.check_injected_languages_auto_install(uri, &languages)
-            .await;
+        // Re-home the injected-language parser install OFF this task (#480 liveness;
+        // the parse-actor ADR's "PR-3"). When a region's injected language has no
+        // parser yet, `check_injected_languages_auto_install` awaits a compile that
+        // can take seconds; on the parse-loop path that would stall the per-URI
+        // coalescing loop's next pass, and on the didOpen install-retry path it would
+        // re-hold work the ingress already returned from. Spawn it instead:
+        //
+        // - The didChange forwarding above already completed (ordered-after-parse,
+        //    before this spawn), so forwarding order is unaffected.
+        // - The injected-language **parser** install only enables kakehashi to PARSE
+        //   deeper-nested regions later; it is independent of the bridge-server
+        //   warmup below, which spawns the **external** language servers for these
+        //   regions (no tree-sitter parser needed), so that warmup still runs
+        //   promptly without waiting on the compile.
+        // - `maybe_auto_install_language`'s `InstallingLanguages` tracker dedupes
+        //   concurrent attempts, and the injected install (`is_injection=true`) never
+        //   reparses or resurrects the host document, so a `didClose` racing this
+        //   spawn is benign (it just finishes installing a global parser).
+        let install_task = {
+            let coordinator = self.clone();
+            let uri = uri.clone();
+            async move {
+                coordinator
+                    .check_injected_languages_auto_install(&uri, &languages)
+                    .await;
+            }
+        };
+        tokio::spawn(install_task);
 
         self.eager_spawn_bridge_servers(uri, &host_language, injections);
     }


### PR DESCRIPTION
## Summary

Follow-up **#5** (the parse-actor ADR's "PR-3") from `__ignored/followups.md`. **Independent** of the in-flight #515/#516 (touches only `injection.rs`), so it targets `main` directly with its own CI.

`process_injections` `await`ed `check_injected_languages_auto_install`, which on a *missing* injected language awaits a tree-sitter parser compile that can take seconds. Since the flip, `process_injections` runs in the off-ingress parse loop — so that await stalls the per-URI coalescing loop's next pass; on the didOpen install-retry path it re-holds work the ingress already returned from. #511 moved only the *auto-install-path* injected install off-ingress; this is the remaining normal path.

## Change

Spawn the injected-language install fire-and-forget **at the `process_injections` call site** (not inside the shared method — the `kakehashi/node` discovery loops in `entry.rs`/`captures.rs` must keep awaiting it for deep-tier discovery):

- `forward_didchange_to_opened_docs` still completes **before** the spawn (forwarding order intact).
- The injected **parser** install only enables parsing deeper-nested regions later; it's independent of the bridge-server warmup (`eager_spawn_bridge_servers` spawns the **external** LS using bridge config + injection content, no tree-sitter parser), which still runs promptly.
- `InstallingLanguages` dedupes concurrent attempts; the injected install (`is_injection=true`) never reparses/resurrects the host doc, so a `didClose` racing the spawn is benign (it just finishes loading a **global** parser).
- `#[derive(Clone)]` on `InjectionCoordinator` (all fields `Client`/`Arc`/`AutoInstallManager`) hands an owned handle to the task.

**Note for maintainers:** the install spawn is now detached/unsupervised (like the eager-open spawns) — it can run to completion after `didClose`/shutdown. Confirmed safe by review: it performs no reparse and no URI-keyed store write, only a global parser load + searchPath settings apply, so it can't resurrect document state or block shutdown.

## Tests
- `cargo test --lib` green (2159).
- Injection e2e regression: `e2e_semantic_blockquote` (41 tests, incl. double/triple-nested markdown→python injection chains) passes.
- Reviewed with `/review` + codex: both clean (eager_spawn parser-independence verified to the settings level, no synchronous caller dependency, no resurrection, node-discovery loops untouched, dedup sufficient).

> Coverage note: the spawn's *timing* (install no longer blocks the parse loop) is hard to assert deterministically without mocking the installer; the e2e injection suite covers no-regression of injection processing, and the change is a minimal spawn of an already-correct awaited call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)