### PR TITLE
fix(semantic): pin resolved language in the full-token cache key (#549)

### DIFF
--- a/src/analysis/semantic_cache.rs
+++ b/src/analysis/semantic_cache.rs
@@ -19,6 +19,18 @@ use url::Url;
 #[derive(Clone)]
 pub struct CachedSemanticTokens {
     pub tokens: SemanticTokens,
+    /// The resolved language these tokens were computed for. The `cache_key`
+    /// folds only text ⊕ settings generation, so it can't tell the same URL
+    /// re-opened under a DIFFERENT language apart. `didClose` evicts the entry
+    /// (`CacheCoordinator::remove_document`), but a pre-close request already
+    /// computing can `store` its tokens *after* that eviction under the unchanged
+    /// `cache_key`; the reopen under the new language neither edits the text nor
+    /// bumps the generation, so a bare `(uri, cache_key)` lookup would then serve
+    /// those wrong-language tokens. Pinning the language makes such a request miss
+    /// and recompute instead. (A *same*-language re-open yields identical tokens,
+    /// so it correctly hits.) Mirrors the range (#535) and injection (#529)
+    /// caches, which already fold their language in.
+    pub language: String,
     /// Opaque validity key these tokens were computed under (built by
     /// `CacheCoordinator::token_cache_key`: the FNV-1a hash of the document text
     /// folded with the settings generation). Lets a repeat request on an
@@ -42,11 +54,18 @@ impl SemanticTokenCache {
         }
     }
 
-    /// Store semantic tokens for a document, tagged with the `cache_key` they
-    /// were computed under (see [`get_if_current`](Self::get_if_current)).
-    pub fn store(&self, uri: Url, tokens: SemanticTokens, cache_key: u64) {
-        self.cache
-            .insert(uri, CachedSemanticTokens { tokens, cache_key });
+    /// Store semantic tokens for a document, tagged with the resolved `language`
+    /// and the `cache_key` they were computed under (see
+    /// [`get_if_current`](Self::get_if_current)).
+    pub fn store(&self, uri: Url, tokens: SemanticTokens, language: String, cache_key: u64) {
+        self.cache.insert(
+            uri,
+            CachedSemanticTokens {
+                tokens,
+                language,
+                cache_key,
+            },
+        );
     }
 
     /// Retrieve semantic tokens for a document.
@@ -54,13 +73,19 @@ impl SemanticTokenCache {
         self.cache.get(uri).map(|entry| entry.clone())
     }
 
-    /// Get cached tokens if they were computed under this `cache_key` — i.e. the
-    /// document text AND the settings generation are unchanged since they were
-    /// cached, so re-tokenizing would reproduce them. Returns None on a mismatch
-    /// (text edit or config reload) or no entry.
-    pub fn get_if_current(&self, uri: &Url, cache_key: u64) -> Option<CachedSemanticTokens> {
+    /// Get cached tokens if they were computed for this exact `language` under
+    /// this `cache_key` — i.e. the resolved language, document text, AND settings
+    /// generation are unchanged since they were cached, so re-tokenizing would
+    /// reproduce them. Returns None on a mismatch (language switch, text edit, or
+    /// config reload) or no entry.
+    pub fn get_if_current(
+        &self,
+        uri: &Url,
+        language: &str,
+        cache_key: u64,
+    ) -> Option<CachedSemanticTokens> {
         self.cache.get(uri).and_then(|entry| {
-            if entry.cache_key == cache_key {
+            if entry.cache_key == cache_key && entry.language == language {
                 Some(entry.clone())
             } else {
                 None
@@ -469,7 +494,7 @@ mod tests {
         };
 
         // Store tokens
-        cache.store(uri.clone(), tokens.clone(), 0);
+        cache.store(uri.clone(), tokens.clone(), "rust".to_string(), 0);
 
         // Retrieve tokens
         let retrieved = cache.get(&uri);
@@ -509,7 +534,7 @@ mod tests {
             }],
         };
 
-        cache.store(uri.clone(), tokens, 0);
+        cache.store(uri.clone(), tokens, "rust".to_string(), 0);
 
         // Matching result_id returns tokens
         let valid = cache.get_if_valid(&uri, "42");
@@ -542,22 +567,54 @@ mod tests {
             result_id: Some("7".to_string()),
             data: vec![],
         };
-        cache.store(uri.clone(), tokens, 0xABCD);
+        cache.store(uri.clone(), tokens, "rust".to_string(), 0xABCD);
 
-        // Same content hash => the document is unchanged => serve cached tokens.
-        let hit = cache.get_if_current(&uri, 0xABCD);
+        // Same content hash AND language => the document is unchanged => serve
+        // cached tokens.
+        let hit = cache.get_if_current(&uri, "rust", 0xABCD);
         assert!(hit.is_some(), "should hit when the content hash matches");
         assert_eq!(hit.unwrap().tokens.result_id, Some("7".to_string()));
 
         // Different content hash => the text changed => recompute (miss).
         assert!(
-            cache.get_if_current(&uri, 0x1234).is_none(),
+            cache.get_if_current(&uri, "rust", 0x1234).is_none(),
             "should miss when the content hash differs"
         );
 
         // Unknown URI => miss.
         let other = Url::parse("file:///o.rs").unwrap();
-        assert!(cache.get_if_current(&other, 0xABCD).is_none());
+        assert!(cache.get_if_current(&other, "rust", 0xABCD).is_none());
+    }
+
+    #[test]
+    fn get_if_current_misses_on_language_switch() {
+        // A `didClose`/`didOpen` that re-assigns the same URI to a different
+        // language keeps the text (and thus `cache_key`) identical, since the key
+        // folds only text ⊕ settings generation. `didClose` evicts, but a
+        // pre-close request still computing can store under the unchanged key
+        // after that eviction, and the reopen bumps no generation — so without the
+        // language guard the cache would serve the previous language's tokens for
+        // the new document (#549); with it, the request misses and recomputes.
+        let cache = SemanticTokenCache::new();
+        let uri = Url::parse("file:///t.txt").unwrap();
+        let tokens = SemanticTokens {
+            result_id: Some("1".to_string()),
+            data: vec![],
+        };
+        cache.store(uri.clone(), tokens, "lua".to_string(), 0xABCD);
+
+        // Same key, same language => hit.
+        assert!(
+            cache.get_if_current(&uri, "lua", 0xABCD).is_some(),
+            "should hit for the same language under the same key"
+        );
+
+        // Same key (unchanged text), different language => miss (no wrong-language
+        // tokens served).
+        assert!(
+            cache.get_if_current(&uri, "python", 0xABCD).is_none(),
+            "must miss when the resolved language differs even if the text is unchanged"
+        );
     }
 
     #[test]
@@ -568,14 +625,14 @@ mod tests {
             result_id: Some("1".to_string()),
             data: vec![],
         };
-        cache.store(uri.clone(), tokens, 0xAA);
-        assert!(cache.get_if_current(&uri, 0xAA).is_some());
+        cache.store(uri.clone(), tokens, "rust".to_string(), 0xAA);
+        assert!(cache.get_if_current(&uri, "rust", 0xAA).is_some());
 
         // A config reload changes tokenization for the same text, so the whole
         // cache must drop — a later request recomputes against the new queries.
         cache.clear();
         assert!(
-            cache.get_if_current(&uri, 0xAA).is_none(),
+            cache.get_if_current(&uri, "rust", 0xAA).is_none(),
             "clear() must drop entries so stale-config tokens are not served"
         );
     }
@@ -596,7 +653,7 @@ mod tests {
         };
 
         // Store tokens
-        cache.store(uri.clone(), tokens, 0);
+        cache.store(uri.clone(), tokens, "rust".to_string(), 0);
         assert!(cache.get(&uri).is_some(), "Should have cached tokens");
 
         // Remove on close

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -356,11 +356,18 @@ impl CacheCoordinator {
         crate::text::fnv1a_hash(text) ^ generation.wrapping_mul(0x100000001b3)
     }
 
-    /// Store semantic tokens for a document, tagged with the `cache_key` they
-    /// were computed under so an unchanged-document repeat request (same text and
-    /// settings) can skip re-tokenizing via [`get_current_tokens`](Self::get_current_tokens).
-    pub(crate) fn store_tokens(&self, uri: Url, tokens: SemanticTokens, cache_key: u64) {
-        self.semantic_cache.store(uri, tokens, cache_key);
+    /// Store semantic tokens for a document, tagged with the resolved `language`
+    /// and the `cache_key` they were computed under so an unchanged-document
+    /// repeat request (same language, text, and settings) can skip re-tokenizing
+    /// via [`get_current_tokens`](Self::get_current_tokens).
+    pub(crate) fn store_tokens(
+        &self,
+        uri: Url,
+        tokens: SemanticTokens,
+        language: String,
+        cache_key: u64,
+    ) {
+        self.semantic_cache.store(uri, tokens, language, cache_key);
     }
 
     /// Store the most-recent `semanticTokens/range` result for a document (#535),
@@ -392,12 +399,18 @@ impl CacheCoordinator {
             .get_if_current(uri, range, language, cache_key)
     }
 
-    /// Return the cached tokens iff they were computed under this `cache_key`
-    /// (same text and settings generation), letting the caller skip the full
-    /// re-tokenization. None on a text edit, a settings reload, or no entry.
-    pub(crate) fn get_current_tokens(&self, uri: &Url, cache_key: u64) -> Option<SemanticTokens> {
+    /// Return the cached tokens iff they were computed for this `language` under
+    /// this `cache_key` (same text and settings generation), letting the caller
+    /// skip the full re-tokenization. None on a language switch, a text edit, a
+    /// settings reload, or no entry.
+    pub(crate) fn get_current_tokens(
+        &self,
+        uri: &Url,
+        language: &str,
+        cache_key: u64,
+    ) -> Option<SemanticTokens> {
         self.semantic_cache
-            .get_if_current(uri, cache_key)
+            .get_if_current(uri, language, cache_key)
             .map(|cached| cached.tokens)
     }
 
@@ -496,7 +509,7 @@ mod tests {
                 token_modifiers_bitset: 0,
             }],
         };
-        cache.store_tokens(uri.clone(), tokens, 0);
+        cache.store_tokens(uri.clone(), tokens, "rust".to_string(), 0);
 
         // Start a request
         let _request_id = cache.start_request(&uri);
@@ -522,15 +535,15 @@ mod tests {
         // A request snapshots the generation, then builds its key (generation 0).
         let gen_before = cache.semantic_token_generation();
         let key_before = cache.cache_key_for(text, gen_before);
-        cache.store_tokens(uri.clone(), tokens.clone(), key_before);
-        assert!(cache.get_current_tokens(&uri, key_before).is_some());
+        cache.store_tokens(uri.clone(), tokens.clone(), "rust".to_string(), key_before);
+        assert!(cache.get_current_tokens(&uri, "rust", key_before).is_some());
 
         // A settings/query reload bumps the generation (and clears the map).
         cache.bump_semantic_token_generation();
 
         // Race: a request that began tokenizing under the OLD queries (it captured
         // `key_before`) stores its now-stale tokens AFTER the reload's clear.
-        cache.store_tokens(uri.clone(), tokens, key_before);
+        cache.store_tokens(uri.clone(), tokens, "rust".to_string(), key_before);
 
         // A fresh post-reload request snapshots the new generation and builds its
         // key for the same text. The stale, old-generation tokens must NOT be
@@ -542,7 +555,7 @@ mod tests {
             "the generation bump must change the key for identical text"
         );
         assert!(
-            cache.get_current_tokens(&uri, key_after).is_none(),
+            cache.get_current_tokens(&uri, "rust", key_after).is_none(),
             "tokens stored under the pre-reload generation must not survive a reload"
         );
     }
@@ -557,7 +570,7 @@ mod tests {
             result_id: Some("test-id".to_string()),
             data: vec![],
         };
-        cache.store_tokens(uri.clone(), tokens, 0);
+        cache.store_tokens(uri.clone(), tokens, "rust".to_string(), 0);
 
         // Verify stored
         assert!(cache.get_tokens_if_valid(&uri, "test-id").is_some());

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -371,7 +371,10 @@ impl Kakehashi {
             // that check. (The compute path below DOES await, which is why it
             // re-checks staleness after the block; this early return needs no such
             // re-check.)
-            if let Some(cached) = self.cache.get_current_tokens(&uri, cache_key) {
+            if let Some(cached) = self
+                .cache
+                .get_current_tokens(&uri, &language_name, cache_key)
+            {
                 self.cache.finish_request(&uri, request_id);
                 return Ok(Some(SemanticTokensResult::Tokens(cached)));
             }
@@ -474,9 +477,10 @@ impl Kakehashi {
         let stored_tokens = tokens_with_id.clone();
         let lsp_tokens = tokens_with_id;
         // Store keyed by result_id (delta baseline) AND cache_key (so an
-        // unchanged-document repeat request short-circuits the re-tokenization above).
+        // unchanged-document repeat request short-circuits the re-tokenization
+        // above). `language_name` is unused after this, so move it in.
         self.cache
-            .store_tokens(uri.clone(), stored_tokens, cache_key);
+            .store_tokens(uri.clone(), stored_tokens, language_name, cache_key);
 
         // Finish tracking this request
         self.cache.finish_request(&uri, request_id);
@@ -636,7 +640,10 @@ impl Kakehashi {
             // re-tokenizing. No `.await` runs between the staleness check above and
             // here, so the cached tokens stay consistent with it. Cleared wholesale
             // on a settings reload.
-            if let Some(cached) = self.cache.get_current_tokens(&uri, cache_key) {
+            if let Some(cached) = self
+                .cache
+                .get_current_tokens(&uri, &language_name, cache_key)
+            {
                 // Fast path: the client's baseline already IS these cached tokens,
                 // so the delta is necessarily empty — return it directly and skip
                 // the `previous_tokens` clone + O(N) `calculate_delta` below.
@@ -756,8 +763,12 @@ impl Kakehashi {
         let final_result = match delta_result {
             SemanticTokensFullDeltaResult::Tokens(mut tokens) => {
                 tokens.result_id = Some(next_result_id());
-                self.cache
-                    .store_tokens(uri.clone(), tokens.clone(), cache_key);
+                self.cache.store_tokens(
+                    uri.clone(),
+                    tokens.clone(),
+                    language_name.clone(),
+                    cache_key,
+                );
                 SemanticTokensFullDeltaResult::Tokens(tokens)
             }
             SemanticTokensFullDeltaResult::TokensDelta(mut delta) if delta.edits.is_empty() => {
@@ -774,8 +785,12 @@ impl Kakehashi {
                 let mut stored_tokens = current_tokens;
                 stored_tokens.result_id = Some(next_result_id());
                 delta.result_id = stored_tokens.result_id.clone();
-                self.cache
-                    .store_tokens(uri.clone(), stored_tokens, cache_key);
+                self.cache.store_tokens(
+                    uri.clone(),
+                    stored_tokens,
+                    language_name.clone(),
+                    cache_key,
+                );
                 SemanticTokensFullDeltaResult::TokensDelta(delta)
             }
             SemanticTokensFullDeltaResult::PartialTokensDelta { .. } => {
@@ -789,8 +804,12 @@ impl Kakehashi {
                 );
                 let mut tokens = current_tokens;
                 tokens.result_id = Some(next_result_id());
-                self.cache
-                    .store_tokens(uri.clone(), tokens.clone(), cache_key);
+                self.cache.store_tokens(
+                    uri.clone(),
+                    tokens.clone(),
+                    language_name.clone(),
+                    cache_key,
+                );
                 SemanticTokensFullDeltaResult::Tokens(tokens)
             }
         };
@@ -1397,6 +1416,76 @@ mod tests {
             first_id, second_id,
             "an unchanged document should reuse cached tokens (stable result_id), \
              not recompute with a fresh id"
+        );
+    }
+
+    /// End-to-end guard for #549: the same URI, re-assigned to a DIFFERENT
+    /// language without any text change, must recompute rather than serve the
+    /// first language's cached tokens. The text (and thus `cache_key`) is
+    /// identical across both requests, so only the language dimension of the key
+    /// prevents the collision. This deliberately does NOT go through `did_close`
+    /// (which evicts the entry): the bug it locks is the lingering entry being
+    /// re-read under the new language (the store-after-evict / reopen race), so
+    /// the entry must survive into the second request.
+    #[tokio::test]
+    async fn semantic_tokens_full_recomputes_after_language_switch_same_text() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let uri = Url::parse("file:///switch.txt").expect("should construct test uri");
+        // Text is only ever compared for equality across the two requests; it need
+        // not be valid in either grammar (tree-sitter still yields a tree + tokens).
+        let text = "local x = 1".to_string();
+
+        for lang in ["lua", "rust"] {
+            let load_result = server.language.ensure_language_loaded(lang);
+            if !load_result.success || server.language.highlight_query(lang).is_none() {
+                eprintln!("Skipping: {lang} parser or highlight query not available");
+                return;
+            }
+        }
+
+        let make_params = || SemanticTokensParams {
+            text_document: TextDocumentIdentifier {
+                uri: crate::lsp::lsp_impl::url_to_uri(&uri).expect("test URI should convert"),
+            },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        };
+
+        // Open as lua, compute + cache tokens under (uri, lua, cache_key).
+        server
+            .documents
+            .insert(uri.clone(), text.clone(), Some("lua".to_string()), None);
+        let lua_result = server
+            .semantic_tokens_full_impl(make_params())
+            .await
+            .expect("lua full request should succeed")
+            .expect("should return tokens");
+        let lua_id = match lua_result {
+            SemanticTokensResult::Tokens(t) => t.result_id.expect("should have result_id"),
+            _ => panic!("expected Tokens variant"),
+        };
+
+        // Re-assign the SAME uri + SAME text to rust WITHOUT closing (so the lua
+        // cache entry lingers). The cache_key is unchanged (text + generation are),
+        // so only the language guard can force a miss here.
+        server
+            .documents
+            .insert(uri.clone(), text, Some("rust".to_string()), None);
+        let rust_result = server
+            .semantic_tokens_full_impl(make_params())
+            .await
+            .expect("rust full request should succeed")
+            .expect("should return tokens");
+        let rust_id = match rust_result {
+            SemanticTokensResult::Tokens(t) => t.result_id.expect("should have result_id"),
+            _ => panic!("expected Tokens variant"),
+        };
+
+        assert_ne!(
+            lua_id, rust_id,
+            "switching the document's language (same text) must recompute, not \
+             serve the previous language's cached tokens"
         );
     }
 


### PR DESCRIPTION
Closes #549. Independent of the other open PRs (disjoint files); branches off `main`.

## Problem
The whole-document semantic-token cache (`SemanticTokenCache`, `src/analysis/semantic_cache.rs`) keyed cached tokens only on `(uri, cache_key)`, where `cache_key = fnv1a(text) ^ (generation * FNV_PRIME)`.

A `didClose` + `didOpen` that reopens the **same URI under a different language** neither edits the text nor bumps the settings generation, so `cache_key` is unchanged. `didClose` evicts the entry, but a pre-close request still computing can `store` its tokens *after* that eviction under the unchanged key; the reopen bumps no generation, so the lingering entry still matches. The whole-document `semanticTokens/full` and `full/delta` paths could then serve the **previous language's tokens** for the new document.

This is the whole-doc twin of the gap already closed for the range cache in #535 and folded into the injection cache (#529) — those fold the resolved language into their validity key; only `SemanticTokenCache` was missing it.

## Fix
- Add `language: String` to `CachedSemanticTokens`; thread the resolved `language_name` through `store_tokens` / `get_current_tokens` (`src/lsp/cache.rs`) and require `entry.language == language` in `get_if_current`.
- Update the 2 reads + 4 stores in the `full` and `full/delta` handlers (`semantic_tokens.rs`) to pass the same `language_name` the tokens were computed under.
- A same-language reopen yields identical tokens, so it still correctly **hits** (no perf regression on the hot path; one `String::eq` + a small `String` per cached doc).

## Tests
- `get_if_current_misses_on_language_switch` (cache layer): identical URI + key, different language ⇒ miss.
- `semantic_tokens_full_recomputes_after_language_switch_same_text` (handler): reopen the same URI + text under a new language *without* `did_close` (so the entry lingers) ⇒ recompute (fresh `result_id`), locking the fix end-to-end.
- Full lib suite green (2234 passed).

## Reviews
Pre-merge: `/review` (10-agent), Codex, and pi-review all returned **no correctness/race/API findings**; the only actionable items were doc-citation precision, a store-after-evict-race comment, a `clone`→move nit, and the optional handler test — all folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)