### PR TITLE
docs(adr): parse snapshot architecture — decouple document lifecycle from parsing

### DIFF
--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -8,8 +8,7 @@
 
 ## Context
 
-The per-document-parse-scheduler decision moved parsing **off the ingress
-ticket**: `didChange` applies the text edit, clears the reader-visible tree, and
+The per-document-parse-scheduler decision moved parsing **off the ingress ticket**: `didChange` applies the text edit, clears the reader-visible tree, and
 schedules a coalesced off-ingress reparse. That closed the ingress-latency and
 large-paste races it set out to close, but two costs it did not address surfaced
 as a user-visible regression against v0.7.0 (which parsed inline on `didChange`):
@@ -40,13 +39,11 @@ The primitives to fix this are largely already present — a process-monotonic
 `ParseScheduler`'s one-loop-per-document coalescing. What is missing is (1) a
 tree that readers can serve **without** waiting for a reparse, and (2) getting
 tree-CPU **off** the shared async runtime. The user goal is explicit:
-**high-performance parsing, no cross-document blocking, and document lifecycle
-management independent of parsing** — and large architectural change is invited.
+**high-performance parsing, no cross-document blocking, and document lifecycle management independent of parsing** — and large architectural change is invited.
 
 ## Decision
 
-Model the document as **versioned inputs** and parsing as a **versioned derived
-computation**, in the shape salsa / rust-analyzer / gopls use: inputs are the
+Model the document as **versioned inputs** and parsing as a **versioned derived computation**, in the shape salsa / rust-analyzer / gopls use: inputs are the
 source of truth and never block on derivation; derivation publishes immutable,
 internally-consistent snapshots that readers observe without blocking.
 
@@ -156,8 +153,7 @@ check-then-act rather than a cross-map TOCTOU against `Document.incarnation`):
   incarnation (so a relabel across lifetimes is already rejected), and within one
   lifetime the language does not change. The three-axis edit-path CAS
   (`incarnation && text && language`) therefore reduces to `incarnation && version`.
-- **Isolation is per-request re-resolution + incarnation validation, not cell
-  identity.** A `latest_snapshot(uri)` call resolves the *current* cell from the
+- **Isolation is per-request re-resolution + incarnation validation, not cell identity.** A `latest_snapshot(uri)` call resolves the *current* cell from the
   store each time and never caches a `Receiver` across requests, and it validates
   `snapshot.incarnation == <live document incarnation>` before serving — the cell
   and the document inputs are one per-URI lifetime object, so there is one
@@ -186,21 +182,18 @@ The incremental-parse **seed** re-homes onto `ParseScheduler`'s per-document sta
 (accumulated `InputEdit`s + the `base_version` they extend). Two obligations,
 enforced by co-location today, become explicit scheduler invariants:
 
-- The seed is applied to the snapshot's tree **iff
-  `snapshot.parsed_version == base_version`**; on mismatch (a publish raced), it
+- The seed is applied to the snapshot's tree **iff `snapshot.parsed_version == base_version`**; on mismatch (a publish raced), it
   reseeds from the current snapshot and parses — never applies edits to a tree
   they do not match (the `#348` external-scanner corruption).
 - A full-text sync **resets** `(pending_edits, base_version)`, so it parses from
   scratch. "Leaves no accumulated edits" is an explicit reset, not an emergent
   property.
 
-A parse pass therefore has a **single version/incarnation-guarded commit
-sequence**, so no downstream effect ever escapes for a snapshot that lost the CAS:
+A parse pass therefore has a **single version/incarnation-guarded commit sequence**, so no downstream effect ever escapes for a snapshot that lost the CAS:
 compute the tree, region map, and tokens **privately** (nothing shared mutated);
 revalidate `incarnation == current_incarnation`; run the one publish primitive; and
 emit the downstream — `semanticTokens/refresh`, injected-language forwarding,
