### PR TITLE
docs(injection-cache): rewrite #529 ADR around the measured delta-path budget

### DIFF
--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -260,9 +260,24 @@ paths; an audit surfaced four the original design did not address:
    injections are discovered as separate `region_id`s but tokenized *jointly*
    (multiple blocks parsed as one document). Editing one block does not change a
    sibling's content hash, so the sibling would serve a hit computed in the
-   *old* joint context. **Mitigation: exclude combined groups from the cache** —
-   the v1 predicate already does, and the vendored Markdown query reserves
-   `combined` for HTML anyway.
+   *old* joint context. **Mitigation (v1): exclude combined groups from the
+   cache** — the v1 predicate already does, and the vendored Markdown query
+   reserves `combined` for HTML anyway.
+
+   *Caching them later (follow-up)* means treating the whole group as one cache
+   unit, which takes three pieces: (a) **one identity** — a composite
+   `injection_id` formed from the members' `region_id`s (e.g. joined with `-`),
+   so a membership change (a block added/removed) changes the id and misses
+   naturally; (b) **a group-wide `content_hash`** over *all* members, so editing
+   any one member invalidates the group — this is the part that actually closes
+   the cross-contamination, since a composite id alone still hits when the member
+   set is unchanged but one member's bytes changed; and (c) **per-member
+   re-anchoring**, because the group spans disjoint host ranges and an edit in
+   the host gap *between* members shifts later members by a different offset than
+   earlier ones — so the trivial single `line += Δ` does not apply. (`region_id`s
+   are minted in the cache layer from byte ranges, not on the semantic combined
+   context, so each member's id is resolved the same way as a single region —
+   see the `NodeTracker` obligation above.)
 2. **Config / query reload (showstopper).** `bump_semantic_token_generation`
    (PR #530) clears the whole-doc cache but never touches `InjectionTokenCache`,
    which has no generation in its key. A query/settings reload with unchanged

--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -88,15 +88,17 @@ re-entering the pipeline *before* `finalize_tokens`.
 
 Per request, in `collect_injection_tokens_parallel`:
 
-1. For each injection region (identified by `region_id` via `InjectionMap`),
-   check `InjectionTokenCache` for an entry whose `content_hash` matches the
-   region's current content.
-2. **Hit**: translate the cached region-local `RawToken`s into host coordinates
-   using the region's *current* `line_range.start` / `start_column` (which the
-   freshly parsed `InjectionMap` already provides), and skip re-parsing /
+1. For each injection region (identified by `region_id` from the freshly parsed
+   tree's `NodeTracker` — not the cached `InjectionMap`; see obligation 2), check
+   `InjectionTokenCache` for a still-valid entry: its `content_hash` matches the
+   region's current content **and** it was stored under the current settings
+   generation (see Hazard 2).
+2. **Hit**: re-anchor the cached region-local `RawToken`s to the region's
+   *current* host position (re-anchor formula below) and skip re-parsing /
    re-querying that region.
-3. **Miss**: compute the region's tokens as today, then store them back in
-   region-local coordinates keyed by `(uri, region_id)` + `content_hash`.
+3. **Miss**: compute the region's tokens as today, then store them in
+   region-local coordinates keyed by `(uri, region_id)`, with `content_hash` and
+   the settings generation as the validity check.
 4. Merge cached-and-recomputed injection tokens with freshly computed host
    tokens and run the existing `finalize_tokens` sweep line over the union.
 
@@ -126,18 +128,22 @@ is a pure uniform translation:
   whole lines — no host bytes interleaved per row), **and**
 - the region is not part of an `injection.combined` group.
 
-These three conditions are **language-agnostic** — they turn on the region's
-coordinate geometry and injection mode, not on which language is injected. A
-fenced code block that starts at column 0 qualifies; a region that interleaves
-host bytes per row (blockquote-style, line-continuation markers, etc.) does not
-— the predicate self-selects regardless of language.
+These three conditions are agnostic of the **injected** language — they turn on
+the region's coordinate geometry and injection mode, not on which language sits
+inside. (They do depend on the *host* grammar's injection query: `combined` and
+`include-children` are host-query properties. The point is that no
+per-injected-language special-casing is needed.) A fenced code block that starts
+at column 0 qualifies; a region that interleaves host bytes per row
+(blockquote-style, line-continuation markers, etc.) does not — the predicate
+self-selects regardless of which language is injected.
 
 **v1 scope: cache only regions satisfying the predicate; recompute the rest.**
 v1 stores **region-local `RawToken`s** (per Decision step 3) keyed by
-`(uri, region_id)` + `content_hash`. On a hit it re-anchors to the region's
-*current* host position: `host_line = region.line_range.start + token.row`, and
-`host_col = token.col` — the row-0 `start_column` term is 0 for every qualifying
-region, so no column rebase is needed. This reads only the current region's
+`(uri, region_id)`, validated by `content_hash` + settings generation. On a hit
+it re-anchors to the region's *current* host position:
+`host_line = region.line_range.start + token.line`, and `host_col = token.col` —
+the row-0 `start_column` term is 0 for every qualifying region, so no column
+rebase is needed. This reads only the current region's
 already-persisted `line_range.start` / `start_column` from
 `CacheableInjectionRegion`: no stored baseline, no delta-decode. The row-0 /
 prefix re-anchoring correctness surface is eliminated by construction, and a
