### PR TITLE
fix(diagnostics): refresh pull clients when a crash evicts diagnostics (#499)

### DIFF
--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -275,6 +275,13 @@ impl DiagnosticPublisher {
     /// spontaneous push under `pullFallback = false` (#425). A pull that ran and
     /// returned clean keeps its empty `PullLayer` (via [`Self::publish_pull_layer`]),
     /// so that path still suppresses a stale push — the two empties differ.
+    ///
+    /// Deliberately does **not** emit `workspace/diagnostic/refresh` (#499). This is
+    /// the empty-contributors branch of the same host-event pull task as
+    /// [`Self::publish_pull_layer`], which #496 left no-refresh: both are always
+    /// downstream of a host event (didOpen/didChange/didSave) the editor originated
+    /// and re-pulls for on its own. There is no spontaneous `clear_pull_layer`, so a
+    /// refresh here would be redundant (the editor's own re-pull already covers it).
     pub(crate) async fn clear_pull_layer(&self, host: &Url) {
         self.aggregator
             .evict_source(host, &DiagnosticSource::PullLayer);
@@ -285,10 +292,30 @@ impl DiagnosticPublisher {
     /// republish the affected hosts (#469). Called when a connection's reader exits
     /// (crash/respawn); a restart's slots carry a fresh connection id and survive,
     /// so this clears only the dead server's contribution.
+    ///
+    /// A downstream reader exit emits **no LSP event the editor sees**, so a
+    /// pull-mode client (which displays the diagnostics it *pulled*, not our
+    /// `publishDiagnostics`) has no trigger to re-pull — the crashed server's now
+    /// removed diagnostics would rot until the next edit-triggered pull. So when an
+    /// eviction actually changed a host's merged set, nudge pull-mode clients to
+    /// re-pull, exactly like the spontaneous-push paths (#499, push/pull-divergence
+    /// #422). `workspace/diagnostic/refresh` is workspace-wide, so emit it once for
+    /// the whole eviction, not per host. Loop-safe: a refresh-induced pull is
+    /// answered inline by `diagnostic_impl` without republishing.
+    ///
+    /// Scope: `evict_connection` clears only **push** slots (the `PullLayer` blob is
+    /// recorded with no connection id, so it survives eviction), so a *purely
+    /// pull-driven* server's crash evicts nothing here and isn't refreshed by this
+    /// path — that case is out of scope and self-heals on the next host-event pull,
+    /// matching the intentional push-only asymmetry of `evict_connection` (#469).
     pub(crate) async fn evict_connection_diagnostics(&self, connection_id: ProgressConnectionId) {
         let affected = self.aggregator.evict_connection(connection_id);
+        let mut any_changed = false;
         for host in affected {
-            self.republish(&host).await;
+            any_changed |= self.republish(&host).await;
+        }
+        if any_changed {
+            self.request_pull_diagnostic_refresh();
         }
     }
 
@@ -391,7 +418,8 @@ impl DiagnosticPublisher {
     }
 
     /// Ask pull-mode clients to re-pull diagnostics (`workspace/diagnostic/refresh`)
-    /// after a **spontaneous downstream push** changed the merged set.
+    /// after a change the editor has no event to learn about — a **spontaneous
+    /// downstream push**, or a **crash-driven eviction** — moved the merged set.
     ///
     /// kakehashi advertises `diagnosticProvider`, so a pull-mode editor (e.g.
     /// Neovim) displays the diagnostics it *pulled* and ignores our
@@ -403,13 +431,17 @@ impl DiagnosticPublisher {
     /// symptom). This refresh closes that gap: it tells the client to re-pull,
     /// which returns the now-current merged set.
     ///
-    /// Emitted **off** the per-host republish lock and **only** from the
-    /// push-origin paths ([`Self::publish_host_push`], [`Self::publish_region_push`]),
-    /// never from the pull-origin republish ([`Self::publish_pull_layer`]) nor the
-    /// edit-origin re-merge (`did_change`): those carry no *new* result the editor
-    /// is unaware of — a pull-origin set is already the answer to a pull the editor
-    /// made, and an edit-origin re-merge is covered by the editor's own `didChange`
-    /// re-pull — so a refresh there would be redundant. (No tight loop forms: a
+    /// Emitted **off** the per-host republish lock and **only** from the origins
+    /// the editor can't learn about on its own — the push-origin paths
+    /// ([`Self::publish_host_push`], [`Self::publish_region_push`]) and the
+    /// crash-driven eviction ([`Self::evict_connection_diagnostics`]) — never from
+    /// the pull-origin republish ([`Self::publish_pull_layer`]), the
+    /// editor-originated eviction paths ([`Self::clear_pull_layer`],
+    /// [`Self::clear_host`]), nor the edit-origin re-merge (`did_change`): those
+    /// carry no *new* result the editor is unaware of — a pull-origin set is already
+    /// the answer to a pull the editor made, and an edit-origin re-merge is covered
+    /// by the editor's own `didChange` re-pull — so a refresh there would be
+    /// redundant. (No tight loop forms: a
     /// refresh-induced pull is answered inline by `diagnostic_impl`, which never
     /// republishes, so a refresh cannot directly beget another; the indirect
     /// push→refresh→re-pull→downstream-re-push→here path is bounded by
@@ -439,7 +471,7 @@ impl DiagnosticPublisher {
             if let Err(e) = client.workspace_diagnostic_refresh().await {
                 log::debug!(
                     target: LOG_TARGET,
-                    "workspace/diagnostic/refresh after push failed: {e}"
+                    "workspace/diagnostic/refresh failed: {e}"
                 );
             }
         });
@@ -827,6 +859,47 @@ mod tests {
         assert!(
             host.contains_key("live_ls"),
             "the live connection's slot survives the eviction"
+        );
+    }
+
+    #[tokio::test]
+    async fn evict_connection_diagnostics_republishes_the_changed_set() {
+        // The eviction path drives `workspace/diagnostic/refresh` off the same
+        // changed-set gate the spontaneous-push paths use (#499): a crashed server's
+        // slot is evicted and the now-empty merged set is republished as a *change*
+        // the editor (pull-mode) has no event to learn about. We assert that gate
+        // (republish's bool) rather than the capability-gated, fire-and-forget
+        // refresh emission, matching `republish_reports_whether_the_published_set_changed`.
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let uri = Url::parse("file:///test/host.rs").unwrap();
+        let dead = ProgressConnectionId::for_test(1);
+        server.diagnostics.record(
+            &uri,
+            DiagnosticSource::Host,
+            "dead_ls".to_string(),
+            Some(dead),
+            vec![diag("from dead")],
+        );
+        let publisher = DiagnosticPublisher::new(server);
+        // Establish the editor's baseline: the non-empty set is published.
+        assert!(
+            publisher.republish(&uri).await,
+            "the initial non-empty set is a change"
+        );
+
+        publisher.evict_connection_diagnostics(dead).await;
+
+        // The eviction already republished the now-empty (changed) set, so a
+        // follow-up republish is a no-op — confirming the eviction itself carried
+        // the change that gates the refresh. The capability-gated, fire-and-forget
+        // refresh spawn isn't asserted directly: that needs driving full server
+        // `initialize` (server→client messages are suppressed until then), the
+        // mock-client harness this file's tests deliberately avoid — true
+        // end-to-end refresh coverage belongs in the e2e suite.
+        assert!(
+            !publisher.republish(&uri).await,
+            "eviction published the empty changed set; re-publishing is unchanged"
         );
     }
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -320,6 +320,13 @@ impl DiagnosticPublisher {
     }
 
     /// Drop the host's cache entry and publish the now-empty set (host `didClose`).
+    ///
+    /// Deliberately does **not** emit `workspace/diagnostic/refresh` (#499): the
+    /// editor itself originated the `didClose`, so it is not displaying (and won't
+    /// re-pull) a closed document — a refresh would be redundant. This is the
+    /// editor-originated sibling of [`Self::clear_pull_layer`], opposite the
+    /// crash-driven [`Self::evict_connection_diagnostics`] (which the editor has no
+    /// event to learn about, so it does refresh).
     pub(crate) async fn clear_host(&self, host: &Url) {
         self.aggregator.evict_host(host);
         self.republish(host).await;

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -49,6 +49,10 @@ fn init_client() -> (LspClient, tempfile::TempDir) {
 }
 
 fn init_client_with_mode(mode: &str) -> (LspClient, tempfile::TempDir) {
+    init_client_with_mode_caps(mode, json!({}))
+}
+
+fn init_client_with_mode_caps(mode: &str, capabilities: Value) -> (LspClient, tempfile::TempDir) {
     let config_dir = tempfile::TempDir::new().expect("temp dir");
     let config_path = config_dir.path().join("push_diagnostics.toml");
     std::fs::write(&config_path, "").expect("write config");
@@ -63,7 +67,7 @@ fn init_client_with_mode(mode: &str) -> (LspClient, tempfile::TempDir) {
         json!({
             "processId": std::process::id(),
             "rootUri": null,
-            "capabilities": {},
+            "capabilities": capabilities,
             "workspaceFolders": null,
             "initializationOptions": {
                 "languageServers": {
@@ -420,6 +424,88 @@ fn e2e_downstream_crash_evicts_its_pushed_diagnostics() {
     assert!(
         cleared.is_some(),
         "a crashed downstream's pushed diagnostics must be evicted and the host republished cleared"
+    );
+
+    client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+/// Client capabilities advertising pull-diagnostic refresh support, so the bridge
+/// will send `workspace/diagnostic/refresh` (it's gated on this; an editor that
+/// doesn't advertise it is never sent the request).
+fn refresh_capable_caps() -> Value {
+    json!({ "workspace": { "diagnostics": { "refreshSupport": true } } })
+}
+
+#[test]
+fn e2e_downstream_crash_refreshes_pull_clients() {
+    // #499: when a downstream server crash evicts its diagnostics and clears the
+    // host, a pull-mode editor (which displays what it *pulled*, not our push) has
+    // no event to learn the diagnostics vanished — so the bridge must nudge it with
+    // `workspace/diagnostic/refresh`. With a refresh-capable client this asserts
+    // the wire path the unit test can't reach (server→client requests are
+    // suppressed until `initialize`, which only the spawned-server e2e harness drives).
+    let (mut client, _config_dir) =
+        init_client_with_mode_caps("diagnostics-push-crash", refresh_capable_caps());
+
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": MD_URI,
+                "languageId": "markdown",
+                "version": 1,
+                "text": MD_TEXT
+            }
+        }),
+    );
+
+    // The crash mock pushes one diagnostic on didOpen; the editor receives it.
+    client
+        .wait_for_notification_where(
+            &["textDocument/publishDiagnostics"],
+            Duration::from_secs(15),
+            has_pushed_diag,
+        )
+        .expect("editor should receive the pushed diagnostic before the crash");
+
+    // That spontaneous push itself changed the merged set, so it also drives a
+    // refresh (push/pull-divergence, #422). Consume it so the next refresh we wait
+    // for is unambiguously the crash-eviction one (#499).
+    assert!(
+        client
+            .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_secs(15))
+            .is_some(),
+        "the spontaneous push must drive a workspace/diagnostic/refresh (#422)"
+    );
+
+    // The content-changing edit reaches the mock, driving it to exit (crash). The
+    // bridge's reader sees EOF, evicts the dead connection's slots, and republishes
+    // the host cleared.
+    client.send_notification(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": MD_URI, "version": 2 },
+            "contentChanges": [{ "text": MD_TEXT_EDITED }]
+        }),
+    );
+
+    client
+        .wait_for_notification_where(
+            &["textDocument/publishDiagnostics"],
+            Duration::from_secs(15),
+            cleared_host_diag,
+        )
+        .expect("the crash must evict the dead server's diagnostic and republish cleared");
+
+    // The eviction changed the merged set with no event the editor could see, so
+    // the bridge must emit a second `workspace/diagnostic/refresh` (#499) after the
+    // cleared publish, telling the pull-mode editor to re-pull the now-current set.
+    assert!(
+        client
+            .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_secs(15))
+            .is_some(),
+        "a crash eviction that clears the host must drive a workspace/diagnostic/refresh (#499)"
     );
 
     client.send_request("shutdown", json!(null));

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -651,6 +651,40 @@ impl LspClient {
         }
     }
 
+    /// Wait for the first server→client **request** (a message carrying both an
+    /// `id` and a `method`) whose method is `expected_method`, returning its
+    /// params (`Value::Null` for a param-less request like
+    /// `workspace/diagnostic/refresh`). Returns None on timeout or disconnect.
+    ///
+    /// `wait_for_notification*` deliberately skip messages with an `id`, so they
+    /// can't observe a server-initiated request; this is the counterpart that does.
+    /// The request's response is left unsent — the server's refresh is spawned and
+    /// not awaited, so an unanswered request doesn't stall it.
+    pub(crate) fn wait_for_server_request(
+        &mut self,
+        expected_method: &str,
+        timeout: Duration,
+    ) -> Option<Value> {
+        let start_time = Instant::now();
+
+        loop {
+            let remaining = timeout.saturating_sub(start_time.elapsed());
+            if remaining.is_zero() {
+                return None;
+            }
+
+            let message = self.try_receive_message(remaining)?;
+
+            if message.get("id").is_some()
+                && message.get("method").and_then(|m| m.as_str()) == Some(expected_method)
+            {
+                return Some(message.get("params").cloned().unwrap_or(Value::Null));
+            }
+            // A response or notification, or a different request — skip and keep
+            // waiting within the deadline.
+        }
+    }
+
     /// Try to receive a message within `timeout`, returning None if none arrives.
     ///
     /// Backed by the background reader thread's channel, so the deadline is

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -673,12 +673,19 @@ impl LspClient {
                 return None;
             }
 
-            let message = self.try_receive_message(remaining)?;
+            let mut message = self.try_receive_message(remaining)?;
 
             if message.get("id").is_some()
                 && message.get("method").and_then(|m| m.as_str()) == Some(expected_method)
             {
-                return Some(message.get("params").cloned().unwrap_or(Value::Null));
+                // `message` is discarded right after, so move `params` out instead
+                // of cloning it.
+                return Some(
+                    message
+                        .get_mut("params")
+                        .map(Value::take)
+                        .unwrap_or(Value::Null),
+                );
             }
             // A response or notification, or a different request — skip and keep
             // waiting within the deadline.


### PR DESCRIPTION
Closes #499.

## Problem
`evict_connection_diagnostics` fires when a downstream language server crashes/respawns (#469): it evicts the dead server's diagnostic slots and republishes via `publishDiagnostics`, but emits **no LSP event the editor sees**. kakehashi advertises `diagnosticProvider`, so a pull-mode editor (e.g. Neovim) displays the diagnostics it *pulled*, not our push — so a crashed downstream's now-removed diagnostics linger until the next edit-triggered pull (the "stale until you edit another line" class #496 fixed for async pushes, but with a *crash* trigger).

## Fix
Emit `workspace/diagnostic/refresh` **once** after an eviction that actually changed a host's merged set, reusing the existing changed-set gate (`republish()` returns whether a changed set reached the editor) and the capability-gated, fire-and-forget refresh helper. The request is workspace-wide/param-less, so it's emitted once per eviction regardless of how many hosts changed. Loop-safe: a refresh-induced pull is answered inline by `diagnostic_impl` without republishing.

Per-path decision (per #499):
- `evict_connection_diagnostics` (crash) → **refreshes** (diagnostics vanished, editor has no event).
- `clear_pull_layer` / `clear_host` → **don't** (editor-originated events the client re-pulls for on its own); documented in code.

**Scope:** `evict_connection` clears only push slots (the `PullLayer` blob survives eviction), so a *purely pull-driven* server's crash is out of scope here and self-heals on the next host-event pull — the intentional push-only asymmetry of `evict_connection` (#469). Documented inline.

## Tests
- Unit: `evict_connection_diagnostics_republishes_the_changed_set` asserts the changed-set bool gate that drives the refresh (the file's convention).
- E2E: `e2e_downstream_crash_refreshes_pull_clients` drives the real `diagnostics-push-crash` mock with a refresh-capable client and asserts both the spontaneous-push refresh (#422) and the crash-eviction refresh (#499) on the wire. Adds an `LspClient::wait_for_server_request` helper to observe server-initiated requests.

## Reviews
Passed multi-perspective `/review` (verdict SHIP), Codex MCP, and pi-review (no functional findings; all addressed or deferred).

## Follow-up (out of scope, filed separately)
- #521 — the pre-existing downstream-forwarded `workspace/diagnostic/refresh` in `lifecycle.rs` is ungated + inline-awaited; should reuse this PR's capability-gated, spawned helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)