### PR TITLE
feat(parse): flip didOpen present-parser parse off the ingress ticket (#6)

### DIFF
--- a/benches/semantic_tokens.rs
+++ b/benches/semantic_tokens.rs
@@ -391,6 +391,12 @@ enum Kind {
     /// so each measured request pays incremental reparse + cache invalidation +
     /// delta diff on top of the (full) token recompute.
     EditDelta,
+    /// Cold-open latency: each iteration opens a FRESH document and times
+    /// `didOpen` → first `semanticTokens/full` response — the editor-visible
+    /// "open the file, see highlights" latency. The one scenario that captures
+    /// the open parse itself (no settle sleep), so it is what validates the
+    /// off-ingress open flip (#6) against the reader's watermark settle budget.
+    OpenFirstToken,
 }
 
 /// Mutable per-run state for [`Kind::EditDelta`]: the next `didChange` version,
@@ -426,6 +432,9 @@ fn measure(
     iters: usize,
     warmup: usize,
 ) -> Vec<Duration> {
+    if let Kind::OpenFirstToken = scn.kind {
+        return measure_open(bin, scn, data_dir, iters, warmup);
+    }
     let mut server = Server::start(&bin.path, data_dir);
     server.did_open(scn.uri, scn.language_id, &scn.content);
     // Let the initial parse settle (didOpen parse may be async).
@@ -457,9 +466,43 @@ fn measure(
     samples
 }
 
+/// Cold-open latency loop for [`Kind::OpenFirstToken`]. Each iteration opens a
+/// FRESH document (unique URI, so it is a genuine cold open rather than a reopen)
+/// and times `didOpen` → first `semanticTokens/full` response. No settle sleep —
+/// capturing the open parse is the whole point: this is the path the off-ingress
+/// flip (#6) changes from "gated by the ingress barrier (always the full parse)"
+/// to "gated by the reader's watermark settle budget, then an on-demand fallback
+/// parse if it times out". The language is driven by `language_id` (detected
+/// before the path's now-mangled extension), so the per-iteration URI suffix is
+/// harmless.
+fn measure_open(
+    bin: &Binary,
+    scn: &Scenario,
+    data_dir: &str,
+    iters: usize,
+    warmup: usize,
+) -> Vec<Duration> {
+    let mut server = Server::start(&bin.path, data_dir);
+    let mut samples = Vec::with_capacity(iters);
+    for i in 0..(warmup + iters) {
+        let uri = format!("{}_{i}", scn.uri);
+        let start = Instant::now();
+        server.did_open(&uri, scn.language_id, &scn.content);
+        // Blocks until the server answers — i.e. until the (off-ingress) open parse
+        // has produced a tree the reader can tokenize, or the reader fell back to an
+        // on-demand parse.
+        let _ = server.semantic_full(&uri);
+        let elapsed = start.elapsed();
+        if i >= warmup {
+            samples.push(elapsed);
+        }
+    }
+    samples
+}
+
 fn seed_result_id(server: &mut Server, scn: &Scenario) -> String {
     match scn.kind {
-        Kind::Full => String::new(),
+        Kind::Full | Kind::OpenFirstToken => String::new(),
         // Both delta-based scenarios need an initial result_id to diff against.
         Kind::DeltaNoop | Kind::EditDelta => {
             result_id_of(&server.semantic_full(scn.uri)).unwrap_or_default()
@@ -474,6 +517,8 @@ fn run_once(
     edit: &mut EditState,
 ) {
     match scn.kind {
+        // Handled by `measure_open`, which never calls `run_once`.
+        Kind::OpenFirstToken => unreachable!("OpenFirstToken uses measure_open"),
         Kind::Full => {
             let _ = server.semantic_full(scn.uri);
         }
@@ -596,6 +641,42 @@ fn main() {
             content: gen_markdown_injections(60),
             kind: Kind::EditDelta,
             targets: "edit→reparse→injection re-detect→cache invalidation→delta (typing)",
+        },
+        // Cold-open latency scenarios for the #6 off-ingress flip. The reader gates
+        // on the **host parse** via the watermark (≤200ms budget), then falls back to
+        // an on-demand parse; the expensive injection work runs off the reader's
+        // critical path. So the regime that risks a regression is a doc whose *host
+        // parse* alone exceeds 200ms — that is dense host-language source, NOT an
+        // injection-heavy doc (whose host parse is small; its cost is injections,
+        // off-path). Empirically: markdown stays well under budget at any realistic
+        // size; rust crosses ~200ms host-parse only around ~4000 dense functions
+        // (~150KB), where the on-demand fallback fires every open — and even there
+        // HEAD ≈ main, because token computation dominates and the redundant parse
+        // overlaps the off-ingress one.
+        Scenario {
+            name: "markdown_injections/open_first_token",
+            language_id: "markdown",
+            uri: "file:///bench/open_md.md",
+            content: gen_markdown_injections(150),
+            kind: Kind::OpenFirstToken,
+            targets: "cold open; injection work moved off the reader path (HEAD faster)",
+        },
+        Scenario {
+            name: "rust_large/open_first_token (host parse under budget)",
+            language_id: "rust",
+            uri: "file:///bench/open_rust_under.rs",
+            content: gen_rust(1500),
+            kind: Kind::OpenFirstToken,
+            targets: "cold open; host parse stays under the 200ms budget — no fallback",
+        },
+        Scenario {
+            name: "rust_xlarge/open_first_token (host parse OVER budget — fallback fires)",
+            language_id: "rust",
+            uri: "file:///bench/open_rust_over.rs",
+            content: gen_rust(4000),
+            kind: Kind::OpenFirstToken,
+            targets: "cold open whose host parse exceeds 200ms — the on-demand fallback \
+                      regime; validates no latency regression there (slow; use low iters)",
         },
     ];
 

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -480,7 +480,13 @@ impl DocumentStore {
     /// it does check, atomically under the same `get_mut` shard lock as the write:
     /// - **text** rejects a within-lifetime stale parse — a `didChange` landed while
     ///   parsing, so this tree (and its language, possibly shebang-derived) is of
-    ///   now-superseded text; the scheduler's reparse covers the newer text;
+    ///   now-superseded text; the scheduler's reparse covers the newer text. The
+    ///   check is `Arc::ptr_eq` on the `Arc<str>` the parse captured, **O(1)** — any
+    ///   text mutation (`didChange`) or reopen swaps in a *fresh* allocation, so
+    ///   pointer identity is exactly "same text this parse read" without an O(n)
+    ///   byte compare under the shard write lock (this is the large-document open
+    ///   path). A spurious mismatch could only drop a still-valid tree to a harmless
+    ///   reparse, never attach a stale one;
     /// - **incarnation** rejects a close + reopen — the result belongs to the prior
     ///   lifetime and must neither attach its tree nor clobber the reopened
     ///   document's freshly-inserted language.
@@ -492,14 +498,16 @@ impl DocumentStore {
     pub(crate) fn set_parse_result_if_text_and_incarnation_unchanged(
         &self,
         uri: &Url,
-        expected_text: &str,
+        expected_text: &Arc<str>,
         expected_incarnation: u64,
         language: Option<String>,
         tree: Option<Tree>,
     ) -> bool {
         let has_tree = tree.is_some();
         let stored = if let Some(mut doc) = self.documents.get_mut(uri) {
-            if doc.incarnation() == expected_incarnation && doc.text() == expected_text {
+            if doc.incarnation() == expected_incarnation
+                && Arc::ptr_eq(&doc.text_arc(), expected_text)
+            {
                 doc.set_parse_result(language, tree);
                 true
             } else {
@@ -1037,11 +1045,14 @@ mod tests {
             Some("text".to_string()),
             None,
         );
-        let incarnation = store.get(&uri).unwrap().incarnation();
+        let (incarnation, text) = {
+            let doc = store.get(&uri).unwrap();
+            (doc.incarnation(), doc.text_arc())
+        };
 
         assert!(store.set_parse_result_if_text_and_incarnation_unchanged(
             &uri,
-            "fn main() {}",
+            &text,
             incarnation,
             Some("rust".to_string()),
             Some(parse_rust("fn main() {}")),
@@ -1065,13 +1076,17 @@ mod tests {
             Some("rust".to_string()),
             None,
         );
-        let incarnation = store.get(&uri).unwrap().incarnation();
+        // Capture the text the parse "read" (its Arc identity) before the edit.
+        let (incarnation, text) = {
+            let doc = store.get(&uri).unwrap();
+            (doc.incarnation(), doc.text_arc())
+        };
         // A didChange landed mid-parse, moving the text on (same lifetime).
         store.apply_edit_clearing_tree(&uri, "fn newer() {}".to_string(), &[]);
 
         let stored = store.set_parse_result_if_text_and_incarnation_unchanged(
             &uri,
-            "fn main() {}",
+            &text,
             incarnation,
             Some("rust".to_string()),
             Some(parse_rust("fn main() {}")),
@@ -1093,9 +1108,12 @@ mod tests {
             Some("rust".to_string()),
             None,
         );
-        // The open parse read this lifetime's incarnation, then a didClose + reopen
-        // (identical text + language) raced it while parsing.
-        let stale_incarnation = store.get(&uri).unwrap().incarnation();
+        // The open parse read this lifetime's incarnation + text, then a didClose +
+        // reopen (identical text + language) raced it while parsing.
+        let (stale_incarnation, stale_text) = {
+            let doc = store.get(&uri).unwrap();
+            (doc.incarnation(), doc.text_arc())
+        };
         store.remove(&uri);
         store.insert(
             uri.clone(),
@@ -1106,7 +1124,7 @@ mod tests {
 
         let stored = store.set_parse_result_if_text_and_incarnation_unchanged(
             &uri,
-            "fn main() {}",
+            &stale_text,
             stale_incarnation,
             Some("rust".to_string()),
             Some(parse_rust("fn main() {}")),
@@ -1128,7 +1146,7 @@ mod tests {
         // No document exists (a didClose removed it before the off-ingress parse ran).
         assert!(!store.set_parse_result_if_text_and_incarnation_unchanged(
             &uri,
-            "fn main() {}",
+            &Arc::<str>::from("fn main() {}"),
             1,
             Some("rust".to_string()),
             Some(parse_rust("fn main() {}")),

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -1076,6 +1076,44 @@ mod tests {
     }
 
     #[test]
+    fn set_parse_result_if_text_and_incarnation_unchanged_records_language_without_a_tree() {
+        // The parse-failed-but-language-detected path (parse timeout / parser
+        // unavailable / join error): the open parse records the detected language
+        // with NO tree, so a host-bridged document keeps its language after a parse
+        // failure rather than being nulled out.
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///open_lang_no_tree.rs").unwrap();
+        store.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("text".to_string()),
+            None,
+        );
+        let (incarnation, text) = {
+            let doc = store.get(&uri).unwrap();
+            (doc.incarnation(), doc.text_arc())
+        };
+
+        assert!(store.set_parse_result_if_text_and_incarnation_unchanged(
+            &uri,
+            &text,
+            incarnation,
+            Some("rust".to_string()),
+            None,
+        ));
+        let doc = store.get(&uri).unwrap();
+        assert_eq!(
+            doc.language_id(),
+            Some("rust"),
+            "the detected language is recorded even though the parse produced no tree"
+        );
+        assert!(
+            doc.tree().is_none(),
+            "no tree lands on the parse-failure path"
+        );
+    }
+
+    #[test]
     fn set_parse_result_if_text_and_incarnation_unchanged_rejects_stale_text() {
         let store = DocumentStore::new();
         let uri = Url::parse("file:///open_stale_text.rs").unwrap();

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -162,7 +162,16 @@ impl DocumentStore {
     }
 
     pub fn mark_parse_finished(&self, uri: &Url, generation: u64, has_tree: bool) {
-        let sender = self.parse_sender(uri);
+        // Non-inserting (`get`, not `parse_sender`'s get-or-insert), mirroring
+        // [`mark_tree_available_if_tracked`]: once the open parse runs off the ingress
+        // ticket (#6) a `didClose` can land between `mark_parse_started` and here, and
+        // `remove` drops `parse_states` first — a get-or-insert would recreate an
+        // orphan default entry for the closed URI. The generation guard already
+        // prevents state corruption; this also stops the resurrection. Holding the
+        // `Ref` serializes against that `remove`.
+        let Some(sender) = self.parse_states.get(uri) else {
+            return;
+        };
         let mut state = *sender.borrow();
         if state.generation != generation {
             return;

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -335,36 +335,6 @@ impl DocumentStore {
         self.ensure_watermark_entry(uri, incarnation);
     }
 
-    /// Record the didOpen parse's result (detected `language` + optional `tree`) on
-    /// the **existing** document, preserving its already-stored text. Returns whether
-    /// it was stored.
-    ///
-    /// The registering `didOpen` inserts the document (with its text) before the
-    /// parse, so the parse never needs to carry the text again — it updates language
-    /// and tree in place, avoiding a full-document copy per open. **Non-inserting**
-    /// (`get_mut`): a document a concurrent `didClose` removed is left gone, not
-    /// resurrected — so once the open parse moves off the ingress ticket (the didOpen
-    /// flip) a close racing it stays closed. Availability is marked only when a tree
-    /// landed (the no-tree paths rely on the following `mark_parse_finished(false)`).
-    pub(crate) fn set_parse_result_if_present(
-        &self,
-        uri: &Url,
-        language: Option<String>,
-        tree: Option<Tree>,
-    ) -> bool {
-        let has_tree = tree.is_some();
-        let stored = if let Some(mut doc) = self.documents.get_mut(uri) {
-            doc.set_parse_result(language, tree);
-            true
-        } else {
-            false
-        };
-        if stored && has_tree {
-            self.mark_tree_available_if_tracked(uri);
-        }
-        stored
-    }
-
     /// Store `new_tree` for an **existing** document, but only if its current text
     /// still equals `expected_text`. Returns `true` iff the tree was stored.
     ///
@@ -492,6 +462,53 @@ impl DocumentStore {
             false
         };
         if stored {
+            self.mark_tree_available_if_tracked(uri);
+        }
+        stored
+    }
+
+    /// Record the didOpen parse's detected `language` + optional `tree` on the
+    /// **existing** document, preserving its already-stored text, but only if the
+    /// text and incarnation observed when the parse read them are unchanged.
+    /// Returns `true` iff it was stored.
+    ///
+    /// For the **off-ingress** didOpen parse ([`parse_document`]). Unlike
+    /// [`update_tree_if_text_and_language_unchanged`] it **sets** the language rather
+    /// than checking it: the open parse refines `language_for_path`'s initial guess
+    /// with content detection (`detect_language`), so it is the writer of the
+    /// authoritative language — there is no language to match against. The two axes
+    /// it does check, atomically under the same `get_mut` shard lock as the write:
+    /// - **text** rejects a within-lifetime stale parse — a `didChange` landed while
+    ///   parsing, so this tree (and its language, possibly shebang-derived) is of
+    ///   now-superseded text; the scheduler's reparse covers the newer text;
+    /// - **incarnation** rejects a close + reopen — the result belongs to the prior
+    ///   lifetime and must neither attach its tree nor clobber the reopened
+    ///   document's freshly-inserted language.
+    ///
+    /// **Non-inserting** (`get_mut`): a document a concurrent `didClose` removed is
+    /// left gone, not resurrected — the resurrection-safety the open parse needs once
+    /// it runs off the ingress ticket. Availability is marked only when a tree
+    /// landed (the no-tree paths rely on the caller's `mark_parse_finished(false)`).
+    pub(crate) fn set_parse_result_if_text_and_incarnation_unchanged(
+        &self,
+        uri: &Url,
+        expected_text: &str,
+        expected_incarnation: u64,
+        language: Option<String>,
+        tree: Option<Tree>,
+    ) -> bool {
+        let has_tree = tree.is_some();
+        let stored = if let Some(mut doc) = self.documents.get_mut(uri) {
+            if doc.incarnation() == expected_incarnation && doc.text() == expected_text {
+                doc.set_parse_result(language, tree);
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+        if stored && has_tree {
             self.mark_tree_available_if_tracked(uri);
         }
         stored
@@ -1005,6 +1022,120 @@ mod tests {
         assert!(
             store.get(&uri).is_none(),
             "must not resurrect a closed document"
+        );
+    }
+
+    #[test]
+    fn set_parse_result_if_text_and_incarnation_unchanged_sets_language_and_tree() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///open_refine.rs").unwrap();
+        // didOpen inserted the document with the path/id language guess ("text");
+        // the open parse refines it to the content-detected "rust" and attaches a tree.
+        store.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("text".to_string()),
+            None,
+        );
+        let incarnation = store.get(&uri).unwrap().incarnation();
+
+        assert!(store.set_parse_result_if_text_and_incarnation_unchanged(
+            &uri,
+            "fn main() {}",
+            incarnation,
+            Some("rust".to_string()),
+            Some(parse_rust("fn main() {}")),
+        ));
+        let doc = store.get(&uri).unwrap();
+        assert_eq!(
+            doc.language_id(),
+            Some("rust"),
+            "the open parse must SET (refine) the language, not just check it"
+        );
+        assert!(doc.tree().is_some(), "the tree must be attached");
+    }
+
+    #[test]
+    fn set_parse_result_if_text_and_incarnation_unchanged_rejects_stale_text() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///open_stale_text.rs").unwrap();
+        store.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        let incarnation = store.get(&uri).unwrap().incarnation();
+        // A didChange landed mid-parse, moving the text on (same lifetime).
+        store.apply_edit_clearing_tree(&uri, "fn newer() {}".to_string(), &[]);
+
+        let stored = store.set_parse_result_if_text_and_incarnation_unchanged(
+            &uri,
+            "fn main() {}",
+            incarnation,
+            Some("rust".to_string()),
+            Some(parse_rust("fn main() {}")),
+        );
+        assert!(!stored, "a tree parsed from now-stale text must be dropped");
+        assert!(
+            store.get(&uri).unwrap().tree().is_none(),
+            "the stale tree must not overwrite the newer text's (still-absent) tree"
+        );
+    }
+
+    #[test]
+    fn set_parse_result_if_text_and_incarnation_unchanged_rejects_a_reopen() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///open_reopen.rs").unwrap();
+        store.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        // The open parse read this lifetime's incarnation, then a didClose + reopen
+        // (identical text + language) raced it while parsing.
+        let stale_incarnation = store.get(&uri).unwrap().incarnation();
+        store.remove(&uri);
+        store.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+
+        let stored = store.set_parse_result_if_text_and_incarnation_unchanged(
+            &uri,
+            "fn main() {}",
+            stale_incarnation,
+            Some("rust".to_string()),
+            Some(parse_rust("fn main() {}")),
+        );
+        assert!(
+            !stored,
+            "a tree from the prior lifetime must not attach to the reopened document"
+        );
+        assert!(
+            store.get(&uri).unwrap().tree().is_none(),
+            "the reopened document keeps no tree from the closed lifetime"
+        );
+    }
+
+    #[test]
+    fn set_parse_result_if_text_and_incarnation_unchanged_does_not_resurrect_closed_document() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///open_closed.rs").unwrap();
+        // No document exists (a didClose removed it before the off-ingress parse ran).
+        assert!(!store.set_parse_result_if_text_and_incarnation_unchanged(
+            &uri,
+            "fn main() {}",
+            1,
+            Some("rust".to_string()),
+            Some(parse_rust("fn main() {}")),
+        ));
+        assert!(
+            store.get(&uri).is_none(),
+            "the off-ingress open parse must not resurrect a closed document"
         );
     }
 

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -509,15 +509,18 @@ impl DocumentStore {
         uri: &Url,
         expected_text: &Arc<str>,
         expected_incarnation: u64,
-        language: Option<String>,
+        language: Option<&str>,
         tree: Option<Tree>,
     ) -> bool {
         let has_tree = tree.is_some();
+        // `language` is borrowed: the `String` allocation is deferred to inside the
+        // successful CAS branch (`language.map(String::from)`), so a CAS that rejects
+        // (a `didChange`/reopen raced this off-ingress parse) allocates nothing.
         let stored = if let Some(mut doc) = self.documents.get_mut(uri) {
             if doc.incarnation() == expected_incarnation
                 && Arc::ptr_eq(&doc.text_arc(), expected_text)
             {
-                doc.set_parse_result(language, tree);
+                doc.set_parse_result(language.map(String::from), tree);
                 true
             } else {
                 false
@@ -1063,7 +1066,7 @@ mod tests {
             &uri,
             &text,
             incarnation,
-            Some("rust".to_string()),
+            Some("rust"),
             Some(parse_rust("fn main() {}")),
         ));
         let doc = store.get(&uri).unwrap();
@@ -1098,7 +1101,7 @@ mod tests {
             &uri,
             &text,
             incarnation,
-            Some("rust".to_string()),
+            Some("rust"),
             None,
         ));
         let doc = store.get(&uri).unwrap();
@@ -1135,7 +1138,7 @@ mod tests {
             &uri,
             &text,
             incarnation,
-            Some("rust".to_string()),
+            Some("rust"),
             Some(parse_rust("fn main() {}")),
         );
         assert!(!stored, "a tree parsed from now-stale text must be dropped");
@@ -1173,7 +1176,7 @@ mod tests {
             &uri,
             &stale_text,
             stale_incarnation,
-            Some("rust".to_string()),
+            Some("rust"),
             Some(parse_rust("fn main() {}")),
         );
         assert!(
@@ -1195,7 +1198,7 @@ mod tests {
             &uri,
             &Arc::<str>::from("fn main() {}"),
             1,
-            Some("rust".to_string()),
+            Some("rust"),
             Some(parse_rust("fn main() {}")),
         ));
         assert!(

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -310,8 +310,31 @@ impl ParseCoordinator {
                 // over the edit's tree.
                 return stored;
             }
+
+            // Parse produced no tree (timeout / parser unavailable / join error) but
+            // the language WAS detected — record it with no tree, rather than falling
+            // through to the no-language path below which would null it out. Host
+            // bridging needs only text + language (never a tree), so preserving the
+            // language keeps a host-bridged document working after a parse failure.
+            if self
+                .documents
+                .set_parse_result_if_text_and_incarnation_unchanged(
+                    &uri,
+                    &text,
+                    incarnation,
+                    Some(language_name),
+                    None,
+                )
+            {
+                self.documents
+                    .mark_parse_finished(&uri, parse_generation, false);
+            }
+            advance_watermark();
+            self.notifier().log_language_events(&events).await;
+            return false;
         }
 
+        // No language detected at all → store no language, no tree.
         if self
             .documents
             .set_parse_result_if_text_and_incarnation_unchanged(
@@ -327,7 +350,6 @@ impl ParseCoordinator {
         }
         advance_watermark();
         self.notifier().log_language_events(&events).await;
-        // Parsed to nothing / no detectable language → no tree landed.
         false
     }
 

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -144,16 +144,22 @@ impl ParseCoordinator {
     /// calling this, so the parse re-reads that stored text (a cheap `Arc<str>`
     /// refcount bump, [`text_arc`](crate::document::Document::text_arc)) rather than
     /// carrying a second owned `String`, and records the detected language + tree
-    /// **in place** via [`set_parse_result_if_present`] instead of re-inserting a
+    /// **in place** via the non-inserting, text + incarnation CAS
+    /// [`set_parse_result_if_text_and_incarnation_unchanged`] instead of re-inserting a
     /// fresh copy of the text. Net: zero full-document text copies in the open parse.
-    /// That store write is **non-inserting**, so it is resurrection-safe once the open
-    /// parse later moves off the ingress ticket (a `didClose` racing it stays closed).
+    /// That store write is **non-inserting** and lifetime-guarded, so it is
+    /// resurrection-safe and stale-safe once the open parse moves off the ingress
+    /// ticket: a `didClose` racing it stays closed, and a `didChange` / reopen landing
+    /// mid-parse drops the now-stale tree rather than clobbering the newer state.
     ///
     /// `ticket` is the ingress writer ticket of the mutation that scheduled this
     /// parse, or `None` for a caller outside the ingress sequence. On every resolution
-    /// path — a tree, a parsed-to-nothing, a previously-crashed parser, no detectable
-    /// language, or a document closed mid-parse — the parse advances the store's
-    /// per-document **watermark** to `ticket`, releasing a reader waiting on it.
+    /// path that still observes this lifetime — a tree, a parsed-to-nothing, a
+    /// previously-crashed parser, or no detectable language — the parse advances the
+    /// store's per-document **watermark** to `ticket` (guarded by the open
+    /// incarnation), releasing a reader waiting on it. The one path that does **not**
+    /// advance is a document already gone (a `didClose` removed it): its watermark
+    /// channel is gone too, so its readers have already fallen back.
     pub(crate) async fn parse_document(
         &self,
         uri: Url,
@@ -162,20 +168,35 @@ impl ParseCoordinator {
     ) {
         let mut events = Vec::new();
 
-        // Publish the watermark on whichever path resolves the parse below.
-        let advance_watermark = || {
-            if let Some(ticket) = ticket {
-                self.documents.advance_watermark(&uri, ticket);
-            }
+        // Read the text the registering didOpen already stored (a refcount bump, not
+        // a copy), together with the open lifetime's **incarnation** — BEFORE marking
+        // the parse started, so a document a `didClose` already removed leaves neither
+        // a resurrected document nor an orphan parse-state entry for the now-closed
+        // URI. A missing document stops **without** touching the watermark: the
+        // watermark is per-lifetime, so a plain advance with this prior-lifetime
+        // ticket could inflate a reopen's freshly-seeded channel and prematurely
+        // release a new-lifetime reader; a genuine close instead drops the channel and
+        // wakes its readers (they fall back). Unreachable while this parse is inline on
+        // the writer ticket (a `didClose` is gated behind the open); the guard is for
+        // the off-ingress open flip (#6), where a `didClose`/reopen can race it.
+        let Some((text, incarnation)) = self
+            .documents
+            .get(&uri)
+            .map(|doc| (doc.text_arc(), doc.incarnation()))
+        else {
+            return;
         };
 
-        // Read the text the registering didOpen already stored (a refcount bump, not
-        // a copy) — BEFORE marking the parse started, so a document a `didClose`
-        // already removed leaves neither a resurrected document nor an orphan
-        // parse-state entry for the now-closed URI. Resolve the watermark and stop.
-        let Some(text) = self.documents.get(&uri).map(|doc| doc.text_arc()) else {
-            advance_watermark();
-            return;
+        // Publish the watermark on whichever path resolves the parse below, but
+        // **only if this lifetime is still current**: a close + reopen re-seeds the
+        // watermark at 0, and this (prior-lifetime) ticket must not inflate it. Same
+        // lifetime → advances (releasing a gated reader even on the no-language /
+        // no-tree paths, to the empty fallback). Mirrors `reparse_latest`.
+        let advance_watermark = || {
+            if let Some(ticket) = ticket {
+                self.documents
+                    .advance_watermark_for_incarnation(&uri, ticket, incarnation);
+            }
         };
 
         let parse_generation = self.documents.mark_parse_started(&uri);
@@ -192,14 +213,21 @@ impl ParseCoordinator {
                     language_name
                 );
                 // Mark the parse finished only if the result actually landed: a
-                // `didClose` that removed the document mid-parse makes the store write
-                // a no-op, and `mark_parse_finished` would otherwise recreate a parse
-                // -state entry (via `parse_sender`'s vacant insert) for the closed URI.
-                // (Unreachable while the open parse is inline on the writer ticket; the
-                // guard is for the off-ingress open flip, #6.)
+                // `didClose` that removed the document mid-parse (or a `didChange` /
+                // reopen that moved the text or incarnation on) makes the CAS a no-op,
+                // and `mark_parse_finished` would otherwise recreate a parse-state
+                // entry (via `parse_sender`'s vacant insert) for the gone URI. The
+                // text + incarnation guard is what makes this resurrection-safe once
+                // the open parse runs off the ingress ticket (#6).
                 if self
                     .documents
-                    .set_parse_result_if_present(&uri, Some(language_name), None)
+                    .set_parse_result_if_text_and_incarnation_unchanged(
+                        &uri,
+                        &text,
+                        incarnation,
+                        Some(language_name),
+                        None,
+                    )
                 {
                     self.documents
                         .mark_parse_finished(&uri, parse_generation, false);
@@ -233,22 +261,31 @@ impl ParseCoordinator {
                 .await;
 
             if let Some(tree) = parsed_tree {
-                self.cache.populate_injections(
-                    &uri,
-                    &text,
-                    &tree,
-                    &language_name,
-                    &self.language,
-                    self.bridge.node_tracker(),
-                );
-
-                // `language_name` is unused past here — move it in (no clone). Gate
-                // `mark_parse_finished` on the store write landing (see the
-                // parser-failed path above).
-                if self
+                // Persist FIRST through the text + incarnation CAS (non-inserting), so
+                // a tree parsed from open-time text/lifetime is dropped when a
+                // `didChange` moved the text on or a `didClose`/reopen changed the
+                // incarnation — instead of clobbering the newer state. Only populate
+                // the injection caches when the tree actually landed, so a `didClose`
+                // racing this off-ingress parse can't leave stale injection entries for
+                // a gone document. (`Tree` clone is a cheap refcount bump.)
+                let stored = self
                     .documents
-                    .set_parse_result_if_present(&uri, Some(language_name), Some(tree))
-                {
+                    .set_parse_result_if_text_and_incarnation_unchanged(
+                        &uri,
+                        &text,
+                        incarnation,
+                        Some(language_name.clone()),
+                        Some(tree.clone()),
+                    );
+                if stored {
+                    self.cache.populate_injections(
+                        &uri,
+                        &text,
+                        &tree,
+                        &language_name,
+                        &self.language,
+                        self.bridge.node_tracker(),
+                    );
                     self.documents
                         .mark_parse_finished(&uri, parse_generation, true);
                 }
@@ -258,7 +295,16 @@ impl ParseCoordinator {
             }
         }
 
-        if self.documents.set_parse_result_if_present(&uri, None, None) {
+        if self
+            .documents
+            .set_parse_result_if_text_and_incarnation_unchanged(
+                &uri,
+                &text,
+                incarnation,
+                None,
+                None,
+            )
+        {
             self.documents
                 .mark_parse_finished(&uri, parse_generation, false);
         }

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -236,7 +236,7 @@ impl ParseCoordinator {
                         &uri,
                         &text,
                         incarnation,
-                        Some(language_name),
+                        Some(&language_name),
                         None,
                     )
                 {
@@ -287,7 +287,7 @@ impl ParseCoordinator {
                         &uri,
                         &text,
                         incarnation,
-                        Some(language_name.clone()),
+                        Some(&language_name),
                         Some(tree.clone()),
                     );
                 if stored {
@@ -322,7 +322,7 @@ impl ParseCoordinator {
                     &uri,
                     &text,
                     incarnation,
-                    Some(language_name),
+                    Some(&language_name),
                     None,
                 )
             {

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -160,12 +160,23 @@ impl ParseCoordinator {
     /// incarnation), releasing a reader waiting on it. The one path that does **not**
     /// advance is a document already gone (a `didClose` removed it): its watermark
     /// channel is gone too, so its readers have already fallen back.
+    ///
+    /// Returns `true` iff **this** call's CAS landed a tree (i.e. it is the parse
+    /// whose tree is now current). The off-ingress open caller gates its
+    /// tree-dependent downstream (`process_injections(forward=false)`, the deferred
+    /// refresh, the synthetic diagnostic) on this — **not** on "the document has a
+    /// tree": a `didChange` racing this parse can move the text on and let the edit
+    /// reparse attach the newer tree (and run `process_injections(forward=true)`)
+    /// first; this parse's CAS then rejects, and re-checking `tree().is_some()` would
+    /// wrongly see the edit's tree and re-run the *open* downstream over it,
+    /// superseding the edit's eager-open batch. Gating on the own-CAS result is the
+    /// same discipline `reparse_latest` follows for its `populate_injections`.
     pub(crate) async fn parse_document(
         &self,
         uri: Url,
         language_id: Option<&str>,
         ticket: Option<u64>,
-    ) {
+    ) -> bool {
         let mut events = Vec::new();
 
         // Read the text the registering didOpen already stored (a refcount bump, not
@@ -184,7 +195,7 @@ impl ParseCoordinator {
             .get(&uri)
             .map(|doc| (doc.text_arc(), doc.incarnation()))
         else {
-            return;
+            return false;
         };
 
         // Publish the watermark on whichever path resolves the parse below, but
@@ -234,7 +245,9 @@ impl ParseCoordinator {
                 }
                 advance_watermark();
                 self.notifier().log_language_events(&events).await;
-                return;
+                // No tree landed (the parser previously crashed): the open caller
+                // must not run its tree-dependent downstream.
+                return false;
             }
 
             let load_result = self.language.ensure_language_loaded(&language_name);
@@ -291,7 +304,11 @@ impl ParseCoordinator {
                 }
                 advance_watermark();
                 self.notifier().log_language_events(&events).await;
-                return;
+                // `stored` is exactly "this call's CAS landed the tree": false when a
+                // racing `didChange`/reopen moved the text or incarnation on and the
+                // edit reparse won, in which case the open downstream must NOT re-run
+                // over the edit's tree.
+                return stored;
             }
         }
 
@@ -310,6 +327,8 @@ impl ParseCoordinator {
         }
         advance_watermark();
         self.notifier().log_language_events(&events).await;
+        // Parsed to nothing / no detectable language → no tree landed.
+        false
     }
 
     /// Re-parse a document after its parser finished installing, **off the

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -2,7 +2,7 @@
 
 use tower_lsp_server::ls_types::DidOpenTextDocumentParams;
 
-use super::super::{Kakehashi, uri_to_url};
+use super::super::{Kakehashi, build_notifier, uri_to_url};
 use crate::language::LanguageEvent;
 
 impl Kakehashi {
@@ -135,52 +135,98 @@ impl Kakehashi {
         // has resolved.
         let ticket = crate::lsp::current_writer_ticket();
 
-        // Only parse if auto-install was NOT triggered. If it was, the spawned
-        // install task reparses off-ingress once the parser is written
-        // (reparse_installed_document), so we must not parse inline here.
-        if !skip_parse {
+        // Parse the document and run its tree-dependent downstream. Three shapes:
+        //
+        // - **auto-install (`skip_parse`)**: the install task spawned above reparses
+        //   off-ingress and runs its own downstream once the parser lands; here we
+        //   only resolve this open's watermark (so a gated reader isn't stranded) and
+        //   run the non-tree-dependent handler tail.
+        // - **CLI one-shot**: parse INLINE and await the downstream. There is one
+        //   document and no concurrent same-URI op to wedge, and the caller reads the
+        //   result — plus the eager-open handles `process_injections` registers
+        //   (`wait_eager_open_finished`) — the moment `did_open_impl` returns, so the
+        //   open parse must be complete before returning.
+        // - **interactive LSP (#6)**: flip the present-parser parse OFF the ingress
+        //   ticket, mirroring the auto-install spawn — a slow/large open parse no
+        //   longer holds the writer ticket and wedges later same-URI readers/writers.
+        //   The handler returns immediately; the spawned parse advances the watermark
+        //   to `ticket` (releasing a reader gated behind this open) and runs the
+        //   tree-dependent downstream once the tree lands.
+        if skip_parse {
+            if let Some(ticket) = ticket {
+                // Parsing is deferred to the spawned off-ingress install reparse.
+                // Advance the watermark now so a reader gated behind this open does
+                // not stall to its timeout waiting for a parse that won't run on the
+                // ingress path; it proceeds and observes the (still tree-less)
+                // install-pending document via its existing has-tree wait.
+                self.documents.advance_watermark(&uri, ticket);
+            }
+            // Deferred SemanticTokensRefresh (empty unless the load succeeded, which
+            // in the skip path it did not — kept for symmetry).
+            if !deferred_events.is_empty() {
+                self.notifier().log_language_events(&deferred_events).await;
+            }
+            // pull-first-diagnostic-forwarding Phase 2: proactive synthetic diagnostic
+            // for clients without pull support. Skipped in one-shot CLI mode (#489):
+            // no editor consumes the proactive `publishDiagnostics` (the stub client
+            // pump discards it), the task is wasted downstream work, and its
+            // abort-without-join on `didClose` races the bridge-state sweep. The
+            // install spawn re-fires it once its reparse produces a tree.
+            if !self.is_cli_mode() {
+                self.diagnostic_scheduler()
+                    .spawn_synthetic_diagnostic_task(uri);
+            }
+        } else if self.is_cli_mode() {
             self.parse_coordinator()
                 .parse_document(uri.clone(), Some(&language_id), ticket)
                 .await;
-        } else if let Some(ticket) = ticket {
-            // Parsing is deferred to the spawned off-ingress install reparse.
-            // Advance the watermark now so a reader gated behind this open does not
-            // stall to its timeout waiting for a parse that won't run on the
-            // ingress path;
-            // it proceeds and observes the (still tree-less) install-pending
-            // document via its existing has-tree wait, exactly as before this
-            // signal existed.
-            self.documents.advance_watermark(&uri, ticket);
-        }
-
-        // Now handle deferred SemanticTokensRefresh events after document is parsed
-        if !deferred_events.is_empty() {
-            self.notifier().log_language_events(&deferred_events).await;
-        }
-
-        // Process injected languages: auto-install missing parsers and spawn bridge servers.
-        // This must be called AFTER parse_document so we have access to the AST.
-        // In the skip-parse (auto-install) path there is no tree yet and the
-        // spawned install task runs this itself once its reparse produces one, so
-        // skip it here to avoid a redundant no-op that would cancel the eager-open
-        // the spawn is about to start.
-        if !skip_parse {
+            if !deferred_events.is_empty() {
+                self.notifier().log_language_events(&deferred_events).await;
+            }
+            // AFTER the parse so the AST exists; registers the eager-open handles the
+            // CLI's `wait_eager_open_finished` polls. No synthetic diagnostic in CLI
+            // mode (#489).
             self.injection_coordinator()
                 .process_injections(&uri, false)
                 .await;
-        }
-
-        // pull-first-diagnostic-forwarding Phase 2: Trigger synthetic diagnostic push on didOpen
-        // This provides proactive diagnostics for clients that don't support pull diagnostics.
-        //
-        // Skipped in one-shot CLI mode (#489): no editor consumes the proactive
-        // `publishDiagnostics` (the stub client pump discards it), so the task is
-        // pure wasted downstream work, and its abort-without-join on `didClose`
-        // races the bridge-state sweep. The CLI's reported diagnostics come from the
-        // explicit `diagnostic_impl` pull, which is unaffected.
-        if !self.is_cli_mode() {
-            self.diagnostic_scheduler()
-                .spawn_synthetic_diagnostic_task(uri);
+        } else {
+            // #6 off-ingress open flip (interactive LSP). The owned coordinators /
+            // Arcs are captured into the spawned task; the handler returns without
+            // awaiting the parse.
+            let parse = self.parse_coordinator();
+            let injection = self.injection_coordinator();
+            let diagnostic_scheduler = self.diagnostic_scheduler();
+            let documents = std::sync::Arc::clone(&self.documents);
+            let client = self.client.clone();
+            let settings_manager = std::sync::Arc::clone(&self.settings_manager);
+            let parse_uri = uri.clone();
+            let parse_language_id = language_id.clone();
+            // Move the deferred SemanticTokensRefresh into the task: firing it now (at
+            // handler return) would make the client re-request semantic tokens against
+            // a still-tree-less document and burn its watermark settle wait; firing it
+            // after the tree lands lets the re-request find the tree immediately.
+            let deferred = std::mem::take(&mut deferred_events);
+            tokio::spawn(async move {
+                parse
+                    .parse_document(parse_uri.clone(), Some(parse_language_id.as_str()), ticket)
+                    .await;
+                // Tree-dependent downstream, only once a tree landed: a parse that
+                // produced none (failed / no language / closed mid-parse) has nothing
+                // to inject or refresh against, and `process_injections` on a
+                // tree-less doc would cancel the eager-open. Mirrors the install spawn.
+                let has_tree = documents
+                    .get(&parse_uri)
+                    .is_some_and(|doc| doc.tree().is_some());
+                if has_tree {
+                    injection.process_injections(&parse_uri, false).await;
+                    if !deferred.is_empty() {
+                        build_notifier(&client, &settings_manager)
+                            .log_language_events(&deferred)
+                            .await;
+                    }
+                    diagnostic_scheduler.spawn_synthetic_diagnostic_task(parse_uri);
+                }
+            });
         }
 
         // NOTE: No semantic_tokens_refresh() on didOpen.
@@ -300,15 +346,23 @@ print("hello")
             })
             .await;
 
-        let document = server
-            .documents
-            .get(&uri)
-            .expect("document should be stored");
+        // The present-parser open parse now runs off the ingress ticket (#6), so the
+        // tree + injection cache appear asynchronously after `did_open_impl` returns.
+        wait_until(|| {
+            server
+                .cache
+                .get_injections(&uri)
+                .is_some_and(|injections| injections.len() == 1)
+        })
+        .await;
+
         assert!(
-            document.tree().is_some(),
+            server
+                .documents
+                .get(&uri)
+                .is_some_and(|doc| doc.tree().is_some()),
             "did_open should parse the document"
         );
-        drop(document);
 
         let injections = server
             .cache
@@ -1046,11 +1100,12 @@ print("hello")
     /// install) must not gate it.
     ///
     /// We block the parse deterministically by holding the parser-pool lock, so
-    /// `parse_document` -> `parse_with_pool` parks on `pool.lock().await` and
-    /// never finishes within the test. We drive `did_open_impl` concurrently and
-    /// assert the host doc still opens. Before the host-tier hoist the attach sat
-    /// *after* this (now-blocked) parse, so the host doc would never open and this
-    /// test would fail at its timeout.
+    /// the (now off-ingress, #6) spawned `parse_document` -> `parse_with_pool` parks
+    /// on `pool.lock().await` and never finishes within the test. The host-tier
+    /// hoist runs synchronously in the handler BEFORE the parse is spawned, so the
+    /// host doc still attaches while the parse is blocked — proving it does not wait
+    /// for the parse. (Before the hoist the attach sat *after* the parse, so with the
+    /// pool lock held the host doc would never open and this test would time out.)
     #[tokio::test]
     async fn host_document_attaches_before_parse_completes() {
         let (service, _socket) = LspService::new(Kakehashi::new);
@@ -1062,7 +1117,7 @@ print("hello")
         let uri = Url::parse("file:///test/host_attach_no_wait.rs").unwrap();
         let lsp_uri = crate::lsp::lsp_impl::url_to_uri(&uri).expect("URI should convert");
 
-        // Hold the parser-pool lock so the parse parks indefinitely (see above).
+        // Hold the parser-pool lock so the spawned parse parks indefinitely (above).
         let pool_guard = server.parser_pool.lock().await;
 
         let params = DidOpenTextDocumentParams {
@@ -1074,44 +1129,32 @@ print("hello")
             },
         };
 
-        let did_open = server.did_open_impl(params);
-        tokio::pin!(did_open);
+        // `did_open_impl` returns immediately — the open parse is off the ingress
+        // ticket (#6) and parked on the held pool lock. The host doc must already be
+        // attaching by the time it returns, since the hoist precedes the spawn.
+        server.did_open_impl(params).await;
 
-        tokio::select! {
-            // The whole point of this test is that the host opens *while the parse
-            // is blocked*. If the handler returns instead, the parse wasn't
-            // actually gating (e.g. parsing got skipped) and the old post-parse
-            // attach position would pass too — i.e. the test would no longer
-            // discriminate the hoist. Fail loudly rather than checking vacuously.
-            _ = &mut did_open => {
-                panic!(
-                    "did_open_impl returned while the parse was blocked; the parse \
-                     was not gating, so this test cannot discriminate the host-tier hoist"
-                );
-            }
-            result = timeout(Duration::from_secs(2), async {
-                loop {
-                    if server
-                        .bridge
-                        .pool()
-                        .is_host_document_opened(&uri, "rust_ls")
-                        .await
-                    {
-                        break;
-                    }
-                    tokio::task::yield_now().await;
+        timeout(Duration::from_secs(2), async {
+            loop {
+                if server
+                    .bridge
+                    .pool()
+                    .is_host_document_opened(&uri, "rust_ls")
+                    .await
+                {
+                    break;
                 }
-            }) => {
-                result.expect(
-                    "host document must attach to the _self server without waiting for the parse",
-                );
+                tokio::task::yield_now().await;
             }
-        }
+        })
+        .await
+        .expect(
+            "host document must attach to the _self server while the parse is blocked \
+             (the hoist precedes the off-ingress parse spawn)",
+        );
 
-        // Cleanup: release the lock so the parked parse can finish, then drive
-        // the handler to completion.
+        // Cleanup: release the lock so the parked spawned parse can finish.
         drop(pool_guard);
-        did_open.await;
     }
 
     /// #425 regression guard: host `pullFallback = false` gates the host **pull**
@@ -1241,6 +1284,10 @@ print("hello")
             })
             .await;
 
+        // The present-parser open parse now runs off the ingress ticket (#6), so the
+        // synthetic diagnostic is scheduled by the spawned task once the tree lands —
+        // asynchronously after `did_open_impl` returns.
+        wait_until(|| server.synthetic_diagnostics.has_active_task(&uri)).await;
         assert!(
             server.synthetic_diagnostics.has_active_task(&uri),
             "LSP-mode didOpen schedules the synthetic diagnostic task"

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -90,6 +90,11 @@ impl Kakehashi {
                     let documents = std::sync::Arc::clone(&self.documents);
                     let lang = lang.clone();
                     let install_uri = uri.clone();
+                    // Mirror the handler's `!is_cli_mode()` gate on the synthetic
+                    // diagnostic (#489): in one-shot CLI mode no editor consumes the
+                    // proactive publishDiagnostics, so re-firing it from the install
+                    // spawn is pure wasted work and races the bridge-state sweep.
+                    let is_cli_mode = self.is_cli_mode();
                     tokio::spawn(async move {
                         install
                             .maybe_auto_install_language(&lang, install_uri.clone(), false)
@@ -114,8 +119,11 @@ impl Kakehashi {
                             // tree exists: the handler's spawn (below) ran in the
                             // skip-parse path with no tree, so its snapshot was None
                             // and the pull-layer diagnostics were skipped on this
-                            // first open of a just-installed parser.
-                            diagnostic_scheduler.spawn_synthetic_diagnostic_task(install_uri);
+                            // first open of a just-installed parser. Skipped in CLI
+                            // mode (#489), matching the handler's own gate.
+                            if !is_cli_mode {
+                                diagnostic_scheduler.spawn_synthetic_diagnostic_task(install_uri);
+                            }
                         }
                     });
                     skip_parse = true;

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -196,7 +196,6 @@ impl Kakehashi {
             let parse = self.parse_coordinator();
             let injection = self.injection_coordinator();
             let diagnostic_scheduler = self.diagnostic_scheduler();
-            let documents = std::sync::Arc::clone(&self.documents);
             let client = self.client.clone();
             let settings_manager = std::sync::Arc::clone(&self.settings_manager);
             let parse_uri = uri.clone();
@@ -207,17 +206,20 @@ impl Kakehashi {
             // after the tree lands lets the re-request find the tree immediately.
             let deferred = std::mem::take(&mut deferred_events);
             tokio::spawn(async move {
-                parse
+                let landed = parse
                     .parse_document(parse_uri.clone(), Some(parse_language_id.as_str()), ticket)
                     .await;
-                // Tree-dependent downstream, only once a tree landed: a parse that
-                // produced none (failed / no language / closed mid-parse) has nothing
-                // to inject or refresh against, and `process_injections` on a
-                // tree-less doc would cancel the eager-open. Mirrors the install spawn.
-                let has_tree = documents
-                    .get(&parse_uri)
-                    .is_some_and(|doc| doc.tree().is_some());
-                if has_tree {
+                // Run the open downstream only when THIS parse's CAS landed the tree —
+                // not merely when "a tree exists". A `didChange` racing this open parse
+                // can move the text on and let the edit reparse attach the newer tree
+                // (and run `process_injections(forward=true)`) first; this parse then
+                // loses its CAS (`landed == false`). Re-running the open downstream
+                // (`process_injections(forward=false)`) over the edit's tree would
+                // supersede the edit's eager-open batch. When `landed` is false the
+                // edit reparse owns the current tree and already ran the correct
+                // downstream, so there is nothing for the open path to do. (A parse
+                // that produced no tree at all also returns false.)
+                if landed {
                     injection.process_injections(&parse_uri, false).await;
                     if !deferred.is_empty() {
                         build_notifier(&client, &settings_manager)


### PR DESCRIPTION
## Summary

Follow-up **#6** from the per-document-parse-scheduler ADR: flip the `didOpen` present-parser tree-sitter parse **off the per-URI ingress writer ticket**, so a slow/large open parse no longer holds the ticket and wedges later same-URI readers/writers. This mirrors the already-shipped `didChange` off-ingress flip (`reparse_latest`/`schedule_reparse`) and the auto-install spawn (#480/#511). It is the last substantive epoch surface from that ADR.

### What changed
- **`parse_document` is now off-ingress-safe** (`refactor` commit, behaviour-identical while still inline):
  - new non-inserting store CAS `set_parse_result_if_text_and_incarnation_unchanged` — sets the content-refined language **+** tree, guarded by **text** (via `Arc::ptr_eq`, O(1)) **+** **incarnation**; replaces the unguarded `set_parse_result_if_present` (removed) on all three store paths;
  - `populate_injections` gated behind the CAS landing (CAS-before-populate);
  - `advance_watermark_for_incarnation` instead of a plain advance; the doc-gone path returns **without** advancing (per-lifetime watermark);
  - returns whether **this** call's CAS landed the tree.
- **The flip itself** (`feat` commit): `did_open_impl` is a 3-way branch —
  - **auto-install** (`skip_parse`): unchanged (the install spawn already reparses off-ingress);
  - **CLI one-shot**: keeps the **inline** parse — the caller reads the result + the eager-open handles `process_injections` registers the moment `did_open_impl` returns, and there is no concurrent same-URI op to wedge;
  - **interactive LSP**: **spawns** the parse; the handler returns immediately, the spawned parse advances the watermark (releasing a gated reader) and runs the tree-dependent downstream (`process_injections(false)`, the deferred `SemanticTokensRefresh`, the synthetic diagnostic) **only when this parse's CAS landed the tree**.
- **Open CAS uses `Arc::ptr_eq`** (`perf` commit) — removes the only O(n) compare the safety refactor added on the large-document open path; plus a cold-open latency benchmark scenario.
- **Downstream gated on the parse's own CAS, not "a tree exists"** (`fix` commit, codex): when a racing `didChange` reparse wins the CAS, the open parse runs no downstream — the edit reparse owns the tree and already ran `process_injections(forward=true)`.

### Performance (the hard constraint: no degradation)
A/B benchmark (HEAD off-ingress vs `origin/main` inline, `didOpen` → first `semanticTokens`):

| scenario | main (inline) | HEAD (off-ingress) | Δ |
|---|---|---|---|
| markdown 150-block open | 49.0ms | 43.2ms | **−11.8%** |
| rust 1500-func open (host parse < budget) | ~neutral | | |
| rust 4000-func open (~150KB; host parse > 200ms, on-demand fallback fires every run) | ~1476ms | ~1472ms | **~0%** |

HEAD is faster or neutral everywhere — the watermark gates on the **host parse** only, so the expensive `process_injections`/handler-tail leaves the reader's critical path. The on-demand fallback (the only double-parse path) fires solely for ~150KB single dense files, and even there latency is unchanged (token computation dominates; the redundant parse overlaps the off-ingress one). New `Kind::OpenFirstToken` benchmark scenarios validate this regime explicitly.

### Tests
- 2177 lib + full e2e (1470 tests / 0 fail).
- 3 `did_open` unit tests that asserted a synchronous open parse now wait for the async result; the host-attach test's premise inverts (returning before the parse completes is now correct).

### Reviews (all converged)
- **`/review` subagent** — 2 HIGH (the 200ms-budget perf risk + a benchmark gap) both resolved empirically (no latency regression even in the on-demand-fallback regime; the markdown "over budget" scenario was mislabeled — its host parse stays under budget); 1 LOW `Arc::ptr_eq` applied to the open CAS.
- **codex** — 1 HIGH: the open downstream was gated on a `tree().is_some()` re-check instead of the parse's own CAS, so a losing open parse could re-run `process_injections(forward=false)` over a racing edit reparse's tree and supersede its eager-open batch. Fixed by returning a `landed` bool and gating on it.
- **pi-review** — 3 LOW (parse-failure nulled the detected language; `mark_parse_finished` get-or-inserted a parse-state for a closed URI; the auto-install spawn re-fired the synthetic diagnostic in CLI mode), all fixed; confirmation pass clean. Core CAS / watermark / resurrection-safety / Send-lifetime verified sound.

### Known follow-up (out of scope, separate PR)
The auto-install spawn (`reparse_installed_document`) has the same pre-existing "gate on has-tree instead of own CAS" pattern codex flagged for the present-parser path; it predates this change and the fix mirrors this one (return whether it landed the tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
