### PR TITLE
fix(diagnostics): gate and detach the downstream-forwarded refresh (#521)

### DIFF
--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -426,7 +426,8 @@ impl DiagnosticPublisher {
 
     /// Ask pull-mode clients to re-pull diagnostics (`workspace/diagnostic/refresh`)
     /// after a change the editor has no event to learn about — a **spontaneous
-    /// downstream push**, or a **crash-driven eviction** — moved the merged set.
+    /// downstream push**, a **crash-driven eviction**, or a **downstream server's
+    /// own refresh request** forwarded upstream — moved (or invalidated) the set.
     ///
     /// kakehashi advertises `diagnosticProvider`, so a pull-mode editor (e.g.
     /// Neovim) displays the diagnostics it *pulled* and ignores our
@@ -440,8 +441,10 @@ impl DiagnosticPublisher {
     ///
     /// Emitted **off** the per-host republish lock and **only** from the origins
     /// the editor can't learn about on its own — the push-origin paths
-    /// ([`Self::publish_host_push`], [`Self::publish_region_push`]) and the
-    /// crash-driven eviction ([`Self::evict_connection_diagnostics`]) — never from
+    /// ([`Self::publish_host_push`], [`Self::publish_region_push`]), the
+    /// crash-driven eviction ([`Self::evict_connection_diagnostics`]), and the
+    /// upstream forwarding loop relaying a downstream server's own
+    /// `workspace/diagnostic/refresh` (`deliver_upstream_notification`) — never from
     /// the pull-origin republish ([`Self::publish_pull_layer`]), the
     /// editor-originated eviction paths ([`Self::clear_pull_layer`],
     /// [`Self::clear_host`]), nor the edit-origin re-merge (`did_change`): those
@@ -464,7 +467,7 @@ impl DiagnosticPublisher {
     /// client that supports pull but not refresh would silently ignore the request,
     /// leaking a tower-lsp pending-request entry plus a parked task — the same gate
     /// the `semantic_tokens_refresh` path uses.
-    fn request_pull_diagnostic_refresh(&self) {
+    pub(crate) fn request_pull_diagnostic_refresh(&self) {
         let supported = self
             .settings_manager
             .client_capabilities_lock()

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -979,12 +979,17 @@ async fn deliver_upstream_notification(
     use tower_lsp_server::ls_types::{ProgressParamsValue, WorkDoneProgress};
     match notification {
         UpstreamNotification::DiagnosticRefresh => {
-            if let Err(e) = client.workspace_diagnostic_refresh().await {
-                log::debug!(
-                    target: "kakehashi::bridge",
-                    "workspace/diagnostic/refresh forwarding failed: {}",
-                    e
-                );
+            // A downstream server asked the editor to re-pull diagnostics. Route it
+            // through the publisher's `request_pull_diagnostic_refresh` so it reuses
+            // the `workspace.diagnostics.refreshSupport` capability gate (a client
+            // that doesn't support refresh would otherwise leak a tower-lsp
+            // pending-request entry + parked task) and the detached `tokio::spawn`
+            // (an inline `.await` here would block this delivery loop on the client
+            // round-trip — head-of-line). A `None` publisher (test loop) has no
+            // settings to gate on, so the forward is dropped; production always has
+            // one (#521).
+            if let Some(publisher) = diagnostic_publisher {
+                publisher.request_pull_diagnostic_refresh();
             }
         }
         UpstreamNotification::PublishDiagnostics {
@@ -1491,8 +1496,10 @@ mod tests {
 
     /// Cancellation is re-checked *between* deliveries of a coalesced batch, so a
     /// shutdown mid-batch is not delayed by the rest of the batch (#426). Two
-    /// `DiagnosticRefresh` are drained into one batch; cancelling during the first's
-    /// editor round-trip must make the loop skip the second and exit.
+    /// `CreateWorkDoneProgress` (distinct tokens — each an inline-awaited request, so
+    /// both survive coalescing as a 2-item barrier batch) are drained into one batch;
+    /// cancelling during the first's editor round-trip must make the loop skip the
+    /// second and exit.
     #[tokio::test]
     async fn forwarding_loop_rechecks_cancellation_between_batched_deliveries() {
         use crate::lsp::bridge::UpstreamNotification;
@@ -1500,7 +1507,7 @@ mod tests {
         use std::sync::{Arc, Mutex};
         use tower::{Service, ServiceExt};
         use tower_lsp_server::jsonrpc::{Request, Response};
-        use tower_lsp_server::ls_types::{InitializeParams, InitializeResult};
+        use tower_lsp_server::ls_types::{InitializeParams, InitializeResult, NumberOrString};
         use tower_lsp_server::{LanguageServer, LspService};
 
         struct Dummy;
@@ -1538,9 +1545,17 @@ mod tests {
         let (_window_tx, window_rx) = tokio::sync::mpsc::channel(16);
         let (_request_tx, request_rx) = tokio::sync::mpsc::unbounded_channel();
 
-        // Two refreshes queued before the loop runs → drained into one batch.
-        tx.send(UpstreamNotification::DiagnosticRefresh).unwrap();
-        tx.send(UpstreamNotification::DiagnosticRefresh).unwrap();
+        // Two creates (distinct tokens) queued before the loop runs → drained into
+        // one batch. Each is an inline-awaited server→client request, so they map to
+        // the "deliver first / cancel mid-round-trip / skip second" scenario.
+        tx.send(UpstreamNotification::CreateWorkDoneProgress {
+            token: NumberOrString::String("batch-canary-a".to_string()),
+        })
+        .unwrap();
+        tx.send(UpstreamNotification::CreateWorkDoneProgress {
+            token: NumberOrString::String("batch-canary-b".to_string()),
+        })
+        .unwrap();
 
         let loop_handle = tokio::spawn(upstream_forwarding_loop(
             rx,
@@ -1553,25 +1568,22 @@ mod tests {
             cancel.clone(),
         ));
 
-        // The loop delivers the first refresh (a request that awaits the editor).
-        let first = requests
-            .next()
-            .await
-            .expect("first refresh request emitted");
-        assert_eq!(first.method(), "workspace/diagnostic/refresh");
+        // The loop delivers the first create (a request that awaits the editor).
+        let first = requests.next().await.expect("first create request emitted");
+        assert_eq!(first.method(), "window/workDoneProgress/create");
         // Cancel during the first delivery's round-trip; when it completes the loop
-        // must re-check cancellation and skip the second batched refresh.
+        // must re-check cancellation and skip the second batched create.
         cancel.cancel();
         responses
             .send(Response::from_ok(
-                first.id().expect("refresh request id").clone(),
+                first.id().expect("create request id").clone(),
                 serde_json::Value::Null,
             ))
             .await
             .unwrap();
 
-        // The loop must skip the second refresh and exit. Were cancellation NOT
-        // re-checked mid-batch, it would deliver the second refresh and block on its
+        // The loop must skip the second create and exit. Were cancellation NOT
+        // re-checked mid-batch, it would deliver the second create and block on its
         // (never-sent) response — so this would hang. The timeout turns that
         // regression into a failure instead of an infinite hang.
         tokio::time::timeout(std::time::Duration::from_secs(5), loop_handle)
@@ -1666,8 +1678,14 @@ mod tests {
             },
         })
         .unwrap();
-        // A later, unrelated request that IS expected to reach the editor.
-        tx.send(UpstreamNotification::DiagnosticRefresh).unwrap();
+        // A later, unrelated message that IS expected to reach the editor — a
+        // telemetry notification, used as the delivery canary because it is
+        // forwarded unconditionally (the refresh forward is now publisher-gated, so
+        // it no longer works as a publisher-independent canary, #521).
+        tx.send(UpstreamNotification::TelemetryEvent {
+            data: serde_json::json!({ "canary": "after-rejected-create" }),
+        })
+        .unwrap();
 
         // First message: the create request — reject it.
         let first = requests.next().await.expect("create request emitted");
@@ -1678,20 +1696,18 @@ mod tests {
             .await
             .unwrap();
 
-        // Next message MUST be the diagnostic refresh, NOT $/progress — the
-        // rejected token's progress was dropped.
-        let next = requests.next().await.expect("a follow-up request emitted");
+        // Next message MUST be the telemetry event, NOT $/progress — the rejected
+        // token's progress was dropped. (telemetry/event is a notification, so there
+        // is no response to send.)
+        let next = tokio::time::timeout(std::time::Duration::from_secs(5), requests.next())
+            .await
+            .expect("the telemetry canary must arrive, not hang (fail fast on a dropped forward)")
+            .expect("a follow-up message emitted");
         assert_eq!(
             next.method(),
-            "workspace/diagnostic/refresh",
-            "progress for a rejected token must be dropped; only the later request survives"
+            "telemetry/event",
+            "progress for a rejected token must be dropped; only the later message survives"
         );
-        // Respond so the loop's inline (un-timed) refresh await completes.
-        let id = next.id().expect("refresh request has an id").clone();
-        responses
-            .send(Response::from_ok(id, serde_json::Value::Null))
-            .await
-            .unwrap();
 
         cancel.cancel();
         let _ = loop_handle.await;
@@ -1794,22 +1810,24 @@ mod tests {
             },
         })
         .unwrap();
-        tx.send(UpstreamNotification::DiagnosticRefresh).unwrap();
+        // Telemetry notification as the delivery canary (unconditionally forwarded,
+        // unlike the now publisher-gated refresh, #521).
+        tx.send(UpstreamNotification::TelemetryEvent {
+            data: serde_json::json!({ "canary": "after-forget" }),
+        })
+        .unwrap();
 
         // The forgotten token's progress must be dropped; the next editor-bound
-        // message is the diagnostic refresh.
-        let next = requests.next().await.expect("a follow-up request emitted");
+        // message is the telemetry event.
+        let next = tokio::time::timeout(std::time::Duration::from_secs(5), requests.next())
+            .await
+            .expect("the telemetry canary must arrive, not hang (fail fast on a dropped forward)")
+            .expect("a follow-up message emitted");
         assert_eq!(
             next.method(),
-            "workspace/diagnostic/refresh",
+            "telemetry/event",
             "progress for a forgotten token must be dropped"
         );
-        // Respond so the loop's inline (un-timed) refresh await completes.
-        let id = next.id().expect("refresh request has an id").clone();
-        responses
-            .send(Response::from_ok(id, serde_json::Value::Null))
-            .await
-            .unwrap();
 
         cancel.cancel();
         let _ = loop_handle.await;
@@ -2037,18 +2055,21 @@ mod tests {
             token.clone(),
         ]))
         .unwrap();
-        tx.send(UpstreamNotification::DiagnosticRefresh).unwrap();
-        let next = requests.next().await.expect("a follow-up request emitted");
+        // Telemetry notification as the delivery canary (unconditionally forwarded,
+        // unlike the now publisher-gated refresh, #521).
+        tx.send(UpstreamNotification::TelemetryEvent {
+            data: serde_json::json!({ "canary": "after-purge-ended" }),
+        })
+        .unwrap();
+        let next = tokio::time::timeout(std::time::Duration::from_secs(5), requests.next())
+            .await
+            .expect("the telemetry canary must arrive, not hang (fail fast on a dropped forward)")
+            .expect("a follow-up message emitted");
         assert_eq!(
             next.method(),
-            "workspace/diagnostic/refresh",
+            "telemetry/event",
             "an already-ended token must not be ended a second time on purge"
         );
-        let id = next.id().expect("refresh request has an id").clone();
-        responses
-            .send(Response::from_ok(id, serde_json::Value::Null))
-            .await
-            .unwrap();
 
         cancel.cancel();
         let _ = loop_handle.await;
@@ -2203,20 +2224,21 @@ mod tests {
             fresh.clone(),
         ]))
         .unwrap();
-        tx.send(UpstreamNotification::DiagnosticRefresh).unwrap();
-        let next = requests.next().await.expect("a follow-up request emitted");
+        // Telemetry notification as the delivery canary (unconditionally forwarded,
+        // unlike the now publisher-gated refresh, #521).
+        tx.send(UpstreamNotification::TelemetryEvent {
+            data: serde_json::json!({ "canary": "after-purge-fresh" }),
+        })
+        .unwrap();
+        let next = tokio::time::timeout(std::time::Duration::from_secs(5), requests.next())
+            .await
+            .expect("the telemetry canary must arrive, not hang (fail fast on a dropped forward)")
+            .expect("a follow-up message emitted");
         assert_eq!(
             next.method(),
-            "workspace/diagnostic/refresh",
+            "telemetry/event",
             "fresh token was ended normally; its purge must synthesize no second End"
         );
-        responses
-            .send(Response::from_ok(
-                next.id().unwrap().clone(),
-                serde_json::Value::Null,
-            ))
-            .await
-            .unwrap();
 
         cancel.cancel();
         let _ = loop_handle.await;

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -62,6 +62,9 @@
 //!   the process on the next `didChange` to simulate a downstream crash while the
 //!   host stays open. Used to prove the bridge evicts the dead connection's slots
 //!   and republishes the host cleared (#469).
+//! - `diagnostics-refresh` — sends a `workspace/diagnostic/refresh` server→client
+//!   request on `didOpen`. The bridge forwards it upstream to the editor; used to
+//!   prove that forward is capability-gated (#521).
 //! - `on-type` — advertises `documentOnTypeFormattingProvider` with `}` and
 //!   `;` as triggers; answers `textDocument/onTypeFormatting` with the
 //!   uppercasing whole-document edit for ANY typed character (bridge-side
@@ -265,6 +268,14 @@ fn main() {
                             "textDocument/publishDiagnostics",
                             push_diagnostics(uri, true),
                         );
+                    }
+                    // `diagnostics-refresh`: ask the client (via the bridge) to
+                    // re-pull diagnostics. The bridge forwards this upstream to the
+                    // editor (#521). Fire-and-forget: the bridge's `null` ack comes
+                    // back as a response with no `method`, which the read loop
+                    // ignores. A fixed id is fine since nothing awaits the ack.
+                    if mode == "diagnostics-refresh" {
+                        request(&mut writer, json!(1000), "workspace/diagnostic/refresh");
                     }
                 }
             }
@@ -651,6 +662,14 @@ fn push_diagnostics(uri: &str, present: bool) -> Value {
         json!([])
     };
     json!({ "uri": uri, "diagnostics": diagnostics })
+}
+
+/// Send a server→client **request** (a message carrying both `id` and `method`,
+/// no params) to the bridge — e.g. an unsolicited `workspace/diagnostic/refresh`.
+fn request<W: Write>(writer: &mut W, id: Value, method: &str) {
+    let body = json!({ "jsonrpc": "2.0", "id": id, "method": method }).to_string();
+    let _ = write!(writer, "Content-Length: {}\r\n\r\n{body}", body.len());
+    let _ = writer.flush();
 }
 
 /// Send a JSON-RPC success response for `id` (no-op for notifications).

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -511,3 +511,61 @@ fn e2e_downstream_crash_refreshes_pull_clients() {
     client.send_request("shutdown", json!(null));
     client.send_notification("exit", json!(null));
 }
+
+/// Send a `didOpen` for the markdown host (with its lua region) so the bridge
+/// spawns the downstream mock for that region and forwards the region's events.
+fn open_host(client: &mut LspClient) {
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": MD_URI,
+                "languageId": "markdown",
+                "version": 1,
+                "text": MD_TEXT
+            }
+        }),
+    );
+}
+
+#[test]
+fn e2e_downstream_refresh_forwarded_to_refresh_capable_client() {
+    // #521: a downstream server's own `workspace/diagnostic/refresh` request is
+    // forwarded upstream to the editor. With a refresh-capable client the bridge
+    // relays it (the `diagnostics-refresh` mock fires one on didOpen).
+    let (mut client, _config_dir) =
+        init_client_with_mode_caps("diagnostics-refresh", refresh_capable_caps());
+    open_host(&mut client);
+
+    assert!(
+        client
+            .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_secs(15))
+            .is_some(),
+        "a downstream's workspace/diagnostic/refresh must reach a refresh-capable editor (#521)"
+    );
+
+    client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
+fn e2e_downstream_refresh_gated_off_for_refresh_incapable_client() {
+    // #521: the same downstream refresh must NOT be forwarded when the client did
+    // not advertise `workspace.diagnostics.refreshSupport` — forwarding it would
+    // leak a tower-lsp pending-request entry on a client that silently ignores it.
+    // Empty capabilities (`init_client_with_mode`) → refresh unsupported. Paired
+    // with the positive test above (same mock mode), so a "no refresh" result here
+    // is the gate working, not the mock failing to emit.
+    let (mut client, _config_dir) = init_client_with_mode("diagnostics-refresh");
+    open_host(&mut client);
+
+    assert!(
+        client
+            .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_secs(6))
+            .is_none(),
+        "the refresh forward must be gated off for a client without refreshSupport (#521)"
+    );
+
+    client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}


