### PR TITLE
perf(semantic): cancel superseded/closed semantic-token computes mid-flight

### DIFF
--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -69,7 +69,7 @@ pub(crate) async fn handle_semantic_tokens_full(
     cancel: Option<crate::cancel::CancelToken>,
 ) -> Option<SemanticTokensResult> {
     tokio::task::spawn_blocking(move || {
-        let is_cancelled = || cancel.as_ref().is_some_and(|c| c.is_cancelled());
+        let is_cancelled = || crate::cancel::is_cancelled(cancel.as_ref());
 
         let mut all_tokens: Vec<RawToken> = Vec::with_capacity(1000);
         let lines: Vec<&str> = text.lines().collect();

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -50,6 +50,12 @@ use {delta::calculate_semantic_tokens_delta, tower_lsp_server::ls_types::Semanti
 /// blocking pool, distributing injections across Rayon workers. Thread-local
 /// parser caches avoid cross-thread synchronization on parse. Returns `None`
 /// on cancellation/failure. `text` and `tree` are moved into `spawn_blocking`.
+///
+/// `cancel` (when provided) is polled at coarse boundaries — after the host
+/// pass, after the injection pass, and per region inside the injection pass — so
+/// a superseded/cancelled request stops instead of running to completion.
+/// Returns `None` once cancelled: the caller drops the (partial) result rather
+/// than storing it (see the compute-superseded checkpoints in the handlers).
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn handle_semantic_tokens_full(
     text: String,
@@ -60,8 +66,11 @@ pub(crate) async fn handle_semantic_tokens_full(
     coordinator: std::sync::Arc<crate::language::LanguageCoordinator>,
     supports_multiline: bool,
     injection_cache: Option<InjectionCacheParams>,
+    cancel: Option<crate::cancel::CancelToken>,
 ) -> Option<SemanticTokensResult> {
     tokio::task::spawn_blocking(move || {
+        let is_cancelled = || cancel.as_ref().is_some_and(|c| c.is_cancelled());
+
         let mut all_tokens: Vec<RawToken> = Vec::with_capacity(1000);
         let lines: Vec<&str> = text.lines().collect();
         let line_starts = build_line_start_bytes(&text);
@@ -84,6 +93,12 @@ pub(crate) async fn handle_semantic_tokens_full(
             &mut all_tokens,
         );
 
+        // Bail before the injection pass — the dominant cost on a large document
+        // — if this request has already been superseded.
+        if is_cancelled() {
+            return None;
+        }
+
         // Borrow the owned cache handle into a request-scoped context for the
         // injection pass (#529); `None` keeps the uncached behavior.
         let cache_ctx = injection_cache.as_ref().map(|p| InjectionCacheCtx {
@@ -95,6 +110,8 @@ pub(crate) async fn handle_semantic_tokens_full(
 
         // Collect injection tokens in parallel using Rayon.
         // Also returns active injection regions for finalize-time exclusion.
+        // `cancel` is polled inside discovery and the per-region fan-out so a
+        // supersede lands mid-pass, not just at these outer boundaries.
         let (injection_tokens, active_injection_regions) = collect_injection_tokens_parallel(
             &text,
             &lines,
@@ -105,7 +122,14 @@ pub(crate) async fn handle_semantic_tokens_full(
             capture_mappings.as_deref(),
             supports_multiline,
             cache_ctx.as_ref(),
+            cancel.as_ref(),
         );
+
+        // A supersede observed during the injection pass leaves a partial token
+        // set; drop it so the handler never stores partial results.
+        if is_cancelled() {
+            return None;
+        }
 
         // Merge injection tokens with host tokens
         all_tokens.extend(injection_tokens);
@@ -593,6 +617,7 @@ local x = 42
             coordinator,
             false,
             None,
+            None,
         )
         .await;
 
@@ -660,6 +685,7 @@ local x = 42
             None,
             coordinator,
             false,
+            None,
             None,
         )
         .await;
@@ -732,6 +758,7 @@ local x = 42
             Some(capture_mappings),
             coordinator,
             false,
+            None,
             None,
         )
         .await;
@@ -846,6 +873,7 @@ local x = 42
             coordinator,
             false,
             None,
+            None,
         )
         .await;
 
@@ -958,6 +986,7 @@ local x = 42
             coordinator,
             false,
             None,
+            None,
         )
         .await;
 
@@ -1069,6 +1098,7 @@ local x = 42
             Some(capture_mappings),
             coordinator,
             true, // multiline support enabled!
+            None,
             None,
         )
         .await;
@@ -1201,6 +1231,7 @@ foo
             coordinator,
             false,
             None,
+            None,
         )
         .await;
 
@@ -1310,6 +1341,7 @@ foo
             Some(capture_mappings),
             coordinator,
             false,
+            None,
             None,
         )
         .await;

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -942,6 +942,19 @@ pub(crate) fn collect_injection_tokens_parallel(
     // Store region-local tokens for newly computed eligible, fully-loaded regions
     // (#529, write half), single-threaded after fan-in so cache writes never run
     // inside a Rayon worker.
+    //
+    // This store deliberately does NOT re-check `is_cancelled(cancel)`. A region
+    // reaches here with `fully_loaded: true` only if its `process_injection_sync`
+    // actually completed (the `process_one` entry check already zeroed out
+    // regions skipped by a cancel). A completed region's tokens are correct for
+    // its content and keyed by `validity_hash` (content + language) and
+    // `generation`, so caching them is valid even when this request was
+    // superseded mid-pass: a later request hits only when content+generation
+    // still match, i.e. only when the tokens are still right. Adding a cancel
+    // recheck here would instead drop these valid entries on every keystroke,
+    // forcing the next request to recompute them — a regression against the very
+    // reuse the cache exists for. (A closed document's residual entry is handled
+    // by the cancel-first ordering in `CacheCoordinator::remove_document`.)
     if let Some(cc) = cache_ctx {
         for (i, res) in &processed {
             if let Some(rc) = &contexts[*i].region_cache
@@ -2380,14 +2393,17 @@ local b = 2
     }
 
     /// End-to-end: a cancelled injection pass must produce no tokens AND persist
-    /// nothing to the region cache — a partial store would later serve an
-    /// incomplete region as a stale-empty hit. A pre-cancelled token here bails
-    /// at the post-discovery guard (before the fan-out), so this pins the
-    /// outer-guard path; the in-fan-out `fully_loaded:false` skip for a mid-pass
-    /// supersede rides on the pre-existing #529 store gate (`res.fully_loaded`),
-    /// which the reuse tests exercise for the stored case. Contrast the
-    /// uncancelled run in `injection_cache_reuse_matches_uncached_output`, which
-    /// stores all eight regions.
+    /// nothing to the region cache. A pre-cancelled token bails at the
+    /// post-discovery guard (before the fan-out), so this pins the outer-guard
+    /// path. The fan-out's own cancel skip is narrower: `process_one`'s entry
+    /// check zeroes only regions whose tokenization had NOT started when the
+    /// token flipped (returning `fully_loaded: false`, which the #529 store gate
+    /// then drops). A region already inside `process_injection_sync` has no inner
+    /// poll — it completes and IS stored, which is correct: its tokens are
+    /// content-keyed (`validity_hash` + `generation`) and so valid for any later
+    /// matching request (see the store-half comment). Contrast the uncancelled
+    /// run in `injection_cache_reuse_matches_uncached_output`, which stores all
+    /// eight regions.
     #[test]
     fn cancelled_token_stores_no_injection_regions() {
         let Some(coordinator) = markdown_lua_coordinator() else {

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -477,10 +477,13 @@ fn collect_injection_contexts_sync<'a>(
         // Poll for supersession per region: this resolve loop is the dominant
         // discovery cost on a large document (one language resolution + query
         // fetch per injection region), so a newer keystroke must be able to
-        // abort it here rather than after all regions are resolved. The
-        // caller discards the partial contexts returned on this early break.
+        // abort it here rather than after all regions are resolved. Return
+        // rather than `break`: the `combined_groups` pass below is itself
+        // expensive (per-group language resolution + query lookups), so a
+        // supersede should skip it too. Discovery is definitionally incomplete
+        // here, hence `false`; the caller discards the partial result on cancel.
         if crate::cancel::is_cancelled(cancel) {
-            break;
+            return (contexts, exclusion_ranges, false);
         }
 
         let start = injection.content_node.start_byte();

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -479,7 +479,7 @@ fn collect_injection_contexts_sync<'a>(
         // fetch per injection region), so a newer keystroke must be able to
         // abort it here rather than after all regions are resolved. The
         // caller discards the partial contexts returned on this early break.
-        if cancel.is_some_and(|c| c.is_cancelled()) {
+        if crate::cancel::is_cancelled(cancel) {
             break;
         }
 
@@ -839,9 +839,8 @@ pub(crate) fn collect_injection_tokens_parallel(
     cache_ctx: Option<&InjectionCacheCtx>,
     cancel: Option<&crate::cancel::CancelToken>,
 ) -> (Vec<RawToken>, Vec<ActiveInjectionBounds>) {
+    use crate::cancel::is_cancelled;
     use rayon::prelude::*;
-
-    let is_cancelled = || cancel.is_some_and(|c| c.is_cancelled());
 
     // Collect top-level injection contexts and their byte ranges. The cache
     // handle (if any) lets the discovery phase resolve region identities
@@ -865,7 +864,7 @@ pub(crate) fn collect_injection_tokens_parallel(
     // Discovery bailed (or genuinely found nothing): either way there is nothing
     // to tokenize. A cancelled discovery returns partial contexts the caller
     // discards, so skip the fan-out entirely.
-    if contexts.is_empty() || is_cancelled() {
+    if contexts.is_empty() || is_cancelled(cancel) {
         return (Vec::new(), Vec::new());
     }
 
@@ -910,7 +909,7 @@ pub(crate) fn collect_injection_tokens_parallel(
     // cache store-half below never persists it. Under a rapid-typing pile-up the
     // remaining Rayon closures drain almost immediately once the token trips.
     let process_one = |i: usize| -> (usize, InjectionTokens) {
-        if cancel.is_some_and(|c| c.is_cancelled()) {
+        if is_cancelled(cancel) {
             return (
                 i,
                 InjectionTokens {
@@ -2331,12 +2330,13 @@ local b = 2
     }
 
     /// The dominant per-compute cost on a large document is the single-threaded
-    /// discovery loop (one language resolution + query fetch per region). A
-    /// superseded request must abort *inside* that loop, not merely at the pass
-    /// boundary — otherwise a supersede still pays the full discovery. Assert a
-    /// pre-cancelled token collapses discovery to zero contexts, while an
-    /// uncancelled run finds all eight. This guards against a regression that
-    /// moves the checkpoint out of the discovery loop.
+    /// discovery loop (one language resolution + query fetch per region), so a
+    /// superseded request must abort there rather than pay the full discovery.
+    /// Assert a pre-cancelled token collapses discovery to zero contexts while an
+    /// uncancelled run finds all eight. (A pre-set flag can't distinguish a
+    /// per-iteration check from one hoisted just above the loop — both yield
+    /// zero — but it does catch the checkpoint being removed entirely, which
+    /// would let all eight regions resolve under cancellation.)
     #[test]
     fn cancelled_token_aborts_injection_discovery() {
         let Some(coordinator) = markdown_lua_coordinator() else {
@@ -2381,7 +2381,12 @@ local b = 2
 
     /// End-to-end: a cancelled injection pass must produce no tokens AND persist
     /// nothing to the region cache — a partial store would later serve an
-    /// incomplete region as a stale hit. Contrast the uncancelled run, which
+    /// incomplete region as a stale-empty hit. A pre-cancelled token here bails
+    /// at the post-discovery guard (before the fan-out), so this pins the
+    /// outer-guard path; the in-fan-out `fully_loaded:false` skip for a mid-pass
+    /// supersede rides on the pre-existing #529 store gate (`res.fully_loaded`),
+    /// which the reuse tests exercise for the stored case. Contrast the
+    /// uncancelled run in `injection_cache_reuse_matches_uncached_output`, which
     /// stores all eight regions.
     #[test]
     fn cancelled_token_stores_no_injection_regions() {

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -262,6 +262,10 @@ pub(crate) fn process_injection_sync(
             ctx.host_start_byte,
             ctx.included_ranges.as_deref(),
             None,
+            // Nested discovery for a single region is bounded; cancellation is
+            // enforced at the per-region fan-out entry (this region was already
+            // committed there), so no token is threaded into the recursion.
+            None,
         );
 
     let mut tokens = Vec::new();
@@ -402,6 +406,7 @@ fn clip_tokens_to_included_ranges(
 /// gap that re-fills when the parser loads without the content changing. A caller
 /// that caches a region must taint it with this so an incomplete subtree is never
 /// stored (and then served stale once the missing parser arrives, #529 Hazard 3).
+#[allow(clippy::too_many_arguments)]
 fn collect_injection_contexts_sync<'a>(
     text: &'a str,
     tree: &Tree,
@@ -410,6 +415,7 @@ fn collect_injection_contexts_sync<'a>(
     content_start_byte: usize,
     parent_included_ranges: Option<&[tree_sitter::Range]>,
     cache_ctx: Option<(&Url, &NodeTracker)>,
+    cancel: Option<&crate::cancel::CancelToken>,
 ) -> (Vec<InjectionContext<'a>>, Vec<(usize, usize)>, bool) {
     use crate::language::injection::collect_all_injections;
 
@@ -468,6 +474,15 @@ fn collect_injection_contexts_sync<'a>(
     let cache_for_singles = cache_ctx.filter(|_| singles.len() >= INJECTION_CACHE_MIN_REGIONS);
 
     for injection in singles {
+        // Poll for supersession per region: this resolve loop is the dominant
+        // discovery cost on a large document (one language resolution + query
+        // fetch per injection region), so a newer keystroke must be able to
+        // abort it here rather than after all regions are resolved. The
+        // caller discards the partial contexts returned on this early break.
+        if cancel.is_some_and(|c| c.is_cancelled()) {
+            break;
+        }
+
         let start = injection.content_node.start_byte();
         let end = injection.content_node.end_byte();
 
@@ -822,12 +837,17 @@ pub(crate) fn collect_injection_tokens_parallel(
     capture_mappings: Option<&CaptureMappings>,
     supports_multiline: bool,
     cache_ctx: Option<&InjectionCacheCtx>,
+    cancel: Option<&crate::cancel::CancelToken>,
 ) -> (Vec<RawToken>, Vec<ActiveInjectionBounds>) {
     use rayon::prelude::*;
 
+    let is_cancelled = || cancel.is_some_and(|c| c.is_cancelled());
+
     // Collect top-level injection contexts and their byte ranges. The cache
     // handle (if any) lets the discovery phase resolve region identities
-    // single-threaded, before the fan-out.
+    // single-threaded, before the fan-out. `cancel` is polled inside the
+    // per-region discovery loop — that resolve loop is the dominant cost on a
+    // large document, so a supersede must be able to abort it mid-loop.
     // A top-level region dropped during discovery isn't cached (no region_cache
     // is built for it), so the top-level completeness flag is irrelevant here —
     // only nested completeness, threaded through process_injection_sync, matters.
@@ -839,9 +859,13 @@ pub(crate) fn collect_injection_tokens_parallel(
         0,
         None,
         cache_ctx.map(|c| (c.uri, c.tracker)),
+        cancel,
     );
 
-    if contexts.is_empty() {
+    // Discovery bailed (or genuinely found nothing): either way there is nothing
+    // to tokenize. A cancelled discovery returns partial contexts the caller
+    // discards, so skip the fan-out entirely.
+    if contexts.is_empty() || is_cancelled() {
         return (Vec::new(), Vec::new());
     }
 
@@ -880,46 +904,40 @@ pub(crate) fn collect_injection_tokens_parallel(
     // Tokenize only the misses: parallel above the threshold, sequential below.
     // Each result carries its context index so the store decision can pair it
     // with the region's cache identity off the Rayon workers.
+    //
+    // A supersede observed at region entry skips the expensive parse+query for
+    // that region; the empty stand-in is marked `fully_loaded: false` so the
+    // cache store-half below never persists it. Under a rapid-typing pile-up the
+    // remaining Rayon closures drain almost immediately once the token trips.
+    let process_one = |i: usize| -> (usize, InjectionTokens) {
+        if cancel.is_some_and(|c| c.is_cancelled()) {
+            return (
+                i,
+                InjectionTokens {
+                    tokens: Vec::new(),
+                    fully_loaded: false,
+                },
+            );
+        }
+        (
+            i,
+            process_injection_sync(
+                &contexts[i],
+                &factory,
+                coordinator,
+                capture_mappings,
+                host_text,
+                host_lines,
+                host_line_starts,
+                1, // depth 1 (first level of injection, host is 0)
+                supports_multiline,
+            ),
+        )
+    };
     let processed: Vec<(usize, InjectionTokens)> = if miss_indices.len() >= PARALLEL_THRESHOLD {
-        miss_indices
-            .par_iter()
-            .map(|&i| {
-                (
-                    i,
-                    process_injection_sync(
-                        &contexts[i],
-                        &factory,
-                        coordinator,
-                        capture_mappings,
-                        host_text,
-                        host_lines,
-                        host_line_starts,
-                        1, // depth 1 (first level of injection, host is 0)
-                        supports_multiline,
-                    ),
-                )
-            })
-            .collect()
+        miss_indices.par_iter().map(|&i| process_one(i)).collect()
     } else {
-        miss_indices
-            .iter()
-            .map(|&i| {
-                (
-                    i,
-                    process_injection_sync(
-                        &contexts[i],
-                        &factory,
-                        coordinator,
-                        capture_mappings,
-                        host_text,
-                        host_lines,
-                        host_line_starts,
-                        1,
-                        supports_multiline,
-                    ),
-                )
-            })
-            .collect()
+        miss_indices.iter().map(|&i| process_one(i)).collect()
     };
 
     // Store region-local tokens for newly computed eligible, fully-loaded regions
@@ -1461,6 +1479,7 @@ mod tests {
             None,
             false,
             None,
+            None,
         );
 
         assert!(tokens.is_empty(), "Empty document should have no tokens");
@@ -1516,6 +1535,7 @@ local x = 42
             &coordinator,
             None,
             false,
+            None,
             None,
         );
 
@@ -1614,6 +1634,7 @@ local x = 42
             None,
             false,
             None,
+            None,
         );
 
         // The surviving `local` keyword maps to host line 2, col 2 (after the
@@ -1706,6 +1727,7 @@ local b = 2
             &coordinator,
             None,
             false,
+            None,
             None,
         );
 
@@ -1923,6 +1945,7 @@ local b = 2
             0,
             None,
             None,
+            None,
         );
 
         assert_eq!(
@@ -2000,6 +2023,7 @@ local b = 2
             0,
             None,
             None,
+            None,
         );
 
         // The vendored query injects more than html (markdown_inline for the
@@ -2061,6 +2085,7 @@ local b = 2
             &coordinator,
             None,
             false,
+            None,
             None,
         );
 
@@ -2125,6 +2150,7 @@ local b = 2
             // Multiline client support must not let the spanning string token
             // bleed across the gap either.
             true,
+            None,
             None,
         );
 
@@ -2252,6 +2278,7 @@ local b = 2
             None,
             false,
             None,
+            None,
         )
         .0;
 
@@ -2275,6 +2302,7 @@ local b = 2
             None,
             false,
             Some(&cc),
+            None,
         )
         .0;
         assert_eq!(first, uncached, "first (store) pass must match uncached");
@@ -2296,9 +2324,106 @@ local b = 2
             None,
             false,
             Some(&cc),
+            None,
         )
         .0;
         assert_eq!(second, uncached, "second (hit) pass must match uncached");
+    }
+
+    /// The dominant per-compute cost on a large document is the single-threaded
+    /// discovery loop (one language resolution + query fetch per region). A
+    /// superseded request must abort *inside* that loop, not merely at the pass
+    /// boundary — otherwise a supersede still pays the full discovery. Assert a
+    /// pre-cancelled token collapses discovery to zero contexts, while an
+    /// uncancelled run finds all eight. This guards against a regression that
+    /// moves the checkpoint out of the discovery loop.
+    #[test]
+    fn cancelled_token_aborts_injection_discovery() {
+        let Some(coordinator) = markdown_lua_coordinator() else {
+            return;
+        };
+        let text = eight_lua_block_doc();
+        let tree = parse_markdown(&coordinator, &text);
+
+        let (live, _excl, _complete) = collect_injection_contexts_sync(
+            &text,
+            &tree,
+            Some("markdown"),
+            &coordinator,
+            0,
+            None,
+            None,
+            None,
+        );
+        assert_eq!(
+            live.len(),
+            8,
+            "sanity: the eight lua blocks are discovered without cancellation"
+        );
+
+        let cancel = crate::cancel::CancelToken::default();
+        cancel.cancel();
+        let (aborted, _excl, _complete) = collect_injection_contexts_sync(
+            &text,
+            &tree,
+            Some("markdown"),
+            &coordinator,
+            0,
+            None,
+            None,
+            Some(&cancel),
+        );
+        assert!(
+            aborted.is_empty(),
+            "a pre-cancelled token must break the discovery loop before resolving any region"
+        );
+    }
+
+    /// End-to-end: a cancelled injection pass must produce no tokens AND persist
+    /// nothing to the region cache — a partial store would later serve an
+    /// incomplete region as a stale hit. Contrast the uncancelled run, which
+    /// stores all eight regions.
+    #[test]
+    fn cancelled_token_stores_no_injection_regions() {
+        let Some(coordinator) = markdown_lua_coordinator() else {
+            return;
+        };
+        let text = eight_lua_block_doc();
+        let tree = parse_markdown(&coordinator, &text);
+        let lines: Vec<&str> = text.lines().collect();
+        let line_starts = build_line_start_bytes(&text);
+
+        let uri = Url::parse("file:///cancel_no_store.md").unwrap();
+        let cache = InjectionTokenCache::new();
+        let tracker = NodeTracker::new();
+        let cc = InjectionCacheCtx {
+            uri: &uri,
+            tracker: &tracker,
+            cache: &cache,
+            generation: 0,
+        };
+
+        let cancel = crate::cancel::CancelToken::default();
+        cancel.cancel();
+        let (tokens, regions) = collect_injection_tokens_parallel(
+            &text,
+            &lines,
+            &line_starts,
+            &tree,
+            Some("markdown"),
+            &coordinator,
+            None,
+            false,
+            Some(&cc),
+            Some(&cancel),
+        );
+        assert!(tokens.is_empty(), "a cancelled pass must yield no tokens");
+        assert!(regions.is_empty(), "a cancelled pass must yield no regions");
+        assert_eq!(
+            cache.test_keys(&uri).len(),
+            0,
+            "a cancelled pass must not persist any (partial) region to the cache"
+        );
     }
 
     /// Proof the reuse path actually *reads* the cache rather than recomputing:
@@ -2336,6 +2461,7 @@ local b = 2
             None,
             false,
             Some(&cc),
+            None,
         );
 
         // Overwrite one region with a region-local sentinel token.
@@ -2366,6 +2492,7 @@ local b = 2
             None,
             false,
             Some(&cc),
+            None,
         )
         .0;
 
@@ -2410,6 +2537,7 @@ local b = 2
             None,
             false,
             Some(&cc),
+            None,
         );
 
         // Insert a blank line at the very top: every region shifts down one line,
@@ -2431,6 +2559,7 @@ local b = 2
             None,
             false,
             Some(&cc),
+            None,
         )
         .0;
 
@@ -2443,6 +2572,7 @@ local b = 2
             &coordinator,
             None,
             false,
+            None,
             None,
         )
         .0;

--- a/src/analysis/semantic/range.rs
+++ b/src/analysis/semantic/range.rs
@@ -41,6 +41,9 @@ pub(crate) async fn handle_semantic_tokens_range_parallel_async(
         coordinator,
         supports_multiline,
         None,
+        // Range requests compute a one-shot slice and aren't part of the
+        // rapid-typing pile-up, so no cancellation token is threaded in.
+        None,
     )
     .await?;
 

--- a/src/cancel.rs
+++ b/src/cancel.rs
@@ -1,0 +1,69 @@
+//! Cooperative cancellation for long-running semantic-token computation.
+//!
+//! A full-document semantic-token compute runs on tokio's blocking pool and
+//! fans out across Rayon workers. Dropping its future does **not** stop it — the
+//! blocking task detaches and runs to completion, burning CPU whose result is
+//! then discarded (see `analysis::handle_semantic_tokens_full`). Under rapid
+//! typing on a large document that turns into a pile-up: every keystroke
+//! supersedes the previous request, but the superseded compute keeps running.
+//!
+//! [`CancelToken`] is the escape hatch. A compute polls it at coarse boundaries
+//! (between the host pass and the injection pass, and once per injection region
+//! during discovery/tokenization) and bails early once it is set. The token is
+//! flipped when the request is superseded by a newer one for the same document,
+//! when the client sends `$/cancelRequest`, or when the document closes — so an
+//! obsolete compute stops instead of running to completion (see
+//! `lsp::semantic_request_tracker::SemanticRequestTracker`).
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// A shared, cheap-to-poll cancellation signal. Clones share the same flag, so
+/// one side can cancel a compute another side is running.
+///
+/// The flag is monotonic (`false` → `true`, never reset) and carries no other
+/// state, so [`Ordering::Relaxed`] is sufficient — we only need eventual
+/// visibility of the flip, not to publish other memory through it.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct CancelToken(Arc<AtomicBool>);
+
+impl CancelToken {
+    /// Signal cancellation to every holder of this token. Idempotent.
+    pub(crate) fn cancel(&self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+
+    /// Returns `true` once [`cancel`](Self::cancel) has been called on this
+    /// token or any clone of it.
+    pub(crate) fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn starts_uncancelled() {
+        assert!(!CancelToken::default().is_cancelled());
+    }
+
+    #[test]
+    fn cancel_is_visible_through_clones() {
+        let token = CancelToken::default();
+        let clone = token.clone();
+        assert!(!clone.is_cancelled());
+        token.cancel();
+        assert!(clone.is_cancelled(), "clone must observe the flip");
+        assert!(token.is_cancelled());
+    }
+
+    #[test]
+    fn cancel_is_idempotent() {
+        let token = CancelToken::default();
+        token.cancel();
+        token.cancel();
+        assert!(token.is_cancelled());
+    }
+}

--- a/src/cancel.rs
+++ b/src/cancel.rs
@@ -40,6 +40,14 @@ impl CancelToken {
     }
 }
 
+/// Checkpoint helper for the pervasive optional-token case: `true` only when a
+/// token is present *and* cancelled. A `None` token (cancellation disabled, e.g.
+/// range requests and tests) is never cancelled, so callers collapse to their
+/// pre-cancellation behavior.
+pub(crate) fn is_cancelled(token: Option<&CancelToken>) -> bool {
+    token.is_some_and(|t| t.is_cancelled())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub(crate) mod analysis;
+pub(crate) mod cancel;
 pub mod cli;
 pub mod config;
 pub(crate) mod document;

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -76,11 +76,20 @@ impl CacheCoordinator {
     /// - Injection token cache
     /// - Request tracking state
     pub(crate) fn remove_document(&self, uri: &Url) {
+        // Cancel any in-flight compute for this URI FIRST, so it has the best
+        // chance to observe the flipped token and bail before its injection
+        // store-half runs — otherwise a compute already past its last checkpoint
+        // could repopulate the caches we clear just below, orphaning entries for
+        // a now-closed document. This narrows but does not fully close that
+        // window (a compute already inside the store-half still writes); the
+        // residual is the same deferred per-document lifecycle-epoch race as the
+        // rest of didClose (see `did_close.rs`), and only leaks a bounded set of
+        // entries for a closed doc that no request can read.
+        self.request_tracker.cancel_all_for_uri(uri);
         self.semantic_cache.remove(uri);
         self.semantic_range_cache.remove(uri);
         self.injection_map.clear(uri);
         self.injection_token_cache.clear_document(uri);
-        self.request_tracker.cancel_all_for_uri(uri);
     }
 
     // ========================================================================

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -438,9 +438,11 @@ impl CacheCoordinator {
 
     /// Start tracking a new request for the given URI.
     ///
-    /// Returns a request ID that should be passed to subsequent operations.
-    /// Automatically supersedes any previous request for the same URI.
-    pub(crate) fn start_request(&self, uri: &Url) -> RequestId {
+    /// Returns the request ID (for `is_request_active` checkpoints) and a
+    /// [`CancelToken`](crate::cancel::CancelToken) the request's compute should
+    /// poll. Automatically supersedes any previous request for the same URI and
+    /// cancels its in-flight compute.
+    pub(crate) fn start_request(&self, uri: &Url) -> (RequestId, crate::cancel::CancelToken) {
         self.request_tracker.start_request(uri)
     }
 
@@ -512,7 +514,7 @@ mod tests {
         cache.store_tokens(uri.clone(), tokens, "rust".to_string(), 0);
 
         // Start a request
-        let _request_id = cache.start_request(&uri);
+        let (_request_id, _token) = cache.start_request(&uri);
 
         // Remove the document
         cache.remove_document(&uri);
@@ -588,11 +590,11 @@ mod tests {
         let uri = create_test_uri("test.rs");
 
         // Start a request
-        let req1 = cache.start_request(&uri);
+        let (req1, _t1) = cache.start_request(&uri);
         assert!(cache.is_request_active(&uri, req1));
 
         // Start another request - should supersede the first
-        let req2 = cache.start_request(&uri);
+        let (req2, _t2) = cache.start_request(&uri);
         assert!(!cache.is_request_active(&uri, req1));
         assert!(cache.is_request_active(&uri, req2));
 
@@ -607,7 +609,7 @@ mod tests {
         let uri = create_test_uri("test.rs");
 
         // Start a request
-        let req = cache.start_request(&uri);
+        let (req, _token) = cache.start_request(&uri);
         assert!(cache.is_request_active(&uri, req));
 
         // Cancel all requests

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -681,6 +681,7 @@ print("hello")
         let manager = DebouncedDiagnosticsManager::with_duration(Duration::ZERO);
 
         let wait_version = |want: i32| {
+            let server = server;
             let uri = &uri;
             async move {
                 timeout(Duration::from_secs(1), async {

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -238,8 +238,11 @@ impl Kakehashi {
             return Ok(None);
         };
 
-        // Start tracking this request - supersedes any previous request for this URI
-        let request_id = self.cache.start_request(&uri);
+        // Start tracking this request - supersedes any previous request for this URI.
+        // `cancel_token` is flipped when a newer request supersedes this one (or
+        // the document closes); it is threaded into the blocking compute so a
+        // superseded request stops mid-flight instead of running to completion.
+        let (request_id, cancel_token) = self.cache.start_request(&uri);
 
         // Snapshot the settings generation NOW, before reading any
         // settings-dependent tokenization input (language resolution, queries,
@@ -414,8 +417,11 @@ impl Kakehashi {
                 tokio::select! {
                     biased;
 
-                    // Cancel notification received - abort immediately
+                    // Cancel notification received - abort immediately. Flip the
+                    // token so the now-detached blocking compute stops early
+                    // instead of running to completion for a discarded result.
                     _ = &mut cancel_rx => {
+                        cancel_token.cancel();
                         self.cache.finish_request(&uri, request_id);
                         log::debug!(
                             target: "kakehashi::semantic",
@@ -435,6 +441,19 @@ impl Kakehashi {
 
             (result, text)
         }; // doc reference is dropped here
+
+        // A supersede/close between compute start and here flips the token; the
+        // compute may have bailed early (returning empty tokens), so drop the
+        // result rather than storing a partial set over the cache.
+        if cancel_token.is_cancelled() {
+            self.cache.finish_request(&uri, request_id);
+            log::debug!(
+                target: "kakehashi::semantic",
+                "[SEMANTIC_TOKENS] CANCELLED uri={} req={} (compute superseded)",
+                uri, request_id
+            );
+            return Ok(None);
+        }
 
         if let Some(reason) = self.check_text_staleness(&uri, &text_used) {
             self.cache.finish_request(&uri, request_id);
@@ -512,8 +531,11 @@ impl Kakehashi {
             return Ok(None);
         };
 
-        // Start tracking this request - supersedes any previous request for this URI
-        let request_id = self.cache.start_request(&uri);
+        // Start tracking this request - supersedes any previous request for this
+        // URI. `cancel_token` (flipped on supersede/close) is threaded into the
+        // blocking compute so a superseded delta stops mid-flight — this is the
+        // steady-state typing path where the pile-up is worst.
+        let (request_id, cancel_token) = self.cache.start_request(&uri);
 
         // Snapshot the settings generation NOW, before any settings-dependent
         // tokenization input is read below (same reload-race safety as
@@ -693,8 +715,12 @@ impl Kakehashi {
                     tokio::select! {
                         biased;
 
-                        // Cancel notification received - abort immediately
+                        // Cancel notification received - abort immediately. Flip
+                        // the token so the now-detached blocking compute stops
+                        // early instead of running to completion for a discarded
+                        // result.
                         _ = &mut cancel_rx => {
+                            cancel_token.cancel();
                             self.cache.finish_request(&uri, request_id);
                             log::debug!(
                                 target: "kakehashi::semantic",
@@ -715,6 +741,19 @@ impl Kakehashi {
                 (result, text)
             }
         };
+
+        // A supersede/close between compute start and here flips the token; the
+        // compute may have bailed early (returning empty tokens), so drop the
+        // result rather than diffing/storing a partial set over the cache.
+        if cancel_token.is_cancelled() {
+            self.cache.finish_request(&uri, request_id);
+            log::debug!(
+                target: "kakehashi::semantic",
+                "[SEMANTIC_TOKENS_DELTA] CANCELLED uri={} req={} (compute superseded)",
+                uri, request_id
+            );
+            return Ok(None);
+        }
 
         if let Some(reason) = self.check_text_staleness(&uri, &text_used) {
             self.cache.finish_request(&uri, request_id);

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -409,6 +409,7 @@ impl Kakehashi {
                 coordinator,
                 supports_multiline,
                 injection_cache,
+                Some(cancel_token.clone()),
             );
 
             let result = if let Some(cancel_rx) = cancel_rx {
@@ -707,6 +708,7 @@ impl Kakehashi {
                     coordinator,
                     supports_multiline,
                     injection_cache,
+                    Some(cancel_token.clone()),
                 );
 
                 let result = if let Some(cancel_rx) = cancel_rx {

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -5,8 +5,14 @@
 //! This module supports immediate cancellation of semantic token requests:
 //! - When `$/cancelRequest` is received, the handler aborts and returns `RequestCancelled` (-32800)
 //! - Uses `tokio::select!` to race between cancel notification and token computation
-//! - The Rayon computation cannot be cancelled mid-execution and will continue to
-//!   completion in the thread pool, consuming CPU resources, but its result is discarded
+//! - The blocking Rayon computation is cancelled *cooperatively*: the handler
+//!   flips a [`CancelToken`](crate::cancel) (also flipped when a newer request
+//!   supersedes this one, or the document closes) and the compute polls it at
+//!   coarse checkpoints — after the host pass, inside the injection discovery
+//!   loop, and at each per-region fan-out entry — bailing early. A region
+//!   already mid-parse runs to completion, but not-yet-started work returns
+//!   immediately, so an obsolete request stops burning CPU instead of computing
+//!   a result that is only discarded.
 //!
 //! This is achieved by subscribing to cancel notifications via `CancelForwarder::subscribe()`
 //! and using biased `tokio::select!` to prioritize cancel handling.
@@ -444,8 +450,8 @@ impl Kakehashi {
         }; // doc reference is dropped here
 
         // A supersede/close between compute start and here flips the token; the
-        // compute may have bailed early (returning empty tokens), so drop the
-        // result rather than storing a partial set over the cache.
+        // compute then bailed at a checkpoint and returned `None`, so drop the
+        // request rather than storing an unwanted result over the cache.
         if cancel_token.is_cancelled() {
             self.cache.finish_request(&uri, request_id);
             log::debug!(
@@ -745,8 +751,8 @@ impl Kakehashi {
         };
 
         // A supersede/close between compute start and here flips the token; the
-        // compute may have bailed early (returning empty tokens), so drop the
-        // result rather than diffing/storing a partial set over the cache.
+        // compute then bailed at a checkpoint and returned `None`, so drop the
+        // request rather than diffing/storing an unwanted result over the cache.
         if cancel_token.is_cancelled() {
             self.cache.finish_request(&uri, request_id);
             log::debug!(

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -6,10 +6,10 @@
 //! - When `$/cancelRequest` is received, the handler aborts and returns `RequestCancelled` (-32800)
 //! - Uses `tokio::select!` to race between cancel notification and token computation
 //! - The blocking Rayon computation is cancelled *cooperatively*: the handler
-//!   flips a [`CancelToken`](crate::cancel) (also flipped when a newer request
-//!   supersedes this one, or the document closes) and the compute polls it at
-//!   coarse checkpoints — after the host pass, inside the injection discovery
-//!   loop, and at each per-region fan-out entry — bailing early. A region
+//!   flips a [`CancelToken`](crate::cancel::CancelToken) (also flipped when a
+//!   newer request supersedes this one, or the document closes) and the compute
+//!   polls it at coarse checkpoints — after the host pass, inside the injection
+//!   discovery loop, and at each per-region fan-out entry — bailing early. A region
 //!   already mid-parse runs to completion, but not-yet-started work returns
 //!   immediately, so an obsolete request stops burning CPU instead of computing
 //!   a result that is only discarded.

--- a/src/lsp/semantic_request_tracker.rs
+++ b/src/lsp/semantic_request_tracker.rs
@@ -7,11 +7,26 @@
 //!
 //! This addresses the primary use case: users typing rapidly generate many semantic token
 //! requests, and we want to skip computation for obsolete requests.
+//!
+//! `is_active()` only gates the handler at checkpoints — it cannot stop the
+//! already-running blocking compute of the superseded request. Each request
+//! therefore also carries a [`CancelToken`]: superseding a request (or closing
+//! the document) flips the previous request's token, and the compute polls it to
+//! bail out mid-flight instead of running to completion (see [`crate::cancel`]).
 
+use crate::cancel::CancelToken;
 use dashmap::DashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use url::Url;
+
+/// The tracking record for the most recent request on a URI: its id (for
+/// `is_active` checkpoints) and the cancel token its compute polls.
+#[derive(Debug, Clone)]
+struct ActiveRequest {
+    id: u64,
+    cancel: CancelToken,
+}
 
 /// Monotonically increasing request ID for tracking
 static NEXT_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
@@ -24,8 +39,8 @@ fn next_request_id() -> u64 {
 /// Tracks active semantic token requests to support cancellation
 #[derive(Debug, Clone)]
 pub struct SemanticRequestTracker {
-    /// Maps URI to the most recent active request ID
-    active_requests: Arc<DashMap<Url, u64>>,
+    /// Maps URI to the most recent active request (id + cancel token)
+    active_requests: Arc<DashMap<Url, ActiveRequest>>,
 }
 
 impl Default for SemanticRequestTracker {
@@ -43,12 +58,28 @@ impl SemanticRequestTracker {
     }
 
     /// Starts tracking a new request for the given URI.
-    /// Returns a request ID that should be passed to subsequent operations.
-    /// Automatically supersedes any previous request for the same URI.
-    pub fn start_request(&self, uri: &Url) -> u64 {
+    ///
+    /// Returns the request ID (for `is_active` checkpoints) and a fresh
+    /// [`CancelToken`] the request's compute should poll. Automatically
+    /// supersedes any previous request for the same URI — and flips that
+    /// previous request's token so its still-running compute bails out.
+    pub fn start_request(&self, uri: &Url) -> (u64, CancelToken) {
         let request_id = next_request_id();
-        self.active_requests.insert(uri.clone(), request_id);
-        request_id
+        let cancel = CancelToken::default();
+        let previous = self.active_requests.insert(
+            uri.clone(),
+            ActiveRequest {
+                id: request_id,
+                cancel: cancel.clone(),
+            },
+        );
+        // Superseding a request means its result is no longer wanted: cancel its
+        // in-flight compute so it stops burning CPU (the `is_active` checkpoints
+        // alone can't interrupt the blocking work).
+        if let Some(previous) = previous {
+            previous.cancel.cancel();
+        }
+        (request_id, cancel)
     }
 
     /// Checks if a request is still active (not superseded by a newer one).
@@ -56,7 +87,7 @@ impl SemanticRequestTracker {
     pub fn is_active(&self, uri: &Url, request_id: u64) -> bool {
         self.active_requests
             .get(uri)
-            .map(|entry| *entry == request_id)
+            .map(|entry| entry.id == request_id)
             .unwrap_or(false)
     }
 
@@ -64,13 +95,16 @@ impl SemanticRequestTracker {
     /// This prevents memory leaks from completed requests.
     pub fn finish_request(&self, uri: &Url, request_id: u64) {
         self.active_requests
-            .remove_if(uri, |_, id| *id == request_id);
+            .remove_if(uri, |_, entry| entry.id == request_id);
     }
 
     /// Cancels all requests for a given URI.
-    /// Useful when a document is closed.
+    /// Useful when a document is closed: the removed request's token is flipped
+    /// so any in-flight compute for the now-gone document stops.
     pub fn cancel_all_for_uri(&self, uri: &Url) {
-        self.active_requests.remove(uri);
+        if let Some((_, removed)) = self.active_requests.remove(uri) {
+            removed.cancel.cancel();
+        }
     }
 }
 
@@ -83,7 +117,7 @@ mod tests {
         let tracker = SemanticRequestTracker::new();
         let uri = Url::parse("file:///test.lua").unwrap();
 
-        let req1 = tracker.start_request(&uri);
+        let (req1, _token1) = tracker.start_request(&uri);
         assert!(tracker.is_active(&uri, req1), "Request should be active");
 
         tracker.finish_request(&uri, req1);
@@ -95,14 +129,14 @@ mod tests {
         let tracker = SemanticRequestTracker::new();
         let uri = Url::parse("file:///test.lua").unwrap();
 
-        let req1 = tracker.start_request(&uri);
+        let (req1, _token1) = tracker.start_request(&uri);
         assert!(
             tracker.is_active(&uri, req1),
             "First request should be active"
         );
 
         // Start a new request - should supersede the first
-        let req2 = tracker.start_request(&uri);
+        let (req2, _token2) = tracker.start_request(&uri);
         assert!(
             !tracker.is_active(&uri, req1),
             "First request should be superseded"
@@ -114,19 +148,42 @@ mod tests {
     }
 
     #[test]
+    fn test_superseding_cancels_previous_token() {
+        let tracker = SemanticRequestTracker::new();
+        let uri = Url::parse("file:///test.lua").unwrap();
+
+        let (_req1, token1) = tracker.start_request(&uri);
+        assert!(
+            !token1.is_cancelled(),
+            "First token should start uncancelled"
+        );
+
+        // Superseding must flip the previous request's token so its compute bails.
+        let (_req2, token2) = tracker.start_request(&uri);
+        assert!(
+            token1.is_cancelled(),
+            "Superseded request's token must be cancelled"
+        );
+        assert!(
+            !token2.is_cancelled(),
+            "New request's token must stay active"
+        );
+    }
+
+    #[test]
     fn test_multiple_uris() {
         let tracker = SemanticRequestTracker::new();
         let uri1 = Url::parse("file:///test1.lua").unwrap();
         let uri2 = Url::parse("file:///test2.lua").unwrap();
 
-        let req1 = tracker.start_request(&uri1);
-        let req2 = tracker.start_request(&uri2);
+        let (req1, _t1) = tracker.start_request(&uri1);
+        let (req2, _t2) = tracker.start_request(&uri2);
 
         assert!(tracker.is_active(&uri1, req1), "Request 1 should be active");
         assert!(tracker.is_active(&uri2, req2), "Request 2 should be active");
 
         // Requests for different URIs don't interfere
-        let req3 = tracker.start_request(&uri1);
+        let (req3, _t3) = tracker.start_request(&uri1);
         assert!(
             !tracker.is_active(&uri1, req1),
             "Request 1 should be superseded"
@@ -143,8 +200,12 @@ mod tests {
         let tracker = SemanticRequestTracker::new();
         let uri = Url::parse("file:///test.lua").unwrap();
 
-        let req = tracker.start_request(&uri);
+        let (req, token) = tracker.start_request(&uri);
         tracker.cancel_all_for_uri(&uri);
         assert!(!tracker.is_active(&uri, req), "Request should be cancelled");
+        assert!(
+            token.is_cancelled(),
+            "Closing the document must cancel the in-flight token"
+        );
     }
 }

--- a/src/lsp/semantic_request_tracker.rs
+++ b/src/lsp/semantic_request_tracker.rs
@@ -66,17 +66,26 @@ impl SemanticRequestTracker {
     pub fn start_request(&self, uri: &Url) -> (u64, CancelToken) {
         let request_id = next_request_id();
         let cancel = CancelToken::default();
-        let previous = self.active_requests.insert(
-            uri.clone(),
-            ActiveRequest {
-                id: request_id,
-                cancel: cancel.clone(),
-            },
-        );
+        let active = ActiveRequest {
+            id: request_id,
+            cancel: cancel.clone(),
+        };
         // Superseding a request means its result is no longer wanted: cancel its
         // in-flight compute so it stops burning CPU (the `is_active` checkpoints
         // alone can't interrupt the blocking work).
-        if let Some(previous) = previous {
+        //
+        // The steady-state path (rapid typing on an already-tracked document)
+        // updates in place via `get_mut`, so the `Url` key isn't re-cloned on
+        // every keystroke — only the first request for a document pays the clone.
+        if let Some(mut entry) = self.active_requests.get_mut(uri) {
+            let previous = std::mem::replace(entry.value_mut(), active);
+            previous.cancel.cancel();
+        } else if let Some(previous) = self.active_requests.insert(uri.clone(), active) {
+            // Race-safety: two concurrent first requests for the same URI can both
+            // observe `None` above and fall here. `insert` is atomic and returns
+            // whatever a racing thread inserted first, so cancel it — otherwise
+            // that superseded compute would never be told to bail. Do NOT
+            // "simplify" this branch to a return-value-less insert.
             previous.cancel.cancel();
         }
         (request_id, cancel)


### PR DESCRIPTION
## Problem

`semanticTokens/full` and `/full/delta` recompute the **whole document** and run on tokio's blocking pool via Rayon. Dropping the request future does **not** stop that compute — the blocking task detaches and runs to completion, its result merely discarded. Under rapid typing on a large document every keystroke supersedes the previous request, so N un-cancellable whole-document recomputes pile up and oversubscribe the CPU. (The module doc even admitted "the Rayon computation cannot be cancelled mid-execution.")

Root-cause analysis: the dominant per-compute cost on a large doc is the single-threaded injection **discovery** loop (one language resolution + injection-query match per region), so cancellation has to be able to abort *there*, not just at a pass boundary.

## Change

Cooperative cancellation via a shared `CancelToken` (`Arc<AtomicBool>`, `src/cancel.rs`):

- Each semantic-token request carries a token owned by `SemanticRequestTracker`. Superseding a request — or closing the document — **flips the previous request's token**.
- The full/delta handlers flip the token on `$/cancelRequest` and drop the result if the token tripped during compute.
- The blocking compute polls the token and bails at coarse checkpoints: after the host pass, **inside the injection discovery loop**, and at each Rayon per-region fan-out entry. A region already mid-parse finishes; not-yet-started work returns immediately.
- Cancelled regions are marked `fully_loaded: false` so the #529 injection-token cache store-half never persists a partial region. Completed regions are still stored — they're content-keyed (`validity_hash` + `generation`), so valid to reuse even if the request was superseded; the store deliberately does **not** re-check cancel (that would drop valid entries every keystroke).
- `remove_document` (didClose) cancels the in-flight compute **before** clearing caches, to narrow the orphaned-entry window.

The uncancelled path is byte-identical (every checkpoint tests `is_cancelled()`, which collapses to the old behavior when the token is `None`/never flipped). Range requests pass `None` (one-shot, not part of the pile-up).

## Tests

Two deterministic tests pin the checkpoint placement: a pre-cancelled token collapses discovery to zero contexts, and a cancelled pass persists no region to the cache. Plus `CancelToken` and tracker (supersede-flips-token, didClose-flips-token) unit tests. Full lib suite green (2238 passing).

## Reviews

Passed a 10-perspective `/review` (no correctness bugs; design safe), Codex (converged to "no comments to provide"), and pi-review (soundness confirmed on ordering/Relaxed/Send-Sync/layering; its one substantive point resolved *against* a code change and is documented at the store-half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)