### PR TITLE
perf(semantic): snapshot-owned injection discovery — never discover twice

### DIFF
--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -138,11 +138,12 @@ def main() -> None:
         first_line_len = len(text.split("\n", 1)[0])
         t0 = time.time()
         req_times = []
+        line_has_extra = False
         for i in range(args.requests):
             for j in range(args.edits):
                 # Toggle a trailing char on line 0 so the text genuinely changes
                 # each time (a no-op didChange would be deduped by hashes).
-                grow = (i + j) % 2 == 0
+                grow = not line_has_extra
                 version += 1
                 if grow:
                     change = {"range": {"start": {"line": 0, "character": first_line_len},
@@ -152,6 +153,7 @@ def main() -> None:
                     change = {"range": {"start": {"line": 0, "character": first_line_len},
                                         "end": {"line": 0, "character": first_line_len + 1}},
                               "text": ""}
+                line_has_extra = grow
                 notify("textDocument/didChange", {
                     "textDocument": {"uri": uri, "version": version},
                     "contentChanges": [change]})

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -24,12 +24,20 @@ from gen_session import gen_rust, gen_markdown_injections  # noqa: E402
 def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--bin", required=True)
+    ap.add_argument("--server-arg", action="append", default=[],
+                    help="extra argument passed to the server (repeatable), e.g. "
+                         "--server-arg=--config-file --server-arg=/path/lsp.toml "
+                         "to reproduce a real user configuration")
     ap.add_argument("--lang", choices=["rust", "markdown"], default="rust")
     ap.add_argument("--size", type=int, default=150)
     ap.add_argument("--requests", type=int, default=300)
     ap.add_argument("--file", help="drive with this file's content instead of a "
                                    "generated document (language inferred from the "
                                    "extension, falling back to --lang)")
+    ap.add_argument(
+        "--settle", type=float, default=0.3,
+        help="seconds to wait after didOpen before the first request "
+             "(0 reproduces a client that requests immediately)")
     ap.add_argument(
         "--edits", type=int, default=0,
         help="simulate typing: before each request, send this many incremental "
@@ -64,7 +72,7 @@ def main() -> None:
     env = dict(os.environ, KAKEHASHI_DATA_DIR=args.data_dir)
     # Let the server's stderr through (it's silent unless RUST_LOG is set) so a
     # crash or panic is visible instead of being swallowed during profiling.
-    srv = subprocess.Popen([args.bin], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+    srv = subprocess.Popen([args.bin, *args.server_arg], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                            env=env)
     rid = 0
 
@@ -118,12 +126,14 @@ def main() -> None:
         notify("initialized", {})
         notify("textDocument/didOpen", {"textDocument": {
             "uri": uri, "languageId": lang, "version": 1, "text": text}})
-        time.sleep(0.3)  # let the initial parse settle
+        if args.settle > 0:
+            time.sleep(args.settle)  # let the initial parse settle
 
         ok, canceled, tokens = 0, 0, 0
         version = 1
         first_line_len = len(text.split("\n", 1)[0])
         t0 = time.time()
+        req_times = []
         for i in range(args.requests):
             for j in range(args.edits):
                 # Toggle a trailing char on line 0 so the text genuinely changes
@@ -143,7 +153,9 @@ def main() -> None:
                     "contentChanges": [change]})
                 # a beat for the off-ingress reparse to run (the profiled work)
                 time.sleep(0.01)
+            t_req = time.time()
             resp = request("textDocument/semanticTokens/full", {"textDocument": {"uri": uri}})
+            req_times.append(time.time() - t_req)
             if "error" in resp:
                 # Only -32800 (request cancelled) is expected here; any other
                 # error means a broken setup that would make the profile
@@ -173,6 +185,8 @@ def main() -> None:
     n_lines = len(text.splitlines())
     source = (f"file={args.file} ({n_bytes}B/{n_lines}L)"
               if args.file else f"size={args.size}")
+    firsts = " ".join(f"{t*1000:.0f}" for t in req_times[:5])
+    sys.stderr.write(f"[drive] first-request ms: {firsts}\n")
     sys.stderr.write(
         f"[drive] lang={lang} {source} requests={args.requests} "
         f"ok={ok} canceled={canceled} tokens/req={tokens} "

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -31,6 +31,13 @@ def main() -> None:
                                    "generated document (language inferred from the "
                                    "extension, falling back to --lang)")
     ap.add_argument(
+        "--edits", type=int, default=0,
+        help="simulate typing: before each request, send this many incremental "
+             "didChange edits (appending/removing a char at the end of the first "
+             "line), then request tokens. Exercises the edit->reparse->recompute "
+             "cycle instead of the unchanged-document cache hit; token counts "
+             "may reflect a trailing snapshot (serve-stale).")
+    ap.add_argument(
         "--data-dir", default=os.path.join(os.getcwd(), "deps/test/kakehashi"),
         help="parser/query data dir; must already contain installed parsers "
              "(populated by `cargo test --features e2e` or `make deps/tree-sitter`), "
@@ -114,8 +121,28 @@ def main() -> None:
         time.sleep(0.3)  # let the initial parse settle
 
         ok, canceled, tokens = 0, 0, 0
+        version = 1
+        first_line_len = len(text.split("\n", 1)[0])
         t0 = time.time()
-        for _ in range(args.requests):
+        for i in range(args.requests):
+            for j in range(args.edits):
+                # Toggle a trailing char on line 0 so the text genuinely changes
+                # each time (a no-op didChange would be deduped by hashes).
+                grow = (i + j) % 2 == 0
+                version += 1
+                if grow:
+                    change = {"range": {"start": {"line": 0, "character": first_line_len},
+                                        "end": {"line": 0, "character": first_line_len}},
+                              "text": "x"}
+                else:
+                    change = {"range": {"start": {"line": 0, "character": first_line_len},
+                                        "end": {"line": 0, "character": first_line_len + 1}},
+                              "text": ""}
+                notify("textDocument/didChange", {
+                    "textDocument": {"uri": uri, "version": version},
+                    "contentChanges": [change]})
+                # a beat for the off-ingress reparse to run (the profiled work)
+                time.sleep(0.01)
             resp = request("textDocument/semanticTokens/full", {"textDocument": {"uri": uri}})
             if "error" in resp:
                 # Only -32800 (request cancelled) is expected here; any other

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -35,6 +35,10 @@ def main() -> None:
                                    "generated document (language inferred from the "
                                    "extension, falling back to --lang)")
     ap.add_argument(
+        "--captures", action="store_true",
+        help="also send kakehashi/captures/full (injection mode) per request, "
+             "mirroring a captures-protocol highlighter client")
+    ap.add_argument(
         "--settle", type=float, default=0.3,
         help="seconds to wait after didOpen before the first request "
              "(0 reproduces a client that requests immediately)")
@@ -155,6 +159,12 @@ def main() -> None:
                 time.sleep(0.01)
             t_req = time.time()
             resp = request("textDocument/semanticTokens/full", {"textDocument": {"uri": uri}})
+            if args.captures:
+                request("kakehashi/captures/full",
+                        {"textDocument": {"uri": uri}, "kind": "highlights", "injection": True})
+                request("kakehashi/captures/full/delta",
+                        {"textDocument": {"uri": uri}, "kind": "highlights",
+                         "previousResultId": "warm-miss"})
             req_times.append(time.time() - t_req)
             if "error" in resp:
                 # Only -32800 (request cancelled) is expected here; any other

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -135,7 +135,9 @@ def main() -> None:
 
         ok, canceled, tokens = 0, 0, 0
         version = 1
-        first_line_len = len(text.split("\n", 1)[0])
+        # LSP `character` offsets are UTF-16 code units, not Unicode code
+        # points — a non-ASCII first line would make the edit range invalid.
+        first_line_len = len(text.split("\n", 1)[0].encode("utf-16-le")) // 2
         t0 = time.time()
         req_times = []
         line_has_extra = False

--- a/benches/profile/profile.sh
+++ b/benches/profile/profile.sh
@@ -38,6 +38,7 @@ while [ $# -gt 0 ]; do
     --size) SIZE="$2"; shift 2;;
     --requests) REQUESTS="$2"; shift 2;;
     --edits) EDITS="$2"; shift 2;;
+    --file) FILE_ARG="$2"; shift 2;;
     *) echo "unknown arg: $1" >&2; exit 1;;
   esac
 done
@@ -69,7 +70,7 @@ dsymutil "$BIN"
 
 echo "==> Recording with samply (lang=$LANG_ARG size=$SIZE requests=$REQUESTS)"
 samply record -s -o "$OUT/profile.json.gz" \
-  -- python3 "$HERE/drive.py" --bin "./$BIN" --lang "$LANG_ARG" --size "$SIZE" --requests "$REQUESTS" --edits "${EDITS:-0}"
+  -- python3 "$HERE/drive.py" --bin "./$BIN" --lang "$LANG_ARG" --size "$SIZE" --requests "$REQUESTS" --edits "${EDITS:-0}" ${FILE_ARG:+--file "$FILE_ARG"}
 
 echo "==> Analyzing + writing collapsed stacks"
 python3 "$HERE/analyze.py" "$OUT/profile.json.gz" --dsym "$DWARF" --arch "$ARCH" \

--- a/benches/profile/profile.sh
+++ b/benches/profile/profile.sh
@@ -69,8 +69,14 @@ echo "==> Generating dSYM for symbolication"
 dsymutil "$BIN"
 
 echo "==> Recording with samply (lang=$LANG_ARG size=$SIZE requests=$REQUESTS)"
+# Build the optional --file argument as an array: ${VAR:+--file "$VAR"} does
+# not apply the inner quoting, so paths with spaces would split.
+FILE_OPTS=()
+if [ -n "${FILE_ARG:-}" ]; then
+  FILE_OPTS=(--file "$FILE_ARG")
+fi
 samply record -s -o "$OUT/profile.json.gz" \
-  -- python3 "$HERE/drive.py" --bin "./$BIN" --lang "$LANG_ARG" --size "$SIZE" --requests "$REQUESTS" --edits "${EDITS:-0}" ${FILE_ARG:+--file "$FILE_ARG"}
+  -- python3 "$HERE/drive.py" --bin "./$BIN" --lang "$LANG_ARG" --size "$SIZE" --requests "$REQUESTS" --edits "${EDITS:-0}" "${FILE_OPTS[@]}"
 
 echo "==> Analyzing + writing collapsed stacks"
 python3 "$HERE/analyze.py" "$OUT/profile.json.gz" --dsym "$DWARF" --arch "$ARCH" \

--- a/benches/profile/profile.sh
+++ b/benches/profile/profile.sh
@@ -37,6 +37,7 @@ while [ $# -gt 0 ]; do
     --lang) LANG_ARG="$2"; shift 2;;
     --size) SIZE="$2"; shift 2;;
     --requests) REQUESTS="$2"; shift 2;;
+    --edits) EDITS="$2"; shift 2;;
     *) echo "unknown arg: $1" >&2; exit 1;;
   esac
 done
@@ -68,7 +69,7 @@ dsymutil "$BIN"
 
 echo "==> Recording with samply (lang=$LANG_ARG size=$SIZE requests=$REQUESTS)"
 samply record -s -o "$OUT/profile.json.gz" \
-  -- python3 "$HERE/drive.py" --bin "./$BIN" --lang "$LANG_ARG" --size "$SIZE" --requests "$REQUESTS"
+  -- python3 "$HERE/drive.py" --bin "./$BIN" --lang "$LANG_ARG" --size "$SIZE" --requests "$REQUESTS" --edits "${EDITS:-0}"
 
 echo "==> Analyzing + writing collapsed stacks"
 python3 "$HERE/analyze.py" "$OUT/profile.json.gz" --dsym "$DWARF" --arch "$ARCH" \

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -171,14 +171,14 @@ pub(crate) async fn handle_semantic_tokens_full(
         // attached — the numbers a user-supplied log needs.
         log::debug!(
             target: "kakehashi::semantic",
-            "[SEMANTIC_TOKENS] compute phases: host={}ms injections={}ms regions_reused={} ",
+            "[SEMANTIC_TOKENS] compute phases: host={}ms injections={}ms regions_reused={}",
             host_elapsed.as_millis(),
             t_start.elapsed().saturating_sub(host_elapsed).as_millis(),
             injection_cache
                 .as_ref()
                 .and_then(|p| p.discovery.as_ref())
-                .map(|d| d.regions.len() as i64)
-                .unwrap_or(-1),
+                .map(|d| d.regions.len().to_string())
+                .unwrap_or_else(|| "none".to_string()),
         );
 
         // Merge injection tokens with host tokens

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -176,7 +176,14 @@ pub(crate) async fn handle_semantic_tokens_full(
             t_start.elapsed().saturating_sub(host_elapsed).as_millis(),
             injection_cache
                 .as_ref()
-                .and_then(|p| p.discovery.as_ref())
+                // The same generation gate the reuse path applies: a
+                // present-but-reload-stale discovery is NOT reused, and
+                // reporting its count would mislead profiling.
+                .and_then(|p| {
+                    p.discovery
+                        .as_ref()
+                        .filter(|d| d.generation == p.generation)
+                })
                 .map(|d| d.regions.len().to_string())
                 .unwrap_or_else(|| "none".to_string()),
         );

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -93,6 +93,7 @@ pub(crate) async fn handle_semantic_tokens_full(
 ) -> Option<SemanticTokensResult> {
     pool.run(cancel.clone(), move || {
         let is_cancelled = || crate::cancel::is_cancelled(cancel.as_ref());
+        let t_start = std::time::Instant::now();
 
         let mut all_tokens: Vec<RawToken> = Vec::with_capacity(1000);
         let lines: Vec<&str> = text.lines().collect();
@@ -115,6 +116,8 @@ pub(crate) async fn handle_semantic_tokens_full(
             &[],
             &mut all_tokens,
         );
+
+        let host_elapsed = t_start.elapsed();
 
         // Bail before the injection pass — the dominant cost on a large document
         // — if this request has already been superseded.
@@ -162,6 +165,21 @@ pub(crate) async fn handle_semantic_tokens_full(
         if is_cancelled() {
             return None;
         }
+
+        // Phase timing at debug level: pinpoints where a slow compute spends
+        // its time (host query pass vs injection fan-out) without a profiler
+        // attached — the numbers a user-supplied log needs.
+        log::debug!(
+            target: "kakehashi::semantic",
+            "[SEMANTIC_TOKENS] compute phases: host={}ms injections={}ms regions_reused={} ",
+            host_elapsed.as_millis(),
+            t_start.elapsed().saturating_sub(host_elapsed).as_millis(),
+            injection_cache
+                .as_ref()
+                .and_then(|p| p.discovery.as_ref())
+                .map(|d| d.regions.len() as i64)
+                .unwrap_or(-1),
+        );
 
         // Merge injection tokens with host tokens
         all_tokens.extend(injection_tokens);

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -13,6 +13,9 @@ use tree_sitter::{Query, Tree};
 // Re-export crate-internal API from submodules
 pub(crate) use delta::calculate_delta_or_full;
 pub(crate) use legend::{LEGEND_MODIFIERS, LEGEND_TYPES};
+#[cfg(test)]
+pub(crate) use parallel::DISCOVERY_REUSE_HITS;
+pub(crate) use parallel::build_document_discovery;
 pub(crate) use range::handle_semantic_tokens_range_parallel_async;
 
 // Re-export for parallel processing
@@ -34,6 +37,13 @@ pub(crate) struct InjectionCacheParams {
     pub documents: std::sync::Arc<crate::document::DocumentStore>,
     pub parsed_version: u64,
     pub incarnation: u64,
+    /// Owned injection discovery from the snapshot being tokenized
+    /// (parse-snapshot ADR §3, the don't-discover-twice lever): rebuilt into
+    /// contexts instead of re-running the injection query, when its
+    /// `generation` still matches `generation` above. `None` re-discovers
+    /// inline (below the region gate, combined groups, or discovery
+    /// incomplete at parse time).
+    pub discovery: Option<std::sync::Arc<crate::document::DiscoveredInjections>>,
 }
 
 // Internal re-exports for production code
@@ -127,6 +137,7 @@ pub(crate) async fn handle_semantic_tokens_full(
                 view.slot.current_incarnation == p.incarnation
                     && view.content_version == p.parsed_version
             }),
+            discovery: p.discovery.as_deref(),
         });
 
         // Collect injection tokens in parallel using Rayon.

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -19,6 +19,7 @@ use super::injection::{InjectionContext, RegionCacheInfo};
 use super::token_collector::{ActiveInjectionBounds, RawToken, collect_host_tokens};
 use crate::analysis::InjectionTokenCache;
 use crate::config::CaptureMappings;
+use crate::document::{DiscoveredInjections, DiscoveredRegion, DiscoveredRegionCache};
 use crate::language::LanguageCoordinator;
 use crate::language::NodeTracker;
 use crate::language::injection::{
@@ -36,6 +37,15 @@ use crate::text::position::byte_to_utf16_col;
 /// byte-identical to the uncached path. The cache only helps once enough regions
 /// exist that reusing the untouched ones outweighs the per-region bookkeeping.
 const INJECTION_CACHE_MIN_REGIONS: usize = 8;
+
+/// Test-only counter of how many times the discovery-reuse branch fired (skipped
+/// the injection query by reusing owned discovery). Lets an in-process server
+/// test assert reuse actually engages end-to-end after a real parse+attach —
+/// the latency benchmark cannot distinguish "reuse fired" from "reuse never
+/// fired, fell back inline" (both read as flat request latency).
+#[cfg(test)]
+pub(crate) static DISCOVERY_REUSE_HITS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
 
 /// Per-context output of [`process_injection_sync`]: the region's tokens plus
 /// whether every parser in its subtree (its own and all nested injections) was
@@ -69,6 +79,11 @@ pub(crate) struct InjectionCacheCtx<'a> {
     /// resolved, and the token cache stays correct via its content-hash
     /// validity gate — so the purge machinery is not worth its cost here.
     pub mint_regions: bool,
+    /// Owned discovery for this tree (#529), or `None`. Reused — skipping the
+    /// injection query — only when its `generation` still matches `generation`
+    /// above (a settings reload bumps the generation, so stale-query discovery
+    /// misses and re-discovers inline).
+    pub discovery: Option<&'a DiscoveredInjections>,
 }
 
 /// Maximum number of parsers to cache per Rayon worker thread.
@@ -498,174 +513,40 @@ fn collect_injection_contexts_sync<'a>(
             return (contexts, exclusion_ranges, false);
         }
 
-        let start = injection.content_node.start_byte();
-        let end = injection.content_node.end_byte();
-
-        // Validate bounds
-        if start > end || end > text.len() {
-            continue;
-        }
-
-        // Extract injection content for language detection
-        let injection_content = &text[start..end];
-
-        // Resolve injection language. A failure here means no parser could be
-        // loaded for it yet — a transient gap, so discovery is incomplete.
-        let Some((resolved_lang, _)) =
-            coordinator.resolve_injection_language(&injection.language, injection_content)
-        else {
-            discovery_complete = false;
-            continue;
-        };
-
-        // Get highlight query for resolved language. Missing query is likewise
-        // transient (loads with the language), so taint discovery.
-        let Some(highlight_query) = coordinator.highlight_query(&resolved_lang) else {
-            discovery_complete = false;
-            continue;
-        };
-
-        // Offset directive resolved at collection time (single source of truth
-        // with the bridge path, which applies it in from_region_info)
-        let offset = injection.offset;
-
-        // Calculate effective content range
-        let content_node = injection.content_node;
-        let (inj_start_byte, inj_end_byte) = if let Some(off) = offset {
-            use crate::analysis::offset_calculator::{ByteRange, calculate_effective_range};
-            let byte_range = ByteRange::new(content_node.start_byte(), content_node.end_byte());
-            // calculate_effective_range clamps, snaps inward to char
-            // boundaries, and normalizes start <= end, so the content slice
-            // below cannot panic.
-            let effective = calculate_effective_range(text, byte_range, off);
-            (effective.start, effective.end)
-        } else {
-            (content_node.start_byte(), content_node.end_byte())
-        };
-
-        // Validate effective range after offset adjustment
-        if inj_start_byte > inj_end_byte || inj_end_byte > text.len() {
-            continue;
-        }
-
-        // Compute included ranges for the injection parser (Problem 1: blockquote prefixes).
-        // When include_children is false and content_node has named children
-        // (e.g., block_continuation), we compute gap ranges so the injection parser
-        // only sees actual code content.
-        //
-        // With an offset directive, content_text starts at inj_start_byte
-        // (offset-adjusted) rather than content_node.start_byte(), so gaps are
-        // clipped to the effective window and relativized to it (#186). The
-        // non-offset path keeps the node-anchored variant, which reuses the
-        // node's cached Points instead of rescanning text.
-        let from_children = if offset.is_some() {
-            compute_included_ranges_clipped(
-                &injection.content_node,
-                injection.include_children,
-                text,
-                inj_start_byte..inj_end_byte,
-            )
-        } else {
-            compute_included_ranges(&injection.content_node, injection.include_children)
-        };
-        let from_parent = parent_included_ranges.and_then(|parent_ranges| {
-            sub_select_included_ranges(parent_ranges, inj_start_byte, inj_end_byte)
-        });
-        let included_ranges = match (from_children, from_parent) {
-            (Some(child_ranges), Some(parent_ranges)) => {
-                let intersected = intersect_included_ranges(&child_ranges, &parent_ranges);
-                if intersected.is_empty() {
-                    None
-                } else {
-                    Some(intersected)
+        // Split into a query-independent owned discovery step and a
+        // context-rebuild step (the load-bearing refactor for the discovery
+        // lever, #529): the same two steps let `populate_injections` produce and
+        // store owned discovery, and a later semantic request rebuild contexts
+        // from it without re-running the injection query. The steps run
+        // back-to-back here, so collect output is unchanged.
+        match discover_single_region(
+            &injection,
+            text,
+            coordinator,
+            parent_included_ranges,
+            cache_for_singles,
+            // Inline path: early-out a query-missing region (no wasted range work).
+            true,
+        ) {
+            SingleDiscovery::Region(region, prebuilt_query) => {
+                match rebuild_context(
+                    &region,
+                    text,
+                    content_start_byte,
+                    coordinator,
+                    &mut exclusion_ranges,
+                    prebuilt_query,
+                ) {
+                    Some(ctx) => contexts.push(ctx),
+                    // Highlight query not loaded yet — transient, taint discovery.
+                    None => discovery_complete = false,
                 }
             }
-            (Some(ranges), None) | (None, Some(ranges)) => Some(ranges),
-            (None, None) => None,
-        };
-
-        // Record exclusion ranges for parent token suppression (Problem 2: host token leaking).
-        // When we have per-gap included ranges, push EACH gap as a separate exclusion entry
-        // so that compute_active_injection_regions() produces per-line ActiveInjectionBounds values.
-        // Otherwise, push the single full content range as before.
-        if let Some(ref ranges) = included_ranges {
-            // Gap ranges are relative to the effective window start: with an
-            // offset directive that is inj_start_byte; without one,
-            // inj_start_byte == content_node.start_byte().
-            for r in ranges {
-                let abs_start = inj_start_byte + r.start_byte;
-                let abs_end = inj_start_byte + r.end_byte;
-                exclusion_ranges.push((abs_start, abs_end));
-            }
-        } else {
-            exclusion_ranges.push((inj_start_byte, inj_end_byte));
+            // Parser/language not loaded yet — transient, taint discovery.
+            SingleDiscovery::Incomplete => discovery_complete = false,
+            // Permanently invalid bounds — nothing dropped.
+            SingleDiscovery::Skip => {}
         }
-
-        // Derive per-line byte prefix widths from included_ranges.
-        // Each range's start_point.column tells us how many bytes of prefix
-        // (e.g., "> ") precede the actual content on that line.
-        let prefix_byte_widths = match &included_ranges {
-            Some(ranges) => derive_prefix_byte_widths(ranges),
-            None => Vec::new(),
-        };
-
-        // Resolve this single region's cache identity (#529). region_id is minted
-        // from the RAW content node — byte-identical to populate_injections
-        // (cache.rs) — so invalidate_for_edits evicts the same entry. Eligibility
-        // is this request's translation predicate: column-0 start AND no per-row
-        // prefixes (singles are never injection.combined).
-        let region_cache = cache_for_singles.and_then(|(uri, tracker, mint_regions)| {
-            // Mint only when the served snapshot was current (see
-            // InjectionCacheCtx::mint_regions): a stale serve's coordinates
-            // must not enter the live tracker. Read-only reuse keeps the
-            // cache warm for regions the edits did not shift; an unknown
-            // region simply goes uncached for this stale serve.
-            let region_id = if mint_regions {
-                tracker.get_or_create(
-                    uri,
-                    injection.content_node.start_byte(),
-                    injection.content_node.end_byte(),
-                    injection.content_node.kind(),
-                )
-            } else {
-                tracker.lookup_in_layer(
-                    uri,
-                    injection.content_node.start_byte(),
-                    injection.content_node.end_byte(),
-                    injection.content_node.kind(),
-                    0,
-                )?
-            }
-            .to_string();
-            let cacheable =
-                CacheableInjectionRegion::from_region_info(&injection, &region_id, text);
-            let eligible = cacheable.start_column == 0 && prefix_byte_widths.is_empty();
-            // Fold the resolved language into the validity hash so a position-
-            // stable region_id with identical content but a different injected
-            // language gets a different key (barring a 64-bit collision) and won't
-            // serve a stale hit — defends the cross-language hazard from a
-            // superseded request's orphaned ULID; same fold style as the
-            // generation fold in cache_key.
-            let validity_hash =
-                cacheable.content_hash ^ fnv1a_hash(&resolved_lang).wrapping_mul(0x100000001b3);
-            Some(RegionCacheInfo {
-                region_id,
-                validity_hash,
-                line_start: cacheable.line_range.start,
-                eligible,
-            })
-        });
-
-        contexts.push(InjectionContext {
-            resolved_lang,
-            highlight_query,
-            content_text: &text[inj_start_byte..inj_end_byte],
-            host_start_byte: content_start_byte + inj_start_byte,
-            included_ranges,
-            prefix_byte_widths,
-            combined: false,
-            region_cache,
-        });
     }
 
     for (_group_key, regions) in combined_groups {
@@ -687,6 +568,353 @@ fn collect_injection_contexts_sync<'a>(
     }
 
     (contexts, exclusion_ranges, discovery_complete)
+}
+
+/// Outcome of [`discover_single_region`] for one top-level single injection.
+enum SingleDiscovery {
+    /// The region resolved to a language and owned discovery data. The
+    /// `Option<Arc<Query>>` is the already-resolved highlight query on the inline
+    /// path (so [`rebuild_context`] reuses it rather than looking it up a second
+    /// time), or `None` on the producer path (which stores no query and lets reuse
+    /// re-resolve it).
+    Region(DiscoveredRegion, Option<std::sync::Arc<tree_sitter::Query>>),
+    /// The injection language/parser isn't loaded yet — a *transient* gap the
+    /// caller taints into `discovery_complete` (never cache such a discovery).
+    Incomplete,
+    /// The region is permanently invalid (out-of-bounds byte range) — nothing is
+    /// dropped, so discovery stays complete.
+    Skip,
+}
+
+/// Build the owned, query-independent discovery for one single injection region:
+/// everything `collect_injection_contexts_sync` needs to later reconstruct an
+/// `InjectionContext` **except** the highlight query (resolved in
+/// [`rebuild_context`]) and the borrowed content slice (stored as a byte range).
+///
+/// Deliberately does *not* look up the highlight query, so the normal collect
+/// path resolves it exactly once (in `rebuild_context`) — no extra lookup versus
+/// the pre-refactor code. The reuse path (`populate_injections` → semantic
+/// request) runs this once off-ingress and reconstructs contexts from the result,
+/// skipping the injection query-match loop entirely.
+fn discover_single_region(
+    injection: &InjectionRegionInfo<'_>,
+    text: &str,
+    coordinator: &LanguageCoordinator,
+    parent_included_ranges: Option<&[tree_sitter::Range]>,
+    cache_for_singles: Option<(&Url, &NodeTracker, bool)>,
+    // On the inline path, skip a region whose highlight query isn't loaded
+    // *before* the per-region range/prefix/id work, exactly as the pre-refactor
+    // code did (`rebuild_context` would otherwise discard it only after that
+    // work). The producer passes `false`: it stores the region regardless and
+    // lets reuse re-resolve the query (self-healing), so it must not gate here.
+    require_highlight_query: bool,
+) -> SingleDiscovery {
+    let start = injection.content_node.start_byte();
+    let end = injection.content_node.end_byte();
+
+    // Validate bounds
+    if start > end || end > text.len() {
+        return SingleDiscovery::Skip;
+    }
+
+    // Extract injection content for language detection
+    let injection_content = &text[start..end];
+
+    // Resolve injection language. A failure here means no parser could be
+    // loaded for it yet — a transient gap, so discovery is incomplete.
+    let Some((resolved_lang, _)) =
+        coordinator.resolve_injection_language(&injection.language, injection_content)
+    else {
+        return SingleDiscovery::Incomplete;
+    };
+
+    // Highlight-query early-out (inline path only): a resolvable language with no
+    // loaded highlight query produces no tokens, so skip it before the range/id
+    // work, matching the pre-refactor taint-and-continue ordering. Resolve the
+    // `Arc<Query>` here (one lookup) and thread it to `rebuild_context`, which then
+    // doesn't look it up again. The producer passes `require_highlight_query = false`
+    // and stores no query (reuse re-resolves it, self-healing).
+    let prebuilt_query = if require_highlight_query {
+        match coordinator.highlight_query(&resolved_lang) {
+            Some(query) => Some(query),
+            None => return SingleDiscovery::Incomplete,
+        }
+    } else {
+        None
+    };
+
+    // Offset directive resolved at collection time (single source of truth
+    // with the bridge path, which applies it in from_region_info)
+    let offset = injection.offset;
+
+    // Calculate effective content range
+    let content_node = injection.content_node;
+    let (inj_start_byte, inj_end_byte) = if let Some(off) = offset {
+        use crate::analysis::offset_calculator::{ByteRange, calculate_effective_range};
+        let byte_range = ByteRange::new(content_node.start_byte(), content_node.end_byte());
+        // calculate_effective_range clamps, snaps inward to char
+        // boundaries, and normalizes start <= end, so the content slice
+        // below cannot panic.
+        let effective = calculate_effective_range(text, byte_range, off);
+        (effective.start, effective.end)
+    } else {
+        (content_node.start_byte(), content_node.end_byte())
+    };
+
+    // Validate effective range after offset adjustment
+    if inj_start_byte > inj_end_byte || inj_end_byte > text.len() {
+        return SingleDiscovery::Skip;
+    }
+
+    // Compute included ranges for the injection parser (Problem 1: blockquote prefixes).
+    // When include_children is false and content_node has named children
+    // (e.g., block_continuation), we compute gap ranges so the injection parser
+    // only sees actual code content.
+    //
+    // With an offset directive, content_text starts at inj_start_byte
+    // (offset-adjusted) rather than content_node.start_byte(), so gaps are
+    // clipped to the effective window and relativized to it (#186). The
+    // non-offset path keeps the node-anchored variant, which reuses the
+    // node's cached Points instead of rescanning text.
+    let from_children = if offset.is_some() {
+        compute_included_ranges_clipped(
+            &injection.content_node,
+            injection.include_children,
+            text,
+            inj_start_byte..inj_end_byte,
+        )
+    } else {
+        compute_included_ranges(&injection.content_node, injection.include_children)
+    };
+    let from_parent = parent_included_ranges.and_then(|parent_ranges| {
+        sub_select_included_ranges(parent_ranges, inj_start_byte, inj_end_byte)
+    });
+    let included_ranges = match (from_children, from_parent) {
+        (Some(child_ranges), Some(parent_ranges)) => {
+            let intersected = intersect_included_ranges(&child_ranges, &parent_ranges);
+            if intersected.is_empty() {
+                None
+            } else {
+                Some(intersected)
+            }
+        }
+        (Some(ranges), None) | (None, Some(ranges)) => Some(ranges),
+        (None, None) => None,
+    };
+
+    // Derive per-line byte prefix widths from included_ranges.
+    // Each range's start_point.column tells us how many bytes of prefix
+    // (e.g., "> ") precede the actual content on that line.
+    let prefix_byte_widths = match &included_ranges {
+        Some(ranges) => derive_prefix_byte_widths(ranges),
+        None => Vec::new(),
+    };
+
+    // Resolve this single region's cache identity (#529). region_id is minted
+    // from the RAW content node — byte-identical to populate_injections
+    // (cache.rs) — so invalidate_for_edits evicts the same entry. Eligibility
+    // is this request's translation predicate: column-0 start AND no per-row
+    // prefixes (singles are never injection.combined).
+    let token_cache = cache_for_singles.and_then(|(uri, tracker, mint_regions)| {
+        // Mint only when the served snapshot was current (see
+        // InjectionCacheCtx::mint_regions): a stale serve's coordinates
+        // must not enter the live tracker. Read-only reuse keeps the
+        // cache warm for regions the edits did not shift; an unknown
+        // region simply goes uncached for this stale serve.
+        let region_id = if mint_regions {
+            tracker.get_or_create(
+                uri,
+                injection.content_node.start_byte(),
+                injection.content_node.end_byte(),
+                injection.content_node.kind(),
+            )
+        } else {
+            tracker.lookup_in_layer(
+                uri,
+                injection.content_node.start_byte(),
+                injection.content_node.end_byte(),
+                injection.content_node.kind(),
+                0,
+            )?
+        }
+        .to_string();
+        let cacheable = CacheableInjectionRegion::from_region_info(injection, &region_id, text);
+        let eligible = cacheable.start_column == 0 && prefix_byte_widths.is_empty();
+        // Fold the resolved language into the validity hash so a position-
+        // stable region_id with identical content but a different injected
+        // language gets a different key (barring a 64-bit collision) and won't
+        // serve a stale hit — defends the cross-language hazard from a
+        // superseded request's orphaned ULID; same fold style as the
+        // generation fold in cache_key.
+        let validity_hash =
+            cacheable.content_hash ^ fnv1a_hash(&resolved_lang).wrapping_mul(0x100000001b3);
+        Some(DiscoveredRegionCache {
+            region_id,
+            validity_hash,
+            line_start: cacheable.line_range.start,
+            eligible,
+        })
+    });
+
+    SingleDiscovery::Region(
+        DiscoveredRegion {
+            resolved_lang,
+            content_start_byte: inj_start_byte,
+            content_end_byte: inj_end_byte,
+            included_ranges,
+            prefix_byte_widths,
+            token_cache,
+        },
+        prebuilt_query,
+    )
+}
+
+/// Reconstruct an [`InjectionContext`] from owned [`DiscoveredRegion`] data,
+/// pushing the region's parent-token exclusion ranges. Resolves the highlight
+/// query fresh (never persisted across a possible settings reload) and re-slices
+/// the content from the current `text`; `content_start_byte` is the host byte
+/// offset of the text the discovery ran over (0 at the top level).
+///
+/// Returns `None` when the highlight query isn't loaded yet (a transient gap the
+/// caller taints into `discovery_complete`, exactly as the pre-refactor
+/// query-missing branch did — and, for a reused discovery, the same query the
+/// settings `generation` gate would already have missed on a reload). No
+/// exclusion is recorded for a dropped region.
+fn rebuild_context<'a>(
+    region: &DiscoveredRegion,
+    text: &'a str,
+    content_start_byte: usize,
+    coordinator: &LanguageCoordinator,
+    exclusion_ranges: &mut Vec<(usize, usize)>,
+    // The highlight query already resolved by `discover_single_region` on the
+    // inline path (reused here so the query is looked up once), or `None` on the
+    // reuse path, where it is re-resolved fresh (never persisted across a possible
+    // settings reload — the generation gate ensures a reload misses).
+    prebuilt_query: Option<std::sync::Arc<tree_sitter::Query>>,
+) -> Option<InjectionContext<'a>> {
+    let inj_start_byte = region.content_start_byte;
+    let inj_end_byte = region.content_end_byte;
+
+    // Guard the re-slice: on the collect path the bounds were just validated; on
+    // the reuse path they were validated against the tree this discovery is bound
+    // to, but a defensive check keeps a corrupt entry from panicking.
+    if inj_start_byte > inj_end_byte || inj_end_byte > text.len() {
+        return None;
+    }
+
+    // Highlight query for the resolved language. Missing = transient (loads with
+    // the language), so drop the region and let the caller taint discovery.
+    let highlight_query = match prebuilt_query {
+        Some(query) => query,
+        None => coordinator.highlight_query(&region.resolved_lang)?,
+    };
+
+    // Record exclusion ranges for parent token suppression (Problem 2: host token
+    // leaking). Per-gap when included_ranges are present so
+    // compute_active_injection_regions() produces per-line bounds; otherwise the
+    // single full content range. Byte ranges are relative to the effective window
+    // start (inj_start_byte).
+    if let Some(ref ranges) = region.included_ranges {
+        for r in ranges {
+            exclusion_ranges.push((inj_start_byte + r.start_byte, inj_start_byte + r.end_byte));
+        }
+    } else {
+        exclusion_ranges.push((inj_start_byte, inj_end_byte));
+    }
+
+    let region_cache = region.token_cache.as_ref().map(|tc| RegionCacheInfo {
+        region_id: tc.region_id.clone(),
+        validity_hash: tc.validity_hash,
+        line_start: tc.line_start,
+        eligible: tc.eligible,
+    });
+
+    Some(InjectionContext {
+        resolved_lang: region.resolved_lang.clone(),
+        highlight_query,
+        content_text: &text[inj_start_byte..inj_end_byte],
+        host_start_byte: content_start_byte + inj_start_byte,
+        included_ranges: region.included_ranges.clone(),
+        prefix_byte_widths: region.prefix_byte_widths.clone(),
+        combined: false,
+        region_cache,
+    })
+}
+
+/// Build the owned injection discovery for a freshly parsed document from the
+/// regions [`collect_all_injections`](crate::language::injection::collect_all_injections)
+/// already returned — the producer half of the "don't discover twice" lever
+/// (#529). Reuses the caller's single injection-query pass (`Q`, the dominant
+/// discovery cost); only the per-region `from_region_info` / `get_or_create`
+/// recompute, negligible beside `Q`.
+///
+/// Returns `None` (store nothing → the semantic path re-discovers inline) when:
+/// - the document has any `injection.combined` group — those keep the inline
+///   path in v1 (their whole-group contexts aren't part of the owned form yet);
+/// - fewer single regions than the token-cache gate, so caching wouldn't pay and
+///   the reuse path must stay byte-identical to pre-#529;
+/// - discovery is incomplete (a parser/language isn't loaded yet), matching the
+///   token half's `fully_loaded` gate — never persist a partial region set, or a
+///   later request bound to this tree would see missing tokens until the next edit.
+pub(crate) fn build_document_discovery(
+    regions: &[InjectionRegionInfo<'_>],
+    injection_query: &tree_sitter::Query,
+    text: &str,
+    coordinator: &LanguageCoordinator,
+    uri: &Url,
+    tracker: &NodeTracker,
+    generation: u64,
+) -> Option<DiscoveredInjections> {
+    // Partition exactly as collect_injection_contexts_sync does: an
+    // injection.combined pattern (with no effective #offset!) → bail, v1 keeps
+    // combined groups on the inline path.
+    let mut singles: Vec<&InjectionRegionInfo> = Vec::with_capacity(regions.len());
+    for injection in regions {
+        if has_combined_for_pattern(injection_query, injection.pattern_index)
+            && effective_offset_for_pattern(injection_query, injection.pattern_index).is_none()
+        {
+            return None;
+        }
+        singles.push(injection);
+    }
+
+    // Same region-count gate as the token half: below it, caching doesn't pay and
+    // the semantic reuse path stays byte-identical to the pre-#529 inline path.
+    if singles.len() < INJECTION_CACHE_MIN_REGIONS {
+        return None;
+    }
+
+    let mut discovered = Vec::with_capacity(singles.len());
+    for injection in singles {
+        // Producer: don't gate on the highlight query — store the region and let
+        // reuse re-resolve the query (a load without a generation bump self-heals).
+        // Producer path: called from populate_injections right after this
+        // parse's CAS landed, so the coordinates are current — minting is the
+        // same write populate's own region tracking already performs.
+        match discover_single_region(
+            injection,
+            text,
+            coordinator,
+            None,
+            Some((uri, tracker, true)),
+            false,
+        ) {
+            // Producer path passes `require_highlight_query = false`, so no query
+            // is resolved here (the `None` companion is ignored); reuse resolves it.
+            SingleDiscovery::Region(region, _) => discovered.push(region),
+            // A not-yet-loaded parser/language taints discovery — never store a
+            // partial region set (the discovery analogue of the fully_loaded gate).
+            SingleDiscovery::Incomplete => return None,
+            // Permanently invalid region: dropped from both discovery and the
+            // inline contexts, so omitting it keeps reuse equivalent.
+            SingleDiscovery::Skip => {}
+        }
+    }
+
+    Some(DiscoveredInjections {
+        generation,
+        regions: discovered,
+    })
 }
 
 /// Per-line byte prefix widths from included ranges: each range's
@@ -871,24 +1099,63 @@ pub(crate) fn collect_injection_tokens_parallel(
     use crate::cancel::is_cancelled;
     use rayon::prelude::*;
 
-    // Collect top-level injection contexts and their byte ranges. The cache
-    // handle (if any) lets the discovery phase resolve region identities
-    // single-threaded, before the fan-out. `cancel` is polled inside the
-    // per-region discovery loop — that resolve loop is the dominant cost on a
-    // large document, so a supersede must be able to abort it mid-loop.
-    // A top-level region dropped during discovery isn't cached (no region_cache
-    // is built for it), so the top-level completeness flag is irrelevant here —
-    // only nested completeness, threaded through process_injection_sync, matters.
-    let (contexts, exclusion_byte_ranges, _discovery_complete) = collect_injection_contexts_sync(
-        host_text,
-        host_tree,
-        host_filetype,
-        coordinator,
-        0,
-        None,
-        cache_ctx.map(|c| (c.uri, c.tracker, c.mint_regions)),
-        cancel,
-    );
+    // Reuse the discovery `populate_injections` already ran on this exact tree,
+    // when present and still generation-current (#529 companion lever): rebuild
+    // the top-level contexts from the owned data and skip the injection query
+    // (`Q`) entirely. Otherwise discover inline exactly as before — the fallback
+    // is byte-identical to the pre-lever path (below the region-count gate, or
+    // with any `injection.combined` group, `populate_injections` stores no
+    // discovery, so this is `None` and we take the inline branch). The reused
+    // region ids were minted while their snapshot was current (populate runs
+    // behind the landed CAS), so rebuilding from them never writes the tracker —
+    // the `mint_regions` stale-serve latch only governs the inline branch.
+    let reusable_discovery =
+        cache_ctx.and_then(|c| c.discovery.filter(|d| d.generation == c.generation));
+    let (contexts, exclusion_byte_ranges) = if let Some(discovery) = reusable_discovery {
+        #[cfg(test)]
+        DISCOVERY_REUSE_HITS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let mut contexts = Vec::with_capacity(discovery.regions.len());
+        let mut exclusion_byte_ranges = Vec::with_capacity(discovery.regions.len());
+        for region in &discovery.regions {
+            // A region whose highlight query isn't loaded is dropped (rebuild
+            // returns None) — same as the inline path's query-missing branch. The
+            // generation match makes this near-impossible, but the drop is safe.
+            if let Some(ctx) = rebuild_context(
+                region,
+                host_text,
+                0,
+                coordinator,
+                &mut exclusion_byte_ranges,
+                // Reuse path: re-resolve the query fresh (generation-gated).
+                None,
+            ) {
+                contexts.push(ctx);
+            }
+        }
+        (contexts, exclusion_byte_ranges)
+    } else {
+        // Collect top-level injection contexts and their byte ranges. The cache
+        // handle (if any) lets the discovery phase resolve region identities
+        // single-threaded, before the fan-out.
+        // A top-level region dropped during discovery isn't cached (no region_cache
+        // is built for it), so the top-level completeness flag is irrelevant here —
+        // only nested completeness, threaded through process_injection_sync, matters.
+        let (contexts, exclusion_byte_ranges, _discovery_complete) =
+            collect_injection_contexts_sync(
+                host_text,
+                host_tree,
+                host_filetype,
+                coordinator,
+                0,
+                None,
+                cache_ctx.map(|c| (c.uri, c.tracker, c.mint_regions)),
+                // `cancel` is polled inside the per-region discovery loop — that
+                // resolve loop is the dominant cost on a large document, so a
+                // supersede must be able to abort it mid-loop.
+                cancel,
+            );
+        (contexts, exclusion_byte_ranges)
+    };
 
     // Discovery bailed (or genuinely found nothing): either way there is nothing
     // to tokenize. A cancelled discovery returns partial contexts the caller
@@ -906,10 +1173,12 @@ pub(crate) fn collect_injection_tokens_parallel(
     // Resolve cache hits before the fan-out (#529, read half): an eligible region
     // whose content hash and settings generation still match a stored entry is
     // re-anchored to its current host line and never re-tokenized; only misses go
-    // to the Rayon workers. Eligibility is evaluated against THIS request's fresh
-    // context, so a region that stopped qualifying recomputes rather than serving
-    // a stale hit. Below the region-count gate `region_cache` is `None`, so every
-    // context misses and the path matches the uncached behavior exactly.
+    // to the Rayon workers. Eligibility comes from each context's `region_cache`:
+    // computed fresh when contexts were discovered inline, or carried in the owned
+    // `DiscoveredRegion` when they were rebuilt from reused discovery — identical
+    // either way, since the discovery is bound to the same tree by `parse_epoch`.
+    // Below the region-count gate `region_cache` is `None`, so every context misses
+    // and the path matches the uncached behavior exactly.
     let mut hit_tokens: Vec<RawToken> = Vec::new();
     let mut miss_indices: Vec<usize> = Vec::with_capacity(contexts.len());
     if let Some(cc) = cache_ctx {
@@ -2321,6 +2590,7 @@ local b = 2
             cache: &cache,
             generation: 0,
             mint_regions: false,
+            discovery: None,
         };
 
         let tokens = collect_injection_tokens_parallel(
@@ -2350,6 +2620,7 @@ local b = 2
             cache: &cache,
             generation: 0,
             mint_regions: true,
+            discovery: None,
         };
         let _ = collect_injection_tokens_parallel(
             &text,
@@ -2423,6 +2694,7 @@ local b = 2
             cache: &cache,
             generation: 0,
             mint_regions: true,
+            discovery: None,
         };
 
         let first = collect_injection_tokens_parallel(
@@ -2461,6 +2733,248 @@ local b = 2
         )
         .0;
         assert_eq!(second, uncached, "second (hit) pass must match uncached");
+    }
+
+    /// The discovery-reuse path (skip the injection query, rebuild contexts from
+    /// the owned discovery `populate_injections` stored) produces byte-identical
+    /// tokens to inline discovery — and a stale generation falls back to inline.
+    #[test]
+    fn discovery_reuse_matches_inline_output() {
+        let Some(coordinator) = markdown_lua_coordinator() else {
+            return;
+        };
+        let text = eight_lua_block_doc();
+        let tree = parse_markdown(&coordinator, &text);
+        let lines: Vec<&str> = text.lines().collect();
+        let line_starts = build_line_start_bytes(&text);
+        let uri = Url::parse("file:///discovery_reuse.md").unwrap();
+        let cache = InjectionTokenCache::new();
+        let tracker = NodeTracker::new();
+
+        // Baseline: inline discovery (no owned discovery threaded in). Reset the
+        // reuse counter FIRST and assert the inline call leaves it at 0, so an
+        // "always-increment" bug (firing the reuse counter even without reuse)
+        // can't slip past the `>= 1` assertion on the reuse call below.
+        DISCOVERY_REUSE_HITS.store(0, std::sync::atomic::Ordering::Relaxed);
+        let inline = collect_injection_tokens_parallel(
+            &text,
+            &lines,
+            &line_starts,
+            &tree,
+            Some("markdown"),
+            &coordinator,
+            None,
+            false,
+            None,
+            None,
+        )
+        .0;
+        assert_eq!(
+            DISCOVERY_REUSE_HITS.load(std::sync::atomic::Ordering::Relaxed),
+            0,
+            "inline discovery (no discovery threaded in) must not touch the reuse counter"
+        );
+
+        // Build the owned discovery exactly as populate_injections does, on the
+        // same tree.
+        let injection_query = coordinator
+            .injection_query("markdown")
+            .expect("markdown injection query");
+        let regions = crate::language::injection::collect_all_injections(
+            &tree.root_node(),
+            &text,
+            Some(injection_query.as_ref()),
+        )
+        .expect("regions");
+        let discovery = build_document_discovery(
+            &regions,
+            injection_query.as_ref(),
+            &text,
+            &coordinator,
+            &uri,
+            &tracker,
+            0,
+        )
+        .expect("eight single lua blocks clear the gate and discovery completes");
+        assert_eq!(discovery.regions.len(), 8);
+
+        // Reuse path: discovery present and generation-current → skips the query.
+        let cc = InjectionCacheCtx {
+            uri: &uri,
+            tracker: &tracker,
+            cache: &cache,
+            generation: 0,
+            mint_regions: true,
+            discovery: Some(&discovery),
+        };
+        // Counter still 0 here (top reset; inline asserted 0; build_document_discovery
+        // doesn't tokenize), so this reuse call is the only thing that can bump it.
+        let reused = collect_injection_tokens_parallel(
+            &text,
+            &lines,
+            &line_starts,
+            &tree,
+            Some("markdown"),
+            &coordinator,
+            None,
+            false,
+            Some(&cc),
+            None,
+        )
+        .0;
+        assert_eq!(
+            reused, inline,
+            "discovery reuse must match inline discovery byte-for-byte"
+        );
+        // Prove the reuse branch actually fired (skipped Q) rather than silently
+        // falling back inline — the safety net the latency bench can't provide.
+        assert_eq!(
+            DISCOVERY_REUSE_HITS.load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "exactly one reuse-branch entry: the single generation-current reuse call"
+        );
+
+        // Second reuse pass composes the two #529 halves: the first pass stored
+        // eligible region tokens, so now the discovery-reuse path (skip Q) also
+        // serves those regions from the token cache (hit), not recompute. Still
+        // byte-identical.
+        let reused_with_token_hits = collect_injection_tokens_parallel(
+            &text,
+            &lines,
+            &line_starts,
+            &tree,
+            Some("markdown"),
+            &coordinator,
+            None,
+            false,
+            Some(&cc),
+            None,
+        )
+        .0;
+        assert_eq!(
+            reused_with_token_hits, inline,
+            "discovery reuse composed with token-cache hits must still match inline"
+        );
+
+        // A stale generation must ignore the discovery and re-discover inline.
+        let cc_stale = InjectionCacheCtx {
+            uri: &uri,
+            tracker: &tracker,
+            cache: &cache,
+            generation: 1,
+            mint_regions: true,
+            discovery: Some(&discovery),
+        };
+        let fell_back = collect_injection_tokens_parallel(
+            &text,
+            &lines,
+            &line_starts,
+            &tree,
+            Some("markdown"),
+            &coordinator,
+            None,
+            false,
+            Some(&cc_stale),
+            None,
+        )
+        .0;
+        assert_eq!(
+            fell_back, inline,
+            "a stale-generation discovery must fall back to inline discovery"
+        );
+    }
+
+    /// `build_document_discovery` stores nothing when the document has any
+    /// `injection.combined` group: v1 keeps combined groups on the inline path, so
+    /// persisting a singles-only discovery would drop the combined captures on
+    /// reuse (missing/wrong tokens for e.g. HTML-in-markdown).
+    #[test]
+    fn build_document_discovery_bails_on_combined_groups() {
+        let Some(coordinator) = combined_lua_coordinator() else {
+            return;
+        };
+        let injection_query = coordinator
+            .injection_query("markdown")
+            .expect("combined injection query");
+        let mut pool = coordinator.create_document_parser_pool();
+        let Some(mut parser) = pool.acquire("markdown") else {
+            return;
+        };
+        let tree = parser
+            .parse(COMBINED_LUA_DOC, None)
+            .expect("parse markdown");
+        pool.release("markdown".to_string(), parser);
+        let regions = crate::language::injection::collect_all_injections(
+            &tree.root_node(),
+            COMBINED_LUA_DOC,
+            Some(injection_query.as_ref()),
+        )
+        .expect("regions");
+        let uri = Url::parse("file:///combined_bail.md").unwrap();
+        let tracker = NodeTracker::new();
+        assert!(
+            build_document_discovery(
+                &regions,
+                injection_query.as_ref(),
+                COMBINED_LUA_DOC,
+                &coordinator,
+                &uri,
+                &tracker,
+                0,
+            )
+            .is_none(),
+            "a document with a combined group must not store discovery"
+        );
+    }
+
+    /// `build_document_discovery` stores nothing when an injected language can't
+    /// be resolved to a parser (the discovery analogue of the token half's
+    /// `fully_loaded` gate): a region whose language is unresolvable taints
+    /// discovery, so a partial region set is never persisted. (A resolvable
+    /// language whose *highlight query* isn't loaded is NOT gated — `rebuild_context`
+    /// re-resolves the query fresh at reuse, so that case self-heals.)
+    #[test]
+    fn build_document_discovery_bails_when_injected_language_unresolvable() {
+        let Some(coordinator) = markdown_lua_coordinator() else {
+            return;
+        };
+        let injection_query = coordinator
+            .injection_query("markdown")
+            .expect("markdown injection query");
+        // Fences of a language with no parser anywhere: `collect_all_injections`
+        // still returns them (the query captures whatever the info string says),
+        // but `resolve_injection_language` fails → SingleDiscovery::Incomplete.
+        let mut text = String::from("# Unresolvable\n\n");
+        for i in 0..10 {
+            text.push_str(&format!("```zzznotalang\ncontent {i}\n```\n\n"));
+        }
+        let mut pool = coordinator.create_document_parser_pool();
+        let Some(mut parser) = pool.acquire("markdown") else {
+            return;
+        };
+        let tree = parser.parse(text.as_str(), None).expect("parse markdown");
+        pool.release("markdown".to_string(), parser);
+        let regions = crate::language::injection::collect_all_injections(
+            &tree.root_node(),
+            &text,
+            Some(injection_query.as_ref()),
+        )
+        .expect("regions");
+        let uri = Url::parse("file:///incomplete_bail.md").unwrap();
+        let tracker = NodeTracker::new();
+        assert!(
+            build_document_discovery(
+                &regions,
+                injection_query.as_ref(),
+                &text,
+                &coordinator,
+                &uri,
+                &tracker,
+                0,
+            )
+            .is_none(),
+            "an unresolvable injected language must taint discovery and store nothing"
+        );
     }
 
     /// The dominant per-compute cost on a large document is the single-threaded
@@ -2544,6 +3058,7 @@ local b = 2
             cache: &cache,
             generation: 0,
             mint_regions: true,
+            discovery: None,
         };
 
         let cancel = crate::cancel::CancelToken::default();
@@ -2592,6 +3107,7 @@ local b = 2
             cache: &cache,
             generation: 0,
             mint_regions: true,
+            discovery: None,
         };
 
         // Populate.
