### PR TITLE
feat(semantic): per-region injection-token cache reuse (#529)

### DIFF
--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -20,7 +20,16 @@ use parallel::collect_injection_tokens_parallel;
 
 // Internal re-exports for production code
 use finalize::finalize_tokens;
-use token_collector::{RawToken, build_line_start_bytes, collect_host_tokens};
+use token_collector::{build_line_start_bytes, collect_host_tokens};
+
+// Region-local token type persisted by the injection-token cache (#529). Lives
+// in `token_collector`; re-exported here so `semantic_cache` can name it.
+pub(crate) use token_collector::RawToken;
+// `TokenKind` is only needed to construct `RawToken`s in `semantic_cache` tests
+// (the production re-anchor path touches only line/column), so its re-export is
+// test-gated to avoid an unused import in release builds.
+#[cfg(test)]
+pub(crate) use token_collector::TokenKind;
 
 // Test-only imports
 #[cfg(test)]

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -16,7 +16,18 @@ pub(crate) use legend::{LEGEND_MODIFIERS, LEGEND_TYPES};
 pub(crate) use range::handle_semantic_tokens_range_parallel_async;
 
 // Re-export for parallel processing
-use parallel::collect_injection_tokens_parallel;
+use parallel::{InjectionCacheCtx, collect_injection_tokens_parallel};
+
+/// Owned handle the LSP layer passes into [`handle_semantic_tokens_full`] to
+/// enable per-region injection-token caching (#529). `None` disables caching
+/// (range requests, tests), reproducing the pre-#529 behavior. Borrowed into an
+/// [`InjectionCacheCtx`] inside the blocking task.
+pub(crate) struct InjectionCacheParams {
+    pub uri: url::Url,
+    pub tracker: std::sync::Arc<crate::language::NodeTracker>,
+    pub cache: std::sync::Arc<crate::analysis::InjectionTokenCache>,
+    pub generation: u64,
+}
 
 // Internal re-exports for production code
 use finalize::finalize_tokens;
@@ -48,6 +59,7 @@ pub(crate) async fn handle_semantic_tokens_full(
     capture_mappings: Option<std::sync::Arc<CaptureMappings>>,
     coordinator: std::sync::Arc<crate::language::LanguageCoordinator>,
     supports_multiline: bool,
+    injection_cache: Option<InjectionCacheParams>,
 ) -> Option<SemanticTokensResult> {
     tokio::task::spawn_blocking(move || {
         let mut all_tokens: Vec<RawToken> = Vec::with_capacity(1000);
@@ -72,6 +84,15 @@ pub(crate) async fn handle_semantic_tokens_full(
             &mut all_tokens,
         );
 
+        // Borrow the owned cache handle into a request-scoped context for the
+        // injection pass (#529); `None` keeps the uncached behavior.
+        let cache_ctx = injection_cache.as_ref().map(|p| InjectionCacheCtx {
+            uri: &p.uri,
+            tracker: p.tracker.as_ref(),
+            cache: p.cache.as_ref(),
+            generation: p.generation,
+        });
+
         // Collect injection tokens in parallel using Rayon.
         // Also returns active injection regions for finalize-time exclusion.
         let (injection_tokens, active_injection_regions) = collect_injection_tokens_parallel(
@@ -83,6 +104,7 @@ pub(crate) async fn handle_semantic_tokens_full(
             &coordinator,
             capture_mappings.as_deref(),
             supports_multiline,
+            cache_ctx.as_ref(),
         );
 
         // Merge injection tokens with host tokens
@@ -570,6 +592,7 @@ local x = 42
             None,
             coordinator,
             false,
+            None,
         )
         .await;
 
@@ -637,6 +660,7 @@ local x = 42
             None,
             coordinator,
             false,
+            None,
         )
         .await;
 
@@ -708,6 +732,7 @@ local x = 42
             Some(capture_mappings),
             coordinator,
             false,
+            None,
         )
         .await;
 
@@ -820,6 +845,7 @@ local x = 42
             Some(capture_mappings),
             coordinator,
             false,
+            None,
         )
         .await;
 
@@ -931,6 +957,7 @@ local x = 42
             Some(capture_mappings),
             coordinator,
             false,
+            None,
         )
         .await;
 
@@ -1042,6 +1069,7 @@ local x = 42
             Some(capture_mappings),
             coordinator,
             true, // multiline support enabled!
+            None,
         )
         .await;
 
@@ -1172,6 +1200,7 @@ foo
             Some(capture_mappings),
             coordinator,
             false,
+            None,
         )
         .await;
 
@@ -1281,6 +1310,7 @@ foo
             Some(capture_mappings),
             coordinator,
             false,
+            None,
         )
         .await;
 

--- a/src/analysis/semantic/injection.rs
+++ b/src/analysis/semantic/injection.rs
@@ -20,11 +20,12 @@ pub(super) struct RegionCacheInfo {
     /// so `invalidate_for_edits` evicts the same entry this stores under.
     pub region_id: String,
     /// Validity hash: the region's content hash folded with its resolved injection
-    /// language. Content distinguishes an edit; the language fold makes a hit
-    /// impossible across two regions that share a position-stable `region_id` and
-    /// identical content bytes but inject *different* languages — including a
-    /// stale ULID minted by a superseded request, which `populate_injections`
-    /// never sees and so can't evict by language change.
+    /// language. Content distinguishes an edit; the language fold means two regions
+    /// that share a position-stable `region_id` and identical content bytes but
+    /// inject *different* languages get different hashes (barring a 64-bit
+    /// collision), so one won't serve the other's tokens — including a stale ULID
+    /// minted by a superseded request, which `populate_injections` never sees and
+    /// so can't evict by language change.
     pub validity_hash: u64,
     /// `line_range.start`: the region's first host line, added back on reuse
     /// (`host_line = line_start + token.line`).

--- a/src/analysis/semantic/injection.rs
+++ b/src/analysis/semantic/injection.rs
@@ -19,8 +19,13 @@ pub(super) struct RegionCacheInfo {
     /// Position-based ULID, byte-identical to the one `populate_injections` mints,
     /// so `invalidate_for_edits` evicts the same entry this stores under.
     pub region_id: String,
-    /// Hash of the region's (effective) content — distinguishes a content edit.
-    pub content_hash: u64,
+    /// Validity hash: the region's content hash folded with its resolved injection
+    /// language. Content distinguishes an edit; the language fold makes a hit
+    /// impossible across two regions that share a position-stable `region_id` and
+    /// identical content bytes but inject *different* languages — including a
+    /// stale ULID minted by a superseded request, which `populate_injections`
+    /// never sees and so can't evict by language change.
+    pub validity_hash: u64,
     /// `line_range.start`: the region's first host line, added back on reuse
     /// (`host_line = line_start + token.line`).
     pub line_start: u32,

--- a/src/analysis/semantic/injection.rs
+++ b/src/analysis/semantic/injection.rs
@@ -7,6 +7,30 @@ use std::sync::Arc;
 
 use tree_sitter::Query;
 
+/// Cache identity for a top-level injection region (#529).
+///
+/// Populated only for top-level singles when injection-token caching is active
+/// (a cache handle is threaded in and the region count clears the gate). Carries
+/// everything the reuse path needs without re-touching the tree-sitter node:
+/// the position-stable `region_id` (minted the same way as `populate_injections`),
+/// the content hash + the region's first host line for re-anchoring, and whether
+/// the region satisfies the language-agnostic translation predicate this request.
+pub(super) struct RegionCacheInfo {
+    /// Position-based ULID, byte-identical to the one `populate_injections` mints,
+    /// so `invalidate_for_edits` evicts the same entry this stores under.
+    pub region_id: String,
+    /// Hash of the region's (effective) content — distinguishes a content edit.
+    pub content_hash: u64,
+    /// `line_range.start`: the region's first host line, added back on reuse
+    /// (`host_line = line_start + token.line`).
+    pub line_start: u32,
+    /// Whether this region qualifies for the trivial re-anchor this request:
+    /// `start_column == 0` ∧ no per-row prefix widths ∧ not `injection.combined`.
+    /// Recomputed every request from the fresh context, so a region that stopped
+    /// qualifying is recomputed rather than served a stale hit.
+    pub eligible: bool,
+}
+
 /// Data for processing a single injection (parser-agnostic).
 ///
 /// This struct captures all the information needed to process an injection
@@ -32,4 +56,9 @@ pub(super) struct InjectionContext<'a> {
     /// clip tokens to `included_ranges`, because a capture node may span the
     /// excluded text between blocks.
     pub combined: bool,
+    /// Cache identity for the injection-token cache (#529), or `None` when this
+    /// context is nested, combined, or caching is gated off for this request.
+    /// Index-aligned with the per-context token results so the store/reuse
+    /// decision is made single-threaded outside the Rayon fan-out.
+    pub region_cache: Option<RegionCacheInfo>,
 }

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -26,6 +26,7 @@ use crate::language::injection::{
     compute_included_ranges_clipped, effective_offset_for_pattern, has_combined_for_pattern,
     intersect_included_ranges, parse_with_ranges, sub_select_included_ranges,
 };
+use crate::text::fnv1a_hash;
 use crate::text::position::byte_to_utf16_col;
 
 /// Minimum number of top-level single injection regions before injection-token
@@ -252,18 +253,21 @@ pub(crate) fn process_injection_sync(
     // exclusion ranges. This suppresses this level's captures within regions
     // that will be handled by deeper injection languages. Nested regions are
     // never cached in v1, so no cache context is threaded into the recursion.
-    let (nested_contexts, nested_exclusion_ranges) = collect_injection_contexts_sync(
-        ctx.content_text,
-        &tree,
-        Some(&ctx.resolved_lang),
-        coordinator,
-        ctx.host_start_byte,
-        ctx.included_ranges.as_deref(),
-        None,
-    );
+    let (nested_contexts, nested_exclusion_ranges, nested_discovery_complete) =
+        collect_injection_contexts_sync(
+            ctx.content_text,
+            &tree,
+            Some(&ctx.resolved_lang),
+            coordinator,
+            ctx.host_start_byte,
+            ctx.included_ranges.as_deref(),
+            None,
+        );
 
     let mut tokens = Vec::new();
-    let mut fully_loaded = true;
+    // A nested injection dropped during discovery (its parser/query not loaded)
+    // leaves this subtree incomplete, so it must not be cached as a hit.
+    let mut fully_loaded = nested_discovery_complete;
 
     // Collect tokens from this injection's highlight query, excluding
     // regions covered by nested injections. Combined contexts force per-line
@@ -390,10 +394,14 @@ fn clip_tokens_to_included_ranges(
 /// works without mutable parser access. It discovers all injections in the
 /// given tree and returns their contexts for processing.
 ///
-/// Returns `(contexts, exclusion_ranges)` where exclusion_ranges are the
-/// content-local byte ranges of each resolved injection. These ranges
-/// correspond to the regions where child injections produce their own tokens,
-/// so parent captures overlapping these ranges should be suppressed.
+/// Returns `(contexts, exclusion_ranges, discovery_complete)`. `exclusion_ranges`
+/// are the content-local byte ranges of each resolved injection (regions where
+/// child injections produce their own tokens, so parent captures overlapping
+/// them should be suppressed). `discovery_complete` is `false` when any injection
+/// was dropped because its parser/highlight query was unavailable — a *transient*
+/// gap that re-fills when the parser loads without the content changing. A caller
+/// that caches a region must taint it with this so an incomplete subtree is never
+/// stored (and then served stale once the missing parser arrives, #529 Hazard 3).
 fn collect_injection_contexts_sync<'a>(
     text: &'a str,
     tree: &Tree,
@@ -402,21 +410,26 @@ fn collect_injection_contexts_sync<'a>(
     content_start_byte: usize,
     parent_included_ranges: Option<&[tree_sitter::Range]>,
     cache_ctx: Option<(&Url, &NodeTracker)>,
-) -> (Vec<InjectionContext<'a>>, Vec<(usize, usize)>) {
+) -> (Vec<InjectionContext<'a>>, Vec<(usize, usize)>, bool) {
     use crate::language::injection::collect_all_injections;
 
     let current_lang = filetype.unwrap_or("unknown");
     let Some(injection_query) = coordinator.injection_query(current_lang) else {
-        return (Vec::new(), Vec::new());
+        // No injection query: there is nothing to discover, so discovery is
+        // trivially complete (no region was dropped).
+        return (Vec::new(), Vec::new(), true);
     };
 
     let Some(injections) = collect_all_injections(&tree.root_node(), text, Some(&injection_query))
     else {
-        return (Vec::new(), Vec::new());
+        return (Vec::new(), Vec::new(), true);
     };
 
     let mut contexts = Vec::with_capacity(injections.len());
     let mut exclusion_ranges = Vec::with_capacity(injections.len());
+    // Tainted to `false` when an injection is skipped because its parser or
+    // highlight query isn't loaded yet (vs. a permanently malformed region).
+    let mut discovery_complete = true;
 
     // Partition out `injection.combined` regions: every capture of one
     // (language, pattern) pair parses as a single document so cross-block
@@ -445,9 +458,13 @@ fn collect_injection_contexts_sync<'a>(
     }
 
     // Resolve cache identity only when a cache handle is threaded in (top-level
-    // request, not a nested pass) AND the region count clears the gate. Below the
-    // gate, `region_cache` stays `None` for every context, so the store/reuse
-    // path is skipped entirely and output matches the pre-#529 code exactly.
+    // request, not a nested pass) AND the region count clears the gate. The count
+    // is `singles.len()` — the raw single captures, an upper bound on the regions
+    // that will actually be cacheable (some may later fail bounds/language/query
+    // resolution). Below the gate, `region_cache` stays `None` for every context,
+    // so the store/reuse path is skipped entirely. The gate only governs whether
+    // the (cheap) bookkeeping runs; output is byte-identical to the pre-#529 code
+    // either way, so the upper-bound count is a safe, conservative trigger.
     let cache_for_singles = cache_ctx.filter(|_| singles.len() >= INJECTION_CACHE_MIN_REGIONS);
 
     for injection in singles {
@@ -462,15 +479,19 @@ fn collect_injection_contexts_sync<'a>(
         // Extract injection content for language detection
         let injection_content = &text[start..end];
 
-        // Resolve injection language
+        // Resolve injection language. A failure here means no parser could be
+        // loaded for it yet — a transient gap, so discovery is incomplete.
         let Some((resolved_lang, _)) =
             coordinator.resolve_injection_language(&injection.language, injection_content)
         else {
+            discovery_complete = false;
             continue;
         };
 
-        // Get highlight query for resolved language
+        // Get highlight query for resolved language. Missing query is likewise
+        // transient (loads with the language), so taint discovery.
         let Some(highlight_query) = coordinator.highlight_query(&resolved_lang) else {
+            discovery_complete = false;
             continue;
         };
 
@@ -575,9 +596,16 @@ fn collect_injection_contexts_sync<'a>(
             let cacheable =
                 CacheableInjectionRegion::from_region_info(&injection, &region_id, text);
             let eligible = cacheable.start_column == 0 && prefix_byte_widths.is_empty();
+            // Fold the resolved language into the validity hash so a position-
+            // stable region_id with identical content but a different injected
+            // language can never serve a stale hit (defends the cross-language
+            // hazard from a superseded request's orphaned ULID; same fold style as
+            // the generation fold in cache_key).
+            let validity_hash =
+                cacheable.content_hash ^ fnv1a_hash(&resolved_lang).wrapping_mul(0x100000001b3);
             RegionCacheInfo {
                 region_id,
-                content_hash: cacheable.content_hash,
+                validity_hash,
                 line_start: cacheable.line_range.start,
                 eligible,
             }
@@ -608,7 +636,7 @@ fn collect_injection_contexts_sync<'a>(
         }
     }
 
-    (contexts, exclusion_ranges)
+    (contexts, exclusion_ranges, discovery_complete)
 }
 
 /// Per-line byte prefix widths from included ranges: each range's
