### PR TITLE
docs: add workspace-resolver and lua-host-api ADRs

### DIFF
--- a/docs/architecture-decisions/lua-host-api.md
+++ b/docs/architecture-decisions/lua-host-api.md
@@ -154,7 +154,7 @@ Mirrors `std::env`. Initially one function:
 
 | Function | Returns |
 |---|---|
-| `env.current_dir()` | `string` — the process working directory, wrapping `std::env::current_dir()` (`getcwd(2)`) |
+| `env.current_dir()` | `string \| nil` — the process working directory, wrapping `std::env::current_dir()` (`getcwd(2)`); `nil` if it is not representable per the encoding contract |
 
 `env.current_dir()` subsumes the `workspaceFallback`/`"$PWD"` idea deferred in
 workspace-resolver: a resolver can simply `return true, kakehashi.env.current_dir()` as
@@ -205,12 +205,25 @@ universally byte-representable, so the boundary needs **one** defined encoding:
   trading exotic-path support for a single, simple, round-trippable string type
   that Lua `string.*` can operate on.
 
-Failure shape is uniform: a path that cannot be represented yields the same
-result as an unreadable/missing path — host **functions** (`fs.*`, `path.*`)
-return `nil`; the **`document_info.path` field** yields `nil`, and a resolver
-that needs the path should treat `nil` as "skip / fall back to
-`workspaceMarkers`" (the same bucket as non-`file://` documents). Not yet
-implemented; the Windows surrogate edge is recorded as an open question.
+Failure shape depends on **direction**, because the declared return types differ:
+
+- **Host → Lua (kakehashi produces an OS path).** These are the only places a
+  non-representable path can surface, and their return types are nullable
+  accordingly: `fs.find_ancestor` and `env.current_dir` return `string | nil`.
+  `document_info.path` is the exception — it is typed plain `string` and never
+  surfaces this failure, because workspace-resolver §2 **skips the resolver
+  entirely** for a document whose path is not representable. So inside a running
+  resolver `document_info.path` is always valid.
+- **Lua → host (a Lua byte-string path argument).** `path.*` are pure
+  byte-string functions — they operate on the bytes and keep their declared
+  return types (`boolean`, or `string | nil` mirroring Rust `None`), with no
+  encoding-failure case. The `fs.*` predicates (`exists`/`is_file`/`is_dir`)
+  must materialize an OS path from the argument; a byte string that is not a
+  valid path on the platform (only reachable on Windows via a deliberately
+  fabricated non-UTF-8 string) raises a **Lua error** rather than a misleading
+  `false`. The error fails the resolver closed (§6), which is the safe outcome.
+
+Not yet implemented; the Windows surrogate edge is recorded as an open question.
 
 ## Considered Options
 

--- a/docs/architecture-decisions/lua-host-api.md
+++ b/docs/architecture-decisions/lua-host-api.md
@@ -214,14 +214,15 @@ Failure shape depends on **direction**, because the declared return types differ
   surfaces this failure, because workspace-resolver §2 **skips the resolver
   entirely** for a document whose path is not representable. So inside a running
   resolver `document_info.path` is always valid.
-- **Lua → host (a Lua byte-string path argument).** `path.*` are pure
-  byte-string functions — they operate on the bytes and keep their declared
-  return types (`boolean`, or `string | nil` mirroring Rust `None`), with no
-  encoding-failure case. The `fs.*` predicates (`exists`/`is_file`/`is_dir`)
-  must materialize an OS path from the argument; a byte string that is not a
-  valid path on the platform (only reachable on Windows via a deliberately
-  fabricated non-UTF-8 string) raises a **Lua error** rather than a misleading
-  `false`. The error fails the resolver closed (§6), which is the safe outcome.
+- **Lua → host (a Lua byte-string path argument).** *Every* path consumer —
+  all `path.*` and all `fs.*` — must decode the argument into an OS `Path` to
+  apply `std::path` semantics, so they share one validation rule: on Unix any
+  byte string is a valid path (infallible); on **Windows** the argument must be
+  valid UTF-8, and a fabricated non-UTF-8 string raises a **Lua error**. The
+  error is out-of-band, so declared return types are unchanged — `path.*` stay
+  pure (deterministic, no I/O) and the `fs.*` predicates keep `boolean` instead
+  of leaking a misleading `false`. The error fails the resolver closed (§6),
+  which is the safe outcome.
 
 Not yet implemented; the Windows surrogate edge is recorded as an open question.
 

--- a/docs/architecture-decisions/lua-host-api.md
+++ b/docs/architecture-decisions/lua-host-api.md
@@ -32,8 +32,11 @@ and the **inclusion criteria** that gate future additions.
 
 A `kakehashi.*` function is provided only if it meets at least one of:
 
-1. **Correctness Lua stdlib cannot guarantee** — e.g. cross-platform path
-   semantics matching Rust's `std::path`, URI percent-decoding.
+1. **Correctness Lua stdlib cannot guarantee** — e.g. cross-platform `std::path`
+   semantics (separators, roots, `ancestors`), which `string.match` cannot get
+   right portably. (URI handling is *not* an example here — it is centralized at
+   the boundary in Rust and deliberately not exposed as a Lua function; see
+   Considered Options.)
 2. **Sandboxed host access** the stripped environment otherwise denies —
    filesystem reads, working directory.
 3. **Reuse of non-trivial kakehashi Rust logic** the resolver should not
@@ -62,8 +65,9 @@ side-effect-free" a guarantee a reader can rely on.
 
 ### Surface (initial)
 
-All functions are snake_case (matching Rust and the resolver examples). A
-return of `nil` corresponds to Rust's `None`.
+All functions are snake_case (matching the resolver examples and the project's
+Lua-side naming — Rust's own methods are camelCase, e.g. `Path::is_absolute`).
+A return of `nil` corresponds to Rust's `None`.
 
 #### `kakehashi.path` — pure path manipulation (no I/O)
 
@@ -87,9 +91,12 @@ needs); deliberately pure and side-effect-free.
 `nil`-returning cases mirror Rust exactly: `parent("/")` → `nil`,
 `extension("README")` → `nil`, etc. All wrapped methods are stable since Rust
 1.0 (`ancestors` since 1.28) **except `Path::file_prefix`, stabilized in 1.91**
-— including it sets an implicit MSRV floor of 1.91. The project currently pins
-no MSRV and builds on ≥1.95, so this is a recorded caveat, not a blocker; drop
-`file_prefix` (it overlaps `file_stem`) if an older toolchain must be supported.
+— including it raises the implicit MSRV floor to 1.91. The project pins no MSRV
+(`Cargo.toml` has no `rust-version`; `flake.nix` tracks `stable.latest` and CI
+uses the default toolchain), so the effective floor just follows that channel —
+a recorded caveat, not a blocker. Drop `file_prefix` (it overlaps `file_stem`),
+or add `rust-version = "1.91"` to `Cargo.toml`, if an older toolchain must be
+supported.
 
 #### `kakehashi.fs` — read-only host filesystem (criteria 2 and 3)
 
@@ -118,14 +125,17 @@ workspace-specific function — finding a project root is just one use. It reuse
 reimplement the walk:
 
 - `start`: a path. The search's **base directory** is `start` itself when it is
-  an existing directory, or `start`'s parent otherwise — including when `start`
-  does **not** exist (e.g. an unsaved/new document path), which is treated as a
-  file path, matching `find_marker_root`. The walk checks the base directory
-  **and** each ancestor.
+  an existing directory (`metadata().is_dir()`), or `start`'s parent otherwise —
+  including when `start` does **not** exist (e.g. an unsaved/new document path),
+  which is treated as a file path. The file case mirrors `find_marker_root`
+  (parent + ancestors); the existing-directory case is the new generalization
+  (see the note). The walk checks the base directory **and** each ancestor.
 - `markers`: `(string | string[])[]` — a nested array is an equal-priority
   group. This is the **same shape** as `workspaceMarkers`, but the function
   does not assume the result is a workspace. (The resolver's return no longer
   accepts raw markers; it calls this function instead — see workspace-resolver.)
+  An **empty list `{}` is the explicit kill switch**: it returns `nil` without
+  searching, matching `find_marker_root`.
 - Returns the first directory (base, then ancestors) containing a marker, or
   `nil`.
 
@@ -201,7 +211,12 @@ universally byte-representable, so the boundary needs **one** defined encoding:
 
 - **Unix:** an `OsStr` path *is* bytes, so paths cross the boundary losslessly
   as raw byte strings — including non-UTF-8 paths (which Lua holds fine, though
-  `string.*` pattern functions may behave oddly on them).
+  `string.*` pattern functions may behave oddly on them). The implementation
+  must use the **byte-level channel** for this to hold: `OsStr::as_bytes` /
+  `OsStrExt::from_bytes` (`std::os::unix::ffi`) paired with `mlua`'s `[u8]`-
+  accepting `create_string` / `String::as_bytes`. A naive `String`/`&str`
+  wrapper would lossily corrupt non-UTF-8 Unix paths — the byte channel is
+  load-bearing, not incidental.
 - **Windows:** paths are **strict UTF-8** (not WTF-8). A Windows path containing
   unpaired UTF-16 surrogates is therefore **not representable and fails
   closed** — we deliberately do *not* adopt WTF-8's lossless surrogate encoding,
@@ -210,13 +225,18 @@ universally byte-representable, so the boundary needs **one** defined encoding:
 
 Failure shape depends on **direction**, because the declared return types differ:
 
-- **Host → Lua (kakehashi produces an OS path).** These are the only places a
-  non-representable path can surface, and their return types are nullable
-  accordingly: `fs.find_ancestor` and `env.current_dir` return `string | nil`.
-  `document_info.path` is the exception — it is typed plain `string` and never
-  surfaces this failure, because workspace-resolver §2 **skips the resolver
-  entirely** for a document whose path is not representable. So inside a running
-  resolver `document_info.path` is always valid.
+- **Host → Lua (kakehashi produces an OS path).** Non-representability can
+  surface only on the **Windows** side (a producible OS path that is not strict
+  UTF-8); on Unix the byte channel above always succeeds. Producers whose return
+  can fail are typed nullable: `fs.find_ancestor` and `env.current_dir` return
+  `string | nil`. `document_info.path` is the exception — typed plain `string`,
+  it never surfaces this failure because workspace-resolver §2 **skips the
+  resolver entirely** for a document whose path is not representable, so inside a
+  running resolver it is always valid. `path.*` returns (`parent`, `ancestors`,
+  `file_name`, …) take a Lua string and produce one: on Windows their input is
+  already strict UTF-8 (per the `Lua → host` rule), so their output is too — no
+  extra failure case, declared return types unchanged; on Unix they round-trip
+  bytes.
 - **Lua → host (a Lua byte-string path argument).** *Every* path that crosses
   back to the host — all `path.*` and `fs.*` arguments **and the resolver's
   string workspace return** — must decode into an OS `Path` to apply `std::path`
