### PR TITLE
feat(diagnostics): instrument the diagnostic path + configurable debounce (#533)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ pub(crate) use merge::{
     merge_aggregation_configs, merge_bridge_language_configs, merge_bridge_server_configs,
     merge_layer_aggregation_configs, merge_workspace_settings, resolve_with_wildcard,
 };
-pub(crate) use settings::{CaptureMappings, QueryTypeMappings};
+pub(crate) use settings::{CaptureMappings, DEFAULT_DEBOUNCE_MS, QueryTypeMappings};
 pub use settings::{LanguageSettings, RawWorkspaceSettings, WorkspaceSettings, json_schema};
 pub(crate) use user::load_user_config;
 
@@ -67,6 +67,9 @@ fn base_convert(settings: &RawWorkspaceSettings) -> WorkspaceSettings {
         languages,
         capture_mappings,
         auto_install: settings.auto_install.unwrap_or(true),
+        diagnostics_debounce_ms: settings
+            .diagnostics_debounce_ms
+            .unwrap_or(DEFAULT_DEBOUNCE_MS),
         language_servers: settings.language_servers.clone().unwrap_or_default(),
     }
 }
@@ -358,6 +361,7 @@ impl From<&WorkspaceSettings> for RawWorkspaceSettings {
             languages,
             capture_mappings,
             auto_install: Some(settings.auto_install),
+            diagnostics_debounce_ms: Some(settings.diagnostics_debounce_ms),
             language_servers: Some(settings.language_servers.clone()),
         }
     }
@@ -496,6 +500,7 @@ mod tests {
             languages: HashMap::new(),
             capture_mappings: HashMap::new(),
             auto_install: None,
+            diagnostics_debounce_ms: None,
             language_servers: None,
         };
 
@@ -524,6 +529,7 @@ mod tests {
             languages: HashMap::new(),
             capture_mappings: HashMap::new(),
             auto_install: None,
+            diagnostics_debounce_ms: None,
             language_servers: None,
         };
 
@@ -545,6 +551,7 @@ mod tests {
             languages: HashMap::new(),
             capture_mappings: HashMap::new(),
             auto_install: None,
+            diagnostics_debounce_ms: None,
             language_servers: None,
         };
 
@@ -570,11 +577,31 @@ mod tests {
             languages: HashMap::new(),
             capture_mappings: HashMap::new(),
             auto_install,
+            diagnostics_debounce_ms: None,
             language_servers: None,
         };
 
         let workspace: WorkspaceSettings = base_convert(&settings);
         assert_eq!(workspace.auto_install, expected);
+    }
+
+    #[rstest]
+    #[case::default(None, DEFAULT_DEBOUNCE_MS)]
+    #[case::explicit(Some(50), 50)]
+    #[case::explicit_zero(Some(0), 0)]
+    fn test_diagnostics_debounce_ms(#[case] raw: Option<u64>, #[case] expected: u64) {
+        // Unset resolves to the runtime default; explicit values (incl. 0) honored.
+        let settings = RawWorkspaceSettings {
+            search_paths: None,
+            languages: HashMap::new(),
+            capture_mappings: HashMap::new(),
+            auto_install: None,
+            diagnostics_debounce_ms: raw,
+            language_servers: None,
+        };
+
+        let workspace: WorkspaceSettings = base_convert(&settings);
+        assert_eq!(workspace.diagnostics_debounce_ms, expected);
     }
 
     #[test]
@@ -857,6 +884,7 @@ mod try_from_settings_tests {
             languages: HashMap::new(),
             capture_mappings: HashMap::new(),
             auto_install: None,
+            diagnostics_debounce_ms: None,
             language_servers: None,
         };
         let env = make_env(&[("TEST_VAR", "/home/user")]);
@@ -879,6 +907,7 @@ mod try_from_settings_tests {
             languages,
             capture_mappings: HashMap::new(),
             auto_install: None,
+            diagnostics_debounce_ms: None,
             language_servers: None,
         };
         let env = make_env(&[("TEST_VAR", "/opt/parsers")]);
