### PR TITLE
feat(parse-scheduler): strict (incarnation, ticket) epoch CAS

### DIFF
--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -6,12 +6,22 @@ use tree_sitter::{InputEdit, Tree};
 pub(crate) struct DocumentSnapshot {
     text: Arc<str>,
     tree: Tree,
+    incarnation: u64,
 }
 
 impl DocumentSnapshot {
     /// Get the text content
     pub(crate) fn text(&self) -> &str {
         &self.text
+    }
+
+    /// The open incarnation of the document this snapshot was taken from
+    /// (see [`Document::incarnation`]). Captured atomically with the text and
+    /// tree under the same shard read lock, so a consumer can later detect a
+    /// close-then-reopen that raced its request by comparing against the URI's
+    /// current incarnation.
+    pub(crate) fn incarnation(&self) -> u64 {
+        self.incarnation
     }
 
     /// Cheaply clone the text as a shared `Arc<str>` (a refcount bump, no copy)
@@ -54,36 +64,60 @@ pub struct Document {
     /// unedited tree against wholly-replaced text would violate tree-sitter's
     /// incremental contract and corrupt external scanners (#348).
     pending_seed: Option<Tree>,
+    /// The document's **open incarnation** — a process-wide-unique number drawn
+    /// from [`DocumentStore`](crate::document::store::DocumentStore)'s monotonic
+    /// counter at every construction (so a `didClose` + reopen of the same URI
+    /// yields a fresh value). Stored *on the document* so a tree-write CAS or a
+    /// watermark advance can check it **atomically with the document state**
+    /// under the same shard lock — closing the residual where an in-flight
+    /// off-ingress parse from a prior lifetime publishes against the reopened
+    /// document (`per-document-parse-scheduler`, the `(incarnation, ticket)`
+    /// epoch).
+    ///
+    /// Edits preserve it (an edit is the same lifetime); only a fresh
+    /// construction (didOpen / a reordered mutation registering an unopened URI)
+    /// draws a new one. A `Document` built outside the store keeps `0`;
+    /// incarnation is only meaningful relative to that store's counter, and the
+    /// store assigns every document it owns a nonzero value.
+    incarnation: u64,
 }
 
 impl Document {
     /// Create a new document with just text
-    pub(crate) fn new(text: String) -> Self {
+    pub(crate) fn new(text: String, incarnation: u64) -> Self {
         Self {
             text: Arc::from(text),
             language_id: None,
             tree: None,
             pending_seed: None,
+            incarnation,
         }
     }
 
     /// Create with language but no tree yet (for early document registration)
-    pub(crate) fn with_language(text: String, language_id: String) -> Self {
+    pub(crate) fn with_language(text: String, language_id: String, incarnation: u64) -> Self {
         Self {
             text: Arc::from(text),
             language_id: Some(language_id),
             tree: None,
             pending_seed: None,
+            incarnation,
         }
     }
 
     /// Create with language and tree
-    pub(crate) fn with_tree(text: String, language_id: String, tree: Tree) -> Self {
+    pub(crate) fn with_tree(
+        text: String,
+        language_id: String,
+        tree: Tree,
+        incarnation: u64,
+    ) -> Self {
         Self {
             text: Arc::from(text),
             language_id: Some(language_id),
             tree: Some(tree),
             pending_seed: None,
+            incarnation,
         }
     }
 
@@ -109,6 +143,12 @@ impl Document {
         self.tree.as_ref()
     }
 
+    /// The document's open incarnation (see the [`incarnation`](Self::incarnation)
+    /// field).
+    pub(crate) fn incarnation(&self) -> u64 {
+        self.incarnation
+    }
+
     /// Get a position mapper for this document
     pub(crate) fn position_mapper(&self) -> crate::text::PositionMapper {
         crate::text::PositionMapper::new(self.text())
@@ -122,6 +162,7 @@ impl Document {
         Some(DocumentSnapshot {
             text: self.text.clone(),
             tree: self.tree.as_ref()?.clone(),
+            incarnation: self.incarnation,
         })
     }
 
@@ -216,7 +257,7 @@ mod tests {
 
     #[test]
     fn test_document_creation() {
-        let doc = Document::new("hello world".to_string());
+        let doc = Document::new("hello world".to_string(), 0);
         assert_eq!(doc.text(), "hello world");
         assert_eq!(doc.text().len(), 11);
         assert!(!doc.text().is_empty());
@@ -230,7 +271,7 @@ mod tests {
             .unwrap();
         let tree = parser.parse("fn main() {}", None).unwrap();
 
-        let doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree);
+        let doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree, 0);
 
         assert_eq!(doc.text(), "fn main() {}");
         assert!(doc.tree().is_some());
@@ -239,7 +280,7 @@ mod tests {
 
     #[test]
     fn test_update_text() {
-        let mut doc = Document::new("initial".to_string());
+        let mut doc = Document::new("initial".to_string(), 0);
         doc.update_text("updated".to_string());
         assert_eq!(doc.text(), "updated");
         assert!(doc.tree().is_none());
@@ -254,7 +295,7 @@ mod tests {
             .set_language(&tree_sitter_rust::LANGUAGE.into())
             .unwrap();
         let tree = parser.parse("fn main() {}", None).unwrap();
-        let mut doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree);
+        let mut doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree, 0);
 
         // Insert a space at byte 11 (before the closing brace): "fn main() { }".
         let edit = InputEdit {
@@ -285,7 +326,7 @@ mod tests {
             .set_language(&tree_sitter_rust::LANGUAGE.into())
             .unwrap();
         let tree = parser.parse("fn main() {}", None).unwrap();
-        let mut doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree);
+        let mut doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree, 0);
 
         // Full-text sync carries no InputEdits.
         doc.apply_edit_and_seed("totally different content".to_string(), &[]);
@@ -306,7 +347,7 @@ mod tests {
             .set_language(&tree_sitter_rust::LANGUAGE.into())
             .unwrap();
         let tree = parser.parse("fn main() {}", None).unwrap();
-        let mut doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree);
+        let mut doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree, 0);
 
         let edit1 = InputEdit {
             start_byte: 11,
@@ -347,7 +388,7 @@ mod tests {
             .set_language(&tree_sitter_rust::LANGUAGE.into())
             .unwrap();
         let tree = parser.parse("fn main() {}", None).unwrap();
-        let mut doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree);
+        let mut doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree, 0);
 
         let edit = InputEdit {
             start_byte: 11,
@@ -390,7 +431,7 @@ mod tests {
 
         // update_tree_and_text clears the seed.
         let tree = parser.parse("fn main() {}", None).unwrap();
-        let mut doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree);
+        let mut doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree, 0);
         doc.apply_edit_and_seed("fn main() { }".to_string(), &[edit]);
         assert!(doc.pending_seed().is_some());
         let t2 = parser.parse("fn main() { }", None).unwrap();
@@ -409,7 +450,7 @@ mod tests {
             .unwrap();
         let tree = parser.parse("fn main() {}", None).unwrap();
 
-        let doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree);
+        let doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree, 0);
 
         // Snapshot should succeed for fully initialized document
         let snapshot = doc.snapshot();
@@ -422,7 +463,7 @@ mod tests {
 
     #[test]
     fn test_document_snapshot_none_when_no_tree() {
-        let doc = Document::new("test".to_string());
+        let doc = Document::new("test".to_string(), 0);
         // No tree, so snapshot should be None
         assert!(doc.snapshot().is_none());
     }
@@ -435,7 +476,7 @@ mod tests {
             .unwrap();
         let tree = parser.parse("fn main() {}", None).unwrap();
 
-        let doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree);
+        let doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree, 0);
 
         // Create snapshot
         let snapshot = doc.snapshot().unwrap();
@@ -454,7 +495,7 @@ mod tests {
 
     #[test]
     fn text_arc_is_a_cheap_shared_clone() {
-        let doc = Document::new("shared text".to_string());
+        let doc = Document::new("shared text".to_string(), 0);
         let a = doc.text_arc();
         let b = doc.text_arc();
         // Both handles point to the SAME allocation — a refcount bump, not a
@@ -470,7 +511,7 @@ mod tests {
             .set_language(&tree_sitter_rust::LANGUAGE.into())
             .unwrap();
         let tree = parser.parse("fn main() {}", None).unwrap();
-        let doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree);
+        let doc = Document::with_tree("fn main() {}".to_string(), "rust".to_string(), tree, 0);
 
         let snapshot = doc.snapshot().unwrap();
 
@@ -483,7 +524,7 @@ mod tests {
     fn update_text_installs_a_fresh_allocation() {
         // An edit replaces the `Arc` (so prior snapshots keep their bytes); the
         // new text is correct.
-        let mut doc = Document::new("v1".to_string());
+        let mut doc = Document::new("v1".to_string(), 0);
         let before = doc.text_arc();
         doc.update_text("v2".to_string());
         let after = doc.text_arc();

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -365,25 +365,38 @@ impl DocumentStore {
     }
 
     /// Like [`update_tree_if_text_unchanged`], but additionally requires the
-    /// document's `language_id` to still equal `expected_language_id`.
+    /// document's `language_id` to still equal `expected_language_id` **and** its
+    /// open incarnation to still equal `expected_incarnation`.
     ///
     /// For the off-ingress edit reparse (`reparse_latest`), whose tree was parsed
-    /// with a grammar chosen from the language detected at read time. A
-    /// `didClose` + reopen of the same URI with **identical text but a different
-    /// `language_id`** while the parse is in flight would, under the text-only CAS,
-    /// attach a tree parsed by the *old* grammar to the reopened document — wrong
-    /// tokens. Folding the language check into the same `get_mut` shard lock as the
-    /// text check rejects that atomically. (Same-language identical-text reopen
-    /// stays benign: the tree is a correct parse of the identical text.)
+    /// from the text, grammar, and lifetime observed at read time. Three axes,
+    /// checked atomically under the same `get_mut` shard lock as the tree write:
+    /// - **text** rejects a within-lifetime stale parse — a `didChange` landed
+    ///   while parsing, so the tree is of now-superseded text (the scheduler's
+    ///   `dirty` loop reparses the newer text);
+    /// - **language** rejects a close + reopen with identical text but a different
+    ///   `language_id` — a tree parsed by the *old* grammar must not attach to the
+    ///   relabelled document;
+    /// - **incarnation** rejects a close + reopen even with identical text *and*
+    ///   language — the tree belongs to the prior lifetime, and attaching it to
+    ///   the reopened document (then advancing its watermark on the old ticket)
+    ///   would let a new-lifetime reader observe a parse it never requested. This
+    ///   is the [`(incarnation, ticket)`](Document::incarnation) epoch's
+    ///   incarnation half; the text and language checks remain because they guard
+    ///   the orthogonal within-lifetime races above.
     pub(crate) fn update_tree_if_text_and_language_unchanged(
         &self,
         uri: &Url,
         expected_text: &str,
         expected_language_id: Option<&str>,
+        expected_incarnation: u64,
         new_tree: Tree,
     ) -> bool {
         let stored = if let Some(mut doc) = self.documents.get_mut(uri) {
-            if doc.text() == expected_text && doc.language_id() == expected_language_id {
+            if doc.incarnation() == expected_incarnation
+                && doc.text() == expected_text
+                && doc.language_id() == expected_language_id
+            {
                 doc.set_tree(new_tree);
                 true
             } else {
@@ -712,11 +725,13 @@ mod tests {
             Some("ruby".to_string()),
             None,
         );
+        let incarnation = store.get(&uri).unwrap().incarnation();
 
         let stored = store.update_tree_if_text_and_language_unchanged(
             &uri,
             "fn main() {}",
             Some("rust"),
+            incarnation,
             parse_rust("fn main() {}"),
         );
         assert!(
@@ -728,14 +743,55 @@ mod tests {
             "the relabelled document keeps no wrong-grammar tree"
         );
 
-        // Same language → stores.
+        // Same language and incarnation → stores.
         assert!(store.update_tree_if_text_and_language_unchanged(
             &uri,
             "fn main() {}",
             Some("ruby"),
+            incarnation,
             parse_rust("fn main() {}"),
         ));
         assert!(store.get(&uri).unwrap().tree().is_some());
+    }
+
+    #[test]
+    fn update_tree_if_text_and_language_unchanged_rejects_a_reopen_with_a_fresh_incarnation() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///reopened.rs").unwrap();
+        store.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        // An off-ingress parse read this lifetime's incarnation, then the document
+        // was closed and reopened with identical text and language while the parse
+        // was in flight.
+        let stale_incarnation = store.get(&uri).unwrap().incarnation();
+        store.remove(&uri);
+        store.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+
+        let stored = store.update_tree_if_text_and_language_unchanged(
+            &uri,
+            "fn main() {}",
+            Some("rust"),
+            stale_incarnation,
+            parse_rust("fn main() {}"),
+        );
+        assert!(
+            !stored,
+            "a tree from the prior lifetime must not attach to the reopened \
+             document even when text and language are identical"
+        );
+        assert!(
+            store.get(&uri).unwrap().tree().is_none(),
+            "the reopened document keeps no tree from the closed lifetime"
+        );
     }
 
     #[test]

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -439,21 +439,33 @@ impl DocumentStore {
         stored
     }
 
-    /// Like [`update_tree_if_text_unchanged`], but additionally stores the tree
-    /// only if the document currently has **no** tree. For the off-ingress install
-    /// reparse (`reparse_installed_document`), whose "don't clobber a concurrent
-    /// parse" guard is a `tree.is_some()` pre-check: a parse attaching a tree for
-    /// the same text *between* that pre-check and this write would otherwise be
-    /// overwritten. Folding the `tree.is_none()` check into the same `get_mut` shard
-    /// lock as the text comparison makes the guard atomic.
+    /// Like [`update_tree_if_text_and_language_unchanged`], but additionally stores
+    /// the tree only if the document currently has **no** tree. For the off-ingress
+    /// install reparse (`reparse_installed_document`), whose "don't clobber a
+    /// concurrent parse" guard is a `tree.is_some()` pre-check: a parse attaching a
+    /// tree for the same text *between* that pre-check and this write would otherwise
+    /// be overwritten. Folding the `tree.is_none()` check into the same `get_mut`
+    /// shard lock as the text comparison makes the guard atomic.
+    ///
+    /// Carries the same `language` and `incarnation` axes as
+    /// [`update_tree_if_text_and_language_unchanged`], for the same reason: the
+    /// install reparse is off-ingress, so a `didClose` + reopen (possibly relabelling
+    /// the language) can race it. Without these checks the freshly-installed grammar's
+    /// tree could attach to a reopened — even relabelled — document.
     pub(crate) fn attach_tree_if_absent(
         &self,
         uri: &Url,
         expected_text: &str,
+        expected_language_id: Option<&str>,
+        expected_incarnation: u64,
         new_tree: Tree,
     ) -> bool {
         let stored = if let Some(mut doc) = self.documents.get_mut(uri) {
-            if doc.tree().is_none() && doc.text() == expected_text {
+            if doc.tree().is_none()
+                && doc.incarnation() == expected_incarnation
+                && doc.text() == expected_text
+                && doc.language_id() == expected_language_id
+            {
                 doc.set_tree(new_tree);
                 true
             } else {
@@ -812,18 +824,70 @@ mod tests {
             Some("rust".to_string()),
             None,
         );
+        let incarnation = store.get(&uri).unwrap().incarnation();
 
         // No tree yet → stores.
-        assert!(store.attach_tree_if_absent(&uri, "fn main() {}", parse_rust("fn main() {}")));
+        assert!(store.attach_tree_if_absent(
+            &uri,
+            "fn main() {}",
+            Some("rust"),
+            incarnation,
+            parse_rust("fn main() {}")
+        ));
         let first = store.get(&uri).unwrap().tree().unwrap().root_node().id();
 
         // A tree is now present → a second attach must NOT clobber it (the guard
         // is atomic with the write, unlike a separate tree.is_some() pre-check).
-        assert!(!store.attach_tree_if_absent(&uri, "fn main() {}", parse_rust("fn main() {}")));
+        assert!(!store.attach_tree_if_absent(
+            &uri,
+            "fn main() {}",
+            Some("rust"),
+            incarnation,
+            parse_rust("fn main() {}")
+        ));
         assert_eq!(
             store.get(&uri).unwrap().tree().unwrap().root_node().id(),
             first,
             "an existing tree must be preserved, not overwritten"
+        );
+    }
+
+    #[test]
+    fn attach_tree_if_absent_rejects_a_reopen_with_a_fresh_incarnation() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///reinstalled.rs").unwrap();
+        store.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        // An install reparse read this lifetime's incarnation, then the document was
+        // closed and reopened (same text + language, no tree yet) while the install
+        // finished.
+        let stale_incarnation = store.get(&uri).unwrap().incarnation();
+        store.remove(&uri);
+        store.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+
+        assert!(
+            !store.attach_tree_if_absent(
+                &uri,
+                "fn main() {}",
+                Some("rust"),
+                stale_incarnation,
+                parse_rust("fn main() {}")
+            ),
+            "a freshly-installed grammar's tree from the prior lifetime must not \
+             attach to the reopened document"
+        );
+        assert!(
+            store.get(&uri).unwrap().tree().is_none(),
+            "the reopened document keeps no tree from the closed lifetime"
         );
     }
 
@@ -912,7 +976,15 @@ mod tests {
     fn attach_tree_if_absent_does_not_resurrect_closed_document() {
         let store = DocumentStore::new();
         let uri = Url::parse("file:///closed.rs").unwrap();
-        assert!(!store.attach_tree_if_absent(&uri, "fn main() {}", parse_rust("fn main() {}")));
+        // No document exists, so the CAS rejects regardless of the expected
+        // language/incarnation (they are never compared on the Vacant path).
+        assert!(!store.attach_tree_if_absent(
+            &uri,
+            "fn main() {}",
+            Some("rust"),
+            1,
+            parse_rust("fn main() {}")
+        ));
         assert!(
             store.get(&uri).is_none(),
             "must not resurrect a closed document"
@@ -1084,6 +1156,26 @@ mod tests {
             watermark_of(&store, &uri),
             Some(1),
             "the reopened lifetime's own parse advances its watermark"
+        );
+    }
+
+    #[test]
+    fn apply_edit_clearing_tree_preserves_the_watermark_ticket() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///wm.rs").unwrap();
+        seed_document(&store, &uri);
+        let incarnation = store.get(&uri).unwrap().incarnation();
+        store.advance_watermark_for_incarnation(&uri, 7, incarnation);
+        assert_eq!(watermark_of(&store, &uri), Some(7));
+
+        // An edit is the same lifetime: `ensure_watermark_entry` must hit its
+        // matching-incarnation fast path and leave the live ticket untouched (a
+        // reset to 0 would prematurely release readers gated behind ticket 7).
+        store.apply_edit_clearing_tree(&uri, "xy".to_string(), &[]);
+        assert_eq!(
+            watermark_of(&store, &uri),
+            Some(7),
+            "an edit (same incarnation) must not reset the live watermark ticket"
         );
     }
 

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -207,12 +207,15 @@ impl DocumentStore {
             _ => Document::new(text, incarnation),
         };
 
-        self.documents.insert(uri.clone(), document);
+        // The parse-state and watermark maps are independent of `documents`, so seed
+        // them with the borrowed `&uri` first and let `documents.insert` consume the
+        // owned `uri` last — avoiding a `Url` clone on every didOpen.
         self.update_tree_availability(&uri, has_tree);
         // Seed the watermark for this lifetime's incarnation so its lifetime tracks
         // the document's; the advance paths are non-inserting and rely on this
         // entry being present. A reopen replaces any leftover prior-lifetime channel.
         self.ensure_watermark_entry(&uri, incarnation);
+        self.documents.insert(uri, document);
     }
 
     // Lock safety: Returns DocumentHandle wrapping Ref - caller holds read lock until drop
@@ -226,41 +229,55 @@ impl DocumentStore {
     pub fn update_document(&self, uri: Url, text: String, new_tree: Option<Tree>) {
         // Use entry API for atomic operations to prevent race conditions
         // between checking if document exists and inserting/updating.
-        let (has_tree, incarnation) = match self.documents.entry(uri.clone()) {
-            Entry::Occupied(mut entry) => {
-                // Document exists - update in place, preserving its incarnation
-                // (an edit is the same lifetime).
-                let doc = entry.get_mut();
-                let has_tree = if let Some(tree) = new_tree {
-                    doc.update_tree_and_text(tree, text);
-                    true
-                } else {
-                    // No new tree provided - clear existing tree and update text only.
-                    // This path is used when text changes without re-parsing (rare edge case).
-                    doc.update_text(text);
-                    false
-                };
-                (has_tree, doc.incarnation())
-            }
-            Entry::Vacant(entry) => {
-                // Document doesn't exist - create new one (a fresh lifetime →
-                // fresh incarnation). `next_incarnation` touches only the atomic
-                // counter, not `documents`, so drawing it while holding this
-                // entry's shard write lock cannot deadlock.
-                let incarnation = self.next_incarnation();
-                let has_tree = if let Some(tree) = new_tree {
-                    entry.insert(Document::with_tree(
-                        text,
-                        "unknown".to_string(),
-                        tree,
-                        incarnation,
-                    ));
-                    true
-                } else {
-                    entry.insert(Document::new(text, incarnation));
-                    false
-                };
-                (has_tree, incarnation)
+        // Hot path (the document already exists): `get_mut` borrows the key, so no
+        // `Url` clone. Only a miss falls back to `entry` (owned key), which re-checks
+        // for a document a concurrent insert added between the `get_mut` and here —
+        // matching `apply_edit_clearing_tree`.
+        let (has_tree, incarnation) = if let Some(mut doc) = self.documents.get_mut(&uri) {
+            // Update in place, preserving the incarnation (an edit is the same lifetime).
+            let has_tree = if let Some(tree) = new_tree {
+                doc.update_tree_and_text(tree, text);
+                true
+            } else {
+                // No new tree provided - clear existing tree and update text only.
+                // This path is used when text changes without re-parsing (rare edge case).
+                doc.update_text(text);
+                false
+            };
+            (has_tree, doc.incarnation())
+        } else {
+            match self.documents.entry(uri.clone()) {
+                Entry::Occupied(mut entry) => {
+                    let doc = entry.get_mut();
+                    let has_tree = if let Some(tree) = new_tree {
+                        doc.update_tree_and_text(tree, text);
+                        true
+                    } else {
+                        doc.update_text(text);
+                        false
+                    };
+                    (has_tree, doc.incarnation())
+                }
+                Entry::Vacant(entry) => {
+                    // Document doesn't exist - create new one (a fresh lifetime →
+                    // fresh incarnation). `next_incarnation` touches only the atomic
+                    // counter, not `documents`, so drawing it while holding this
+                    // entry's shard write lock cannot deadlock.
+                    let incarnation = self.next_incarnation();
+                    let has_tree = if let Some(tree) = new_tree {
+                        entry.insert(Document::with_tree(
+                            text,
+                            "unknown".to_string(),
+                            tree,
+                            incarnation,
+                        ));
+                        true
+                    } else {
+                        entry.insert(Document::new(text, incarnation));
+                        false
+                    };
+                    (has_tree, incarnation)
+                }
             }
         };
         self.update_tree_availability(&uri, has_tree);

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -507,6 +507,36 @@ impl DocumentStore {
         });
     }
 
+    /// Advance the watermark to `ticket`, but only if the document's current open
+    /// incarnation still equals `expected_incarnation` — the lifetime that issued
+    /// the ticket.
+    ///
+    /// For the off-ingress parse: its ticket is the *intra-lifetime* wire order,
+    /// and the watermark is removed on close and re-seeded at 0 on reopen
+    /// (per-lifetime, not globally monotonic). So a parse from a prior lifetime
+    /// completing after a close + reopen must **not** advance the reopened
+    /// document's fresh watermark — its (smaller) ticket could exceed a
+    /// new-lifetime reader's target and release that reader before the reopen's
+    /// own parse has run (a stale/empty read). Gating on the incarnation confines
+    /// each lifetime's watermark to its own parses. A closed (absent) document is
+    /// a no-op: its watermark is already gone and its readers were woken by the
+    /// close. The `documents` `Ref` is dropped before the `watermarks` lock is
+    /// taken (the documents → watermarks order).
+    pub(crate) fn advance_watermark_for_incarnation(
+        &self,
+        uri: &Url,
+        ticket: u64,
+        expected_incarnation: u64,
+    ) {
+        let current_incarnation = match self.documents.get(uri) {
+            Some(doc) => doc.incarnation(),
+            None => return,
+        };
+        if current_incarnation == expected_incarnation {
+            self.advance_watermark(uri, ticket);
+        }
+    }
+
     /// Wait until the parse watermark for `uri` reaches `target` — the tail
     /// ingress ticket a virt/native reader must observe — bounded by `timeout`.
     ///
@@ -924,6 +954,52 @@ mod tests {
             watermark_of(&store, &uri),
             None,
             "a publish after close must not resurrect a watermark entry"
+        );
+    }
+
+    #[test]
+    fn advance_watermark_for_incarnation_advances_within_the_same_lifetime() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///wm.rs").unwrap();
+        seed_document(&store, &uri);
+        let incarnation = store.get(&uri).unwrap().incarnation();
+
+        store.advance_watermark_for_incarnation(&uri, 5, incarnation);
+        assert_eq!(
+            watermark_of(&store, &uri),
+            Some(5),
+            "a parse from the current lifetime advances the watermark"
+        );
+    }
+
+    #[test]
+    fn advance_watermark_for_incarnation_skips_a_prior_lifetime() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///wm.rs").unwrap();
+        seed_document(&store, &uri);
+        let stale_incarnation = store.get(&uri).unwrap().incarnation();
+
+        // Close + reopen: the watermark is dropped and re-seeded at 0 for the new
+        // lifetime. A straggler parse from the prior lifetime then resolves with
+        // its old ticket; it must NOT advance the reopened document's watermark
+        // (which would prematurely release a new-lifetime reader).
+        store.remove(&uri);
+        seed_document(&store, &uri);
+
+        store.advance_watermark_for_incarnation(&uri, 9, stale_incarnation);
+        assert_eq!(
+            watermark_of(&store, &uri),
+            Some(0),
+            "a prior lifetime's parse must not advance the reopened watermark"
+        );
+
+        // The reopen's own parse (current incarnation) does advance it.
+        let fresh_incarnation = store.get(&uri).unwrap().incarnation();
+        store.advance_watermark_for_incarnation(&uri, 1, fresh_incarnation);
+        assert_eq!(
+            watermark_of(&store, &uri),
+            Some(1),
+            "the reopened lifetime's own parse advances its watermark"
         );
     }
 

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -50,12 +50,12 @@ pub struct DocumentStore {
     /// parse *off* the ingress ticket, at which point ticket-completion no longer
     /// implies a fresh tree and this watermark — not the completion channel — is
     /// what tells a virt/native reader the store reflects its tail edit. Keyed on
-    /// the ticket (the intra-lifetime wire order); the incarnation half of the
-    /// `(incarnation, ticket)` epoch gates the off-ingress *advance*
-    /// ([`advance_watermark_for_incarnation`](Self::advance_watermark_for_incarnation)),
-    /// so a prior lifetime's parse cannot advance a reopened document's
-    /// re-seeded watermark.
-    watermarks: DashMap<Url, watch::Sender<u64>>,
+    /// the ticket (the intra-lifetime wire order). The channel value carries the
+    /// lifetime's [`incarnation`](Watermark) too, so the off-ingress advance
+    /// ([`advance_watermark_for_incarnation`](Self::advance_watermark_for_incarnation))
+    /// gates on it atomically with the ticket write — a prior lifetime's parse
+    /// cannot advance a reopened document's re-seeded watermark.
+    watermarks: DashMap<Url, watch::Sender<Watermark>>,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -63,6 +63,20 @@ struct ParseState {
     generation: u64,
     in_progress: bool,
     has_tree: bool,
+}
+
+/// The value carried by a document's parse-watermark channel: the open
+/// `incarnation` the channel belongs to, and the highest `ticket` whose parse
+/// has resolved for that lifetime. Storing the incarnation **in the channel**
+/// lets the off-ingress advance compare it against the parse's captured
+/// incarnation *atomically* with the ticket write (inside `send_if_modified`,
+/// under the watch's own lock), so a straggler parse from a prior lifetime can
+/// never advance a reopened document's freshly re-seeded watermark — without a
+/// second-map lookup or any documents↔watermarks lock ordering.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct Watermark {
+    incarnation: u64,
+    ticket: u64,
 }
 
 pub struct DocumentHandle<'a> {
@@ -195,9 +209,10 @@ impl DocumentStore {
 
         self.documents.insert(uri.clone(), document);
         self.update_tree_availability(&uri, has_tree);
-        // Seed the watermark so its lifetime tracks the document's; `advance_watermark`
-        // is non-inserting and relies on this entry being present.
-        self.ensure_watermark_entry(&uri);
+        // Seed the watermark for this lifetime's incarnation so its lifetime tracks
+        // the document's; the advance paths are non-inserting and rely on this
+        // entry being present. A reopen replaces any leftover prior-lifetime channel.
+        self.ensure_watermark_entry(&uri, incarnation);
     }
 
     // Lock safety: Returns DocumentHandle wrapping Ref - caller holds read lock until drop
@@ -211,11 +226,12 @@ impl DocumentStore {
     pub fn update_document(&self, uri: Url, text: String, new_tree: Option<Tree>) {
         // Use entry API for atomic operations to prevent race conditions
         // between checking if document exists and inserting/updating.
-        let has_tree = match self.documents.entry(uri.clone()) {
+        let (has_tree, incarnation) = match self.documents.entry(uri.clone()) {
             Entry::Occupied(mut entry) => {
-                // Document exists - update in place
+                // Document exists - update in place, preserving its incarnation
+                // (an edit is the same lifetime).
                 let doc = entry.get_mut();
-                if let Some(tree) = new_tree {
+                let has_tree = if let Some(tree) = new_tree {
                     doc.update_tree_and_text(tree, text);
                     true
                 } else {
@@ -223,7 +239,8 @@ impl DocumentStore {
                     // This path is used when text changes without re-parsing (rare edge case).
                     doc.update_text(text);
                     false
-                }
+                };
+                (has_tree, doc.incarnation())
             }
             Entry::Vacant(entry) => {
                 // Document doesn't exist - create new one (a fresh lifetime →
@@ -231,7 +248,7 @@ impl DocumentStore {
                 // counter, not `documents`, so drawing it while holding this
                 // entry's shard write lock cannot deadlock.
                 let incarnation = self.next_incarnation();
-                if let Some(tree) = new_tree {
+                let has_tree = if let Some(tree) = new_tree {
                     entry.insert(Document::with_tree(
                         text,
                         "unknown".to_string(),
@@ -242,15 +259,16 @@ impl DocumentStore {
                 } else {
                     entry.insert(Document::new(text, incarnation));
                     false
-                }
+                };
+                (has_tree, incarnation)
             }
         };
         self.update_tree_availability(&uri, has_tree);
         // Keep the "live document ⟺ watermark entry" invariant: `update_document`
         // can insert on its `Vacant` branch, and a present document with no
         // watermark entry would make `wait_for_epoch` treat it as unregistered.
-        // Idempotent on the (common) update-in-place path.
-        self.ensure_watermark_entry(&uri);
+        // Idempotent on the (common) update-in-place path (same incarnation).
+        self.ensure_watermark_entry(&uri, incarnation);
     }
 
     /// Apply a `didChange`'s new text and stash an **incremental parse seed**,
@@ -276,21 +294,28 @@ impl DocumentStore {
         // of the prior `update_document`. The `RefMut` / entry is dropped before the
         // parse-state and watermark updates below (separate maps), keeping the
         // `documents` shard lock held no longer than `update_document` did.
-        if let Some(mut doc) = self.documents.get_mut(uri) {
+        let incarnation = if let Some(mut doc) = self.documents.get_mut(uri) {
             doc.apply_edit_and_seed(text, edits);
+            doc.incarnation()
         } else {
             match self.documents.entry(uri.clone()) {
-                Entry::Occupied(mut entry) => entry.get_mut().apply_edit_and_seed(text, edits),
+                Entry::Occupied(mut entry) => {
+                    let doc = entry.get_mut();
+                    doc.apply_edit_and_seed(text, edits);
+                    doc.incarnation()
+                }
                 Entry::Vacant(entry) => {
                     // Reordered edit registering an unopened URI: a fresh
                     // lifetime → fresh incarnation (mirrors `update_document`).
-                    entry.insert(Document::new(text, self.next_incarnation()));
+                    let incarnation = self.next_incarnation();
+                    entry.insert(Document::new(text, incarnation));
+                    incarnation
                 }
             }
-        }
+        };
         self.update_tree_availability(uri, false);
         // Keep the "live document ⟺ watermark entry" invariant (see `update_document`).
-        self.ensure_watermark_entry(uri);
+        self.ensure_watermark_entry(uri, incarnation);
     }
 
     /// Record the didOpen parse's result (detected `language` + optional `tree`) on
@@ -466,20 +491,38 @@ impl DocumentStore {
         self.edit_locks.remove(uri);
     }
 
-    /// Ensure a watermark entry exists for `uri`, created at ticket 0. Idempotent:
-    /// an already-advanced watermark is left untouched. Called when a document is
-    /// registered ([`insert`](Self::insert)) so the watermark's lifetime tracks the
-    /// document's — it exists exactly while the document is open and is dropped by
-    /// [`remove`](Self::remove) on close.
-    fn ensure_watermark_entry(&self, uri: &Url) {
-        // `insert()` runs on every didChange; the entry almost always already
-        // exists. Probe with a borrowed `get` first so the common hit path takes
-        // no `Url` clone, paying the clone only on the (rare) first registration.
-        if self.watermarks.get(uri).is_none() {
-            self.watermarks
-                .entry(uri.clone())
-                .or_insert_with(|| watch::channel(0).0);
+    /// Ensure a watermark channel exists for `uri` carrying the current lifetime's
+    /// `incarnation`, created at ticket 0. Called when a document is registered or
+    /// edited so the watermark's lifetime tracks the document's — it exists exactly
+    /// while the document is open and is dropped by [`remove`](Self::remove) on close.
+    ///
+    /// Idempotent **within a lifetime**: an existing channel whose incarnation
+    /// already matches is left untouched, so an edit never resets the ticket. But a
+    /// channel left over from a *prior* lifetime (a different incarnation) is
+    /// **replaced** with a fresh one — this is what guarantees the channel's
+    /// incarnation always equals the document's, so a reopen starts at ticket 0 for
+    /// its own incarnation even if the prior channel somehow outlived its `remove`.
+    /// Replacing drops the old sender, waking any reader still parked on the prior
+    /// lifetime's channel (it falls back, exactly as on a close).
+    fn ensure_watermark_entry(&self, uri: &Url, incarnation: u64) {
+        // Probe with a borrowed `get` first (the common edit hit path takes no
+        // `Url` clone). Drop the `Ref` before any `insert` on the same map — a
+        // held read `Ref` across a write on the same key deadlocks.
+        let matches_current = self
+            .watermarks
+            .get(uri)
+            .is_some_and(|sender| sender.borrow().incarnation == incarnation);
+        if matches_current {
+            return;
         }
+        self.watermarks.insert(
+            uri.clone(),
+            watch::channel(Watermark {
+                incarnation,
+                ticket: 0,
+            })
+            .0,
+        );
     }
 
     /// Publish that the parse covering ingress writer `ticket` for `uri` has
@@ -500,9 +543,12 @@ impl DocumentStore {
         let Some(sender) = self.watermarks.get(uri).map(|sender| sender.clone()) else {
             return;
         };
+        // Bumps only the ticket; the channel's incarnation is fixed for the
+        // lifetime. For the on-ingress open parse, whose writer ticket gates any
+        // reopen, so it always runs against its own lifetime's channel.
         sender.send_if_modified(|watermark| {
-            if ticket > *watermark {
-                *watermark = ticket;
+            if ticket > watermark.ticket {
+                watermark.ticket = ticket;
                 true
             } else {
                 false
@@ -510,9 +556,8 @@ impl DocumentStore {
         });
     }
 
-    /// Advance the watermark to `ticket`, but only if the document's current open
-    /// incarnation still equals `expected_incarnation` — the lifetime that issued
-    /// the ticket.
+    /// Advance the watermark to `ticket`, but only if the channel still belongs to
+    /// `expected_incarnation` — the lifetime that issued the ticket.
     ///
     /// For the off-ingress parse: its ticket is the *intra-lifetime* wire order,
     /// and the watermark is removed on close and re-seeded at 0 on reopen
@@ -520,24 +565,35 @@ impl DocumentStore {
     /// completing after a close + reopen must **not** advance the reopened
     /// document's fresh watermark — its (smaller) ticket could exceed a
     /// new-lifetime reader's target and release that reader before the reopen's
-    /// own parse has run (a stale/empty read). Gating on the incarnation confines
-    /// each lifetime's watermark to its own parses. A closed (absent) document is
-    /// a no-op: its watermark is already gone and its readers were woken by the
-    /// close. The `documents` `Ref` is dropped before the `watermarks` lock is
-    /// taken (the documents → watermarks order).
+    /// own parse has run (a stale/empty read).
+    ///
+    /// The incarnation lives **in the channel value**, so the compare and the
+    /// ticket write happen together inside `send_if_modified`, under the watch's
+    /// own lock, against one consistent value — there is no check-then-write seam
+    /// for a concurrent reopen to slip through (the off-ingress advance holds no
+    /// `edit_lock`, so a `didClose`+`didOpen` *does* run concurrently with it).
+    /// Whichever channel this resolves against, the compare is against *that*
+    /// channel's incarnation: the reopen's fresh channel (incarnation mismatch →
+    /// skip) or the prior lifetime's now-detached channel (a harmless bump of a
+    /// channel whose readers the close already woke). A closed (absent) document
+    /// is a no-op.
     pub(crate) fn advance_watermark_for_incarnation(
         &self,
         uri: &Url,
         ticket: u64,
         expected_incarnation: u64,
     ) {
-        let current_incarnation = match self.documents.get(uri) {
-            Some(doc) => doc.incarnation(),
-            None => return,
+        let Some(sender) = self.watermarks.get(uri).map(|sender| sender.clone()) else {
+            return;
         };
-        if current_incarnation == expected_incarnation {
-            self.advance_watermark(uri, ticket);
-        }
+        sender.send_if_modified(|watermark| {
+            if watermark.incarnation == expected_incarnation && ticket > watermark.ticket {
+                watermark.ticket = ticket;
+                true
+            } else {
+                false
+            }
+        });
     }
 
     /// Wait until the parse watermark for `uri` reaches `target` — the tail
@@ -567,8 +623,13 @@ impl DocumentStore {
 
         let wait_future = async {
             // Err => the sender was dropped (entry removed after a close): every
-            // parse that will ever run for this lifetime has, so proceed.
-            let _ = receiver.wait_for(|watermark| *watermark >= target).await;
+            // parse that will ever run for this lifetime has, so proceed. A reader
+            // waits on its own lifetime's channel ticket; a reopen replaces the
+            // channel (dropping this sender → Err → fallback), so the target (an
+            // intra-lifetime ticket) is only ever compared within one lifetime.
+            let _ = receiver
+                .wait_for(|watermark| watermark.ticket >= target)
+                .await;
         };
 
         let _ = tokio::time::timeout(timeout, wait_future).await;
@@ -863,9 +924,9 @@ mod tests {
         );
     }
 
-    /// Read the published watermark for a URI (test-only; the field is private).
+    /// Read the published watermark ticket for a URI (test-only; the field is private).
     fn watermark_of(store: &DocumentStore, uri: &Url) -> Option<u64> {
-        store.watermarks.get(uri).map(|s| *s.borrow())
+        store.watermarks.get(uri).map(|s| s.borrow().ticket)
     }
 
     /// Register a document so its watermark entry is seeded (mirrors a didOpen).

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -505,24 +505,44 @@ impl DocumentStore {
     /// Replacing drops the old sender, waking any reader still parked on the prior
     /// lifetime's channel (it falls back, exactly as on a close).
     fn ensure_watermark_entry(&self, uri: &Url, incarnation: u64) {
-        // Probe with a borrowed `get` first (the common edit hit path takes no
-        // `Url` clone). Drop the `Ref` before any `insert` on the same map — a
-        // held read `Ref` across a write on the same key deadlocks.
-        let matches_current = self
+        // Fast path: a borrowed `get` (no `Url` clone) covers the common case — an
+        // edit whose channel is already at this incarnation needs nothing. The
+        // `Ref` is dropped at the end of this `if` before any write on the map.
+        if self
             .watermarks
             .get(uri)
-            .is_some_and(|sender| sender.borrow().incarnation == incarnation);
-        if matches_current {
+            .is_some_and(|sender| sender.borrow().incarnation == incarnation)
+        {
             return;
         }
-        self.watermarks.insert(
-            uri.clone(),
-            watch::channel(Watermark {
-                incarnation,
-                ticket: 0,
-            })
-            .0,
-        );
+        // Slow path: take the entry (shard write lock) and re-check under it, so two
+        // concurrent registrations for the same live incarnation can't both insert
+        // and reset a live ticket to 0 (the probe-then-insert race). A matching
+        // channel another racer just seeded is left untouched; only a missing or
+        // prior-lifetime channel is (re)seeded at ticket 0.
+        match self.watermarks.entry(uri.clone()) {
+            Entry::Occupied(mut entry) => {
+                let same_incarnation = entry.get().borrow().incarnation == incarnation;
+                if !same_incarnation {
+                    entry.insert(
+                        watch::channel(Watermark {
+                            incarnation,
+                            ticket: 0,
+                        })
+                        .0,
+                    );
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(
+                    watch::channel(Watermark {
+                        incarnation,
+                        ticket: 0,
+                    })
+                    .0,
+                );
+            }
+        }
     }
 
     /// Publish that the parse covering ingress writer `ticket` for `uri` has

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -51,7 +51,10 @@ pub struct DocumentStore {
     /// implies a fresh tree and this watermark — not the completion channel — is
     /// what tells a virt/native reader the store reflects its tail edit. Keyed on
     /// the ticket (the intra-lifetime wire order); the incarnation half of the
-    /// eventual `(incarnation, ticket)` epoch is not folded in yet.
+    /// `(incarnation, ticket)` epoch gates the off-ingress *advance*
+    /// ([`advance_watermark_for_incarnation`](Self::advance_watermark_for_incarnation)),
+    /// so a prior lifetime's parse cannot advance a reopened document's
+    /// re-seeded watermark.
     watermarks: DashMap<Url, watch::Sender<u64>>,
 }
 

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -27,13 +27,16 @@ pub struct DocumentStore {
     /// <https://github.com/atusy/kakehashi/issues/342>). Different documents keep
     /// their own locks and run concurrently.
     edit_locks: DashMap<Url, Arc<Mutex<()>>>,
-    /// Monotonic "open generation" per URI, lazily assigned on first ask and
-    /// cleared by [`remove`](Self::remove). A consumer that captures the
-    /// generation alongside a snapshot can later detect that the document was
-    /// closed and reopened in between — the reopened document draws a fresh
-    /// generation even though the URI looks alive again. See
+    /// Source of the process-wide-unique **open incarnation** stamped onto every
+    /// [`Document`] this store constructs (see [`Document::incarnation`] and
+    /// [`next_incarnation`](Self::next_incarnation)). Starts at 1, so a document
+    /// built outside the store (incarnation `0`) is always distinguishable from
+    /// one this store owns. The incarnation lives *on the document* rather than
+    /// in a side map, so a tree-write CAS or a watermark advance can check it
+    /// atomically with the document state under the same shard lock; a consumer
+    /// that captured a snapshot detects a close-then-reopen by comparing the
+    /// snapshot's incarnation against the URI's current one. See
     /// `Kakehashi::store_lineage` (captures-protocol §"Delta semantics").
-    open_generations: DashMap<Url, u64>,
     open_counter: std::sync::atomic::AtomicU64,
     /// Per-document **parse watermark**: the highest ingress writer ticket whose
     /// parse has reached a terminal outcome (a tree, or parsed-to-nothing). It is
@@ -83,8 +86,7 @@ impl Default for DocumentStore {
             documents: DashMap::new(),
             parse_states: DashMap::new(),
             edit_locks: DashMap::new(),
-            open_generations: DashMap::new(),
-            open_counter: std::sync::atomic::AtomicU64::new(0),
+            open_counter: std::sync::atomic::AtomicU64::new(1),
             watermarks: DashMap::new(),
         }
     }
@@ -179,10 +181,13 @@ impl DocumentStore {
     // Lock safety: Single insert() call - no read lock held before or during write
     pub fn insert(&self, uri: Url, text: String, language_id: Option<String>, tree: Option<Tree>) {
         let has_tree = tree.is_some();
+        // didOpen registers a fresh lifetime → a fresh incarnation, so an
+        // in-flight parse from a prior open of this URI can't publish against it.
+        let incarnation = self.next_incarnation();
         let document = match (language_id, tree) {
-            (Some(lang), Some(t)) => Document::with_tree(text, lang, t),
-            (Some(lang), None) => Document::with_language(text, lang),
-            _ => Document::new(text),
+            (Some(lang), Some(t)) => Document::with_tree(text, lang, t, incarnation),
+            (Some(lang), None) => Document::with_language(text, lang, incarnation),
+            _ => Document::new(text, incarnation),
         };
 
         self.documents.insert(uri.clone(), document);
@@ -218,12 +223,21 @@ impl DocumentStore {
                 }
             }
             Entry::Vacant(entry) => {
-                // Document doesn't exist - create new one
+                // Document doesn't exist - create new one (a fresh lifetime →
+                // fresh incarnation). `next_incarnation` touches only the atomic
+                // counter, not `documents`, so drawing it while holding this
+                // entry's shard write lock cannot deadlock.
+                let incarnation = self.next_incarnation();
                 if let Some(tree) = new_tree {
-                    entry.insert(Document::with_tree(text, "unknown".to_string(), tree));
+                    entry.insert(Document::with_tree(
+                        text,
+                        "unknown".to_string(),
+                        tree,
+                        incarnation,
+                    ));
                     true
                 } else {
-                    entry.insert(Document::new(text));
+                    entry.insert(Document::new(text, incarnation));
                     false
                 }
             }
@@ -265,7 +279,9 @@ impl DocumentStore {
             match self.documents.entry(uri.clone()) {
                 Entry::Occupied(mut entry) => entry.get_mut().apply_edit_and_seed(text, edits),
                 Entry::Vacant(entry) => {
-                    entry.insert(Document::new(text));
+                    // Reordered edit registering an unopened URI: a fresh
+                    // lifetime → fresh incarnation (mirrors `update_document`).
+                    entry.insert(Document::new(text, self.next_incarnation()));
                 }
             }
         }
@@ -516,7 +532,6 @@ impl DocumentStore {
     pub(crate) fn remove(&self, uri: &Url) -> Option<Document> {
         self.parse_states.remove(uri);
         self.edit_locks.remove(uri);
-        self.open_generations.remove(uri);
         // Dropping the watermark sender wakes any reader still blocked on
         // `wait_for_epoch` for this document, so a reader racing the close
         // proceeds into the empty fallback instead of stalling to the timeout.
@@ -524,39 +539,15 @@ impl DocumentStore {
         self.documents.remove(uri).map(|(_, doc)| doc)
     }
 
-    /// The current open generation for `uri`, lazily assigned. Two reads
-    /// straddling a [`remove`](Self::remove) (didClose) return different
-    /// values, because the removal clears the entry and the next ask draws a
-    /// fresh number — letting callers detect a close-then-reopen even when the
-    /// URI looks alive on both sides. Fetch it **before** snapshotting: if a
-    /// reopen races in between, the stale generation makes the later
-    /// comparison fail (conservative), whereas the reverse order could pair an
-    /// old snapshot with the new document's generation.
-    pub(crate) fn open_generation(&self, uri: &Url) -> u64 {
-        *self.open_generations.entry(uri.clone()).or_insert_with(|| {
-            self.open_counter
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-        })
-    }
-
-    /// Drop the lazily-created generation entry for a URI that turned out to
-    /// have no document — the cleanup for an [`open_generation`](Self::open_generation)
-    /// ask that raced a `didClose`. Safety does not depend on this (the
-    /// counter is monotonic, so a pre-close generation can never equal any
-    /// later one); it only prevents entries accumulating for closed URIs.
-    /// Check-then-remove rather than `remove_if`: the predicate would read
-    /// `documents` while holding the `open_generations` shard write lock,
-    /// inverting the documents → open_generations order taken by callers
-    /// that hold a document `Ref` while asking for the generation — a latent
-    /// ABBA deadlock under a writer-preferring shard lock. The TOCTOU this
-    /// opens (a reopen racing between check and removal loses its entry)
-    /// merely hands the reopened document a fresh number on its next ask,
-    /// which is the conservative direction.
-    pub(crate) fn forget_open_generation_if_closed(&self, uri: &Url) {
-        if self.documents.get(uri).is_some() {
-            return;
-        }
-        self.open_generations.remove(uri);
+    /// Draw the next process-wide-unique **open incarnation** (see
+    /// [`Document::incarnation`]). Monotonic and never reused, so two documents
+    /// — including a close-then-reopen of the same URI — always get distinct
+    /// values, which is what lets a consumer detect a reopen by comparing a
+    /// captured incarnation against the document's current one. Starts at 1, so
+    /// `0` is reserved for a document built outside any store.
+    pub(crate) fn next_incarnation(&self) -> u64 {
+        self.open_counter
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
     }
 }
 
@@ -569,35 +560,50 @@ mod tests {
     use tokio::time::timeout;
 
     #[test]
-    fn forget_open_generation_keeps_live_document_entry() {
+    fn insert_stamps_a_fresh_nonzero_incarnation() {
         let store = DocumentStore::new();
         let uri = Url::parse("file:///gen.rs").unwrap();
         store.insert(uri.clone(), "x".to_string(), Some("rust".to_string()), None);
-        let generation = store.open_generation(&uri);
-
-        store.forget_open_generation_if_closed(&uri);
-
-        assert_eq!(
-            store.open_generation(&uri),
-            generation,
-            "cleanup must not disturb the generation of an open document"
+        let incarnation = store.get(&uri).unwrap().incarnation();
+        assert_ne!(
+            incarnation, 0,
+            "a store-owned document must carry a nonzero incarnation (0 is the \
+             outside-the-store sentinel)"
         );
     }
 
     #[test]
-    fn forget_open_generation_drops_entry_for_closed_document() {
+    fn reopen_draws_a_fresh_incarnation() {
         let store = DocumentStore::new();
         let uri = Url::parse("file:///gen.rs").unwrap();
-        // A generation asked while no document exists (request racing didClose)
-        let stale = store.open_generation(&uri);
-
-        store.forget_open_generation_if_closed(&uri);
-
         store.insert(uri.clone(), "x".to_string(), Some("rust".to_string()), None);
+        let first = store.get(&uri).unwrap().incarnation();
+
+        store.remove(&uri);
+        store.insert(uri.clone(), "x".to_string(), Some("rust".to_string()), None);
+        let second = store.get(&uri).unwrap().incarnation();
+
         assert_ne!(
-            store.open_generation(&uri),
-            stale,
-            "a closed URI's entry must be dropped so a reopen draws a fresh generation"
+            first, second,
+            "a close-then-reopen must draw a fresh incarnation so a consumer can \
+             detect the reopen"
+        );
+    }
+
+    #[test]
+    fn edit_preserves_the_incarnation() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///gen.rs").unwrap();
+        store.insert(uri.clone(), "x".to_string(), Some("rust".to_string()), None);
+        let before = store.get(&uri).unwrap().incarnation();
+
+        // An edit is the same lifetime — the incarnation must not move.
+        store.apply_edit_clearing_tree(&uri, "xy".to_string(), &[]);
+        let after = store.get(&uri).unwrap().incarnation();
+
+        assert_eq!(
+            before, after,
+            "an edit stays within one lifetime and must preserve the incarnation"
         );
     }
 

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -414,7 +414,7 @@ impl ParseCoordinator {
         // `pending_seed` (a cheap `Tree` refcount-clone) is the edit's incremental
         // parse seed stashed by `didChange`; `None` for a full-text sync / freshly
         // installed parse, in which case we parse from scratch.
-        let (language_name, language_id, text, seed) = {
+        let (language_name, language_id, text, seed, incarnation) = {
             let Some(doc) = self.documents.get(uri) else {
                 advance_watermark();
                 return;
@@ -424,10 +424,14 @@ impl ParseCoordinator {
             let text = doc.text_arc();
             let language_id = doc.language_id().map(|s| s.to_string());
             let seed = doc.pending_seed().cloned();
+            // The lifetime this parse is for: a close+reopen before the tree write
+            // changes it, and the CAS below rejects on the mismatch (so a tree from
+            // this lifetime never attaches to a reopened document).
+            let incarnation = doc.incarnation();
             let language_name =
                 self.language
                     .detect_language(uri.path(), &text, None, language_id.as_deref());
-            (language_name, language_id, text, seed)
+            (language_name, language_id, text, seed, incarnation)
         };
 
         let Some(language_name) = language_name else {
@@ -461,19 +465,18 @@ impl ParseCoordinator {
             .await;
 
         if let Some(tree) = parsed {
-            // Text + language CAS (non-inserting). Rejecting on a changed
-            // `language_id` closes the close→reopen-with-different-language race
-            // (a tree parsed by the old grammar must not attach to a relabelled
-            // document). The remaining residual — a same-language reopen with
-            // *identical* text — is benign (the tree is a correct parse of that
-            // text); only the watermark ticket is from the old lifetime, and reads
-            // stay correct. The strict `(incarnation, ticket)` epoch CAS
-            // (incarnation stored on the Document, atomic with the write) is the
-            // follow-up that closes even that.
+            // Text + language + incarnation CAS (non-inserting), all three checked
+            // atomically under the tree-write shard lock. Text rejects a
+            // within-lifetime stale parse (a `didChange` landed mid-parse);
+            // language rejects a reopen that relabelled the URI; incarnation
+            // rejects a same-language, identical-text reopen — the tree belongs to
+            // the prior lifetime and must not attach to the reopened document (nor
+            // let the watermark advance below run on the old lifetime's ticket).
             let stored = self.documents.update_tree_if_text_and_language_unchanged(
                 uri,
                 &text,
                 language_id.as_deref(),
+                incarnation,
                 tree.clone(),
             );
             if stored {

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -324,15 +324,22 @@ impl ParseCoordinator {
 
         for _ in 0..MAX_REPARSE_ATTEMPTS {
             // Re-read the latest text each attempt. Gone => closed (no resurrect);
-            // already has a tree => a concurrent parse won, nothing to do.
-            let text = {
+            // already has a tree => a concurrent parse won, nothing to do. Capture
+            // the lifetime's incarnation and the document's language alongside the
+            // text so the CAS below can reject a close+reopen (possibly a relabel)
+            // that raced this off-ingress install reparse.
+            let (text, cas_language_id, incarnation) = {
                 let Some(doc) = self.documents.get(&uri) else {
                     break;
                 };
                 if doc.tree().is_some() {
                     break;
                 }
-                doc.text().to_string()
+                (
+                    doc.text().to_string(),
+                    doc.language_id().map(|s| s.to_string()),
+                    doc.incarnation(),
+                )
             };
 
             let text_len = text.len();
@@ -359,9 +366,13 @@ impl ParseCoordinator {
             // the tree actually landed, so a `didClose` racing this reparse can't
             // leave stale injection entries for a gone document. (`Tree` clone is a
             // cheap refcount bump.)
-            let stored = self
-                .documents
-                .attach_tree_if_absent(&uri, &text, tree.clone());
+            let stored = self.documents.attach_tree_if_absent(
+                &uri,
+                &text,
+                cas_language_id.as_deref(),
+                incarnation,
+                tree.clone(),
+            );
             if stored {
                 self.cache.populate_injections(
                     &uri,
@@ -401,25 +412,22 @@ impl ParseCoordinator {
     /// it diffs cached token arrays by `result_id` (never `changed_ranges`), so as
     /// long as the seed keeps this reparse cheap the delta stays cheap too.
     pub(crate) async fn reparse_latest(&self, uri: &Url, ticket: Option<u64>) {
-        let advance_watermark = || {
-            if let Some(ticket) = ticket {
-                self.documents.advance_watermark(uri, ticket);
-            }
-        };
-
         // Re-read the latest text + detect the language under one read guard. A
-        // missing document means a `didClose` ran — resolve the watermark and stop
-        // (no resurrection). `language_id` is captured so the tree write can reject
-        // a reopen that changed the language while this parse was in flight. The
+        // missing document means a `didClose` ran — stop without touching the
+        // watermark (no resurrection). Advancing it here would be unsafe: the
+        // watermark is per-lifetime, so if a reopen has *already* re-seeded a fresh
+        // channel, a plain advance with this prior-lifetime ticket would inflate it
+        // and prematurely release a new-lifetime reader — and it is also
+        // unnecessary, since a genuine close drops the channel and wakes its readers
+        // (they fall back). The incarnation isn't known on this path, but it isn't
+        // needed: only the post-read paths below (which captured it) advance, and
+        // they gate on it. `language_id` is captured so the tree write can reject a
+        // reopen that changed the language while this parse was in flight. The
         // `pending_seed` (a cheap `Tree` refcount-clone) is the edit's incremental
         // parse seed stashed by `didChange`; `None` for a full-text sync / freshly
         // installed parse, in which case we parse from scratch.
         let (language_name, language_id, text, seed, incarnation) = {
             let Some(doc) = self.documents.get(uri) else {
-                // Document already closed: its watermark is gone (advance no-ops)
-                // and its readers were woken by the close. The incarnation isn't
-                // known on this path, but it is not needed.
-                advance_watermark();
                 return;
             };
             // `text_arc()` is a refcount bump, not a full copy of the document text

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -336,7 +336,10 @@ impl ParseCoordinator {
                     break;
                 }
                 (
-                    doc.text().to_string(),
+                    // `text_arc()` is a refcount bump, not a full copy (#498) — the
+                    // original stays here for the CAS while a cheap clone goes to
+                    // the blocking parse closure.
+                    doc.text_arc(),
                     doc.language_id().map(|s| s.to_string()),
                     doc.incarnation(),
                 )
@@ -345,18 +348,20 @@ impl ParseCoordinator {
             let text_len = text.len();
             let auto_install = self.auto_install.clone();
             let language_name_clone = language_name.clone();
-            // Move the owned `text` into the blocking closure and hand it back with
-            // the tree, so the (potentially large) document text is never cloned.
+            // Hand a cheap `Arc<str>` clone (refcount bump) to the blocking closure;
+            // the original stays here for the CAS below, so the (potentially large)
+            // document text is never copied.
+            let text_for_parse = text.clone();
             let parsed = self
                 .parse_with_pool(&language_name, &uri, text_len, move |mut parser| {
                     let _ = auto_install.begin_parsing(&language_name_clone);
-                    let result = parser.parse(&text, None);
+                    let result = parser.parse(&*text_for_parse, None);
                     let _ = auto_install.end_parsing(&language_name_clone);
-                    (parser, result.map(|tree| (tree, text)))
+                    (parser, result)
                 })
                 .await;
 
-            let Some((tree, text)) = parsed else { break };
+            let Some(tree) = parsed else { break };
 
             // Persist FIRST through the non-inserting, tree-absent CAS: a closed
             // (Vacant) document, one whose text moved (a concurrent `didChange`),

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -303,15 +303,30 @@ impl ParseCoordinator {
         // resurrect it) or already parsed (a concurrent parse won — nothing to do,
         // and skip the `ensure_language_loaded` work). Detection borrows the stored
         // text (synchronous, no `.await` and no document write under the `Ref`).
-        let language_name = {
+        // Capture the grammar **and** the (language_id, incarnation) it is resolved
+        // for, together under one read guard. `language_name` is fixed for the whole
+        // loop, so the CAS must check against the language_id/incarnation captured
+        // *here* — not re-read per attempt. Otherwise a relabelling reopen mid-loop
+        // would have its new language_id captured per attempt, satisfy the CAS's
+        // language check, and let a tree parsed by the *old* grammar attach to the
+        // relabelled document. The incarnation is likewise lifetime-stable; only the
+        // text legitimately changes within a lifetime (a `didChange`), so only the
+        // text is re-read per attempt.
+        let (language_name, expected_language_id, expected_incarnation) = {
             let Some(doc) = self.documents.get(&uri) else {
                 return;
             };
             if doc.tree().is_some() {
                 return;
             }
-            self.language
-                .detect_language(uri.path(), doc.text(), None, language_id.as_deref())
+            let language_name =
+                self.language
+                    .detect_language(uri.path(), doc.text(), None, language_id.as_deref());
+            (
+                language_name,
+                doc.language_id().map(|s| s.to_string()),
+                doc.incarnation(),
+            )
         };
         let Some(language_name) = language_name else {
             return;
@@ -324,25 +339,25 @@ impl ParseCoordinator {
 
         for _ in 0..MAX_REPARSE_ATTEMPTS {
             // Re-read the latest text each attempt. Gone => closed (no resurrect);
-            // already has a tree => a concurrent parse won, nothing to do. Capture
-            // the lifetime's incarnation and the document's language alongside the
-            // text so the CAS below can reject a close+reopen (possibly a relabel)
-            // that raced this off-ingress install reparse.
-            let (text, cas_language_id, incarnation) = {
+            // already has a tree => a concurrent parse won; a changed incarnation =>
+            // a close+reopen, whose new lifetime drives its own parse — stop rather
+            // than parse its text with this lifetime's (possibly relabelled-away)
+            // grammar (the CAS would reject it anyway; this just avoids the wasted
+            // parses).
+            let text = {
                 let Some(doc) = self.documents.get(&uri) else {
                     break;
                 };
                 if doc.tree().is_some() {
                     break;
                 }
-                (
-                    // `text_arc()` is a refcount bump, not a full copy (#498) — the
-                    // original stays here for the CAS while a cheap clone goes to
-                    // the blocking parse closure.
-                    doc.text_arc(),
-                    doc.language_id().map(|s| s.to_string()),
-                    doc.incarnation(),
-                )
+                if doc.incarnation() != expected_incarnation {
+                    break;
+                }
+                // `text_arc()` is a refcount bump, not a full copy (#498) — the
+                // original stays here for the CAS while a cheap clone goes to the
+                // blocking parse closure.
+                doc.text_arc()
             };
 
             let text_len = text.len();
@@ -374,8 +389,8 @@ impl ParseCoordinator {
             let stored = self.documents.attach_tree_if_absent(
                 &uri,
                 &text,
-                cas_language_id.as_deref(),
-                incarnation,
+                expected_language_id.as_deref(),
+                expected_incarnation,
                 tree.clone(),
             );
             if stored {

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -416,6 +416,9 @@ impl ParseCoordinator {
         // installed parse, in which case we parse from scratch.
         let (language_name, language_id, text, seed, incarnation) = {
             let Some(doc) = self.documents.get(uri) else {
+                // Document already closed: its watermark is gone (advance no-ops)
+                // and its readers were woken by the close. The incarnation isn't
+                // known on this path, but it is not needed.
                 advance_watermark();
                 return;
             };
@@ -432,6 +435,18 @@ impl ParseCoordinator {
                 self.language
                     .detect_language(uri.path(), &text, None, language_id.as_deref());
             (language_name, language_id, text, seed, incarnation)
+        };
+
+        // Post-read resolutions advance the watermark **only if this lifetime is
+        // still current** — a close+reopen re-seeds the watermark at 0, and this
+        // (prior-lifetime) ticket must not inflate it and prematurely release a
+        // new-lifetime reader. Same lifetime → advances (releasing readers even on
+        // the no-language / no-tree paths, to the empty fallback).
+        let advance_watermark = || {
+            if let Some(ticket) = ticket {
+                self.documents
+                    .advance_watermark_for_incarnation(uri, ticket, incarnation);
+            }
         };
 
         let Some(language_name) = language_name else {

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -243,12 +243,12 @@ fn load_kind_query(
 }
 
 /// Outcome of the shared resolution + execution pipeline: the resolved `Url`
-/// (cache key half), the document's open generation at snapshot time (so the
+/// (cache key half), the document's open incarnation at snapshot time (so the
 /// lineage store can detect a close-then-reopen racing the request), and the
 /// wire-shaped `matches` / `skipped` arrays.
 struct ComputedCaptures {
     uri: Url,
-    open_generation: u64,
+    incarnation: u64,
     matches: Vec<Value>,
     skipped: Vec<Value>,
 }
@@ -289,9 +289,9 @@ impl Kakehashi {
     /// - liveness: a close that won the lock first leaves the document gone,
     ///   so the check skips the insert; an insert that won first is cleared by
     ///   the close's cache cleanup, which runs after the removal;
-    /// - generation: a close **followed by a fast reopen** makes the URI look
-    ///   alive again, but the reopened document draws a fresh open generation,
-    ///   so a stale request's snapshot-time generation no longer matches and
+    /// - incarnation: a close **followed by a fast reopen** makes the URI look
+    ///   alive again, but the reopened document carries a fresh open incarnation,
+    ///   so a stale request's snapshot-time incarnation no longer matches and
     ///   the insert is skipped — a reopened document starts its lineage fresh
     ///   (captures-protocol §"Delta semantics").
     async fn store_lineage(
@@ -304,13 +304,17 @@ impl Kakehashi {
         let uri = computed.uri;
         let edit_lock = self.documents.edit_lock(&uri);
         let _guard = edit_lock.lock().await;
-        // Separate statement so the documents Ref (a shard read lock) drops
-        // before open_generation's entry() takes an open_generations shard
-        // write — holding a Ref across another map's write acquisition is
-        // the lock-order half of a latent ABBA inversion (see
-        // forget_open_generation_if_closed).
-        let document_is_open = self.documents.get(&uri).is_some();
-        if document_is_open && self.documents.open_generation(&uri) == computed.open_generation {
+        // A single `documents` lookup reads both liveness and the current
+        // incarnation atomically: a closed URI is `None` (skip), and a reopened
+        // one carries a fresh incarnation that no longer equals the snapshot's
+        // (skip). The incarnation lives on the document, so this no longer
+        // straddles two maps — the former ABBA-avoidance dance (drop the Ref
+        // before a separate `open_generations` write) is gone.
+        let still_current = self
+            .documents
+            .get(&uri)
+            .is_some_and(|doc| doc.incarnation() == computed.incarnation);
+        if still_current {
             let mut entry = self.captures_cache.entry((uri, kind)).or_default();
             entry[usize::from(injection)] = Some((result_id, computed.matches));
         }
@@ -518,21 +522,16 @@ impl Kakehashi {
             self.ensure_document_parsed(&uri).await;
         }
 
-        // Fetch the open generation BEFORE snapshotting: if a close+reopen
-        // races in between, the stale generation makes store_lineage's
-        // comparison fail (conservative skip). The reverse order could pair
-        // an old snapshot with the reopened document's generation and seed
-        // the new document with stale lineage.
-        let open_generation = self.documents.open_generation(&uri);
+        // The snapshot carries the document's open incarnation, captured under
+        // the same shard read lock as its text and tree — so there is no longer
+        // a separate "fetch the generation before snapshotting" ordering to get
+        // right. If a close+reopen races after this, store_lineage sees a fresh
+        // incarnation on the URI and skips the stale insert (conservative).
         let Some(snapshot) = self.documents.get(&uri).and_then(|doc| doc.snapshot()) else {
-            // The generation ask above may have lazily created an entry for a
-            // URI that a racing didClose just removed; drop it again so
-            // closed URIs don't accumulate entries (safety never depended on
-            // it — the counter is monotonic).
-            self.documents.forget_open_generation_if_closed(&uri);
             log::debug!(target: "kakehashi::captures", "no parsed document for {uri}");
             return Ok(None);
         };
+        let incarnation = snapshot.incarnation();
         let text = snapshot.text();
         let tree = snapshot.tree();
 
@@ -675,7 +674,7 @@ impl Kakehashi {
 
         Ok(Some(ComputedCaptures {
             uri,
-            open_generation,
+            incarnation,
             matches,
             skipped,
         }))


### PR DESCRIPTION
## Summary

Implements the strict **`(incarnation, ticket)` epoch** for the per-document parse scheduler (follow-up #2 from the ADR2 effort). Closes the residual where an in-flight **off-ingress** parse from a prior document lifetime publishes against a reopened document — both the tree it attaches and the watermark it advances.

Background: `didChange` clears the reader-visible tree and reparses **off the ingress ticket**. The scheduler is single-flight per URI, but a `didClose` + reopen of the same URI can race a parse that's still running, because the off-ingress paths hold no `edit_lock`. The ticket axis (reader watermark) already existed; this adds the **incarnation** axis so each lifetime's parses only ever publish against their own lifetime.

## What changed

- **`incarnation: u64` on `Document`** — drawn from the store's monotonic counter at every construction (didOpen `insert`, the reordered-mutation Vacant branches), preserved across edits. `0` is the outside-the-store sentinel. `DocumentSnapshot` carries it.
- **Unified the captures lineage path onto it** — deleted the side `open_generations` map plus `open_generation()` / `forget_open_generation_if_closed()`; `store_lineage` now reads `doc.incarnation()` atomically with the snapshot. This *removes* the old fragile fetch-before-snapshot ordering and a documents→`open_generations` ABBA-avoidance dance.
- **Tree-write CAS gains an incarnation axis** — `update_tree_if_text_and_language_unchanged` rejects a same-text, same-language reopen attaching a prior-lifetime tree (text + language axes stay; they guard the orthogonal within-lifetime races). The install-reparse CAS `attach_tree_if_absent` gains the same language + incarnation axes.
- **The watermark watch channel carries `{incarnation, ticket}`** — `advance_watermark_for_incarnation` gates the incarnation compare *atomically* with the ticket write inside `send_if_modified`, so a prior-lifetime straggler can never advance a reopened document's re-seeded watermark and prematurely release a new-lifetime reader. No second-map lookup and no documents↔watermarks lock ordering. The doc-already-closed early return advances nothing (a genuine close drops the channel and wakes its readers; a reopen advances its own).

## Performance

No hot-path regression (the user's hard constraint). Net **cheaper**: the deleted `open_generations` map removes a per-captures-request lookup, and `reparse_installed_document` no longer full-copies the document text per retry (`text_arc()` refcount bump, matching `reparse_latest`). The incarnation is read under locks already held.

## Review

Converged through `/review` (subagent), **codex MCP (3 rounds)**, and **pi-review (2 rounds, multi-aspect)**. codex found the first-cut advance was a check-then-write TOCTOU → fixed by moving the gate into the channel value; a second round found the channel re-seed itself wasn't atomic → fixed via the `entry` API. pi-review found the doc-gone early return still used the plain advance (HIGH) and that the install CAS lacked the incarnation/language axes (MED) → both fixed with coverage tests. Final passes report no actionable findings; all unit tests + the full e2e suite pass.

## Follow-up

The injection-cache publication guard (`populate_injections` recreating a stale entry for a closed/reopened URI) is the remaining epoch-for-caches work and lands as a stacked PR on top of this one.