@@ -152,16 +158,25 @@ Two implementation obligations follow, neither inferable from
   write.** `start_column` is on `CacheableInjectionRegion`, but
   `prefix_byte_widths` and combined-ness live on the transient `InjectionContext`
   that tokenization builds (and `injection.combined` is a query property, not
-  range geometry). Re-checking at read is what makes `content_hash` sufficient:
-  a host-tree restructure that changes a region's prefix geometry without
-  changing its content bytes (e.g. a fenced block gaining a `block_continuation`)
-  flips it to ineligible, forcing a recompute rather than a stale hit.
-- **Source `region_id` from the freshly parsed tree, not the cached
-  `InjectionMap`.** `InjectionContext` carries no `region_id` today, so v1 must
-  either add one or resolve it per request from the fresh tree (via `NodeTracker`
-  / `InjectionMap` by byte range). Using the fresh tree also closes the
-  stale-`InjectionMap` window between `invalidate_for_edits` and the off-ingress
-  `populate_injections`.
+  range geometry). Re-checking all three clauses against the fresh context means
+  a region that has *stopped* qualifying — its start no longer at column 0, or it
+  acquired per-row prefixes — is recomputed rather than served a stale hit; only
+  regions still satisfying the predicate take the reuse path. (A column-0 fence
+  stays eligible even if it gains a column-0 `block_continuation`: column-0
+  continuations leave `prefix_byte_widths` empty, so that remains a *valid* hit.)
+- **Source `region_id` from the freshly parsed tree's `NodeTracker`, not the
+  cached `InjectionMap`.** `InjectionContext` carries no `region_id` today, so v1
+  resolves it per request — e.g. `tracker.get_or_create(uri, host_start_byte,
+  end_byte, kind)` at the boundary between `collect_injection_contexts_sync` and
+  the parallel fan-out (no new field on `InjectionContext` needed). This is safe
+  because `apply_input_edits` updates the `NodeTracker` synchronously under the
+  edit lock the moment an edit lands — *before* the off-ingress reparse — so the
+  ULIDs are consistent even while the cached `InjectionMap` is still pre-edit
+  (see [lazy-node-identity-tracking](lazy-node-identity-tracking.md)). Reading
+  the `NodeTracker` rather than the cached `InjectionMap` is what closes the
+  window between `invalidate_for_edits` and the off-ingress `populate_injections`
+  — and means a fallback parse that skips `populate_injections` stays safe and
+  must not be "fixed" by calling it there.
 
 ### Companion lever: injection discovery
 
@@ -239,11 +254,16 @@ paths; an audit surfaced four the original design did not address:
    (PR #530) clears the whole-doc cache but never touches `InjectionTokenCache`,
    which has no generation in its key. A query/settings reload with unchanged
    text would serve tokens computed under the *old* highlight query.
-   **Mitigation: fold the settings generation into the entry's validity (the
-   same fix PR #530 applied to the whole-doc cache) — implementable with no new
-   API. Clearing the injection cache on generation bump is the alternative, but
-   needs a new global clear: today `InjectionTokenCache` exposes only per-region
-   `remove` and per-document `clear_document`.**
+   **Mitigation: fold the settings generation into the entry's validity, the
+   same fix PR #530 applied to the whole-doc cache (where the inner cache takes a
+   derived `cache_key`). This is the right design — it matches the existing
+   pattern and avoids a global flush — but it is not free: wiring the reuse half
+   already promotes `store`/`get` from `#[cfg(test)]` to production, extends their
+   signatures to thread the validity key, and changes the value type to
+   `Vec<RawToken>` (Option A); folding the generation rides along on those same
+   signatures. The alternative — a new global `clear()` on `InjectionTokenCache`
+   called from `bump_semantic_token_generation` — is a single new method, but
+   flushes every region on any reload.**
 3. **Parser-load race (guard).** `process_injection_sync` returns empty tokens
    when a region's parser is not yet loaded — indistinguishable from a genuinely
    empty region. **Mitigation: never store on the parser-missing branch.**

--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -260,8 +260,8 @@ paths; an audit surfaced four the original design did not address:
    injections are discovered as separate `region_id`s but tokenized *jointly*
    (multiple blocks parsed as one document). Editing one block does not change a
    sibling's content hash, so the sibling would serve a hit computed in the
-   *old* joint context. **Mitigation (v1): exclude combined groups from the
-   cache** — the v1 predicate already does, and the vendored Markdown query
+   *old* joint context. **Mitigation (v1):** exclude combined groups from the
+   cache — the v1 predicate already does, and the vendored Markdown query
    reserves `combined` for HTML anyway.
 
    *Caching them later (follow-up)* means treating the whole group as one cache
@@ -282,7 +282,7 @@ paths; an audit surfaced four the original design did not address:
    (PR #530) clears the whole-doc cache but never touches `InjectionTokenCache`,
    which has no generation in its key. A query/settings reload with unchanged
    text would serve tokens computed under the *old* highlight query.
-   **Mitigation: fold the settings generation into the entry's validity, the
+   **Mitigation:** fold the settings generation into the entry's validity, the
    same fix PR #530 applied to the whole-doc cache (where the inner cache takes a
    derived `cache_key`). This is preferred for a concrete correctness reason, not
    just neatness: a bare global `clear()` on reload has a store-after-clear race —
@@ -296,11 +296,11 @@ paths; an audit surfaced four the original design did not address:
    `Vec<RawToken>` (Option A), and the generation rides along on those same
    signatures. A one-method global `clear()` from `bump_semantic_token_generation`
    is simpler and the flush is cheap on a rare reload, but it trades that
-   race-safety away.**
+   race-safety away.
 3. **Parser-load race (guard).** `process_injection_sync` returns an empty
    `Vec<RawToken>` when a region's parser is not yet loaded — indistinguishable
    from a genuinely empty region, so "never store on the parser-missing branch"
-   first requires making that branch *observable*. **Mitigation: have
+   first requires making that branch *observable*. **Mitigation:** have
    `process_injection_sync` return a structured result that separates
    parser-missing from genuinely-empty (e.g. `Option`/`Result` or a
    `parser_loaded` flag) and let the orchestration layer
@@ -309,7 +309,7 @@ paths; an audit surfaced four the original design did not address:
    inside `process_injection_sync`: it runs in parallel Rayon workers, so an
    in-function write would thread thread-safe cache-write access into parallel
    tokenization and add side-effects there, whereas a pure structured return
-   keeps the store decision at the single-threaded orchestration boundary.**
+   keeps the store decision at the single-threaded orchestration boundary.
 4. **Row-0 `start_column` re-anchoring (guard, sidestepped by v1 scope).** A
    same-line-before edit shifts row-0 columns without changing the content hash.
    Out of scope for v1 by the `content_start_col == 0` predicate; required only

--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -126,13 +126,22 @@ is a pure uniform translation:
   whole lines — no host bytes interleaved per row), **and**
 - the region is not part of an `injection.combined` group.
 
