### PR TITLE
docs(readme): reframe README as a user-facing pitch for the bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,95 +2,97 @@
 
 # 🌉 kakehashi (架け橋)
 
-**kakehashi** is a Tree-sitter-based language server that bridges the gap between languages, editors, and tooling.
+kakehashi is a bridge (架け橋) across your editors, your languages, and the language servers that make them smart.
+
+- bridge to consistent syntax highlighting and smart selection — for any language with a Tree-sitter grammar
+- bridge to your language servers' features — configured once in kakehashi, available in any editor
+- bridge to all of the above — even for code embedded inside other code
 
 ```mermaid
 flowchart TB
-    K[kakehashi] <-->|Syntax Highlight<br>Selection Range<br>Go-to Definition<br>...| E["Editor<br>(Any LSP Client)"]
-    K[kakehashi] <-.->|Optional bridging<br>for embedded<br>languages| LS["External<br>Language Servers"]
+    K[🌉 kakehashi] <-->|Highlighting, selection,<br>and more — everywhere| E["Your editor<br>(any LSP client)"]
+    K <-.->|Borrows the smarts of<br>real language servers| LS["pyright, rust-analyzer,<br>and friends"]
 ```
 
-## What is kakehashi?
+## 🎨 Highlighting & smart selection, for any language
 
