### PR TITLE
fix(semantic): serve-current token reads + admission/cancel fixes for concurrent-feature latency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,12 +83,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,7 +1015,6 @@ dependencies = [
  "rayon",
  "regex",
  "rstest",
- "rust-lapper",
  "schemars",
  "serde",
  "serde_json",
@@ -1203,15 +1196,6 @@ name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "once_cell"
@@ -1596,15 +1580,6 @@ dependencies = [
  "rustc_version",
  "syn",
  "unicode-ident",
-]
-
-[[package]]
-name = "rust-lapper"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2274b9cc4f205bc0945b7be3e4fc1a102b0b7119ba6482faaedb9c4f76dde5d1"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,6 @@ log = "0.4"
 lua-pattern = { version = "0.1", features = ["to-regex"] }
 path-clean = "1"
 regex = "1"
-rust-lapper = "1.1"
 schemars = { version = "1", features = ["preserve_order"] }
 serde = { version = "1", features = ["derive"] }
 # regex-fancy (pure Rust) over regex-onig (C oniguruma): we only compile

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ ignore = "0.4"
 tar = "0.4.46"
 tempfile = "3"
 thiserror = "2"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "io-util", "time", "process", "fs"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "io-util", "time", "process", "fs", "signal"] }
 tokio-util = "0.7"
 toml = "1"
 tower = { version = "0.5", default-features = false }

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -266,12 +266,17 @@ The decision therefore **separates three concerns that today all ride the tracke
   settings reload, the #530 discipline — *not* the per-edit parse-run counter), so a
   byte-identical region reuses across edits and is invalidated only on a real config
   change. Two snapshots' byte-identical regions thus reuse tokens without any stable
-  id. That in turn reworks **eviction**:
-  `invalidate_for_edits` currently point-deletes by `region_id` via the interval
-  tree, which has no target once the key drops it, so it must become a content-keyed
-  clear (or a side index) — losing the "typed region preserves reuse on an unrelated
-  edit" optimization measured by the injection-token-cache-reuse work unless that
-  index is added. Reworking the key **and** the eviction surface is a **companion decision to injection-token-cache-reuse**, not silently folded in here.
+  id. That in turn reworks **eviction** — and this companion decision is now
+  **implemented**: the key is `(uri, validity_hash)` (content ⊕ resolved
+  language, one shared fold), spatial `invalidate_for_edits` is deleted
+  (content addressing self-invalidates: an edited region misses under its new
+  hash, and an unrelated edit cannot touch a region's entry at all — the
+  "typed region preserves reuse" property holds *without* the interval
+  index), and the growth bound is a per-populate **live-hash sweep** run
+  inside the mint-epoch commit (a stale pass sweeps nothing). The live set
+  comes from the discovery's own per-region cache identities so the sweep and
+  the store/read path can never disagree on the fold. Free extras: duplicate
+  fences share one entry, and an undo back to previous content is a hit.
 - **Cross-edit bridge / virtual-document identity** — the stable handle a
   downstream language server's virtual document is keyed by — **remains the shared `NodeTracker` ULID**, a live-position (`content_version`) concern. Because regions
   are only *discovered* by a parse, minting still originates from a parse pass, but

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -301,20 +301,41 @@ reconciliation above is the one place a parse still mints them.
 Any reader that must resolve against **live** positions is position-critical
 (below).
 