@@ -228,7 +248,16 @@ Failure shape depends on **direction**, because the declared return types differ
   of leaking a misleading `false`. The error fails the resolver closed (§6),
   which is the safe outcome.
 
-Not yet implemented; the Windows surrogate edge is recorded as an open question.
+### Open questions
+
+Deferred to implementation (cross-referenced from workspace-resolver § "Open
+questions"):
+
+- **`fs.read_to_string` size cap value** — the read is capped (the §3 in-VM hook
+  cannot interrupt a host read), but the exact byte limit is open.
+- **Windows surrogate edge** — paths with unpaired UTF-16 surrogates fail closed
+  under the strict-UTF-8 contract; whether any caller ever needs lossless
+  (WTF-8) handling is open.
 
 ## Considered Options
 
@@ -271,7 +300,9 @@ Not yet implemented; the Windows surrogate edge is recorded as an open question.
   returns an ancestor *directory*; finding a workspace root is one use, not its
   definition. `find_workspace`/`find_root` over-narrow it to a single consumer,
   and `find_marker` misreads as returning the marker. `find_ancestor` names the
-  return type and pairs with `path.ancestors`.
+  return type, and reads as a filtered `path.ancestors` walk (the first ancestor
+  matching a marker) — though `path.ancestors` returns the full list while
+  `find_ancestor` returns just that first match.
 
 - **Writable `fs` / `os.execute` / env-var reads.** Rejected for now. Read-only
   fs covers the known use cases; writes and subprocess spawning enlarge the

--- a/docs/architecture-decisions/lua-host-api.md
+++ b/docs/architecture-decisions/lua-host-api.md
@@ -1,0 +1,261 @@
+# Lua Host API
+
+## Context
+
+workspace-resolver introduces a user-authored Lua function that decides whether
+to attach a document to a bridged server and what workspace to use. To make
+real decisions (Deno vs. Node/tsgo, content-dependent attach), the resolver
+needs to inspect paths, look at files on disk, and find a project root.
+
+Two boundaries shape what kakehashi must provide:
+
+1. **The resolver runs in a restricted sandbox.** For determinism, safety, and
+   the worker-thread/timeout execution model (see workspace-resolver), the Lua
+   environment is stripped: `string`, `table`, `math` stay; `io`, `os`,
+   `package`, `require`, `load`/`loadstring`, `dofile`, and FFI are removed.
+   So *any* host access — filesystem, working directory — must be an explicit
+   kakehashi-provided function, not Lua's stdlib.
+
+2. **Lua's `string` library is already powerful.** Splitting, matching, and
+   substituting path-like strings is trivial with `string.match`/`gsub`. We do
+   not want to wrap what Lua already does well.
+
+The risk is an ever-growing host API. This decision fixes a **minimal surface**
+and the **inclusion criteria** that gate future additions.
+
+## Decision
+
+### Inclusion criteria
+
+A `kakehashi.*` function is provided only if it meets at least one of:
+
+1. **Correctness Lua stdlib cannot guarantee** — e.g. cross-platform path
+   semantics matching Rust's `std::path`, URI percent-decoding.
+2. **Sandboxed host access** the stripped environment otherwise denies —
+   filesystem reads, working directory.
+3. **Reuse of non-trivial kakehashi Rust logic** the resolver should not
+   reimplement — root finding / marker resolution.
+
+Pure string conveniences that Lua's `string` library does trivially are
+**excluded** on principle.
+
+### Submodules only, mirroring Rust `std`
+
+`kakehashi.*` exposes **only submodules** — no bare top-level functions — and
+each submodule mirrors a Rust `std` module, keeping one naming language:
+
+- `kakehashi.path` ← `std::path` — **pure**: deterministic string functions, no I/O.
+- `kakehashi.fs` ← `std::fs` — **impure**: anything that touches the disk,
+  including the `find_ancestor` walk.
+- `kakehashi.env` ← `std::env` — **impure**: ambient process environment
+  (`current_dir`; env-var reads if later promoted from deferred).
+- `kakehashi.log` — diagnostics output.
+
+The `path`/`fs` divide is the **purity line**, which keeps "any `path.X` is
+side-effect-free" a guarantee a reader can rely on.
+
+### Surface (initial)
+
+All functions are snake_case (matching Rust and the resolver examples). A
+return of `nil` corresponds to Rust's `None`.
+
+#### `kakehashi.path` — pure path manipulation (no I/O)
+
+Thin wrappers over `std::path::Path`, operating on OS-native path strings so
+separator and root handling are correct on every platform. Justified by
+criterion 1 (and supplies the `parent`/`ancestors` primitives root-finding
+needs); deliberately pure and side-effect-free.
+
+| Function | Returns | Rust analogue |
+|---|---|---|
+| `path.is_absolute(p)` | `boolean` | `Path::is_absolute` |
+| `path.is_relative(p)` | `boolean` | `Path::is_relative` |
+| `path.parent(p)` | `string \| nil` | `Path::parent` |
+| `path.ancestors(p)` | `string[]` (self first → root last) | `Path::ancestors` |
+| `path.file_name(p)` | `string \| nil` | `Path::file_name` |
+| `path.file_stem(p)` | `string \| nil` | `Path::file_stem` |
+| `path.file_prefix(p)` | `string \| nil` | `Path::file_prefix` |
+| `path.extension(p)` | `string \| nil` | `Path::extension` |
+| `path.join(base, ...)` | `string` | `Path::join` (variadic for convenience) |
+
+`nil`-returning cases mirror Rust exactly: `parent("/")` → `nil`,
+`extension("README")` → `nil`, etc.
+
+#### `kakehashi.fs` — read-only host filesystem (criteria 2 and 3)
+
+The sandbox removes `io`/`os`, so content-dependent decisions (does
+`deno.json` exist? what is in `package.json`?) require explicit, **read-only**
+accessors. Root finding lives here too: it is fundamentally an upward walk of
+the filesystem, so it belongs with the other impure disk operations rather than
+in the pure `path` module.
+
+| Function | Returns |
+|---|---|
+| `fs.exists(p)` | `boolean` |
+| `fs.is_file(p)` | `boolean` |
+| `fs.is_dir(p)` | `boolean` |
+| `fs.read_to_string(p)` | `string \| nil` (nil on missing / unreadable / non-UTF-8) |
+| `fs.find_ancestor(start, markers)` | `string \| nil` (the matching ancestor directory) |
+
+`fs.find_ancestor` is a **general upward-search primitive**, not a
+workspace-specific function — finding a project root is just one use. It reuses
+`src/lsp/bridge/root_markers.rs` (criterion 3) rather than having every caller
+reimplement the walk:
+
+- `start`: a path (file or directory). Search begins at the file's directory
+  (Neovim `vim.fs.root` semantics) and walks upward.
+- `markers`: `(string | string[])[]` — a nested array is an equal-priority
+  group. This is the **same shape** as `workspaceMarkers`, but the function
+  does not assume the result is a workspace. (The resolver's return no longer
+  accepts raw markers; it calls this function instead — see workspace-resolver.)
+- Returns the first **ancestor directory** containing a marker, or `nil`.
+
+It pairs with the pure `path.ancestors`: `fs.find_ancestor(start, markers)` is
+"the first directory in `path.ancestors(start)` that contains a marker." Named
+for what it returns (an ancestor directory) and the mechanism, **not** for the
+workspace use case — `find_workspace`/`find_root` would over-narrow a reusable
+primitive to one consumer. A resolver can combine it with content checks
+imperatively — e.g. find the `package.json` directory, then branch on whether
+`deno.json` sits beside it.
+
+No writes, no spawning. Reads and walks are **point-in-time**, consistent with
+the evaluate-once-at-didOpen cache contract in workspace-resolver: a later
+change to a file the resolver read does not re-trigger resolution.
+
+#### `kakehashi.env` — ambient process environment (criterion 2)
+
+Mirrors `std::env`. Initially one function:
+
+| Function | Returns |
+|---|---|
+| `env.current_dir()` | `string` — the process working directory, wrapping `std::env::current_dir()` (`getcwd(2)`) |
+
+`env.current_dir()` subsumes the `workspaceFallback`/`"$PWD"` idea deferred in
+workspace-resolver: a resolver can simply `return true, kakehashi.env.current_dir()` as
+its own fallback, so no separate declarative key is needed. Grouping it under
+`env` (rather than a bare `kakehashi.current_dir()`) keeps `kakehashi.*` submodule-only
+and gives the deferred env-var reads (`env.var("DENO_DIR")`) a natural home —
+exactly the `current_dir`/`var` pairing `std::env` itself uses.
+
+`env.current_dir()` cannot be replaced by `os.getenv("PWD")`: `os` is stripped from the sandbox,
+and even unsandboxed `$PWD` is an unreliable proxy — a shell convention that may
+be unset when the server is exec'd directly, is not updated by `chdir()` (so it
+can be stale), and does not exist on Windows. `getcwd(2)` is the correct,
+cross-platform source.
+
+#### `kakehashi.log.{debug,info,warn,error}(msg)` — diagnostics
+
+Because the resolver fails closed (a Lua error or timeout silently does not
+attach, per workspace-resolver), authors need a way to see why. These route to
+the server log. Included as the one concession to debuggability; not for
+control flow.
+
+### Paths, not URIs, at the Lua boundary
+
+`document_info.uri` is a `file://` URI, but the host API speaks **OS paths**.
+To keep resolvers in path-space and avoid a URI module:
+
+- `document_info.path` is exposed (lazily, via the same metatable as `text`) as
+  the already-decoded OS path of the document.
+- The resolver's **string workspace return is interpreted as a filesystem
+  path**; kakehashi converts it to a `file://` `WorkspaceFolder` URI at the
+  boundary — the same conversion marker resolution already performs. This
+  pins down the otherwise-ambiguous "folder" string in workspace-resolver.
+
+Percent-decoding and `file://` handling thus happen once, in Rust, not in every
+resolver.
+
+## Considered Options
+
+- **A `kakehashi.uri` module (`to_path`/`from_path`).** Rejected for the
+  initial surface: exposing `document_info.path` and accepting path returns
+  moves all URI↔path conversion to the kakehashi boundary, so typical resolvers
+  never touch URIs. Revisit only if a resolver must synthesize sibling URIs
+  directly.
+
+- **No path module; rely on Lua `string`.** Rejected. `string.match` can fake
+  `parent`/`extension`, but gets platform separators, trailing slashes, and
+  root edge cases wrong, and `ancestors` (the root-finding workhorse) is fiddly
+  to write correctly. Matching `std::path` semantics once, in Rust, is worth
+  the thin wrapper.
+
+- **Folding `fs` (and `find_ancestor`) into `path`.** Rejected. The split is
+  on purity, not topic: `path.*` is pure and side-effect-free, which makes it
+  independently testable and lets a reader assume `path.X` never touches the
+  disk. Mixing in `exists`/`read_to_string`/`find_ancestor` would destroy that
+  invariant. `find_root` *was* merged — but into `fs` as `fs.find_ancestor`,
+  because it is a filesystem walk, not a string operation.
+
+- **`os.getenv("PWD")` instead of `kakehashi.env.current_dir()`.** Rejected — see the
+  env section: `os` is stripped from the sandbox, and `$PWD` is an unreliable,
+  non-portable proxy for `getcwd(2)`.
+
+- **`kakehashi.uv.cwd()` (mirroring Neovim's `vim.uv`).** Rejected. `vim.uv` is
+  a libuv binding; naming a module `uv` promises the libuv surface
+  (timers, spawn, tcp, fs_event) that the sandbox deliberately withholds, and
+  it breaks from this API's Rust-`std` naming language (`path`/`fs`/`env`).
+  `cwd` lives where Rust itself puts it — `std::env::current_dir` →
+  `kakehashi.env.current_dir()`.
+
+- **Bare `kakehashi.current_dir()` (top-level function).** Rejected in favor of
+  `kakehashi.env.current_dir()`: keeping `kakehashi.*` submodule-only avoids a grab-bag
+  of loose functions and gives env-var reads a home next to `current_dir`.
+
+- **Naming the walk `find_workspace` / `find_marker` / `find_root`.** Rejected
+  for `find_ancestor`. The function is a general upward-search primitive that
+  returns an ancestor *directory*; finding a workspace root is one use, not its
+  definition. `find_workspace`/`find_root` over-narrow it to a single consumer,
+  and `find_marker` misreads as returning the marker. `find_ancestor` names the
+  return type and pairs with `path.ancestors`.
+
+- **Writable `fs` / `os.execute` / env-var reads.** Rejected for now. Read-only
+  fs covers the known use cases; writes and subprocess spawning enlarge the
+  attack and nondeterminism surface against the timeout/cache model. General
+  env-var access (`kakehashi.env.var(...)`, e.g. `DENO_DIR`) is plausible future
+  work — the `env` module already exists for `current_dir`, so promoting it is a small
+  addition — but is deferred under the minimal-surface principle.
+
+- **Leaving the Lua stdlib intact (`io`/`os` available).** Rejected. It would
+  make resolvers nondeterministic, unsandboxed, and able to block or escape the
+  worker-thread model. All host access must be explicit and gated.
+
+## Consequences
+
+### Positive
+
+- Small, principled surface; the inclusion criteria give a clear test for
+  future additions.
+- Resolvers stay in path-space; URI handling is centralized and correct.
+- `fs.find_ancestor` reuse means one upward-search implementation shared by
+  markers, resolvers, and any future caller.
+- Two modules split on purity (`path` pure, `fs` impure) — fewer to learn, and
+  `path.*` stays a side-effect-free, independently testable layer.
+- `kakehashi.env.current_dir()` retires the deferred `workspaceFallback` cleanly.
+- `kakehashi.*` is submodule-only and each submodule mirrors a Rust `std`
+  module (`path`/`fs`/`env`), so there is one naming language and no bare
+  top-level functions to accrete.
+
+### Negative
+
+- Every host capability a resolver needs must be anticipated and wrapped; an
+  unforeseen need means a new ADR-gated API rather than reaching for Lua stdlib.
+- Read-only fs reads make resolution disk-dependent (already true of marker
+  checking); combined with evaluate-once caching, stale on-disk state is not
+  re-observed until re-attach.
+
+### Neutral
+
+- The `kakehashi.*` namespace is introduced for workspace resolving but is
+  designed to host future Lua-extensible features under the same criteria.
+- `path.*` is pure and could be unit-tested independently of the resolver.
+
+## Decision–Implementation Gap
+
+Not yet implemented. No Lua VM dependency exists yet (only `lua-pattern`), so
+the sandbox, the `kakehashi.*` modules, `document_info.path`, and the
+path-return conversion are all unbuilt. This ADR fixes the intended surface
+ahead of that work.
+
+## Related Decisions
+
+- [workspace-resolver](workspace-resolver.md): the consumer of this API; defines the resolver signature, sandbox/timeout execution model, and cache contract this surface assumes.

--- a/docs/architecture-decisions/lua-host-api.md
+++ b/docs/architecture-decisions/lua-host-api.md
@@ -118,8 +118,10 @@ workspace-specific function — finding a project root is just one use. It reuse
 reimplement the walk:
 
 - `start`: a path. The search's **base directory** is `start` itself when it is
-  a directory, or `start`'s parent when it is a file (Neovim `vim.fs.root`
-  semantics). The walk checks the base directory **and** each ancestor.
+  an existing directory, or `start`'s parent otherwise — including when `start`
+  does **not** exist (e.g. an unsaved/new document path), which is treated as a
+  file path, matching `find_marker_root`. The walk checks the base directory
+  **and** each ancestor.
 - `markers`: `(string | string[])[]` — a nested array is an equal-priority
   group. This is the **same shape** as `workspaceMarkers`, but the function
   does not assume the result is a workspace. (The resolver's return no longer
@@ -130,9 +132,11 @@ reimplement the walk:
 > **Implementation note:** the reused `root_markers.rs::find_marker_root` takes
 > a *document file* and starts at `parent().ancestors()`, so it never inspects
 > the passed path itself. Generalizing it to `fs.find_ancestor` must check the
-> base directory when `start` is a directory — otherwise a marker sitting *in*
-> a directory `start` (e.g. `find_ancestor(kakehashi.env.current_dir(), …)`)
-> is missed.
+> base directory when `start` is an existing directory — otherwise a marker
+> sitting *in* a directory `start` (e.g.
+> `find_ancestor(kakehashi.env.current_dir(), …)`) is missed. The file-vs-dir
+> test reads filesystem metadata; a nonexistent `start` skips the probe and is
+> treated as a file path (base = parent).
 
 Named for what it returns (a directory among the base + ancestors) and the
 mechanism, **not** for the workspace use case — `find_workspace`/`find_root`
@@ -186,6 +190,24 @@ To keep resolvers in path-space and avoid a URI module:
 
 Percent-decoding and `file://` handling thus happen once, in Rust, not in every
 resolver.
+
+#### Path encoding contract
+
+Lua strings are arbitrary **byte** strings, but Rust `Path`/`OsStr` are not
+universally byte-representable, so the boundary needs a defined encoding:
+
+- **Unix:** an `OsStr` path *is* bytes, so paths cross the boundary losslessly
+  as raw byte strings — including non-UTF-8 paths (which Lua holds fine, though
+  `string.*` pattern functions may behave oddly on them).
+- **Windows:** paths are UTF-16 and are passed as UTF-8 (WTF-8). A path that is
+  not representable (an unpaired surrogate) **fails closed** — the host function
+  returns `nil`/error rather than handing back a lossy, non-round-trippable
+  string. Callers that pass a path string back to `kakehashi.fs`/`path` get
+  byte-for-byte the value they received, so round-tripping holds for every path
+  that crossed the boundary in the first place.
+
+This is a recorded contract, not yet implemented; the exact Windows policy is
+an open question (see workspace-resolver Open Questions).
 
 ## Considered Options
 

--- a/docs/architecture-decisions/lua-host-api.md
+++ b/docs/architecture-decisions/lua-host-api.md
@@ -186,7 +186,10 @@ To keep resolvers in path-space and avoid a URI module:
 - The resolver's **string workspace return is interpreted as a filesystem
   path**; kakehashi converts it to a `file://` `WorkspaceFolder` URI at the
   boundary — the same conversion marker resolution already performs. This
-  pins down the otherwise-ambiguous "folder" string in workspace-resolver.
+  pins down the otherwise-ambiguous "folder" string in workspace-resolver. As a
+  Lua→host path input it obeys the **same decoding rule** below as `path.*`/`fs.*`
+  arguments: on Windows an invalid-UTF-8 return raises a boundary error and
+  triggers §6 fail-closed.
 
 Percent-decoding and `file://` handling thus happen once, in Rust, not in every
 resolver.
@@ -214,9 +217,10 @@ Failure shape depends on **direction**, because the declared return types differ
   surfaces this failure, because workspace-resolver §2 **skips the resolver
   entirely** for a document whose path is not representable. So inside a running
   resolver `document_info.path` is always valid.
-- **Lua → host (a Lua byte-string path argument).** *Every* path consumer —
-  all `path.*` and all `fs.*` — must decode the argument into an OS `Path` to
-  apply `std::path` semantics, so they share one validation rule: on Unix any
+- **Lua → host (a Lua byte-string path argument).** *Every* path that crosses
+  back to the host — all `path.*` and `fs.*` arguments **and the resolver's
+  string workspace return** — must decode into an OS `Path` to apply `std::path`
+  semantics, so they share one validation rule: on Unix any
   byte string is a valid path (infallible); on **Windows** the argument must be
   valid UTF-8, and a fabricated non-UTF-8 string raises a **Lua error**. The
   error is out-of-band, so declared return types are unchanged — `path.*` stay

--- a/docs/architecture-decisions/lua-host-api.md
+++ b/docs/architecture-decisions/lua-host-api.md
@@ -194,20 +194,23 @@ resolver.
 #### Path encoding contract
 
 Lua strings are arbitrary **byte** strings, but Rust `Path`/`OsStr` are not
-universally byte-representable, so the boundary needs a defined encoding:
+universally byte-representable, so the boundary needs **one** defined encoding:
 
 - **Unix:** an `OsStr` path *is* bytes, so paths cross the boundary losslessly
   as raw byte strings — including non-UTF-8 paths (which Lua holds fine, though
   `string.*` pattern functions may behave oddly on them).
-- **Windows:** paths are UTF-16 and are passed as UTF-8 (WTF-8). A path that is
-  not representable (an unpaired surrogate) **fails closed** — the host function
-  returns `nil`/error rather than handing back a lossy, non-round-trippable
-  string. Callers that pass a path string back to `kakehashi.fs`/`path` get
-  byte-for-byte the value they received, so round-tripping holds for every path
-  that crossed the boundary in the first place.
+- **Windows:** paths are **strict UTF-8** (not WTF-8). A Windows path containing
+  unpaired UTF-16 surrogates is therefore **not representable and fails
+  closed** — we deliberately do *not* adopt WTF-8's lossless surrogate encoding,
+  trading exotic-path support for a single, simple, round-trippable string type
+  that Lua `string.*` can operate on.
 
-This is a recorded contract, not yet implemented; the exact Windows policy is
-an open question (see workspace-resolver Open Questions).
+Failure shape is uniform: a path that cannot be represented yields the same
+result as an unreadable/missing path — host **functions** (`fs.*`, `path.*`)
+return `nil`; the **`document_info.path` field** yields `nil`, and a resolver
+that needs the path should treat `nil` as "skip / fall back to
+`workspaceMarkers`" (the same bucket as non-`file://` documents). Not yet
+implemented; the Windows surrogate edge is recorded as an open question.
 
 ## Considered Options
 

--- a/docs/architecture-decisions/lua-host-api.md
+++ b/docs/architecture-decisions/lua-host-api.md
@@ -12,8 +12,11 @@ Two boundaries shape what kakehashi must provide:
 1. **The resolver runs in a restricted sandbox.** For determinism, safety, and
    the worker-thread/timeout execution model (see workspace-resolver), the Lua
    environment is stripped: `string`, `table`, `math` stay; `io`, `os`,
-   `package`, `require`, `load`/`loadstring`, `dofile`, and FFI are removed.
-   So *any* host access — filesystem, working directory — must be an explicit
+   `package`, `require`, `load`/`loadstring`, `dofile`, `debug`, and FFI are
+   removed (also `string.dump`; `collectgarbage` left read-only or removed).
+   `debug` is on the list deliberately — `debug.getupvalue`/`setupvalue`/
+   `sethook`/`getregistry` are introspection and sandbox-escape vectors. So
+   *any* host access — filesystem, working directory — must be an explicit
    kakehashi-provided function, not Lua's stdlib.
 
 2. **Lua's `string` library is already powerful.** Splitting, matching, and
@@ -49,7 +52,10 @@ each submodule mirrors a Rust `std` module, keeping one naming language:
   including the `find_ancestor` walk.
 - `kakehashi.env` ← `std::env` — **impure**: ambient process environment
   (`current_dir`; env-var reads if later promoted from deferred).
-- `kakehashi.log` — diagnostics output.
+- `kakehashi.log` — diagnostics output. The one deliberate exception to the
+  std-mirror rule: there is no `std::log` (logging is the `log` crate's
+  facade), but a sanctioned output channel is needed since `print`/`io` are
+  stripped.
 
 The `path`/`fs` divide is the **purity line**, which keeps "any `path.X` is
 side-effect-free" a guarantee a reader can rely on.
@@ -79,7 +85,11 @@ needs); deliberately pure and side-effect-free.
 | `path.join(base, ...)` | `string` | `Path::join` (variadic for convenience) |
 
 `nil`-returning cases mirror Rust exactly: `parent("/")` → `nil`,