-diagnostic republish, and any shared injection-token-cache write — **only if that
-exact publish succeeded** (the shared `NodeTracker` is not mutated on this path at
+diagnostic republish, and any shared injection-token-cache write — **only if that exact publish succeeded** (the shared `NodeTracker` is not mutated on this path at
 all; see §3), in the order the
 per-document-parse-scheduler loop already uses (`populate → mark finished →
 downstream`). A rejected publish (a racing edit or reopen advanced the slot) emits
@@ -239,8 +232,7 @@ edit-shifted to `content_version` — cannot be made atomic without holding
 shared, edit-shifted identity index off the derivation path is fundamentally at
 odds with the snapshot model.
 
-The decision therefore **separates three concerns that today all ride the tracker
-ULID**, so none needs a shared, edit-shifted mint off the parse path:
+The decision therefore **separates three concerns that today all ride the tracker ULID**, so none needs a shared, edit-shifted mint off the parse path:
 
 - **Within-snapshot enumeration** — the id `populate` puts in `injection_regions`
   is a **document-order ordinal** (the region's index in the injection-query match
@@ -259,11 +251,9 @@ ULID**, so none needs a shared, edit-shifted mint off the parse path:
   tree, which has no target once the key drops it, so it must become a content-keyed
   clear (or a side index) — losing the "typed region preserves reuse on an unrelated
   edit" optimization measured by the injection-token-cache-reuse work unless that
-  index is added. Reworking the key **and** the eviction surface is a **companion
-  decision to injection-token-cache-reuse**, not silently folded in here.
+  index is added. Reworking the key **and** the eviction surface is a **companion decision to injection-token-cache-reuse**, not silently folded in here.
 - **Cross-edit bridge / virtual-document identity** — the stable handle a
-  downstream language server's virtual document is keyed by — **remains the shared
-  `NodeTracker` ULID**, a live-position (`content_version`) concern. Because regions
+  downstream language server's virtual document is keyed by — **remains the shared `NodeTracker` ULID**, a live-position (`content_version`) concern. Because regions
   are only *discovered* by a parse, minting still originates from a parse pass, but
   as a distinct **current-version reconciliation step**, not off the stale-read
   path: the tracker ULID mint that `populate_injections` performs inline today
@@ -299,8 +289,7 @@ Any reader that must resolve against **live** positions is position-critical
   `didChange` handler — `didChange` deliberately does not emit refresh because a
   synchronous client (vim-lsp on Vim) cannot answer a server request while
   processing a notification; emitting from the off-ingress loop, after the
-  notification returns, avoids that reentrancy. This **reverses the current
-  handler**, which *rejects* a stale/superseded `semanticTokens` full/delta with
+  notification returns, avoids that reentrancy. This **reverses the current handler**, which *rejects* a stale/superseded `semanticTokens` full/delta with
   `None` (via `check_text_staleness` and the merged compute-superseded
   `is_cancelled` bail) rather than serving a trailing snapshot. Stage 2 replaces
   reject-on-stale with serve-stale + refresh; the `CancelToken` bail then narrows to
@@ -346,8 +335,7 @@ Any reader that must resolve against **live** positions is position-critical
     re-issues, self-healing on its next request. A captures `full` that *does*
     compute (snapshot current at entry) can still race an edit during its async
     compute; its lineage store must therefore carry the computed `parsed_version`
-    and, under `edit_lock`, install the lineage **only if `incarnation` and the
-    current `content_version` still match it** (today `store_lineage` re-checks only
+    and, under `edit_lock`, install the lineage **only if `incarnation` and the current `content_version` still match it** (today `store_lineage` re-checks only
     incarnation) — otherwise it stores nothing and returns `null`, so the lineage
     never records matches for a text the client no longer has.
 
@@ -378,8 +366,7 @@ the result, so no tree-CPU ever executes on a tokio worker. `DocumentParserPool`
 guard becomes a sync mutex (`std`/`parking_lot`) since acquisition now runs on pool
 threads that cannot `.await`.
 
-The guarantee this design **actually** makes is narrow and unconditional: **the
-async runtime is never blocked by synchronous tree-CPU** — leg (1), no tree-work on
+The guarantee this design **actually** makes is narrow and unconditional: **the async runtime is never blocked by synchronous tree-CPU** — leg (1), no tree-work on
 the tokio workers, so B's handler and the timer driver are always pollable and the
 timeouts that were being defeated now fire. It does **not** by itself guarantee
 "no cross-document starvation" in the strong sense: the pool has finite threads,
@@ -392,8 +379,7 @@ a real guarantee requires **explicit fair admission** — a focused-document pri
 queue plus a per-document in-flight concurrency cap — which this decision names as
 required follow-on work, not something the bounded pool delivers on its own.
 
-**Cooperative cancellation is the complement to the pool, and it has already
-landed on the current architecture.** The pool isolates tree-CPU but cannot stop a
+**Cooperative cancellation is the complement to the pool, and it has already landed on the current architecture.** The pool isolates tree-CPU but cannot stop a
 *superseded* compute: Rayon does not preempt, and dropping the `oneshot`-bridged
 future leaves the work-unit running to completion — wasting a pool thread that is
 now scarcer than the process-global Rayon pool it replaces. The merged `CancelToken`
@@ -402,8 +388,7 @@ supersede, `$/cancelRequest`, or `didClose`, which the compute polls at coarse
 checkpoints — the injection discovery loop and the per-region fan-out — and bails)
 closes exactly that gap. It **composes with** this design rather than competing, so
 it is carried forward, not re-derived: the token is an architecture-independent
-primitive, **re-homed at Stage 1 as a cancellation hook on the bounded-pool
-work-unit (the `oneshot` bridge) contract**. Keep the split explicit — §2's terminal
+primitive, **re-homed at Stage 1 as a cancellation hook on the bounded-pool work-unit (the `oneshot` bridge) contract**. Keep the split explicit — §2's terminal
 `SnapshotSlot` + incarnation rejection guarantees *correctness* on close/supersede
 (a stale or cross-lifetime result is never served), while the `CancelToken` is the
 orthogonal *CPU-reclamation* mechanism (a superseded compute stops burning a pool
@@ -429,8 +414,7 @@ inside the existing safety contracts at each step:
   channel + `latest_snapshot`. **The parse loop dual-writes under one guard**: the
   legacy tree CAS (the incremental seed still reads `Document::tree`/`pending_seed`,
   which Stage 3 removes) is made strict-version like the publish, both writes run
-  under the same `(incarnation, parsed_version)` guard, and the **snapshot publish
-  is the sole commit point** — all downstream (refresh, forwarding, diagnostics,
+  under the same `(incarnation, parsed_version)` guard, and the **snapshot publish is the sole commit point** — all downstream (refresh, forwarding, diagnostics,
   shared cache writes) gates on the *publish* result, never the legacy CAS (§2). So
   `latest_snapshot` retains a servable tree across an edit's `tree.take()`; the two
   stores may transiently sit at different versions (a lost legacy CAS just reseeds
@@ -444,8 +428,7 @@ inside the existing safety contracts at each step:
   passive-refresh family (`documentSymbol`/`documentColor`/`documentLink`/
   `foldingRange`/`codeLens`/pull-`diagnostic`) to serve-stale; the position/range
   family — `semanticTokens/range`, `node/*`, `formatting`/`rangeFormatting`, the
-  bridge-context requests, **and `selectionRange`, whose inline `parse_with_pool` +
-  `update_document` must be replaced by `latest_snapshot`** — to `ContentModified`;
+  bridge-context requests, **and `selectionRange`, whose inline `parse_with_pool` + `update_document` must be replaced by `latest_snapshot`** — to `ContentModified`;
   and `captures` to `null` (its re-sync signal). Removes `get_tree_with_wait` /
   `wait_for_epoch` / `ensure_document_parsed` **and** the inline-parse fallbacks
   (`try_parse_and_update_document`, `selection_range_impl`) — closing the
@@ -467,11 +450,9 @@ inside the existing safety contracts at each step:
   reparse (or fall into an on-demand full parse). And `spawn_blocking` **alone**
   trades HOL-blocking for CPU oversubscription on the default 512-thread blocking
   pool, so it must be paired with a bounded pool regardless. The *idea* — get the
-  CPU off the async workers — is what **Stage 1** adopts, but via the **bounded
-  Rayon pool** of §4, **not** raw `spawn_blocking`; and Stage 1 is a step toward the
+  CPU off the async workers — is what **Stage 1** adopts, but via the **bounded Rayon pool** of §4, **not** raw `spawn_blocking`; and Stage 1 is a step toward the
   snapshot destination, not the destination itself.
-- **Serve the pre-edit / seeded tree immediately without versioning
-  (naive stale-serve).** Rejected. It is crash-safe (the `#348` hazard is a
+- **Serve the pre-edit / seeded tree immediately without versioning (naive stale-serve).** Rejected. It is crash-safe (the `#348` hazard is a
   parse-seed/external-scanner issue, not a query-cursor issue, and the read paths
   are already stale-offset-hardened), but readers **write** persistent caches. The
   whole-document token cache (in `semantic_cache` / `cache`, keyed by text hash) is
@@ -507,8 +488,7 @@ inside the existing safety contracts at each step:
   pool itself additionally needs the fair-admission follow-on §4 names.)
 - High-performance reads: highlight requests return against the latest snapshot
   immediately instead of waiting hundreds of ms for a reparse + populate.
-- The scheduler ADR's residual **reader-fallback resurrection vector is eliminated
-  at Stage 2**: once every reader routes through wait-free `latest_snapshot` and no
+- The scheduler ADR's residual **reader-fallback resurrection vector is eliminated at Stage 2**: once every reader routes through wait-free `latest_snapshot` and no
   reader parses inline, there is no reader path that can re-insert a document a
   `didClose` removed. (It is *not* closed by Stage 1, which leaves the current
   inline-parse fallbacks — `try_parse_and_update_document`, `selection_range_impl` —
@@ -525,8 +505,7 @@ inside the existing safety contracts at each step:
 
 ### Negative
 
-- Highlight-class results may be **stale — usually one edit, potentially several
-  under sustained typing** (the scheduler coalesces) — until a fresh snapshot
+- Highlight-class results may be **stale — usually one edit, potentially several under sustained typing** (the scheduler coalesces) — until a fresh snapshot
   publishes. `semanticTokens` is re-driven by an added
   post-edit `semanticTokens/refresh` (emitted from the parse loop to dodge the
   synchronous-client reentrancy that keeps it out of `didChange`);

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -57,7 +57,10 @@ monotonic `content_version` (bumped on every edit, `0` at `didOpen`). It no
 longer holds `tree` or `pending_seed`, and `apply_edit` never clears a tree — it
 installs the new text and bumps the version. The document lifecycle
 (`didOpen`/`didChange`/`didClose`) becomes independent of parsing: it mutates
-inputs and returns, never awaiting or gating on a parse.
+inputs and returns, never awaiting or gating on a parse. `content_version` is a
+**new input-side field** that threads into `DocumentSnapshot` and (as
+`parsed_version`) into `ParseSnapshot` and `ComputedCaptures`; adding it and the
+`apply_edit` bump is a Stage 1 prerequisite for the version comparisons below.
 
 Two input-side concerns are explicitly **retained**, because they are not parse
 gates:
@@ -119,9 +122,14 @@ executed inside `send_if_modified` so the guard and the write are atomic under t
 channel's own lock (the co-location is what makes this a single atomic
 check-then-act rather than a cross-map TOCTOU against `Document.incarnation`):
 
-> Install `snapshot` iff `snapshot.incarnation == slot.current_incarnation` **and**
-> `snapshot.parsed_version > slot.snapshot.parsed_version` (strict; `None` →
-> first snapshot is the sole bootstrap exception).
+> Install `snapshot` iff **both** clauses hold — the incarnation clause is never
+> bypassed:
+> 1. `snapshot.incarnation == slot.current_incarnation`, **and**
+> 2. `slot.snapshot.is_none()` (bootstrap) **or**
+>    `snapshot.parsed_version > slot.snapshot.parsed_version` (strict monotonic).
+>
+> The bootstrap case relaxes only the version compare (clause 2), never the
+> incarnation check (clause 1).
 
 - **Incarnation-scoped, strict monotonicity.** The `>` is strict — equal-version
   double-publishes (e.g. a racing open-parse and reparse both at version 0) must
@@ -226,25 +234,36 @@ ULID**, so none needs a shared, edit-shifted mint off the parse path:
   for byte-identical regions (the ordinal disambiguates), so `(URI, region_id)`
   cannot alias two regions of one snapshot. It is **not** a cross-edit-stable handle
   and is not claimed to be — an edit that inserts a region renumbers ordinals.
-- **Cross-edit token reuse** (the injection-token-cache-reuse benefit) is re-keyed
-  off the ordinal onto **`(region content hash, validity_hash)`**: two snapshots'
-  byte-identical regions reuse tokens regardless of ordinal, which is what actually
-  makes reuse survive edits. Reworking that cache key is a **companion decision to
-  injection-token-cache-reuse**, not silently folded in here.
+- **Cross-edit token reuse** (the injection-token-cache-reuse benefit): the cache
+  is already content-validated at read (its entry carries `validity_hash` = content
+  ⊕ language, and `generation`), but its *key* is today the tracker ULID. The change
+  is to **drop `region_id` from the key** — key on `(uri, content_hash,
+  validity_hash, generation)` — so two snapshots' byte-identical regions reuse
+  tokens without any stable id. That in turn reworks **eviction**:
+  `invalidate_for_edits` currently point-deletes by `region_id` via the interval
+  tree, which has no target once the key drops it, so it must become a content-keyed
+  clear (or a side index) — losing the "typed region preserves reuse on an unrelated
+  edit" optimization measured by the injection-token-cache-reuse work unless that
+  index is added. Reworking the key **and** the eviction surface is a **companion
+  decision to injection-token-cache-reuse**, not silently folded in here.
 - **Cross-edit bridge / virtual-document identity** — the stable handle a
   downstream language server's virtual document is keyed by — **remains the shared
   `NodeTracker` ULID**, a live-position (`content_version`) concern. Because regions
   are only *discovered* by a parse, minting still originates from a parse pass, but
   as a distinct **current-version reconciliation step**, not off the stale-read
-  path: when a pass completes and (under `edit_lock`) its `parsed_version` still
-  equals `content_version`, a reconciliation maps the snapshot's region geometry to
-  tracker ULIDs — reusing an existing id by position, minting a fresh one for a
-  genuinely new region — exactly as discovery mints today. If the pass is stale
-  (`content_version` moved on), reconciliation is skipped and deferred to the next
-  current pass; the tracker is meanwhile kept live by the ordinary `didChange`
-  edit-shift, so the bridge always resolves against a `content_version`-consistent
-  index. A *stale-tree read* still never mints or mutates it — only the
-  current-version reconciliation does.
+  path: the tracker ULID mint that `populate_injections` performs inline today
+  **moves out of `populate` into a distinct reconciliation step**. When a pass
+  completes and (under `edit_lock`) its `parsed_version` still equals
+  `content_version`, that step maps the snapshot's region geometry to tracker ULIDs
+  — reusing an existing id by position, minting a fresh one for a genuinely new
+  region — exactly the mint discovery does today, just gated and relocated. If the
+  pass is stale (`content_version` moved on), reconciliation is skipped and deferred
+  to the next current pass; the tracker is meanwhile kept live by the ordinary
+  `didChange` edit-shift (`apply_input_edits`), so the bridge always resolves
+  against a `content_version`-consistent index. A *stale-tree read* still never
+  mints or mutates it — only the current-version reconciliation does. So `populate`
+  splits into two: derive the snapshot-owned ordinals + geometry (always), and (only
+  at current version) reconcile tracker ULIDs.
 
 So a stale-tree reader reads self-consistent ordinals + geometry from its own
 snapshot and touches no shared identity index (the mint-race and the
@@ -266,18 +285,28 @@ Any reader that must resolve against **live** positions is position-critical
   synchronous client (vim-lsp on Vim) cannot answer a server request while
   processing a notification; emitting from the off-ingress loop, after the
   notification returns, avoids that reentrancy.
-- **Serve-stale, passively refreshed** — `documentSymbol`, `documentColor`.
-  No server→client refresh exists for these, and adding one is out of scope; they
-  serve the latest snapshot and self-correct on the client's **next** request
-  (symbols/colors are re-requested on redraw/scroll, not held live). The staleness
-  window is one or more edits (unbounded under sustained typing) but
-  non-visual-jarring; this is the deliberate,
-  user-sanctioned relaxation.
-- **Staleness-reject** — `semanticTokens/range`, `kakehashi/node/*`,
-  `selectionRange`, `formatting`, `rangeFormatting`, and `captures` (full and
-  range). Their request positions/ranges are authored against the **live** text; a
-  stale tree cannot answer them, and captures/node additionally resolve against the
-  live `content_version` tracker. The rejection signal differs by protocol contract:
+- **Serve-stale, passively refreshed** — whole-document, no-position reads:
+  `documentSymbol`, `documentColor`, `documentLink`, `foldingRange`, `codeLens`
+  (the `whole_document_preferred_fan_out` family), and pull-mode
+  `textDocument/diagnostic` (the `virt_enabled` branch that calls
+  `ensure_document_parsed`). `did_save`'s synthetic-diagnostic effect is likewise
+  passive (a notification, not a request — its *diagnostics* may trail a snapshot,
+  self-healing on republish). No server→client refresh exists for these and adding
+  one is out of scope; they serve the latest snapshot and self-correct on the
+  client's **next** request (re-requested on redraw/scroll, not held live). The
+  staleness window is one or more edits (unbounded under sustained typing) but
+  non-visual-jarring; this is the deliberate, user-sanctioned relaxation.
+- **Staleness-reject** — every **position/range** reader, because its
+  coordinates are authored against the **live** text: `semanticTokens/range`,
+  `kakehashi/node/*`, `selectionRange`, `formatting`, `rangeFormatting`, `captures`
+  (full and range), **and the ~16 position/range bridge-context requests** that
+  resolve an injection region before forwarding to a downstream server (hover,
+  definition, references, declaration, typeDefinition, implementation, rename /
+  prepareRename, completion, signatureHelp, documentHighlight, linkedEditingRange,
+  moniker, on-type formatting, inlayHint, colorPresentation — the
+  `bridge_context` `ensure_document_parsed` site). A stale tree cannot answer them,
+  and captures/node/bridge additionally resolve against the live `content_version`
+  tracker. The rejection signal differs by protocol contract:
   - The LSP requests return **`ContentModified`** (-32801) when
     `content_version > parsed_version`. The spec does **not** mandate client
     auto-retry — a client that does not re-request simply gets the answer on its
@@ -359,14 +388,23 @@ inside the existing safety contracts at each step:
   `latest_snapshot` retains a servable tree across an edit's `tree.take()`; the two
   stores may transiently sit at different versions (a lost legacy CAS just reseeds
   next pass), but no **reader** sees the difference because every reader reads the
-  snapshot, not the legacy tree. Derive snapshot-owned region ids in
-  `populate` (no shared-tracker mint). Convert `semanticTokens` to serve-stale + the
-  refresh trigger; `documentSymbol`/`documentColor` to serve-stale + passive;
-  range/formatting/`node/*` to `ContentModified` and `captures` to `null` (its
-  re-sync signal). Removes `get_tree_with_wait` / `wait_for_epoch` /
-  `ensure_document_parsed` blocking. Delivers *instant reads* and *lifecycle
-  independent of parsing*. Without the dual-write this stage would reproduce the
-  empty-after-edit regression, so it is mandatory here, not deferred.
+  snapshot, not the legacy tree. Split `populate` into ordinal/geometry derivation
+  (snapshot-owned) and the current-version tracker reconciliation (§3), and move the
+  grammar auto-install that `compute_captures` does inline
+  (`ensure_injection_languages_loaded_for_document`) into that reconciliation under
+  `edit_lock` — the read handlers stop being install triggers. Convert
+  `semanticTokens` to serve-stale + the refresh trigger; the whole-document
+  passive-refresh family (`documentSymbol`/`documentColor`/`documentLink`/
+  `foldingRange`/`codeLens`/pull-`diagnostic`) to serve-stale; the position/range
+  family — `semanticTokens/range`, `node/*`, `formatting`/`rangeFormatting`, the
+  bridge-context requests, **and `selectionRange`, whose inline `parse_with_pool` +
+  `update_document` must be replaced by `latest_snapshot`** — to `ContentModified`;
+  and `captures` to `null` (its re-sync signal). Removes `get_tree_with_wait` /
+  `wait_for_epoch` / `ensure_document_parsed` **and** the inline-parse fallbacks
+  (`try_parse_and_update_document`, `selection_range_impl`) — closing the
+  resurrection vector. Delivers *instant reads* and *lifecycle independent of
+  parsing*. Without the dual-write this stage would reproduce the empty-after-edit
+  regression, so it is mandatory here, not deferred.
 - **Stage 3 — consolidation.** Remove `Document::tree` / `pending_seed` (the seed
   now lives on the scheduler), collapse the CAS methods into the one publish
   primitive, delete the watermark waits, and prune the now-superseded passages
@@ -419,9 +457,12 @@ inside the existing safety contracts at each step:
   pool itself additionally needs the fair-admission follow-on §4 names.)
 - High-performance reads: highlight requests return against the latest snapshot
   immediately instead of waiting hundreds of ms for a reparse + populate.
-- The scheduler ADR's residual **reader-fallback resurrection vector is
-  eliminated**: wait-free borrowing readers never parse inline, so there is no
-  reader path that can re-insert a document a `didClose` removed.
+- The scheduler ADR's residual **reader-fallback resurrection vector is eliminated
+  at Stage 2**: once every reader routes through wait-free `latest_snapshot` and no
+  reader parses inline, there is no reader path that can re-insert a document a
+  `didClose` removed. (It is *not* closed by Stage 1, which leaves the current
+  inline-parse fallbacks — `try_parse_and_update_document`, `selection_range_impl` —
+  in place; those are the vector, and they are removed in Stage 2.)
 - State and coupling shrink: two `watch` maps collapse to one, six store CAS /
   watermark methods to one publish primitive, and the `pending_seed` invariant
   surface on `Document` is deleted (favorable on the State > Coupling > Complexity

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -323,11 +323,12 @@ Any reader that must resolve against **live** positions is position-critical
     *implicit/background* requests (hover, signatureHelp, documentHighlight, inlayHint,
     …) reject immediately and get their answer on the client's next natural request.
     *Explicit, user-initiated, infrequent* actions (`formatting`, `rangeFormatting`,
-    `rename`/`prepareRename`) take a **brief bounded wait** (the reader's only
-    permitted wait besides first-parse) for the in-flight parse to land before
-    falling back to `ContentModified` — because a silent no-op on an action the user
-    consciously triggered is jarring, and the wait is affordable exactly because
-    these are not per-keystroke.
+    `rename`/`prepareRename`, and `selectionRange` — keyboard-triggered
+    expand/shrink) take a **brief bounded wait** (the reader's only permitted wait
+    besides first-parse) for the in-flight parse to land before falling back to
+    `ContentModified` — because a silent no-op on an action the user consciously
+    triggered is jarring, and the wait is affordable exactly because these are not
+    per-keystroke.
   - `kakehashi/captures` returns **`null`**, which is precisely the re-sync signal
     captures-protocol already defines ("on null, call full again") — a JSON-RPC
     *error* would violate that contract, since a captures client is only contracted
@@ -402,12 +403,20 @@ inside the existing safety contracts at each step:
 - **Stage 1 — tree-CPU off the async workers onto the bounded pool.** Move
   `populate` (all call sites) and the captures / node layer walks off the tokio
   workers; introduce the bounded pool and route parse + populate + walks + fan-out
-  through it; convert `parser_pool` to a sync mutex. Delivers *the async runtime is
-  never blocked by tree-CPU* (killing the cross-document freeze) and most of
-  *high-performance parsing*; fair admission on the compute pool is a later stage.
-  The read path and the
-  clear-tree-on-edit contract are untouched, so the stale-tree guarantee is not at
-  risk; the sole new obligation is that `populate` is **awaited** (not detached),
+  through it; convert `parser_pool` to a sync mutex. **All** `parse_with_pool` call
+  sites move onto the pool, including the reader on-demand parse fallbacks
+  (`try_parse_and_update_document`, `selection_range_impl`) — this is required, not
+  optional: converting `parser_pool` to a sync mutex while a reader still parses
+  *inline on a tokio worker* would let that worker synchronously block on the mutex
+  a Rayon thread holds, reintroducing exactly the block Stage 1 removes. Routing
+  those fallbacks through the pool means the sync mutex is only ever acquired on a
+  Rayon thread. The reader *contract* is otherwise unchanged (a fallback still
+  blocks its own request on the parse — Stage 2 is what makes reads non-blocking);
+  Stage 1 only relocates the CPU. Delivers *the async runtime is never blocked by
+  tree-CPU* (killing the cross-document freeze) and most of *high-performance
+  parsing*; fair admission on the compute pool is a later stage. The
+  clear-tree-on-edit contract is untouched, so the stale-tree guarantee is not at
+  risk; a further obligation is that `populate` is **awaited** (not detached),
   preserving the `populate → finish` ordering the injection-map invalidation
   depends on.
 - **Stage 2 — versioned snapshot reads.** Introduce `SnapshotSlot` + the `watch`

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -356,8 +356,10 @@ inside the existing safety contracts at each step:
   under the same `(incarnation, parsed_version)` guard, and the **snapshot publish
   is the sole commit point** — all downstream (refresh, forwarding, diagnostics,
   shared cache writes) gates on the *publish* result, never the legacy CAS (§2). So
-  `latest_snapshot` retains a servable tree across an edit's `tree.take()` and the
-  two writes cannot expose different versions. Derive snapshot-owned region ids in
+  `latest_snapshot` retains a servable tree across an edit's `tree.take()`; the two
+  stores may transiently sit at different versions (a lost legacy CAS just reseeds
+  next pass), but no **reader** sees the difference because every reader reads the
+  snapshot, not the legacy tree. Derive snapshot-owned region ids in
   `populate` (no shared-tracker mint). Convert `semanticTokens` to serve-stale + the
   refresh trigger; `documentSymbol`/`documentColor` to serve-stale + passive;
   range/formatting/`node/*` to `ContentModified` and `captures` to `null` (its

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -151,9 +151,13 @@ check-then-act rather than a cross-map TOCTOU against `Document.incarnation`):
   **detached** old cell, which no current-request reader resolves, so the publish
   is unobservable; and a reader mid-compute holding a lifetime-`N` `Arc<ParseSnapshot>`
   rejects it against the live `N+1` incarnation. The one reader that *does* hold a
-  `Receiver` — a first-parse waiter parked on `watch::changed()` — is woken when
-  `didClose` drops the sender (`Err` → falls through to `null`), exactly as today's
-  watermark-drop wakes parked `wait_for_epoch` readers.
+  `Receiver` — a first-parse waiter parked on `watch::changed()` — must be woken by
+  an **explicit close publish**: `didClose` sends a terminal `SnapshotSlot` state
+  (incarnation-invalidated / closed sentinel) rather than relying on the channel's
+  senders dropping, since stale parse tasks may still hold `Sender` clones that keep
+  the channel alive. The parked waiter observes the close state and falls through to
+  `null` — this is the wake the current `wait_for_epoch` gets from the watermark
+  sender dropping, made explicit because the snapshot channel outlives more clones.
 
 The incremental-parse **seed** re-homes onto `ParseScheduler`'s per-document state
 (accumulated `InputEdit`s + the `base_version` they extend). Two obligations,
@@ -177,13 +181,16 @@ exact publish succeeded** (the shared `NodeTracker` is not mutated on this path 
 all; see §3), in the order the
 per-document-parse-scheduler loop already uses (`populate → mark finished →
 downstream`). A rejected publish (a racing edit or reopen advanced the slot) emits
-nothing and mutates no shared state. During Stage 2's dual-write window the
-**snapshot publish is the sole commit point**: the legacy tree CAS is made
-strict-version too (it must not replace an equal-or-newer tree), a pass performs
-both writes under the same `(incarnation, parsed_version)` guard, and **all**
-downstream gates on the *snapshot publish* result — never on the legacy CAS. So the
-two writes cannot land for different versions, and no downstream effect fires for a
-snapshot the publish rejected even if the legacy CAS happened to win.
+nothing and mutates no shared state. The two Stage-2 stores are **not** written in
+one cross-store transaction — that is unnecessary, because they are not co-equal:
+the **snapshot publish is the sole commit point and runs first**, and every
+downstream effect gates on *its* result. The legacy tree CAS that follows is a
+Stage-2-only compatibility shim feeding the incremental seed (which still reads
+`Document::tree` until Stage 3 removes it); it is made strict-version so it never
+regresses, but if it *loses* a race the only consequence is that the next pass
+reseeds from the current snapshot instead of the legacy tree — a self-correcting
+perf blip, never a served inconsistency, since readers already read the snapshot,
+not the legacy tree. So no reader-visible divergence can arise from the ordering.
 
 ### 3. Reader contract — non-blocking, three classes
 
@@ -226,11 +233,18 @@ ULID**, so none needs a shared, edit-shifted mint off the parse path:
   injection-token-cache-reuse**, not silently folded in here.
 - **Cross-edit bridge / virtual-document identity** — the stable handle a
   downstream language server's virtual document is keyed by — **remains the shared
-  `NodeTracker` ULID**, which is a live-position (`content_version`) concern: it is
-  minted/adjusted on the `didChange` edit path (as today) and consumed by the
-  bridge and `kakehashi/node/*`, all of which operate on the live document and
-  staleness-reject rather than serve a stale snapshot. The parse/stale-read path
-  neither mints nor mutates it.
+  `NodeTracker` ULID**, a live-position (`content_version`) concern. Because regions
+  are only *discovered* by a parse, minting still originates from a parse pass, but
+  as a distinct **current-version reconciliation step**, not off the stale-read
+  path: when a pass completes and (under `edit_lock`) its `parsed_version` still
+  equals `content_version`, a reconciliation maps the snapshot's region geometry to
+  tracker ULIDs — reusing an existing id by position, minting a fresh one for a
+  genuinely new region — exactly as discovery mints today. If the pass is stale
+  (`content_version` moved on), reconciliation is skipped and deferred to the next
+  current pass; the tracker is meanwhile kept live by the ordinary `didChange`
+  edit-shift, so the bridge always resolves against a `content_version`-consistent
+  index. A *stale-tree read* still never mints or mutates it — only the
+  current-version reconciliation does.
 
 So a stale-tree reader reads self-consistent ordinals + geometry from its own
 snapshot and touches no shared identity index (the mint-race and the

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -91,18 +91,24 @@ snapshot:
 SnapshotSlot { current_incarnation: u64, snapshot: Option<Arc<ParseSnapshot>> }
 ```
 
-This channel **subsumes** the current `parse_states` (`has_tree`) and `watermarks`
-(`(incarnation, ticket)`) maps: `snapshot.is_some()` is has-tree; `parsed_version`
-is the watermark ticket; `current_incarnation` is the per-lifetime guard.
+This channel **subsumes** the current `parse_states` and `watermarks` maps, but the
+mapping is not one-to-one and must be stated precisely:
 
-A **resolved-but-tree-less** outcome — a parse that completed with no usable tree
-(no parser installed, install failed, or a quarantined crashed grammar), distinct
-from the pre-first-parse `None` — must still release readers parked on the
-first-parse wait. It carries its own resolved-version marker: `ParseSnapshot.tree`
-is `Option` (`None` = resolved, no tree), so `snapshot.is_some()` means "resolved"
-and the inner `tree` distinguishes "resolved with a tree" from "resolved, none
-available"; a tree-less snapshot advances `parsed_version` like any other and
-readers fall through to their empty / `ContentModified` paths.
+- Two distinct predicates replace the old single `has_tree`: **`resolved`** =
+  `slot.snapshot.is_some()` (a parse for this lifetime has completed at least once)
+  and **`has_tree`** = `slot.snapshot.and_then(|s| s.tree.as_ref()).is_some()`. A
+  **resolved-but-tree-less** outcome — a parse that completed with no usable tree
+  (no parser installed, install failed, or a quarantined crashed grammar), distinct
+  from the pre-first-parse `None` — is `resolved && !has_tree`; it advances
+  `parsed_version` and releases first-parse waiters (who then fall through to their
+  empty / `null` / `ContentModified` paths), which the old boolean `has_tree` could
+  not express.
+- `parsed_version` is the watermark ticket; `current_incarnation` is the
+  per-lifetime guard.
+- `ParseState`'s other fields do **not** vanish: the settings **`generation`**
+  (token-cache invalidation) and the **`in_progress`** flag re-home onto
+  `ParseScheduler`'s per-document state (which already owns the parse lifecycle),
+  not onto the read-side slot. Deleting `parse_states` is contingent on that move.
 
 The store's tree/watermark CAS methods (four tree writes —
 `update_tree_if_text_unchanged`, `update_tree_if_text_and_language_unchanged`,
@@ -133,6 +139,19 @@ check-then-act rather than a cross-map TOCTOU against `Document.incarnation`):
   incarnation (so a relabel across lifetimes is already rejected), and within one
   lifetime the language does not change. The three-axis edit-path CAS
   (`incarnation && text && language`) therefore reduces to `incarnation && version`.
+- **Incarnation is the lifetime-isolation mechanism, not channel replacement.**
+  Replacing the URI's `watch` entry on reopen does not invalidate `Sender`/`Receiver`
+  clones a prior-lifetime parse task or in-flight reader already holds. So isolation
+  cannot rely on "the old channel is gone": every **publish** re-checks
+  `snapshot.incarnation == slot.current_incarnation` inside `send_if_modified`
+  (a straggler from lifetime N publishing into a clone of N's sender is rejected
+  once the slot carries N+1), and every **reader** validates
+  `snapshot.incarnation == <live incarnation>` on borrow and discards a
+  cross-lifetime snapshot rather than serving it. Because both the input
+  `incarnation` and `current_incarnation` denote the same per-URI lifetime, the
+  intended shape is a **single per-URI lifetime object** owning both the inputs and
+  the slot, so there is one authoritative incarnation rather than a cross-map
+  compare.
 
 The incremental-parse **seed** re-homes onto `ParseScheduler`'s per-document state
 (accumulated `InputEdit`s + the `base_version` they extend). Two obligations,
@@ -146,10 +165,30 @@ enforced by co-location today, become explicit scheduler invariants:
   scratch. "Leaves no accumulated edits" is an explicit reset, not an emergent
   property.
 
+A parse pass therefore has a **single version/incarnation-guarded commit
+sequence**, so no downstream effect ever escapes for a snapshot that lost the CAS:
+compute the tree, region map, and tokens **privately** (nothing shared mutated);
+revalidate `incarnation == current_incarnation`; run the one publish primitive; and
+emit the downstream — `semanticTokens/refresh`, injected-language forwarding,
+diagnostic republish, and (the deferred perf lever) any shared injection-cache /
+node-tracker mutation — **only if that exact publish succeeded**, in the order the
+per-document-parse-scheduler loop already uses (`populate → mark finished →
+downstream`). A rejected publish (a racing edit or reopen advanced the slot) emits
+nothing and mutates no shared state. During Stage 2's dual-write window the legacy
+tree CAS is the commit point the snapshot publish and downstream both gate on, so
+the two writes cannot expose different versions.
+
 ### 3. Reader contract — non-blocking, three classes
 
 Readers call a wait-free `latest_snapshot(uri)` (a `watch` borrow) and never parse
-inline. A reader is at most one edit stale when `parsed_version < content_version`.
+inline. A reader serves the **latest completed snapshot**; when
+`parsed_version < content_version` it is stale by however many edits the scheduler
+coalesced since — one under light typing, but **potentially several** under
+sustained typing (per-document-parse-scheduler deliberately coalesces, so the
+watermark can trail the input indefinitely under a fast enough edit stream). The
+refresh path re-drives the client each time a fresher snapshot lands; the model
+does not promise a bounded edit-lag without the fair-admission backpressure §4
+defers.
 
 Region identity is the load-bearing subtlety. The `NodeTracker`
 (lazy-node-identity-tracking) is edit-shifted **synchronously on `didChange`**, so
@@ -164,15 +203,21 @@ snapshot's `injection_regions` (this is the injection-token-cache-reuse
 change). A stale-tree reader then only **reads** region ids from its own snapshot
 — internally consistent with that snapshot's tree, minting nothing.
 
-This **relocates** the tracker-skew hazard rather than fully closing it: `populate`
-mints at `parsed_version` into a `NodeTracker` that has already been edit-shifted
-to `content_version`, so a mispositioned entry can still land when the tracker is
-ahead of the snapshot. Unlike the seed, the mint has no `parsed_version ==`-guard.
-The residual is **performance-only**, not correctness: region-cache reads are gated
-by a `validity_hash` (content + language), so a mispositioned id simply misses and
-recomputes — it never serves wrong tokens — and it accumulates orphan entries that
-lifecycle eviction reclaims. A future decision that forks a per-snapshot tracker
-view would close it entirely; this decision accepts the perf residual.
+This requires a **mint-time version guard**, because writing stale coordinates into
+the shared `NodeTracker` is not a mere cache miss — `get_or_create` mutates a
+bidirectional identity index that `kakehashi/node/*` resolution and captures also
+read, so a mispositioned entry is a correctness hazard for *those* consumers, not
+just degraded token-cache reuse. Therefore `populate` mutates the tracker **only
+when `parsed_version == content_version` at mint time** (mirroring the seed's
+`==`-guard): if an edit raced the parse and moved `content_version` ahead, the
+pass computes the snapshot's own `injection_regions` (private to the snapshot, used
+by that snapshot's readers) but **skips the shared-tracker mutation**, deferring it
+to the next reparse, which mints at a matching version. The live tracker is thus
+never written with coordinates that disagree with its own `content_version`. (A
+future decision that forks a per-snapshot tracker view would let even the shared
+identities update every pass; this decision keeps the shared tracker
+edit-`content_version`-consistent and defers cross-pass identity refresh to the
+current-version passes.)
 
 Any reader that must resolve against **live** positions is position-critical
 (below).
@@ -207,7 +252,13 @@ Any reader that must resolve against **live** positions is position-critical
     captures-protocol already defines ("on null, call full again") — a JSON-RPC
     *error* would violate that contract, since a captures client is only contracted
     to re-request on null. So a stale captures request serves `null` and the client
-    re-issues, self-healing on its next request.
+    re-issues, self-healing on its next request. A captures `full` that *does*
+    compute (snapshot current at entry) can still race an edit during its async
+    compute; its lineage store must therefore carry the computed `parsed_version`
+    and, under `edit_lock`, install the lineage **only if `incarnation` and the
+    current `content_version` still match it** (today `store_lineage` re-checks only
+    incarnation) — otherwise it stores nothing and returns `null`, so the lineage
+    never records matches for a text the client no longer has.
 
 The only bounded wait that remains is the **first parse after `didOpen`** (the
 snapshot is `None`); it waits briefly on `watch::changed()` then serves `null` —
@@ -220,28 +271,31 @@ future decision forks the tracker per snapshot, they can move to serve-stale.)*
 
 ### 4. All tree-CPU runs on one bounded compute pool
 
-A single dedicated `rayon` pool sized `max(2, num_cpus - 2)` — reserving at least
-two cores for the tokio workers and the timer driver — runs **all** synchronous
-tree work: the parse, `populate` (region minting + content hash), the
-`compute_captures` / node layer walks, and the semantic-token injection fan-out
-(folded off the process-global Rayon pool into this one). Async handlers hand a
-whole work-unit to the pool (bridged by a `oneshot`) and `await` the result, so no
-tree-CPU ever executes on a tokio worker. `DocumentParserPool`'s guard becomes a
-sync mutex (`std`/`parking_lot`) since acquisition now runs on pool threads that
-cannot `.await`.
+A single dedicated `rayon` pool sized `available_parallelism().saturating_sub(2).max(1)`
+— strictly below `available_parallelism` whenever there are ≥3 cores, and reserving
+at least one core for the tokio workers + timer driver on 2-core machines (on a
+1-core host no isolation is achievable and the pool degrades to shared time-slicing)
+— runs **all** synchronous tree work: the parse, `populate` (region minting +
+content hash), the `compute_captures` / node layer walks, and the semantic-token
+injection fan-out (folded off the process-global Rayon pool into this one). Async
+handlers hand a whole work-unit to the pool (bridged by a `oneshot`) and `await`
+the result, so no tree-CPU ever executes on a tokio worker. `DocumentParserPool`'s
+guard becomes a sync mutex (`std`/`parking_lot`) since acquisition now runs on pool
+threads that cannot `.await`.
 
-The guarantee that document A cannot **starve** document B rests on two legs that
-hold unconditionally: (1) no synchronous tree-CPU on the tokio workers, so B's
-handler and the timer driver are always pollable; (2) the pool is bounded below
-`num_cpus`, so A cannot oversubscribe the CPU and starve those workers. What
-remains is bounded **queueing** on the compute pool itself: A's parse burst can sit
-ahead of B's fan-out. `ParseScheduler` coalescing (already built) caps each
-document to one queued parse, giving fairness across documents; a focused-document
-priority — not yet built — would order *admission* so the document the user edits
-drains first (rayon has no preemption, so this orders queueing, it cannot preempt
-in-flight sub-tasks). The strong claim is therefore **no cross-document
-starvation**; residual queue latency under many simultaneous large parses is
-bounded by the coalescing + pool size, and the priority queue is a later knob.
+The guarantee this design **actually** makes is narrow and unconditional: **the
+async runtime is never blocked by synchronous tree-CPU** — leg (1), no tree-work on
+the tokio workers, so B's handler and the timer driver are always pollable and the
+timeouts that were being defeated now fire. It does **not** by itself guarantee
+"no cross-document starvation" in the strong sense: the pool has finite threads,
+Rayon does not preempt, `ParseScheduler` coalescing caps *parse submissions* per
+document but not fan-out task count, task duration, or the number of documents, and
+a fan-out on A can still occupy every pool thread ahead of B's work. What Stage 1
+buys is that this contention is confined to the compute pool and no longer freezes
+unrelated async I/O, diagnostics, or the request loop. Turning "no starvation" into
+a real guarantee requires **explicit fair admission** — a focused-document priority
+queue plus a per-document in-flight concurrency cap — which this decision names as
+required follow-on work, not something the bounded pool delivers on its own.
 
 ### 5. Staged rollout
 
@@ -251,8 +305,10 @@ inside the existing safety contracts at each step:
 - **Stage 1 — tree-CPU off the async workers onto the bounded pool.** Move
   `populate` (all call sites) and the captures / node layer walks off the tokio
   workers; introduce the bounded pool and route parse + populate + walks + fan-out
-  through it; convert `parser_pool` to a sync mutex. Delivers *no cross-document
-  starvation* and most of *high-performance parsing*. The read path and the
+  through it; convert `parser_pool` to a sync mutex. Delivers *the async runtime is
+  never blocked by tree-CPU* (killing the cross-document freeze) and most of
+  *high-performance parsing*; fair admission on the compute pool is a later stage.
+  The read path and the
   clear-tree-on-edit contract are untouched, so the stale-tree guarantee is not at
   risk; the sole new obligation is that `populate` is **awaited** (not detached),
   preserving the `populate → finish` ordering the injection-map invalidation
@@ -312,9 +368,11 @@ inside the existing safety contracts at each step:
 
 - Document lifecycle is fully decoupled from parsing: `didChange` never awaits a
   parse; readers never block on one.
-- No cross-document starvation: with all tree-CPU on a bounded pool below
-  `num_cpus`, a slow parse on one document cannot starve the async runtime or
-  another document's requests.
+- The async runtime is never blocked by tree-CPU: with all synchronous tree work
+  on the bounded pool, a slow parse on one document cannot freeze the request loop,
+  timers, diagnostics, or another document's async handlers — the specific defect
+  behind the 0.5–1.4 s cross-document waits. (Full *no-starvation* on the compute
+  pool itself additionally needs the fair-admission follow-on §4 names.)
 - High-performance reads: highlight requests return against the latest snapshot
   immediately instead of waiting hundreds of ms for a reparse + populate.
 - The scheduler ADR's residual **reader-fallback resurrection vector is
@@ -327,8 +385,9 @@ inside the existing safety contracts at each step:
 
 ### Negative
 
-- Highlight-class results may be **one edit stale for a few milliseconds** until
-  the fresh snapshot publishes. `semanticTokens` is re-driven by an added
+- Highlight-class results may be **stale — usually one edit, potentially several
+  under sustained typing** (the scheduler coalesces) — until a fresh snapshot
+  publishes. `semanticTokens` is re-driven by an added
   post-edit `semanticTokens/refresh` (emitted from the parse loop to dodge the
   synchronous-client reentrancy that keeps it out of `didChange`);
   `documentSymbol`/`documentColor` self-correct only on the client's next natural
@@ -342,9 +401,9 @@ inside the existing safety contracts at each step:
   captures/node from the original serve-stale intent is the
   cost of not forking a per-snapshot tracker view now.
 - The `#342`/`#374` stale-tree guarantee (a reader observes at least its own edit)
-  is relaxed to "a reader observes a *consistent* but possibly one-edit-old
-  snapshot, and knows it via the version tag." Correctness now rests on the version
-  tag + refresh rather than on the reader having waited.
+  is relaxed to "a reader observes a *consistent* snapshot that may trail the input
+  by one or more edits, and knows it via the version tag." Correctness now rests on
+  the version tag + refresh rather than on the reader having waited.
 - Folding the semantic fan-out from the process-global Rayon pool (all cores) into
   the bounded `max(2, num_cpus - 2)` pool caps single-document tokenization
   throughput (≈ −50 % on a 4-core machine for one huge file) in exchange for
@@ -359,10 +418,11 @@ inside the existing safety contracts at each step:
 ### Neutral
 
 - `didClose` drops the single channel (waking any reader parked on the first-parse
-  `watch::changed()`); a reopen replaces it with a fresh `SnapshotSlot`. A wait-free
-  `latest_snapshot` borrow racing close+reopen may observe the prior lifetime's
-  snapshot momentarily — bounded and self-healing via the next publish, the same
-  class as today's borrow-then-reopen races.
+  `watch::changed()`); a reopen installs a fresh `SnapshotSlot`. A wait-free
+  `latest_snapshot` borrow racing close+reopen may hand back the prior lifetime's
+  snapshot momentarily, but the reader's mandatory `snapshot.incarnation == <live
+  incarnation>` check (§2) rejects it, so a cross-lifetime snapshot is discarded
+  rather than served — it degrades to the empty/`null` path, not stale data.
 - The `ParseScheduler` (one loop per document, coalescing, panic re-arm),
   `incarnation`, the `edit_lock`, and the incremental-seed concept are retained —
   re-homed, not removed.

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -261,7 +261,7 @@ The decision therefore **separates three concerns that today all ride the tracke
   completes and (under `edit_lock`) its `parsed_version` still equals
   `content_version`, that step maps the snapshot's region geometry to tracker ULIDs
   — reusing an existing id by position, minting a fresh one for a genuinely new
-  region — exactly the mint discovery does today, just gated and relocated. If the
+  region — exactly what the mint discovery does today, just gated and relocated. If the
   pass is stale (`content_version` moved on), reconciliation is skipped and deferred
   to the next current pass; the tracker is meanwhile kept live by the ordinary
   `didChange` edit-shift (`apply_input_edits`), so the bridge always resolves
@@ -415,7 +415,7 @@ inside the existing safety contracts at each step:
   legacy tree CAS (the incremental seed still reads `Document::tree`/`pending_seed`,
   which Stage 3 removes) is made strict-version like the publish, both writes run
   under the same `(incarnation, parsed_version)` guard, and the **snapshot publish is the sole commit point** — all downstream (refresh, forwarding, diagnostics,
-  shared cache writes) gates on the *publish* result, never the legacy CAS (§2). So
+  shared cache writes) gate on the *publish* result, never the legacy CAS (§2). So
   `latest_snapshot` retains a servable tree across an edit's `tree.take()`; the two
   stores may transiently sit at different versions (a lost legacy CAS just reseeds
   next pass), but no **reader** sees the difference because every reader reads the

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -1,0 +1,225 @@
+# Parse Snapshot Architecture
+
+**Related Decisions**: [per-document-parse-scheduler](per-document-parse-scheduler.md),
+[parse-decoupled-document-lifecycle](parse-decoupled-document-lifecycle.md),
+[injection-token-cache-reuse](injection-token-cache-reuse.md),
+[captures-protocol](captures-protocol.md)
+
+## Context
+
+The per-document-parse-scheduler decision moved parsing **off the ingress
+ticket**: `didChange` applies the text edit, clears the reader-visible tree, and
+schedules a coalesced off-ingress reparse. That closed the ingress-latency and
+large-paste races it set out to close, but two costs it did not address surfaced
+as a user-visible regression against v0.7.0 (which parsed inline on `didChange`):
+
+1. **Per-keystroke read latency on large documents.** `Document::apply_edit_and_seed`
+   does `self.tree.take()`: after an edit there is **no servable tree** until the
+   off-ingress reparse republishes one. So every tree reader —
+   `textDocument/semanticTokens`, `kakehashi/captures`, `kakehashi/node/*`,
+   `documentSymbol`, selection ranges — must **block** waiting for the reparse.
+   The semantic-token reader (`get_tree_with_wait`) waits on the per-document
+   parse **watermark** (`wait_for_epoch`), bounded to a 200ms budget; the
+   captures / node readers wait via `ensure_document_parsed`.
+
+2. **Cross-document blocking.** A slow reparse on document A stalls semantic
+   tokens on an unrelated document B. Instrumentation showed the reader wait on
+   a 300-line injection-heavy markdown file spiking to **0.5–1.4 s** per
+   keystroke — far past the 200ms budget. The budget is defeated because the
+   reparse's downstream CPU runs **inline on tokio worker threads**:
+   `populate_injections` (the injection-cache build from injection-token-cache-reuse,
+   O(regions): a per-region node-tracker ULID mint + content hash, hundreds of
+   ms for ~900 regions) runs inline in the off-ingress parse loop, and
+   `compute_captures` / the `kakehashi/node/*` layer walks run inline in their
+   async handlers. On the default `num_cpus`-worker runtime those bursts saturate
+   the worker pool, so the tokio timer wheel and `watch` notifications that back
+   the 200ms caps cannot fire, and unrelated documents' handlers cannot be polled.
+
+The primitives to fix this are largely already present — a process-monotonic
+`incarnation` per document lifetime, a per-URI parse watermark, and the
+`ParseScheduler`'s one-loop-per-document coalescing. What is missing is (1) a
+tree that readers can serve **without** waiting for a reparse, and (2) getting
+tree-CPU **off** the shared async runtime. The user goal is explicit:
+**high-performance parsing, no cross-document blocking, and document lifecycle
+management independent of parsing** — and large architectural change is invited.
+
+## Decision
+
+Model the document as **versioned inputs** and parsing as a **versioned derived
+computation**, in the shape salsa / rust-analyzer / gopls use: inputs are the
+source of truth and never block on derivation; derivation publishes immutable,
+internally-consistent snapshots that readers observe without blocking.
+
+### 1. `Document` holds inputs only
+
+`Document` carries `text: Arc<str>`, `language_id`, `incarnation`, and a
+monotonic `content_version` (bumped on every edit, `0` at `didOpen`). It no
+longer holds `tree` or `pending_seed`, and `apply_edit` never clears a tree — it
+installs the new text and bumps the version. The document lifecycle
+(`didOpen`/`didChange`/`didClose`) becomes fully independent of parsing: it
+mutates inputs and returns, never awaiting or gating on a parse.
+
+### 2. Parsing publishes a versioned `ParseSnapshot`
+
+```
+ParseSnapshot { text: Arc<str>, tree: Tree, language: String, incarnation: u64, parsed_version: u64 }
+```
+
+A snapshot's `text` is exactly the text its `tree` was parsed from — the two
+always agree (the gopls immutable-snapshot property). Snapshots live per-URI in
+a single `watch::Sender<Option<Arc<ParseSnapshot>>>`, which **subsumes both** the
+current `parse_states` (`has_tree`) and `watermarks` (`ticket`) maps: `Some`
+vs `None` is has-tree; `parsed_version` is the watermark; `incarnation` inside
+the snapshot is the per-lifetime guard. The store's five tree/watermark CAS
+methods collapse to **one publish primitive**: install a snapshot iff its
+`incarnation` is current and its `parsed_version` is not older than the published
+one. Monotonic version + incarnation give the same stale-drop / no-resurrection /
+no-reopen-clobber guarantees the CAS methods encode today, in one place.
+
+The incremental-parse **seed** re-homes onto `ParseScheduler`'s per-document
+state (accumulated `InputEdit`s + the base version they extend), which already
+*is* the per-document mutable parse state. A full-text sync leaves no accumulated
+edits, so it parses from scratch — the `#348` incremental-contract stays closed
+as a natural consequence rather than a special case.
+
+### 3. Readers take a non-blocking latest snapshot
+
+Readers call a wait-free `latest_snapshot(uri)` (a `watch` borrow) and never
+parse inline. Two reader classes:
+
+- **Highlight-class** (`semanticTokens` full/delta, `captures/full`,
+  `kakehashi/node/*`, `documentSymbol`, `documentColor`): **serve-stale +
+  self-heal.** Compute against the snapshot's internally-consistent
+  `(text, tree)`. If `parsed_version < content_version` the result is at most one
+  edit stale; the parse loop publishes a fresh snapshot moments later and emits
+  `workspace/semanticTokens/refresh` (and the existing diagnostic republish) so
+  the client re-requests. The client refresh plumbing already exists; only the
+  post-edit trigger is added.
+- **Position-critical** (`semanticTokens/range`, `captures/range`,
+  selectionRange, formatting, rangeFormatting): the request's positions are
+  authored against the **live** text, so a stale tree cannot be used. When
+  `content_version > parsed_version`, return LSP **`ContentModified`** so the
+  client retries — never map a live-text range onto stale bytes.
+
+The only bounded wait that remains is the **first parse after `didOpen`** (the
+snapshot is `None` and no prior snapshot exists); it waits briefly on
+`watch::changed()` then serves `null`.
+
+### 4. All tree-CPU runs on one bounded compute pool
+
+A single dedicated `rayon` pool sized `max(2, num_cpus - 2)` — reserving at least
+two cores for the tokio workers and the timer driver — runs **all** synchronous
+tree work: the parse, `populate_injections`, the `compute_captures` / node layer
+walks, and the semantic-token injection fan-out (folded off the process-global
+Rayon pool into this one). Async handlers hand a whole work-unit to the pool
+(bridged by a `oneshot`) and `await` the result, so no tree-CPU ever executes on
+a tokio worker.
+
+The guarantee that document A cannot block document B rests on **three legs
+together**: (1) no synchronous tree-CPU on the tokio workers, so B's handler and
+the timer driver are always pollable; (2) the pool is bounded below `num_cpus`,
+so A cannot oversubscribe the CPU and starve those workers; (3) `ParseScheduler`
+coalescing (already built) plus a focused-document priority queue keep A's jobs
+from monopolizing the pool ahead of B and the document the user is editing.
+
+### 5. Staged rollout
+
+The change is delivered in independently shippable, reviewable, measurable
+stages that stay inside the existing safety contracts at each step:
+
+- **Stage 1 — tree-CPU off the async workers onto the bounded pool.** Move
+  `populate_injections` (all call sites) and the captures / node layer walks off
+  the tokio workers; introduce the bounded pool and route parse + populate +
+  walks + fan-out through it. Delivers *no cross-document blocking* and most of
+  *high-performance parsing*. The read path is untouched, so the stale-tree
+  contract is not at risk.
+- **Stage 2 — versioned snapshot reads.** Introduce `ParseSnapshot` + the `watch`
+  channel + `latest_snapshot`; convert highlight-class readers to serve-stale +
+  refresh and position-critical readers to `ContentModified`. Removes
+  `get_tree_with_wait` / `wait_for_epoch` / `ensure_document_parsed` blocking.
+  Delivers *instant reads* and *lifecycle independent of parsing*.
+- **Stage 3 — consolidation.** Remove `Document::tree` / `pending_seed`, collapse
+  the five store CAS methods into the one publish primitive, re-home the seed on
+  the scheduler, delete the now-unused watermark waits.
+
+## Considered Options
+
+- **Keep the scheduler, only move `populate_injections` to `spawn_blocking`
+  (the interim "fix D" + offload).** Rejected as the endpoint: it removes the
+  cross-document CPU starvation but not the per-keystroke read latency — with the
+  tree still cleared on edit, readers keep blocking on the reparse (or fall into
+  an on-demand full parse). And `spawn_blocking` **alone** trades HOL-blocking for
+  CPU oversubscription on the default 512-thread blocking pool, so it must be
+  paired with a bounded pool regardless. It is adopted as **Stage 1**, not the
+  destination.
+- **Serve the pre-edit / seeded tree immediately without versioning
+  (naive stale-serve).** Rejected. It is crash-safe (the `#348` hazard is a
+  parse-seed/external-scanner issue, not a query-cursor issue, and the read paths
+  are already stale-offset-hardened), but readers **write** persistent caches —
+  the node-tracker ULIDs, the injection-token cache, and the whole-document token
+  cache — keyed by the **new** text hash. Serving old-tree tokens under a
+  new-text key poisons those caches permanently (no generation bump, no refresh
+  today). The versioned snapshot fixes exactly this: caches key off the
+  snapshot's own `(text, version)`, which are consistent, so nothing is poisoned.
+- **A text-owning parse actor (the scheduler ADR's Option 4).** Still rejected
+  for the reason recorded there: reads bypass the owner, so owning the text buys
+  nothing while resurrection-safety must still guard every reader fallback. This
+  decision *reuses* the scheduler and its epoch rather than replacing them with an
+  actor.
+- **Block all readers until fully current (status quo).** Rejected: it is the
+  behavior producing the 0.5–1.4 s waits. The user explicitly accepts a one-edit
+  stale highlight (healed by refresh) in exchange for never blocking, with
+  position-critical requests staleness-rejecting rather than serving stale.
+
+## Consequences
+
+### Positive
+
+- Document lifecycle is fully decoupled from parsing: `didChange` never awaits a
+  parse; readers never block on one.
+- No cross-document blocking: with all tree-CPU on a bounded pool below
+  `num_cpus`, a slow parse on one document cannot starve the async runtime or
+  another document's requests.
+- High-performance reads: highlight requests return against the latest snapshot
+  immediately instead of waiting hundreds of ms for a reparse + populate.
+- State and coupling shrink: two `watch` maps collapse to one, five store CAS
+  methods to one publish primitive, and the `pending_seed` invariant surface on
+  `Document` is deleted (favorable on the State > Coupling > Complexity > Code
+  ordering the repo optimizes for).
+
+### Negative
+
+- Highlight-class results may be **one edit stale for a few milliseconds** until
+  the fresh snapshot publishes and a refresh re-drives the client. This is the
+  deliberate, user-sanctioned tradeoff; it requires adding the post-edit
+  `semanticTokens/refresh` trigger (absent today) and a captures-refresh path.
+- Position-critical requests (range, formatting) now return `ContentModified`
+  during the reparse window, relying on client retry — a behavior change from
+  today's block-until-fresh.
+- The `#342`/`#374` stale-tree guarantee (a reader observes at least its own
+  edit) is relaxed to "a reader observes a *consistent* but possibly one-edit-old
+  snapshot, and knows it via the version tag." Correctness now rests on the
+  version tag + refresh rather than on the reader having waited.
+- Migration touches wide surface: `Document`, `DocumentStore`, `ParseScheduler`,
+  the parse coordinator, `parser_pool` (a `tokio::sync::Mutex` becomes a sync
+  mutex once acquisition moves onto pool threads that cannot `.await`), and the
+  ~13 `ensure_document_parsed` call sites. Each invariant from the scheduler and
+  lifecycle decisions must be re-proved against the snapshot model.
+
+### Neutral
+
+- The `ParseScheduler` (one loop per document, coalescing, panic re-arm),
+  `incarnation`, and the incremental-seed concept are retained — re-homed, not
+  removed.
+- The bounded pool's size and the focused-document priority are a single knob;
+  strict fairness (a per-document concurrency cap) can be added later without
+  changing the model.
+
+## Decision–Implementation Gap
+
+Not yet implemented — this decision is aspirational and rolls out over the three
+stages above. An interim fix advancing the parse watermark before
+`populate_injections` (so readers wake on the tree rather than after the populate)
+was prototyped and measured as a partial improvement; it is subsumed by Stage 1
+(which moves the populate off the async workers entirely) and Stage 2 (which
+removes the reader wait) and is not carried forward on its own.

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -126,32 +126,32 @@ check-then-act rather than a cross-map TOCTOU against `Document.incarnation`):
 - **Incarnation-scoped, strict monotonicity.** The `>` is strict — equal-version
   double-publishes (e.g. a racing open-parse and reparse both at version 0) must
   not swap the `Tree` under an already-issued `result_id` and fire a spurious
-  refresh. `didOpen` sets `current_incarnation`; a reopen **installs a fresh
-  `SnapshotSlot` (next incarnation, `snapshot = None`)**. Resetting `snapshot` to
-  `None` is what clears the version floor — the first post-reopen publish takes the
-  `None` bootstrap branch, so a leftover `parsed_version = 5` from the prior
-  lifetime cannot make a fresh `0 > 5` fail forever; the incarnation bump alone
-  would not reset the floor. The `None` bootstrap still checks
-  `incarnation == current_incarnation` (it is not an unconditional early-return), so
-  a straggler publish from lifetime N is rejected against N+1 and the version
-  compare is only ever within one lifetime.
+  refresh. `didOpen` sets `current_incarnation`; a reopen **resets the same cell in
+  place** to `(current_incarnation = N+1, snapshot = None)` (never a new cell — see
+  the isolation bullet below). Resetting `snapshot` to `None` is what clears the
+  version floor — the first post-reopen publish takes the `None` bootstrap branch,
+  so a leftover `parsed_version = 5` from the prior lifetime cannot make a fresh
+  `0 > 5` fail forever; the incarnation bump alone would not reset the floor. The
+  `None` bootstrap still checks `incarnation == current_incarnation` (it is not an
+  unconditional early-return), so a straggler publish from lifetime N is rejected
+  against N+1 and the version compare is only ever within one lifetime.
 - **Language axis** is subsumed by incarnation: every reopen draws a fresh
   incarnation (so a relabel across lifetimes is already rejected), and within one
   lifetime the language does not change. The three-axis edit-path CAS
   (`incarnation && text && language`) therefore reduces to `incarnation && version`.
-- **Incarnation is the lifetime-isolation mechanism, not channel replacement.**
-  Replacing the URI's `watch` entry on reopen does not invalidate `Sender`/`Receiver`
-  clones a prior-lifetime parse task or in-flight reader already holds. So isolation
-  cannot rely on "the old channel is gone": every **publish** re-checks
-  `snapshot.incarnation == slot.current_incarnation` inside `send_if_modified`
-  (a straggler from lifetime N publishing into a clone of N's sender is rejected
-  once the slot carries N+1), and every **reader** validates
-  `snapshot.incarnation == <live incarnation>` on borrow and discards a
-  cross-lifetime snapshot rather than serving it. Because both the input
-  `incarnation` and `current_incarnation` denote the same per-URI lifetime, the
-  intended shape is a **single per-URI lifetime object** owning both the inputs and
-  the slot, so there is one authoritative incarnation rather than a cross-map
-  compare.
+- **One stable per-URI cell, reset in place — never replaced.** The channel must
+  **not** be swapped out on reopen: replacing it would leave a prior-lifetime parse
+  task or in-flight reader holding `Sender`/`Receiver` clones of the *old* cell
+  (whose `current_incarnation` stays `N`), so an `N` straggler would publish into
+  the old cell and pass its own `== N` check, and an old-cell reader would still
+  observe it. Instead the per-URI cell is stable for the URI's whole existence and
+  **reset in place** on reopen — `send_if_modified` sets `current_incarnation = N+1`
+  and `snapshot = None` atomically. Because every clone points at the *same* cell,
+  a straggler `N` publish now fails `incarnation == current_incarnation` (`N != N+1`)
+  and every reader's `snapshot.incarnation == cell.current_incarnation` check
+  discards a cross-lifetime snapshot rather than serving it. The cell and the
+  document inputs are the **single per-URI lifetime object**, so there is one
+  authoritative incarnation, not a cross-map compare.
 
 The incremental-parse **seed** re-homes onto `ParseScheduler`'s per-document state
 (accumulated `InputEdit`s + the `base_version` they extend). Two obligations,
@@ -170,8 +170,9 @@ sequence**, so no downstream effect ever escapes for a snapshot that lost the CA
 compute the tree, region map, and tokens **privately** (nothing shared mutated);
 revalidate `incarnation == current_incarnation`; run the one publish primitive; and
 emit the downstream — `semanticTokens/refresh`, injected-language forwarding,
-diagnostic republish, and (the deferred perf lever) any shared injection-cache /
-node-tracker mutation — **only if that exact publish succeeded**, in the order the
+diagnostic republish, and any shared injection-token-cache write — **only if that
+exact publish succeeded** (the shared `NodeTracker` is not mutated on this path at
+all; see §3), in the order the
 per-document-parse-scheduler loop already uses (`populate → mark finished →
 downstream`). A rejected publish (a racing edit or reopen advanced the slot) emits
 nothing and mutates no shared state. During Stage 2's dual-write window the legacy
@@ -190,34 +191,41 @@ refresh path re-drives the client each time a fresher snapshot lands; the model
 does not promise a bounded edit-lag without the fair-admission backpressure §4
 defers.
 
-Region identity is the load-bearing subtlety. The `NodeTracker`
-(lazy-node-identity-tracking) is edit-shifted **synchronously on `didChange`**, so
-it tracks `content_version`; a stale-tree reader minting region-ids/ULIDs against
-its own (`parsed_version`) byte ranges would write entries at positions the live
-tracker has already moved — orphaned/duplicated ids, wrong-position reuse. Today
-`compute_captures` avoids this only by *waiting* for the parse and re-snapshotting.
-The decision therefore moves **region-id minting off every reader path**: the
-parse-loop `populate` mints region ids once, at `parsed_version`, into the
-snapshot's `injection_regions` (this is the injection-token-cache-reuse
-"don't discover twice" lever, realized here as a consequence, not a separate
-change). A stale-tree reader then only **reads** region ids from its own snapshot
-— internally consistent with that snapshot's tree, minting nothing.
+Region identity is the load-bearing subtlety, and it forces a clean split. The
+shared `NodeTracker` (lazy-node-identity-tracking) is a **mutable, edit-shifted**
+index: it is adjusted synchronously on `didChange` to keep `kakehashi/node/*`
+references stable across edits, so it tracks `content_version`. A snapshot's tree
+tracks `parsed_version`. Minting region ids by mutating that shared tracker from a
+parse pass — at `parsed_version`, into an index the live document has already
+edit-shifted to `content_version` — cannot be made atomic without holding
+`edit_lock` across the whole parse, and even a version-gated mutation leaves the
+"where do the ids come from when the gate fails?" question undefined. Mutating a
+shared, edit-shifted identity index off the derivation path is fundamentally at
+odds with the snapshot model.
 
-This requires a **mint-time version guard**, because writing stale coordinates into
-the shared `NodeTracker` is not a mere cache miss — `get_or_create` mutates a
-bidirectional identity index that `kakehashi/node/*` resolution and captures also
-read, so a mispositioned entry is a correctness hazard for *those* consumers, not
-just degraded token-cache reuse. Therefore `populate` mutates the tracker **only
-when `parsed_version == content_version` at mint time** (mirroring the seed's
-`==`-guard): if an edit raced the parse and moved `content_version` ahead, the
-pass computes the snapshot's own `injection_regions` (private to the snapshot, used
-by that snapshot's readers) but **skips the shared-tracker mutation**, deferring it
-to the next reparse, which mints at a matching version. The live tracker is thus
-never written with coordinates that disagree with its own `content_version`. (A
-future decision that forks a per-snapshot tracker view would let even the shared
-identities update every pass; this decision keeps the shared tracker
-edit-`content_version`-consistent and defers cross-pass identity refresh to the
-current-version passes.)
+The decision therefore **separates the two identities**:
+
+- **Injection region identity is snapshot-owned and derived — it does not touch
+  the shared tracker.** `populate` computes each snapshot's `injection_regions`
+  (id + geometry) deterministically from *that snapshot's own tree* (a
+  content/structure-addressed id, stable for a given region content, computed with
+  no shared mutation). A reader reads region ids from its own snapshot, internally
+  consistent by construction; nothing is minted on the read path or written to the
+  shared tracker, so F2/F3's races do not arise.
+- **The shared `NodeTracker` stays exactly as-is, for the `kakehashi/node/*`
+  protocol only.** Those readers are position-critical (they resolve against live
+  positions), so they run at `content_version` and staleness-reject when the
+  snapshot trails — they never consult a stale snapshot, and the parse path never
+  mutates the tracker on their behalf.
+
+The cost is a **changed interaction with injection-token-cache-reuse**, which today
+keys the injection-token cache on the tracker's position-stable ULID so token
+reuse survives across edits. With snapshot-owned ids, cross-edit reuse must be
+re-keyed on the derived (content-addressed) region id + the existing
+`validity_hash`; content-identical regions still reuse, but the reuse key changes.
+Reworking that cache key is scoped as a **companion decision to
+injection-token-cache-reuse**, not silently folded in here — this ADR commits only
+to *not* minting shared identities off the parse/read path.
 
 Any reader that must resolve against **live** positions is position-critical
 (below).
@@ -235,7 +243,8 @@ Any reader that must resolve against **live** positions is position-critical
   No server→client refresh exists for these, and adding one is out of scope; they
   serve the latest snapshot and self-correct on the client's **next** request
   (symbols/colors are re-requested on redraw/scroll, not held live). The staleness
-  window is one edit and non-visual-jarring; this is the deliberate,
+  window is one or more edits (unbounded under sustained typing) but
+  non-visual-jarring; this is the deliberate,
   user-sanctioned relaxation.
 - **Staleness-reject** — `semanticTokens/range`, `kakehashi/node/*`,
   `selectionRange`, `formatting`, `rangeFormatting`, and `captures` (full and
@@ -405,8 +414,9 @@ inside the existing safety contracts at each step:
   by one or more edits, and knows it via the version tag." Correctness now rests on
   the version tag + refresh rather than on the reader having waited.
 - Folding the semantic fan-out from the process-global Rayon pool (all cores) into
-  the bounded `max(2, num_cpus - 2)` pool caps single-document tokenization
-  throughput (≈ −50 % on a 4-core machine for one huge file) in exchange for
+  the bounded `available_parallelism().saturating_sub(2).max(1)` pool caps
+  single-document tokenization throughput (e.g. ~2 of 4 cores for one huge file) in
+  exchange for
   cross-document isolation. Acceptable given the isolation goal, but a real
   single-doc regression to measure.
 - Migration touches wide surface: `Document`, `DocumentStore`, `ParseScheduler`,

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -3,6 +3,7 @@
 **Related Decisions**: [per-document-parse-scheduler](per-document-parse-scheduler.md),
 [parse-decoupled-document-lifecycle](parse-decoupled-document-lifecycle.md),
 [injection-token-cache-reuse](injection-token-cache-reuse.md),
+[lazy-node-identity-tracking](lazy-node-identity-tracking.md),
 [captures-protocol](captures-protocol.md)
 
 ## Context
@@ -17,23 +18,22 @@ as a user-visible regression against v0.7.0 (which parsed inline on `didChange`)
    does `self.tree.take()`: after an edit there is **no servable tree** until the
    off-ingress reparse republishes one. So every tree reader —
    `textDocument/semanticTokens`, `kakehashi/captures`, `kakehashi/node/*`,
-   `documentSymbol`, selection ranges — must **block** waiting for the reparse.
-   The semantic-token reader (`get_tree_with_wait`) waits on the per-document
-   parse **watermark** (`wait_for_epoch`), bounded to a 200ms budget; the
-   captures / node readers wait via `ensure_document_parsed`.
+   `documentSymbol`, selection ranges — must **block** waiting for the reparse
+   (`get_tree_with_wait` on the parse **watermark** via `wait_for_epoch`;
+   `ensure_document_parsed` for the captures / node readers).
 
 2. **Cross-document blocking.** A slow reparse on document A stalls semantic
    tokens on an unrelated document B. Instrumentation showed the reader wait on
    a 300-line injection-heavy markdown file spiking to **0.5–1.4 s** per
-   keystroke — far past the 200ms budget. The budget is defeated because the
+   keystroke — far past the 200 ms budget. The budget is defeated because the
    reparse's downstream CPU runs **inline on tokio worker threads**:
    `populate_injections` (the injection-cache build from injection-token-cache-reuse,
-   O(regions): a per-region node-tracker ULID mint + content hash, hundreds of
-   ms for ~900 regions) runs inline in the off-ingress parse loop, and
+   O(regions): a per-region node-tracker ULID mint + content hash, hundreds of ms
+   for ~900 regions) runs inline in the off-ingress parse loop, and
    `compute_captures` / the `kakehashi/node/*` layer walks run inline in their
    async handlers. On the default `num_cpus`-worker runtime those bursts saturate
    the worker pool, so the tokio timer wheel and `watch` notifications that back
-   the 200ms caps cannot fire, and unrelated documents' handlers cannot be polled.
+   the 200 ms caps cannot fire, and unrelated documents' handlers cannot be polled.
 
 The primitives to fix this are largely already present — a process-monotonic
 `incarnation` per document lifetime, a per-URI parse watermark, and the
@@ -56,116 +56,214 @@ internally-consistent snapshots that readers observe without blocking.
 monotonic `content_version` (bumped on every edit, `0` at `didOpen`). It no
 longer holds `tree` or `pending_seed`, and `apply_edit` never clears a tree — it
 installs the new text and bumps the version. The document lifecycle
-(`didOpen`/`didChange`/`didClose`) becomes fully independent of parsing: it
-mutates inputs and returns, never awaiting or gating on a parse.
+(`didOpen`/`didChange`/`didClose`) becomes independent of parsing: it mutates
+inputs and returns, never awaiting or gating on a parse.
+
+Two input-side concerns are explicitly **retained**, because they are not parse
+gates:
+
+- The per-URI **`edit_lock`** still serializes the non-atomic
+  read-old-text → apply-range → persist cycle within `didChange` (and against
+  `didClose`). Removing it reopens the stale-base race that pre-clamping panicked
+  on in `replace_range`; "mutates inputs and returns" must not be read as
+  dropping it.
+- Content-based **language detection** stays an input concern: `didOpen`/the
+  language-detect path writes `language_id` on the `Document`. Derivation reads
+  it and copies it into the snapshot; derivation never writes back to the input
+  (that would be the layering violation the model exists to avoid).
 
 ### 2. Parsing publishes a versioned `ParseSnapshot`
 
 ```
-ParseSnapshot { text: Arc<str>, tree: Tree, language: String, incarnation: u64, parsed_version: u64 }
+ParseSnapshot { text: Arc<str>, tree: Tree, language: String, parsed_version: u64,
+                injection_regions: /* region-id + geometry, minted here (see §3) */ }
 ```
 
 A snapshot's `text` is exactly the text its `tree` was parsed from — the two
-always agree (the gopls immutable-snapshot property). Snapshots live per-URI in
-a single `watch::Sender<Option<Arc<ParseSnapshot>>>`, which **subsumes both** the
-current `parse_states` (`has_tree`) and `watermarks` (`ticket`) maps: `Some`
-vs `None` is has-tree; `parsed_version` is the watermark; `incarnation` inside
-the snapshot is the per-lifetime guard. The store's five tree/watermark CAS
-methods collapse to **one publish primitive**: install a snapshot iff its
-`incarnation` is current and its `parsed_version` is not older than the published
-one. Monotonic version + incarnation give the same stale-drop / no-resurrection /
-no-reopen-clobber guarantees the CAS methods encode today, in one place.
+always agree (the gopls immutable-snapshot property). Snapshots live per-URI in a
+single `watch` channel whose value co-locates the current lifetime with the
+snapshot:
 
-The incremental-parse **seed** re-homes onto `ParseScheduler`'s per-document
-state (accumulated `InputEdit`s + the base version they extend), which already
-*is* the per-document mutable parse state. A full-text sync leaves no accumulated
-edits, so it parses from scratch — the `#348` incremental-contract stays closed
-as a natural consequence rather than a special case.
+```
+SnapshotSlot { current_incarnation: u64, snapshot: Option<Arc<ParseSnapshot>> }
+```
 
-### 3. Readers take a non-blocking latest snapshot
+This channel **subsumes** the current `parse_states` (`has_tree`) and `watermarks`
+(`(incarnation, ticket)`) maps: `snapshot.is_some()` is has-tree; `parsed_version`
+is the watermark ticket; `current_incarnation` is the per-lifetime guard.
 
-Readers call a wait-free `latest_snapshot(uri)` (a `watch` borrow) and never
-parse inline. Two reader classes:
+The store's tree/watermark CAS methods (four tree writes —
+`update_tree_if_text_unchanged`, `update_tree_if_text_and_language_unchanged`,
+`attach_tree_if_absent`, `set_parse_result_if_text_and_incarnation_unchanged` —
+plus the two watermark advances `advance_watermark` /
+`advance_watermark_for_incarnation`) collapse to **one publish primitive**,
+executed inside `send_if_modified` so the guard and the write are atomic under the
+channel's own lock (the co-location is what makes this a single atomic
+check-then-act rather than a cross-map TOCTOU against `Document.incarnation`):
 
-- **Highlight-class** (`semanticTokens` full/delta, `captures/full`,
-  `kakehashi/node/*`, `documentSymbol`, `documentColor`): **serve-stale +
-  self-heal.** Compute against the snapshot's internally-consistent
-  `(text, tree)`. If `parsed_version < content_version` the result is at most one
-  edit stale; the parse loop publishes a fresh snapshot moments later and emits
-  `workspace/semanticTokens/refresh` (and the existing diagnostic republish) so
-  the client re-requests. The client refresh plumbing already exists; only the
-  post-edit trigger is added.
-- **Position-critical** (`semanticTokens/range`, `captures/range`,
-  selectionRange, formatting, rangeFormatting): the request's positions are
-  authored against the **live** text, so a stale tree cannot be used. When
-  `content_version > parsed_version`, return LSP **`ContentModified`** so the
-  client retries — never map a live-text range onto stale bytes.
+> Install `snapshot` iff `snapshot.incarnation == slot.current_incarnation` **and**
+> `snapshot.parsed_version > slot.snapshot.parsed_version` (strict; `None` →
+> first snapshot is the sole bootstrap exception).
+
+- **Incarnation-scoped, strict monotonicity.** The `>` is strict — equal-version
+  double-publishes (e.g. a racing open-parse and reparse both at version 0) must
+  not swap the `Tree` under an already-issued `result_id` and fire a spurious
+  refresh. `didOpen` sets `current_incarnation`; a reopen bumps it, so a straggler
+  publish from lifetime N is rejected against N+1, and the version compare is only
+  ever within one lifetime (fixing the reopen-regression where a leftover
+  `parsed_version = 5` would make a fresh `0 > 5` fail forever).
+- **Language axis** is subsumed by incarnation: every reopen draws a fresh
+  incarnation (so a relabel across lifetimes is already rejected), and within one
+  lifetime the language does not change. The three-axis edit-path CAS
+  (`incarnation && text && language`) therefore reduces to `incarnation && version`.
+
+The incremental-parse **seed** re-homes onto `ParseScheduler`'s per-document state
+(accumulated `InputEdit`s + the `base_version` they extend). Two obligations,
+enforced by co-location today, become explicit scheduler invariants:
+
+- The seed is applied to the snapshot's tree **iff
+  `snapshot.parsed_version == base_version`**; on mismatch (a publish raced), it
+  reseeds from the current snapshot and parses — never applies edits to a tree
+  they do not match (the `#348` external-scanner corruption).
+- A full-text sync **resets** `(pending_edits, base_version)`, so it parses from
+  scratch. "Leaves no accumulated edits" is an explicit reset, not an emergent
+  property.
+
+### 3. Reader contract — non-blocking, three classes
+
+Readers call a wait-free `latest_snapshot(uri)` (a `watch` borrow) and never parse
+inline. A reader is at most one edit stale when `parsed_version < content_version`.
+
+Region identity is the load-bearing subtlety. The `NodeTracker`
+(lazy-node-identity-tracking) is edit-shifted **synchronously on `didChange`**, so
+it tracks `content_version`; a stale-tree reader minting region-ids/ULIDs against
+its own (`parsed_version`) byte ranges would write entries at positions the live
+tracker has already moved — orphaned/duplicated ids, wrong-position reuse. Today
+`compute_captures` avoids this only by *waiting* for the parse and re-snapshotting.
+The decision therefore moves **region-id minting off every reader path**: the
+parse-loop `populate` mints region ids once, at `parsed_version`, into the
+snapshot's `injection_regions` (this is the injection-token-cache-reuse
+"don't discover twice" lever, realized here as a consequence, not a separate
+change). Readers only **read** region ids from their snapshot, so a stale-tree read
+is self-consistent and mints nothing. Any reader that would still need to mint
+against live positions is position-critical (below).
+
+- **Serve-stale, actively refreshed** — `semanticTokens` full/delta. Compute
+  against the snapshot's consistent `(text, tree, injection_regions)`; caches key
+  off the snapshot's `(text, parsed_version)` so nothing is poisoned. When the
+  parse loop publishes a fresh snapshot it emits `workspace/semanticTokens/refresh`.
+  The trigger is added at the **parse-loop** publish point, **not** in the
+  `didChange` handler — `didChange` deliberately does not emit refresh because a
+  synchronous client (vim-lsp on Vim) cannot answer a server request while
+  processing a notification; emitting from the off-ingress loop, after the
+  notification returns, avoids that reentrancy.
+- **Serve-stale, passively refreshed** — `documentSymbol`, `documentColor`.
+  No server→client refresh exists for these, and adding one is out of scope; they
+  serve the latest snapshot and self-correct on the client's **next** request
+  (symbols/colors are re-requested on redraw/scroll, not held live). The staleness
+  window is one edit and non-visual-jarring; this is the deliberate,
+  user-sanctioned relaxation.
+- **Position-critical → `ContentModified`** — `semanticTokens/range`,
+  `captures` (full and range), `kakehashi/node/*`, selectionRange, formatting,
+  rangeFormatting. Their request positions/ranges are authored against the **live**
+  text; a stale tree cannot answer them, and captures/node additionally resolve
+  against the live `content_version` tracker. When `content_version > parsed_version`
+  return LSP **`ContentModified`** (-32801). Note: the spec does **not** mandate
+  client auto-retry — a client that does not re-request simply gets the answer on
+  its next natural request; formatting may no-op for that keystroke. This is
+  acceptable because these are not per-keystroke-critical, and it never serves a
+  wrong-position result.
 
 The only bounded wait that remains is the **first parse after `didOpen`** (the
-snapshot is `None` and no prior snapshot exists); it waits briefly on
-`watch::changed()` then serves `null`.
+snapshot is `None`); it waits briefly on `watch::changed()` then serves `null`.
+
+*(Reclassifying `captures/full` and `kakehashi/node/*` as position-critical is a
+deliberate scope choice: making them serve-stale would require the snapshot to own
+a versioned tracker view, a larger change than this decision commits to. If a
+future decision forks the tracker per snapshot, they can move to serve-stale.)*
 
 ### 4. All tree-CPU runs on one bounded compute pool
 
 A single dedicated `rayon` pool sized `max(2, num_cpus - 2)` — reserving at least
 two cores for the tokio workers and the timer driver — runs **all** synchronous
-tree work: the parse, `populate_injections`, the `compute_captures` / node layer
-walks, and the semantic-token injection fan-out (folded off the process-global
-Rayon pool into this one). Async handlers hand a whole work-unit to the pool
-(bridged by a `oneshot`) and `await` the result, so no tree-CPU ever executes on
-a tokio worker.
+tree work: the parse, `populate` (region minting + content hash), the
+`compute_captures` / node layer walks, and the semantic-token injection fan-out
+(folded off the process-global Rayon pool into this one). Async handlers hand a
+whole work-unit to the pool (bridged by a `oneshot`) and `await` the result, so no
+tree-CPU ever executes on a tokio worker. `DocumentParserPool`'s guard becomes a
+sync mutex (`std`/`parking_lot`) since acquisition now runs on pool threads that
+cannot `.await`.
 
-The guarantee that document A cannot block document B rests on **three legs
-together**: (1) no synchronous tree-CPU on the tokio workers, so B's handler and
-the timer driver are always pollable; (2) the pool is bounded below `num_cpus`,
-so A cannot oversubscribe the CPU and starve those workers; (3) `ParseScheduler`
-coalescing (already built) plus a focused-document priority queue keep A's jobs
-from monopolizing the pool ahead of B and the document the user is editing.
+The guarantee that document A cannot **starve** document B rests on two legs that
+hold unconditionally: (1) no synchronous tree-CPU on the tokio workers, so B's
+handler and the timer driver are always pollable; (2) the pool is bounded below
+`num_cpus`, so A cannot oversubscribe the CPU and starve those workers. What
+remains is bounded **queueing** on the compute pool itself: A's parse burst can sit
+ahead of B's fan-out. `ParseScheduler` coalescing (already built) caps each
+document to one queued parse, giving fairness across documents; a focused-document
+priority — not yet built — would order *admission* so the document the user edits
+drains first (rayon has no preemption, so this orders queueing, it cannot preempt
+in-flight sub-tasks). The strong claim is therefore **no cross-document
+starvation**; residual queue latency under many simultaneous large parses is
+bounded by the coalescing + pool size, and the priority queue is a later knob.
 
 ### 5. Staged rollout
 
-The change is delivered in independently shippable, reviewable, measurable
-stages that stay inside the existing safety contracts at each step:
+Delivered in independently shippable, reviewable, measurable stages that stay
+inside the existing safety contracts at each step:
 
 - **Stage 1 — tree-CPU off the async workers onto the bounded pool.** Move
-  `populate_injections` (all call sites) and the captures / node layer walks off
-  the tokio workers; introduce the bounded pool and route parse + populate +
-  walks + fan-out through it. Delivers *no cross-document blocking* and most of
-  *high-performance parsing*. The read path is untouched, so the stale-tree
-  contract is not at risk.
-- **Stage 2 — versioned snapshot reads.** Introduce `ParseSnapshot` + the `watch`
-  channel + `latest_snapshot`; convert highlight-class readers to serve-stale +
-  refresh and position-critical readers to `ContentModified`. Removes
-  `get_tree_with_wait` / `wait_for_epoch` / `ensure_document_parsed` blocking.
-  Delivers *instant reads* and *lifecycle independent of parsing*.
-- **Stage 3 — consolidation.** Remove `Document::tree` / `pending_seed`, collapse
-  the five store CAS methods into the one publish primitive, re-home the seed on
-  the scheduler, delete the now-unused watermark waits.
+  `populate` (all call sites) and the captures / node layer walks off the tokio
+  workers; introduce the bounded pool and route parse + populate + walks + fan-out
+  through it; convert `parser_pool` to a sync mutex. Delivers *no cross-document
+  starvation* and most of *high-performance parsing*. The read path and the
+  clear-tree-on-edit contract are untouched, so the stale-tree guarantee is not at
+  risk; the sole new obligation is that `populate` is **awaited** (not detached),
+  preserving the `populate → finish` ordering the injection-map invalidation
+  depends on.
+- **Stage 2 — versioned snapshot reads.** Introduce `SnapshotSlot` + the `watch`
+  channel + `latest_snapshot`. **The parse loop dual-writes**: it keeps the legacy
+  tree CAS (the incremental seed still reads `Document::tree`/`pending_seed`, which
+  Stage 3 removes) **and** publishes a `ParseSnapshot` to the new channel, so
+  `latest_snapshot` retains a servable tree across an edit's `tree.take()`. Move
+  region minting into `populate`. Convert `semanticTokens` to serve-stale + the
+  refresh trigger; `documentSymbol`/`documentColor` to serve-stale + passive;
+  range/formatting/captures/node to `ContentModified`. Removes `get_tree_with_wait`
+  / `wait_for_epoch` / `ensure_document_parsed` blocking. Delivers *instant reads*
+  and *lifecycle independent of parsing*. Without the dual-write this stage would
+  reproduce the empty-after-edit regression, so it is mandatory here, not deferred.
+- **Stage 3 — consolidation.** Remove `Document::tree` / `pending_seed` (the seed
+  now lives on the scheduler), collapse the CAS methods into the one publish
+  primitive, delete the watermark waits, and prune the now-superseded passages
+  from per-document-parse-scheduler (its tree-clear-on-edit and watermark/epoch
+  sections) per delete-on-supersede — done **here**, when the behavior actually
+  changes, not before.
 
 ## Considered Options
 
-- **Keep the scheduler, only move `populate_injections` to `spawn_blocking`
-  (the interim "fix D" + offload).** Rejected as the endpoint: it removes the
-  cross-document CPU starvation but not the per-keystroke read latency — with the
-  tree still cleared on edit, readers keep blocking on the reparse (or fall into
-  an on-demand full parse). And `spawn_blocking` **alone** trades HOL-blocking for
-  CPU oversubscription on the default 512-thread blocking pool, so it must be
-  paired with a bounded pool regardless. It is adopted as **Stage 1**, not the
-  destination.
+- **Keep the scheduler, only move `populate` to `spawn_blocking`.** Rejected as the
+  endpoint: it removes the cross-document CPU starvation but not the per-keystroke
+  read latency — with the tree still cleared on edit, readers keep blocking on the
+  reparse (or fall into an on-demand full parse). And `spawn_blocking` **alone**
+  trades HOL-blocking for CPU oversubscription on the default 512-thread blocking
+  pool, so it must be paired with a bounded pool regardless. It is adopted as
+  **Stage 1**, not the destination.
 - **Serve the pre-edit / seeded tree immediately without versioning
   (naive stale-serve).** Rejected. It is crash-safe (the `#348` hazard is a
   parse-seed/external-scanner issue, not a query-cursor issue, and the read paths
-  are already stale-offset-hardened), but readers **write** persistent caches —
-  the node-tracker ULIDs, the injection-token cache, and the whole-document token
-  cache — keyed by the **new** text hash. Serving old-tree tokens under a
-  new-text key poisons those caches permanently (no generation bump, no refresh
-  today). The versioned snapshot fixes exactly this: caches key off the
-  snapshot's own `(text, version)`, which are consistent, so nothing is poisoned.
-- **A text-owning parse actor (the scheduler ADR's Option 4).** Still rejected
-  for the reason recorded there: reads bypass the owner, so owning the text buys
-  nothing while resurrection-safety must still guard every reader fallback. This
-  decision *reuses* the scheduler and its epoch rather than replacing them with an
-  actor.
+  are already stale-offset-hardened), but readers **write** persistent caches. The
+  whole-document token cache (in `semantic_cache` / `cache`, keyed by text hash) is
+  closed by keying off the snapshot's text. The **injection-token cache** (keyed
+  `(Url, region_id)`) and the **node-tracker ULIDs** are *not* closed by
+  text-keying — they are closed only by moving region minting into the snapshot's
+  `populate` (§3) so a stale read consumes stale-but-consistent ids and mints
+  nothing. Naive stale-serve does neither and poisons both permanently (no
+  generation bump, no refresh today).
+- **A text-owning parse actor (per-document-parse-scheduler's Option 4).** Still
+  rejected for the reason recorded there: reads bypass the owner, so owning the
+  text buys nothing while resurrection-safety must still guard every reader
+  fallback. This decision *reuses* the scheduler and its epoch rather than
+  replacing them with an actor.
 - **Block all readers until fully current (status quo).** Rejected: it is the
   behavior producing the 0.5–1.4 s waits. The user explicitly accepts a one-edit
   stale highlight (healed by refresh) in exchange for never blocking, with
@@ -177,40 +275,58 @@ stages that stay inside the existing safety contracts at each step:
 
 - Document lifecycle is fully decoupled from parsing: `didChange` never awaits a
   parse; readers never block on one.
-- No cross-document blocking: with all tree-CPU on a bounded pool below
+- No cross-document starvation: with all tree-CPU on a bounded pool below
   `num_cpus`, a slow parse on one document cannot starve the async runtime or
   another document's requests.
 - High-performance reads: highlight requests return against the latest snapshot
   immediately instead of waiting hundreds of ms for a reparse + populate.
-- State and coupling shrink: two `watch` maps collapse to one, five store CAS
-  methods to one publish primitive, and the `pending_seed` invariant surface on
-  `Document` is deleted (favorable on the State > Coupling > Complexity > Code
-  ordering the repo optimizes for).
+- The scheduler ADR's residual **reader-fallback resurrection vector is
+  eliminated**: wait-free borrowing readers never parse inline, so there is no
+  reader path that can re-insert a document a `didClose` removed.
+- State and coupling shrink: two `watch` maps collapse to one, six store CAS /
+  watermark methods to one publish primitive, and the `pending_seed` invariant
+  surface on `Document` is deleted (favorable on the State > Coupling > Complexity
+  > Code ordering the repo optimizes for).
 
 ### Negative
 
 - Highlight-class results may be **one edit stale for a few milliseconds** until
-  the fresh snapshot publishes and a refresh re-drives the client. This is the
-  deliberate, user-sanctioned tradeoff; it requires adding the post-edit
-  `semanticTokens/refresh` trigger (absent today) and a captures-refresh path.
-- Position-critical requests (range, formatting) now return `ContentModified`
-  during the reparse window, relying on client retry — a behavior change from
-  today's block-until-fresh.
-- The `#342`/`#374` stale-tree guarantee (a reader observes at least its own
-  edit) is relaxed to "a reader observes a *consistent* but possibly one-edit-old
-  snapshot, and knows it via the version tag." Correctness now rests on the
-  version tag + refresh rather than on the reader having waited.
+  the fresh snapshot publishes. `semanticTokens` is re-driven by an added
+  post-edit `semanticTokens/refresh` (emitted from the parse loop to dodge the
+  synchronous-client reentrancy that keeps it out of `didChange`);
+  `documentSymbol`/`documentColor` self-correct only on the client's next natural
+  request (no active refresh added).
+- Position-critical requests (`captures`, `kakehashi/node/*`, range, formatting)
+  return `ContentModified` during the reparse window. The LSP spec does not mandate
+  client retry, so on a client that does not re-request (e.g. Neovim's built-in
+  client for formatting) that keystroke's request **no-ops** until the next natural
+  request. Reclassifying captures/node from the original serve-stale intent is the
+  cost of not forking a per-snapshot tracker view now.
+- The `#342`/`#374` stale-tree guarantee (a reader observes at least its own edit)
+  is relaxed to "a reader observes a *consistent* but possibly one-edit-old
+  snapshot, and knows it via the version tag." Correctness now rests on the version
+  tag + refresh rather than on the reader having waited.
+- Folding the semantic fan-out from the process-global Rayon pool (all cores) into
+  the bounded `max(2, num_cpus - 2)` pool caps single-document tokenization
+  throughput (≈ −50 % on a 4-core machine for one huge file) in exchange for
+  cross-document isolation. Acceptable given the isolation goal, but a real
+  single-doc regression to measure.
 - Migration touches wide surface: `Document`, `DocumentStore`, `ParseScheduler`,
-  the parse coordinator, `parser_pool` (a `tokio::sync::Mutex` becomes a sync
-  mutex once acquisition moves onto pool threads that cannot `.await`), and the
-  ~13 `ensure_document_parsed` call sites. Each invariant from the scheduler and
-  lifecycle decisions must be re-proved against the snapshot model.
+  the parse coordinator, `parser_pool` (Stage 1 sync-mutex conversion), and the
+  ~17 `ensure_document_parsed` call sites. Each invariant from the scheduler and
+  lifecycle decisions (edit_lock ordering, captures lineage, diagnostic republish
+  order, incarnation CAS on reopen) must be re-proved against the snapshot model.
 
 ### Neutral
 
+- `didClose` drops the single channel (waking any reader parked on the first-parse
+  `watch::changed()`); a reopen replaces it with a fresh `SnapshotSlot`. A wait-free
+  `latest_snapshot` borrow racing close+reopen may observe the prior lifetime's
+  snapshot momentarily — bounded and self-healing via the next publish, the same
+  class as today's borrow-then-reopen races.
 - The `ParseScheduler` (one loop per document, coalescing, panic re-arm),
-  `incarnation`, and the incremental-seed concept are retained — re-homed, not
-  removed.
+  `incarnation`, the `edit_lock`, and the incremental-seed concept are retained —
+  re-homed, not removed.
 - The bounded pool's size and the focused-document priority are a single knob;
   strict fairness (a per-document concurrency cap) can be added later without
   changing the model.
@@ -218,8 +334,10 @@ stages that stay inside the existing safety contracts at each step:
 ## Decision–Implementation Gap
 
 Not yet implemented — this decision is aspirational and rolls out over the three
-stages above. An interim fix advancing the parse watermark before
-`populate_injections` (so readers wake on the tree rather than after the populate)
-was prototyped and measured as a partial improvement; it is subsumed by Stage 1
-(which moves the populate off the async workers entirely) and Stage 2 (which
-removes the reader wait) and is not carried forward on its own.
+stages above. An interim fix advancing the parse watermark before `populate` (so
+readers wake on the tree rather than after the populate) was prototyped and
+measured as a partial improvement; it is subsumed by Stage 1 (which moves the
+populate off the async workers) and Stage 2 (which removes the reader wait) and is
+not carried forward on its own. The delete-on-supersede pruning of the overtaken
+per-document-parse-scheduler passages is deferred to Stage 3, when the behavior
+they describe is actually removed.

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -126,32 +126,34 @@ check-then-act rather than a cross-map TOCTOU against `Document.incarnation`):
 - **Incarnation-scoped, strict monotonicity.** The `>` is strict — equal-version
   double-publishes (e.g. a racing open-parse and reparse both at version 0) must
   not swap the `Tree` under an already-issued `result_id` and fire a spurious
