### PR TITLE
perf(semantic): cache semanticTokens/range results (#535)

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -8,7 +8,9 @@ pub(crate) mod semantic_cache;
 pub(crate) use result_id::next_result_id;
 pub(crate) use selection::handle_selection_range;
 pub(crate) use semantic::{LEGEND_MODIFIERS, LEGEND_TYPES, calculate_delta_or_full};
-pub(crate) use semantic_cache::{InjectionMap, InjectionTokenCache, SemanticTokenCache};
+pub(crate) use semantic_cache::{
+    InjectionMap, InjectionTokenCache, SemanticTokenCache, SemanticTokenRangeCache,
+};
 
 // Re-export crate-internal functions used by LSP layer
 pub(crate) use semantic::{

--- a/src/analysis/semantic_cache.rs
+++ b/src/analysis/semantic_cache.rs
@@ -12,7 +12,7 @@ use crate::analysis::semantic::RawToken;
 use crate::language::injection::CacheableInjectionRegion;
 use dashmap::DashMap;
 use rust_lapper::{Interval, Lapper};
-use tower_lsp_server::ls_types::SemanticTokens;
+use tower_lsp_server::ls_types::{Range, SemanticTokens};
 use url::Url;
 
 /// Cached semantic tokens for delta calculations.
@@ -101,6 +101,105 @@ impl SemanticTokenCache {
 }
 
 impl Default for SemanticTokenCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Cached tokens for a `textDocument/semanticTokens/range` request (#535).
+///
+/// Unlike full/delta, the range path has no short-circuit and re-tokenizes the
+/// visible window on every request. Range is local kakehashi tree-sitter compute
+/// (no downstream fan-out), so the result is a pure function of the document text,
+/// the requested `range`, and the settings generation — keying by all three is
+/// safe. The hit is narrow (only an *identical-viewport* re-request of an unchanged
+/// document under unchanged settings), so a single most-recent entry per URI is
+/// kept rather than a per-range map.
+#[derive(Clone)]
+pub struct CachedRangeTokens {
+    pub tokens: SemanticTokens,
+    /// The viewport these tokens were computed for. A scroll changes the range, so
+    /// a differing range is a miss even when text/settings are unchanged.
+    pub range: Range,
+    /// The resolved language these tokens were computed for. The `cache_key` folds
+    /// only text + settings generation, so it cannot distinguish the same URI+text
+    /// re-opened under a DIFFERENT language (a `didClose`/`didOpen` language switch,
+    /// which neither edits the text nor bumps the generation). Pinning the language
+    /// makes such a request miss and recompute instead of serving wrong-language
+    /// tokens. (A *same*-language re-open yields identical tokens, so it correctly
+    /// still hits.)
+    pub language: String,
+    /// The `cache_key` (FNV-1a of text folded with the settings generation, built
+    /// by `CacheCoordinator::cache_key_for`) the tokens were computed under.
+    pub cache_key: u64,
+}
+
+/// Thread-safe most-recent `semanticTokens/range` result cache, one entry per URI.
+pub struct SemanticTokenRangeCache {
+    cache: DashMap<Url, CachedRangeTokens>,
+}
+
+impl SemanticTokenRangeCache {
+    pub fn new() -> Self {
+        Self {
+            cache: DashMap::new(),
+        }
+    }
+
+    /// Store the most-recent range tokens for a document, tagged with the viewport
+    /// `range`, resolved `language`, and the `cache_key` they were computed under.
+    pub fn store(
+        &self,
+        uri: Url,
+        range: Range,
+        language: String,
+        tokens: SemanticTokens,
+        cache_key: u64,
+    ) {
+        self.cache.insert(
+            uri,
+            CachedRangeTokens {
+                tokens,
+                range,
+                language,
+                cache_key,
+            },
+        );
+    }
+
+    /// Return the cached tokens iff the most-recent entry matches the requested
+    /// viewport `range`, the resolved `language`, AND the `cache_key` (text +
+    /// settings generation unchanged). None on a scroll, a language switch, a text
+    /// edit, a settings reload, or no entry.
+    pub fn get_if_current(
+        &self,
+        uri: &Url,
+        range: &Range,
+        language: &str,
+        cache_key: u64,
+    ) -> Option<SemanticTokens> {
+        self.cache.get(uri).and_then(|entry| {
+            if entry.cache_key == cache_key && entry.range == *range && entry.language == language {
+                Some(entry.tokens.clone())
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Drop every cached entry (on a settings/query reload, alongside the
+    /// generation bump that makes the invalidation race-safe).
+    pub fn clear(&self) {
+        self.cache.clear();
+    }
+
+    /// Remove the cached entry for a document (on `didClose`).
+    pub fn remove(&self, uri: &Url) {
+        self.cache.remove(uri);
+    }
+}
+
+impl Default for SemanticTokenRangeCache {
     fn default() -> Self {
         Self::new()
     }

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -17,7 +17,9 @@ use tower_lsp_server::ls_types::SemanticTokens;
 use tree_sitter::{InputEdit, Tree};
 use url::Url;
 
-use crate::analysis::{InjectionMap, InjectionTokenCache, SemanticTokenCache};
+use crate::analysis::{
+    InjectionMap, InjectionTokenCache, SemanticTokenCache, SemanticTokenRangeCache,
+};
 use crate::language::LanguageCoordinator;
 use crate::language::NodeTracker;
 use crate::language::injection::{CacheableInjectionRegion, collect_all_injections};
@@ -33,6 +35,10 @@ pub(crate) type RequestId = u64;
 /// for document lifecycle management, edit handling, and token operations.
 pub(crate) struct CacheCoordinator {
     semantic_cache: SemanticTokenCache,
+    /// Most-recent `semanticTokens/range` result per URI (#535), keyed by viewport
+    /// range + the same `cache_key` as `semantic_cache`. Cleared on a generation
+    /// bump and evicted on `didClose` alongside `semantic_cache`.
+    semantic_range_cache: SemanticTokenRangeCache,
     injection_map: InjectionMap,
     injection_token_cache: std::sync::Arc<InjectionTokenCache>,
     request_tracker: SemanticRequestTracker,
@@ -49,6 +55,7 @@ impl CacheCoordinator {
     pub(crate) fn new() -> Self {
         Self {
             semantic_cache: SemanticTokenCache::new(),
+            semantic_range_cache: SemanticTokenRangeCache::new(),
             injection_map: InjectionMap::new(),
             injection_token_cache: std::sync::Arc::new(InjectionTokenCache::new()),
             request_tracker: SemanticRequestTracker::new(),
@@ -69,6 +76,7 @@ impl CacheCoordinator {
     /// - Request tracking state
     pub(crate) fn remove_document(&self, uri: &Url) {
         self.semantic_cache.remove(uri);
+        self.semantic_range_cache.remove(uri);
         self.injection_map.clear(uri);
         self.injection_token_cache.clear_document(uri);
         self.request_tracker.cancel_all_for_uri(uri);
@@ -354,6 +362,35 @@ impl CacheCoordinator {
         self.semantic_cache.store(uri, tokens, cache_key);
     }
 
+    /// Store the most-recent `semanticTokens/range` result for a document (#535),
+    /// tagged with the viewport `range` and the `cache_key` it was computed under.
+    pub(crate) fn store_range_tokens(
+        &self,
+        uri: Url,
+        range: tower_lsp_server::ls_types::Range,
+        language: String,
+        tokens: SemanticTokens,
+        cache_key: u64,
+    ) {
+        self.semantic_range_cache
+            .store(uri, range, language, tokens, cache_key);
+    }
+
+    /// Return the cached range tokens iff they were computed for this exact
+    /// viewport `range` and `language` under this `cache_key` (same text + settings
+    /// generation), letting the caller skip the range re-tokenization. None on a
+    /// scroll, a language switch, a text edit, a settings reload, or no entry.
+    pub(crate) fn get_current_range_tokens(
+        &self,
+        uri: &Url,
+        range: &tower_lsp_server::ls_types::Range,
+        language: &str,
+        cache_key: u64,
+    ) -> Option<SemanticTokens> {
+        self.semantic_range_cache
+            .get_if_current(uri, range, language, cache_key)
+    }
+
     /// Return the cached tokens iff they were computed under this `cache_key`
     /// (same text and settings generation), letting the caller skip the full
     /// re-tokenization. None on a text edit, a settings reload, or no entry.
@@ -376,6 +413,9 @@ impl CacheCoordinator {
         // them too so a reload doesn't leak per-region entries until each
         // document closes.
         self.injection_token_cache.clear();
+        // The range cache folds the same generation into its key, so the bump
+        // already invalidates it; clear to reclaim the dead entries (#535).
+        self.semantic_range_cache.clear();
     }
 
     // ========================================================================
@@ -814,6 +854,112 @@ print("goodbye")
                 .get(&uri, &initial_region_id, initial_content_hash, 0)
                 .is_none(),
             "cached tokens should be invalidated when content changes"
+        );
+    }
+
+    // ========================================================================
+    // semanticTokens/range cache (#535)
+    // ========================================================================
+
+    fn range_tokens(len: u32) -> SemanticTokens {
+        SemanticTokens {
+            result_id: None,
+            data: vec![SemanticToken {
+                delta_line: 0,
+                delta_start: 0,
+                length: len,
+                token_type: 0,
+                token_modifiers_bitset: 0,
+            }],
+        }
+    }
+
+    fn test_range(start_line: u32, end_line: u32) -> tower_lsp_server::ls_types::Range {
+        use tower_lsp_server::ls_types::{Position, Range};
+        Range::new(Position::new(start_line, 0), Position::new(end_line, 0))
+    }
+
+    #[test]
+    fn range_cache_hits_only_on_matching_range_language_and_key() {
+        let cache = CacheCoordinator::new();
+        let uri = create_test_uri("range.rs");
+        let range = test_range(0, 10);
+        let key = cache.cache_key_for("hello", cache.semantic_token_generation());
+        cache.store_range_tokens(uri.clone(), range, "rust".to_string(), range_tokens(5), key);
+
+        // Same range + language + key → hit.
+        assert!(
+            cache
+                .get_current_range_tokens(&uri, &range, "rust", key)
+                .is_some(),
+            "identical viewport + language + unchanged text/settings should hit"
+        );
+        // Different viewport (a scroll) → miss.
+        assert!(
+            cache
+                .get_current_range_tokens(&uri, &test_range(5, 15), "rust", key)
+                .is_none(),
+            "a different range must miss even with the same language and key"
+        );
+        // Different language (same URI+text re-opened as another language) → miss.
+        assert!(
+            cache
+                .get_current_range_tokens(&uri, &range, "python", key)
+                .is_none(),
+            "a language switch must miss even with the same range and key"
+        );
+        // Different key (text edit or settings reload) → miss.
+        assert!(
+            cache
+                .get_current_range_tokens(&uri, &range, "rust", key ^ 1)
+                .is_none(),
+            "a different cache_key must miss even with the same range and language"
+        );
+    }
+
+    #[test]
+    fn range_cache_cleared_on_generation_bump() {
+        let cache = CacheCoordinator::new();
+        let uri = create_test_uri("range.rs");
+        let range = test_range(0, 10);
+        let key = cache.cache_key_for("hello", cache.semantic_token_generation());
+        cache.store_range_tokens(uri.clone(), range, "rust".to_string(), range_tokens(5), key);
+        assert!(
+            cache
+                .get_current_range_tokens(&uri, &range, "rust", key)
+                .is_some()
+        );
+
+        // A settings/query reload must drop range entries (same must-do wiring as
+        // the full-token cache), or they would serve stale after the reload.
+        cache.bump_semantic_token_generation();
+        assert!(
+            cache
+                .get_current_range_tokens(&uri, &range, "rust", key)
+                .is_none(),
+            "generation bump must clear the range cache"
+        );
+    }
+
+    #[test]
+    fn range_cache_evicted_on_remove_document() {
+        let cache = CacheCoordinator::new();
+        let uri = create_test_uri("range.rs");
+        let range = test_range(0, 10);
+        let key = cache.cache_key_for("hello", cache.semantic_token_generation());
+        cache.store_range_tokens(uri.clone(), range, "rust".to_string(), range_tokens(5), key);
+        assert!(
+            cache
+                .get_current_range_tokens(&uri, &range, "rust", key)
+                .is_some()
+        );
+
+        cache.remove_document(&uri);
+        assert!(
+            cache
+                .get_current_range_tokens(&uri, &range, "rust", key)
+                .is_none(),
+            "didClose must evict the range cache entry"
         );
     }
 }

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -1,6 +1,6 @@
-//! `CacheCoordinator` unifies the four semantic-token caches under one API:
-//! `SemanticTokenCache`, `InjectionMap`, `InjectionTokenCache`, and
-//! `SemanticRequestTracker` (in-flight cancellation).
+//! `CacheCoordinator` unifies the semantic-token caches under one API:
+//! `SemanticTokenCache`, `SemanticTokenRangeCache`, `InjectionMap`,
+//! `InjectionTokenCache`, and `SemanticRequestTracker` (in-flight cancellation).
 //!
 //! The semantic-token cache is intentionally **not** invalidated on `didChange`
 //! — `semanticTokens/full/delta` needs the previous version for delta
@@ -31,8 +31,9 @@ pub(crate) type RequestId = u64;
 
 /// Coordinates all cache structures for semantic token operations.
 ///
-/// This struct wraps four underlying caches and provides a unified API
-/// for document lifecycle management, edit handling, and token operations.
+/// This struct wraps five underlying caches (full tokens, range tokens, the
+/// injection map, injection-region tokens, and request tracking) and provides a
+/// unified API for document lifecycle management, edit handling, and token operations.
 pub(crate) struct CacheCoordinator {
     semantic_cache: SemanticTokenCache,
     /// Most-recent `semanticTokens/range` result per URI (#535), keyed by viewport

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -895,17 +895,18 @@ impl Kakehashi {
         )
         .await;
 
-        // Convert to RangeResult, treating partial responses as empty for now.
-        // Cache ONLY a clean `Tokens` result (#535): a `Partial` is a degraded
-        // response and a `None` is a transient miss/cancel — caching either could
-        // serve a degraded set on a later identical-viewport re-request.
+        // Convert to RangeResult. Cache ONLY a clean `Tokens` result (#535); a
+        // `Partial` is passed through to the client as-is but NOT cached (it is a
+        // degraded response), and a `None` becomes an empty `Tokens` and is not
+        // cached either (transient miss/cancel) — caching either could serve a
+        // degraded set on a later identical-viewport re-request.
         let domain_range_result = match result {
             Some(tower_lsp_server::ls_types::SemanticTokensResult::Tokens(tokens)) => {
-                // `language_name` is unused after this arm, so move it (no clone);
-                // `tokens` is cloned because the store and the response below each
-                // need an owned copy.
+                // `uri` and `language_name` are unused after this arm, so move them
+                // (no clone); `tokens` is cloned because the store and the response
+                // below each need an owned copy.
                 self.cache.store_range_tokens(
-                    uri.clone(),
+                    uri,
                     domain_range,
                     language_name,
                     tokens.clone(),

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -822,6 +822,12 @@ impl Kakehashi {
 
         let domain_range = range;
 
+        // Snapshot the settings generation at the top, before any await (#535): a
+        // reload that bumps the generation after this leaves this request's stored
+        // key on the old generation — invisible to post-reload requests (which
+        // compute the new-generation key) — so a stale entry can never be served.
+        let generation = self.cache.semantic_token_generation();
+
         let Some(language_name) = self.document_language(&uri) else {
             return Ok(Some(SemanticTokensRangeResult::Tokens(SemanticTokens {
                 result_id: None,
@@ -857,6 +863,19 @@ impl Kakehashi {
             })));
         };
 
+        // Short-circuit an identical-viewport re-request of an unchanged document
+        // (#535). `cache_key` folds the document text with the settings generation,
+        // and the entry also pins the viewport `range`, so a hit means re-tokenizing
+        // would reproduce these exact tokens. Misses (scroll, edit, or reload) fall
+        // through to the recompute below, which restores the entry.
+        let cache_key = self.cache.cache_key_for(text, generation);
+        if let Some(tokens) =
+            self.cache
+                .get_current_range_tokens(&uri, &domain_range, &language_name, cache_key)
+        {
+            return Ok(Some(SemanticTokensRangeResult::Tokens(tokens)));
+        }
+
         // Get capture mappings for token type resolution
         let capture_mappings = self.language.capture_mappings();
 
@@ -876,21 +895,33 @@ impl Kakehashi {
         )
         .await;
 
-        // Convert to RangeResult, treating partial responses as empty for now
-        let domain_range_result = match result.unwrap_or_else(|| {
-            tower_lsp_server::ls_types::SemanticTokensResult::Tokens(
+        // Convert to RangeResult, treating partial responses as empty for now.
+        // Cache ONLY a clean `Tokens` result (#535): a `Partial` is a degraded
+        // response and a `None` is a transient miss/cancel — caching either could
+        // serve a degraded set on a later identical-viewport re-request.
+        let domain_range_result = match result {
+            Some(tower_lsp_server::ls_types::SemanticTokensResult::Tokens(tokens)) => {
+                // `language_name` is unused after this arm, so move it (no clone);
+                // `tokens` is cloned because the store and the response below each
+                // need an owned copy.
+                self.cache.store_range_tokens(
+                    uri.clone(),
+                    domain_range,
+                    language_name,
+                    tokens.clone(),
+                    cache_key,
+                );
+                tower_lsp_server::ls_types::SemanticTokensRangeResult::from(tokens)
+            }
+            Some(tower_lsp_server::ls_types::SemanticTokensResult::Partial(partial)) => {
+                tower_lsp_server::ls_types::SemanticTokensRangeResult::from(partial)
+            }
+            None => tower_lsp_server::ls_types::SemanticTokensRangeResult::Tokens(
                 tower_lsp_server::ls_types::SemanticTokens {
                     result_id: None,
                     data: Vec::new(),
                 },
-            )
-        }) {
-            tower_lsp_server::ls_types::SemanticTokensResult::Tokens(tokens) => {
-                tower_lsp_server::ls_types::SemanticTokensRangeResult::from(tokens)
-            }
-            tower_lsp_server::ls_types::SemanticTokensResult::Partial(partial) => {
-                tower_lsp_server::ls_types::SemanticTokensRangeResult::from(partial)
-            }
+            ),
         };
 
         Ok(Some(domain_range_result))


### PR DESCRIPTION
Closes #535. Independent of #538/#539/#541 (disjoint files); branches off `main`.

## Scope correction (important)
#535 originally proposed result caches for **documentColor**, **semanticTokens-range**, and **documentSymbol-virt**, on the premise they are "local tree compute". Investigation found that's **false for documentColor and documentSymbol**: both dispatch to **downstream bridge servers** per injection region (`send_document_color_request` / `send_document_symbol_request`). Their results are downstream-sourced, so caching them carries a suppress-data staleness edge (a downstream that was warming up / returned empty gets its empty result cached) — the same class as #534 (on hold), **not** the local #530 token cache. Per maintainer decision, **only the range cache is implemented here**; documentColor/documentSymbol are dropped from #535 as downstream-dependent (the issue body is updated with this).

Only `semanticTokens/range` is genuinely local (`handle_semantic_tokens_range_parallel_async`, Rayon, no downstream fan-out).

## Change
`semanticTokens/range` had no short-circuit and re-tokenized the visible window on every request, unlike full/delta (cached since #530). Add `SemanticTokenRangeCache` (one most-recent entry per URI) keyed `(uri, range, language, cache_key)` where `cache_key = fnv1a(text) ^ generation` (the exact key/infra #530 uses). `semantic_tokens_range_impl` snapshots the generation at the top, short-circuits on a matching entry before the Rayon recompute, and stores **only** a clean `Tokens` result (never `Partial`/`None`, which are degraded/transient).

**`language` is pinned in the key** (a finding from Codex review): `cache_key` folds only text + generation, so it can't distinguish the same URI+text re-opened under a **different language** (a `didClose`/`didOpen` language switch edits neither the text nor the generation). Without it, an in-flight request could store wrong-language tokens a post-switch request would serve. A same-language re-open yields identical tokens, so it correctly still hits.

### Must-do invalidation wiring (the class of gap #530's review caught)
- `bump_semantic_token_generation` now **also clears** the range cache on a config/query reload (the generation is also folded into the key, so it can't serve stale).
- `remove_document` now **also evicts** the entry on `didClose` to bound memory.

The hit is narrow by design — only an identical-viewport, same-language re-request of an unchanged document hits (a scroll changes the range → miss) — but harmless. The full-text `fnv1a` is microsecond-scale vs the full-document Rayon tokenize-then-filter it guards, so no perf regression.

## Related observations (out of scope, not fixed here)
- **#530's full-token cache has the same latent wrong-language exposure** (its key also omits `language`). Pre-existing; worth a separate issue.
- The range path reads `query` before the parse await but `capture_mappings`/`supports_multiline` after, so a reload during that await can yield a *response* mixing old+new settings. The **cache stays race-safe** (entry keyed under the old generation, invisible post-reload), so this is not a stale-serve bug — it's a pre-existing response-consistency window in the range path, unchanged by this PR.

## Review
Local cycle clean: `/review` (doc-comment fix applied), Codex MCP (caught the wrong-language HIGH → fixed → re-confirmed resolved), pi-review (clean — key verified complete, invariants structurally enforced). 3 unit tests (hit-only-on-matching-range+language+key, cleared-on-generation-bump, evicted-on-didClose); full lib suite **2193 passing**; `clippy --lib -D warnings` + `fmt` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)