@@ -907,6 +936,7 @@ mod try_from_settings_tests {
             languages,
             capture_mappings: HashMap::new(),
             auto_install: None,
+            diagnostics_debounce_ms: None,
             language_servers: None,
         };
         let env = make_env(&[("TEST_VAR", "/queries")]);
@@ -941,6 +971,7 @@ mod try_from_settings_tests {
             languages,
             capture_mappings: HashMap::new(),
             auto_install: None,
+            diagnostics_debounce_ms: None,
             language_servers: None,
         };
 
@@ -961,6 +992,7 @@ mod try_from_settings_tests {
             languages: HashMap::new(),
             capture_mappings: HashMap::new(),
             auto_install: None,
+            diagnostics_debounce_ms: None,
             language_servers: None,
         };
         let env = make_env(&[]);
@@ -989,6 +1021,7 @@ mod try_from_settings_tests {
             languages,
             capture_mappings: HashMap::new(),
             auto_install: None,
+            diagnostics_debounce_ms: None,
             language_servers: None,
         };
         let env = make_env(&[]);
@@ -1007,6 +1040,7 @@ mod try_from_settings_tests {
             languages: HashMap::new(),
             capture_mappings: HashMap::new(),
             auto_install: None,
+            diagnostics_debounce_ms: None,
             language_servers: None,
         };
         let env = make_env(&[]);

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -6,8 +6,8 @@
 use super::WILDCARD_KEY;
 use super::settings::{
     AggregationConfig, AggregationStrategy, BridgeLanguageConfig, BridgeServerConfig,
-    CaptureMapping, CaptureMappings, LanguageSettings, LayerAggregationConfig, LayerSource,
-    LayersConfig, QueryTypeMappings, RawWorkspaceSettings, RootMarker,
+    CaptureMapping, CaptureMappings, DEFAULT_DEBOUNCE_MS, LanguageSettings, LayerAggregationConfig,
+    LayerSource, LayersConfig, QueryTypeMappings, RawWorkspaceSettings, RootMarker,
 };
 use std::collections::HashMap;
 
@@ -20,6 +20,7 @@ pub fn default_settings() -> RawWorkspaceSettings {
         languages: default_languages(),
         capture_mappings: default_capture_mappings(),
         auto_install: Some(true),
+        diagnostics_debounce_ms: Some(DEFAULT_DEBOUNCE_MS),
         language_servers: Some(default_language_servers()),
     }
 }
@@ -452,6 +453,19 @@ mod tests {
             settings.auto_install,
             Some(true),
             "autoInstall should be Some(true) by default"
+        );
+    }
+
+    #[test]
+    fn default_settings_mirrors_runtime_debounce_default() {
+        // Convention: the `config init` template must spell out the same value the
+        // runtime resolves when the key is unset, so deleting it never changes
+        // behavior (see config-init-template-convention).
+        let settings = default_settings();
+        assert_eq!(
+            settings.diagnostics_debounce_ms,
+            Some(DEFAULT_DEBOUNCE_MS),
+            "template diagnosticsDebounceMs must mirror the runtime default"
         );
     }
 

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -369,6 +369,9 @@ pub(crate) fn merge_workspace_settings(
                     overlay.capture_mappings,
                 ),
                 auto_install: overlay.auto_install.or(base.auto_install),
