### PR TITLE
perf(parse): drop the didOpen parse's redundant text copies (#5b)

### DIFF
--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -150,6 +150,20 @@ impl Document {
         self.pending_seed = None;
     }
 
+    /// Store the open-time parse result — the detected `language` and the parsed
+    /// `tree` (`None` for a parsed-to-nothing / no-language / crashed-parser open) —
+    /// **preserving the existing text**.
+    ///
+    /// For the didOpen parse, whose text was already stored when the document was
+    /// registered: it reparses that same text and records the result *in place*,
+    /// rather than re-inserting a fresh copy of the (potentially large) text. Clears
+    /// any `pending_seed` (the open path never has one — it is set only by an edit).
+    pub(crate) fn set_parse_result(&mut self, language: Option<String>, tree: Option<Tree>) {
+        self.language_id = language;
+        self.tree = tree;
+        self.pending_seed = None;
+    }
+
     /// Apply an edit's new text and stash an **incremental parse seed** for the
     /// off-ingress reparse, clearing the reader-visible tree.
     ///

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -274,6 +274,36 @@ impl DocumentStore {
         self.ensure_watermark_entry(uri);
     }
 
+    /// Record the didOpen parse's result (detected `language` + optional `tree`) on
+    /// the **existing** document, preserving its already-stored text. Returns whether
+    /// it was stored.
+    ///
+    /// The registering `didOpen` inserts the document (with its text) before the
+    /// parse, so the parse never needs to carry the text again — it updates language
+    /// and tree in place, avoiding a full-document copy per open. **Non-inserting**
+    /// (`get_mut`): a document a concurrent `didClose` removed is left gone, not
+    /// resurrected — so once the open parse moves off the ingress ticket (the didOpen
+    /// flip) a close racing it stays closed. Availability is marked only when a tree
+    /// landed (the no-tree paths rely on the following `mark_parse_finished(false)`).
+    pub(crate) fn set_parse_result_if_present(
+        &self,
+        uri: &Url,
+        language: Option<String>,
+        tree: Option<Tree>,
+    ) -> bool {
+        let has_tree = tree.is_some();
+        let stored = if let Some(mut doc) = self.documents.get_mut(uri) {
+            doc.set_parse_result(language, tree);
+            true
+        } else {
+            false
+        };
+        if stored && has_tree {
+            self.mark_tree_available_if_tracked(uri);
+        }
+        stored
+    }
+
     /// Store `new_tree` for an **existing** document, but only if its current text
     /// still equals `expected_text`. Returns `true` iff the tree was stored.
     ///

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -160,7 +160,6 @@ impl ParseCoordinator {
         language_id: Option<&str>,
         ticket: Option<u64>,
     ) {
-        let parse_generation = self.documents.mark_parse_started(&uri);
         let mut events = Vec::new();
 
         // Publish the watermark on whichever path resolves the parse below.
@@ -171,14 +170,15 @@ impl ParseCoordinator {
         };
 
         // Read the text the registering didOpen already stored (a refcount bump, not
-        // a copy). Gone => a didClose removed the document; resolve the watermark and
-        // stop without resurrecting it.
+        // a copy) — BEFORE marking the parse started, so a document a `didClose`
+        // already removed leaves neither a resurrected document nor an orphan
+        // parse-state entry for the now-closed URI. Resolve the watermark and stop.
         let Some(text) = self.documents.get(&uri).map(|doc| doc.text_arc()) else {
-            self.documents
-                .mark_parse_finished(&uri, parse_generation, false);
             advance_watermark();
             return;
         };
+
+        let parse_generation = self.documents.mark_parse_started(&uri);
 
         let language_name = self
             .language

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -191,10 +191,19 @@ impl ParseCoordinator {
                     "Skipping parsing for '{}' - parser previously crashed",
                     language_name
                 );
-                self.documents
-                    .set_parse_result_if_present(&uri, Some(language_name), None);
-                self.documents
-                    .mark_parse_finished(&uri, parse_generation, false);
+                // Mark the parse finished only if the result actually landed: a
+                // `didClose` that removed the document mid-parse makes the store write
+                // a no-op, and `mark_parse_finished` would otherwise recreate a parse
+                // -state entry (via `parse_sender`'s vacant insert) for the closed URI.
+                // (Unreachable while the open parse is inline on the writer ticket; the
+                // guard is for the off-ingress open flip, #6.)
+                if self
+                    .documents
+                    .set_parse_result_if_present(&uri, Some(language_name), None)
+                {
+                    self.documents
+                        .mark_parse_finished(&uri, parse_generation, false);
+                }
                 advance_watermark();
                 self.notifier().log_language_events(&events).await;
                 return;
@@ -233,23 +242,26 @@ impl ParseCoordinator {
                     self.bridge.node_tracker(),
                 );
 
-                self.documents.set_parse_result_if_present(
-                    &uri,
-                    Some(language_name.clone()),
-                    Some(tree),
-                );
-
-                self.documents
-                    .mark_parse_finished(&uri, parse_generation, true);
+                // `language_name` is unused past here — move it in (no clone). Gate
+                // `mark_parse_finished` on the store write landing (see the
+                // parser-failed path above).
+                if self
+                    .documents
+                    .set_parse_result_if_present(&uri, Some(language_name), Some(tree))
+                {
+                    self.documents
+                        .mark_parse_finished(&uri, parse_generation, true);
+                }
                 advance_watermark();
                 self.notifier().log_language_events(&events).await;
                 return;
             }
         }
 
