### PR TITLE
docs(adr): rename per-document-parse ADR to scheduler; record the chosen architecture

### DIFF
--- a/docs/architecture-decisions/parse-decoupled-document-lifecycle.md
+++ b/docs/architecture-decisions/parse-decoupled-document-lifecycle.md
@@ -211,8 +211,8 @@ itself off the ingress path.
 - The edit-path text-freshness change (persist text before parse) is a small
   structural reordering within `did_change_impl`; the per-document parse scheduler
   later builds on it by moving the parse off-ingress with coalescing (the text
-  stays in the shared store; single-owner text application is the deferred actor
-  alternative, not the chosen scheduler).
+  stays in the shared store; single-owner text application is the actor
+  alternative considered and not chosen, not the scheduler that shipped).
 
 ## Decision–Implementation Gap
 

--- a/docs/architecture-decisions/parse-decoupled-document-lifecycle.md
+++ b/docs/architecture-decisions/parse-decoupled-document-lifecycle.md
@@ -159,24 +159,23 @@ tree work it does not need, up to and including an unbounded compiler hold. The
 measured 120–310 ms parse and the unbounded install are paid by every host-tier
 feature for nothing.
 
-### 2. Fold this into the parse-actor refactor only (rejected as the *first* step)
+### 2. Fold this into the parse-scheduler refactor only (rejected as the *first* step)
 
 Wait for the full per-document parse scheduler (per-document-parse-scheduler) to land,
-and let the actor's "non-parse side effects run first" structure deliver the
-decoupling.
+and let its off-ingress restructuring deliver the decoupling as a side effect.
 
 Rejected as the *sequencing*, not as the end state. The tier decoupling is a
 small, self-contained reordering with the single largest UX payoff, and it does
-not require the actor, the epoch unification, or the off-ingress parse. Tying it
-to an ADR-sized refactor needlessly delays the win. It is recorded as its own
-decision so it can ship first.
+not require the parse scheduler, the epoch unification, or the off-ingress parse.
+Tying it to an ADR-sized refactor needlessly delays the win. It is recorded as its
+own decision so it can ship first.
 
 ### 3. Tier decoupling, host hoisted to the front (chosen)
 
 Reorder the handlers so host-tier work precedes everything it does not depend on,
 with the open-before-change invariant made explicit. Independently shippable;
-complementary to the parse actor, which later moves the virt/native parse itself
-off the ingress path.
+complementary to the parse scheduler, which later moves the virt/native parse
+itself off the ingress path.
 
 ## Consequences
 
@@ -186,8 +185,9 @@ off the ingress path.
   available as soon as the document is registered, regardless of parse latency or
   an installing/hung parser. This is the direct user-visible win.
 - **The unbounded install is de-risked for the common case** even before the
-  parse actor lands: a missing/installing main parser no longer blocks host-tier
-  features (it still blocks virt/native, which the actor addresses separately).
+  parse scheduler lands: a missing/installing main parser no longer blocks
+  host-tier features (it still blocks virt/native, which the scheduler addresses
+  separately).
 - **A clear, documented contract** for which tier needs the tree, so future
   handlers are placed correctly by construction.
 
@@ -210,8 +210,9 @@ off the ingress path.
   features faster; it stops non-tree features from waiting on them.
 - The edit-path text-freshness change (persist text before parse) is a small
   structural reordering within `did_change_impl`; the per-document parse scheduler
-  later generalizes it into full single-owner text application with parse
-  coalescing.
+  later builds on it by moving the parse off-ingress with coalescing (the text
+  stays in the shared store; single-owner text application is the deferred actor
+  alternative, not the chosen scheduler).
 
 ## Decision–Implementation Gap
 

--- a/docs/architecture-decisions/parse-decoupled-document-lifecycle.md
+++ b/docs/architecture-decisions/parse-decoupled-document-lifecycle.md
@@ -1,6 +1,6 @@
 # Parse-Decoupled Document Lifecycle
 
-**Related Decisions**: [per-document-parse-actor](per-document-parse-actor.md),
+**Related Decisions**: [per-document-parse-scheduler](per-document-parse-scheduler.md),
 [host-document-bridge](host-document-bridge.md),
 [push-propagation-diagnostic-forwarding](push-propagation-diagnostic-forwarding.md),
 [ls-bridge-message-ordering](ls-bridge-message-ordering.md)
@@ -42,7 +42,7 @@ tiers by their dependence on kakehashi's own tree-sitter parse:
 
 1. `maybe_auto_install_language` (when the main parser is missing and
    auto-install is on) — network/git plus an **unbounded** C-compiler step (see
-   per-document-parse-actor for the liveness analysis);
+   per-document-parse-scheduler for the liveness analysis);
 2. `parse_document` plus the injection processing it feeds — measured together
    at **~120–310 ms** for a 50–2000-block injection-heavy Markdown
    (10 KB–435 KB), and bounded only by a 10 s parse timeout;
@@ -69,7 +69,7 @@ forward that reads store text sees the new text only after the parse completes.
 |   2000 |   435 KB |                ~308 ms |                      ~183 ms |
 
 These are the latencies the host tier pays today for nothing (parse + injection
-isolated from token computation; see per-document-parse-actor for method).
+isolated from token computation; see per-document-parse-scheduler for method).
 
 ## Decision
 
@@ -161,7 +161,7 @@ feature for nothing.
 
 ### 2. Fold this into the parse-actor refactor only (rejected as the *first* step)
 
-Wait for the full per-document parse actor (per-document-parse-actor) to land,
+Wait for the full per-document parse scheduler (per-document-parse-scheduler) to land,
 and let the actor's "non-parse side effects run first" structure deliver the
 decoupling.
 
@@ -209,7 +209,7 @@ off the ingress path.
   because they intrinsically depend on it. The decoupling does not make tree
   features faster; it stops non-tree features from waiting on them.
 - The edit-path text-freshness change (persist text before parse) is a small
-  structural reordering within `did_change_impl`; the per-document parse actor
+  structural reordering within `did_change_impl`; the per-document parse scheduler
   later generalizes it into full single-owner text application with parse
   coalescing.
 
@@ -220,4 +220,4 @@ only after awaiting auto-install, `parse_document`, and `process_injections`, an
 `did_change_impl` persists the post-delta text via `parse_document` (so host
 forwards see new text only after the parse). The tier taxonomy is described here;
 the handler reordering and the explicit open-before-change assertion are unbuilt.
-This decision can land independently of, and before, the per-document parse actor.
+This decision can land independently of, and before, the per-document parse scheduler.

--- a/docs/architecture-decisions/per-document-parse-actor.md
+++ b/docs/architecture-decisions/per-document-parse-actor.md
@@ -93,15 +93,27 @@ scheduling have **no single owner**.
 
 ## Decision
 
-Introduce a **per-document parse actor**: one actor task per open document that
-exclusively owns that document's text, parser-readiness state, and parse
-scheduling, and a **single per-document epoch** — the pair
+Give a document's parse lifecycle a **single per-document owner that drives the
+parse off the ingress ticket**, and a **single per-document epoch** — the pair
 `(incarnation, ticket)` — that is the one source of truth for ordering,
-resurrection-safety, and parse-staleness. It pairs the retained process-wide open
-generation (the incarnation, monotonic across reopen) with the ingress writer
-ticket (intra-lifetime wire order), folds `ParseState.generation` and the
-otherwise-new reader watermark into those two axes, and its per-write check
-additionally takes over the `edit_lock`'s resurrection-guard duty.
+resurrection-safety, and parse-staleness. The epoch pairs the retained
+process-wide open generation (the incarnation, monotonic across reopen) with the
+ingress writer ticket (intra-lifetime wire order), folds `ParseState.generation`
+and the otherwise-new reader watermark into those two axes, and its per-write
+check additionally takes over the `edit_lock`'s resurrection-guard duty.
+
+The owner is a **per-document coalescing parse scheduler**: the text stays in the
+shared document store, and the owner holds only the parse-scheduling decision —
+collapsing a burst of edits into a single off-ingress reparse. It is deliberately
+**not** a mailbox actor that owns the document's text (that is Option 4,
+considered and deferred below). The two are architecturally equivalent for the
+concerns this decision settles — off-ingress parsing, burst coalescing, the
+epoch, and resurrection-safety — because **reads bypass the owner in either
+design** (readers snapshot the store, gated on the epoch watermark), so owning the
+text inside the owner buys readers nothing. The mechanism subsections below are
+written in actor terms because that was the original formulation; each property
+they describe holds for the chosen scheduler, the only difference being where the
+text lives.
 
 ### Writes are messages; the loop never blocks on the slow op
 