-  refresh. `didOpen` sets `current_incarnation`; a reopen **resets the same cell in
-  place** to `(current_incarnation = N+1, snapshot = None)` (never a new cell — see
-  the isolation bullet below). Resetting `snapshot` to `None` is what clears the
-  version floor — the first post-reopen publish takes the `None` bootstrap branch,
-  so a leftover `parsed_version = 5` from the prior lifetime cannot make a fresh
-  `0 > 5` fail forever; the incarnation bump alone would not reset the floor. The
-  `None` bootstrap still checks `incarnation == current_incarnation` (it is not an
-  unconditional early-return), so a straggler publish from lifetime N is rejected
-  against N+1 and the version compare is only ever within one lifetime.
+  refresh. `didOpen` sets `current_incarnation`; a reopen starts the URI's cell
+  fresh at `(current_incarnation = N+1, snapshot = None)` (whether the cell is reset
+  in place or recreated is a correctness-irrelevant implementation choice — see the
+  isolation bullet). Starting `snapshot` at `None` is what clears the version floor:
+  the first post-reopen publish takes the `None` bootstrap branch, so a leftover
+  `parsed_version = 5` from the prior lifetime cannot make a fresh `0 > 5` fail
+  forever; the incarnation bump alone would not reset the floor. The `None` bootstrap
+  still checks `incarnation == current_incarnation` (it is not an unconditional
+  early-return), so a straggler publish from lifetime N is rejected against N+1 and
+  the version compare is only ever within one lifetime.
 - **Language axis** is subsumed by incarnation: every reopen draws a fresh
   incarnation (so a relabel across lifetimes is already rejected), and within one
   lifetime the language does not change. The three-axis edit-path CAS
   (`incarnation && text && language`) therefore reduces to `incarnation && version`.