-        self.documents.set_parse_result_if_present(&uri, None, None);
-        self.documents
-            .mark_parse_finished(&uri, parse_generation, false);
+        if self.documents.set_parse_result_if_present(&uri, None, None) {
+            self.documents
+                .mark_parse_finished(&uri, parse_generation, false);
+        }
         advance_watermark();
         self.notifier().log_language_events(&events).await;
     }

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -138,22 +138,25 @@ impl ParseCoordinator {
         }
     }
 
-    /// Parse `uri`'s text and publish the result into the store.
+    /// Parse the (already-registered) document at `uri` and publish the result.
+    ///
+    /// The registering `didOpen` inserts the document — **with its text** — before
+    /// calling this, so the parse re-reads that stored text (a cheap `Arc<str>`
+    /// refcount bump, [`text_arc`](crate::document::Document::text_arc)) rather than
+    /// carrying a second owned `String`, and records the detected language + tree
+    /// **in place** via [`set_parse_result_if_present`] instead of re-inserting a
+    /// fresh copy of the text. Net: zero full-document text copies in the open parse.
+    /// That store write is **non-inserting**, so it is resurrection-safe once the open
+    /// parse later moves off the ingress ticket (a `didClose` racing it stays closed).
     ///
     /// `ticket` is the ingress writer ticket of the mutation that scheduled this