@@ -391,29 +403,44 @@ in non-cancellable `spawn_blocking` with no exposed child, so a real deadline
 needs a killable subprocess, not a `timeout` wrapper. Retained as a
 *complementary* mitigation, not an alternative.
 
-### 3. Decompose without an actor (generation-checked store + killable installer)
+### 3. A per-document coalescing scheduler, text left in the store (chosen)
 
-Keep the concurrent handlers, but (a) make every tree write epoch-checked CAS so
-resurrection is closed without an owner, (b) move install off-ingress as a
-subscribe/notify, and (c) add the killable installer. This delivers liveness and
-resurrection-safety with no mailbox and no watermark.
+Keep the text in the store and the concurrent handlers, but add a per-document
+parse-scheduling owner: (a) every tree write is an epoch-checked, non-inserting
+store update so resurrection is closed without owning the text, (b) install moves
+off-ingress as a subscribe/notify, (c) the killable installer bounds compilation,
+and (d) a per-document coalescing scheduler collapses a burst into a single
+off-ingress reparse and keeps one parse in flight per document.
 
-Rejected, narrowly, on the **cost** and **change-path** forces. It distributes
-the epoch-check and edit-application discipline across more call sites (each
-`didChange`, the install-completion parse, every reader fallback), and — crucially
-— it has no natural place to **coalesce a burst into one parse**, which the cost
-table shows is worth tens-to-hundreds of milliseconds per superseded edit on
-injection-heavy documents. The single-consumer actor gets coalescing for free;
-the decomposed design would have to bolt on a per-URI debounce that re-creates an
-ad-hoc owner. The epoch unification (the largest simplification) is adopted from
-this option regardless of the actor.
+Originally rejected on the **cost** and **change-path** forces — the worry that a
+decomposed design "has no natural place to coalesce a burst" and would "bolt on a
+per-URI debounce that re-creates an ad-hoc owner." That objection did not hold:
+the per-document scheduler **is** that owner, and it is a small, self-contained
+coalescing point rather than an ad-hoc one. It gives the same burst-coalescing the
+actor would and keeps per-document parse concurrency, without a mailbox or a
+text-owning task. Chosen because it settles the same forces as Option 4 — the
+epoch (the largest simplification), off-ingress parse and install, and
+resurrection-safety — with materially less moving structure.
 
-### 4. Per-document parse actor with a unified epoch (chosen)
+### 4. Per-document parse actor that owns the text (considered; deferred)
 
-Serializes by construction, folds `skip_parse` into state, unifies the four
+A mailbox actor per open document that **owns the text**, serializes by
+construction, folds `skip_parse` into an explicit state, unifies the four
 sequences into one epoch, closes the resurrection path with CAS writes, coalesces
 bursts, and keeps install/parse off the ingress path — at the cost of an
-ADR-sized refactor.
+ADR-sized refactor and a new task-lifecycle and cancellation surface.
+
+Deferred in favor of Option 3. The actor's one distinguishing trait over the
+scheduler is that it owns the document text, and that buys nothing for the decided
+concerns: reads bypass the owner in both designs, so latency and throughput are
+unchanged; the epoch, coalescing, and resurrection-safety are equally expressible
+without text ownership; and the remaining epoch work an actor would absorb —
+enforcing the incarnation axis on store writes — still has to guard the reader
+fallbacks, which bypass the actor, so the actor would relocate that work rather
+than remove it. Owning the text was expected to make incremental parsing cleaner;
+in practice incremental parsing was achieved without it. Retained as the
+documented ideal — a no-behavior-change refactor worth revisiting only if a future
+need turns out genuinely cleaner under single text ownership.
 
 ### 5. Actor answers read requests directly (mailbox-query reads)
 
@@ -424,6 +451,11 @@ the same mailbox, reintroducing the blocking the design removes. The
 write-only-mailbox / shared-store-read split is load-bearing.
 
 ## Consequences
+
+These are stated for the actor formulation. All hold for the chosen scheduler
+except the two that specifically concern owning the text — a single owner of the
+document *text*, and folding `skip_parse` into the actor's state machine — which
+pertain to the deferred Option 4.
 
 ### Positive
 
@@ -486,17 +518,15 @@ write-only-mailbox / shared-store-read split is load-bearing.
 
 ## Decision–Implementation Gap
 
-Not yet implemented. This ADR records the target design; it runs ahead of the
-code. As of writing, `did_open_impl` still awaits auto-install inline and carries
-`skip_parse`, `did_change_impl` still serializes via `edit_lock`,
-`reload_language_after_install` still re-enters the parse path, and readers still
-wait on `has_tree` (no epoch watermark, no install-pending signal). The store
-still keeps `open_generations` and `ParseState.generation` as separate counters,
-and `update_document` still inserts on vacancy. The `IngressOrderGate` ticket is
-still middleware-private. Injected-language auto-install is still awaited inline,
-reader fallbacks still write the store, and compilation still runs in
-non-cancellable `spawn_blocking`. The actor, the unified epoch, the CAS writes,
-the child-task model, the ingress plumbing, the injected-install re-homing, and
-the killable-subprocess install deadline are all unbuilt. A staged rollout may
-land Option 1 (minimal spawn) and parse-decoupled-document-lifecycle first as
-interim steps before the full actor.
+Realized as Option 3, the per-document coalescing scheduler. The parse runs off
+the ingress ticket, a burst collapses to one reparse, install is off-ingress,
+readers wait on the epoch watermark rather than on tree presence, store writes are
+resurrection-safe (non-inserting), and injection orchestration is re-homed off the
+ingress path.
+
+Two architectural elements of the decision remain deferred. The epoch's
+**incarnation** axis is not yet enforced on tree writes — only the intra-lifetime
+ticket is — so a close-then-reopen race during an in-flight parse is not yet fully
+closed. And the `didOpen` parse still runs on the ingress ticket rather than off
+it (a one-time open cost; change-path immediacy is already covered). The
+text-owning actor of Option 4 is not pursued; see Considered Options.

--- a/docs/architecture-decisions/per-document-parse-actor.md
+++ b/docs/architecture-decisions/per-document-parse-actor.md
@@ -111,9 +111,12 @@ concerns this decision settles — off-ingress parsing, burst coalescing, the
 epoch, and resurrection-safety — because **reads bypass the owner in either
 design** (readers snapshot the store, gated on the epoch watermark), so owning the
 text inside the owner buys readers nothing. The mechanism subsections below are
-written in actor terms because that was the original formulation; each property
-they describe holds for the chosen scheduler, the only difference being where the
-text lives.
+written in actor terms because that was the original formulation. Off-ingress
+parsing, burst coalescing, the epoch, and resurrection-safety all carry over to
+the chosen scheduler. Two properties do **not**, because they follow from owning
+the text rather than from the off-ingress architecture: folding `skip_parse` into
+an explicit state machine, and shedding the `edit_lock` by funneling edits through
+a single consumer. Both belong to the deferred Option 4.
 
 ### Writes are messages; the loop never blocks on the slow op
 
@@ -388,8 +391,8 @@ the eager-open supersede machinery.
 Rejected as the end state. It fixes the immediate liveness exposure with a small
 diff, but leaves `skip_parse`, the `edit_lock`, the install re-entry, and the
 four ad-hoc sequences in place, and adds a *second* spawn/cancel lifecycle bolted
-onto the parse path. It remains a reasonable interim step if the full actor is
-staged.
+onto the parse path. It remains a reasonable interim step toward the chosen
+off-ingress owner.
 
 ### 2. Install-wide deadline only
 
@@ -418,9 +421,12 @@ per-URI debounce that re-creates an ad-hoc owner." That objection did not hold:
 the per-document scheduler **is** that owner, and it is a small, self-contained
 coalescing point rather than an ad-hoc one. It gives the same burst-coalescing the
 actor would and keeps per-document parse concurrency, without a mailbox or a