-- **One stable per-URI cell, reset in place — never replaced.** The channel must
-  **not** be swapped out on reopen: replacing it would leave a prior-lifetime parse
-  task or in-flight reader holding `Sender`/`Receiver` clones of the *old* cell
-  (whose `current_incarnation` stays `N`), so an `N` straggler would publish into
-  the old cell and pass its own `== N` check, and an old-cell reader would still
-  observe it. Instead the per-URI cell is stable for the URI's whole existence and
-  **reset in place** on reopen — `send_if_modified` sets `current_incarnation = N+1`
-  and `snapshot = None` atomically. Because every clone points at the *same* cell,
-  a straggler `N` publish now fails `incarnation == current_incarnation` (`N != N+1`)
-  and every reader's `snapshot.incarnation == cell.current_incarnation` check
-  discards a cross-lifetime snapshot rather than serving it. The cell and the
-  document inputs are the **single per-URI lifetime object**, so there is one
-  authoritative incarnation, not a cross-map compare.
+- **Isolation is per-request re-resolution + incarnation validation, not cell
+  identity.** A `latest_snapshot(uri)` call resolves the *current* cell from the
+  store each time and never caches a `Receiver` across requests, and it validates
+  `snapshot.incarnation == <live document incarnation>` before serving — the cell
+  and the document inputs are one per-URI lifetime object, so there is one
+  authoritative incarnation. This makes cell lifecycle irrelevant to correctness:
+  on reopen the store may drop and recreate the cell, and a prior-lifetime parse
+  task holding a stale `Sender` clone can still publish — but only into that now
+  **detached** old cell, which no current-request reader resolves, so the publish
+  is unobservable; and a reader mid-compute holding a lifetime-`N` `Arc<ParseSnapshot>`
+  rejects it against the live `N+1` incarnation. The one reader that *does* hold a
+  `Receiver` — a first-parse waiter parked on `watch::changed()` — is woken when
+  `didClose` drops the sender (`Err` → falls through to `null`), exactly as today's
+  watermark-drop wakes parked `wait_for_epoch` readers.
 
 The incremental-parse **seed** re-homes onto `ParseScheduler`'s per-document state
 (accumulated `InputEdit`s + the `base_version` they extend). Two obligations,