### PR DESCRIPTION
Closes #521. Follow-up from #499/#522 (pre-existing gap, not introduced there).

## Problem
The upstream forwarding loop's `UpstreamNotification::DiagnosticRefresh` arm (`deliver_upstream_notification`) relayed a **downstream server's own** `workspace/diagnostic/refresh` to the editor with a bare inline `client.workspace_diagnostic_refresh().await`:
- **Ungated** — no `workspace.diagnostics.refreshSupport` check, so a client that supports pull diagnostics but not refresh would silently ignore it, leaking a tower-lsp pending-request entry + parked task (the hazard `request_pull_diagnostic_refresh` and the `semantic_tokens_refresh` path both gate against).
- **Inline-awaited** — blocked the delivery loop on the client round-trip (head-of-line).

## Fix
Make `DiagnosticPublisher::request_pull_diagnostic_refresh` `pub(crate)` (it already applies the capability gate **and** detaches via `tokio::spawn`) and route the arm through it. Production always passes `Some(publisher)` (`lifecycle.rs` ~402); a `None` publisher (test-only loop) has no settings to gate on, so the forward is dropped there.

## Test re-anchoring (the subtle part)
`DiagnosticRefresh` was the **only** unconditionally-forwarded, inline-awaited server→client request, so 5 forwarding-loop unit tests used it as a delivery canary with a `None` publisher — which this change makes hang. Re-anchored:
- `forwarding_loop_rechecks_cancellation_between_batched_deliveries` → `CreateWorkDoneProgress` (two distinct tokens; still an inline-awaited request that yields mid-batch — actually a *stronger* test, since the old back-to-back refreshes never yielded).
- The four terminal-canary tests → a `TelemetryEvent` notification (still unconditionally forwarded; no round-trip). Each canary read is now wrapped in a `timeout` so a future regression fails fast instead of hanging.

The pure `coalesce_upstream_batch` tests are unchanged (`DiagnosticRefresh` is still a valid barrier variant).

## E2E coverage
A `diagnostics-refresh` mock mode emits a `workspace/diagnostic/refresh` on didOpen; two e2e tests prove the gate end-to-end: forwarded to a refresh-capable client, dropped for one without `refreshSupport`.

## Reviews
`/review` (caught the hang — fixed + full `cargo test --lib` verified green: 2166 passed, 0 failed), Codex MCP (no findings), pi-review (no correctness defects; applied its fail-fast-timeout + e2e-timeout-bump hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)