-These are **geometry predicates on the region's included ranges, not
-language-specific**. A fenced code block that starts at column 0 qualifies; a
-region that interleaves host bytes per row (blockquote-style, line-continuation
-markers, etc.) does not — the predicate self-selects regardless of language. For
-a qualifying region, re-anchoring after any content-preserving edit is a single
-additive `line += Δ`, and a same-line-before edit is impossible because the
-content starts at column 0 on its own line.
+These three conditions are **language-agnostic** — they turn on the region's
+coordinate geometry and injection mode, not on which language is injected. A
+fenced code block that starts at column 0 qualifies; a region that interleaves
+host bytes per row (blockquote-style, line-continuation markers, etc.) does not
+— the predicate self-selects regardless of language. For a qualifying region,
+re-anchoring after any content-preserving edit is a single additive `line += Δ`,
+and a same-line-before edit is impossible because the content starts at column 0
+on its own line.
+
+Implementation note: these facts (start column, per-row prefix widths,
+combined-ness) live today on the transient `InjectionContext` that tokenization
+builds, not on the persisted `CacheableInjectionRegion`, and `injection.combined`
+is a query property rather than range geometry. v1 must therefore evaluate
+eligibility from the injection context tokenization actually uses and carry it
+alongside the cached entry — not infer it from `CacheableInjectionRegion`
+metadata alone.
 
 **v1 scope: cache only regions satisfying the predicate; recompute the rest.**
 This eliminates the row-0 / prefix re-anchoring correctness surface entirely
@@ -200,11 +209,14 @@ complementary, not a substitute.
 
 ## Correctness hazards
 
-The cache is **push-based / evict-on-mutation**: `get` does no read-time
-validity check, so every mutation path that can change a region's tokens must
-evict its entry before it is re-served. The existing eviction (edit-overlap,
-content/language change, region removed, close) covers most paths. An audit
-surfaced four the original design did not address:
+Today's `get` does no read-time validity check (it keys on `(uri, region_id)`
+only), so the cache is **push-based / evict-on-mutation**: every mutation path
+that can change a region's tokens must evict its entry before it is re-served.
+v1 adds a `content_hash` gate on read (Decision step 1), but `content_hash` is
+text-only — it does *not* change when a region's surrounding *context* changes,
+so that gate alone misses the first two hazards below. The existing eviction
+(edit-overlap, content/language change, region removed, close) covers most
+paths; an audit surfaced four the original design did not address:
 
 1. **`injection.combined` sibling cross-contamination (showstopper).** Combined
    injections are discovered as separate `region_id`s but tokenized *jointly*

--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -93,7 +93,8 @@ re-entering the pipeline *before* `finalize_tokens`.
 Per request, in `collect_injection_tokens_parallel`:
 
 1. For each injection region (identified by `region_id` from the freshly parsed
-   tree's `NodeTracker` — not the cached `InjectionMap`; see obligation 2), check
+   tree's `NodeTracker` — not the cached `InjectionMap`; see the `NodeTracker`
+   obligation below), check
    `InjectionTokenCache` for a still-valid entry: its `content_hash` matches the
    region's current content **and** it was stored under the current settings
    generation (see Hazard 2).
@@ -178,8 +179,9 @@ Two implementation obligations follow, neither inferable from
   `host_start_byte`, not the `end_byte` / node `kind` that `get_or_create` needs.
   Either way this threads two new inputs into `collect_injection_tokens_parallel`
   and `handle_semantic_tokens_full`, which take neither today: the document `uri`
-  and the `NodeTracker` (it lives on `CacheCoordinator`, not the
-  `LanguageCoordinator` they currently receive). This is safe
+  and the `NodeTracker` (owned by the bridge coordinator and passed *into* cache
+  methods like `populate_injections`, not held by the `LanguageCoordinator` these
+  functions receive). This is safe
   because `apply_input_edits` updates the `NodeTracker` synchronously under the
   edit lock the moment an edit lands — *before* the off-ingress reparse — so the
   ULIDs are consistent even while the cached `InjectionMap` is still pre-edit

--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -277,9 +277,15 @@ paths; an audit surfaced four the original design did not address:
    signatures. The alternative — a new global `clear()` on `InjectionTokenCache`
    called from `bump_semantic_token_generation` — is a single new method, but
    flushes every region on any reload.**
-3. **Parser-load race (guard).** `process_injection_sync` returns empty tokens
-   when a region's parser is not yet loaded — indistinguishable from a genuinely
-   empty region. **Mitigation: never store on the parser-missing branch.**
+3. **Parser-load race (guard).** `process_injection_sync` returns an empty
+   `Vec<RawToken>` when a region's parser is not yet loaded — indistinguishable
+   from a genuinely empty region, so "never store on the parser-missing branch"
+   first requires making that branch *observable*. **Mitigation: have
+   `process_injection_sync` return a structured result that separates
+   parser-missing from genuinely-empty (e.g. `Option`/`Result` or a
+   `parser_loaded` flag), or perform the cache write inside `process_injection_sync`
+   where the parser's presence is explicit — so a parser-missing result is never
+   stored.**
 4. **Row-0 `start_column` re-anchoring (guard, sidestepped by v1 scope).** A
    same-line-before edit shifts row-0 columns without changing the content hash.
    Out of scope for v1 by the `content_start_col == 0` predicate; required only

--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -44,9 +44,10 @@ Two structural facts fall out:
 
 1. **The delta diff and incremental parse are nearly free.** The per-keystroke
    CPU is almost entirely the *token recompute* — exactly what a per-region
-   cache avoids. (This is also why the whole-doc cache helps `full` but not
-   `delta`: both endpoints run the same recompute; the diff that distinguishes
-   them costs nothing.)
+   cache avoids. (The whole-doc cache keys on text alone, so it hits for both
+   `full` and `delta` when the document is unchanged and misses for both after
+   an edit; the typing path is always a miss, so the recompute — not the
+   endpoint — is what matters here.)
 2. **Per-region tokenize is ~1/3 of the recompute, not all of it.** Host token
    collection and injection *discovery* are each roughly equal in cost, and
    `finalize` adds ~10%. Even a perfect per-region tokenize cache leaves a hard
@@ -136,9 +137,12 @@ content starts at column 0 on its own line.
 **v1 scope: cache only regions satisfying the predicate; recompute the rest.**
 This eliminates the row-0 / prefix re-anchoring correctness surface entirely
 while covering the common "many fenced code blocks" case the measurements
-target. A later version may store true region-local tokens and run the rebase
-math on read to cover the remaining regions, but that is not required to land
-the win.
+target. For the qualifying set, region-local and host-absolute coordinates
+differ only by an additive line constant, so v1 can store the host-absolute
+tokens exactly as emitted and reuse them with `line += Δ` — which equals the
+region-local design of Decision step 3 for this set. True region-local storage
+(with the column rebase run on read) is the later, broader-coverage version that
+extends the cache to non-qualifying regions; it is not required to land the win.
 
 ### Companion lever: injection discovery
 