@@ -175,9 +177,13 @@ exact publish succeeded** (the shared `NodeTracker` is not mutated on this path 
 all; see §3), in the order the
 per-document-parse-scheduler loop already uses (`populate → mark finished →
 downstream`). A rejected publish (a racing edit or reopen advanced the slot) emits
-nothing and mutates no shared state. During Stage 2's dual-write window the legacy
-tree CAS is the commit point the snapshot publish and downstream both gate on, so
-the two writes cannot expose different versions.
+nothing and mutates no shared state. During Stage 2's dual-write window the
+**snapshot publish is the sole commit point**: the legacy tree CAS is made
+strict-version too (it must not replace an equal-or-newer tree), a pass performs
+both writes under the same `(incarnation, parsed_version)` guard, and **all**
+downstream gates on the *snapshot publish* result — never on the legacy CAS. So the
+two writes cannot land for different versions, and no downstream effect fires for a
+snapshot the publish rejected even if the legacy CAS happened to win.
 
 ### 3. Reader contract — non-blocking, three classes
 
@@ -203,29 +209,35 @@ edit-shifted to `content_version` — cannot be made atomic without holding
 shared, edit-shifted identity index off the derivation path is fundamentally at
 odds with the snapshot model.
 
-The decision therefore **separates the two identities**:
+The decision therefore **separates three concerns that today all ride the tracker
+ULID**, so none needs a shared, edit-shifted mint off the parse path:
 