-`extension("README")` → `nil`, etc.
+`extension("README")` → `nil`, etc. All wrapped methods are stable since Rust
+1.0 (`ancestors` since 1.28) **except `Path::file_prefix`, stabilized in 1.91**
+— including it sets an implicit MSRV floor of 1.91. The project currently pins
+no MSRV and builds on ≥1.95, so this is a recorded caveat, not a blocker; drop
+`file_prefix` (it overlaps `file_stem`) if an older toolchain must be supported.
 
 #### `kakehashi.fs` — read-only host filesystem (criteria 2 and 3)
 
@@ -94,29 +104,41 @@ in the pure `path` module.
 | `fs.exists(p)` | `boolean` |
 | `fs.is_file(p)` | `boolean` |
 | `fs.is_dir(p)` | `boolean` |
-| `fs.read_to_string(p)` | `string \| nil` (nil on missing / unreadable / non-UTF-8) |
-| `fs.find_ancestor(start, markers)` | `string \| nil` (the matching ancestor directory) |
+| `fs.read_to_string(p)` | `string \| nil` (nil on missing / unreadable / non-UTF-8 / over size cap) |
+| `fs.find_ancestor(start, markers)` | `string \| nil` (the matching directory) |
+
+`fs.read_to_string` is **size-capped**: the workspace-resolver in-VM timeout
+hook cannot interrupt a host read, so an unbounded read of a huge file could
+block the worker thread or OOM. Over the cap it returns `nil` (treated like
+unreadable). The cap value is an open question (see workspace-resolver).
 
 `fs.find_ancestor` is a **general upward-search primitive**, not a
 workspace-specific function — finding a project root is just one use. It reuses
 `src/lsp/bridge/root_markers.rs` (criterion 3) rather than having every caller
 reimplement the walk:
 
