### PR TITLE
fix(injection): forward refresh events from injected-language loads (#532)

### DIFF
--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -4,17 +4,18 @@ use url::Url;
 
 use crate::document::DocumentStore;
 use crate::language::injection::{InjectionResolver, collect_all_injections};
-use crate::language::{DocumentParserPool, LanguageCoordinator};
+use crate::language::{DocumentParserPool, LanguageCoordinator, LanguageEvent};
 use crate::lsp::auto_install::AutoInstallManager;
 use crate::lsp::bridge::BridgeCoordinator;
 use crate::lsp::bridge::coordinator::BridgeInjection;
 use crate::lsp::cache::CacheCoordinator;
+use crate::lsp::client::ClientNotifier;
 use crate::lsp::diagnostic_cache::{DiagnosticAggregator, DiagnosticSource};
 use crate::lsp::lsp_impl::Kakehashi;
 use crate::lsp::settings_manager::SettingsManager;
 use tower_lsp_server::Client;
 
-use crate::lsp::lsp_impl::detect_document_language;
+use crate::lsp::lsp_impl::{build_notifier, detect_document_language};
 
 use super::InstallCoordinator;
 use super::install::InstallCoordinatorDeps;
@@ -216,6 +217,30 @@ impl InjectionCoordinator {
             install.auto_install_disabled_reason()
         };
 
+        // Events emitted while loading an injected-language parser that was on disk
+        // but not yet loaded — a one-time `Log` plus (when the language has queries)
+        // a `SemanticTokensRefresh`. These were previously dropped here, so a freshly
+        // loaded injected language never nudged the editor to re-pull its tokens
+        // (#532). Collected and forwarded once after the loop; #531's batch dedup
+        // collapses multiple refresh events into a single workspace-wide request.
+        //
+        // Scope/value: this only matters in the narrow window where the editor
+        // already pulled tokens before this background install-check loaded the
+        // parser. The async auto-install case is already covered by
+        // `reload_language_after_install`, and when a parser is on disk the
+        // token-collection path loads it inline and returns the injected tokens in
+        // the same `semanticTokens/full` response. So this is a defensive nudge, not
+        // a hot path.
+        //
+        // Only the success path is collected: the failure path delegates to
+        // `notify_parser_missing` / `maybe_auto_install_language`, which emit their
+        // own user-facing messages (and the install path forwards its own load
+        // events), so forwarding failure events here would double-message. The whole
+        // success vector is forwarded (log + refresh) for consistency with the
+        // host/derived load path; it fires at most once per language (a re-load of
+        // an already-registered language returns no events).
+        let mut load_events: Vec<LanguageEvent> = Vec::new();
+
         for lang in languages {
             let resolved_lang = if self.language.has_parser_available(lang) {
                 lang.clone()
@@ -227,6 +252,7 @@ impl InjectionCoordinator {
 
             let load_result = self.language.ensure_language_loaded(&resolved_lang);
             if load_result.success {
+                load_events.extend(load_result.events);
                 continue;
             }
 
@@ -244,6 +270,16 @@ impl InjectionCoordinator {
                     .await;
             }
         }
+
+        // Forward the collected load events (deduped to ≤1 refresh by #531) so the
+        // editor re-pulls tokens for any injected language loaded just now.
+        if !load_events.is_empty() {
+            self.notifier().log_language_events(&load_events).await;
+        }
+    }
+
+    fn notifier(&self) -> ClientNotifier<'_> {
+        build_notifier(&self.client, &self.settings_manager)
     }
 
     /// Eagerly spawn bridge servers and open virtual documents for detected injections.


### PR DESCRIPTION
Closes #532. **Stacked on #538 (#531)** — base is `perf/semantic-tokens-refresh-dedup`; review/merge #538 first.

## Problem
`check_injected_languages_auto_install` (`src/lsp/lsp_impl/coordinator/injection.rs`) loaded an on-disk injected-language parser via `ensure_language_loaded` but dropped `LanguageLoadResult.events` on the success path (`if load_result.success { continue; }`). A freshly-loaded injected language therefore never forwarded its `SemanticTokensRefresh` (nor the one-time "loaded" log) to the client.

## Fix
Collect success-path load events into `load_events` and forward them once after the loop via a new private `notifier()` (built with `build_notifier`). #531 (the parent PR) dedups multiple `SemanticTokensRefresh` events into a single workspace-wide request.

- **Success path only.** The failure path delegates to `notify_parser_missing` / `maybe_auto_install_language`, which emit their own messages (and `reload_language_after_install` already forwards the install path's own load events) — so forwarding failure events here would double-message. The two branches are mutually exclusive per language.
- **At most once per language.** `ensure_language_loaded` returns empty events for an already-registered language, so a re-load (every later parse pass) forwards nothing — no per-parse storm.
- **Whole success vector (log + refresh)** is forwarded for consistency with the host/derived load path; the log is `window/logMessage` (output panel), not a popup.

## Scope (deliberate, maintainer-approved)
This is a **minimal defensive nudge**, not a hot-path fix. The async auto-install case is already covered by `reload_language_after_install`, and on-disk parsers are loaded inline by the token-collection path (so injected tokens already ship in the same `semanticTokens/full` response). The forward adds value only in the narrow window where the editor pulled tokens before this background install-check loaded the parser. The robust alternative (a `LanguageCoordinator`-level pending-refresh queue drained at every notifier point) was considered and declined as disproportionate to the marginal value.

## Test
The method needs a real `Client` (not unit-testable) and the target race is inherently non-deterministic, so the change is verified by-construction (forwards previously-dropped, independently-tested events) — consistent with #531. Event *production* is covered by the `ensure_language_loaded` coordinator tests; *forwarding + dedup* by the `client.rs` tests.

## Review
Local cycle clean: `/review` (multi-perspective), Codex MCP, and pi-review (2 independent passes) all found no actionable issues; verified no double-forward, no lock held across the new `.await`, no `didClose` race. `cargo test --lib injection` (108), `clippy --lib -D warnings`, `fmt` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)