-text-owning task. Chosen because it settles the same forces as Option 4 — the
-epoch (the largest simplification), off-ingress parse and install, and
-resurrection-safety — with materially less moving structure.
+text-owning task. The rejection's other prong — that decomposition spreads the
+epoch-check and edit discipline across more call sites than a single consumer
+would — does hold, and is accepted as a worthwhile tradeoff (see Negative and the
+Gap). Chosen because it settles the same forces as Option 4 — the epoch (the
+largest simplification), off-ingress parse and install, and resurrection-safety —
+with materially less moving structure.
 
 ### 4. Per-document parse actor that owns the text (considered; deferred)
 

--- a/docs/architecture-decisions/per-document-parse-scheduler.md
+++ b/docs/architecture-decisions/per-document-parse-scheduler.md
@@ -1,4 +1,4 @@
-# Per-Document Parse Actor
+# Per-Document Parse Scheduler
 
 **Related Decisions**:
 [parse-decoupled-document-lifecycle](parse-decoupled-document-lifecycle.md),

--- a/docs/architecture-decisions/per-document-parse-scheduler.md
+++ b/docs/architecture-decisions/per-document-parse-scheduler.md
@@ -35,21 +35,14 @@ writer ticket indefinitely, wedging every later same-URI reader and writer.
 treat the parse as a few milliseconds, but for Markdown — where every inline span
 is a `markdown_inline` injection and every fenced block is its own
 injected-language parse — it is not. Measured on a release build against real
-parsers:
-
-| blocks | doc size | cold parse + injection | per-edit reparse + injection |
-| -----: | -------: | ---------------------: | ---------------------------: |
-|     50 |    10 KB |                ~120 ms |                            — |
-|    500 |   107 KB |                ~146 ms |                       ~56 ms |
-|   1000 |   215 KB |                ~186 ms |                       ~73 ms |
-|   2000 |   435 KB |                ~308 ms |                      ~183 ms |
-
-Method: each figure is the document-ready latency (didOpen→first response, or
-didChange→response) with the warm-median token-compute time subtracted, isolating
-parse + injection from token computation; driven synchronously one request at a
-time, so these are per-operation costs, not a concurrent burst. A burst of edits
-therefore costs real time per edit. Coalescing a burst into a single parse over
-the accumulated text is a genuine optimization, not a speculative one.
+parsers, the document-ready latency (parse + injection, token computation
+subtracted) is on the order of ~120 ms for a small document and rises to a few
+hundred milliseconds for large ones; a single per-edit reparse on a 500-block
+Markdown document costs roughly 50 ms, climbing with size. Crucially these are
+*per-operation* costs, so a burst of edits costs real time per edit. **Coalescing
+a burst into a single parse over the accumulated text is therefore a genuine
+optimization, not a speculative one** — that is the force the parse owner must
+answer.
 
 **Change-path host immediacy requires the parse to be off-ingress.** Per
 parse-decoupled-document-lifecycle, host-tier forwards must be immediate on the
@@ -88,82 +81,46 @@ design needs would be a *fourth*. They are four implementations of two axes:
 *which lifetime* (incarnation) and *where in that lifetime's wire order*
 (ticket).
 
-The common root is that a document's text, parser readiness, and parse
-scheduling have **no single owner**.
+The common root is that a document's parser readiness and parse scheduling have
+**no single owner**.
 
 ## Decision
 
 Give a document's parse lifecycle a **single per-document owner that drives the
-parse off the ingress ticket**, and a **single per-document epoch** — the pair
-`(incarnation, ticket)` — that is the one source of truth for ordering,
-resurrection-safety, and parse-staleness. The epoch pairs the retained
-process-wide open generation (the incarnation, monotonic across reopen) with the
-ingress writer ticket (intra-lifetime wire order), folds `ParseState.generation`
-and the otherwise-new reader watermark into those two axes, and its per-write
-check additionally takes over the `edit_lock`'s resurrection-guard duty.
+parse off the ingress ticket**, realized as a **per-document coalescing parse
+scheduler**: the text stays in the shared document store, and the owner holds only
+the parse-scheduling decision. Pair it with a **single per-document epoch** — the
+pair `(incarnation, ticket)` — that is the one source of truth for ordering,
+resurrection-safety, and parse-staleness: the retained process-wide open
+generation (the incarnation, monotonic across reopen) paired with the ingress
+writer ticket (intra-lifetime wire order), folding `ParseState.generation` and the
+otherwise-new reader watermark into those two axes, and taking over the
+`edit_lock`'s resurrection-guard duty at the tree write.
 
-The owner is a **per-document coalescing parse scheduler**: the text stays in the
-shared document store, and the owner holds only the parse-scheduling decision —
-collapsing a burst of edits into a single off-ingress reparse. It is deliberately
-**not** a mailbox actor that owns the document's text (that is Option 4,
-considered and deferred below). The two are architecturally equivalent for the
-concerns this decision settles — off-ingress parsing, burst coalescing, the
-epoch, and resurrection-safety — because **reads bypass the owner in either
-design** (readers snapshot the store, gated on the epoch watermark), so owning the
-text inside the owner buys readers nothing. The mechanism subsections below are
-written in actor terms because that was the original formulation. Off-ingress
-parsing, burst coalescing, the epoch, and resurrection-safety all carry over to
-the chosen scheduler. Two properties do **not**, because they follow from owning
-the text rather than from the off-ingress architecture: folding `skip_parse` into
-an explicit state machine, and shedding the `edit_lock` by funneling edits through
-a single consumer. Both belong to the deferred Option 4.
+The owner is deliberately a scheduler rather than a mailbox actor that owns the
+document's text (the actor is Option 4, considered and deferred below). Because
+**reads bypass the owner either way** — readers snapshot the store, gated on the
+epoch watermark — owning the text inside the owner would buy readers nothing; the
+scheduler settles the same forces with less moving structure.
 
-### Writes are messages; the loop never blocks on the slow op
+### Writes return at enqueue; the slow work runs off-ingress
 
-`didOpen`, `didChange`, and `didClose` become non-blocking sends to the actor's
-mailbox and return immediately:
+`didOpen`, `didChange`, and `didClose` record their effect and return without
+awaiting the parse. On `didChange` the edit is applied to the stored text, the
+reader-visible tree is cleared, and the document is handed to the scheduler, which
+runs the parse **off the ingress ticket**. The scheduler keeps **one parse in
+flight per document** and **coalesces a burst**: an edit arriving while a parse
+runs marks the document dirty rather than starting a second parse, so a run of
+keystrokes collapses to a single reparse over the latest text — the coalescing the
+cost force demands. Install is likewise off-ingress: the owner *subscribes* to a
+shared installer's completion instead of awaiting it. So neither a slow parse nor
+a hung compiler holds the ingress ticket, and a later `didClose` is never
+sequenced behind them — the liveness fix.
 
-- `didOpen` → `Open { text, language }`
-- `didChange` → `SetText { content_changes }` (LSP deltas, applied in order)
-- `didClose` → `Close`
-
-The actor's run loop `select!`s over the mailbox **and** the completion signals
-for the install it is waiting on and the parse it owns. It **never `.await`s a
-long operation inline**:
-
-```text
-loop {
-  select! {
-    msg       = mailbox.recv()      => handle(msg),       // Open / SetText / Close
-    installed = install_done.recv() => on_installed(),    // shared install completed
-    parsed    = parse_done.recv()   => on_parsed(),       // this doc's parse completed
-  }
-}
-```
-
-Both the install and the parse run **off** the actor loop, their completion
-arriving as just another message. Because the loop stays responsive to the
-mailbox while either runs, a `Close` (and a queued `SetText`) is processed
-*during* an in-flight install — even an unbounded, hung-compiler install. This
-is the liveness fix: no ingress ticket and no mailbox is ever held hostage by
-compilation.
-
-The mailbox is **unbounded**, which is what makes the sends non-blocking. Deltas
-are **never dropped** — dropping one corrupts the text, and standard LSP
-incremental sync offers no server-initiated full-text resynchronization to
-recover from a drop — so the mailbox cannot be capped by shedding messages. What
-keeps memory in check is the actor's per-message cost: applying a delta to the
-owned text is a cheap string op (parse and install are offloaded off the loop),
-so the actor drains the mailbox far faster than an editor produces edits, and the
-backlog stays transient even while a parse or an unbounded install is
-outstanding. The actor further **drains all currently-ready `SetText`s and
-applies them before scheduling a single parse**, collapsing a burst into one
-parse rather than one per message — the coalescing the cost table makes
-worthwhile. The deliberate tradeoff: the only lever that could hard-cap the queue
-is transport backpressure, which would push the stall back onto the ingress
-thread and re-create exactly what this design removes — so unboundedness is
-accepted, relied on staying transient by the drain-rate argument, not by a drop
-policy.
+A coalesced reparse can be **incremental** when a base tree exists (feeding
+tree-sitter the accumulated edits since the last parse) and degrades cleanly to a
+full parse otherwise. Incrementality is a performance optimization, never a
+correctness requirement.
 
 ### One epoch for ordering, resurrection, and staleness
 