@@ -162,9 +166,10 @@ Re-anchoring is a single additive line/column offset. The sweep line still sees
 the full token set, so host-vs-injection exclusion and transparent-token
 breakpoints at region boundaries keep working unchanged. Cost: change
 `InjectionTokenCache`'s value type from `SemanticTokens` to `Vec<RawToken>` (or a
-region-local newtype), and make `RawToken` storable across requests (it already
-holds only owned/`Copy` fields after `perf(semantic): pre-resolve token type to
-legend indices` removed the `String`).
+region-local newtype), and make `RawToken` storable across requests (it is
+`Clone` and holds only owned, borrow-free fields — `TokenKind` carries an owned
+`Box<str>` for the not-in-legend case, so there are no lifetimes to outlive the
+request).
 
 ### B. Cache post-finalize `SemanticTokens`, splice into output (today's type)
 
@@ -178,7 +183,8 @@ right). It also forces a delta-decode + re-encode to re-anchor coordinates.
 ### C. Whole-document memoization keyed by content hash (shipped, complementary)
 
 Cache the entire finalized result per `(uri, content_hash)`. **Shipped as PR
-#530** (`SemanticTokenCache`, keyed by `fnv1a_hash(text) ^ generation`). It
+#530** (`SemanticTokenCache`, keyed by
+`fnv1a_hash(text) ^ generation.wrapping_mul(FNV_PRIME)`). It
 covers the *unchanged-document* case — idle `full` re-requests and no-op deltas.
 It does nothing for the typing path, because every keystroke changes the
 document hash, which is exactly why this ADR exists. The two are complementary

--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -170,13 +170,16 @@ Two implementation obligations follow, neither inferable from
   continuations leave `prefix_byte_widths` empty, so that remains a *valid* hit.)
 - **Source `region_id` from the freshly parsed tree's `NodeTracker`, not the
   cached `InjectionMap`.** `InjectionContext` carries no `region_id` today, so v1
-  resolves it per request — e.g. `tracker.get_or_create(uri, host_start_byte,
-  end_byte, kind)` at the boundary between `collect_injection_contexts_sync` and
-  the parallel fan-out (no new field on `InjectionContext` needed). This threads
-  two new inputs into `collect_injection_tokens_parallel` and
-  `handle_semantic_tokens_full`, which take neither today: the document `uri` and
-  the `NodeTracker` (it lives on `CacheCoordinator`, not the `LanguageCoordinator`
-  they currently receive). This is safe
+  resolves it *inside* `collect_injection_contexts_sync`, where the tree-sitter
+  node is in hand — `tracker.get_or_create(uri, start_byte, end_byte, kind)` —
+  and carries the ULIDs to the fan-out as a parallel `Vec` aligned with the
+  contexts (or as a new `region_id` field on `InjectionContext`). It cannot be
+  deferred to the fan-out boundary: `InjectionContext` keeps only
+  `host_start_byte`, not the `end_byte` / node `kind` that `get_or_create` needs.
+  Either way this threads two new inputs into `collect_injection_tokens_parallel`
+  and `handle_semantic_tokens_full`, which take neither today: the document `uri`
+  and the `NodeTracker` (it lives on `CacheCoordinator`, not the
+  `LanguageCoordinator` they currently receive). This is safe
   because `apply_input_edits` updates the `NodeTracker` synchronously under the
   edit lock the moment an edit lands — *before* the off-ingress reparse — so the
   ULIDs are consistent even while the cached `InjectionMap` is still pre-edit

--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -105,6 +105,55 @@ Caching **region-local pre-finalize `RawToken`s** (not post-finalize
 re-anchoring a pure `line += region_line_offset` translation rather than a
 delta-decode-then-re-encode.
 
+### Re-anchoring and the language-agnostic scope (v1)
+
+Injection `RawToken`s today are emitted in **host-absolute** coordinates, with
+the per-region host offset baked in at emission (`token_collector.rs`).
+Re-anchoring a cached region therefore means reproducing the same host-absolute
+tokens after the region has moved. For an arbitrary region this is non-trivial:
+row 0 carries the region's `start_column`, deeper rows can carry per-row
+host-byte prefixes (e.g. a blockquote `> ` strip), and UTF-16 columns depend on
+host line bytes. A same-line edit *before* the region would shift row-0 columns
+without changing the region's content hash — a stale-position hazard.
+
+But the re-anchor is **trivial and exact** for any region whose host↔content map
+is a pure uniform translation:
+
+- `content_start_col == 0` (the content begins at column 0 of its first line),
+  **and**
+- the region has no per-row prefix widths (its included ranges are contiguous
+  whole lines — no host bytes interleaved per row), **and**
+- the region is not part of an `injection.combined` group.
+
+These are **geometry predicates on the region's included ranges, not
+language-specific**. A fenced code block that starts at column 0 qualifies; a
+region that interleaves host bytes per row (blockquote-style, line-continuation
+markers, etc.) does not — the predicate self-selects regardless of language. For
+a qualifying region, re-anchoring after any content-preserving edit is a single
+additive `line += Δ`, and a same-line-before edit is impossible because the
+content starts at column 0 on its own line.
+
+**v1 scope: cache only regions satisfying the predicate; recompute the rest.**
+This eliminates the row-0 / prefix re-anchoring correctness surface entirely
+while covering the common "many fenced code blocks" case the measurements
+target. A later version may store true region-local tokens and run the rebase
+math on read to cover the remaining regions, but that is not required to land
+the win.
+
+### Companion lever: injection discovery
+
+The per-keystroke table shows injection *discovery* (the injection query over
+the whole host tree, run every request to enumerate regions) costs as much as
+tokenize and is also recomputed every keystroke. It is not cached by v1, but the
+same position-stable `region_id` / `InjectionMap` identity that makes token
+reuse possible could let an edit reuse the previous region *set* instead of
+re-querying. Caching discovery + tokenize together roughly doubles the
+per-keystroke saving (measured projection: ~−1/3 for tokenize alone vs ~−60% for
+both at 150–300 blocks — the discovery figure is an optimistic ceiling, since
+the tracked region set still costs something to update per edit). Treated as a
+follow-up, not part of v1: skipping discovery means trusting the tracked set
+rather than re-deriving it from the tree, a larger correctness commitment.
+
 ## Considered Options
 
 ### A. Cache region-local `RawToken`s, re-enter before finalize (chosen)
@@ -126,12 +175,15 @@ breakpoints at their boundaries — splicing them in risks wrong winners exactly
 at region edges (the subtlety `semantic-token-overlap-resolution` exists to get
 right). It also forces a delta-decode + re-encode to re-anchor coordinates.
 
-### C. Whole-document memoization keyed by content hash
+### C. Whole-document memoization keyed by content hash (shipped, complementary)
 
-Cache the entire finalized result per `(uri, content_hash)`. Trivial to wire,
-but only helps when the *whole* document is unchanged — which the existing
-`result_id` no-op short-circuit already covers. Provides nothing for the actual
-hot case (one region edited, the rest reused). Rejected as redundant.
+Cache the entire finalized result per `(uri, content_hash)`. **Shipped as PR
+#530** (`SemanticTokenCache`, keyed by `fnv1a_hash(text) ^ generation`). It
+covers the *unchanged-document* case — idle `full` re-requests and no-op deltas.
+It does nothing for the typing path, because every keystroke changes the
+document hash, which is exactly why this ADR exists. The two are complementary
+layers, not alternatives: the whole-doc cache is the cheap outer gate, the
+per-region cache is the inner reuse on the typing path.
 
 ### D. Leave as-is, optimize allocation/algorithm only
 

--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -192,14 +192,49 @@ conversion, pre-resolved token indices). Real wins, but all O(work) constant-
 factor reductions — none removes the *recompute-everything* structure. Kept as
 complementary, not a substitute.
 