-- `start`: a path (file or directory). Search begins at the file's directory
-  (Neovim `vim.fs.root` semantics) and walks upward.
+- `start`: a path. The search's **base directory** is `start` itself when it is
+  a directory, or `start`'s parent when it is a file (Neovim `vim.fs.root`
+  semantics). The walk checks the base directory **and** each ancestor.
 - `markers`: `(string | string[])[]` — a nested array is an equal-priority
   group. This is the **same shape** as `workspaceMarkers`, but the function
   does not assume the result is a workspace. (The resolver's return no longer
   accepts raw markers; it calls this function instead — see workspace-resolver.)
-- Returns the first **ancestor directory** containing a marker, or `nil`.
+- Returns the first directory (base, then ancestors) containing a marker, or
+  `nil`.
 
-It pairs with the pure `path.ancestors`: `fs.find_ancestor(start, markers)` is
-"the first directory in `path.ancestors(start)` that contains a marker." Named
-for what it returns (an ancestor directory) and the mechanism, **not** for the
-workspace use case — `find_workspace`/`find_root` would over-narrow a reusable
-primitive to one consumer. A resolver can combine it with content checks
-imperatively — e.g. find the `package.json` directory, then branch on whether
-`deno.json` sits beside it.
+> **Implementation note:** the reused `root_markers.rs::find_marker_root` takes
+> a *document file* and starts at `parent().ancestors()`, so it never inspects
+> the passed path itself. Generalizing it to `fs.find_ancestor` must check the
+> base directory when `start` is a directory — otherwise a marker sitting *in*
+> a directory `start` (e.g. `find_ancestor(kakehashi.env.current_dir(), …)`)
+> is missed.
+
+Named for what it returns (a directory among the base + ancestors) and the
+mechanism, **not** for the workspace use case — `find_workspace`/`find_root`
+would over-narrow a reusable primitive to one consumer. A resolver can combine
+it with content checks imperatively — e.g. find the `package.json` directory,
+then branch on whether `deno.json` sits beside it.
 
 No writes, no spawning. Reads and walks are **point-in-time**, consistent with
 the evaluate-once-at-didOpen cache contract in workspace-resolver: a later
@@ -232,8 +254,8 @@ resolver.
   `path.*` stays a side-effect-free, independently testable layer.
 - `kakehashi.env.current_dir()` retires the deferred `workspaceFallback` cleanly.
 - `kakehashi.*` is submodule-only and each submodule mirrors a Rust `std`
-  module (`path`/`fs`/`env`), so there is one naming language and no bare
-  top-level functions to accrete.
+  module (`path`/`fs`/`env`; `log` is the one documented exception), so there
+  is one naming language and no bare top-level functions to accrete.
 
 ### Negative
 