-kakehashi（架け橋）means "bridge" in Japanese — and that's exactly what this language server does:
+Open a file and kakehashi highlights it — consistently, in every editor. It parses with Tree-sitter, so any language with a grammar just works (that's hundreds of them), and it fetches the grammar it needs automatically the first time you open a file. No manual installs, no config to get started.
 
-### 🌐 Bridge across Languages & Editors
+The same engine powers **smart selection**: grow or shrink your selection along the code's real structure, not just by lines and words.
 
-Tree-sitter grammars work everywhere. By leveraging Tree-sitter for parsing, kakehashi provides consistent syntax highlighting, selection ranges, and more across **any editor** that supports LSP and **any language** with a Tree-sitter grammar.
+Need a niche language, or want highlighting your way? Bring your own Tree-sitter grammar and query files and kakehashi picks them up too — nothing is locked in.
 
-No more fragmented tooling per editor or language.
+## 🔌 Your language servers, in any editor
 
-### 🔗 Bridge for Embedded Languages (Injection)
+The deep features — completions, hover, go-to-definition — come from the real language servers you already trust, like pyright, rust-analyzer, or marksman. kakehashi connects your document to the right one and routes its answers back into your editor.
 
-Markdown with code blocks? HTML with inline JavaScript? kakehashi detects these **injection regions** and can:
+Best of all, you set them up **once** in kakehashi. Move from Neovim to VS Code to Helix and the same language tooling follows you — no per-editor configuration to redo.
 
-1. **Provide Tree-sitter features directly** — semantic tokens and selection ranges work inside embedded code
-2. **Delegate to external language servers** — go-to-definition, hover, completion, etc. are forwarded to the appropriate language server (e.g., rust-analyzer for Rust code blocks)
+## 🪄 …even for code inside code
 
-This "virtual file" bridging lets you get full IDE features even inside embedded code.
+You're writing a Markdown README, a Jupyter-style notebook, or an R Markdown report. It's full of embedded code:
 
----
+````markdown
+```python
+import pandas as pd
+df = pd.read_csv("data.csv")
+df.   # ← completions, right here
+```
+````
 
-## Features
+kakehashi spots these embedded regions and reaches both bridges right inside them:
 
-| Feature | Host | Injection | Bridge |
-|---------|:----:|:---------:|:------:|
-| Semantic Tokens | ✅ | ✅ | — |
-| Selection Range | ✅ | ✅ | — |
-| Go-to Definition | — | — | ✅ |
-| Go-to Type Definition | — | — | ✅ |
-| Go-to Implementation | — | — | ✅ |
-| Go-to Declaration | — | — | ✅ |
-| Hover | — | — | ✅ |
-| Completion | — | — | ✅ |
-| Signature Help | — | — | ✅ |
-| Find References | — | — | ✅ |
+- ✨ **Highlighting** that understands each embedded language
+- 🧠 **Completions, hover, and go-to-definition** from its language server, inline
+- 🎯 **Smart selection** that follows the embedded code's structure
 
-- **Host**: Features for the main document language
-- **Injection**: Features for embedded language regions
-- **Bridge**: Features delegated to external language servers
+The same trick works anywhere languages nest — SQL in a JavaScript string, CSS and JavaScript in HTML, code blocks in Markdown. A single Markdown file can get marksman for the prose **and** pyright for the Python blocks, all at once.
 
----
+## Take it for a spin
 
-## Installation
-
-### Pre-built Binaries
-
-Download the latest release for your platform from [GitHub Releases](https://github.com/atusy/kakehashi/releases).
-
-### Enable Automatic Parser/Query Installation
-
-Prepare the following, and kakehashi will auto-install Tree-sitter parsers and queries as needed:
-
-- C compiler
-- Git (optional — only needed for non-GitHub parser repositories)
-
----
-
-## Quick Start
-
-See [docs/README.md](docs/README.md) for detailed setup instructions for various editors.
-
-### Neovim
+Want to see kakehashi in action before wiring it into your own setup? Clone the repo and launch a ready-to-go Neovim:
 
 ```bash
 make deps/nvim
 nvim -u scripts/minimal_init.lua
 ```
 
----
+Open a Markdown file with a code block and watch the highlighting and completions light up.
 
-## Why kakehashi?
+## Quick Start
 
-Traditional language servers are language-specific. Tree-sitter parsers are fast and universal, but historically lacked the "smart" features. kakehashi bridges both worlds:
+### 1. Install
 
-- **Universal parsing** via Tree-sitter
-- **Smart features** via LSP bridge to specialized language servers
-- **Editor-agnostic** — works with any LSP client
+Download the binary for your platform from [GitHub Releases](https://github.com/atusy/kakehashi/releases) and put it on your `PATH`.
 
-Whether you're editing a Markdown document with embedded Rust, or an HTML file with inline CSS and JavaScript, kakehashi acts as the 架け橋 (bridge) that connects everything together.
+To let kakehashi auto-install the parsers it needs, make sure a **C compiler** is available (`xcode-select --install` on macOS, `build-essential` on Debian/Ubuntu, Build Tools on Windows).
 
----
+### 2. Wire it into your editor
+
+**Neovim** (built-in LSP, 0.11+):
+
+```lua
+vim.lsp.config.kakehashi = {
+  cmd = { "kakehashi" },
+  init_options = { autoInstall = true },
+}
+vim.lsp.enable("kakehashi")
+
+-- Let kakehashi own highlighting (avoids double-highlighting)
+vim.api.nvim_create_autocmd("FileType", {
+  callback = function()
+    vim.treesitter.stop()
+  end,
+})
+```
+
+Open a file and you'll have highlighting and smart selection immediately.
+
+### 3. Bring in the language servers (optional)
+
+Want completions and hover inside your code blocks? Point kakehashi at the language servers you already use — for example pyright for Python or lua-language-server for Lua.
+
+See **[docs/README.md](docs/README.md)** for the full setup: connecting language servers, configuring other editors, the CLI, and every option.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -73,17 +73,21 @@ To let kakehashi auto-install the parsers it needs, make sure a **C compiler** i
 
 ```lua
 vim.lsp.config.kakehashi = {
-  cmd = { "kakehashi" },
-  init_options = { autoInstall = true },
+    cmd = { "kakehashi" },
+    init_options = { autoInstall = true },
+    on_attach = function(_, bufnr)
+        -- Let kakehashi own highlighting (avoids double-highlighting)
+        vim.api.nvim_create_autocmd("LspTokenUpdate", {
+            buffer = bufnr,
+            once = true,
+            callback = function()
+                vim.opt_local.syntax = "OFF"
+                vim.treesitter.stop(bufnr)
+            end,
+        })
+    end,
 }
 vim.lsp.enable("kakehashi")
-
--- Let kakehashi own highlighting (avoids double-highlighting)
-vim.api.nvim_create_autocmd("FileType", {
-  callback = function()
-    vim.treesitter.stop()
-  end,
-})
 ```
 
 Open a file and you'll have highlighting and smart selection immediately.


### PR DESCRIPTION
## Why

The README read like a technical spec — LSP/injection/semantic-token jargon, a partial feature matrix, and a Quick Start that pointed users at contributor tooling (`make deps/nvim; nvim -u scripts/minimal_init.lua`) as if it were setup. Its own header comment asks to *avoid technical details and focus on users*, which the content didn't honor. This recasts it as an entrypoint whose job is to make people *want* kakehashi.

## What changed

- **Headline reframed around kakehashi's true identity: the bridge (架け橋)** — across editors, languages, and the language servers that make them smart. The previous draft's "one language server that brings rich editing" overclaimed; the deep features come from *other* servers kakehashi bridges to.
- **Body mirrors the three-bridge headline**, in order:
  - 🎨 native highlighting + smart selection for any Tree-sitter language — and **extensible** with your own grammar/queries
  - 🔌 your language servers' features, **configured once in kakehashi** and portable across editors
  - 🪄 both bridges brought **inside embedded code** (Python in Markdown, SQL in JS…), plus host-document bridging
- **Quick Start is now a real user setup** (Neovim `vim.lsp.config`), with the clone-and-run `minimal_init.lua` kept as a zero-commitment "take it for a spin" demo.
- **Exhaustive reference stays in `docs/README.md`** — the README links to it rather than duplicating config/CLI/feature tables.

## Note

Docs-only change. Accuracy was checked against `docs/README.md` and the bridge behavior (`bridge._self` host bridging, layer ordering) — no invented or overstated features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)