+## Correctness hazards
+
+The cache is **push-based / evict-on-mutation**: `get` does no read-time
+validity check, so every mutation path that can change a region's tokens must
+evict its entry before it is re-served. The existing eviction (edit-overlap,
+content/language change, region removed, close) covers most paths. An audit
+surfaced four the original design did not address:
+
+1. **`injection.combined` sibling cross-contamination (showstopper).** Combined
+   injections are discovered as separate `region_id`s but tokenized *jointly*
+   (multiple blocks parsed as one document). Editing one block does not change a
+   sibling's content hash, so the sibling would serve a hit computed in the
+   *old* joint context. **Mitigation: exclude combined groups from the cache** —
+   the v1 predicate already does, and the vendored Markdown query reserves
+   `combined` for HTML anyway.
+2. **Config / query reload (showstopper).** `bump_semantic_token_generation`
+   (PR #530) clears the whole-doc cache but never touches `InjectionTokenCache`,
+   which has no `clear()` and no generation in its key. A query/settings reload
+   with unchanged text would serve tokens computed under the *old* highlight
+   query. **Mitigation: clear the injection cache in
+   `bump_semantic_token_generation`, or fold the generation into its validity.**
+3. **Parser-load race (guard).** `process_injection_sync` returns empty tokens
+   when a region's parser is not yet loaded — indistinguishable from a genuinely
+   empty region. **Mitigation: never store on the parser-missing branch.**
+4. **Row-0 `start_column` re-anchoring (guard, sidestepped by v1 scope).** A
+   same-line-before edit shifts row-0 columns without changing the content hash.
+   Out of scope for v1 by the `content_start_col == 0` predicate; required only
+   if a later version caches non-column-0 regions.
+
+Stale-position bugs here are the same family as the rejected content-epoch
+version gate and the delta-encoding position trap — a stale hit is
+*wrong-colored text*, worse than a slow recompute. The v1 scope plus the
+two showstopper mitigations are the price of correctness, not optional polish.
+
 ## Consequences
 
 ### Positive
 
-- Editing one region recomputes one region; the rest are O(token-count) copies
-  with an offset. Turns per-edit cost from "reparse whole document" into
-  "reparse the edited region", which is the dominant cost for large injected
-  documents.
+- On the typing path (where the whole-doc cache is structurally useless),
+  editing one region recomputes one region; the rest are O(token-count) copies
+  with a line offset. Measured ceiling at 150–300 injection blocks: ~−1/3 of
+  per-keystroke compute for tokenize-only, up to ~−60% with the discovery
+  companion.
 - Reuses infrastructure already built, maintained, and tested (`InjectionMap`,
   `content_hash`, eviction in `src/lsp/cache.rs`).
 
@@ -207,12 +242,14 @@ complementary, not a substitute.
 
 - `RawToken` becomes a cross-request persisted type, so its memory layout and
   any future field changes now affect cache validity, not just one request.
-- Re-anchoring logic is a new correctness surface: an off-by-one in the line/
-  column offset would mis-place every token in a reused region. Needs targeted
-  tests (edit-above-shifts-region, same-line-edit-before-region, region added/
-  removed) plus the existing e2e snapshot coverage as a backstop.
-- Column re-anchoring is only trivial for the region's *first* line; multi-line
-  regions whose `start_column` changes need care (only line-0 columns shift).
+- Re-anchoring logic is a new correctness surface; the v1 scope bounds it to a
+  trivial `line += Δ`, but still needs targeted tests (edit-above-shifts-region,
+  region added/removed) plus the existing e2e snapshot coverage as a backstop.
+- **The win is bounded.** Host-collect + discovery + finalize stay on every
+  keystroke (~2/3 of the recompute for tokenize-only v1). On fast hardware the
+  absolute saving is sub-frame until documents are very large — this lever is
+  for very large injected documents and/or slower hardware, not a universal
+  speedup.
 
 ### Neutral
 
@@ -224,6 +261,12 @@ complementary, not a substitute.
 Only the invalidation half is implemented today: `InjectionMap` population +
 `find_overlapping` + `InjectionTokenCache::{remove, clear_document}` are wired in
 `src/lsp/cache.rs`; `InjectionTokenCache::{store, get}` are `#[cfg(test)]`-only
-and never called from production. This ADR records the intended design for the
-reuse half; until it lands, the cache is maintained-but-unread and the hot path
-recomputes in full.
+and never called from production. The whole-document layer (Option C) shipped
+separately as PR #530.
+
+This ADR records the intended design for the per-region reuse half — scoped to
+the language-agnostic translation predicate, gated on the two showstopper
+mitigations (exclude `injection.combined`; clear the injection cache on
+generation bump) — plus the injection-discovery companion as a follow-up. Until
+it lands, the cache is maintained-but-unread and the typing path recomputes in
+full.

--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -130,28 +130,38 @@ These three conditions are **language-agnostic** — they turn on the region's
 coordinate geometry and injection mode, not on which language is injected. A
 fenced code block that starts at column 0 qualifies; a region that interleaves
 host bytes per row (blockquote-style, line-continuation markers, etc.) does not
-— the predicate self-selects regardless of language. For a qualifying region,
-re-anchoring after any content-preserving edit is a single additive `line += Δ`,
-and a same-line-before edit is impossible because the content starts at column 0
-on its own line.
-
-Implementation note: these facts (start column, per-row prefix widths,
-combined-ness) live today on the transient `InjectionContext` that tokenization
-builds, not on the persisted `CacheableInjectionRegion`, and `injection.combined`
-is a query property rather than range geometry. v1 must therefore evaluate
-eligibility from the injection context tokenization actually uses and carry it
-alongside the cached entry — not infer it from `CacheableInjectionRegion`
-metadata alone.
+— the predicate self-selects regardless of language.
 
 **v1 scope: cache only regions satisfying the predicate; recompute the rest.**
-This eliminates the row-0 / prefix re-anchoring correctness surface entirely
-while covering the common "many fenced code blocks" case the measurements
-target. For the qualifying set, region-local and host-absolute coordinates
-differ only by an additive line constant, so v1 can store the host-absolute
-tokens exactly as emitted and reuse them with `line += Δ` — which equals the
-region-local design of Decision step 3 for this set. True region-local storage
-(with the column rebase run on read) is the later, broader-coverage version that
-extends the cache to non-qualifying regions; it is not required to land the win.
+v1 stores **region-local `RawToken`s** (per Decision step 3) keyed by
+`(uri, region_id)` + `content_hash`. On a hit it re-anchors to the region's
+*current* host position: `host_line = region.line_range.start + token.row`, and
+`host_col = token.col` — the row-0 `start_column` term is 0 for every qualifying
+region, so no column rebase is needed. This reads only the current region's
+already-persisted `line_range.start` / `start_column` from
+`CacheableInjectionRegion`: no stored baseline, no delta-decode. The row-0 /
+prefix re-anchoring correctness surface is eliminated by construction, and a
+same-line-before edit is impossible because the content starts at column 0 on
+its own line. Carrying the column rebase to non-qualifying regions is the later,
+broader-coverage version; it is not required to land the win.
+
+Two implementation obligations follow, neither inferable from
+`CacheableInjectionRegion` alone:
+
+- **Evaluate eligibility on the *current* injection context, at read as well as
+  write.** `start_column` is on `CacheableInjectionRegion`, but
+  `prefix_byte_widths` and combined-ness live on the transient `InjectionContext`
+  that tokenization builds (and `injection.combined` is a query property, not
+  range geometry). Re-checking at read is what makes `content_hash` sufficient:
+  a host-tree restructure that changes a region's prefix geometry without
+  changing its content bytes (e.g. a fenced block gaining a `block_continuation`)
+  flips it to ineligible, forcing a recompute rather than a stale hit.
+- **Source `region_id` from the freshly parsed tree, not the cached
+  `InjectionMap`.** `InjectionContext` carries no `region_id` today, so v1 must
+  either add one or resolve it per request from the fresh tree (via `NodeTracker`
+  / `InjectionMap` by byte range). Using the fresh tree also closes the
+  stale-`InjectionMap` window between `invalidate_for_edits` and the off-ingress
+  `populate_injections`.
 
 ### Companion lever: injection discovery
 
@@ -227,10 +237,13 @@ paths; an audit surfaced four the original design did not address:
    `combined` for HTML anyway.
 2. **Config / query reload (showstopper).** `bump_semantic_token_generation`
    (PR #530) clears the whole-doc cache but never touches `InjectionTokenCache`,
-   which has no `clear()` and no generation in its key. A query/settings reload
-   with unchanged text would serve tokens computed under the *old* highlight
-   query. **Mitigation: clear the injection cache in
-   `bump_semantic_token_generation`, or fold the generation into its validity.**
+   which has no generation in its key. A query/settings reload with unchanged
+   text would serve tokens computed under the *old* highlight query.
+   **Mitigation: fold the settings generation into the entry's validity (the
+   same fix PR #530 applied to the whole-doc cache) — implementable with no new
+   API. Clearing the injection cache on generation bump is the alternative, but
+   needs a new global clear: today `InjectionTokenCache` exposes only per-region
+   `remove` and per-document `clear_document`.**
 3. **Parser-load race (guard).** `process_injection_sync` returns empty tokens
    when a region's parser is not yet loaded — indistinguishable from a genuinely
    empty region. **Mitigation: never store on the parser-missing branch.**
@@ -283,8 +296,8 @@ and never called from production. The whole-document layer (Option C) shipped
 separately as PR #530.
 
 This ADR records the intended design for the per-region reuse half — scoped to
-the language-agnostic translation predicate, gated on the two showstopper
-mitigations (exclude `injection.combined`; clear the injection cache on
-generation bump) — plus the injection-discovery companion as a follow-up. Until
-it lands, the cache is maintained-but-unread and the typing path recomputes in
-full.
+the language-agnostic translation predicate (re-evaluated at read time), gated on
+the two showstopper mitigations (exclude `injection.combined`; fold the settings
+generation into injection-cache validity) — plus the injection-discovery
+companion as a follow-up. Until it lands, the cache is maintained-but-unread and
+the typing path recomputes in full.

--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -5,16 +5,52 @@ Status: Proposed (aspirational). The invalidation half described here is
 implemented; the reuse half is not. See "Decision–Implementation Gap".
 -->
 
-**Related Decisions**: [semantic-token-overlap-resolution](semantic-token-overlap-resolution.md), [lazy-node-identity-tracking](lazy-node-identity-tracking.md)
+**Related Decisions**: [semantic-token-overlap-resolution](semantic-token-overlap-resolution.md), [lazy-node-identity-tracking](lazy-node-identity-tracking.md), [per-document-parse-scheduler](per-document-parse-scheduler.md)
 
 ## Context
 
 Semantic tokens for a document with code injections (e.g. a Markdown file with
 many fenced code blocks) are recomputed *in full* on every `semanticTokens/full`
 and `semanticTokens/full/delta` request. The delta request additionally diffs
-the freshly computed token vector against the previous one — saving wire size
-but not CPU. Editing a single character inside one Python block re-parses and
+the freshly computed token vector against the previous one.
+
+A whole-document content-hash cache (`SemanticTokenCache`, shipped in PR #530)
+already short-circuits the case where the *entire* document text is unchanged —
+so an idle re-request of `semanticTokens/full` is free. **That cache cannot help
+the steady-state typing path**: every keystroke changes the document text, so
+its content-hash key always misses and the hot path recomputes from scratch. The
+`semanticTokens/full/delta`-after-edit request is therefore the path this
+decision targets — editing one character inside one injected block re-parses and
 re-queries the host plus *every* injection region in the document.
+
+### Where the per-keystroke time actually goes
+
+Measured on the `full/delta`-after-edit path for a single-character,
+single-region edit (production-faithful: incremental `tree.edit` +
+`reparse(Some(seed))`, then the token recompute, then the delta diff), release
+build, warm, on Markdown with N fenced code blocks (rust/lua/yaml):
+
+| phase | 60 blocks | 150 blocks | 300 blocks | cacheable here? |
+|---|---|---|---|---|
+| incremental host parse | 0.06 ms | 0.17 ms | 0.37 ms | no — already incremental & cheap |
+| host token collect | 0.45 | 1.28 | 2.88 | no |
+| **injection discovery** | 0.45 | 1.28 | 2.92 | not in v1 (see Companion lever) |
+| **per-region tokenize** | **0.75** | **1.66** | **3.27** | **yes — the target** |
+| finalize sweep line | 0.18 | 0.50 | 1.10 | no |
+| delta diff | 0.002 | 0.004 | 0.008 | no — negligible |
+| **per-keystroke total** | **1.89** | **4.90** | **10.54** | |
+
+Two structural facts fall out:
+
+1. **The delta diff and incremental parse are nearly free.** The per-keystroke
+   CPU is almost entirely the *token recompute* — exactly what a per-region
+   cache avoids. (This is also why the whole-doc cache helps `full` but not
+   `delta`: both endpoints run the same recompute; the diff that distinguishes
+   them costs nothing.)
+2. **Per-region tokenize is ~1/3 of the recompute, not all of it.** Host token
+   collection and injection *discovery* are each roughly equal in cost, and
+   `finalize` adds ~10%. Even a perfect per-region tokenize cache leaves a hard
+   floor of host-collect + discovery + finalize on every keystroke.
 
 The codebase already contains most of the machinery to avoid this, but only its
 *invalidation* half is wired up:
@@ -37,10 +73,11 @@ guards an always-empty cache. The hot path (`handle_semantic_tokens_full` in
 `src/analysis/semantic.rs`) unconditionally calls `collect_host_tokens` +
 `collect_injection_tokens_parallel` over the whole document.
 
-This is the single highest-impact remaining performance lever for the feature.
-The reason it has not been wired in is a genuine design question, not an
-oversight: what to cache, and how to keep coordinates correct when an edit above
-a region shifts that region's position in the host document.
+This is the largest remaining *typing-path* lever for injection-heavy documents
+(the whole-doc cache having already taken the unchanged-document case). The
+reason it has not been wired in is a genuine design question, not an oversight:
+what to cache, and how to keep coordinates correct when an edit above a region
+shifts that region's position in the host document.
 
 ## Decision
 

--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -141,9 +141,9 @@ self-selects regardless of which language is injected.
 v1 stores **region-local `RawToken`s** (per Decision step 3) keyed by
 `(uri, region_id)`, validated by `content_hash` + settings generation. On a hit
 it re-anchors to the region's *current* host position:
-`host_line = region.line_range.start + token.line`, and `host_col = token.col` —
-the row-0 `start_column` term is 0 for every qualifying region, so no column
-rebase is needed. This reads only the current region's
+`host_line = region.line_range.start + token.line`, and
+`host_col = token.column` — the row-0 `start_column` term is 0 for every
+qualifying region, so no column rebase is needed. This reads only the current region's
 already-persisted `line_range.start` / `start_column` from
 `CacheableInjectionRegion`: no stored baseline, no delta-decode. The row-0 /
 prefix re-anchoring correctness surface is eliminated by construction, and a
@@ -168,7 +168,11 @@ Two implementation obligations follow, neither inferable from
   cached `InjectionMap`.** `InjectionContext` carries no `region_id` today, so v1
   resolves it per request — e.g. `tracker.get_or_create(uri, host_start_byte,
   end_byte, kind)` at the boundary between `collect_injection_contexts_sync` and
-  the parallel fan-out (no new field on `InjectionContext` needed). This is safe
+  the parallel fan-out (no new field on `InjectionContext` needed). This threads
+  two new inputs into `collect_injection_tokens_parallel` and
+  `handle_semantic_tokens_full`, which take neither today: the document `uri` and
+  the `NodeTracker` (it lives on `CacheCoordinator`, not the `LanguageCoordinator`
+  they currently receive). This is safe
   because `apply_input_edits` updates the `NodeTracker` synchronously under the
   edit lock the moment an edit lands — *before* the off-ingress reparse — so the
   ULIDs are consistent even while the cached `InjectionMap` is still pre-edit

--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -171,12 +171,17 @@ Two implementation obligations follow, neither inferable from
   continuations leave `prefix_byte_widths` empty, so that remains a *valid* hit.)
 - **Source `region_id` from the freshly parsed tree's `NodeTracker`, not the
   cached `InjectionMap`.** `InjectionContext` carries no `region_id` today, so v1
-  resolves it *inside* `collect_injection_contexts_sync`, where the tree-sitter
-  node is in hand — `tracker.get_or_create(uri, start_byte, end_byte, kind)` —
-  and carries the ULIDs to the fan-out as a parallel `Vec` aligned with the
-  contexts (or as a new `region_id` field on `InjectionContext`). It cannot be
-  deferred to the fan-out boundary: `InjectionContext` keeps only
-  `host_start_byte`, not the `end_byte` / node `kind` that `get_or_create` needs.
+  resolves it *inside* `collect_injection_contexts_sync` — the single-threaded
+  discovery phase that runs *before* the Rayon fan-out — where the tree-sitter
+  node is in hand: `tracker.get_or_create(uri, start_byte, end_byte, kind)`, with
+  the ULIDs carried to the fan-out as an index-aligned `Vec` (or as a new
+  `region_id` field on `InjectionContext`). Resolving here, not inside the
+  parallel workers, is deliberate: `NodeTracker.entries` is a
+  `DashMap<Url, UriEntries>`, so calling `get_or_create` for the same `uri` from
+  many workers at once would contend on that document's single write lock — the
+  sequential phase sidesteps the contention. It also cannot be deferred to the
+  fan-out boundary anyway: `InjectionContext` keeps only `host_start_byte`, not
+  the `end_byte` / node `kind` that `get_or_create` needs.
   Either way this threads two new inputs into `collect_injection_tokens_parallel`
   and `handle_semantic_tokens_full`, which take neither today: the document `uri`
   and the `NodeTracker` (owned by the bridge coordinator and passed *into* cache

--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -40,6 +40,10 @@ build, warm, on Markdown with N fenced code blocks (rust/lua/yaml):
 | delta diff | 0.002 | 0.004 | 0.008 | no — negligible |
 | **per-keystroke total** | **1.89** | **4.90** | **10.54** | |
 
+(Each cell is an independently measured-and-rounded average; the total is the
+measured per-keystroke total, so a column may not sum *exactly* to it — e.g. the
+300-block phases round-sum to 10.55 vs a measured 10.54.)
+
 Two structural facts fall out:
 
 1. **The delta diff and incremental parse are nearly free.** The per-keystroke

--- a/docs/architecture-decisions/injection-token-cache-reuse.md
+++ b/docs/architecture-decisions/injection-token-cache-reuse.md
@@ -284,23 +284,32 @@ paths; an audit surfaced four the original design did not address:
    text would serve tokens computed under the *old* highlight query.
    **Mitigation: fold the settings generation into the entry's validity, the
    same fix PR #530 applied to the whole-doc cache (where the inner cache takes a
-   derived `cache_key`). This is the right design — it matches the existing
-   pattern and avoids a global flush — but it is not free: wiring the reuse half
-   already promotes `store`/`get` from `#[cfg(test)]` to production, extends their
+   derived `cache_key`). This is preferred for a concrete correctness reason, not
+   just neatness: a bare global `clear()` on reload has a store-after-clear race —
+   a request already computing when the reload fires captured the pre-bump
+   generation and writes its now-stale entry *after* the clear, which the clear
+   cannot prevent (exactly why #530 folds a generation into the key instead of
+   only clearing; see the `semantic_token_generation` note on `CacheCoordinator`
+   in `src/lsp/cache.rs`). The fold is not free — wiring the reuse half already
+   promotes `store`/`get` from `#[cfg(test)]` to production, extends their
    signatures to thread the validity key, and changes the value type to
-   `Vec<RawToken>` (Option A); folding the generation rides along on those same
-   signatures. The alternative — a new global `clear()` on `InjectionTokenCache`
-   called from `bump_semantic_token_generation` — is a single new method, but
-   flushes every region on any reload.**
+   `Vec<RawToken>` (Option A), and the generation rides along on those same
+   signatures. A one-method global `clear()` from `bump_semantic_token_generation`
+   is simpler and the flush is cheap on a rare reload, but it trades that
+   race-safety away.**
 3. **Parser-load race (guard).** `process_injection_sync` returns an empty
    `Vec<RawToken>` when a region's parser is not yet loaded — indistinguishable
    from a genuinely empty region, so "never store on the parser-missing branch"
    first requires making that branch *observable*. **Mitigation: have
    `process_injection_sync` return a structured result that separates
    parser-missing from genuinely-empty (e.g. `Option`/`Result` or a
-   `parser_loaded` flag), or perform the cache write inside `process_injection_sync`
-   where the parser's presence is explicit — so a parser-missing result is never
-   stored.**
+   `parser_loaded` flag) and let the orchestration layer
+   (`collect_injection_tokens_parallel`) make the store decision — so a
+   parser-missing result is never stored. Prefer this over writing the cache
+   inside `process_injection_sync`: it runs in parallel Rayon workers, so an
+   in-function write would thread thread-safe cache-write access into parallel
+   tokenization and add side-effects there, whereas a pure structured return
+   keeps the store decision at the single-threaded orchestration boundary.**
 4. **Row-0 `start_column` re-anchoring (guard, sidestepped by v1 scope).** A
    same-line-before edit shifts row-0 columns without changing the content hash.
    Out of scope for v1 by the `content_start_col == 0` predicate; required only


