### PR TITLE
feat(bridge): downstream workspace settings propagation

### DIFF
--- a/docs/architecture-decisions/configuration-merging-strategy.md
+++ b/docs/architecture-decisions/configuration-merging-strategy.md
@@ -140,7 +140,7 @@ final_config = [defaults, user_config, project_config, InitializationOptions]
 
 **Bridge servers HashMap** (`languageServers`):
 - **Deep merge at server level**: Keys (server names) from later sources override same keys from earlier sources
-- **Deep merge within each server**: Individual fields (`cmd`, `languages`, `initializationOptions`, `onTypeFormattingTriggers`) are merged (list options like `onTypeFormattingTriggers` are overlay-wins-when-present, not unioned)
+- **Deep merge within each server**: Individual fields (`cmd`, `languages`, `initializationOptions`, `settings`, `onTypeFormattingTriggers`) are merged (JSON-object fields `initializationOptions` and `settings` deep-merge; list options like `onTypeFormattingTriggers` are overlay-wins-when-present, not unioned). `settings` carries downstream workspace configuration propagated post-initialize — see downstream-settings-propagation.
 - Example:
   ```toml
   # user config

--- a/docs/architecture-decisions/downstream-settings-propagation.md
+++ b/docs/architecture-decisions/downstream-settings-propagation.md
@@ -53,17 +53,25 @@ tree.** Concretely, three coupled changes:
 
 ### (a) Advertise the client capability and seed initial settings
 
-- `build_bridge_client_capabilities` advertises
-  `workspace.configuration = true` so spec-compliant downstream servers will
-  send `workspace/configuration`.
+- `build_bridge_client_capabilities` advertises `workspace.configuration` so a
+  spec-compliant downstream server sends `workspace/configuration` — but **gated
+  per-server on that server having `settings` to serve** (`settings.is_some()`,
+  evaluated at spawn from the resolved config). Advertising it for a server with
+  no `settings` would flip a server configured only via `initializationOptions`
+  (today's only mechanism, so every existing setup) into pulling, then answer
+  every section `null` — clobbering config it held. The gate makes (a) safe to
+  ship alongside (b) without an empirical per-server validation step.
 - Add `settings: Option<Value>` to `BridgeServerConfig` (opaque passthrough;
   kakehashi never interprets the contents) and to `merge_bridge_server_configs`,
   where it **deep-merges** across config layers exactly like
   `initialization_options` (nested objects merge, overlay scalars win), so a
   project layer can override one sub-key without restating the rest.
-- After `initialized`, if the server's merged `settings` is non-null, kakehashi
+- After `initialized`, if the server's settings cell is non-null, kakehashi
   sends one `workspace/didChangeConfiguration { settings }` so push-model
-  servers are configured even before they pull.
+  servers are configured even before they pull. It reads the **live cell**, not
+  the spawn-time value, so a (c) re-propagation that landed during the handshake
+  is not overwritten by a stale push — the push always agrees with what (b)
+  would answer.
 
 `initialization_options` and `settings` are kept distinct, matching their LSP
 roles: `initialization_options` is consumed only at `initialize` time;
@@ -155,12 +163,15 @@ keeps propagation proportional to actual change.
 
 ### Negative
 
-- **Regression risk in (a)↔(b) coupling**: advertising
-  `workspace.configuration` may cause a server that previously relied solely on
-  `initializationOptions` to start *pulling*. If (b) resolves a section to
-  `null` where the server expected a value, that server can *lose* config it
-  used to have. (a) must not ship without (b) returning correct values for an
-  actually-configured server.
+- **A server that starts with no `settings` never pulls, even if settings are
+  added at runtime**: the capability is negotiated once at `initialize` and the
+  per-server gate evaluates `settings.is_some()` then. If a user later adds
+  `settings` for that server, push-model servers still receive it via (c)'s
+  `didChangeConfiguration`, but a pure pull-model server will not pull until it
+  respawns. This is the deliberate cost of the gate (see (a)) — accepted because
+  the alternative (advertising unconditionally) regresses the *common* case:
+  every server configured via `initializationOptions` only, which is every
+  existing setup, would flip to pulling and be answered `null`.
 - **`initializationOptions` changes still need a restart**: a server that reads
   a given key only from `initializationOptions` (and ignores
   `didChangeConfiguration`) will not see a runtime change to it until respawn.
@@ -194,10 +205,13 @@ The following are **deferred** and intentionally out of scope:
 ## Validation
 
 Section resolution cannot be reasoned out in the abstract — real servers differ
-on whether `section` is `null` or their own name. (a) is therefore a
-**prerequisite** for (b): advertise the capability, log the incoming `items`
-(`section` + `scopeUri`) from an actually-configured server, then make
-resolution match what was observed. A unit test written on the wrong assumption
-passes while the real server gets `null` back. Confirm an actually-configured
-server still receives its settings after (a)+(b) land together (the regression
-guard above).
+on whether `section` is `null` or their own name. The handler logs the incoming
+`items` (`section` + `scopeUri`) at debug, so the resolution convention can be
+confirmed against an actually-configured server. A unit test written on the
+wrong assumption passes while the real server gets `null` back; the
+dotted-path-into-editor-root convention is chosen because it handles both the
+`null` and own-namespace cases, but observing a real server is still the
+acceptance check. The per-server capability gate (a) removes the earlier
+"(a) must not ship without (b) validated" coupling: a server with no `settings`
+is never told to pull, so an incorrect resolution can only affect a server the
+user explicitly gave `settings`.

--- a/docs/architecture-decisions/downstream-settings-propagation.md
+++ b/docs/architecture-decisions/downstream-settings-propagation.md
@@ -194,11 +194,13 @@ keeps propagation proportional to actual change.
 - **Accepted narrow race during the handshake window**: path (a) reads the cell
   then sends; a path-(c) store that lands between that read and send (a few-
   hundred-ms window, multithreaded runtime) can leave a push-model server one
-  revision stale while the cell — and any pull — already holds the new value.
-  This is the same deferred-epoch-class race accepted elsewhere (e.g. the pull
-  refresh coverage gate); pull-model servers self-heal, and the worst case is
-  bounded staleness, not corruption. Fully closing it would require serializing
-  (a) and (c) on a per-connection lock.
+  revision behind while the cell — and any pull — already holds the new value.
+  The staleness is bounded by *revision*, not time: it persists until the next
+  config change re-pushes or the server respawns. This is the same deferred-
+  epoch-class race accepted elsewhere (e.g. the pull refresh coverage gate);
+  pull-model servers self-heal, and the worst case is bounded staleness, not
+  corruption. Fully closing it would require serializing (a) and (c) on a
+  per-connection lock.
 
 ### Neutral
 

--- a/docs/architecture-decisions/downstream-settings-propagation.md
+++ b/docs/architecture-decisions/downstream-settings-propagation.md
@@ -1,0 +1,186 @@
+# Downstream Settings Propagation
+
+**Related**: [configuration-merging-strategy](configuration-merging-strategy.md)
+
+## Context
+
+kakehashi bridges editor requests to downstream language servers (rust-analyzer,
+pyright, lua-ls, …). Those servers need workspace configuration — e.g.
+`rust-analyzer.cargo.features`, `Lua.diagnostics.globals`. Today kakehashi can
+only deliver such config **once**, via `initializationOptions` in the
+`initialize` request (`BridgeServerConfig.initialization_options`). There is no
+path for:
+
+- a downstream server to **pull** its configuration after startup
+  (`workspace/configuration`), nor
+- kakehashi to **push** configuration changes to an already-running server
+  (`workspace/didChangeConfiguration`).
+
+The editor cannot fill this gap directly: it configures *kakehashi*, not
+`rust-analyzer`. A request the editor receives for section `"rust-analyzer"`
+has no answer on the editor side. The bridge must therefore own and serve
+downstream configuration itself.
+
+kakehashi already maintains a single merged settings tree (see
+configuration-merging-strategy): defaults → user file → project file →
+`initializationOptions` → `didChangeConfiguration`, exposed at runtime through
+`SettingsManager`. The merged tree already carries a per-server map
+(`languageServers.<name>`). What is missing is (1) a place in that per-server
+config to hold the opaque downstream settings, and (2) the two LSP mechanisms
+that move it across the bridge boundary.
+
+Two LSP facts shape the design (LSP 3.18):
+
+- `workspace/didChangeConfiguration` carries the value in a field literally
+  named `settings` (`DidChangeConfigurationParams.settings: LSPAny`). Push-model
+  servers read it directly.
+- `workspace/configuration` carries no such named field: the request is
+  `ConfigurationParams { items: ConfigurationItem[] }` where each item has an
+  optional `section` / `scopeUri`, and the **response is `LSPAny[]`** — one
+  element per item, same order, with the configuration value (or `null`) for
+  each. Pull-model servers ignore the `didChangeConfiguration` payload and
+  re-request via this round-trip.
+
+A bridge that supports both models must therefore answer the pull request *and*
+send the push notification, both sourced from the same merged settings.
+
+## Decision
+
+**Add a per-server `settings` field whose merged value kakehashi propagates to
+each downstream server over both `workspace/configuration` (pull) and
+`workspace/didChangeConfiguration` (push), keyed off the live merged settings
+tree.** Concretely, three coupled changes:
+
+### (a) Advertise the client capability and seed initial settings
+
+- `build_bridge_client_capabilities` advertises
+  `workspace.configuration = true` so spec-compliant downstream servers will
+  send `workspace/configuration`.
+- Add `settings: Option<Value>` to `BridgeServerConfig` (opaque passthrough;
+  kakehashi never interprets the contents) and to the deep-merge in
+  `merge_bridge_server_configs` (overlay-wins-when-present, like
+  `initialization_options`), so it composes across config layers.
+- After `initialized`, if the server's merged `settings` is non-null, kakehashi
+  sends one `workspace/didChangeConfiguration { settings }` so push-model
+  servers are configured even before they pull.
+
+`initialization_options` and `settings` are kept distinct, matching their LSP
+roles: `initialization_options` is consumed only at `initialize` time;
+`settings` is what flows over `didChangeConfiguration` and answers
+`workspace/configuration`. A runtime change to `settings` propagates to running
+servers (see (c)); a change to `initialization_options` only takes effect on the
+**next** start of that server (it cannot be re-sent post-initialize).
+
+### (b) Answer `workspace/configuration` from the live merged tree
+
+A new arm in the downstream server-request dispatch (`reader.rs`, alongside
+`client/registerCapability`, `workspace/workspaceFolders`) handles
+`workspace/configuration`. For each requested item it resolves the item's
+`section` against this server's merged `settings` and returns an `LSPAny[]` of
+the **same length and order** as `items`, using JSON `null` (not an omitted
+element) for any miss.
+
+**Section-resolution convention:** the server's merged `settings` object is the
+root. An item with `section` omitted/null returns the whole root; a non-null
+`section` is a dotted path indexed into the root (`"rust-analyzer.cargo"` →
+`settings["rust-analyzer"]["cargo"]`), `null` when absent.
+
+The handler needs two things the dispatch does not carry today:
+
+- **Server identity** — already available: `ServerRequestDeps.server_name` is the
+  config-map key.
+- **Live merged settings** — *not* available in `ServerRequestDeps`. Wiring a
+  settings source (a `SettingsManager` handle or per-connection snapshot) into
+  the server-request path is the substantive part of (b), not the section math.
+
+### (c) Re-propagate on merge change, diffing per server
+
+Whenever the merged settings tree changes — `did_change_configuration_impl` and
+any config-file reload path — kakehashi, for each **live** downstream
+connection, compares that server's current merged `settings` slice against the
+**last value sent to that connection**; on a difference it sends
+`workspace/didChangeConfiguration { settings }` (pull-model servers then
+re-request and are answered by (b)). Unchanged servers get nothing, so a global
+reload does not storm every connection.
+
+This requires per-connection **last-sent settings** state to diff against
+(owned by the connection/pool), plus the reload paths enumerating live
+connections. Not-yet-started servers need no notification — they pick up the
+latest merged value at startup via (a).
+
+## Considered Options
+
+### Reuse `initializationOptions` for everything
+Send all downstream config as `initializationOptions` only. Rejected: it is
+delivered once at `initialize` and cannot carry runtime changes; pull-model
+servers (which expect `workspace/configuration`) get nothing.
+
+### Forward the downstream `workspace/configuration` up to the editor
+When a server pulls, proxy the request to the editor. Rejected: the editor has
+no config under the downstream server's section name, the round-trip adds
+init-time latency and deadlock risk on the request path, and the request must be
+answered promptly. Answering from kakehashi's already-merged local state avoids
+all three.
+
+### Always push, never answer the pull (or vice-versa)
+Support only one model. Rejected: real servers split across push and pull;
+supporting one strands the other. Both are cheap once `settings` exists.
+
+### Broadcast on every reload without diffing
+Notify all connections on any merge change. Rejected: floods unaffected servers
+and, for pull-model servers, triggers a needless re-pull each. Per-server diff
+keeps propagation proportional to actual change.
+
+## Consequences
+
+### Positive
+
+- Downstream servers receive workspace configuration both at startup and on
+  runtime change, over whichever mechanism (push/pull) they implement.
+- One source of truth: the existing merged settings tree; no parallel config
+  store.
+- Diff-on-change keeps notifications proportional to real changes.
+
+### Negative
+
+- **Regression risk in (a)↔(b) coupling**: advertising
+  `workspace.configuration` may cause a server that previously relied solely on
+  `initializationOptions` to start *pulling*. If (b) resolves a section to
+  `null` where the server expected a value, that server can *lose* config it
+  used to have. (a) must not ship without (b) returning correct values for an
+  actually-configured server.
+- **`initializationOptions` changes still need a restart**: a server that reads
+  a given key only from `initializationOptions` (and ignores
+  `didChangeConfiguration`) will not see a runtime change to it until respawn.
+- Adds per-connection last-sent-settings state to the bridge pool.
+
+### Neutral
+
+- `settings` is opaque to kakehashi; correctness of its *contents* is the
+  user's responsibility, exactly like `initializationOptions`.
+- `settings` joins the per-server deep-merge field list in
+  configuration-merging-strategy.
+
+## Decision–Implementation Gap
+
+The following are **deferred** and intentionally out of scope:
+
+- **Upstream pull** (kakehashi → editor `workspace/configuration`): needed only
+  to support pull-model editors (e.g. VS Code sends `didChangeConfiguration`
+  with no usable `settings` and expects the server to pull). Editors that push
+  full settings via `initializationOptions` / `didChangeConfiguration` (e.g.
+  Neovim) do not need it. When added, it must be gated on the editor's
+  `capabilities.workspace.configuration`.
+- **`scopeUri` / multi-root resolution**: `ConfigurationItem.scopeUri` is
+  ignored; a single per-server `settings` value answers all scopes.
+
+## Validation
+
+Section resolution cannot be reasoned out in the abstract — real servers differ
+on whether `section` is `null` or their own name. (a) is therefore a
+**prerequisite** for (b): advertise the capability, log the incoming `items`
+(`section` + `scopeUri`) from an actually-configured server, then make
+resolution match what was observed. A unit test written on the wrong assumption
+passes while the real server gets `null` back. Confirm an actually-configured
+server still receives its settings after (a)+(b) land together (the regression
+guard above).

--- a/docs/architecture-decisions/downstream-settings-propagation.md
+++ b/docs/architecture-decisions/downstream-settings-propagation.md
@@ -57,9 +57,10 @@ tree.** Concretely, three coupled changes:
   `workspace.configuration = true` so spec-compliant downstream servers will
   send `workspace/configuration`.
 - Add `settings: Option<Value>` to `BridgeServerConfig` (opaque passthrough;
-  kakehashi never interprets the contents) and to the deep-merge in
-  `merge_bridge_server_configs` (overlay-wins-when-present, like
-  `initialization_options`), so it composes across config layers.
+  kakehashi never interprets the contents) and to `merge_bridge_server_configs`,
+  where it **deep-merges** across config layers exactly like
+  `initialization_options` (nested objects merge, overlay scalars win), so a
+  project layer can override one sub-key without restating the rest.
 - After `initialized`, if the server's merged `settings` is non-null, kakehashi
   sends one `workspace/didChangeConfiguration { settings }` so push-model
   servers are configured even before they pull.

--- a/docs/architecture-decisions/downstream-settings-propagation.md
+++ b/docs/architecture-decisions/downstream-settings-propagation.md
@@ -109,11 +109,19 @@ that every reload already funnels through — `didChangeConfiguration`, the
 auto-install reload, and initialize. For each **live** downstream connection
 kakehashi re-resolves that server's `settings` (through the same wildcard merge
 used at spawn) and compares it against the connection's current settings cell;
-on a difference it re-stores the cell and sends
-`workspace/didChangeConfiguration { settings }` (pull-model servers then
+on a difference it re-stores the cell and, **for a `Ready` connection only**,
+sends `workspace/didChangeConfiguration { settings }` (pull-model servers then
 re-request and are answered by (b)). The cell is updated **before** the push so
 a pull-model re-pull never races onto the stale value. Unchanged servers get
 nothing, so a global reload does not storm every connection.
+
+A still-initializing connection is **not** notified — a
+`workspace/didChangeConfiguration` before its `initialized` would violate LSP
+ordering. Its cell is still advanced, and the post-`initialized` push (a), which
+reads the live cell, delivers the latest value once the handshake completes.
+That push is queued *before* the connection flips to `Ready`, so the
+single-writer FIFO carries it ahead of any `didOpen` a waiter enqueues on
+observing `Ready` — the server never processes a document under default config.
 
 The per-connection settings cell *is* the diff baseline: it holds the latest
 resolved value (what (b) serves), updated unconditionally on change with the
@@ -180,7 +188,17 @@ keeps propagation proportional to actual change.
 - A failed push (queue full / channel closed) to a push-model server leaves it
   with stale config until it re-pulls or respawns; the cell still holds the
   current value, so a pull-model server self-heals. Guaranteed push delivery
-  would need a separate retry baseline and is not implemented.
+  would need a separate retry baseline and is not implemented. (The push count
+  (c) returns counts only successfully-enqueued notifications, so a drop is
+  never reported as delivered.)
+- **Accepted narrow race during the handshake window**: path (a) reads the cell
+  then sends; a path-(c) store that lands between that read and send (a few-
+  hundred-ms window, multithreaded runtime) can leave a push-model server one
+  revision stale while the cell — and any pull — already holds the new value.
+  This is the same deferred-epoch-class race accepted elsewhere (e.g. the pull
+  refresh coverage gate); pull-model servers self-heal, and the worst case is
+  bounded staleness, not corruption. Fully closing it would require serializing
+  (a) and (c) on a per-connection lock.
 
 ### Neutral
 

--- a/docs/architecture-decisions/downstream-settings-propagation.md
+++ b/docs/architecture-decisions/downstream-settings-propagation.md
@@ -66,12 +66,15 @@ tree.** Concretely, three coupled changes:
   where it **deep-merges** across config layers exactly like
   `initialization_options` (nested objects merge, overlay scalars win), so a
   project layer can override one sub-key without restating the rest.
-- After `initialized`, if the server's settings cell is non-null, kakehashi
-  sends one `workspace/didChangeConfiguration { settings }` so push-model
-  servers are configured even before they pull. It reads the **live cell**, not
-  the spawn-time value, so a (c) re-propagation that landed during the handshake
-  is not overwritten by a stale push — the push always agrees with what (b)
-  would answer.
+- After `initialized`, kakehashi sends one `workspace/didChangeConfiguration
+  { settings }` so push-model servers are configured even before they pull. It
+  reads the **live cell**, not the spawn-time value, so a (c) re-propagation
+  that landed during the handshake is reflected — the push always agrees with
+  what (b) would answer. It fires when the server advertised `configuration`
+  (so a clear to `None` during the handshake reaches the server as `null`
+  instead of leaving it on stale settings) **or** when the cell now holds
+  settings (added during the handshake); when neither holds there is nothing to
+  send.
 
 `initialization_options` and `settings` are kept distinct, matching their LSP
 roles: `initialization_options` is consumed only at `initialize` time;

--- a/docs/architecture-decisions/downstream-settings-propagation.md
+++ b/docs/architecture-decisions/downstream-settings-propagation.md
@@ -96,18 +96,29 @@ The handler needs two things the dispatch does not carry today:
 
 ### (c) Re-propagate on merge change, diffing per server
 
-Whenever the merged settings tree changes — `did_change_configuration_impl` and
-any config-file reload path — kakehashi, for each **live** downstream
-connection, compares that server's current merged `settings` slice against the
-**last value sent to that connection**; on a difference it sends
+Propagation hooks the single settings-apply choke point (`apply_shared_settings`)
+that every reload already funnels through — `didChangeConfiguration`, the
+auto-install reload, and initialize. For each **live** downstream connection
+kakehashi re-resolves that server's `settings` (through the same wildcard merge
+used at spawn) and compares it against the connection's current settings cell;
+on a difference it re-stores the cell and sends
 `workspace/didChangeConfiguration { settings }` (pull-model servers then
-re-request and are answered by (b)). Unchanged servers get nothing, so a global
-reload does not storm every connection.
+re-request and are answered by (b)). The cell is updated **before** the push so
+a pull-model re-pull never races onto the stale value. Unchanged servers get
+nothing, so a global reload does not storm every connection.
 
-This requires per-connection **last-sent settings** state to diff against
-(owned by the connection/pool), plus the reload paths enumerating live
-connections. Not-yet-started servers need no notification — they pick up the
-latest merged value at startup via (a).
+The per-connection settings cell *is* the diff baseline: it holds the latest
+resolved value (what (b) serves), updated unconditionally on change with the
+push sent best-effort afterward — a dropped push self-heals when a pull-model
+server re-requests, or on respawn (re-seed + (a) re-push). Not-yet-started
+servers need no notification — they pick up the latest merged value at startup
+via (a). At initialize time there are no live connections, so the hook is a
+clean no-op.
+
+(There is no runtime config-file *re-read* path today; `./kakehashi.toml` and
+the user file are read once at startup. Runtime changes arrive via
+`didChangeConfiguration`. If a file-watch reload is ever added, routing it
+through `apply_shared_settings` extends (c) for free.)
 
 ## Considered Options
 
@@ -153,7 +164,12 @@ keeps propagation proportional to actual change.
 - **`initializationOptions` changes still need a restart**: a server that reads
   a given key only from `initializationOptions` (and ignores
   `didChangeConfiguration`) will not see a runtime change to it until respawn.
-- Adds per-connection last-sent-settings state to the bridge pool.
+- Adds a per-connection settings cell to the bridge pool, shared between the
+  reader (serves pulls) and the pool (re-stores on change).
+- A failed push (queue full / channel closed) to a push-model server leaves it
+  with stale config until it re-pulls or respawns; the cell still holds the
+  current value, so a pull-model server self-heals. Guaranteed push delivery
+  would need a separate retry baseline and is not implemented.
 
 ### Neutral
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -430,6 +430,7 @@ mod tests {
             root_markers: None,
             on_type_formatting_triggers: None,
             prefer_shared_instance: None,
+            settings: None,
         };
 
         // Only the built-in `_` defaults entry (empty cmd): not runnable.

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -42,6 +42,7 @@ fn default_language_servers() -> HashMap<String, BridgeServerConfig> {
             // generated template documents the opt-in and the knob is
             // discoverable (#391). Concrete servers inherit it via the wildcard.
             prefer_shared_instance: Some(false),
+            settings: None,
         },
     )])
 }

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -83,6 +83,10 @@ pub(crate) fn merge_bridge_server_configs(
                 .clone()
                 .or(base.initialization_options.clone()),
         },
+        settings: match (&base.settings, &overlay.settings) {
+            (Some(b), Some(o)) => Some(deep_merge_json(b, o)),
+            _ => overlay.settings.clone().or(base.settings.clone()),
+        },
         root_markers: overlay
             .root_markers
             .clone()
@@ -517,6 +521,7 @@ mod tests {
                         root_markers: None,
                         on_type_formatting_triggers: None,
                         prefer_shared_instance: None,
+                        settings: None,
                     },
                 ),
                 (
@@ -528,6 +533,7 @@ mod tests {
                         root_markers: None,
                         on_type_formatting_triggers: None,
                         prefer_shared_instance: None,
+                        settings: None,
                     },
                 ),
             ])),
@@ -598,6 +604,7 @@ mod tests {
                         root_markers: None,
                         on_type_formatting_triggers: None,
                         prefer_shared_instance: None,
+                        settings: None,
                     },
                 ),
                 (
@@ -610,6 +617,7 @@ mod tests {
                         root_markers: None,
                         on_type_formatting_triggers: None,
                         prefer_shared_instance: None,
+                        settings: None,
                     },
                 ),
             ])),
@@ -677,6 +685,7 @@ mod tests {
                     root_markers: None,
                     on_type_formatting_triggers: None,
                     prefer_shared_instance: None,
+                    settings: None,
                 },
             )])),
             ..Default::default()
@@ -1066,6 +1075,7 @@ mod tests {
                 root_markers: None,
                 on_type_formatting_triggers: None,
                 prefer_shared_instance: None,
+                settings: None,
             },
         )]);
         let resolved = resolve_with_wildcard(&servers, "ra", merge_bridge_server_configs).unwrap();
@@ -1082,6 +1092,7 @@ mod tests {
                 root_markers: None,
                 on_type_formatting_triggers: None,
                 prefer_shared_instance: None,
+                settings: None,
             },
         )]);
         let resolved = resolve_with_wildcard(&servers, "ra", merge_bridge_server_configs).unwrap();
@@ -1099,6 +1110,7 @@ mod tests {
                     root_markers: None,
                     on_type_formatting_triggers: None,
                     prefer_shared_instance: None,
+                    settings: None,
                 },
             ),
             (
@@ -1110,6 +1122,7 @@ mod tests {
                     root_markers: None,
                     on_type_formatting_triggers: None,
                     prefer_shared_instance: None,
+                    settings: None,
                 },
             ),
         ]);
@@ -1139,6 +1152,7 @@ mod tests {
             root_markers: Some(vec![RootMarker::Single(".git".to_string())]),
             on_type_formatting_triggers: None,
             prefer_shared_instance: None,
+            settings: None,
         };
 
         // Unset overlay inherits from base (wildcard default applies)
@@ -1149,6 +1163,7 @@ mod tests {
             root_markers: None,
             on_type_formatting_triggers: None,
             prefer_shared_instance: None,
+            settings: None,
         };
         let merged = merge_bridge_server_configs(&base, &inheriting);
         assert_eq!(
@@ -1192,6 +1207,7 @@ mod tests {
             root_markers: None,
             on_type_formatting_triggers: None,
             prefer_shared_instance: prefer,
+            settings: None,
         };
 
         // Unset overlay inherits the base (wildcard) value.
@@ -1239,6 +1255,7 @@ mod tests {
             root_markers: None,
             on_type_formatting_triggers: None,
             prefer_shared_instance: None,
+            settings: None,
         };
         let overlay = BridgeServerConfig {
             cmd: vec!["rust-analyzer".to_string()],
@@ -1251,6 +1268,7 @@ mod tests {
             root_markers: None,
             on_type_formatting_triggers: None,
             prefer_shared_instance: None,
+            settings: None,
         };
 
         let resolved = merge_bridge_server_configs(&base, &overlay);
@@ -1259,6 +1277,69 @@ mod tests {
         snap_settings.bind(|| {
             insta::assert_json_snapshot!(resolved.initialization_options);
         });
+    }
+
+    #[test]
+    fn test_merge_bridge_server_configs_settings_deep_merge() {
+        use serde_json::json;
+        use settings::BridgeServerConfig;
+
+        // `settings` composes across config layers exactly like
+        // `initialization_options`: nested objects deep-merge, scalars take the
+        // overlay (downstream-settings-propagation).
+        let base = BridgeServerConfig {
+            settings: Some(json!({
+                "rust-analyzer": {
+                    "cargo": { "features": "all", "noDefaultFeatures": false },
+                    "check": { "command": "clippy" }
+                }
+            })),
+            ..Default::default()
+        };
+        let overlay = BridgeServerConfig {
+            settings: Some(json!({
+                "rust-analyzer": {
+                    "cargo": { "features": ["foo"] }
+                }
+            })),
+            ..Default::default()
+        };
+
+        let resolved = merge_bridge_server_configs(&base, &overlay);
+
+        assert_eq!(
+            resolved.settings,
+            Some(json!({
+                "rust-analyzer": {
+                    "cargo": { "features": ["foo"], "noDefaultFeatures": false },
+                    "check": { "command": "clippy" }
+                }
+            })),
+            "overlay scalar replaces, sibling keys are preserved by deep merge"
+        );
+    }
+
+    #[test]
+    fn test_merge_bridge_server_configs_settings_overlay_or_base_when_one_side_none() {
+        use serde_json::json;
+        use settings::BridgeServerConfig;
+
+        let with_settings = BridgeServerConfig {
+            settings: Some(json!({ "Lua": { "diagnostics": { "globals": ["vim"] } } })),
+            ..Default::default()
+        };
+        let without = BridgeServerConfig::default();
+
+        // base has settings, overlay does not → base survives.
+        assert_eq!(
+            merge_bridge_server_configs(&with_settings, &without).settings,
+            with_settings.settings,
+        );
+        // overlay has settings, base does not → overlay wins.
+        assert_eq!(
+            merge_bridge_server_configs(&without, &with_settings).settings,
+            with_settings.settings,
+        );
     }
 
     /// `onTypeFormattingTriggers` merges overlay-wins-when-present, so a
@@ -1276,6 +1357,7 @@ mod tests {
             on_type_formatting_triggers: triggers
                 .map(|t| t.into_iter().map(String::from).collect()),
             prefer_shared_instance: None,
+            settings: None,
         };
 
         let base = server(Some(vec!["}"]));
@@ -1427,6 +1509,7 @@ mod tests {
                     root_markers: None,
                     on_type_formatting_triggers: None,
                     prefer_shared_instance: None,
+                    settings: None,
                 },
             ),
             // rust-analyzer: only specifies cmd and languages
@@ -1439,6 +1522,7 @@ mod tests {
                     root_markers: None,
                     on_type_formatting_triggers: None,
                     prefer_shared_instance: None,
+                    settings: None,
                 },
             ),
         ]);
@@ -1478,6 +1562,7 @@ mod tests {
                     root_markers: None,
                     on_type_formatting_triggers: None,
                     prefer_shared_instance: None,
+                    settings: None,
                 },
             ),
             // rust-analyzer: specifies only cmd, inherits languages from wildcard
@@ -1490,6 +1575,7 @@ mod tests {
                     root_markers: None,
                     on_type_formatting_triggers: None,
                     prefer_shared_instance: None,
+                    settings: None,
                 },
             ),
         ]);

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -341,7 +341,7 @@ impl RootMarker {
 ///
 /// This is used to configure external language servers (like rust-analyzer, pyright)
 /// that kakehashi can redirect requests to for injection regions.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, JsonSchema)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct BridgeServerConfig {
     /// Command array: first element is the program, rest are arguments
@@ -357,6 +357,20 @@ pub struct BridgeServerConfig {
     pub languages: Vec<String>,
     /// Optional initialization options to pass to the server during initialize
     pub initialization_options: Option<Value>,
+    /// Optional workspace settings for the server, propagated *after*
+    /// initialize: answered to the server's `workspace/configuration` pulls and
+    /// pushed via `workspace/didChangeConfiguration` (downstream-settings-propagation).
+    ///
+    /// Distinct from `initialization_options`, which is consumed only at
+    /// `initialize` time: a runtime change to `settings` reaches a running
+    /// server, whereas an `initialization_options` change needs a restart.
+    ///
+    /// Treated as the editor-style settings root: a downstream
+    /// `workspace/configuration` item's `section` (e.g. `"rust-analyzer.cargo"`)
+    /// is resolved as a dotted path into this object. The contents are opaque to
+    /// kakehashi (passthrough), exactly like `initialization_options`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub settings: Option<Value>,
     /// Marker files/directories that locate the workspace root for this
     /// server, mirroring Neovim's `vim.fs.root` `(string|string[])[]` shape:
     /// entries are tried in list order (earlier = higher priority) and each
@@ -1418,6 +1432,7 @@ mod tests {
             on_type_formatting_triggers: triggers
                 .map(|t| t.into_iter().map(String::from).collect()),
             prefer_shared_instance: None,
+            settings: None,
         };
         let servers = HashMap::from([
             ("a".to_string(), server(Some(vec!["}", ";"]))),
@@ -1456,6 +1471,7 @@ mod tests {
                 root_markers: None,
                 on_type_formatting_triggers: Some(vec![String::new()]),
                 prefer_shared_instance: None,
+                settings: None,
             },
         )]);
         assert_eq!(
@@ -1550,6 +1566,7 @@ mod tests {
             ]),
             on_type_formatting_triggers: None,
             prefer_shared_instance: None,
+            settings: None,
         };
 
         let json = serde_json::to_value(&config).unwrap();

--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -267,6 +267,7 @@ mod tests {
                 root_markers: None,
                 on_type_formatting_triggers: None,
                 prefer_shared_instance: None,
+                settings: None,
             }),
         }
     }

--- a/src/lsp/aggregation/server/fan_out.rs
+++ b/src/lsp/aggregation/server/fan_out.rs
@@ -143,6 +143,7 @@ mod tests {
                 root_markers: None,
                 on_type_formatting_triggers: None,
                 prefer_shared_instance: None,
+                settings: None,
             }),
         }
     }

--- a/src/lsp/aggregation/server/priority.rs
+++ b/src/lsp/aggregation/server/priority.rs
@@ -156,6 +156,7 @@ mod tests {
                 root_markers: None,
                 on_type_formatting_triggers: None,
                 prefer_shared_instance: None,
+                settings: None,
             }),
         }
     }

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -248,6 +248,13 @@ pub(crate) struct ServerRequestDeps {
     pub(crate) progress_registry: Arc<crate::lsp::bridge::ProgressRegistry>,
     /// This connection's id, used to scope forward token translation.
     pub(crate) progress_connection_id: crate::lsp::bridge::ProgressConnectionId,
+    /// This server's current workspace settings, shared with the pool, used to
+    /// answer downstream `workspace/configuration` pulls (downstream-settings-propagation).
+    /// `None` slot = no settings configured for this server. The pool seeds it at
+    /// spawn from the resolved `BridgeServerConfig.settings` and (later) re-stores
+    /// it on a merge change, so a re-pull after a `didChangeConfiguration` reads
+    /// the current value.
+    pub(crate) settings: Arc<arc_swap::ArcSwapOption<serde_json::Value>>,
     /// Routes bridge-minted client-progress tokens (`kakehashi/bridge/cprog/*`)
     /// to their aggregator (ls-bridge-client-progress).
     pub(crate) client_progress_registry: Arc<crate::lsp::bridge::ClientProgressRegistry>,
@@ -502,6 +509,7 @@ pub(crate) fn spawn_reader_task_with_liveness(
         router,
         liveness_timeout,
         ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             response_tx,
             dynamic_capabilities,
@@ -592,6 +600,7 @@ async fn reader_loop(
     let progress_registry = Arc::new(crate::lsp::bridge::ProgressRegistry::new());
     let progress_connection_id = progress_registry.new_connection_id();
     let server_request_deps = ServerRequestDeps {
+        settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
         server_name: None,
         response_tx,
         dynamic_capabilities,
@@ -918,6 +927,9 @@ async fn handle_server_request(
             workspace::diagnostic_refresh::handle(server_prefix, deps)
         }
         "workspace/workspaceFolders" => workspace::workspace_folders::handle(server_prefix, deps),
+        "workspace/configuration" => {
+            workspace::configuration::handle(&message, server_prefix, deps)
+        }
         _ => {
             debug!(
                 target: "kakehashi::bridge::reader",
@@ -1048,6 +1060,7 @@ mod tests {
         let progress_registry = Arc::new(crate::lsp::bridge::ProgressRegistry::new());
         let progress_connection_id = progress_registry.new_connection_id();
         let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             response_tx: tx,
             dynamic_capabilities: caps,
@@ -1161,6 +1174,7 @@ mod tests {
         let progress_registry = Arc::new(crate::lsp::bridge::ProgressRegistry::new());
         let progress_connection_id = progress_registry.new_connection_id();
         let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: server_name.map(String::from),
             response_tx: tx,
             dynamic_capabilities: caps,
@@ -1258,6 +1272,7 @@ mod tests {
         let progress_registry = Arc::new(crate::lsp::bridge::ProgressRegistry::new());
         let progress_connection_id = progress_registry.new_connection_id();
         let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: Some("mock-ls".to_string()),
             response_tx: tx,
             dynamic_capabilities: caps,
@@ -1334,6 +1349,7 @@ mod tests {
             Arc::clone(&router),
             None,
             ServerRequestDeps {
+                settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
                 server_name: None,
                 response_tx,
                 dynamic_capabilities: Arc::new(DynamicCapabilityRegistry::new()),
@@ -1787,6 +1803,7 @@ mod tests {
         let (upstream_tx, _upstream_rx) = mpsc::unbounded_channel();
         let (window_tx, _window_rx) = mpsc::channel(16);
         let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             response_tx,
             dynamic_capabilities: Arc::clone(&dynamic_capabilities),
@@ -1848,6 +1865,7 @@ mod tests {
         assert!(dynamic_capabilities.has_registration("textDocument/diagnostic"));
 
         let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             response_tx,
             dynamic_capabilities: Arc::clone(&dynamic_capabilities),
@@ -1908,6 +1926,7 @@ mod tests {
         let progress_registry = Arc::new(crate::lsp::bridge::ProgressRegistry::new());
         let progress_connection_id = progress_registry.new_connection_id();
         let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             response_tx,
             dynamic_capabilities,
@@ -1968,6 +1987,7 @@ mod tests {
         let progress_connection_id = progress_registry.new_connection_id();
         let (window_tx, _window_rx) = mpsc::channel(16);
         let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             response_tx,
             dynamic_capabilities,
@@ -2027,6 +2047,7 @@ mod tests {
         let progress_connection_id = progress_registry.new_connection_id();
         let (window_tx, _window_rx) = mpsc::channel(16);
         let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             response_tx,
             dynamic_capabilities,
@@ -2083,6 +2104,7 @@ mod tests {
         );
         let (window_tx, _window_rx) = mpsc::channel(16);
         let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             response_tx,
             dynamic_capabilities,
@@ -2140,6 +2162,7 @@ mod tests {
         let progress_connection_id = progress_registry.new_connection_id();
         let (window_tx, _window_rx) = mpsc::channel(16);
         let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             response_tx,
             dynamic_capabilities,
@@ -2179,6 +2202,7 @@ mod tests {
         let (upstream_tx, mut upstream_rx) = mpsc::unbounded_channel();
         let (window_tx, _window_rx) = mpsc::channel(16);
         let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             response_tx,
             dynamic_capabilities,
@@ -2235,6 +2259,7 @@ mod tests {
             name: "repo".to_string(),
         }];
         let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             response_tx,
             dynamic_capabilities,
@@ -2279,6 +2304,7 @@ mod tests {
         let (upstream_tx, _upstream_rx) = mpsc::unbounded_channel();
         let (window_tx, _window_rx) = mpsc::channel(1);
         let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             response_tx,
             dynamic_capabilities,
@@ -2323,6 +2349,7 @@ mod tests {
         let (upstream_tx, mut upstream_rx) = mpsc::unbounded_channel();
         let (window_tx, _window_rx) = mpsc::channel(16);
         let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             response_tx,
             dynamic_capabilities,
@@ -2373,6 +2400,7 @@ mod tests {
         let (upstream_tx, mut upstream_rx) = mpsc::unbounded_channel();
         let (window_tx, _window_rx) = mpsc::channel(16);
         let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: Some("luals".to_string()),
             response_tx,
             dynamic_capabilities: Arc::new(DynamicCapabilityRegistry::new()),
@@ -2431,6 +2459,7 @@ mod tests {
         let (upstream_tx, mut upstream_rx) = mpsc::unbounded_channel();
         let (window_tx, _window_rx) = mpsc::channel(16);
         let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: Some("lua_ls".to_string()),
             response_tx,
             dynamic_capabilities: Arc::new(DynamicCapabilityRegistry::new()),
@@ -2482,6 +2511,7 @@ mod tests {
             let (upstream_tx, upstream_rx) = mpsc::unbounded_channel();
             let (window_tx, _window_rx) = mpsc::channel(16);
             let deps = ServerRequestDeps {
+                settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
                 server_name: Some("luals".to_string()),
                 response_tx,
                 dynamic_capabilities: Arc::new(DynamicCapabilityRegistry::new()),
@@ -2563,6 +2593,7 @@ mod tests {
         let (upstream_tx, _upstream_rx) = mpsc::unbounded_channel();
         let (window_tx, _window_rx) = mpsc::channel(16);
         let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             response_tx,
             dynamic_capabilities,
@@ -2603,6 +2634,7 @@ mod tests {
         let (upstream_tx, _upstream_rx) = mpsc::unbounded_channel();
         let (window_tx, _window_rx) = mpsc::channel(16);
         let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             response_tx,
             dynamic_capabilities: Arc::clone(&dynamic_capabilities),
@@ -2658,6 +2690,7 @@ mod tests {
         }]);
 
         let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             response_tx,
             dynamic_capabilities: Arc::clone(&dynamic_capabilities),
@@ -2724,6 +2757,7 @@ mod tests {
 
         // Spawn handle_server_request in a separate task (it needs to await)
         let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             response_tx: response_tx.clone(),
             dynamic_capabilities,
@@ -2785,6 +2819,7 @@ mod tests {
         drop(response_rx);
 
         let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
             response_tx,
             dynamic_capabilities,
@@ -3088,6 +3123,7 @@ mod tests {
         let progress_registry = Arc::new(crate::lsp::bridge::ProgressRegistry::new());
         let progress_connection_id = progress_registry.new_connection_id();
         let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: Some("mock-ls".to_string()),
             response_tx,
             dynamic_capabilities: Arc::new(DynamicCapabilityRegistry::new()),

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -1077,6 +1077,7 @@ mod tests {
                 root_markers: None,
                 on_type_formatting_triggers: None,
                 prefer_shared_instance: None,
+                settings: None,
             },
         );
 
@@ -1113,6 +1114,7 @@ mod tests {
                 root_markers: None,
                 on_type_formatting_triggers: None,
                 prefer_shared_instance: None,
+                settings: None,
             },
         );
 
@@ -1153,6 +1155,7 @@ mod tests {
                 )]),
                 on_type_formatting_triggers: None,
                 prefer_shared_instance: None,
+                settings: None,
             },
         );
         servers.insert(
@@ -1164,6 +1167,7 @@ mod tests {
                 root_markers: None,
                 on_type_formatting_triggers: None,
                 prefer_shared_instance: None,
+                settings: None,
             },
         );
 
@@ -1229,6 +1233,7 @@ mod tests {
                 root_markers: None,
                 on_type_formatting_triggers: None,
                 prefer_shared_instance: None,
+                settings: None,
             },
         );
         servers.insert(
@@ -1240,6 +1245,7 @@ mod tests {
                 root_markers: None,
                 on_type_formatting_triggers: None,
                 prefer_shared_instance: None,
+                settings: None,
             },
         );
 
@@ -1293,6 +1299,7 @@ mod tests {
                 root_markers: None,
                 on_type_formatting_triggers: None,
                 prefer_shared_instance: None,
+                settings: None,
             },
         );
 
@@ -1329,6 +1336,7 @@ mod tests {
                 root_markers: None,
                 on_type_formatting_triggers: None,
                 prefer_shared_instance: None,
+                settings: None,
             },
         );
 
@@ -1446,6 +1454,7 @@ mod tests {
                 root_markers: None,
                 on_type_formatting_triggers: None,
                 prefer_shared_instance: None,
+                settings: None,
             },
         );
 
@@ -1670,6 +1679,7 @@ mod tests {
                 root_markers: None,
                 on_type_formatting_triggers: None,
                 prefer_shared_instance: None,
+                settings: None,
             },
         );
 

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -201,8 +201,9 @@ impl BridgeCoordinator {
     /// Propagate a merged-settings change to every live downstream connection
     /// (downstream-settings-propagation, path c). Each server's settings are
     /// re-resolved through the same wildcard merge used at spawn, so an
-    /// unchanged config yields identical values and pushes nothing.
-    pub(crate) async fn propagate_settings(&self, settings: &WorkspaceSettings) {
+    /// unchanged config yields identical values and pushes nothing. Returns the
+    /// number of connections pushed.
+    pub(crate) async fn propagate_settings(&self, settings: &WorkspaceSettings) -> usize {
         self.pool
             .propagate_settings(|server_name| {
                 resolve_with_wildcard(
@@ -212,7 +213,7 @@ impl BridgeCoordinator {
                 )
                 .and_then(|config| config.settings)
             })
-            .await;
+            .await
     }
 
     /// Access the cancel forwarder.

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -198,6 +198,23 @@ impl BridgeCoordinator {
         Arc::clone(&self.pool)
     }
 
+    /// Propagate a merged-settings change to every live downstream connection
+    /// (downstream-settings-propagation, path c). Each server's settings are
+    /// re-resolved through the same wildcard merge used at spawn, so an
+    /// unchanged config yields identical values and pushes nothing.
+    pub(crate) async fn propagate_settings(&self, settings: &WorkspaceSettings) {
+        self.pool
+            .propagate_settings(|server_name| {
+                resolve_with_wildcard(
+                    &settings.language_servers,
+                    server_name,
+                    merge_bridge_server_configs,
+                )
+                .and_then(|config| config.settings)
+            })
+            .await;
+    }
+
     /// Access the cancel forwarder.
     ///
     /// Used by:

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -2072,6 +2072,7 @@ mod tests {
     fn shared_config() -> crate::config::settings::BridgeServerConfig {
         crate::config::settings::BridgeServerConfig {
             prefer_shared_instance: Some(true),
+            settings: None,
             ..devnull_config()
         }
     }
@@ -2677,6 +2678,7 @@ mod tests {
             root_markers: None,
             on_type_formatting_triggers: None,
             prefer_shared_instance: None,
+            settings: None,
         };
 
         let result = pool

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -52,7 +52,8 @@ use crate::error::LockResultExt;
 
 use super::protocol::{
     JsonRpcNotification, RequestId, VirtualDocumentUri,
-    build_did_change_workspace_folders_notification, build_didopen_notification,
+    build_did_change_configuration_notification, build_did_change_workspace_folders_notification,
+    build_didopen_notification,
 };
 
 /// Timeout for the LSP initialize handshake and for wait-for-ready on an
@@ -1452,6 +1453,11 @@ impl LanguageServerPool {
         // - If this function's caller is cancelled, only the JoinHandle await is dropped
         // - The spawned handshake task continues to completion
         let init_options = server_config.initialization_options.clone();
+        // Seed value for the post-`initialized` settings push (path a). Same
+        // value the reader's settings cell was seeded with; push-model servers
+        // read it directly, pull-model servers re-request via
+        // workspace/configuration (downstream-settings-propagation).
+        let seed_settings = server_config.settings.clone();
         let client_capabilities = self.client_capabilities();
         let handle_for_handshake = Arc::clone(&handle);
         let server_name_for_log = server_name.to_string();
@@ -1481,6 +1487,16 @@ impl LanguageServerPool {
                     );
                     handle_for_handshake.set_server_capabilities(capabilities);
                     handle_for_handshake.set_state(ConnectionState::Ready);
+                    // Path a: push this server's seed settings now that it is
+                    // initialized, so push-model servers are configured even
+                    // before they pull (downstream-settings-propagation).
+                    // Best-effort: a dropped notification self-heals when a
+                    // pull-model server re-requests via workspace/configuration.
+                    if let Some(settings) = seed_settings {
+                        handle_for_handshake.send_notification(
+                            build_did_change_configuration_notification(settings),
+                        );
+                    }
                     Ok(())
                 }
                 Ok(Err(e)) => {

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1411,6 +1411,13 @@ impl LanguageServerPool {
                 progress_registry: Arc::clone(&self.progress_registry),
                 client_progress_registry: Arc::clone(&self.client_progress_registry),
                 progress_connection_id: self.progress_registry.new_connection_id(),
+                // Seed this connection's settings cell from the resolved config
+                // so the reader can answer downstream `workspace/configuration`
+                // pulls (downstream-settings-propagation). Updated on later merge
+                // changes by the propagation path (c).
+                settings: Arc::new(arc_swap::ArcSwapOption::from(
+                    server_config.settings.clone().map(Arc::new),
+                )),
             },
         );
 

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -472,11 +472,15 @@ impl LanguageServerPool {
     /// `null` when settings were cleared). Unchanged servers get nothing, so a
     /// global reload does not storm every connection. The cell is updated before
     /// the push so a pull-model server's re-pull never races onto the old value.
+    ///
+    /// Returns the number of connections that changed (and were pushed), so the
+    /// anti-storm behavior is observable to callers and tests.
     pub(crate) async fn propagate_settings(
         &self,
         resolve: impl Fn(&str) -> Option<serde_json::Value>,
-    ) {
+    ) -> usize {
         let connections = self.connections.lock().await;
+        let mut pushed = 0;
         for handle in connections.values() {
             let resolved = resolve(handle.key().server());
             // Diff by value (Arc identity is irrelevant); skip unchanged servers
@@ -488,7 +492,9 @@ impl LanguageServerPool {
             handle.send_notification(build_did_change_configuration_notification(
                 resolved.unwrap_or(serde_json::Value::Null),
             ));
+            pushed += 1;
         }
+        pushed
     }
 
     /// Among `candidates`, the server names that have a **live connection
@@ -1486,12 +1492,12 @@ impl LanguageServerPool {
         // - If this function's caller is cancelled, only the JoinHandle await is dropped
         // - The spawned handshake task continues to completion
         let init_options = server_config.initialization_options.clone();
-        // Seed value for the post-`initialized` settings push (path a). Same
-        // value the reader's settings cell was seeded with; push-model servers
-        // read it directly, pull-model servers re-request via
-        // workspace/configuration (downstream-settings-propagation).
-        let seed_settings = server_config.settings.clone();
         let client_capabilities = self.client_capabilities();
+        // Only advertise `workspace.configuration` when this server actually has
+        // settings to serve. Advertising it otherwise would flip an
+        // `initializationOptions`-configured server to pull and get every
+        // section answered `null` (downstream-settings-propagation).
+        let advertise_configuration = server_config.settings.is_some();
         let handle_for_handshake = Arc::clone(&handle);
         let server_name_for_log = server_name.to_string();
         let handshake_task = tokio::spawn(async move {
@@ -1505,6 +1511,7 @@ impl LanguageServerPool {
                     root_uri,
                     init_folders,
                     client_capabilities,
+                    advertise_configuration,
                 ),
             )
             .await;
@@ -1520,14 +1527,18 @@ impl LanguageServerPool {
                     );
                     handle_for_handshake.set_server_capabilities(capabilities);
                     handle_for_handshake.set_state(ConnectionState::Ready);
-                    // Path a: push this server's seed settings now that it is
+                    // Path a: push this server's settings now that it is
                     // initialized, so push-model servers are configured even
-                    // before they pull (downstream-settings-propagation).
-                    // Best-effort: a dropped notification self-heals when a
-                    // pull-model server re-requests via workspace/configuration.
-                    if let Some(settings) = seed_settings {
+                    // before they pull (downstream-settings-propagation). Read
+                    // the *live* cell, not the spawn-time value: a path-c
+                    // re-propagation during the handshake may have already
+                    // advanced it, and the cell is exactly what (b) serves — so
+                    // this pushes what a pull would return, never a stale
+                    // snapshot. Best-effort: a dropped notification self-heals on
+                    // the next pull.
+                    if let Some(settings) = handle_for_handshake.current_settings() {
                         handle_for_handshake.send_notification(
-                            build_did_change_configuration_notification(settings),
+                            build_did_change_configuration_notification((*settings).clone()),
                         );
                     }
                     Ok(())
@@ -5145,13 +5156,18 @@ mod tests {
         let ra_value = json!({ "rust-analyzer": { "cargo": { "features": "all" } } });
         let ra_value_for_resolve = ra_value.clone();
         let lua_value_for_resolve = (*lua_value).clone();
-        pool.propagate_settings(move |name| match name {
-            "rust-analyzer" => Some(ra_value_for_resolve.clone()),
-            "lua" => Some(lua_value_for_resolve.clone()),
-            _ => None,
-        })
-        .await;
+        let pushed = pool
+            .propagate_settings(move |name| match name {
+                "rust-analyzer" => Some(ra_value_for_resolve.clone()),
+                "lua" => Some(lua_value_for_resolve.clone()),
+                _ => None,
+            })
+            .await;
 
+        assert_eq!(
+            pushed, 1,
+            "only the changed connection is pushed — the unchanged one does not storm"
+        );
         assert_eq!(
             ra.current_settings().as_deref(),
             Some(&ra_value),
@@ -5162,6 +5178,18 @@ mod tests {
             Some(lua_value.as_ref()),
             "unchanged connection keeps its settings"
         );
+
+        // Re-running with the same resolver now pushes nothing: both cells match.
+        let lua_again = (*lua_value).clone();
+        let ra_again = ra_value.clone();
+        let pushed_again = pool
+            .propagate_settings(move |name| match name {
+                "rust-analyzer" => Some(ra_again.clone()),
+                "lua" => Some(lua_again.clone()),
+                _ => None,
+            })
+            .await;
+        assert_eq!(pushed_again, 0, "an unchanged reload pushes nothing");
     }
 
     /// Path c with no live connections (e.g. initialize-time apply) is a clean
@@ -5169,7 +5197,9 @@ mod tests {
     #[tokio::test]
     async fn propagate_settings_no_connections_is_noop() {
         let pool = LanguageServerPool::new();
-        pool.propagate_settings(|_| Some(serde_json::json!({ "x": 1 })))
+        let pushed = pool
+            .propagate_settings(|_| Some(serde_json::json!({ "x": 1 })))
             .await;
+        assert_eq!(pushed, 0, "no live connections → nothing pushed");
     }
 }

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -488,11 +488,24 @@ impl LanguageServerPool {
             if resolved.as_ref() == handle.current_settings().as_deref() {
                 continue;
             }
+            // Always advance the cell so a later pull / the post-`initialized`
+            // push (path a) reflects the change, even for a connection we don't
+            // notify yet.
             handle.store_settings(resolved.clone().map(Arc::new));
-            handle.send_notification(build_did_change_configuration_notification(
-                resolved.unwrap_or(serde_json::Value::Null),
-            ));
-            pushed += 1;
+            // Only notify a Ready connection: sending
+            // `workspace/didChangeConfiguration` to a still-initializing server
+            // would precede its `initialized` and violate LSP ordering. An
+            // Initializing connection instead gets its (now-updated) cell pushed
+            // by path (a) once the handshake completes. Count only a successful
+            // enqueue, so the returned count never reports a dropped push.
+            if handle.state() == ConnectionState::Ready {
+                let result = handle.send_notification(build_did_change_configuration_notification(
+                    resolved.unwrap_or(serde_json::Value::Null),
+                ));
+                if result == NotificationSendResult::Queued {
+                    pushed += 1;
+                }
+            }
         }
         pushed
     }
@@ -1526,21 +1539,23 @@ impl LanguageServerPool {
                         server_name_for_log
                     );
                     handle_for_handshake.set_server_capabilities(capabilities);
-                    handle_for_handshake.set_state(ConnectionState::Ready);
-                    // Path a: push this server's settings now that it is
-                    // initialized, so push-model servers are configured even
-                    // before they pull (downstream-settings-propagation). Read
-                    // the *live* cell, not the spawn-time value: a path-c
-                    // re-propagation during the handshake may have already
-                    // advanced it, and the cell is exactly what (b) serves — so
-                    // this pushes what a pull would return, never a stale
-                    // snapshot. Best-effort: a dropped notification self-heals on
-                    // the next pull.
+                    // Path a: push this server's settings now that `initialized`
+                    // has been sent, so push-model servers are configured even
+                    // before they pull (downstream-settings-propagation). Queue it
+                    // *before* flipping to Ready: a waiter unblocked by the Ready
+                    // transition may enqueue `didOpen`, and the single-writer FIFO
+                    // must carry the settings ahead of it so the server never
+                    // processes a document under default config. Read the *live*
+                    // cell, not the spawn-time value, so a path-c re-propagation
+                    // that landed during the handshake is reflected and the push
+                    // agrees with what (b) would answer. Best-effort: a dropped
+                    // notification self-heals on the next pull.
                     if let Some(settings) = handle_for_handshake.current_settings() {
                         handle_for_handshake.send_notification(
                             build_did_change_configuration_notification((*settings).clone()),
                         );
                     }
+                    handle_for_handshake.set_state(ConnectionState::Ready);
                     Ok(())
                 }
                 Ok(Err(e)) => {
@@ -5190,6 +5205,38 @@ mod tests {
             })
             .await;
         assert_eq!(pushed_again, 0, "an unchanged reload pushes nothing");
+    }
+
+    /// Path c does NOT notify a still-initializing connection (that would
+    /// precede its `initialized` and break LSP ordering), but it DOES advance the
+    /// cell so the post-`initialized` push (path a) carries the latest value.
+    #[tokio::test]
+    async fn propagate_settings_updates_but_does_not_notify_initializing_connection() {
+        use serde_json::json;
+
+        let pool = LanguageServerPool::new();
+        let initializing = create_handle_with_key(
+            ConnectionState::Initializing,
+            ConnectionKey::for_server("rust-analyzer"),
+        )
+        .await;
+        pool.connections().await.insert(
+            ConnectionKey::for_server("rust-analyzer"),
+            Arc::clone(&initializing),
+        );
+
+        let value = json!({ "rust-analyzer": { "cargo": { "features": "all" } } });
+        let value_for_resolve = value.clone();
+        let pushed = pool
+            .propagate_settings(move |_| Some(value_for_resolve.clone()))
+            .await;
+
+        assert_eq!(pushed, 0, "an initializing connection is not notified");
+        assert_eq!(
+            initializing.current_settings().as_deref(),
+            Some(&value),
+            "but its cell is advanced so path (a) pushes the latest value",
+        );
     }
 
     /// Path c with no live connections (e.g. initialize-time apply) is a clean

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1560,9 +1560,19 @@ impl LanguageServerPool {
                     // that landed during the handshake is reflected and the push
                     // agrees with what (b) would answer. Best-effort: a dropped
                     // notification self-heals on the next pull.
-                    if let Some(settings) = handle_for_handshake.current_settings() {
+                    //
+                    // Push when we advertised `configuration` (so a clear to
+                    // `None` during the handshake still reaches the server as
+                    // `null` instead of leaving it on stale settings) OR when the
+                    // cell now holds settings (added during the handshake). When
+                    // neither holds there is nothing to communicate.
+                    let current = handle_for_handshake.current_settings();
+                    if advertise_configuration || current.is_some() {
+                        let payload = current
+                            .map(|s| (*s).clone())
+                            .unwrap_or(serde_json::Value::Null);
                         handle_for_handshake.send_notification(
-                            build_did_change_configuration_notification((*settings).clone()),
+                            build_did_change_configuration_notification(payload),
                         );
                     }
                     handle_for_handshake.set_state(ConnectionState::Ready);

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -461,6 +461,36 @@ impl LanguageServerPool {
         self.connections.lock().await
     }
 
+    /// Propagate a workspace-settings change to every live connection whose
+    /// settings changed (downstream-settings-propagation, path c).
+    ///
+    /// `resolve` maps a server name to its newly merged settings. For each
+    /// connection the resolved value is diffed against the connection's current
+    /// settings cell; on a change the cell is re-stored — so a later
+    /// `workspace/configuration` re-pull reflects it — and a best-effort
+    /// `workspace/didChangeConfiguration` is pushed (carrying the new value, or
+    /// `null` when settings were cleared). Unchanged servers get nothing, so a
+    /// global reload does not storm every connection. The cell is updated before
+    /// the push so a pull-model server's re-pull never races onto the old value.
+    pub(crate) async fn propagate_settings(
+        &self,
+        resolve: impl Fn(&str) -> Option<serde_json::Value>,
+    ) {
+        let connections = self.connections.lock().await;
+        for handle in connections.values() {
+            let resolved = resolve(handle.key().server());
+            // Diff by value (Arc identity is irrelevant); skip unchanged servers
+            // so an unchanged config reload pushes nothing.
+            if resolved.as_ref() == handle.current_settings().as_deref() {
+                continue;
+            }
+            handle.store_settings(resolved.clone().map(Arc::new));
+            handle.send_notification(build_did_change_configuration_notification(
+                resolved.unwrap_or(serde_json::Value::Null),
+            ));
+        }
+    }
+
     /// Among `candidates`, the server names that have a **live connection
     /// advertising pull diagnostics** — `textDocument/diagnostic`, via static
     /// initialize caps or a dynamic registration — checked WITHOUT creating a
@@ -1393,6 +1423,14 @@ impl LanguageServerPool {
         // Now spawn reader task with liveness timeout - it can route the initialize response immediately
         // Liveness timeout is configured via LivenessTimeout::default() (60s per ls-bridge-timeout-hierarchy Tier 2)
         // Server name is passed for structured logging and notification prefixes
+        // Per-connection settings cell, shared between the reader (answers
+        // workspace/configuration pulls, path b) and the handle (re-stored on a
+        // merge change, path c). Seeded from the resolved config
+        // (downstream-settings-propagation).
+        let settings_cell = Arc::new(arc_swap::ArcSwapOption::from(
+            server_config.settings.clone().map(Arc::new),
+        ));
+
         let liveness_timeout = liveness_timeout::LivenessTimeout::default();
         let reader_handle = spawn_reader_task_for_server(
             reader,
@@ -1412,13 +1450,7 @@ impl LanguageServerPool {
                 progress_registry: Arc::clone(&self.progress_registry),
                 client_progress_registry: Arc::clone(&self.client_progress_registry),
                 progress_connection_id: self.progress_registry.new_connection_id(),
-                // Seed this connection's settings cell from the resolved config
-                // so the reader can answer downstream `workspace/configuration`
-                // pulls (downstream-settings-propagation). Updated on later merge
-                // changes by the propagation path (c).
-                settings: Arc::new(arc_swap::ArcSwapOption::from(
-                    server_config.settings.clone().map(Arc::new),
-                )),
+                settings: Arc::clone(&settings_cell),
             },
         );
 
@@ -1435,6 +1467,7 @@ impl LanguageServerPool {
             dynamic_capabilities,
             connection_key.clone(),
             workspace_folders,
+            settings_cell,
         ));
 
         // Insert into pool immediately so concurrent requests see Initializing state
@@ -3445,6 +3478,7 @@ mod tests {
             Arc::new(DynamicCapabilityRegistry::new()),
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
+            std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
         ));
 
         // Add connection to pool
@@ -5080,5 +5114,62 @@ mod tests {
                 .await
                 .is_empty()
         );
+    }
+
+    /// Path c: `propagate_settings` re-stores each live connection's cell from the
+    /// resolver, so a later `workspace/configuration` re-pull reflects the change.
+    /// A connection whose resolved value is unchanged keeps its cell as-is.
+    #[tokio::test]
+    async fn propagate_settings_updates_changed_connections() {
+        use serde_json::json;
+
+        let pool = LanguageServerPool::new();
+
+        // Two live connections: "rust-analyzer" gets new settings; "lua" already
+        // holds its value and the resolver returns the same thing (unchanged).
+        let ra = create_handle_with_key(
+            ConnectionState::Ready,
+            ConnectionKey::for_server("rust-analyzer"),
+        )
+        .await;
+        let lua_value = Arc::new(json!({ "Lua": { "telemetry": { "enable": false } } }));
+        let lua =
+            create_handle_with_key(ConnectionState::Ready, ConnectionKey::for_server("lua")).await;
+        lua.store_settings(Some(Arc::clone(&lua_value)));
+        {
+            let mut conns = pool.connections().await;
+            conns.insert(ConnectionKey::for_server("rust-analyzer"), Arc::clone(&ra));
+            conns.insert(ConnectionKey::for_server("lua"), Arc::clone(&lua));
+        }
+
+        let ra_value = json!({ "rust-analyzer": { "cargo": { "features": "all" } } });
+        let ra_value_for_resolve = ra_value.clone();
+        let lua_value_for_resolve = (*lua_value).clone();
+        pool.propagate_settings(move |name| match name {
+            "rust-analyzer" => Some(ra_value_for_resolve.clone()),
+            "lua" => Some(lua_value_for_resolve.clone()),
+            _ => None,
+        })
+        .await;
+
+        assert_eq!(
+            ra.current_settings().as_deref(),
+            Some(&ra_value),
+            "changed connection's cell is updated to the resolved value"
+        );
+        assert_eq!(
+            lua.current_settings().as_deref(),
+            Some(lua_value.as_ref()),
+            "unchanged connection keeps its settings"
+        );
+    }
+
+    /// Path c with no live connections (e.g. initialize-time apply) is a clean
+    /// no-op, not a panic.
+    #[tokio::test]
+    async fn propagate_settings_no_connections_is_noop() {
+        let pool = LanguageServerPool::new();
+        pool.propagate_settings(|_| Some(serde_json::json!({ "x": 1 })))
+            .await;
     }
 }

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -490,18 +490,28 @@ impl LanguageServerPool {
             }
             // Always advance the cell so a later pull / the post-`initialized`
             // push (path a) reflects the change, even for a connection we don't
-            // notify yet.
-            handle.store_settings(resolved.clone().map(Arc::new));
+            // notify yet. Wrap once in `Arc` and store a cheap `Arc` clone; the
+            // inner `Value` is cloned only for an actual push below.
+            let resolved = resolved.map(Arc::new);
+            handle.store_settings(resolved.clone());
             // Only notify a Ready connection: sending
             // `workspace/didChangeConfiguration` to a still-initializing server
             // would precede its `initialized` and violate LSP ordering. An
             // Initializing connection instead gets its (now-updated) cell pushed
             // by path (a) once the handshake completes. Count only a successful
             // enqueue, so the returned count never reports a dropped push.
+            //
+            // No `Arc::ptr_eq`-against-the-map liveness recheck is needed here:
+            // this loop holds the `connections` lock and iterates the map's live
+            // values directly (never retrieve-then-release), so a respawn — which
+            // takes the same lock — cannot replace a handle mid-iteration.
             if handle.state() == ConnectionState::Ready {
-                let result = handle.send_notification(build_did_change_configuration_notification(
-                    resolved.unwrap_or(serde_json::Value::Null),
-                ));
+                let payload = resolved
+                    .as_deref()
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null);
+                let result =
+                    handle.send_notification(build_did_change_configuration_notification(payload));
                 if result == NotificationSendResult::Queued {
                     pushed += 1;
                 }

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -133,6 +133,12 @@ pub(crate) struct ConnectionHandle {
     /// falling back to per-root instances" log for this server (#391), so the
     /// per-acquisition capability check does not spam the log.
     incapable_fallback_logged: AtomicBool,
+    /// This server's current workspace settings, shared with the reader task's
+    /// `ServerRequestDeps` (downstream-settings-propagation). The same `Arc` cell
+    /// the reader reads to answer `workspace/configuration` pulls; the pool
+    /// re-stores it here on a merge change (path c) so a re-pull reflects the
+    /// current config. `None` slot = no settings configured for this server.
+    settings: Arc<arc_swap::ArcSwapOption<serde_json::Value>>,
 }
 
 impl ConnectionHandle {
@@ -158,6 +164,7 @@ impl ConnectionHandle {
             dynamic_capabilities,
             ConnectionKey::for_server("test"),
             WorkspaceFolderSet::new(None),
+            Arc::new(arc_swap::ArcSwapOption::empty()),
         )
     }
 
@@ -175,6 +182,7 @@ impl ConnectionHandle {
         dynamic_capabilities: Arc<DynamicCapabilityRegistry>,
         connection_key: ConnectionKey,
         workspace_folders: WorkspaceFolderSet,
+        settings: Arc<arc_swap::ArcSwapOption<serde_json::Value>>,
     ) -> Self {
         use crate::lsp::bridge::actor::spawn_writer_task;
 
@@ -197,7 +205,22 @@ impl ConnectionHandle {
             connection_key,
             workspace_folders,
             incapable_fallback_logged: AtomicBool::new(false),
+            settings,
         }
+    }
+
+    /// This connection's current workspace settings, if any
+    /// (downstream-settings-propagation). Read by the propagation diff to decide
+    /// whether a merge change needs a `workspace/didChangeConfiguration` push.
+    pub(super) fn current_settings(&self) -> Option<Arc<serde_json::Value>> {
+        self.settings.load_full()
+    }
+
+    /// Re-store this connection's settings after a merge change (path c). The
+    /// reader's `ServerRequestDeps` shares the same cell, so a subsequent
+    /// `workspace/configuration` pull reflects the new value.
+    pub(super) fn store_settings(&self, settings: Option<Arc<serde_json::Value>>) {
+        self.settings.store(settings);
     }
 
     /// This connection's pool identity: `(server_name, resolved_root)`.
@@ -872,6 +895,54 @@ mod tests {
         Arc::new(DynamicCapabilityRegistry::new())
     }
 
+    /// The settings cell stored on the handle is the *same* `Arc` the reader's
+    /// `ServerRequestDeps` clones, so a path-c `store_settings` is observable by a
+    /// path-b pull (downstream-settings-propagation).
+    #[tokio::test]
+    async fn settings_cell_roundtrips_and_is_shared_with_the_reader() {
+        use serde_json::json;
+
+        let mut conn = AsyncBridgeConnection::spawn(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "cat > /dev/null".to_string(),
+        ])
+        .await
+        .expect("spawn sink");
+        let (writer, reader) = conn.split();
+        let router = Arc::new(ResponseRouter::new());
+        let reader_handle = spawn_reader_task(reader, Arc::clone(&router));
+        let (tx, rx) = mpsc::channel(OUTBOUND_QUEUE_CAPACITY);
+
+        // The shared cell, as the pool builds it — one Arc cloned into both the
+        // reader deps and the handle.
+        let cell = Arc::new(arc_swap::ArcSwapOption::empty());
+        let handle = ConnectionHandle::with_state(
+            writer,
+            router,
+            reader_handle,
+            ConnectionState::Ready,
+            tx,
+            rx,
+            default_dynamic_caps(),
+            ConnectionKey::for_server("test"),
+            crate::lsp::bridge::WorkspaceFolderSet::new(None),
+            Arc::clone(&cell),
+        );
+
+        assert!(handle.current_settings().is_none(), "starts empty");
+
+        let value = Arc::new(json!({ "Lua": { "diagnostics": { "globals": ["vim"] } } }));
+        handle.store_settings(Some(Arc::clone(&value)));
+
+        assert_eq!(handle.current_settings().as_deref(), Some(value.as_ref()));
+        // The reader's clone of the same Arc observes the write.
+        assert_eq!(cell.load_full().as_deref(), Some(value.as_ref()));
+
+        handle.store_settings(None);
+        assert!(handle.current_settings().is_none(), "clears to None");
+    }
+
     /// Test that ConnectionHandle provides unique request IDs via atomic counter.
     ///
     /// Each call to next_request_id() should return a unique, incrementing value.
@@ -1003,6 +1074,7 @@ mod tests {
             default_dynamic_caps(),
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
+            std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
         ));
 
         // Verify initial state is Ready
@@ -1078,6 +1150,7 @@ mod tests {
             default_dynamic_caps(),
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
+            std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
         ));
 
         // Register a request to start the liveness timer
@@ -1137,6 +1210,7 @@ mod tests {
             default_dynamic_caps(),
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
+            std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
         ));
 
         // Register a request - this should NOT start the liveness timer
@@ -1203,6 +1277,7 @@ mod tests {
             default_dynamic_caps(),
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
+            std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
         ));
 
         // Register first request - this starts the liveness timer
@@ -1297,6 +1372,7 @@ mod tests {
             default_dynamic_caps(),
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
+            std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
         );
 
         // Register a request with upstream ID
@@ -1340,6 +1416,7 @@ mod tests {
             default_dynamic_caps(),
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
+            std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
         );
 
         // Register without upstream ID
@@ -1382,6 +1459,7 @@ mod tests {
             default_dynamic_caps(),
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
+            std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
         );
 
         // Should return immediately
@@ -1416,6 +1494,7 @@ mod tests {
             default_dynamic_caps(),
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
+            std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
         ));
 
         // Spawn a task that will transition to Ready after a delay
@@ -1461,6 +1540,7 @@ mod tests {
             default_dynamic_caps(),
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
+            std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
         ));
 
         // Spawn a task that will transition to Failed
@@ -1508,6 +1588,7 @@ mod tests {
             default_dynamic_caps(),
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
+            std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
         );
 
         // Wait with short timeout - should timeout
@@ -1544,6 +1625,7 @@ mod tests {
             default_dynamic_caps(),
             ConnectionKey::for_server("test"),
             crate::lsp::bridge::WorkspaceFolderSet::new(None),
+            std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
         ));
 
         // Spawn a task that will transition to Closing

--- a/src/lsp/bridge/pool/handshake.rs
+++ b/src/lsp/bridge/pool/handshake.rs
@@ -27,6 +27,7 @@ use crate::lsp::bridge::protocol::{
 /// `ServerCapabilities`. Invoked by `get_or_create_connection_with_timeout`
 /// once the connection has spawned and the reader task is up; goes through
 /// the single-writer channel (ls-bridge-message-ordering) for FIFO ordering.
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn perform_lsp_handshake(
     handle: &ConnectionHandle,
     init_request_id: RequestId,
@@ -35,6 +36,7 @@ pub(super) async fn perform_lsp_handshake(
     root_uri: Option<String>,
     workspace_folders: Option<Vec<WorkspaceFolder>>,
     client_capabilities: Option<ClientCapabilities>,
+    advertise_configuration: bool,
 ) -> io::Result<ServerCapabilities> {
     // 1. Build and send initialize request via the single-writer loop
     let init_request = build_initialize_request(
@@ -43,6 +45,7 @@ pub(super) async fn perform_lsp_handshake(
         root_uri,
         workspace_folders,
         client_capabilities.as_ref(),
+        advertise_configuration,
     );
     handle
         .send_request(init_request, init_request_id)

--- a/src/lsp/bridge/pool/test_helpers.rs
+++ b/src/lsp/bridge/pool/test_helpers.rs
@@ -54,6 +54,7 @@ pub(in crate::lsp::bridge) fn lua_ls_config() -> BridgeServerConfig {
         root_markers: None,
         on_type_formatting_triggers: None,
         prefer_shared_instance: None,
+        settings: None,
     }
 }
 
@@ -76,6 +77,7 @@ pub(in crate::lsp::bridge) fn devnull_config_for_language(language: &str) -> Bri
         root_markers: None,
         on_type_formatting_triggers: None,
         prefer_shared_instance: None,
+        settings: None,
     }
 }
 

--- a/src/lsp/bridge/pool/test_helpers.rs
+++ b/src/lsp/bridge/pool/test_helpers.rs
@@ -176,6 +176,7 @@ pub(in crate::lsp::bridge) async fn create_handle_with_state_and_pid_keyed(
         dynamic_capabilities,
         key,
         crate::lsp::bridge::WorkspaceFolderSet::new(None),
+        std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
     ));
     (handle, pid)
 }

--- a/src/lsp/bridge/protocol/client_capabilities.rs
+++ b/src/lsp/bridge/protocol/client_capabilities.rs
@@ -92,6 +92,11 @@ fn build_baseline_capabilities() -> ClientCapabilities {
             // passthrough or the rootMarkers-derived folder), which LSP makes
             // conditional on this capability.
             workspace_folders: Some(true),
+            // The bridge owns and serves each server's workspace settings
+            // (downstream-settings-propagation): advertise `configuration` so a
+            // spec-compliant downstream server pulls via `workspace/configuration`,
+            // answered from the per-connection settings cell.
+            configuration: Some(true),
             ..Default::default()
         }),
         general: Some(GeneralClientCapabilities {

--- a/src/lsp/bridge/protocol/client_capabilities.rs
+++ b/src/lsp/bridge/protocol/client_capabilities.rs
@@ -8,7 +8,7 @@ use tower_lsp_server::ls_types::ClientCapabilities;
 /// Build the baseline client capabilities the bridge declares to downstream servers.
 ///
 /// Returns typed `ClientCapabilities` for use with [`merge_upstream_capabilities`].
-fn build_baseline_capabilities() -> ClientCapabilities {
+fn build_baseline_capabilities(advertise_configuration: bool) -> ClientCapabilities {
     use tower_lsp_server::ls_types::{
         CompletionClientCapabilities, CompletionItemCapability, DiagnosticClientCapabilities,
         DiagnosticWorkspaceClientCapabilities, DocumentLinkClientCapabilities,
@@ -95,8 +95,11 @@ fn build_baseline_capabilities() -> ClientCapabilities {
             // The bridge owns and serves each server's workspace settings
             // (downstream-settings-propagation): advertise `configuration` so a
             // spec-compliant downstream server pulls via `workspace/configuration`,
-            // answered from the per-connection settings cell.
-            configuration: Some(true),
+            // answered from the per-connection settings cell. Gated per-server on
+            // having settings to serve: advertising it for a server with no
+            // `settings` would flip an `initializationOptions`-configured server
+            // to pull and answer every section `null`, clobbering config it held.
+            configuration: advertise_configuration.then_some(true),
             ..Default::default()
         }),
         general: Some(GeneralClientCapabilities {
@@ -288,8 +291,12 @@ fn merge_upstream_capabilities(
 /// See [`merge_upstream_capabilities`] for merge semantics.
 pub(super) fn build_bridge_client_capabilities(
     upstream: Option<&ClientCapabilities>,
+    advertise_configuration: bool,
 ) -> ClientCapabilities {
-    merge_upstream_capabilities(build_baseline_capabilities(), upstream)
+    merge_upstream_capabilities(
+        build_baseline_capabilities(advertise_configuration),
+        upstream,
+    )
 }
 
 #[cfg(test)]
@@ -306,7 +313,7 @@ mod tests {
 
     #[test]
     fn bridge_client_capabilities_snapshot() {
-        let capabilities = build_bridge_client_capabilities(None);
+        let capabilities = build_bridge_client_capabilities(None, true);
         insta::with_settings!({snapshot_suffix => feature_suffix()}, {
             insta::assert_json_snapshot!(capabilities);
         });
@@ -314,7 +321,7 @@ mod tests {
 
     #[test]
     fn merge_with_none_upstream_equals_baseline() {
-        let base = build_baseline_capabilities();
+        let base = build_baseline_capabilities(true);
         let merged = merge_upstream_capabilities(base.clone(), None);
         // Serializing both should produce identical JSON
         assert_eq!(
@@ -335,7 +342,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let base = build_baseline_capabilities();
+        let base = build_baseline_capabilities(true);
         let base_json = serde_json::to_value(&base).unwrap();
         let merged = merge_upstream_capabilities(base, Some(&upstream));
         let merged_json = serde_json::to_value(&merged).unwrap();
@@ -391,7 +398,7 @@ mod tests {
             ..Default::default()
         };
 
-        let base = build_baseline_capabilities();
+        let base = build_baseline_capabilities(true);
         let merged = merge_upstream_capabilities(base, Some(&upstream));
         let item = merged
             .text_document
@@ -463,7 +470,7 @@ mod tests {
             ..Default::default()
         };
 
-        let base = build_baseline_capabilities();
+        let base = build_baseline_capabilities(true);
         let merged = merge_upstream_capabilities(base, Some(&upstream));
         let td = merged.text_document.as_ref().unwrap();
 
@@ -541,7 +548,7 @@ mod tests {
             ..Default::default()
         };
 
-        let base = build_baseline_capabilities();
+        let base = build_baseline_capabilities(true);
         let base_json = serde_json::to_value(&base).unwrap();
         let merged = merge_upstream_capabilities(base, Some(&upstream));
         let merged_json = serde_json::to_value(&merged).unwrap();
@@ -593,7 +600,7 @@ mod tests {
         use tower_lsp_server::ls_types::WindowClientCapabilities;
 
         // Baseline declares no window capability, so no upstream → none downstream.
-        let baseline = build_baseline_capabilities();
+        let baseline = build_baseline_capabilities(true);
         assert!(
             baseline.window.is_none(),
             "baseline must not advertise window.workDoneProgress on its own"
@@ -607,7 +614,8 @@ mod tests {
             }),
             ..Default::default()
         };
-        let merged = merge_upstream_capabilities(build_baseline_capabilities(), Some(&supporting));
+        let merged =
+            merge_upstream_capabilities(build_baseline_capabilities(true), Some(&supporting));
         assert_eq!(
             merged.window.and_then(|w| w.work_done_progress),
             Some(true),
@@ -617,7 +625,7 @@ mod tests {
         // Upstream omits it → not advertised downstream (gated).
         let non_supporting = ClientCapabilities::default();
         let merged =
-            merge_upstream_capabilities(build_baseline_capabilities(), Some(&non_supporting));
+            merge_upstream_capabilities(build_baseline_capabilities(true), Some(&non_supporting));
         assert!(
             merged.window.and_then(|w| w.work_done_progress).is_none(),
             "must not invite progress the editor can't handle"
@@ -633,7 +641,7 @@ mod tests {
             ..Default::default()
         };
         let merged =
-            merge_upstream_capabilities(build_baseline_capabilities(), Some(&explicit_false));
+            merge_upstream_capabilities(build_baseline_capabilities(true), Some(&explicit_false));
         assert!(
             merged.window.is_none(),
             "explicit false must leave window unadvertised, not materialize workDoneProgress:false"
@@ -654,7 +662,8 @@ mod tests {
             }),
             ..Default::default()
         };
-        let merged = merge_upstream_capabilities(build_baseline_capabilities(), Some(&supporting));
+        let merged =
+            merge_upstream_capabilities(build_baseline_capabilities(true), Some(&supporting));
         assert_eq!(
             merged
                 .window
@@ -672,7 +681,8 @@ mod tests {
             }),
             ..Default::default()
         };
-        let merged = merge_upstream_capabilities(build_baseline_capabilities(), Some(&unsupported));
+        let merged =
+            merge_upstream_capabilities(build_baseline_capabilities(true), Some(&unsupported));
         assert!(
             merged.window.is_none(),
             "support=false must leave window unadvertised (bridge would only answer success:false)"
@@ -697,7 +707,8 @@ mod tests {
             }),
             ..Default::default()
         };
-        let merged = merge_upstream_capabilities(build_baseline_capabilities(), Some(&upstream));
+        let merged =
+            merge_upstream_capabilities(build_baseline_capabilities(true), Some(&upstream));
         assert_eq!(
             merged
                 .window
@@ -781,9 +792,32 @@ mod tests {
             ..Default::default()
         };
 
-        let merged = build_bridge_client_capabilities(Some(&upstream));
+        let merged = build_bridge_client_capabilities(Some(&upstream), true);
         insta::with_settings!({snapshot_suffix => feature_suffix()}, {
             insta::assert_json_snapshot!(merged);
         });
+    }
+
+    #[test]
+    fn configuration_capability_is_gated_on_advertise_flag() {
+        // Advertised only when the server has settings to serve
+        // (downstream-settings-propagation): otherwise an
+        // initializationOptions-configured server would be flipped to pull and
+        // answered `null`.
+        let advertised = build_bridge_client_capabilities(None, true);
+        assert_eq!(
+            advertised.workspace.as_ref().and_then(|w| w.configuration),
+            Some(true),
+        );
+
+        let not_advertised = build_bridge_client_capabilities(None, false);
+        assert_eq!(
+            not_advertised
+                .workspace
+                .as_ref()
+                .and_then(|w| w.configuration),
+            None,
+            "no settings to serve → capability withheld",
+        );
     }
 }

--- a/src/lsp/bridge/protocol/lifecycle.rs
+++ b/src/lsp/bridge/protocol/lifecycle.rs
@@ -25,6 +25,7 @@ pub(crate) fn build_initialize_request(
     root_uri: Option<String>,
     workspace_folders: Option<Vec<WorkspaceFolder>>,
     upstream_capabilities: Option<&ClientCapabilities>,
+    advertise_configuration: bool,
 ) -> JsonRpcRequest<InitializeParams> {
     let root_path = root_uri.as_deref().and_then(|uri| {
         url::Url::parse(uri)
@@ -40,7 +41,10 @@ pub(crate) fn build_initialize_request(
         root_uri,
         root_path,
         workspace_folders,
-        capabilities: build_bridge_client_capabilities(upstream_capabilities),
+        capabilities: build_bridge_client_capabilities(
+            upstream_capabilities,
+            advertise_configuration,
+        ),
         initialization_options,
         ..Default::default()
     };
@@ -167,7 +171,7 @@ mod tests {
 
     #[test]
     fn initialize_request_has_correct_structure() {
-        let request = build_initialize_request(RequestId::new(1), None, None, None, None);
+        let request = build_initialize_request(RequestId::new(1), None, None, None, None, true);
 
         insta::with_settings!({snapshot_suffix => feature_suffix()}, {
             insta::assert_json_snapshot!(request, {
@@ -185,8 +189,14 @@ mod tests {
                 }
             }
         });
-        let request =
-            build_initialize_request(RequestId::new(42), Some(options.clone()), None, None, None);
+        let request = build_initialize_request(
+            RequestId::new(42),
+            Some(options.clone()),
+            None,
+            None,
+            None,
+            true,
+        );
 
         insta::with_settings!({snapshot_suffix => feature_suffix()}, {
             insta::assert_json_snapshot!(request, {
@@ -204,6 +214,7 @@ mod tests {
             Some(root_uri.to_string()),
             None,
             None,
+            true,
         );
 
         let json = serde_json::to_value(&request).unwrap();
@@ -212,7 +223,7 @@ mod tests {
 
     #[test]
     fn initialize_request_has_null_root_uri_when_not_provided() {
-        let request = build_initialize_request(RequestId::new(1), None, None, None, None);
+        let request = build_initialize_request(RequestId::new(1), None, None, None, None, true);
 
         let json = serde_json::to_value(&request).unwrap();
         assert!(json["params"]["rootUri"].is_null());
@@ -224,7 +235,8 @@ mod tests {
             uri: Uri::from_str("file:///home/user/project").unwrap(),
             name: "project".to_string(),
         }];
-        let request = build_initialize_request(RequestId::new(1), None, None, Some(folders), None);
+        let request =
+            build_initialize_request(RequestId::new(1), None, None, Some(folders), None, true);
 
         insta::with_settings!({snapshot_suffix => feature_suffix()}, {
             insta::assert_json_snapshot!(request, {
@@ -235,7 +247,7 @@ mod tests {
 
     #[test]
     fn initialize_request_has_null_workspace_folders_when_not_provided() {
-        let request = build_initialize_request(RequestId::new(1), None, None, None, None);
+        let request = build_initialize_request(RequestId::new(1), None, None, None, None, true);
 
         let json = serde_json::to_value(&request).unwrap();
         assert!(json["params"]["workspaceFolders"].is_null());
@@ -250,6 +262,7 @@ mod tests {
             Some(root_uri.to_string()),
             None,
             None,
+            true,
         );
 
         let json = serde_json::to_value(&request).unwrap();
@@ -258,7 +271,7 @@ mod tests {
 
     #[test]
     fn initialize_request_has_null_root_path_when_no_root_uri() {
-        let request = build_initialize_request(RequestId::new(1), None, None, None, None);
+        let request = build_initialize_request(RequestId::new(1), None, None, None, None, true);
 
         let json = serde_json::to_value(&request).unwrap();
         assert!(json["params"]["rootPath"].is_null());
@@ -292,7 +305,7 @@ mod tests {
         };
 
         let request =
-            build_initialize_request(RequestId::new(1), None, None, None, Some(&upstream));
+            build_initialize_request(RequestId::new(1), None, None, None, Some(&upstream), true);
 
         insta::with_settings!({snapshot_suffix => feature_suffix()}, {
             insta::assert_json_snapshot!(request, {

--- a/src/lsp/bridge/protocol/lifecycle.rs
+++ b/src/lsp/bridge/protocol/lifecycle.rs
@@ -6,9 +6,9 @@
 use std::str::FromStr;
 
 use tower_lsp_server::ls_types::{
-    ClientCapabilities, DidChangeWorkspaceFoldersParams, DidCloseTextDocumentParams,
-    InitializeParams, InitializedParams, TextDocumentIdentifier, Uri, WorkspaceFolder,
-    WorkspaceFoldersChangeEvent,
+    ClientCapabilities, DidChangeConfigurationParams, DidChangeWorkspaceFoldersParams,
+    DidCloseTextDocumentParams, InitializeParams, InitializedParams, TextDocumentIdentifier, Uri,
+    WorkspaceFolder, WorkspaceFoldersChangeEvent,
 };
 
 use super::client_capabilities::build_bridge_client_capabilities;
@@ -104,6 +104,21 @@ pub(crate) fn build_did_change_workspace_folders_notification(
         },
     };
     JsonRpcNotification::new("workspace/didChangeWorkspaceFolders", params)
+}
+
+/// Build a `workspace/didChangeConfiguration` notification carrying this
+/// server's workspace settings (downstream-settings-propagation).
+///
+/// Sent after `initialized` to seed push-model servers, and again whenever the
+/// merged settings for this server change. Pull-model servers ignore the
+/// `settings` payload and re-request via `workspace/configuration` instead.
+pub(crate) fn build_did_change_configuration_notification(
+    settings: serde_json::Value,
+) -> JsonRpcNotification<DidChangeConfigurationParams> {
+    JsonRpcNotification::new(
+        "workspace/didChangeConfiguration",
+        DidChangeConfigurationParams { settings },
+    )
 }
 
 /// Validates a JSON-RPC initialize response.
@@ -462,5 +477,15 @@ mod tests {
             expected_message,
             err_msg
         );
+    }
+
+    #[test]
+    fn did_change_configuration_notification_carries_settings_verbatim() {
+        let settings = serde_json::json!({ "rust-analyzer": { "cargo": { "features": "all" } } });
+        let notif = build_did_change_configuration_notification(settings.clone());
+        let wire = serde_json::to_value(&notif).expect("serializable");
+
+        assert_eq!(wire["method"], "workspace/didChangeConfiguration");
+        assert_eq!(wire["params"]["settings"], settings);
     }
 }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@default.snap
@@ -5,6 +5,7 @@ expression: merged
 {
   "workspace": {
     "workspaceFolders": true,
+    "configuration": true,
     "diagnostics": {
       "refreshSupport": true
     }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@default.snap
@@ -5,6 +5,7 @@ expression: capabilities
 {
   "workspace": {
     "workspaceFolders": true,
+    "configuration": true,
     "diagnostics": {
       "refreshSupport": true
     }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@default.snap
@@ -12,6 +12,7 @@ expression: request
     "capabilities": {
       "workspace": {
         "workspaceFolders": true,
+        "configuration": true,
         "diagnostics": {
           "refreshSupport": true
         }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@default.snap
@@ -23,6 +23,7 @@ expression: request
     "capabilities": {
       "workspace": {
         "workspaceFolders": true,
+        "configuration": true,
         "diagnostics": {
           "refreshSupport": true
         }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@default.snap
@@ -12,6 +12,7 @@ expression: request
     "capabilities": {
       "workspace": {
         "workspaceFolders": true,
+        "configuration": true,
         "diagnostics": {
           "refreshSupport": true
         }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@default.snap
@@ -12,6 +12,7 @@ expression: request
     "capabilities": {
       "workspace": {
         "workspaceFolders": true,
+        "configuration": true,
         "diagnostics": {
           "refreshSupport": true
         }

--- a/src/lsp/bridge/workspace.rs
+++ b/src/lsp/bridge/workspace.rs
@@ -14,6 +14,7 @@
 //! The dispatcher in [`actor::reader`](super::actor) owns the shared transport
 //! and routes each method here.
 
+pub(in crate::lsp::bridge) mod configuration;
 pub(in crate::lsp::bridge) mod diagnostic_refresh;
 mod folder_set;
 pub(in crate::lsp::bridge) mod workspace_folders;

--- a/src/lsp/bridge/workspace/configuration.rs
+++ b/src/lsp/bridge/workspace/configuration.rs
@@ -1,0 +1,184 @@
+//! `workspace/configuration` server-request handler.
+//!
+//! Inbound (downstream → bridge). The bridge advertises the
+//! `workspace.configuration` capability, so a downstream server pulls its
+//! workspace settings; the bridge answers from this connection's current
+//! settings cell (the resolved `BridgeServerConfig.settings`), which the pool
+//! seeds at spawn and re-stores on a merge change (downstream-settings-propagation).
+//!
+//! The editor cannot answer for a downstream server's config section (it
+//! configures kakehashi, not `rust-analyzer`), so the bridge owns and serves
+//! the configuration itself.
+
+use log::debug;
+use serde_json::Value;
+use tower_lsp_server::jsonrpc;
+
+use crate::lsp::bridge::actor::ServerRequestDeps;
+
+/// Handle a `workspace/configuration` request, returning the JSON-RPC body the
+/// dispatcher wraps in a response.
+///
+/// The response is an `LSPAny[]` with one element per requested item, in the
+/// same order, resolved against this server's settings root (see
+/// [`resolve_section`]). A missing item resolves to JSON `null` (never an
+/// omitted element), keeping the array aligned with the request's `items`.
+pub(in crate::lsp::bridge) fn handle(
+    message: &Value,
+    server_prefix: &str,
+    deps: &ServerRequestDeps,
+) -> jsonrpc::Result<Value> {
+    let items = message
+        .get("params")
+        .and_then(|p| p.get("items"))
+        .and_then(|i| i.as_array());
+
+    // Log the incoming items (section + scopeUri) so the resolution convention
+    // can be validated against a real downstream server, which is the only way
+    // to confirm what `section` it actually sends (downstream-settings-propagation).
+    debug!(
+        target: "kakehashi::bridge::reader",
+        "{}Answering workspace/configuration for items: {}",
+        server_prefix,
+        items
+            .map(|i| serde_json::Value::Array(i.clone()).to_string())
+            .unwrap_or_else(|| "<missing>".to_string())
+    );
+
+    let guard = deps.settings.load();
+    let root = guard.as_ref().map(|arc| arc.as_ref());
+
+    Ok(Value::Array(build_response(root, items)))
+}
+
+/// Build the `LSPAny[]` response: one element per requested item, in request
+/// order, each resolved against `root`. A missing `items` (malformed request,
+/// `items` is spec-required) yields an empty array rather than an error,
+/// mirroring the bridge's lenient request handling.
+fn build_response(root: Option<&Value>, items: Option<&Vec<Value>>) -> Vec<Value> {
+    let Some(items) = items else {
+        return Vec::new();
+    };
+    items
+        .iter()
+        .map(|item| {
+            let section = item.get("section").and_then(Value::as_str);
+            resolve_section(root, section)
+        })
+        .collect()
+}
+
+/// Resolve one `ConfigurationItem.section` against this server's settings root.
+///
+/// The settings root is treated as the editor-style configuration object, so a
+/// `section` is a dotted path indexed into it — the standard editor convention,
+/// which works whether a server sends its own namespace (`"rust-analyzer"`) or
+/// `null` for the whole object:
+/// - `None` / empty string → the whole root,
+/// - `"a.b"` → `root["a"]["b"]`,
+/// - any missing segment or absent root → JSON `null`.
+fn resolve_section(root: Option<&Value>, section: Option<&str>) -> Value {
+    let Some(root) = root else {
+        return Value::Null;
+    };
+    match section {
+        None | Some("") => root.clone(),
+        Some(path) => {
+            let mut current = root;
+            for segment in path.split('.') {
+                match current.get(segment) {
+                    Some(next) => current = next,
+                    None => return Value::Null,
+                }
+            }
+            current.clone()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn root() -> Value {
+        json!({
+            "rust-analyzer": {
+                "cargo": { "features": "all" },
+                "check": { "command": "clippy" }
+            },
+            "top": 1
+        })
+    }
+
+    #[test]
+    fn none_section_returns_whole_root() {
+        let r = root();
+        assert_eq!(resolve_section(Some(&r), None), r);
+    }
+
+    #[test]
+    fn empty_section_returns_whole_root() {
+        let r = root();
+        assert_eq!(resolve_section(Some(&r), Some("")), r);
+    }
+
+    #[test]
+    fn dotted_section_indexes_into_root() {
+        let r = root();
+        assert_eq!(
+            resolve_section(Some(&r), Some("rust-analyzer.cargo")),
+            json!({ "features": "all" })
+        );
+        assert_eq!(
+            resolve_section(Some(&r), Some("rust-analyzer.check.command")),
+            json!("clippy")
+        );
+        assert_eq!(resolve_section(Some(&r), Some("top")), json!(1));
+    }
+
+    #[test]
+    fn missing_segment_resolves_to_null() {
+        let r = root();
+        assert_eq!(resolve_section(Some(&r), Some("nope")), Value::Null);
+        assert_eq!(
+            resolve_section(Some(&r), Some("rust-analyzer.nope")),
+            Value::Null
+        );
+        // Indexing into a scalar fails to null rather than panicking.
+        assert_eq!(resolve_section(Some(&r), Some("top.deeper")), Value::Null);
+    }
+
+    #[test]
+    fn absent_root_resolves_every_section_to_null() {
+        assert_eq!(resolve_section(None, None), Value::Null);
+        assert_eq!(resolve_section(None, Some("rust-analyzer")), Value::Null);
+    }
+
+    #[test]
+    fn response_preserves_item_order_and_aligns_null_for_misses() {
+        let r = root();
+        let items = vec![
+            json!({ "section": "rust-analyzer.cargo" }),
+            json!({ "section": "missing" }),
+            json!({}), // no section → whole root
+        ];
+        let resp = build_response(Some(&r), Some(&items));
+        assert_eq!(resp.len(), items.len(), "one element per item, same length");
+        assert_eq!(resp[0], json!({ "features": "all" }));
+        assert_eq!(resp[1], Value::Null, "miss is JSON null, not omitted");
+        assert_eq!(resp[2], r, "no section → whole root");
+    }
+
+    #[test]
+    fn response_is_empty_array_when_items_missing() {
+        assert!(build_response(Some(&root()), None).is_empty());
+    }
+
+    #[test]
+    fn response_is_all_null_when_no_settings_configured() {
+        let items = vec![json!({ "section": "rust-analyzer" }), json!({})];
+        let resp = build_response(None, Some(&items));
+        assert_eq!(resp, vec![Value::Null, Value::Null]);
+    }
+}

--- a/src/lsp/bridge/workspace/configuration.rs
+++ b/src/lsp/bridge/workspace/configuration.rs
@@ -92,6 +92,13 @@ fn resolve_section(root: Option<&Value>, section: Option<&str>) -> Value {
         Some(path) => {
             let mut current = root;
             for segment in path.split('.') {
+                // An empty segment (leading/trailing/double dot) is a malformed
+                // path, not a lookup of a literal `""` key — reject it explicitly
+                // so the result never depends on whether settings happens to
+                // contain an empty-string key.
+                if segment.is_empty() {
+                    return Value::Null;
+                }
                 match current.get(segment) {
                     Some(next) => current = next,
                     None => return Value::Null,
@@ -179,6 +186,20 @@ mod tests {
                 "section {section:?}"
             );
         }
+    }
+
+    #[test]
+    fn empty_segment_does_not_reach_a_literal_empty_string_key() {
+        // Even when settings contains an empty-string key, an empty path segment
+        // resolves to null rather than indexing it (the path is malformed).
+        let r = json!({ "server": { "": "trap" }, "": "trap2" });
+        assert_eq!(resolve_section(Some(&r), Some("server.")), Value::Null);
+        assert_eq!(resolve_section(Some(&r), Some(".server")), Value::Null);
+        // …but a non-empty key is still reachable.
+        assert_eq!(
+            resolve_section(Some(&r), Some("server")),
+            json!({ "": "trap" })
+        );
     }
 
     #[test]

--- a/src/lsp/bridge/workspace/configuration.rs
+++ b/src/lsp/bridge/workspace/configuration.rs
@@ -9,6 +9,13 @@
 //! The editor cannot answer for a downstream server's config section (it
 //! configures kakehashi, not `rust-analyzer`), so the bridge owns and serves
 //! the configuration itself.
+//!
+//! Limitations (downstream-settings-propagation, deferred scope):
+//! `ConfigurationItem.scopeUri` is ignored — the one per-server settings value
+//! answers every scope. `section` is treated as a dotted path into the settings
+//! root (the editor convention), not a JSON Pointer; a segment is a literal
+//! object key, so a section that indexes into an array or a scalar, or that has
+//! an empty segment (`"a."`, `".a"`, `"a..b"`), resolves to `null`.
 
 use log::debug;
 use serde_json::Value;
@@ -153,6 +160,53 @@ mod tests {
     fn absent_root_resolves_every_section_to_null() {
         assert_eq!(resolve_section(None, None), Value::Null);
         assert_eq!(resolve_section(None, Some("rust-analyzer")), Value::Null);
+    }
+
+    #[test]
+    fn empty_segments_resolve_to_null() {
+        // A literal-key dotted path: an empty segment indexes a `""` key, which
+        // never exists, so trailing/leading/double dots resolve to null
+        // (panic-free).
+        let r = root();
+        for section in [
+            "rust-analyzer.",
+            ".rust-analyzer",
+            "rust-analyzer..cargo",
+            ".",
+        ] {
+            assert_eq!(
+                resolve_section(Some(&r), Some(section)),
+                Value::Null,
+                "section {section:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_null_leaf_is_returned_as_null() {
+        // A section whose value is genuinely JSON `null` returns that null — the
+        // same wire value as a miss, which is correct for `LSPAny`.
+        let r = json!({ "server": { "feature": Value::Null } });
+        assert_eq!(
+            resolve_section(Some(&r), Some("server.feature")),
+            Value::Null
+        );
+    }
+
+    #[test]
+    fn indexing_into_an_array_resolves_to_null() {
+        // A string segment can only index an object; descending into an array
+        // value yields null rather than panicking or coercing.
+        let r = json!({ "server": { "list": [1, 2, 3] } });
+        assert_eq!(
+            resolve_section(Some(&r), Some("server.list.0")),
+            Value::Null
+        );
+        // …but addressing the array itself returns it verbatim.
+        assert_eq!(
+            resolve_section(Some(&r), Some("server.list")),
+            json!([1, 2, 3])
+        );
     }
 
     #[test]

--- a/src/lsp/bridge/workspace/configuration.rs
+++ b/src/lsp/bridge/workspace/configuration.rs
@@ -43,26 +43,25 @@ pub(in crate::lsp::bridge) fn handle(
     // Log the incoming items (section + scopeUri) so the resolution convention
     // can be validated against a real downstream server, which is the only way
     // to confirm what `section` it actually sends (downstream-settings-propagation).
+    // `{:?}` borrows `items` — no clone or intermediate string on this path.
     debug!(
         target: "kakehashi::bridge::reader",
-        "{}Answering workspace/configuration for items: {}",
+        "{}Answering workspace/configuration for items: {:?}",
         server_prefix,
         items
-            .map(|i| serde_json::Value::Array(i.clone()).to_string())
-            .unwrap_or_else(|| "<missing>".to_string())
     );
 
     let guard = deps.settings.load();
     let root = guard.as_ref().map(|arc| arc.as_ref());
 
-    Ok(Value::Array(build_response(root, items)))
+    Ok(Value::Array(build_response(root, items.map(Vec::as_slice))))
 }
 
 /// Build the `LSPAny[]` response: one element per requested item, in request
 /// order, each resolved against `root`. A missing `items` (malformed request,
 /// `items` is spec-required) yields an empty array rather than an error,
 /// mirroring the bridge's lenient request handling.
-fn build_response(root: Option<&Value>, items: Option<&Vec<Value>>) -> Vec<Value> {
+fn build_response(root: Option<&Value>, items: Option<&[Value]>) -> Vec<Value> {
     let Some(items) = items else {
         return Vec::new();
     };

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -106,7 +106,13 @@ pub(super) async fn apply_shared_settings(
     // auto-install reload), before `settings` is consumed by the apply below.
     // At initialize time there are no connections yet, so it is a clean no-op
     // (downstream-settings-propagation).
-    bridge.propagate_settings(&settings).await;
+    let pushed = bridge.propagate_settings(&settings).await;
+    if pushed > 0 {
+        log::debug!(
+            target: "kakehashi::bridge",
+            "Propagated settings change to {} downstream connection(s)", pushed
+        );
+    }
     match raw_settings {
         Some(raw_settings) => settings_manager.apply_settings_with_raw(raw_settings, settings),
         None => settings_manager.apply_settings(settings),

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -96,10 +96,17 @@ pub(super) async fn apply_shared_settings(
     language: &LanguageCoordinator,
     settings_manager: &SettingsManager,
     cache: &CacheCoordinator,
+    bridge: &BridgeCoordinator,
     raw_settings: Option<RawWorkspaceSettings>,
     settings: WorkspaceSettings,
 ) {
     let summary = language.load_settings(&settings);
+    // Path c: push the new per-server settings to live downstream connections
+    // at this single reload choke point (initialize, didChangeConfiguration,
+    // auto-install reload), before `settings` is consumed by the apply below.
+    // At initialize time there are no connections yet, so it is a clean no-op
+    // (downstream-settings-propagation).
+    bridge.propagate_settings(&settings).await;
     match raw_settings {
         Some(raw_settings) => settings_manager.apply_settings_with_raw(raw_settings, settings),
         None => settings_manager.apply_settings(settings),
@@ -304,6 +311,7 @@ impl Kakehashi {
             &self.language,
             &self.settings_manager,
             &self.cache,
+            &self.bridge,
             Some(raw_settings),
             settings,
         )

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -932,6 +932,7 @@ mod tests {
             root_markers: None,
             on_type_formatting_triggers: None,
             prefer_shared_instance: None,
+            settings: None,
         }
     }
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -661,6 +661,7 @@ mod tests {
                 root_markers: None,
                 on_type_formatting_triggers: None,
                 prefer_shared_instance: None,
+                settings: None,
             },
         )
     }

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -218,6 +218,7 @@ impl InstallCoordinator {
             &self.language,
             &self.settings_manager,
             &self.cache,
+            &self.bridge,
             Some(raw_settings),
             settings,
         )

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -323,6 +323,7 @@ mod tests {
                 root_markers: None,
                 on_type_formatting_triggers: None,
                 prefer_shared_instance: None,
+                settings: None,
             },
         );
         server.settings_manager.apply_settings(WorkspaceSettings {
@@ -415,6 +416,7 @@ print("hello")
                 root_markers: None,
                 on_type_formatting_triggers: None,
                 prefer_shared_instance: None,
+                settings: None,
             },
         );
         let mut languages = HashMap::new();

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -1837,6 +1837,7 @@ mod tests {
                 root_markers: None,
                 on_type_formatting_triggers: None,
                 prefer_shared_instance: None,
+                settings: None,
             }),
         }
     }


### PR DESCRIPTION
## Summary

Make the bridge own and serve each downstream language server's **workspace configuration**, so a downstream server (rust-analyzer, lua-ls, …) receives its settings both at startup and on runtime change — not only once via `initializationOptions`.

The editor configures *kakehashi*, not `rust-analyzer`, so it cannot answer a downstream server's `workspace/configuration` request. The bridge therefore serves the configuration itself, sourced from its already-merged settings tree.

ADR: `docs/architecture-decisions/downstream-settings-propagation.md`.

## What changed

- **`settings` config field** — new `languageServers.<name>.settings` (`BridgeServerConfig.settings`), opaque passthrough, deep-merged across config layers like `initializationOptions`. Distinct from `initializationOptions` (consumed only at `initialize`); `settings` flows over `didChangeConfiguration` and answers `workspace/configuration`.
- **(b) Answer pulls** — new `workspace/configuration` handler resolves each item's dotted `section` against this server's settings root and returns an `LSPAny[]` of the same length/order as `items`, JSON `null` for misses. Backed by a per-connection settings cell shared with the reader.
- **(a) Advertise + seed** — advertise `workspace.configuration` downstream, **gated per-server on `settings.is_some()`** so a server configured only via `initializationOptions` (every existing setup) is not flipped to pulling and answered `null`. After `initialized`, push `workspace/didChangeConfiguration` (reading the live cell, queued before the `Ready` flip so it precedes any `didOpen`).
- **(c) Re-propagate** — on any merged-settings change (`apply_shared_settings` choke point: `didChangeConfiguration`, auto-install reload, initialize), re-resolve each live connection's settings, diff against its cell, and on change re-store the cell + push best-effort to `Ready` connections (initializing ones get the cell advanced and are pushed by (a) after `initialized`). Returns the push count; unchanged servers get nothing.

## Scope / deferred

- Upstream pull (kakehashi → editor `workspace/configuration`) — only needed for pull-model editors; deferred.
- `scopeUri` / multi-root resolution — ignored; one per-server value answers all scopes.
- Guaranteed push delivery — a dropped push self-heals on the next pull or respawn (single-cell, no retry baseline). The narrow (a)/(c) handshake-window race is the accepted, ADR-documented epoch-class race.

## Review

Converged through `/review` (10-perspective), codex, and pi-review before opening:
- per-server capability gating, live-cell post-init push, push-count observability;
- LSP init-ordering (no `didChangeConfiguration` to an initializing server; push queued before `Ready`);
- section-resolution edge cases (empty segments, null leaf, array mid-traversal).

## Testing

- `cargo test --lib` green (2219 passed); clippy `--lib` clean.
- Unit tests cover section resolution + response shape, `settings` deep-merge, the notification builder, the shared settings cell, `propagate_settings` selective update / initializing-skip / empty-pool, and capability gating.
- e2e deferred to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