--- a/docs/architecture-decisions/workspace-resolver.md
+++ b/docs/architecture-decisions/workspace-resolver.md
@@ -46,13 +46,13 @@ workspaceMarkers = [ ".git" ]            # used only when workspaceResolver is u
 workspaceResolver = """
 ---@param server_info { name: string, config: table }
 ---@param document_info { uri: string, language_id: string, text: string } -- fields resolved lazily via metatable
----@return boolean, nil | string | (string | string[])[]
+---@return boolean, nil | string
 --- first return  — attach? if false, do not attach this document to this server.
---- second return — workspace (ignored when first is false):
----   nil:                       attach without adding a workspace folder.
----   string:                    attach with the given folder; add it if missing.
----   (string | string[])[]:     treat as workspace markers; resolve a folder via
----                              the same path as workspaceMarkers; add if missing.
+--- second return — workspace folder, a filesystem path (ignored when first is false):
+---   nil:    attach without adding a workspace folder.
+---   string: attach with the given folder; add it if missing.
+--- To resolve a folder from markers, call kakehashi.fs.find_ancestor and return
+--- its result, e.g. `return true, kakehashi.fs.find_ancestor(document_info.path, {"deno.json"})`.
 return function(server_info, document_info)
     ...
 end
@@ -72,8 +72,12 @@ Key properties:
   reads them.
 - **`workspaceMarkers` is the fallback**, used only when `workspaceResolver` is
   unset. They are not layered; a configured resolver fully governs the decision.
-- The marker-array return form **joins the existing `root_markers.rs`
-  resolution path** — there is one folder-from-markers implementation, reused.
+- **The second return is always a filesystem path (or nil)** — never raw
+  markers. A resolver that wants marker-based resolution calls
+  `kakehashi.fs.find_ancestor` itself (see lua-host-api), so there is one
+  folder-from-markers entry point (`root_markers.rs`), reached either by the
+  `workspaceMarkers` fallback or by an explicit `find_ancestor` call — not by a
+  second, return-value-shaped path.
 
 ### 3. Execution model: synchronous return-style on a worker thread
 
@@ -140,6 +144,15 @@ silently misroute, nor tie up a worker thread indefinitely.
   Rejected for the explicit 2-tuple `(attach, workspace)`: four return shapes
   on one value are error-prone to author in Lua.
 
+- **Marker-array second return (`(string | string[])[]`).** The 2-tuple's
+  workspace slot once also accepted raw markers, which kakehashi would resolve
+  via `root_markers.rs`. Dropped once `kakehashi.fs.find_ancestor` exposed that
+  same resolution to Lua: the return form was a redundant second entry point to
+  one implementation. Folding it away makes the second return uniformly a path
+  (or nil), simplifies the boundary, and lets the resolver author control the
+  no-marker-found fallback explicitly instead of relying on an implicit
+  kakehashi rule.
+
 - **`event: "initialize" | "didOpen"` parameter.** Considered so the resolver
   could branch on spawn vs. attach. Rejected: in the file-first model both
   carry a document, and folding the spawn/attach distinction into kakehashi's
@@ -192,6 +205,7 @@ Not yet implemented. As of this record:
 
 ## Related Decisions
 
+- [lua-host-api](lua-host-api.md): the `kakehashi.*` Lua functions the resolver calls (`path`, `fs` incl. `find_ancestor`, `env.current_dir`) and the path-vs-URI boundary.
 - [language-server-bridge](language-server-bridge.md): the bridge this resolver feeds.
 - [ls-bridge-server-pool-coordination](ls-bridge-server-pool-coordination.md): pool keys and spawn-time workspace seeding the resolver result must integrate with.
 - [wildcard-config-inheritance](wildcard-config-inheritance.md): how `languageServers._` defaults (including `workspaceMarkers`/`workspaceResolver`) are inherited.

--- a/docs/architecture-decisions/workspace-resolver.md
+++ b/docs/architecture-decisions/workspace-resolver.md
@@ -1,0 +1,197 @@
+# Workspace Resolver
+
+## Context
+
+A bridged language server needs a workspace root to base its `rootUri`/
+`workspaceFolders` on at initialization. Today this is decided statically by
+`languageServers.<name>.rootMarkers` (see `src/config/settings.rs`, default
+`[".git"]` in `src/config/defaults.rs`), resolved upward from the document path
+by `src/lsp/bridge/root_markers.rs`.
+
+Two forces push beyond static markers:
+
+1. **Naming drift from the LSP spec.** The spec deprecated `rootUri`/`rootPath`
+   in favor of `workspaceFolders`. `rootMarkers` (a name inherited from
+   Neovim's `vim.fs.root`) reads as the deprecated vocabulary.
+
+2. **Static markers cannot make content-dependent decisions.** For
+   ecosystems like Deno vs. Node (`deno`/`tsserver`/`tsgo`), *which* server to
+   attach — and *whether* to attach at all — can depend on more than the
+   presence of a marker file: it may require inspecting the document text or
+   running custom logic (e.g. "`package.json` present but no `deno.json`").
+   Markers alone, even with priority groups, cannot express this.
+
+kakehashi is **file-first**: bridged servers are spawned on demand when a
+document that needs them is opened. There is no document-less activation path —
+every workspace decision happens with a concrete triggering document in hand.
+
+## Decision
+
+### 1. Rename `rootMarkers` → `workspaceMarkers`
+
+Adopt `workspaceMarkers` as the configuration key, aligning vocabulary with the
+LSP spec's `workspaceFolders`. `rootMarkers` remains a **deprecated serde
+alias** (`#[serde(alias = "rootMarkers")]`) for backward compatibility. The
+default is unchanged: `[".git"]`. Resolution semantics (upward search, nested
+arrays = equal-priority groups) are unchanged.
+
+### 2. Introduce `workspaceResolver` — a Lua pure function
+
+A new optional key holds a Lua function that dynamically decides both **whether
+to attach** and **what workspace** to use:
+
+```toml
+[languageServers.<serverName>]
+workspaceMarkers = [ ".git" ]            # used only when workspaceResolver is unset
+workspaceResolver = """
+---@param server_info { name: string, config: table }
+---@param document_info { uri: string, language_id: string, text: string } -- fields resolved lazily via metatable
+---@return boolean, nil | string | (string | string[])[]
+--- first return  — attach? if false, do not attach this document to this server.
+--- second return — workspace (ignored when first is false):
+---   nil:                       attach without adding a workspace folder.
+---   string:                    attach with the given folder; add it if missing.
+---   (string | string[])[]:     treat as workspace markers; resolve a folder via
+---                              the same path as workspaceMarkers; add if missing.
+return function(server_info, document_info)
+    ...
+end
+"""
+```
+
+Key properties:
+
+- **Pure function `(server_info, document_info) -> (attach, workspace)`.** No
+  `event` parameter. The resolver does not know — and must not care — whether
+  this document is spawning the server or attaching to a running one; it is
+  expected to be **idempotent** for a given `document_info`. kakehashi decides
+  how to apply the result from the server's current state (below).
+- **`document_info` is always present** (file-first model), so it is
+  non-optional. Its fields — including `text` — are materialized **lazily via a
+  metatable** to avoid copying large documents into Lua when the resolver never
+  reads them.
+- **`workspaceMarkers` is the fallback**, used only when `workspaceResolver` is
+  unset. They are not layered; a configured resolver fully governs the decision.
+- The marker-array return form **joins the existing `root_markers.rs`
+  resolution path** — there is one folder-from-markers implementation, reused.
+
+### 3. Execution model: synchronous return-style on a worker thread
+
+The resolver runs **synchronously** (return-style, not continuation-passing) on
+a blocking worker thread (`spawn_blocking` or a dedicated thread), off the tokio
+runtime, guarded by a **timeout**.
+
+- A blocking resolver therefore cannot stall the LSP event loop — the
+  async-friendliness is achieved at the Rust↔Lua boundary, not inside Lua.
+- The `text` snapshot is **owned in Rust** (`Arc<str>` or equivalent) before
+  entering Lua; the metatable only defers *materialization into Lua*, never
+  performs async I/O. A metatable `__index` must not await.
+
+### 4. Veto and wiring
+
+- **Veto (`attach = false`)** is applied as a filter **after** the
+  language-based server selection in `src/lsp/bridge/coordinator.rs` (the
+  `c.languages.iter().any(...)` filters). Language match first, resolver
+  refinement second.
+- **Result application is inferred from server state**, not signaled by the
+  resolver:
+  - Server not yet running, this document triggers the spawn → resolved
+    workspace **seeds `InitializeParams`** (`src/lsp/bridge/protocol/lifecycle.rs`
+    `build_initialize_request`), overriding the marker input at
+    `src/lsp/bridge/pool.rs` (`workspace_from_marker`).
+  - Server already running, a new document arrives → a returned folder is added
+    via `workspace/didChangeWorkspaceFolders` (the `WorkspaceFolderSet` in
+    `pool.rs`).
+
+### 5. Cache contract
+
+The resolver is evaluated **once, at didOpen attach time**, and the resolved
+workspace is fixed to the connection-pool key. It is **not re-evaluated on
+didChange** — server routing does not change mid-edit. This bounds resolver
+cost to O(documents attached), not O(edits), despite the resolver depending on
+document text.
+
+### 6. Error policy
+
+A Lua error **or** a timeout overrun is treated as **fail-closed**: do not
+attach the document to that server, and log. A broken or slow resolver must not
+silently misroute, nor tie up a worker thread indefinitely.
+
+## Considered Options
+
+- **Pure declarative extensions (negative markers / `requireWorkspace`).**
+  Rejected as the sole mechanism: it can express "`package.json` but not
+  `deno.json`" but cannot inspect document *content*, which is a stated
+  requirement. `workspaceMarkers` is retained as the declarative common case;
+  the resolver is the escape hatch for what declarations cannot express.
+
+- **Continuation-passing `on_dir(root_dir)` callback (Neovim's `root_dir`
+  form).** Neovim uses CPS because its Lua runs on the editor's single-threaded
+  main loop, where blocking freezes the UI; calling `on_dir` later lets the
+  resolver do async work, and *not* calling it doubles as the skip signal.
+  kakehashi has neither constraint: Lua runs on a worker thread, so a
+  synchronous resolver does not block the event loop, and an explicit
+  `attach = false` is a safer veto than Neovim's "forgot to call `on_dir` →
+  silent no-attach" footgun. The single lesson imported from Neovim is the
+  **timeout**, not the callback shape.
+
+- **Single overloaded return (`false | nil | string | table`).** An earlier
+  shape folded attach-or-not and the workspace value into one return.
+  Rejected for the explicit 2-tuple `(attach, workspace)`: four return shapes
+  on one value are error-prone to author in Lua.
+
+- **`event: "initialize" | "didOpen"` parameter.** Considered so the resolver
+  could branch on spawn vs. attach. Rejected: in the file-first model both
+  carry a document, and folding the spawn/attach distinction into kakehashi's
+  state (rather than the resolver's logic) keeps the resolver a pure,
+  idempotent function and removes a state-management responsibility from
+  resolver authors.
+
+- **`workspaceFallback` (e.g. `"$PWD"`) when neither markers nor resolver
+  resolve.** Deferred — not part of this decision. A resolver can already
+  return a literal string for the same effect; revisit only if a purely
+  declarative fallback proves needed.
+
+## Consequences
+
+### Positive
+
+- Vocabulary aligns with the LSP spec (`workspaceFolders`), with a no-break
+  deprecation alias.
+- Content-dependent server selection (Deno vs. Node/tsgo) becomes expressible.
+- The resolver is a pure, idempotent function; spawn-vs-attach routing stays in
+  kakehashi, not in user Lua.
+- One folder-from-markers implementation, shared by markers and resolver.
+
+### Negative
+
+- **Introduces a Lua VM as a new dependency** (e.g. `mlua`). Today only
+  `lua-pattern` (Lua-pattern→regex) is present; there is no general Lua
+  runtime. This changes the nature of config from purely declarative data to
+  embedded executable code, with the attendant sandboxing, sync/async-boundary,
+  and timeout machinery.
+- Resolver correctness depends on author discipline (idempotence) that the type
+  signature cannot enforce.
+
+### Neutral
+
+- Resolver evaluation is off the request hot path (attach time only) and capped
+  by timeout, so it does not affect semantic-token or diagnostic latency.
+- `workspaceResolver` and `workspaceMarkers` are either/or per server, not
+  layered.
+
+## Decision–Implementation Gap
+
+Not yet implemented. As of this record:
+
+- The config key is still `rootMarkers`; the rename and `#[serde(alias)]` are
+  pending.
+- No Lua VM dependency is present; `workspaceResolver` evaluation, the lazy
+  `document_info` metatable, the worker-thread/timeout harness, the
+  coordinator-level veto, and the cache contract are all unbuilt.
+
+## Related Decisions
+
+- [language-server-bridge](language-server-bridge.md): the bridge this resolver feeds.
+- [ls-bridge-server-pool-coordination](ls-bridge-server-pool-coordination.md): pool keys and spawn-time workspace seeding the resolver result must integrate with.
+- [wildcard-config-inheritance](wildcard-config-inheritance.md): how `languageServers._` defaults (including `workspaceMarkers`/`workspaceResolver`) are inherited.

--- a/docs/architecture-decisions/workspace-resolver.md
+++ b/docs/architecture-decisions/workspace-resolver.md
@@ -125,8 +125,8 @@ async-friendliness is achieved at the Rust↔Lua boundary, not inside Lua.
     `workspace_from_marker` (defined in `root_markers.rs`, called from `pool.rs`)
     would otherwise supply.
   - Server already running, a new document arrives → a returned folder is added
-    via `workspace/didChangeWorkspaceFolders` (the `WorkspaceFolderSet` in
-    `pool.rs`). **Precondition:** this only reaches a server that advertised
+    via `workspace/didChangeWorkspaceFolders` (the `WorkspaceFolderSet`, defined
+    in `workspace/folder_set.rs` and driven from `pool.rs`). **Precondition:** this only reaches a server that advertised
     `workspace.workspaceFolders.changeNotifications` (or dynamically registered
     it); the implementation already gates on `supports_workspace_folder_changes`,
     so for a non-supporting running server a resolver's returned folder is

--- a/docs/architecture-decisions/workspace-resolver.md
+++ b/docs/architecture-decisions/workspace-resolver.md
@@ -102,10 +102,11 @@ async-friendliness is achieved at the Rust↔Lua boundary, not inside Lua.
   elapsed time and raises. This bounds Lua-level loops.
   - **Caveat:** an instruction hook cannot interrupt time spent inside a host
     C-call (`kakehashi.fs.find_ancestor`'s filesystem walk, `read_to_string`)
-    or the lazy `document_info` metatable `__index`. Those host operations must
-    carry **their own bounds** (e.g. a capped `read_to_string`, see
-    lua-host-api) — the §6 "must not tie up a worker thread" guarantee depends
-    on both the hook and these host-side limits.
+    or the lazy `document_info` metatable `__index`. Host operations carry their
+    own bounds (a capped `read_to_string`, see lua-host-api) — but those bound
+    *memory*, not *syscall latency*: a synchronous fs call stalled on a hung
+    NFS/FUSE mount is bounded by neither the hook nor a size cap. §6 states the
+    liveness guarantee honestly and points at stuck-worker replacement.
 - The `text` snapshot is **owned in Rust** (`Arc<str>` or equivalent) before
   entering Lua; the metatable only defers *materialization into Lua*, never
   performs async I/O. A metatable `__index` must not await (and, per the caveat,
@@ -117,20 +118,27 @@ async-friendliness is achieved at the Rust↔Lua boundary, not inside Lua.
   language-based server selection in `src/lsp/bridge/coordinator.rs` (the
   `c.languages.iter().any(...)` filters). Language match first, resolver
   refinement second.
-- **Result application is inferred from server state**, not signaled by the
-  resolver:
-  - Server not yet running, this document triggers the spawn → resolved
-    workspace **seeds `InitializeParams`** via `build_initialize_request`
-    (`protocol/lifecycle.rs`), replacing the `marker` argument that
-    `workspace_from_marker` (defined in `root_markers.rs`, called from `pool.rs`)
-    would otherwise supply.
-  - Server already running, a new document arrives → a returned folder is added
-    via `workspace/didChangeWorkspaceFolders` (the `WorkspaceFolderSet`, defined
-    in `workspace/folder_set.rs` and driven from `pool.rs`). **Precondition:** this only reaches a server that advertised
-    `workspace.workspaceFolders.changeNotifications` (or dynamically registered
-    it); the implementation already gates on `supports_workspace_folder_changes`,
-    so for a non-supporting running server a resolver's returned folder is
-    **silently dropped**. See Open Questions.
+- **The resolved workspace replaces the marker in the existing acquire flow**,
+  not signaled separately by the resolver. It is exactly what
+  `resolve_marker_and_key` / `resolve_acquire` (`pool.rs`) would otherwise
+  compute from `workspaceMarkers` via `workspace_from_marker` (defined in
+  `root_markers.rs`); everything downstream is unchanged. The workspace is thus
+  part of the connection's identity, not a late add-on:
+  - **Per-root (default).** `ConnectionKey` is `(server, root)`
+    (`connection_key.rs`), so a distinct resolved workspace is a distinct
+    `Marker(root)` key → its own connection: reused if one already runs for that
+    root, else spawned with the workspace seeding `InitializeParams` via
+    `build_initialize_request` (`protocol/lifecycle.rs`). A `nil` workspace maps
+    to the `ClientFallback` key (attach, no folder).
+  - **Shared instance (`preferSharedInstance`, #391).** Marker-rooted documents
+    join one `Shared` connection via `workspace/didChangeWorkspaceFolders` (the
+    `WorkspaceFolderSet`, defined in `workspace/folder_set.rs`, driven from
+    `pool.rs`). If that shared connection came up **without**
+    `workspace.workspaceFolders.changeNotifications`
+    (`supports_workspace_folder_changes` reads static `InitializeResult`
+    capabilities only — there is no dynamic `client/registerCapability`
+    tracking), `resolve_acquire` **diverts the document to its own per-root
+    process** rather than dropping it.
 
 ### 5. Cache contract
 
@@ -144,9 +152,17 @@ document text.
 
 A Lua error **or** a timeout overrun is treated as **fail-closed**: do not
 attach the document to that server, and log. A broken or slow resolver must not
-silently misroute. "Tie up a worker thread indefinitely" is prevented by the
-in-VM hook **plus** the host-side bounds of §3 — a hook alone cannot stop a
-runaway host call, so both are load-bearing for this guarantee.
+silently misroute.
+
+**Scope of the liveness guarantee, honestly stated.** The in-VM hook bounds
+runaway *Lua compute*; the host-side size cap bounds *memory / read volume*.
+Neither time-bounds a synchronous host **syscall** stalled on a pathological
+filesystem (a hung NFS/FUSE mount can block `find_ancestor`/`read_to_string`
+indefinitely). So "never tie up a worker thread" is **not** an absolute
+in-process guarantee. Defending against arbitrary I/O latency requires
+abandoning and replacing a stuck worker — the dedicated-thread model of §3
+permits this (spawn a replacement, leak the wedged thread), but the policy is
+left to implementation (see Open Questions).
 
 ### 7. Open questions
 
@@ -161,9 +177,11 @@ Deferred to implementation, recorded so they are not lost:
   path. What `document_info.path` (and the path-based host API) yield for
   `untitled:` and other non-`file://` URIs is undefined; likely the resolver
   should be skipped (fall back to `workspaceMarkers`/no folder) for those.
-- **Folder dropped on a non-supporting running server** (§4): whether to fall
-  back (e.g. respawn with the folder, or surface a warning) instead of silently
-  dropping is open.
+- **Stuck-worker recovery** (§3, §6): the policy for abandoning and replacing a
+  worker wedged in a hung filesystem syscall — timeout, replacement, and what to
+  leak — is left open.
+- **Windows path encoding** (see lua-host-api § Path encoding contract): the
+  exact fail-closed policy for paths not representable as UTF-8/WTF-8 is open.
 
 ## Considered Options
 

--- a/docs/architecture-decisions/workspace-resolver.md
+++ b/docs/architecture-decisions/workspace-resolver.md
@@ -50,8 +50,9 @@ workspaceResolver = """
 ---@return boolean, nil | string
 --- first return  — attach? if false, do not attach this document to this server.
 --- second return — workspace folder, a filesystem path (ignored when first is false):
