### PR TITLE
feat(diagnostics): single-flight + coverage-gate the workspace diagnostic refresh (#497)

### DIFF
--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -379,6 +379,14 @@ pub(crate) struct DiagnosticAggregator {
     /// that window set `pending`, which fires exactly one more refresh on
     /// completion. Drives [`Self::try_begin_refresh`]/[`Self::finish_refresh`].
     refresh_flight: Mutex<RefreshFlight>,
+    /// Per-host coverage versions for the refresh **coverage gate** (#497, commit 2).
+    /// `current` bumps on every set-changing republish (the editor's pulled view is
+    /// now stale); `served` records the `current` a pull was answered against. A
+    /// gated refresh fires only when some host has `current > served` ("dirty") — so
+    /// a change the editor already re-pulled (its own `didChange` pull advances
+    /// `served`) sends no redundant nudge. Drives [`Self::bump_current`],
+    /// [`Self::mark_served`], [`Self::is_dirty`]; forgotten on `didClose`.
+    coverage: Mutex<HashMap<Url, HostCoverage>>,
 }
 
 /// Workspace-wide single-flight state for `workspace/diagnostic/refresh` (#497).
@@ -386,8 +394,23 @@ pub(crate) struct DiagnosticAggregator {
 struct RefreshFlight {
     /// A refresh request has been sent and its ack is not yet received.
     in_flight: bool,
-    /// A refresh was requested while one was in flight; fire one more on completion.
+    /// A refresh was requested while one was in flight; bounds the trailing refresh
+    /// to one per window-with-activity (so a never-pulling editor can't spin).
     pending: bool,
+    /// At least one request during this window was **forced** (a downstream-forwarded
+    /// refresh, #521), so the trailing must fire regardless of the coverage gate —
+    /// there is no version representing what the downstream asked to refresh.
+    pending_forced: bool,
+}
+
+/// Per-host coverage versions for the refresh gate (#497, commit 2).
+#[derive(Default, Clone, Copy)]
+struct HostCoverage {
+    /// Bumped on each set-changing republish for this host.
+    current: u64,
+    /// The `current` value a pull was last answered against (a lower bound — read
+    /// before the pull's fold, so never ahead of what the editor actually received).
+    served: u64,
 }
 
 impl DiagnosticAggregator {
@@ -561,47 +584,155 @@ impl DiagnosticAggregator {
             .remove(host);
     }
 
-    /// Begin a workspace-wide refresh under the single-flight guard (#497).
+    /// Begin a workspace-wide refresh under the single-flight + coverage guard
+    /// (#497). `forced` is `true` for a downstream-forwarded refresh (#521), which
+    /// **bypasses the coverage gate** (no version represents what the downstream
+    /// asked to refresh); `false` for a push/eviction-origin refresh, which sends
+    /// only when some host is dirty ([`Self::is_dirty`]).
     ///
-    /// Returns `true` if the caller should actually send the refresh (no other was
-    /// in flight); `false` if one is already in flight — the request is recorded as
-    /// `pending` so [`Self::finish_refresh`] fires exactly one more on completion.
-    /// The caller pairs a `true` with sending the refresh and a later
-    /// [`Self::finish_refresh`]; a `false` requires no further action.
-    pub(crate) fn try_begin_refresh(&self) -> bool {
+    /// Returns `true` if the caller should send the refresh now; `false` otherwise.
+    /// A `false` means either one is already in flight (recorded as `pending` so
+    /// [`Self::finish_refresh`] fires one more on completion) or a gated request found
+    /// nothing dirty (the editor already has the current set — no nudge needed).
+    ///
+    /// `is_dirty` is evaluated **while holding** the guard lock, so the "set pending"
+    /// of a racing request is serialized against the "read pending + dirty" of a
+    /// concurrent [`Self::finish_refresh`] — without that, a push that bumps `current`
+    /// and sets `pending` between a stale dirty read and the lock could have its
+    /// trailing refresh dropped. Lock order is `refresh_flight → coverage` (the
+    /// coverage lock is a leaf; `bump_current`/`mark_served`/`is_dirty` never take
+    /// `refresh_flight`), so no cycle.
+    pub(crate) fn try_begin_refresh(&self, forced: bool) -> bool {
         let mut flight = self
             .refresh_flight
             .lock()
             .recover_poison("DiagnosticAggregator::refresh_flight");
         if flight.in_flight {
             flight.pending = true;
-            false
-        } else {
-            flight.in_flight = true;
-            true
+            flight.pending_forced |= forced;
+            return false;
         }
+        if !(forced || self.is_dirty()) {
+            return false; // gated + clean: the editor already has the current set
+        }
+        flight.in_flight = true;
+        true
     }
 
-    /// Complete an in-flight refresh (its ack arrived) under the single-flight
-    /// guard (#497). Returns `true` if a refresh was requested while this one was in
-    /// flight (`pending`) and the caller should send exactly one more — `in_flight`
-    /// stays set so the next requester still coalesces; `false` clears the guard.
+    /// Complete an in-flight refresh (its ack arrived) under the single-flight +
+    /// coverage guard (#497). Returns `true` if the caller should send exactly one
+    /// more — `in_flight` stays set so the next requester still coalesces — and
+    /// `false` clears the guard.
     ///
-    /// Setting `pending` and this check both take the guard lock, so a request that
-    /// races completion is never lost: it either sets `pending` before this reads it
-    /// (→ re-fire) or finds `in_flight` already cleared and sends fresh.
+    /// The trailing fires only when a request arrived during this window (`pending`,
+    /// which bounds it to one per window-with-activity so a never-pulling editor
+    /// can't spin) AND that work still needs a nudge — either it was `forced`, or a
+    /// host is still dirty (a covering pull would have advanced `served` and cleared
+    /// it). `pending`/`pending_forced` AND `is_dirty` are all read under this one
+    /// lock, so a request racing completion is never lost: it sets the flags (and its
+    /// bump is visible to the in-lock dirty read) before this reads them, or finds
+    /// `in_flight` already cleared and sends fresh.
     pub(crate) fn finish_refresh(&self) -> bool {
         let mut flight = self
             .refresh_flight
             .lock()
             .recover_poison("DiagnosticAggregator::refresh_flight");
-        if flight.pending {
-            flight.pending = false;
+        let fire = flight.pending && (flight.pending_forced || self.is_dirty());
+        flight.pending = false;
+        flight.pending_forced = false;
+        if fire {
             true
         } else {
             flight.in_flight = false;
             false
         }
+    }
+
+    /// Bump a host's `current` coverage version (#497) — a **push-origin** change the
+    /// editor doesn't know about just landed, so its last-pulled view is now stale.
+    /// Called only from the push/eviction paths (`publish_host_push`,
+    /// `publish_region_push`, `evict_connection_diagnostics`) when their `republish`
+    /// published a changed set — paired with the gated `request_pull_diagnostic_refresh`.
+    ///
+    /// Deliberately **not** bumped on editor-originated republishes (`publish_pull_layer`
+    /// /`clear_pull_layer`/edit-remerge/`clear_host`): those are answered by the
+    /// editor's own re-pull, so bumping there would strand `current > served` between
+    /// the editor's pull and its next one — defeating the gate during active editing.
+    ///
+    /// INVARIANT: every `current` bump must be **coverable by a later pull** so
+    /// `served` catches up — push/region/eviction fold into the pull
+    /// (`fold_push_fallback_diagnostics`). A future bump whose change a pull would NOT
+    /// reflect would strand `current > served` and turn every later push into a
+    /// refresh storm — keep this property (and the push-origin-only rule) when adding
+    /// bump sites.
+    pub(crate) fn bump_current(&self, host: &Url) {
+        let mut coverage = self
+            .coverage
+            .lock()
+            .recover_poison("DiagnosticAggregator::coverage");
+        // Look up by `&Url` first, cloning the host key only on first insert (the
+        // common path is a repeat push for an already-tracked host), matching
+        // `record`'s convention — no `Url` clone on the hot path.
+        if let Some(cov) = coverage.get_mut(host) {
+            cov.current += 1;
+        } else {
+            coverage.insert(
+                host.clone(),
+                HostCoverage {
+                    current: 1,
+                    served: 0,
+                },
+            );
+        }
+    }
+
+    /// Read a host's current coverage version (`0` if it has never changed). A pull
+    /// captures this *before* its fold and later passes it to [`Self::mark_served`],
+    /// so `served` is a lower bound (never ahead of the set the editor received).
+    pub(crate) fn current_version(&self, host: &Url) -> u64 {
+        self.coverage
+            .lock()
+            .recover_poison("DiagnosticAggregator::coverage")
+            .get(host)
+            .map_or(0, |c| c.current)
+    }
+
+    /// Record that a pull was answered for `host` against coverage version
+    /// `version` (#497): the editor now has the set as of `version`, so it is no
+    /// longer dirty up to there. Pure bookkeeping — it must **never** bump `current`
+    /// or republish, so a refresh→pull→`mark_served` cannot beget another refresh
+    /// (keeps #496/#499 loop-safety). Monotonic via `max`, so a slower concurrent
+    /// pull can't regress `served`. No-op for a host with no coverage entry (nothing
+    /// was ever pushed → nothing to be dirty about).
+    pub(crate) fn mark_served(&self, host: &Url, version: u64) {
+        if let Some(cov) = self
+            .coverage
+            .lock()
+            .recover_poison("DiagnosticAggregator::coverage")
+            .get_mut(host)
+        {
+            cov.served = cov.served.max(version);
+        }
+    }
+
+    /// Whether any open host has an uncovered set-change (`current > served`) — the
+    /// coverage gate for [`Self::try_begin_refresh`]/[`Self::finish_refresh`] (#497).
+    pub(crate) fn is_dirty(&self) -> bool {
+        self.coverage
+            .lock()
+            .recover_poison("DiagnosticAggregator::coverage")
+            .values()
+            .any(|c| c.current > c.served)
+    }
+
+    /// Forget a host's coverage versions (#497) — `didClose`, so the doc can no
+    /// longer be pulled and must not keep the workspace dirty. Paired with
+    /// [`Self::forget_published`].
+    pub(crate) fn forget_coverage(&self, host: &Url) {
+        self.coverage
+            .lock()
+            .recover_poison("DiagnosticAggregator::coverage")
+            .remove(host);
     }
 
     /// Drop one `source`'s slots (every server) under `host` — e.g. a region
@@ -1641,14 +1772,15 @@ mod tests {
     fn refresh_single_flight_collapses_a_burst_into_at_most_one_trailing() {
         // #497: while a workspace refresh is in flight (awaiting the editor's ack),
         // a burst of further requests must coalesce — at most ONE trailing refresh
-        // fires on completion, regardless of how many requests arrived.
+        // fires on completion. Uses `forced` requests so the test exercises the pure
+        // single-flight machinery without the coverage gate (covered separately).
         let agg = DiagnosticAggregator::new();
 
         // The first request of an idle guard is sent.
-        assert!(agg.try_begin_refresh(), "first request sends");
+        assert!(agg.try_begin_refresh(true), "first request sends");
         // Everything during the in-flight window coalesces (no new send).
-        assert!(!agg.try_begin_refresh(), "in-flight: coalesced");
-        assert!(!agg.try_begin_refresh(), "in-flight: still coalesced");
+        assert!(!agg.try_begin_refresh(true), "in-flight: coalesced");
+        assert!(!agg.try_begin_refresh(true), "in-flight: still coalesced");
 
         // On completion, the recorded `pending` fires exactly one trailing refresh
         // (guard stays in-flight so a request racing it still coalesces).
@@ -1658,7 +1790,7 @@ mod tests {
 
         // Guard clear → the next request sends again (no stuck in-flight).
         assert!(
-            agg.try_begin_refresh(),
+            agg.try_begin_refresh(true),
             "cleared guard → next request sends"
         );
         assert!(!agg.finish_refresh(), "no pending → clears");
@@ -1670,15 +1802,127 @@ mod tests {
         // must itself coalesce and drive one more trailing refresh — the guard
         // re-arms per window, so no change is ever stranded.
         let agg = DiagnosticAggregator::new();
-        assert!(agg.try_begin_refresh(), "first sends");
-        assert!(!agg.try_begin_refresh(), "coalesced → pending");
+        assert!(agg.try_begin_refresh(true), "first sends");
+        assert!(!agg.try_begin_refresh(true), "coalesced → pending");
         assert!(
             agg.finish_refresh(),
             "pending → trailing refresh, stays in-flight"
         );
         // A new request during the trailing refresh's window coalesces again.
-        assert!(!agg.try_begin_refresh(), "coalesced during trailing window");
+        assert!(
+            !agg.try_begin_refresh(true),
+            "coalesced during trailing window"
+        );
         assert!(agg.finish_refresh(), "second pending → one more trailing");
         assert!(!agg.finish_refresh(), "now drained → clears");
+    }
+
+    #[test]
+    fn coverage_gate_blocks_a_clean_request_and_passes_a_dirty_one() {
+        // #497 commit 2: a non-forced (push/eviction-origin) request sends only when
+        // some host is dirty (`current > served`); a `forced` one always sends.
+        let agg = DiagnosticAggregator::new();
+        let h = host();
+
+        // Nothing has changed → not dirty → a gated request sends nothing…
+        assert!(!agg.is_dirty(), "fresh aggregator is clean");
+        assert!(!agg.try_begin_refresh(false), "gated + clean → no refresh");
+        // …but a forced (downstream-forwarded) refresh bypasses the gate.
+        assert!(agg.try_begin_refresh(true), "forced bypasses the gate");
+        assert!(!agg.finish_refresh(), "no pending → clears");
+
+        // A set-change makes the host dirty → the gated request now sends.
+        agg.bump_current(&h);
+        assert!(agg.is_dirty(), "a bumped, un-served host is dirty");
+        assert!(agg.try_begin_refresh(false), "gated + dirty → sends");
+        assert!(!agg.finish_refresh(), "no pending → clears");
+    }
+
+    #[test]
+    fn coverage_gate_suppresses_the_trailing_when_a_pull_covered_the_change() {
+        // The win: a change pushed during the in-flight window is covered by the
+        // editor's own pull (which advances `served`), so the trailing is suppressed.
+        let agg = DiagnosticAggregator::new();
+        let h = host();
+
+        agg.bump_current(&h); // current=1, served=0 → dirty
+        assert!(agg.try_begin_refresh(false), "dirty → first refresh sends");
+        // Another change lands during the in-flight window (coalesced as pending).
+        agg.bump_current(&h); // current=2
+        assert!(!agg.try_begin_refresh(false), "in-flight → pending");
+        // The editor pulls and is answered against the latest version → not dirty.
+        agg.mark_served(&h, 2);
+        assert!(!agg.is_dirty(), "the pull covered both changes");
+        // Completion: pending was set, but nothing is dirty and it wasn't forced →
+        // the trailing is suppressed.
+        assert!(
+            !agg.finish_refresh(),
+            "covered by a pull → no redundant trailing refresh"
+        );
+    }
+
+    #[test]
+    fn coverage_gate_fires_the_trailing_when_still_dirty() {
+        // The complement: a change lands during the window and the editor has NOT
+        // pulled it → still dirty → the trailing fires.
+        let agg = DiagnosticAggregator::new();
+        let h = host();
+
+        agg.bump_current(&h); // dirty
+        assert!(agg.try_begin_refresh(false), "dirty → sends");
+        agg.bump_current(&h); // another change during the window → pending
+        assert!(!agg.try_begin_refresh(false), "in-flight → pending");
+        // No pull → still dirty → trailing fires once, then drains.
+        assert!(
+            agg.finish_refresh(),
+            "pending + still dirty → trailing fires"
+        );
+        assert!(!agg.finish_refresh(), "no further pending → clears");
+    }
+
+    #[test]
+    fn coverage_gate_does_not_spin_without_new_requests() {
+        // acks-but-never-pulls bound: with a host left dirty (editor acks the refresh
+        // but never pulls), `finish_refresh` must NOT keep firing — the trailing
+        // requires a `pending` (a request *during* the window), so absent new
+        // requests it fires zero trailing and clears. This is what prevents an
+        // ack-rate refresh spin.
+        let agg = DiagnosticAggregator::new();
+        let h = host();
+        agg.bump_current(&h); // dirty, and stays dirty (no pull ever)
+        assert!(agg.try_begin_refresh(false), "dirty → first refresh sends");
+        // No request arrived during the window → no pending → no trailing despite dirty.
+        assert!(
+            !agg.finish_refresh(),
+            "dirty but no pending → no trailing (no spin)"
+        );
+        // And it really cleared — a subsequent completion is a no-op.
+        assert!(!agg.finish_refresh(), "guard already clear");
+    }
+
+    #[test]
+    fn coverage_forget_and_served_bookkeeping() {
+        let agg = DiagnosticAggregator::new();
+        let h = host();
+        assert_eq!(agg.current_version(&h), 0, "unseen host starts at 0");
+        agg.bump_current(&h);
+        agg.bump_current(&h);
+        assert_eq!(agg.current_version(&h), 2);
+        // `served` is monotonic: a stale (lower) mark can't regress it.
+        agg.mark_served(&h, 2);
+        agg.mark_served(&h, 1);
+        assert!(
+            !agg.is_dirty(),
+            "served caught up and a stale mark didn't regress it"
+        );
+        // didClose forgets coverage entirely → a re-open starts clean.
+        agg.bump_current(&h); // dirty again
+        assert!(agg.is_dirty());
+        agg.forget_coverage(&h);
+        assert!(
+            !agg.is_dirty(),
+            "a closed host no longer keeps the workspace dirty"
+        );
+        assert_eq!(agg.current_version(&h), 0, "re-open starts fresh");
     }
 }

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -370,6 +370,24 @@ pub(crate) struct DiagnosticAggregator {
     /// (#422). Updated under the host's republish lock (same-host republishes are
     /// serialized), and forgotten on `didClose` ([`Self::forget_published`]).
     last_published: Mutex<HashMap<Url, Vec<Diagnostic>>>,
+    /// Single-flight guard for the **workspace-wide** `workspace/diagnostic/refresh`
+    /// nudge (#497). `workspace/diagnostic/refresh` is param-less and workspace-wide,
+    /// so concurrent refreshes are redundant; without this, a burst of set-changing
+    /// pushes spawns one detached refresh request *each*, every one a tower-lsp
+    /// pending-request entry until the editor acks. This collapses a burst: at most
+    /// one refresh is in flight (awaiting the editor's ack); further requests during
+    /// that window set `pending`, which fires exactly one more refresh on
+    /// completion. Drives [`Self::try_begin_refresh`]/[`Self::finish_refresh`].
+    refresh_flight: Mutex<RefreshFlight>,
+}
+
+/// Workspace-wide single-flight state for `workspace/diagnostic/refresh` (#497).
+#[derive(Default)]
+struct RefreshFlight {
+    /// A refresh request has been sent and its ack is not yet received.
+    in_flight: bool,
+    /// A refresh was requested while one was in flight; fire one more on completion.
+    pending: bool,
 }
 
 impl DiagnosticAggregator {
@@ -541,6 +559,49 @@ impl DiagnosticAggregator {
             .lock()
             .recover_poison("DiagnosticAggregator::last_published")
             .remove(host);
+    }
+
+    /// Begin a workspace-wide refresh under the single-flight guard (#497).
+    ///
+    /// Returns `true` if the caller should actually send the refresh (no other was
+    /// in flight); `false` if one is already in flight — the request is recorded as
+    /// `pending` so [`Self::finish_refresh`] fires exactly one more on completion.
+    /// The caller pairs a `true` with sending the refresh and a later
+    /// [`Self::finish_refresh`]; a `false` requires no further action.
+    pub(crate) fn try_begin_refresh(&self) -> bool {
+        let mut flight = self
+            .refresh_flight
+            .lock()
+            .recover_poison("DiagnosticAggregator::refresh_flight");
+        if flight.in_flight {
+            flight.pending = true;
+            false
+        } else {
+            flight.in_flight = true;
+            true
+        }
+    }
+
+    /// Complete an in-flight refresh (its ack arrived) under the single-flight
+    /// guard (#497). Returns `true` if a refresh was requested while this one was in
+    /// flight (`pending`) and the caller should send exactly one more — `in_flight`
+    /// stays set so the next requester still coalesces; `false` clears the guard.
+    ///
+    /// Setting `pending` and this check both take the guard lock, so a request that
+    /// races completion is never lost: it either sets `pending` before this reads it
+    /// (→ re-fire) or finds `in_flight` already cleared and sends fresh.
+    pub(crate) fn finish_refresh(&self) -> bool {
+        let mut flight = self
+            .refresh_flight
+            .lock()
+            .recover_poison("DiagnosticAggregator::refresh_flight");
+        if flight.pending {
+            flight.pending = false;
+            true
+        } else {
+            flight.in_flight = false;
+            false
+        }
     }
 
     /// Drop one `source`'s slots (every server) under `host` — e.g. a region
@@ -1574,5 +1635,50 @@ mod tests {
             vec![diag("r")],
         );
         assert!(agg.has_region_slots(&host()));
+    }
+
+    #[test]
+    fn refresh_single_flight_collapses_a_burst_into_at_most_one_trailing() {
+        // #497: while a workspace refresh is in flight (awaiting the editor's ack),
+        // a burst of further requests must coalesce — at most ONE trailing refresh
+        // fires on completion, regardless of how many requests arrived.
+        let agg = DiagnosticAggregator::new();
+
+        // The first request of an idle guard is sent.
+        assert!(agg.try_begin_refresh(), "first request sends");
+        // Everything during the in-flight window coalesces (no new send).
+        assert!(!agg.try_begin_refresh(), "in-flight: coalesced");
+        assert!(!agg.try_begin_refresh(), "in-flight: still coalesced");
+
+        // On completion, the recorded `pending` fires exactly one trailing refresh
+        // (guard stays in-flight so a request racing it still coalesces).
+        assert!(agg.finish_refresh(), "pending → one trailing refresh");
+        // The trailing refresh saw no further requests → it clears the guard.
+        assert!(!agg.finish_refresh(), "no further pending → guard clears");
+
+        // Guard clear → the next request sends again (no stuck in-flight).
+        assert!(
+            agg.try_begin_refresh(),
+            "cleared guard → next request sends"
+        );
+        assert!(!agg.finish_refresh(), "no pending → clears");
+    }
+
+    #[test]
+    fn refresh_single_flight_re_pends_each_window_independently() {
+        // A request arriving during the *trailing* refresh's own in-flight window
+        // must itself coalesce and drive one more trailing refresh — the guard
+        // re-arms per window, so no change is ever stranded.
+        let agg = DiagnosticAggregator::new();
+        assert!(agg.try_begin_refresh(), "first sends");
+        assert!(!agg.try_begin_refresh(), "coalesced → pending");
+        assert!(
+            agg.finish_refresh(),
+            "pending → trailing refresh, stays in-flight"
+        );
+        // A new request during the trailing refresh's window coalesces again.
+        assert!(!agg.try_begin_refresh(), "coalesced during trailing window");
+        assert!(agg.finish_refresh(), "second pending → one more trailing");
+        assert!(!agg.finish_refresh(), "now drained → clears");
     }
 }

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -113,9 +113,27 @@ impl DiagnosticPublisher {
         );
         // A host `_self` push is spontaneous and asynchronous; a pull-mode client
         // won't know to re-pull, so nudge it when the merged set actually changed
-        // (push/pull-divergence, #422).
+        // (push/pull-divergence, #422). Bump the coverage version first so the gated
+        // refresh sees this push-origin change as dirty (#497) — only push/eviction
+        // origins bump; editor-originated republishes don't (the editor re-pulls).
         if self.republish(&host).await {
-            self.request_pull_diagnostic_refresh();
+            self.bump_current_if_open(&host);
+            self.request_pull_diagnostic_refresh(false);
+        }
+    }
+
+    /// Bump a host's coverage version, but only if it is still an open document
+    /// (#497). The open-check at the top of a push path and this bump straddle the
+    /// push's `record` + `republish().await`, so a `didClose` in that macro-window
+    /// could otherwise strand a coverage entry on a now-closed host that no pull will
+    /// ever clear — defeating the workspace-wide suppression for the rest of the
+    /// session. Re-reading `documents` here collapses that to the same narrow
+    /// resolve-vs-`didClose` micro-window the codebase already accepts (see
+    /// `text_document/did_close.rs`); fully closing it needs the deferred per-host
+    /// tombstone/epoch gate.
+    fn bump_current_if_open(&self, host: &Url) {
+        if self.documents.get(host).is_some() {
+            self.aggregator.bump_current(host);
         }
     }
 
@@ -242,8 +260,10 @@ impl DiagnosticPublisher {
         // A region push is spontaneous and asynchronous (a push-only injected-
         // language server); like the host push, nudge a pull-mode client to
         // re-pull when the merged set actually changed (push/pull-divergence, #422).
+        // Bump the coverage version (a push-origin change) before the gated refresh (#497).
         if self.republish(&host).await {
-            self.request_pull_diagnostic_refresh();
+            self.bump_current_if_open(&host);
+            self.request_pull_diagnostic_refresh(false);
         }
     }
 
@@ -312,10 +332,15 @@ impl DiagnosticPublisher {
         let affected = self.aggregator.evict_connection(connection_id);
         let mut any_changed = false;
         for host in affected {
-            any_changed |= self.republish(&host).await;
+            if self.republish(&host).await {
+                // A crash eviction is a push-origin change the editor doesn't know
+                // about → bump coverage so the gated refresh below fires (#497).
+                self.bump_current_if_open(&host);
+                any_changed = true;
+            }
         }
         if any_changed {
-            self.request_pull_diagnostic_refresh();
+            self.request_pull_diagnostic_refresh(false);
         }
     }
 
@@ -334,6 +359,11 @@ impl DiagnosticPublisher {
         // linger and a later re-open publishes afresh (#422). Done after the
         // clear-republish above so that publish still sees the prior set.
         self.aggregator.forget_published(host);
+        // Likewise forget its coverage versions (#497) — a closed doc can't be
+        // pulled, so it must not keep the workspace dirty; a re-open starts fresh at
+        // 0. (`clear_host` is editor-originated, so its republish doesn't bump
+        // `current`; this just drops any prior push-origin coverage state.)
+        self.aggregator.forget_coverage(host);
         // didClose is off the hot path: reclaim republish-lock entries whose lock
         // now has no live holder — this host's, once the clear-republish above
         // released it, plus any earlier-closed hosts that have since drained (#466).
@@ -477,7 +507,7 @@ impl DiagnosticPublisher {
     /// client that supports pull but not refresh would silently ignore the request,
     /// leaking a tower-lsp pending-request entry plus a parked task — the same gate
     /// the `semantic_tokens_refresh` path uses.
-    pub(crate) fn request_pull_diagnostic_refresh(&self) {
+    pub(crate) fn request_pull_diagnostic_refresh(&self, forced: bool) {
         let supported = self
             .settings_manager
             .client_capabilities_lock()
@@ -486,10 +516,12 @@ impl DiagnosticPublisher {
         if !supported {
             return;
         }
-        // Coalesce against any in-flight refresh: if one is already outstanding,
-        // this request is recorded as `pending` and the outstanding task's loop
-        // fires the trailing refresh — nothing more to do here.
-        if !self.aggregator.try_begin_refresh() {
+        // Coalesce against any in-flight refresh and apply the coverage gate (#497):
+        // `false` here means either one is already outstanding (recorded as `pending`,
+        // so the outstanding task's loop fires the trailing) or — for a non-`forced`
+        // request — nothing is dirty (the editor already has the current set). A
+        // `forced` downstream-forwarded refresh (#521) bypasses the coverage gate.
+        if !self.aggregator.try_begin_refresh(forced) {
             return;
         }
         let client = self.client.clone();
@@ -701,6 +733,60 @@ mod tests {
             .expect("a Host slot should be recorded for an open _self-bridged doc");
         assert_eq!(host_slots["rust_ls"].diagnostics.len(), 1);
         assert_eq!(host_slots["rust_ls"].diagnostics[0].message, "boom");
+    }
+
+    #[tokio::test]
+    async fn coverage_bumps_on_push_origin_not_on_pull_layer() {
+        // #497: only push/eviction-origin republishes bump the coverage version. An
+        // editor-originated `publish_pull_layer` changes the set but must NOT bump —
+        // bumping there would strand the host dirty between the editor's own pulls and
+        // defeat the gate during active editing (the debounce-vs-pull race).
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        register_rust(server);
+        server.settings_manager.apply_settings(rust_settings(true));
+        let uri = Url::parse("file:///test/host.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        let publisher = DiagnosticPublisher::new(server);
+
+        assert!(!server.diagnostics.is_dirty(), "fresh host is clean");
+
+        // A push-origin change bumps coverage → dirty.
+        publisher
+            .publish_host_push(
+                uri.as_str(),
+                "rust_ls".to_string(),
+                ProgressConnectionId::for_test(1),
+                vec![diag("boom")],
+            )
+            .await;
+        assert!(
+            server.diagnostics.is_dirty(),
+            "a push-origin change makes the host dirty"
+        );
+
+        // The editor pulls and is answered against the current version → clean.
+        let v = server.diagnostics.current_version(&uri);
+        server.diagnostics.mark_served(&uri, v);
+        assert!(
+            !server.diagnostics.is_dirty(),
+            "a covering pull clears dirty"
+        );
+
+        // An editor-originated pull-layer republish changes the merged set (it is
+        // published) but must NOT re-dirty the host.
+        publisher
+            .publish_pull_layer(&uri, vec![diag("from-pull-layer")])
+            .await;
+        assert!(
+            !server.diagnostics.is_dirty(),
+            "pull-layer (editor-origin) republish must not bump the coverage version"
+        );
     }
 
     #[tokio::test]

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -463,6 +463,16 @@ impl DiagnosticPublisher {
     /// that doesn't answer). Detaching it keeps the push path non-blocking and
     /// avoids the upstream-notification loop's inline-await head-of-line block.
     ///
+    /// **Single-flight (#497):** `workspace/diagnostic/refresh` is param-less and
+    /// workspace-wide, so concurrent refreshes are redundant. A burst of
+    /// set-changing pushes would otherwise spawn one detached refresh request each —
+    /// every one an un-acked tower-lsp pending-request entry. The aggregator's
+    /// guard ([`DiagnosticAggregator::try_begin_refresh`]) collapses the burst: at
+    /// most one refresh is in flight (awaiting the editor's ack); requests during
+    /// that window set `pending`, and the spawned task loops to fire exactly one
+    /// more on completion ([`DiagnosticAggregator::finish_refresh`]). The trailing
+    /// refresh still guarantees the editor re-pulls after the last change.
+    ///
     /// Gated on the client advertising `workspace.diagnostics.refreshSupport`: a
     /// client that supports pull but not refresh would silently ignore the request,
     /// leaking a tower-lsp pending-request entry plus a parked task — the same gate
@@ -476,13 +486,52 @@ impl DiagnosticPublisher {
         if !supported {
             return;
         }
+        // Coalesce against any in-flight refresh: if one is already outstanding,
+        // this request is recorded as `pending` and the outstanding task's loop
+        // fires the trailing refresh — nothing more to do here.
+        if !self.aggregator.try_begin_refresh() {
+            return;
+        }
         let client = self.client.clone();
+        let aggregator = Arc::clone(&self.aggregator);
         tokio::spawn(async move {
-            if let Err(e) = client.workspace_diagnostic_refresh().await {
-                log::debug!(
-                    target: LOG_TARGET,
-                    "workspace/diagnostic/refresh failed: {e}"
-                );
+            loop {
+                // `workspace_diagnostic_refresh()` resolves when the editor answers
+                // the request. A conformant client always answers (the transport is
+                // reliable), so this resolves and `finish_refresh` runs. The lone
+                // wedge is a live client that advertises `refreshSupport`, receives
+                // the request, and never answers (a protocol violation, or a client
+                // bug): the await never resolves, `in_flight` stays set, and further
+                // refreshes coalesce into a `pending` that never fires. That is
+                // accepted degradation — such a client ignores refreshes anyway, so
+                // suppressing further (useless) ones is harmless. We deliberately do
+                // **not** wrap this in `tokio::time::timeout`: dropping the request
+                // future strands tower-lsp's pending-request entry (it is reaped only
+                // on a matching response or socket close, never on receiver-drop), so
+                // re-firing on timeout would accumulate one stranded entry per change
+                // — the very leak this single-flight exists to bound.
+                //
+                // Panic-safety: the one panic this task can hit is tower-lsp's
+                // shutdown-time `expect("sender already dropped")` in the response
+                // await — reachable only when the whole pending-request map drops
+                // with the `ClientSocket` at teardown (a real response always *sends*
+                // on the waiter, never drops it). At shutdown the stuck `in_flight`
+                // is moot (the aggregator is being dropped) and tokio isolates the
+                // panicking task, so no `catch_unwind` is warranted. TRIPWIRE: if a
+                // future change adds a *pre-shutdown* panic source to this task,
+                // revisit — it would wedge the guard (and a drop-guard "fix" would
+                // reopen the `finish_refresh` lost-wakeup, so clear it atomically).
+                if let Err(e) = client.workspace_diagnostic_refresh().await {
+                    log::debug!(
+                        target: LOG_TARGET,
+                        "workspace/diagnostic/refresh failed: {e}"
+                    );
+                }
+                // Fire exactly one more iff a refresh was requested while this one
+                // was in flight; otherwise the guard is now clear and we stop.
+                if !aggregator.finish_refresh() {
+                    break;
+                }
             }
         });
     }

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -989,7 +989,9 @@ async fn deliver_upstream_notification(
             // settings to gate on, so the forward is dropped; production always has
             // one (#521).
             if let Some(publisher) = diagnostic_publisher {
-                publisher.request_pull_diagnostic_refresh();
+                // `forced`: a downstream server explicitly asked for a refresh, which
+                // no coverage version represents, so bypass the coverage gate (#497).
+                publisher.request_pull_diagnostic_refresh(true);
             }
         }
         UpstreamNotification::PublishDiagnostics {

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -109,9 +109,27 @@ impl Kakehashi {
             return Ok(empty_diagnostic_report());
         }
 
+        // Capture the coverage version BEFORE doing any work (the fold below reads
+        // the push cache), so the `served` we record once we hand the editor a report
+        // is a lower bound — never ahead of the set it actually receives (#497). A
+        // concurrent push bumping `current` after this read just makes the *next*
+        // refresh redundant, never skips a needed one. Recorded only on the paths
+        // that return a report for this open doc (not the cancel path).
+        //
+        // Known limitation (deferred epoch class, like `did_close.rs`): if this doc
+        // is closed and re-opened while this pull is in flight, `forget_coverage`
+        // resets the entry to 0 and this captured version becomes stale-HIGH for the
+        // re-opened incarnation. `mark_served` then sets `served` above the re-opened
+        // `current`, leaving the gate briefly stuck-clean → a needed refresh can be
+        // skipped (narrow staleness) until `current` catches back up. Closing this
+        // fully needs a per-incarnation epoch; the editor's own re-open pull
+        // self-heals it.
+        let served_version = self.diagnostics.current_version(&uri);
+
         // Get the language for this document
         let Some(language_name) = self.document_language(&uri) else {
             log::debug!(target: "kakehashi::diagnostic", "No language detected");
+            self.diagnostics.mark_served(&uri, served_version);
             return Ok(empty_diagnostic_report());
         };
 
@@ -132,6 +150,7 @@ impl Kakehashi {
                 "no diagnostic layer enabled for {} (layers.aggregation priorities / bridge._self)",
                 language_name
             );
+            self.diagnostics.mark_served(&uri, served_version);
             return Ok(empty_diagnostic_report());
         }
 
@@ -296,6 +315,12 @@ impl Kakehashi {
             &mut host_items,
         )
         .await;
+
+        // The editor is about to receive the current merged set: advance `served` to
+        // the version captured at entry, so the refresh gate stops treating those
+        // changes as dirty (#497). Pure bookkeeping — never republishes — so this
+        // can't beget a refresh.
+        self.diagnostics.mark_served(&uri, served_version);
 
         Ok(make_diagnostic_report(combine_layer_diagnostics(
             &layer_cfg, virt_items, host_items,

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -470,14 +470,13 @@ fn e2e_downstream_crash_refreshes_pull_clients() {
         .expect("editor should receive the pushed diagnostic before the crash");
 
     // That spontaneous push itself changed the merged set, so it also drives a
-    // refresh (push/pull-divergence, #422). Consume it so the next refresh we wait
-    // for is unambiguously the crash-eviction one (#499).
-    assert!(
-        client
-            .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_secs(15))
-            .is_some(),
-        "the spontaneous push must drive a workspace/diagnostic/refresh (#422)"
-    );
+    // refresh (push/pull-divergence, #422). Consume it, and **ack** it: the bridge
+    // single-flights the workspace refresh (#497), so the crash-eviction refresh
+    // below won't be sent until this one is answered.
+    let (push_refresh_id, _) = client
+        .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_secs(15))
+        .expect("the spontaneous push must drive a workspace/diagnostic/refresh (#422)");
+    client.send_response(push_refresh_id, json!(null));
 
     // The content-changing edit reaches the mock, driving it to exit (crash). The
     // bridge's reader sees EOF, evicts the dead connection's slots, and republishes

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -653,18 +653,20 @@ impl LspClient {
 
     /// Wait for the first server→client **request** (a message carrying both an
     /// `id` and a `method`) whose method is `expected_method`, returning its
-    /// params (`Value::Null` for a param-less request like
+    /// `(id, params)` (`params` is `Value::Null` for a param-less request like
     /// `workspace/diagnostic/refresh`). Returns None on timeout or disconnect.
     ///
     /// `wait_for_notification*` deliberately skip messages with an `id`, so they
     /// can't observe a server-initiated request; this is the counterpart that does.
-    /// The request's response is left unsent — the server's refresh is spawned and
-    /// not awaited, so an unanswered request doesn't stall it.
+    /// The `id` is returned so the caller can ack via [`Self::send_response`] —
+    /// needed when the server single-flights on the ack (e.g. the workspace
+    /// diagnostic refresh, #497): the next refresh won't fire until this one is
+    /// answered.
     pub(crate) fn wait_for_server_request(
         &mut self,
         expected_method: &str,
         timeout: Duration,
-    ) -> Option<Value> {
+    ) -> Option<(Value, Value)> {
         let start_time = Instant::now();
 
         loop {
@@ -673,23 +675,28 @@ impl LspClient {
                 return None;
             }
 
-            let mut message = self.try_receive_message(remaining)?;
+            let message = self.try_receive_message(remaining)?;
 
-            if message.get("id").is_some()
-                && message.get("method").and_then(|m| m.as_str()) == Some(expected_method)
+            // A server→client request carries both an `id` and a `method`. The
+            // message is discarded right after, so destructure it and `remove` the
+            // fields (one lookup each, moved rather than cloned). A message with no
+            // `id` (a notification) fails the inner `remove` and is skipped.
+            if let Value::Object(mut map) = message
+                && map.get("method").and_then(|m| m.as_str()) == Some(expected_method)
+                && let Some(id) = map.remove("id")
             {
-                // `message` is discarded right after, so move `params` out instead
-                // of cloning it.
-                return Some(
-                    message
-                        .get_mut("params")
-                        .map(Value::take)
-                        .unwrap_or(Value::Null),
-                );
+                let params = map.remove("params").unwrap_or(Value::Null);
+                return Some((id, params));
             }
             // A response or notification, or a different request — skip and keep
             // waiting within the deadline.
         }
+    }
+
+    /// Send a JSON-RPC success response for a server→client request `id` (e.g. to
+    /// ack a `workspace/diagnostic/refresh`).
+    pub(crate) fn send_response(&mut self, id: Value, result: Value) {
+        self.send_message(&json!({ "jsonrpc": "2.0", "id": id, "result": result }));
     }
 
     /// Try to receive a message within `timeout`, returning None if none arrives.


### PR DESCRIPTION
Implements #497 in two commits: **single-flight** + **coverage gate**.

## Problem
Every set-changing downstream push — `publish_host_push` / `publish_region_push`, crash-eviction, and the #521 forwarded refresh — spawned a fresh detached workspace-wide `workspace/diagnostic/refresh`. Concurrent ones are redundant and each un-acked one is a tower-lsp pending-request entry; and even one-at-a-time, a refresh fired on every change even when the editor had already re-pulled it.

## Commit 1 — single-flight
Workspace-wide guard in the shared `DiagnosticAggregator` (`try_begin_refresh`/`finish_refresh`): at most one refresh in flight (awaiting the editor's ack); requests during that window set `pending`; the spawned task loops to fire exactly one trailing refresh on completion. Bounds concurrent un-acked refreshes to one and collapses bursts (incl. the #521 forwarded refresh). **No `tokio::time::timeout`** deliberately (dropping the request future strands tower-lsp's pending entry → re-fire leak); the mute-editor wedge is accepted + documented + tripwired.

## Commit 2 — coverage gate
Per-host `current` (bumped on push/eviction-origin set-changes only) and `served` (the `current` a pull was answered against, captured before the fold → a lower bound). A push/eviction refresh fires only when some host is **dirty** (`current > served`); the trailing fires only when a request arrived during the window AND it was `forced` or a host is still dirty. So a change the editor already re-pulled (its own `didChange` pull advances `served`) sends no redundant nudge; a never-pulling editor can't spin (the trailing needs a `pending`); the #521 forwarded refresh bypasses the gate (`forced`). `is_dirty` is read under the `refresh_flight` lock (no TOCTOU); editor-originated republishes (pull-layer/edit/`clear_host`) don't bump.

## Known limitations (deferred per-incarnation epoch class — same as `did_close.rs:78-82`)
Commit 2's optimization is fully robust only once the deferred tombstone/epoch gate lands. Until then, two narrow `didClose`-race windows exist:
1. **Stranded coverage entry** (degrades to commit-1, not staleness): a `didClose` racing a push between the doc-open check and `bump_current` could strand a `current>served` entry on a closed host → workspace-wide suppression defeated → every push fires an un-suppressed (single-flighted) refresh = **exactly commit-1 behavior**. Mitigated by re-reading `documents` immediately before the bump (`bump_current_if_open`), collapsing it to the same micro-window the codebase already accepts; full closure needs the epoch gate.
2. **Stale `served`** (narrow staleness, self-healing): a `didClose`→`didOpen`→push during an in-flight pull can mark `served` above the re-opened `current`, briefly skipping a needed refresh until `current` catches up; the editor's own re-open pull self-heals it. Documented at the capture site.

Net: commit 2 is ≥ commit 1 under limitation 1 and adds only the narrow, self-healing window of limitation 2 — both inherit the already-deferred epoch race class.

## Tests
- Unit: single-flight collapse + per-window re-arm; coverage gate block/pass, trailing suppressed by a covering pull, trailing-when-still-dirty, no-spin bound, served/forget bookkeeping; push-origin-only bump (pull-layer doesn't dirty).
- E2E: the #499 crash-refresh and #521 forwarded/gated refresh tests pass.

Local: full `cargo test --lib` 2180 pass, e2e push 33 pass, clippy clean. Reviews: /review + Codex (caught & fixed a finish_refresh TOCTOU + a bump-stranding) + pi-review (caught the two didClose-race limitations above) + Gemini (commit 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)