### PR DESCRIPTION
## What

Rewrites the **injection-token-cache-reuse** ADR (the design doc for #529, a *proposed*, not-yet-implemented per-region injection-token cache) to reflect a faithful measurement of the `semanticTokens/full/delta`-after-edit path and to close the correctness gaps the original design left implicit. Docs-only.

## Why

After PR #530 shipped the whole-document semantic-token cache, the open question was whether #529 is still worth doing and where its win actually lands. I measured the per-keystroke budget on the delta-after-edit path (production-faithful incremental `tree.edit` + `reparse(Some(seed))`, then recompute, then diff), which reframes the ADR substantially:

- The whole-doc cache (#530) **cannot** help the typing path (every keystroke changes the text hash → always a miss). The `full/delta`-after-edit recompute is the path #529 targets.
- Per-keystroke total ≈ **1.9 / 4.9 / 10.5 ms** at 60 / 150 / 300 injection blocks. The incremental parse and the delta diff are nearly free; the CPU is almost entirely the token recompute.
- **Per-region tokenize is only ~1/3 of that recompute** — host-collect + injection discovery + finalize are a ~2/3 floor that stays on every keystroke. So #529 alone caps at ~−1/3; caching injection *discovery* too (a companion lever) roughly doubles it to ~−60%.

## Key design points the rewrite adds

- A **language-agnostic** v1 scope: cache only regions whose host↔content map is a pure uniform translation (`content_start_col == 0`, no per-row prefix widths, non-combined). These are geometry/injection-mode predicates, not markdown-specific — fenced blocks qualify, blockquote/line-continuation regions self-exclude. Re-anchor reduces to a trivial `line += Δ` (region-local storage, no baseline).
- A **correctness-hazards** section the original design omitted: two showstoppers (`injection.combined` joint-context cross-contamination; config/query reload not invalidating the injection cache) plus two guards (parser-load empty-store; row-0 `start_column`, sidestepped by the v1 scope). Stale-position bugs here = wrong-colored text, worse than a slow recompute.

## Review

Converged through `/review` (subagent, all 8 factual claims verified against source), codex MCP, and three pi-review rounds — every claim checked against the actual code; the final pass reports the ADR correct and converged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)