@@ -186,40 +143,36 @@ within one open document). The design makes the per-document **epoch** the pair
 Two derived quantities read off this one pair; the unification is of the
 *source*, not of a single scalar:
 
-- **Wire order / readiness (reader watermark).** Each mutation handler stamps its
-  enqueued message with `(incarnation, ticket)`. The actor publishes a
-  **processed-through watermark**: the highest ticket (within the current
-  incarnation) whose state has reached a terminal outcome — `Parsed`, `NoTree`
-  (parsed to nothing), or `InstallFailed`. It advances on **resolution**, not
-  only on a successful tree write, or a parse/install failure would never advance
-  it and readers would burn the full timeout. Because the actor **coalesces**, a
-  single parse covers a contiguous run of tickets; the watermark advances to the
-  highest ticket that parse **covered**, and a parse superseded by a newer edit
-  before it completes does not strand its tickets — they are carried into the
-  next (covering) parse. The watermark never regresses and advances on a covering
-  terminal completion, but no bound is claimed on how quickly a *given* ticket is
-  covered under sustained editing — continuous edits can keep the watermark behind
-  a reader's target ticket indefinitely. The **hard** guarantee is the reader
-  side: the existing 200 ms bound plus the empty fallback caps any wait, so
-  sustained editing degrades a reader to the empty fallback rather than starving
-  it. A virt/native reader waits — bounded by that 200 ms — until the watermark
-  reaches the tail ticket that preceded it, then reads whatever the store holds
-  (a tree, or empty),
-  instead of waiting on `has_tree`. This is required because, with the handler
-  returning at *enqueue*, a bare `has_tree` check would be satisfied while the
-  store still holds the **old** tree — reintroducing the #342/#374 stale-tree
-  race.
+- **Wire order / readiness (reader watermark).** Each mutation stamps its write
+  with `(incarnation, ticket)`. The owner publishes a **processed-through
+  watermark**: the highest ticket (within the current incarnation) whose state has
+  reached a terminal outcome — `Parsed`, `NoTree` (parsed to nothing), or
+  `InstallFailed`. It advances on **resolution**, not only on a successful tree
+  write, or a parse/install failure would never advance it and readers would burn
+  the full timeout. Because the owner **coalesces**, a single parse covers a
+  contiguous run of tickets; the watermark advances to the highest ticket that
+  parse **covered**, and a parse superseded by a newer edit before it completes
+  does not strand its tickets — they are carried into the next (covering) parse.
+  The watermark never regresses, but no bound is claimed on how quickly a *given*
+  ticket is covered under sustained editing — continuous edits can keep the
+  watermark behind a reader's target ticket indefinitely. The **hard** guarantee
+  is the reader side: the existing 200 ms bound plus the empty fallback caps any
+  wait, so sustained editing degrades a reader to the empty fallback rather than
+  starving it. A virt/native reader waits — bounded by that 200 ms — until the
+  watermark reaches the tail ticket that preceded it, then reads whatever the
+  store holds (a tree, or empty), instead of waiting on `has_tree`. This is
+  required because, with the handler returning at *enqueue*, a bare `has_tree`
+  check would be satisfied while the store still holds the **old** tree —
+  reintroducing the #342/#374 stale-tree race.
 - **Resurrection-safety (epoch-checked CAS writes).** Every tree write becomes an
   **atomic, non-inserting** store update checked against the full
   `(incarnation, ticket)` pair: it no-ops if the document is gone (`Vacant`), the
   incarnation differs (a reopen happened), or the ticket moved. This folds both
   `open_generations` (incarnation mismatch) and `ParseState.generation` (ticket
   mismatch) into one comparison, generalizing the existing `mark_parse_finished`
-  stale-check from the parse-state to the tree itself. The actor's own parse is
-  one writer; the reader on-demand fallback is the other (see below). The
-  unguarded site today is `kakehashi/node`'s `ensure_parsed_for_node_lookup`
-  (`entry.rs`); the `semanticTokens` and `selectionRange` fallbacks are already
-  `edit_lock`-guarded but switch to the same CAS write.
+  stale-check from the parse-state to the tree itself. The owner's parse is one
+  writer; the reader on-demand fallbacks are the others (see below) — the guarantee
+  holds only if **every** store-writing path uses this CAS.
 - **Close-then-reopen detection** is the incarnation half: a reopen draws a fresh
   incarnation, so a stale lineage insert or a late parse from the previous
   lifetime fails the incarnation check even though the reopened lifetime's
@@ -231,88 +184,43 @@ reader handler does not receive the tail ticket the `ReaderBarrier` snapshots at
 `call` time. Both must be exposed (via a task-local, a request extension, or by
 moving the enqueue into the middleware). Crucially, because the epoch is the pair
 `(incarnation, ticket)` and tickets restart on reopen, the **incarnation must be