----   nil:    attach without adding a workspace folder.
----   string: attach with the given folder; add it if missing.
+---   nil:    attach using the client-supplied workspace fallback — the upstream
+---           rootUri/workspaceFolders (the ClientFallback root), not "no folder".
+---   string: attach rooted at the given folder (becomes the connection's root).
 --- To resolve a folder from markers, call kakehashi.fs.find_ancestor and return
 --- its result, e.g. `return true, kakehashi.fs.find_ancestor(document_info.path, {"deno.json"})`.
 return function(server_info, document_info)
@@ -129,7 +130,9 @@ async-friendliness is achieved at the Rust↔Lua boundary, not inside Lua.
     `Marker(root)` key → its own connection: reused if one already runs for that
     root, else spawned with the workspace seeding `InitializeParams` via
     `build_initialize_request` (`protocol/lifecycle.rs`). A `nil` workspace maps
-    to the `ClientFallback` key (attach, no folder).
+    to the `ClientFallback` key — which `workspace_from_marker`'s fallback roots
+    at the **upstream client's** `rootUri`/`workspaceFolders`, not at "no
+    folder".
   - **Shared instance (`preferSharedInstance`, #391).** Marker-rooted documents
     join one `Shared` connection via `workspace/didChangeWorkspaceFolders` (the
     `WorkspaceFolderSet`, defined in `workspace/folder_set.rs`, driven from
@@ -180,8 +183,9 @@ Deferred to implementation, recorded so they are not lost:
 - **Stuck-worker recovery** (§3, §6): the policy for abandoning and replacing a
   worker wedged in a hung filesystem syscall — timeout, replacement, and what to
   leak — is left open.
-- **Windows path encoding** (see lua-host-api § Path encoding contract): the
-  exact fail-closed policy for paths not representable as UTF-8/WTF-8 is open.
+- **Windows path encoding** (see lua-host-api § Path encoding contract): paths
+  are strict UTF-8 and unpaired-surrogate paths fail closed; whether that
+  exotic edge ever needs lossless (WTF-8) support is open.
 
 ## Considered Options
 

--- a/docs/architecture-decisions/workspace-resolver.md
+++ b/docs/architecture-decisions/workspace-resolver.md
@@ -74,9 +74,19 @@ Key properties:
 - **`document_info` is always present** (file-first model), so it is
   non-optional. Its fields — including `text` — are materialized **lazily via a
   metatable** to avoid copying large documents into Lua when the resolver never
-  reads them.
+  reads them. `document_info.path` is a plain `string` (never nil) **because**
+  of the skip rule below: a document without a representable filesystem path
+  never reaches a running resolver.
 - **`workspaceMarkers` is the fallback**, used only when `workspaceResolver` is
-  unset. They are not layered; a configured resolver fully governs the decision.
+  unset — with **one exception**: a configured resolver is **skipped** for a
+  document that has no representable filesystem path (a non-`file://` URI, or a
+  `file://` path that fails the encoding contract in lua-host-api). Such a
+  document is resolved exactly as if no `workspaceResolver` were set — via
+  `workspaceMarkers`, which itself falls through to `ClientFallback` when no
+  marker resolves (a non-file URI resolves no marker, so it lands on
+  `ClientFallback`). This skip is distinct from §6 fail-closed: the resolver was
+  not run, so the document still attaches; fail-closed applies only when a
+  resolver that *did* run errors or times out.
 - **The second return is always a filesystem path (or nil)** — never raw
   markers. A resolver that wants marker-based resolution calls
   `kakehashi.fs.find_ancestor` itself (see lua-host-api), so there is one
@@ -176,10 +186,10 @@ Deferred to implementation, recorded so they are not lost:
 - **`read_to_string` size cap.** Per §3 the in-VM hook cannot interrupt a host
   read, so `kakehashi.fs.read_to_string` needs its own large-file bound (see
   lua-host-api); the exact cap is open.
-- **Non-`file://` documents.** The "file-first" framing assumes a filesystem
-  path. What `document_info.path` (and the path-based host API) yield for
-  `untitled:` and other non-`file://` URIs is undefined; likely the resolver
-  should be skipped (fall back to `workspaceMarkers`/no folder) for those.
+- **Non-`file://` documents.** Per §2 these skip the resolver and resolve via
+  `workspaceMarkers` → `ClientFallback`. Open: whether any non-`file://` scheme
+  (e.g. a remote/virtual fs) should instead derive a usable path and run the
+  resolver after all.
 - **Stuck-worker recovery** (§3, §6): the policy for abandoning and replacing a
   worker wedged in a hung filesystem syscall — timeout, replacement, and what to
   leak — is left open.
@@ -257,7 +267,8 @@ Deferred to implementation, recorded so they are not lost:
 - Resolver evaluation is off the request hot path (attach time only) and capped
   by timeout, so it does not affect semantic-token or diagnostic latency.
 - `workspaceResolver` and `workspaceMarkers` are either/or per server, not
-  layered.
+  layered — the one exception being the §2 skip rule (a document with no
+  representable path resolves via `workspaceMarkers`/`ClientFallback`).
 
 ## Decision–Implementation Gap
 

--- a/docs/architecture-decisions/workspace-resolver.md
+++ b/docs/architecture-decisions/workspace-resolver.md
@@ -10,9 +10,10 @@ by `src/lsp/bridge/root_markers.rs`.
 
 Two forces push beyond static markers:
 
-1. **Naming drift from the LSP spec.** The spec deprecated `rootUri`/`rootPath`
-   in favor of `workspaceFolders`. `rootMarkers` (a name inherited from
-   Neovim's `vim.fs.root`) reads as the deprecated vocabulary.
+1. **Naming drift from the LSP spec.** The spec deprecates `rootPath` in favor
+   of `rootUri`, and `rootUri` in favor of `workspaceFolders`. `rootMarkers`
+   (a name inherited from Neovim's `vim.fs.root`) reads as the deprecated
+   vocabulary.
 
 2. **Static markers cannot make content-dependent decisions.** For
    ecosystems like Deno vs. Node (`deno`/`tsserver`/`tsgo`), *which* server to
@@ -35,7 +36,7 @@ alias** (`#[serde(alias = "rootMarkers")]`) for backward compatibility. The
 default is unchanged: `[".git"]`. Resolution semantics (upward search, nested
 arrays = equal-priority groups) are unchanged.
 
-### 2. Introduce `workspaceResolver` — a Lua pure function
+### 2. Introduce `workspaceResolver` — a Lua function
 
 A new optional key holds a Lua function that dynamically decides both **whether
 to attach** and **what workspace** to use:
@@ -45,7 +46,7 @@ to attach** and **what workspace** to use:
 workspaceMarkers = [ ".git" ]            # used only when workspaceResolver is unset
 workspaceResolver = """
 ---@param server_info { name: string, config: table }
----@param document_info { uri: string, language_id: string, text: string } -- fields resolved lazily via metatable
+---@param document_info { uri: string, path: string, language_id: string, text: string } -- fields resolved lazily via metatable
 ---@return boolean, nil | string
 --- first return  — attach? if false, do not attach this document to this server.
 --- second return — workspace folder, a filesystem path (ignored when first is false):
@@ -61,11 +62,14 @@ end
 
 Key properties:
 
-- **Pure function `(server_info, document_info) -> (attach, workspace)`.** No
-  `event` parameter. The resolver does not know — and must not care — whether
-  this document is spawning the server or attaching to a running one; it is
-  expected to be **idempotent** for a given `document_info`. kakehashi decides
-  how to apply the result from the server's current state (below).
+- **Idempotent function `(server_info, document_info) -> (attach, workspace)`.**
+  Not pure — it reads the filesystem and cwd through `kakehashi.fs`/`env` (see
+  lua-host-api). The point is statelessness w.r.t. spawn-vs-attach: there is no
+  `event` parameter, the resolver does not know — and must not care — whether
+  this document is spawning the server or attaching to a running one, and it is
+  expected to return the **same result for a given `document_info`** (modulo
+  on-disk changes). kakehashi decides how to apply the result from the server's
+  current state (below).
 - **`document_info` is always present** (file-first model), so it is
   non-optional. Its fields — including `text` — are materialized **lazily via a
   metatable** to avoid copying large documents into Lua when the resolver never
@@ -81,15 +85,31 @@ Key properties:
 
 ### 3. Execution model: synchronous return-style on a worker thread
 
-The resolver runs **synchronously** (return-style, not continuation-passing) on
-a blocking worker thread (`spawn_blocking` or a dedicated thread), off the tokio
-runtime, guarded by a **timeout**.
+The resolver runs **synchronously** (return-style, not continuation-passing) off
+the tokio runtime, so a blocking resolver cannot stall the LSP event loop — the
+async-friendliness is achieved at the Rust↔Lua boundary, not inside Lua.
 
-- A blocking resolver therefore cannot stall the LSP event loop — the
-  async-friendliness is achieved at the Rust↔Lua boundary, not inside Lua.
+- **Thread ownership.** `mlua::Lua` is `!Send` by default, so the VM cannot be
+  moved across threads or held across an `await`. A reusable compiled VM
+  therefore lives on a **dedicated thread** that owns it and receives requests
+  over a channel (not an ad-hoc `spawn_blocking` per call, which would force
+  re-creating the VM and a `Send` bound on every `kakehashi.*` callback).
+- **Timeout is in-VM, not wall-clock-only.** Wrapping the call in
+  `tokio::time::timeout` (or dropping the join handle) only stops *awaiting* the
+  result; the Lua code keeps running and keeps occupying the worker thread. Real
+  interruption requires an **in-VM hook** — `Lua::set_hook` with
+  `HookTriggers::every_nth_instruction` (or Luau `set_interrupt`) that checks
+  elapsed time and raises. This bounds Lua-level loops.
+  - **Caveat:** an instruction hook cannot interrupt time spent inside a host
+    C-call (`kakehashi.fs.find_ancestor`'s filesystem walk, `read_to_string`)
+    or the lazy `document_info` metatable `__index`. Those host operations must
+    carry **their own bounds** (e.g. a capped `read_to_string`, see
+    lua-host-api) — the §6 "must not tie up a worker thread" guarantee depends
+    on both the hook and these host-side limits.
 - The `text` snapshot is **owned in Rust** (`Arc<str>` or equivalent) before
   entering Lua; the metatable only defers *materialization into Lua*, never
-  performs async I/O. A metatable `__index` must not await.
+  performs async I/O. A metatable `__index` must not await (and, per the caveat,
+  must itself be cheap/bounded).
 
 ### 4. Veto and wiring
 
@@ -100,12 +120,17 @@ runtime, guarded by a **timeout**.
 - **Result application is inferred from server state**, not signaled by the
   resolver:
   - Server not yet running, this document triggers the spawn → resolved
-    workspace **seeds `InitializeParams`** (`src/lsp/bridge/protocol/lifecycle.rs`
-    `build_initialize_request`), overriding the marker input at
-    `src/lsp/bridge/pool.rs` (`workspace_from_marker`).
+    workspace **seeds `InitializeParams`** via `build_initialize_request`
+    (`protocol/lifecycle.rs`), replacing the `marker` argument that
+    `workspace_from_marker` (defined in `root_markers.rs`, called from `pool.rs`)
+    would otherwise supply.
   - Server already running, a new document arrives → a returned folder is added
     via `workspace/didChangeWorkspaceFolders` (the `WorkspaceFolderSet` in
-    `pool.rs`).
+    `pool.rs`). **Precondition:** this only reaches a server that advertised
+    `workspace.workspaceFolders.changeNotifications` (or dynamically registered
+    it); the implementation already gates on `supports_workspace_folder_changes`,
+    so for a non-supporting running server a resolver's returned folder is
+    **silently dropped**. See Open Questions.
 
 ### 5. Cache contract
 
@@ -119,7 +144,26 @@ document text.
 
 A Lua error **or** a timeout overrun is treated as **fail-closed**: do not
 attach the document to that server, and log. A broken or slow resolver must not
-silently misroute, nor tie up a worker thread indefinitely.
+silently misroute. "Tie up a worker thread indefinitely" is prevented by the
+in-VM hook **plus** the host-side bounds of §3 — a hook alone cannot stop a
+runaway host call, so both are load-bearing for this guarantee.
+
+### 7. Open questions
+
+Deferred to implementation, recorded so they are not lost:
+
+- **Timeout default value.** Not fixed here; must be generous enough for a
+  filesystem walk yet bound a misbehaving resolver.
+- **`read_to_string` size cap.** Per §3 the in-VM hook cannot interrupt a host
+  read, so `kakehashi.fs.read_to_string` needs its own large-file bound (see
+  lua-host-api); the exact cap is open.
+- **Non-`file://` documents.** The "file-first" framing assumes a filesystem
+  path. What `document_info.path` (and the path-based host API) yield for
+  `untitled:` and other non-`file://` URIs is undefined; likely the resolver
+  should be skipped (fall back to `workspaceMarkers`/no folder) for those.
+- **Folder dropped on a non-supporting running server** (§4): whether to fall
+  back (e.g. respawn with the folder, or surface a warning) instead of silently
+  dropping is open.
 
 ## Considered Options
 
@@ -156,8 +200,8 @@ silently misroute, nor tie up a worker thread indefinitely.
 - **`event: "initialize" | "didOpen"` parameter.** Considered so the resolver
   could branch on spawn vs. attach. Rejected: in the file-first model both
   carry a document, and folding the spawn/attach distinction into kakehashi's
-  state (rather than the resolver's logic) keeps the resolver a pure,
-  idempotent function and removes a state-management responsibility from
+  state (rather than the resolver's logic) keeps the resolver an idempotent,
+  stateless function and removes a state-management responsibility from
   resolver authors.
 
 - **`workspaceFallback` (e.g. `"$PWD"`) when neither markers nor resolver
@@ -172,8 +216,8 @@ silently misroute, nor tie up a worker thread indefinitely.
 - Vocabulary aligns with the LSP spec (`workspaceFolders`), with a no-break
   deprecation alias.
 - Content-dependent server selection (Deno vs. Node/tsgo) becomes expressible.
-- The resolver is a pure, idempotent function; spawn-vs-attach routing stays in
-  kakehashi, not in user Lua.
+- The resolver is an idempotent, stateless function; spawn-vs-attach routing
+  stays in kakehashi, not in user Lua.
 - One folder-from-markers implementation, shared by markers and resolver.
 
 ### Negative

--- a/docs/architecture-decisions/workspace-resolver.md
+++ b/docs/architecture-decisions/workspace-resolver.md
@@ -36,6 +36,12 @@ alias** (`#[serde(alias = "rootMarkers")]`) for backward compatibility. The
 default is unchanged: `[".git"]`. Resolution semantics (upward search, nested
 arrays = equal-priority groups) are unchanged.
 
+Concretely, the Rust field `root_markers: Option<Vec<RootMarker>>`
+(`src/config/settings.rs`) is renamed `workspace_markers`; the
+`#[serde(rename_all = "camelCase")]` on `BridgeServerConfig` emits the
+`workspaceMarkers` TOML/JSON key automatically, and `#[serde(alias =
+"rootMarkers")]` keeps the old key parsing.
+
 ### 2. Introduce `workspaceResolver` — a Lua function
 
 A new optional key holds a Lua function that dynamically decides both **whether
@@ -61,6 +67,11 @@ end
 """
 ```
 
+kakehashi **compiles the source once, in Rust** (via the sandbox-restricted
+`mlua::Lua::load`) and keeps the resulting `Function`. Because the sandbox
+strips `load`/`loadstring` (see lua-host-api), the resolver source is never
+recompiled from inside Lua per call.
+
 Key properties:
 
 - **Idempotent function `(server_info, document_info) -> (attach, workspace)`.**
@@ -81,11 +92,15 @@ Key properties:
   unset — with **one exception**: a configured resolver is **skipped** for a
   document that has no representable filesystem path (a non-`file://` URI, or a
   `file://` path that fails the encoding contract in lua-host-api). Such a
-  document is resolved exactly as if no `workspaceResolver` were set — via
-  `workspaceMarkers`, which itself falls through to `ClientFallback` when no
-  marker resolves (a non-file URI resolves no marker, so it lands on
-  `ClientFallback`). This skip is distinct from §6 fail-closed: the resolver was
-  not run, so the document still attaches; fail-closed applies only when a
+  document is resolved exactly as if no `workspaceResolver` were set — the
+  normal `workspaceMarkers` → `ClientFallback` path. Note the two skip sub-cases
+  differ underneath: a non-representable `file://` path still has a URL, so the
+  Rust-side marker walk runs normally; a **non-`file://` URI** has no file path
+  at all, so `resolve_marker_root` returns `None` *immediately*
+  (`document_uri?.to_file_path()` fails) and the marker walk never runs — the
+  document lands directly on `ClientFallback`. Either way the result is the
+  no-resolver behavior. This skip is distinct from §6 fail-closed: the resolver
+  was not run, so the document still attaches; fail-closed applies only when a
   resolver that *did* run errors or times out.
 - **The second return is always a filesystem path (or nil)** — never raw
   markers. A resolver that wants marker-based resolution calls
@@ -108,9 +123,11 @@ async-friendliness is achieved at the Rust↔Lua boundary, not inside Lua.
 - **Timeout is in-VM, not wall-clock-only.** Wrapping the call in
   `tokio::time::timeout` (or dropping the join handle) only stops *awaiting* the
   result; the Lua code keeps running and keeps occupying the worker thread. Real
-  interruption requires an **in-VM hook** — `Lua::set_hook` with
-  `HookTriggers::every_nth_instruction` (or Luau `set_interrupt`) that checks
-  elapsed time and raises. This bounds Lua-level loops.
+  interruption requires an **in-VM hook**: an instruction-counting hook that
+  raises a timeout error from inside the VM (in `mlua` 0.9, `Lua::set_hook` with
+  `HookTriggers::every_nth_instruction`, or Luau `set_interrupt` — names are
+  illustrative and to be reconciled with whatever `mlua` version is adopted,
+  since none is in `Cargo.toml` yet). This bounds Lua-level loops.
   - **Caveat:** an instruction hook cannot interrupt time spent inside a host
     C-call (`kakehashi.fs.find_ancestor`'s filesystem walk, `read_to_string`)
     or the lazy `document_info` metatable `__index`. Host operations carry their
@@ -137,21 +154,29 @@ async-friendliness is achieved at the Rust↔Lua boundary, not inside Lua.
   part of the connection's identity, not a late add-on:
   - **Per-root (default).** `ConnectionKey` is `(server, root)`
     (`connection_key.rs`), so a distinct resolved workspace is a distinct
-    `Marker(root)` key → its own connection: reused if one already runs for that
-    root, else spawned with the workspace seeding `InitializeParams` via
-    `build_initialize_request` (`protocol/lifecycle.rs`). A `nil` workspace maps
-    to the `ClientFallback` key — which `workspace_from_marker`'s fallback roots
-    at the **upstream client's** `rootUri`/`workspaceFolders`, not at "no
-    folder".
+    `ConnectionKey::new(server, Some(root))` (i.e. `ConnectionRoot::Marker`) →
+    its own connection: reused if one already runs for that root, else spawned
+    with the workspace seeding `InitializeParams` via `build_initialize_request`
+    (`protocol/lifecycle.rs`). A `nil` workspace maps to the `ClientFallback`
+    key — which `workspace_from_marker`'s fallback roots at the **upstream
+    client's** `rootUri`/`workspaceFolders`, not at "no folder".
   - **Shared instance (`preferSharedInstance`, #391).** Marker-rooted documents
     join one `Shared` connection via `workspace/didChangeWorkspaceFolders` (the
     `WorkspaceFolderSet`, defined in `workspace/folder_set.rs`, driven from
-    `pool.rs`). If that shared connection came up **without**
+    `pool.rs`). A shared connection that came up **without**
     `workspace.workspaceFolders.changeNotifications`
-    (`supports_workspace_folder_changes` reads static `InitializeResult`
-    capabilities only — there is no dynamic `client/registerCapability`
-    tracking), `resolve_acquire` **diverts the document to its own per-root
-    process** rather than dropping it.
+    (`supports_workspace_folder_changes`, static `InitializeResult` capabilities
+    only — no dynamic `client/registerCapability` tracking) cannot take on a new
+    root, so the document is **diverted to its own per-root process** (not
+    dropped). This divert happens at **two** sites, because the shared
+    connection's capability is only known once it is `Ready`:
+    - **Early** in `resolve_acquire` — when the shared handle is *already*
+      `Ready` and incapable.
+    - **Late** in `get_or_create_connection_wait_ready` — when the shared
+      handle was still `Initializing` at acquire time (the catch-all routes it
+      to the shared key optimistically), then comes up incapable; after
+      `wait_for_ready` it re-checks and re-keys to the per-root process,
+      reusing the already-resolved marker to avoid a second filesystem walk.
 
 ### 5. Cache contract
 
@@ -285,4 +310,4 @@ Not yet implemented. As of this record:
 - [lua-host-api](lua-host-api.md): the `kakehashi.*` Lua functions the resolver calls (`path`, `fs` incl. `find_ancestor`, `env.current_dir`) and the path-vs-URI boundary.
 - [language-server-bridge](language-server-bridge.md): the bridge this resolver feeds.
 - [ls-bridge-server-pool-coordination](ls-bridge-server-pool-coordination.md): pool keys and spawn-time workspace seeding the resolver result must integrate with.
-- [wildcard-config-inheritance](wildcard-config-inheritance.md): how `languageServers._` defaults (including `workspaceMarkers`/`workspaceResolver`) are inherited.
+- [wildcard-config-inheritance](wildcard-config-inheritance.md): how `languageServers._` defaults *will* inherit `workspaceMarkers`/`workspaceResolver` — via the existing per-field merge in `merge_bridge_server_configs` (`src/config/merge.rs`); that ADR documents the wildcard model generally and does not yet name these fields.


### PR DESCRIPTION
## Summary

Adds two Architecture Decision Records for dynamic, content-aware workspace resolution in the language-server bridge:

- **`workspace-resolver`** — rename config key `rootMarkers` → `workspaceMarkers` (deprecated `#[serde(alias)]`, default `[".git"]`), and add an optional sandboxed Lua `workspaceResolver` function `(server_info, document_info) -> (boolean attach, nil | string workspace_path)`. It dynamically decides whether to attach a bridged server and which workspace folder to use (motivating case: Deno vs Node/tsgo). Executed synchronously on a dedicated worker thread with an in-VM timeout hook; fail-closed; evaluated once at didOpen. The resolved workspace replaces the marker fed into the existing `resolve_acquire` flow (per-root keying by default; `preferSharedInstance` shared instance otherwise).
- **`lua-host-api`** — the minimal `kakehashi.*` Lua surface the resolver may call: submodule-only, each mirroring a Rust `std` module — `path` (`std::path`, pure), `fs` (`std::fs`, incl. `find_ancestor` reusing `root_markers.rs`), `env` (`std::env`, `current_dir`), `log`. Sandbox strips `io`/`os`/`require`/`load`/`debug`/FFI. OS-path boundary (not URIs) with a defined encoding contract (Unix byte channel; Windows strict UTF-8, fail-closed).

Both are **aspirational** (no Lua VM exists yet — only `lua-pattern`); each has a Decision–Implementation Gap section. Open questions (timeout default, `read_to_string` size cap, stuck-worker recovery, non-`file://` documents, Windows surrogate edge) are recorded, not resolved.

## Review

Converged through three independent review passes before opening, with all source-code references fact-checked against the actual repo:
1. Multi-agent `/review` (10 perspectives) — 4 MAJOR + minors fixed, re-review clean.
2. Codex MCP — 7 rounds; caught a real architecture mismatch (the workspace is part of `ConnectionKey`, so a distinct workspace is a distinct per-root connection, not a `didChangeWorkspaceFolders` add-on) and the path-encoding/`nil`-semantics edges; converged to "no comments to provide".
3. `pi-review` — surfaced the two incapable-shared divert sites and the byte-level `OsStr` channel; converged to "no actionable findings".

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)