@@ -777,7 +805,10 @@ pub(crate) fn collect_injection_tokens_parallel(
     // Collect top-level injection contexts and their byte ranges. The cache
     // handle (if any) lets the discovery phase resolve region identities
     // single-threaded, before the fan-out.
-    let (contexts, exclusion_byte_ranges) = collect_injection_contexts_sync(
+    // A top-level region dropped during discovery isn't cached (no region_cache
+    // is built for it), so the top-level completeness flag is irrelevant here —
+    // only nested completeness, threaded through process_injection_sync, matters.
+    let (contexts, exclusion_byte_ranges, _discovery_complete) = collect_injection_contexts_sync(
         host_text,
         host_tree,
         host_filetype,
@@ -812,7 +843,7 @@ pub(crate) fn collect_injection_tokens_parallel(
                 && rc.eligible
                 && let Some(local) =
                     cc.cache
-                        .get(cc.uri, &rc.region_id, rc.content_hash, cc.generation)
+                        .get(cc.uri, &rc.region_id, rc.validity_hash, cc.generation)
             {
                 hit_tokens.extend(reanchor_to_host(local, rc.line_start));
             } else {
@@ -878,8 +909,13 @@ pub(crate) fn collect_injection_tokens_parallel(
                 && res.fully_loaded
             {
                 let local = to_region_local(&res.tokens, rc.line_start);
-                cc.cache
-                    .store(cc.uri, &rc.region_id, rc.content_hash, cc.generation, local);
+                cc.cache.store(
+                    cc.uri,
+                    &rc.region_id,
+                    rc.validity_hash,
+                    cc.generation,
+                    local,
+                );
             }
         }
     }
@@ -1844,7 +1880,7 @@ local b = 2
             .expect("markdown must parse");
         parser_pool.release("markdown".to_string(), parser);
 
-        let (contexts, exclusions) = collect_injection_contexts_sync(
+        let (contexts, exclusions, _complete) = collect_injection_contexts_sync(
             COMBINED_LUA_DOC,
             &tree,
             Some("markdown"),
@@ -1921,7 +1957,7 @@ local b = 2
         let tree = parser.parse(doc, None).expect("markdown must parse");
         parser_pool.release("markdown".to_string(), parser);
 
-        let (contexts, _exclusions) = collect_injection_contexts_sync(
+        let (contexts, _exclusions, _complete) = collect_injection_contexts_sync(
             doc,
             &tree,
             Some("markdown"),

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -797,53 +797,83 @@ pub(crate) fn collect_injection_tokens_parallel(
     // Threshold for parallel processing - below this, Rayon scheduling overhead exceeds benefit
     const PARALLEL_THRESHOLD: usize = 4;
 
-    // Process injections: parallel for larger collections, sequential for small
-    // ones. Each context yields an `InjectionTokens` (tokens + fully_loaded),
-    // index-aligned with `contexts` so the store decision below can pair each
-    // result with its region's cache identity off the Rayon workers.
-    let results: Vec<InjectionTokens> = if contexts.len() >= PARALLEL_THRESHOLD {
-        contexts
+    // Resolve cache hits before the fan-out (#529, read half): an eligible region
+    // whose content hash and settings generation still match a stored entry is
+    // re-anchored to its current host line and never re-tokenized; only misses go
+    // to the Rayon workers. Eligibility is evaluated against THIS request's fresh
+    // context, so a region that stopped qualifying recomputes rather than serving
+    // a stale hit. Below the region-count gate `region_cache` is `None`, so every
+    // context misses and the path matches the uncached behavior exactly.
+    let mut hit_tokens: Vec<RawToken> = Vec::new();
+    let mut miss_indices: Vec<usize> = Vec::with_capacity(contexts.len());
+    if let Some(cc) = cache_ctx {
+        for (i, ctx) in contexts.iter().enumerate() {
+            if let Some(rc) = &ctx.region_cache
+                && rc.eligible
+                && let Some(local) =
+                    cc.cache
+                        .get(cc.uri, &rc.region_id, rc.content_hash, cc.generation)
+            {
+                hit_tokens.extend(reanchor_to_host(local, rc.line_start));
+            } else {
+                miss_indices.push(i);
+            }
+        }
+    } else {
+        miss_indices.extend(0..contexts.len());
+    }
+
+    // Tokenize only the misses: parallel above the threshold, sequential below.
+    // Each result carries its context index so the store decision can pair it
+    // with the region's cache identity off the Rayon workers.
+    let processed: Vec<(usize, InjectionTokens)> = if miss_indices.len() >= PARALLEL_THRESHOLD {
+        miss_indices
             .par_iter()
-            .map(|ctx| {
-                process_injection_sync(
-                    ctx,
-                    &factory,
-                    coordinator,
-                    capture_mappings,
-                    host_text,
-                    host_lines,
-                    host_line_starts,
-                    1, // depth 1 (first level of injection, host is 0)
-                    supports_multiline,
+            .map(|&i| {
+                (
+                    i,
+                    process_injection_sync(
+                        &contexts[i],
+                        &factory,
+                        coordinator,
+                        capture_mappings,
+                        host_text,
+                        host_lines,
+                        host_line_starts,
+                        1, // depth 1 (first level of injection, host is 0)
+                        supports_multiline,
+                    ),
                 )
             })
             .collect()
     } else {
-        contexts
+        miss_indices
             .iter()
-            .map(|ctx| {
-                process_injection_sync(
-                    ctx,
-                    &factory,
-                    coordinator,
-                    capture_mappings,
-                    host_text,
-                    host_lines,
-                    host_line_starts,
-                    1,
-                    supports_multiline,
+            .map(|&i| {
+                (
+                    i,
+                    process_injection_sync(
+                        &contexts[i],
+                        &factory,
+                        coordinator,
+                        capture_mappings,
+                        host_text,
+                        host_lines,
+                        host_line_starts,
+                        1,
+                        supports_multiline,
+                    ),
                 )
             })
             .collect()
     };
 
-    // Store region-local tokens for eligible, fully-loaded regions (#529),
-    // single-threaded after fan-in so cache writes never run inside a Rayon
-    // worker. `region_cache` is `Some` only when caching is active and the region
-    // is a top-level single; `eligible` is this request's translation predicate.
+    // Store region-local tokens for newly computed eligible, fully-loaded regions
+    // (#529, write half), single-threaded after fan-in so cache writes never run
+    // inside a Rayon worker.
     if let Some(cc) = cache_ctx {
-        for (ctx, res) in contexts.iter().zip(results.iter()) {
-            if let Some(rc) = &ctx.region_cache
+        for (i, res) in &processed {
+            if let Some(rc) = &contexts[*i].region_cache
                 && rc.eligible
                 && res.fully_loaded
             {
@@ -854,8 +884,11 @@ pub(crate) fn collect_injection_tokens_parallel(
         }
     }
 
-    // Flatten per-context tokens into one vector, then sort by position.
-    let mut all_tokens: Vec<RawToken> = results.into_iter().flat_map(|r| r.tokens).collect();
+    // Merge cache-hit and freshly computed tokens, then sort by position.
+    let mut all_tokens: Vec<RawToken> = hit_tokens;
+    for (_, res) in processed {
+        all_tokens.extend(res.tokens);
+    }
     all_tokens.sort_by(|a, b| a.line.cmp(&b.line).then_with(|| a.column.cmp(&b.column)));
 
     // Convert byte ranges to line/column ActiveInjectionBounds values, but only for
@@ -882,6 +915,23 @@ fn to_region_local(tokens: &[RawToken], line_start: u32) -> Vec<RawToken> {
     tokens
         .iter()
         .map(|t| t.with_span(t.line.saturating_sub(line_start), t.column, t.length))
+        .collect()
+}
+
+/// Re-anchor cached region-local tokens to the region's current host position:
+/// the inverse of [`to_region_local`]. Because the region is eligible
+/// (`start_column == 0`, no per-row prefixes), the column is already correct and
+/// only the line shifts by the region's current first host line — so an edit
+/// *above* an unchanged region (which leaves its content hash, hence the cache
+/// entry, intact but moves it) is re-anchored exactly.
+fn reanchor_to_host(tokens: Vec<RawToken>, line_start: u32) -> Vec<RawToken> {
+    let line_start = line_start as usize;
+    tokens
+        .into_iter()
+        .map(|t| {
+            let line = t.line;
+            t.with_span(line + line_start, t.column, t.length)
+        })
         .collect()
 }
 
@@ -2030,6 +2080,267 @@ local b = 2
             leaked.is_empty(),
             "combined-layer tokens must not leak into gap lines 2..=6, got {:?}",
             leaked
+        );
+    }
+
+    /// Markdown with eight lua fences — enough to clear
+    /// `INJECTION_CACHE_MIN_REGIONS`. Each block starts at column 0 with no
+    /// per-row prefix, so every region is cache-eligible.
+    fn eight_lua_block_doc() -> String {
+        let mut text = String::new();
+        for i in 0..8 {
+            text.push_str(&format!("```lua\nlocal x{i} = {i}\n```\n\n"));
+        }
+        text
+    }
+
+    /// Coordinator with markdown + lua loaded, or `None` to skip when the
+    /// parsers aren't available in the environment.
+    fn markdown_lua_coordinator() -> Option<LanguageCoordinator> {
+        use crate::config::WorkspaceSettings;
+        let coordinator = LanguageCoordinator::new();
+        let settings = WorkspaceSettings {
+            search_paths: vec![test_search_path()],
+            ..Default::default()
+        };
+        let _ = coordinator.load_settings(&settings);
+        let md = coordinator.ensure_language_loaded("markdown");
+        let lua = coordinator.ensure_language_loaded("lua");
+        if !md.success || !lua.success {
+            eprintln!("Skipping: markdown or lua parser not available");
+            return None;
+        }
+        Some(coordinator)
+    }
+
+    fn parse_markdown(coordinator: &LanguageCoordinator, text: &str) -> Tree {
+        let mut pool = coordinator.create_document_parser_pool();
+        let mut parser = pool.acquire("markdown").expect("markdown parser");
+        let tree = parser.parse(text, None).expect("parse markdown");
+        pool.release("markdown".to_string(), parser);
+        tree
+    }
+
+    /// The cached path must produce byte-identical tokens to the uncached path,
+    /// on both the first (all-miss, store) and second (all-hit) request.
+    #[test]
+    fn injection_cache_reuse_matches_uncached_output() {
+        let Some(coordinator) = markdown_lua_coordinator() else {
+            return;
+        };
+        let text = eight_lua_block_doc();
+        let tree = parse_markdown(&coordinator, &text);
+        let lines: Vec<&str> = text.lines().collect();
+        let line_starts = build_line_start_bytes(&text);
+
+        let uncached = collect_injection_tokens_parallel(
+            &text,
+            &lines,
+            &line_starts,
+            &tree,
+            Some("markdown"),
+            &coordinator,
+            None,
+            false,
+            None,
+        )
+        .0;
+
+        let uri = Url::parse("file:///cache_reuse.md").unwrap();
+        let cache = InjectionTokenCache::new();
+        let tracker = NodeTracker::new();
+        let cc = InjectionCacheCtx {
+            uri: &uri,
+            tracker: &tracker,
+            cache: &cache,
+            generation: 0,
+        };
+
+        let first = collect_injection_tokens_parallel(
+            &text,
+            &lines,
+            &line_starts,
+            &tree,
+            Some("markdown"),
+            &coordinator,
+            None,
+            false,
+            Some(&cc),
+        )
+        .0;
+        assert_eq!(first, uncached, "first (store) pass must match uncached");
+
+        // All eight eligible regions should have been stored.
+        assert_eq!(
+            cache.test_keys(&uri).len(),
+            8,
+            "every eligible region should be cached after the first pass"
+        );
+
+        let second = collect_injection_tokens_parallel(
+            &text,
+            &lines,
+            &line_starts,
+            &tree,
+            Some("markdown"),
+            &coordinator,
+            None,
+            false,
+            Some(&cc),
+        )
+        .0;
+        assert_eq!(second, uncached, "second (hit) pass must match uncached");
+    }
+
+    /// Proof the reuse path actually *reads* the cache rather than recomputing:
+    /// overwrite one region's stored entry with a sentinel token (length 999,
+    /// which no real lua token has), then re-run. The sentinel can only appear in
+    /// the output if the region was served from the cache.
+    #[test]
+    fn injection_cache_reuse_serves_stored_tokens() {
+        let Some(coordinator) = markdown_lua_coordinator() else {
+            return;
+        };
+        let text = eight_lua_block_doc();
+        let tree = parse_markdown(&coordinator, &text);
+        let lines: Vec<&str> = text.lines().collect();
+        let line_starts = build_line_start_bytes(&text);
+
+        let uri = Url::parse("file:///cache_sentinel.md").unwrap();
+        let cache = InjectionTokenCache::new();
+        let tracker = NodeTracker::new();
+        let cc = InjectionCacheCtx {
+            uri: &uri,
+            tracker: &tracker,
+            cache: &cache,
+            generation: 0,
+        };
+
+        // Populate.
+        let _ = collect_injection_tokens_parallel(
+            &text,
+            &lines,
+            &line_starts,
+            &tree,
+            Some("markdown"),
+            &coordinator,
+            None,
+            false,
+            Some(&cc),
+        );
+
+        // Overwrite one region with a region-local sentinel token.
+        let (rid, ch, generation) = cache
+            .test_keys(&uri)
+            .into_iter()
+            .next()
+            .expect("a region should be cached");
+        let sentinel = RawToken {
+            line: 0,
+            column: 0,
+            length: 999,
+            kind: crate::analysis::semantic::token_collector::TokenKind::Mapped(1, 0),
+            depth: 1,
+            pattern_index: 0,
+            priority: 100,
+            node_byte_len: 999,
+        };
+        cache.store(&uri, &rid, ch, generation, vec![sentinel]);
+
+        let tokens = collect_injection_tokens_parallel(
+            &text,
+            &lines,
+            &line_starts,
+            &tree,
+            Some("markdown"),
+            &coordinator,
+            None,
+            false,
+            Some(&cc),
+        )
+        .0;
+
+        assert!(
+            tokens.iter().any(|t| t.length == 999),
+            "the sentinel token must surface, proving the reuse path read the cache"
+        );
+    }
+
+    /// An edit *above* an unchanged region must re-anchor its cached tokens to the
+    /// new host line. With the tracker positions adjusted (as production does in
+    /// did_change), the cached entry stays valid and is shifted by the inserted
+    /// line — matching a fresh uncached compute of the edited document.
+    #[test]
+    fn injection_cache_reanchors_after_edit_above() {
+        let Some(coordinator) = markdown_lua_coordinator() else {
+            return;
+        };
+        let old_text = eight_lua_block_doc();
+        let old_tree = parse_markdown(&coordinator, &old_text);
+        let old_lines: Vec<&str> = old_text.lines().collect();
+        let old_line_starts = build_line_start_bytes(&old_text);
+
+        let uri = Url::parse("file:///cache_reanchor.md").unwrap();
+        let cache = InjectionTokenCache::new();
+        let tracker = NodeTracker::new();
+        let cc = InjectionCacheCtx {
+            uri: &uri,
+            tracker: &tracker,
+            cache: &cache,
+            generation: 0,
+        };
+
+        // Populate against the original document.
+        let _ = collect_injection_tokens_parallel(
+            &old_text,
+            &old_lines,
+            &old_line_starts,
+            &old_tree,
+            Some("markdown"),
+            &coordinator,
+            None,
+            false,
+            Some(&cc),
+        );
+
+        // Insert a blank line at the very top: every region shifts down one line,
+        // none of their content changes. Adjust the tracker positions the way
+        // did_change does, so the stored entries stay addressable (stable ULIDs).
+        let new_text = format!("\n{old_text}");
+        tracker.apply_text_diff(&uri, &old_text, &new_text);
+        let new_tree = parse_markdown(&coordinator, &new_text);
+        let new_lines: Vec<&str> = new_text.lines().collect();
+        let new_line_starts = build_line_start_bytes(&new_text);
+
+        let cached = collect_injection_tokens_parallel(
+            &new_text,
+            &new_lines,
+            &new_line_starts,
+            &new_tree,
+            Some("markdown"),
+            &coordinator,
+            None,
+            false,
+            Some(&cc),
+        )
+        .0;
+
+        let uncached = collect_injection_tokens_parallel(
+            &new_text,
+            &new_lines,
+            &new_line_starts,
+            &new_tree,
+            Some("markdown"),
+            &coordinator,
+            None,
+            false,
+            None,
+        )
+        .0;
+
+        assert_eq!(
+            cached, uncached,
+            "re-anchored cached tokens must match a fresh compute of the edited doc"
         );
     }
 }

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -973,7 +973,18 @@ fn to_region_local(tokens: &[RawToken], line_start: u32) -> Vec<RawToken> {
     let line_start = line_start as usize;
     tokens
         .iter()
-        .map(|t| t.with_span(t.line.saturating_sub(line_start), t.column, t.length))
+        .map(|t| {
+            // Invariant: every token of an eligible region sits on or below the
+            // region's first host line, so the subtraction never truncates. The
+            // saturating_sub is a release-build backstop only.
+            debug_assert!(
+                t.line >= line_start,
+                "injection token at host line {} precedes its region start {}",
+                t.line,
+                line_start
+            );
+            t.with_span(t.line.saturating_sub(line_start), t.column, t.length)
+        })
         .collect()
 }
 
@@ -2178,6 +2189,44 @@ local b = 2
         let tree = parser.parse(text, None).expect("parse markdown");
         pool.release("markdown".to_string(), parser);
         tree
+    }
+
+    /// `to_region_local` and `reanchor_to_host` are exact inverses, and a region
+    /// that moved (re-anchored at a different `line_start`) shifts uniformly by
+    /// the line delta with columns untouched.
+    #[test]
+    fn region_local_roundtrip_and_shift() {
+        let host = vec![
+            raw_token_at(5, 2, 3),
+            raw_token_at(6, 0, 4),
+            raw_token_at(7, 8, 1),
+        ];
+
+        // Store at line_start 5, re-anchor at the same start → identical.
+        let local = to_region_local(&host, 5);
+        assert_eq!(local.iter().map(|t| t.line).collect::<Vec<_>>(), [0, 1, 2]);
+        assert_eq!(reanchor_to_host(local.clone(), 5), host);
+
+        // Region moved down 3 lines (edit above): re-anchor shifts every token by
+        // +3, columns unchanged.
+        let moved = reanchor_to_host(local, 8);
+        assert_eq!(
+            moved.iter().map(|t| (t.line, t.column)).collect::<Vec<_>>(),
+            [(8, 2), (9, 0), (10, 8)]
+        );
+    }
+
+    fn raw_token_at(line: usize, column: usize, length: usize) -> RawToken {
+        RawToken {
+            line,
+            column,
+            length,
+            kind: crate::analysis::semantic::token_collector::TokenKind::Mapped(1, 0),
+            depth: 1,
+            pattern_index: 0,
+            priority: 100,
+            node_byte_len: length,
+        }
     }
 
     /// The cached path must produce byte-identical tokens to the uncached path,

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -598,9 +598,10 @@ fn collect_injection_contexts_sync<'a>(
             let eligible = cacheable.start_column == 0 && prefix_byte_widths.is_empty();
             // Fold the resolved language into the validity hash so a position-
             // stable region_id with identical content but a different injected
-            // language can never serve a stale hit (defends the cross-language
-            // hazard from a superseded request's orphaned ULID; same fold style as
-            // the generation fold in cache_key).
+            // language gets a different key (barring a 64-bit collision) and won't
+            // serve a stale hit — defends the cross-language hazard from a
+            // superseded request's orphaned ULID; same fold style as the
+            // generation fold in cache_key.
             let validity_hash =
                 cacheable.content_hash ^ fnv1a_hash(&resolved_lang).wrapping_mul(0x100000001b3);
             RegionCacheInfo {
@@ -624,7 +625,7 @@ fn collect_injection_contexts_sync<'a>(
     }
 
     for (_group_key, regions) in combined_groups {
-        if let Some(ctx) = build_combined_context(
+        match build_combined_context(
             &regions,
             text,
             coordinator,
@@ -632,7 +633,12 @@ fn collect_injection_contexts_sync<'a>(
             parent_included_ranges,
             &mut exclusion_ranges,
         ) {
-            contexts.push(ctx);
+            Ok(Some(ctx)) => contexts.push(ctx),
+            // Permanently empty/invalid/clipped-away group — nothing dropped.
+            Ok(None) => {}
+            // Parser/highlight query for the group isn't loaded yet — a transient
+            // drop, same as the single-region case, so taint discovery.
+            Err(CombinedDiscoveryIncomplete) => discovery_complete = false,
         }
     }
 
@@ -662,6 +668,11 @@ fn derive_prefix_byte_widths(ranges: &[tree_sitter::Range]) -> Vec<usize> {
     widths
 }
 
+/// A combined-injection group was dropped because its parser/highlight query
+/// isn't loaded yet — a transient gap the caller taints into `discovery_complete`
+/// (distinct from a permanent `Ok(None)` empty/invalid group).
+struct CombinedDiscoveryIncomplete;
+
 /// Build one [`InjectionContext`] covering every region of an
 /// `injection.combined` group (#187): the content slice spans from the first
 /// block's start to the last block's end, and `included_ranges` restricts the
@@ -669,9 +680,11 @@ fn derive_prefix_byte_widths(ranges: &[tree_sitter::Range]) -> Vec<usize> {
 /// opened in one `html_block` and closed in another) while the host text
 /// between blocks stays invisible to the injected parser.
 ///
-/// Returns `None` when the group's language/query doesn't resolve or every
-/// range is clipped away by the parent's exclusions — the regions then simply
-/// produce no tokens, like any unresolvable injection.
+/// Returns `Ok(None)` for a permanently empty/invalid/clipped-away group (no
+/// tokens, nothing dropped) and `Err(CombinedDiscoveryIncomplete)` when the
+/// group's language/query isn't loaded yet — a *transient* drop the caller must
+/// taint into `discovery_complete` so a parent injection isn't cached with an
+/// incomplete combined subtree.
 fn build_combined_context<'a>(
     regions: &[InjectionRegionInfo<'_>],
     text: &'a str,
@@ -679,22 +692,32 @@ fn build_combined_context<'a>(
     content_start_byte: usize,
     parent_included_ranges: Option<&[tree_sitter::Range]>,
     exclusion_ranges: &mut Vec<(usize, usize)>,
-) -> Option<InjectionContext<'a>> {
+) -> Result<Option<InjectionContext<'a>>, CombinedDiscoveryIncomplete> {
     // collect_all_injections sorts by start byte, so `first` anchors the group.
-    let first = regions.first()?;
+    let Some(first) = regions.first() else {
+        return Ok(None);
+    };
     let group_start = first.content_node.start_byte();
     let group_start_pos = first.content_node.start_position();
-    let group_end = regions.iter().map(|r| r.content_node.end_byte()).max()?;
+    let Some(group_end) = regions.iter().map(|r| r.content_node.end_byte()).max() else {
+        return Ok(None);
+    };
     if group_start >= group_end || group_end > text.len() {
-        return None;
+        return Ok(None);
     }
 
     // Resolve the language once from the first block's content — the grouping
-    // key guarantees every region shares the raw injection language.
+    // key guarantees every region shares the raw injection language. A missing
+    // language/query is transient (loads later without the content changing).
     let first_content = &text[first.content_node.start_byte()..first.content_node.end_byte()];
-    let (resolved_lang, _) =
-        coordinator.resolve_injection_language(&first.language, first_content)?;
-    let highlight_query = coordinator.highlight_query(&resolved_lang)?;
+    let Some((resolved_lang, _)) =
+        coordinator.resolve_injection_language(&first.language, first_content)
+    else {
+        return Err(CombinedDiscoveryIncomplete);
+    };
+    let Some(highlight_query) = coordinator.highlight_query(&resolved_lang) else {
+        return Err(CombinedDiscoveryIncomplete);
+    };
 
     // Rebase an absolute point into the combined content's coordinate space.
     let to_relative_point = |abs: tree_sitter::Point| tree_sitter::Point {
@@ -748,7 +771,7 @@ fn build_combined_context<'a>(
         Some(parent_ranges) => {
             let intersected = intersect_included_ranges(&group_ranges, &parent_ranges);
             if intersected.is_empty() {
-                return None;
+                return Ok(None);
             }
             intersected
         }
@@ -762,7 +785,7 @@ fn build_combined_context<'a>(
 
     let prefix_byte_widths = derive_prefix_byte_widths(&included_ranges);
 
-    Some(InjectionContext {
+    Ok(Some(InjectionContext {
         resolved_lang,
         highlight_query,
         content_text: &text[group_start..group_end],
@@ -773,7 +796,7 @@ fn build_combined_context<'a>(
         // Combined groups are excluded from the v1 cache (sibling
         // cross-contamination hazard); see the ADR's correctness hazards.
         region_cache: None,
-    })
+    }))
 }
 
 /// Walk top-level injections of the host doc in parallel via Rayon work-stealing,

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -13,17 +13,50 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 
 use tree_sitter::{Parser, Tree};
+use url::Url;
 
-use super::injection::InjectionContext;
+use super::injection::{InjectionContext, RegionCacheInfo};
 use super::token_collector::{ActiveInjectionBounds, RawToken, collect_host_tokens};
+use crate::analysis::InjectionTokenCache;
 use crate::config::CaptureMappings;
 use crate::language::LanguageCoordinator;
+use crate::language::NodeTracker;
 use crate::language::injection::{
-    InjectionRegionInfo, MAX_INJECTION_DEPTH, compute_included_ranges,
+    CacheableInjectionRegion, InjectionRegionInfo, MAX_INJECTION_DEPTH, compute_included_ranges,
     compute_included_ranges_clipped, effective_offset_for_pattern, has_combined_for_pattern,
     intersect_included_ranges, parse_with_ranges, sub_select_included_ranges,
 };
 use crate::text::position::byte_to_utf16_col;
+
+/// Minimum number of top-level single injection regions before injection-token
+/// caching engages. Below this, `collect_injection_tokens_parallel` runs exactly
+/// as it did pre-#529 — no region-id resolution, no content hashing, no store —
+/// so small documents (the overwhelming majority) pay zero overhead and are
+/// byte-identical to the uncached path. The cache only helps once enough regions
+/// exist that reusing the untouched ones outweighs the per-region bookkeeping.
+const INJECTION_CACHE_MIN_REGIONS: usize = 8;
+
+/// Per-context output of [`process_injection_sync`]: the region's tokens plus
+/// whether every parser in its subtree (its own and all nested injections) was
+/// loaded. `fully_loaded == false` means at least one region produced an empty
+/// token set only because its parser was missing — caching that would serve an
+/// incomplete result forever, since the content hash won't change when the
+/// parser later loads. The store decision gates on this.
+pub(crate) struct InjectionTokens {
+    pub tokens: Vec<RawToken>,
+    pub fully_loaded: bool,
+}
+
+/// Borrowed handle bundling everything the top-level injection pass needs to
+/// resolve region identities and read/write the injection-token cache (#529).
+/// Threaded as `Option`: `None` disables caching (nested passes, range requests,
+/// tests) and reproduces the pre-#529 behavior exactly.
+pub(crate) struct InjectionCacheCtx<'a> {
+    pub uri: &'a Url,
+    pub tracker: &'a NodeTracker,
+    pub cache: &'a InjectionTokenCache,
+    pub generation: u64,
+}
 
 /// Maximum number of parsers to cache per Rayon worker thread.
 ///
@@ -191,24 +224,34 @@ pub(crate) fn process_injection_sync(
     host_line_starts: &[usize],
     depth: usize,
     supports_multiline: bool,
-) -> Vec<RawToken> {
-    // Check recursion depth
+) -> InjectionTokens {
+    // Check recursion depth. Hitting the cap is a deliberate truncation, not a
+    // missing parser, so the result is still "fully loaded" for caching purposes.
     if depth >= MAX_INJECTION_DEPTH {
-        return Vec::new();
+        return InjectionTokens {
+            tokens: Vec::new(),
+            fully_loaded: true,
+        };
     }
 
-    // Parse the injection content (with optional included ranges for blockquotes)
+    // Parse the injection content (with optional included ranges for blockquotes).
+    // A missing parser is indistinguishable from an empty region by tokens alone,
+    // so flag it: the orchestration layer must not cache a parser-missing result.
     let Some(tree) = factory.parse(
         &ctx.resolved_lang,
         ctx.content_text,
         ctx.included_ranges.as_deref(),
     ) else {
-        return Vec::new();
+        return InjectionTokens {
+            tokens: Vec::new(),
+            fully_loaded: false,
+        };
     };
 
     // Discover nested injections BEFORE collecting tokens so we can compute
     // exclusion ranges. This suppresses this level's captures within regions
-    // that will be handled by deeper injection languages.
+    // that will be handled by deeper injection languages. Nested regions are
+    // never cached in v1, so no cache context is threaded into the recursion.
     let (nested_contexts, nested_exclusion_ranges) = collect_injection_contexts_sync(
         ctx.content_text,
         &tree,
@@ -216,9 +259,11 @@ pub(crate) fn process_injection_sync(
         coordinator,
         ctx.host_start_byte,
         ctx.included_ranges.as_deref(),
+        None,
     );
 
     let mut tokens = Vec::new();
+    let mut fully_loaded = true;
 
     // Collect tokens from this injection's highlight query, excluding
     // regions covered by nested injections. Combined contexts force per-line
@@ -245,9 +290,12 @@ pub(crate) fn process_injection_sync(
         clip_tokens_to_included_ranges(&mut tokens, ctx, host_lines, host_line_starts);
     }
 
-    // Recursively process nested injections (same thread, no parallelism)
+    // Recursively process nested injections (same thread, no parallelism). A
+    // nested region with a missing parser taints this whole subtree's
+    // `fully_loaded`, so the top-level region it belongs to is not cached until
+    // every parser it depends on is available.
     for nested_ctx in nested_contexts {
-        let nested_tokens = process_injection_sync(
+        let nested = process_injection_sync(
             &nested_ctx,
             factory,
             coordinator,
@@ -258,10 +306,14 @@ pub(crate) fn process_injection_sync(
             depth + 1,
             supports_multiline,
         );
-        tokens.extend(nested_tokens);
+        tokens.extend(nested.tokens);
+        fully_loaded &= nested.fully_loaded;
     }
 
-    tokens
+    InjectionTokens {
+        tokens,
+        fully_loaded,
+    }
 }
 
 /// Clip a combined context's tokens to its included ranges (#187).
@@ -349,6 +401,7 @@ fn collect_injection_contexts_sync<'a>(
     coordinator: &LanguageCoordinator,
     content_start_byte: usize,
     parent_included_ranges: Option<&[tree_sitter::Range]>,
+    cache_ctx: Option<(&Url, &NodeTracker)>,
 ) -> (Vec<InjectionContext<'a>>, Vec<(usize, usize)>) {
     use crate::language::injection::collect_all_injections;
 
@@ -390,6 +443,12 @@ fn collect_injection_contexts_sync<'a>(
             singles.push(injection);
         }
     }
+
+    // Resolve cache identity only when a cache handle is threaded in (top-level
+    // request, not a nested pass) AND the region count clears the gate. Below the
+    // gate, `region_cache` stays `None` for every context, so the store/reuse
+    // path is skipped entirely and output matches the pre-#529 code exactly.
+    let cache_for_singles = cache_ctx.filter(|_| singles.len() >= INJECTION_CACHE_MIN_REGIONS);
 
     for injection in singles {
         let start = injection.content_node.start_byte();
@@ -499,6 +558,31 @@ fn collect_injection_contexts_sync<'a>(
             None => Vec::new(),
         };
 
+        // Resolve this single region's cache identity (#529). region_id is minted
+        // from the RAW content node — byte-identical to populate_injections
+        // (cache.rs) — so invalidate_for_edits evicts the same entry. Eligibility
+        // is this request's translation predicate: column-0 start AND no per-row
+        // prefixes (singles are never injection.combined).
+        let region_cache = cache_for_singles.map(|(uri, tracker)| {
+            let region_id = tracker
+                .get_or_create(
+                    uri,
+                    injection.content_node.start_byte(),
+                    injection.content_node.end_byte(),
+                    injection.content_node.kind(),
+                )
+                .to_string();
+            let cacheable =
+                CacheableInjectionRegion::from_region_info(&injection, &region_id, text);
+            let eligible = cacheable.start_column == 0 && prefix_byte_widths.is_empty();
+            RegionCacheInfo {
+                region_id,
+                content_hash: cacheable.content_hash,
+                line_start: cacheable.line_range.start,
+                eligible,
+            }
+        });
+
         contexts.push(InjectionContext {
             resolved_lang,
             highlight_query,
@@ -507,6 +591,7 @@ fn collect_injection_contexts_sync<'a>(
             included_ranges,
             prefix_byte_widths,
             combined: false,
+            region_cache,
         });
     }
 
@@ -657,6 +742,9 @@ fn build_combined_context<'a>(
         included_ranges: Some(included_ranges),
         prefix_byte_widths,
         combined: true,
+        // Combined groups are excluded from the v1 cache (sibling
+        // cross-contamination hazard); see the ADR's correctness hazards.
+        region_cache: None,
     })
 }
 
@@ -682,12 +770,22 @@ pub(crate) fn collect_injection_tokens_parallel(
     coordinator: &LanguageCoordinator,
     capture_mappings: Option<&CaptureMappings>,
     supports_multiline: bool,
+    cache_ctx: Option<&InjectionCacheCtx>,
 ) -> (Vec<RawToken>, Vec<ActiveInjectionBounds>) {
     use rayon::prelude::*;
 
-    // Collect top-level injection contexts and their byte ranges
-    let (contexts, exclusion_byte_ranges) =
-        collect_injection_contexts_sync(host_text, host_tree, host_filetype, coordinator, 0, None);
+    // Collect top-level injection contexts and their byte ranges. The cache
+    // handle (if any) lets the discovery phase resolve region identities
+    // single-threaded, before the fan-out.
+    let (contexts, exclusion_byte_ranges) = collect_injection_contexts_sync(
+        host_text,
+        host_tree,
+        host_filetype,
+        coordinator,
+        0,
+        None,
+        cache_ctx.map(|c| (c.uri, c.tracker)),
+    );
 
     if contexts.is_empty() {
         return (Vec::new(), Vec::new());
@@ -699,12 +797,14 @@ pub(crate) fn collect_injection_tokens_parallel(
     // Threshold for parallel processing - below this, Rayon scheduling overhead exceeds benefit
     const PARALLEL_THRESHOLD: usize = 4;
 
-    // Process injections: parallel for larger collections, sequential for small ones
-    let mut all_tokens: Vec<RawToken> = if contexts.len() >= PARALLEL_THRESHOLD {
-        // Parallel processing for larger collections
+    // Process injections: parallel for larger collections, sequential for small
+    // ones. Each context yields an `InjectionTokens` (tokens + fully_loaded),
+    // index-aligned with `contexts` so the store decision below can pair each
+    // result with its region's cache identity off the Rayon workers.
+    let results: Vec<InjectionTokens> = if contexts.len() >= PARALLEL_THRESHOLD {
         contexts
             .par_iter()
-            .flat_map(|ctx| {
+            .map(|ctx| {
                 process_injection_sync(
                     ctx,
                     &factory,
@@ -719,10 +819,9 @@ pub(crate) fn collect_injection_tokens_parallel(
             })
             .collect()
     } else {
-        // Sequential processing for small collections to avoid Rayon overhead
         contexts
             .iter()
-            .flat_map(|ctx| {
+            .map(|ctx| {
                 process_injection_sync(
                     ctx,
                     &factory,
@@ -738,7 +837,25 @@ pub(crate) fn collect_injection_tokens_parallel(
             .collect()
     };
 
-    // Sort tokens by position (line, then column)
+    // Store region-local tokens for eligible, fully-loaded regions (#529),
+    // single-threaded after fan-in so cache writes never run inside a Rayon
+    // worker. `region_cache` is `Some` only when caching is active and the region
+    // is a top-level single; `eligible` is this request's translation predicate.
+    if let Some(cc) = cache_ctx {
+        for (ctx, res) in contexts.iter().zip(results.iter()) {
+            if let Some(rc) = &ctx.region_cache
+                && rc.eligible
+                && res.fully_loaded
+            {
+                let local = to_region_local(&res.tokens, rc.line_start);
+                cc.cache
+                    .store(cc.uri, &rc.region_id, rc.content_hash, cc.generation, local);
+            }
+        }
+    }
+
+    // Flatten per-context tokens into one vector, then sort by position.
+    let mut all_tokens: Vec<RawToken> = results.into_iter().flat_map(|r| r.tokens).collect();
     all_tokens.sort_by(|a, b| a.line.cmp(&b.line).then_with(|| a.column.cmp(&b.column)));
 
     // Convert byte ranges to line/column ActiveInjectionBounds values, but only for
@@ -752,6 +869,20 @@ pub(crate) fn collect_injection_tokens_parallel(
     );
 
     (all_tokens, active_regions)
+}
+
+/// Translate an eligible region's host-absolute tokens into region-local
+/// coordinates for caching: subtract the region's first host line so a stored
+/// entry re-anchors with a single `line += line_start` on reuse. The column is
+/// already region-invariant for an eligible region (`start_column == 0`, no
+/// per-row prefixes), so only the line shifts. `saturating_sub` guards the
+/// (unexpected) case of a token above the region start rather than underflowing.
+fn to_region_local(tokens: &[RawToken], line_start: u32) -> Vec<RawToken> {
+    let line_start = line_start as usize;
+    tokens
+        .iter()
+        .map(|t| t.with_span(t.line.saturating_sub(line_start), t.column, t.length))
+        .collect()
 }
 
 /// Convert byte-based exclusion ranges to line/column `ActiveInjectionBounds`s,
@@ -971,6 +1102,7 @@ mod tests {
             included_ranges: None,
             prefix_byte_widths: Vec::new(),
             combined: false,
+            region_cache: None,
         };
 
         assert_eq!(ctx.resolved_lang, "rust");
@@ -1075,6 +1207,7 @@ mod tests {
             included_ranges: None,
             prefix_byte_widths: Vec::new(),
             combined: false,
+            region_cache: None,
         };
 
         let tokens = process_injection_sync(
@@ -1087,7 +1220,8 @@ mod tests {
             &build_line_start_bytes(host_text),
             1, // depth 1 (not host document)
             false,
-        );
+        )
+        .tokens;
 
         // Should produce some tokens (at minimum "fn" keyword and "main" identifier)
         assert!(
@@ -1133,6 +1267,7 @@ mod tests {
             included_ranges: None,
             prefix_byte_widths: Vec::new(),
             combined: false,
+            region_cache: None,
         };
 
         // Process at MAX_INJECTION_DEPTH should return empty
@@ -1146,7 +1281,8 @@ mod tests {
             &build_line_start_bytes(host_text),
             MAX_INJECTION_DEPTH,
             false,
-        );
+        )
+        .tokens;
 
         assert!(
             tokens.is_empty(),
@@ -1203,6 +1339,7 @@ mod tests {
             &coordinator,
             None,
             false,
+            None,
         );
 
         assert!(tokens.is_empty(), "Empty document should have no tokens");
@@ -1258,6 +1395,7 @@ local x = 42
             &coordinator,
             None,
             false,
+            None,
         );
 
         // Should have tokens from the Lua injection
@@ -1354,6 +1492,7 @@ local x = 42
             &coordinator,
             None,
             false,
+            None,
         );
 
         // The surviving `local` keyword maps to host line 2, col 2 (after the
@@ -1446,6 +1585,7 @@ local b = 2
             &coordinator,
             None,
             false,
+            None,
         );
 
         // Verify tokens are sorted by position
@@ -1661,6 +1801,7 @@ local b = 2
             &coordinator,
             0,
             None,
+            None,
         );
 
         assert_eq!(
@@ -1730,8 +1871,15 @@ local b = 2
         let tree = parser.parse(doc, None).expect("markdown must parse");
         parser_pool.release("markdown".to_string(), parser);
 
-        let (contexts, _exclusions) =
-            collect_injection_contexts_sync(doc, &tree, Some("markdown"), &coordinator, 0, None);
+        let (contexts, _exclusions) = collect_injection_contexts_sync(
+            doc,
+            &tree,
+            Some("markdown"),
+            &coordinator,
+            0,
+            None,
+            None,
+        );
 
         // The vendored query injects more than html (markdown_inline for the
         // prose); only the html contexts matter here.
@@ -1792,6 +1940,7 @@ local b = 2
             &coordinator,
             None,
             false,
+            None,
         );
 
         let (keyword_type, keyword_mods) =
@@ -1855,6 +2004,7 @@ local b = 2
             // Multiline client support must not let the spanning string token
             // bleed across the gap either.
             true,
+            None,
         );
 
         // The combined parse produces lua tokens inside both blocks…

--- a/src/analysis/semantic/range.rs
+++ b/src/analysis/semantic/range.rs
@@ -29,7 +29,9 @@ pub(crate) async fn handle_semantic_tokens_range_parallel_async(
     coordinator: std::sync::Arc<crate::language::LanguageCoordinator>,
     supports_multiline: bool,
 ) -> Option<SemanticTokensResult> {
-    // Get all tokens using the parallel full handler
+    // Get all tokens using the parallel full handler. Range requests don't
+    // populate the injection-token cache (v1 targets the full/delta typing path),
+    // so no cache handle is threaded in.
     let full_result = handle_semantic_tokens_full(
         text,
         tree,
@@ -38,6 +40,7 @@ pub(crate) async fn handle_semantic_tokens_range_parallel_async(
         capture_mappings,
         coordinator,
         supports_multiline,
+        None,
     )
     .await?;
 

--- a/src/analysis/semantic_cache.rs
+++ b/src/analysis/semantic_cache.rs
@@ -208,13 +208,14 @@ impl Default for InjectionMap {
 /// hot path can reuse them across edits that don't touch the region, re-anchoring
 /// them to the region's current host line at read time.
 ///
-/// The key carries the region's validity inline: `(uri, region_id, content_hash,
-/// generation)`. `content_hash` distinguishes a region whose *content* changed
-/// (a stale entry simply isn't found) and `generation` is the settings/query
-/// generation (a config reload changes it, so old-query tokens stop matching) —
-/// the same race-safe fold `SemanticTokenCache` applies to its own key, rather
-/// than a bare `clear()`. A lookup is therefore an exact key match; no separate
-/// read-time validity check is needed.
+/// The key carries the region's validity inline: `(uri, region_id, validity_hash,
+/// generation)`. `validity_hash` folds the region's content hash with its
+/// resolved injection language (a content edit OR a language change at the same
+/// position misses), and `generation` is the settings/query generation (a config
+/// reload changes it, so old-query tokens stop matching) — the same race-safe
+/// fold `SemanticTokenCache` applies to its own key, rather than a bare
+/// `clear()`. A lookup is therefore an exact key match; no separate read-time
+/// validity check is needed.
 ///
 /// `supports_multiline` is deliberately *not* part of the key: it changes
 /// multiline-token emission, but it comes from the client capabilities snapshot
@@ -238,12 +239,17 @@ impl InjectionTokenCache {
         &self,
         uri: &Url,
         region_id: &str,
-        content_hash: u64,
+        validity_hash: u64,
         generation: u64,
         tokens: Vec<RawToken>,
     ) {
         self.cache.insert(
-            (uri.clone(), region_id.to_string(), content_hash, generation),
+            (
+                uri.clone(),
+                region_id.to_string(),
+                validity_hash,
+                generation,
+            ),
             tokens,
         );
     }
@@ -254,12 +260,17 @@ impl InjectionTokenCache {
         &self,
         uri: &Url,
         region_id: &str,
-        content_hash: u64,
+        validity_hash: u64,
         generation: u64,
     ) -> Option<Vec<RawToken>> {
         let result = self
             .cache
-            .get(&(uri.clone(), region_id.to_string(), content_hash, generation))
+            .get(&(
+                uri.clone(),
+                region_id.to_string(),
+                validity_hash,
+                generation,
+            ))
             .map(|entry| entry.clone());
 
         if result.is_some() {

--- a/src/analysis/semantic_cache.rs
+++ b/src/analysis/semantic_cache.rs
@@ -208,21 +208,33 @@ impl Default for InjectionMap {
 /// hot path can reuse them across edits that don't touch the region, re-anchoring
 /// them to the region's current host line at read time.
 ///
-/// The key carries the region's validity inline: `(uri, region_id, validity_hash,
-/// generation)`. `validity_hash` folds the region's content hash with its
-/// resolved injection language (a content edit OR a language change at the same
-/// position misses), and `generation` is the settings/query generation (a config
-/// reload changes it, so old-query tokens stop matching) — the same race-safe
-/// fold `SemanticTokenCache` applies to its own key, rather than a bare
-/// `clear()`. A lookup is therefore an exact key match; no separate read-time
-/// validity check is needed.
+/// The key is just `(uri, region_id)`; the validity lives in the *value* — the
+/// same shape `SemanticTokenCache` uses for its `cache_key`. `validity_hash`
+/// folds the region's content hash with its resolved injection language (a
+/// content edit OR a language change at the same position misses on read), and
+/// `generation` is the settings/query generation (a config reload changes it, so
+/// old-query tokens stop matching) — the race-safe fold, not a bare `clear()`.
+/// Keeping these out of the *key* means each region holds exactly one entry
+/// (`store` overwrites), so `remove` is an O(1) point delete instead of a full
+/// scan and stale validity-siblings can't accumulate.
 ///
-/// `supports_multiline` is deliberately *not* part of the key: it changes
+/// `supports_multiline` is deliberately *not* in the validity: it changes
 /// multiline-token emission, but it comes from the client capabilities snapshot
 /// (a `OnceLock` set once at `initialize()`), so it is session-constant and
 /// cannot flip mid-session — no entry can outlive a change to it.
 pub(crate) struct InjectionTokenCache {
-    cache: DashMap<(Url, String, u64, u64), Vec<RawToken>>,
+    cache: DashMap<(Url, String), CachedRegionTokens>,
+}
+
+/// A region's cached tokens with the validity they were computed under.
+#[derive(Clone)]
+struct CachedRegionTokens {
+    /// Content hash folded with the resolved injection language.
+    validity_hash: u64,
+    /// Settings/query generation in effect when these were computed.
+    generation: u64,
+    /// Region-local pre-finalize tokens.
+    tokens: Vec<RawToken>,
 }
 
 impl InjectionTokenCache {
@@ -233,8 +245,10 @@ impl InjectionTokenCache {
         }
     }
 
-    /// Store region-local tokens for an injection region under its validity key
-    /// (`validity_hash` = content ⊕ resolved language, plus settings `generation`).
+    /// Store region-local tokens for an injection region, tagged with the
+    /// validity (`validity_hash` = content ⊕ resolved language, plus settings
+    /// `generation`) they were computed under. Overwrites any prior entry for the
+    /// region, so a region never holds more than one (possibly stale) entry.
     pub(crate) fn store(
         &self,
         uri: &Url,
@@ -244,18 +258,19 @@ impl InjectionTokenCache {
         tokens: Vec<RawToken>,
     ) {
         self.cache.insert(
-            (
-                uri.clone(),
-                region_id.to_string(),
+            (uri.clone(), region_id.to_string()),
+            CachedRegionTokens {
                 validity_hash,
                 generation,
-            ),
-            tokens,
+                tokens,
+            },
         );
     }
 
-    /// Retrieve region-local tokens iff an entry exists for this exact validity
-    /// key — same region, same content + resolved language, same settings generation.
+    /// Retrieve region-local tokens iff the stored entry was computed under this
+    /// exact validity — same content + resolved language, same settings
+    /// generation. A mismatch (content/language edit or config reload) reads as a
+    /// miss so the region is recomputed.
     pub(crate) fn get(
         &self,
         uri: &Url,
@@ -265,13 +280,9 @@ impl InjectionTokenCache {
     ) -> Option<Vec<RawToken>> {
         let result = self
             .cache
-            .get(&(
-                uri.clone(),
-                region_id.to_string(),
-                validity_hash,
-                generation,
-            ))
-            .map(|entry| entry.clone());
+            .get(&(uri.clone(), region_id.to_string()))
+            .filter(|entry| entry.validity_hash == validity_hash && entry.generation == generation)
+            .map(|entry| entry.tokens.clone());
 
         if result.is_some() {
             log::debug!(
@@ -292,13 +303,11 @@ impl InjectionTokenCache {
         result
     }
 
-    /// Remove every cached entry for an injection region, across all validity
-    /// hashes / generations. `validity_hash` and `generation` are part of the key,
-    /// so a single `(uri, region_id)` can have stale siblings; eviction
-    /// (edit-overlap, content/language change, region removed) must drop them all.
+    /// Remove an injection region's cached entry — an O(1) point delete, since a
+    /// region holds at most one entry. Called on eviction (edit-overlap,
+    /// content/language change, region removed).
     pub(crate) fn remove(&self, uri: &Url, region_id: &str) {
-        self.cache
-            .retain(|key, _| !(&key.0 == uri && key.1 == region_id));
+        self.cache.remove(&(uri.clone(), region_id.to_string()));
     }
 
     /// Remove all cached tokens for a document (all its injection regions).
@@ -315,15 +324,21 @@ impl InjectionTokenCache {
         self.cache.clear();
     }
 
-    /// Validity keys `(region_id, validity_hash, generation)` currently stored for
-    /// a document — lets a test confirm what the hot path persisted and overwrite
-    /// a specific entry to prove the reuse path reads it.
+    /// `(region_id, validity_hash, generation)` currently stored for a document —
+    /// lets a test confirm what the hot path persisted and overwrite a specific
+    /// entry to prove the reuse path reads it.
     #[cfg(test)]
     pub(crate) fn test_keys(&self, uri: &Url) -> Vec<(String, u64, u64)> {
         self.cache
             .iter()
             .filter(|e| &e.key().0 == uri)
-            .map(|e| (e.key().1.clone(), e.key().2, e.key().3))
+            .map(|e| {
+                (
+                    e.key().1.clone(),
+                    e.value().validity_hash,
+                    e.value().generation,
+                )
+            })
             .collect()
     }
 }
@@ -637,21 +652,24 @@ mod tests {
     }
 
     #[test]
-    fn injection_token_cache_remove_drops_all_validity_siblings() {
+    fn injection_token_cache_store_overwrites_and_remove_is_point_delete() {
         let cache = InjectionTokenCache::new();
         let uri = Url::parse("file:///t.md").unwrap();
 
-        // Two entries for the same region under different content hashes (e.g. a
-        // stale pre-edit entry that overlap-eviction never reached, plus a fresh
-        // one). `remove` must drop both.
+        // Validity lives in the value, so a second store for the same region
+        // OVERWRITES the first — a region never accumulates stale siblings, which
+        // is what lets `remove` be an O(1) point delete.
         cache.store(&uri, "r", 0x1111, 0, vec![raw_token(0, 0, 4)]);
         cache.store(&uri, "r", 0x2222, 0, vec![raw_token(0, 0, 5)]);
-        assert!(cache.get(&uri, "r", 0x1111, 0).is_some());
-        assert!(cache.get(&uri, "r", 0x2222, 0).is_some());
+        assert!(
+            cache.get(&uri, "r", 0x1111, 0).is_none(),
+            "the overwritten (old-validity) entry must be gone"
+        );
+        let current = cache.get(&uri, "r", 0x2222, 0).expect("latest entry hits");
+        assert_eq!(current[0].length, 5);
 
+        // remove drops that single entry.
         cache.remove(&uri, "r");
-
-        assert!(cache.get(&uri, "r", 0x1111, 0).is_none());
         assert!(cache.get(&uri, "r", 0x2222, 0).is_none());
     }
 

--- a/src/analysis/semantic_cache.rs
+++ b/src/analysis/semantic_cache.rs
@@ -234,7 +234,7 @@ impl InjectionTokenCache {
     }
 
     /// Store region-local tokens for an injection region under its validity key
-    /// (`content_hash` + settings `generation`).
+    /// (`validity_hash` = content ⊕ resolved language, plus settings `generation`).
     pub(crate) fn store(
         &self,
         uri: &Url,
@@ -255,7 +255,7 @@ impl InjectionTokenCache {
     }
 
     /// Retrieve region-local tokens iff an entry exists for this exact validity
-    /// key — same region, same content, same settings generation.
+    /// key — same region, same content + resolved language, same settings generation.
     pub(crate) fn get(
         &self,
         uri: &Url,
@@ -292,8 +292,8 @@ impl InjectionTokenCache {
         result
     }
 
-    /// Remove every cached entry for an injection region, across all content
-    /// hashes / generations. `content_hash` and `generation` are part of the key,
+    /// Remove every cached entry for an injection region, across all validity
+    /// hashes / generations. `validity_hash` and `generation` are part of the key,
     /// so a single `(uri, region_id)` can have stale siblings; eviction
     /// (edit-overlap, content/language change, region removed) must drop them all.
     pub(crate) fn remove(&self, uri: &Url, region_id: &str) {
@@ -306,7 +306,7 @@ impl InjectionTokenCache {
         self.cache.retain(|key, _| &key.0 != uri);
     }
 
-    /// Validity keys `(region_id, content_hash, generation)` currently stored for
+    /// Validity keys `(region_id, validity_hash, generation)` currently stored for
     /// a document — lets a test confirm what the hot path persisted and overwrite
     /// a specific entry to prove the reuse path reads it.
     #[cfg(test)]

--- a/src/analysis/semantic_cache.rs
+++ b/src/analysis/semantic_cache.rs
@@ -229,7 +229,6 @@ impl InjectionTokenCache {
 
     /// Store region-local tokens for an injection region under its validity key
     /// (`content_hash` + settings `generation`).
-    #[cfg(test)]
     pub fn store(
         &self,
         uri: &Url,

--- a/src/analysis/semantic_cache.rs
+++ b/src/analysis/semantic_cache.rs
@@ -215,13 +215,18 @@ impl Default for InjectionMap {
 /// the same race-safe fold `SemanticTokenCache` applies to its own key, rather
 /// than a bare `clear()`. A lookup is therefore an exact key match; no separate
 /// read-time validity check is needed.
-pub struct InjectionTokenCache {
+///
+/// `supports_multiline` is deliberately *not* part of the key: it changes
+/// multiline-token emission, but it comes from the client capabilities snapshot
+/// (a `OnceLock` set once at `initialize()`), so it is session-constant and
+/// cannot flip mid-session — no entry can outlive a change to it.
+pub(crate) struct InjectionTokenCache {
     cache: DashMap<(Url, String, u64, u64), Vec<RawToken>>,
 }
 
 impl InjectionTokenCache {
     /// Create a new empty cache.
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             cache: DashMap::new(),
         }
@@ -229,7 +234,7 @@ impl InjectionTokenCache {
 
     /// Store region-local tokens for an injection region under its validity key
     /// (`content_hash` + settings `generation`).
-    pub fn store(
+    pub(crate) fn store(
         &self,
         uri: &Url,
         region_id: &str,
@@ -245,7 +250,7 @@ impl InjectionTokenCache {
 
     /// Retrieve region-local tokens iff an entry exists for this exact validity
     /// key — same region, same content, same settings generation.
-    pub fn get(
+    pub(crate) fn get(
         &self,
         uri: &Url,
         region_id: &str,
@@ -280,13 +285,13 @@ impl InjectionTokenCache {
     /// hashes / generations. `content_hash` and `generation` are part of the key,
     /// so a single `(uri, region_id)` can have stale siblings; eviction
     /// (edit-overlap, content/language change, region removed) must drop them all.
-    pub fn remove(&self, uri: &Url, region_id: &str) {
+    pub(crate) fn remove(&self, uri: &Url, region_id: &str) {
         self.cache
             .retain(|key, _| !(&key.0 == uri && key.1 == region_id));
     }
 
     /// Remove all cached tokens for a document (all its injection regions).
-    pub fn clear_document(&self, uri: &Url) {
+    pub(crate) fn clear_document(&self, uri: &Url) {
         self.cache.retain(|key, _| &key.0 != uri);
     }
 
@@ -294,7 +299,7 @@ impl InjectionTokenCache {
     /// a document — lets a test confirm what the hot path persisted and overwrite
     /// a specific entry to prove the reuse path reads it.
     #[cfg(test)]
-    pub fn test_keys(&self, uri: &Url) -> Vec<(String, u64, u64)> {
+    pub(crate) fn test_keys(&self, uri: &Url) -> Vec<(String, u64, u64)> {
         self.cache
             .iter()
             .filter(|e| &e.key().0 == uri)

--- a/src/analysis/semantic_cache.rs
+++ b/src/analysis/semantic_cache.rs
@@ -306,6 +306,15 @@ impl InjectionTokenCache {
         self.cache.retain(|key, _| &key.0 != uri);
     }
 
+    /// Drop every cached entry. Used on a settings/query reload (alongside the
+    /// generation bump) to reclaim memory: the generation fold already makes
+    /// old-generation entries unreachable — this just stops them leaking until
+    /// each document closes. Mirrors `SemanticTokenCache::clear`; the fold, not
+    /// this clear, is what makes a concurrent store race-safe.
+    pub(crate) fn clear(&self) {
+        self.cache.clear();
+    }
+
     /// Validity keys `(region_id, validity_hash, generation)` currently stored for
     /// a document — lets a test confirm what the hot path persisted and overwrite
     /// a specific entry to prove the reuse path reads it.

--- a/src/analysis/semantic_cache.rs
+++ b/src/analysis/semantic_cache.rs
@@ -245,7 +245,6 @@ impl InjectionTokenCache {
 
     /// Retrieve region-local tokens iff an entry exists for this exact validity
     /// key — same region, same content, same settings generation.
-    #[cfg(test)]
     pub fn get(
         &self,
         uri: &Url,
@@ -289,6 +288,18 @@ impl InjectionTokenCache {
     /// Remove all cached tokens for a document (all its injection regions).
     pub fn clear_document(&self, uri: &Url) {
         self.cache.retain(|key, _| &key.0 != uri);
+    }
+
+    /// Validity keys `(region_id, content_hash, generation)` currently stored for
+    /// a document — lets a test confirm what the hot path persisted and overwrite
+    /// a specific entry to prove the reuse path reads it.
+    #[cfg(test)]
+    pub fn test_keys(&self, uri: &Url) -> Vec<(String, u64, u64)> {
+        self.cache
+            .iter()
+            .filter(|e| &e.key().0 == uri)
+            .map(|e| (e.key().1.clone(), e.key().2, e.key().3))
+            .collect()
     }
 }
 

--- a/src/analysis/semantic_cache.rs
+++ b/src/analysis/semantic_cache.rs
@@ -8,6 +8,7 @@
 //! - `InjectionTokenCache`: per-(URI, region_id) tokens, reusable when an edit
 //!   lies outside that region.
 
+use crate::analysis::semantic::RawToken;
 use crate::language::injection::CacheableInjectionRegion;
 use dashmap::DashMap;
 use rust_lapper::{Interval, Lapper};
@@ -200,12 +201,22 @@ impl Default for InjectionMap {
     }
 }
 
-/// Thread-safe cache for per-injection semantic tokens.
+/// Thread-safe cache for per-injection-region semantic tokens (#529).
 ///
-/// Unlike `SemanticTokenCache` which stores tokens per document, this cache
-/// stores tokens keyed by (uri, region_id), enabling injection-level caching.
+/// Unlike `SemanticTokenCache` (per-document, finalized tokens), this stores the
+/// **region-local pre-finalize `RawToken`s** of a single injection region so the
+/// hot path can reuse them across edits that don't touch the region, re-anchoring
+/// them to the region's current host line at read time.
+///
+/// The key carries the region's validity inline: `(uri, region_id, content_hash,
+/// generation)`. `content_hash` distinguishes a region whose *content* changed
+/// (a stale entry simply isn't found) and `generation` is the settings/query
+/// generation (a config reload changes it, so old-query tokens stop matching) —
+/// the same race-safe fold `SemanticTokenCache` applies to its own key, rather
+/// than a bare `clear()`. A lookup is therefore an exact key match; no separate
+/// read-time validity check is needed.
 pub struct InjectionTokenCache {
-    cache: DashMap<(Url, String), SemanticTokens>,
+    cache: DashMap<(Url, String, u64, u64), Vec<RawToken>>,
 }
 
 impl InjectionTokenCache {
@@ -216,19 +227,36 @@ impl InjectionTokenCache {
         }
     }
 
-    /// Store semantic tokens for a specific injection region (test-only).
+    /// Store region-local tokens for an injection region under its validity key
+    /// (`content_hash` + settings `generation`).
     #[cfg(test)]
-    pub fn store(&self, uri: &Url, region_id: &str, tokens: SemanticTokens) {
-        self.cache
-            .insert((uri.clone(), region_id.to_string()), tokens);
+    pub fn store(
+        &self,
+        uri: &Url,
+        region_id: &str,
+        content_hash: u64,
+        generation: u64,
+        tokens: Vec<RawToken>,
+    ) {
+        self.cache.insert(
+            (uri.clone(), region_id.to_string(), content_hash, generation),
+            tokens,
+        );
     }
 
-    /// Retrieve semantic tokens for a specific injection region (test-only).
+    /// Retrieve region-local tokens iff an entry exists for this exact validity
+    /// key — same region, same content, same settings generation.
     #[cfg(test)]
-    pub fn get(&self, uri: &Url, region_id: &str) -> Option<SemanticTokens> {
+    pub fn get(
+        &self,
+        uri: &Url,
+        region_id: &str,
+        content_hash: u64,
+        generation: u64,
+    ) -> Option<Vec<RawToken>> {
         let result = self
             .cache
-            .get(&(uri.clone(), region_id.to_string()))
+            .get(&(uri.clone(), region_id.to_string(), content_hash, generation))
             .map(|entry| entry.clone());
 
         if result.is_some() {
@@ -250,9 +278,13 @@ impl InjectionTokenCache {
         result
     }
 
-    /// Remove cached tokens for a specific injection region.
+    /// Remove every cached entry for an injection region, across all content
+    /// hashes / generations. `content_hash` and `generation` are part of the key,
+    /// so a single `(uri, region_id)` can have stale siblings; eviction
+    /// (edit-overlap, content/language change, region removed) must drop them all.
     pub fn remove(&self, uri: &Url, region_id: &str) {
-        self.cache.remove(&(uri.clone(), region_id.to_string()));
+        self.cache
+            .retain(|key, _| !(&key.0 == uri && key.1 == region_id));
     }
 
     /// Remove all cached tokens for a document (all its injection regions).
@@ -501,52 +533,91 @@ mod tests {
         map.clear(&other_uri); // Should not panic
     }
 
+    /// Minimal region-local `RawToken` for cache tests: an emitted token at the
+    /// given region-local line/column with the given UTF-16 length.
+    fn raw_token(line: usize, column: usize, length: usize) -> RawToken {
+        use crate::analysis::semantic::TokenKind;
+        RawToken {
+            line,
+            column,
+            length,
+            kind: TokenKind::Mapped(1, 0),
+            depth: 1,
+            pattern_index: 0,
+            priority: 100,
+            node_byte_len: length,
+        }
+    }
+
     #[test]
     fn test_injection_token_cache_store_retrieve() {
         let cache = InjectionTokenCache::new();
         let uri = Url::parse("file:///test.md").unwrap();
 
-        let tokens1 = SemanticTokens {
-            result_id: Some("lua-region-1".to_string()),
-            data: vec![SemanticToken {
-                delta_line: 0,
-                delta_start: 0,
-                length: 5,
-                token_type: 0,
-                token_modifiers_bitset: 0,
-            }],
-        };
+        let tokens1 = vec![raw_token(0, 0, 5)];
+        let tokens2 = vec![raw_token(1, 2, 10)];
 
-        let tokens2 = SemanticTokens {
-            result_id: Some("python-region-2".to_string()),
-            data: vec![SemanticToken {
-                delta_line: 1,
-                delta_start: 2,
-                length: 10,
-                token_type: 1,
-                token_modifiers_bitset: 0,
-            }],
-        };
+        // Store region-local tokens under a content hash + generation.
+        cache.store(&uri, "region-1", 0xAA, 0, tokens1.clone());
+        cache.store(&uri, "region-2", 0xBB, 0, tokens2.clone());
 
-        // Store tokens for different regions in same document
-        cache.store(&uri, "region-1", tokens1.clone());
-        cache.store(&uri, "region-2", tokens2.clone());
-
-        // Retrieve by (uri, region_id)
-        let retrieved1 = cache.get(&uri, "region-1");
+        // Retrieve by the full validity key.
+        let retrieved1 = cache.get(&uri, "region-1", 0xAA, 0);
         assert!(retrieved1.is_some(), "Should retrieve tokens for region-1");
-        assert_eq!(retrieved1.unwrap().data[0].length, 5);
+        assert_eq!(retrieved1.unwrap()[0].length, 5);
 
-        let retrieved2 = cache.get(&uri, "region-2");
+        let retrieved2 = cache.get(&uri, "region-2", 0xBB, 0);
         assert!(retrieved2.is_some(), "Should retrieve tokens for region-2");
-        assert_eq!(retrieved2.unwrap().data[0].length, 10);
+        assert_eq!(retrieved2.unwrap()[0].length, 10);
 
         // Non-existent region returns None
-        assert!(cache.get(&uri, "region-3").is_none());
+        assert!(cache.get(&uri, "region-3", 0xAA, 0).is_none());
 
         // Non-existent URI returns None
         let other_uri = Url::parse("file:///other.md").unwrap();
-        assert!(cache.get(&other_uri, "region-1").is_none());
+        assert!(cache.get(&other_uri, "region-1", 0xAA, 0).is_none());
+    }
+
+    #[test]
+    fn injection_token_cache_validity_key_gates_reads() {
+        let cache = InjectionTokenCache::new();
+        let uri = Url::parse("file:///t.md").unwrap();
+        cache.store(&uri, "r", 0x1111, 7, vec![raw_token(0, 0, 4)]);
+
+        // Exact key hits.
+        assert!(cache.get(&uri, "r", 0x1111, 7).is_some());
+
+        // A different content hash (region content changed) misses.
+        assert!(
+            cache.get(&uri, "r", 0x2222, 7).is_none(),
+            "content-hash mismatch must miss so edited content is recomputed"
+        );
+
+        // A different generation (settings/query reload) misses, even for the
+        // same content — the race-safe fold, not a bare clear.
+        assert!(
+            cache.get(&uri, "r", 0x1111, 8).is_none(),
+            "generation mismatch must miss so post-reload requests recompute"
+        );
+    }
+
+    #[test]
+    fn injection_token_cache_remove_drops_all_validity_siblings() {
+        let cache = InjectionTokenCache::new();
+        let uri = Url::parse("file:///t.md").unwrap();
+
+        // Two entries for the same region under different content hashes (e.g. a
+        // stale pre-edit entry that overlap-eviction never reached, plus a fresh
+        // one). `remove` must drop both.
+        cache.store(&uri, "r", 0x1111, 0, vec![raw_token(0, 0, 4)]);
+        cache.store(&uri, "r", 0x2222, 0, vec![raw_token(0, 0, 5)]);
+        assert!(cache.get(&uri, "r", 0x1111, 0).is_some());
+        assert!(cache.get(&uri, "r", 0x2222, 0).is_some());
+
+        cache.remove(&uri, "r");
+
+        assert!(cache.get(&uri, "r", 0x1111, 0).is_none());
+        assert!(cache.get(&uri, "r", 0x2222, 0).is_none());
     }
 
     #[test]
@@ -578,18 +649,8 @@ mod tests {
         ];
         injection_map.insert(uri.clone(), regions);
 
-        // Set up cached tokens for each region
-        let lua_tokens = SemanticTokens {
-            result_id: Some("lua-tokens".to_string()),
-            data: vec![SemanticToken {
-                delta_line: 0,
-                delta_start: 0,
-                length: 3,
-                token_type: 0,
-                token_modifiers_bitset: 0,
-            }],
-        };
-        token_cache.store(&uri, "lua-region-1", lua_tokens);
+        // Set up cached tokens for the lua region, keyed by its content hash.
+        token_cache.store(&uri, "lua-region-1", 11111, 0, vec![raw_token(0, 0, 3)]);
 
         // Find region containing byte offset and get its cached tokens
         let regions = injection_map.get(&uri).unwrap();
@@ -599,10 +660,10 @@ mod tests {
         let region = region_at_byte_30.unwrap();
         assert_eq!(region.language, "lua");
 
-        // Use region_id to get cached tokens
-        let cached = token_cache.get(&uri, &region.region_id);
+        // Use region_id + content_hash to get cached tokens
+        let cached = token_cache.get(&uri, &region.region_id, region.content_hash, 0);
         assert!(cached.is_some(), "Should have cached tokens for lua region");
-        assert_eq!(cached.unwrap().data[0].length, 3);
+        assert_eq!(cached.unwrap()[0].length, 3);
     }
 
     #[test]

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -79,7 +79,7 @@ struct EagerOpenBatch {
 /// genuinely benefits from a semantic name (e.g., document lifecycle, shutdown).
 pub(crate) struct BridgeCoordinator {
     pool: Arc<LanguageServerPool>,
-    node_tracker: NodeTracker,
+    node_tracker: Arc<NodeTracker>,
     /// Cancel forwarder for upstream cancel notification and downstream forwarding.
     ///
     /// This is shared with the `RequestIdCapture` middleware via `cancel_forwarder()`.
@@ -127,7 +127,7 @@ impl BridgeCoordinator {
         let cancel_forwarder = CancelForwarder::new(Arc::clone(&pool));
         Self {
             pool,
-            node_tracker: NodeTracker::new(),
+            node_tracker: Arc::new(NodeTracker::new()),
             cancel_forwarder,
             eager_open_generation: std::sync::atomic::AtomicU64::new(0),
             eager_open_tasks: DashMap::new(),
@@ -149,7 +149,7 @@ impl BridgeCoordinator {
     ) -> Self {
         Self {
             pool,
-            node_tracker: NodeTracker::new(),
+            node_tracker: Arc::new(NodeTracker::new()),
             cancel_forwarder,
             eager_open_generation: std::sync::atomic::AtomicU64::new(0),
             eager_open_tasks: DashMap::new(),

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -175,6 +175,14 @@ impl BridgeCoordinator {
         &self.node_tracker
     }
 
+    /// Share the node tracker for use on the blocking semantic-token pool.
+    ///
+    /// Returns an owned `Arc` so the tracker can be moved into `spawn_blocking`
+    /// (injection-token-cache region-id resolution, #529) without borrowing `self`.
+    pub(crate) fn node_tracker_arc(&self) -> Arc<NodeTracker> {
+        Arc::clone(&self.node_tracker)
+    }
+
     /// Access the underlying language server pool.
     ///
     /// Used by handlers for `send_*_request()` methods.

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -407,10 +407,25 @@ impl Default for CacheCoordinator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::analysis::semantic::{RawToken, TokenKind};
     use tower_lsp_server::ls_types::SemanticToken;
 
     fn create_test_uri(path: &str) -> Url {
         Url::parse(&format!("file:///{}", path)).unwrap()
+    }
+
+    /// One region-local `RawToken`, for seeding the injection token cache.
+    fn injection_raw_tokens() -> Vec<RawToken> {
+        vec![RawToken {
+            line: 0,
+            column: 0,
+            length: 5,
+            kind: TokenKind::Mapped(1, 0),
+            depth: 1,
+            pattern_index: 0,
+            priority: 100,
+            node_byte_len: 5,
+        }]
     }
 
     #[test]
@@ -592,28 +607,23 @@ print("hello")
         let regions = cache.get_injections(&uri).expect("should have injections");
         assert_eq!(regions.len(), 1);
         let initial_region_id = regions[0].region_id.clone();
+        let initial_content_hash = regions[0].content_hash;
         assert_eq!(regions[0].language, "lua");
 
-        // Store tokens for this injection region
-        let lua_tokens = SemanticTokens {
-            result_id: Some("lua-tokens".to_string()),
-            data: vec![SemanticToken {
-                delta_line: 0,
-                delta_start: 0,
-                length: 5,
-                token_type: 1,
-                token_modifiers_bitset: 0,
-            }],
-        };
-        cache
-            .injection_token_cache
-            .store(&uri, &initial_region_id, lua_tokens);
+        // Store region-local tokens under the region's current content hash.
+        cache.injection_token_cache.store(
+            &uri,
+            &initial_region_id,
+            initial_content_hash,
+            0,
+            injection_raw_tokens(),
+        );
 
         // Verify tokens are stored
         assert!(
             cache
                 .injection_token_cache
-                .get(&uri, &initial_region_id)
+                .get(&uri, &initial_region_id, initial_content_hash, 0)
                 .is_some(),
             "tokens should be cached before language change"
         );
@@ -672,7 +682,7 @@ print("hello")
         assert!(
             cache
                 .injection_token_cache
-                .get(&uri, &initial_region_id)
+                .get(&uri, &initial_region_id, initial_content_hash, 0)
                 .is_none(),
             "cached tokens should be invalidated when language changes"
         );
@@ -731,25 +741,19 @@ print("hello")
         let initial_region_id = regions[0].region_id.clone();
         let initial_content_hash = regions[0].content_hash;
 
-        // Store tokens
-        let lua_tokens = SemanticTokens {
-            result_id: Some("lua-tokens".to_string()),
-            data: vec![SemanticToken {
-                delta_line: 0,
-                delta_start: 0,
-                length: 5,
-                token_type: 1,
-                token_modifiers_bitset: 0,
-            }],
-        };
-        cache
-            .injection_token_cache
-            .store(&uri, &initial_region_id, lua_tokens);
+        // Store region-local tokens under the region's current content hash.
+        cache.injection_token_cache.store(
+            &uri,
+            &initial_region_id,
+            initial_content_hash,
+            0,
+            injection_raw_tokens(),
+        );
 
         assert!(
             cache
                 .injection_token_cache
-                .get(&uri, &initial_region_id)
+                .get(&uri, &initial_region_id, initial_content_hash, 0)
                 .is_some(),
             "tokens should be cached before content change"
         );
@@ -796,7 +800,7 @@ print("goodbye")
         assert!(
             cache
                 .injection_token_cache
-                .get(&uri, &initial_region_id)
+                .get(&uri, &initial_region_id, initial_content_hash, 0)
                 .is_none(),
             "cached tokens should be invalidated when content changes"
         );

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -371,6 +371,11 @@ impl CacheCoordinator {
         self.semantic_token_generation
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         self.semantic_cache.clear();
+        // The injection token cache folds the same generation into its key, so
+        // old-generation entries are already unreachable after the bump; clear
+        // them too so a reload doesn't leak per-region entries until each
+        // document closes.
+        self.injection_token_cache.clear();
     }
 
     // ========================================================================

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -269,6 +269,12 @@ impl CacheCoordinator {
         self.injection_map.get(uri)
     }
 
+    /// Share the per-region injection token cache for use on the blocking
+    /// semantic-token pool (#529), where the hot path reuses/stores region tokens.
+    pub(crate) fn injection_token_cache_arc(&self) -> std::sync::Arc<InjectionTokenCache> {
+        std::sync::Arc::clone(&self.injection_token_cache)
+    }
+
     // ========================================================================
     // Semantic tokens (semantic_tokens.rs)
     // ========================================================================

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -34,7 +34,7 @@ pub(crate) type RequestId = u64;
 pub(crate) struct CacheCoordinator {
     semantic_cache: SemanticTokenCache,
     injection_map: InjectionMap,
-    injection_token_cache: InjectionTokenCache,
+    injection_token_cache: std::sync::Arc<InjectionTokenCache>,
     request_tracker: SemanticRequestTracker,
     /// Settings generation folded into every semantic-token `cache_key`. Bumped
     /// on a query/config reload so cached tokens computed under the old queries
@@ -50,7 +50,7 @@ impl CacheCoordinator {
         Self {
             semantic_cache: SemanticTokenCache::new(),
             injection_map: InjectionMap::new(),
-            injection_token_cache: InjectionTokenCache::new(),
+            injection_token_cache: std::sync::Arc::new(InjectionTokenCache::new()),
             request_tracker: SemanticRequestTracker::new(),
             semantic_token_generation: std::sync::atomic::AtomicU64::new(0),
         }

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -382,6 +382,17 @@ impl Kakehashi {
             // instead of the shared parser pool, avoiding lock contention.
             let coordinator = std::sync::Arc::clone(&self.language);
 
+            // Enable per-region injection-token reuse (#529). The generation is
+            // the one snapshotted at the top of the handler (same value folded
+            // into `cache_key`), so a config reload racing this request can't make
+            // it serve or store stale-query tokens.
+            let injection_cache = Some(crate::analysis::semantic::InjectionCacheParams {
+                uri: uri.clone(),
+                tracker: self.bridge.node_tracker_arc(),
+                cache: self.cache.injection_token_cache_arc(),
+                generation: token_generation,
+            });
+
             // Compute tokens, racing against cancel notification if provided
             let compute_future = handle_semantic_tokens_full(
                 text.clone(),
@@ -391,6 +402,7 @@ impl Kakehashi {
                 Some(capture_mappings),
                 coordinator,
                 supports_multiline,
+                injection_cache,
             );
 
             let result = if let Some(cancel_rx) = cancel_rx {
@@ -646,6 +658,16 @@ impl Kakehashi {
                 // parallel injection processing (SAME as semanticTokens/full).
                 let coordinator = std::sync::Arc::clone(&self.language);
 
+                // Enable per-region injection-token reuse (#529) on the delta
+                // path too — this is the steady-state typing path the cache
+                // targets. Generation pinned to the top-of-handler snapshot.
+                let injection_cache = Some(crate::analysis::semantic::InjectionCacheParams {
+                    uri: uri.clone(),
+                    tracker: self.bridge.node_tracker_arc(),
+                    cache: self.cache.injection_token_cache_arc(),
+                    generation: token_generation,
+                });
+
                 // Compute tokens, racing against cancel notification if provided
                 let compute_future = handle_semantic_tokens_full(
                     text.clone(),
@@ -655,6 +677,7 @@ impl Kakehashi {
                     Some(capture_mappings),
                     coordinator,
                     supports_multiline,
+                    injection_cache,
                 );
 
                 let result = if let Some(cancel_rx) = cancel_rx {


### PR DESCRIPTION
Implements the per-region injection-token cache from ADR `docs/architecture-decisions/injection-token-cache-reuse.md` (#529). On the steady-state typing path, editing one injected block now recomputes that block and **reuses** the other regions' cached tokens (re-anchored to their current host line) instead of re-tokenizing every region.

## What changed

The whole-doc cache (#530) short-circuits the *unchanged-document* path but is structurally useless while typing (every keystroke changes the text hash). This wires the long-built-but-unread `InjectionTokenCache` into the hot path to cover that gap.

- `InjectionTokenCache` re-keyed to `(uri, region_id, validity_hash, generation) → Vec<RawToken>` (region-local pre-finalize tokens). `validity_hash = content_hash ⊕ fnv1a(resolved_language)·PRIME`, so a content edit **or** a language change misses; `generation` is the settings/query epoch (race-safe fold, same as #530).
- `collect_injection_tokens_parallel`: resolve cache hits **before** the Rayon fan-out (re-anchor `line += region.line_range.start`, column unchanged), tokenize **only** the misses, store eligible regions **after** fan-in — so cache reads/writes never run on a worker thread.
- **Language-agnostic v1 scope**: only regions whose host↔content map is a pure translation are cached — `start_column == 0` ∧ no per-row prefix widths ∧ not `injection.combined`. No per-language special-casing; the predicate self-selects on geometry/injection-mode and is re-evaluated against the fresh context every request.
- **Region-count gate** (`INJECTION_CACHE_MIN_REGIONS = 8`): below it, no identity resolution / hashing / store happens — small documents are byte-identical to the pre-#529 path by construction.
- `fully_loaded` + `discovery_complete` gate the store so a token set computed while any parser (own, nested, or a dropped combined group) was missing is never cached (it would go stale when the parser later loads, since the content hash wouldn't change).

## Correctness

Region identity is minted from the **raw** content-node bytes — byte-identical to `populate_injections` — so `invalidate_for_edits` evicts the same entry. The language fold additionally neutralizes a wrong-colored-text hazard where a superseded request could mint a `region_id` that escapes `populate_injections`' language-change eviction.

New tests prove the load-bearing properties: cached output is byte-identical to uncached, the reuse path actually *reads* the cache (a sentinel entry surfaces), and an edit *above* an unchanged region re-anchors correctly.

## Performance (A/B vs `main`, 150 iters, release, warm)

| scenario | Δ HEAD vs main |
|---|---|
| `markdown_injections/edit_delta` (typing path, the target) | **−23.3%** |
| `markdown_injections/open_first_token` (all-miss cold open) | −0.4% |
| full/unchanged scenarios | noise (±10%; short-circuited by #530 before this code runs — confirmed by the symmetric swing on injection-free `unicode_rust`) |

No regression: small docs are byte-identical by construction (gate), and the all-miss write path is negligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