@@ -2669,6 +3185,7 @@ local b = 2
             cache: &cache,
             generation: 0,
             mint_regions: true,
+            discovery: None,
         };
 
         // Populate against the original document.

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -800,10 +800,14 @@ fn rebuild_context<'a>(
 
     // Guard the re-slice: on the collect path the bounds were just validated; on
     // the reuse path they were validated against the tree this discovery is bound
-    // to, but a defensive check keeps a corrupt entry from panicking.
-    if inj_start_byte > inj_end_byte || inj_end_byte > text.len() {
+    // to, but a defensive check keeps a corrupt entry from panicking. `get`
+    // (below) additionally rejects a mid-codepoint boundary instead of
+    // panicking — impossible for tree-sitter-derived offsets on the bound
+    // text, so failing closed (drop the region) is the right degradation.
+    if inj_start_byte > inj_end_byte {
         return None;
     }
+    let content_text = text.get(inj_start_byte..inj_end_byte)?;
 
     // Highlight query for the resolved language. Missing = transient (loads with
     // the language), so drop the region and let the caller taint discovery.
@@ -835,7 +839,7 @@ fn rebuild_context<'a>(
     Some(InjectionContext {
         resolved_lang: region.resolved_lang.clone(),
         highlight_query,
-        content_text: &text[inj_start_byte..inj_end_byte],
+        content_text,
         host_start_byte: content_start_byte + inj_start_byte,
         included_ranges: region.included_ranges.clone(),
         prefix_byte_widths: region.prefix_byte_widths.clone(),
@@ -1200,7 +1204,9 @@ pub(crate) fn collect_injection_tokens_parallel(
     // to the Rayon workers. Eligibility comes from each context's `region_cache`:
     // computed fresh when contexts were discovered inline, or carried in the owned
     // `DiscoveredRegion` when they were rebuilt from reused discovery — identical
-    // either way, since the discovery is bound to the same tree by `parse_epoch`.
+    // either way, since snapshot immutability binds the discovery to the same
+    // tree (text, tree, and regions are one value) and the generation gate
+    // rejects reload-stale discoveries.
     // Below the region-count gate `region_cache` is `None`, so every context misses
     // and the path matches the uncached behavior exactly.
     let mut hit_tokens: Vec<RawToken> = Vec::new();

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -873,6 +873,11 @@ pub(crate) fn build_document_discovery(
         if has_combined_for_pattern(injection_query, injection.pattern_index)
             && effective_offset_for_pattern(injection_query, injection.pattern_index).is_none()
         {
+            log::debug!(
+                target: "kakehashi::semantic",
+                "discovery not stored: combined-group region (lang={})",
+                injection.language
+            );
             return None;
         }
         singles.push(injection);
@@ -881,6 +886,12 @@ pub(crate) fn build_document_discovery(
     // Same region-count gate as the token half: below it, caching doesn't pay and
     // the semantic reuse path stays byte-identical to the pre-#529 inline path.
     if singles.len() < INJECTION_CACHE_MIN_REGIONS {
+        log::debug!(
+            target: "kakehashi::semantic",
+            "discovery not stored: {} single region(s) below the {} gate",
+            singles.len(),
+            INJECTION_CACHE_MIN_REGIONS
+        );
         return None;
     }
 
@@ -902,9 +913,16 @@ pub(crate) fn build_document_discovery(
             // Producer path passes `require_highlight_query = false`, so no query
             // is resolved here (the `None` companion is ignored); reuse resolves it.
             SingleDiscovery::Region(region, _) => discovered.push(region),
-            // A not-yet-loaded parser/language taints discovery — never store a
-            // partial region set (the discovery analogue of the fully_loaded gate).
-            SingleDiscovery::Incomplete => return None,
+            // A language whose parser isn't loadable is DROPPED, matching the
+            // inline path's own drop of that region — the reuse output stays
+            // byte-identical. Storing (rather than the reference impl's
+            // never-store-partial taint) is sound because a failed load can
+            // only become a success through a settings/post-install reload
+            // (`ensure_language_loaded` negative-caches failures until
+            // `load_settings`), and that reload bumps the semantic-token
+            // generation — which invalidates this discovery and forces the
+            // inline re-discovery that picks the region back up.
+            SingleDiscovery::Incomplete => {}
             // Permanently invalid region: dropped from both discovery and the
             // inline contexts, so omitting it keeps reuse equivalent.
             SingleDiscovery::Skip => {}
@@ -2927,12 +2945,14 @@ local b = 2
         );
     }
 
-    /// `build_document_discovery` stores nothing when an injected language can't
-    /// be resolved to a parser (the discovery analogue of the token half's
-    /// `fully_loaded` gate): a region whose language is unresolvable taints
-    /// discovery, so a partial region set is never persisted. (A resolvable
-    /// language whose *highlight query* isn't loaded is NOT gated — `rebuild_context`
-    /// re-resolves the query fresh at reuse, so that case self-heals.)
+    /// A region whose injected language can't be resolved to a parser is
+    /// DROPPED from the stored discovery — matching the inline path, which
+    /// drops it too, so reuse output stays byte-identical. Storing (rather
+    /// than the former never-store-partial taint) is sound because a failed
+    /// load is negative-cached until a settings/post-install reload, and that
+    /// reload bumps the semantic-token generation, invalidating this
+    /// discovery. Here EVERY region is unresolvable, so the stored discovery
+    /// is present but empty.
     #[test]
     fn build_document_discovery_bails_when_injected_language_unresolvable() {
         let Some(coordinator) = markdown_lua_coordinator() else {
@@ -2962,18 +2982,27 @@ local b = 2
         .expect("regions");
         let uri = Url::parse("file:///incomplete_bail.md").unwrap();
         let tracker = NodeTracker::new();
+        let discovery = build_document_discovery(
+            &regions,
+            injection_query.as_ref(),
+            &text,
+            &coordinator,
+            &uri,
+            &tracker,
+            0,
+        )
+        .expect("discovery is stored with the unresolvable regions dropped");
         assert!(
-            build_document_discovery(
-                &regions,
-                injection_query.as_ref(),
-                &text,
-                &coordinator,
-                &uri,
-                &tracker,
-                0,
-            )
-            .is_none(),
-            "an unresolvable injected language must taint discovery and store nothing"
+            discovery
+                .regions
+                .iter()
+                .all(|r| r.resolved_lang == "markdown_inline"),
+            "the unresolvable fenced regions are dropped; only the document's \
+             own markdown_inline regions remain"
+        );
+        assert!(
+            discovery.regions.len() < regions.len(),
+            "the ten zzznotalang fences must not be stored"
         );
     }
 

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -525,6 +525,8 @@ fn collect_injection_contexts_sync<'a>(
             coordinator,
             parent_included_ranges,
             cache_for_singles,
+            // Inline path: no producer-prebuilt identity to reuse.
+            None,
             // Inline path: early-out a query-missing region (no wasted range work).
             true,
         ) {
@@ -605,6 +607,11 @@ fn discover_single_region(
     coordinator: &LanguageCoordinator,
     parent_included_ranges: Option<&[tree_sitter::Range]>,
     cache_for_singles: Option<(&Url, &NodeTracker, bool)>,
+    // The producer path's already-built cache identity for THIS region
+    // (populate minted the id and hashed the content moments earlier):
+    // reused instead of a second tracker op + content hash on the
+    // pre-publish critical path, the same pattern as `resolve_from_prebuilt`.
+    prebuilt_cacheable: Option<&CacheableInjectionRegion>,
     // On the inline path, skip a region whose highlight query isn't loaded
     // *before* the per-region range/prefix/id work, exactly as the pre-refactor
     // code did (`rebuild_context` would otherwise discard it only after that
@@ -719,29 +726,37 @@ fn discover_single_region(
     // is this request's translation predicate: column-0 start AND no per-row
     // prefixes (singles are never injection.combined).
     let token_cache = cache_for_singles.and_then(|(uri, tracker, mint_regions)| {
-        // Mint only when the served snapshot was current (see
-        // InjectionCacheCtx::mint_regions): a stale serve's coordinates
-        // must not enter the live tracker. Read-only reuse keeps the
-        // cache warm for regions the edits did not shift; an unknown
-        // region simply goes uncached for this stale serve.
-        let region_id = if mint_regions {
-            tracker.get_or_create(
-                uri,
-                injection.content_node.start_byte(),
-                injection.content_node.end_byte(),
-                injection.content_node.kind(),
-            )
-        } else {
-            tracker.lookup_in_layer(
-                uri,
-                injection.content_node.start_byte(),
-                injection.content_node.end_byte(),
-                injection.content_node.kind(),
-                0,
-            )?
-        }
-        .to_string();
-        let cacheable = CacheableInjectionRegion::from_region_info(injection, &region_id, text);
+        let cacheable_owned;
+        let cacheable = match prebuilt_cacheable {
+            Some(prebuilt) => prebuilt,
+            None => {
+                // Mint only when the served snapshot was current (see
+                // InjectionCacheCtx::mint_regions): a stale serve's coordinates
+                // must not enter the live tracker. Read-only reuse keeps the
+                // cache warm for regions the edits did not shift; an unknown
+                // region simply goes uncached for this stale serve.
+                let region_id = if mint_regions {
+                    tracker.get_or_create(
+                        uri,
+                        injection.content_node.start_byte(),
+                        injection.content_node.end_byte(),
+                        injection.content_node.kind(),
+                    )
+                } else {
+                    tracker.lookup_in_layer(
+                        uri,
+                        injection.content_node.start_byte(),
+                        injection.content_node.end_byte(),
+                        injection.content_node.kind(),
+                        0,
+                    )?
+                }
+                .to_string();
+                cacheable_owned =
+                    CacheableInjectionRegion::from_region_info(injection, &region_id, text);
+                &cacheable_owned
+            }
+        };
         let eligible = cacheable.start_column == 0 && prefix_byte_widths.is_empty();
         // Fold the resolved language into the validity hash so a position-
         // stable region_id with identical content but a different injected
@@ -752,7 +767,7 @@ fn discover_single_region(
         let validity_hash =
             cacheable.content_hash ^ fnv1a_hash(&resolved_lang).wrapping_mul(0x100000001b3);
         Some(DiscoveredRegionCache {
-            region_id,
+            region_id: cacheable.region_id.clone(),
             validity_hash,
             line_start: cacheable.line_range.start,
             eligible,
@@ -866,8 +881,14 @@ fn rebuild_context<'a>(
 /// for them either, and the failed load is negative-cached until a reload —
 /// which bumps the generation, invalidating this discovery — so the store can
 /// never mask a later-loadable region.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn build_document_discovery(
     regions: &[InjectionRegionInfo<'_>],
+    // Index-aligned with `regions` (both derive from one
+    // `collect_all_injections` pass): the caller's already-minted ids and
+    // content hashes, reused instead of a second tracker op + hash per
+    // region on the pre-publish critical path.
+    prebuilt_cacheable: &[CacheableInjectionRegion],
     injection_query: &tree_sitter::Query,
     text: &str,
     coordinator: &LanguageCoordinator,
@@ -906,18 +927,20 @@ pub(crate) fn build_document_discovery(
     }
 
     let mut discovered = Vec::with_capacity(singles.len());
-    for injection in singles {
+    for (injection, prebuilt) in singles.iter().zip(prebuilt_cacheable.iter()) {
         // Producer: don't gate on the highlight query — store the region and let
         // reuse re-resolve the query (a load without a generation bump self-heals).
         // Producer path: called from populate_injections right after this
-        // parse's CAS landed, so the coordinates are current — minting is the
-        // same write populate's own region tracking already performs.
+        // parse's CAS landed, so the coordinates are current; the region id +
+        // content hash are REUSED from the caller's just-built identity
+        // (`prebuilt`), not recomputed.
         match discover_single_region(
             injection,
             text,
             coordinator,
             None,
             Some((uri, tracker, true)),
+            Some(prebuilt),
             false,
         ) {
             // Producer path passes `require_highlight_query = false`, so no query
@@ -2583,6 +2606,31 @@ local b = 2
         );
     }
 
+    /// Build the producer's index-aligned cache identities for `regions`,
+    /// the way `populate_injections` does before calling
+    /// `build_document_discovery`.
+    fn cacheable_for(
+        regions: &[crate::language::injection::InjectionRegionInfo<'_>],
+        uri: &Url,
+        tracker: &NodeTracker,
+        text: &str,
+    ) -> Vec<CacheableInjectionRegion> {
+        regions
+            .iter()
+            .map(|info| {
+                let id = tracker
+                    .get_or_create(
+                        uri,
+                        info.content_node.start_byte(),
+                        info.content_node.end_byte(),
+                        info.content_node.kind(),
+                    )
+                    .to_string();
+                CacheableInjectionRegion::from_region_info(info, &id, text)
+            })
+            .collect()
+    }
+
     fn raw_token_at(line: usize, column: usize, length: usize) -> RawToken {
         RawToken {
             line,
@@ -2818,6 +2866,7 @@ local b = 2
         .expect("regions");
         let discovery = build_document_discovery(
             &regions,
+            &cacheable_for(&regions, &uri, &tracker, &text),
             injection_query.as_ref(),
             &text,
             &coordinator,
@@ -2945,6 +2994,7 @@ local b = 2
         assert!(
             build_document_discovery(
                 &regions,
+                &cacheable_for(&regions, &uri, &tracker, COMBINED_LUA_DOC),
                 injection_query.as_ref(),
                 COMBINED_LUA_DOC,
                 &coordinator,
@@ -2996,6 +3046,7 @@ local b = 2
         let tracker = NodeTracker::new();
         let discovery = build_document_discovery(
             &regions,
+            &cacheable_for(&regions, &uri, &tracker, &text),
             injection_query.as_ref(),
             &text,
             &coordinator,

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -578,8 +578,11 @@ enum SingleDiscovery {
     /// time), or `None` on the producer path (which stores no query and lets reuse
     /// re-resolve it).
     Region(DiscoveredRegion, Option<std::sync::Arc<tree_sitter::Query>>),
-    /// The injection language/parser isn't loaded yet — a *transient* gap the
-    /// caller taints into `discovery_complete` (never cache such a discovery).
+    /// The injection language/parser isn't loaded yet — a *transient* gap.
+    /// The inline path taints `discovery_complete`; the producer path DROPS
+    /// the region from the stored discovery (sound: the failed load is
+    /// negative-cached until a reload, which bumps the generation and
+    /// invalidates the store).
     Incomplete,
     /// The region is permanently invalid (out-of-bounds byte range) — nothing is
     /// dropped, so discovery stays complete.
@@ -853,9 +856,12 @@ fn rebuild_context<'a>(
 ///   path in v1 (their whole-group contexts aren't part of the owned form yet);
 /// - fewer single regions than the token-cache gate, so caching wouldn't pay and
 ///   the reuse path must stay byte-identical to pre-#529;
-/// - discovery is incomplete (a parser/language isn't loaded yet), matching the
-///   token half's `fully_loaded` gate — never persist a partial region set, or a
-///   later request bound to this tree would see missing tokens until the next edit.
+///
+/// Regions whose language/parser isn't loaded are DROPPED from the stored
+/// discovery rather than tainting it: the inline path would produce no tokens
+/// for them either, and the failed load is negative-cached until a reload —
+/// which bumps the generation, invalidating this discovery — so the store can
+/// never mask a later-loadable region.
 pub(crate) fn build_document_discovery(
     regions: &[InjectionRegionInfo<'_>],
     injection_query: &tree_sitter::Query,
@@ -2954,7 +2960,7 @@ local b = 2
     /// discovery. Here EVERY region is unresolvable, so the stored discovery
     /// is present but empty.
     #[test]
-    fn build_document_discovery_bails_when_injected_language_unresolvable() {
+    fn build_document_discovery_stores_empty_when_every_region_unresolvable() {
         let Some(coordinator) = markdown_lua_coordinator() else {
             return;
         };

--- a/src/document.rs
+++ b/src/document.rs
@@ -9,6 +9,7 @@ pub(crate) mod snapshot;
 // Re-export main types
 pub(crate) use injections::{
     DiscoveredBridgeRegion, DiscoveredInjections, DiscoveredRegion, DiscoveredRegionCache,
+    SnapshotLayerTree,
 };
 pub(crate) use model::Document;
 pub use store::DocumentStore;

--- a/src/document.rs
+++ b/src/document.rs
@@ -2,8 +2,11 @@ pub(crate) mod store;
 
 pub(crate) mod model;
 
+pub(crate) mod injections;
+
 pub(crate) mod snapshot;
 
 // Re-export main types
+pub(crate) use injections::{DiscoveredInjections, DiscoveredRegion, DiscoveredRegionCache};
 pub(crate) use model::Document;
 pub use store::DocumentStore;

--- a/src/document.rs
+++ b/src/document.rs
@@ -7,6 +7,8 @@ pub(crate) mod injections;
 pub(crate) mod snapshot;
 
 // Re-export main types
-pub(crate) use injections::{DiscoveredInjections, DiscoveredRegion, DiscoveredRegionCache};
+pub(crate) use injections::{
+    DiscoveredBridgeRegion, DiscoveredInjections, DiscoveredRegion, DiscoveredRegionCache,
+};
 pub(crate) use model::Document;
 pub use store::DocumentStore;

--- a/src/document/injections.rs
+++ b/src/document/injections.rs
@@ -84,3 +84,23 @@ pub(crate) struct DiscoveredInjections {
     pub generation: u64,
     pub regions: Vec<DiscoveredRegion>,
 }
+
+/// One discovered injection region in the owned form the **bridge** downstream
+/// (`process_injections` → eager spawn / didChange forwarding / auto-install)
+/// consumes — the parse-pass twin of `BridgeInjection`, kept here so `document`
+/// need not depend on `lsp::bridge`. Built by `populate_injections` from the
+/// same single injection-query pass as everything else (never re-discovered on
+/// the downstream path), and carried on the `ParseSnapshot`.
+#[derive(Clone)]
+pub(crate) struct DiscoveredBridgeRegion {
+    /// The RAW injection language identifier (e.g. `"py"`), exactly as the
+    /// query captured it — bridge config lookup and auto-install resolve it
+    /// themselves, so no canonicalization here (identical to the inline path).
+    pub raw_language: String,
+    /// Position-stable tracker ULID, byte-identical to the one minted for the
+    /// `InjectionMap` (same `get_or_create` on the same node).
+    pub region_id: String,
+    /// The region's clean content (gap ranges removed), the exact virtual-
+    /// document text the bridge opens downstream.
+    pub content: String,
+}

--- a/src/document/injections.rs
+++ b/src/document/injections.rs
@@ -1,0 +1,86 @@
+//! Owned, borrow-free injection **discovery** attached to a document's parse
+//! result (#529 companion lever — "don't discover twice").
+//!
+//! The off-ingress `populate_injections` runs the injection query once over a
+//! freshly parsed tree and, when discovery is complete, records the result here
+//! via [`DocumentStore::set_injections_if_epoch_unchanged`](crate::document::DocumentStore).
+//! A later `semanticTokens` request bound to that same tree rebuilds its
+//! injection contexts from this owned data instead of re-running the query — the
+//! query-match loop (`Q`) is the dominant cost of injection discovery, so
+//! skipping the second run on the request path is the whole point of the lever.
+//!
+//! Everything here is **fully owned**: no borrow of the document text (the
+//! content slice is stored as a byte range, re-sliced from the current text at
+//! reuse) and no `Arc<Query>` (the highlight query is looked up fresh by
+//! `resolved_lang`, so a settings reload can't serve a stale query — see
+//! `generation`). This is what lets it live on the [`Document`](super::Document)
+//! across requests. Reuse is bound to the exact tree it was discovered on by the
+//! document's `parse_epoch`; see the write-back CAS.
+
+/// The injection-token-cache identity of a discovered region (#529 token half),
+/// or absent when the region isn't token-cacheable (combined groups, or below
+/// the region-count gate). The owned twin of the analysis layer's
+/// `RegionCacheInfo`, kept here so `document` need not depend on `analysis`.
+#[derive(Clone)]
+pub(crate) struct DiscoveredRegionCache {
+    /// Position-stable region id, byte-identical to the one `populate_injections`
+    /// minted for this region in the `InjectionMap` (the discovery build reuses
+    /// that same id — no new off-ingress minting).
+    pub region_id: String,
+    /// Content hash folded with the resolved language (the injection-token
+    /// cache's per-region validity key).
+    pub validity_hash: u64,
+    /// The region's first host line, added back on token re-anchor.
+    pub line_start: u32,
+    /// Whether the region satisfied the token-reuse translation predicate
+    /// (`start_column == 0` ∧ no per-row prefixes ∧ not combined) at discovery.
+    pub eligible: bool,
+}
+
+/// One discovered top-level injection region, in the owned form the semantic
+/// path rebuilds an `InjectionContext` from. Mirrors the fields
+/// `collect_injection_contexts_sync` computes, minus the borrowed `content_text`
+/// (stored as `content_start_byte..content_end_byte`) and the `Arc<Query>`
+/// (re-resolved from `resolved_lang`).
+#[derive(Clone)]
+pub(crate) struct DiscoveredRegion {
+    /// Resolved injection language (e.g. `"lua"`); the highlight query is looked
+    /// up fresh from this at reuse, never persisted.
+    pub resolved_lang: String,
+    /// Content byte range, relative to the text the discovery ran over
+    /// (offset-directive applied): the injection content is
+    /// `&text[content_start_byte..content_end_byte]`, and the host start byte is
+    /// `content_start_byte_of_the_pass + content_start_byte`.
+    pub content_start_byte: usize,
+    pub content_end_byte: usize,
+    /// Included ranges for the injection parser (content-relative), or `None`
+    /// when the whole content is parsed. Owned so it survives the request.
+    pub included_ranges: Option<Vec<tree_sitter::Range>>,
+    /// Per-content-line byte prefix widths (empty when no `included_ranges`).
+    pub prefix_byte_widths: Vec<usize>,
+    /// Token-cache identity, or `None` when the region isn't token-cacheable.
+    pub token_cache: Option<DiscoveredRegionCache>,
+}
+
+/// The complete owned injection discovery for one parse of a document: every
+/// top-level single region plus the settings `generation` it was resolved under.
+///
+/// Stored on the [`Document`](super::Document) by the off-ingress write-back only
+/// when discovery was *complete* (no region dropped because its injected language
+/// couldn't be resolved to a parser) and the document had no `injection.combined`
+/// group (those keep the inline path in v1), so a present value is always the full
+/// single-region set for the bound tree. A resolvable language whose highlight
+/// query isn't loaded is *not* excluded — the query is re-resolved fresh at reuse,
+/// so that case self-heals rather than persisting an incomplete set.
+#[derive(Clone)]
+pub(crate) struct DiscoveredInjections {
+    /// Settings generation at discovery time. The reader skips reuse when it no
+    /// longer matches the current generation — a reload rebuilt the injection /
+    /// highlight queries, so the owned contexts (and the language resolution
+    /// behind them) may be stale. One integer compare; the same discipline the
+    /// injection-token cache key uses. (On-`Document` discovery is not reached by
+    /// `bump_semantic_token_generation`, which clears the side caches only, so
+    /// this gate is what a reload relies on.)
+    pub generation: u64,
+    pub regions: Vec<DiscoveredRegion>,
+}

--- a/src/document/injections.rs
+++ b/src/document/injections.rs
@@ -15,9 +15,11 @@
 //! content slice is stored as a byte range, re-sliced from the current text at
 //! reuse) and no `Arc<Query>` (the highlight query is looked up fresh by
 //! `resolved_lang`, so a settings reload can't serve a stale query — see
-//! `generation`). This is what lets it live on the [`Document`](super::Document)
-//! across requests. Reuse is bound to the exact tree it was discovered on by the
-//! document's `parse_epoch`; see the write-back CAS.
+//! `generation`). This is what lets it ride the
+//! [`ParseSnapshot`](super::snapshot::ParseSnapshot) across requests. Reuse
+//! is bound to the exact tree it was discovered on by snapshot immutability:
+//! text, tree, and regions are one value, so the regions can never be
+//! consumed against a different tree.
 
 /// The injection-token-cache identity of a discovered region (#529 token half),
 /// or absent when the region isn't token-cacheable (combined groups, or below
@@ -110,11 +112,12 @@ pub(crate) struct DiscoveredBridgeRegion {
 
 /// One pre-parsed injection layer of a document, in document-order DFS —
 /// the owned product of the captures/node layer walk
-/// (`walk_document_layers`), built ONCE per parse by `populate_injections`
-/// and carried on the `ParseSnapshot` so the per-keystroke `kakehashi/captures`
-/// requests (full AND delta both walk) iterate these instead of re-running
-/// the injection query, re-resolving every region's language, and re-parsing
-/// every injected region per request.
+/// (`walk_document_layers`), built LAZILY by the first walking request on a
+/// snapshot (never on the parse critical path) and carried on the
+/// `ParseSnapshot` so the per-keystroke `kakehashi/captures` requests (full
+/// AND delta both walk) iterate these instead of re-running the injection
+/// query, re-resolving every region's language, and re-parsing every
+/// injected region per request.
 ///
 /// `tree` is parsed with the exact absolute included ranges the inline walk
 /// computes (same code, run at populate time), so consuming these is

--- a/src/document/injections.rs
+++ b/src/document/injections.rs
@@ -2,8 +2,10 @@
 //! result (#529 companion lever — "don't discover twice").
 //!
 //! The off-ingress `populate_injections` runs the injection query once over a
-//! freshly parsed tree and, when discovery is complete, records the result here
-//! via [`DocumentStore::set_injections_if_epoch_unchanged`](crate::document::DocumentStore).
+//! freshly parsed tree and records the result here (regions whose injected
+//! language cannot be resolved to a parser are DROPPED from the stored set —
+//! sound because a failed load is negative-cached until a reload, which bumps
+//! the generation and invalidates this discovery).
 //! A later `semanticTokens` request bound to that same tree rebuilds its
 //! injection contexts from this owned data instead of re-running the query — the
 //! query-match loop (`Q`) is the dominant cost of injection discovery, so
@@ -65,13 +67,14 @@ pub(crate) struct DiscoveredRegion {
 /// The complete owned injection discovery for one parse of a document: every
 /// top-level single region plus the settings `generation` it was resolved under.
 ///
-/// Stored on the [`Document`](super::Document) by the off-ingress write-back only
-/// when discovery was *complete* (no region dropped because its injected language
-/// couldn't be resolved to a parser) and the document had no `injection.combined`
-/// group (those keep the inline path in v1), so a present value is always the full
-/// single-region set for the bound tree. A resolvable language whose highlight
-/// query isn't loaded is *not* excluded — the query is re-resolved fresh at reuse,
-/// so that case self-heals rather than persisting an incomplete set.
+/// Stored by the off-ingress write-back with unresolvable regions DROPPED
+/// (their injected language has no parser; the inline path would produce no
+/// tokens for them either, and the failed load is negative-cached until a
+/// reload — which bumps `generation`, invalidating this discovery) and only
+/// when the document had no `injection.combined` group (those keep the inline
+/// path in v1). A resolvable language whose highlight query isn't loaded is
+/// *not* excluded — the query is re-resolved fresh at reuse, so that case
+/// self-heals rather than persisting an incomplete set.
 #[derive(Clone)]
 pub(crate) struct DiscoveredInjections {
     /// Settings generation at discovery time. The reader skips reuse when it no

--- a/src/document/injections.rs
+++ b/src/document/injections.rs
@@ -104,3 +104,29 @@ pub(crate) struct DiscoveredBridgeRegion {
     /// document text the bridge opens downstream.
     pub content: String,
 }
+
+/// One pre-parsed injection layer of a document, in document-order DFS —
+/// the owned product of the captures/node layer walk
+/// (`walk_document_layers`), built ONCE per parse by `populate_injections`
+/// and carried on the `ParseSnapshot` so the per-keystroke `kakehashi/captures`
+/// requests (full AND delta both walk) iterate these instead of re-running
+/// the injection query, re-resolving every region's language, and re-parsing
+/// every injected region per request.
+///
+/// `tree` is parsed with the exact absolute included ranges the inline walk
+/// computes (same code, run at populate time), so consuming these is
+/// byte-identical to walking inline over the same snapshot.
+#[derive(Clone)]
+pub(crate) struct SnapshotLayerTree {
+    /// Resolved injection language (e.g. `"markdown_inline"`).
+    pub language: String,
+    /// The layer's tree, parsed against the host text with the layer's
+    /// absolute included ranges (`Tree::included_ranges` recovers them).
+    pub tree: tree_sitter::Tree,
+    /// Injection depth (host is 0; these start at 1).
+    pub depth: usize,
+    /// Host-byte span covering the layer's included ranges, for cheap
+    /// range-request pruning (conservative: a false-positive visit only makes
+    /// the layer's query yield nothing for the clipped range).
+    pub span: std::ops::Range<usize>,
+}

--- a/src/document/snapshot.rs
+++ b/src/document/snapshot.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use tree_sitter::Tree;
 
-use super::injections::{DiscoveredBridgeRegion, DiscoveredInjections};
+use super::injections::{DiscoveredBridgeRegion, DiscoveredInjections, SnapshotLayerTree};
 use crate::language::injection::ResolvedInjection;
 
 /// The reserved terminal incarnation `didClose` installs in a slot
@@ -63,6 +63,16 @@ pub(crate) struct ParseSnapshot {
     /// which previously each re-ran the injection query per request. Same
     /// `None`/`Some(empty)` semantics as `bridge_regions`.
     pub(crate) resolved_regions: Option<Arc<Vec<ResolvedInjection>>>,
+    /// Lazily-built, per-snapshot injection layer trees (document-order DFS,
+    /// depth ≥ 1) for the captures/node layer walk: the FIRST walking request
+    /// on this snapshot builds them (on the compute pool — the same cost the
+    /// inline walk paid), and every subsequent walk on the same snapshot —
+    /// captures full + delta both walk per keystroke, plus range and node
+    /// lookups — reuses the parsed trees instead of re-running the injection
+    /// query and re-parsing every region. Deliberately lazy rather than
+    /// populate-built: non-captures users never pay, and the parse loop's
+    /// publish latency is untouched.
+    pub(crate) layer_trees: std::sync::OnceLock<Arc<Vec<SnapshotLayerTree>>>,
 }
 
 /// The per-URI `watch` value: the current lifetime plus the latest snapshot.
@@ -139,6 +149,7 @@ mod tests {
             injection_regions: None,
             bridge_regions: None,
             resolved_regions: None,
+            layer_trees: std::sync::OnceLock::new(),
         }
     }
 
@@ -185,6 +196,7 @@ mod tests {
             injection_regions: None,
             bridge_regions: None,
             resolved_regions: None,
+            layer_trees: std::sync::OnceLock::new(),
         }
     }
 

--- a/src/document/snapshot.rs
+++ b/src/document/snapshot.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use tree_sitter::Tree;
 
 use super::injections::{DiscoveredBridgeRegion, DiscoveredInjections};
+use crate::language::injection::ResolvedInjection;
 
 /// The reserved terminal incarnation `didClose` installs in a slot
 /// (`u64::MAX`). Keeping the closed slot at its old incarnation would let a
@@ -56,6 +57,12 @@ pub(crate) struct ParseSnapshot {
     /// (`None` when populate didn't run for this snapshot — the downstream
     /// then resolves inline; `Some(empty)` means genuinely no regions).
     pub(crate) bridge_regions: Option<Arc<Vec<DiscoveredBridgeRegion>>>,
+    /// Fully resolved injection regions (`InjectionResolver::resolve_all`'s
+    /// shape) from the same populate pass, for the whole-document readers —
+    /// pull/push diagnostics, documentSymbol/Color, formatting's virt layer —
+    /// which previously each re-ran the injection query per request. Same
+    /// `None`/`Some(empty)` semantics as `bridge_regions`.
+    pub(crate) resolved_regions: Option<Arc<Vec<ResolvedInjection>>>,
 }
 
 /// The per-URI `watch` value: the current lifetime plus the latest snapshot.
@@ -131,6 +138,7 @@ mod tests {
             incarnation,
             injection_regions: None,
             bridge_regions: None,
+            resolved_regions: None,
         }
     }
 
@@ -176,6 +184,7 @@ mod tests {
             incarnation,
             injection_regions: None,
             bridge_regions: None,
+            resolved_regions: None,
         }
     }
 

--- a/src/document/snapshot.rs
+++ b/src/document/snapshot.rs
@@ -12,6 +12,8 @@ use std::sync::Arc;
 
 use tree_sitter::Tree;
 
+use super::injections::DiscoveredInjections;
+
 /// The reserved terminal incarnation `didClose` installs in a slot
 /// (`u64::MAX`). Keeping the closed slot at its old incarnation would let a
 /// stale same-lifetime publish pass both the incarnation check and the
@@ -40,6 +42,16 @@ pub(crate) struct ParseSnapshot {
     pub(crate) parsed_version: u64,
     /// The document lifetime the parse belongs to.
     pub(crate) incarnation: u64,
+    /// Owned injection discovery derived from THIS snapshot's tree by the
+    /// parse pass (ADR §3, don't-discover-twice): readers rebuild injection
+    /// contexts from it instead of re-running the injection query per request.
+    /// `None` when discovery didn't run or didn't qualify (tree-less snapshot,
+    /// below the region gate, combined groups, or a not-yet-loaded injected
+    /// parser tainted it) — readers then discover inline, byte-identically to
+    /// the pre-lever path. Immutability of the snapshot is the tree-identity
+    /// binding: text, tree, and regions are one value, so the regions can
+    /// never be consumed against a different tree.
+    pub(crate) injection_regions: Option<Arc<DiscoveredInjections>>,
 }
 
 /// The per-URI `watch` value: the current lifetime plus the latest snapshot.
@@ -113,6 +125,7 @@ mod tests {
             language: None,
             parsed_version,
             incarnation,
+            injection_regions: None,
         }
     }
 
@@ -156,6 +169,7 @@ mod tests {
             language: Some("rust".to_string()),
             parsed_version,
             incarnation,
+            injection_regions: None,
         }
     }
 

--- a/src/document/snapshot.rs
+++ b/src/document/snapshot.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use tree_sitter::Tree;
 
-use super::injections::DiscoveredInjections;
+use super::injections::{DiscoveredBridgeRegion, DiscoveredInjections};
 
 /// The reserved terminal incarnation `didClose` installs in a slot
 /// (`u64::MAX`). Keeping the closed slot at its old incarnation would let a
@@ -52,6 +52,10 @@ pub(crate) struct ParseSnapshot {
     /// binding: text, tree, and regions are one value, so the regions can
     /// never be consumed against a different tree.
     pub(crate) injection_regions: Option<Arc<DiscoveredInjections>>,
+    /// The bridge downstream's region list, derived by the same populate pass
+    /// (`None` when populate didn't run for this snapshot — the downstream
+    /// then resolves inline; `Some(empty)` means genuinely no regions).
+    pub(crate) bridge_regions: Option<Arc<Vec<DiscoveredBridgeRegion>>>,
 }
 
 /// The per-URI `watch` value: the current lifetime plus the latest snapshot.
@@ -126,6 +130,7 @@ mod tests {
             parsed_version,
             incarnation,
             injection_regions: None,
+            bridge_regions: None,
         }
     }
 
@@ -170,6 +175,7 @@ mod tests {
             parsed_version,
             incarnation,
             injection_regions: None,
+            bridge_regions: None,
         }
     }
 

--- a/src/document/snapshot.rs
+++ b/src/document/snapshot.rs
@@ -54,9 +54,14 @@ pub(crate) struct ParseSnapshot {
     /// never be consumed against a different tree.
     pub(crate) injection_regions: Option<Arc<DiscoveredInjections>>,
     /// The bridge downstream's region list, derived by the same populate pass
-    /// (`None` when populate didn't run for this snapshot — the downstream
-    /// then resolves inline; `Some(empty)` means genuinely no regions).
-    pub(crate) bridge_regions: Option<Arc<Vec<DiscoveredBridgeRegion>>>,
+    /// (`None` when populate didn't run for this snapshot or no bridge server
+    /// was configured — the downstream then resolves inline; `Some(empty)`
+    /// means genuinely no regions). Stamped with the settings generation the
+    /// discovery ran under, like `resolved_regions`: a reload can change the
+    /// injection query without publishing a new snapshot, and the consumer
+    /// must fall back inline rather than open virtual documents for regions
+    /// the new query would not discover.
+    pub(crate) bridge_regions: Option<(u64, Arc<Vec<DiscoveredBridgeRegion>>)>,
     /// Fully resolved injection regions (`InjectionResolver::resolve_all`'s
     /// shape) from the same populate pass, for the whole-document readers —
     /// pull/push diagnostics, documentSymbol/Color, formatting's virt layer —

--- a/src/document/snapshot.rs
+++ b/src/document/snapshot.rs
@@ -62,7 +62,12 @@ pub(crate) struct ParseSnapshot {
     /// pull/push diagnostics, documentSymbol/Color, formatting's virt layer —
     /// which previously each re-ran the injection query per request. Same
     /// `None`/`Some(empty)` semantics as `bridge_regions`.
-    pub(crate) resolved_regions: Option<Arc<Vec<ResolvedInjection>>>,
+    /// Stamped with the settings generation the populate pass ran under: a
+    /// reload (which can change injection resolution) bumps the generation
+    /// WITHOUT publishing a new snapshot, so consumers gate on the stamp and
+    /// fall back to inline resolution on mismatch (same pattern as
+    /// `DiscoveredInjections.generation` and `layer_trees`).
+    pub(crate) resolved_regions: Option<(u64, Arc<Vec<ResolvedInjection>>)>,
     /// Lazily-built, per-snapshot injection layer trees (document-order DFS,
     /// depth ≥ 1) for the captures/node layer walk: the FIRST walking request
     /// on this snapshot builds them (on the compute pool — the same cost the
@@ -72,7 +77,14 @@ pub(crate) struct ParseSnapshot {
     /// query and re-parsing every region. Deliberately lazy rather than
     /// populate-built: non-captures users never pay, and the parse loop's
     /// publish latency is untouched.
-    pub(crate) layer_trees: std::sync::OnceLock<Arc<Vec<SnapshotLayerTree>>>,
+    ///
+    /// The `u64` is the settings generation the trees were built under: an
+    /// injected-grammar auto-install bumps the generation WITHOUT publishing
+    /// a new snapshot, and trees built pre-install would keep serving an
+    /// empty embedded layer for the rest of this snapshot's life. A walker
+    /// seeing a generation mismatch bypasses the cell and walks fresh (the
+    /// pre-cache per-request cost) until the next snapshot rebuilds it.
+    pub(crate) layer_trees: std::sync::OnceLock<(u64, Arc<Vec<SnapshotLayerTree>>)>,
 }
 
 /// The per-URI `watch` value: the current lifetime plus the latest snapshot.

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -756,6 +756,7 @@ impl DocumentStore {
             language: doc.language_id().map(|s| s.to_string()),
             parsed_version: doc.content_version(),
             incarnation: doc.incarnation(),
+            injection_regions: None,
         };
         doc.publish_snapshot(Arc::new(snapshot));
     }
@@ -800,6 +801,7 @@ mod tests {
                 language: Some("rust".to_string()),
                 parsed_version,
                 incarnation: doc.incarnation(),
+                injection_regions: None,
             }
         }
 

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -759,6 +759,7 @@ impl DocumentStore {
             injection_regions: None,
             bridge_regions: None,
             resolved_regions: None,
+            layer_trees: std::sync::OnceLock::new(),
         };
         doc.publish_snapshot(Arc::new(snapshot));
     }
@@ -822,6 +823,7 @@ mod tests {
                 injection_regions: None,
                 bridge_regions: None,
                 resolved_regions: None,
+                layer_trees: std::sync::OnceLock::new(),
             }
         }
 

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -757,6 +757,7 @@ impl DocumentStore {
             parsed_version: doc.content_version(),
             incarnation: doc.incarnation(),
             injection_regions: None,
+            bridge_regions: None,
         };
         doc.publish_snapshot(Arc::new(snapshot));
     }
@@ -802,6 +803,7 @@ mod tests {
                 parsed_version,
                 incarnation: doc.incarnation(),
                 injection_regions: None,
+                bridge_regions: None,
             }
         }
 

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -758,8 +758,25 @@ impl DocumentStore {
             incarnation: doc.incarnation(),
             injection_regions: None,
             bridge_regions: None,
+            resolved_regions: None,
         };
         doc.publish_snapshot(Arc::new(snapshot));
+    }
+
+    /// The CURRENT snapshot's fully resolved injection regions, or `None` when
+    /// there is no current snapshot or its populate pass didn't derive them —
+    /// the caller then resolves inline against the live tree, exactly as
+    /// before (parse-snapshot ADR §3, never discover twice).
+    pub(crate) fn current_resolved_regions(
+        &self,
+        uri: &Url,
+    ) -> Option<std::sync::Arc<Vec<crate::language::injection::ResolvedInjection>>> {
+        let view = self.latest_snapshot(uri)?;
+        let snapshot = view.slot.snapshot?;
+        if snapshot.parsed_version != view.content_version {
+            return None;
+        }
+        snapshot.resolved_regions.clone()
     }
 
     /// Subscribe to `uri`'s snapshot-slot changes for a **bounded** wait (the
@@ -804,6 +821,7 @@ mod tests {
                 incarnation: doc.incarnation(),
                 injection_regions: None,
                 bridge_regions: None,
+                resolved_regions: None,
             }
         }
 

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -765,19 +765,23 @@ impl DocumentStore {
     }
 
     /// The CURRENT snapshot's fully resolved injection regions, or `None` when
-    /// there is no current snapshot or its populate pass didn't derive them —
-    /// the caller then resolves inline against the live tree, exactly as
-    /// before (parse-snapshot ADR §3, never discover twice).
+    /// there is no current snapshot, its populate pass didn't derive them, or
+    /// they were derived under a different settings generation (a reload can
+    /// change injection resolution without publishing a new snapshot) — the
+    /// caller then resolves inline against the live tree, exactly as before
+    /// (parse-snapshot ADR §3, never discover twice).
     pub(crate) fn current_resolved_regions(
         &self,
         uri: &Url,
+        current_generation: u64,
     ) -> Option<std::sync::Arc<Vec<crate::language::injection::ResolvedInjection>>> {
         let view = self.latest_snapshot(uri)?;
         let snapshot = view.slot.snapshot?;
         if snapshot.parsed_version != view.content_version {
             return None;
         }
-        snapshot.resolved_regions.clone()
+        let (stamped_generation, regions) = snapshot.resolved_regions.as_ref()?;
+        (*stamped_generation == current_generation).then(|| std::sync::Arc::clone(regions))
     }
 
     /// Subscribe to `uri`'s snapshot-slot changes for a **bounded** wait (the

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -38,18 +38,20 @@ pub(crate) struct LanguageCoordinator {
     derived_languages: RwLock<HashSet<String>>,
     config_warnings: RwLock<Vec<String>>,
     /// Negative cache for parser-load attempts: a language whose load failed
-    /// (no library found on the search paths) is recorded here so repeated
-    /// resolution attempts — e.g. per injection region, per compute, for a
-    /// not-installed injected language like `latex` inside `markdown_inline` —
-    /// return immediately instead of re-scanning the filesystem every time.
-    /// Cleared on every `load_settings` (settings reload / post-install
-    /// reload), which is the only event that can make a failed load succeed.
-    failed_loads: dashmap::DashSet<String>,
-    /// Bumped by every `load_settings` AFTER the `failed_loads` clear. A load
-    /// attempt captures it BEFORE scanning and inserts its failure only when
-    /// still current — otherwise an attempt that captured the OLD search
-    /// paths could straddle the reload and re-insert a failure for a parser
-    /// the new paths can load, suppressing it until the next reload.
+    /// (no library found on the search paths) is recorded here — tagged with
+    /// the [`load_generation`](Self::load_generation) the attempt captured
+    /// BEFORE scanning — so repeated resolution attempts (per injection
+    /// region, per compute, for a not-installed injected language like
+    /// `latex` inside `markdown_inline`) return immediately instead of
+    /// re-scanning the filesystem. Validity lives in the READ: an entry only
+    /// suppresses when its generation equals the current one, so an insert
+    /// racing a reload (any check-then-insert window) lands inert instead of
+    /// re-poisoning — no clear-vs-store ordering to get right. The clear on
+    /// `load_settings` is memory hygiene, not the correctness mechanism.
+    failed_loads: dashmap::DashMap<String, u64>,
+    /// Bumped by every `load_settings` (the only event that can make a
+    /// failed load succeed) before the hygiene clear. Read-validated against
+    /// `failed_loads` entries; see there.
     load_generation: std::sync::atomic::AtomicU64,
 }
 
@@ -69,7 +71,7 @@ impl LanguageCoordinator {
             parser_loader: RwLock::new(ParserLoader::new()),
             base_map: RwLock::new(HashMap::new()),
             derived_languages: RwLock::new(HashSet::new()),
-            failed_loads: dashmap::DashSet::new(),
+            failed_loads: dashmap::DashMap::new(),
             load_generation: std::sync::atomic::AtomicU64::new(0),
             config_warnings: RwLock::new(Vec::new()),
         }
@@ -83,25 +85,28 @@ impl LanguageCoordinator {
         if self.language_registry.contains(language_id) {
             return LanguageLoadResult::success_with(Vec::new());
         }
-        // Known-failed load: skip the filesystem scan (and the warning events —
-        // the first attempt already surfaced them). See `failed_loads`.
-        if self.failed_loads.contains(language_id) {
-            return LanguageLoadResult::default();
-        }
-        let attempt_generation = self
+        let current_generation = self
             .load_generation
             .load(std::sync::atomic::Ordering::Acquire);
-        let result = self.try_load_language_by_id(language_id);
-        if !result.success
-            && attempt_generation
-                == self
-                    .load_generation
-                    .load(std::sync::atomic::Ordering::Acquire)
+        // Known-failed load UNDER THE CURRENT GENERATION: skip the filesystem
+        // scan (and the warning events — the first attempt already surfaced
+        // them). An old-generation entry is inert garbage, not a suppression
+        // (see `failed_loads`).
+        if self
+            .failed_loads
+            .get(language_id)
+            .is_some_and(|generation| *generation == current_generation)
         {
-            // Insert only when no reload happened during the scan: an attempt
-            // that captured the OLD search paths must not negative-cache a
-            // parser the new paths can load (see `load_generation`).
-            self.failed_loads.insert(language_id.to_string());
+            return LanguageLoadResult::default();
+        }
+        let result = self.try_load_language_by_id(language_id);
+        if !result.success {
+            // Tagged with the generation captured BEFORE the scan: if a
+            // reload landed mid-scan, the tag is already stale and this
+            // entry suppresses nothing — the store itself cannot re-poison,
+            // closing the check-then-insert window an insert-time gate had.
+            self.failed_loads
+                .insert(language_id.to_string(), current_generation);
         }
         result
     }
@@ -114,15 +119,12 @@ impl LanguageCoordinator {
         self.config_store.update_from_settings(settings);
         self.clear_derived_languages();
         // A reload (new search paths, or the post-install reload) is the only
-        // event that can turn a failed load into a success — retry everything.
-        // Bump the generation BEFORE clearing: an in-flight attempt that
-        // captured the pre-bump generation fails its insert gate from this
-        // instant, so it cannot re-poison the cache after the clear (with
-        // clear-first, an attempt reading the generation in the clear→bump
-        // window would still pass the gate). An attempt that starts in the
-        // bump→clear window scans with the NEW paths (installed above) and
-        // may have its valid failure wiped by the clear — one wasted rescan,
-        // never a wrong suppression.
+        // event that can turn a failed load into a success — bump the
+        // generation so every existing negative entry stops suppressing
+        // (validity is read-side; see `failed_loads`). The clear is memory
+        // hygiene only: a stale store racing it lands with an old tag and is
+        // inert, so no ordering between bump, clear, and in-flight scans can
+        // produce a wrong suppression.
         self.load_generation
             .fetch_add(1, std::sync::atomic::Ordering::Release);
         self.failed_loads.clear();

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -115,12 +115,17 @@ impl LanguageCoordinator {
         self.clear_derived_languages();
         // A reload (new search paths, or the post-install reload) is the only
         // event that can turn a failed load into a success — retry everything.
-        // Clear BEFORE bumping the generation: an in-flight attempt that
-        // captured the pre-bump generation then fails its insert gate, so it
-        // cannot re-poison the cache it just watched being cleared.
-        self.failed_loads.clear();
+        // Bump the generation BEFORE clearing: an in-flight attempt that
+        // captured the pre-bump generation fails its insert gate from this
+        // instant, so it cannot re-poison the cache after the clear (with
+        // clear-first, an attempt reading the generation in the clear→bump
+        // window would still pass the gate). An attempt that starts in the
+        // bump→clear window scans with the NEW paths (installed above) and
+        // may have its valid failure wiped by the clear — one wasted rescan,
+        // never a wrong suppression.
         self.load_generation
             .fetch_add(1, std::sync::atomic::Ordering::Release);
+        self.failed_loads.clear();
 
         // Build base map from language configs
         self.build_base_map(&settings.languages);

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -45,6 +45,12 @@ pub(crate) struct LanguageCoordinator {
     /// Cleared on every `load_settings` (settings reload / post-install
     /// reload), which is the only event that can make a failed load succeed.
     failed_loads: dashmap::DashSet<String>,
+    /// Bumped by every `load_settings` AFTER the `failed_loads` clear. A load
+    /// attempt captures it BEFORE scanning and inserts its failure only when
+    /// still current — otherwise an attempt that captured the OLD search
+    /// paths could straddle the reload and re-insert a failure for a parser
+    /// the new paths can load, suppressing it until the next reload.
+    load_generation: std::sync::atomic::AtomicU64,
 }
 
 impl Default for LanguageCoordinator {
@@ -64,6 +70,7 @@ impl LanguageCoordinator {
             base_map: RwLock::new(HashMap::new()),
             derived_languages: RwLock::new(HashSet::new()),
             failed_loads: dashmap::DashSet::new(),
+            load_generation: std::sync::atomic::AtomicU64::new(0),
             config_warnings: RwLock::new(Vec::new()),
         }
     }
@@ -81,8 +88,19 @@ impl LanguageCoordinator {
         if self.failed_loads.contains(language_id) {
             return LanguageLoadResult::default();
         }
+        let attempt_generation = self
+            .load_generation
+            .load(std::sync::atomic::Ordering::Acquire);
         let result = self.try_load_language_by_id(language_id);
-        if !result.success {
+        if !result.success
+            && attempt_generation
+                == self
+                    .load_generation
+                    .load(std::sync::atomic::Ordering::Acquire)
+        {
+            // Insert only when no reload happened during the scan: an attempt
+            // that captured the OLD search paths must not negative-cache a
+            // parser the new paths can load (see `load_generation`).
             self.failed_loads.insert(language_id.to_string());
         }
         result
@@ -97,7 +115,12 @@ impl LanguageCoordinator {
         self.clear_derived_languages();
         // A reload (new search paths, or the post-install reload) is the only
         // event that can turn a failed load into a success — retry everything.
+        // Clear BEFORE bumping the generation: an in-flight attempt that
+        // captured the pre-bump generation then fails its insert gate, so it
+        // cannot re-poison the cache it just watched being cleared.
         self.failed_loads.clear();
+        self.load_generation
+            .fetch_add(1, std::sync::atomic::Ordering::Release);
 
         // Build base map from language configs
         self.build_base_map(&settings.languages);

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -37,6 +37,14 @@ pub(crate) struct LanguageCoordinator {
     base_map: RwLock<HashMap<String, String>>,
     derived_languages: RwLock<HashSet<String>>,
     config_warnings: RwLock<Vec<String>>,
+    /// Negative cache for parser-load attempts: a language whose load failed
+    /// (no library found on the search paths) is recorded here so repeated
+    /// resolution attempts — e.g. per injection region, per compute, for a
+    /// not-installed injected language like `latex` inside `markdown_inline` —
+    /// return immediately instead of re-scanning the filesystem every time.
+    /// Cleared on every `load_settings` (settings reload / post-install
+    /// reload), which is the only event that can make a failed load succeed.
+    failed_loads: dashmap::DashSet<String>,
 }
 
 impl Default for LanguageCoordinator {
@@ -55,6 +63,7 @@ impl LanguageCoordinator {
             parser_loader: RwLock::new(ParserLoader::new()),
             base_map: RwLock::new(HashMap::new()),
             derived_languages: RwLock::new(HashSet::new()),
+            failed_loads: dashmap::DashSet::new(),
             config_warnings: RwLock::new(Vec::new()),
         }
     }
@@ -65,10 +74,18 @@ impl LanguageCoordinator {
     /// and analysis modules to ensure parsers are available before use.
     pub(crate) fn ensure_language_loaded(&self, language_id: &str) -> LanguageLoadResult {
         if self.language_registry.contains(language_id) {
-            LanguageLoadResult::success_with(Vec::new())
-        } else {
-            self.try_load_language_by_id(language_id)
+            return LanguageLoadResult::success_with(Vec::new());
         }
+        // Known-failed load: skip the filesystem scan (and the warning events —
+        // the first attempt already surfaced them). See `failed_loads`.
+        if self.failed_loads.contains(language_id) {
+            return LanguageLoadResult::default();
+        }
+        let result = self.try_load_language_by_id(language_id);
+        if !result.success {
+            self.failed_loads.insert(language_id.to_string());
+        }
+        result
     }
 
     /// Initialize from workspace-level settings and return coordination events.
@@ -78,6 +95,9 @@ impl LanguageCoordinator {
     pub(crate) fn load_settings(&self, settings: &WorkspaceSettings) -> LanguageLoadSummary {
         self.config_store.update_from_settings(settings);
         self.clear_derived_languages();
+        // A reload (new search paths, or the post-install reload) is the only
+        // event that can turn a failed load into a success — retry everything.
+        self.failed_loads.clear();
 
         // Build base map from language configs
         self.build_base_map(&settings.languages);

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -598,6 +598,37 @@ impl InjectionResolver {
             .map(|region| Self::build_resolved_injection(coordinator, tracker, uri, region, text))
             .collect()
     }
+
+    /// [`resolve_from_regions`](Self::resolve_from_regions) fed with the
+    /// `CacheableInjectionRegion`s the caller already built from the SAME
+    /// `regions` (populate's path): skips the duplicate per-region id mint
+    /// and content hash — populate runs on the pre-publish critical path,
+    /// where repeating work the caller just did delays the settle signal.
+    /// `regions` and `cacheable` must be index-aligned (both derive from one
+    /// `collect_all_injections` pass).
+    pub(crate) fn resolve_from_prebuilt(
+        coordinator: &LanguageCoordinator,
+        regions: &[InjectionRegionInfo<'_>],
+        cacheable: &[CacheableInjectionRegion],
+        text: &str,
+    ) -> Vec<ResolvedInjection> {
+        regions
+            .iter()
+            .zip(cacheable.iter())
+            .map(|(region, cacheable_region)| {
+                let (virtual_content, line_column_offsets) =
+                    extract_virtual_content_and_offsets(region, cacheable_region, text);
+                let resolved_language =
+                    Self::resolve_language(coordinator, &region.language, &virtual_content);
+                ResolvedInjection {
+                    region: cacheable_region.clone(),
+                    injection_language: resolved_language,
+                    virtual_content,
+                    line_column_offsets,
+                }
+            })
+            .collect()
+    }
 }
 
 #[cfg(test)]

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -444,6 +444,7 @@ fn find_injection_at_position<'a>(
 }
 
 /// Resolved injection region with all necessary context for LSP bridge requests
+#[derive(Clone)]
 pub(crate) struct ResolvedInjection {
     /// Cacheable injection region with line range information
     pub region: CacheableInjectionRegion,
@@ -579,7 +580,20 @@ impl InjectionResolver {
             return Vec::new();
         };
 
-        injections
+        Self::resolve_from_regions(coordinator, tracker, uri, &injections, text)
+    }
+
+    /// [`resolve_all`](Self::resolve_all) minus the injection-query run, for a
+    /// caller that already collected the regions (the populate pass — never
+    /// discover twice, parse-snapshot ADR §3).
+    pub(crate) fn resolve_from_regions(
+        coordinator: &LanguageCoordinator,
+        tracker: &NodeTracker,
+        uri: &Url,
+        regions: &[InjectionRegionInfo<'_>],
+        text: &str,
+    ) -> Vec<ResolvedInjection> {
+        regions
             .iter()
             .map(|region| Self::build_resolved_injection(coordinator, tracker, uri, region, text))
             .collect()

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -723,30 +723,32 @@ impl NodeTracker {
     }
 
     /// Run `commit` only if `uri`'s (shift generation, cleanup epoch) still
-    /// equals `expected` — checked while HOLDING the tracker entry's shared
-    /// lock, which coordinate shifts (`apply_*_edits`) and `cleanup` acquire
-    /// exclusively: a commit that passes the check therefore serializes
-    /// strictly BEFORE any concurrent shift, closing the check-to-commit
-    /// window a bare re-read would leave. Returns `None` without running
-    /// `commit` on a mismatch. (For a URI with no tracker entry yet there is
-    /// no lock to hold; the residual first-ever-edit interleave only affects
-    /// callers committing conservative clears.)
+    /// equals `expected` — checked while HOLDING the tracker entry's
+    /// EXCLUSIVE lock, which coordinate shifts (`apply_*_edits`) and
+    /// `cleanup` also acquire: a commit that passes the check therefore
+    /// serializes strictly before any concurrent shift, closing the
+    /// check-to-commit window a bare re-read would leave. The entry is
+    /// materialized (`or_default`) for a URI that never minted, so
+    /// absent-entry commits serialize with a concurrent FIRST edit too; an
+    /// entry materialized only to fail the check stays behind as an empty
+    /// index (bounded: it takes a stale pass racing a close to produce one,
+    /// and any later mint reuses it). Returns `None` without running
+    /// `commit` on a mismatch.
     ///
     /// `commit` MUST NOT touch this tracker: it runs while this method holds
-    /// the entry's shared lock, so any re-entrant `get_mut`/`entry` on the
-    /// same URI would self-deadlock.
+    /// the entry's exclusive lock, so any re-entrant access to the same URI
+    /// (or shard) would self-deadlock.
     pub(crate) fn commit_if_unshifted<R>(
         &self,
         uri: &Url,
         expected: (u64, u64),
         commit: impl FnOnce() -> R,
     ) -> Option<R> {
-        let entry = self.entries.get(uri);
-        let shift_gen = entry.as_ref().map(|e| e.shift_gen).unwrap_or(0);
+        let entry = self.entries.entry(uri.clone()).or_default();
         let epoch = self
             .cleanup_epoch
             .load(std::sync::atomic::Ordering::Acquire);
-        if (shift_gen, epoch) != expected {
+        if (entry.shift_gen, epoch) != expected {
             return None;
         }
         Some(commit())

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -722,6 +722,36 @@ impl NodeTracker {
             .fetch_add(1, std::sync::atomic::Ordering::Release);
     }
 
+    /// Run `commit` only if `uri`'s (shift generation, cleanup epoch) still
+    /// equals `expected` — checked while HOLDING the tracker entry's shared
+    /// lock, which coordinate shifts (`apply_*_edits`) and `cleanup` acquire
+    /// exclusively: a commit that passes the check therefore serializes
+    /// strictly BEFORE any concurrent shift, closing the check-to-commit
+    /// window a bare re-read would leave. Returns `None` without running
+    /// `commit` on a mismatch. (For a URI with no tracker entry yet there is
+    /// no lock to hold; the residual first-ever-edit interleave only affects
+    /// callers committing conservative clears.)
+    ///
+    /// `commit` MUST NOT touch this tracker: it runs while this method holds
+    /// the entry's shared lock, so any re-entrant `get_mut`/`entry` on the
+    /// same URI would self-deadlock.
+    pub(crate) fn commit_if_unshifted<R>(
+        &self,
+        uri: &Url,
+        expected: (u64, u64),
+        commit: impl FnOnce() -> R,
+    ) -> Option<R> {
+        let entry = self.entries.get(uri);
+        let shift_gen = entry.as_ref().map(|e| e.shift_gen).unwrap_or(0);
+        let epoch = self
+            .cleanup_epoch
+            .load(std::sync::atomic::Ordering::Acquire);
+        if (shift_gen, epoch) != expected {
+            return None;
+        }
+        Some(commit())
+    }
+
     /// The (per-URI shift generation, global cleanup epoch) pair the
     /// serve-stale walks latch alongside their currency check and compare at
     /// exit: a mismatch in either half means the mint landed in a superseded

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -151,8 +151,8 @@ struct ConfigMemo {
     /// rather than a `(String, String)` key so the per-region hit path looks
     /// up with a borrowed `&str` and scans a handful of pairs — zero
     /// allocations per hit (a tuple key cannot be borrowed field-wise).
-    /// Concurrent same-pair computes may push a duplicate; the linear scan
-    /// returns the first, both hold identical data.
+    /// Inserts re-check under the entry lock, so racing same-pair computes
+    /// cannot append duplicates.
     virt: DashMap<String, Vec<VirtMemoEntry>>,
     /// `host_language` → `_self` host-bridge configs.
     host: DashMap<String, Arc<Vec<ResolvedServerConfig>>>,
@@ -418,10 +418,13 @@ impl BridgeCoordinator {
                         pairs.push(entry);
                     }
                 } else {
-                    memo.virt
-                        .entry(host_language.to_string())
-                        .or_default()
-                        .push(entry);
+                    let mut pairs = memo.virt.entry(host_language.to_string()).or_default();
+                    // Re-check under the entry lock: two racing misses for
+                    // the same host both fall into this branch; the loser
+                    // must not append a duplicate pair.
+                    if !pairs.iter().any(|(lang, _)| lang == injection_language) {
+                        pairs.push(entry);
+                    }
                 }
                 configs
             }

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -130,7 +130,9 @@ pub(crate) struct BridgeCoordinator {
     /// and stall every other response. The memo keys results by the settings
     /// snapshot's `Arc` identity (settings are hot-swapped whole via
     /// `ArcSwap`, so pointer identity IS snapshot identity) and by language
-    /// pair, making repeat resolutions an `Arc` clone.
+    /// pair, making repeat resolutions a shallow `Vec` clone (one `String` +
+    /// one `Arc` bump per configured server — the settings blobs themselves
+    /// stay behind their `Arc`s).
     config_memo: ArcSwap<ConfigMemo>,
 }
 
@@ -371,13 +373,20 @@ impl BridgeCoordinator {
             .as_ref()
             .is_some_and(|s| Arc::ptr_eq(s, settings))
         {
-            memo
+            arc_swap::Guard::into_inner(memo)
         } else {
-            // New settings snapshot: swap in a fresh generation. A racing
-            // swap for the same snapshot just discards one empty memo.
-            self.config_memo
-                .store(Arc::new(ConfigMemo::empty(Some(Arc::clone(settings)))));
-            self.config_memo.load()
+            // New settings snapshot: swap in a fresh generation and keep
+            // USING the locally-built Arc rather than re-loading. A re-load
+            // could return a memo a racing caller anchored to a DIFFERENT
+            // (newer) snapshot — inserting this caller's configs (computed
+            // from ITS settings) there would poison every later hit for that
+            // snapshot until the next reload. Inserting into our own anchor
+            // is always self-consistent: if a newer anchor replaced it in
+            // the cell, our inserts are simply invisible to its callers (one
+            // wasted compute, no wrong serve).
+            let fresh = Arc::new(ConfigMemo::empty(Some(Arc::clone(settings))));
+            self.config_memo.store(Arc::clone(&fresh));
+            fresh
         };
         match injection_language {
             Some(injection_language) => {

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -4,6 +4,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
+use arc_swap::ArcSwap;
 use dashmap::DashMap;
 use tokio_util::sync::CancellationToken;
 use ulid::Ulid;
@@ -118,6 +119,42 @@ pub(crate) struct BridgeCoordinator {
     /// `CancellationToken` is in the map before any task spawns, each task `select!`s
     /// on it before its first side effect, and cancel/supersede/abort cancel it.
     host_eager_open_tasks: DashMap<Url, EagerOpenBatch>,
+    /// Resolved-config memo for the current settings snapshot.
+    ///
+    /// `get_all_configs_for_language` / `get_host_configs_for_language`
+    /// re-merge every configured server (deep-cloning each server's
+    /// `settings` JSON blob) on every call. Whole-document handlers call
+    /// them once **per injection region**, so on a fence-heavy document with
+    /// a large user config that is seconds of clone/drop CPU inside a single
+    /// handler poll — enough to wedge the transport's shared dispatch task
+    /// and stall every other response. The memo keys results by the settings
+    /// snapshot's `Arc` identity (settings are hot-swapped whole via
+    /// `ArcSwap`, so pointer identity IS snapshot identity) and by language
+    /// pair, making repeat resolutions an `Arc` clone.
+    config_memo: ArcSwap<ConfigMemo>,
+}
+
+/// One settings snapshot's worth of resolved-config lookups (see
+/// [`BridgeCoordinator::config_memo`]). Replaced wholesale when a lookup
+/// arrives for a different settings snapshot.
+struct ConfigMemo {
+    /// Identity anchor: results below are valid only for this snapshot.
+    /// `None` for the initial placeholder, which never matches.
+    settings: Option<Arc<WorkspaceSettings>>,
+    /// `(host_language, injection_language)` → virt-bridge configs.
+    virt: DashMap<(String, String), Arc<Vec<ResolvedServerConfig>>>,
+    /// `host_language` → `_self` host-bridge configs.
+    host: DashMap<String, Arc<Vec<ResolvedServerConfig>>>,
+}
+
+impl ConfigMemo {
+    fn empty(settings: Option<Arc<WorkspaceSettings>>) -> Self {
+        Self {
+            settings,
+            virt: DashMap::new(),
+            host: DashMap::new(),
+        }
+    }
 }
 
 impl BridgeCoordinator {
@@ -133,6 +170,7 @@ impl BridgeCoordinator {
             eager_open_tasks: DashMap::new(),
             host_eager_open_generation: std::sync::atomic::AtomicU64::new(0),
             host_eager_open_tasks: DashMap::new(),
+            config_memo: ArcSwap::new(Arc::new(ConfigMemo::empty(None))),
         }
     }
 
@@ -155,6 +193,7 @@ impl BridgeCoordinator {
             eager_open_tasks: DashMap::new(),
             host_eager_open_generation: std::sync::atomic::AtomicU64::new(0),
             host_eager_open_tasks: DashMap::new(),
+            config_memo: ArcSwap::new(Arc::new(ConfigMemo::empty(None))),
         }
     }
 
@@ -313,6 +352,80 @@ impl BridgeCoordinator {
         }
 
         None
+    }
+
+    /// Memo-resolving front for [`Self::get_all_configs_for_language`] /
+    /// [`Self::get_host_configs_for_language`]: returns the memoized result
+    /// for the current settings snapshot, computing (and caching) it on
+    /// first use. Callers on request paths — especially per-region loops —
+    /// must use this instead of the raw resolvers (see `config_memo`).
+    fn cached_configs(
+        &self,
+        settings: &Arc<WorkspaceSettings>,
+        host_language: &str,
+        injection_language: Option<&str>,
+    ) -> Vec<ResolvedServerConfig> {
+        let memo = self.config_memo.load();
+        let memo = if memo
+            .settings
+            .as_ref()
+            .is_some_and(|s| Arc::ptr_eq(s, settings))
+        {
+            memo
+        } else {
+            // New settings snapshot: swap in a fresh generation. A racing
+            // swap for the same snapshot just discards one empty memo.
+            self.config_memo
+                .store(Arc::new(ConfigMemo::empty(Some(Arc::clone(settings)))));
+            self.config_memo.load()
+        };
+        match injection_language {
+            Some(injection_language) => {
+                if let Some(hit) = memo
+                    .virt
+                    .get(&(host_language.to_string(), injection_language.to_string()))
+                {
+                    return hit.value().as_ref().clone();
+                }
+                let configs =
+                    self.get_all_configs_for_language(settings, host_language, injection_language);
+                memo.virt.insert(
+                    (host_language.to_string(), injection_language.to_string()),
+                    Arc::new(configs.clone()),
+                );
+                configs
+            }
+            None => {
+                if let Some(hit) = memo.host.get(host_language) {
+                    return hit.value().as_ref().clone();
+                }
+                let configs = self.get_host_configs_for_language(settings, host_language);
+                memo.host
+                    .insert(host_language.to_string(), Arc::new(configs.clone()));
+                configs
+            }
+        }
+    }
+
+    /// Memoized [`Self::get_all_configs_for_language`] for the current
+    /// settings snapshot.
+    pub(crate) fn cached_configs_for_injection_language(
+        &self,
+        settings: &Arc<WorkspaceSettings>,
+        host_language: &str,
+        injection_language: &str,
+    ) -> Vec<ResolvedServerConfig> {
+        self.cached_configs(settings, host_language, Some(injection_language))
+    }
+
+    /// Memoized [`Self::get_host_configs_for_language`] for the current
+    /// settings snapshot.
+    pub(crate) fn cached_host_configs_for_language(
+        &self,
+        settings: &Arc<WorkspaceSettings>,
+        host_language: &str,
+    ) -> Vec<ResolvedServerConfig> {
+        self.cached_configs(settings, host_language, None)
     }
 
     /// Get all bridge server configs for a given injection language from settings.

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -409,10 +409,20 @@ impl BridgeCoordinator {
                 }
                 let configs =
                     self.get_all_configs_for_language(settings, host_language, injection_language);
-                memo.virt
-                    .entry(host_language.to_string())
-                    .or_default()
-                    .push((injection_language.to_string(), Arc::new(configs.clone())));
+                let entry = (injection_language.to_string(), Arc::new(configs.clone()));
+                // `get_mut` first (borrowed key; `entry()` would clone the
+                // host Url-sized String even on a present host), and skip the
+                // push when a racing compute already recorded this pair.
+                if let Some(mut pairs) = memo.virt.get_mut(host_language) {
+                    if !pairs.iter().any(|(lang, _)| lang == injection_language) {
+                        pairs.push(entry);
+                    }
+                } else {
+                    memo.virt
+                        .entry(host_language.to_string())
+                        .or_default()
+                        .push(entry);
+                }
                 configs
             }
             None => {

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -139,12 +139,21 @@ pub(crate) struct BridgeCoordinator {
 /// One settings snapshot's worth of resolved-config lookups (see
 /// [`BridgeCoordinator::config_memo`]). Replaced wholesale when a lookup
 /// arrives for a different settings snapshot.
+/// One `(injection_language, configs)` pair in [`ConfigMemo::virt`]'s
+/// per-host list.
+type VirtMemoEntry = (String, Arc<Vec<ResolvedServerConfig>>);
+
 struct ConfigMemo {
     /// Identity anchor: results below are valid only for this snapshot.
     /// `None` for the initial placeholder, which never matches.
     settings: Option<Arc<WorkspaceSettings>>,
-    /// `(host_language, injection_language)` → virt-bridge configs.
-    virt: DashMap<(String, String), Arc<Vec<ResolvedServerConfig>>>,
+    /// `host_language` → `(injection_language, configs)` pairs. A nested Vec
+    /// rather than a `(String, String)` key so the per-region hit path looks
+    /// up with a borrowed `&str` and scans a handful of pairs — zero
+    /// allocations per hit (a tuple key cannot be borrowed field-wise).
+    /// Concurrent same-pair computes may push a duplicate; the linear scan
+    /// returns the first, both hold identical data.
+    virt: DashMap<String, Vec<VirtMemoEntry>>,
     /// `host_language` → `_self` host-bridge configs.
     host: DashMap<String, Arc<Vec<ResolvedServerConfig>>>,
 }
@@ -390,18 +399,20 @@ impl BridgeCoordinator {
         };
         match injection_language {
             Some(injection_language) => {
-                if let Some(hit) = memo
-                    .virt
-                    .get(&(host_language.to_string(), injection_language.to_string()))
+                if let Some(hit) = memo.virt.get(host_language)
+                    && let Some((_, configs)) = hit
+                        .value()
+                        .iter()
+                        .find(|(lang, _)| lang == injection_language)
                 {
-                    return hit.value().as_ref().clone();
+                    return configs.as_ref().clone();
                 }
                 let configs =
                     self.get_all_configs_for_language(settings, host_language, injection_language);
-                memo.virt.insert(
-                    (host_language.to_string(), injection_language.to_string()),
-                    Arc::new(configs.clone()),
-                );
+                memo.virt
+                    .entry(host_language.to_string())
+                    .or_default()
+                    .push((injection_language.to_string(), Arc::new(configs.clone())));
                 configs
             }
             None => {

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -58,6 +58,7 @@ pub(crate) struct CacheCoordinator {
 pub(crate) struct PopulatedInjections {
     pub(crate) discovery: Option<crate::document::DiscoveredInjections>,
     pub(crate) bridge_regions: Vec<crate::document::DiscoveredBridgeRegion>,
+    pub(crate) resolved_regions: Vec<crate::language::injection::ResolvedInjection>,
 }
 
 impl PopulatedInjections {
@@ -67,6 +68,7 @@ impl PopulatedInjections {
         Self {
             discovery: None,
             bridge_regions: Vec::new(),
+            resolved_regions: Vec::new(),
         }
     }
 }
@@ -361,9 +363,16 @@ impl CacheCoordinator {
                 tracker,
                 generation,
             );
+            // The whole-document readers' fully resolved regions, again from
+            // the same single query run.
+            let resolved_regions =
+                crate::language::injection::InjectionResolver::resolve_from_regions(
+                    language, tracker, uri, &regions, text,
+                );
             return PopulatedInjections {
                 discovery,
                 bridge_regions,
+                resolved_regions,
             };
         }
 

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -525,6 +525,12 @@ impl CacheCoordinator {
     /// `parsed_version` was served for `uri` (monotonic max — a stale-serve
     /// racing a fresher one must not regress the mark).
     pub(crate) fn record_served_semantic_version(&self, uri: &Url, parsed_version: u64) {
+        // `get_mut` first: the hot path (every token serve) avoids the `Url`
+        // clone `entry()` needs for its owned key.
+        if let Some(mut served) = self.served_semantic_versions.get_mut(uri) {
+            *served = (*served).max(parsed_version);
+            return;
+        }
         self.served_semantic_versions
             .entry(uri.clone())
             .and_modify(|v| *v = (*v).max(parsed_version))

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -178,6 +178,15 @@ impl CacheCoordinator {
     /// enabling stable IDs across document edits when position adjustments are applied.
     ///
     /// Also clears stale InjectionTokenCache entries for removed regions.
+    ///
+    /// Returns the owned injection **discovery** for this parse (parse-snapshot
+    /// ADR §3, the don't-discover-twice lever) when it should ride the
+    /// [`ParseSnapshot`](crate::document::snapshot::ParseSnapshot) for readers
+    /// to reuse — `None` when there is nothing worth reusing (no query,
+    /// no/empty regions, below the region-count gate, an `injection.combined`
+    /// group, or a not-yet-loaded parser). The discovery query (`Q`) is run
+    /// **once** here and shared; the request path never re-runs it.
+    #[must_use]
     pub(crate) fn populate_injections(
         &self,
         uri: &Url,
@@ -186,7 +195,19 @@ impl CacheCoordinator {
         language_name: &str,
         language: &LanguageCoordinator,
         tracker: &NodeTracker,
-    ) {
+    ) -> Option<crate::document::DiscoveredInjections> {
+        // Snapshot the generation FIRST — before reading the injection query or
+        // resolving any language below — so the stamp can never be *newer* than
+        // the queries the discovery was built with. A reload swaps queries and
+        // then bumps the generation (`lsp_impl::apply_shared_settings`); reading
+        // the generation last would let a reload landing mid-`populate` stamp a
+        // stale-query region set with the *new* generation, which the consumer's
+        // generation gate would then wrongly accept. Read first, a raced
+        // discovery carries the *old* generation and the post-reload consumer
+        // re-discovers inline — the "snapshot generation at the top" discipline
+        // the token handlers use.
+        let generation = self.semantic_token_generation();
+
         // Get the injection query for this language
         let injection_query = match language.injection_query(language_name) {
             Some(q) => q,
@@ -195,7 +216,7 @@ impl CacheCoordinator {
                 // Clear any stale injection caches
                 self.injection_map.clear(uri);
                 self.injection_token_cache.clear_document(uri);
-                return;
+                return None;
             }
         };
 
@@ -207,7 +228,7 @@ impl CacheCoordinator {
                 // Clear any existing regions and caches for this document
                 self.injection_map.clear(uri);
                 self.injection_token_cache.clear_document(uri);
-                return;
+                return None;
             }
 
             // Get existing regions for cache cleanup and content comparison
@@ -278,7 +299,25 @@ impl CacheCoordinator {
 
             // Store in injection map
             self.injection_map.insert(uri.clone(), cacheable_regions);
+
+            // Producer half of the discovery lever: build the owned discovery
+            // from the SAME `regions` just collected — the injection query (`Q`)
+            // is not re-run — so a semanticTokens request bound to the snapshot
+            // this parse publishes can rebuild its contexts without
+            // re-discovering. `None` when not worth reusing
+            // (gate/combined/incomplete).
+            return crate::analysis::semantic::build_document_discovery(
+                &regions,
+                injection_query.as_ref(),
+                text,
+                language,
+                uri,
+                tracker,
+                generation,
+            );
         }
+
+        None
     }
 
     /// Get all injection regions for a document (test helper).
@@ -670,7 +709,7 @@ print("hello")
         let tree = parser.parse(initial_text, None).expect("parse");
 
         // Populate injections - this should create a region with position-based ULID
-        cache.populate_injections(
+        let _ = cache.populate_injections(
             &uri,
             initial_text,
             &tree,
@@ -728,7 +767,7 @@ print("hello")
         // Key insight: After apply_text_diff, the tracker's positions are adjusted,
         // so get_or_create returns the SAME ULID. The invalidation check in
         // populate_injections should detect language_changed and remove cached tokens.
-        cache.populate_injections(
+        let _ = cache.populate_injections(
             &uri,
             edited_text,
             &edited_tree,
@@ -803,7 +842,7 @@ print("hello")
         let tree = parser.parse(initial_text, None).expect("parse");
 
         // Populate injections
-        cache.populate_injections(
+        let _ = cache.populate_injections(
             &uri,
             initial_text,
             &tree,
@@ -848,7 +887,7 @@ print("goodbye")
         let edited_tree = parser.parse(edited_text, None).expect("parse edited");
 
         // Re-populate injections
-        cache.populate_injections(
+        let _ = cache.populate_injections(
             &uri,
             edited_text,
             &edited_tree,

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -67,18 +67,26 @@ pub(crate) struct CacheCoordinator {
 /// (ungated). Both ride the `ParseSnapshot` the parse publishes.
 pub(crate) struct PopulatedInjections {
     pub(crate) discovery: Option<crate::document::DiscoveredInjections>,
-    pub(crate) bridge_regions: Vec<crate::document::DiscoveredBridgeRegion>,
+    /// `None` when the build was skipped (no bridge server configured) —
+    /// bridge readers then fall back to inline resolution — vs `Some(empty)`
+    /// for "ran, nothing matched" (readers skip their work).
+    pub(crate) bridge_regions: Option<Vec<crate::document::DiscoveredBridgeRegion>>,
     pub(crate) resolved_regions: Vec<crate::language::injection::ResolvedInjection>,
+    /// The settings generation this populate pass ran under — stamped onto
+    /// the snapshot's `resolved_regions` so reload-stale resolution is never
+    /// served (see `ParseSnapshot::resolved_regions`).
+    pub(crate) generation: u64,
 }
 
 impl PopulatedInjections {
     /// No regions (no injection query, or none matched): the downstream skips
     /// its work, exactly as the inline resolution's empty result did.
-    pub(crate) fn empty() -> Self {
+    pub(crate) fn empty(generation: u64) -> Self {
         Self {
             discovery: None,
-            bridge_regions: Vec::new(),
+            bridge_regions: Some(Vec::new()),
             resolved_regions: Vec::new(),
+            generation,
         }
     }
 }
@@ -221,6 +229,7 @@ impl CacheCoordinator {
     /// group, or a not-yet-loaded parser). The discovery query (`Q`) is run
     /// **once** here and shared; the request path never re-runs it.
     #[must_use]
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn populate_injections(
         &self,
         uri: &Url,
@@ -229,6 +238,7 @@ impl CacheCoordinator {
         language_name: &str,
         language: &LanguageCoordinator,
         tracker: &NodeTracker,
+        build_bridge_regions: bool,
     ) -> PopulatedInjections {
         // Snapshot the generation FIRST — before reading the injection query or
         // resolving any language below — so the stamp can never be *newer* than
@@ -250,7 +260,7 @@ impl CacheCoordinator {
                 // Clear any stale injection caches
                 self.injection_map.clear(uri);
                 self.injection_token_cache.clear_document(uri);
-                return PopulatedInjections::empty();
+                return PopulatedInjections::empty(generation);
             }
         };
 
@@ -262,7 +272,7 @@ impl CacheCoordinator {
                 // Clear any existing regions and caches for this document
                 self.injection_map.clear(uri);
                 self.injection_token_cache.clear_document(uri);
-                return PopulatedInjections::empty();
+                return PopulatedInjections::empty(generation);
             }
 
             // Get existing regions for cache cleanup and content comparison
@@ -335,27 +345,47 @@ impl CacheCoordinator {
             // (parse-snapshot ADR §3, never discover twice): the exact
             // (raw language, region_id, clean content) triple
             // `resolve_injection_data` used to re-derive by re-running the
-            // injection query per downstream pass.
-            let bridge_regions: Vec<crate::document::DiscoveredBridgeRegion> = regions
-                .iter()
-                .zip(cacheable_regions.iter())
-                .map(|(info, cacheable)| {
-                    let included_ranges = crate::language::injection::compute_included_ranges(
-                        &info.content_node,
-                        info.include_children,
-                    );
-                    let content = crate::language::injection::extract_clean_content(
-                        text,
-                        info.content_node.byte_range(),
-                        included_ranges.as_deref(),
-                    );
-                    crate::document::DiscoveredBridgeRegion {
-                        raw_language: info.language.clone(),
-                        region_id: cacheable.region_id.clone(),
-                        content,
-                    }
-                })
-                .collect();
+            // injection query per downstream pass. Gated on a bridge server
+            // actually being configured: populate runs on the pre-publish
+            // critical path, and the per-region content copies are pure
+            // waste for the (common) bridge-less deployment — `None` makes
+            // any late-configured bridge fall back to inline resolution.
+            let bridge_regions: Option<Vec<crate::document::DiscoveredBridgeRegion>> =
+                build_bridge_regions.then(|| {
+                    regions
+                        .iter()
+                        .zip(cacheable_regions.iter())
+                        .map(|(info, cacheable)| {
+                            let included_ranges =
+                                crate::language::injection::compute_included_ranges(
+                                    &info.content_node,
+                                    info.include_children,
+                                );
+                            let content = crate::language::injection::extract_clean_content(
+                                text,
+                                info.content_node.byte_range(),
+                                included_ranges.as_deref(),
+                            );
+                            crate::document::DiscoveredBridgeRegion {
+                                raw_language: info.language.clone(),
+                                region_id: cacheable.region_id.clone(),
+                                content,
+                            }
+                        })
+                        .collect()
+                });
+
+            // The whole-document readers' fully resolved regions, from the
+            // same single query run — and from the SAME per-region ids and
+            // content hashes already in `cacheable_regions` (no duplicate
+            // mint/hash on this critical path).
+            let resolved_regions =
+                crate::language::injection::InjectionResolver::resolve_from_prebuilt(
+                    language,
+                    &regions,
+                    &cacheable_regions,
+                    text,
+                );
 
             // Store in injection map
             self.injection_map.insert(uri.clone(), cacheable_regions);
@@ -375,20 +405,15 @@ impl CacheCoordinator {
                 tracker,
                 generation,
             );
-            // The whole-document readers' fully resolved regions, again from
-            // the same single query run.
-            let resolved_regions =
-                crate::language::injection::InjectionResolver::resolve_from_regions(
-                    language, tracker, uri, &regions, text,
-                );
             return PopulatedInjections {
                 discovery,
                 bridge_regions,
                 resolved_regions,
+                generation,
             };
         }
 
-        PopulatedInjections::empty()
+        PopulatedInjections::empty(generation)
     }
 
     /// Get all injection regions for a document (test helper).
@@ -453,15 +478,6 @@ impl CacheCoordinator {
         }
     }
 
-    /// Snapshot the current settings generation. Take this at the TOP of a token
-    /// handler — before reading ANY settings-dependent tokenization input
-    /// (language resolution, `ensure_language_loaded`, highlight query, capture
-    /// mappings) — and pass it to [`cache_key_for`](Self::cache_key_for) once the
-    /// text is available. A reload that bumps the generation after this snapshot
-    /// leaves the request's stored key on the old generation, invisible to
-    /// post-reload requests (which compute the new-generation key) — so a request
-    /// racing a `didChangeConfiguration` can never poison the cache, regardless of
-    /// whether it observed the old or new queries.
     /// Record that a semantic-token response computed from snapshot
     /// `parsed_version` was served for `uri` (monotonic max — a stale-serve
     /// racing a fresher one must not regress the mark).
@@ -478,6 +494,15 @@ impl CacheCoordinator {
         self.served_semantic_versions.get(uri).map(|v| *v)
     }
 
+    /// Snapshot the current settings generation. Take this at the TOP of a token
+    /// handler — before reading ANY settings-dependent tokenization input
+    /// (language resolution, `ensure_language_loaded`, highlight query, capture
+    /// mappings) — and pass it to [`cache_key_for`](Self::cache_key_for) once the
+    /// text is available. A reload that bumps the generation after this snapshot
+    /// leaves the request's stored key on the old generation, invisible to
+    /// post-reload requests (which compute the new-generation key) — so a request
+    /// racing a `didChangeConfiguration` can never poison the cache, regardless of
+    /// whether it observed the old or new queries.
     pub(crate) fn semantic_token_generation(&self) -> u64 {
         self.semantic_token_generation
             .load(std::sync::atomic::Ordering::SeqCst)
@@ -804,6 +829,7 @@ print("hello")
             "markdown",
             &coordinator,
             &tracker,
+            true,
         );
 
         // Verify we have one injection region
@@ -862,6 +888,7 @@ print("hello")
             "markdown",
             &coordinator,
             &tracker,
+            true,
         );
 
         // Verify the region still exists with the same region_id (position-based stability)
@@ -937,6 +964,7 @@ print("hello")
             "markdown",
             &coordinator,
             &tracker,
+            true,
         );
 
         let regions = cache.get_injections(&uri).expect("should have injections");
@@ -982,6 +1010,7 @@ print("goodbye")
             "markdown",
             &coordinator,
             &tracker,
+            true,
         );
 
         let regions_after = cache.get_injections(&uri).expect("should have injections");

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -49,6 +49,16 @@ pub(crate) struct CacheCoordinator {
     /// that was already computing (it captured the pre-bump generation), which a
     /// bare clear could not prevent.
     semantic_token_generation: std::sync::atomic::AtomicU64,
+    /// The highest snapshot `parsed_version` whose semantic tokens were
+    /// actually SERVED to the client, per document. The parse loop consults
+    /// this to decide whether a fresh publish needs a
+    /// `workspace/semanticTokens/refresh`: the request is workspace-scoped and
+    /// clients (Neovim) already re-request per `didChange`, so a refresh is
+    /// warranted only when the document has settled and the client's last
+    /// served tokens predate the settled snapshot — one refresh per settle,
+    /// none during a typing burst, none for documents whose tokens no client
+    /// ever asked for.
+    served_semantic_versions: dashmap::DashMap<Url, u64>,
 }
 
 /// Everything one `populate_injections` pass derives from its single
@@ -83,6 +93,7 @@ impl CacheCoordinator {
             injection_token_cache: std::sync::Arc::new(InjectionTokenCache::new()),
             request_tracker: SemanticRequestTracker::new(),
             semantic_token_generation: std::sync::atomic::AtomicU64::new(0),
+            served_semantic_versions: dashmap::DashMap::new(),
         }
     }
 
@@ -108,6 +119,7 @@ impl CacheCoordinator {
         // rest of didClose (see `did_close.rs`), and only leaks a bounded set of
         // entries for a closed doc that no request can read.
         self.request_tracker.cancel_all_for_uri(uri);
+        self.served_semantic_versions.remove(uri);
         self.semantic_cache.remove(uri);
         self.semantic_range_cache.remove(uri);
         self.injection_map.clear(uri);
@@ -450,6 +462,22 @@ impl CacheCoordinator {
     /// post-reload requests (which compute the new-generation key) — so a request
     /// racing a `didChangeConfiguration` can never poison the cache, regardless of
     /// whether it observed the old or new queries.
+    /// Record that a semantic-token response computed from snapshot
+    /// `parsed_version` was served for `uri` (monotonic max — a stale-serve
+    /// racing a fresher one must not regress the mark).
+    pub(crate) fn record_served_semantic_version(&self, uri: &Url, parsed_version: u64) {
+        self.served_semantic_versions
+            .entry(uri.clone())
+            .and_modify(|v| *v = (*v).max(parsed_version))
+            .or_insert(parsed_version);
+    }
+
+    /// The last snapshot version whose tokens were served for `uri`, or `None`
+    /// when no client ever consumed semantic tokens for it.
+    pub(crate) fn served_semantic_version(&self, uri: &Url) -> Option<u64> {
+        self.served_semantic_versions.get(uri).map(|v| *v)
+    }
+
     pub(crate) fn semantic_token_generation(&self) -> u64 {
         self.semantic_token_generation
             .load(std::sync::atomic::Ordering::SeqCst)
@@ -569,6 +597,7 @@ impl CacheCoordinator {
     #[cfg(test)]
     pub(crate) fn cancel_requests(&self, uri: &Url) {
         self.request_tracker.cancel_all_for_uri(uri);
+        self.served_semantic_versions.remove(uri);
     }
 }
 

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -415,6 +415,7 @@ impl CacheCoordinator {
             // (gate/combined/incomplete).
             let discovery = crate::analysis::semantic::build_document_discovery(
                 &regions,
+                &cacheable_regions,
                 injection_query.as_ref(),
                 text,
                 language,

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -264,10 +264,14 @@ impl CacheCoordinator {
         let injection_query = match language.injection_query(language_name) {
             Some(q) => q,
             None => {
-                // No injection query = no injections to track
-                // Clear any stale injection caches
-                self.injection_map.clear(uri);
-                self.injection_token_cache.clear_document(uri);
+                // No injection query = no injections to track. Clear any
+                // stale injection caches — but only when no edit landed
+                // during this pass (a stale pass must not clobber state the
+                // newer text's own populate maintains).
+                let _ = tracker.commit_if_unshifted(uri, entry_mint_epoch, || {
+                    self.injection_map.clear(uri);
+                    self.injection_token_cache.clear_document(uri);
+                });
                 return PopulatedInjections::empty(generation);
             }
         };
@@ -277,9 +281,12 @@ impl CacheCoordinator {
             collect_all_injections(&tree.root_node(), text, Some(injection_query.as_ref()))
         {
             if regions.is_empty() {
-                // Clear any existing regions and caches for this document
-                self.injection_map.clear(uri);
-                self.injection_token_cache.clear_document(uri);
+                // Clear any existing regions and caches for this document —
+                // epoch-gated like the commit below.
+                let _ = tracker.commit_if_unshifted(uri, entry_mint_epoch, || {
+                    self.injection_map.clear(uri);
+                    self.injection_token_cache.clear_document(uri);
+                });
                 return PopulatedInjections::empty(generation);
             }
 
@@ -416,25 +423,31 @@ impl CacheCoordinator {
                 generation,
             );
 
-            // Exit half of the mint reconciliation: an edit (or close/reopen)
-            // landed during this pass — its coordinates are superseded. Purge
+            // Exit half of the mint reconciliation, atomic with coordinate
+            // shifts: the commit runs under the tracker entry's shared lock
+            // and only while the (shift generation, cleanup epoch) latch
+            // still matches — an edit (or close/reopen) that landed during
+            // this pass fails the check INSIDE the lock, so a shift can
+            // never interleave between check and commit. On mismatch, purge
             // exactly this pass's tracker creations (the base invariant: a
             // stale pass never leaves wrong-space entries as live), keep the
             // injection map's previous entry (the newer text's own populate
             // replaces it), and withhold the region-id-bearing products; the
-            // snapshot then rides without regions and every reader falls back
-            // inline, byte-identically to the pre-lever path. The token-cache
-            // evictions this pass already performed are conservative
-            // (idempotent removes) and need no rollback.
-            if tracker.mint_epoch(uri) != entry_mint_epoch {
+            // snapshot then rides without regions and every reader falls
+            // back inline, byte-identically to the pre-lever path. The
+            // token-cache evictions this pass already performed are
+            // conservative (idempotent removes) and need no rollback.
+            let committed = tracker.commit_if_unshifted(uri, entry_mint_epoch, || {
+                // Commit point: store the region set the token-cache
+                // bookkeeping (reanchor/eviction) keys off.
+                self.injection_map.insert(uri.clone(), cacheable_regions);
+            });
+            if committed.is_none() {
                 for id in &minted_ids {
                     tracker.remove_id(uri, id);
                 }
                 return PopulatedInjections::empty(generation);
             }
-            // Commit point: store the region set the token-cache bookkeeping
-            // (reanchor/eviction) keys off.
-            self.injection_map.insert(uri.clone(), cacheable_regions);
             return PopulatedInjections {
                 discovery,
                 bridge_regions,

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -251,6 +251,14 @@ impl CacheCoordinator {
         // re-discovers inline — the "snapshot generation at the top" discipline
         // the token handlers use.
         let generation = self.semantic_token_generation();
+        // Entry half of the mint reconciliation (the captures walk's #554
+        // pattern, applied to the WRITER): populate runs post-CAS but an edit
+        // can land DURING this pass, shift the live-coordinate NodeTracker,
+        // and leave this pass minting the old tree's coordinates into it. The
+        // exit check below purges this pass's own creations and withholds
+        // every region-id-bearing product when the latch no longer matches.
+        let entry_mint_epoch = tracker.mint_epoch(uri);
+        let mut minted_ids: Vec<ulid::Ulid> = Vec::new();
 
         // Get the injection query for this language
         let injection_query = match language.injection_query(language_name) {
@@ -288,13 +296,18 @@ impl CacheCoordinator {
             let cacheable_regions: Vec<CacheableInjectionRegion> = regions
                 .iter()
                 .map(|info| {
-                    // Get position-based ULID from tracker
-                    let ulid = tracker.get_or_create(
+                    // Get position-based ULID from tracker, recording
+                    // creations for the exit reconciliation's purge set.
+                    let (ulid, created, _) = tracker.get_or_create_in_layer_tracked(
                         uri,
                         info.content_node.start_byte(),
                         info.content_node.end_byte(),
                         info.content_node.kind(),
+                        0,
                     );
+                    if created {
+                        minted_ids.push(ulid);
+                    }
                     let region_id = ulid.to_string();
                     let new_region =
                         CacheableInjectionRegion::from_region_info(info, &region_id, text);
@@ -387,9 +400,6 @@ impl CacheCoordinator {
                     text,
                 );
 
-            // Store in injection map
-            self.injection_map.insert(uri.clone(), cacheable_regions);
-
             // Producer half of the discovery lever: build the owned discovery
             // from the SAME `regions` just collected — the injection query (`Q`)
             // is not re-run — so a semanticTokens request bound to the snapshot
@@ -405,6 +415,26 @@ impl CacheCoordinator {
                 tracker,
                 generation,
             );
+
+            // Exit half of the mint reconciliation: an edit (or close/reopen)
+            // landed during this pass — its coordinates are superseded. Purge
+            // exactly this pass's tracker creations (the base invariant: a
+            // stale pass never leaves wrong-space entries as live), keep the
+            // injection map's previous entry (the newer text's own populate
+            // replaces it), and withhold the region-id-bearing products; the
+            // snapshot then rides without regions and every reader falls back
+            // inline, byte-identically to the pre-lever path. The token-cache
+            // evictions this pass already performed are conservative
+            // (idempotent removes) and need no rollback.
+            if tracker.mint_epoch(uri) != entry_mint_epoch {
+                for id in &minted_ids {
+                    tracker.remove_id(uri, id);
+                }
+                return PopulatedInjections::empty(generation);
+            }
+            // Commit point: store the region set the token-cache bookkeeping
+            // (reanchor/eviction) keys off.
+            self.injection_map.insert(uri.clone(), cacheable_regions);
             return PopulatedInjections {
                 discovery,
                 bridge_regions,

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -51,6 +51,26 @@ pub(crate) struct CacheCoordinator {
     semantic_token_generation: std::sync::atomic::AtomicU64,
 }
 
+/// Everything one `populate_injections` pass derives from its single
+/// injection-query run (parse-snapshot ADR §3, never discover twice): the
+/// semantic-path discovery (gated) and the bridge-downstream region list
+/// (ungated). Both ride the `ParseSnapshot` the parse publishes.
+pub(crate) struct PopulatedInjections {
+    pub(crate) discovery: Option<crate::document::DiscoveredInjections>,
+    pub(crate) bridge_regions: Vec<crate::document::DiscoveredBridgeRegion>,
+}
+
+impl PopulatedInjections {
+    /// No regions (no injection query, or none matched): the downstream skips
+    /// its work, exactly as the inline resolution's empty result did.
+    pub(crate) fn empty() -> Self {
+        Self {
+            discovery: None,
+            bridge_regions: Vec::new(),
+        }
+    }
+}
+
 impl CacheCoordinator {
     /// Create a new cache coordinator with empty caches.
     pub(crate) fn new() -> Self {
@@ -195,7 +215,7 @@ impl CacheCoordinator {
         language_name: &str,
         language: &LanguageCoordinator,
         tracker: &NodeTracker,
-    ) -> Option<crate::document::DiscoveredInjections> {
+    ) -> PopulatedInjections {
         // Snapshot the generation FIRST — before reading the injection query or
         // resolving any language below — so the stamp can never be *newer* than
         // the queries the discovery was built with. A reload swaps queries and
@@ -216,7 +236,7 @@ impl CacheCoordinator {
                 // Clear any stale injection caches
                 self.injection_map.clear(uri);
                 self.injection_token_cache.clear_document(uri);
-                return None;
+                return PopulatedInjections::empty();
             }
         };
 
@@ -228,7 +248,7 @@ impl CacheCoordinator {
                 // Clear any existing regions and caches for this document
                 self.injection_map.clear(uri);
                 self.injection_token_cache.clear_document(uri);
-                return None;
+                return PopulatedInjections::empty();
             }
 
             // Get existing regions for cache cleanup and content comparison
@@ -297,6 +317,32 @@ impl CacheCoordinator {
                 }
             }
 
+            // Bridge-downstream regions from the SAME collected `regions`
+            // (parse-snapshot ADR §3, never discover twice): the exact
+            // (raw language, region_id, clean content) triple
+            // `resolve_injection_data` used to re-derive by re-running the
+            // injection query per downstream pass.
+            let bridge_regions: Vec<crate::document::DiscoveredBridgeRegion> = regions
+                .iter()
+                .zip(cacheable_regions.iter())
+                .map(|(info, cacheable)| {
+                    let included_ranges = crate::language::injection::compute_included_ranges(
+                        &info.content_node,
+                        info.include_children,
+                    );
+                    let content = crate::language::injection::extract_clean_content(
+                        text,
+                        info.content_node.byte_range(),
+                        included_ranges.as_deref(),
+                    );
+                    crate::document::DiscoveredBridgeRegion {
+                        raw_language: info.language.clone(),
+                        region_id: cacheable.region_id.clone(),
+                        content,
+                    }
+                })
+                .collect();
+
             // Store in injection map
             self.injection_map.insert(uri.clone(), cacheable_regions);
 
@@ -306,7 +352,7 @@ impl CacheCoordinator {
             // this parse publishes can rebuild its contexts without
             // re-discovering. `None` when not worth reusing
             // (gate/combined/incomplete).
-            return crate::analysis::semantic::build_document_discovery(
+            let discovery = crate::analysis::semantic::build_document_discovery(
                 &regions,
                 injection_query.as_ref(),
                 text,
@@ -315,9 +361,13 @@ impl CacheCoordinator {
                 tracker,
                 generation,
             );
+            return PopulatedInjections {
+                discovery,
+                bridge_regions,
+            };
         }
 
-        None
+        PopulatedInjections::empty()
     }
 
     /// Get all injection regions for a document (test helper).

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -6,6 +6,7 @@
 //! capabilities are absent and the call is skipped instead of panicking.
 
 use std::sync::OnceLock;
+use std::sync::atomic::Ordering;
 use tower_lsp_server::Client;
 use tower_lsp_server::ls_types::notification::Progress;
 use tower_lsp_server::ls_types::{ClientCapabilities, MessageType};
@@ -57,6 +58,22 @@ pub(crate) fn check_diagnostic_refresh_support(caps: &ClientCapabilities) -> boo
 /// unit tests). Note: this tests the *trigger* (does the batch want a refresh), not
 /// the N→1 *collapse* — the collapse is guaranteed structurally by the single spawn
 /// site in `log_language_events`.
+/// Single-flight state for `workspace/semanticTokens/refresh` (#531): one
+/// in-flight request plus at most one trailing covers any burst of publishes.
+/// Process-global because the server serves exactly one client; reset is
+/// unnecessary (a stuck `in_flight` on a never-responding client is the same
+/// accepted trade-off as the pending-map leak documented at the send site,
+/// and the per-keystroke client re-request heals the visible highlight).
+struct RefreshFlight {
+    in_flight: std::sync::atomic::AtomicBool,
+    pending: std::sync::atomic::AtomicBool,
+}
+
+static REFRESH_FLIGHT: RefreshFlight = RefreshFlight {
+    in_flight: std::sync::atomic::AtomicBool::new(false),
+    pending: std::sync::atomic::AtomicBool::new(false),
+};
+
 fn batch_requests_semantic_tokens_refresh(events: &[LanguageEvent]) -> bool {
     events
         .iter()
@@ -161,12 +178,48 @@ impl<'a> ClientNotifier<'a> {
                 // Trade-off: If a client never responds (e.g., vim-lsp), this causes:
                 // - A small memory leak in tower-lsp's pending requests map
                 // - A spawned task waiting indefinitely
-                let client = self.client.clone();
-                tokio::spawn(async move {
-                    if let Err(err) = client.semantic_tokens_refresh().await {
-                        log::debug!("semantic_tokens_refresh failed: {}", err);
-                    }
-                });
+                //
+                // Workspace-wide single-flight (#531, the twin of the #497
+                // diagnostic-refresh guard): during a typing burst every
+                // parse-loop publish requests a refresh, and each un-answered
+                // duplicate both forces a redundant client re-tokenization
+                // pass and (on a non-responding client) leaks another pending
+                // entry. The request is parameterless, so one in-flight
+                // refresh plus at most one trailing covers any number of
+                // publishes: a publish landing mid-flight sets `pending`, and
+                // the flight loops once more after the answer.
+                if !REFRESH_FLIGHT.in_flight.swap(true, Ordering::AcqRel) {
+                    let client = self.client.clone();
+                    tokio::spawn(async move {
+                        loop {
+                            if let Err(err) = client.semantic_tokens_refresh().await {
+                                log::debug!("semantic_tokens_refresh failed: {}", err);
+                            }
+                            // Claim the trailing slot; loop while publishes
+                            // kept arriving during the request.
+                            if REFRESH_FLIGHT.pending.swap(false, Ordering::AcqRel) {
+                                continue;
+                            }
+                            REFRESH_FLIGHT.in_flight.store(false, Ordering::Release);
+                            // Narrow re-check: a publish that set `pending`
+                            // between the swap above and the store may have
+                            // found `in_flight` still true and NOT spawned its
+                            // own flight — reclaim it here. A publish that
+                            // instead won the new `swap(true)` runs its own
+                            // flight and this one stops.
+                            if REFRESH_FLIGHT.pending.swap(false, Ordering::AcqRel) {
+                                if REFRESH_FLIGHT.in_flight.swap(true, Ordering::AcqRel) {
+                                    break;
+                                }
+                                continue;
+                            }
+                            break;
+                        }
+                    });
+                } else {
+                    REFRESH_FLIGHT.pending.store(true, Ordering::Release);
+                    log::debug!("semantic_tokens_refresh coalesced into the in-flight request");
+                }
             } else {
                 // Only send refresh if client supports it (LSP @since 3.16.0 compliance).
                 log::debug!(

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -45,19 +45,6 @@ pub(crate) fn check_diagnostic_refresh_support(caps: &ClientCapabilities) -> boo
         .unwrap_or(false)
 }
 
-/// Whether a batch of language events asks for a `workspace/semanticTokens/refresh`.
-///
-/// The refresh request is parameterless and workspace-wide, so every
-/// `SemanticTokensRefresh` event in a single batch is interchangeable: the batch
-/// either wants a refresh or it doesn't. [`ClientNotifier::log_language_events`]
-/// uses this to collapse N refresh events into a single request (#531) — firing N
-/// would only force `(N-1)` redundant workspace re-tokenizations and leak that many
-/// tower-lsp pending entries on a non-responding client.
-///
-/// Extracted as a pure function for unit testing (the notifier cannot be built in
-/// unit tests). Note: this tests the *trigger* (does the batch want a refresh), not
-/// the N→1 *collapse* — the collapse is guaranteed structurally by the single spawn
-/// site in `log_language_events`.
 /// Single-flight state for `workspace/semanticTokens/refresh` (#531): one
 /// in-flight request plus at most one trailing covers any burst of publishes.
 /// Process-global because the server serves exactly one client; reset is
@@ -74,6 +61,19 @@ static REFRESH_FLIGHT: RefreshFlight = RefreshFlight {
     pending: std::sync::atomic::AtomicBool::new(false),
 };
 
+/// Whether a batch of language events asks for a `workspace/semanticTokens/refresh`.
+///
+/// The refresh request is parameterless and workspace-wide, so every
+/// `SemanticTokensRefresh` event in a single batch is interchangeable: the batch
+/// either wants a refresh or it doesn't. [`ClientNotifier::log_language_events`]
+/// uses this to collapse N refresh events into a single request (#531) — firing N
+/// would only force `(N-1)` redundant workspace re-tokenizations and leak that many
+/// tower-lsp pending entries on a non-responding client.
+///
+/// Extracted as a pure function for unit testing (the notifier cannot be built in
+/// unit tests). Note: this tests the *trigger* (does the batch want a refresh), not
+/// the N→1 *collapse* — the collapse is guaranteed structurally by the single spawn
+/// site in `log_language_events`.
 fn batch_requests_semantic_tokens_refresh(events: &[LanguageEvent]) -> bool {
     events
         .iter()

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -5,8 +5,8 @@
 //! semantic-token refresh) work safely before `initialize()` — pre-init,
 //! capabilities are absent and the call is skipped instead of panicking.
 
+use crate::error::LockResultExt;
 use std::sync::OnceLock;
-use std::sync::atomic::Ordering;
 use tower_lsp_server::Client;
 use tower_lsp_server::ls_types::notification::Progress;
 use tower_lsp_server::ls_types::{ClientCapabilities, MessageType};
@@ -51,15 +51,24 @@ pub(crate) fn check_diagnostic_refresh_support(caps: &ClientCapabilities) -> boo
 /// unnecessary (a stuck `in_flight` on a never-responding client is the same
 /// accepted trade-off as the pending-map leak documented at the send site,
 /// and the per-keystroke client re-request heals the visible highlight).
-struct RefreshFlight {
-    in_flight: std::sync::atomic::AtomicBool,
-    pending: std::sync::atomic::AtomicBool,
+///
+/// A Mutex over both flags (the #526 diagnostic-refresh pattern), NOT a pair
+/// of atomics: every attempted lock-free version of the release/trailing
+/// handshake had an interleaving that dropped one trailing refresh (a
+/// publisher storing `pending` after the flight's final re-check, or one
+/// flight swallowing a `pending` aimed at another). The critical sections
+/// are two bool ops; the lock is effectively uncontended.
+#[derive(Default)]
+struct RefreshFlightState {
+    in_flight: bool,
+    pending: bool,
 }
 
-static REFRESH_FLIGHT: RefreshFlight = RefreshFlight {
-    in_flight: std::sync::atomic::AtomicBool::new(false),
-    pending: std::sync::atomic::AtomicBool::new(false),
-};
+static REFRESH_FLIGHT: std::sync::Mutex<RefreshFlightState> =
+    std::sync::Mutex::new(RefreshFlightState {
+        in_flight: false,
+        pending: false,
+    });
 
 /// Whether a batch of language events asks for a `workspace/semanticTokens/refresh`.
 ///
@@ -188,36 +197,43 @@ impl<'a> ClientNotifier<'a> {
                 // refresh plus at most one trailing covers any number of
                 // publishes: a publish landing mid-flight sets `pending`, and
                 // the flight loops once more after the answer.
-                if !REFRESH_FLIGHT.in_flight.swap(true, Ordering::AcqRel) {
+                let spawn_flight = {
+                    let mut state = REFRESH_FLIGHT
+                        .lock()
+                        .recover_poison("ClientNotifier::refresh_flight(begin)");
+                    if state.in_flight {
+                        // Coalesce: the in-flight request answers for this
+                        // publish too; at most one trailing refresh follows.
+                        state.pending = true;
+                        false
+                    } else {
+                        state.in_flight = true;
+                        true
+                    }
+                };
+                if spawn_flight {
                     let client = self.client.clone();
                     tokio::spawn(async move {
                         loop {
                             if let Err(err) = client.semantic_tokens_refresh().await {
                                 log::debug!("semantic_tokens_refresh failed: {}", err);
                             }
-                            // Claim the trailing slot; loop while publishes
-                            // kept arriving during the request.
-                            if REFRESH_FLIGHT.pending.swap(false, Ordering::AcqRel) {
+                            // One atomic decision under the lock: either claim
+                            // the trailing slot and loop, or release the
+                            // flight — no interleaving can strand a `pending`
+                            // set by a publisher that saw `in_flight == true`.
+                            let mut state = REFRESH_FLIGHT
+                                .lock()
+                                .recover_poison("ClientNotifier::refresh_flight(release)");
+                            if state.pending {
+                                state.pending = false;
                                 continue;
                             }
-                            REFRESH_FLIGHT.in_flight.store(false, Ordering::Release);
-                            // Narrow re-check: a publish that set `pending`
-                            // between the swap above and the store may have
-                            // found `in_flight` still true and NOT spawned its
-                            // own flight — reclaim it here. A publish that
-                            // instead won the new `swap(true)` runs its own
-                            // flight and this one stops.
-                            if REFRESH_FLIGHT.pending.swap(false, Ordering::AcqRel) {
-                                if REFRESH_FLIGHT.in_flight.swap(true, Ordering::AcqRel) {
-                                    break;
-                                }
-                                continue;
-                            }
+                            state.in_flight = false;
                             break;
                         }
                     });
                 } else {
-                    REFRESH_FLIGHT.pending.store(true, Ordering::Release);
                     log::debug!("semantic_tokens_refresh coalesced into the in-flight request");
                 }
             } else {

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -88,7 +88,7 @@ pub(super) fn bridge_configs_for_injection_language(
     injection_language: &str,
 ) -> Vec<ResolvedServerConfig> {
     let settings = settings_manager.load_settings();
-    bridge.get_all_configs_for_language(&settings, host_language, injection_language)
+    bridge.cached_configs_for_injection_language(&settings, host_language, injection_language)
 }
 
 pub(super) async fn apply_shared_settings(

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -204,6 +204,25 @@ pub struct Kakehashi {
     /// is live (unambiguous), otherwise `null`.
     #[allow(clippy::type_complexity)]
     captures_cache: dashmap::DashMap<(Url, String), [Option<(String, Vec<serde_json::Value>)>; 2]>,
+    /// Memoized captures walk results per `(uri, kind, injection-mode)`,
+    /// tagged with the exact inputs they were computed from — snapshot
+    /// `(parsed_version, incarnation)` and the settings generation. A typing
+    /// client sends `captures/full` AND `captures/full/delta` per keystroke;
+    /// both walk the same snapshot, so the second (and any repeat on an
+    /// unchanged document) serves the memo instead of re-executing the kind
+    /// query over every layer. One entry per key (insert-overwrites), dropped
+    /// with the lineage cache on `didClose`.
+    #[allow(clippy::type_complexity)]
+    captures_walk_cache: dashmap::DashMap<
+        (Url, String, bool),
+        (
+            u64,
+            u64,
+            u64,
+            Vec<serde_json::Value>,
+            Vec<serde_json::Value>,
+        ),
+    >,
     /// True when the process runs as a one-shot CLI (`kakehashi diagnose`/`format`)
     /// rather than a long-lived LSP server. Set once by `cli_initialize`. No editor
     /// consumes a proactive `publishDiagnostics` in CLI mode (the stub client pump
@@ -286,6 +305,7 @@ impl Kakehashi {
             shutdown_token: tokio_util::sync::CancellationToken::new(),
             home_dir: dirs::home_dir().map(|p| p.to_string_lossy().into_owned()),
             captures_cache: dashmap::DashMap::new(),
+            captures_walk_cache: dashmap::DashMap::new(),
             cli_mode: std::sync::atomic::AtomicBool::new(false),
             parse_scheduler: std::sync::Arc::new(parse_scheduler::ParseScheduler::default()),
         }

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -213,16 +213,8 @@ pub struct Kakehashi {
     /// query over every layer. One entry per key (insert-overwrites), dropped
     /// with the lineage cache on `didClose`.
     #[allow(clippy::type_complexity)]
-    captures_walk_cache: dashmap::DashMap<
-        (Url, String, bool),
-        (
-            u64,
-            u64,
-            u64,
-            Vec<serde_json::Value>,
-            Vec<serde_json::Value>,
-        ),
-    >,
+    captures_walk_cache:
+        dashmap::DashMap<(Url, String, bool), kakehashi::captures::CachedCapturesWalk>,
     /// True when the process runs as a one-shot CLI (`kakehashi diagnose`/`format`)
     /// rather than a long-lived LSP server. Set once by `cli_initialize`. No editor
     /// consumes a proactive `publishDiagnostics` in CLI mode (the stub client pump

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -100,6 +100,16 @@ pub(super) async fn apply_shared_settings(
     raw_settings: Option<RawWorkspaceSettings>,
     settings: WorkspaceSettings,
 ) {
+    // TRANSITIONAL generation bump BEFORE any query/config mutation: from
+    // this instant, every generation-stamped product built from the OLD
+    // queries (snapshot-riding discovery/bridge/resolved regions, layer
+    // trees, kind queries, walk memos) stops matching and consumers fall
+    // back inline — without it, `load_settings` swaps the queries first and
+    // the (possibly long: `propagate_settings` awaits the network) window
+    // until the post-reload bump kept serving old-query products as current.
+    // The second bump below then also invalidates anything a racing request
+    // built MID-swap against a half-updated query set.
+    cache.bump_semantic_token_generation();
     let summary = language.load_settings(&settings);
     // Path c: push the new per-server settings to live downstream connections
     // at this single reload choke point (initialize, didChangeConfiguration,
@@ -118,15 +128,17 @@ pub(super) async fn apply_shared_settings(
         None => settings_manager.apply_settings(settings),
     }
     // A settings/query reload can change tokenization for unchanged text, so bump
-    // the semantic-token cache generation — otherwise a repeat request on an
-    // unedited document would serve tokens from the old queries. Done at this single
-    // choke point so every reload path (initialize, didChangeConfiguration, and the
-    // auto-install reload) is covered, and *before* the refresh below so the editor's
-    // re-request recomputes. The generation bump (not a bare clear) also defeats a
-    // request that was mid-tokenization across the reload and stores afterwards: it
-    // captured the old generation, so its entry can't be served post-reload.
-    // `didChange` deliberately does NOT invalidate (delta needs the previous tokens);
-    // only a query/config reload does.
+    // the semantic-token cache generation again — the transitional bump above
+    // covered products built from the OLD queries; this one covers anything a
+    // racing request built DURING the swap against a half-updated query set.
+    // Done at this single choke point so every reload path (initialize,
+    // didChangeConfiguration, and the auto-install reload) is covered, and
+    // *before* the refresh below so the editor's re-request recomputes. The
+    // generation bump (not a bare clear) also defeats a request that was
+    // mid-tokenization across the reload and stores afterwards: it captured
+    // an old generation, so its entry can't be served post-reload.
+    // `didChange` deliberately does NOT invalidate (delta needs the previous
+    // tokens); only a query/config reload does.
     cache.bump_semantic_token_generation();
     build_notifier(client, settings_manager)
         .log_language_events(&summary.events)

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -2,7 +2,7 @@ pub(crate) mod bridge_context;
 mod cli;
 mod coordinator;
 pub(crate) use coordinator::DiagnosticPublisher;
-mod kakehashi;
+pub(crate) mod kakehashi;
 mod lifecycle;
 mod parse_scheduler;
 mod show_document_translation;

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -111,6 +111,13 @@ pub(super) async fn apply_shared_settings(
     // built MID-swap against a half-updated query set.
     cache.bump_semantic_token_generation();
     let summary = language.load_settings(&settings);
+    // Second bump IMMEDIATELY after the query swap, before any await: a
+    // request that started after the transitional bump above but before the
+    // swap computed against the OLD queries yet stamped the new generation —
+    // without this bump those products would be accepted as current for the
+    // whole awaited propagate below. (The final bump after apply_settings
+    // covers the settings-side inputs the apply swaps.)
+    cache.bump_semantic_token_generation();
     // Path c: push the new per-server settings to live downstream connections
     // at this single reload choke point (initialize, didChangeConfiguration,
     // auto-install reload), before `settings` is consumed by the apply below.
@@ -127,10 +134,13 @@ pub(super) async fn apply_shared_settings(
         Some(raw_settings) => settings_manager.apply_settings_with_raw(raw_settings, settings),
         None => settings_manager.apply_settings(settings),
     }
-    // A settings/query reload can change tokenization for unchanged text, so bump
-    // the semantic-token cache generation again — the transitional bump above
-    // covered products built from the OLD queries; this one covers anything a
-    // racing request built DURING the swap against a half-updated query set.
+    // A settings/query reload can change tokenization for unchanged text, so
+    // bump the semantic-token cache generation once more: the ladder is one
+    // bump per mutation boundary — before the query swap (kills old-query
+    // stamps), after it (kills mid-swap stamps), and here after the settings
+    // apply (kills stamps that read the new queries but the OLD
+    // settings-side inputs, e.g. capture mappings, during the awaited
+    // propagate).
     // Done at this single choke point so every reload path (initialize,
     // didChangeConfiguration, and the auto-install reload) is covered, and
     // *before* the refresh below so the editor's re-request recomputes. The

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -696,7 +696,7 @@ impl Kakehashi {
 
         let configs = self
             .bridge
-            .get_host_configs_for_language(&settings, &language_name);
+            .cached_host_configs_for_language(&settings, &language_name);
         if configs.is_empty() {
             log::debug!(
                 "{}: no host-capable server configured for {}",

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -48,6 +48,7 @@ pub(crate) struct DiagnosticScheduler {
     documents: std::sync::Arc<DocumentStore>,
     bridge: std::sync::Arc<BridgeCoordinator>,
     settings_manager: std::sync::Arc<SettingsManager>,
+    cache: std::sync::Arc<crate::lsp::cache::CacheCoordinator>,
     debounced_diagnostics: std::sync::Arc<DebouncedDiagnosticsManager>,
     synthetic_diagnostics: std::sync::Arc<SyntheticDiagnosticsManager>,
     /// The single proactive publisher: the host-event pull below feeds its
@@ -64,6 +65,7 @@ impl DiagnosticScheduler {
             documents: std::sync::Arc::clone(&server.documents),
             bridge: std::sync::Arc::clone(&server.bridge),
             settings_manager: std::sync::Arc::clone(&server.settings_manager),
+            cache: std::sync::Arc::clone(&server.cache),
             debounced_diagnostics: std::sync::Arc::clone(&server.debounced_diagnostics),
             synthetic_diagnostics: std::sync::Arc::clone(&server.synthetic_diagnostics),
             publisher: std::sync::Arc::new(super::DiagnosticPublisher::new(server)),
@@ -188,7 +190,10 @@ impl DiagnosticScheduler {
                         // Prefer the populate pass's regions riding the current
                         // parse snapshot (never discover twice, ADR §3); fall
                         // back to the inline resolution when absent/stale.
-                        let all_regions = match self.documents.current_resolved_regions(uri) {
+                        let all_regions = match self
+                            .documents
+                            .current_resolved_regions(uri, self.cache.semantic_token_generation())
+                        {
                             Some(regions) => regions.as_ref().clone(),
                             None => InjectionResolver::resolve_all(
                                 &self.language,

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -185,14 +185,20 @@ impl DiagnosticScheduler {
                 self.language
                     .injection_query(&language_name)
                     .map(|injection_query| {
-                        let all_regions = InjectionResolver::resolve_all(
-                            &self.language,
-                            self.bridge.node_tracker(),
-                            uri,
-                            snapshot.tree(),
-                            snapshot.text(),
-                            injection_query.as_ref(),
-                        );
+                        // Prefer the populate pass's regions riding the current
+                        // parse snapshot (never discover twice, ADR §3); fall
+                        // back to the inline resolution when absent/stale.
+                        let all_regions = match self.documents.current_resolved_regions(uri) {
+                            Some(regions) => regions.as_ref().clone(),
+                            None => InjectionResolver::resolve_all(
+                                &self.language,
+                                self.bridge.node_tracker(),
+                                uri,
+                                snapshot.tree(),
+                                snapshot.text(),
+                                injection_query.as_ref(),
+                            ),
+                        };
 
                         let mut contexts = Vec::new();
                         // Configs + aggregation are keyed by injection language, so

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -194,15 +194,15 @@ impl DiagnosticScheduler {
                             .documents
                             .current_resolved_regions(uri, self.cache.semantic_token_generation())
                         {
-                            Some(regions) => regions.as_ref().clone(),
-                            None => InjectionResolver::resolve_all(
+                            Some(regions) => regions,
+                            None => std::sync::Arc::new(InjectionResolver::resolve_all(
                                 &self.language,
                                 self.bridge.node_tracker(),
                                 uri,
                                 snapshot.tree(),
                                 snapshot.text(),
                                 injection_query.as_ref(),
-                            ),
+                            )),
                         };
 
                         let mut contexts = Vec::new();
@@ -216,7 +216,7 @@ impl DiagnosticScheduler {
                             Option<(Vec<ResolvedServerConfig>, ResolvedAggregationConfig)>;
                         let mut resolved_by_lang: std::collections::HashMap<String, ResolvedLang> =
                             std::collections::HashMap::new();
-                        for resolved in all_regions {
+                        for resolved in all_regions.iter() {
                             // `get` on the common (cache-hit) path is a single lookup;
                             // only the resolving miss touches the map again, cloning
                             // the language key just for that insert.
@@ -273,7 +273,7 @@ impl DiagnosticScheduler {
 
                             contexts.push(DocumentRequestContext {
                                 uri: uri.clone(),
-                                resolved,
+                                resolved: resolved.clone(),
                                 configs: configs.clone(),
                                 upstream_request_id: None,
                                 priorities: agg.priorities.clone(),

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -624,14 +624,18 @@ impl DiagnosticPublisher {
             return offsets;
         };
 
-        for resolved in InjectionResolver::resolve_all(
-            &self.language,
-            self.bridge.node_tracker(),
-            host,
-            snapshot.tree(),
-            snapshot.text(),
-            injection_query.as_ref(),
-        ) {
+        let resolved_regions = match self.documents.current_resolved_regions(host) {
+            Some(regions) => regions.as_ref().clone(),
+            None => InjectionResolver::resolve_all(
+                &self.language,
+                self.bridge.node_tracker(),
+                host,
+                snapshot.tree(),
+                snapshot.text(),
+                injection_query.as_ref(),
+            ),
+        };
+        for resolved in resolved_regions {
             offsets.insert(
                 resolved.region.region_id.clone(),
                 RegionOffset::with_per_line_offsets(

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -38,6 +38,7 @@ pub(crate) struct DiagnosticPublisher {
     documents: Arc<DocumentStore>,
     bridge: Arc<BridgeCoordinator>,
     settings_manager: Arc<SettingsManager>,
+    cache: Arc<crate::lsp::cache::CacheCoordinator>,
     aggregator: Arc<DiagnosticAggregator>,
 }
 
@@ -49,6 +50,7 @@ impl DiagnosticPublisher {
             documents: Arc::clone(&server.documents),
             bridge: Arc::clone(&server.bridge),
             settings_manager: Arc::clone(&server.settings_manager),
+            cache: Arc::clone(&server.cache),
             aggregator: Arc::clone(&server.diagnostics),
         }
     }
@@ -624,7 +626,10 @@ impl DiagnosticPublisher {
             return offsets;
         };
 
-        let resolved_regions = match self.documents.current_resolved_regions(host) {
+        let resolved_regions = match self
+            .documents
+            .current_resolved_regions(host, self.cache.semantic_token_generation())
+        {
             Some(regions) => regions.as_ref().clone(),
             None => InjectionResolver::resolve_all(
                 &self.language,

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -630,17 +630,17 @@ impl DiagnosticPublisher {
             .documents
             .current_resolved_regions(host, self.cache.semantic_token_generation())
         {
-            Some(regions) => regions.as_ref().clone(),
-            None => InjectionResolver::resolve_all(
+            Some(regions) => regions,
+            None => std::sync::Arc::new(InjectionResolver::resolve_all(
                 &self.language,
                 self.bridge.node_tracker(),
                 host,
                 snapshot.tree(),
                 snapshot.text(),
                 injection_query.as_ref(),
-            ),
+            )),
         };
-        for resolved in resolved_regions {
+        for resolved in resolved_regions.iter() {
             offsets.insert(
                 resolved.region.region_id.clone(),
                 RegionOffset::with_per_line_offsets(

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -340,3 +340,118 @@ impl InjectionCoordinator {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use tower_lsp_server::LspService;
+    use url::Url;
+
+    /// The snapshot fast path of `resolve_injection_data` must produce
+    /// exactly what the inline (live-tree) resolution produces — the fast
+    /// path's output is forwarded verbatim to downstream servers, so a
+    /// divergence would silently mis-forward.
+    #[tokio::test]
+    async fn bridge_fast_path_matches_inline_resolution() {
+        let (service, _socket) = LspService::new(crate::lsp::lsp_impl::Kakehashi::new);
+        let server = service.inner();
+
+        let settings = crate::config::WorkspaceSettings {
+            search_paths: vec![
+                std::env::var("TREE_SITTER_GRAMMARS")
+                    .unwrap_or_else(|_| "deps/tree-sitter".to_string()),
+            ],
+            ..Default::default()
+        };
+        let _ = server.language.load_settings(&settings);
+        for lang in ["markdown", "markdown_inline", "lua"] {
+            if !server.language.ensure_language_loaded(lang).success {
+                eprintln!("Skipping: {lang} parser not available");
+                return;
+            }
+        }
+
+        let text = "# T\n\n```lua\nlocal x = 1\n```\n\n```lua\nlocal y = 2\n```\n";
+        let mut pool = server.language.create_document_parser_pool();
+        let Some(mut parser) = pool.acquire("markdown") else {
+            return;
+        };
+        let tree = parser.parse(text, None).expect("parse markdown");
+        pool.release("markdown".to_string(), parser);
+
+        let uri = Url::parse("file:///bridge_fast_path.md").unwrap();
+        server
+            .documents
+            .insert(uri.clone(), text.to_string(), Some("markdown".into()), None);
+        server
+            .documents
+            .update_document(uri.clone(), text.to_string(), Some(tree.clone()));
+
+        let injection = server.injection_coordinator();
+
+        // INLINE: a current snapshot with no bridge_regions falls through to
+        // the live-tree resolution.
+        let incarnation = server
+            .documents
+            .latest_snapshot(&uri)
+            .unwrap()
+            .slot
+            .current_incarnation;
+        let content_version = server.documents.get(&uri).unwrap().content_version();
+        let publish = |bridge_regions, parsed_version| {
+            let landed = server
+                .documents
+                .get(&uri)
+                .map(|doc| {
+                    doc.publish_snapshot(std::sync::Arc::new(
+                        crate::document::snapshot::ParseSnapshot {
+                            text: std::sync::Arc::from(text),
+                            tree: Some(tree.clone()),
+                            language: Some("markdown".to_string()),
+                            parsed_version,
+                            incarnation,
+                            injection_regions: None,
+                            bridge_regions,
+                            resolved_regions: None,
+                            layer_trees: std::sync::OnceLock::new(),
+                        },
+                    ))
+                })
+                .unwrap_or(false);
+            assert!(landed, "test publish must land");
+        };
+        publish(None, content_version);
+        let inline = injection.resolve_injection_data(&uri, "markdown");
+        assert!(!inline.is_empty(), "the two fences must resolve");
+
+        // FAST PATH: populate derives the bridge regions from the same tree
+        // (same tracker → same region ids); a newer current snapshot carries
+        // them and the resolver consumes them verbatim.
+        let populated = server.cache.populate_injections(
+            &uri,
+            text,
+            &tree,
+            "markdown",
+            &server.language,
+            &server.bridge.node_tracker_arc(),
+            true,
+        );
+        let bridge_regions = populated.bridge_regions.expect("gate was true");
+        server
+            .documents
+            .update_document(uri.clone(), text.to_string(), Some(tree.clone()));
+        let content_version = server.documents.get(&uri).unwrap().content_version();
+        publish(Some(std::sync::Arc::new(bridge_regions)), content_version);
+        let fast = injection.resolve_injection_data(&uri, "markdown");
+
+        assert_eq!(
+            inline.len(),
+            fast.len(),
+            "fast path must resolve the same regions"
+        );
+        for (a, b) in inline.iter().zip(fast.iter()) {
+            assert_eq!(a.language, b.language, "raw language must match");
+            assert_eq!(a.region_id, b.region_id, "region id must match");
+            assert_eq!(a.content, b.content, "clean content must match");
+        }
+    }
+}

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -97,6 +97,28 @@ impl InjectionCoordinator {
         uri: &Url,
         host_language: &str,
     ) -> Vec<BridgeInjection> {
+        // Fast path (parse-snapshot ADR §3, never discover twice): the parse
+        // pass that scheduled this downstream already derived the bridge
+        // regions from its single injection-query run and published them on
+        // the snapshot. Consume them when the snapshot is CURRENT — this
+        // downstream runs right after the publish, so it virtually always is;
+        // a raced edit falls back to the inline resolution below (which reads
+        // the live tree, exactly as before).
+        if let Some(view) = self.documents.latest_snapshot(uri)
+            && let Some(snapshot) = &view.slot.snapshot
+            && snapshot.parsed_version == view.content_version
+            && let Some(bridge_regions) = &snapshot.bridge_regions
+        {
+            return bridge_regions
+                .iter()
+                .map(|region| BridgeInjection {
+                    language: region.raw_language.clone(),
+                    region_id: region.region_id.clone(),
+                    content: region.content.clone(),
+                })
+                .collect();
+        }
+
         let Some(injection_query) = self.language.injection_query(host_language) else {
             return Vec::new();
         };

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -107,7 +107,12 @@ impl InjectionCoordinator {
         if let Some(view) = self.documents.latest_snapshot(uri)
             && let Some(snapshot) = &view.slot.snapshot
             && snapshot.parsed_version == view.content_version
-            && let Some(bridge_regions) = &snapshot.bridge_regions
+            && let Some((stamped_generation, bridge_regions)) = &snapshot.bridge_regions
+            // Generation gate (like resolved_regions): a reload can change
+            // the injection query without a new snapshot — consuming the old
+            // query's regions would open/update virtual documents the new
+            // query would not discover. Mismatch falls back inline below.
+            && *stamped_generation == self.cache.semantic_token_generation()
         {
             return bridge_regions
                 .iter()
@@ -440,7 +445,10 @@ mod tests {
             .documents
             .update_document(uri.clone(), text.to_string(), Some(tree.clone()));
         let content_version = server.documents.get(&uri).unwrap().content_version();
-        publish(Some(std::sync::Arc::new(bridge_regions)), content_version);
+        publish(
+            Some((populated.generation, std::sync::Arc::new(bridge_regions))),
+            content_version,
+        );
         let fast = injection.resolve_injection_data(&uri, "markdown");
 
         assert_eq!(

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -507,17 +507,13 @@ impl ParseCoordinator {
                 // populate — the snapshot then publishes without discovery and
                 // readers discover inline for that (already-superseded) snapshot.
                 let regions = if stored {
-                    let populated = self
-                        .populate_injections_on_pool(
-                            uri.clone(),
-                            text.clone(),
-                            tree.clone(),
-                            language_name.clone(),
-                        )
-                        .await;
-                    self.documents
-                        .mark_parse_finished(&uri, parse_generation, true);
-                    populated
+                    self.populate_injections_on_pool(
+                        uri.clone(),
+                        text.clone(),
+                        tree.clone(),
+                        language_name.clone(),
+                    )
+                    .await
                 } else {
                     PopulatedSnapshotRegions::default()
                 };
@@ -535,6 +531,15 @@ impl ParseCoordinator {
                         layer_trees: std::sync::OnceLock::new(),
                     },
                 );
+                if stored {
+                    // AFTER the publish: a downstream task woken by this mark
+                    // on another runtime thread must find the snapshot (and
+                    // its fast-path regions) already in the cell — marking
+                    // first let it read the previous snapshot and fall back
+                    // to inline resolution for one cycle.
+                    self.documents
+                        .mark_parse_finished(&uri, parse_generation, true);
+                }
                 advance_watermark();
                 self.notifier().log_language_events(&events).await;
                 // `stored` is exactly "this call's CAS landed the tree": false when a

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -394,6 +394,7 @@ impl ParseCoordinator {
                         injection_regions: None,
                         bridge_regions: None,
                         resolved_regions: None,
+                        layer_trees: std::sync::OnceLock::new(),
                     },
                 );
                 advance_watermark();
@@ -490,6 +491,7 @@ impl ParseCoordinator {
                         injection_regions: regions.discovery,
                         bridge_regions: regions.bridge_regions,
                         resolved_regions: regions.resolved_regions,
+                        layer_trees: std::sync::OnceLock::new(),
                     },
                 );
                 advance_watermark();
@@ -530,6 +532,7 @@ impl ParseCoordinator {
                     injection_regions: None,
                     bridge_regions: None,
                     resolved_regions: None,
+                    layer_trees: std::sync::OnceLock::new(),
                 },
             );
             advance_watermark();
@@ -562,6 +565,7 @@ impl ParseCoordinator {
                 injection_regions: None,
                 bridge_regions: None,
                 resolved_regions: None,
+                layer_trees: std::sync::OnceLock::new(),
             },
         );
         advance_watermark();
@@ -734,6 +738,7 @@ impl ParseCoordinator {
                     injection_regions: regions.discovery,
                     bridge_regions: regions.bridge_regions,
                     resolved_regions: regions.resolved_regions,
+                    layer_trees: std::sync::OnceLock::new(),
                 },
             );
             // Serve-stale's heal signal, mirroring reparse_latest: a token
@@ -926,6 +931,7 @@ impl ParseCoordinator {
                     injection_regions: regions.discovery,
                     bridge_regions: regions.bridge_regions,
                     resolved_regions: regions.resolved_regions,
+                    layer_trees: std::sync::OnceLock::new(),
                 },
             );
             // Serve-stale's heal signal (ADR §3): a fresh publish re-drives the

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -934,18 +934,38 @@ impl ParseCoordinator {
                     layer_trees: std::sync::OnceLock::new(),
                 },
             );
-            // Serve-stale's heal signal (ADR §3): a fresh publish re-drives the
-            // client with workspace/semanticTokens/refresh so a request served
-            // one edit behind is re-requested against this snapshot. Emitted
-            // HERE — at the parse-loop publish point, after the notification
-            // returned — never from didChange, whose synchronous clients
-            // (vim-lsp) cannot answer a server request mid-notification. Gated
-            // on the publish landing: a rejected publish emits nothing. The
-            // notifier batches and capability-gates the actual request.
+            // Serve-stale's heal signal (ADR §3), narrowed to the cases the
+            // workspace-scoped request is actually FOR. `refresh` is expensive
+            // for the client (Neovim's handler cancels its in-flight token
+            // request and re-tokenizes every attached buffer), and clients
+            // already re-request per didChange — so a publish emits it only
+            // when ALL of:
+            // - the publish landed (a rejected publish emits nothing);
+            // - the document has SETTLED (this parse's version is still the
+            //   live content_version — during a typing burst the scheduler is
+            //   already reparsing newer text, whose own publish re-evaluates);
+            // - some client actually consumes this document's semantic tokens
+            //   (a served-version mark exists) AND its last served tokens
+            //   predate this snapshot (otherwise its own didChange-driven
+            //   request already caught up).
+            // Net: at most one refresh per settle, none mid-burst, none for
+            // documents nobody highlights. Emitted from the parse loop, never
+            // didChange (synchronous clients can't answer a server request
+            // mid-notification).
             if published {
-                events.push(crate::language::LanguageEvent::semantic_tokens_refresh(
-                    language_name.clone(),
-                ));
+                let settled = self
+                    .documents
+                    .get(uri)
+                    .is_some_and(|doc| doc.content_version() == content_version);
+                let client_is_stale = self
+                    .cache
+                    .served_semantic_version(uri)
+                    .is_some_and(|served| served < content_version);
+                if settled && client_is_stale {
+                    events.push(crate::language::LanguageEvent::semantic_tokens_refresh(
+                        language_name.clone(),
+                    ));
+                }
             }
         }
 

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -18,7 +18,10 @@ use crate::lsp::settings_manager::SettingsManager;
 struct PopulatedSnapshotRegions {
     discovery: Option<std::sync::Arc<crate::document::DiscoveredInjections>>,
     bridge_regions: Option<std::sync::Arc<Vec<crate::document::DiscoveredBridgeRegion>>>,
-    resolved_regions: Option<std::sync::Arc<Vec<crate::language::injection::ResolvedInjection>>>,
+    resolved_regions: Option<(
+        u64,
+        std::sync::Arc<Vec<crate::language::injection::ResolvedInjection>>,
+    )>,
 }
 
 /// Timeout for compute-pool parse operations to prevent hangs on pathological inputs.
@@ -50,6 +53,27 @@ fn parse_text_with_deadline(
     deadline: std::time::Instant,
 ) -> Option<tree_sitter::Tree> {
     crate::language::injection::parse_with_deadline(parser, text, old_tree, deadline)
+}
+
+/// The settled+stale gate for the parse loop's `semanticTokens/refresh`
+/// emission (its full rationale lives at the call site): emit only when the
+/// published parse is still the LIVE content version (settled — mid-burst
+/// publishes skip; the newer text's own publish re-evaluates) AND some
+/// client's last served tokens predate it (a served-version mark exists and
+/// is older — no mark means nobody highlights this document).
+fn should_emit_settle_refresh(
+    documents: &DocumentStore,
+    cache: &CacheCoordinator,
+    uri: &Url,
+    content_version: u64,
+) -> bool {
+    let settled = documents
+        .get(uri)
+        .is_some_and(|doc| doc.content_version() == content_version);
+    let client_is_stale = cache
+        .served_semantic_version(uri)
+        .is_some_and(|served| served < content_version);
+    settled && client_is_stale
 }
 
 pub(super) struct ParseCoordinatorDeps {
@@ -255,6 +279,14 @@ impl ParseCoordinator {
         let cache = std::sync::Arc::clone(&self.cache);
         let language = std::sync::Arc::clone(&self.language);
         let tracker = self.bridge.node_tracker_arc();
+        // Coarse per-parse gate: with no runnable bridge server configured,
+        // the bridge-region build (per-region content copies) is pure waste
+        // on the pre-publish critical path. `None` on the snapshot makes a
+        // bridge configured by a later reload fall back to inline resolution.
+        let build_bridge_regions = self
+            .settings_manager
+            .load_settings()
+            .any_bridge_server_runnable();
         self.compute_pool
             .run(None, move || {
                 let populated = cache.populate_injections(
@@ -264,11 +296,15 @@ impl ParseCoordinator {
                     &language_name,
                     &language,
                     &tracker,
+                    build_bridge_regions,
                 );
                 PopulatedSnapshotRegions {
                     discovery: populated.discovery.map(std::sync::Arc::new),
-                    bridge_regions: Some(std::sync::Arc::new(populated.bridge_regions)),
-                    resolved_regions: Some(std::sync::Arc::new(populated.resolved_regions)),
+                    bridge_regions: populated.bridge_regions.map(std::sync::Arc::new),
+                    resolved_regions: Some((
+                        populated.generation,
+                        std::sync::Arc::new(populated.resolved_regions),
+                    )),
                 }
             })
             .await
@@ -952,20 +988,12 @@ impl ParseCoordinator {
             // documents nobody highlights. Emitted from the parse loop, never
             // didChange (synchronous clients can't answer a server request
             // mid-notification).
-            if published {
-                let settled = self
-                    .documents
-                    .get(uri)
-                    .is_some_and(|doc| doc.content_version() == content_version);
-                let client_is_stale = self
-                    .cache
-                    .served_semantic_version(uri)
-                    .is_some_and(|served| served < content_version);
-                if settled && client_is_stale {
-                    events.push(crate::language::LanguageEvent::semantic_tokens_refresh(
-                        language_name.clone(),
-                    ));
-                }
+            if published
+                && should_emit_settle_refresh(&self.documents, &self.cache, uri, content_version)
+            {
+                events.push(crate::language::LanguageEvent::semantic_tokens_refresh(
+                    language_name.clone(),
+                ));
             }
         }
 
@@ -985,6 +1013,40 @@ impl ParseCoordinator {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The four documented invariants of the settle-refresh gate.
+    #[test]
+    fn settle_refresh_gate_emits_only_for_settled_and_stale() {
+        let documents = DocumentStore::new();
+        let cache = CacheCoordinator::new();
+        let uri = url::Url::parse("file:///settle_gate.rs").unwrap();
+        documents.insert(uri.clone(), "a".into(), Some("rust".into()), None);
+        // content_version == 0 now.
+
+        // No served mark: nobody highlights this document -> no refresh.
+        assert!(!should_emit_settle_refresh(&documents, &cache, &uri, 0));
+
+        // Client already served THIS version -> its didChange-driven request
+        // caught up -> no refresh.
+        cache.record_served_semantic_version(&uri, 0);
+        assert!(!should_emit_settle_refresh(&documents, &cache, &uri, 0));
+
+        // An edit bumps the live version; the publish for v1 finds the client
+        // stale (served 0 < 1) and the document settled (live == 1) -> emit.
+        documents.update_document(uri.clone(), "ab".into(), None);
+        assert!(should_emit_settle_refresh(&documents, &cache, &uri, 1));
+
+        // Mid-burst: another edit already moved the live version past this
+        // publish (live 2, publish v1) -> not settled -> no refresh (the v2
+        // publish re-evaluates).
+        documents.update_document(uri.clone(), "abc".into(), None);
+        assert!(!should_emit_settle_refresh(&documents, &cache, &uri, 1));
+
+        // The mark is monotonic: a stale serve cannot regress it.
+        cache.record_served_semantic_version(&uri, 2);
+        cache.record_served_semantic_version(&uri, 1);
+        assert!(!should_emit_settle_refresh(&documents, &cache, &uri, 2));
+    }
 
     /// The deadline must actually abort the native parse (an expired one
     /// yields `None` fast) and must not poison the parser for reuse.

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -10,6 +10,17 @@ use url::Url;
 use crate::lsp::lsp_impl::{Kakehashi, build_notifier};
 use crate::lsp::settings_manager::SettingsManager;
 
+/// Everything one populate pass derives for the snapshot it rides on
+/// (parse-snapshot ADR §3): all `None` when populate was skipped (raced CAS)
+/// or the pool work-unit panicked — readers then fall back to inline
+/// resolution for that snapshot.
+#[derive(Default)]
+struct PopulatedSnapshotRegions {
+    discovery: Option<std::sync::Arc<crate::document::DiscoveredInjections>>,
+    bridge_regions: Option<std::sync::Arc<Vec<crate::document::DiscoveredBridgeRegion>>>,
+    resolved_regions: Option<std::sync::Arc<Vec<crate::language::injection::ResolvedInjection>>>,
+}
+
 /// Timeout for compute-pool parse operations to prevent hangs on pathological inputs.
 /// Shared across all parse-with-pool call sites (didChange, semantic tokens, selection range).
 /// THE SAME constant bounds the injected-layer re-parses (`parse_with_ranges`),
@@ -240,10 +251,7 @@ impl ParseCoordinator {
         text: std::sync::Arc<str>,
         tree: tree_sitter::Tree,
         language_name: String,
-    ) -> (
-        Option<std::sync::Arc<crate::document::DiscoveredInjections>>,
-        Option<std::sync::Arc<Vec<crate::document::DiscoveredBridgeRegion>>>,
-    ) {
+    ) -> PopulatedSnapshotRegions {
         let cache = std::sync::Arc::clone(&self.cache);
         let language = std::sync::Arc::clone(&self.language);
         let tracker = self.bridge.node_tracker_arc();
@@ -257,13 +265,14 @@ impl ParseCoordinator {
                     &language,
                     &tracker,
                 );
-                (
-                    populated.discovery.map(std::sync::Arc::new),
-                    Some(std::sync::Arc::new(populated.bridge_regions)),
-                )
+                PopulatedSnapshotRegions {
+                    discovery: populated.discovery.map(std::sync::Arc::new),
+                    bridge_regions: Some(std::sync::Arc::new(populated.bridge_regions)),
+                    resolved_regions: Some(std::sync::Arc::new(populated.resolved_regions)),
+                }
             })
             .await
-            .unwrap_or((None, None))
+            .unwrap_or_default()
     }
 
     /// Parse the (already-registered) document at `uri` and publish the result.
@@ -384,6 +393,7 @@ impl ParseCoordinator {
                         incarnation,
                         injection_regions: None,
                         bridge_regions: None,
+                        resolved_regions: None,
                     },
                 );
                 advance_watermark();
@@ -454,7 +464,7 @@ impl ParseCoordinator {
                 // the previous snapshot meanwhile. A rejected CAS (raced) skips
                 // populate — the snapshot then publishes without discovery and
                 // readers discover inline for that (already-superseded) snapshot.
-                let (discovery, bridge_regions) = if stored {
+                let regions = if stored {
                     let populated = self
                         .populate_injections_on_pool(
                             uri.clone(),
@@ -467,7 +477,7 @@ impl ParseCoordinator {
                         .mark_parse_finished(&uri, parse_generation, true);
                     populated
                 } else {
-                    (None, None)
+                    PopulatedSnapshotRegions::default()
                 };
                 self.publish_parse_snapshot(
                     &uri,
@@ -477,8 +487,9 @@ impl ParseCoordinator {
                         language: Some(language_name.clone()),
                         parsed_version: content_version,
                         incarnation,
-                        injection_regions: discovery,
-                        bridge_regions,
+                        injection_regions: regions.discovery,
+                        bridge_regions: regions.bridge_regions,
+                        resolved_regions: regions.resolved_regions,
                     },
                 );
                 advance_watermark();
@@ -518,6 +529,7 @@ impl ParseCoordinator {
                     incarnation,
                     injection_regions: None,
                     bridge_regions: None,
+                    resolved_regions: None,
                 },
             );
             advance_watermark();
@@ -549,6 +561,7 @@ impl ParseCoordinator {
                 incarnation,
                 injection_regions: None,
                 bridge_regions: None,
+                resolved_regions: None,
             },
         );
         advance_watermark();
@@ -699,7 +712,7 @@ impl ParseCoordinator {
             // (ADR §3); the cell guard still rejects a stale lifetime or an
             // out-of-order version at publish. A rejected CAS skips populate —
             // the snapshot still publishes as stale-but-consistent.
-            let (discovery, bridge_regions) = if stored {
+            let regions = if stored {
                 self.populate_injections_on_pool(
                     uri.clone(),
                     text.clone(),
@@ -708,7 +721,7 @@ impl ParseCoordinator {
                 )
                 .await
             } else {
-                (None, None)
+                PopulatedSnapshotRegions::default()
             };
             let published = self.publish_parse_snapshot(
                 &uri,
@@ -718,8 +731,9 @@ impl ParseCoordinator {
                     language: Some(language_name.clone()),
                     parsed_version: content_version,
                     incarnation: expected_incarnation,
-                    injection_regions: discovery,
-                    bridge_regions,
+                    injection_regions: regions.discovery,
+                    bridge_regions: regions.bridge_regions,
+                    resolved_regions: regions.resolved_regions,
                 },
             );
             // Serve-stale's heal signal, mirroring reparse_latest: a token
@@ -890,7 +904,7 @@ impl ParseCoordinator {
             // (the text moved on mid-parse) skips populate — the snapshot still
             // publishes as stale-but-consistent (its readers discover inline;
             // the scheduler's dirty loop is already reparsing the newer text).
-            let (discovery, bridge_regions) = if stored {
+            let regions = if stored {
                 self.populate_injections_on_pool(
                     uri.clone(),
                     text.clone(),
@@ -899,7 +913,7 @@ impl ParseCoordinator {
                 )
                 .await
             } else {
-                (None, None)
+                PopulatedSnapshotRegions::default()
             };
             let published = self.publish_parse_snapshot(
                 uri,
@@ -909,8 +923,9 @@ impl ParseCoordinator {
                     language: Some(language_name.clone()),
                     parsed_version: content_version,
                     incarnation,
-                    injection_regions: discovery,
-                    bridge_regions,
+                    injection_regions: regions.discovery,
+                    bridge_regions: regions.bridge_regions,
+                    resolved_regions: regions.resolved_regions,
                 },
             );
             // Serve-stale's heal signal (ADR §3): a fresh publish re-drives the

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -17,7 +17,10 @@ use crate::lsp::settings_manager::SettingsManager;
 #[derive(Default)]
 struct PopulatedSnapshotRegions {
     discovery: Option<std::sync::Arc<crate::document::DiscoveredInjections>>,
-    bridge_regions: Option<std::sync::Arc<Vec<crate::document::DiscoveredBridgeRegion>>>,
+    bridge_regions: Option<(
+        u64,
+        std::sync::Arc<Vec<crate::document::DiscoveredBridgeRegion>>,
+    )>,
     resolved_regions: Option<(
         u64,
         std::sync::Arc<Vec<crate::language::injection::ResolvedInjection>>,
@@ -300,7 +303,9 @@ impl ParseCoordinator {
                 );
                 PopulatedSnapshotRegions {
                     discovery: populated.discovery.map(std::sync::Arc::new),
-                    bridge_regions: populated.bridge_regions.map(std::sync::Arc::new),
+                    bridge_regions: populated
+                        .bridge_regions
+                        .map(|regions| (populated.generation, std::sync::Arc::new(regions))),
                     resolved_regions: Some((
                         populated.generation,
                         std::sync::Arc::new(populated.resolved_regions),

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -230,27 +230,40 @@ impl ParseCoordinator {
     /// It is **awaited**, not detached, preserving the `populate → mark finished
     /// → downstream` ordering the injection-map invalidation depends on (Stage-1
     /// obligation). All parameters are cheap clones (refcount bumps).
-    /// Returns the owned injection discovery for this parse (`None` when not
-    /// reusable — or when the pool work-unit panicked), destined for the
-    /// snapshot this pass publishes (ADR §3, don't-discover-twice).
+    /// Returns everything the populate pass derived from its single injection
+    /// query — the semantic discovery and the bridge-downstream regions — both
+    /// destined for the snapshot this pass publishes (ADR §3,
+    /// don't-discover-twice). `(None, None)` when the work-unit panicked.
     async fn populate_injections_on_pool(
         &self,
         uri: Url,
         text: std::sync::Arc<str>,
         tree: tree_sitter::Tree,
         language_name: String,
-    ) -> Option<std::sync::Arc<crate::document::DiscoveredInjections>> {
+    ) -> (
+        Option<std::sync::Arc<crate::document::DiscoveredInjections>>,
+        Option<std::sync::Arc<Vec<crate::document::DiscoveredBridgeRegion>>>,
+    ) {
         let cache = std::sync::Arc::clone(&self.cache);
         let language = std::sync::Arc::clone(&self.language);
         let tracker = self.bridge.node_tracker_arc();
         self.compute_pool
             .run(None, move || {
-                cache
-                    .populate_injections(&uri, &text, &tree, &language_name, &language, &tracker)
-                    .map(std::sync::Arc::new)
+                let populated = cache.populate_injections(
+                    &uri,
+                    &text,
+                    &tree,
+                    &language_name,
+                    &language,
+                    &tracker,
+                );
+                (
+                    populated.discovery.map(std::sync::Arc::new),
+                    Some(std::sync::Arc::new(populated.bridge_regions)),
+                )
             })
             .await
-            .flatten()
+            .unwrap_or((None, None))
     }
 
     /// Parse the (already-registered) document at `uri` and publish the result.
@@ -370,6 +383,7 @@ impl ParseCoordinator {
                         parsed_version: content_version,
                         incarnation,
                         injection_regions: None,
+                        bridge_regions: None,
                     },
                 );
                 advance_watermark();
@@ -440,8 +454,8 @@ impl ParseCoordinator {
                 // the previous snapshot meanwhile. A rejected CAS (raced) skips
                 // populate — the snapshot then publishes without discovery and
                 // readers discover inline for that (already-superseded) snapshot.
-                let discovery = if stored {
-                    let discovery = self
+                let (discovery, bridge_regions) = if stored {
+                    let populated = self
                         .populate_injections_on_pool(
                             uri.clone(),
                             text.clone(),
@@ -451,9 +465,9 @@ impl ParseCoordinator {
                         .await;
                     self.documents
                         .mark_parse_finished(&uri, parse_generation, true);
-                    discovery
+                    populated
                 } else {
-                    None
+                    (None, None)
                 };
                 self.publish_parse_snapshot(
                     &uri,
@@ -464,6 +478,7 @@ impl ParseCoordinator {
                         parsed_version: content_version,
                         incarnation,
                         injection_regions: discovery,
+                        bridge_regions,
                     },
                 );
                 advance_watermark();
@@ -502,6 +517,7 @@ impl ParseCoordinator {
                     parsed_version: content_version,
                     incarnation,
                     injection_regions: None,
+                    bridge_regions: None,
                 },
             );
             advance_watermark();
@@ -532,6 +548,7 @@ impl ParseCoordinator {
                 parsed_version: content_version,
                 incarnation,
                 injection_regions: None,
+                bridge_regions: None,
             },
         );
         advance_watermark();
@@ -682,7 +699,7 @@ impl ParseCoordinator {
             // (ADR §3); the cell guard still rejects a stale lifetime or an
             // out-of-order version at publish. A rejected CAS skips populate —
             // the snapshot still publishes as stale-but-consistent.
-            let discovery = if stored {
+            let (discovery, bridge_regions) = if stored {
                 self.populate_injections_on_pool(
                     uri.clone(),
                     text.clone(),
@@ -691,7 +708,7 @@ impl ParseCoordinator {
                 )
                 .await
             } else {
-                None
+                (None, None)
             };
             let published = self.publish_parse_snapshot(
                 &uri,
@@ -702,6 +719,7 @@ impl ParseCoordinator {
                     parsed_version: content_version,
                     incarnation: expected_incarnation,
                     injection_regions: discovery,
+                    bridge_regions,
                 },
             );
             // Serve-stale's heal signal, mirroring reparse_latest: a token
@@ -872,7 +890,7 @@ impl ParseCoordinator {
             // (the text moved on mid-parse) skips populate — the snapshot still
             // publishes as stale-but-consistent (its readers discover inline;
             // the scheduler's dirty loop is already reparsing the newer text).
-            let discovery = if stored {
+            let (discovery, bridge_regions) = if stored {
                 self.populate_injections_on_pool(
                     uri.clone(),
                     text.clone(),
@@ -881,7 +899,7 @@ impl ParseCoordinator {
                 )
                 .await
             } else {
-                None
+                (None, None)
             };
             let published = self.publish_parse_snapshot(
                 uri,
@@ -892,6 +910,7 @@ impl ParseCoordinator {
                     parsed_version: content_version,
                     incarnation,
                     injection_regions: discovery,
+                    bridge_regions,
                 },
             );
             // Serve-stale's heal signal (ADR §3): a fresh publish re-drives the

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -230,21 +230,27 @@ impl ParseCoordinator {
     /// It is **awaited**, not detached, preserving the `populate → mark finished
     /// → downstream` ordering the injection-map invalidation depends on (Stage-1
     /// obligation). All parameters are cheap clones (refcount bumps).
+    /// Returns the owned injection discovery for this parse (`None` when not
+    /// reusable — or when the pool work-unit panicked), destined for the
+    /// snapshot this pass publishes (ADR §3, don't-discover-twice).
     async fn populate_injections_on_pool(
         &self,
         uri: Url,
         text: std::sync::Arc<str>,
         tree: tree_sitter::Tree,
         language_name: String,
-    ) {
+    ) -> Option<std::sync::Arc<crate::document::DiscoveredInjections>> {
         let cache = std::sync::Arc::clone(&self.cache);
         let language = std::sync::Arc::clone(&self.language);
         let tracker = self.bridge.node_tracker_arc();
         self.compute_pool
             .run(None, move || {
-                cache.populate_injections(&uri, &text, &tree, &language_name, &language, &tracker);
+                cache
+                    .populate_injections(&uri, &text, &tree, &language_name, &language, &tracker)
+                    .map(std::sync::Arc::new)
             })
-            .await;
+            .await
+            .flatten()
     }
 
     /// Parse the (already-registered) document at `uri` and publish the result.
@@ -363,6 +369,7 @@ impl ParseCoordinator {
                         language: Some(language_name.clone()),
                         parsed_version: content_version,
                         incarnation,
+                        injection_regions: None,
                     },
                 );
                 advance_watermark();
@@ -428,6 +435,26 @@ impl ParseCoordinator {
                         Some(&language_name),
                         Some(tree.clone()),
                     );
+                // Populate BEFORE the publish so the derived discovery rides the
+                // snapshot (ADR §3 don't-discover-twice); readers keep serving
+                // the previous snapshot meanwhile. A rejected CAS (raced) skips
+                // populate — the snapshot then publishes without discovery and
+                // readers discover inline for that (already-superseded) snapshot.
+                let discovery = if stored {
+                    let discovery = self
+                        .populate_injections_on_pool(
+                            uri.clone(),
+                            text.clone(),
+                            tree.clone(),
+                            language_name.clone(),
+                        )
+                        .await;
+                    self.documents
+                        .mark_parse_finished(&uri, parse_generation, true);
+                    discovery
+                } else {
+                    None
+                };
                 self.publish_parse_snapshot(
                     &uri,
                     crate::document::snapshot::ParseSnapshot {
@@ -436,19 +463,9 @@ impl ParseCoordinator {
                         language: Some(language_name.clone()),
                         parsed_version: content_version,
                         incarnation,
+                        injection_regions: discovery,
                     },
                 );
-                if stored {
-                    self.populate_injections_on_pool(
-                        uri.clone(),
-                        text.clone(),
-                        tree.clone(),
-                        language_name.clone(),
-                    )
-                    .await;
-                    self.documents
-                        .mark_parse_finished(&uri, parse_generation, true);
-                }
                 advance_watermark();
                 self.notifier().log_language_events(&events).await;
                 // `stored` is exactly "this call's CAS landed the tree": false when a
@@ -484,6 +501,7 @@ impl ParseCoordinator {
                     language: Some(language_name.clone()),
                     parsed_version: content_version,
                     incarnation,
+                    injection_regions: None,
                 },
             );
             advance_watermark();
@@ -513,6 +531,7 @@ impl ParseCoordinator {
                 language: None,
                 parsed_version: content_version,
                 incarnation,
+                injection_regions: None,
             },
         );
         advance_watermark();
@@ -659,8 +678,21 @@ impl ParseCoordinator {
                 expected_incarnation,
                 tree.clone(),
             );
-            // The cell guard rejects a stale lifetime or an out-of-order
-            // version on its own.
+            // Populate BEFORE the publish so the discovery rides the snapshot
+            // (ADR §3); the cell guard still rejects a stale lifetime or an
+            // out-of-order version at publish. A rejected CAS skips populate —
+            // the snapshot still publishes as stale-but-consistent.
+            let discovery = if stored {
+                self.populate_injections_on_pool(
+                    uri.clone(),
+                    text.clone(),
+                    tree.clone(),
+                    language_name.clone(),
+                )
+                .await
+            } else {
+                None
+            };
             let published = self.publish_parse_snapshot(
                 &uri,
                 crate::document::snapshot::ParseSnapshot {
@@ -669,6 +701,7 @@ impl ParseCoordinator {
                     language: Some(language_name.clone()),
                     parsed_version: content_version,
                     incarnation: expected_incarnation,
+                    injection_regions: discovery,
                 },
             );
             // Serve-stale's heal signal, mirroring reparse_latest: a token
@@ -682,13 +715,6 @@ impl ParseCoordinator {
                 ));
             }
             if stored {
-                self.populate_injections_on_pool(
-                    uri.clone(),
-                    text.clone(),
-                    tree.clone(),
-                    language_name.clone(),
-                )
-                .await;
                 break;
             }
             // CAS rejected: the text moved under us (a concurrent `didChange`).
@@ -840,10 +866,23 @@ impl ParseCoordinator {
                 incarnation,
                 tree.clone(),
             );
-            // The cell guard admits this even when the legacy CAS above
-            // rejected a text that moved on — a stale-but-consistent snapshot
-            // is exactly what serve-stale readers consume; the scheduler's
-            // dirty loop reparses the newer text and supersedes it.
+            // Populate BEFORE the publish so the derived discovery rides the
+            // snapshot (ADR §3, don't-discover-twice); readers keep serving the
+            // previous snapshot for populate's duration. A rejected legacy CAS
+            // (the text moved on mid-parse) skips populate — the snapshot still
+            // publishes as stale-but-consistent (its readers discover inline;
+            // the scheduler's dirty loop is already reparsing the newer text).
+            let discovery = if stored {
+                self.populate_injections_on_pool(
+                    uri.clone(),
+                    text.clone(),
+                    tree.clone(),
+                    language_name.clone(),
+                )
+                .await
+            } else {
+                None
+            };
             let published = self.publish_parse_snapshot(
                 uri,
                 crate::document::snapshot::ParseSnapshot {
@@ -852,6 +891,7 @@ impl ParseCoordinator {
                     language: Some(language_name.clone()),
                     parsed_version: content_version,
                     incarnation,
+                    injection_regions: discovery,
                 },
             );
             // Serve-stale's heal signal (ADR §3): a fresh publish re-drives the
@@ -866,15 +906,6 @@ impl ParseCoordinator {
                 events.push(crate::language::LanguageEvent::semantic_tokens_refresh(
                     language_name.clone(),
                 ));
-            }
-            if stored {
-                self.populate_injections_on_pool(
-                    uri.clone(),
-                    text.clone(),
-                    tree.clone(),
-                    language_name.clone(),
-                )
-                .await;
             }
         }
 

--- a/src/lsp/lsp_impl/kakehashi.rs
+++ b/src/lsp/lsp_impl/kakehashi.rs
@@ -1,3 +1,3 @@
 mod captures;
 mod internal;
-mod node;
+pub(crate) mod node;

--- a/src/lsp/lsp_impl/kakehashi.rs
+++ b/src/lsp/lsp_impl/kakehashi.rs
@@ -1,3 +1,3 @@
-mod captures;
+pub(in crate::lsp::lsp_impl) mod captures;
 mod internal;
 pub(crate) mod node;

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -173,6 +173,46 @@ struct KindQuery {
     skipped: Vec<crate::language::query_loader::SkippedPattern>,
 }
 
+/// Compiled-kind-query cache keyed by `(language, kind file, settings
+/// generation)`. `load_kind_query` re-read and re-COMPILED every visited
+/// language's kind file on every request — for a per-keystroke highlighter
+/// over an injection-heavy document that meant re-compiling several large
+/// query files per keystroke, dwarfing the walk itself. The generation key
+/// gives the same hot-reload discipline as the highlight-query store: a
+/// settings reload (which also re-resolves search paths) starts a fresh
+/// generation and old entries become unreachable garbage (bounded by the
+/// handful of (language, kind) pairs a session touches).
+type KindQueryCache = dashmap::DashMap<(String, String, u64), std::sync::Arc<KindQueryLoad>>;
+
+fn kind_query_cache() -> &'static KindQueryCache {
+    static CACHE: std::sync::OnceLock<KindQueryCache> = std::sync::OnceLock::new();
+    CACHE.get_or_init(KindQueryCache::default)
+}
+
+/// Generation-cached wrapper around [`load_kind_query`].
+fn load_kind_query_cached(
+    registry: &LanguageRegistry,
+    search_paths: &[PathBuf],
+    language_id: &str,
+    file_name: &str,
+    generation: u64,
+) -> std::sync::Arc<KindQueryLoad> {
+    let key = (language_id.to_string(), file_name.to_string(), generation);
+    if let Some(hit) = kind_query_cache().get(&key) {
+        return std::sync::Arc::clone(&hit);
+    }
+    let loaded = std::sync::Arc::new(load_kind_query(
+        registry,
+        search_paths,
+        language_id,
+        file_name,
+    ));
+    kind_query_cache()
+        .entry(key)
+        .or_insert_with(|| std::sync::Arc::clone(&loaded));
+    loaded
+}
+
 /// Per-language outcome of resolving `queries/<lang>/<kind>.scm`.
 ///
 /// `Broken` is distinct from `Unavailable` so a kind file that exists but
@@ -580,9 +620,32 @@ impl Kakehashi {
         let tracker = self.bridge.node_tracker_arc();
         let documents = std::sync::Arc::clone(&self.documents);
         let parsed_version = snapshot.parsed_version;
+        // Settings generation for the kind-query compile cache — the same
+        // reload discipline the token caches use.
+        let generation = self.cache.semantic_token_generation();
+        let snapshot_for_layers = std::sync::Arc::clone(&snapshot);
         let walked = self
             .compute_pool
             .run(None, move || {
+                // Lazily build the snapshot's layer trees on first use (this
+                // is the same walk the inline path would run) and share them
+                // across every subsequent walk on this snapshot — captures
+                // full + delta both walk per keystroke. Concurrent walkers on
+                // one snapshot block on the OnceLock and reuse the winner's.
+                let layers = if injection {
+                    Some(snapshot_for_layers.layer_trees.get_or_init(|| {
+                        std::sync::Arc::new(
+                            crate::lsp::lsp_impl::kakehashi::node::injection_stack::collect_document_layer_trees(
+                                &language,
+                                &language_id,
+                                &text,
+                                &tree,
+                            ),
+                        )
+                    }))
+                } else {
+                    None
+                };
                 execute_captures_walk(
                     &uri_for_walk,
                     &kind,
@@ -591,11 +654,13 @@ impl Kakehashi {
                     &language_id,
                     &text,
                     &tree,
+                    layers.map(|l| l.as_slice()),
                     &language,
                     &tracker,
                     &documents,
                     parsed_version,
                     incarnation,
+                    generation,
                 )
             })
             .await;
@@ -627,11 +692,13 @@ fn execute_captures_walk(
     language_id: &str,
     text: &str,
     tree: &tree_sitter::Tree,
+    layer_trees: Option<&[crate::document::SnapshotLayerTree]>,
     language: &crate::language::LanguageCoordinator,
     tracker: &crate::language::NodeTracker,
     documents: &crate::document::DocumentStore,
     parsed_version: u64,
     incarnation: u64,
+    generation: u64,
 ) -> Option<(Vec<Value>, Vec<Value>)> {
     // Tracker minting is currency-gated: the NodeTracker is a LIVE-coordinate
     // index (didChange shifts every entry before the reparse), so a trailing
@@ -679,20 +746,27 @@ fn execute_captures_walk(
     let search_paths = language.search_paths();
     let file_name = format!("{kind}.scm");
 
-    // One kind-query load per language per request: with many regions of
-    // the same language (e.g. dozens of python blocks), the memo keeps
-    // file IO + compilation at one per language, and yields each
-    // language's `skipped` exactly once.
-    let mut kind_queries: HashMap<String, KindQueryLoad> = HashMap::new();
+    // One kind-query load per language per request — served from the
+    // process-wide generation-keyed compile cache, so across requests each
+    // (language, kind) compiles once per settings generation instead of once
+    // per keystroke. The per-request map still yields each language's
+    // `skipped` exactly once.
+    let mut kind_queries: HashMap<String, std::sync::Arc<KindQueryLoad>> = HashMap::new();
     let mut matches: Vec<Value> = Vec::new();
 
     let mut visit = |layer_language: &str, layer_tree: &tree_sitter::Tree, depth: usize| {
         let entry = kind_queries
             .entry(layer_language.to_string())
             .or_insert_with(|| {
-                load_kind_query(&registry, &search_paths, layer_language, &file_name)
+                load_kind_query_cached(
+                    &registry,
+                    &search_paths,
+                    layer_language,
+                    &file_name,
+                    generation,
+                )
             });
-        let KindQueryLoad::Loaded(kind_query) = entry else {
+        let KindQueryLoad::Loaded(kind_query) = entry.as_ref() else {
             return;
         };
         for m in execute_query(&kind_query.query, layer_tree, text, byte_range.clone()) {
@@ -775,14 +849,32 @@ fn execute_captures_walk(
     };
 
     if injection {
-        walk_document_layers(
-            language,
-            language_id,
-            text,
-            tree,
-            byte_range.as_ref(),
-            &mut visit,
-        );
+        if let Some(layers) = layer_trees {
+            // Pre-parsed layers from the snapshot's populate pass (the
+            // layer-tree half of never-discover-twice): identical to the
+            // inline walk below by construction — populate built them with
+            // that walk over this same (text, tree). The span check mirrors
+            // the walk's byte_filter pruning: a false-positive visit only
+            // makes the layer's query yield nothing for the clipped range.
+            visit(language_id, tree, 0);
+            for layer in layers {
+                if let Some(filter) = &byte_range
+                    && (layer.span.end <= filter.start || layer.span.start >= filter.end)
+                {
+                    continue;
+                }
+                visit(&layer.language, &layer.tree, layer.depth);
+            }
+        } else {
+            walk_document_layers(
+                language,
+                language_id,
+                text,
+                tree,
+                byte_range.as_ref(),
+                &mut visit,
+            );
+        }
     } else {
         visit(language_id, tree, 0);
     }
@@ -818,7 +910,7 @@ fn execute_captures_walk(
     // result.
     if !kind_queries
         .values()
-        .any(|load| matches!(load, KindQueryLoad::Loaded(_)))
+        .any(|load| matches!(load.as_ref(), KindQueryLoad::Loaded(_)))
     {
         return None;
     }
@@ -832,7 +924,7 @@ fn execute_captures_walk(
     let mut reportable: Vec<(&String, &[crate::language::query_loader::SkippedPattern])> =
         kind_queries
             .iter()
-            .filter_map(|(lang, load)| match load {
+            .filter_map(|(lang, load)| match load.as_ref() {
                 KindQueryLoad::Loaded(kq) => Some((lang, kq.skipped.as_slice())),
                 KindQueryLoad::Broken(skipped) => Some((lang, skipped.as_slice())),
                 KindQueryLoad::Unavailable => None,
@@ -929,11 +1021,13 @@ mod tests {
             "rust",
             text,
             &tree,
+            None,
             &coordinator,
             &tracker,
             &store,
             0,
             incarnation,
+            0,
         )
         .expect("kind query should load");
         assert!(!matches.is_empty(), "identifiers should match");
@@ -955,11 +1049,13 @@ mod tests {
             "rust",
             text,
             &tree,
+            None,
             &coordinator,
             &tracker,
             &store,
             0,
             incarnation,
+            0,
         )
         .expect("kind query should load");
         assert!(
@@ -983,11 +1079,13 @@ mod tests {
             "rust",
             text,
             &tree,
+            None,
             &coordinator,
             &stale_tracker,
             &store,
             0,
             incarnation,
+            0,
         )
         .expect("kind query should load");
         let id = first_node_id(&stale_matches);

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -166,6 +166,18 @@ fn metadata_object(pairs: Vec<(String, Option<String>)>) -> Option<Value> {
     Some(Value::Object(map))
 }
 
+/// A memoized full-mode captures walk result, tagged with the exact inputs
+/// it was computed from: the snapshot identity `(parsed_version,
+/// incarnation)` and the settings `generation`. Named fields (three adjacent
+/// `u64`s as a tuple invited a silent swap).
+pub(in crate::lsp::lsp_impl) struct CachedCapturesWalk {
+    pub(in crate::lsp::lsp_impl) parsed_version: u64,
+    pub(in crate::lsp::lsp_impl) incarnation: u64,
+    pub(in crate::lsp::lsp_impl) generation: u64,
+    pub(in crate::lsp::lsp_impl) matches: Vec<Value>,
+    pub(in crate::lsp::lsp_impl) skipped: Vec<Value>,
+}
+
 /// A kind query compiled for one language, with the patterns tolerant
 /// compilation dropped.
 struct KindQuery {
@@ -180,8 +192,9 @@ struct KindQuery {
 /// query files per keystroke, dwarfing the walk itself. The generation key
 /// gives the same hot-reload discipline as the highlight-query store: a
 /// settings reload (which also re-resolves search paths) starts a fresh
-/// generation and old entries become unreachable garbage (bounded by the
-/// handful of (language, kind) pairs a session touches).
+/// generation, and the first MISS of a new generation sweeps the previous
+/// generation's entries (see `load_kind_query_cached`), so reload churn
+/// cannot accumulate dead compiled queries.
 type KindQueryCache = dashmap::DashMap<(String, String, u64), std::sync::Arc<KindQueryLoad>>;
 
 fn kind_query_cache() -> &'static KindQueryCache {
@@ -201,6 +214,10 @@ fn load_kind_query_cached(
     if let Some(hit) = kind_query_cache().get(&key) {
         return std::sync::Arc::clone(&hit);
     }
+    // Miss (once per (language, kind) per generation): sweep entries from
+    // other generations so a reload-heavy session doesn't accumulate dead
+    // compiled queries. Off the hit path by construction.
+    kind_query_cache().retain(|(_, _, cached_generation), _| *cached_generation == generation);
     let loaded = std::sync::Arc::new(load_kind_query(
         registry,
         search_paths,
@@ -627,16 +644,16 @@ impl Kakehashi {
         let walk_key = (uri.clone(), kind.to_string(), injection);
         if lsp_range.is_none()
             && let Some(hit) = self.captures_walk_cache.get(&walk_key)
-            && hit.0 == snapshot.parsed_version
-            && hit.1 == incarnation
-            && hit.2 == generation
+            && hit.parsed_version == snapshot.parsed_version
+            && hit.incarnation == incarnation
+            && hit.generation == generation
         {
             return Ok(Some(ComputedCaptures {
                 uri,
                 incarnation,
                 entry_content_version,
-                matches: hit.3.clone(),
-                skipped: hit.4.clone(),
+                matches: hit.matches.clone(),
+                skipped: hit.skipped.clone(),
             }));
         }
 
@@ -655,17 +672,39 @@ impl Kakehashi {
                 // across every subsequent walk on this snapshot — captures
                 // full + delta both walk per keystroke. Concurrent walkers on
                 // one snapshot block on the OnceLock and reuse the winner's.
+                let fresh_layers;
                 let layers = if injection {
-                    Some(snapshot_for_layers.layer_trees.get_or_init(|| {
-                        std::sync::Arc::new(
+                    let cached = snapshot_for_layers.layer_trees.get_or_init(|| {
+                        (
+                            generation,
+                            std::sync::Arc::new(
+                                crate::lsp::lsp_impl::kakehashi::node::injection_stack::collect_document_layer_trees(
+                                    &language,
+                                    &language_id,
+                                    &text,
+                                    &tree,
+                                ),
+                            ),
+                        )
+                    });
+                    // Settings-generation gate (the DiscoveredInjections
+                    // pattern): an injected-grammar auto-install bumps the
+                    // generation without a new snapshot, so cached trees
+                    // would keep an embedded layer empty long after its
+                    // parser landed. On mismatch walk fresh, uncached — the
+                    // pre-cache per-request cost — until the next snapshot.
+                    if cached.0 == generation {
+                        Some(cached.1.as_slice())
+                    } else {
+                        fresh_layers =
                             crate::lsp::lsp_impl::kakehashi::node::injection_stack::collect_document_layer_trees(
                                 &language,
                                 &language_id,
                                 &text,
                                 &tree,
-                            ),
-                        )
-                    }))
+                            );
+                        Some(fresh_layers.as_slice())
+                    }
                 } else {
                     None
                 };
@@ -677,7 +716,7 @@ impl Kakehashi {
                     &language_id,
                     &text,
                     &tree,
-                    layers.map(|l| l.as_slice()),
+                    layers,
                     &language,
                     &tracker,
                     &documents,
@@ -694,13 +733,13 @@ impl Kakehashi {
             if lsp_range.is_none() {
                 self.captures_walk_cache.insert(
                     walk_key,
-                    (
-                        snapshot.parsed_version,
+                    CachedCapturesWalk {
+                        parsed_version: snapshot.parsed_version,
                         incarnation,
                         generation,
-                        matches.clone(),
-                        skipped.clone(),
-                    ),
+                        matches: matches.clone(),
+                        skipped: skipped.clone(),
+                    },
                 );
             }
             ComputedCaptures {

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -651,21 +651,28 @@ impl Kakehashi {
         // memo instead of re-executing the kind query over every layer. The
         // tag must match the exact inputs: snapshot identity
         // (parsed_version, incarnation) and the settings generation.
-        let walk_key = (uri.clone(), kind.to_string(), injection);
-        if lsp_range.is_none()
-            && let Some(hit) = self.captures_walk_cache.get(&walk_key)
-            && hit.parsed_version == snapshot.parsed_version
-            && hit.incarnation == incarnation
-            && hit.generation == generation
-        {
-            return Ok(Some(ComputedCaptures {
-                uri,
-                incarnation,
-                entry_content_version,
-                matches: hit.matches.clone(),
-                skipped: hit.skipped.clone(),
-            }));
-        }
+        // Key built only on the full-mode path (range bypasses the memo), and
+        // carried to the store below so the Url/String allocations happen at
+        // most once per request.
+        let walk_key = if lsp_range.is_none() {
+            let key = (uri.clone(), kind.to_string(), injection);
+            if let Some(hit) = self.captures_walk_cache.get(&key)
+                && hit.parsed_version == snapshot.parsed_version
+                && hit.incarnation == incarnation
+                && hit.generation == generation
+            {
+                return Ok(Some(ComputedCaptures {
+                    uri,
+                    incarnation,
+                    entry_content_version,
+                    matches: hit.matches.clone(),
+                    skipped: hit.skipped.clone(),
+                }));
+            }
+            Some(key)
+        } else {
+            None
+        };
 
         let uri_for_walk = uri.clone();
         let kind = kind.to_string();
@@ -740,9 +747,9 @@ impl Kakehashi {
             return Ok(None);
         };
         Ok(walked.map(|(matches, skipped)| {
-            if lsp_range.is_none() {
+            if let Some(key) = walk_key {
                 self.captures_walk_cache.insert(
-                    walk_key,
+                    key,
                     CachedCapturesWalk {
                         parsed_version: snapshot.parsed_version,
                         incarnation,

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -185,18 +185,20 @@ struct KindQuery {
     skipped: Vec<crate::language::query_loader::SkippedPattern>,
 }
 
-/// Compiled-kind-query cache keyed by `(language, kind file)` with the
-/// settings generation in the VALUE. `load_kind_query` re-read and
-/// re-COMPILED every visited language's kind file on every request — for a
-/// per-keystroke highlighter over an injection-heavy document that meant
-/// re-compiling several large query files per keystroke, dwarfing the walk
-/// itself. A hit requires the stored generation to equal the caller's (the
-/// same hot-reload discipline as the highlight-query store); a miss simply
-/// OVERWRITES the entry, which is also the eviction: the map never holds
-/// more than one generation per (language, kind), no sweep, no
+/// Compiled-kind-query cache, `language → kind file → (query, generation)`.
+/// `load_kind_query` re-read and re-COMPILED every visited language's kind
+/// file on every request — for a per-keystroke highlighter over an
+/// injection-heavy document that meant re-compiling several large query
+/// files per keystroke, dwarfing the walk itself. Nested maps so the hit
+/// path looks up with two borrowed `&str`s (a tuple key would allocate two
+/// `String`s per lookup). A hit requires the stored generation to equal the
+/// caller's (the same hot-reload discipline as the highlight-query store); a
+/// miss simply OVERWRITES the entry, which is also the eviction: never more
+/// than one generation per (language, kind), no sweep, no
 /// clear-vs-concurrent-store race, and reload churn cannot accumulate dead
 /// compiled queries.
-type KindQueryCache = dashmap::DashMap<(String, String), (std::sync::Arc<KindQueryLoad>, u64)>;
+type KindQueryCache =
+    dashmap::DashMap<String, dashmap::DashMap<String, (std::sync::Arc<KindQueryLoad>, u64)>>;
 
 fn kind_query_cache() -> &'static KindQueryCache {
     static CACHE: std::sync::OnceLock<KindQueryCache> = std::sync::OnceLock::new();
@@ -211,8 +213,8 @@ fn load_kind_query_cached(
     file_name: &str,
     generation: u64,
 ) -> std::sync::Arc<KindQueryLoad> {
-    let key = (language_id.to_string(), file_name.to_string());
-    if let Some(hit) = kind_query_cache().get(&key)
+    if let Some(by_kind) = kind_query_cache().get(language_id)
+        && let Some(hit) = by_kind.get(file_name)
         && hit.1 == generation
     {
         return std::sync::Arc::clone(&hit.0);
@@ -224,8 +226,17 @@ fn load_kind_query_cached(
         file_name,
     ));
     // Overwrite-on-miss doubles as eviction (one generation per entry). A
-    // racing same-generation compute overwrites with identical data.
-    kind_query_cache().insert(key, (std::sync::Arc::clone(&loaded), generation));
+    // racing same-generation compute overwrites with identical data. `get`
+    // first so a present language avoids the key clone `entry()` needs.
+    let stored = (std::sync::Arc::clone(&loaded), generation);
+    if let Some(by_kind) = kind_query_cache().get(language_id) {
+        by_kind.insert(file_name.to_string(), stored);
+    } else {
+        kind_query_cache()
+            .entry(language_id.to_string())
+            .or_default()
+            .insert(file_name.to_string(), stored);
+    }
     loaded
 }
 

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -614,15 +614,38 @@ impl Kakehashi {
         // (parse-snapshot ADR §4). Everything moved in is an owned snapshot
         // piece or a cheap Arc clone; `None` from the pool (work-unit panic)
         // degrades to the protocol's `null`.
+        // Settings generation for the kind-query compile cache — the same
+        // reload discipline the token caches use.
+        let generation = self.cache.semantic_token_generation();
+
+        // Walk-result memo (full mode only — range results depend on the
+        // viewport): a typing client sends captures/full AND full/delta per
+        // keystroke, both walking the SAME snapshot; the second serves this
+        // memo instead of re-executing the kind query over every layer. The
+        // tag must match the exact inputs: snapshot identity
+        // (parsed_version, incarnation) and the settings generation.
+        let walk_key = (uri.clone(), kind.to_string(), injection);
+        if lsp_range.is_none()
+            && let Some(hit) = self.captures_walk_cache.get(&walk_key)
+            && hit.0 == snapshot.parsed_version
+            && hit.1 == incarnation
+            && hit.2 == generation
+        {
+            return Ok(Some(ComputedCaptures {
+                uri,
+                incarnation,
+                entry_content_version,
+                matches: hit.3.clone(),
+                skipped: hit.4.clone(),
+            }));
+        }
+
         let uri_for_walk = uri.clone();
         let kind = kind.to_string();
         let language = std::sync::Arc::clone(&self.language);
         let tracker = self.bridge.node_tracker_arc();
         let documents = std::sync::Arc::clone(&self.documents);
         let parsed_version = snapshot.parsed_version;
-        // Settings generation for the kind-query compile cache — the same
-        // reload discipline the token caches use.
-        let generation = self.cache.semantic_token_generation();
         let snapshot_for_layers = std::sync::Arc::clone(&snapshot);
         let walked = self
             .compute_pool
@@ -667,12 +690,26 @@ impl Kakehashi {
         let Some(walked) = walked else {
             return Ok(None);
         };
-        Ok(walked.map(|(matches, skipped)| ComputedCaptures {
-            uri,
-            incarnation,
-            entry_content_version,
-            matches,
-            skipped,
+        Ok(walked.map(|(matches, skipped)| {
+            if lsp_range.is_none() {
+                self.captures_walk_cache.insert(
+                    walk_key,
+                    (
+                        snapshot.parsed_version,
+                        incarnation,
+                        generation,
+                        matches.clone(),
+                        skipped.clone(),
+                    ),
+                );
+            }
+            ComputedCaptures {
+                uri,
+                incarnation,
+                entry_content_version,
+                matches,
+                skipped,
+            }
         }))
     }
 }

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -185,17 +185,18 @@ struct KindQuery {
     skipped: Vec<crate::language::query_loader::SkippedPattern>,
 }
 
-/// Compiled-kind-query cache keyed by `(language, kind file, settings
-/// generation)`. `load_kind_query` re-read and re-COMPILED every visited
-/// language's kind file on every request — for a per-keystroke highlighter
-/// over an injection-heavy document that meant re-compiling several large
-/// query files per keystroke, dwarfing the walk itself. The generation key
-/// gives the same hot-reload discipline as the highlight-query store: a
-/// settings reload (which also re-resolves search paths) starts a fresh
-/// generation, and the first MISS of a new generation sweeps the previous
-/// generation's entries (see `load_kind_query_cached`), so reload churn
-/// cannot accumulate dead compiled queries.
-type KindQueryCache = dashmap::DashMap<(String, String, u64), std::sync::Arc<KindQueryLoad>>;
+/// Compiled-kind-query cache keyed by `(language, kind file)` with the
+/// settings generation in the VALUE. `load_kind_query` re-read and
+/// re-COMPILED every visited language's kind file on every request — for a
+/// per-keystroke highlighter over an injection-heavy document that meant
+/// re-compiling several large query files per keystroke, dwarfing the walk
+/// itself. A hit requires the stored generation to equal the caller's (the
+/// same hot-reload discipline as the highlight-query store); a miss simply
+/// OVERWRITES the entry, which is also the eviction: the map never holds
+/// more than one generation per (language, kind), no sweep, no
+/// clear-vs-concurrent-store race, and reload churn cannot accumulate dead
+/// compiled queries.
+type KindQueryCache = dashmap::DashMap<(String, String), (std::sync::Arc<KindQueryLoad>, u64)>;
 
 fn kind_query_cache() -> &'static KindQueryCache {
     static CACHE: std::sync::OnceLock<KindQueryCache> = std::sync::OnceLock::new();
@@ -210,23 +211,21 @@ fn load_kind_query_cached(
     file_name: &str,
     generation: u64,
 ) -> std::sync::Arc<KindQueryLoad> {
-    let key = (language_id.to_string(), file_name.to_string(), generation);
-    if let Some(hit) = kind_query_cache().get(&key) {
-        return std::sync::Arc::clone(&hit);
+    let key = (language_id.to_string(), file_name.to_string());
+    if let Some(hit) = kind_query_cache().get(&key)
+        && hit.1 == generation
+    {
+        return std::sync::Arc::clone(&hit.0);
     }
-    // Miss (once per (language, kind) per generation): sweep entries from
-    // other generations so a reload-heavy session doesn't accumulate dead
-    // compiled queries. Off the hit path by construction.
-    kind_query_cache().retain(|(_, _, cached_generation), _| *cached_generation == generation);
     let loaded = std::sync::Arc::new(load_kind_query(
         registry,
         search_paths,
         language_id,
         file_name,
     ));
-    kind_query_cache()
-        .entry(key)
-        .or_insert_with(|| std::sync::Arc::clone(&loaded));
+    // Overwrite-on-miss doubles as eviction (one generation per entry). A
+    // racing same-generation compute overwrites with identical data.
+    kind_query_cache().insert(key, (std::sync::Arc::clone(&loaded), generation));
     loaded
 }
 

--- a/src/lsp/lsp_impl/kakehashi/node.rs
+++ b/src/lsp/lsp_impl/kakehashi/node.rs
@@ -15,7 +15,7 @@ mod field;
 // Widened beyond `node/`: the captures handlers reuse the injection-layer
 // machinery (document-wide layer walk, language discovery) for
 // captures-protocol's `injection: true` mode.
-pub(in crate::lsp::lsp_impl::kakehashi) mod injection_stack;
+pub(crate) mod injection_stack;
 mod lookup;
 mod metadata;
 mod navigation;

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -727,37 +727,13 @@ fn ranges_intersect(
         .any(|r| r.start_byte < filter.end && filter.start < r.end_byte)
 }
 
-/// Visit every injection layer of the document in **document-order DFS**: the
-/// host first, then each injection region by ascending start byte, recursing
-/// into nested injections before moving to the next sibling
-/// (captures-protocol §"The `injection` parameter").
-///
-/// `visit` receives the layer's resolved language, its tree (parsed against
-/// the full host text via `set_included_ranges`, so byte coordinates are in
-/// host space), and its depth — the same depth index `injection_stack_at`
-/// assigns, so nodes minted with it resolve through the per-layer Scope rule.
-///
-/// Regions whose grammar is not loaded (or fails to parse) are skipped
-/// silently — discovery and auto-install are the caller's job, via
-/// [`collect_injection_languages_in_document`]. `byte_filter` prunes regions
-/// (and their entire subtrees) that don't intersect the given host-byte range.
-///
-/// Known limitation (#350): when two injection regions at the same depth
-/// **overlap**, the walker visits both, but [`with_resolved_node`] resolves a
-/// minted id by rebuilding the cursor-path stack, which keeps only the
-/// smallest region containing the byte — so an id minted from the larger
-/// sibling may resolve in the **wrong same-depth region** (if that region's
-/// tree happens to hold a node with the identical `(start, end, kind)`) or
-/// return `null` (the protocol's re-acquire signal). Same depth-as-identity
-/// weakness documented in lazy-node-identity-tracking; disjoint same-depth
-/// regions (the norm) are unaffected.
 /// Run the standard layer walk once and collect every injected layer's
 /// parsed tree in document-order DFS (parse-snapshot ADR §3, the layer-tree
-/// half of never-discover-twice): `populate_injections` calls this at parse
-/// time and the result rides the `ParseSnapshot`, so the per-keystroke
-/// captures requests iterate pre-parsed layers instead of re-running the
-/// walk. Byte-identical to the inline walk by construction — it IS the
-/// inline walk, with a collecting visitor.
+/// half of never-discover-twice): the FIRST walking captures request on a
+/// snapshot calls this lazily and the result rides the `ParseSnapshot`, so
+/// subsequent per-keystroke walks iterate pre-parsed layers instead of
+/// re-running the walk. Byte-identical to the inline walk by construction —
+/// it IS the inline walk, with a collecting visitor.
 pub(crate) fn collect_document_layer_trees(
     coordinator: &LanguageCoordinator,
     host_language: &str,
@@ -793,6 +769,30 @@ pub(crate) fn collect_document_layer_trees(
     layers
 }
 
+/// Visit every injection layer of the document in **document-order DFS**: the
+/// host first, then each injection region by ascending start byte, recursing
+/// into nested injections before moving to the next sibling
+/// (captures-protocol §"The `injection` parameter").
+///
+/// `visit` receives the layer's resolved language, its tree (parsed against
+/// the full host text via `set_included_ranges`, so byte coordinates are in
+/// host space), and its depth — the same depth index `injection_stack_at`
+/// assigns, so nodes minted with it resolve through the per-layer Scope rule.
+///
+/// Regions whose grammar is not loaded (or fails to parse) are skipped
+/// silently — discovery and auto-install are the caller's job, via
+/// [`collect_injection_languages_in_document`]. `byte_filter` prunes regions
+/// (and their entire subtrees) that don't intersect the given host-byte range.
+///
+/// Known limitation (#350): when two injection regions at the same depth
+/// **overlap**, the walker visits both, but [`with_resolved_node`] resolves a
+/// minted id by rebuilding the cursor-path stack, which keeps only the
+/// smallest region containing the byte — so an id minted from the larger
+/// sibling may resolve in the **wrong same-depth region** (if that region's
+/// tree happens to hold a node with the identical `(start, end, kind)`) or
+/// return `null` (the protocol's re-acquire signal). Same depth-as-identity
+/// weakness documented in lazy-node-identity-tracking; disjoint same-depth
+/// regions (the norm) are unaffected.
 pub(in crate::lsp::lsp_impl::kakehashi) fn walk_document_layers(
     coordinator: &LanguageCoordinator,
     host_language: &str,

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -751,6 +751,48 @@ fn ranges_intersect(
 /// return `null` (the protocol's re-acquire signal). Same depth-as-identity
 /// weakness documented in lazy-node-identity-tracking; disjoint same-depth
 /// regions (the norm) are unaffected.
+/// Run the standard layer walk once and collect every injected layer's
+/// parsed tree in document-order DFS (parse-snapshot ADR §3, the layer-tree
+/// half of never-discover-twice): `populate_injections` calls this at parse
+/// time and the result rides the `ParseSnapshot`, so the per-keystroke
+/// captures requests iterate pre-parsed layers instead of re-running the
+/// walk. Byte-identical to the inline walk by construction — it IS the
+/// inline walk, with a collecting visitor.
+pub(crate) fn collect_document_layer_trees(
+    coordinator: &LanguageCoordinator,
+    host_language: &str,
+    host_text: &str,
+    host_tree: &tree_sitter::Tree,
+) -> Vec<crate::document::SnapshotLayerTree> {
+    let mut layers = Vec::new();
+    walk_document_layers(
+        coordinator,
+        host_language,
+        host_text,
+        host_tree,
+        None,
+        &mut |language, tree, depth| {
+            // The host layer (depth 0) already lives on the snapshot as
+            // `ParseSnapshot::tree`; store only the injected layers.
+            if depth == 0 {
+                return;
+            }
+            let ranges = tree.included_ranges();
+            let span = match (ranges.first(), ranges.last()) {
+                (Some(first), Some(last)) => first.start_byte..last.end_byte,
+                _ => 0..host_text.len(),
+            };
+            layers.push(crate::document::SnapshotLayerTree {
+                language: language.to_string(),
+                tree: tree.clone(),
+                depth,
+                span,
+            });
+        },
+    );
+    layers
+}
+
 pub(in crate::lsp::lsp_impl::kakehashi) fn walk_document_layers(
     coordinator: &LanguageCoordinator,
     host_language: &str,
@@ -832,6 +874,82 @@ fn walk_child_layers(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The stored layer trees must be exactly what the inline walk would
+    /// visit over the same (text, tree): same (language, depth) sequence and
+    /// same included ranges per layer — the equivalence the captures fast
+    /// path relies on.
+    #[test]
+    fn collect_document_layer_trees_matches_the_inline_walk() {
+        let coordinator = crate::language::LanguageCoordinator::new();
+        let settings = crate::config::WorkspaceSettings {
+            search_paths: vec![
+                std::env::var("TREE_SITTER_GRAMMARS")
+                    .unwrap_or_else(|_| "deps/tree-sitter".to_string()),
+            ],
+            ..Default::default()
+        };
+        let _ = coordinator.load_settings(&settings);
+        for lang in ["markdown", "markdown_inline", "lua"] {
+            if !coordinator.ensure_language_loaded(lang).success {
+                eprintln!("Skipping: {lang} parser not available");
+                return;
+            }
+        }
+
+        let text = "# T\n\nsome *inline* text\n\n```lua\nlocal x = 1\n```\n";
+        let mut pool = coordinator.create_document_parser_pool();
+        let Some(mut parser) = pool.acquire("markdown") else {
+            return;
+        };
+        let tree = parser.parse(text, None).expect("parse markdown");
+        pool.release("markdown".to_string(), parser);
+
+        type LayerShape = (String, usize, Vec<(usize, usize)>);
+        let mut inline: Vec<LayerShape> = Vec::new();
+        walk_document_layers(
+            &coordinator,
+            "markdown",
+            text,
+            &tree,
+            None,
+            &mut |lang, layer_tree, depth| {
+                if depth == 0 {
+                    return;
+                }
+                inline.push((
+                    lang.to_string(),
+                    depth,
+                    layer_tree
+                        .included_ranges()
+                        .iter()
+                        .map(|r| (r.start_byte, r.end_byte))
+                        .collect(),
+                ));
+            },
+        );
+        assert!(
+            !inline.is_empty(),
+            "sanity: the document has injected layers"
+        );
+
+        let stored = collect_document_layer_trees(&coordinator, "markdown", text, &tree);
+        let stored_shape: Vec<LayerShape> = stored
+            .iter()
+            .map(|l| {
+                (
+                    l.language.clone(),
+                    l.depth,
+                    l.tree
+                        .included_ranges()
+                        .iter()
+                        .map(|r| (r.start_byte, r.end_byte))
+                        .collect(),
+                )
+            })
+            .collect();
+        assert_eq!(stored_shape, inline, "stored layers == inline walk");
+    }
 
     #[test]
     fn build_effective_ranges_combines_offset_with_child_exclusion() {

--- a/src/lsp/lsp_impl/snapshot_read.rs
+++ b/src/lsp/lsp_impl/snapshot_read.rs
@@ -150,6 +150,7 @@ mod tests {
                     language: Some("rust".to_string()),
                     parsed_version: version,
                     incarnation: inc,
+                    injection_regions: None,
                 }))
             })
             .unwrap_or(false);

--- a/src/lsp/lsp_impl/snapshot_read.rs
+++ b/src/lsp/lsp_impl/snapshot_read.rs
@@ -151,6 +151,7 @@ mod tests {
                     parsed_version: version,
                     incarnation: inc,
                     injection_regions: None,
+                    bridge_regions: None,
                 }))
             })
             .unwrap_or(false);

--- a/src/lsp/lsp_impl/snapshot_read.rs
+++ b/src/lsp/lsp_impl/snapshot_read.rs
@@ -153,6 +153,7 @@ mod tests {
                     injection_regions: None,
                     bridge_regions: None,
                     resolved_regions: None,
+                    layer_trees: std::sync::OnceLock::new(),
                 }))
             })
             .unwrap_or(false);

--- a/src/lsp/lsp_impl/snapshot_read.rs
+++ b/src/lsp/lsp_impl/snapshot_read.rs
@@ -152,6 +152,7 @@ mod tests {
                     incarnation: inc,
                     injection_regions: None,
                     bridge_regions: None,
+                    resolved_regions: None,
                 }))
             })
             .unwrap_or(false);

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -189,8 +189,11 @@ impl Kakehashi {
             (true, Some(snapshot)) => self
                 .language
                 .injection_query(&language_name)
-                .map(
-                    |injection_query| match self.documents.current_resolved_regions(&uri) {
+                .map(|injection_query| {
+                    match self
+                        .documents
+                        .current_resolved_regions(&uri, self.cache.semantic_token_generation())
+                    {
                         Some(regions) => regions.as_ref().clone(),
                         None => InjectionResolver::resolve_all(
                             &self.language,
@@ -200,8 +203,8 @@ impl Kakehashi {
                             snapshot.text(),
                             injection_query.as_ref(),
                         ),
-                    },
-                )
+                    }
+                })
                 .unwrap_or_default(),
             // Virt gated off, or no tree yet (the host layer still pulls). The
             // wait+on-demand above already tried, so a missing tree here is the

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -194,22 +194,22 @@ impl Kakehashi {
                         .documents
                         .current_resolved_regions(&uri, self.cache.semantic_token_generation())
                     {
-                        Some(regions) => regions.as_ref().clone(),
-                        None => InjectionResolver::resolve_all(
+                        Some(regions) => regions,
+                        None => std::sync::Arc::new(InjectionResolver::resolve_all(
                             &self.language,
                             self.bridge.node_tracker(),
                             &uri,
                             snapshot.tree(),
                             snapshot.text(),
                             injection_query.as_ref(),
-                        ),
+                        )),
                     }
                 })
                 .unwrap_or_default(),
             // Virt gated off, or no tree yet (the host layer still pulls). The
             // wait+on-demand above already tried, so a missing tree here is the
             // rare parse-failure case, self-healing on the next pull.
-            _ => Vec::new(),
+            _ => std::sync::Arc::new(Vec::new()),
         };
         // Lightweight per-region metadata `(region_id, injection_language,
         // current offset)` for the pushFallback fold; the live pull below moves
@@ -233,7 +233,7 @@ impl Kakehashi {
         //   Outer: collect across regions
         let virt_fut = async {
             let mut outer_join_set: JoinSet<Vec<Diagnostic>> = JoinSet::new();
-            for resolved in virt_regions {
+            for resolved in virt_regions.iter() {
                 let configs = self.bridge_configs_for_injection_language(
                     &language_name,
                     &resolved.injection_language,
@@ -252,7 +252,7 @@ impl Kakehashi {
                 let strategy = agg.strategy;
                 let region_ctx = DocumentRequestContext {
                     uri: uri.clone(),
-                    resolved,
+                    resolved: resolved.clone(),
                     configs,
                     upstream_request_id: upstream_request_id.clone(),
                     priorities: agg.priorities,

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -189,16 +189,19 @@ impl Kakehashi {
             (true, Some(snapshot)) => self
                 .language
                 .injection_query(&language_name)
-                .map(|injection_query| {
-                    InjectionResolver::resolve_all(
-                        &self.language,
-                        self.bridge.node_tracker(),
-                        &uri,
-                        snapshot.tree(),
-                        snapshot.text(),
-                        injection_query.as_ref(),
-                    )
-                })
+                .map(
+                    |injection_query| match self.documents.current_resolved_regions(&uri) {
+                        Some(regions) => regions.as_ref().clone(),
+                        None => InjectionResolver::resolve_all(
+                            &self.language,
+                            self.bridge.node_tracker(),
+                            &uri,
+                            snapshot.tree(),
+                            snapshot.text(),
+                            injection_query.as_ref(),
+                        ),
+                    },
+                )
                 .unwrap_or_default(),
             // Virt gated off, or no tree yet (the host layer still pulls). The
             // wait+on-demand above already tried, so a missing tree here is the

--- a/src/lsp/lsp_impl/text_document/did_close.rs
+++ b/src/lsp/lsp_impl/text_document/did_close.rs
@@ -36,6 +36,7 @@ impl Kakehashi {
             // degrades to the self-healing "delta answers null → client calls
             // full again", never to stale data.)
             self.captures_cache.retain(|key, _| key.0 != uri);
+            self.captures_walk_cache.retain(|key, _| key.0 != uri);
             self.documents.remove(&uri);
         }
 

--- a/src/lsp/lsp_impl/text_document/document_color.rs
+++ b/src/lsp/lsp_impl/text_document/document_color.rs
@@ -70,7 +70,10 @@ impl Kakehashi {
         };
 
         // Collect all injection regions
-        let all_regions = match self.documents.current_resolved_regions(&uri) {
+        let all_regions = match self
+            .documents
+            .current_resolved_regions(&uri, self.cache.semantic_token_generation())
+        {
             Some(regions) => regions.as_ref().clone(),
             None => InjectionResolver::resolve_all(
                 &self.language,

--- a/src/lsp/lsp_impl/text_document/document_color.rs
+++ b/src/lsp/lsp_impl/text_document/document_color.rs
@@ -74,15 +74,15 @@ impl Kakehashi {
             .documents
             .current_resolved_regions(&uri, self.cache.semantic_token_generation())
         {
-            Some(regions) => regions.as_ref().clone(),
-            None => InjectionResolver::resolve_all(
+            Some(regions) => regions,
+            None => std::sync::Arc::new(InjectionResolver::resolve_all(
                 &self.language,
                 self.bridge.node_tracker(),
                 &uri,
                 snapshot.tree(),
                 snapshot.text(),
                 injection_query.as_ref(),
-            ),
+            )),
         };
 
         if all_regions.is_empty() {
@@ -101,7 +101,7 @@ impl Kakehashi {
         // Outer JoinSet: one task per injection region, all in parallel
         let mut outer_join_set: JoinSet<Vec<ColorInformation>> = JoinSet::new();
 
-        for resolved in all_regions {
+        for resolved in all_regions.iter() {
             // Get ALL bridge server configs for this injection language
             let configs = self.bridge_configs_for_injection_language(
                 &language_name,
@@ -118,7 +118,7 @@ impl Kakehashi {
             );
             let region_ctx = DocumentRequestContext {
                 uri: uri.clone(),
-                resolved,
+                resolved: resolved.clone(),
                 configs,
                 upstream_request_id: upstream_request_id.clone(),
                 priorities: agg.priorities,

--- a/src/lsp/lsp_impl/text_document/document_color.rs
+++ b/src/lsp/lsp_impl/text_document/document_color.rs
@@ -70,14 +70,17 @@ impl Kakehashi {
         };
 
         // Collect all injection regions
-        let all_regions = InjectionResolver::resolve_all(
-            &self.language,
-            self.bridge.node_tracker(),
-            &uri,
-            snapshot.tree(),
-            snapshot.text(),
-            injection_query.as_ref(),
-        );
+        let all_regions = match self.documents.current_resolved_regions(&uri) {
+            Some(regions) => regions.as_ref().clone(),
+            None => InjectionResolver::resolve_all(
+                &self.language,
+                self.bridge.node_tracker(),
+                &uri,
+                snapshot.tree(),
+                snapshot.text(),
+                injection_query.as_ref(),
+            ),
+        };
 
         if all_regions.is_empty() {
             return Ok(Vec::new());

--- a/src/lsp/lsp_impl/text_document/document_symbol.rs
+++ b/src/lsp/lsp_impl/text_document/document_symbol.rs
@@ -99,14 +99,17 @@ impl Kakehashi {
         };
 
         // Collect all injection regions
-        let all_regions = InjectionResolver::resolve_all(
-            &self.language,
-            self.bridge.node_tracker(),
-            &uri,
-            snapshot.tree(),
-            snapshot.text(),
-            injection_query.as_ref(),
-        );
+        let all_regions = match self.documents.current_resolved_regions(&uri) {
+            Some(regions) => regions.as_ref().clone(),
+            None => InjectionResolver::resolve_all(
+                &self.language,
+                self.bridge.node_tracker(),
+                &uri,
+                snapshot.tree(),
+                snapshot.text(),
+                injection_query.as_ref(),
+            ),
+        };
 
         if all_regions.is_empty() {
             return Ok(None);

--- a/src/lsp/lsp_impl/text_document/document_symbol.rs
+++ b/src/lsp/lsp_impl/text_document/document_symbol.rs
@@ -103,15 +103,15 @@ impl Kakehashi {
             .documents
             .current_resolved_regions(&uri, self.cache.semantic_token_generation())
         {
-            Some(regions) => regions.as_ref().clone(),
-            None => InjectionResolver::resolve_all(
+            Some(regions) => regions,
+            None => std::sync::Arc::new(InjectionResolver::resolve_all(
                 &self.language,
                 self.bridge.node_tracker(),
                 &uri,
                 snapshot.tree(),
                 snapshot.text(),
                 injection_query.as_ref(),
-            ),
+            )),
         };
 
         if all_regions.is_empty() {
@@ -143,7 +143,7 @@ impl Kakehashi {
         });
         let mut cp_minted: Vec<NumberOrString> = Vec::new();
 
-        for resolved in all_regions {
+        for resolved in all_regions.iter() {
             // Get ALL bridge server configs for this injection language
             let configs = self.bridge_configs_for_injection_language(
                 &language_name,
@@ -160,7 +160,7 @@ impl Kakehashi {
             );
             let region_ctx = DocumentRequestContext {
                 uri: uri.clone(),
-                resolved,
+                resolved: resolved.clone(),
                 configs,
                 upstream_request_id: upstream_request_id.clone(),
                 priorities: agg.priorities,

--- a/src/lsp/lsp_impl/text_document/document_symbol.rs
+++ b/src/lsp/lsp_impl/text_document/document_symbol.rs
@@ -99,7 +99,10 @@ impl Kakehashi {
         };
 
         // Collect all injection regions
-        let all_regions = match self.documents.current_resolved_regions(&uri) {
+        let all_regions = match self
+            .documents
+            .current_resolved_regions(&uri, self.cache.semantic_token_generation())
+        {
             Some(regions) => regions.as_ref().clone(),
             None => InjectionResolver::resolve_all(
                 &self.language,

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -243,7 +243,10 @@ impl Kakehashi {
             return Ok(None);
         };
 
-        let all_regions = match self.documents.current_resolved_regions(uri) {
+        let all_regions = match self
+            .documents
+            .current_resolved_regions(uri, self.cache.semantic_token_generation())
+        {
             Some(regions) => regions.as_ref().clone(),
             None => InjectionResolver::resolve_all(
                 &self.language,

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -247,15 +247,15 @@ impl Kakehashi {
             .documents
             .current_resolved_regions(uri, self.cache.semantic_token_generation())
         {
-            Some(regions) => regions.as_ref().clone(),
-            None => InjectionResolver::resolve_all(
+            Some(regions) => regions,
+            None => std::sync::Arc::new(InjectionResolver::resolve_all(
                 &self.language,
                 self.bridge.node_tracker(),
                 uri,
                 snapshot.tree(),
                 snapshot.text(),
                 injection_query.as_ref(),
-            ),
+            )),
         };
 
         if all_regions.is_empty() {
@@ -288,7 +288,7 @@ impl Kakehashi {
         });
         let mut cp_minted: Vec<NumberOrString> = Vec::new();
 
-        for resolved in all_regions {
+        for resolved in all_regions.iter() {
             let configs = self
                 .bridge_configs_for_injection_language(language_name, &resolved.injection_language);
             if configs.is_empty() {
@@ -302,7 +302,7 @@ impl Kakehashi {
             );
             let region_ctx = DocumentRequestContext {
                 uri: uri.clone(),
-                resolved,
+                resolved: resolved.clone(),
                 configs,
                 upstream_request_id: upstream_request_id.clone(),
                 priorities: agg.priorities,

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -243,14 +243,17 @@ impl Kakehashi {
             return Ok(None);
         };
 
-        let all_regions = InjectionResolver::resolve_all(
-            &self.language,
-            self.bridge.node_tracker(),
-            uri,
-            snapshot.tree(),
-            snapshot.text(),
-            injection_query.as_ref(),
-        );
+        let all_regions = match self.documents.current_resolved_regions(uri) {
+            Some(regions) => regions.as_ref().clone(),
+            None => InjectionResolver::resolve_all(
+                &self.language,
+                self.bridge.node_tracker(),
+                uri,
+                snapshot.tree(),
+                snapshot.text(),
+                injection_query.as_ref(),
+            ),
+        };
 
         if all_regions.is_empty() {
             return Ok(None);

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -116,14 +116,17 @@ impl Kakehashi {
                 return Ok(None);
             };
 
-            let all_regions = InjectionResolver::resolve_all(
-                &self.language,
-                self.bridge.node_tracker(),
-                &uri,
-                snapshot.tree(),
-                snapshot.text(),
-                injection_query.as_ref(),
-            );
+            let all_regions = match self.documents.current_resolved_regions(&uri) {
+                Some(regions) => regions.as_ref().clone(),
+                None => InjectionResolver::resolve_all(
+                    &self.language,
+                    self.bridge.node_tracker(),
+                    &uri,
+                    snapshot.tree(),
+                    snapshot.text(),
+                    injection_query.as_ref(),
+                ),
+            };
 
             if all_regions.is_empty() {
                 return Ok(None);

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -116,7 +116,10 @@ impl Kakehashi {
                 return Ok(None);
             };
 
-            let all_regions = match self.documents.current_resolved_regions(&uri) {
+            let all_regions = match self
+                .documents
+                .current_resolved_regions(&uri, self.cache.semantic_token_generation())
+            {
                 Some(regions) => regions.as_ref().clone(),
                 None => InjectionResolver::resolve_all(
                     &self.language,

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -120,15 +120,15 @@ impl Kakehashi {
                 .documents
                 .current_resolved_regions(&uri, self.cache.semantic_token_generation())
             {
-                Some(regions) => regions.as_ref().clone(),
-                None => InjectionResolver::resolve_all(
+                Some(regions) => regions,
+                None => std::sync::Arc::new(InjectionResolver::resolve_all(
                     &self.language,
                     self.bridge.node_tracker(),
                     &uri,
                     snapshot.tree(),
                     snapshot.text(),
                     injection_query.as_ref(),
-                ),
+                )),
             };
 
             if all_regions.is_empty() {
@@ -176,7 +176,7 @@ impl Kakehashi {
             });
             let mut cp_minted: Vec<NumberOrString> = Vec::new();
 
-            for resolved in all_regions {
+            for resolved in all_regions.iter() {
                 // A covering request (its byte span encloses the whole region)
                 // prefers full formatting; a partial request range-formats the
                 // clipped span. Either way we compute the clipped+content-clamped
@@ -230,7 +230,7 @@ impl Kakehashi {
                 );
                 let region_ctx = DocumentRequestContext {
                     uri: uri.clone(),
-                    resolved,
+                    resolved: resolved.clone(),
                     configs,
                     upstream_request_id: upstream_request_id.clone(),
                     priorities: agg.priorities,

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -926,6 +926,7 @@ mod tests {
                         parsed_version: 0,
                         incarnation,
                         injection_regions: None,
+                        bridge_regions: None,
                     },
                 ))
             })

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -927,6 +927,7 @@ mod tests {
                         incarnation,
                         injection_regions: None,
                         bridge_regions: None,
+                        resolved_regions: None,
                     },
                 ))
             })

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -928,6 +928,7 @@ mod tests {
                         injection_regions: None,
                         bridge_regions: None,
                         resolved_regions: None,
+                        layer_trees: std::sync::OnceLock::new(),
                     },
                 ))
             })

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -245,6 +245,10 @@ impl Kakehashi {
                 documents: std::sync::Arc::clone(&self.documents),
                 parsed_version: snapshot.parsed_version,
                 incarnation: snapshot.incarnation,
+                // The snapshot's own discovery (ADR §3, don't-discover-twice):
+                // rebuilt into contexts instead of re-running the injection
+                // query, when its generation still matches.
+                discovery: snapshot.injection_regions.clone(),
             });
 
             // Compute tokens, racing against cancel notification if provided
@@ -518,6 +522,8 @@ impl Kakehashi {
                     documents: std::sync::Arc::clone(&self.documents),
                     parsed_version: snapshot.parsed_version,
                     incarnation: snapshot.incarnation,
+                    // The snapshot's own discovery (ADR §3, don't-discover-twice).
+                    discovery: snapshot.injection_regions.clone(),
                 });
 
                 // Compute tokens, racing against cancel notification if provided
@@ -919,6 +925,7 @@ mod tests {
                         language: Some("rust".to_string()),
                         parsed_version: 0,
                         incarnation,
+                        injection_regions: None,
                     },
                 ))
             })
@@ -1069,6 +1076,85 @@ mod tests {
         assert!(
             follow_up_result.is_ok(),
             "follow-up delta request should succeed"
+        );
+    }
+
+    /// End-to-end for the don't-discover-twice lever (parse-snapshot ADR §3):
+    /// the parse loop's `populate_injections` derives the injection discovery
+    /// once, the published snapshot carries it, and the semantic handler
+    /// consumes it — so the request-path compute never re-runs the injection
+    /// query. Pinned via the reuse-hit counter around a real
+    /// `semanticTokens/full` request.
+    #[tokio::test]
+    async fn semantic_full_reuses_snapshot_discovery() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let uri = Url::parse("file:///discovery_reuse.md").expect("test uri");
+
+        // Eight lua blocks: clears INJECTION_CACHE_MIN_REGIONS so populate
+        // stores a discovery.
+        let mut text = String::new();
+        for i in 0..8 {
+            text.push_str(&format!("# h{i}\n\n```lua\nlocal x{i} = {i}\n```\n\n"));
+        }
+        server
+            .documents
+            .insert(uri.clone(), text, Some("markdown".to_string()), None);
+
+        let settings = crate::config::WorkspaceSettings {
+            search_paths: vec![
+                std::env::var("TREE_SITTER_GRAMMARS")
+                    .unwrap_or_else(|_| "deps/tree-sitter".to_string()),
+            ],
+            ..Default::default()
+        };
+        let _ = server.language.load_settings(&settings);
+        for lang in ["markdown", "markdown_inline", "lua"] {
+            if !server.language.ensure_language_loaded(lang).success {
+                eprintln!("Skipping: {lang} parser not available");
+                return;
+            }
+        }
+        if server.language.highlight_query("markdown").is_none() {
+            eprintln!("Skipping: markdown highlight query not available");
+            return;
+        }
+
+        server
+            .parse_coordinator()
+            .parse_document(uri.clone(), Some("markdown"), None)
+            .await;
+
+        // The published snapshot must carry the derived discovery.
+        let view = server
+            .documents
+            .latest_snapshot(&uri)
+            .expect("document registered");
+        let snapshot = view.slot.snapshot.expect("open parse published");
+        assert!(
+            snapshot.injection_regions.is_some(),
+            "populate must derive a discovery onto the snapshot for an 8-region document"
+        );
+
+        // A real full request must take the reuse path (no injection-query re-run).
+        use crate::analysis::semantic::DISCOVERY_REUSE_HITS;
+        DISCOVERY_REUSE_HITS.store(0, std::sync::atomic::Ordering::Relaxed);
+        let params = SemanticTokensParams {
+            text_document: TextDocumentIdentifier {
+                uri: crate::lsp::lsp_impl::url_to_uri(&uri).expect("test URI should convert"),
+            },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        };
+        let result = server
+            .semantic_tokens_full_impl(params)
+            .await
+            .expect("full request should succeed")
+            .expect("should return tokens");
+        assert!(matches!(result, SemanticTokensResult::Tokens(t) if !t.data.is_empty()));
+        assert!(
+            DISCOVERY_REUSE_HITS.load(std::sync::atomic::Ordering::Relaxed) >= 1,
+            "the request must rebuild contexts from the snapshot's discovery"
         );
     }
 

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -145,7 +145,11 @@ impl Kakehashi {
         let (Some(language_name), Some(tree)) = (snapshot.language.clone(), snapshot.tree.clone())
         else {
             // No detectable language, or resolved-but-tree-less (no parser
-            // installed / crashed grammar): nothing to tokenize.
+            // installed / crashed grammar): nothing to tokenize. The empty set
+            // IS this snapshot's served state — record it so the parse loop
+            // doesn't keep refreshing a document that has no tokens.
+            self.cache
+                .record_served_semantic_version(&uri, snapshot.parsed_version);
             self.cache.finish_request(&uri, request_id);
             return Ok(Some(SemanticTokensResult::Tokens(SemanticTokens {
                 result_id: None,
@@ -223,6 +227,8 @@ impl Kakehashi {
                 .cache
                 .get_current_tokens(&uri, &language_name, cache_key)
             {
+                self.cache
+                    .record_served_semantic_version(&uri, snapshot.parsed_version);
                 self.cache.finish_request(&uri, request_id);
                 return Ok(Some(SemanticTokensResult::Tokens(cached)));
             }
@@ -347,6 +353,8 @@ impl Kakehashi {
             .store_tokens(uri.clone(), stored_tokens, language_name, cache_key);
 
         // Finish tracking this request
+        self.cache
+            .record_served_semantic_version(&uri, snapshot.parsed_version);
         self.cache.finish_request(&uri, request_id);
 
         log::debug!(
@@ -416,6 +424,8 @@ impl Kakehashi {
         };
         let (Some(language_name), Some(tree)) = (snapshot.language.clone(), snapshot.tree.clone())
         else {
+            self.cache
+                .record_served_semantic_version(&uri, snapshot.parsed_version);
             self.cache.finish_request(&uri, request_id);
             return Ok(Some(SemanticTokensFullDeltaResult::Tokens(
                 SemanticTokens {
@@ -494,6 +504,8 @@ impl Kakehashi {
                 // so the delta is necessarily empty — return it directly and skip
                 // the `previous_tokens` clone + O(N) `calculate_delta` below.
                 if cached.result_id.as_deref() == Some(previous_result_id.as_str()) {
+                    self.cache
+                        .record_served_semantic_version(&uri, snapshot.parsed_version);
                     self.cache.finish_request(&uri, request_id);
                     return Ok(Some(SemanticTokensFullDeltaResult::TokensDelta(
                         tower_lsp_server::ls_types::SemanticTokensDelta {
@@ -675,6 +687,8 @@ impl Kakehashi {
         };
 
         // Finish tracking this request
+        self.cache
+            .record_served_semantic_version(&uri, snapshot.parsed_version);
         self.cache.finish_request(&uri, request_id);
 
         log::debug!(

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -101,15 +101,15 @@ impl Kakehashi {
                 .documents
                 .current_resolved_regions(&uri, self.cache.semantic_token_generation())
             {
-                Some(regions) => regions.as_ref().clone(),
-                None => InjectionResolver::resolve_all(
+                Some(regions) => regions,
+                None => std::sync::Arc::new(InjectionResolver::resolve_all(
                     &self.language,
                     self.bridge.node_tracker(),
                     &uri,
                     snapshot_tree,
                     &snapshot.text,
                     injection_query.as_ref(),
-                ),
+                )),
             };
 
             if all_regions.is_empty() {
@@ -142,7 +142,7 @@ impl Kakehashi {
             });
             let mut cp_minted: Vec<NumberOrString> = Vec::new();
 
-            for resolved in all_regions {
+            for resolved in all_regions.iter() {
                 // Get ALL bridge server configs for this injection language
                 let configs = self.bridge_configs_for_injection_language(
                     &language_name,
@@ -159,7 +159,7 @@ impl Kakehashi {
                 );
                 let region_ctx = DocumentRequestContext {
                     uri: uri.clone(),
-                    resolved,
+                    resolved: resolved.clone(),
                     configs,
                     upstream_request_id: upstream_request_id.clone(),
                     priorities: agg.priorities,

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -97,14 +97,17 @@ impl Kakehashi {
             };
 
             // Collect all injection regions
-            let all_regions = InjectionResolver::resolve_all(
-                &self.language,
-                self.bridge.node_tracker(),
-                &uri,
-                snapshot_tree,
-                &snapshot.text,
-                injection_query.as_ref(),
-            );
+            let all_regions = match self.documents.current_resolved_regions(&uri) {
+                Some(regions) => regions.as_ref().clone(),
+                None => InjectionResolver::resolve_all(
+                    &self.language,
+                    self.bridge.node_tracker(),
+                    &uri,
+                    snapshot_tree,
+                    &snapshot.text,
+                    injection_query.as_ref(),
+                ),
+            };
 
             if all_regions.is_empty() {
                 return Ok(None);

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -96,12 +96,19 @@ impl Kakehashi {
                 return Ok(None);
             };
 
-            // Collect all injection regions
-            let all_regions = match self
-                .documents
-                .current_resolved_regions(&uri, self.cache.semantic_token_generation())
+            // Collect all injection regions — from THIS snapshot's own
+            // resolved_regions (generation-gated), never a store re-read: a
+            // parse publishing between the wait above and a store lookup
+            // could pair this snapshot's tree/text with a NEWER snapshot's
+            // regions. Snapshot immutability makes tree, text, and regions
+            // one value; absent/reload-stale falls back inline over the same
+            // tree.
+            let all_regions = match snapshot
+                .resolved_regions
+                .as_ref()
+                .filter(|(stamped, _)| *stamped == self.cache.semantic_token_generation())
             {
-                Some(regions) => regions,
+                Some((_, regions)) => std::sync::Arc::clone(regions),
                 None => std::sync::Arc::new(InjectionResolver::resolve_all(
                     &self.language,
                     self.bridge.node_tracker(),

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -97,7 +97,10 @@ impl Kakehashi {
             };
 
             // Collect all injection regions
-            let all_regions = match self.documents.current_resolved_regions(&uri) {
+            let all_regions = match self
+                .documents
+                .current_resolved_regions(&uri, self.cache.semantic_token_generation())
+            {
                 Some(regions) => regions.as_ref().clone(),
                 None => InjectionResolver::resolve_all(
                     &self.language,


### PR DESCRIPTION
Stacked on #554. Implements the parse-snapshot ADR's §3 don't-discover-twice lever — the dominant remaining cost behind "large.md is still slow": every semanticTokens recompute re-ran the injection query over the whole host tree and re-resolved every region's language (a live-editor log showed **11,825 `markdown_inline` resolutions in one session, 2,000–3,800/sec while typing**; the query-match loop was previously measured at 76–88% of the discovery bucket).

## What it does

- The off-ingress `populate_injections` builds an owned `DiscoveredInjections` from the **same** `collect_all_injections` pass it already runs (Q executes once per parse) and the parse loop attaches it to the `ParseSnapshot` it publishes.
- The semantic compute rebuilds its injection contexts from the snapshot's discovery — no injection query, no per-region language resolution on the request path. A generation mismatch (settings reload), combined groups, below-the-gate documents, or incomplete discovery fall back to the inline path, byte-identical to before.

## Provenance

Adapted from the converged reference implementation of #551 (`feat/injection-discovery-cache`, closed as subsumed by the ADR — all 7 review-pipeline steps had converged). The snapshot model **deletes that design's hardest problem**: the tree-identity binding (per-parse epoch CAS, cross-map TOCTOU hardening from the codex rounds) is free here, because text + tree + regions are one immutable snapshot value. The cooperative-cancellation checkpoints merged since (#547) are re-applied on top.

## Verification

- `discovery_reuse_matches_inline_output` (reference): reuse output byte-identical to inline discovery, reuse-hit counter fires.
- New end-to-end test pins the full chain: parse → snapshot carries discovery → a real `semanticTokens/full` request rebuilds from it.
- Gate + 2282 lib tests + semantic/captures/blockquote e2e suites green.

## Landed during review (originally deferred)

- Bridge-context readers now reuse the snapshot's regions instead of re-resolving per request: `whole_document_preferred_fan_out` reads the snapshot's own generation-gated `resolved_regions`, and `documentColor` goes through `DocumentStore::current_resolved_regions`; `InjectionResolver::resolve_all` remains only as the inline fallback (generation mismatch / absent discovery).
- A first slice of the §3 tracker-mint reconciliation: `populate_injections` commits its injection map via `commit_if_unshifted` (per-URI shift-generation + global cleanup-epoch latch), so a populate racing an edit or didClose can no longer commit stale mints.

## Not in this PR

- The full §3 mint-ownership split (readers never mint; snapshot-owned region ordinals). Readers on the reuse path don't mint, but the inline fallback and mid-fan-out paths still can.
- The `(uri, content_hash)` token-cache re-key (companion decision to injection-token-cache-reuse; unblocks the mint-ownership split above). Direction decided: keep point-eviction via a side index (region/position → content-hash key) so the "typed region preserves reuse on an unrelated edit" property from #540 survives the re-key — not the simpler content-keyed clear. Needs its own ADR revision + PR, stacked after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