-- **Serve-stale, actively refreshed** — `semanticTokens` full/delta. Compute
-  against the snapshot's consistent `(text, tree, injection_regions)`; caches key
-  off the snapshot's `(text, parsed_version)` so nothing is poisoned. When the
-  parse loop publishes a fresh snapshot it emits `workspace/semanticTokens/refresh`.
-  The trigger is added at the **parse-loop** publish point, **not** in the
-  `didChange` handler — `didChange` deliberately does not emit refresh because a
+- **Serve-current (parked wait), refresh as backstop** — `semanticTokens`
+  full/delta. The handler parks (racing the client's `$/cancelRequest`) until
+  the latest snapshot is **current** (`parsed_version == content_version`),
+  then computes against that snapshot's consistent
+  `(text, tree, injection_regions)`; caches key off the snapshot's
+  `(text, parsed_version)` so nothing is poisoned.
+
+  Stage 2 originally shipped this reader as *serve-stale + refresh* (answer
+  from the latest completed snapshot immediately; let the parse loop's
+  `workspace/semanticTokens/refresh` re-drive the client once a fresher one
+  lands). Live-editor evidence overturned that: the dominant client
+  (`vim.lsp.semantic_tokens`) stamps a response with the buffer version **at
+  request time** and draws it as soon as that version matches the live buffer
+  (extmarks placed with `strict = false`), so tokens computed for older text
+  render visibly misplaced on *unchanged* lines until the refresh round-trip
+  converges — highlight corruption, not mere latency. While the server stays
+  silent instead, the editor keeps its previous tokens as extmarks that shift
+  naturally with edits: the acceptable degradation. Serving stale is strictly
+  worse than parking for every client that draws responses against the live
+  buffer, and parking is affordable because the wait is bounded by parse
+  completion (every edit's parse resolution publishes), not by typing — a
+  superseding request (the client re-requests per edit) or `$/cancelRequest`
+  releases a parked handler early.
+
+  On the settle backstop expiring (pipeline pathologically behind), the
+  handler rejects with `ContentModified` and the parse loop's settled+stale
+  refresh gate re-drives the client once the parse lands. The refresh trigger
+  stays at the **parse-loop** publish point, **not** in the `didChange`
+  handler — `didChange` deliberately does not emit refresh because a
   synchronous client (vim-lsp on Vim) cannot answer a server request while
   processing a notification; emitting from the off-ingress loop, after the
-  notification returns, avoids that reentrancy. This **reverses the current handler**, which *rejects* a stale/superseded `semanticTokens` full/delta with
-  `None` (via `check_text_staleness` and the merged compute-superseded
-  `is_cancelled` bail) rather than serving a trailing snapshot. Stage 2 replaces
-  reject-on-stale with serve-stale + refresh; the `CancelToken` bail then narrows to
-  reclaiming the superseded compute's CPU (§4) without also discarding the — now
-  servable — snapshot. This is a decision Stage 2 deliberately overwrites.
+  notification returns, avoids that reentrancy. Under serve-current the gate
+  rarely fires (a parked request records the served version at settle); it
+  remains for the backstop path and non-edit token changes. The `CancelToken`
+  bail stays narrowed to reclaiming a superseded compute's CPU (§4).
 - **Serve-stale, passively refreshed** — whole-document, no-position reads:
   `documentSymbol`, `documentColor`, `documentLink`, `foldingRange`, `codeLens`
   (the `whole_document_preferred_fan_out` family), and pull-mode
@@ -368,11 +389,13 @@ Any reader that must resolve against **live** positions is position-critical
     nothing and returns `null`, so the lineage never records matches for a text the
     client no longer has.
 
-Only two bounded waits remain, both deliberate: the **first parse after `didOpen`**
+Three bounded waits remain, all deliberate: the **first parse after `didOpen`**
 (the snapshot is `None`; it waits briefly on `watch::changed()` then serves `null` —
 the same decoupling parse-decoupled-document-lifecycle applies to its host tier),
-and the **explicit-action wait** above (`formatting`/`rename`). No *per-keystroke*
-read ever waits.
+the **explicit-action wait** above (`formatting`/`rename`), and the
+**serve-current token wait** (`semanticTokens` full/delta — parked, not
+polling; bounded by parse completion and released early by supersede/cancel).
+No other *per-keystroke* read ever waits.
 
 *(`kakehashi/node/*` stays staleness-reject rather than serve-stale: a node
 request resolves to a specific live-position node, so a stale-position answer is
@@ -469,7 +492,8 @@ inside the existing safety contracts at each step:
   detect-and-spawn is near the lock, and even that need not hold it. The region is
   re-minted on a later reconciliation once the grammar lands. Only the fast
   tracker-mint itself runs under `edit_lock`. Convert
-  `semanticTokens` **and `captures/full`** to serve-stale (the latter reserving
+  `semanticTokens` full/delta to the serve-current parked wait and
+  `captures/full` to serve-stale (the latter reserving
   `null` for no-snapshot / no-lineage, not routine staleness); the whole-document
   passive-refresh family (`documentSymbol`/`documentColor`/`documentLink`/
   `foldingRange`/`codeLens`/pull-`diagnostic`) to serve-stale; the position/range
@@ -520,19 +544,27 @@ inside the existing safety contracts at each step:
   fallback. This decision *reuses* the scheduler and its epoch rather than
   replacing them with an actor.
 - **Block all readers until fully current (status quo).** Rejected: it is the
-  behavior producing the 0.5–1.4 s waits. The user explicitly accepts a one-edit
-  stale highlight (healed by refresh) in exchange for never blocking, with
-  position-critical requests staleness-rejecting rather than serving stale.
+  behavior producing the 0.5–1.4 s waits — those waits were *synchronous*
+  (inline parses and lock convoys on the request path, stalling unrelated
+  documents). The `semanticTokens` full/delta reader has since moved back to a
+  **parked** current-wait (§3) because live-editor evidence showed serve-stale
+  corrupting drawn highlights; the crucial difference from the status quo is
+  that the park is a cheap `watch` subscription bounded by the off-ingress
+  parse (§4 keeps the runtime pollable), released early by supersede/cancel,
+  and never blocks other documents or other readers.
 
 ## Consequences
 
 ### Positive
 
 - Document lifecycle is fully decoupled from parsing: `didChange` never awaits a
-  parse, and no *per-keystroke* read blocks on a parse. The only two bounded waits
-  are deliberate and rare: the first-parse wait after `didOpen` (no snapshot yet)
-  and the explicit-action wait (`formatting`/`rename`) that trades a jarring no-op
-  for a short pause on a user-triggered command.
+  parse, and no read *blocks* the runtime on a parse. The bounded waits are
+  deliberate: the first-parse wait after `didOpen` (no snapshot yet), the
+  explicit-action wait (`formatting`/`rename`) that trades a jarring no-op
+  for a short pause on a user-triggered command, and the serve-current token
+  park (§3) — a `watch` subscription released by the parse's own publish,
+  chosen over serve-stale because answering from a trailing snapshot corrupts
+  what the editor draws.
 - The async runtime is never blocked by tree-CPU: with all synchronous tree work
   on the bounded pool, a slow parse on one document cannot freeze the request loop,
   timers, diagnostics, or another document's async handlers — the specific defect
@@ -557,12 +589,13 @@ inside the existing safety contracts at each step:
 
 ### Negative
 
-- Highlight-class results may be **stale — usually one edit, potentially several under sustained typing** (the scheduler coalesces) — until a fresh snapshot
-  publishes. `semanticTokens` is re-driven by an added
-  post-edit `semanticTokens/refresh` (emitted from the parse loop to dodge the
-  synchronous-client reentrancy that keeps it out of `didChange`);
-  `documentSymbol`/`documentColor` self-correct only on the client's next natural
-  request (no active refresh added).
+- Highlight-class results trail the input until a fresh snapshot publishes.
+  `semanticTokens` full/delta **parks** for the current snapshot (silence keeps
+  the editor's shifted extmarks intact — see §3) and falls back to
+  `ContentModified` + the settle refresh only past its backstop; `captures/full`
+  serves stale (usually one edit behind, healed by its per-keystroke
+  re-request); `documentSymbol`/`documentColor` self-correct only on the
+  client's next natural request (no active refresh added).
 - Staleness-reject requests (`kakehashi/node/*`, range requests, formatting) return
   `ContentModified` during the reparse window (`captures/range` returns `null`, its
   protocol re-sync signal). The LSP spec does not mandate retry on `ContentModified`,
@@ -623,7 +656,9 @@ dequeue hook (§4).
 incarnation guard, `u64::MAX` close sentinel, reserved in `next_incarnation`
 and refused by the guard itself); the parse loop dual-writes on every
 resolution path and emits `semanticTokens/refresh` at its publish point;
-`semanticTokens` full/delta and `captures/full` serve-stale (the lineage store
+`semanticTokens` full/delta serve-current via the parked wait (initially
+shipped serve-stale; revised on live-editor evidence — see §3) and
+`captures/full` serves-stale (the lineage store
 gains the §3 request-entry version guard); `semanticTokens/range` and the
 bridge/formatting/node families staleness-reject (`ContentModified`, or the
 protocol-appropriate `null`); `formatting`, `rangeFormatting`, and

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -373,21 +373,24 @@ Any reader that must resolve against **live** positions is position-critical
   - `kakehashi/captures/range` uses `null` where the LSP requests use
     `ContentModified` — `null` is the re-sync signal captures-protocol already
     defines ("on null, call full again"), and a JSON-RPC *error* would violate that
-    contract. But `null`-**on-routine-staleness must be avoided for `captures/full`**:
-    it is a per-keystroke highlighter, so returning `null` while the snapshot merely
-    trails, against a client contracted to re-request on `null`, is a busy-spin
-    (edit → stale → `null` → re-request → still stale → …). So `captures/full`
-    instead **serves-stale**, like `semanticTokens`: it returns the latest snapshot's
-    matches (one edit behind, healing on the next edit's captures request, which the
-    client sends per keystroke anyway), and reserves `null` for the cases the
-    protocol actually means it — no snapshot yet (pre-first-parse) or a delta with no
-    lineage. The match node-ids are the snapshot's own; a one-edit-stale id
-    self-heals, the same relaxation `semanticTokens` takes. When a served `full`
-    installs lineage, it carries the computed `parsed_version` and — under
-    `edit_lock` — stores it **only if `incarnation` and the current `content_version`
-    still match** (today `store_lineage` re-checks only incarnation), else stores
-    nothing and returns `null`, so the lineage never records matches for a text the
-    client no longer has.
+    contract. `captures/full` and `full/delta` take the **serve-current parked
+    wait**, like `semanticTokens`. This revises the original serve-stale choice,
+    which was motivated by avoiding a `null` busy-spin (edit → stale → `null` →
+    re-request → …): live-editor evidence (capture 01KWSECM…) showed serve-stale
+    *creating* exactly that spin one layer down — every stale walk completed its
+    full compute, was then voided by the lineage still-current gate, answered
+    `null`, and triggered a re-request that walked the next trailing snapshot
+    (41 walks in ~15s, most doomed, saturating the compute pool and queueing the
+    semantic delta ~10s behind them). Parking costs a `watch` subscription,
+    releases on the parse's own publish (or the client's cancel), and each
+    settle then walks once per kind with lineage installing. `null` remains for
+    what the protocol means by it: no snapshot yet (pre-first-parse), the settle
+    backstop, and a delta with no lineage. When a served `full` installs
+    lineage, it carries the computed `parsed_version` and — under `edit_lock` —
+    stores it **only if `incarnation` and the current `content_version` still
+    match**, else stores nothing and returns `null`, so the lineage never
+    records matches for a text the client no longer has (under serve-current
+    this guards the resolve→delivery window).
 
 Three bounded waits remain, all deliberate: the **first parse after `didOpen`**
 (the snapshot is `None`; it waits briefly on `watch::changed()` then serves `null` —
@@ -397,13 +400,12 @@ the **explicit-action wait** above (`formatting`/`rename`), and the
 polling; bounded by parse completion and released early by supersede/cancel).
 No other *per-keystroke* read ever waits.
 
-*(`kakehashi/node/*` stays staleness-reject rather than serve-stale: a node
-request resolves to a specific live-position node, so a stale-position answer is
-wrong, not merely late — and unlike `captures/full` it has no per-keystroke
-re-request to heal it. `captures/full` can afford serve-stale precisely because its
-matches are snapshot-consistent and its per-edit re-request heals a one-edit-stale
-node-id; giving `node/*` the same would need a per-snapshot tracker view, which
-this decision does not commit to.)*
+*(`kakehashi/node/*` stays staleness-reject: a node request resolves to a
+specific live-position node, so a stale-position answer is wrong, not merely
+late — and it has no per-keystroke re-request to heal it. Serving it stale
+would need a per-snapshot tracker view, which this decision does not commit
+to; parking it like the token readers is possible but unmotivated — its
+implicit-trigger cadence means the client's next natural request heals.)*
 
 ### 4. All tree-CPU runs on one bounded compute pool
 
@@ -492,9 +494,9 @@ inside the existing safety contracts at each step:
   detect-and-spawn is near the lock, and even that need not hold it. The region is
   re-minted on a later reconciliation once the grammar lands. Only the fast
   tracker-mint itself runs under `edit_lock`. Convert
-  `semanticTokens` full/delta to the serve-current parked wait and
-  `captures/full` to serve-stale (the latter reserving
-  `null` for no-snapshot / no-lineage, not routine staleness); the whole-document
+  `semanticTokens` full/delta and `captures/full` to the serve-current parked
+  wait (the latter reserving
+  `null` for no-snapshot / no-lineage / the settle backstop); the whole-document
   passive-refresh family (`documentSymbol`/`documentColor`/`documentLink`/
   `foldingRange`/`codeLens`/pull-`diagnostic`) to serve-stale; the position/range
   family — `semanticTokens/range`, `node/*`, `captures/range`,
@@ -602,8 +604,8 @@ inside the existing safety contracts at each step:
   so on a client that does not re-request (e.g. Neovim's built-in client for
   formatting) that keystroke's request **no-ops** until the next natural request;
   `formatting`/`rename`/`selectionRange` mitigate with the brief bounded wait.
-  `captures/full` is *not* in this class — it serves-stale (§3) to avoid a
-  null-then-re-request busy-spin during typing. Keeping `node/*` staleness-reject
+  `captures/full` is *not* in this class — it takes the serve-current parked
+  wait (§3). Keeping `node/*` staleness-reject
   rather than serve-stale is the cost of not forking a per-snapshot tracker view now.
 - The `#342`/`#374` stale-tree guarantee (a reader observes at least its own edit)
   is relaxed to "a reader observes a *consistent* snapshot that may trail the input
@@ -658,8 +660,9 @@ and refused by the guard itself); the parse loop dual-writes on every
 resolution path and emits `semanticTokens/refresh` at its publish point;
 `semanticTokens` full/delta serve-current via the parked wait (initially
 shipped serve-stale; revised on live-editor evidence — see §3) and
-`captures/full` serves-stale (the lineage store
-gains the §3 request-entry version guard); `semanticTokens/range` and the
+`captures/full` likewise serve-current (initially serve-stale; revised after
+its stale walks proved guaranteed-null compute waste — the lineage store
+keeps the §3 request-entry version guard for the resolve→delivery window); `semanticTokens/range` and the
 bridge/formatting/node families staleness-reject (`ContentModified`, or the
 protocol-appropriate `null`); `formatting`, `rangeFormatting`, and
 `selectionRange` take the explicit-action bounded wait (the two formatting

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -258,9 +258,10 @@ The decision therefore **separates three concerns that today all ride the tracke
 - **Cross-edit token reuse** (the injection-token-cache-reuse benefit): the cache
   is already content-validated at read (its entry carries `validity_hash` = content
   ⊕ language, and the settings `generation`), but its *key* is today the tracker
-  ULID. The change is to **drop `region_id` from the key** — key on
-  `(uri, content_hash)`, keeping `validity_hash` and the settings `generation` as
-  entry metadata checked at read, not as key components. The key **must stay stable
+  ULID. The change is to **drop `region_id` from the key** — key on the content
+  identity (implemented as `(uri, validity_hash)`, the content ⊕ resolved-language
+  fold), keeping the settings `generation` as entry metadata checked at read, not
+  as a key component. The key **must stay stable
   across edits** for reuse to work, so it must not include anything that turns over
   per edit; the `generation` here is the **config/settings epoch** (bumped only on a
   settings reload, the #530 discipline — *not* the per-edit parse-run counter), so a
@@ -398,8 +399,10 @@ Any reader that must resolve against **live** positions is position-critical
     this guards the resolve→delivery window).
 
 Three bounded waits remain, all deliberate: the **first parse after `didOpen`**
-(the snapshot is `None`; it waits briefly on `watch::changed()` then serves `null` —
-the same decoupling parse-decoupled-document-lifecycle applies to its host tier),
+(the snapshot is `None`; it waits briefly on `watch::changed()` then serves each
+reader's empty fallback — protocol `null` for captures/node, an empty
+`SemanticTokens` for the token handlers — the same decoupling
+parse-decoupled-document-lifecycle applies to its host tier),
 the **explicit-action wait** above (`formatting`/`rename`), and the
 **serve-current token wait** (`semanticTokens` full/delta — parked, not
 polling; bounded by parse completion and released early by supersede/cancel).
@@ -600,9 +603,11 @@ inside the existing safety contracts at each step:
   `semanticTokens` full/delta **parks** for the current snapshot (silence keeps
   the editor's shifted extmarks intact — see §3) and falls back to
   `ContentModified` + the settle refresh only past its backstop; `captures/full`
-  serves stale (usually one edit behind, healed by its per-keystroke
-  re-request); `documentSymbol`/`documentColor` self-correct only on the
-  client's next natural request (no active refresh added).
+  and `full/delta` take the same parked wait (§3 — revised from the original
+  serve-stale on live-editor evidence), answering `null` (their protocol
+  re-sync signal) past the backstop; `documentSymbol`/`documentColor`
+  self-correct only on the client's next natural request (no active refresh
+  added).
 - Staleness-reject requests (`kakehashi/node/*`, range requests, formatting) return
   `ContentModified` during the reparse window (`captures/range` returns `null`, its
   protocol re-sync signal). The LSP spec does not mandate retry on `ContentModified`,

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -182,7 +182,7 @@ pub(crate) async fn handle_semantic_tokens_full(
                 .and_then(|p| {
                     p.discovery
                         .as_ref()
-                        .filter(|d| d.generation == p.generation)
+                        .filter(|d| d.generation == p.generation && d.complete)
                 })
                 .map(|d| d.regions.len().to_string())
                 .unwrap_or_else(|| "none".to_string()),

--- a/src/analysis/semantic/injection.rs
+++ b/src/analysis/semantic/injection.rs
@@ -16,16 +16,11 @@ use tree_sitter::Query;
 /// the content hash + the region's first host line for re-anchoring, and whether
 /// the region satisfies the language-agnostic translation predicate this request.
 pub(super) struct RegionCacheInfo {
-    /// Position-based ULID, byte-identical to the one `populate_injections` mints,
-    /// so `invalidate_for_edits` evicts the same entry this stores under.
-    pub region_id: String,
-    /// Validity hash: the region's content hash folded with its resolved injection
-    /// language. Content distinguishes an edit; the language fold means two regions
-    /// that share a position-stable `region_id` and identical content bytes but
-    /// inject *different* languages get different hashes (barring a 64-bit
-    /// collision), so one won't serve the other's tokens — including a stale ULID
-    /// minted by a superseded request, which `populate_injections` never sees and
-    /// so can't evict by language change.
+    /// Content-addressed cache key ([`region_validity_hash`]): the region's
+    /// content hash folded with its resolved injection language. The content
+    /// half distinguishes an edit; the language fold means identical bytes
+    /// injecting *different* languages get different keys (barring a 64-bit
+    /// collision), so one can't serve the other's tokens.
     pub validity_hash: u64,
     /// `line_range.start`: the region's first host line, added back on reuse
     /// (`host_line = line_start + token.line`).

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -760,8 +760,10 @@ fn discover_single_region(
         // Content-addressed cache key: content hash folded with the resolved
         // language (one shared definition — populate's eviction sweep must
         // compute the same fold).
-        let validity_hash =
-            crate::analysis::semantic_cache::region_validity_hash(cacheable.content_hash, &resolved_lang);
+        let validity_hash = crate::analysis::semantic_cache::region_validity_hash(
+            cacheable.content_hash,
+            &resolved_lang,
+        );
         Some(DiscoveredRegionCache {
             validity_hash,
             line_start: cacheable.line_range.start,

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -721,7 +721,8 @@ fn discover_single_region(
 
     // Resolve this single region's cache identity (#529). region_id is minted
     // from the RAW content node — byte-identical to populate_injections
-    // (cache.rs) — so invalidate_for_edits evicts the same entry. Eligibility
+    // (cache.rs), which keeps the bridge/tracker identities in sync (token
+    // eviction itself is content-addressed and needs no id). Eligibility
     // is this request's translation predicate: column-0 start AND no per-row
     // prefixes (singles are never injection.combined).
     let token_cache = cache_for_singles.and_then(|(uri, tracker, mint_regions)| {

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -1179,8 +1179,10 @@ pub(crate) fn collect_injection_tokens_parallel(
     // region ids were minted while their snapshot was current (populate runs
     // behind the landed CAS), so rebuilding from them never writes the tracker —
     // the `mint_regions` stale-serve latch only governs the inline branch.
-    let reusable_discovery =
-        cache_ctx.and_then(|c| c.discovery.filter(|d| d.generation == c.generation && d.complete));
+    let reusable_discovery = cache_ctx.and_then(|c| {
+        c.discovery
+            .filter(|d| d.generation == c.generation && d.complete)
+    });
     let (contexts, exclusion_byte_ranges) = if let Some(discovery) = reusable_discovery {
         #[cfg(test)]
         DISCOVERY_REUSE_HITS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -3048,10 +3050,7 @@ local b = 2
             "singles kept, combined group dropped"
         );
         assert!(
-            discovery
-                .regions
-                .iter()
-                .all(|r| r.token_cache.is_some()),
+            discovery.regions.iter().all(|r| r.token_cache.is_some()),
             "singles keep their token-cache identities for the eviction sweep"
         );
 

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -866,11 +866,20 @@ fn rebuild_context<'a>(
 /// discovery cost); only the per-region `from_region_info` / `get_or_create`
 /// recompute, negligible beside `Q`.
 ///
-/// Returns `None` (store nothing → the semantic path re-discovers inline) when:
-/// - the document has any `injection.combined` group — those keep the inline
-///   path in v1 (their whole-group contexts aren't part of the owned form yet);
-/// - fewer single regions than the token-cache gate, so caching wouldn't pay and
-///   the reuse path must stay byte-identical to pre-#529;
+/// Returns `None` (store nothing → the semantic path re-discovers inline) when
+/// there are fewer single regions than the token-cache gate — caching wouldn't
+/// pay, and the reuse path must stay byte-identical to pre-#529. The gate
+/// counts `singles` exactly as the inline path's `cache_for_singles` gate does
+/// (combined-group regions excluded), so "discovery stored" and "token cache
+/// active" are the same predicate — the eviction sweep's live set can never go
+/// empty while the inline path is still storing entries.
+///
+/// A document with an `injection.combined` group (no effective `#offset!`)
+/// stores a PARTIAL discovery: the combined group keeps the inline path in v1
+/// (its whole-group contexts aren't part of the owned form), so the group is
+/// dropped and `complete` is `false` — context reuse falls back inline, while
+/// the singles' token-cache identities stay available to the read/store path
+/// and the eviction sweep.
 ///
 /// Regions whose language/parser isn't loaded are DROPPED from the stored
 /// discovery rather than tainting it: the inline path would produce no tokens
@@ -893,21 +902,25 @@ pub(crate) fn build_document_discovery(
     generation: u64,
 ) -> Option<DiscoveredInjections> {
     // Partition exactly as collect_injection_contexts_sync does: an
-    // injection.combined pattern (with no effective #offset!) → bail, v1 keeps
-    // combined groups on the inline path.
-    let mut singles: Vec<&InjectionRegionInfo> = Vec::with_capacity(regions.len());
-    for injection in regions {
+    // injection.combined pattern (with no effective #offset!) → drop the
+    // region and mark the discovery partial; v1 keeps combined groups on the
+    // inline path. The singles are kept — their token-cache identities feed
+    // the read/store path and the eviction sweep even when reuse can't fire.
+    let mut complete = true;
+    let mut singles: Vec<(usize, &InjectionRegionInfo)> = Vec::with_capacity(regions.len());
+    for (idx, injection) in regions.iter().enumerate() {
         if has_combined_for_pattern(injection_query, injection.pattern_index)
             && effective_offset_for_pattern(injection_query, injection.pattern_index).is_none()
         {
             log::debug!(
                 target: "kakehashi::semantic",
-                "discovery not stored: combined-group region (lang={})",
+                "discovery stored partial: combined-group region dropped (lang={})",
                 injection.language
             );
-            return None;
+            complete = false;
+            continue;
         }
-        singles.push(injection);
+        singles.push((idx, injection));
     }
 
     // Same region-count gate as the token half: below it, caching doesn't pay and
@@ -923,7 +936,13 @@ pub(crate) fn build_document_discovery(
     }
 
     let mut discovered = Vec::with_capacity(singles.len());
-    for (injection, prebuilt) in singles.iter().zip(prebuilt_cacheable.iter()) {
+    // Pair by the ORIGINAL region index, not zip: dropped combined regions
+    // would otherwise shift every later single onto the wrong prebuilt
+    // identity (wrong ULID + content hash).
+    for (injection, prebuilt) in singles
+        .iter()
+        .map(|(idx, injection)| (injection, &prebuilt_cacheable[*idx]))
+    {
         // Producer: don't gate on the highlight query — store the region and let
         // reuse re-resolve the query (a load without a generation bump self-heals).
         // Producer path: called from populate_injections right after this
@@ -960,6 +979,7 @@ pub(crate) fn build_document_discovery(
 
     Some(DiscoveredInjections {
         generation,
+        complete,
         regions: discovered,
     })
 }
@@ -1150,14 +1170,17 @@ pub(crate) fn collect_injection_tokens_parallel(
     // when present and still generation-current (#529 companion lever): rebuild
     // the top-level contexts from the owned data and skip the injection query
     // (`Q`) entirely. Otherwise discover inline exactly as before — the fallback
-    // is byte-identical to the pre-lever path (below the region-count gate, or
-    // with any `injection.combined` group, `populate_injections` stores no
-    // discovery, so this is `None` and we take the inline branch). The reused
+    // is byte-identical to the pre-lever path (below the region-count gate
+    // `populate_injections` stores no discovery, so this is `None`; a document
+    // with an `injection.combined` group stores a PARTIAL discovery whose
+    // `complete: false` fails the filter — either way the inline branch runs,
+    // while the partial discovery's singles still feed the token-cache
+    // read/store path and the eviction sweep). The reused
     // region ids were minted while their snapshot was current (populate runs
     // behind the landed CAS), so rebuilding from them never writes the tracker —
     // the `mint_regions` stale-serve latch only governs the inline branch.
     let reusable_discovery =
-        cache_ctx.and_then(|c| c.discovery.filter(|d| d.generation == c.generation));
+        cache_ctx.and_then(|c| c.discovery.filter(|d| d.generation == c.generation && d.complete));
     let (contexts, exclusion_byte_ranges) = if let Some(discovery) = reusable_discovery {
         #[cfg(test)]
         DISCOVERY_REUSE_HITS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -2952,47 +2975,136 @@ local b = 2
         );
     }
 
-    /// `build_document_discovery` stores nothing when the document has any
-    /// `injection.combined` group: v1 keeps combined groups on the inline path, so
-    /// persisting a singles-only discovery would drop the combined captures on
-    /// reuse (missing/wrong tokens for e.g. HTML-in-markdown).
+    /// A document that mixes an `injection.combined` group with gate-clearing
+    /// single regions stores a PARTIAL discovery: `complete: false` (context
+    /// reuse must fall back inline — a singles-only rebuild would drop the
+    /// combined captures), but the singles keep their token-cache identities so
+    /// the eviction sweep's live set matches what the inline path stores
+    /// (before this, any combined group made the sweep wipe every live entry
+    /// each populate while the inline path kept re-storing them).
     #[test]
-    fn build_document_discovery_bails_on_combined_groups() {
-        let Some(coordinator) = combined_lua_coordinator() else {
+    fn build_document_discovery_partial_on_combined_groups() {
+        let Some(coordinator) = markdown_lua_coordinator() else {
             return;
         };
-        let injection_query = coordinator
-            .injection_query("markdown")
-            .expect("combined injection query");
-        let mut pool = coordinator.create_document_parser_pool();
-        let Some(mut parser) = pool.acquire("markdown") else {
-            return;
-        };
-        let tree = parser
-            .parse(COMBINED_LUA_DOC, None)
-            .expect("parse markdown");
-        pool.release("markdown".to_string(), parser);
+        let md_language = coordinator
+            .language_registry_for_parallel()
+            .get("markdown")
+            .expect("markdown language must be loaded");
+        // Structurally disjoint patterns (no dedupe ambiguity): indented code
+        // blocks form a combined lua group; fenced blocks stay singles.
+        let query = Query::new(
+            &md_language,
+            r#"
+            ((indented_code_block) @injection.content
+              (#set! injection.language "lua")
+              (#set! injection.combined))
+
+            (fenced_code_block
+              (info_string (language) @injection.language)
+              (code_fence_content) @injection.content)
+            "#,
+        )
+        .expect("valid mixed injection query");
+        let injection_query = Arc::new(query);
+        coordinator
+            .query_store()
+            .insert_injection_query("markdown".to_string(), Arc::clone(&injection_query));
+
+        // Eight single lua fences (clears the gate) + two indented blocks
+        // (one combined group).
+        let mut text = eight_lua_block_doc();
+        text.push_str("prose\n\n    local y1 = 1\n\nprose\n\n    local y2 = 2\n");
+
+        let tree = parse_markdown(&coordinator, &text);
         let regions = crate::language::injection::collect_all_injections(
             &tree.root_node(),
-            COMBINED_LUA_DOC,
+            &text,
             Some(injection_query.as_ref()),
         )
         .expect("regions");
-        let uri = Url::parse("file:///combined_bail.md").unwrap();
+        assert_eq!(regions.len(), 10, "8 fences + 2 indented blocks");
+
+        let uri = Url::parse("file:///combined_partial.md").unwrap();
         let tracker = NodeTracker::new();
+        let discovery = build_document_discovery(
+            &regions,
+            &cacheable_for(&regions, &uri, &tracker, &text),
+            injection_query.as_ref(),
+            &text,
+            &coordinator,
+            &uri,
+            &tracker,
+            0,
+        )
+        .expect("gate-clearing singles must store a (partial) discovery");
         assert!(
-            build_document_discovery(
-                &regions,
-                &cacheable_for(&regions, &uri, &tracker, COMBINED_LUA_DOC),
-                injection_query.as_ref(),
-                COMBINED_LUA_DOC,
-                &coordinator,
-                &uri,
-                &tracker,
-                0,
-            )
-            .is_none(),
-            "a document with a combined group must not store discovery"
+            !discovery.complete,
+            "a dropped combined group must mark the discovery partial"
+        );
+        assert_eq!(
+            discovery.regions.len(),
+            8,
+            "singles kept, combined group dropped"
+        );
+        assert!(
+            discovery
+                .regions
+                .iter()
+                .all(|r| r.token_cache.is_some()),
+            "singles keep their token-cache identities for the eviction sweep"
+        );
+
+        // The partial discovery must NOT be consumed by the context-reuse
+        // path: if it were, the combined group's tokens would be missing.
+        // Byte-equality against the inline pass is the discriminating check
+        // (the indented blocks are valid lua, so they contribute tokens).
+        let lines: Vec<&str> = text.lines().collect();
+        let line_starts = build_line_start_bytes(&text);
+        let inline = collect_injection_tokens_parallel(
+            &text,
+            &lines,
+            &line_starts,
+            &tree,
+            Some("markdown"),
+            &coordinator,
+            None,
+            false,
+            None,
+            None,
+        )
+        .0;
+        assert!(
+            inline
+                .iter()
+                .any(|t| t.line >= lines.len().saturating_sub(7)),
+            "the combined indented blocks must contribute tokens for the check to discriminate"
+        );
+        let cache = InjectionTokenCache::new();
+        let cc = InjectionCacheCtx {
+            uri: &uri,
+            tracker: &tracker,
+            cache: &cache,
+            generation: 0,
+            mint_regions: true,
+            discovery: Some(&discovery),
+        };
+        let with_partial = collect_injection_tokens_parallel(
+            &text,
+            &lines,
+            &line_starts,
+            &tree,
+            Some("markdown"),
+            &coordinator,
+            None,
+            false,
+            Some(&cc),
+            None,
+        )
+        .0;
+        assert_eq!(
+            with_partial, inline,
+            "a partial discovery must fall back to inline discovery (combined tokens intact)"
         );
     }
 

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -940,10 +940,8 @@ pub(crate) fn build_document_discovery(
     // Pair by the ORIGINAL region index, not zip: dropped combined regions
     // would otherwise shift every later single onto the wrong prebuilt
     // identity (wrong ULID + content hash).
-    for (injection, prebuilt) in singles
-        .iter()
-        .map(|(idx, injection)| (injection, &prebuilt_cacheable[*idx]))
-    {
+    for (idx, injection) in singles {
+        let prebuilt = &prebuilt_cacheable[idx];
         // Producer: don't gate on the highlight query — store the region and let
         // reuse re-resolve the query (a load without a generation bump self-heals).
         // Producer path: called from populate_injections right after this

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -27,7 +27,6 @@ use crate::language::injection::{
     compute_included_ranges_clipped, effective_offset_for_pattern, has_combined_for_pattern,
     intersect_included_ranges, parse_with_ranges, sub_select_included_ranges,
 };
-use crate::text::fnv1a_hash;
 use crate::text::position::byte_to_utf16_col;
 
 /// Minimum number of top-level single injection regions before injection-token
@@ -758,16 +757,12 @@ fn discover_single_region(
             }
         };
         let eligible = cacheable.start_column == 0 && prefix_byte_widths.is_empty();
-        // Fold the resolved language into the validity hash so a position-
-        // stable region_id with identical content but a different injected
-        // language gets a different key (barring a 64-bit collision) and won't
-        // serve a stale hit — defends the cross-language hazard from a
-        // superseded request's orphaned ULID; same fold style as the
-        // generation fold in cache_key.
+        // Content-addressed cache key: content hash folded with the resolved
+        // language (one shared definition — populate's eviction sweep must
+        // compute the same fold).
         let validity_hash =
-            cacheable.content_hash ^ fnv1a_hash(&resolved_lang).wrapping_mul(0x100000001b3);
+            crate::analysis::semantic_cache::region_validity_hash(cacheable.content_hash, &resolved_lang);
         Some(DiscoveredRegionCache {
-            region_id: cacheable.region_id.clone(),
             validity_hash,
             line_start: cacheable.line_range.start,
             eligible,
@@ -845,7 +840,6 @@ fn rebuild_context<'a>(
     }
 
     let region_cache = region.token_cache.as_ref().map(|tc| RegionCacheInfo {
-        region_id: tc.region_id.clone(),
         validity_hash: tc.validity_hash,
         line_start: tc.line_start,
         eligible: tc.eligible,
@@ -1238,9 +1232,7 @@ pub(crate) fn collect_injection_tokens_parallel(
         for (i, ctx) in contexts.iter().enumerate() {
             if let Some(rc) = &ctx.region_cache
                 && rc.eligible
-                && let Some(local) =
-                    cc.cache
-                        .get(cc.uri, &rc.region_id, rc.validity_hash, cc.generation)
+                && let Some(local) = cc.cache.get(cc.uri, rc.validity_hash, cc.generation)
             {
                 hit_tokens.extend(reanchor_to_host(local, rc.line_start));
             } else {
@@ -1313,13 +1305,8 @@ pub(crate) fn collect_injection_tokens_parallel(
                 && res.fully_loaded
             {
                 let local = to_region_local(&res.tokens, rc.line_start);
-                cc.cache.store(
-                    cc.uri,
-                    &rc.region_id,
-                    rc.validity_hash,
-                    cc.generation,
-                    local,
-                );
+                cc.cache
+                    .store(cc.uri, rc.validity_hash, cc.generation, local);
             }
         }
     }
@@ -3217,7 +3204,7 @@ local b = 2
         );
 
         // Overwrite one region with a region-local sentinel token.
-        let (rid, ch, generation) = cache
+        let (ch, generation) = cache
             .test_keys(&uri)
             .into_iter()
             .next()
@@ -3232,7 +3219,7 @@ local b = 2
             priority: 100,
             node_byte_len: 999,
         };
-        cache.store(&uri, &rid, ch, generation, vec![sentinel]);
+        cache.store(&uri, ch, generation, vec![sentinel]);
 
         let tokens = collect_injection_tokens_parallel(
             &text,

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -3014,10 +3014,19 @@ local b = 2
             .query_store()
             .insert_injection_query("markdown".to_string(), Arc::clone(&injection_query));
 
-        // Eight single lua fences (clears the gate) + two indented blocks
-        // (one combined group).
-        let mut text = eight_lua_block_doc();
-        text.push_str("prose\n\n    local y1 = 1\n\nprose\n\n    local y2 = 2\n");
+        // Eight single lua fences (clears the gate) with the two combined
+        // indented blocks INTERLEAVED — one before the singles, one mid-list —
+        // so a zip-style pairing of the filtered singles against the
+        // index-aligned prebuilt identities would shift every later single
+        // onto the wrong identity (the off-by-one this test discriminates).
+        let mut text = String::from("prose\n\n    local y1 = 1\n\n");
+        for i in 0..4 {
+            text.push_str(&format!("```lua\nlocal x{i} = {i}\n```\n\n"));
+        }
+        text.push_str("prose\n\n    local y2 = 2\n\n");
+        for i in 4..8 {
+            text.push_str(&format!("```lua\nlocal x{i} = {i}\n```\n\n"));
+        }
 
         let tree = parse_markdown(&coordinator, &text);
         let regions = crate::language::injection::collect_all_injections(
@@ -3030,9 +3039,10 @@ local b = 2
 
         let uri = Url::parse("file:///combined_partial.md").unwrap();
         let tracker = NodeTracker::new();
+        let prebuilt = cacheable_for(&regions, &uri, &tracker, &text);
         let discovery = build_document_discovery(
             &regions,
-            &cacheable_for(&regions, &uri, &tracker, &text),
+            &prebuilt,
             injection_query.as_ref(),
             &text,
             &coordinator,
@@ -3050,9 +3060,31 @@ local b = 2
             8,
             "singles kept, combined group dropped"
         );
-        assert!(
-            discovery.regions.iter().all(|r| r.token_cache.is_some()),
-            "singles keep their token-cache identities for the eviction sweep"
+        // Identity alignment: each stored single must carry the validity hash
+        // of ITS OWN prebuilt identity (by original region index). A zip over
+        // the filtered singles would pair post-combined singles with the
+        // dropped combined regions' hashes and fail this set equality.
+        let expected_hashes: std::collections::HashSet<u64> = regions
+            .iter()
+            .zip(prebuilt.iter())
+            .filter(|(r, _)| !has_combined_for_pattern(injection_query.as_ref(), r.pattern_index))
+            .map(|(_, c)| {
+                crate::analysis::semantic_cache::region_validity_hash(c.content_hash, "lua")
+            })
+            .collect();
+        let stored_hashes: std::collections::HashSet<u64> = discovery
+            .regions
+            .iter()
+            .map(|r| {
+                r.token_cache
+                    .as_ref()
+                    .expect("singles keep their token-cache identities for the eviction sweep")
+                    .validity_hash
+            })
+            .collect();
+        assert_eq!(
+            stored_hashes, expected_hashes,
+            "stored singles must keep their own (index-aligned) cache identities"
         );
 
         // The partial discovery must NOT be consumed by the context-reuse
@@ -3074,10 +3106,14 @@ local b = 2
             None,
         )
         .0;
+        let indented_lines: Vec<usize> = lines
+            .iter()
+            .enumerate()
+            .filter(|(_, l)| l.contains("local y"))
+            .map(|(i, _)| i)
+            .collect();
         assert!(
-            inline
-                .iter()
-                .any(|t| t.line >= lines.len().saturating_sub(7)),
+            inline.iter().any(|t| indented_lines.contains(&t.line)),
             "the combined indented blocks must contribute tokens for the check to discriminate"
         );
         let cache = InjectionTokenCache::new();

--- a/src/analysis/semantic_cache.rs
+++ b/src/analysis/semantic_cache.rs
@@ -450,13 +450,14 @@ impl InjectionTokenCache {
     /// racing a store of an already-dead hash merely leaks that entry until
     /// the next sweep.
     pub(crate) fn retain_document(&self, uri: &Url, live: &std::collections::HashSet<u64>) {
-        if let Some(mut doc) = self.cache.get_mut(uri) {
+        // One shard write lock for both the sweep and the empty-entry
+        // reclaim: `remove_if_mut` mutates in place and removes only when
+        // the closure returns true, so a concurrent store can never land
+        // between the sweep and the reclaim.
+        self.cache.remove_if_mut(uri, |_, doc| {
             doc.retain(|hash, _| live.contains(hash));
-        }
-        // Reclaim the emptied outer entry; `remove_if` re-checks under the
-        // shard write lock so a concurrent store that repopulated the map
-        // between the sweep above and this call is never dropped.
-        self.cache.remove_if(uri, |_, doc| doc.is_empty());
+            doc.is_empty()
+        });
     }
 
     /// Remove all cached tokens for a document (all its injection regions).

--- a/src/analysis/semantic_cache.rs
+++ b/src/analysis/semantic_cache.rs
@@ -12,7 +12,6 @@
 use crate::analysis::semantic::RawToken;
 use crate::language::injection::CacheableInjectionRegion;
 use dashmap::DashMap;
-use rust_lapper::{Interval, Lapper};
 use tower_lsp_server::ls_types::{Range, SemanticTokens};
 use url::Url;
 
@@ -231,83 +230,63 @@ impl Default for SemanticTokenRangeCache {
     }
 }
 
-/// Thread-safe map of injection regions per document.
+/// Thread-safe map of injection regions per document: the region set of the
+/// last COMMITTED populate pass.
 ///
-/// Tracks all `CacheableInjectionRegion`s for each document URI. The interval
-/// tree used to drive spatial token-cache invalidation; content addressing
-/// removed that production consumer (`find_overlapping` is now test-only), so
-/// today the map is populate-written state consumed by tests — and the natural
-/// substrate for the §3 mint reconciliation's reuse-by-position step, which is
-/// why it stays.
+/// Content addressing removed the spatial-invalidation consumer, so no
+/// production path reads this today — populate writes it at the commit point
+/// (a plain move of the already-built region vec, no per-populate index
+/// build) and tests observe it to pin what a committed pass recorded. The
+/// spatial queries are test-only linear scans; if the §3 mint-reconciliation
+/// split doesn't end up consuming the map, delete it and port the tests.
 pub struct InjectionMap {
-    /// Stores interval trees per document URI
-    /// Each Interval contains the byte range and the full CacheableInjectionRegion as data
-    lappers: DashMap<Url, Lapper<usize, CacheableInjectionRegion>>,
+    regions: DashMap<Url, Vec<CacheableInjectionRegion>>,
 }
 
 impl InjectionMap {
     /// Create a new empty injection map.
     pub fn new() -> Self {
         Self {
-            lappers: DashMap::new(),
+            regions: DashMap::new(),
         }
     }
 
     /// Store injection regions for a document, replacing any existing regions.
-    /// Builds an interval tree from the regions for efficient overlap queries.
+    /// A plain move — nothing on the pre-publish critical path is built here.
     pub fn insert(&self, uri: Url, regions: Vec<CacheableInjectionRegion>) {
-        // Convert regions to intervals for the Lapper
-        let intervals: Vec<Interval<usize, CacheableInjectionRegion>> = regions
-            .into_iter()
-            .map(|region| {
-                let start = region.byte_range.start;
-                let stop = region.byte_range.end;
-                Interval {
-                    start,
-                    stop,
-                    val: region,
-                }
-            })
-            .collect();
-
-        // Create Lapper from intervals (builds interval tree)
-        let lapper = Lapper::new(intervals);
-        self.lappers.insert(uri, lapper);
+        self.regions.insert(uri, regions);
     }
 
     /// Retrieve all injection regions for a document.
     #[cfg(test)]
     pub fn get(&self, uri: &Url) -> Option<Vec<CacheableInjectionRegion>> {
-        self.lappers
-            .get(uri)
-            .map(|entry| entry.iter().map(|interval| interval.val.clone()).collect())
+        self.regions.get(uri).map(|entry| entry.clone())
     }
 
     /// Remove all injection regions for a document (e.g., on document close).
     pub fn clear(&self, uri: &Url) {
-        self.lappers.remove(uri);
+        self.regions.remove(uri);
     }
 
-    /// Find the injection region containing the given byte position (test-only).
+    /// Find the injection region containing the given byte position (test-only
+    /// linear scan).
     #[cfg(test)]
     pub fn find_at_position(
         &self,
         uri: &Url,
         byte_position: usize,
     ) -> Option<CacheableInjectionRegion> {
-        self.lappers.get(uri).and_then(|lapper| {
-            // Find intervals that overlap the single byte position
-            lapper
-                .find(byte_position, byte_position + 1)
-                .next()
-                .map(|interval| interval.val.clone())
+        self.regions.get(uri).and_then(|regions| {
+            regions
+                .iter()
+                .find(|r| r.byte_range.start <= byte_position && byte_position < r.byte_range.end)
+                .cloned()
         })
     }
 
-    /// Find all injection regions that overlap with the given byte range.
-    ///
-    /// Test-only since content addressing removed the spatial invalidation
-    /// path that consumed it.
+    /// Find all injection regions that overlap with the given byte range
+    /// (test-only linear scan — content addressing removed the spatial
+    /// invalidation path that needed an index).
     #[cfg(test)]
     pub fn find_overlapping(
         &self,
@@ -315,10 +294,11 @@ impl InjectionMap {
         start: usize,
         end: usize,
     ) -> Option<Vec<CacheableInjectionRegion>> {
-        self.lappers.get(uri).map(|lapper| {
-            lapper
-                .find(start, end)
-                .map(|interval| interval.val.clone())
+        self.regions.get(uri).map(|regions| {
+            regions
+                .iter()
+                .filter(|r| r.byte_range.start < end && start < r.byte_range.end)
+                .cloned()
                 .collect()
         })
     }
@@ -424,14 +404,11 @@ impl InjectionTokenCache {
         validity_hash: u64,
         generation: u64,
     ) -> Option<Vec<RawToken>> {
-        let result = self
-            .cache
-            .get(uri)
-            .and_then(|doc| {
-                doc.get(&validity_hash)
-                    .filter(|entry| entry.generation == generation)
-                    .map(|entry| entry.tokens.clone())
-            });
+        let result = self.cache.get(uri).and_then(|doc| {
+            doc.get(&validity_hash)
+                .filter(|entry| entry.generation == generation)
+                .map(|entry| entry.tokens.clone())
+        });
 
         if result.is_some() {
             log::debug!(

--- a/src/analysis/semantic_cache.rs
+++ b/src/analysis/semantic_cache.rs
@@ -355,6 +355,12 @@ pub(crate) struct InjectionTokenCache {
 /// different language (or a language re-resolution after install) get a
 /// different key barring a 64-bit collision. One definition shared by the
 /// store/read path and populate's eviction sweep — the two must never drift.
+///
+/// Accepted bound: the 64-bit FNV-1a fold is not collision-resistant, and a
+/// collision has no secondary gate — but an accidental one is ~2⁻⁶⁴ and a
+/// *crafted* one only mis-highlights the crafting user's own buffer (tokens
+/// never cross documents: the outer key is the URI), so a cryptographic hash
+/// isn't worth its per-keystroke cost here.
 pub(crate) fn region_validity_hash(content_hash: u64, resolved_lang: &str) -> u64 {
     content_hash ^ crate::text::fnv1a_hash(resolved_lang).wrapping_mul(0x100000001b3)
 }

--- a/src/analysis/semantic_cache.rs
+++ b/src/analysis/semantic_cache.rs
@@ -2,11 +2,12 @@
 //!
 //! Three layers (all `DashMap`-backed for concurrent access):
 //! - `SemanticTokenCache`: per-URI tokens, served when LSP `result_id` matches.
-//! - `InjectionMap`: per-URI interval tree (rust_lapper) of injection regions
-//!   keyed by region_id (ULID), giving O(log n) overlap queries so an edit only
-//!   invalidates regions it actually touches.
-//! - `InjectionTokenCache`: per-(URI, region_id) tokens, reusable when an edit
-//!   lies outside that region.
+//! - `InjectionMap`: per-URI set of injection regions from the last committed
+//!   populate pass (spatial queries are test-only since token eviction went
+//!   content-addressed).
+//! - `InjectionTokenCache`: per-(URI, content-validity-hash) region tokens —
+//!   content-addressed, so an edit outside a region can't touch its entry and
+//!   byte-identical regions reuse each other's tokens.
 
 use crate::analysis::semantic::RawToken;
 use crate::language::injection::CacheableInjectionRegion;
@@ -232,9 +233,12 @@ impl Default for SemanticTokenRangeCache {
 
 /// Thread-safe map of injection regions per document.
 ///
-/// Tracks all `CacheableInjectionRegion`s for each document URI,
-/// enabling targeted cache invalidation when only specific injections change.
-/// Uses interval tree (rust_lapper) for O(log n) overlap queries.
+/// Tracks all `CacheableInjectionRegion`s for each document URI. The interval
+/// tree used to drive spatial token-cache invalidation; content addressing
+/// removed that production consumer (`find_overlapping` is now test-only), so
+/// today the map is populate-written state consumed by tests — and the natural
+/// substrate for the §3 mint reconciliation's reuse-by-position step, which is
+/// why it stays.
 pub struct InjectionMap {
     /// Stores interval trees per document URI
     /// Each Interval contains the byte range and the full CacheableInjectionRegion as data
@@ -272,6 +276,7 @@ impl InjectionMap {
     }
 
     /// Retrieve all injection regions for a document.
+    #[cfg(test)]
     pub fn get(&self, uri: &Url) -> Option<Vec<CacheableInjectionRegion>> {
         self.lappers
             .get(uri)
@@ -301,9 +306,9 @@ impl InjectionMap {
 
     /// Find all injection regions that overlap with the given byte range.
     ///
-    /// Uses O(log n) interval tree query instead of O(n) iteration through all regions.
-    ///
-    /// Returns `Some(Vec)` with overlapping regions (may be empty), or `None` if URI unknown.
+    /// Test-only since content addressing removed the spatial invalidation
+    /// path that consumed it.
+    #[cfg(test)]
     pub fn find_overlapping(
         &self,
         uri: &Url,
@@ -332,29 +337,44 @@ impl Default for InjectionMap {
 /// hot path can reuse them across edits that don't touch the region, re-anchoring
 /// them to the region's current host line at read time.
 ///
-/// The key is just `(uri, region_id)`; the validity lives in the *value* — the
-/// same shape `SemanticTokenCache` uses for its `cache_key`. `validity_hash`
-/// folds the region's content hash with its resolved injection language (a
-/// content edit OR a language change at the same position misses on read), and
-/// `generation` is the settings/query generation (a config reload changes it, so
-/// old-query tokens stop matching) — the race-safe fold, not a bare `clear()`.
-/// Keeping these out of the *key* means each region holds exactly one entry
-/// (`store` overwrites), so `remove` is an O(1) point delete instead of a full
-/// scan and stale validity-siblings can't accumulate.
+/// The key is `(uri, validity_hash)` — **content-addressed** (parse-snapshot
+/// ADR §3's companion decision), where `validity_hash` folds the region's
+/// content hash with its resolved injection language (see
+/// [`region_validity_hash`]). Content addressing replaces the earlier
+/// tracker-ULID key: a byte-identical region reuses tokens across edits with
+/// no stable id at all (undo round-trips and duplicate fences hit for free),
+/// and no read path needs the tracker — the identity decoupling the §3 mint
+/// split relies on. An entry can never be *wrong* for its key (the key IS the
+/// content), so spatial edit invalidation disappears; eviction is a
+/// per-populate sweep ([`retain_document`](Self::retain_document)) that drops
+/// hashes no longer present in the parse's live region set — without it,
+/// typing inside a region would leak one entry per keystroke content.
+///
+/// `generation` (the settings/query epoch — bumped on config reload only,
+/// never per edit, the #530 discipline) stays in the *value* and is checked
+/// at read, so stale-generation entries read as misses even before the
+/// reload's `clear()` reclaims them.
 ///
 /// `supports_multiline` is deliberately *not* in the validity: it changes
 /// multiline-token emission, but it comes from the client capabilities snapshot
 /// (a `OnceLock` set once at `initialize()`), so it is session-constant and
 /// cannot flip mid-session — no entry can outlive a change to it.
 pub(crate) struct InjectionTokenCache {
-    cache: DashMap<(Url, String), CachedRegionTokens>,
+    cache: DashMap<(Url, u64), CachedRegionTokens>,
 }
 
-/// A region's cached tokens with the validity they were computed under.
+/// The per-region validity/cache key: the region's content hash folded with
+/// its **resolved** injection language, so identical bytes injecting a
+/// different language (or a language re-resolution after install) get a
+/// different key barring a 64-bit collision. One definition shared by the
+/// store/read path and populate's eviction sweep — the two must never drift.
+pub(crate) fn region_validity_hash(content_hash: u64, resolved_lang: &str) -> u64 {
+    content_hash ^ crate::text::fnv1a_hash(resolved_lang).wrapping_mul(0x100000001b3)
+}
+
+/// A region's cached tokens with the generation they were computed under.
 #[derive(Clone)]
 struct CachedRegionTokens {
-    /// Content hash folded with the resolved injection language.
-    validity_hash: u64,
     /// Settings/query generation in effect when these were computed.
     generation: u64,
     /// Region-local pre-finalize tokens.
@@ -369,57 +389,52 @@ impl InjectionTokenCache {
         }
     }
 
-    /// Store region-local tokens for an injection region, tagged with the
-    /// validity (`validity_hash` = content ⊕ resolved language, plus settings
-    /// `generation`) they were computed under. Overwrites any prior entry for the
-    /// region, so a region never holds more than one (possibly stale) entry.
+    /// Store region-local tokens under the region's content-addressed
+    /// `validity_hash`, tagged with the settings `generation` they were
+    /// computed under. Overwrites any prior entry for the same content —
+    /// byte-identical regions (including duplicates within one document)
+    /// share the entry.
     pub(crate) fn store(
         &self,
         uri: &Url,
-        region_id: &str,
         validity_hash: u64,
         generation: u64,
         tokens: Vec<RawToken>,
     ) {
         self.cache.insert(
-            (uri.clone(), region_id.to_string()),
-            CachedRegionTokens {
-                validity_hash,
-                generation,
-                tokens,
-            },
+            (uri.clone(), validity_hash),
+            CachedRegionTokens { generation, tokens },
         );
     }
 
-    /// Retrieve region-local tokens iff the stored entry was computed under this
-    /// exact validity — same content + resolved language, same settings
-    /// generation. A mismatch (content/language edit or config reload) reads as a
-    /// miss so the region is recomputed.
+    /// Retrieve region-local tokens for this exact content (`validity_hash`
+    /// keys content ⊕ resolved language) iff they were computed under the
+    /// same settings generation. A config reload reads as a miss so the
+    /// region is recomputed under the new queries.
     pub(crate) fn get(
         &self,
         uri: &Url,
-        region_id: &str,
         validity_hash: u64,
         generation: u64,
     ) -> Option<Vec<RawToken>> {
         let result = self
             .cache
-            .get(&(uri.clone(), region_id.to_string()))
-            .filter(|entry| entry.validity_hash == validity_hash && entry.generation == generation)
+            .get(&(uri.clone(), validity_hash))
+            .filter(|entry| entry.generation == generation)
             .map(|entry| entry.tokens.clone());
 
         if result.is_some() {
             log::debug!(
                 target: "kakehashi::injection_cache",
-                "Cache HIT for injection region '{}' in {}",
-                region_id,
+                "Cache HIT for injection content {:#018x} in {}",
+                validity_hash,
                 uri.path()
             );
         } else {
             log::trace!(
                 target: "kakehashi::injection_cache",
-                "Cache MISS for injection region '{}' in {}",
-                region_id,
+                "Cache MISS for injection content {:#018x} in {}",
+                validity_hash,
                 uri.path()
             );
         }
@@ -427,11 +442,16 @@ impl InjectionTokenCache {
         result
     }
 
-    /// Remove an injection region's cached entry — an O(1) point delete, since a
-    /// region holds at most one entry. Called on eviction (edit-overlap,
-    /// content/language change, region removed).
-    pub(crate) fn remove(&self, uri: &Url, region_id: &str) {
-        self.cache.remove(&(uri.clone(), region_id.to_string()));
+    /// Eviction sweep (the content-addressed replacement for per-region point
+    /// deletes): keep only entries whose hash is in the parse's `live` region
+    /// set. Called by `populate_injections` after each parse — without it,
+    /// typing inside a region would leak one entry per keystroke content.
+    /// Entries are never *incorrect* (the key is the content), so a sweep
+    /// racing a store of an already-dead hash merely leaks that entry until
+    /// the next sweep.
+    pub(crate) fn retain_document(&self, uri: &Url, live: &std::collections::HashSet<u64>) {
+        self.cache
+            .retain(|(entry_uri, hash), _| entry_uri != uri || live.contains(hash));
     }
 
     /// Remove all cached tokens for a document (all its injection regions).
@@ -448,21 +468,15 @@ impl InjectionTokenCache {
         self.cache.clear();
     }
 
-    /// `(region_id, validity_hash, generation)` currently stored for a document —
-    /// lets a test confirm what the hot path persisted and overwrite a specific
-    /// entry to prove the reuse path reads it.
+    /// `(validity_hash, generation)` currently stored for a document — lets a
+    /// test confirm what the hot path persisted and overwrite a specific entry
+    /// to prove the reuse path reads it.
     #[cfg(test)]
-    pub(crate) fn test_keys(&self, uri: &Url) -> Vec<(String, u64, u64)> {
+    pub(crate) fn test_keys(&self, uri: &Url) -> Vec<(u64, u64)> {
         self.cache
             .iter()
             .filter(|e| &e.key().0 == uri)
-            .map(|e| {
-                (
-                    e.key().1.clone(),
-                    e.value().validity_hash,
-                    e.value().generation,
-                )
-            })
+            .map(|e| (e.key().1, e.value().generation))
             .collect()
     }
 }
@@ -764,69 +778,78 @@ mod tests {
         let tokens2 = vec![raw_token(1, 2, 10)];
 
         // Store region-local tokens under a content hash + generation.
-        cache.store(&uri, "region-1", 0xAA, 0, tokens1.clone());
-        cache.store(&uri, "region-2", 0xBB, 0, tokens2.clone());
+        cache.store(&uri, 0xAA, 0, tokens1.clone());
+        cache.store(&uri, 0xBB, 0, tokens2.clone());
 
         // Retrieve by the full validity key.
-        let retrieved1 = cache.get(&uri, "region-1", 0xAA, 0);
+        let retrieved1 = cache.get(&uri, 0xAA, 0);
         assert!(retrieved1.is_some(), "Should retrieve tokens for region-1");
         assert_eq!(retrieved1.unwrap()[0].length, 5);
 
-        let retrieved2 = cache.get(&uri, "region-2", 0xBB, 0);
+        let retrieved2 = cache.get(&uri, 0xBB, 0);
         assert!(retrieved2.is_some(), "Should retrieve tokens for region-2");
         assert_eq!(retrieved2.unwrap()[0].length, 10);
 
-        // Non-existent region returns None
-        assert!(cache.get(&uri, "region-3", 0xAA, 0).is_none());
+        // Unknown content hash returns None
+        assert!(cache.get(&uri, 0xCC, 0).is_none());
 
         // Non-existent URI returns None
         let other_uri = Url::parse("file:///other.md").unwrap();
-        assert!(cache.get(&other_uri, "region-1", 0xAA, 0).is_none());
+        assert!(cache.get(&other_uri, 0xAA, 0).is_none());
     }
 
     #[test]
     fn injection_token_cache_validity_key_gates_reads() {
         let cache = InjectionTokenCache::new();
         let uri = Url::parse("file:///t.md").unwrap();
-        cache.store(&uri, "r", 0x1111, 7, vec![raw_token(0, 0, 4)]);
+        cache.store(&uri, 0x1111, 7, vec![raw_token(0, 0, 4)]);
 
         // Exact key hits.
-        assert!(cache.get(&uri, "r", 0x1111, 7).is_some());
+        assert!(cache.get(&uri, 0x1111, 7).is_some());
 
         // A different content hash (region content changed) misses.
         assert!(
-            cache.get(&uri, "r", 0x2222, 7).is_none(),
+            cache.get(&uri, 0x2222, 7).is_none(),
             "content-hash mismatch must miss so edited content is recomputed"
         );
 
         // A different generation (settings/query reload) misses, even for the
         // same content — the race-safe fold, not a bare clear.
         assert!(
-            cache.get(&uri, "r", 0x1111, 8).is_none(),
+            cache.get(&uri, 0x1111, 8).is_none(),
             "generation mismatch must miss so post-reload requests recompute"
         );
     }
 
     #[test]
-    fn injection_token_cache_store_overwrites_and_remove_is_point_delete() {
+    fn injection_token_cache_sweep_bounds_distinct_contents() {
         let cache = InjectionTokenCache::new();
         let uri = Url::parse("file:///t.md").unwrap();
 
-        // Validity lives in the value, so a second store for the same region
-        // OVERWRITES the first — a region never accumulates stale siblings, which
-        // is what lets `remove` be an O(1) point delete.
-        cache.store(&uri, "r", 0x1111, 0, vec![raw_token(0, 0, 4)]);
-        cache.store(&uri, "r", 0x2222, 0, vec![raw_token(0, 0, 5)]);
-        assert!(
-            cache.get(&uri, "r", 0x1111, 0).is_none(),
-            "the overwritten (old-validity) entry must be gone"
-        );
-        let current = cache.get(&uri, "r", 0x2222, 0).expect("latest entry hits");
-        assert_eq!(current[0].length, 5);
+        // Content-addressed: distinct contents COEXIST (an edited region's old
+        // entry stays readable-by-nobody until swept; an undo back to 0x1111
+        // would hit again).
+        cache.store(&uri, 0x1111, 0, vec![raw_token(0, 0, 4)]);
+        cache.store(&uri, 0x2222, 0, vec![raw_token(0, 0, 5)]);
+        assert!(cache.get(&uri, 0x1111, 0).is_some());
+        assert!(cache.get(&uri, 0x2222, 0).is_some());
 
-        // remove drops that single entry.
-        cache.remove(&uri, "r");
-        assert!(cache.get(&uri, "r", 0x2222, 0).is_none());
+        // Identical content overwrites in place (one entry per content).
+        cache.store(&uri, 0x2222, 0, vec![raw_token(0, 0, 6)]);
+        assert_eq!(cache.get(&uri, 0x2222, 0).expect("hits")[0].length, 6);
+
+        // The populate sweep is the growth bound: only live hashes survive,
+        // and other documents' entries are untouched.
+        let other_uri = Url::parse("file:///other.md").unwrap();
+        cache.store(&other_uri, 0x1111, 0, vec![raw_token(0, 0, 7)]);
+        let live = std::collections::HashSet::from([0x2222]);
+        cache.retain_document(&uri, &live);
+        assert!(cache.get(&uri, 0x1111, 0).is_none(), "dead hash swept");
+        assert!(cache.get(&uri, 0x2222, 0).is_some(), "live hash retained");
+        assert!(
+            cache.get(&other_uri, 0x1111, 0).is_some(),
+            "other documents' entries survive a sweep"
+        );
     }
 
     #[test]
@@ -859,7 +882,7 @@ mod tests {
         injection_map.insert(uri.clone(), regions);
 
         // Set up cached tokens for the lua region, keyed by its content hash.
-        token_cache.store(&uri, "lua-region-1", 11111, 0, vec![raw_token(0, 0, 3)]);
+        token_cache.store(&uri, 11111, 0, vec![raw_token(0, 0, 3)]);
 
         // Find region containing byte offset and get its cached tokens
         let regions = injection_map.get(&uri).unwrap();
@@ -869,8 +892,8 @@ mod tests {
         let region = region_at_byte_30.unwrap();
         assert_eq!(region.language, "lua");
 
-        // Use region_id + content_hash to get cached tokens
-        let cached = token_cache.get(&uri, &region.region_id, region.content_hash, 0);
+        // Content-addressed lookup: the region's content hash is the key half.
+        let cached = token_cache.get(&uri, region.content_hash, 0);
         assert!(cached.is_some(), "Should have cached tokens for lua region");
         assert_eq!(cached.unwrap()[0].length, 3);
     }

--- a/src/analysis/semantic_cache.rs
+++ b/src/analysis/semantic_cache.rs
@@ -911,8 +911,16 @@ mod tests {
         ];
         injection_map.insert(uri.clone(), regions);
 
-        // Set up cached tokens for the lua region, keyed by its content hash.
-        token_cache.store(&uri, 11111, 0, vec![raw_token(0, 0, 3)]);
+        // Set up cached tokens for the lua region, keyed by the cache's real
+        // contract: the content ⊕ resolved-language fold, never the raw
+        // content hash (identical bytes injecting a different language must
+        // not share an entry).
+        token_cache.store(
+            &uri,
+            region_validity_hash(11111, "lua"),
+            0,
+            vec![raw_token(0, 0, 3)],
+        );
 
         // Find region containing byte offset and get its cached tokens
         let regions = injection_map.get(&uri).unwrap();
@@ -922,10 +930,15 @@ mod tests {
         let region = region_at_byte_30.unwrap();
         assert_eq!(region.language, "lua");
 
-        // Content-addressed lookup: the region's content hash is the key half.
-        let cached = token_cache.get(&uri, region.content_hash, 0);
+        // Content-addressed lookup through the same fold the read path uses.
+        let cached = token_cache.get(&uri, region_validity_hash(region.content_hash, "lua"), 0);
         assert!(cached.is_some(), "Should have cached tokens for lua region");
         assert_eq!(cached.unwrap()[0].length, 3);
+        // The raw content hash alone must MISS — the fold is load-bearing.
+        assert!(
+            token_cache.get(&uri, region.content_hash, 0).is_none(),
+            "raw content hash without the language fold must not hit"
+        );
     }
 
     #[test]

--- a/src/analysis/semantic_cache.rs
+++ b/src/analysis/semantic_cache.rs
@@ -847,6 +847,28 @@ mod tests {
         );
     }
 
+    /// The validity fold must separate resolved languages for identical bytes
+    /// (the #530 wrong-language discipline) and be deterministic — the store/
+    /// read path and populate's eviction sweep both compute it and must agree.
+    #[test]
+    fn region_validity_hash_separates_languages_and_is_deterministic() {
+        let content_hash = 0xDEAD_BEEF_u64;
+        assert_eq!(
+            region_validity_hash(content_hash, "lua"),
+            region_validity_hash(content_hash, "lua"),
+        );
+        assert_ne!(
+            region_validity_hash(content_hash, "lua"),
+            region_validity_hash(content_hash, "python"),
+            "identical bytes injecting a different language must key differently"
+        );
+        assert_ne!(
+            region_validity_hash(0x1111, "lua"),
+            region_validity_hash(0x2222, "lua"),
+            "different content must key differently for the same language"
+        );
+    }
+
     #[test]
     fn test_injection_map_get_tokens_via_region_id() {
         use crate::language::injection::CacheableInjectionRegion;

--- a/src/analysis/semantic_cache.rs
+++ b/src/analysis/semantic_cache.rs
@@ -360,7 +360,14 @@ impl Default for InjectionMap {
 /// (a `OnceLock` set once at `initialize()`), so it is session-constant and
 /// cannot flip mid-session — no entry can outlive a change to it.
 pub(crate) struct InjectionTokenCache {
-    cache: DashMap<(Url, u64), CachedRegionTokens>,
+    /// Outer key: document; inner key: `validity_hash`. Nested (rather than a
+    /// flat `(Url, u64)` key) so the per-populate eviction sweep touches only
+    /// the swept document's entries — a flat `DashMap::retain` scans every
+    /// shard of every document under write locks on each parse commit. Reads
+    /// and stores are single-threaded per request (pre-fan-out resolve loop /
+    /// post-fan-in store loop), so the coarser per-document entry adds no
+    /// contention, and the read path drops its per-lookup `Url` clone.
+    cache: DashMap<Url, std::collections::HashMap<u64, CachedRegionTokens>>,
 }
 
 /// The per-region validity/cache key: the region's content hash folded with
@@ -401,10 +408,10 @@ impl InjectionTokenCache {
         generation: u64,
         tokens: Vec<RawToken>,
     ) {
-        self.cache.insert(
-            (uri.clone(), validity_hash),
-            CachedRegionTokens { generation, tokens },
-        );
+        self.cache
+            .entry(uri.clone())
+            .or_default()
+            .insert(validity_hash, CachedRegionTokens { generation, tokens });
     }
 
     /// Retrieve region-local tokens for this exact content (`validity_hash`
@@ -419,9 +426,12 @@ impl InjectionTokenCache {
     ) -> Option<Vec<RawToken>> {
         let result = self
             .cache
-            .get(&(uri.clone(), validity_hash))
-            .filter(|entry| entry.generation == generation)
-            .map(|entry| entry.tokens.clone());
+            .get(uri)
+            .and_then(|doc| {
+                doc.get(&validity_hash)
+                    .filter(|entry| entry.generation == generation)
+                    .map(|entry| entry.tokens.clone())
+            });
 
         if result.is_some() {
             log::debug!(
@@ -450,13 +460,18 @@ impl InjectionTokenCache {
     /// racing a store of an already-dead hash merely leaks that entry until
     /// the next sweep.
     pub(crate) fn retain_document(&self, uri: &Url, live: &std::collections::HashSet<u64>) {
-        self.cache
-            .retain(|(entry_uri, hash), _| entry_uri != uri || live.contains(hash));
+        if let Some(mut doc) = self.cache.get_mut(uri) {
+            doc.retain(|hash, _| live.contains(hash));
+        }
+        // Reclaim the emptied outer entry; `remove_if` re-checks under the
+        // shard write lock so a concurrent store that repopulated the map
+        // between the sweep above and this call is never dropped.
+        self.cache.remove_if(uri, |_, doc| doc.is_empty());
     }
 
     /// Remove all cached tokens for a document (all its injection regions).
     pub(crate) fn clear_document(&self, uri: &Url) {
-        self.cache.retain(|key, _| &key.0 != uri);
+        self.cache.remove(uri);
     }
 
     /// Drop every cached entry. Used on a settings/query reload (alongside the
@@ -474,10 +489,13 @@ impl InjectionTokenCache {
     #[cfg(test)]
     pub(crate) fn test_keys(&self, uri: &Url) -> Vec<(u64, u64)> {
         self.cache
-            .iter()
-            .filter(|e| &e.key().0 == uri)
-            .map(|e| (e.key().1, e.value().generation))
-            .collect()
+            .get(uri)
+            .map(|doc| {
+                doc.iter()
+                    .map(|(hash, entry)| (*hash, entry.generation))
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 }
 

--- a/src/analysis/semantic_cache.rs
+++ b/src/analysis/semantic_cache.rs
@@ -394,6 +394,13 @@ impl InjectionTokenCache {
         generation: u64,
         tokens: Vec<RawToken>,
     ) {
+        // `get_mut` first: the steady-state store (document entry exists)
+        // avoids the `Url` clone the `entry` API needs for its owned key —
+        // the same discipline as `record_served_semantic_version`.
+        if let Some(mut doc) = self.cache.get_mut(uri) {
+            doc.insert(validity_hash, CachedRegionTokens { generation, tokens });
+            return;
+        }
         self.cache
             .entry(uri.clone())
             .or_default()

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1007,5 +1007,16 @@ async fn run_lsp_server() {
     // observe every edit that preceded them on the wire (#342).
     let service = IngressOrderGate::new(service);
 
-    Server::new(stdin, stdout, socket).serve(service).await;
+    // Lift tower-lsp's default 4-message `buffer_unordered` cap: editors fire
+    // bursts of concurrent requests per keystroke (Neovim: semanticTokens +
+    // captures lineages + diagnostics + …), and handlers park awaiting the
+    // per-URI parse snapshot. With only 4 slots, parked readers exhaust the
+    // buffer and the very didChange/$/cancelRequest notifications that would
+    // release them queue behind — a priority inversion observed as multi-second
+    // handler-start delays. Ordering is IngressOrderGate's job and CPU is the
+    // bounded ComputePool's; admission just needs to never be the bottleneck.
+    Server::new(stdin, stdout, socket)
+        .concurrency_level(64)
+        .serve(service)
+        .await;
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1027,8 +1027,9 @@ async fn run_lsp_server() {
     // the wedge threshold becomes INGRESS_CONCURRENCY + tower-lsp's 100-slot
     // channel queue of outstanding messages, and a wedge self-heals within
     // the parked readers' settle backstop. `$/cancelRequest` is immune either
-    // way — its forwarding runs synchronously inside `RequestIdCapture::call`
-    // and needs no admission slot. Sized for the worst observed per-keystroke
+    // way — `RequestIdCapture::call` dispatches its forwarding as a detached
+    // fire-and-forget spawn and needs no admission slot to do so. Sized for
+    // the worst observed per-keystroke
     // burst (≈10 concurrent reader parks per document) across several
     // documents, with headroom.
     const INGRESS_CONCURRENCY: usize = 64;

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1018,12 +1018,22 @@ async fn run_lsp_server() {
     // bursts of concurrent requests per keystroke (Neovim: semanticTokens +
     // captures lineages + diagnostics + …), and handlers park awaiting the
     // per-URI parse snapshot. With only 4 slots, parked readers exhaust the
-    // buffer and the very didChange/$/cancelRequest notifications that would
-    // release them queue behind — a priority inversion observed as multi-second
-    // handler-start delays. Ordering is IngressOrderGate's job and CPU is the
-    // bounded ComputePool's; admission just needs to never be the bottleneck.
+    // buffer and the very didChange notifications that would release them
+    // queue behind — a priority inversion observed as multi-second
+    // handler-start delays. Ordering is IngressOrderGate's job (tickets are
+    // assigned synchronously in wire order, independent of this value) and
+    // CPU is the bounded ComputePool's, so a wider admission costs only
+    // parked futures. This NARROWS the inversion rather than removing it:
+    // the wedge threshold becomes INGRESS_CONCURRENCY + tower-lsp's 100-slot
+    // channel queue of outstanding messages, and a wedge self-heals within
+    // the parked readers' settle backstop. `$/cancelRequest` is immune either
+    // way — its forwarding runs synchronously inside `RequestIdCapture::call`
+    // and needs no admission slot. Sized for the worst observed per-keystroke
+    // burst (≈10 concurrent reader parks per document) across several
+    // documents, with headroom.
+    const INGRESS_CONCURRENCY: usize = 64;
     Server::new(stdin, stdout, socket)
-        .concurrency_level(64)
+        .concurrency_level(INGRESS_CONCURRENCY)
         .serve(service)
         .await;
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -997,6 +997,13 @@ async fn run_lsp_server() {
     )
     .finish();
 
+    // Reap downstream servers when the editor terminates this process without
+    // completing the shutdown handshake (SIGTERM/SIGHUP) — without this, the
+    // spawned language servers are orphaned to launchd and can outlive the
+    // session indefinitely.
+    #[cfg(unix)]
+    service.inner().spawn_termination_cleanup();
+
     // Wrap service with RequestIdCapture to:
     // 1. Capture upstream request IDs (for ls-bridge-server-pool-coordination bridge requests)
     // 2. Forward $/cancelRequest notifications to downstream servers

--- a/src/cancel.rs
+++ b/src/cancel.rs
@@ -15,28 +15,36 @@
 //! obsolete compute stops instead of running to completion (see
 //! `lsp::semantic_request_tracker::SemanticRequestTracker`).
 
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-
-/// A shared, cheap-to-poll cancellation signal. Clones share the same flag, so
-/// one side can cancel a compute another side is running.
+/// A shared cancellation signal: cheap to poll from blocking compute AND
+/// awaitable from async parks. Clones share the same state, so one side can
+/// cancel a compute another side is running.
 ///
-/// The flag is monotonic (`false` → `true`, never reset) and carries no other
-/// state, so [`Ordering::Relaxed`] is sufficient — we only need eventual
-/// visibility of the flip, not to publish other memory through it.
+/// Backed by [`tokio_util::sync::CancellationToken`] (monotonic
+/// `false` → `true`, never reset): `is_cancelled` stays a single atomic load
+/// for the per-region compute checkpoints, while [`cancelled`](Self::cancelled)
+/// lets the serve-current parked waits complete promptly when a newer request
+/// supersedes this one — an `AtomicBool` alone made supersession invisible to
+/// a parked future until its next wakeup.
 #[derive(Debug, Clone, Default)]
-pub(crate) struct CancelToken(Arc<AtomicBool>);
+pub(crate) struct CancelToken(tokio_util::sync::CancellationToken);
 
 impl CancelToken {
     /// Signal cancellation to every holder of this token. Idempotent.
     pub(crate) fn cancel(&self) {
-        self.0.store(true, Ordering::Relaxed);
+        self.0.cancel();
     }
 
     /// Returns `true` once [`cancel`](Self::cancel) has been called on this
     /// token or any clone of it.
     pub(crate) fn is_cancelled(&self) -> bool {
-        self.0.load(Ordering::Relaxed)
+        self.0.is_cancelled()
+    }
+
+    /// Completes when [`cancel`](Self::cancel) is called on this token or any
+    /// clone of it (immediately if it already was). Cancel-safe: dropping the
+    /// future loses nothing.
+    pub(crate) async fn cancelled(&self) {
+        self.0.cancelled().await;
     }
 }
 

--- a/src/document/injections.rs
+++ b/src/document/injections.rs
@@ -69,11 +69,14 @@ pub(crate) struct DiscoveredRegion {
 /// Stored by the off-ingress write-back with unresolvable regions DROPPED
 /// (their injected language has no parser; the inline path would produce no
 /// tokens for them either, and the failed load is negative-cached until a
-/// reload — which bumps `generation`, invalidating this discovery) and only
-/// when the document had no `injection.combined` group (those keep the inline
-/// path in v1). A resolvable language whose highlight query isn't loaded is
-/// *not* excluded — the query is re-resolved fresh at reuse, so that case
-/// self-heals rather than persisting an incomplete set.
+/// reload — which bumps `generation`, invalidating this discovery). A document
+/// with an `injection.combined` group stores a PARTIAL discovery (singles
+/// only, `complete: false`): the token-cache eviction sweep still needs the
+/// singles' cache identities, but context reuse must fall back inline (those
+/// whole-group contexts aren't part of the owned form in v1). A resolvable
+/// language whose highlight query isn't loaded is *not* excluded — the query
+/// is re-resolved fresh at reuse, so that case self-heals rather than
+/// persisting an incomplete set.
 #[derive(Clone)]
 pub(crate) struct DiscoveredInjections {
     /// Settings generation at discovery time. The reader skips reuse when it no
@@ -84,6 +87,13 @@ pub(crate) struct DiscoveredInjections {
     /// `bump_semantic_token_generation`, which clears the side caches only, so
     /// this gate is what a reload relies on.)
     pub generation: u64,
+    /// `true` when `regions` covers every top-level injection region of the
+    /// parse. `false` when an `injection.combined` group was dropped: the
+    /// singles in `regions` are still authoritative token-cache identities
+    /// (read/store and the eviction sweep key off them), but the semantic
+    /// context-reuse path must not consume a partial region set — it would
+    /// silently drop the combined group's tokens.
+    pub complete: bool,
     pub regions: Vec<DiscoveredRegion>,
 }
 

--- a/src/document/injections.rs
+++ b/src/document/injections.rs
@@ -27,12 +27,9 @@
 /// `RegionCacheInfo`, kept here so `document` need not depend on `analysis`.
 #[derive(Clone)]
 pub(crate) struct DiscoveredRegionCache {
-    /// Position-stable region id, byte-identical to the one `populate_injections`
-    /// minted for this region in the `InjectionMap` (the discovery build reuses
-    /// that same id — no new off-ingress minting).
-    pub region_id: String,
-    /// Content hash folded with the resolved language (the injection-token
-    /// cache's per-region validity key).
+    /// Content hash folded with the resolved language — the injection-token
+    /// cache's content-addressed key (parse-snapshot ADR §3 companion
+    /// decision), needing no tracker identity at all.
     pub validity_hash: u64,
     /// The region's first host line, added back on token re-anchor.
     pub line_start: u32,

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -997,7 +997,10 @@ impl LanguageCoordinator {
         identifier: &str,
         content: &str,
     ) -> Option<(String, LanguageLoadResult)> {
-        log::debug!(
+        // trace!, not debug!: this runs per injection region per parse/walk
+        // (thousands per keystroke on injection-heavy documents), and at
+        // debug level the log volume itself becomes a measurable cost.
+        log::trace!(
             target: "kakehashi::language_detection",
             "Resolving injection language for identifier='{}', content_len={}",
             identifier,
@@ -1008,7 +1011,7 @@ impl LanguageCoordinator {
         if identifier != "plaintext"
             && let Some(found) = self.try_load_with_base(identifier)
         {
-            log::debug!(
+            log::trace!(
                 target: "kakehashi::language_detection",
                 "Resolved injection '{}' -> '{}' via identifier (direct or base)",
                 identifier, found.0
@@ -1020,7 +1023,7 @@ impl LanguageCoordinator {
         if let Some(normalized) = super::heuristic::detect_from_token(identifier)
             && let Some(found) = self.try_load_with_base(&normalized)
         {
-            log::debug!(
+            log::trace!(
                 target: "kakehashi::language_detection",
                 "Resolved injection '{}' -> '{}' via syntect token (direct or base)",
                 identifier, found.0
@@ -1032,7 +1035,7 @@ impl LanguageCoordinator {
         if let Some(first_line_lang) = super::heuristic::detect_from_first_line(content)
             && let Some(found) = self.try_load_with_base(&first_line_lang)
         {
-            log::debug!(
+            log::trace!(
                 target: "kakehashi::language_detection",
                 "Resolved injection '{}' -> '{}' via first-line detection (direct or base)",
                 identifier, found.0
@@ -1040,7 +1043,7 @@ impl LanguageCoordinator {
             return Some(found);
         }
 
-        log::debug!(
+        log::trace!(
             target: "kakehashi::language_detection",
             "Failed to resolve injection language for identifier='{}'",
             identifier

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -212,6 +212,13 @@ impl AutoInstallManager {
         self.failed_parsers.persist_state()
     }
 
+    /// Clone-handle to the crash-detection registry (`Arc`-backed), for tasks
+    /// that outlive `&self` — the signal-reap task persists crash-detection
+    /// state before exiting, exactly like the graceful shutdown path.
+    pub fn failed_parsers_handle(&self) -> FailedParserRegistry {
+        self.failed_parsers.clone()
+    }
+
     /// Attempt to install a language parser.
     ///
     /// Intentionally isolated to enable unit testing without LSP infrastructure:

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -11,10 +11,9 @@
 //! `bump_semantic_token_generation`) so post-reload requests recompute; `didChange`
 //! never invalidates.
 
-use std::collections::{HashMap, HashSet};
 
 use tower_lsp_server::ls_types::SemanticTokens;
-use tree_sitter::{InputEdit, Tree};
+use tree_sitter::Tree;
 use url::Url;
 
 use crate::analysis::{
@@ -134,48 +133,6 @@ impl CacheCoordinator {
         self.injection_token_cache.clear_document(uri);
     }
 
-    // ========================================================================
-    // Edit handling (did_change)
-    // ========================================================================
-
-    /// Invalidate injection caches for regions that overlap with edits.
-    ///
-    /// Called by `did_change` BEFORE the tree is cleared and the off-ingress reparse
-    /// is scheduled, so it uses pre-edit byte offsets against pre-edit injection
-    /// regions: edits outside injections preserve caches, edits inside invalidate
-    /// only affected regions.
-    ///
-    /// Uses an O(log n) interval tree query.
-    pub(crate) fn invalidate_for_edits(&self, uri: &Url, edits: &[InputEdit]) {
-        if edits.is_empty() {
-            return;
-        }
-
-        // Find all regions that overlap with any edit using O(log n) queries
-        for edit in edits {
-            let edit_start = edit.start_byte;
-            let edit_end = edit.old_end_byte;
-
-            // Query interval tree for overlapping regions (O(log n) instead of O(n))
-            if let Some(overlapping_regions) = self
-                .injection_map
-                .find_overlapping(uri, edit_start, edit_end)
-            {
-                for region in overlapping_regions {
-                    // This region is affected - invalidate its cache
-                    self.injection_token_cache.remove(uri, &region.region_id);
-                    log::debug!(
-                        target: "kakehashi::injection_cache",
-                        "Invalidated injection cache for {} region (edit bytes {}..{})",
-                        region.language,
-                        edit_start,
-                        edit_end
-                    );
-                }
-            }
-        }
-    }
-
     /// Invalidate semantic token cache for a document.
     ///
     /// Note: This should NOT be called during `didChange` - the cached tokens are
@@ -194,16 +151,6 @@ impl CacheCoordinator {
             );
         }
         self.semantic_cache.remove(uri);
-    }
-
-    /// Remove injection token cache entries for specific ULIDs.
-    ///
-    /// Called when region IDs are invalidated (e.g., due to edits touching their START).
-    /// The corresponding virtual documents become orphaned in downstream LSs.
-    pub(crate) fn remove_injection_tokens_for_ulids(&self, uri: &Url, ulids: &[ulid::Ulid]) {
-        for ulid in ulids {
-            self.injection_token_cache.remove(uri, &ulid.to_string());
-        }
     }
 
     // ========================================================================
@@ -290,14 +237,6 @@ impl CacheCoordinator {
                 return PopulatedInjections::empty(generation);
             }
 
-            // Get existing regions for cache cleanup and content comparison
-            let existing_regions = self.injection_map.get(uri);
-
-            // Build lookup map for existing regions by region_id (skip if no existing regions)
-            let existing_by_id: Option<HashMap<&str, &CacheableInjectionRegion>> = existing_regions
-                .as_ref()
-                .map(|regions| regions.iter().map(|r| (r.region_id.as_str(), r)).collect());
-
             // Convert to CacheableInjectionRegion using position-based ULIDs
             // NodeTracker provides stable IDs based on (uri, start_byte, end_byte, kind)
             let cacheable_regions: Vec<CacheableInjectionRegion> = regions
@@ -316,50 +255,9 @@ impl CacheCoordinator {
                         minted_ids.push(ulid);
                     }
                     let region_id = ulid.to_string();
-                    let new_region =
-                        CacheableInjectionRegion::from_region_info(info, &region_id, text);
-
-                    // Check if content_hash or language changed - invalidate semantic token cache
-                    // Position-based ULIDs are stable, but cached tokens become invalid when:
-                    // - content_hash changes: code content was modified
-                    // - language changes: info string changed (e.g., ```lua → ```python)
-                    //
-                    // NOTE: This may double-invalidate regions already handled by invalidate_for_edits().
-                    // This is intentional and correct because the two functions serve different purposes:
-                    // - invalidate_for_edits(): Called BEFORE parse, handles spatial overlap (edit touched region)
-                    // - This code: Called AFTER parse, handles semantic change (content/language changed)
-                    // Double removal is idempotent (DashMap remove on missing key is a no-op), so this
-                    // is safe. Combining these checks would require tracking invalidation state, adding
-                    // complexity for negligible performance gain.
-                    //
-                    // Skip this check entirely if no existing regions (first document open)
-                    if let Some(ref map) = existing_by_id
-                        && let Some(old) = map.get(region_id.as_str())
-                    {
-                        let content_changed = old.content_hash != new_region.content_hash;
-                        let language_changed = old.language != new_region.language;
-                        if content_changed || language_changed {
-                            self.injection_token_cache.remove(uri, &region_id);
-                        }
-                    }
-
-                    new_region
+                    CacheableInjectionRegion::from_region_info(info, &region_id, text)
                 })
                 .collect();
-
-            // Find stale region IDs that are no longer present
-            if let Some(old_regions) = existing_regions {
-                let new_region_ids: HashSet<_> = cacheable_regions
-                    .iter()
-                    .map(|r| r.region_id.as_str())
-                    .collect();
-                for old in old_regions.iter() {
-                    if !new_region_ids.contains(old.region_id.as_str()) {
-                        // This region no longer exists - clear its cache
-                        self.injection_token_cache.remove(uri, &old.region_id);
-                    }
-                }
-            }
 
             // Bridge-downstream regions from the SAME collected `regions`
             // (parse-snapshot ADR §3, never discover twice): the exact
@@ -424,6 +322,25 @@ impl CacheCoordinator {
                 generation,
             );
 
+            // Live-hash set for the content-addressed injection-token cache's
+            // eviction sweep, taken from the DISCOVERY's own per-region cache
+            // identities — the exact fold and language resolution the
+            // store/read path uses (deriving it from any other resolver would
+            // silently evict live entries whenever the two resolvers
+            // disagree). `None` discovery (below the gate, combined groups,
+            // incomplete) yields an empty set: the token cache is inactive
+            // there, so sweeping everything for the document is the correct
+            // bound.
+            let live_hashes: std::collections::HashSet<u64> = discovery
+                .as_ref()
+                .map(|d| {
+                    d.regions
+                        .iter()
+                        .filter_map(|r| r.token_cache.as_ref().map(|tc| tc.validity_hash))
+                        .collect()
+                })
+                .unwrap_or_default();
+
             // Exit half of the mint reconciliation, atomic with coordinate
             // shifts: the commit runs under the tracker entry's shared lock
             // and only while the (shift generation, cleanup epoch) latch
@@ -436,12 +353,18 @@ impl CacheCoordinator {
             // replaces it), and withhold the region-id-bearing products; the
             // snapshot then rides without regions and every reader falls
             // back inline, byte-identically to the pre-lever path. The
-            // token-cache evictions this pass already performed are
-            // conservative (idempotent removes) and need no rollback.
+            // token-cache sweep runs inside the commit closure, so a stale
+            // pass performs no eviction at all.
             let committed = tracker.commit_if_unshifted(uri, entry_mint_epoch, || {
                 // Commit point: store the region set the token-cache
-                // bookkeeping (reanchor/eviction) keys off.
+                // bookkeeping (reanchor) keys off, and run the
+                // content-addressed token cache's eviction sweep with the
+                // same epoch gate — a stale pass must not sweep entries the
+                // LIVE text's regions still hit (a wrongly swept entry is
+                // only a recompute, but a gratuitous one).
                 self.injection_map.insert(uri.clone(), cacheable_regions);
+                self.injection_token_cache
+                    .retain_document(uri, &live_hashes);
             });
             if committed.is_none() {
                 for id in &minted_ids {
@@ -889,11 +812,15 @@ print("hello")
         let initial_content_hash = regions[0].content_hash;
         assert_eq!(regions[0].language, "lua");
 
-        // Store region-local tokens under the region's current content hash.
+        // Store region-local tokens under the region's LIVE validity hash (the
+        // content ⊕ resolved-language fold the production path uses; with no
+        // lua parser registered the resolver falls back to the raw
+        // identifier, deterministically).
+        let initial_validity =
+            crate::analysis::semantic_cache::region_validity_hash(initial_content_hash, "lua");
         cache.injection_token_cache.store(
             &uri,
-            &initial_region_id,
-            initial_content_hash,
+            initial_validity,
             0,
             injection_raw_tokens(),
         );
@@ -902,7 +829,7 @@ print("hello")
         assert!(
             cache
                 .injection_token_cache
-                .get(&uri, &initial_region_id, initial_content_hash, 0)
+                .get(&uri, initial_validity, 0)
                 .is_some(),
             "tokens should be cached before language change"
         );
@@ -953,18 +880,16 @@ print("hello")
             "language should be updated to python"
         );
 
-        // CRITICAL ASSERTION: Cached tokens should be INVALIDATED
-        // This is the key behavior that wasn't tested before.
-        // The invalidation happens at lines 231-235 in populate_injections:
-        //   if content_changed || language_changed {
-        //       self.injection_token_cache.remove(uri, &region_id);
-        //   }
+        // CRITICAL ASSERTION: the old-language entry must be gone. Content
+        // addressing gives this twice over: the read path now looks up the
+        // python fold (a natural miss), and populate's eviction sweep drops
+        // the lua-fold entry because it is no longer in the live hash set.
         assert!(
             cache
                 .injection_token_cache
-                .get(&uri, &initial_region_id, initial_content_hash, 0)
+                .get(&uri, initial_validity, 0)
                 .is_none(),
-            "cached tokens should be invalidated when language changes"
+            "the old-language entry must be swept when the language changes"
         );
     }
 
@@ -1022,11 +947,12 @@ print("hello")
         let initial_region_id = regions[0].region_id.clone();
         let initial_content_hash = regions[0].content_hash;
 
-        // Store region-local tokens under the region's current content hash.
+        // Store region-local tokens under the region's LIVE validity hash.
+        let initial_validity =
+            crate::analysis::semantic_cache::region_validity_hash(initial_content_hash, "lua");
         cache.injection_token_cache.store(
             &uri,
-            &initial_region_id,
-            initial_content_hash,
+            initial_validity,
             0,
             injection_raw_tokens(),
         );
@@ -1034,7 +960,7 @@ print("hello")
         assert!(
             cache
                 .injection_token_cache
-                .get(&uri, &initial_region_id, initial_content_hash, 0)
+                .get(&uri, initial_validity, 0)
                 .is_some(),
             "tokens should be cached before content change"
         );
@@ -1078,13 +1004,15 @@ print("goodbye")
             "content_hash should change"
         );
 
-        // Cached tokens should be invalidated due to content change
+        // The old-content entry must be swept: its hash left the live set
+        // when the region's content changed (the read path also misses
+        // naturally, keyed by the NEW content).
         assert!(
             cache
                 .injection_token_cache
-                .get(&uri, &initial_region_id, initial_content_hash, 0)
+                .get(&uri, initial_validity, 0)
                 .is_none(),
-            "cached tokens should be invalidated when content changes"
+            "the old-content entry must be swept when the content changes"
         );
     }
 

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -358,9 +358,10 @@ impl CacheCoordinator {
             // token-cache sweep runs inside the commit closure, so a stale
             // pass performs no eviction at all.
             let committed = tracker.commit_if_unshifted(uri, entry_mint_epoch, || {
-                // Commit point: store the region set the token-cache
-                // bookkeeping (reanchor) keys off, and run the
-                // content-addressed token cache's eviction sweep with the
+                // Commit point: record the committed pass's region set (test
+                // observability today; no production reader since token
+                // eviction went content-addressed — a plain move), and run
+                // the content-addressed token cache's eviction sweep with the
                 // same epoch gate — a stale pass must not sweep entries the
                 // LIVE text's regions still hit (a wrongly swept entry is
                 // only a recompute, but a gratuitous one).

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -326,8 +326,11 @@ impl CacheCoordinator {
             // identities — the exact fold and language resolution the
             // store/read path uses (deriving it from any other resolver would
             // silently evict live entries whenever the two resolvers
-            // disagree). `None` discovery (below the gate, combined groups,
-            // incomplete) yields an empty set: the token cache is inactive
+            // disagree). A PARTIAL discovery (combined group present) still
+            // carries every single region's identity, so the sweep keeps the
+            // entries the inline path stores for those docs. `None` discovery
+            // (below the gate — the same singles count that gates the inline
+            // store path) yields an empty set: the token cache is inactive
             // there, so sweeping everything for the document is the correct
             // bound.
             let live_hashes: std::collections::HashSet<u64> = discovery

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -11,7 +11,6 @@
 //! `bump_semantic_token_generation`) so post-reload requests recompute; `didChange`
 //! never invalidates.
 
-
 use tower_lsp_server::ls_types::SemanticTokens;
 use tree_sitter::Tree;
 use url::Url;
@@ -818,12 +817,9 @@ print("hello")
         // identifier, deterministically).
         let initial_validity =
             crate::analysis::semantic_cache::region_validity_hash(initial_content_hash, "lua");
-        cache.injection_token_cache.store(
-            &uri,
-            initial_validity,
-            0,
-            injection_raw_tokens(),
-        );
+        cache
+            .injection_token_cache
+            .store(&uri, initial_validity, 0, injection_raw_tokens());
 
         // Verify tokens are stored
         assert!(
@@ -950,12 +946,9 @@ print("hello")
         // Store region-local tokens under the region's LIVE validity hash.
         let initial_validity =
             crate::analysis::semantic_cache::region_validity_hash(initial_content_hash, "lua");
-        cache.injection_token_cache.store(
-            &uri,
-            initial_validity,
-            0,
-            injection_raw_tokens(),
-        );
+        cache
+            .injection_token_cache
+            .store(&uri, initial_validity, 0, injection_raw_tokens());
 
         assert!(
             cache

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -225,7 +225,10 @@ pub struct Kakehashi {
     /// `resultId` falls back to a full response only when a single mode slot
     /// is live (unambiguous), otherwise `null`.
     #[allow(clippy::type_complexity)]
-    captures_cache: dashmap::DashMap<(Url, String), [Option<(String, Vec<serde_json::Value>)>; 2]>,
+    captures_cache: dashmap::DashMap<
+        (Url, String),
+        [Option<(String, std::sync::Arc<Vec<serde_json::Value>>)>; 2],
+    >,
     /// Memoized captures walk results per `(uri, kind, injection-mode)`,
     /// tagged with the exact inputs they were computed from — snapshot
     /// `(parsed_version, incarnation)` and the settings generation. A typing

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -240,6 +240,14 @@ pub struct Kakehashi {
     #[allow(clippy::type_complexity)]
     captures_walk_cache:
         dashmap::DashMap<(Url, String, bool), kakehashi::captures::CachedCapturesWalk>,
+    /// Single-flight markers for in-progress captures walks, keyed like the
+    /// walk memo above: concurrent identical requests (a client's `full` +
+    /// `delta`s for one kind) park on the winner's `Notify` and serve the
+    /// memo instead of re-executing the walk. Entries are removed by the
+    /// winner's drop guard; the map only ever holds walks currently running.
+    #[allow(clippy::type_complexity)]
+    captures_walk_inflight:
+        dashmap::DashMap<(Url, String, bool), std::sync::Arc<tokio::sync::Notify>>,
     /// True when the process runs as a one-shot CLI (`kakehashi diagnose`/`format`)
     /// rather than a long-lived LSP server. Set once by `cli_initialize`. No editor
     /// consumes a proactive `publishDiagnostics` in CLI mode (the stub client pump
@@ -323,6 +331,7 @@ impl Kakehashi {
             home_dir: dirs::home_dir().map(|p| p.to_string_lossy().into_owned()),
             captures_cache: dashmap::DashMap::new(),
             captures_walk_cache: dashmap::DashMap::new(),
+            captures_walk_inflight: dashmap::DashMap::new(),
             cli_mode: std::sync::atomic::AtomicBool::new(false),
             parse_scheduler: std::sync::Arc::new(parse_scheduler::ParseScheduler::default()),
         }

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -56,9 +56,10 @@ impl InjectionCoordinator {
     /// Send didClose for invalidated virtual documents.
     ///
     /// Region IDs invalidated by edits touching their START orphan their virtual
-    /// documents downstream; this clears their token cache and delegates didClose to
-    /// the BridgeCoordinator. Never-opened documents are skipped automatically (no
-    /// didOpen was sent).
+    /// documents downstream; this delegates their didClose to the
+    /// BridgeCoordinator and evicts their diagnostic slots (the injection-token
+    /// cache is content-addressed and needs no per-ULID eviction — see below).
+    /// Never-opened documents are skipped automatically (no didOpen was sent).
     pub(crate) async fn close_invalidated_virtual_docs(
         &self,
         host_uri: &Url,

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -68,9 +68,9 @@ impl InjectionCoordinator {
             return;
         }
 
-        self.cache
-            .remove_injection_tokens_for_ulids(host_uri, invalidated_ulids);
-
+        // No token-cache eviction here: the injection-token cache is
+        // content-addressed (no ULID keys), self-validating on read, and
+        // swept by populate's live-hash retain.
         self.bridge
             .close_invalidated_docs(host_uri, invalidated_ulids)
             .await;

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -196,10 +196,9 @@ struct WalkFlightGuard<'a> {
 
 impl Drop for WalkFlightGuard<'_> {
     fn drop(&mut self) {
-        self.map
-            .remove_if(&self.key, |_, current| {
-                std::sync::Arc::ptr_eq(current, &self.notify)
-            });
+        self.map.remove_if(&self.key, |_, current| {
+            std::sync::Arc::ptr_eq(current, &self.notify)
+        });
         self.notify.notify_waiters();
     }
 }
@@ -1291,11 +1290,10 @@ mod tests {
         };
         publish("fn main() {}", 0);
         // Edit: content_version moves to 1, the v0 snapshot now trails.
-        service.inner().documents.update_document(
-            uri.clone(),
-            "fn main() { }".to_string(),
-            None,
-        );
+        service
+            .inner()
+            .documents
+            .update_document(uri.clone(), "fn main() { }".to_string(), None);
 
         let request = {
             let service = std::sync::Arc::clone(&service);

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -828,7 +828,7 @@ impl Kakehashi {
                 let winner_live = self
                     .captures_walk_inflight
                     .get(&key)
-                    .is_some_and(|current| std::sync::Arc::ptr_eq(&current, &notify));
+                    .is_some_and(|current| std::sync::Arc::ptr_eq(&*current, &notify));
                 if winner_live {
                     match cancel_rx.as_mut() {
                         Some(rx) => {

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -625,7 +625,15 @@ impl Kakehashi {
         // several deltas per keystroke); without a cancel signal each walk ran
         // to completion on a compute-pool thread. The token doubles as the
         // pool's dequeue hook (a cancelled work-unit is skipped before it ever
-        // takes a thread) and as the walk's per-layer checkpoint.
+        // takes a thread) and as the walk's per-layer checkpoint. Two accepted
+        // bounds on that granularity: (a) the layer-tree BUILD phase
+        // (`layer_trees.get_or_init`) deliberately ignores cancel — its result
+        // is shared by every subsequent walk on the snapshot via OnceLock, and
+        // a cancelled partial build must never be cached, so it runs at most
+        // once per snapshot to completion; (b) the token's only cancel source
+        // is the select arm below — if this handler future is dropped wholesale
+        // (client disconnect / service teardown) a walk already dequeued runs
+        // to completion once, bounded by the walk itself.
         let upstream_id = crate::lsp::current_upstream_id();
         let (mut cancel_rx, _cancel_guard) = self.subscribe_cancel(upstream_id.as_ref());
         let cancel_token = crate::cancel::CancelToken::default();
@@ -643,6 +651,11 @@ impl Kakehashi {
         // walks run once, on the settled snapshot, and install lineage.
         // `null` stays the protocol's re-sync signal for no-snapshot
         // (pre-first-parse), the settle backstop, and the lineage gate.
+        // Deliberate asymmetry with semanticTokens: tokens get the parse
+        // loop's settle refresh (server re-drive) and so may reject silently;
+        // captures rely entirely on the client's null-retry — past the
+        // backstop that cycles at one park per retry (~0.1 req/s per kind),
+        // churn but never dark, and no server-side re-drive is needed.
         // The injected-grammar install is not triggered inline here: the
         // parse loop's downstream (`process_injections`) detects missing
         // injected grammars and spawns the install as a detached task; a
@@ -740,7 +753,11 @@ impl Kakehashi {
         // a `null` outcome as a negative entry — so the no-kind-file case
         // can't convoy the losers into sequential identical walks. The 1s
         // re-loop timeout is a lost-wakeup backstop only — correctness never
-        // depends on it.
+        // depends on it. Accepted dedup gap: each request resolves its
+        // snapshot BEFORE this loop, so a loser whose wake finds the memo
+        // tagged one publish newer than its own snapshot misses and re-walks
+        // — correct (the lineage gate voids nothing), just less deduped
+        // exactly under burst load.
         let mut flight_guard = None;
         let walk_key = if lsp_range.is_none() {
             let key = (uri.clone(), kind.to_string(), injection);
@@ -1337,6 +1354,7 @@ mod tests {
             "the handler must park on the trailing snapshot, not answer from it"
         );
         publish("fn main() { }", 1);
+        let woke_at = tokio::time::Instant::now();
         let result = request
             .await
             .expect("handler must not panic")
@@ -1344,6 +1362,13 @@ mod tests {
         // Tree-less snapshot → the walk degrades to the protocol null; what
         // matters here is WHEN it answered (after currency), not the shape.
         assert_eq!(result, Value::Null);
+        // Discriminate woke-on-publish from backstop-timeout: under the
+        // paused clock a handler that missed the publish would only answer
+        // after auto-advancing through the settle backstop.
+        assert!(
+            woke_at.elapsed() < crate::lsp::lsp_impl::snapshot_read::TOKEN_SETTLE_BACKSTOP,
+            "the handler must wake on the publish, not ride out the backstop"
+        );
     }
 
     /// Single-flight: a request that finds another walk in flight for the
@@ -1537,10 +1562,13 @@ mod tests {
             .expect("node id is a ULID")
     }
 
-    /// The NodeTracker is a live-coordinate index; a walk over a snapshot
-    /// that trails the live document must still serve matches (serve-stale)
-    /// but must NOT register its ids in the tracker — a stale read never
-    /// mints (see the currency gate in `execute_captures_walk`).
+    /// The NodeTracker is a live-coordinate index; the walk CORE, run
+    /// directly against a snapshot that trails the live document, must still
+    /// serve matches but must NOT register its ids in the tracker — a stale
+    /// read never mints (see the currency gate in `execute_captures_walk`).
+    /// The handler above it parks for the current snapshot (serve-current),
+    /// so this is defense in depth for the close/reopen races the handler's
+    /// own incarnation checks bound but cannot eliminate.
     #[test]
     fn stale_serve_returns_matches_but_never_mints_into_the_tracker() {
         use crate::config::WorkspaceSettings;
@@ -1635,7 +1663,7 @@ mod tests {
         .expect("kind query should load");
         assert!(
             !stale_matches.is_empty(),
-            "serve-stale still returns matches"
+            "a stale walk still returns matches"
         );
         assert_eq!(
             first_node_id(&stale_matches),

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -585,6 +585,15 @@ impl Kakehashi {
             return Ok(None);
         };
 
+        // A typing client cancels superseded captures aggressively (one full +
+        // several deltas per keystroke); without a cancel signal each walk ran
+        // to completion on a compute-pool thread. The token doubles as the
+        // pool's dequeue hook (a cancelled work-unit is skipped before it ever
+        // takes a thread) and as the walk's per-layer checkpoint.
+        let upstream_id = crate::lsp::current_upstream_id();
+        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(upstream_id.as_ref());
+        let cancel_token = crate::cancel::CancelToken::default();
+
         // Resolve the latest parse snapshot, with only the bounded first-parse
         // wait (parse-snapshot ADR §3). `full` SERVES-STALE — it is a
         // per-keystroke highlighter, and `null`-on-routine-staleness against a
@@ -681,17 +690,22 @@ impl Kakehashi {
         let documents = std::sync::Arc::clone(&self.documents);
         let parsed_version = snapshot.parsed_version;
         let snapshot_for_layers = std::sync::Arc::clone(&snapshot);
-        let walked = self
+        let walk_cancel = cancel_token.clone();
+        let inner_cancel = cancel_token.clone();
+        let walk_future = self
             .compute_pool
-            .run(None, move || {
+            .run(Some(cancel_token.clone()), move || {
                 // Lazily build the snapshot's layer trees on first use (this
                 // is the same walk the inline path would run) and share them
                 // across every subsequent walk on this snapshot — captures
                 // full + delta both walk per keystroke. Concurrent walkers on
                 // one snapshot block on the OnceLock and reuse the winner's.
+                let build_start = std::time::Instant::now();
+                let mut layers_were_cached = true;
                 let fresh_layers;
                 let layers = if injection {
                     let cached = snapshot_for_layers.layer_trees.get_or_init(|| {
+                        layers_were_cached = false;
                         (
                             generation,
                             std::sync::Arc::new(
@@ -725,7 +739,9 @@ impl Kakehashi {
                 } else {
                     None
                 };
-                execute_captures_walk(
+                let build_elapsed = build_start.elapsed();
+                let walk_start = std::time::Instant::now();
+                let walked = execute_captures_walk(
                     &uri_for_walk,
                     &kind,
                     lsp_range,
@@ -740,12 +756,49 @@ impl Kakehashi {
                     parsed_version,
                     incarnation,
                     generation,
-                )
-            })
-            .await;
+                    Some(&inner_cancel),
+                );
+                log::debug!(
+                    target: "kakehashi::captures",
+                    "walk {uri_for_walk} kind={kind} v{parsed_version}: layers {}={}ms walk={}ms matches={}",
+                    if layers_were_cached { "cached" } else { "built" },
+                    build_elapsed.as_millis(),
+                    walk_start.elapsed().as_millis(),
+                    walked.as_ref().map_or(0, |(m, _)| m.len()),
+                );
+                walked
+            });
+        let walked = if let Some(cancel_rx) = cancel_rx {
+            tokio::pin!(cancel_rx);
+            tokio::select! {
+                biased;
+                // $/cancelRequest while queued/walking: flip the token so a
+                // queued unit is skipped at dequeue and a running walk bails
+                // at its next per-layer checkpoint, then answer the protocol
+                // cancellation instead of `null` (which would make the client
+                // immediately re-request).
+                _ = &mut cancel_rx => {
+                    walk_cancel.cancel();
+                    return Err(JsonRpcError::request_cancelled());
+                }
+                walked = walk_future => walked,
+            }
+        } else {
+            walk_future.await
+        };
         let Some(walked) = walked else {
+            // A pool-skip of an already-cancelled unit (or a work-unit panic).
+            if walk_cancel.is_cancelled() {
+                return Err(JsonRpcError::request_cancelled());
+            }
             return Ok(None);
         };
+        // A cancel landing after the walk finished: the result is complete,
+        // but never cache or serve a walk raced by its own cancellation's
+        // supersessor — the client already discarded this request.
+        if walk_cancel.is_cancelled() {
+            return Err(JsonRpcError::request_cancelled());
+        }
         Ok(walked.map(|(matches, skipped)| {
             if let Some(key) = walk_key {
                 self.captures_walk_cache.insert(
@@ -792,6 +845,7 @@ fn execute_captures_walk(
     parsed_version: u64,
     incarnation: u64,
     generation: u64,
+    cancel: Option<&crate::cancel::CancelToken>,
 ) -> Option<(Vec<Value>, Vec<Value>)> {
     // Tracker minting is currency-gated: the NodeTracker is a LIVE-coordinate
     // index (didChange shifts every entry before the reparse), so a trailing
@@ -848,6 +902,11 @@ fn execute_captures_walk(
     let mut matches: Vec<Value> = Vec::new();
 
     let mut visit = |layer_language: &str, layer_tree: &tree_sitter::Tree, depth: usize| {
+        // Per-layer cancellation checkpoint: a cancelled walk stops doing
+        // query/mint work; the caller discards the (partial) result.
+        if crate::cancel::is_cancelled(cancel) {
+            return;
+        }
         let entry = kind_queries
             .entry(layer_language.to_string())
             .or_insert_with(|| {
@@ -951,6 +1010,9 @@ fn execute_captures_walk(
             // makes the layer's query yield nothing for the clipped range.
             visit(language_id, tree, 0);
             for layer in layers {
+                if crate::cancel::is_cancelled(cancel) {
+                    break;
+                }
                 if let Some(filter) = &byte_range
                     && (layer.span.end <= filter.start || layer.span.start >= filter.end)
                 {
@@ -965,6 +1027,7 @@ fn execute_captures_walk(
                 text,
                 tree,
                 byte_range.as_ref(),
+                cancel,
                 &mut visit,
             );
         }
@@ -993,6 +1056,15 @@ fn execute_captures_walk(
                 tracker.remove_id(uri, id);
             }
         }
+    }
+
+    // A cancelled walk must not shape a partial result: the caller answers
+    // the protocol cancellation, and nothing may reach the walk memo. The
+    // minted-id reconciliation above still ran, so entries minted before the
+    // bail were purged/kept under the same rules as a completed walk — only
+    // the response is discarded.
+    if crate::cancel::is_cancelled(cancel) {
+        return None;
     }
 
     // The kind is "available" when at least one visited language COMPILED
@@ -1121,6 +1193,7 @@ mod tests {
             0,
             incarnation,
             0,
+            None,
         )
         .expect("kind query should load");
         assert!(!matches.is_empty(), "identifiers should match");
@@ -1149,6 +1222,7 @@ mod tests {
             0,
             incarnation,
             0,
+            None,
         )
         .expect("kind query should load");
         assert!(
@@ -1179,6 +1253,7 @@ mod tests {
             0,
             incarnation,
             0,
+            None,
         )
         .expect("kind query should load");
         let id = first_node_id(&stale_matches);

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -802,6 +802,28 @@ impl Kakehashi {
                 } else {
                     match self.captures_walk_inflight.entry(key.clone()) {
                         dashmap::mapref::entry::Entry::Vacant(vacant) => {
+                            // Re-check the memo before claiming winnership: a
+                            // concurrent winner may have stored its result and
+                            // dropped its marker between the memo check at the
+                            // top of the loop and this claim — claiming here
+                            // would re-run the identical walk right past its
+                            // fresh result. (Ordering is inflight-shard →
+                            // memo-shard; no path acquires them in reverse.)
+                            if let Some(hit) = self.captures_walk_cache.get(&key)
+                                && hit.parsed_version == snapshot.parsed_version
+                                && hit.incarnation == incarnation
+                                && hit.generation == generation
+                            {
+                                let result = hit.result.clone();
+                                drop(hit);
+                                return Ok(result.map(|(matches, skipped)| ComputedCaptures {
+                                    uri,
+                                    incarnation,
+                                    entry_content_version,
+                                    matches,
+                                    skipped,
+                                }));
+                            }
                             let notify = std::sync::Arc::new(tokio::sync::Notify::new());
                             vacant.insert(std::sync::Arc::clone(&notify));
                             flight_guard = Some(WalkFlightGuard {

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -957,9 +957,13 @@ impl Kakehashi {
             }
             return Ok(None);
         };
-        // A cancel landing after the walk finished: the result is complete,
-        // but never cache or serve a walk raced by its own cancellation's
-        // supersessor — the client already discarded this request.
+        // Forward-looking guard, unreachable today: the only current writer of
+        // this token is the `cancel_rx` select arm above, which returns
+        // instead of falling through. It stays because the token is designed
+        // to gain writers (captures supersession would flip it the way
+        // `SemanticRequestTracker` flips the token handlers'), and a completed
+        // walk raced by its own cancellation must never be cached or served —
+        // the client already discarded this request.
         if walk_cancel.is_cancelled() {
             return Err(JsonRpcError::request_cancelled());
         }

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -174,13 +174,24 @@ pub(in crate::lsp::lsp_impl) struct CachedCapturesWalk {
     pub(in crate::lsp::lsp_impl) parsed_version: u64,
     pub(in crate::lsp::lsp_impl) incarnation: u64,
     pub(in crate::lsp::lsp_impl) generation: u64,
-    /// `Arc`'d: a memo hit and the lineage store share the array by refcount.
-    /// A deep clone of a large document's matches (19.6k `Value`s on the
-    /// profiling corpus) taxed every repeat request twice — once out of this
-    /// memo, once into the lineage slot.
-    pub(in crate::lsp::lsp_impl) matches: std::sync::Arc<Vec<Value>>,
-    pub(in crate::lsp::lsp_impl) skipped: std::sync::Arc<Vec<Value>>,
+    /// `Some((matches, skipped))` — `Arc`'d: a memo hit and the lineage store
+    /// share the array by refcount. A deep clone of a large document's
+    /// matches (19.6k `Value`s on the profiling corpus) taxed every repeat
+    /// request twice — once out of this memo, once into the lineage slot.
+    ///
+    /// `None` is a NEGATIVE memo: the walk completed and no visited language
+    /// had a kind file (protocol `null`). That outcome is deterministic for
+    /// the tag (same snapshot, same generation — a kind file can only appear
+    /// via a settings reload or post-install, both of which bump the
+    /// generation), so without it every parked single-flight loser re-elected
+    /// itself winner and re-ran the identical doomed walk SEQUENTIALLY, and
+    /// each client `null`-retry re-walked from scratch.
+    pub(in crate::lsp::lsp_impl) result: Option<WalkArrays>,
 }
+
+/// The shared `(matches, skipped)` arrays of one completed walk.
+pub(in crate::lsp::lsp_impl) type WalkArrays =
+    (std::sync::Arc<Vec<Value>>, std::sync::Arc<Vec<Value>>);
 
 /// Winner-side handle of the single-flight captures walk: holds the
 /// in-flight marker for one `(uri, kind, injection)` and, on drop (every
@@ -724,9 +735,12 @@ impl Kakehashi {
         // first walk completes — concurrent misses all re-executed the same
         // walk (the 01KWSECM… capture shows the same (snapshot, kind) walked
         // up to 4× at once). Losers park on the winner's Notify and re-check
-        // the memo; a winner that stores nothing (cancelled, null) wakes them
-        // to elect a new winner. The 1s re-loop timeout is a lost-wakeup
-        // backstop only — correctness never depends on it.
+        // the memo; a winner that stores nothing (cancelled, pool panic)
+        // wakes them to elect a new winner. A COMPLETED walk always stores —
+        // a `null` outcome as a negative entry — so the no-kind-file case
+        // can't convoy the losers into sequential identical walks. The 1s
+        // re-loop timeout is a lost-wakeup backstop only — correctness never
+        // depends on it.
         let mut flight_guard = None;
         let walk_key = if lsp_range.is_none() {
             let key = (uri.clone(), kind.to_string(), injection);
@@ -736,12 +750,17 @@ impl Kakehashi {
                     && hit.incarnation == incarnation
                     && hit.generation == generation
                 {
-                    return Ok(Some(ComputedCaptures {
-                        uri,
-                        incarnation,
-                        entry_content_version,
-                        matches: hit.matches.clone(),
-                        skipped: hit.skipped.clone(),
+                    // A negative entry (`None`) serves the protocol `null`
+                    // without a walk — no kind file for this snapshot +
+                    // generation, see `CachedCapturesWalk::result`.
+                    return Ok(hit.result.clone().map(|(matches, skipped)| {
+                        ComputedCaptures {
+                            uri,
+                            incarnation,
+                            entry_content_version,
+                            matches,
+                            skipped,
+                        }
                     }));
                 }
                 let notify = match self.captures_walk_inflight.entry(key.clone()) {
@@ -914,30 +933,29 @@ impl Kakehashi {
         if walk_cancel.is_cancelled() {
             return Err(JsonRpcError::request_cancelled());
         }
-        Ok(walked.map(|(matches, skipped)| {
-            // Arc once; the memo and the returned ComputedCaptures share the
-            // arrays by refcount instead of deep-cloning ~20k `Value`s.
-            let matches = std::sync::Arc::new(matches);
-            let skipped = std::sync::Arc::new(skipped);
-            if let Some(key) = walk_key {
-                self.captures_walk_cache.insert(
-                    key,
-                    CachedCapturesWalk {
-                        parsed_version: snapshot.parsed_version,
-                        incarnation,
-                        generation,
-                        matches: std::sync::Arc::clone(&matches),
-                        skipped: std::sync::Arc::clone(&skipped),
-                    },
-                );
-            }
-            ComputedCaptures {
-                uri,
-                incarnation,
-                entry_content_version,
-                matches,
-                skipped,
-            }
+        // Arc once; the memo and the returned ComputedCaptures share the
+        // arrays by refcount instead of deep-cloning ~20k `Value`s. A `None`
+        // walk (no kind file) is memoized too — the negative entry, see
+        // `CachedCapturesWalk::result`.
+        let result = walked
+            .map(|(matches, skipped)| (std::sync::Arc::new(matches), std::sync::Arc::new(skipped)));
+        if let Some(key) = walk_key {
+            self.captures_walk_cache.insert(
+                key,
+                CachedCapturesWalk {
+                    parsed_version: snapshot.parsed_version,
+                    incarnation,
+                    generation,
+                    result: result.clone(),
+                },
+            );
+        }
+        Ok(result.map(|(matches, skipped)| ComputedCaptures {
+            uri,
+            incarnation,
+            entry_content_version,
+            matches,
+            skipped,
         }))
     }
 }

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -663,7 +663,18 @@ impl Kakehashi {
         // heals on a later request.
         let snapshot = {
             use crate::lsp::lsp_impl::snapshot_read::{SnapshotWait, TOKEN_SETTLE_BACKSTOP};
-            let wait = self.wait_for_current_snapshot(&uri, TOKEN_SETTLE_BACKSTOP);
+            // The parked settle wait is the full/delta policy. `range` is the
+            // position/range class (ADR §3): its byte range is authored
+            // against the LIVE text and it fires per redraw, so it
+            // staleness-rejects to `null` IMMEDIATELY (zero stale wait —
+            // only the bounded first-parse wait inside applies) instead of
+            // holding an ingress slot for up to the backstop.
+            let stale_wait = if lsp_range.is_some() {
+                std::time::Duration::ZERO
+            } else {
+                TOKEN_SETTLE_BACKSTOP
+            };
+            let wait = self.wait_for_current_snapshot(&uri, stale_wait);
             let outcome = match cancel_rx.as_mut() {
                 Some(rx) => {
                     tokio::select! {
@@ -701,10 +712,11 @@ impl Kakehashi {
         if snapshot.incarnation != view.slot.current_incarnation {
             return Ok(None);
         }
-        // `range` is the position/range class: its byte range is authored
-        // against the LIVE text, so a trailing snapshot cannot answer it.
-        // `null` — the captures protocol's re-sync signal — not ContentModified
-        // (a JSON-RPC error would violate the captures contract).
+        // `range` re-check against the LIVE version read above: the resolve
+        // returned a then-current snapshot, but an edit can land between it
+        // and this read. `null` — the captures protocol's re-sync signal —
+        // not ContentModified (a JSON-RPC error would violate the captures
+        // contract). Defense in depth behind the zero-stale-wait resolve.
         if lsp_range.is_some() && entry_content_version != snapshot.parsed_version {
             log::debug!(
                 target: "kakehashi::captures",
@@ -1368,6 +1380,76 @@ mod tests {
         assert!(
             woke_at.elapsed() < crate::lsp::lsp_impl::snapshot_read::TOKEN_SETTLE_BACKSTOP,
             "the handler must wake on the publish, not ride out the backstop"
+        );
+    }
+
+    /// `captures/range` is the position/range class: a trailing snapshot must
+    /// re-sync via `null` IMMEDIATELY (zero stale wait) — the parked settle
+    /// wait is the full/delta policy only. A per-redraw viewport request that
+    /// parked would hold an ingress slot for up to the backstop.
+    #[tokio::test(start_paused = true)]
+    async fn captures_range_stale_rejects_immediately_via_null() {
+        let (service, _socket) = tower_lsp_server::LspService::new(Kakehashi::new);
+        let service = std::sync::Arc::new(service);
+        let uri = Url::parse("file:///captures_range_stale.rs").expect("valid test uri");
+
+        service.inner().documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        let incarnation = service
+            .inner()
+            .documents
+            .latest_snapshot(&uri)
+            .expect("document just inserted")
+            .slot
+            .current_incarnation;
+        let landed = service
+            .inner()
+            .documents
+            .get(&uri)
+            .map(|doc| {
+                doc.publish_snapshot(std::sync::Arc::new(
+                    crate::document::snapshot::ParseSnapshot {
+                        text: std::sync::Arc::from("fn main() {}"),
+                        tree: None,
+                        language: Some("rust".to_string()),
+                        parsed_version: 0,
+                        incarnation,
+                        injection_regions: None,
+                        bridge_regions: None,
+                        resolved_regions: None,
+                        layer_trees: std::sync::OnceLock::new(),
+                    },
+                ))
+            })
+            .unwrap_or(false);
+        assert!(landed, "test snapshot must land");
+        // Edit past the published parse: the v0 snapshot now trails.
+        service
+            .inner()
+            .documents
+            .update_document(uri.clone(), "fn main() { }".to_string(), None);
+
+        let started_at = tokio::time::Instant::now();
+        let result = service
+            .inner()
+            .kakehashi_captures_range(CapturesRangeParams {
+                text_document: TextDocumentIdentifier {
+                    uri: crate::lsp::lsp_impl::url_to_uri(&uri).expect("test URI should convert"),
+                },
+                kind: "highlights".to_string(),
+                range: Range::default(),
+                injection: false,
+            })
+            .await
+            .expect("range must not error");
+        assert_eq!(result, Value::Null, "trailing snapshot re-syncs via null");
+        assert!(
+            started_at.elapsed() < crate::lsp::lsp_impl::snapshot_read::TOKEN_SETTLE_BACKSTOP,
+            "range must reject immediately, not park out the settle backstop"
         );
     }
 

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -174,8 +174,12 @@ pub(in crate::lsp::lsp_impl) struct CachedCapturesWalk {
     pub(in crate::lsp::lsp_impl) parsed_version: u64,
     pub(in crate::lsp::lsp_impl) incarnation: u64,
     pub(in crate::lsp::lsp_impl) generation: u64,
-    pub(in crate::lsp::lsp_impl) matches: Vec<Value>,
-    pub(in crate::lsp::lsp_impl) skipped: Vec<Value>,
+    /// `Arc`'d: a memo hit and the lineage store share the array by refcount.
+    /// A deep clone of a large document's matches (19.6k `Value`s on the
+    /// profiling corpus) taxed every repeat request twice — once out of this
+    /// memo, once into the lineage slot.
+    pub(in crate::lsp::lsp_impl) matches: std::sync::Arc<Vec<Value>>,
+    pub(in crate::lsp::lsp_impl) skipped: std::sync::Arc<Vec<Value>>,
 }
 
 /// A kind query compiled for one language, with the patterns tolerant
@@ -321,8 +325,8 @@ struct ComputedCaptures {
     /// *trailed* at entry still serves and stores — that is the deliberate
     /// serve-stale relaxation, healed by the client's per-keystroke re-request.
     entry_content_version: u64,
-    matches: Vec<Value>,
-    skipped: Vec<Value>,
+    matches: std::sync::Arc<Vec<Value>>,
+    skipped: std::sync::Arc<Vec<Value>>,
 }
 
 impl Kakehashi {
@@ -345,8 +349,8 @@ impl Kakehashi {
         // below — exactly one materialization of the matches per request.
         let response = json!({
             "resultId": result_id,
-            "matches": c.matches,
-            "skipped": c.skipped,
+            "matches": &*c.matches,
+            "skipped": &*c.skipped,
         });
         // A full that cannot install lineage (the text moved past the computed
         // snapshot, or a close/reopen raced) answers `null` instead: handing
@@ -510,7 +514,7 @@ impl Kakehashi {
                 let (_, prev_matches) = entry.value()[slot_index]
                     .as_ref()
                     .expect("slot verified Some by the guard above");
-                let edits = match matches_delta_edit(prev_matches, &c.matches) {
+                let edits = match matches_delta_edit(prev_matches, &c.matches[..]) {
                     None => json!([]),
                     Some((start, delete_count, data)) => json!([{
                         "start": start,
@@ -525,8 +529,8 @@ impl Kakehashi {
             // answer a delta with a full).
             _ => json!({
                 "resultId": result_id,
-                "matches": c.matches,
-                "skipped": c.skipped,
+                "matches": &*c.matches,
+                "skipped": &*c.skipped,
             }),
         };
         // Same gate as `full`: a delta whose fresh lineage cannot install
@@ -554,7 +558,7 @@ impl Kakehashi {
             )
             .await?;
         Ok(match computed {
-            Some(c) => json!({ "matches": c.matches, "skipped": c.skipped }),
+            Some(c) => json!({ "matches": &*c.matches, "skipped": &*c.skipped }),
             None => Value::Null,
         })
     }
@@ -800,6 +804,10 @@ impl Kakehashi {
             return Err(JsonRpcError::request_cancelled());
         }
         Ok(walked.map(|(matches, skipped)| {
+            // Arc once; the memo and the returned ComputedCaptures share the
+            // arrays by refcount instead of deep-cloning ~20k `Value`s.
+            let matches = std::sync::Arc::new(matches);
+            let skipped = std::sync::Arc::new(skipped);
             if let Some(key) = walk_key {
                 self.captures_walk_cache.insert(
                     key,
@@ -807,8 +815,8 @@ impl Kakehashi {
                         parsed_version: snapshot.parsed_version,
                         incarnation,
                         generation,
-                        matches: matches.clone(),
-                        skipped: skipped.clone(),
+                        matches: std::sync::Arc::clone(&matches),
+                        skipped: std::sync::Arc::clone(&skipped),
                     },
                 );
             }

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -793,19 +793,29 @@ impl Kakehashi {
                             skipped,
                         }));
                 }
-                let notify = match self.captures_walk_inflight.entry(key.clone()) {
-                    dashmap::mapref::entry::Entry::Vacant(vacant) => {
-                        let notify = std::sync::Arc::new(tokio::sync::Notify::new());
-                        vacant.insert(std::sync::Arc::clone(&notify));
-                        flight_guard = Some(WalkFlightGuard {
-                            map: &self.captures_walk_inflight,
-                            key: key.clone(),
-                            notify,
-                        });
-                        break;
-                    }
-                    dashmap::mapref::entry::Entry::Occupied(occupied) => {
-                        std::sync::Arc::clone(occupied.get())
+                // `get` before `entry`: the loser path (marker present) is
+                // the one taken repeatedly under a burst, and `entry` would
+                // clone the (Url, String) key just to find it occupied. Only
+                // a would-be winner pays the owned-key clone.
+                let notify = if let Some(current) = self.captures_walk_inflight.get(&key) {
+                    std::sync::Arc::clone(&current)
+                } else {
+                    match self.captures_walk_inflight.entry(key.clone()) {
+                        dashmap::mapref::entry::Entry::Vacant(vacant) => {
+                            let notify = std::sync::Arc::new(tokio::sync::Notify::new());
+                            vacant.insert(std::sync::Arc::clone(&notify));
+                            flight_guard = Some(WalkFlightGuard {
+                                map: &self.captures_walk_inflight,
+                                key: key.clone(),
+                                notify,
+                            });
+                            break;
+                        }
+                        // A racing winner claimed the marker between the get
+                        // and the entry: park on it like any loser.
+                        dashmap::mapref::entry::Entry::Occupied(occupied) => {
+                            std::sync::Arc::clone(occupied.get())
+                        }
                     }
                 };
                 // Register interest BEFORE re-validating the marker: enable()

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -753,15 +753,16 @@ impl Kakehashi {
                     // A negative entry (`None`) serves the protocol `null`
                     // without a walk — no kind file for this snapshot +
                     // generation, see `CachedCapturesWalk::result`.
-                    return Ok(hit.result.clone().map(|(matches, skipped)| {
-                        ComputedCaptures {
+                    return Ok(hit
+                        .result
+                        .clone()
+                        .map(|(matches, skipped)| ComputedCaptures {
                             uri,
                             incarnation,
                             entry_content_version,
                             matches,
                             skipped,
-                        }
-                    }));
+                        }));
                 }
                 let notify = match self.captures_walk_inflight.entry(key.clone()) {
                     dashmap::mapref::entry::Entry::Vacant(vacant) => {
@@ -1343,6 +1344,189 @@ mod tests {
         // Tree-less snapshot → the walk degrades to the protocol null; what
         // matters here is WHEN it answered (after currency), not the shape.
         assert_eq!(result, Value::Null);
+    }
+
+    /// Single-flight: a request that finds another walk in flight for the
+    /// same `(uri, kind, injection)` parks on the winner's `Notify`, and on
+    /// wake serves the winner's memo instead of re-executing the walk. Pinned
+    /// with a sentinel memo no real walk could produce.
+    #[tokio::test(start_paused = true)]
+    async fn captures_full_single_flight_loser_serves_winner_memo() {
+        let (service, _socket) = tower_lsp_server::LspService::new(Kakehashi::new);
+        let service = std::sync::Arc::new(service);
+        let uri = Url::parse("file:///captures_single_flight.rs").expect("valid test uri");
+        let text = "fn main() {}";
+
+        service.inner().documents.insert(
+            uri.clone(),
+            text.to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        let incarnation = service
+            .inner()
+            .documents
+            .latest_snapshot(&uri)
+            .expect("document just inserted")
+            .slot
+            .current_incarnation;
+        // A real tree so the handler passes the tree check and reaches the
+        // single-flight loop (a tree-less snapshot short-circuits to null).
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .expect("rust grammar loads");
+        let tree = parser.parse(text, None).expect("parse rust");
+        let landed = service
+            .inner()
+            .documents
+            .get(&uri)
+            .map(|doc| {
+                doc.publish_snapshot(std::sync::Arc::new(
+                    crate::document::snapshot::ParseSnapshot {
+                        text: std::sync::Arc::from(text),
+                        tree: Some(tree),
+                        language: Some("rust".to_string()),
+                        parsed_version: 0,
+                        incarnation,
+                        injection_regions: None,
+                        bridge_regions: None,
+                        resolved_regions: None,
+                        layer_trees: std::sync::OnceLock::new(),
+                    },
+                ))
+            })
+            .unwrap_or(false);
+        assert!(landed, "test snapshot must land");
+        let generation = service.inner().cache.semantic_token_generation();
+
+        // Simulate a winner already walking this key.
+        let key = (uri.clone(), "highlights".to_string(), false);
+        let winner_notify = std::sync::Arc::new(tokio::sync::Notify::new());
+        service
+            .inner()
+            .captures_walk_inflight
+            .insert(key.clone(), std::sync::Arc::clone(&winner_notify));
+
+        let request = {
+            let service = std::sync::Arc::clone(&service);
+            let uri = uri.clone();
+            tokio::spawn(async move {
+                service
+                    .inner()
+                    .kakehashi_captures_full(CapturesFullParams {
+                        text_document: TextDocumentIdentifier {
+                            uri: crate::lsp::lsp_impl::url_to_uri(&uri)
+                                .expect("test URI should convert"),
+                        },
+                        kind: "highlights".to_string(),
+                        injection: false,
+                    })
+                    .await
+            })
+        };
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(
+            !request.is_finished(),
+            "the loser must park on the winner's in-flight marker"
+        );
+
+        // Winner completes: memo BEFORE marker removal + wake — the same
+        // ordering the handler's `_flight_guard` drop guarantees.
+        let sentinel = json!({"sentinel": "from-winner-memo"});
+        service.inner().captures_walk_cache.insert(
+            key.clone(),
+            CachedCapturesWalk {
+                parsed_version: 0,
+                incarnation,
+                generation,
+                result: Some((
+                    std::sync::Arc::new(vec![sentinel.clone()]),
+                    std::sync::Arc::new(Vec::new()),
+                )),
+            },
+        );
+        service.inner().captures_walk_inflight.remove(&key);
+        winner_notify.notify_waiters();
+
+        let result = request
+            .await
+            .expect("handler task must not panic")
+            .expect("captures full must not error");
+        assert_eq!(
+            result["matches"][0], sentinel,
+            "the loser must serve the winner's memo, not run its own walk"
+        );
+    }
+
+    /// A `$/cancelRequest` arriving while the handler is parked on a trailing
+    /// snapshot must answer RequestCancelled promptly — not sit out the
+    /// settle backstop.
+    #[tokio::test(start_paused = true)]
+    async fn captures_full_cancel_while_parked_answers_request_cancelled() {
+        use tower_lsp_server::jsonrpc::Id;
+
+        let (service, _socket) = tower_lsp_server::LspService::new(Kakehashi::new);
+        let service = std::sync::Arc::new(service);
+        let uri = Url::parse("file:///captures_cancel_parked.rs").expect("valid test uri");
+
+        service.inner().documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        // No snapshot published for the live content version: with an edit
+        // past the (absent) parse, the handler parks in the serve-current
+        // wait.
+        service
+            .inner()
+            .documents
+            .update_document(uri.clone(), "fn main() { }".to_string(), None);
+
+        let request = {
+            let service = std::sync::Arc::clone(&service);
+            let uri = uri.clone();
+            // The upstream request id rides task-local storage (installed by
+            // the RequestIdCapture middleware in production).
+            tokio::spawn(crate::lsp::request_id::CURRENT_REQUEST_ID.scope(
+                Some(Id::Number(77)),
+                async move {
+                    service
+                        .inner()
+                        .kakehashi_captures_full(CapturesFullParams {
+                            text_document: TextDocumentIdentifier {
+                                uri: crate::lsp::lsp_impl::url_to_uri(&uri)
+                                    .expect("test URI should convert"),
+                            },
+                            kind: "highlights".to_string(),
+                            injection: false,
+                        })
+                        .await
+                },
+            ))
+        };
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(
+            !request.is_finished(),
+            "the handler must be parked awaiting the current snapshot"
+        );
+
+        service
+            .inner()
+            .bridge
+            .cancel_forwarder()
+            .forward_cancel(crate::lsp::bridge::UpstreamId::Number(77))
+            .await
+            .expect("cancel forward must not error");
+
+        let result = request.await.expect("handler task must not panic");
+        let err = result.expect_err("a cancelled parked request must error, not answer");
+        assert_eq!(
+            err.code,
+            JsonRpcError::request_cancelled().code,
+            "the parked handler must answer RequestCancelled on $/cancelRequest"
+        );
     }
 
     fn first_node_id(matches: &[Value]) -> ulid::Ulid {

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -182,6 +182,28 @@ pub(in crate::lsp::lsp_impl) struct CachedCapturesWalk {
     pub(in crate::lsp::lsp_impl) skipped: std::sync::Arc<Vec<Value>>,
 }
 
+/// Winner-side handle of the single-flight captures walk: holds the
+/// in-flight marker for one `(uri, kind, injection)` and, on drop (every
+/// exit path — success, cancel, panic-unwind), removes it and wakes the
+/// parked losers so they re-check the walk memo or elect a new winner.
+/// `remove_if` with pointer equality so a slow winner can never evict a
+/// successor's marker.
+struct WalkFlightGuard<'a> {
+    map: &'a dashmap::DashMap<(Url, String, bool), std::sync::Arc<tokio::sync::Notify>>,
+    key: (Url, String, bool),
+    notify: std::sync::Arc<tokio::sync::Notify>,
+}
+
+impl Drop for WalkFlightGuard<'_> {
+    fn drop(&mut self) {
+        self.map
+            .remove_if(&self.key, |_, current| {
+                std::sync::Arc::ptr_eq(current, &self.notify)
+            });
+        self.notify.notify_waiters();
+    }
+}
+
 /// A kind query compiled for one language, with the patterns tolerant
 /// compilation dropped.
 struct KindQuery {
@@ -318,12 +340,11 @@ fn load_kind_query(
 struct ComputedCaptures {
     uri: Url,
     incarnation: u64,
-    /// The live `content_version` at request entry. The lineage store re-checks
-    /// it so an edit landing DURING the request voids the store: the response
+    /// The live `content_version` at snapshot resolution. The resolved
+    /// snapshot is current at that instant (serve-current park), but an edit
+    /// landing DURING the walk still voids the lineage store: the response
     /// was already outdated at delivery, and lineage must not record matches
-    /// for a text the client no longer has (ADR §3). A snapshot that merely
-    /// *trailed* at entry still serves and stores — that is the deliberate
-    /// serve-stale relaxation, healed by the client's per-keystroke re-request.
+    /// for a text the client no longer has (ADR §3).
     entry_content_version: u64,
     matches: std::sync::Arc<Vec<Value>>,
     skipped: std::sync::Arc<Vec<Value>>,
@@ -385,8 +406,9 @@ impl Kakehashi {
     ///   `content_version` moved past its request-entry value) makes the
     ///   response outdated at delivery; storing it would record lineage for a
     ///   text the client no longer has (parse-snapshot ADR §3), so nothing is
-    ///   stored and the caller answers `null`. A snapshot that merely trailed
-    ///   at entry still stores — the serve-stale relaxation.
+    ///   stored and the caller answers `null`. Under serve-current the
+    ///   snapshot was current at resolution, so this guard covers exactly the
+    ///   resolve→delivery window.
     async fn store_lineage(
         &self,
         computed: ComputedCaptures,
@@ -595,22 +617,52 @@ impl Kakehashi {
         // pool's dequeue hook (a cancelled work-unit is skipped before it ever
         // takes a thread) and as the walk's per-layer checkpoint.
         let upstream_id = crate::lsp::current_upstream_id();
-        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(upstream_id.as_ref());
+        let (mut cancel_rx, _cancel_guard) = self.subscribe_cancel(upstream_id.as_ref());
         let cancel_token = crate::cancel::CancelToken::default();
 
-        // Resolve the latest parse snapshot, with only the bounded first-parse
-        // wait (parse-snapshot ADR §3). `full` SERVES-STALE — it is a
-        // per-keystroke highlighter, and `null`-on-routine-staleness against a
-        // client contracted to re-request on `null` would busy-spin; `null` is
-        // reserved for no-snapshot (pre-first-parse) and the lineage gate
-        // below. The injected-grammar install is no longer triggered inline
-        // here: the parse loop's downstream (`process_injections`) detects
-        // missing injected grammars and spawns the install as a detached task;
-        // a layer whose grammar is still installing is skipped by the walk and
+        // Serve-current (parse-snapshot ADR §3, revised like semanticTokens):
+        // park — racing the client's cancel — until the latest snapshot
+        // matches the live text, then walk THAT. The previous serve-stale
+        // policy walked whatever snapshot was latest; during a typing burst
+        // every one of those walks completed its full compute and was then
+        // voided by the lineage still-current gate → `null` → the client
+        // re-requested → another doomed walk. A live capture (01KWSECM…)
+        // shows 41 walks in ~15s, most for snapshots several edits behind,
+        // all nulled — saturating the compute pool and queueing the semantic
+        // delta 10s behind them. Parking costs a watch subscription instead;
+        // walks run once, on the settled snapshot, and install lineage.
+        // `null` stays the protocol's re-sync signal for no-snapshot
+        // (pre-first-parse), the settle backstop, and the lineage gate.
+        // The injected-grammar install is not triggered inline here: the
+        // parse loop's downstream (`process_injections`) detects missing
+        // injected grammars and spawns the install as a detached task; a
+        // layer whose grammar is still installing is skipped by the walk and
         // heals on a later request.
-        let Some(snapshot) = self.snapshot_for_tokens(&uri).await else {
-            log::debug!(target: "kakehashi::captures", "no parsed document for {uri}");
-            return Ok(None);
+        let snapshot = {
+            use crate::lsp::lsp_impl::snapshot_read::{SnapshotWait, TOKEN_SETTLE_BACKSTOP};
+            let wait = self.wait_for_current_snapshot(&uri, TOKEN_SETTLE_BACKSTOP);
+            let outcome = match cancel_rx.as_mut() {
+                Some(rx) => {
+                    tokio::select! {
+                        biased;
+                        _ = rx => {
+                            return Err(JsonRpcError::request_cancelled());
+                        }
+                        outcome = wait => outcome,
+                    }
+                }
+                None => wait.await,
+            };
+            match outcome {
+                SnapshotWait::Current(snapshot) => snapshot,
+                SnapshotWait::Stale | SnapshotWait::Unparsed | SnapshotWait::Gone => {
+                    log::debug!(
+                        target: "kakehashi::captures",
+                        "no current snapshot for {uri}: re-sync via null"
+                    );
+                    return Ok(None);
+                }
+            }
         };
         // The live input state at request entry: `range` staleness-rejects
         // against it, and the lineage store re-checks it (see ComputedCaptures).
@@ -667,25 +719,85 @@ impl Kakehashi {
         // Key built only on the full-mode path (range bypasses the memo), and
         // carried to the store below so the Url/String allocations happen at
         // most once per request.
+        //
+        // Single-flight: a typing client sends `full` AND several `delta`s
+        // for the same kind concurrently, and the memo only helps AFTER the
+        // first walk completes — concurrent misses all re-executed the same
+        // walk (the 01KWSECM… capture shows the same (snapshot, kind) walked
+        // up to 4× at once). Losers park on the winner's Notify and re-check
+        // the memo; a winner that stores nothing (cancelled, null) wakes them
+        // to elect a new winner. The 1s re-loop timeout is a lost-wakeup
+        // backstop only — correctness never depends on it.
+        let mut flight_guard = None;
         let walk_key = if lsp_range.is_none() {
             let key = (uri.clone(), kind.to_string(), injection);
-            if let Some(hit) = self.captures_walk_cache.get(&key)
-                && hit.parsed_version == snapshot.parsed_version
-                && hit.incarnation == incarnation
-                && hit.generation == generation
-            {
-                return Ok(Some(ComputedCaptures {
-                    uri,
-                    incarnation,
-                    entry_content_version,
-                    matches: hit.matches.clone(),
-                    skipped: hit.skipped.clone(),
-                }));
+            loop {
+                if let Some(hit) = self.captures_walk_cache.get(&key)
+                    && hit.parsed_version == snapshot.parsed_version
+                    && hit.incarnation == incarnation
+                    && hit.generation == generation
+                {
+                    return Ok(Some(ComputedCaptures {
+                        uri,
+                        incarnation,
+                        entry_content_version,
+                        matches: hit.matches.clone(),
+                        skipped: hit.skipped.clone(),
+                    }));
+                }
+                let notify = match self.captures_walk_inflight.entry(key.clone()) {
+                    dashmap::mapref::entry::Entry::Vacant(vacant) => {
+                        let notify = std::sync::Arc::new(tokio::sync::Notify::new());
+                        vacant.insert(std::sync::Arc::clone(&notify));
+                        flight_guard = Some(WalkFlightGuard {
+                            map: &self.captures_walk_inflight,
+                            key: key.clone(),
+                            notify,
+                        });
+                        break;
+                    }
+                    dashmap::mapref::entry::Entry::Occupied(occupied) => {
+                        std::sync::Arc::clone(occupied.get())
+                    }
+                };
+                // Register interest BEFORE re-validating the marker: enable()
+                // makes a notify_waiters() between here and the await visible,
+                // and the marker re-check catches a winner that exited before
+                // we registered (its notify_waiters preceded our enable).
+                let notified = notify.notified();
+                tokio::pin!(notified);
+                notified.as_mut().enable();
+                let winner_live = self
+                    .captures_walk_inflight
+                    .get(&key)
+                    .is_some_and(|current| std::sync::Arc::ptr_eq(&current, &notify));
+                if winner_live {
+                    match cancel_rx.as_mut() {
+                        Some(rx) => {
+                            tokio::select! {
+                                biased;
+                                _ = rx => return Err(JsonRpcError::request_cancelled()),
+                                _ = &mut notified => {}
+                                _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {}
+                            }
+                        }
+                        None => {
+                            tokio::select! {
+                                _ = &mut notified => {}
+                                _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {}
+                            }
+                        }
+                    }
+                }
             }
             Some(key)
         } else {
             None
         };
+        // Holds the in-flight marker for the winner until this function
+        // returns (its Drop removes the marker and wakes the losers, AFTER
+        // the memo store below on the success path).
+        let _flight_guard = flight_guard;
 
         let uri_for_walk = uri.clone();
         let kind = kind.to_string();
@@ -859,9 +971,11 @@ fn execute_captures_walk(
     // index (didChange shifts every entry before the reparse), so a trailing
     // snapshot's byte offsets must never be written into it — they would be
     // wrong-space entries that later edits keep shifting as if they were live
-    // (the "a stale read never mints" invariant, see snapshot_read.rs). A
-    // stale serve still returns matches — serve-stale is the point of the
-    // per-keystroke `full` mode — but goes READ-ONLY on the tracker: a
+    // (the "a stale read never mints" invariant, see snapshot_read.rs). The
+    // handler resolves a CURRENT snapshot (serve-current park), but an edit
+    // can land between that resolution and this work-unit reaching the front
+    // of the pool queue; a walk that starts outrun still returns matches
+    // (voided later by the lineage gate) but goes READ-ONLY on the tracker: a
     // position the intervening edits did not shift reuses its live id (so
     // the delta lineage stays a minimal diff), and an unknown position gets
     // an unregistered id — resolving one via `kakehashi/node/*` yields
@@ -1127,6 +1241,92 @@ mod tests {
 
     fn vals(ns: &[i64]) -> Vec<Value> {
         ns.iter().map(|n| json!(n)).collect()
+    }
+
+    /// Serve-current (ADR §3, revised): a captures request arriving while the
+    /// latest snapshot trails the live text parks until the current snapshot
+    /// publishes instead of walking the trailing one (whose result the
+    /// lineage gate would void into a `null` → re-request busy-loop).
+    #[tokio::test(start_paused = true)]
+    async fn captures_full_parks_until_current_snapshot() {
+        let (service, _socket) = tower_lsp_server::LspService::new(Kakehashi::new);
+        let service = std::sync::Arc::new(service);
+        let uri = Url::parse("file:///captures_serve_current.rs").expect("valid test uri");
+
+        service.inner().documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        let incarnation = service
+            .inner()
+            .documents
+            .latest_snapshot(&uri)
+            .expect("document just inserted")
+            .slot
+            .current_incarnation;
+        let publish = |text: &str, parsed_version: u64| {
+            let landed = service
+                .inner()
+                .documents
+                .get(&uri)
+                .map(|doc| {
+                    doc.publish_snapshot(std::sync::Arc::new(
+                        crate::document::snapshot::ParseSnapshot {
+                            text: std::sync::Arc::from(text),
+                            tree: None,
+                            language: Some("rust".to_string()),
+                            parsed_version,
+                            incarnation,
+                            injection_regions: None,
+                            bridge_regions: None,
+                            resolved_regions: None,
+                            layer_trees: std::sync::OnceLock::new(),
+                        },
+                    ))
+                })
+                .unwrap_or(false);
+            assert!(landed, "test snapshot must land");
+        };
+        publish("fn main() {}", 0);
+        // Edit: content_version moves to 1, the v0 snapshot now trails.
+        service.inner().documents.update_document(
+            uri.clone(),
+            "fn main() { }".to_string(),
+            None,
+        );
+
+        let request = {
+            let service = std::sync::Arc::clone(&service);
+            let uri = uri.clone();
+            tokio::spawn(async move {
+                service
+                    .inner()
+                    .kakehashi_captures_full(CapturesFullParams {
+                        text_document: TextDocumentIdentifier {
+                            uri: crate::lsp::lsp_impl::url_to_uri(&uri)
+                                .expect("test URI should convert"),
+                        },
+                        kind: "highlights".to_string(),
+                        injection: false,
+                    })
+                    .await
+            })
+        };
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(
+            !request.is_finished(),
+            "the handler must park on the trailing snapshot, not answer from it"
+        );
+        publish("fn main() { }", 1);
+        let result = request
+            .await
+            .expect("handler must not panic")
+            .expect("captures full must not error");
+        // Tree-less snapshot → the walk degrades to the protocol null; what
+        // matters here is WHEN it answered (after currency), not the shape.
+        assert_eq!(result, Value::Null);
     }
 
     fn first_node_id(matches: &[Value]) -> ulid::Ulid {

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -747,6 +747,7 @@ pub(crate) fn collect_document_layer_trees(
         host_text,
         host_tree,
         None,
+        None,
         &mut |language, tree, depth| {
             // The host layer (depth 0) already lives on the snapshot as
             // `ParseSnapshot::tree`; store only the injected layers.
@@ -799,6 +800,7 @@ pub(in crate::lsp::lsp_impl::kakehashi) fn walk_document_layers(
     host_text: &str,
     host_tree: &tree_sitter::Tree,
     byte_filter: Option<&std::ops::Range<usize>>,
+    cancel: Option<&crate::cancel::CancelToken>,
     visit: &mut dyn FnMut(&str, &tree_sitter::Tree, usize),
 ) {
     visit(host_language, host_tree, 0);
@@ -810,6 +812,7 @@ pub(in crate::lsp::lsp_impl::kakehashi) fn walk_document_layers(
         host_text,
         1,
         byte_filter,
+        cancel,
         visit,
     );
 }
@@ -823,6 +826,7 @@ fn walk_child_layers(
     host_text: &str,
     depth: usize,
     byte_filter: Option<&std::ops::Range<usize>>,
+    cancel: Option<&crate::cancel::CancelToken>,
     visit: &mut dyn FnMut(&str, &tree_sitter::Tree, usize),
 ) {
     // Allows injected depths 1..=MAX_INJECTION_DEPTH — deliberately matching
@@ -832,6 +836,11 @@ fn walk_child_layers(
     // (`depth >= MAX` with a different base); resolution does not depend on
     // it, so the cursor-path stack is the convention that matters here.
     if depth > MAX_INJECTION_DEPTH {
+        return;
+    }
+    // Cancellation checkpoint before the per-depth injection query and the
+    // per-region resolve+parse below — the walk's expensive units.
+    if crate::cancel::is_cancelled(cancel) {
         return;
     }
     for (region, absolute_ranges) in effective_child_regions(
@@ -866,6 +875,7 @@ fn walk_child_layers(
             host_text,
             depth + 1,
             byte_filter,
+            cancel,
             visit,
         );
     }
@@ -912,6 +922,7 @@ mod tests {
             "markdown",
             text,
             &tree,
+            None,
             None,
             &mut |lang, layer_tree, depth| {
                 if depth == 0 {

--- a/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/injection_stack.rs
@@ -851,6 +851,14 @@ fn walk_child_layers(
         host_text,
         byte_filter,
     ) {
+        // Per-region checkpoint: each iteration below runs a language
+        // resolve + a full injected-region reparse, so on an
+        // injection-heavy document a cancel landing mid-loop must not pay
+        // for the remaining siblings before the per-depth check above sees
+        // it on the next recursion.
+        if crate::cancel::is_cancelled(cancel) {
+            return;
+        }
         let content = &host_text[region.content_node.start_byte()..region.content_node.end_byte()];
         let Some((resolved_lang, _)) =
             coordinator.resolve_injection_language(&region.language, content)

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -473,9 +473,7 @@ impl Kakehashi {
                 _ = term.recv() => SIGTERM_NUM,
                 _ = hup.recv() => SIGHUP_NUM,
             };
-            log::info!(
-                "received signal {signum}: reaping downstream servers before exit"
-            );
+            log::info!("received signal {signum}: reaping downstream servers before exit");
             bridge.shutdown_all().await;
             std::process::exit(128 + signum);
         });

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -474,13 +474,13 @@ impl Kakehashi {
                     return;
                 }
             };
-            // POSIX signal numbers, avoiding a libc dependency for two
-            // constants that are identical on every Unix Rust supports.
-            const SIGHUP_NUM: i32 = 1;
-            const SIGTERM_NUM: i32 = 15;
+            // Platform signal numbers straight from the SignalKind
+            // constructors (tokio exposes the libc constants via
+            // `as_raw_value`), so the 128+signum exit status is correct even
+            // on a Unix that renumbers them — no hard-coded 1/15.
             let signum = tokio::select! {
-                _ = term.recv() => SIGTERM_NUM,
-                _ = hup.recv() => SIGHUP_NUM,
+                _ = term.recv() => SignalKind::terminate().as_raw_value(),
+                _ = hup.recv() => SignalKind::hangup().as_raw_value(),
             };
             log::info!("received signal {signum}: reaping downstream servers before exit");
             // Crash-detection parity with `shutdown_impl`: a kill mid-parse is

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -428,6 +428,59 @@ impl Kakehashi {
         }
     }
 
+    /// Arm a Unix-signal watcher that reaps the downstream server pool when
+    /// the process is terminated WITHOUT the LSP shutdown handshake.
+    ///
+    /// Editors escalate: Neovim SIGTERMs a server that hasn't exited shortly
+    /// after `shutdown`/`exit`, and a user restart can kill it outright. With
+    /// no handler, kakehashi dies mid-handshake and its downstream children
+    /// are orphaned — observed live as a `with-logging emmylua_ls` wrapper
+    /// re-parented to launchd and running for hours, because not every
+    /// downstream exits on stdin EOF. On SIGTERM/SIGHUP this runs the same
+    /// bounded `shutdown_all` as the graceful path (LSP handshake, then
+    /// SIGTERM→SIGKILL escalation, global timeout) and exits with the
+    /// conventional 128+signal status. A SIGKILL still orphans children —
+    /// nothing can intercept it — but the escalation path an editor actually
+    /// takes starts with SIGTERM, which this converts into a clean reap.
+    ///
+    /// Server mode only (the one-shot CLI has no downstream pool worth a
+    /// watcher); `pub` because the binary arms it before serving.
+    #[cfg(unix)]
+    pub fn spawn_termination_cleanup(&self) {
+        let bridge = std::sync::Arc::clone(&self.bridge);
+        tokio::spawn(async move {
+            use tokio::signal::unix::{SignalKind, signal};
+            let (mut term, mut hup) = match (
+                signal(SignalKind::terminate()),
+                signal(SignalKind::hangup()),
+            ) {
+                (Ok(term), Ok(hup)) => (term, hup),
+                (term, hup) => {
+                    log::warn!(
+                        "termination cleanup disabled: signal handler install failed \
+                         (SIGTERM: {:?}, SIGHUP: {:?})",
+                        term.err(),
+                        hup.err()
+                    );
+                    return;
+                }
+            };
+            // POSIX signal numbers, avoiding a libc dependency for two
+            // constants that are identical on every Unix Rust supports.
+            const SIGHUP_NUM: i32 = 1;
+            const SIGTERM_NUM: i32 = 15;
+            let signum = tokio::select! {
+                _ = term.recv() => SIGTERM_NUM,
+                _ = hup.recv() => SIGHUP_NUM,
+            };
+            log::info!(
+                "received signal {signum}: reaping downstream servers before exit"
+            );
+            bridge.shutdown_all().await;
+            std::process::exit(128 + signum);
+        });
+    }
+
     pub(crate) async fn shutdown_impl(&self) -> Result<()> {
         // Persist crash detection state before shutdown
         // This enables crash recovery to detect if parsing was in progress

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -436,18 +436,27 @@ impl Kakehashi {
     /// no handler, kakehashi dies mid-handshake and its downstream children
     /// are orphaned — observed live as a `with-logging emmylua_ls` wrapper
     /// re-parented to launchd and running for hours, because not every
-    /// downstream exits on stdin EOF. On SIGTERM/SIGHUP this runs the same
-    /// bounded `shutdown_all` as the graceful path (LSP handshake, then
-    /// SIGTERM→SIGKILL escalation, global timeout) and exits with the
-    /// conventional 128+signal status. A SIGKILL still orphans children —
-    /// nothing can intercept it — but the escalation path an editor actually
-    /// takes starts with SIGTERM, which this converts into a clean reap.
+    /// downstream exits on stdin EOF. On SIGTERM/SIGHUP this persists the
+    /// crash-detection marker (`parsing_in_progress` — a kill mid-parse is
+    /// precisely what that marker detects) and runs the same bounded
+    /// `shutdown_all` as the graceful path (LSP handshake, then
+    /// SIGTERM→SIGKILL escalation, global timeout), then exits with the
+    /// conventional 128+signal status. Unlike `shutdown_impl` it does NOT
+    /// stop in-process work (forwarding loops, timers) — the process exits
+    /// immediately after the reap, so only the two effects that outlive the
+    /// process matter. A second signal during the reap aborts it and exits
+    /// immediately — installing a handler replaces the default kill-now
+    /// disposition, so impatient senders must keep working. A SIGKILL still
+    /// orphans children — nothing can intercept it — but the escalation path
+    /// an editor actually takes starts with SIGTERM, which this converts
+    /// into a clean reap.
     ///
     /// Server mode only (the one-shot CLI has no downstream pool worth a
     /// watcher); `pub` because the binary arms it before serving.
     #[cfg(unix)]
     pub fn spawn_termination_cleanup(&self) {
         let bridge = std::sync::Arc::clone(&self.bridge);
+        let failed_parsers = self.auto_install.failed_parsers_handle();
         tokio::spawn(async move {
             use tokio::signal::unix::{SignalKind, signal};
             let (mut term, mut hup) = match (
@@ -474,7 +483,30 @@ impl Kakehashi {
                 _ = hup.recv() => SIGHUP_NUM,
             };
             log::info!("received signal {signum}: reaping downstream servers before exit");
-            bridge.shutdown_all().await;
+            // Crash-detection parity with `shutdown_impl`: a kill mid-parse is
+            // exactly the case the `parsing_in_progress` marker exists for, so
+            // persist it before the (comparatively slow) downstream reap.
+            if let Err(e) = failed_parsers.persist_state() {
+                log::warn!(
+                    target: "kakehashi::crash_recovery",
+                    "Failed to persist crash detection state on signal: {e}"
+                );
+            }
+            // Race the reap against a SECOND signal: the installed handler
+            // replaced the default kill-now disposition, so without this arm a
+            // repeat SIGTERM during the bounded (~13s worst-case) reap would be
+            // silently swallowed. An impatient sender gets an immediate exit;
+            // still-running downstreams fall back to their own stdin-EOF /
+            // kill handling.
+            tokio::select! {
+                _ = bridge.shutdown_all() => {}
+                _ = term.recv() => {
+                    log::warn!("second SIGTERM during reap: exiting immediately");
+                }
+                _ = hup.recv() => {
+                    log::warn!("second SIGHUP during reap: exiting immediately");
+                }
+            }
             std::process::exit(128 + signum);
         });
     }

--- a/src/lsp/lsp_impl/snapshot_read.rs
+++ b/src/lsp/lsp_impl/snapshot_read.rs
@@ -46,6 +46,12 @@ pub(crate) const FIRST_PARSE_BACKSTOP: std::time::Duration = std::time::Duration
 /// (shifted by the editor across edits), which is strictly better than
 /// receiving tokens computed for text it no longer has. On expiry the parse
 /// loop's settle refresh re-drives the client once the snapshot lands.
+///
+/// This constant governs the *stale* park only (a snapshot exists but
+/// trails). A document with NO snapshot for its lifetime parks on
+/// [`FIRST_PARSE_BACKSTOP`] instead, regardless of the caller's `wait` — a
+/// token reader's worst-case park is therefore the first-parse bound (15s),
+/// not this.
 pub(crate) const TOKEN_SETTLE_BACKSTOP: std::time::Duration = std::time::Duration::from_secs(10);
 
 impl Kakehashi {

--- a/src/lsp/lsp_impl/snapshot_read.rs
+++ b/src/lsp/lsp_impl/snapshot_read.rs
@@ -30,18 +30,23 @@ pub(crate) enum SnapshotWait {
 /// handlers' `snapshot_for_tokens` and the explicit-action
 /// `wait_for_current_snapshot`): generous on purpose, because it only runs
 /// while the lifetime has NO snapshot and every open-parse resolution path
-/// publishes one (tree, tree-less give-up, or the didClose sentinel) — so it
-/// is bounded by parse completion, not wall time. One constant so the two
-/// reader classes cannot drift apart.
+/// publishes one (tree, tree-less give-up, or the didClose sentinel) — the
+/// wait is normally RELEASED by that publish long before this wall-clock
+/// deadline; the deadline exists for the pathological case (a parse pipeline
+/// that never resolves), and an unusually slow first parse that outruns it
+/// degrades to the reader's empty fallback. One constant so the two reader
+/// classes cannot drift apart.
 pub(crate) const FIRST_PARSE_BACKSTOP: std::time::Duration = std::time::Duration::from_secs(15);
 
 /// Settle backstop for the serve-current token readers (`semanticTokens`
 /// full/delta): how long a token request may park waiting for the snapshot to
 /// catch up with the live text before rejecting with `ContentModified`.
 ///
-/// Like the first-parse backstop this is bounded by parse completion, not
-/// wall time — every edit's parse resolution publishes — so it only expires
-/// when the compute pool is pathologically saturated. Generous on purpose:
+/// Like the first-parse backstop this is a wall-clock deadline that is
+/// normally never reached: every edit's parse resolution publishes and
+/// releases the park, so it expires only when the parse pipeline is slow
+/// enough (saturation, a pathologically slow parse) that the snapshot cannot
+/// catch up within it. Generous on purpose:
 /// while the request parks, the client keeps drawing its previous tokens
 /// (shifted by the editor across edits), which is strictly better than
 /// receiving tokens computed for text it no longer has. On expiry the parse

--- a/src/lsp/lsp_impl/snapshot_read.rs
+++ b/src/lsp/lsp_impl/snapshot_read.rs
@@ -35,6 +35,19 @@ pub(crate) enum SnapshotWait {
 /// reader classes cannot drift apart.
 pub(crate) const FIRST_PARSE_BACKSTOP: std::time::Duration = std::time::Duration::from_secs(15);
 
+/// Settle backstop for the serve-current token readers (`semanticTokens`
+/// full/delta): how long a token request may park waiting for the snapshot to
+/// catch up with the live text before rejecting with `ContentModified`.
+///
+/// Like the first-parse backstop this is bounded by parse completion, not
+/// wall time — every edit's parse resolution publishes — so it only expires
+/// when the compute pool is pathologically saturated. Generous on purpose:
+/// while the request parks, the client keeps drawing its previous tokens
+/// (shifted by the editor across edits), which is strictly better than
+/// receiving tokens computed for text it no longer has. On expiry the parse
+/// loop's settle refresh re-drives the client once the snapshot lands.
+pub(crate) const TOKEN_SETTLE_BACKSTOP: std::time::Duration = std::time::Duration::from_secs(10);
+
 impl Kakehashi {
     /// Wait (bounded) until `uri`'s latest snapshot is current, re-resolving
     /// the cell per wakeup (per-request re-resolution + incarnation validation

--- a/src/lsp/lsp_impl/text_document/did_change.rs
+++ b/src/lsp/lsp_impl/text_document/did_change.rs
@@ -76,10 +76,9 @@ impl Kakehashi {
             self.bridge.apply_input_edits(&uri, &edit_infos)
         };
 
-        // Invalidate injection caches for regions overlapping with edits. Must run
-        // here (pre-edit invalidation) before the off-ingress reparse loop
-        // repopulates the injection map from the freshly parsed tree.
-        self.cache.invalidate_for_edits(&uri, &edits);
+        // No pre-edit injection-token-cache invalidation: the cache is
+        // content-addressed, so an edited region simply misses under its new
+        // content hash and the old entry is swept by the reparse's populate.
 
         // Apply the edit to the store and CLEAR the reader-visible tree
         // synchronously, here under the edit lock (per-document-parse-scheduler ADR).

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -37,15 +37,32 @@ use crate::lsp::current_upstream_id;
 
 use super::super::{Kakehashi, uri_to_url};
 
+/// Outcome of the serve-current snapshot resolution for the whole-document
+/// token handlers (see [`Kakehashi::current_snapshot_for_tokens`]).
+pub(crate) enum TokenSnapshot {
+    /// The snapshot is current (`parsed_version == content_version`) —
+    /// compute against it.
+    Current(std::sync::Arc<crate::document::snapshot::ParseSnapshot>),
+    /// Unregistered/closed URI, or the first parse never landed within its
+    /// backstop — the handlers' empty-tokens fallback applies.
+    Absent,
+    /// The snapshot still trailed the live text when the settle backstop
+    /// expired — reject with `ContentModified`; the parse loop's settle
+    /// refresh re-drives the client once the parse lands.
+    Stale,
+    /// The client cancelled the request while it was parked.
+    Cancelled,
+}
+
 impl Kakehashi {
-    /// Serve-stale snapshot resolution for the semantic-token handlers
-    /// (parse-snapshot ADR §3): returns the **latest completed** snapshot,
-    /// which may trail the input by however many edits the scheduler
-    /// coalesced — the parse loop's `semanticTokens/refresh` re-drives the
-    /// client once a fresher one lands. The only wait is the bounded
-    /// first-parse wait (no snapshot for this lifetime yet); no per-keystroke
-    /// read ever waits on a reparse. `None` for an unregistered/closed URI or
-    /// when no parse resolves within the wait.
+    /// Latest-completed snapshot resolution (parse-snapshot ADR §3): returns
+    /// the newest published snapshot, which may trail the input. The only
+    /// wait is the bounded first-parse wait (no snapshot for this lifetime
+    /// yet); no per-keystroke read ever waits on a reparse. Used by the
+    /// currency-*checking* readers (`semanticTokens/range` via
+    /// [`current_snapshot`](Self::current_snapshot)) that reject stale reads
+    /// themselves. `None` for an unregistered/closed URI or when no parse
+    /// resolves within the wait.
     pub(crate) async fn snapshot_for_tokens(
         &self,
         uri: &Url,
@@ -86,12 +103,54 @@ impl Kakehashi {
         }
     }
 
+    /// Serve-current snapshot resolution for `semanticTokens/full` and
+    /// `full/delta`: park (racing the client's `$/cancelRequest`) until the
+    /// latest snapshot is **current**, then compute against that.
+    ///
+    /// Why not serve the latest completed snapshot and let the parse loop's
+    /// refresh heal the client? Because the editor draws whatever we answer
+    /// against the text it has NOW: Neovim stamps the response with the
+    /// buffer version at request time and renders it as soon as that matches
+    /// the live buffer (`vim.lsp.semantic_tokens`: `process_response` /
+    /// `on_win`, extmarks placed with `strict = false`), so tokens computed
+    /// for older text land visibly misplaced on unchanged lines. While we
+    /// park instead, the editor keeps its previous tokens as extmarks that
+    /// shift with the edit — temporarily unhighlighted new text, never
+    /// corrupted existing text. The wait is bounded by parse completion
+    /// (every edit's parse publishes), not by typing: the settle backstop
+    /// only expires when the pipeline is pathologically behind.
+    pub(crate) async fn current_snapshot_for_tokens(
+        &self,
+        uri: &Url,
+        cancel_rx: Option<&mut crate::lsp::request_id::CancelReceiver>,
+    ) -> TokenSnapshot {
+        use crate::lsp::lsp_impl::snapshot_read::{SnapshotWait, TOKEN_SETTLE_BACKSTOP};
+        let wait = self.wait_for_current_snapshot(uri, TOKEN_SETTLE_BACKSTOP);
+        let outcome = match cancel_rx {
+            Some(rx) => {
+                tokio::select! {
+                    biased;
+                    // Fires on $/cancelRequest (and on forwarder teardown,
+                    // which the compute-race arms below treat as cancel too).
+                    _ = rx => return TokenSnapshot::Cancelled,
+                    outcome = wait => outcome,
+                }
+            }
+            None => wait.await,
+        };
+        match outcome {
+            SnapshotWait::Current(snapshot) => TokenSnapshot::Current(snapshot),
+            SnapshotWait::Stale => TokenSnapshot::Stale,
+            SnapshotWait::Unparsed | SnapshotWait::Gone => TokenSnapshot::Absent,
+        }
+    }
+
     pub(crate) async fn semantic_tokens_full_impl(
         &self,
         params: SemanticTokensParams,
     ) -> Result<Option<SemanticTokensResult>> {
         let upstream_id = current_upstream_id();
-        let (cancel_rx, _subscription_guard) = self.subscribe_cancel(upstream_id.as_ref());
+        let (mut cancel_rx, _subscription_guard) = self.subscribe_cancel(upstream_id.as_ref());
         let lsp_uri = params.text_document.uri;
 
         // Convert ls_types::Uri to url::Url for internal use
@@ -130,17 +189,39 @@ impl Kakehashi {
             return Ok(None);
         }
 
-        // Serve-stale (ADR §3): resolve the latest completed snapshot up front;
-        // its (text, tree, language) triple is internally consistent, and every
-        // input below (query, mappings) resolves against the snapshot's own
-        // detected language — never a live re-detection that could diverge
-        // from the tree's grammar.
-        let Some(snapshot) = self.snapshot_for_tokens(&uri).await else {
-            self.cache.finish_request(&uri, request_id);
-            return Ok(Some(SemanticTokensResult::Tokens(SemanticTokens {
-                result_id: None,
-                data: vec![],
-            })));
+        // Serve-current (ADR §3, revised): park until the snapshot matches the
+        // live text — see `current_snapshot_for_tokens` for why answering from
+        // a trailing snapshot corrupts the editor's existing highlights. The
+        // resolved snapshot's (text, tree, language) triple is internally
+        // consistent, and every input below (query, mappings) resolves against
+        // the snapshot's own detected language — never a live re-detection
+        // that could diverge from the tree's grammar.
+        let snapshot = match self
+            .current_snapshot_for_tokens(&uri, cancel_rx.as_mut())
+            .await
+        {
+            TokenSnapshot::Current(snapshot) => snapshot,
+            TokenSnapshot::Absent => {
+                self.cache.finish_request(&uri, request_id);
+                return Ok(Some(SemanticTokensResult::Tokens(SemanticTokens {
+                    result_id: None,
+                    data: vec![],
+                })));
+            }
+            TokenSnapshot::Stale => {
+                self.cache.finish_request(&uri, request_id);
+                return Err(crate::error::content_modified_error());
+            }
+            TokenSnapshot::Cancelled => {
+                cancel_token.cancel();
+                self.cache.finish_request(&uri, request_id);
+                log::debug!(
+                    target: "kakehashi::semantic",
+                    "[SEMANTIC_TOKENS] CANCELLED via $/cancelRequest uri={} req={} (while parked)",
+                    uri, request_id
+                );
+                return Err(Error::request_cancelled());
+            }
         };
         let (Some(language_name), Some(tree)) = (snapshot.language.clone(), snapshot.tree.clone())
         else {
@@ -209,15 +290,14 @@ impl Kakehashi {
         // Validity key for the snapshot's text under the generation captured at
         // the top: keys both the unchanged-document cache short-circuit below
         // and the store of the freshly computed tokens. Keying off the
-        // snapshot's own text (not the live text) is what makes serve-stale
-        // cache-safe — a stale compute stores under the stale text's hash,
-        // which a post-edit request never looks up.
+        // snapshot's own text hash means a compute racing a fresh edit stores
+        // under its own text's hash, which a post-edit request never looks up.
         let cache_key = self.cache.cache_key_for(&text, token_generation);
 
-        // Compute tokens against the snapshot (no live-text staleness gate:
-        // Stage 2 deliberately replaced reject-on-stale with serve-stale +
-        // refresh — the parse loop re-drives the client when a fresher
-        // snapshot lands).
+        // Compute tokens against the (current-at-resolution) snapshot. An edit
+        // landing after the resolution supersedes this request via the client's
+        // next didChange-driven request; the CancelToken then reclaims the
+        // compute mid-flight.
         let result = {
             // Snapshot-identical repeat request: tokens already cached for this
             // exact text are still correct, so skip re-tokenizing. Returns the
@@ -304,8 +384,9 @@ impl Kakehashi {
         // compute then bailed at a checkpoint and returned `None` (a partial
         // result), so drop the request rather than storing it over the cache.
         // This is CPU-reclamation, not staleness-rejection: an *un*-superseded
-        // compute over a snapshot the live text has since outrun still serves
-        // (§4's narrowed CancelToken role under serve-stale).
+        // compute over a snapshot the live text has since outrun still serves —
+        // the client's didChange-driven follow-up request supersedes and heals
+        // (§4's narrowed CancelToken role).
         if cancel_token.is_cancelled() {
             self.cache.finish_request(&uri, request_id);
             log::debug!(
@@ -371,7 +452,7 @@ impl Kakehashi {
         params: SemanticTokensDeltaParams,
     ) -> Result<Option<SemanticTokensFullDeltaResult>> {
         let upstream_id = current_upstream_id();
-        let (cancel_rx, _subscription_guard) = self.subscribe_cancel(upstream_id.as_ref());
+        let (mut cancel_rx, _subscription_guard) = self.subscribe_cancel(upstream_id.as_ref());
         let lsp_uri = params.text_document.uri;
         let previous_result_id = params.previous_result_id;
 
@@ -411,16 +492,38 @@ impl Kakehashi {
             return Ok(None);
         }
 
-        // Serve-stale (ADR §3): resolve the latest completed snapshot up front
-        // (same rationale as semanticTokens/full).
-        let Some(snapshot) = self.snapshot_for_tokens(&uri).await else {
-            self.cache.finish_request(&uri, request_id);
-            return Ok(Some(SemanticTokensFullDeltaResult::Tokens(
-                SemanticTokens {
-                    result_id: None,
-                    data: vec![],
-                },
-            )));
+        // Serve-current (ADR §3, revised): park until the snapshot matches the
+        // live text (same rationale as semanticTokens/full — this is the
+        // steady-state typing path where a stale answer corrupts the editor's
+        // existing highlights AND poisons the client's delta baseline).
+        let snapshot = match self
+            .current_snapshot_for_tokens(&uri, cancel_rx.as_mut())
+            .await
+        {
+            TokenSnapshot::Current(snapshot) => snapshot,
+            TokenSnapshot::Absent => {
+                self.cache.finish_request(&uri, request_id);
+                return Ok(Some(SemanticTokensFullDeltaResult::Tokens(
+                    SemanticTokens {
+                        result_id: None,
+                        data: vec![],
+                    },
+                )));
+            }
+            TokenSnapshot::Stale => {
+                self.cache.finish_request(&uri, request_id);
+                return Err(crate::error::content_modified_error());
+            }
+            TokenSnapshot::Cancelled => {
+                cancel_token.cancel();
+                self.cache.finish_request(&uri, request_id);
+                log::debug!(
+                    target: "kakehashi::semantic",
+                    "[SEMANTIC_TOKENS_DELTA] CANCELLED via $/cancelRequest uri={} req={} (while parked)",
+                    uri, request_id
+                );
+                return Err(Error::request_cancelled());
+            }
         };
         let (Some(language_name), Some(tree)) = (snapshot.language.clone(), snapshot.tree.clone())
         else {
@@ -488,11 +591,11 @@ impl Kakehashi {
 
         // Validity key for the snapshot's text under the generation captured at
         // the top (see semanticTokens/full for why snapshot-text keying makes
-        // serve-stale cache-safe).
+        // a compute racing a fresh edit cache-safe).
         let cache_key = self.cache.cache_key_for(&text, token_generation);
 
-        // Compute tokens against the snapshot (serve-stale; same as
-        // semanticTokens/full)
+        // Compute tokens against the (current-at-resolution) snapshot; same as
+        // semanticTokens/full.
         let result = {
             // Snapshot-identical repeat request: reuse the cached full tokens
             // instead of re-tokenizing.
@@ -587,7 +690,7 @@ impl Kakehashi {
         // compute then bailed at a checkpoint and returned `None` (partial), so
         // drop the request rather than diffing/storing it over the cache. This
         // is CPU-reclamation, not staleness-rejection (§4's narrowed CancelToken
-        // role under serve-stale).
+        // role).
         if cancel_token.is_cancelled() {
             self.cache.finish_request(&uri, request_id);
             log::debug!(
@@ -839,6 +942,198 @@ mod tests {
     use tokio::time::{Duration, sleep, timeout};
     use tower_lsp_server::LspService;
     use url::Url;
+
+    /// Publish a snapshot for `uri` built from `text` at `parsed_version`,
+    /// tree-less (no parser needed): the handlers' snapshot-resolution and
+    /// served-version bookkeeping are observable without tokenizing.
+    fn publish_treeless(server: &Kakehashi, uri: &Url, text: &str, parsed_version: u64) {
+        let incarnation = server
+            .documents
+            .latest_snapshot(uri)
+            .expect("document must be open")
+            .slot
+            .current_incarnation;
+        let landed = server
+            .documents
+            .get(uri)
+            .map(|doc| {
+                doc.publish_snapshot(std::sync::Arc::new(
+                    crate::document::snapshot::ParseSnapshot {
+                        text: std::sync::Arc::from(text),
+                        tree: None,
+                        language: Some("rust".to_string()),
+                        parsed_version,
+                        incarnation,
+                        injection_regions: None,
+                        bridge_regions: None,
+                        resolved_regions: None,
+                        layer_trees: std::sync::OnceLock::new(),
+                    },
+                ))
+            })
+            .unwrap_or(false);
+        assert!(landed, "test snapshot must land");
+    }
+
+    fn full_params(uri: &Url) -> SemanticTokensParams {
+        SemanticTokensParams {
+            text_document: TextDocumentIdentifier {
+                uri: crate::lsp::lsp_impl::url_to_uri(uri).expect("test URI should convert"),
+            },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        }
+    }
+
+    /// Serve-current (the Neovim client contract): a full request arriving
+    /// while the latest snapshot trails the live text must NOT serve the
+    /// stale snapshot — it parks until the current one publishes and serves
+    /// that. Pinned via the served-version mark: the old serve-stale model
+    /// recorded the trailing `parsed_version` immediately.
+    #[tokio::test(start_paused = true)]
+    async fn semantic_tokens_full_parks_until_current_snapshot() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let service = std::sync::Arc::new(service);
+        let uri = Url::parse("file:///serve_current.rs").expect("valid test uri");
+
+        service.inner().documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        publish_treeless(service.inner(), &uri, "fn main() {}", 0);
+        // An edit bumps content_version past the published parse: the v0
+        // snapshot is now stale.
+        service
+            .inner()
+            .documents
+            .update_document(uri.clone(), "fn main() { }".to_string(), None);
+
+        let request = {
+            let service = std::sync::Arc::clone(&service);
+            let uri = uri.clone();
+            tokio::spawn(async move {
+                service
+                    .inner()
+                    .semantic_tokens_full_impl(full_params(&uri))
+                    .await
+            })
+        };
+        // Let the handler reach its snapshot wait, then publish the current
+        // parse (well inside the settle backstop).
+        sleep(Duration::from_millis(50)).await;
+        assert!(
+            service
+                .inner()
+                .cache
+                .served_semantic_version(&uri)
+                .is_none(),
+            "the handler must not have served the stale v0 snapshot"
+        );
+        publish_treeless(service.inner(), &uri, "fn main() { }", 1);
+
+        let result = request.await.expect("handler task must not panic");
+        assert!(result.is_ok(), "current-snapshot serve must succeed");
+        assert_eq!(
+            service.inner().cache.served_semantic_version(&uri),
+            Some(1),
+            "the response must be computed from the CURRENT snapshot"
+        );
+    }
+
+    /// When no parse catches up within the settle backstop, the handler must
+    /// reject with ContentModified (the parse loop's settle refresh re-drives
+    /// the client later) — never answer with tokens for text the client no
+    /// longer has.
+    #[tokio::test(start_paused = true)]
+    async fn semantic_tokens_full_rejects_content_modified_when_parse_never_catches_up() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let uri = Url::parse("file:///serve_current_timeout.rs").expect("valid test uri");
+
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        publish_treeless(server, &uri, "fn main() {}", 0);
+        server
+            .documents
+            .update_document(uri.clone(), "fn main() { }".to_string(), None);
+
+        let result = server.semantic_tokens_full_impl(full_params(&uri)).await;
+        let err = result.expect_err("a snapshot that never catches up must reject");
+        assert_eq!(
+            err.code,
+            crate::error::content_modified_error().code,
+            "staleness past the settle backstop signals ContentModified"
+        );
+        assert!(
+            server.cache.served_semantic_version(&uri).is_none(),
+            "a rejected request must not record a served version"
+        );
+    }
+
+    /// The delta path shares the serve-current wait: a delta against a
+    /// trailing snapshot parks and answers from the current one.
+    #[tokio::test(start_paused = true)]
+    async fn semantic_tokens_delta_parks_until_current_snapshot() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let service = std::sync::Arc::new(service);
+        let uri = Url::parse("file:///serve_current_delta.rs").expect("valid test uri");
+
+        service.inner().documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        publish_treeless(service.inner(), &uri, "fn main() {}", 0);
+        service
+            .inner()
+            .documents
+            .update_document(uri.clone(), "fn main() { }".to_string(), None);
+
+        let request = {
+            let service = std::sync::Arc::clone(&service);
+            let uri = uri.clone();
+            tokio::spawn(async move {
+                let params = SemanticTokensDeltaParams {
+                    text_document: TextDocumentIdentifier {
+                        uri: crate::lsp::lsp_impl::url_to_uri(&uri)
+                            .expect("test URI should convert"),
+                    },
+                    previous_result_id: "1".to_string(),
+                    work_done_progress_params: WorkDoneProgressParams::default(),
+                    partial_result_params: PartialResultParams::default(),
+                };
+                service
+                    .inner()
+                    .semantic_tokens_full_delta_impl(params)
+                    .await
+            })
+        };
+        sleep(Duration::from_millis(50)).await;
+        assert!(
+            service
+                .inner()
+                .cache
+                .served_semantic_version(&uri)
+                .is_none(),
+            "the delta handler must not have served the stale v0 snapshot"
+        );
+        publish_treeless(service.inner(), &uri, "fn main() { }", 1);
+
+        let result = request.await.expect("handler task must not panic");
+        assert!(result.is_ok(), "current-snapshot delta serve must succeed");
+        assert_eq!(
+            service.inner().cache.served_semantic_version(&uri),
+            Some(1),
+            "the delta must be computed from the CURRENT snapshot"
+        );
+    }
 
     #[tokio::test]
     async fn semantic_tokens_delta_does_not_overwrite_newer_text() {

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -1042,6 +1042,67 @@ mod tests {
         );
     }
 
+    /// A `$/cancelRequest` arriving while the handler is parked on a trailing
+    /// snapshot must answer RequestCancelled promptly (the
+    /// `TokenSnapshot::Cancelled` arm) — not sit out the settle backstop.
+    #[tokio::test(start_paused = true)]
+    async fn semantic_tokens_full_cancel_while_parked_answers_request_cancelled() {
+        use tower_lsp_server::jsonrpc::Id;
+
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let service = std::sync::Arc::new(service);
+        let uri = Url::parse("file:///serve_current_cancel.rs").expect("valid test uri");
+
+        service.inner().documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        // No snapshot for the live content version → the handler parks.
+        service
+            .inner()
+            .documents
+            .update_document(uri.clone(), "fn main() { }".to_string(), None);
+
+        let request = {
+            let service = std::sync::Arc::clone(&service);
+            let uri = uri.clone();
+            // The upstream request id rides task-local storage (installed by
+            // the RequestIdCapture middleware in production).
+            tokio::spawn(crate::lsp::request_id::CURRENT_REQUEST_ID.scope(
+                Some(Id::Number(42)),
+                async move {
+                    service
+                        .inner()
+                        .semantic_tokens_full_impl(full_params(&uri))
+                        .await
+                },
+            ))
+        };
+        sleep(Duration::from_millis(50)).await;
+        assert!(
+            !request.is_finished(),
+            "the handler must be parked awaiting the current snapshot"
+        );
+
+        service
+            .inner()
+            .bridge
+            .cancel_forwarder()
+            .forward_cancel(crate::lsp::bridge::UpstreamId::Number(42))
+            .await
+            .expect("cancel forward must not error");
+
+        let result = request.await.expect("handler task must not panic");
+        let err = result.expect_err("a cancelled parked request must error, not answer");
+        assert_eq!(
+            err.code,
+            Error::request_cancelled().code,
+            "the parked handler must answer RequestCancelled on $/cancelRequest"
+        );
+    }
+
     /// When no parse catches up within the settle backstop, the handler must
     /// reject with ContentModified (the parse loop's settle refresh re-drives
     /// the client later) — never answer with tokens for text the client no

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -59,9 +59,9 @@ impl Kakehashi {
     /// the newest published snapshot, which may trail the input. The only
     /// wait is the bounded first-parse wait (no snapshot for this lifetime
     /// yet); no per-keystroke read ever waits on a reparse. Used by the
-    /// currency-*checking* readers (`semanticTokens/range` via
-    /// [`current_snapshot`](Self::current_snapshot)) that reject stale reads
-    /// themselves. `None` for an unregistered/closed URI or when no parse
+    /// currency-*checking* readers (`semanticTokens/range`, which resolves
+    /// through this and then staleness-rejects inline against the live
+    /// version). `None` for an unregistered/closed URI or when no parse
     /// resolves within the wait.
     pub(crate) async fn snapshot_for_tokens(
         &self,
@@ -209,6 +209,13 @@ impl Kakehashi {
                 })));
             }
             TokenSnapshot::Stale => {
+                // Register token interest (version 0, monotonic max — a real
+                // serve overwrites) so the settle-refresh gate re-drives this
+                // client even when EVERY request so far rejected: without a
+                // served mark the gate reads "nobody highlights this
+                // document" and the client would stay dark until its next
+                // didChange-driven request.
+                self.cache.record_served_semantic_version(&uri, 0);
                 self.cache.finish_request(&uri, request_id);
                 return Err(crate::error::content_modified_error());
             }
@@ -511,6 +518,13 @@ impl Kakehashi {
                 )));
             }
             TokenSnapshot::Stale => {
+                // Register token interest (version 0, monotonic max — a real
+                // serve overwrites) so the settle-refresh gate re-drives this
+                // client even when EVERY request so far rejected: without a
+                // served mark the gate reads "nobody highlights this
+                // document" and the client would stay dark until its next
+                // didChange-driven request.
+                self.cache.record_served_semantic_version(&uri, 0);
                 self.cache.finish_request(&uri, request_id);
                 return Err(crate::error::content_modified_error());
             }
@@ -839,9 +853,10 @@ impl Kakehashi {
         };
         // Staleness-reject: the request's `range` is authored against the
         // LIVE text, so a trailing (or cross-incarnation) snapshot cannot
-        // answer it — unlike full/delta (whole-document, serve-stale). A
-        // stale snapshot → ContentModified; the client's next natural request
-        // (this is a per-redraw viewport read) gets the fresh one.
+        // answer it — unlike full/delta (whole-document, which PARK for the
+        // current snapshot instead). A stale snapshot → ContentModified; the
+        // client's next natural request (this is a per-redraw viewport read)
+        // gets the fresh one.
         let Some(view) = self.documents.latest_snapshot(&uri) else {
             return Ok(Some(SemanticTokensRangeResult::Tokens(SemanticTokens {
                 result_id: None,
@@ -1131,9 +1146,12 @@ mod tests {
             crate::error::content_modified_error().code,
             "staleness past the settle backstop signals ContentModified"
         );
-        assert!(
-            server.cache.served_semantic_version(&uri).is_none(),
-            "a rejected request must not record a served version"
+        assert_eq!(
+            server.cache.served_semantic_version(&uri),
+            Some(0),
+            "a rejected request must register token interest (version 0, \
+             never the stale snapshot's version) so the settle-refresh gate \
+             re-drives a client whose every request rejected"
         );
     }
 
@@ -1259,7 +1277,8 @@ mod tests {
         );
     }
 
-    /// The serve-stale model never parses on demand: a request against a
+    /// Snapshot readers never parse on demand (ADR §3 — the property survived
+    /// the serve-stale → serve-current revision): a request against a
     /// resolved-but-tree-less snapshot (what `parse_document` publishes when
     /// no parser is available) releases the first-parse wait immediately,
     /// serves the empty fallback, and leaves the document's tree untouched.
@@ -1334,7 +1353,7 @@ mod tests {
         let doc = server.documents.get(&uri).expect("document still open");
         assert!(
             doc.tree().is_none(),
-            "serve-stale never parses inline: the tree must stay absent"
+            "snapshot readers never parse inline: the tree must stay absent"
         );
     }
 

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -52,6 +52,14 @@ pub(crate) enum TokenSnapshot {
     Stale,
     /// The client cancelled the request while it was parked.
     Cancelled,
+    /// A newer request for the same document superseded this one while it was
+    /// parked (`SemanticRequestTracker` flipped its token). Answer `Ok(None)`
+    /// — the same contract as a compute superseded mid-flight — instead of
+    /// riding out the park: on a client that supersedes without sending
+    /// `$/cancelRequest`, obsolete parked requests would otherwise hold
+    /// ingress admission slots until the parse settles or the backstop
+    /// expires.
+    Superseded,
 }
 
 impl Kakehashi {
@@ -123,6 +131,7 @@ impl Kakehashi {
         &self,
         uri: &Url,
         cancel_rx: Option<&mut crate::lsp::request_id::CancelReceiver>,
+        supersede: &crate::cancel::CancelToken,
     ) -> TokenSnapshot {
         use crate::lsp::lsp_impl::snapshot_read::{SnapshotWait, TOKEN_SETTLE_BACKSTOP};
         let wait = self.wait_for_current_snapshot(uri, TOKEN_SETTLE_BACKSTOP);
@@ -133,10 +142,20 @@ impl Kakehashi {
                     // Fires on $/cancelRequest (and on forwarder teardown,
                     // which the compute-race arms below treat as cancel too).
                     _ = rx => return TokenSnapshot::Cancelled,
+                    // Fires when a newer request for this document flips this
+                    // request's tracker token — release the park (and its
+                    // admission slot) instead of computing a discarded result.
+                    _ = supersede.cancelled() => return TokenSnapshot::Superseded,
                     outcome = wait => outcome,
                 }
             }
-            None => wait.await,
+            None => {
+                tokio::select! {
+                    biased;
+                    _ = supersede.cancelled() => return TokenSnapshot::Superseded,
+                    outcome = wait => outcome,
+                }
+            }
         };
         match outcome {
             SnapshotWait::Current(snapshot) => TokenSnapshot::Current(snapshot),
@@ -197,7 +216,7 @@ impl Kakehashi {
         // the snapshot's own detected language — never a live re-detection
         // that could diverge from the tree's grammar.
         let snapshot = match self
-            .current_snapshot_for_tokens(&uri, cancel_rx.as_mut())
+            .current_snapshot_for_tokens(&uri, cancel_rx.as_mut(), &cancel_token)
             .await
         {
             TokenSnapshot::Current(snapshot) => snapshot,
@@ -228,6 +247,17 @@ impl Kakehashi {
                     uri, request_id
                 );
                 return Err(Error::request_cancelled());
+            }
+            TokenSnapshot::Superseded => {
+                // Same contract as a compute superseded mid-flight (below):
+                // the newer request answers; this one drops out quietly.
+                self.cache.finish_request(&uri, request_id);
+                log::debug!(
+                    target: "kakehashi::semantic",
+                    "[SEMANTIC_TOKENS] CANCELLED uri={} req={} (superseded while parked)",
+                    uri, request_id
+                );
+                return Ok(None);
             }
         };
         let (Some(language_name), Some(tree)) = (snapshot.language.clone(), snapshot.tree.clone())
@@ -504,7 +534,7 @@ impl Kakehashi {
         // steady-state typing path where a stale answer corrupts the editor's
         // existing highlights AND poisons the client's delta baseline).
         let snapshot = match self
-            .current_snapshot_for_tokens(&uri, cancel_rx.as_mut())
+            .current_snapshot_for_tokens(&uri, cancel_rx.as_mut(), &cancel_token)
             .await
         {
             TokenSnapshot::Current(snapshot) => snapshot,
@@ -537,6 +567,17 @@ impl Kakehashi {
                     uri, request_id
                 );
                 return Err(Error::request_cancelled());
+            }
+            TokenSnapshot::Superseded => {
+                // Same contract as a compute superseded mid-flight: the newer
+                // request answers; this one drops out quietly.
+                self.cache.finish_request(&uri, request_id);
+                log::debug!(
+                    target: "kakehashi::semantic",
+                    "[SEMANTIC_TOKENS_DELTA] CANCELLED uri={} req={} (superseded while parked)",
+                    uri, request_id
+                );
+                return Ok(None);
             }
         };
         let (Some(language_name), Some(tree)) = (snapshot.language.clone(), snapshot.tree.clone())
@@ -1054,6 +1095,63 @@ mod tests {
             service.inner().cache.served_semantic_version(&uri),
             Some(1),
             "the response must be computed from the CURRENT snapshot"
+        );
+    }
+
+    /// A parked request superseded by a newer request for the same document
+    /// (the tracker flips its token — no `$/cancelRequest` involved) must
+    /// release promptly with the compute-superseded contract `Ok(None)`, not
+    /// hold its ingress admission slot until the parse settles or the
+    /// backstop expires.
+    #[tokio::test(start_paused = true)]
+    async fn semantic_tokens_full_superseded_while_parked_releases_with_none() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let service = std::sync::Arc::new(service);
+        let uri = Url::parse("file:///serve_current_supersede.rs").expect("valid test uri");
+
+        service.inner().documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        // No snapshot for the live content version → the handler parks.
+        service
+            .inner()
+            .documents
+            .update_document(uri.clone(), "fn main() { }".to_string(), None);
+
+        let request = {
+            let service = std::sync::Arc::clone(&service);
+            let uri = uri.clone();
+            tokio::spawn(async move {
+                service
+                    .inner()
+                    .semantic_tokens_full_impl(full_params(&uri))
+                    .await
+            })
+        };
+        sleep(Duration::from_millis(50)).await;
+        assert!(
+            !request.is_finished(),
+            "the handler must be parked awaiting the current snapshot"
+        );
+
+        // A newer request for the same URI supersedes the parked one.
+        let woke_at = tokio::time::Instant::now();
+        let _newer = service.inner().cache.start_request(&uri);
+
+        let result = request
+            .await
+            .expect("handler task must not panic")
+            .expect("a superseded parked request answers, not errors");
+        assert!(
+            result.is_none(),
+            "superseded-while-parked follows the compute-superseded contract (None)"
+        );
+        assert!(
+            woke_at.elapsed() < crate::lsp::lsp_impl::snapshot_read::TOKEN_SETTLE_BACKSTOP,
+            "the park must release on supersession, not ride out the backstop"
         );
     }
 


### PR DESCRIPTION
Stacked on #555. Fixes the highlight corruption and multi-second edit→highlight convergence captured in two live sessions (01KWS72W…, 01KWSECM…), plus a downstream-orphan leak found along the way. Seven commits, each gate + full-e2e green.

## Root causes (from the captures + Neovim client source)

1. **Serve-stale corrupted drawn highlights.** `vim.lsp.semantic_tokens` stamps a full/delta response with the buffer version *at request time* and draws it as soon as that matches the live buffer (`process_response`/`on_win`, extmarks with `strict = false`), so tokens computed for older text render misplaced on unchanged lines. Staying silent is strictly better: nvim keeps its previous extmarks, which shift naturally with edits.
2. **A 4-message admission cap starved everything.** tower-lsp-server's `buffer_unordered` defaults to 4 in-flight messages of any kind; ~10 concurrent requests per keystroke meant the very `didChange`/`$/cancelRequest` notifications that would release parked readers queued behind them (measured 15s handler-start delay).
3. **Captures serve-stale was a doomed-walk generator.** Every walk of a trailing snapshot completed its full compute, was voided by the lineage still-current gate, answered `null`, and the client re-request walked the next trailing snapshot — 41 walks in ~15s, one (snapshot, kind) walked 4× concurrently, the semantic delta queued ~10s behind the backlog.
4. **Orphaned downstream servers.** kakehashi had no signal handler; an editor SIGTERM mid-shutdown orphaned children to launchd (observed: an `emmylua_ls` wrapper running for hours; emmylua does not exit on stdin EOF).

## Changes

- `perf(server)`: `concurrency_level(64)` — ordering stays with IngressOrderGate, CPU with the bounded ComputePool.
- `fix(semantic)`: semanticTokens full/delta **serve-current** — park (racing `$/cancelRequest`) until `parsed_version == content_version`; settle backstop → `ContentModified` + the existing settled+stale refresh gate. Refresh storms disappear in steady state. ADR §3 revised; 3 new lib tests.
- `perf(captures)`: client-cancel wiring (pool dequeue hook + per-layer checkpoints) + per-walk phase instrumentation.
- `perf(captures)`: Arc'd match arrays (memo + lineage share; was 2 deep clones of ~20k Values/4.5MB per request); per-region resolver logs debug→trace (~2,100/keystroke).
- `fix(captures)`: **serve-current + single-flight** — captures full/delta park like semanticTokens (killing the null busy-loop of guaranteed-dead compute), and concurrent identical walks share one execution via a Notify-based single-flight with enable-then-revalidate wakeup. ADR §3 records why the original anti-busy-spin argument inverted.
- `fix(lifecycle)`: SIGTERM/SIGHUP handler reaps the downstream pool via the same bounded `shutdown_all` (LSP handshake → SIGTERM → SIGKILL escalation), exits 128+signum. Verified live (exit 143 + reap log).
- `perf(semantic)`: **content-addressed injection token cache** — implements the ADR §3 companion decision: key `(uri, content ⊕ resolved-language)`, spatial invalidation deleted (self-invalidating by construction; unrelated edits can't touch entries), eviction = per-populate live-hash sweep inside the mint-epoch commit. Duplicate fences share entries; undo is a hit; no read path touches the tracker — the identity decoupling the §3 mint split needs. Net −68 lines.

## Measurements (release, 38KB/5,079-line example.md)

- **Storm replay** (async flood mirroring the captures: 5 keystrokes, each didChange + semantic delta cancel/reissue + 4 captures deltas + a captures full): final semantic delta answers **182ms** after the last keystroke vs **1,423ms** on the base branch (7.8×); all 21 flooded requests drain in 1.2s vs 2.0s. The real editor sessions (debug logging, more request types) showed 12.5s before this branch.
- Sequential typing: edit → current-text tokens ≈50ms/cycle; tokens + captures full+delta cycle 745 → 609ms. Instrumentation: layer build ≈35ms, walk ≈110ms; the cycle's bulk is the protocol-inherent 4.5MB `captures/full` serialization, which real clients avoid via deltas.

## PR #555 "Not in this PR" status

- Whole-document/bridge readers reusing populate's resolutions: **done upstream** (bot rounds).
- `(uri, content_hash)` token-cache re-key: **done here** (last commit).
- §3 tracker-mint reconciliation split: the stale-pass-never-mints substance already landed upstream (epoch-gated commit + purge); the remaining relocate-mint-into-reconciliation refactor is deliberately left for its own PR — no measured perf payoff, high blast radius on bridge identity.

## Evaluated and deferred (measurement-driven)

- nvim-LanguageTree-style incremental layer-tree reuse (`tree.edit` propagation): layer build is only ≈35ms/keystroke — below noise.
- Cross-snapshot captures **match** caching: matches embed tracker ULIDs — unsound without the §3 identity work.
- nvim-`on_win`-style viewport windowing for captures: a kakehashi.nvim (client) change — `captures/range` already exists server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review-pipeline commits (rounds after the original 7)

`/review` (10-perspective + fact-check, 2 rounds) and Codex (2 rounds) each converged; every actionable finding fixed in its own commit:

- `0579c4d5` combined-group docs: partial discovery (`complete: false`) keeps the token-cache live-hash sweep symmetric with the inline store gate (was: every populate wiped the doc's live entries).
- `b381a487` signal path persists the `parsing_in_progress` crash marker (graceful-path parity) and honors a second SIGTERM/SIGHUP during the bounded reap.
- `e30377ea` injection token cache nested per document — the eviction sweep touches only the swept document (was: `DashMap::retain` across every shard per parse commit); read path drops a per-lookup `Url` clone.
- `7df94eea` `InjectionMap` stores a plain `Vec` (readers are test-only) — no more per-populate interval-tree build; `rust-lapper` dependency removed.
- `cd52da86` negative walk memo: a completed null walk (no kind file) is memoized, so single-flight losers and client null-retries stop re-running identical doomed walks sequentially.
- `fedfe7d2` + `79b55052` tests: single-flight loser-serves-winner-memo (sentinel), cancel-while-parked (captures + tokens, real task-local id + CancelForwarder wiring), `region_validity_hash` properties, index-aligned pairing discriminator.
- `2b99d872` settle refresh now reaches never-served documents (Stale arms register a version-0 interest mark) + ADR/comment drift batch (INGRESS_CONCURRENCY const with honest derivation, backstop docs, accepted-tradeoff notes).
- `231cdc3e` (Codex) parked token requests release on supersession: `CancelToken` now backed by `tokio_util::sync::CancellationToken`, park races `cancelled()`, superseded park answers `Ok(None)` like a superseded compute.
- `5be3ac2d` (Codex) `captures/range` keeps the immediate staleness-reject (zero stale wait) — the parked settle wait is full/delta policy only.