+                diagnostics_debounce_ms: overlay
+                    .diagnostics_debounce_ms
+                    .or(base.diagnostics_debounce_ms),
                 language_servers: merge_language_servers(
                     base.language_servers,
                     overlay.language_servers,
@@ -483,6 +486,7 @@ mod tests {
         let base = RawWorkspaceSettings {
             search_paths: Some(vec!["/base/path".to_string()]),
             auto_install: Some(true),
+            diagnostics_debounce_ms: None,
             languages: HashMap::from([
                 (
                     "python".to_string(),
@@ -572,6 +576,7 @@ mod tests {
         let overlay = RawWorkspaceSettings {
             search_paths: Some(vec!["/overlay/path".to_string()]),
             auto_install: Some(false),
+            diagnostics_debounce_ms: None,
             languages: HashMap::from([
                 (
                     // shared key: python — overlay overrides queries, inherits parser/bridge/aliases

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -747,6 +747,10 @@ mod tests {
         assert!(props.get("searchPaths").is_some(), "missing searchPaths");
         assert!(props.get("autoInstall").is_some(), "missing autoInstall");
         assert!(
+            props.get("diagnosticsDebounceMs").is_some(),
+            "missing diagnosticsDebounceMs"
+        );
+        assert!(
             props.get("captureMappings").is_some(),
             "missing captureMappings"
         );

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -564,6 +564,10 @@ pub struct RawWorkspaceSettings {
     pub capture_mappings: CaptureMappings,
     /// Whether to automatically install missing parsers and queries.
     pub auto_install: Option<bool>,
+    /// Debounce delay, in milliseconds, between a `didChange` and the diagnostic
+    /// pull it triggers. Higher values cut refresh/pull volume during rapid typing
+    /// at the cost of latency. Defaults to [`DEFAULT_DEBOUNCE_MS`] when unset.
+    pub diagnostics_debounce_ms: Option<u64>,
     /// Language servers for bridging LSP requests to injection regions.
     /// Map of server name to server configuration.
     pub language_servers: Option<HashMap<String, BridgeServerConfig>>,
@@ -704,6 +708,7 @@ pub struct WorkspaceSettings {
     pub languages: HashMap<String, LanguageSettings>,
     pub capture_mappings: CaptureMappings,
     pub auto_install: bool,
+    pub diagnostics_debounce_ms: u64,
     pub language_servers: HashMap<String, BridgeServerConfig>,
 }
 
@@ -714,10 +719,16 @@ impl Default for WorkspaceSettings {
             languages: HashMap::new(),
             capture_mappings: CaptureMappings::default(),
             auto_install: true, // Default to true for zero-config experience
+            diagnostics_debounce_ms: DEFAULT_DEBOUNCE_MS,
             language_servers: HashMap::new(),
         }
     }
 }
+
+/// Default `didChange`→diagnostic debounce, in milliseconds. The runtime default
+/// (used when `diagnostics_debounce_ms` is unset) and the `config init` template
+/// both resolve to this; [`crate::config::defaults`] asserts the mirror.
+pub const DEFAULT_DEBOUNCE_MS: u64 = 500;
 
 #[cfg(test)]
 mod tests {
@@ -1080,6 +1091,7 @@ mod tests {
             languages: HashMap::new(),
             capture_mappings: HashMap::new(),
             auto_install: None,
+            diagnostics_debounce_ms: None,
             language_servers: None,
         };
 

--- a/src/config/snapshots/kakehashi__config__merge__tests__merge_workspace_settings_all_fields.snap
+++ b/src/config/snapshots/kakehashi__config__merge__tests__merge_workspace_settings_all_fields.snap
@@ -75,6 +75,7 @@ expression: result
     }
   },
   "autoInstall": false,
+  "diagnosticsDebounceMs": null,
   "languageServers": {
     "lua-language-server": {
       "cmd": [

--- a/src/lsp/debounced_diagnostics.rs
+++ b/src/lsp/debounced_diagnostics.rs
@@ -9,6 +9,7 @@
 //! in-flight publishes via `SyntheticDiagnosticsManager`'s `AbortHandle`.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use dashmap::DashMap;
@@ -23,11 +24,14 @@ use super::lsp_impl::text_document::publish_diagnostic::{
 };
 use super::synthetic_diagnostics::SyntheticDiagnosticsManager;
 
-/// Default debounce duration for `didChange` events (500ms).
+/// Default debounce duration for `didChange` events.
 ///
 /// This value balances responsiveness with avoiding excessive diagnostic
-/// requests during rapid typing. It matches common IDE debounce patterns.
-pub(crate) const DEFAULT_DEBOUNCE_DURATION: Duration = Duration::from_millis(500);
+/// requests during rapid typing. It matches common IDE debounce patterns and is
+/// the fallback when `diagnostics_debounce_ms` is unset — shares the single source
+/// of truth with the config default ([`crate::config::settings::DEFAULT_DEBOUNCE_MS`]).
+pub(crate) const DEFAULT_DEBOUNCE_DURATION: Duration =
+    Duration::from_millis(crate::config::settings::DEFAULT_DEBOUNCE_MS);
 
 /// Logging target for debounced diagnostics.
 const LOG_TARGET: &str = "kakehashi::debounced_diag";
@@ -67,8 +71,11 @@ pub(crate) struct DebouncedDiagnosticsManager {
     /// The AbortHandle allows cancelling the timer when a new change arrives.
     active_timers: DashMap<Url, AbortHandle>,
 
-    /// Duration to wait after the last change before triggering diagnostics.
-    debounce_duration: Duration,
+    /// Milliseconds to wait after the last change before triggering diagnostics.
+    /// Atomic so a `diagnostics_debounce_ms` config change applies to subsequent
+    /// schedules without rebuilding the manager (it lives behind an `Arc`). Read at
+    /// schedule time; in-flight timers keep the value they were spawned with.
+    debounce_millis: AtomicU64,
 }
 
 impl Default for DebouncedDiagnosticsManager {
@@ -87,8 +94,14 @@ impl DebouncedDiagnosticsManager {
     pub(crate) fn with_duration(debounce_duration: Duration) -> Self {
         Self {
             active_timers: DashMap::new(),
-            debounce_duration,
+            debounce_millis: AtomicU64::new(debounce_duration.as_millis() as u64),
         }
+    }
+
+    /// Update the debounce delay (milliseconds) from the resolved
+    /// `diagnostics_debounce_ms` setting. Applies to subsequent schedules.
+    pub(crate) fn set_debounce_millis(&self, millis: u64) {
+        self.debounce_millis.store(millis, Ordering::Relaxed);
     }
 
     /// Schedule a debounced diagnostic for a document.
@@ -134,7 +147,7 @@ impl DebouncedDiagnosticsManager {
             documents,
         };
 
-        let duration = self.debounce_duration;
+        let duration = Duration::from_millis(self.debounce_millis.load(Ordering::Relaxed));
 
         // Spawn the debounce timer task
         let task = tokio::spawn(async move {

--- a/src/lsp/debounced_diagnostics.rs
+++ b/src/lsp/debounced_diagnostics.rs
@@ -104,6 +104,12 @@ impl DebouncedDiagnosticsManager {
         self.debounce_millis.store(millis, Ordering::Relaxed);
     }
 
+    /// The debounce delay (milliseconds) the next schedule will use.
+    #[cfg(test)]
+    pub(crate) fn debounce_millis(&self) -> u64 {
+        self.debounce_millis.load(Ordering::Relaxed)
+    }
+
     /// Schedule a debounced diagnostic for a document.
     ///
     /// Any existing timer for this document is cancelled and replaced; on expiry
@@ -310,6 +316,24 @@ async fn execute_debounced_diagnostic(data: DebouncedDiagnosticData) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn debounce_millis_defaults_and_reflects_config_updates() {
+        let manager = DebouncedDiagnosticsManager::new();
+        assert_eq!(
+            manager.debounce_millis(),
+            crate::config::settings::DEFAULT_DEBOUNCE_MS,
+            "a fresh manager uses the runtime default"
+        );
+
+        // A config reload pushes a new value via set_debounce_millis; the next
+        // schedule reads it (production wiring in `schedule_debounced_diagnostic`).
+        manager.set_debounce_millis(120);
+        assert_eq!(manager.debounce_millis(), 120);
+
+        manager.set_debounce_millis(0);
+        assert_eq!(manager.debounce_millis(), 0, "explicit zero is honored");
+    }
 
     #[tokio::test]
     async fn test_initial_state_and_cancel_noop() {

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -48,6 +48,7 @@
 //! into a reopen-resurrection hide); the stale-overwrite is left self-healing.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use tower_lsp_server::ls_types::Diagnostic;
@@ -387,6 +388,13 @@ pub(crate) struct DiagnosticAggregator {
     /// `served`) sends no redundant nudge. Drives [`Self::bump_current`],
     /// [`Self::mark_served`], [`Self::is_dirty`]; forgotten on `didClose`.
     coverage: Mutex<HashMap<Url, HostCoverage>>,
+    /// Always-on counters for the diagnostic path (#533): push-origin republishes
+    /// in, `workspace/diagnostic/refresh` requested vs actually sent (the gap is
+    /// what the #497 single-flight + coverage gate saves), and pulls answered with
+    /// coarse latency. Read on shutdown / in tests to quantify refresh amplification
+    /// on a real session before/after a change. Relaxed atomics — free on the hot
+    /// path, and the counts need no cross-counter ordering.
+    metrics: DiagnosticMetrics,
 }
 
 /// Workspace-wide single-flight state for `workspace/diagnostic/refresh` (#497).
@@ -413,9 +421,106 @@ struct HostCoverage {
     served: u64,
 }
 
+/// Always-on diagnostic-path counters (#533). The four counts trace the refresh
+/// amplification chain — push-origin republishes in → refreshes requested vs sent →
+/// pulls answered — so one [`Self::snapshot`] reveals where volume is created or
+/// saved. Plain relaxed `AtomicU64`s: incrementing on the hot path is negligible and
+/// the counters carry no cross-counter invariant.
+#[derive(Default)]
+pub(crate) struct DiagnosticMetrics {
+    /// Push/eviction-origin republishes that changed the editor-visible set (the
+    /// ingress that can drive a refresh). Counted in [`DiagnosticAggregator::bump_current`].
+    push_republishes: AtomicU64,
+    /// `workspace/diagnostic/refresh` asks that passed the client capability gate
+    /// (entry to `request_pull_diagnostic_refresh`), *before* the single-flight /
+    /// coverage gate decides whether to actually send.
+    refreshes_requested: AtomicU64,
+    /// `workspace/diagnostic/refresh` requests actually written to the wire (post
+    /// single-flight + coverage gate, including trailing fires). `requested - sent`
+    /// is what the #497 gate saves.
+    refreshes_sent: AtomicU64,
+    /// `textDocument/diagnostic` pulls answered (every return of the LSP handler).
+    pulls_answered: AtomicU64,
+    /// Total wall time spent in the pull handler, microseconds.
+    /// `pull_micros_total / pulls_answered` = mean pull latency.
+    pull_micros_total: AtomicU64,
+}
+
+/// A point-in-time copy of [`DiagnosticMetrics`] for logging and assertions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct DiagnosticMetricsSnapshot {
+    pub push_republishes: u64,
+    pub refreshes_requested: u64,
+    pub refreshes_sent: u64,
+    pub pulls_answered: u64,
+    pub pull_micros_total: u64,
+}
+
+impl DiagnosticMetrics {
+    fn record_push_republish(&self) {
+        self.push_republishes.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_refresh_requested(&self) {
+        self.refreshes_requested.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_refresh_sent(&self) {
+        self.refreshes_sent.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn record_pull(&self, micros: u64) {
+        self.pulls_answered.fetch_add(1, Ordering::Relaxed);
+        self.pull_micros_total.fetch_add(micros, Ordering::Relaxed);
+    }
+
+    /// Snapshot all counters. Not atomic across counters (a concurrent update may
+    /// land between reads), which is fine for monitoring — the chain ratios are
+    /// still representative.
+    pub(crate) fn snapshot(&self) -> DiagnosticMetricsSnapshot {
+        DiagnosticMetricsSnapshot {
+            push_republishes: self.push_republishes.load(Ordering::Relaxed),
+            refreshes_requested: self.refreshes_requested.load(Ordering::Relaxed),
+            refreshes_sent: self.refreshes_sent.load(Ordering::Relaxed),
+            pulls_answered: self.pulls_answered.load(Ordering::Relaxed),
+            pull_micros_total: self.pull_micros_total.load(Ordering::Relaxed),
+        }
+    }
+}
+
+impl DiagnosticMetricsSnapshot {
+    /// Mean pull-handler latency in microseconds (`0` when no pulls answered).
+    pub(crate) fn mean_pull_micros(&self) -> u64 {
+        self.pull_micros_total
+            .checked_div(self.pulls_answered)
+            .unwrap_or(0)
+    }
+}
+
 impl DiagnosticAggregator {
     pub(crate) fn new() -> Self {
         Self::default()
+    }
+
+    /// Record that a `workspace/diagnostic/refresh` was requested (passed the client
+    /// capability gate, before the single-flight/coverage gate). See [`DiagnosticMetrics`].
+    pub(crate) fn record_refresh_requested(&self) {
+        self.metrics.record_refresh_requested();
+    }
+
+    /// Record that a `workspace/diagnostic/refresh` was actually written to the wire.
+    pub(crate) fn record_refresh_sent(&self) {
+        self.metrics.record_refresh_sent();
+    }
+
+    /// Record an answered `textDocument/diagnostic` pull and its handler latency.
+    pub(crate) fn record_pull(&self, micros: u64) {
+        self.metrics.record_pull(micros);
+    }
+
+    /// Snapshot the diagnostic-path counters (#533) for logging or assertions.
+    pub(crate) fn metrics_snapshot(&self) -> DiagnosticMetricsSnapshot {
+        self.metrics.snapshot()
     }
 
     /// Acquire the republish lock for `host`; held by the publisher across
@@ -666,6 +771,7 @@ impl DiagnosticAggregator {
     /// refresh storm — keep this property (and the push-origin-only rule) when adding
     /// bump sites.
     pub(crate) fn bump_current(&self, host: &Url) {
+        self.metrics.record_push_republish();
         let mut coverage = self
             .coverage
             .lock()
@@ -1924,5 +2030,47 @@ mod tests {
             "a closed host no longer keeps the workspace dirty"
         );
         assert_eq!(agg.current_version(&h), 0, "re-open starts fresh");
+    }
+
+    #[test]
+    fn metrics_start_at_zero() {
+        let agg = DiagnosticAggregator::new();
+        assert_eq!(agg.metrics_snapshot(), DiagnosticMetricsSnapshot::default());
+    }
+
+    #[test]
+    fn bump_current_counts_a_push_republish() {
+        let agg = DiagnosticAggregator::new();
+        agg.bump_current(&host());
+        agg.bump_current(&host());
+        assert_eq!(agg.metrics_snapshot().push_republishes, 2);
+    }
+
+    #[test]
+    fn refresh_and_pull_counters_track_each_record() {
+        let agg = DiagnosticAggregator::new();
+        agg.record_refresh_requested();
+        agg.record_refresh_requested();
+        agg.record_refresh_requested();
+        agg.record_refresh_sent(); // gate let one through; two coalesced away
+        agg.record_pull(100);
+        agg.record_pull(300);
+
+        let m = agg.metrics_snapshot();
+        assert_eq!(m.refreshes_requested, 3);
+        assert_eq!(m.refreshes_sent, 1);
+        assert_eq!(
+            m.refreshes_requested.saturating_sub(m.refreshes_sent),
+            2,
+            "requested - sent is what the gate saved"
+        );
+        assert_eq!(m.pulls_answered, 2);
+        assert_eq!(m.pull_micros_total, 400);
+        assert_eq!(m.mean_pull_micros(), 200);
+    }
+
+    #[test]
+    fn mean_pull_micros_is_zero_without_pulls() {
+        assert_eq!(DiagnosticMetricsSnapshot::default().mean_pull_micros(), 0);
     }
 }

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -427,7 +427,7 @@ struct HostCoverage {
 /// saved. Plain relaxed `AtomicU64`s: incrementing on the hot path is negligible and
 /// the counters carry no cross-counter invariant.
 #[derive(Default)]
-pub(crate) struct DiagnosticMetrics {
+struct DiagnosticMetrics {
     /// Push/eviction-origin republishes that changed the editor-visible set (the
     /// ingress that can drive a refresh). Counted in [`DiagnosticAggregator::bump_current`].
     push_republishes: AtomicU64,
@@ -449,11 +449,11 @@ pub(crate) struct DiagnosticMetrics {
 /// A point-in-time copy of [`DiagnosticMetrics`] for logging and assertions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub(crate) struct DiagnosticMetricsSnapshot {
-    pub push_republishes: u64,
-    pub refreshes_requested: u64,
-    pub refreshes_sent: u64,
-    pub pulls_answered: u64,
-    pub pull_micros_total: u64,
+    pub(crate) push_republishes: u64,
+    pub(crate) refreshes_requested: u64,
+    pub(crate) refreshes_sent: u64,
+    pub(crate) pulls_answered: u64,
+    pub(crate) pull_micros_total: u64,
 }
 
 impl DiagnosticMetrics {
@@ -477,7 +477,7 @@ impl DiagnosticMetrics {
     /// Snapshot all counters. Not atomic across counters (a concurrent update may
     /// land between reads), which is fine for monitoring — the chain ratios are
     /// still representative.
-    pub(crate) fn snapshot(&self) -> DiagnosticMetricsSnapshot {
+    fn snapshot(&self) -> DiagnosticMetricsSnapshot {
         DiagnosticMetricsSnapshot {
             push_republishes: self.push_republishes.load(Ordering::Relaxed),
             refreshes_requested: self.refreshes_requested.load(Ordering::Relaxed),

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -913,6 +913,7 @@ mod tests {
             languages,
             capture_mappings: Default::default(),
             auto_install: false,
+            diagnostics_debounce_ms: crate::config::settings::DEFAULT_DEBOUNCE_MS,
             language_servers: HashMap::new(),
         }
     }

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -78,6 +78,15 @@ impl DiagnosticScheduler {
     pub(crate) fn schedule_debounced_diagnostic(&self, uri: Url) {
         let snapshot_data = self.prepare_diagnostic_snapshot(&uri);
 
+        // Apply the current `diagnostics_debounce_ms` setting (#533). The snapshot
+        // is a cheap arc-swap clone, so reading it per schedule keeps the debounce
+        // in sync with config reloads without a dedicated apply hook.
+        self.debounced_diagnostics.set_debounce_millis(
+            self.settings_manager
+                .load_settings()
+                .diagnostics_debounce_ms,
+        );
+
         self.debounced_diagnostics.schedule(
             uri,
             snapshot_data,

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -516,6 +516,9 @@ impl DiagnosticPublisher {
         if !supported {
             return;
         }
+        // Count the ask before the gate so `requested - sent` measures what the
+        // single-flight + coverage gate saves (#533).
+        self.aggregator.record_refresh_requested();
         // Coalesce against any in-flight refresh and apply the coverage gate (#497):
         // `false` here means either one is already outstanding (recorded as `pending`,
         // so the outstanding task's loop fires the trailing) or — for a non-`forced`
@@ -553,6 +556,8 @@ impl DiagnosticPublisher {
                 // future change adds a *pre-shutdown* panic source to this task,
                 // revisit — it would wedge the guard (and a drop-guard "fix" would
                 // reopen the `finish_refresh` lost-wakeup, so clear it atomically).
+                // Count each wire send, including trailing fires (#533).
+                aggregator.record_refresh_sent();
                 if let Err(e) = client.workspace_diagnostic_refresh().await {
                     log::debug!(
                         target: LOG_TARGET,

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -444,6 +444,21 @@ impl Kakehashi {
         // - Escalates to SIGTERM/SIGKILL for unresponsive servers (Unix)
         self.bridge.shutdown_all().await;
 
+        // Dump diagnostic-path counters (#533) so a session's refresh amplification
+        // (push republishes in → refreshes requested vs sent → pulls answered) is
+        // readable without a profiler. `requested - sent` is what the #497 gate saved.
+        let m = self.diagnostics.metrics_snapshot();
+        log::info!(
+            target: "kakehashi::diag_metrics",
+            "diagnostic path totals: push_republishes={} refreshes_requested={} refreshes_sent={} (gate saved {}) pulls_answered={} mean_pull_us={}",
+            m.push_republishes,
+            m.refreshes_requested,
+            m.refreshes_sent,
+            m.refreshes_requested.saturating_sub(m.refreshes_sent),
+            m.pulls_answered,
+            m.mean_pull_micros(),
+        );
+
         Ok(())
     }
 }

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -449,7 +449,7 @@ impl Kakehashi {
         // readable without a profiler. `requested - sent` is what the #497 gate saved.
         let m = self.diagnostics.metrics_snapshot();
         log::info!(
-            target: "kakehashi::diag_metrics",
+            target: "kakehashi::diagnostic_metrics",
             "diagnostic path totals: push_republishes={} refreshes_requested={} refreshes_sent={} (gate saved {}) pulls_answered={} mean_pull_us={}",
             m.push_republishes,
             m.refreshes_requested,

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -79,7 +79,14 @@ impl Kakehashi {
         &self,
         params: DocumentDiagnosticParams,
     ) -> Result<DocumentDiagnosticReportResult> {
-        self.diagnostic_impl_with_error_sink(params, None).await
+        // Count every answered LSP pull and its handler latency (#533). Measured
+        // here (the LSP entry) rather than the shared inner so the one-shot CLI
+        // `diagnose` path, which calls `_with_error_sink` directly, is excluded.
+        let start = std::time::Instant::now();
+        let result = self.diagnostic_impl_with_error_sink(params, None).await;
+        self.diagnostics
+            .record_pull(start.elapsed().as_micros() as u64);
+        result
     }
 
     /// Like [`Self::diagnostic_impl`], but records request-time downstream


### PR DESCRIPTION
Part of #533 (measure-first gate). Independent of #538/#539 (disjoint files); branches off `main`.

## Why
The diagnostic subsystem (#497 et al.) was **100% uninstrumented**, yet #497's own premise was "measure first". This adds the measurement capability and a direct volume lever so any later diagnostic-path optimization can be quantified on a real session.

## Commit 1 — always-on counters
`DiagnosticMetrics` (relaxed `AtomicU64`) on `DiagnosticAggregator`, tracing the refresh **amplification chain**:
- `push_republishes` — push/eviction-origin republishes that changed the set (counted in `bump_current`).
- `refreshes_requested` (post-capability-gate) vs `refreshes_sent` (the wire send inside the #497 single-flight loop, incl. trailing fires). **`requested − sent` is exactly what the #497 gate saves.**
- `pulls_answered` + `pull_micros_total` — answered LSP pulls and handler latency (mean = total/answered), measured at the `diagnostic_impl` LSP entry (the one-shot CLI `diagnose` path is excluded).

`shutdown_impl` logs a one-line summary at the `kakehashi::diagnostic_metrics` target, so a real Neovim session's refresh volume is readable before/after a change without a profiler. Counters are unit-tested.

## Commit 2 — configurable debounce
`DEFAULT_DEBOUNCE_DURATION` (500ms) was hardcoded; only tests could vary it. Exposed as `diagnosticsDebounceMs` (itself a direct refresh/pull volume lever, now A/B-able without a recompile):
- Added to `RawWorkspaceSettings` + resolved `WorkspaceSettings` (default = shared `DEFAULT_DEBOUNCE_MS`), merge `.or` precedence mirroring `auto_install`.
- Per the config-init-template convention, the `config init` template spells out the same default; a test asserts the mirror so deleting the entry never changes behavior.
- `DebouncedDiagnosticsManager` holds the delay as `AtomicU64`, refreshed from the cheap arc-swap settings snapshot at the single production schedule site — a config reload applies to subsequent debounces without rebuilding the Arc-held manager; in-flight timers keep their spawned value.

## Commit 3 — review polish
Visibility tightening, a debounce setter test (closing the setting→timer gap), JSON-schema assertion, log-target rename.

## Scope — deferred
The **A/B benchmark harness** (the issue's third item — a stub-downstream-driven `didChange → pull` scenario counting server→client refreshes) is deliberately **deferred to a follow-up PR**: it is the heaviest part (needs a stub pusher + an A/A noise-floor methodology) and is not a prerequisite for the token-path cache issues (#535/#536), which are measurable via the existing semantic-tokens bench. The manual counters + debounce lever satisfy the measure-first gate now.

## Review
Local cycle clean: `/review` (3 LOW polish applied), Codex MCP (no findings), pi-review (2 passes, no actionable findings). Full lib suite **2198 passing**; `clippy --lib -D warnings` + `fmt` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)