-    /// parse (plumbed from `IngressOrderGate` via the handler), or `None` for a
-    /// caller outside the ingress sequence (a post-install reparse, or a test
-    /// driving the coordinator directly). On every resolution path — a tree, a
-    /// parsed-to-nothing, a previously-crashed parser, or no detectable language —
-    /// the parse advances the store's per-document **watermark** to `ticket`, so a
-    /// virt/native reader waiting on the watermark is released once the parse
-    /// covering its tail edit has resolved. Threading the ticket as an explicit
-    /// value (rather than reading a task-local here) keeps this signature stable
-    /// when the per-document parse actor later runs this off the ingress task.
+    /// parse, or `None` for a caller outside the ingress sequence. On every resolution
+    /// path — a tree, a parsed-to-nothing, a previously-crashed parser, no detectable
+    /// language, or a document closed mid-parse — the parse advances the store's
+    /// per-document **watermark** to `ticket`, releasing a reader waiting on it.
     pub(crate) async fn parse_document(
         &self,
         uri: Url,
-        text: String,
         language_id: Option<&str>,
         ticket: Option<u64>,
     ) {
@@ -165,6 +168,16 @@ impl ParseCoordinator {
             if let Some(ticket) = ticket {
                 self.documents.advance_watermark(&uri, ticket);
             }
+        };
+
+        // Read the text the registering didOpen already stored (a refcount bump, not
+        // a copy). Gone => a didClose removed the document; resolve the watermark and
+        // stop without resurrecting it.
+        let Some(text) = self.documents.get(&uri).map(|doc| doc.text_arc()) else {
+            self.documents
+                .mark_parse_finished(&uri, parse_generation, false);
+            advance_watermark();
+            return;
         };
 
         let language_name = self
@@ -179,7 +192,7 @@ impl ParseCoordinator {
                     language_name
                 );
                 self.documents
-                    .insert(uri.clone(), text, Some(language_name), None);
+                    .set_parse_result_if_present(&uri, Some(language_name), None);
                 self.documents
                     .mark_parse_finished(&uri, parse_generation, false);
                 advance_watermark();
@@ -197,14 +210,14 @@ impl ParseCoordinator {
             // without an edited old tree: reusing an unedited tree against different
             // text violates tree-sitter's incremental contract and corrupts external
             // scanners (#348).
-            let text_clone = text.clone();
+            let text_for_parse = text.clone();
             let auto_install = self.auto_install.clone();
             let language_name_clone = language_name.clone();
 
             let parsed_tree = self
                 .parse_with_pool(&language_name, &uri, text.len(), move |mut parser| {
                     let _ = auto_install.begin_parsing(&language_name_clone);
-                    let parse_result = parser.parse(&text_clone, None);
+                    let parse_result = parser.parse(&*text_for_parse, None);
                     let _ = auto_install.end_parsing(&language_name_clone);
                     (parser, parse_result)
                 })
@@ -220,8 +233,11 @@ impl ParseCoordinator {
                     self.bridge.node_tracker(),
                 );
 
-                self.documents
-                    .insert(uri.clone(), text, Some(language_name.clone()), Some(tree));
+                self.documents.set_parse_result_if_present(
+                    &uri,
+                    Some(language_name.clone()),
+                    Some(tree),
+                );
 
                 self.documents
                     .mark_parse_finished(&uri, parse_generation, true);
@@ -231,7 +247,7 @@ impl ParseCoordinator {
             }
         }
 
-        self.documents.insert(uri.clone(), text, None, None);
+        self.documents.set_parse_result_if_present(&uri, None, None);
         self.documents
             .mark_parse_finished(&uri, parse_generation, false);
         advance_watermark();

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -140,12 +140,7 @@ impl Kakehashi {
         // (reparse_installed_document), so we must not parse inline here.
         if !skip_parse {
             self.parse_coordinator()
-                .parse_document(
-                    uri.clone(),
-                    params.text_document.text,
-                    Some(&language_id),
-                    ticket,
-                )
+                .parse_document(uri.clone(), Some(&language_id), ticket)
                 .await;
         } else if let Some(ticket) = ticket {
             // Parsing is deferred to the spawned off-ingress install reparse.
@@ -702,7 +697,7 @@ print("hello")
             .insert(uri.clone(), text.clone(), Some("rust".to_string()), None);
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), text, Some("rust"), None)
+            .parse_document(uri.clone(), Some("rust"), None)
             .await;
 
         let snapshot = server
@@ -740,7 +735,7 @@ print("hello")
         );
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), "fn main() {}".to_string(), Some("rust"), None)
+            .parse_document(uri.clone(), Some("rust"), None)
             .await;
         assert!(
             server
@@ -787,7 +782,7 @@ print("hello")
         );
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), "fn main() {}".to_string(), Some("rust"), None)
+            .parse_document(uri.clone(), Some("rust"), None)
             .await;
 
         // did_change applies the edit and CLEARS the tree synchronously.