-plumbed alongside the ticket** — to both the writer (so its stamped message names
+plumbed alongside the ticket** — to both the writer (so its stamped write names
 the right lifetime) and the reader (so the tail it waits on names
 `(incarnation, ticket)`, not a bare ticket that a reopen's restarted sequence
 could ambiguate). Equivalently, the reader can hold an incarnation-bound watermark
 handle that is invalidated on close. The ingress middleware is part of the
 refactor surface.
 
-### Install is shared and global; only the parse is the actor's child
+### Install is shared and global; only the parse is the owner's work
 
-Install is **not** a per-document operation the actor owns. `try_install` dedupes
+Install is **not** a per-document operation the owner owns. `try_install` dedupes
 per language: the second document of the same uninstalled language gets an
 `AlreadyInstalling` outcome, while the install "winner" mutates **global** state
 (pushing the data dir into `search_paths`, re-applying settings, calling
 `ensure_language_loaded`). So the two operations are separated deliberately:
 
 - **Global install** — shared, deduplicated, deadline-bounded (see below), owned
-  by a process-wide installer. An actor in `Installing` *subscribes* to its
-  completion; it does not own or abort it.
-- **Per-document parse** — owned by the actor, the **authoritative** epoch-checked
-  writer of the document's tree into the store, and the only child aborted on
-  `Close`.
+  by a process-wide installer. The owner *subscribes* to its completion; it does
+  not own or abort it. When the install completes, the owner parses the **latest**
+  text (not the open-time text), subsuming the `reload_language_after_install`
+  re-entry.
+- **Per-document parse** — owned by the parse owner, the **authoritative**
+  epoch-checked writer of the document's tree into the store, and the only work
+  cancelled on close.
 
 This split is what lets both the liveness fix and the resurrection guarantee
-hold: aborting the per-document parse on `Close` never kills an install a
-*sibling* actor still needs, and a global install completing after a `Close` is
+hold: cancelling the per-document parse on close never kills an install a
+*sibling* document still needs, and a global install completing after a close is
 harmless because the store-writing parse is already gone and its epoch is stale.
 
-### State machine folds `skip_parse`
+### Reads bypass the owner
 
-The actor holds an explicit state, which subsumes the `skip_parse` flag and the
-install path's re-entry:
-
-- `Uninstalled` → parser missing; the actor has subscribed to a shared install.
-- `Installing` → same; `SetText` only applies the delta to the owned text (no
-  parse).
-- `Ready` → parser available; `SetText` schedules a parse.
-
-On install completion the actor transitions `Installing → Ready` and parses the
-**latest** text (not the open-time text). There is no separate
-`reload_language_after_install` re-entry: re-parse is the actor's normal `Ready`
-behavior applied to current state.
-
-### The actor owns the text; only the *parse* coalesces
-
-LSP incremental `didChange` sends **deltas**, not full text, so deltas **cannot
-be coalesced by keeping only the latest** — dropping an intermediate delta
-corrupts the text. The split is: the actor **applies every delta in order to the
-text it owns** (a cheap string op, never dropped); only the **parse** coalesces.
-It keeps a `latest_text` cell, a `dirty` flag, and the accumulated `InputEdits`
-since the last completed parse:
-
-```text
-on SetText(delta):  latest = apply(latest, delta); pending_edits += delta.edits;
-                    if parsing { dirty = true } else { parsing = true; start_parse(latest, take(pending_edits)) }
-on parse_done:      if dirty { dirty = false; start_parse(latest, take(pending_edits)) } else { parsing = false }
-```
-
-A parse is incremental when a base tree exists, feeding tree-sitter the
-**accumulated** `InputEdits` since the last parse; with no base tree (e.g. just
-after install) it degrades cleanly to a full parse. Incrementality is a
-performance optimization, never a correctness requirement.
-
-This removes the `edit_lock` **from the parse / edit-application path**: moving
-delta application into the single-consumer actor makes the read-old-text →
-resolve-deltas → persist cycle non-interleavable by construction. But the
-`edit_lock` carries a *second* duty the actor does **not** subsume:
-`did_close_impl` holds it to serialize the captures-lineage clear
-(`captures_cache.retain`) against a concurrent captures `full` reader's
-`store_lineage` insert. Because readers bypass the actor, this reader-vs-close
-ordering needs a named replacement — either a dedicated lock for the captures
-lineage, or folding the lineage write into the epoch check (a stale lineage
-insert fails its epoch check, the same mechanism that guards tree writes).
-
-### Reads bypass the mailbox
-
-Read requests do **not** query the actor's mailbox. The actor *publishes* parse
+Read requests do **not** route through the owner. The owner *publishes* parse
 results into the shared `DocumentStore`; readers snapshot the store directly,
 using the existing bounded wait — now keyed to the **epoch** rather than
-`has_tree` — plus an empty/`null` fallback. Having reads queue behind in-flight
-parses and buffered `SetText`s in the same mailbox would reintroduce exactly the
-blocking this design removes; the write-only-mailbox / shared-store-read split is
-load-bearing.
+`has_tree` — plus an empty/`null` fallback. Routing reads through the owner would
+queue them behind in-flight parses and reintroduce exactly the blocking this
+design removes; the publish-to-store / read-from-store split is load-bearing.
 
 The reader on-demand parse fallbacks must stop being **unguarded store writers**:
 they either return a **private** tree without writing the store, or persist
@@ -321,29 +229,28 @@ they use today is check-then-write over a store that inserts on vacancy, so a
 concurrent `didClose` can slip between the check and the write and resurrect the
 document; the CAS write closes that at the write itself.
 
-Optionally, the actor publishes an *install-pending* signal into the store so a
+Optionally, the owner publishes an *install-pending* signal into the store so a
 virt/native reader returns empty immediately rather than burning the 200 ms wait,
 with the existing `semantic_tokens_refresh` event prompting capable clients to
-re-request once the actor reaches `Ready`. This is optional scope; the
-load-bearing property is that the mailbox stays write-only.
+re-request once the parser is ready. This is optional scope; the load-bearing
+property is that reads are served from the store, never through the owner.
 
 ### Lifetime equals document lifetime
 
-The actor's lifetime is exactly the open document's lifetime. `Close` aborts the
-in-flight **parse** (the store-writing child), unsubscribes from the shared
-install, advances the epoch, and terminates the actor; the store entry is
-removed. The shared install itself is *not* aborted. A late install completing
-afterward has no actor to hand off to, and any straggler write fails its epoch
-check (the incarnation no longer matches), so **the install/parse resurrection
-path is structurally closed** with no separate supersede machinery — *provided*
-every store-writing path, including the reader on-demand fallback, goes through the
-epoch-checked CAS write above; that fallback is the one residual vector, and it is
-closed at the write, not by a check a concurrent close can slip past. A reopen
-creates a fresh actor at a fresh incarnation.
+The owner's lifetime is exactly the open document's lifetime. On `didClose` the
+store entry is removed and the epoch advances; an in-flight parse is cancelled,
+and any straggler write fails its epoch check (the incarnation no longer matches),
+so **the install/parse resurrection path is structurally closed** with no separate
+supersede machinery — *provided* every store-writing path, including the reader
+on-demand fallback, goes through the epoch-checked CAS write above; that fallback
+is the one residual vector, and it is closed at the write, not by a check a
+concurrent close can slip past. A reopen draws a fresh incarnation. The shared
+install is *not* aborted; a late completion has no document to hand off to and a
+stale epoch.
 
 Teardown must also wake any reader blocked on an epoch that will now never be
-reached: dropping the epoch channel on actor termination signals those waiters to
-proceed (into the empty fallback), mirroring how the sequencer's
+reached: dropping the epoch channel on close signals those waiters to proceed
+(into the empty fallback), mirroring how the sequencer's
 `DocumentSequencer::finish_close` drops its `done` sender. Without it a reader
 racing the close would stall to the 200 ms timeout — bounded, but needless.
 
@@ -361,12 +268,12 @@ reap) when the deadline fires, publishing failure only after termination. This
 **reconciles with, and does not supersede,** replace-tree-sitter-cli-with-loader:
 the loader still owns header/scanner/platform handling; we only wrap its call in
 a killable boundary instead of reaching into the `cc` invocation. Complementary
-to the actor, not a substitute.
+to the parse owner, not a substitute.
 
 ### Injection orchestration stays downstream
 
-`process_injections` runs as a consequence of a completed main parse, not inside
-the actor loop, so injection work never stalls main-document parsing. It is not
+`process_injections` runs as a consequence of a completed main parse, not on the
+ingress path, so injection work never stalls main-document parsing. It is not
 uniformly fire-and-forget, and it hides a **second instance of the liveness
 hazard**: it awaits `check_injected_languages_auto_install` →
 `maybe_auto_install_language(is_injection=true)` — the same untimed C compiler,
@@ -374,7 +281,7 @@ for an *injected* language. Re-homing it has three parts:
 
 - **Injected-language auto-install** — must route through the *same* shared,
   deadline-bounded installer as the main language and be subscribed to, never
-  awaited in a gated handler or the actor loop. A liveness requirement.
+  awaited in a gated handler or on the parse path. A liveness requirement.
 - **External bridge-server spawn** — genuinely fire-and-forget.
 - **`didChange` forwarding to already-opened virtual documents** — wire-order
   sensitive; sequenced **after** the parse it depends on and in writer order, not
@@ -418,23 +325,37 @@ off-ingress reparse and keeps one parse in flight per document.
 Originally rejected on the **cost** and **change-path** forces — the worry that a
 decomposed design "has no natural place to coalesce a burst" and would "bolt on a
 per-URI debounce that re-creates an ad-hoc owner." That objection did not hold:
-the per-document scheduler **is** that owner, and it is a small, self-contained
-coalescing point rather than an ad-hoc one. It gives the same burst-coalescing the
-actor would and keeps per-document parse concurrency, without a mailbox or a
-text-owning task. The rejection's other prong — that decomposition spreads the
-epoch-check and edit discipline across more call sites than a single consumer
-would — does hold, and is accepted as a worthwhile tradeoff (see Negative and the
-Gap). Chosen because it settles the same forces as Option 4 — the epoch (the
-largest simplification), off-ingress parse and install, and resurrection-safety —
-with materially less moving structure.
+the per-document scheduler **is** that owner, a small, self-contained coalescing
+point rather than an ad-hoc one. It gives the same burst-coalescing the actor
+would and keeps per-document parse concurrency, without a mailbox or a text-owning
+task. The rejection's other prong — that decomposition spreads the epoch-check and
+edit discipline across more call sites than a single consumer would — *does* hold,
+and is accepted as a worthwhile tradeoff (see Negative and the Gap). Chosen because
+it settles the same forces as Option 4 — the epoch (the largest simplification),
+off-ingress parse and install, and resurrection-safety — with materially less
+moving structure.
 
 ### 4. Per-document parse actor that owns the text (considered; deferred)
 