-- **Injection region identity is snapshot-owned and derived — it does not touch
-  the shared tracker.** `populate` computes each snapshot's `injection_regions`
-  (id + geometry) deterministically from *that snapshot's own tree* (a
-  content/structure-addressed id, stable for a given region content, computed with
-  no shared mutation). A reader reads region ids from its own snapshot, internally
-  consistent by construction; nothing is minted on the read path or written to the
-  shared tracker, so F2/F3's races do not arise.
-- **The shared `NodeTracker` stays exactly as-is, for the `kakehashi/node/*`
-  protocol only.** Those readers are position-critical (they resolve against live
-  positions), so they run at `content_version` and staleness-reject when the
-  snapshot trails — they never consult a stale snapshot, and the parse path never
-  mutates the tracker on their behalf.
+- **Within-snapshot enumeration** — the id `populate` puts in `injection_regions`
+  is a **document-order ordinal** (the region's index in the injection-query match
+  order over the snapshot's tree), paired with the region's byte geometry. It is
+  deterministic from the snapshot's own tree and unique within the snapshot even
+  for byte-identical regions (the ordinal disambiguates), so `(URI, region_id)`
+  cannot alias two regions of one snapshot. It is **not** a cross-edit-stable handle
+  and is not claimed to be — an edit that inserts a region renumbers ordinals.
+- **Cross-edit token reuse** (the injection-token-cache-reuse benefit) is re-keyed
+  off the ordinal onto **`(region content hash, validity_hash)`**: two snapshots'
+  byte-identical regions reuse tokens regardless of ordinal, which is what actually
+  makes reuse survive edits. Reworking that cache key is a **companion decision to
+  injection-token-cache-reuse**, not silently folded in here.
+- **Cross-edit bridge / virtual-document identity** — the stable handle a
+  downstream language server's virtual document is keyed by — **remains the shared
+  `NodeTracker` ULID**, which is a live-position (`content_version`) concern: it is
+  minted/adjusted on the `didChange` edit path (as today) and consumed by the
+  bridge and `kakehashi/node/*`, all of which operate on the live document and
+  staleness-reject rather than serve a stale snapshot. The parse/stale-read path
+  neither mints nor mutates it.
 
-The cost is a **changed interaction with injection-token-cache-reuse**, which today
-keys the injection-token cache on the tracker's position-stable ULID so token
-reuse survives across edits. With snapshot-owned ids, cross-edit reuse must be
-re-keyed on the derived (content-addressed) region id + the existing
-`validity_hash`; content-identical regions still reuse, but the reuse key changes.
-Reworking that cache key is scoped as a **companion decision to
-injection-token-cache-reuse**, not silently folded in here — this ADR commits only
-to *not* minting shared identities off the parse/read path.
+So a stale-tree reader reads self-consistent ordinals + geometry from its own
+snapshot and touches no shared identity index (the mint-race and the
+undefined-id-on-gate-failure both vanish); token reuse is content-keyed; and the
+one identity that genuinely needs cross-edit stability (the bridge's) keeps the
+tracker that already provides it. This ADR commits only to *not* minting shared
+identities off the parse/read path.
 
 Any reader that must resolve against **live** positions is position-critical
 (below).
@@ -323,17 +335,21 @@ inside the existing safety contracts at each step:
   preserving the `populate → finish` ordering the injection-map invalidation
   depends on.
 - **Stage 2 — versioned snapshot reads.** Introduce `SnapshotSlot` + the `watch`
-  channel + `latest_snapshot`. **The parse loop dual-writes**: it keeps the legacy
-  tree CAS (the incremental seed still reads `Document::tree`/`pending_seed`, which
-  Stage 3 removes) **and** publishes a `ParseSnapshot` to the new channel, so
-  `latest_snapshot` retains a servable tree across an edit's `tree.take()`. Move
-  region minting into `populate`. Convert `semanticTokens` to serve-stale + the
+  channel + `latest_snapshot`. **The parse loop dual-writes under one guard**: the
+  legacy tree CAS (the incremental seed still reads `Document::tree`/`pending_seed`,
+  which Stage 3 removes) is made strict-version like the publish, both writes run
+  under the same `(incarnation, parsed_version)` guard, and the **snapshot publish
+  is the sole commit point** — all downstream (refresh, forwarding, diagnostics,
+  shared cache writes) gates on the *publish* result, never the legacy CAS (§2). So
+  `latest_snapshot` retains a servable tree across an edit's `tree.take()` and the
+  two writes cannot expose different versions. Derive snapshot-owned region ids in
+  `populate` (no shared-tracker mint). Convert `semanticTokens` to serve-stale + the
   refresh trigger; `documentSymbol`/`documentColor` to serve-stale + passive;
   range/formatting/`node/*` to `ContentModified` and `captures` to `null` (its
-  re-sync signal). Removes `get_tree_with_wait`
-  / `wait_for_epoch` / `ensure_document_parsed` blocking. Delivers *instant reads*
-  and *lifecycle independent of parsing*. Without the dual-write this stage would
-  reproduce the empty-after-edit regression, so it is mandatory here, not deferred.
+  re-sync signal). Removes `get_tree_with_wait` / `wait_for_epoch` /
+  `ensure_document_parsed` blocking. Delivers *instant reads* and *lifecycle
+  independent of parsing*. Without the dual-write this stage would reproduce the
+  empty-after-edit regression, so it is mandatory here, not deferred.
 - **Stage 3 — consolidation.** Remove `Document::tree` / `pending_seed` (the seed
   now lives on the scheduler), collapse the CAS methods into the one publish
   primitive, delete the watermark waits, and prune the now-superseded passages

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -75,9 +75,12 @@ gates:
 ### 2. Parsing publishes a versioned `ParseSnapshot`
 
 ```
-ParseSnapshot { text: Arc<str>, tree: Tree, language: String, parsed_version: u64,
+ParseSnapshot { text: Arc<str>, tree: Option<Tree>, language: String,
+                parsed_version: u64, incarnation: u64,
                 injection_regions: /* region-id + geometry, minted here (see §3) */ }
 ```
+
+(`tree: Option` so a resolved-but-parser-less outcome is representable — see below.)
 
 A snapshot's `text` is exactly the text its `tree` was parsed from — the two
 always agree (the gopls immutable-snapshot property). Snapshots live per-URI in a
@@ -91,6 +94,15 @@ SnapshotSlot { current_incarnation: u64, snapshot: Option<Arc<ParseSnapshot>> }
 This channel **subsumes** the current `parse_states` (`has_tree`) and `watermarks`
 (`(incarnation, ticket)`) maps: `snapshot.is_some()` is has-tree; `parsed_version`
 is the watermark ticket; `current_incarnation` is the per-lifetime guard.
+
+A **resolved-but-tree-less** outcome — a parse that completed with no usable tree
+(no parser installed, install failed, or a quarantined crashed grammar), distinct
+from the pre-first-parse `None` — must still release readers parked on the
+first-parse wait. It carries its own resolved-version marker: `ParseSnapshot.tree`
+is `Option` (`None` = resolved, no tree), so `snapshot.is_some()` means "resolved"
+and the inner `tree` distinguishes "resolved with a tree" from "resolved, none
+available"; a tree-less snapshot advances `parsed_version` like any other and
+readers fall through to their empty / `ContentModified` paths.
 
 The store's tree/watermark CAS methods (four tree writes —
 `update_tree_if_text_unchanged`, `update_tree_if_text_and_language_unchanged`,
@@ -108,10 +120,15 @@ check-then-act rather than a cross-map TOCTOU against `Document.incarnation`):
 - **Incarnation-scoped, strict monotonicity.** The `>` is strict — equal-version
   double-publishes (e.g. a racing open-parse and reparse both at version 0) must
   not swap the `Tree` under an already-issued `result_id` and fire a spurious
-  refresh. `didOpen` sets `current_incarnation`; a reopen bumps it, so a straggler
-  publish from lifetime N is rejected against N+1, and the version compare is only
-  ever within one lifetime (fixing the reopen-regression where a leftover
-  `parsed_version = 5` would make a fresh `0 > 5` fail forever).
+  refresh. `didOpen` sets `current_incarnation`; a reopen **installs a fresh
+  `SnapshotSlot` (next incarnation, `snapshot = None`)**. Resetting `snapshot` to
+  `None` is what clears the version floor — the first post-reopen publish takes the
+  `None` bootstrap branch, so a leftover `parsed_version = 5` from the prior
+  lifetime cannot make a fresh `0 > 5` fail forever; the incarnation bump alone
+  would not reset the floor. The `None` bootstrap still checks
+  `incarnation == current_incarnation` (it is not an unconditional early-return), so
+  a straggler publish from lifetime N is rejected against N+1 and the version
+  compare is only ever within one lifetime.
 - **Language axis** is subsumed by incarnation: every reopen draws a fresh
   incarnation (so a relabel across lifetimes is already rejected), and within one
   lifetime the language does not change. The three-axis edit-path CAS
@@ -144,9 +161,21 @@ The decision therefore moves **region-id minting off every reader path**: the
 parse-loop `populate` mints region ids once, at `parsed_version`, into the
 snapshot's `injection_regions` (this is the injection-token-cache-reuse
 "don't discover twice" lever, realized here as a consequence, not a separate
-change). Readers only **read** region ids from their snapshot, so a stale-tree read
-is self-consistent and mints nothing. Any reader that would still need to mint
-against live positions is position-critical (below).
+change). A stale-tree reader then only **reads** region ids from its own snapshot
+— internally consistent with that snapshot's tree, minting nothing.
+
+This **relocates** the tracker-skew hazard rather than fully closing it: `populate`
+mints at `parsed_version` into a `NodeTracker` that has already been edit-shifted
+to `content_version`, so a mispositioned entry can still land when the tracker is
+ahead of the snapshot. Unlike the seed, the mint has no `parsed_version ==`-guard.
+The residual is **performance-only**, not correctness: region-cache reads are gated
+by a `validity_hash` (content + language), so a mispositioned id simply misses and
+recomputes — it never serves wrong tokens — and it accumulates orphan entries that
+lifecycle eviction reclaims. A future decision that forks a per-snapshot tracker
+view would close it entirely; this decision accepts the perf residual.
+
+Any reader that must resolve against **live** positions is position-critical
+(below).
 
 - **Serve-stale, actively refreshed** — `semanticTokens` full/delta. Compute
   against the snapshot's consistent `(text, tree, injection_regions)`; caches key
@@ -163,21 +192,28 @@ against live positions is position-critical (below).
   (symbols/colors are re-requested on redraw/scroll, not held live). The staleness
   window is one edit and non-visual-jarring; this is the deliberate,
   user-sanctioned relaxation.
-- **Position-critical → `ContentModified`** — `semanticTokens/range`,
-  `captures` (full and range), `kakehashi/node/*`, selectionRange, formatting,
-  rangeFormatting. Their request positions/ranges are authored against the **live**
-  text; a stale tree cannot answer them, and captures/node additionally resolve
-  against the live `content_version` tracker. When `content_version > parsed_version`
-  return LSP **`ContentModified`** (-32801). Note: the spec does **not** mandate
-  client auto-retry — a client that does not re-request simply gets the answer on
-  its next natural request; formatting may no-op for that keystroke. This is
-  acceptable because these are not per-keystroke-critical, and it never serves a
-  wrong-position result.
+- **Staleness-reject** — `semanticTokens/range`, `kakehashi/node/*`,
+  `selectionRange`, `formatting`, `rangeFormatting`, and `captures` (full and
+  range). Their request positions/ranges are authored against the **live** text; a
+  stale tree cannot answer them, and captures/node additionally resolve against the
+  live `content_version` tracker. The rejection signal differs by protocol contract:
+  - The LSP requests return **`ContentModified`** (-32801) when
+    `content_version > parsed_version`. The spec does **not** mandate client
+    auto-retry — a client that does not re-request simply gets the answer on its
+    next natural request; formatting may no-op for that keystroke. Acceptable
+    because these are not per-keystroke-critical, and it never serves a
+    wrong-position result.
+  - `kakehashi/captures` returns **`null`**, which is precisely the re-sync signal
+    captures-protocol already defines ("on null, call full again") — a JSON-RPC
+    *error* would violate that contract, since a captures client is only contracted
+    to re-request on null. So a stale captures request serves `null` and the client
+    re-issues, self-healing on its next request.
 
 The only bounded wait that remains is the **first parse after `didOpen`** (the
-snapshot is `None`); it waits briefly on `watch::changed()` then serves `null`.
+snapshot is `None`); it waits briefly on `watch::changed()` then serves `null` —
+the same decoupling parse-decoupled-document-lifecycle applies to its host tier.
 
-*(Reclassifying `captures/full` and `kakehashi/node/*` as position-critical is a
+*(Reclassifying `captures/full` and `kakehashi/node/*` off serve-stale is a
 deliberate scope choice: making them serve-stale would require the snapshot to own
 a versioned tracker view, a larger change than this decision commits to. If a
 future decision forks the tracker per snapshot, they can move to serve-stale.)*
@@ -228,7 +264,8 @@ inside the existing safety contracts at each step:
   `latest_snapshot` retains a servable tree across an edit's `tree.take()`. Move
   region minting into `populate`. Convert `semanticTokens` to serve-stale + the
   refresh trigger; `documentSymbol`/`documentColor` to serve-stale + passive;
-  range/formatting/captures/node to `ContentModified`. Removes `get_tree_with_wait`
+  range/formatting/`node/*` to `ContentModified` and `captures` to `null` (its
+  re-sync signal). Removes `get_tree_with_wait`
   / `wait_for_epoch` / `ensure_document_parsed` blocking. Delivers *instant reads*
   and *lifecycle independent of parsing*. Without the dual-write this stage would
   reproduce the empty-after-edit regression, so it is mandatory here, not deferred.
@@ -296,11 +333,13 @@ inside the existing safety contracts at each step:
   synchronous-client reentrancy that keeps it out of `didChange`);
   `documentSymbol`/`documentColor` self-correct only on the client's next natural
   request (no active refresh added).