@@ -802,6 +797,32 @@ print("hello")
         assert!(
             server.documents.get(&uri).unwrap().tree().is_some(),
             "the freshness helper must restore the tree so post-edit readers aren't empty"
+        );
+    }
+
+    /// `parse_document` now records its result onto the already-registered document
+    /// in place (non-inserting). If the document was closed before the parse ran
+    /// (no entry in the store), the parse must NOT resurrect it — it reads no text,
+    /// stores nothing, and returns. This is the resurrection-safety the open parse
+    /// gains for free once it moves off the ingress ticket.
+    #[tokio::test]
+    async fn parse_document_does_not_resurrect_a_closed_document() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        configure_rust_self_host(server);
+
+        let uri = Url::parse("file:///test/closed_before_parse.rs").unwrap();
+        // The document is absent (a didClose removed it before this parse ran).
+        assert!(server.documents.get(&uri).is_none());
+
+        server
+            .parse_coordinator()
+            .parse_document(uri.clone(), Some("rust"), None)
+            .await;
+
+        assert!(
+            server.documents.get(&uri).is_none(),
+            "parse_document must not resurrect a document closed before it ran"
         );
     }
 
@@ -829,7 +850,7 @@ print("hello")
         );
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), "fn main() {}".to_string(), Some("rust"), None)
+            .parse_document(uri.clone(), Some("rust"), None)
             .await;
         assert!(
             server
@@ -1135,7 +1156,7 @@ print("hello")
             .insert(uri.clone(), text.clone(), Some("rust".to_string()), None);
         server
             .parse_coordinator()
-            .parse_document(uri.clone(), text, Some("rust"), None)
+            .parse_document(uri.clone(), Some("rust"), None)
             .await;
 
         let snapshot = server


### PR DESCRIPTION
## Summary

Follow-up **#5b** (Gemini-suggested, deferred from #516). **Stacked on #516** (`chore/remove-vestigial-prev-tree`) since it further simplifies `parse_document` — review/merge #515 → #516 first.

`parse_document` (the didOpen parse) took `text: String` and persisted via `DocumentStore::insert`, so the open path copied the full document text **twice** — `text.clone()` for the blocking parse closure, then `Arc::from(text)` inside `insert` — even though the registering `didOpen` had *already* stored the text when it inserted the document moments earlier.

## Change

- Drop the `text` param. `parse_document` reads the stored text back as a cheap `Arc<str>` (`text_arc()`, a refcount bump) and records the detected language + tree **in place** via a new non-inserting `DocumentStore::set_parse_result_if_present` → `Document::set_parse_result` (sets language_id + tree, preserves text), replacing all 3 `insert` sites. **Net: zero full-document text copies in the open parse.**
- The in-place write is **non-inserting** (`get_mut`), so it's resurrection-safe: a `didClose` that removed the document before the parse landed leaves it gone rather than resurrecting it — the property the open parse needs once it moves off the ingress ticket (#6).
- The absent-document path reads presence **before** `mark_parse_started`, so a closed URI touches no per-document parse-state at all.

## Behavior

Identical today: `parse_document` runs **inline on the ingress writer ticket** (the `WriterGate` is held across the entire `didOpen` handler including the awaited parse), giving per-URI mutual exclusion — so the document is always present and its text unchanged during the parse, and the in-place update produces the same final `Document`/parse-state as the old `insert` on every path. `/review` and codex both *verified* this invariant (not assumed) and confirmed equivalence on all paths.

## Tests
- New `parse_document_does_not_resurrect_a_closed_document`.
- `cargo test --lib` green (2164); open-path e2e (`e2e_semantic` 32, `e2e_semantic_blockquote` 41) pass.

> Forward note (for #6, off-ingress open parse): the non-inserting `set_parse_result` is the right primitive there (preserves an interleaved edit's text instead of clobbering it), but the flip will additionally need the text/language CAS that `reparse_latest` already uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)