-A mailbox actor per open document that **owns the text**, serializes by
-construction, folds `skip_parse` into an explicit state, unifies the four
-sequences into one epoch, closes the resurrection path with CAS writes, coalesces
-bursts, and keeps install/parse off the ingress path — at the cost of an
-ADR-sized refactor and a new task-lifecycle and cancellation surface.
+A mailbox actor per open document that **owns the text**. `didOpen` / `didChange`
+/ `didClose` become non-blocking sends to an **unbounded mailbox**; the actor's
+run loop `select!`s over the mailbox and the completion signals for the install
+and the parse, never awaiting a long operation inline, so a `Close` is processed
+even *during* a hung-compiler install. Because the actor is the **single
+consumer** of edits, three properties follow that the scheduler does not have:
+
+- it **applies every delta in order to the text it owns** and so **sheds the
+  `edit_lock`** from the edit/parse path entirely — the read-old-text →
+  resolve-deltas → persist cycle is non-interleavable by construction;
+- it folds `skip_parse` into an explicit `Uninstalled/Installing/Ready` **state
+  machine**, with no separate install re-entry; and
+- `Close` aborts the in-flight parse child and **terminates the actor**.
+
+It unifies the four sequences into one epoch, closes the resurrection path with
+the same CAS writes, coalesces bursts, and keeps install/parse off the ingress
+path — at the cost of an ADR-sized refactor, a new task-lifecycle and cancellation
+surface, and an unbounded mailbox that cannot be capped without pushing
+backpressure back onto the ingress thread (re-creating what the design removes).
 
 Deferred in favor of Option 3. The actor's one distinguishing trait over the
 scheduler is that it owns the document text, and that buys nothing for the decided
@@ -444,69 +365,63 @@ without text ownership; and the remaining epoch work an actor would absorb —
 enforcing the incarnation axis on store writes — still has to guard the reader
 fallbacks, which bypass the actor, so the actor would relocate that work rather
 than remove it. Owning the text was expected to make incremental parsing cleaner;
-in practice incremental parsing was achieved without it. Retained as the
+in practice incremental parsing was achieved without it. The `edit_lock`-shedding
+and `skip_parse` state-machine simplifications are real, but they are the *only*
+gains unique to the actor and do not justify the extra structure. Retained as the
 documented ideal — a no-behavior-change refactor worth revisiting only if a future
 need turns out genuinely cleaner under single text ownership.
 
 ### 5. Actor answers read requests directly (mailbox-query reads)
 
-Have read handlers send a request message to the actor and await its reply.
+A variant of Option 4 in which read handlers send a request message to the actor
+and await its reply, rather than snapshotting the store.
 
-Rejected. A read would queue behind in-flight parses and buffered `SetText`s in
-the same mailbox, reintroducing the blocking the design removes. The
-write-only-mailbox / shared-store-read split is load-bearing.
+Rejected. A read would queue behind in-flight parses and buffered edits in the
+same mailbox, reintroducing the blocking the design removes. Serving reads from
+the store rather than through the owner is load-bearing — and is why the chosen
+scheduler keeps the text in the store in the first place.
 
 ## Consequences
-
-These are stated for the actor formulation. Off-ingress parsing, burst
-coalescing, the epoch, and resurrection-safety all carry over to the chosen
-scheduler. What does **not** carry over are the consequences of the actor *owning
-the text* — and these pertain to the deferred Option 4: single ownership of the
-document *text*, folding `skip_parse` into the state machine, and shedding the
-`edit_lock` by funneling edits through a single consumer (the scheduler retains
-the `edit_lock`). This matches the carve-out in the Decision intro.
 
 ### Positive
 
 - **Liveness.** An unbounded/hung install can no longer wedge same-URI readers or
-  writers; the actor loop stays responsive and `Close` always lands.
+  writers: install is off-ingress and the handler returns at enqueue, so a
+  `didClose` is never sequenced behind a hung compiler.
 - **Burst coalescing.** A run of edits collapses to one parse over the
-  accumulated text, saving the measured per-edit reparse cost on injection-heavy
-  documents.
+  accumulated text, saving the per-edit reparse cost on injection-heavy documents
+  (the cost force).
 - **One epoch, two axes, not four sequences.** Wire-order readiness,
   resurrection-safety, and parse-staleness key on a single composite epoch
   `(incarnation, ticket)` — the retained process-wide open generation paired with
   the ingress ticket — into which `ParseState.generation` and the reader watermark
-  fold, and whose per-write check additionally takes over the `edit_lock`'s
-  resurrection-guard duty. The incarnation half keeps the epoch monotonic across a
-  reopen even though tickets restart.
-- **`skip_parse` disappears**, folded into the `Uninstalled/Installing/Ready`
-  state machine; the install path stops re-entering parsing from a second call
-  site. *(Option-4 part — the shipped scheduler retains `skip_parse` and the
-  install re-entry.)*
-- **The install/parse resurrection path is structurally closed** — `Close` aborts
-  the actor's store-writing parse and advances the epoch, so a later
-  shared-install completion has no actor and a stale epoch — without adding
-  supersede machinery. This holds *provided* the reader on-demand fallback also
-  writes through the epoch-checked CAS path (the one residual vector; see
-  Negative), not as an unconditional property of `Close` alone.
-- **One owner** for a document's parse-readiness and parse scheduling (global
-  install stays shared); single ownership of the document *text* is the Option-4
-  part — the scheduler leaves the text in the store.
+  fold, and whose per-write check takes over the `edit_lock`'s resurrection-guard
+  duty. The incarnation half keeps the epoch monotonic across a reopen even though
+  tickets restart.
+- **The install/parse resurrection path is structurally closed** — a close removes
+  the store entry and advances the epoch, so a later parse or shared-install
+  completion finds a stale epoch and its non-inserting write no-ops — without
+  supersede machinery. This holds *provided* every store-writing path, including
+  the reader on-demand fallback, goes through the epoch-checked CAS (see Negative).
+- **One owner** for a document's parse-readiness and parse scheduling; the text
+  stays in the shared store and the global install stays shared.
 
 ### Negative
 
-- **ADR-sized refactor** touching `did_open`, `did_change`, `did_close`, the
-  install coordinator, the store, the `IngressOrderGate` middleware (to plumb the
-  ticket and tail ticket to handlers), and every virt/native reader's wait path.
-- **Lifecycle and cancellation must be exact.** Child-task abort on `Close`,
-  completion plumbed back as messages, and the unbounded mailbox are new surface
-  area.
-- **Carefully tuned races must be preserved**: the captures-lineage close
-  ordering (under Option 4 it would ride the `edit_lock` the single-consumer path
-  sheds and so would need a dedicated-lock-or-epoch-check replacement; the chosen
-  scheduler retains the `edit_lock`, so the ordering still rides it); the geometry
-  re-merge / no-op suppression on `didChange`
+- **Refactor surface** across `did_open`, `did_change`, `did_close`, the install
+  coordinator, the store, the `IngressOrderGate` middleware (to plumb the ticket
+  and tail ticket to handlers), and every virt/native reader's wait path.
+- **An off-ingress parse lifecycle to manage**: scheduling, cancellation on close,
+  and completion handling become explicit surface where previously the parse was
+  inline.
+- **Resurrection-safety is a multi-site proof obligation.** Because the scheduler
+  keeps the concurrent handlers and the reader fallbacks bypass the owner, the
+  epoch-checked write must be applied at *every* store-writing site rather than
+  being a single-consumer invariant — the accepted cost of decomposing instead of
+  funneling all writes through one actor.
+- **Carefully tuned races must be preserved**: the captures-lineage close ordering
+  still rides the retained `edit_lock` (the scheduler keeps it, so no replacement
+  is needed); the geometry re-merge / no-op suppression on `didChange`
   (push-propagation-diagnostic-forwarding); and the diagnostic teardown ordering
   in `didClose`.
 - **A new read-path coupling**: virt/native readers wait on the epoch instead of
@@ -522,10 +437,10 @@ the `edit_lock`). This matches the carve-out in the Decision intro.
 ### Neutral
 
 - `IngressOrderGate` still issues per-URI tickets, but the writer ticket now