-- Position-critical requests (`captures`, `kakehashi/node/*`, range, formatting)
-  return `ContentModified` during the reparse window. The LSP spec does not mandate
-  client retry, so on a client that does not re-request (e.g. Neovim's built-in
+- Staleness-reject requests (`kakehashi/node/*`, range, formatting) return
+  `ContentModified` during the reparse window, and `kakehashi/captures` returns
+  `null` (its protocol re-sync signal). The LSP spec does not mandate retry on
+  `ContentModified`, so on a client that does not re-request (e.g. Neovim's built-in
   client for formatting) that keystroke's request **no-ops** until the next natural
-  request. Reclassifying captures/node from the original serve-stale intent is the
+  request; the captures `null` path is contracted to re-request. Reclassifying
+  captures/node from the original serve-stale intent is the
   cost of not forking a per-snapshot tracker view now.
 - The `#342`/`#374` stale-tree guarantee (a reader observes at least its own edit)
   is relaxed to "a reader observes a *consistent* but possibly one-edit-old

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -348,9 +348,11 @@ A single dedicated `rayon` pool sized `available_parallelism().saturating_sub(2)
 — strictly below `available_parallelism` whenever there are ≥3 cores, and reserving
 at least one core for the tokio workers + timer driver on 2-core machines (on a
 1-core host no isolation is achievable and the pool degrades to shared time-slicing)
-— runs **all** synchronous tree work: the parse, `populate` (region minting +
-content hash), the `compute_captures` / node layer walks, and the semantic-token
-injection fan-out (folded off the process-global Rayon pool into this one). Async
+— runs **all** synchronous tree work: the parse, `populate` (snapshot
+ordinal/geometry derivation + content hash, and — only at current version — the
+tracker reconciliation, §3), the `compute_captures` / node layer walks, and the
+semantic-token injection fan-out (folded off the process-global Rayon pool into
+this one). Async
 handlers hand a whole work-unit to the pool (bridged by a `oneshot`) and `await`
 the result, so no tree-CPU ever executes on a tokio worker. `DocumentParserPool`'s
 guard becomes a sync mutex (`std`/`parking_lot`) since acquisition now runs on pool

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -115,10 +115,11 @@ mapping is not one-to-one and must be stated precisely:
   per-lifetime guard.
 - `ParseState`'s three fields are each accounted for, none silently dropped:
   `has_tree` is **replaced** by the two slot predicates above (not re-homed); the
-  settings **`generation`** (token-cache invalidation) and the **`in_progress`**
-  flag **re-home** onto `ParseScheduler`'s per-document state (which already owns the
-  parse lifecycle), not onto the read-side slot. Deleting `parse_states` is
-  contingent on those two moves.
+  **`generation`** (a monotonic parse-run counter that `mark_parse_started` bumps
+  and `mark_parse_finished` checks to reject an out-of-order finish) and the
+  **`in_progress`** flag **re-home** onto `ParseScheduler`'s per-document state
+  (which already owns the parse lifecycle), not onto the read-side slot. Deleting
+  `parse_states` is contingent on those two moves.
 
 The store's tree/watermark CAS methods (four tree writes —
 `update_tree_if_text_unchanged`, `update_tree_if_text_and_language_unchanged`,
@@ -321,11 +322,16 @@ Any reader that must resolve against **live** positions is position-critical
   and captures/node/bridge additionally resolve against the live `content_version`
   tracker. The rejection signal differs by protocol contract:
   - The LSP requests return **`ContentModified`** (-32801) when
-    `content_version > parsed_version`. The spec does **not** mandate client
-    auto-retry — a client that does not re-request simply gets the answer on its
-    next natural request; formatting may no-op for that keystroke. Acceptable
-    because these are not per-keystroke-critical, and it never serves a
-    wrong-position result.
+    `content_version > parsed_version`, and never serve a wrong-position result.
+    The spec does not mandate client auto-retry, so the reject is split by trigger:
+    *implicit/background* requests (hover, signatureHelp, documentHighlight, inlayHint,
+    …) reject immediately and get their answer on the client's next natural request.
+    *Explicit, user-initiated, infrequent* actions (`formatting`, `rangeFormatting`,
+    `rename`/`prepareRename`) take a **brief bounded wait** (the reader's only
+    permitted wait besides first-parse) for the in-flight parse to land before
+    falling back to `ContentModified` — because a silent no-op on an action the user
+    consciously triggered is jarring, and the wait is affordable exactly because
+    these are not per-keystroke.
   - `kakehashi/captures` returns **`null`**, which is precisely the re-sync signal
     captures-protocol already defines ("on null, call full again") — a JSON-RPC
     *error* would violate that contract, since a captures client is only contracted
@@ -338,9 +344,11 @@ Any reader that must resolve against **live** positions is position-critical
     incarnation) — otherwise it stores nothing and returns `null`, so the lineage
     never records matches for a text the client no longer has.
 
-The only bounded wait that remains is the **first parse after `didOpen`** (the
-snapshot is `None`); it waits briefly on `watch::changed()` then serves `null` —
-the same decoupling parse-decoupled-document-lifecycle applies to its host tier.
+Only two bounded waits remain, both deliberate: the **first parse after `didOpen`**
+(the snapshot is `None`; it waits briefly on `watch::changed()` then serves `null` —
+the same decoupling parse-decoupled-document-lifecycle applies to its host tier),
+and the **explicit-action wait** above (`formatting`/`rename`). No *per-keystroke*
+read ever waits.
 
 *(Reclassifying `captures/full` and `kakehashi/node/*` off serve-stale is a
 deliberate scope choice: making them serve-stale would require the snapshot to own
@@ -451,8 +459,10 @@ inside the existing safety contracts at each step:
   read latency — with the tree still cleared on edit, readers keep blocking on the
   reparse (or fall into an on-demand full parse). And `spawn_blocking` **alone**
   trades HOL-blocking for CPU oversubscription on the default 512-thread blocking
-  pool, so it must be paired with a bounded pool regardless. It is adopted as
-  **Stage 1**, not the destination.
+  pool, so it must be paired with a bounded pool regardless. The *idea* — get the
+  CPU off the async workers — is what **Stage 1** adopts, but via the **bounded
+  Rayon pool** of §4, **not** raw `spawn_blocking`; and Stage 1 is a step toward the
+  snapshot destination, not the destination itself.
 - **Serve the pre-edit / seeded tree immediately without versioning
   (naive stale-serve).** Rejected. It is crash-safe (the `#348` hazard is a
   parse-seed/external-scanner issue, not a query-cursor issue, and the read paths
@@ -479,9 +489,10 @@ inside the existing safety contracts at each step:
 ### Positive
 
 - Document lifecycle is fully decoupled from parsing: `didChange` never awaits a
-  parse, and a reader never blocks on a parse once a snapshot exists (the sole
-  exception is the brief, bounded first-parse wait after `didOpen`, when no
-  snapshot exists yet).
+  parse, and no *per-keystroke* read blocks on a parse. The only two bounded waits
+  are deliberate and rare: the first-parse wait after `didOpen` (no snapshot yet)
+  and the explicit-action wait (`formatting`/`rename`) that trades a jarring no-op
+  for a short pause on a user-triggered command.
 - The async runtime is never blocked by tree-CPU: with all synchronous tree work
   on the bounded pool, a slow parse on one document cannot freeze the request loop,
   timers, diagnostics, or another document's async handlers — the specific defect

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -168,12 +168,19 @@ check-then-act rather than a cross-map TOCTOU against `Document.incarnation`):
   is unobservable; and a reader mid-compute holding a lifetime-`N` `Arc<ParseSnapshot>`
   rejects it against the live `N+1` incarnation. The one reader that *does* hold a
   `Receiver` — a first-parse waiter parked on `watch::changed()` — must be woken by
-  an **explicit close publish**: `didClose` sends a terminal `SnapshotSlot` state
-  (incarnation-invalidated / closed sentinel) rather than relying on the channel's
-  senders dropping, since stale parse tasks may still hold `Sender` clones that keep
-  the channel alive. The parked waiter observes the close state and falls through to
-  `null` — this is the wake the current `wait_for_epoch` gets from the watermark
-  sender dropping, made explicit because the snapshot channel outlives more clones.
+  an **explicit close publish**: `didClose` sets the slot to a terminal state whose
+  `current_incarnation` is a **reserved sentinel** (`u64::MAX`, never drawn by the
+  monotonic incarnation counter) with `snapshot = None`, rather than relying on the
+  channel's senders dropping — stale parse tasks may still hold `Sender` clones that
+  keep the channel alive. Setting the sentinel is load-bearing: keeping
+  `current_incarnation = N` would let a stale lifetime-`N` publish pass *both* the
+  incarnation check (`N == N`) and the bootstrap branch (`snapshot` is now `None`),
+  overwriting the terminal state with `Some(_)` and resurrecting the closed document
+  for the parked waiter. With the sentinel, that publish fails `incarnation ==
+  current_incarnation` (`N != u64::MAX`) and the waiter unambiguously observes the
+  closed state and falls through to `null` — the wake the current `wait_for_epoch`
+  gets from the watermark sender dropping, made explicit because the snapshot channel
+  outlives more clones.
 
 The incremental-parse **seed** re-homes onto `ParseScheduler`'s per-document state
 (accumulated `InputEdit`s + the `base_version` they extend). Two obligations,
@@ -551,10 +558,11 @@ inside the existing safety contracts at each step:
 
 ### Neutral
 
-- `didClose` publishes an explicit terminal/incarnation-invalidated `SnapshotSlot`
-  state (§2) — not merely dropping the channel, since stale parse-task `Sender`
-  clones can keep it alive — which wakes any reader parked on the first-parse
-  `watch::changed()`; a reopen starts the cell fresh at the next incarnation. A
+- `didClose` publishes a terminal `SnapshotSlot` with the sentinel
+  `current_incarnation = u64::MAX` and `snapshot = None` (§2) — not merely dropping
+  the channel, since stale parse-task `Sender` clones can keep it alive — which
+  wakes any reader parked on the first-parse `watch::changed()` and rejects any
+  stale-lifetime publish; a reopen starts the cell fresh at the next incarnation. A
   wait-free `latest_snapshot` borrow racing close+reopen may hand back the prior
   lifetime's snapshot momentarily, but the reader's mandatory
   `snapshot.incarnation == <live incarnation>` check (§2) rejects it, so a

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -108,10 +108,12 @@ mapping is not one-to-one and must be stated precisely:
   not express.
 - `parsed_version` is the watermark ticket; `current_incarnation` is the
   per-lifetime guard.
-- `ParseState`'s other fields do **not** vanish: the settings **`generation`**
-  (token-cache invalidation) and the **`in_progress`** flag re-home onto
-  `ParseScheduler`'s per-document state (which already owns the parse lifecycle),
-  not onto the read-side slot. Deleting `parse_states` is contingent on that move.
+- `ParseState`'s three fields are each accounted for, none silently dropped:
+  `has_tree` is **replaced** by the two slot predicates above (not re-homed); the
+  settings **`generation`** (token-cache invalidation) and the **`in_progress`**
+  flag **re-home** onto `ParseScheduler`'s per-document state (which already owns the
+  parse lifecycle), not onto the read-side slot. Deleting `parse_states` is
+  contingent on those two moves.
 
 The store's tree/watermark CAS methods (four tree writes —
 `update_tree_if_text_unchanged`, `update_tree_if_text_and_language_unchanged`,
@@ -486,6 +488,11 @@ inside the existing safety contracts at each step:
   `didClose` removed. (It is *not* closed by Stage 1, which leaves the current
   inline-parse fallbacks — `try_parse_and_update_document`, `selection_range_impl` —
   in place; those are the vector, and they are removed in Stage 2.)
+- Latent language-detection staleness is closed as a side effect: today a delayed
+  open parse racing an early `didChange` can leave `Document::language_id` at the
+  path-based guess for the document's lifetime even though the reparse's tree was
+  detected correctly. `ParseSnapshot.language` carries the *parse's* detected
+  language, so readers see the right one without a re-`didOpen`.
 - State and coupling shrink: two `watch` maps collapse to one, six store CAS /
   watermark methods to one publish primitive, and the `pending_seed` invariant
   surface on `Document` is deleted (favorable on the State > Coupling > Complexity

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -182,9 +182,12 @@ The incremental-parse **seed** re-homes onto `ParseScheduler`'s per-document sta
 (accumulated `InputEdit`s + the `base_version` they extend). Two obligations,
 enforced by co-location today, become explicit scheduler invariants:
 
-- The seed is applied to the snapshot's tree **iff `snapshot.parsed_version == base_version`**; on mismatch (a publish raced), it
-  reseeds from the current snapshot and parses — never applies edits to a tree
-  they do not match (the `#348` external-scanner corruption).
+- The seed is applied to the snapshot's tree **iff `snapshot.parsed_version ==
+  base_version` and `snapshot.tree` is `Some`**; on a version mismatch (a publish
+  raced) *or* a tree-less base snapshot (resolved-but-parser-less), there is nothing
+  to incrementally seed from, so it parses from scratch — it never applies edits to
+  a tree they do not match (the `#348` external-scanner corruption) nor to an absent
+  tree.
 - A full-text sync **resets** `(pending_edits, base_version)`, so it parses from
   scratch. "Leaves no accumulated edits" is an explicit reset, not an emergent
   property.
@@ -219,6 +222,13 @@ watermark can trail the input indefinitely under a fast enough edit stream). The
 refresh path re-drives the client each time a fresher snapshot lands; the model
 does not promise a bounded edit-lag without the fair-admission backpressure §4
 defers.
+
+A handler resolves `latest_snapshot(uri)` **once**, at entry, and threads the
+resulting `Arc<ParseSnapshot>` (a refcount clone) into any parallel fan-out —
+never calling `latest_snapshot` per fan-out task, which would hammer the store's
+`DashMap` shard from every worker. The single up-front resolution also pins one
+consistent snapshot for the whole request; a publish landing mid-fan-out is
+observed by the *next* request, not by half of this one.
 
 Region identity is the load-bearing subtlety, and it forces a clean split. The
 shared `NodeTracker` (lazy-node-identity-tracking) is a **mutable, edit-shifted**
@@ -429,10 +439,14 @@ inside the existing safety contracts at each step:
   stores may transiently sit at different versions (a lost legacy CAS just reseeds
   next pass), but no **reader** sees the difference because every reader reads the
   snapshot, not the legacy tree. Split `populate` into ordinal/geometry derivation
-  (snapshot-owned) and the current-version tracker reconciliation (§3), and move the
-  grammar auto-install that `compute_captures` does inline
-  (`ensure_injection_languages_loaded_for_document`) into that reconciliation under
-  `edit_lock` — the read handlers stop being install triggers. Convert
+  (snapshot-owned) and the current-version tracker reconciliation (§3). Take the
+  grammar auto-install off the read handlers (`compute_captures` no longer triggers
+  `ensure_injection_languages_loaded_for_document` inline): the parse loop
+  *detects* a missing injected grammar and **spawns the install asynchronously,
+  never under `edit_lock`** — an install is seconds of download + compile and must
+  not block concurrent `didChange` edits — with the region re-minted on a later
+  reconciliation once the grammar lands. Only the fast tracker-mint itself runs
+  under `edit_lock`. Convert
   `semanticTokens` to serve-stale + the refresh trigger; the whole-document
   passive-refresh family (`documentSymbol`/`documentColor`/`documentLink`/
   `foldingRange`/`codeLens`/pull-`diagnostic`) to serve-stale; the position/range

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -284,7 +284,13 @@ Any reader that must resolve against **live** positions is position-critical
   `didChange` handler — `didChange` deliberately does not emit refresh because a
   synchronous client (vim-lsp on Vim) cannot answer a server request while
   processing a notification; emitting from the off-ingress loop, after the
-  notification returns, avoids that reentrancy.
+  notification returns, avoids that reentrancy. This **reverses the current
+  handler**, which *rejects* a stale/superseded `semanticTokens` full/delta with
+  `None` (via `check_text_staleness` and the merged compute-superseded
+  `is_cancelled` bail) rather than serving a trailing snapshot. Stage 2 replaces
+  reject-on-stale with serve-stale + refresh; the `CancelToken` bail then narrows to
+  reclaiming the superseded compute's CPU (§4) without also discarding the — now
+  servable — snapshot. This is a decision Stage 2 deliberately overwrites.
 - **Serve-stale, passively refreshed** — whole-document, no-position reads:
   `documentSymbol`, `documentColor`, `documentLink`, `foldingRange`, `codeLens`
   (the `whole_document_preferred_fan_out` family), and pull-mode
@@ -361,6 +367,23 @@ unrelated async I/O, diagnostics, or the request loop. Turning "no starvation" i
 a real guarantee requires **explicit fair admission** — a focused-document priority
 queue plus a per-document in-flight concurrency cap — which this decision names as
 required follow-on work, not something the bounded pool delivers on its own.
+
+**Cooperative cancellation is the complement to the pool, and it has already
+landed on the current architecture.** The pool isolates tree-CPU but cannot stop a
+*superseded* compute: Rayon does not preempt, and dropping the `oneshot`-bridged
+future leaves the work-unit running to completion — wasting a pool thread that is
+now scarcer than the process-global Rayon pool it replaces. The merged `CancelToken`
+(`src/cancel.rs`: an `Arc<AtomicBool>` flipped by `SemanticRequestTracker` on
+supersede, `$/cancelRequest`, or `didClose`, which the compute polls at coarse
+checkpoints — the injection discovery loop and the per-region fan-out — and bails)
+closes exactly that gap. It **composes with** this design rather than competing, so
+it is carried forward, not re-derived: the token is an architecture-independent
+primitive, **re-homed at Stage 1 as a cancellation hook on the bounded-pool
+work-unit (the `oneshot` bridge) contract**. Keep the split explicit — §2's terminal
+`SnapshotSlot` + incarnation rejection guarantees *correctness* on close/supersede
+(a stale or cross-lifetime result is never served), while the `CancelToken` is the
+orthogonal *CPU-reclamation* mechanism (a superseded compute stops burning a pool
+thread); both are wanted, and neither subsumes the other.
 
 ### 5. Staged rollout
 
@@ -529,3 +552,9 @@ populate off the async workers) and Stage 2 (which removes the reader wait) and 
 not carried forward on its own. The delete-on-supersede pruning of the overtaken
 per-document-parse-scheduler passages is deferred to Stage 3, when the behavior
 they describe is actually removed.
+
+One piece of the destination is **already merged** onto the current architecture:
+the cooperative-cancellation primitive (`CancelToken` + `SemanticRequestTracker`
+compute bail-out). It is not re-derived — Stage 1 re-homes it as the bounded-pool
+work-unit's cancellation hook (§4), and Stage 2 narrows its role from
+reject-on-stale to CPU-reclamation-under-serve-stale (§3).

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -250,8 +250,9 @@ So a stale-tree reader reads self-consistent ordinals + geometry from its own
 snapshot and touches no shared identity index (the mint-race and the
 undefined-id-on-gate-failure both vanish); token reuse is content-keyed; and the
 one identity that genuinely needs cross-edit stability (the bridge's) keeps the
-tracker that already provides it. This ADR commits only to *not* minting shared
-identities off the parse/read path.
+tracker that already provides it. This ADR commits only to *not* mutating shared
+identities from a **stale** parse pass or any read path — the current-version
+reconciliation above is the one place a parse still mints them.
 
 Any reader that must resolve against **live** positions is position-critical
 (below).

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -406,7 +406,9 @@ inside the existing safety contracts at each step:
 ### Positive
 
 - Document lifecycle is fully decoupled from parsing: `didChange` never awaits a
-  parse; readers never block on one.
+  parse, and a reader never blocks on a parse once a snapshot exists (the sole
+  exception is the brief, bounded first-parse wait after `didOpen`, when no
+  snapshot exists yet).
 - The async runtime is never blocked by tree-CPU: with all synchronous tree work
   on the bounded pool, a slow parse on one document cannot freeze the request loop,
   timers, diagnostics, or another document's async handlers — the specific defect

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -457,12 +457,15 @@ inside the existing safety contracts at each step:
 
 ### Neutral
 
-- `didClose` drops the single channel (waking any reader parked on the first-parse
-  `watch::changed()`); a reopen installs a fresh `SnapshotSlot`. A wait-free
-  `latest_snapshot` borrow racing close+reopen may hand back the prior lifetime's
-  snapshot momentarily, but the reader's mandatory `snapshot.incarnation == <live
-  incarnation>` check (§2) rejects it, so a cross-lifetime snapshot is discarded
-  rather than served — it degrades to the empty/`null` path, not stale data.
+- `didClose` publishes an explicit terminal/incarnation-invalidated `SnapshotSlot`
+  state (§2) — not merely dropping the channel, since stale parse-task `Sender`
+  clones can keep it alive — which wakes any reader parked on the first-parse
+  `watch::changed()`; a reopen starts the cell fresh at the next incarnation. A
+  wait-free `latest_snapshot` borrow racing close+reopen may hand back the prior
+  lifetime's snapshot momentarily, but the reader's mandatory
+  `snapshot.incarnation == <live incarnation>` check (§2) rejects it, so a
+  cross-lifetime snapshot is discarded rather than served — it degrades to the
+  empty/`null` path, not stale data.
 - The `ParseScheduler` (one loop per document, coalescing, panic re-arm),
   `incarnation`, the `edit_lock`, and the incremental-seed concept are retained —
   re-homed, not removed.

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -104,7 +104,7 @@ mapping is not one-to-one and must be stated precisely:
 
 - Two distinct predicates replace the old single `has_tree`: **`resolved`** =
   `slot.snapshot.is_some()` (a parse for this lifetime has completed at least once)
-  and **`has_tree`** = `slot.snapshot.and_then(|s| s.tree.as_ref()).is_some()`. A
+  and **`has_tree`** = `slot.snapshot.as_ref().and_then(|s| s.tree.as_ref()).is_some()`. A
   **resolved-but-tree-less** outcome — a parse that completed with no usable tree
   (no parser installed, install failed, or a quarantined crashed grammar), distinct
   from the pre-first-parse `None` — is `resolved && !has_tree`; it advances
@@ -349,7 +349,7 @@ future decision forks the tracker per snapshot, they can move to serve-stale.)*
 
 ### 4. All tree-CPU runs on one bounded compute pool
 
-A single dedicated `rayon` pool sized `available_parallelism().saturating_sub(2).max(1)`
+A single dedicated `rayon` pool sized `available_parallelism().map(|n| n.get()).unwrap_or(2).saturating_sub(2).max(1)`
 — strictly below `available_parallelism` whenever there are ≥3 cores, and reserving
 at least one core for the tokio workers + timer driver on 2-core machines (on a
 1-core host no isolation is achievable and the pool degrades to shared time-slicing)
@@ -527,7 +527,7 @@ inside the existing safety contracts at each step:
   by one or more edits, and knows it via the version tag." Correctness now rests on
   the version tag + refresh rather than on the reader having waited.
 - Folding the semantic fan-out from the process-global Rayon pool (all cores) into
-  the bounded `available_parallelism().saturating_sub(2).max(1)` pool caps
+  the bounded `available_parallelism().map(|n| n.get()).unwrap_or(2).saturating_sub(2).max(1)` pool caps
   single-document tokenization throughput (e.g. ~2 of 4 cores for one huge file) in
   exchange for
   cross-document isolation. Acceptable given the isolation goal, but a real

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -155,8 +155,11 @@ check-then-act rather than a cross-map TOCTOU against `Document.incarnation`):
   (`incarnation && text && language`) therefore reduces to `incarnation && version`.
 - **Isolation is per-request re-resolution + incarnation validation, not cell identity.** A `latest_snapshot(uri)` call resolves the *current* cell from the
   store each time and never caches a `Receiver` across requests, and it validates
-  `snapshot.incarnation == <live document incarnation>` before serving — the cell
-  and the document inputs are one per-URI lifetime object, so there is one
+  `snapshot.incarnation == <live document incarnation>` before serving. To keep that
+  a **single `DashMap` lookup** (not a `documents` lookup *plus* a separate
+  channel-map lookup), the `SnapshotSlot` `watch` channel lives **on the `Document`
+  entry itself** — inputs and slot are one per-URI lifetime object, so one lookup
+  yields both the live incarnation and the latest snapshot, and there is one
   authoritative incarnation. This makes cell lifecycle irrelevant to correctness:
   on reopen the store may drop and recreate the cell, and a prior-lifetime parse
   task holding a stale `Sender` clone can still publish — but only into that now
@@ -165,8 +168,9 @@ check-then-act rather than a cross-map TOCTOU against `Document.incarnation`):
   rejects it against the live `N+1` incarnation. The one reader that *does* hold a
   `Receiver` — a first-parse waiter parked on `watch::changed()` — must be woken by
   an **explicit close publish**: `didClose` sets the slot to a terminal state whose
-  `current_incarnation` is a **reserved sentinel** (`u64::MAX`, never drawn by the
-  monotonic incarnation counter) with `snapshot = None`, rather than relying on the
+  `current_incarnation` is a **reserved sentinel** (`u64::MAX` — the counter starts
+  at 1 and must reserve this value, guarding its `fetch_add` against ever drawing
+  it) with `snapshot = None`, rather than relying on the
   channel's senders dropping — stale parse tasks may still hold `Sender` clones that
   keep the channel alive. Setting the sentinel is load-bearing: keeping
   `current_incarnation = N` would let a stale lifetime-`N` publish pass *both* the
@@ -253,10 +257,16 @@ The decision therefore **separates three concerns that today all ride the tracke
   and is not claimed to be — an edit that inserts a region renumbers ordinals.
 - **Cross-edit token reuse** (the injection-token-cache-reuse benefit): the cache
   is already content-validated at read (its entry carries `validity_hash` = content
-  ⊕ language, and `generation`), but its *key* is today the tracker ULID. The change
-  is to **drop `region_id` from the key** — key on `(uri, content_hash,
-  validity_hash, generation)` — so two snapshots' byte-identical regions reuse
-  tokens without any stable id. That in turn reworks **eviction**:
+  ⊕ language, and the settings `generation`), but its *key* is today the tracker
+  ULID. The change is to **drop `region_id` from the key** — key on
+  `(uri, content_hash)`, keeping `validity_hash` and the settings `generation` as
+  entry metadata checked at read, not as key components. The key **must stay stable
+  across edits** for reuse to work, so it must not include anything that turns over
+  per edit; the `generation` here is the **config/settings epoch** (bumped only on a
+  settings reload, the #530 discipline — *not* the per-edit parse-run counter), so a
+  byte-identical region reuses across edits and is invalidated only on a real config
+  change. Two snapshots' byte-identical regions thus reuse tokens without any stable
+  id. That in turn reworks **eviction**:
   `invalidate_for_edits` currently point-deletes by `region_id` via the interval
   tree, which has no target once the key drops it, so it must become a content-keyed
   clear (or a side index) — losing the "typed region preserves reuse on an unrelated
@@ -453,11 +463,12 @@ inside the existing safety contracts at each step:
   (snapshot-owned) and the current-version tracker reconciliation (§3). Take the
   grammar auto-install off the read handlers (`compute_captures` no longer triggers
   `ensure_injection_languages_loaded_for_document` inline): the parse loop
-  *detects* a missing injected grammar and **spawns the install asynchronously,
-  never under `edit_lock`** — an install is seconds of download + compile and must
-  not block concurrent `didChange` edits — with the region re-minted on a later
-  reconciliation once the grammar lands. Only the fast tracker-mint itself runs
-  under `edit_lock`. Convert
+  *detects* a missing injected grammar and spawns the install as a **detached
+  off-ingress task**. The download + compile (seconds) runs entirely on that task,
+  **never on the ingress path and never under `edit_lock`** — only the O(1)
+  detect-and-spawn is near the lock, and even that need not hold it. The region is
+  re-minted on a later reconciliation once the grammar lands. Only the fast
+  tracker-mint itself runs under `edit_lock`. Convert
   `semanticTokens` **and `captures/full`** to serve-stale (the latter reserving
   `null` for no-snapshot / no-lineage, not routine staleness); the whole-document
   passive-refresh family (`documentSymbol`/`documentColor`/`documentLink`/
@@ -477,7 +488,11 @@ inside the existing safety contracts at each step:
   primitive, delete the watermark waits, and prune the now-superseded passages
   from per-document-parse-scheduler (its tree-clear-on-edit and watermark/epoch
   sections) per delete-on-supersede — done **here**, when the behavior actually
-  changes, not before.
+  changes, not before. Per the repo's structural-vs-behavioral separation
+  guideline, the **pure dead-code / doc-pruning** parts of this stage (dropping the
+  now-unused fields, deleting the superseded ADR passages) land as **separate PRs**
+  from the behavioral collapse (the CAS→publish merge, scheduler seed re-homing),
+  each shipped only after its behavioral prerequisite is in.
 
 ## Considered Options
 

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -70,10 +70,15 @@ gates:
   `didClose`). Removing it reopens the stale-base race that pre-clamping panicked
   on in `replace_range`; "mutates inputs and returns" must not be read as
   dropping it.
-- Content-based **language detection** stays an input concern: `didOpen`/the
-  language-detect path writes `language_id` on the `Document`. Derivation reads
-  it and copies it into the snapshot; derivation never writes back to the input
-  (that would be the layering violation the model exists to avoid).
+- **Language detection is split by layer.** The input `language_id` is the
+  client-declared / path-based value `didOpen` records and never changes within a
+  lifetime (a genuine relabel is a reopen → new incarnation, which is why the CAS
+  in §2 folds language into incarnation). The *parse* additionally re-runs
+  content-based detection (its `detect_language(path, text, language_id)`) and
+  records the result as the snapshot's own **derived** `language` — which may refine
+  the input guess. Derivation never writes that refinement **back** to the input
+  (the layering violation the model avoids); the snapshot simply carries the
+  more-accurate detected language, and readers use the snapshot's.
 
 ### 2. Parsing publishes a versioned `ParseSnapshot`
 

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -318,8 +318,8 @@ Any reader that must resolve against **live** positions is position-critical
   non-visual-jarring; this is the deliberate, user-sanctioned relaxation.
 - **Staleness-reject** — every **position/range** reader, because its
   coordinates are authored against the **live** text: `semanticTokens/range`,
-  `kakehashi/node/*`, `selectionRange`, `formatting`, `rangeFormatting`, `captures`
-  (full and range), **and the ~16 position/range bridge-context requests** that
+  `kakehashi/node/*`, `selectionRange`, `formatting`, `rangeFormatting`,
+  `captures/range`, **and the ~16 position/range bridge-context requests** that
   resolve an injection region before forwarding to a downstream server (hover,
   definition, references, declaration, typeDefinition, implementation, rename /
   prepareRename, completion, signatureHelp, documentHighlight, linkedEditingRange,
@@ -339,16 +339,24 @@ Any reader that must resolve against **live** positions is position-critical
     `ContentModified` — because a silent no-op on an action the user consciously
     triggered is jarring, and the wait is affordable exactly because these are not
     per-keystroke.
-  - `kakehashi/captures` returns **`null`**, which is precisely the re-sync signal
-    captures-protocol already defines ("on null, call full again") — a JSON-RPC
-    *error* would violate that contract, since a captures client is only contracted
-    to re-request on null. So a stale captures request serves `null` and the client
-    re-issues, self-healing on its next request. A captures `full` that *does*
-    compute (snapshot current at entry) can still race an edit during its async
-    compute; its lineage store must therefore carry the computed `parsed_version`
-    and, under `edit_lock`, install the lineage **only if `incarnation` and the current `content_version` still match it** (today `store_lineage` re-checks only
-    incarnation) — otherwise it stores nothing and returns `null`, so the lineage
-    never records matches for a text the client no longer has.
+  - `kakehashi/captures/range` uses `null` where the LSP requests use
+    `ContentModified` — `null` is the re-sync signal captures-protocol already
+    defines ("on null, call full again"), and a JSON-RPC *error* would violate that
+    contract. But `null`-**on-routine-staleness must be avoided for `captures/full`**:
+    it is a per-keystroke highlighter, so returning `null` while the snapshot merely
+    trails, against a client contracted to re-request on `null`, is a busy-spin
+    (edit → stale → `null` → re-request → still stale → …). So `captures/full`
+    instead **serves-stale**, like `semanticTokens`: it returns the latest snapshot's
+    matches (one edit behind, healing on the next edit's captures request, which the
+    client sends per keystroke anyway), and reserves `null` for the cases the
+    protocol actually means it — no snapshot yet (pre-first-parse) or a delta with no
+    lineage. The match node-ids are the snapshot's own; a one-edit-stale id
+    self-heals, the same relaxation `semanticTokens` takes. When a served `full`
+    installs lineage, it carries the computed `parsed_version` and — under
+    `edit_lock` — stores it **only if `incarnation` and the current `content_version`
+    still match** (today `store_lineage` re-checks only incarnation), else stores
+    nothing and returns `null`, so the lineage never records matches for a text the
+    client no longer has.
 
 Only two bounded waits remain, both deliberate: the **first parse after `didOpen`**
 (the snapshot is `None`; it waits briefly on `watch::changed()` then serves `null` —
@@ -356,10 +364,13 @@ the same decoupling parse-decoupled-document-lifecycle applies to its host tier)
 and the **explicit-action wait** above (`formatting`/`rename`). No *per-keystroke*
 read ever waits.
 
-*(Reclassifying `captures/full` and `kakehashi/node/*` off serve-stale is a
-deliberate scope choice: making them serve-stale would require the snapshot to own
-a versioned tracker view, a larger change than this decision commits to. If a
-future decision forks the tracker per snapshot, they can move to serve-stale.)*
+*(`kakehashi/node/*` stays staleness-reject rather than serve-stale: a node
+request resolves to a specific live-position node, so a stale-position answer is
+wrong, not merely late — and unlike `captures/full` it has no per-keystroke
+re-request to heal it. `captures/full` can afford serve-stale precisely because its
+matches are snapshot-consistent and its per-edit re-request heals a one-edit-stale
+node-id; giving `node/*` the same would need a per-snapshot tracker view, which
+this decision does not commit to.)*
 
 ### 4. All tree-CPU runs on one bounded compute pool
 
@@ -447,12 +458,15 @@ inside the existing safety contracts at each step:
   not block concurrent `didChange` edits — with the region re-minted on a later
   reconciliation once the grammar lands. Only the fast tracker-mint itself runs
   under `edit_lock`. Convert
-  `semanticTokens` to serve-stale + the refresh trigger; the whole-document
+  `semanticTokens` **and `captures/full`** to serve-stale (the latter reserving
+  `null` for no-snapshot / no-lineage, not routine staleness); the whole-document
   passive-refresh family (`documentSymbol`/`documentColor`/`documentLink`/
   `foldingRange`/`codeLens`/pull-`diagnostic`) to serve-stale; the position/range
-  family — `semanticTokens/range`, `node/*`, `formatting`/`rangeFormatting`, the
-  bridge-context requests, **and `selectionRange`, whose inline `parse_with_pool` + `update_document` must be replaced by `latest_snapshot`** — to `ContentModified`;
-  and `captures` to `null` (its re-sync signal). Removes `get_tree_with_wait` /
+  family — `semanticTokens/range`, `node/*`, `captures/range`,
+  `formatting`/`rangeFormatting`, the bridge-context requests, **and
+  `selectionRange`, whose inline `parse_with_pool` + `update_document` must be
+  replaced by `latest_snapshot`** — to `ContentModified` (or `null` for
+  `captures/range`). Removes `get_tree_with_wait` /
   `wait_for_epoch` / `ensure_document_parsed` **and** the inline-parse fallbacks
   (`try_parse_and_update_document`, `selection_range_impl`) — closing the
   resurrection vector. Delivers *instant reads* and *lifecycle independent of
@@ -534,14 +548,15 @@ inside the existing safety contracts at each step:
   synchronous-client reentrancy that keeps it out of `didChange`);
   `documentSymbol`/`documentColor` self-correct only on the client's next natural
   request (no active refresh added).
-- Staleness-reject requests (`kakehashi/node/*`, range, formatting) return
-  `ContentModified` during the reparse window, and `kakehashi/captures` returns
-  `null` (its protocol re-sync signal). The LSP spec does not mandate retry on
-  `ContentModified`, so on a client that does not re-request (e.g. Neovim's built-in
-  client for formatting) that keystroke's request **no-ops** until the next natural
-  request; the captures `null` path is contracted to re-request. Reclassifying
-  captures/node from the original serve-stale intent is the
-  cost of not forking a per-snapshot tracker view now.
+- Staleness-reject requests (`kakehashi/node/*`, range requests, formatting) return
+  `ContentModified` during the reparse window (`captures/range` returns `null`, its
+  protocol re-sync signal). The LSP spec does not mandate retry on `ContentModified`,
+  so on a client that does not re-request (e.g. Neovim's built-in client for
+  formatting) that keystroke's request **no-ops** until the next natural request;
+  `formatting`/`rename`/`selectionRange` mitigate with the brief bounded wait.
+  `captures/full` is *not* in this class — it serves-stale (§3) to avoid a
+  null-then-re-request busy-spin during typing. Keeping `node/*` staleness-reject
+  rather than serve-stale is the cost of not forking a per-snapshot tracker view now.
 - The `#342`/`#374` stale-tree guarantee (a reader observes at least its own edit)
   is relaxed to "a reader observes a *consistent* snapshot that may trail the input
   by one or more edits, and knows it via the version tag." Correctness now rests on


### PR DESCRIPTION
## What

An aspirational ADR — `docs/architecture-decisions/parse-snapshot-architecture.md` — recording the decision to decouple document lifecycle from parsing, to fix the post-v0.7.0 regression where large injection-heavy markdown highlights at **0.5–1.4 s per keystroke** and a slow document blocks unrelated documents.

## Root cause (measured, this session)

`didChange` clears the reader-visible tree (`apply_edit_and_seed` → `self.tree.take()`), so every tree reader **blocks** on the off-ingress reparse. The reader wait was measured entirely in `wait_for_epoch`, blowing past its 200 ms cap to **1.4 s** — a `tokio::time::timeout` defeated by **worker starvation**: `populate_injections` and `compute_captures` run **inline on the tokio workers**, saturating the pool so the timer can't fire and other documents starve.

## Decision

Model the document the way salsa/rust-analyzer/gopls do — **versioned inputs** + a **versioned derived `ParseSnapshot`**:

- `Document` = inputs only (`text` + `content_version`, no tree); `didChange` never awaits a parse.
- Parsing publishes an immutable `ParseSnapshot { text, tree, parsed_version, incarnation, injection_regions }` into **one per-URI `watch` cell** (subsumes `parse_states` + `watermarks`; six CAS methods → one publish primitive).
- Readers take a non-blocking `latest_snapshot()`, in three classes: **serve-stale + refresh** (`semanticTokens`); **serve-stale + passive** (whole-document reads); **staleness-reject** (position/range → `ContentModified`, `captures` → `null`).
- Injection region identity is **snapshot-owned** (derived); the shared `NodeTracker` ULID stays for the bridge via a current-version reconciliation step.
- **All tree-CPU on one bounded compute pool** (`available_parallelism − 2`), so the async runtime is never blocked.
- The **merged cooperative-cancellation** `CancelToken` complements the pool (it stops the superseded computes Rayon can't preempt) and is re-homed as the pool work-unit's cancellation hook.

Rolled out in **3 stages** (1: CPU→pool; 2: snapshot reads; 3: consolidate). Docs-only — no code change.

## Review

Passed the local pipeline before this PR: multi-round `/review`, **8 rounds of codex** (converged to "no comments to provide"), and **pi-review** (2 rounds, "no substantive error; all claims supported by source"). The design was materially hardened through review — cross-lifetime isolation via incarnation validation, a three-way region-identity split, honest scoping of the pool's guarantee, and precise commit sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)