-  completes at **enqueue** rather than after parse; its old
-  reader-observes-preceding-writes guarantee is carried by the published epoch
-  instead. Handlers **enqueue from within the gated critical section**, so mailbox
-  FIFO still equals wire order.
+  completes at **enqueue** rather than after the parse; its old
+  reader-observes-preceding-writes guarantee is carried by the epoch watermark
+  instead. The writer stamps its effect from within the gated critical section, so
+  the watermark order still equals wire order.
 - Host-tier work is out of scope here — it neither needs the tree nor waits on the
   parse; see parse-decoupled-document-lifecycle.
 

--- a/docs/architecture-decisions/per-document-parse-scheduler.md
+++ b/docs/architecture-decisions/per-document-parse-scheduler.md
@@ -98,7 +98,7 @@ otherwise-new reader watermark into those two axes, and taking over the
 `edit_lock`'s resurrection-guard duty at the tree write.
 
 The owner is deliberately a scheduler rather than a mailbox actor that owns the
-document's text (the actor is Option 4, considered and deferred below). Because
+document's text (the actor is Option 4, not chosen; see below). Because
 **reads bypass the owner either way** — readers snapshot the store, gated on the
 epoch watermark — owning the text inside the owner would buy readers nothing; the
 scheduler settles the same forces with less moving structure.
@@ -338,7 +338,7 @@ it settles the same forces as Option 4 — the epoch (the largest simplification
 off-ingress parse and install, and resurrection-safety — with materially less
 moving structure.
 
-### 4. Per-document parse actor that owns the text (considered; deferred)
+### 4. Per-document parse actor that owns the text
 
 A mailbox actor per open document that **owns the text**. `didOpen` / `didChange`
 / `didClose` become non-blocking sends to an **unbounded mailbox**; the actor's
@@ -360,7 +360,7 @@ path — at the cost of an ADR-sized refactor, a new task-lifecycle and cancella
 surface, and an unbounded mailbox that cannot be capped without pushing
 backpressure back onto the ingress thread (re-creating what the design removes).
 
-Deferred in favor of Option 3. The actor's one distinguishing trait over the
+Not chosen, in favor of Option 3. The actor's one distinguishing trait over the
 scheduler is that it owns the document text, and that buys nothing for the decided
 concerns: reads bypass the owner in both designs, so latency and throughput are
 unchanged; the epoch, coalescing, and resurrection-safety are equally expressible
@@ -370,9 +370,11 @@ fallbacks, which bypass the actor, so the actor would relocate that work rather
 than remove it. Owning the text was expected to make incremental parsing cleaner;
 in practice incremental parsing was achieved without it. The `edit_lock`-shedding
 and `skip_parse` state-machine simplifications are real, but they are the *only*
-gains unique to the actor and do not justify the extra structure. Retained as the
-documented ideal — a no-behavior-change refactor worth revisiting only if a future
-need turns out genuinely cleaner under single text ownership.
+gains unique to the actor — internal-structure simplifications, not user-visible —
+and do not justify the extra structure. Recorded here as the considered
+alternative, not as planned work; the one motivation that might have outweighed
+its cost (a cleaner incremental parse under single text ownership) did not
+materialize.
 
 ### 5. Actor answers read requests directly (mailbox-query reads)
 

--- a/docs/architecture-decisions/per-document-parse-scheduler.md
+++ b/docs/architecture-decisions/per-document-parse-scheduler.md
@@ -458,10 +458,13 @@ write-only-mailbox / shared-store-read split is load-bearing.
 
 ## Consequences
 
-These are stated for the actor formulation. All hold for the chosen scheduler
-except the two that specifically concern owning the text — a single owner of the
-document *text*, and folding `skip_parse` into the actor's state machine — which
-pertain to the deferred Option 4.
+These are stated for the actor formulation. Off-ingress parsing, burst
+coalescing, the epoch, and resurrection-safety all carry over to the chosen
+scheduler. What does **not** carry over are the consequences of the actor *owning
+the text* — and these pertain to the deferred Option 4: single ownership of the
+document *text*, folding `skip_parse` into the state machine, and shedding the
+`edit_lock` by funneling edits through a single consumer (the scheduler retains
+the `edit_lock`). This matches the carve-out in the Decision intro.
 
 ### Positive
 
@@ -486,8 +489,9 @@ pertain to the deferred Option 4.
   supersede machinery. This holds *provided* the reader on-demand fallback also
   writes through the epoch-checked CAS path (the one residual vector; see
   Negative), not as an unconditional property of `Close` alone.
-- **One owner** for a document's text, parse-readiness, and parse scheduling
-  (global install stays shared).
+- **One owner** for a document's parse-readiness and parse scheduling (global
+  install stays shared); single ownership of the document *text* is the Option-4
+  part — the scheduler leaves the text in the store.
 
 ### Negative
 
@@ -498,10 +502,12 @@ pertain to the deferred Option 4.
   completion plumbed back as messages, and the unbounded mailbox are new surface
   area.
 - **Carefully tuned races must be preserved**: the captures-lineage close
-  ordering (it rides the `edit_lock` the parse path sheds, so it needs the
-  dedicated-lock-or-epoch-check replacement); the geometry re-merge / no-op
-  suppression on `didChange` (push-propagation-diagnostic-forwarding); and the
-  diagnostic teardown ordering in `didClose`.
+  ordering (under Option 4 it would ride the `edit_lock` the single-consumer path
+  sheds and so would need a dedicated-lock-or-epoch-check replacement; the chosen
+  scheduler retains the `edit_lock`, so the ordering still rides it); the geometry
+  re-merge / no-op suppression on `didChange`
+  (push-propagation-diagnostic-forwarding); and the diagnostic teardown ordering
+  in `didClose`.
 - **A new read-path coupling**: virt/native readers wait on the epoch instead of
   `has_tree`. Getting it wrong silently reintroduces the #342/#374 stale-tree
   race.

--- a/docs/architecture-decisions/per-document-parse-scheduler.md
+++ b/docs/architecture-decisions/per-document-parse-scheduler.md
@@ -202,8 +202,11 @@ per language: the second document of the same uninstalled language gets an
 - **Global install** — shared, deduplicated, deadline-bounded (see below), owned
   by a process-wide installer. The owner *subscribes* to its completion; it does
   not own or abort it. When the install completes, the owner parses the **latest**
-  text (not the open-time text), subsuming the `reload_language_after_install`
-  re-entry.
+  text (not the open-time text) — the completion-triggered reparse that
+  `reload_language_after_install` performs today, now coordinated by the owner
+  rather than re-entered from a second call site. (Collapsing the
+  readiness/`skip_parse` structure into a single explicit state machine is unique
+  to the Option-4 actor; the scheduler retains that structure.)
 - **Per-document parse** — owned by the parse owner, the **authoritative**
   epoch-checked writer of the document's tree into the store, and the only work
   cancelled on close.

--- a/docs/architecture-decisions/per-document-parse-scheduler.md
+++ b/docs/architecture-decisions/per-document-parse-scheduler.md
@@ -482,7 +482,8 @@ the `edit_lock`). This matches the carve-out in the Decision intro.
   reopen even though tickets restart.
 - **`skip_parse` disappears**, folded into the `Uninstalled/Installing/Ready`
   state machine; the install path stops re-entering parsing from a second call
-  site.
+  site. *(Option-4 part — the shipped scheduler retains `skip_parse` and the
+  install re-entry.)*
 - **The install/parse resurrection path is structurally closed** — `Close` aborts
   the actor's store-writing parse and advances the epoch, so a later
   shared-install completion has no actor and a stale epoch — without adding

--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -37,7 +37,7 @@ pub struct Document {
     language_id: Option<String>,
     tree: Option<Tree>,
     /// Edited-but-not-yet-reparsed seed for the **off-ingress** incremental parse
-    /// (per-document-parse-actor).
+    /// (per-document-parse-scheduler).
     ///
     /// `didChange` clears the reader-visible `tree` (so a reader never sees a tree
     /// that predates the edit — the flip's reader-safety invariant) but stashes the

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -43,7 +43,7 @@ pub struct DocumentStore {
     /// completion channel. Today the parse resolves *inline*, before its writer
     /// ticket completes, so the watermark and ticket-completion move in lockstep;
     /// a reader gated behind the ticket already observes a fresh tree. The
-    /// per-document parse actor (see `per-document-parse-actor` ADR) will run the
+    /// per-document parse scheduler (see `per-document-parse-scheduler` ADR) will run the
     /// parse *off* the ingress ticket, at which point ticket-completion no longer
     /// implies a fresh tree and this watermark — not the completion channel — is
     /// what tells a virt/native reader the store reflects its tail edit. Keyed on
@@ -237,7 +237,7 @@ impl DocumentStore {
     }
 
     /// Apply a `didChange`'s new text and stash an **incremental parse seed**,
-    /// clearing the reader-visible tree — the per-document-parse-actor flip's edit
+    /// clearing the reader-visible tree — the per-document-parse-scheduler flip's edit
     /// path.
     ///
     /// Replaces the prior `update_document(uri, text, None)`: it still clears the

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -235,7 +235,7 @@ fn self_exe_for_reexec() -> Result<PathBuf, ParserInstallError> {
 /// child, so a `tokio::time::timeout` cannot kill a hung compiler (the blocking
 /// thread and its `cc` would keep running). Instead we **re-exec** this binary's
 /// hidden `__compile-parser` subcommand inside a killable process group (see the
-/// per-document-parse-actor ADR, "a real install deadline via a killable
+/// per-document-parse-scheduler ADR, "a real install deadline via a killable
 /// subprocess") and bound it with [`PARSER_COMPILE_TIMEOUT`]. Re-exec rather than
 /// `fork`: forking a multithreaded process is unsafe past the child's first
 /// non-async-signal-safe call.

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -182,7 +182,7 @@ pub struct Kakehashi {
     /// avoids both the wasted downstream pull and the abort-vs-`didClose` race (#489).
     cli_mode: std::sync::atomic::AtomicBool,
     /// Per-document coalescing scheduler for the off-ingress parse
-    /// (per-document-parse-actor ADR): `did_change` applies the edit and clears the
+    /// (per-document-parse-scheduler ADR): `did_change` applies the edit and clears the
     /// tree synchronously, then schedules the (re)parse here so the parse runs off
     /// the ingress writer ticket, coalescing bursts to one reparse over the latest
     /// text. Shared (`Arc`) with the spawned parse loops.
@@ -356,7 +356,7 @@ impl Kakehashi {
     }
 
     /// Schedule the **off-ingress** (re)parse of `uri` after a `did_change` applied
-    /// the edit and cleared the tree (per-document-parse-actor ADR). The parse runs
+    /// the edit and cleared the tree (per-document-parse-scheduler ADR). The parse runs
     /// in a spawned loop off the writer ticket, so `did_change` returns without
     /// waiting on it; the [`ParseScheduler`](parse_scheduler::ParseScheduler)
     /// coalesces a burst of edits into a single follow-up reparse over the latest

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -397,7 +397,7 @@ impl Kakehashi {
     /// if needed. The shared post-edit freshness helper for every request handler
     /// that snapshots the document tree.
     ///
-    /// Since the per-document parse actor flip, `didChange` clears the tree and
+    /// Since the per-document parse scheduler flip, `didChange` clears the tree and
     /// reparses **off-ingress**, so a request arriving in the reparse window finds
     /// `Document::snapshot()` returning `None`. Any tree-reading handler must call
     /// this first: it waits the bounded `wait_for_parse_completion` for the

--- a/src/lsp/lsp_impl/parse_scheduler.rs
+++ b/src/lsp/lsp_impl/parse_scheduler.rs
@@ -1,5 +1,5 @@
 //! Per-document coalescing scheduler for the **off-ingress parse**
-//! (per-document-parse-actor ADR).
+//! (per-document-parse-scheduler ADR).
 //!
 //! `did_change` applies the edit to the store and clears the tree synchronously
 //! (under the edit lock), then asks this scheduler to (re)parse off the ingress

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -82,7 +82,7 @@ impl Kakehashi {
         self.cache.invalidate_for_edits(&uri, &edits);
 
         // Apply the edit to the store and CLEAR the reader-visible tree
-        // synchronously, here under the edit lock (per-document-parse-actor ADR).
+        // synchronously, here under the edit lock (per-document-parse-scheduler ADR).
         // Clearing the visible tree (rather than leaving the pre-edit one) is what
         // keeps readers safe once the parse is off-ingress: a virt/native reader now
         // sees *no* tree until the reparse lands (empty / on-demand fallback) instead

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -940,7 +940,7 @@ print("hello")
         );
     }
 
-    /// Off-ingress edit reparse (per-document-parse-actor flip): `reparse_latest`
+    /// Off-ingress edit reparse (per-document-parse-scheduler flip): `reparse_latest`
     /// parses the latest store text and advances the watermark, but must NOT
     /// resurrect a document a `didClose` removed mid-parse.
     #[tokio::test]

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -108,12 +108,12 @@ impl Kakehashi {
         // not stack to ~400ms).
         //
         // First wait on the parse **watermark** for this reader's tail edit
-        // (per-document-parse-actor ADR). In the current inline-parse world this
+        // (per-document-parse-scheduler ADR). In the current inline-parse world this
         // returns effectively immediately — the parse runs within the writer's
         // gated critical section, so by the time the gate releases this reader the
         // watermark already covers the tail ticket — leaving the full budget for
         // the has-tree wait below (so today this adds no measurable latency). Once
-        // the per-document parse actor runs the parse off the ingress ticket this
+        // the per-document parse scheduler runs the parse off the ingress ticket this
         // genuinely waits — that is the point: a bare `has_tree` check would
         // instead pass while the store still holds the *old* tree (the #342/#374
         // stale-tree race), and this watermark wait is what closes it.

--- a/tests/test_compile_parser_subprocess.rs
+++ b/tests/test_compile_parser_subprocess.rs
@@ -1,6 +1,6 @@
 //! Integration coverage for the hidden `__compile-parser` subcommand — the
 //! re-exec target of the killable parser-compile deadline (see the
-//! per-document-parse-actor ADR). A *successful* in-process compile is unit-tested
+//! per-document-parse-scheduler ADR). A *successful* in-process compile is unit-tested
 //! in `install::parser` (`test_compile_parser_with_loader`); here we lock the
 //! subcommand's contract through the real binary: it exists, is hidden from
 //! `--help`, and maps a failed compile to a non-zero exit without producing an


### PR DESCRIPTION
## Summary

Brings the per-document-parse ADR in line with the architecture that was actually decided and built — and (per review feedback) keeps it at **architecture** altitude, not implementation inventory.

The ADR recorded **Option 4** (a mailbox actor that *owns the document text*) as the chosen design, "not yet implemented." The decided+built architecture is **Option 3**: a per-document coalescing parse **scheduler** that leaves the text in the shared store. This PR:

- **Renames** `per-document-parse-actor.md` → `per-document-parse-scheduler.md` (and the title), updating every cross-reference (the sibling ADR + ADR-citation comments in source; comment-only, `cargo check` passes).
- **Reframes the Decision** to describe the chosen scheduler in scheduler terms (off-ingress submission, per-document coalescing, cancellation, completion, epoch publication, reads-bypass). The `(incarnation, ticket)` epoch model is kept.
- **Confines the actor machinery** (unbounded mailbox + `select!` loop, owns-the-text + `edit_lock` shedding, the `skip_parse` state machine, `Close`/child-task termination) to **Option 4**, where the deferred actor belongs.
- **Marks Option 3 chosen** (its original "can't coalesce a burst" rejection didn't survive — the per-document scheduler *is* that coalescing owner) and **Option 4 deferred** with an architectural rationale: owning the text buys nothing for the decided concerns because reads bypass the owner in both designs; it would relocate, not remove, the remaining incarnation-axis epoch work; and the incremental-parse motivation didn't materialize.
- Adds a **Negative** consequence: resurrection-safety is a multi-site proof obligation (epoch-check at every store-writing site) — the accepted cost of decomposing rather than funneling writes through one consumer.
- Rewrites the implementation-gap section as an architecture-level **realized-vs-deferred** summary (realized: scheduler, off-ingress parse/install, epoch watermark, resurrection-safe writes, injection re-homing; deferred: the incarnation axis of the epoch, the off-ingress `didOpen` parse, and the actor itself).

## Review

Docs-only (plus comment-only citation updates). Reviewed as an **architecture document** — explicitly not code-fidelity — through several `/review` passes and codex rounds, converging to "clear, sound, and internally consistent as an architecture document." Net effect is a reduction in size: the framing-note/implementation scaffolding was removed once the actor-prose moved into Option 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)