### PR TITLE
perf(captures): cross-snapshot content-addressed match cache

### DIFF
--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -248,6 +248,13 @@ pub struct Kakehashi {
     #[allow(clippy::type_complexity)]
     captures_walk_inflight:
         dashmap::DashMap<(Url, String, bool), std::sync::Arc<tokio::sync::Notify>>,
+    /// Cross-snapshot, content-addressed cache of per-layer captures query
+    /// matches: a layer whose content merely SHIFTED between snapshots (the
+    /// per-keystroke common case — an edit above a fence) reuses its cached
+    /// ID-free match data instead of re-executing the kind query. `Arc`'d
+    /// because the compute-pool walk runs off `self`. Swept per completed
+    /// walk, dropped on `didClose`; see `captures_match_cache` module docs.
+    captures_match_cache: std::sync::Arc<kakehashi::captures_match_cache::CapturesMatchCache>,
     /// True when the process runs as a one-shot CLI (`kakehashi diagnose`/`format`)
     /// rather than a long-lived LSP server. Set once by `cli_initialize`. No editor
     /// consumes a proactive `publishDiagnostics` in CLI mode (the stub client pump
@@ -332,6 +339,9 @@ impl Kakehashi {
             captures_cache: dashmap::DashMap::new(),
             captures_walk_cache: dashmap::DashMap::new(),
             captures_walk_inflight: dashmap::DashMap::new(),
+            captures_match_cache: std::sync::Arc::new(
+                kakehashi::captures_match_cache::CapturesMatchCache::new(),
+            ),
             cli_mode: std::sync::atomic::AtomicBool::new(false),
             parse_scheduler: std::sync::Arc::new(parse_scheduler::ParseScheduler::default()),
         }

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -253,7 +253,8 @@ pub struct Kakehashi {
     /// per-keystroke common case — an edit above a fence) reuses its cached
     /// ID-free match data instead of re-executing the kind query. `Arc`'d
     /// because the compute-pool walk runs off `self`. Swept per completed
-    /// walk, dropped on `didClose`; see `captures_match_cache` module docs.
+    /// current-at-entry full walk, dropped on `didClose`; see the
+    /// `captures_match_cache` module docs.
     captures_match_cache: std::sync::Arc<kakehashi::captures_match_cache::CapturesMatchCache>,
     /// True when the process runs as a one-shot CLI (`kakehashi diagnose`/`format`)
     /// rather than a long-lived LSP server. Set once by `cli_initialize`. No editor

--- a/src/lsp/lsp_impl/kakehashi.rs
+++ b/src/lsp/lsp_impl/kakehashi.rs
@@ -1,3 +1,4 @@
 pub(in crate::lsp::lsp_impl) mod captures;
+pub(in crate::lsp::lsp_impl) mod captures_match_cache;
 mod internal;
 pub(crate) mod node;

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -1935,22 +1935,35 @@ mod tests {
     /// ranges restricted to `[start, end)` — the shape `SnapshotLayerTree`
     /// carries for a real fence.
     fn rust_layer(text: &str, start: usize, end: usize) -> crate::document::SnapshotLayerTree {
-        let line = text[..start].matches('\n').count();
-        let col = start - text[..start].rfind('\n').map_or(0, |i| i + 1);
-        let end_line = text[..end].matches('\n').count();
-        let end_col = end - text[..end].rfind('\n').map_or(0, |i| i + 1);
+        rust_layer_ranges(text, &[(start, end)])
+    }
+
+    /// Multi-range variant of [`rust_layer`] — the blockquote-gap shape,
+    /// where a layer's included ranges are disjoint spans of the host text.
+    fn rust_layer_ranges(
+        text: &str,
+        ranges: &[(usize, usize)],
+    ) -> crate::document::SnapshotLayerTree {
+        let point_at = |byte: usize| {
+            let line = text[..byte].matches('\n').count();
+            let col = byte - text[..byte].rfind('\n').map_or(0, |i| i + 1);
+            tree_sitter::Point::new(line, col)
+        };
+        let ts_ranges: Vec<tree_sitter::Range> = ranges
+            .iter()
+            .map(|&(start, end)| tree_sitter::Range {
+                start_byte: start,
+                end_byte: end,
+                start_point: point_at(start),
+                end_point: point_at(end),
+            })
+            .collect();
+        let (start, end) = (ranges[0].0, ranges[ranges.len() - 1].1);
         let mut parser = tree_sitter::Parser::new();
         parser
             .set_language(&tree_sitter_rust::LANGUAGE.into())
             .unwrap();
-        parser
-            .set_included_ranges(&[tree_sitter::Range {
-                start_byte: start,
-                end_byte: end,
-                start_point: tree_sitter::Point::new(line, col),
-                end_point: tree_sitter::Point::new(end_line, end_col),
-            }])
-            .unwrap();
+        parser.set_included_ranges(&ts_ranges).unwrap();
         crate::document::SnapshotLayerTree {
             language: "rust".to_string(),
             tree: parser.parse(text, None).unwrap(),
@@ -2010,6 +2023,19 @@ mod tests {
             parsed_version: u64,
             lsp_range: Option<Range>,
         ) -> Option<(Vec<Value>, Vec<Value>)> {
+            self.walk_with(text, layers, parsed_version, lsp_range, true, None)
+        }
+
+        #[allow(clippy::too_many_arguments)]
+        fn walk_with(
+            &self,
+            text: &str,
+            layers: &[crate::document::SnapshotLayerTree],
+            parsed_version: u64,
+            lsp_range: Option<Range>,
+            injection: bool,
+            cancel: Option<&crate::cancel::CancelToken>,
+        ) -> Option<(Vec<Value>, Vec<Value>)> {
             let mut parser = tree_sitter::Parser::new();
             parser
                 .set_language(&tree_sitter_rust::LANGUAGE.into())
@@ -2025,11 +2051,11 @@ mod tests {
                 &self.uri,
                 "locals",
                 lsp_range,
-                true,
+                injection,
                 "rust",
                 text,
                 &tree,
-                Some(layers),
+                injection.then_some(layers),
                 &self.coordinator,
                 &self.tracker,
                 &self.store,
@@ -2037,7 +2063,7 @@ mod tests {
                 incarnation,
                 0,
                 &self.match_cache,
-                None,
+                cancel,
             )
         }
     }
@@ -2131,7 +2157,9 @@ mod tests {
     /// Correctness of the reuse: a walk served from the (translated) cache
     /// must be byte-identical on the wire to a walk computed fresh — same
     /// positions, same node ids (`get_or_create` on the same tracker), same
-    /// metadata.
+    /// metadata. On the caching axis this test alone would pass vacuously
+    /// (no hit → cached == fresh trivially); the sentinel test above proves
+    /// hits actually occur for this exact fixture shape.
     #[test]
     fn cached_and_fresh_walks_agree_on_the_wire() {
         let code = "let a = 1;\n";
@@ -2199,6 +2227,221 @@ mod tests {
                     .get_host(&rig.uri, "locals", host_hash, 0)
                     .is_none(),
             "a range walk must not populate the match cache"
+        );
+    }
+
+    /// The read half of the range-walk gate: even when full-key entries
+    /// exist, a range walk must not serve them (its results are clipped to
+    /// the viewport, and a full-layer cache entry is not).
+    #[test]
+    fn range_walks_do_not_serve_cached_entries() {
+        let text = "let a = 1;\n";
+        let rig = MatchCacheRig::new("file:///match_cache_range_read.rs", text);
+        let layer = rust_layer(text, 0, text.len());
+        let (_, layer_hash) =
+            super::super::captures_match_cache::tree_cache_key("locals", "rust", &layer.tree, text);
+        rig.match_cache.store_layer(
+            &rig.uri,
+            "locals",
+            layer_hash,
+            0,
+            std::sync::Arc::new(vec![crate::language::query_exec::MatchData {
+                pattern_index: 0,
+                captures: vec![crate::language::query_exec::CapturedNode {
+                    name: "sentinel-must-not-serve".to_string(),
+                    start_byte: 0,
+                    end_byte: 3,
+                    kind: "identifier",
+                    metadata: Vec::new(),
+                }],
+                metadata: Vec::new(),
+            }]),
+            || true,
+        );
+
+        let (matches, _) = rig
+            .walk(
+                text,
+                &[layer],
+                0,
+                Some(Range::new(
+                    tower_lsp_server::ls_types::Position::new(0, 0),
+                    tower_lsp_server::ls_types::Position::new(0, 11),
+                )),
+            )
+            .expect("kind query should load");
+        assert!(
+            !capture_names(&matches)
+                .iter()
+                .any(|n| n == "sentinel-must-not-serve"),
+            "a range walk must compute fresh, not serve full-walk entries"
+        );
+    }
+
+    /// A capture in a LATER included range of a multi-range (blockquote-gap
+    /// shaped) layer: rebase is relative to the FIRST range's start, so this
+    /// is where an anchor off-by-one would hide. After a vertical shift the
+    /// hit must place the later-range capture at its exact new position,
+    /// byte-identical to a fresh compute.
+    #[test]
+    fn multi_range_layer_hit_reanchors_later_range_captures_exactly() {
+        let (part_a, gap, part_b) = ("let a = 1;\n", "// gap\n", "let b = 2;\n");
+        let make = |pad: &str| {
+            let text = format!("{pad}{part_a}{gap}{part_b}");
+            let a_start = text.find(part_a).unwrap();
+            let b_start = text.find(part_b).unwrap();
+            let ranges = [
+                (a_start, a_start + part_a.len()),
+                (b_start, b_start + part_b.len()),
+            ];
+            let layer = rust_layer_ranges(&text, &ranges);
+            (text, layer)
+        };
+
+        let (text_v1, layer_v1) = make("AAAA\n");
+        let rig = MatchCacheRig::new("file:///match_cache_multirange.rs", &text_v1);
+        rig.walk(&text_v1, &[layer_v1], 0, None)
+            .expect("kind query should load");
+
+        // Shift down by one line: both ranges translate, geometry unchanged.
+        let (text_v2, layer_v2) = make("AAAA\nBBBB\n");
+        rig.store
+            .update_document(rig.uri.clone(), text_v2.clone(), None);
+        let (_, hash_v2) = super::super::captures_match_cache::tree_cache_key(
+            "locals",
+            "rust",
+            &layer_v2.tree,
+            &text_v2,
+        );
+        assert!(
+            rig.match_cache.get_layer(&rig.uri, hash_v2, 0).is_some(),
+            "the translated multi-range layer must hit the v1 store"
+        );
+
+        let (cached, _) = rig
+            .walk(&text_v2, &[layer_v2], 1, None)
+            .expect("kind query should load");
+        // The later-range capture (`b`) must sit at its exact v2 position.
+        let b_line = text_v2[..text_v2.find(part_b).unwrap()]
+            .matches('\n')
+            .count() as u64;
+        let b = cached
+            .iter()
+            .flat_map(|m| m["captures"].as_array().unwrap())
+            .find(|c| {
+                c["range"]["start"]["line"] == b_line && c["range"]["start"]["character"] == 4
+            });
+        assert!(
+            b.is_some(),
+            "later-range capture must reanchor to line {b_line} col 4: {cached:?}"
+        );
+        // And the whole wire output must equal a fresh compute.
+        rig.match_cache.clear_document(&rig.uri);
+        let (fresh, _) = rig
+            .walk(
+                &text_v2,
+                &[{
+                    let (_, layer) = make("AAAA\nBBBB\n");
+                    layer
+                }],
+                1,
+                None,
+            )
+            .expect("kind query should load");
+        assert_eq!(cached, fresh, "multi-range hit must match fresh compute");
+    }
+
+    /// A cancelled walk bails before the sweep: its (empty) touched set must
+    /// not evict the live entries a completed walk stored. Guards the
+    /// ordering of the cancel bail vs the sweep in `execute_captures_walk`.
+    #[test]
+    fn cancelled_walk_does_not_sweep_live_entries() {
+        let code = "let a = 1;\n";
+        let text = format!("AAAA\n{code}");
+        let start = text.find(code).unwrap();
+        let rig = MatchCacheRig::new("file:///match_cache_cancel_sweep.rs", &text);
+        rig.walk(&text, &[rust_layer(&text, start, text.len())], 0, None)
+            .expect("kind query should load");
+        let (_, hash) = super::super::captures_match_cache::tree_cache_key(
+            "locals",
+            "rust",
+            &rust_layer(&text, start, text.len()).tree,
+            &text,
+        );
+        assert!(rig.match_cache.get_layer(&rig.uri, hash, 0).is_some());
+
+        // A pre-cancelled walk visits nothing (touched set empty) and must
+        // return None WITHOUT sweeping the entry away.
+        let cancel = crate::cancel::CancelToken::default();
+        cancel.cancel();
+        let cancelled = rig.walk_with(
+            &text,
+            &[rust_layer(&text, start, text.len())],
+            0,
+            None,
+            true,
+            Some(&cancel),
+        );
+        assert!(cancelled.is_none(), "a cancelled walk serves nothing");
+        assert!(
+            rig.match_cache.get_layer(&rig.uri, hash, 0).is_some(),
+            "a cancelled walk must not sweep live entries"
+        );
+    }
+
+    /// `injection = false` walks visit only the host layer (depth 0): the
+    /// host slot must serve on exact content recurrence (undo/redo), pinned
+    /// with a sentinel like the layer test above.
+    #[test]
+    fn host_slot_serves_on_content_recurrence() {
+        let text = "let a = 1;\n";
+        let rig = MatchCacheRig::new("file:///match_cache_host.rs", text);
+        rig.walk_with(text, &[], 0, None, false, None)
+            .expect("kind query should load");
+
+        // Host key for the same content: parse without included ranges.
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let host_tree = parser.parse(text, None).unwrap();
+        let (anchor, host_hash) =
+            super::super::captures_match_cache::tree_cache_key("locals", "rust", &host_tree, text);
+        assert_eq!(anchor, 0, "host layer anchors at 0");
+        assert!(
+            rig.match_cache
+                .get_host(&rig.uri, "locals", host_hash, 0)
+                .is_some(),
+            "the host walk must store under the host slot"
+        );
+        rig.match_cache.store_host(
+            &rig.uri,
+            "locals",
+            host_hash,
+            0,
+            std::sync::Arc::new(vec![crate::language::query_exec::MatchData {
+                pattern_index: 0,
+                captures: vec![crate::language::query_exec::CapturedNode {
+                    name: "sentinel-host-slot".to_string(),
+                    start_byte: 4,
+                    end_byte: 5,
+                    kind: "identifier",
+                    metadata: Vec::new(),
+                }],
+                metadata: Vec::new(),
+            }]),
+            || true,
+        );
+
+        // Same content again (undo/redo shape): must serve the host slot.
+        let (matches, _) = rig
+            .walk_with(text, &[], 0, None, false, None)
+            .expect("kind query should load");
+        assert!(
+            capture_names(&matches)
+                .iter()
+                .any(|n| n == "sentinel-host-slot"),
+            "an unchanged host must serve the host slot, not re-execute"
         );
     }
 

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -1174,6 +1174,11 @@ fn execute_captures_walk(
             });
             let arc = std::sync::Arc::new(fresh);
             if let Some((anchor, hash)) = rebased_key {
+                // The doc-open probe only runs when the store must CREATE the
+                // per-document slot (first store after open, or a walk racing
+                // its own didClose) — see the resurrection-leak note on
+                // `store_host`.
+                let doc_open = || documents.latest_snapshot(uri).is_some();
                 if depth == 0 {
                     match_cache.store_host(
                         uri,
@@ -1181,6 +1186,7 @@ fn execute_captures_walk(
                         hash,
                         generation,
                         std::sync::Arc::clone(&arc),
+                        doc_open,
                     );
                 } else {
                     match_cache.store_layer(
@@ -1189,6 +1195,7 @@ fn execute_captures_walk(
                         kind,
                         generation,
                         std::sync::Arc::clone(&arc),
+                        doc_open,
                     );
                     touched_layer_hashes.insert(hash);
                 }
@@ -2076,6 +2083,7 @@ mod tests {
                 }],
                 metadata: Vec::new(),
             }]),
+            || true,
         );
 
         let (matches, _) = rig

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -159,11 +159,13 @@ fn metadata_object(pairs: &[(String, Option<String>)]) -> Option<Value> {
     if pairs.is_empty() {
         return None;
     }
-    let mut map = serde_json::Map::new();
+    let mut map = serde_json::Map::with_capacity(pairs.len());
     for (key, value) in pairs {
         map.insert(
             key.clone(),
-            value.clone().map_or(Value::Bool(true), Value::String),
+            value
+                .as_ref()
+                .map_or(Value::Bool(true), |v| Value::String(v.clone())),
         );
     }
     Some(Value::Object(map))

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -1116,6 +1116,8 @@ fn execute_captures_walk(
     // Layer-entry hashes this walk read or wrote — the live set for the
     // post-walk sweep (host slots self-replace and need no sweep).
     let mut touched_layer_hashes: std::collections::HashSet<u64> = std::collections::HashSet::new();
+    // Hit/miss counters for the walk log line (cache-behavior diagnostics).
+    let (mut layers_reused, mut layers_executed) = (0usize, 0usize);
 
     let mut visit = |layer_language: &str, layer_tree: &tree_sitter::Tree, depth: usize| {
         // Per-layer cancellation checkpoint: a cancelled walk stops doing
@@ -1159,8 +1161,10 @@ fn execute_captures_walk(
             if depth > 0 {
                 touched_layer_hashes.insert(hash);
             }
+            layers_reused += 1;
             (cached, anchor)
         } else {
+            layers_executed += 1;
             let mut fresh = execute_query(&kind_query.query, layer_tree, text, byte_range.clone());
             // Rebase to anchor-relative before storing; a refusal (a capture
             // below the layer anchor, e.g. a root node reaching outside its
@@ -1346,6 +1350,10 @@ fn execute_captures_walk(
     if cache_full_walk && injection && mint_into_tracker {
         match_cache.sweep_layers(uri, kind, &touched_layer_hashes);
     }
+    log::debug!(
+        target: "kakehashi::captures",
+        "walk {uri} kind={kind}: match-cache reused={layers_reused} executed={layers_executed}",
+    );
 
     // The kind is "available" when at least one visited language COMPILED
     // the file — a host without a context.scm still surfaces the embedded

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -36,7 +36,7 @@
 //! - JSON-RPC `InvalidParams` for a malformed `kind` (fails the character
 //!   whitelist guarding the filesystem lookup).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use serde::Deserialize;
@@ -1118,7 +1118,7 @@ fn execute_captures_walk(
     let cache_full_walk = byte_range.is_none();
     // Layer-entry hashes this walk read or wrote — the live set for the
     // post-walk sweep (host slots self-replace and need no sweep).
-    let mut touched_layer_hashes: std::collections::HashSet<u64> = std::collections::HashSet::new();
+    let mut touched_layer_hashes: HashSet<u64> = HashSet::new();
     // Hit/miss counters for the walk log line (cache-behavior diagnostics).
     let (mut layers_reused, mut layers_executed) = (0usize, 0usize);
 
@@ -1152,9 +1152,9 @@ fn execute_captures_walk(
         // keystroke changes host bytes and misses: its hit case is exact
         // content recurrence (undo/redo, revert), which replays the most
         // expensive single query of the walk for free. The price is one
-        // FNV pass over the layer bytes per visit (~2x document bytes per
-        // full walk, sub-ms on real corpora) against the ~10% walk-time
-        // win measured for the injected layers alone.
+        // FNV pass over the layer bytes per visit — about twice the
+        // document bytes per full walk, sub-ms against the walk times the
+        // per-walk debug line reports (see the reused/executed counters).
         let cache_key = cache_full_walk.then(|| {
             super::captures_match_cache::tree_cache_key(kind, layer_language, layer_tree, text)
         });

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -884,6 +884,7 @@ impl Kakehashi {
         let language = std::sync::Arc::clone(&self.language);
         let tracker = self.bridge.node_tracker_arc();
         let documents = std::sync::Arc::clone(&self.documents);
+        let match_cache = std::sync::Arc::clone(&self.captures_match_cache);
         let parsed_version = snapshot.parsed_version;
         let snapshot_for_layers = std::sync::Arc::clone(&snapshot);
         let walk_cancel = cancel_token.clone();
@@ -952,6 +953,7 @@ impl Kakehashi {
                     parsed_version,
                     incarnation,
                     generation,
+                    &match_cache,
                     Some(&inner_cancel),
                 );
                 log::debug!(
@@ -1048,6 +1050,7 @@ fn execute_captures_walk(
     parsed_version: u64,
     incarnation: u64,
     generation: u64,
+    match_cache: &super::captures_match_cache::CapturesMatchCache,
     cancel: Option<&crate::cancel::CancelToken>,
 ) -> Option<(Vec<Value>, Vec<Value>)> {
     // Tracker minting is currency-gated: the NodeTracker is a LIVE-coordinate
@@ -1106,6 +1109,14 @@ fn execute_captures_walk(
     let mut kind_queries: HashMap<String, std::sync::Arc<KindQueryLoad>> = HashMap::new();
     let mut matches: Vec<Value> = Vec::new();
 
+    // Cross-snapshot match reuse is a full-walk concern only: a range walk
+    // produces results clipped to the viewport, which must neither be
+    // served as a layer's full matches nor stored as them.
+    let cache_full_walk = byte_range.is_none();
+    // Layer-entry hashes this walk read or wrote — the live set for the
+    // post-walk sweep (host slots self-replace and need no sweep).
+    let mut touched_layer_hashes: std::collections::HashSet<u64> = std::collections::HashSet::new();
+
     let mut visit = |layer_language: &str, layer_tree: &tree_sitter::Tree, depth: usize| {
         // Per-layer cancellation checkpoint: a cancelled walk stops doing
         // query/mint work; the caller discards the (partial) result.
@@ -1126,16 +1137,74 @@ fn execute_captures_walk(
         let KindQueryLoad::Loaded(kind_query) = entry.as_ref() else {
             return;
         };
-        for m in execute_query(&kind_query.query, layer_tree, text, byte_range.clone()) {
-            let match_metadata = metadata_object(m.metadata);
+        // Content-addressed cross-snapshot reuse: a layer whose included
+        // ranges carry the same bytes in the same relative geometry (merely
+        // translated by edits elsewhere) serves its cached MatchData and
+        // skips execute_query. Only the ID-free byte-offset stage is cached;
+        // minting/positions/shaping below run identically on hit and miss.
+        let cache_key = cache_full_walk.then(|| {
+            super::captures_match_cache::tree_cache_key(kind, layer_language, layer_tree, text)
+        });
+        let reused = cache_key.and_then(|(_, hash)| {
+            if depth == 0 {
+                match_cache.get_host(uri, kind, hash, generation)
+            } else {
+                match_cache.get_layer(uri, hash, generation)
+            }
+        });
+        let (layer_matches, anchor): (
+            std::sync::Arc<Vec<crate::language::query_exec::MatchData>>,
+            usize,
+        ) = if let (Some(cached), Some((anchor, hash))) = (reused, cache_key) {
+            if depth > 0 {
+                touched_layer_hashes.insert(hash);
+            }
+            (cached, anchor)
+        } else {
+            let mut fresh = execute_query(&kind_query.query, layer_tree, text, byte_range.clone());
+            // Rebase to anchor-relative before storing; a refusal (a capture
+            // below the layer anchor, e.g. a root node reaching outside its
+            // included ranges) leaves the matches absolute and uncached.
+            let rebased_key = cache_key.filter(|&(anchor, _)| {
+                super::captures_match_cache::rebase_matches(&mut fresh, anchor)
+            });
+            let arc = std::sync::Arc::new(fresh);
+            if let Some((anchor, hash)) = rebased_key {
+                if depth == 0 {
+                    match_cache.store_host(
+                        uri,
+                        kind,
+                        hash,
+                        generation,
+                        std::sync::Arc::clone(&arc),
+                    );
+                } else {
+                    match_cache.store_layer(
+                        uri,
+                        hash,
+                        kind,
+                        generation,
+                        std::sync::Arc::clone(&arc),
+                    );
+                    touched_layer_hashes.insert(hash);
+                }
+                (arc, anchor)
+            } else {
+                (arc, 0)
+            }
+        };
+        for m in layer_matches.iter() {
+            let match_metadata = metadata_object(m.metadata.clone());
             let captures: Vec<Value> = m
                 .captures
-                .into_iter()
+                .iter()
                 .filter_map(|c| {
                     // A capture whose bytes don't map to positions (corrupt
                     // span) is dropped rather than failing the whole request.
-                    let start = mapper.byte_to_position(c.start_byte)?;
-                    let end = mapper.byte_to_position(c.end_byte)?;
+                    let start_byte = c.start_byte + anchor;
+                    let end_byte = c.end_byte + anchor;
+                    let start = mapper.byte_to_position(start_byte)?;
+                    let end = mapper.byte_to_position(end_byte)?;
                     // Minted in the layer's depth, so the id resolves in
                     // its minting layer via kakehashi/node/* (per-layer
                     // Scope rule). Same mint as `mint_node_info`, done via
@@ -1144,11 +1213,7 @@ fn execute_captures_walk(
                     // currency gate above).
                     let ulid = if mint_into_tracker {
                         let (ulid, created, shift_gen) = tracker.get_or_create_in_layer_tracked(
-                            uri,
-                            c.start_byte,
-                            c.end_byte,
-                            c.kind,
-                            depth,
+                            uri, start_byte, end_byte, c.kind, depth,
                         );
                         // Recorded for the post-walk purge: if an edit lands
                         // mid-walk, entries created after its shift were
@@ -1163,8 +1228,7 @@ fn execute_captures_walk(
                         }
                         ulid
                     } else {
-                        match tracker.lookup_in_layer(uri, c.start_byte, c.end_byte, c.kind, depth)
-                        {
+                        match tracker.lookup_in_layer(uri, start_byte, end_byte, c.kind, depth) {
                             Some(live) => live,
                             // NOT Ulid::default() (the nil id): unregistered
                             // ids must still be unique per capture.
@@ -1179,7 +1243,7 @@ fn execute_captures_walk(
                     });
                     // Capture-scoped `#set! @cap key value` metadata,
                     // only when the capture was annotated.
-                    if let Some(meta) = metadata_object(c.metadata) {
+                    if let Some(meta) = metadata_object(c.metadata.clone()) {
                         capture["metadata"] = meta;
                     }
                     Some(capture)
@@ -1270,6 +1334,17 @@ fn execute_captures_walk(
     // the response is discarded.
     if crate::cancel::is_cancelled(cancel) {
         return None;
+    }
+
+    // Match-cache sweep: after a COMPLETED full-coverage walk (all layers
+    // visited: injection mode, no viewport clip, no cancel bail), the
+    // touched set IS the document's live layer set for this kind — retain
+    // exactly it. Gated on entry-currency (`mint_into_tracker`) so a stale
+    // walk finishing late cannot evict the entries the current content
+    // hits; its own stores are harmless (content-addressed — they only hit
+    // if that content returns, e.g. undo) and the next current walk sweeps.
+    if cache_full_walk && injection && mint_into_tracker {
+        match_cache.sweep_layers(uri, kind, &touched_layer_hashes);
     }
 
     // The kind is "available" when at least one visited language COMPILED
@@ -1732,6 +1807,7 @@ mod tests {
 
         // Current (parsed_version == content_version == 0): minting is live.
         let tracker = NodeTracker::new();
+        let match_cache = super::super::captures_match_cache::CapturesMatchCache::new();
         let (matches, _) = execute_captures_walk(
             &uri,
             "locals",
@@ -1747,6 +1823,7 @@ mod tests {
             0,
             incarnation,
             0,
+            &match_cache,
             None,
         )
         .expect("kind query should load");
@@ -1776,6 +1853,7 @@ mod tests {
             0,
             incarnation,
             0,
+            &match_cache,
             None,
         )
         .expect("kind query should load");
@@ -1807,6 +1885,7 @@ mod tests {
             0,
             incarnation,
             0,
+            &match_cache,
             None,
         )
         .expect("kind query should load");
@@ -1814,6 +1893,276 @@ mod tests {
         assert!(
             stale_tracker.lookup_node(&uri, &id).is_none(),
             "a stale serve must not mint into the live tracker"
+        );
+    }
+
+    /// Build a rust "injection layer": the full text parsed with included
+    /// ranges restricted to `[start, end)` — the shape `SnapshotLayerTree`
+    /// carries for a real fence.
+    fn rust_layer(text: &str, start: usize, end: usize) -> crate::document::SnapshotLayerTree {
+        let line = text[..start].matches('\n').count();
+        let col = start - text[..start].rfind('\n').map_or(0, |i| i + 1);
+        let end_line = text[..end].matches('\n').count();
+        let end_col = end - text[..end].rfind('\n').map_or(0, |i| i + 1);
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        parser
+            .set_included_ranges(&[tree_sitter::Range {
+                start_byte: start,
+                end_byte: end,
+                start_point: tree_sitter::Point::new(line, col),
+                end_point: tree_sitter::Point::new(end_line, end_col),
+            }])
+            .unwrap();
+        crate::document::SnapshotLayerTree {
+            language: "rust".to_string(),
+            tree: parser.parse(text, None).unwrap(),
+            depth: 1,
+            span: start..end,
+        }
+    }
+
+    /// Test rig for the cross-snapshot match cache: a statically-linked rust
+    /// grammar with a locals.scm, so both the host layer and a synthetic
+    /// injected layer produce captures.
+    struct MatchCacheRig {
+        _dir: tempfile::TempDir,
+        coordinator: std::sync::Arc<crate::language::LanguageCoordinator>,
+        store: crate::document::DocumentStore,
+        tracker: crate::language::NodeTracker,
+        match_cache: super::super::captures_match_cache::CapturesMatchCache,
+        uri: Url,
+    }
+
+    impl MatchCacheRig {
+        fn new(uri: &str, text: &str) -> Self {
+            use crate::config::WorkspaceSettings;
+            let dir = tempfile::tempdir().unwrap();
+            let query_dir = dir.path().join("queries/rust");
+            std::fs::create_dir_all(&query_dir).unwrap();
+            std::fs::write(
+                query_dir.join("locals.scm"),
+                "(identifier) @local.reference\n",
+            )
+            .unwrap();
+            let coordinator = std::sync::Arc::new(crate::language::LanguageCoordinator::new());
+            coordinator.load_settings(&WorkspaceSettings {
+                search_paths: vec![dir.path().to_string_lossy().into_owned()],
+                ..Default::default()
+            });
+            coordinator
+                .language_registry_for_parallel()
+                .register("rust".to_string(), tree_sitter_rust::LANGUAGE.into());
+            let store = crate::document::DocumentStore::new();
+            let uri = Url::parse(uri).unwrap();
+            store.insert(uri.clone(), text.to_string(), Some("rust".into()), None);
+            Self {
+                _dir: dir,
+                coordinator,
+                store,
+                tracker: crate::language::NodeTracker::new(),
+                match_cache: super::super::captures_match_cache::CapturesMatchCache::new(),
+                uri,
+            }
+        }
+
+        fn walk(
+            &self,
+            text: &str,
+            layers: &[crate::document::SnapshotLayerTree],
+            parsed_version: u64,
+            lsp_range: Option<Range>,
+        ) -> Option<(Vec<Value>, Vec<Value>)> {
+            let mut parser = tree_sitter::Parser::new();
+            parser
+                .set_language(&tree_sitter_rust::LANGUAGE.into())
+                .unwrap();
+            let tree = parser.parse(text, None).unwrap();
+            let incarnation = self
+                .store
+                .latest_snapshot(&self.uri)
+                .unwrap()
+                .slot
+                .current_incarnation;
+            execute_captures_walk(
+                &self.uri,
+                "locals",
+                lsp_range,
+                true,
+                "rust",
+                text,
+                &tree,
+                Some(layers),
+                &self.coordinator,
+                &self.tracker,
+                &self.store,
+                parsed_version,
+                incarnation,
+                0,
+                &self.match_cache,
+                None,
+            )
+        }
+    }
+
+    fn capture_names(matches: &[Value]) -> Vec<String> {
+        matches
+            .iter()
+            .flat_map(|m| m["captures"].as_array().unwrap())
+            .map(|c| c["name"].as_str().unwrap().to_string())
+            .collect()
+    }
+
+    /// The read path of the cross-snapshot match cache: after an edit ABOVE
+    /// the layer (content translated, not changed), the walk must serve the
+    /// layer's cached matches instead of re-executing the query. Pinned with
+    /// a sentinel entry, pre-stored under the shifted layer's key, that no
+    /// real query execution could produce.
+    #[test]
+    fn translated_layer_serves_cached_matches_without_reexecuting() {
+        let code = "let a = 1;\n";
+        let text_v1 = format!("AAAA\n{code}");
+        let start_v1 = text_v1.find(code).unwrap();
+        let rig = MatchCacheRig::new("file:///match_cache_translated.rs", &text_v1);
+
+        let layer_v1 = rust_layer(&text_v1, start_v1, text_v1.len());
+        rig.walk(&text_v1, &[layer_v1], 0, None)
+            .expect("kind query should load");
+
+        // Edit above the layer: same layer content, shifted by 4 bytes.
+        let text_v2 = format!("AAAABBBB\n{code}");
+        let start_v2 = text_v2.find(code).unwrap();
+        let layer_v2 = rust_layer(&text_v2, start_v2, text_v2.len());
+        rig.store
+            .update_document(rig.uri.clone(), text_v2.clone(), None);
+
+        // The shifted layer must key IDENTICALLY to what v1 stored
+        // (translation invariance); plant a sentinel there to discriminate
+        // "served from cache" from "silently re-executed".
+        let (anchor_v2, hash_v2) = super::super::captures_match_cache::tree_cache_key(
+            "locals",
+            "rust",
+            &layer_v2.tree,
+            &text_v2,
+        );
+        assert_eq!(anchor_v2, start_v2);
+        assert!(
+            rig.match_cache.get_layer(&rig.uri, hash_v2, 0).is_some(),
+            "the translated layer's key must hit what the v1 walk stored"
+        );
+        rig.match_cache.store_layer(
+            &rig.uri,
+            hash_v2,
+            "locals",
+            0,
+            std::sync::Arc::new(vec![crate::language::query_exec::MatchData {
+                pattern_index: 0,
+                captures: vec![crate::language::query_exec::CapturedNode {
+                    name: "sentinel-from-cache".to_string(),
+                    start_byte: 4,
+                    end_byte: 5,
+                    kind: "identifier",
+                    metadata: Vec::new(),
+                }],
+                metadata: Vec::new(),
+            }]),
+        );
+
+        let (matches, _) = rig
+            .walk(&text_v2, &[layer_v2], 1, None)
+            .expect("kind query should load");
+        let names = capture_names(&matches);
+        assert!(
+            names.iter().any(|n| n == "sentinel-from-cache"),
+            "the layer walk must serve the cached entry, not re-execute: {names:?}"
+        );
+        // And the cached (anchor-relative) offsets must be re-anchored to the
+        // layer's CURRENT position: rel 4..5 inside the layer is `a`.
+        let sentinel = matches
+            .iter()
+            .flat_map(|m| m["captures"].as_array().unwrap())
+            .find(|c| c["name"] == "sentinel-from-cache")
+            .unwrap();
+        assert_eq!(
+            sentinel["range"]["start"]["line"], 1,
+            "anchor must be the v2 layer start, not the v1 one"
+        );
+        assert_eq!(sentinel["range"]["start"]["character"], 4);
+    }
+
+    /// Correctness of the reuse: a walk served from the (translated) cache
+    /// must be byte-identical on the wire to a walk computed fresh — same
+    /// positions, same node ids (`get_or_create` on the same tracker), same
+    /// metadata.
+    #[test]
+    fn cached_and_fresh_walks_agree_on_the_wire() {
+        let code = "let a = 1;\n";
+        let text_v1 = format!("AAAA\n{code}");
+        let start_v1 = text_v1.find(code).unwrap();
+        let rig = MatchCacheRig::new("file:///match_cache_equality.rs", &text_v1);
+        rig.walk(
+            &text_v1,
+            &[rust_layer(&text_v1, start_v1, text_v1.len())],
+            0,
+            None,
+        )
+        .expect("kind query should load");
+
+        let text_v2 = format!("AAAABBBB\n{code}");
+        let start_v2 = text_v2.find(code).unwrap();
+        rig.store
+            .update_document(rig.uri.clone(), text_v2.clone(), None);
+
+        let (cached, _) = rig
+            .walk(
+                &text_v2,
+                &[rust_layer(&text_v2, start_v2, text_v2.len())],
+                1,
+                None,
+            )
+            .expect("kind query should load");
+        // Fresh compute of the same walk, cache emptied: must agree exactly.
+        rig.match_cache.clear_document(&rig.uri);
+        let (fresh, _) = rig
+            .walk(
+                &text_v2,
+                &[rust_layer(&text_v2, start_v2, text_v2.len())],
+                1,
+                None,
+            )
+            .expect("kind query should load");
+        assert_eq!(cached, fresh, "cache-served wire output must be identical");
+    }
+
+    /// Range walks produce viewport-clipped results: they must neither store
+    /// into nor serve from the cross-snapshot match cache.
+    #[test]
+    fn range_walks_bypass_the_match_cache() {
+        let text = "let a = 1;\n";
+        let rig = MatchCacheRig::new("file:///match_cache_range.rs", text);
+        let layer = rust_layer(text, 0, text.len());
+        let (_, host_hash) =
+            super::super::captures_match_cache::tree_cache_key("locals", "rust", &layer.tree, text);
+
+        rig.walk(
+            text,
+            &[layer],
+            0,
+            Some(Range::new(
+                tower_lsp_server::ls_types::Position::new(0, 0),
+                tower_lsp_server::ls_types::Position::new(0, 5),
+            )),
+        )
+        .expect("kind query should load");
+        assert!(
+            rig.match_cache.get_layer(&rig.uri, host_hash, 0).is_none()
+                && rig
+                    .match_cache
+                    .get_host(&rig.uri, "locals", host_hash, 0)
+                    .is_none(),
+            "a range walk must not populate the match cache"
         );
     }
 

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -155,13 +155,16 @@ fn matches_delta_edit(previous: &[Value], current: &[Value]) -> Option<(usize, u
 /// A valued key maps to its string; the bare flag form `(#set! key)` maps to
 /// `true` (a flag a client can test for, unlike Neovim's nil no-op). Duplicate
 /// keys are last-write-wins, matching Neovim's in-order directive application.
-fn metadata_object(pairs: Vec<(String, Option<String>)>) -> Option<Value> {
+fn metadata_object(pairs: &[(String, Option<String>)]) -> Option<Value> {
     if pairs.is_empty() {
         return None;
     }
     let mut map = serde_json::Map::new();
     for (key, value) in pairs {
-        map.insert(key, value.map_or(Value::Bool(true), Value::String));
+        map.insert(
+            key.clone(),
+            value.clone().map_or(Value::Bool(true), Value::String),
+        );
     }
     Some(Value::Object(map))
 }
@@ -1144,6 +1147,14 @@ fn execute_captures_walk(
         // translated by edits elsewhere) serves its cached MatchData and
         // skips execute_query. Only the ID-free byte-offset stage is cached;
         // minting/positions/shaping below run identically on hit and miss.
+        //
+        // The host layer (depth 0) is DELIBERATELY included even though any
+        // keystroke changes host bytes and misses: its hit case is exact
+        // content recurrence (undo/redo, revert), which replays the most
+        // expensive single query of the walk for free. The price is one
+        // FNV pass over the layer bytes per visit (~2x document bytes per
+        // full walk, sub-ms on real corpora) against the ~10% walk-time
+        // win measured for the injected layers alone.
         let cache_key = cache_full_walk.then(|| {
             super::captures_match_cache::tree_cache_key(kind, layer_language, layer_tree, text)
         });
@@ -1191,8 +1202,8 @@ fn execute_captures_walk(
                 } else {
                     match_cache.store_layer(
                         uri,
-                        hash,
                         kind,
+                        hash,
                         generation,
                         std::sync::Arc::clone(&arc),
                         doc_open,
@@ -1205,7 +1216,7 @@ fn execute_captures_walk(
             }
         };
         for m in layer_matches.iter() {
-            let match_metadata = metadata_object(m.metadata.clone());
+            let match_metadata = metadata_object(&m.metadata);
             let captures: Vec<Value> = m
                 .captures
                 .iter()
@@ -1254,7 +1265,7 @@ fn execute_captures_walk(
                     });
                     // Capture-scoped `#set! @cap key value` metadata,
                     // only when the capture was annotated.
-                    if let Some(meta) = metadata_object(c.metadata.clone()) {
+                    if let Some(meta) = metadata_object(&c.metadata) {
                         capture["metadata"] = meta;
                     }
                     Some(capture)
@@ -1350,10 +1361,19 @@ fn execute_captures_walk(
     // Match-cache sweep: after a COMPLETED full-coverage walk (all layers
     // visited: injection mode, no viewport clip, no cancel bail), the
     // touched set IS the document's live layer set for this kind — retain
-    // exactly it. Gated on entry-currency (`mint_into_tracker`) so a stale
-    // walk finishing late cannot evict the entries the current content
-    // hits; its own stores are harmless (content-addressed — they only hit
-    // if that content returns, e.g. undo) and the next current walk sweeps.
+    // exactly it. Two things bound eviction of CURRENT entries:
+    // - the `mint_into_tracker` entry-currency gate drops the sweep of a
+    //   walk that was already trailing when it started (a stale-at-entry
+    //   walk never sweeps; its stores are harmless — content-addressed,
+    //   they only hit if that content returns, e.g. undo);
+    // - for a walk outrun DURING the walk (current at entry, edit lands
+    //   mid-flight), it is the single-flight winner guard — held across
+    //   walk AND sweep for this same (uri, kind, injection) key — that
+    //   keeps the successor's stores out until this sweep lands, so the
+    //   stale touched set can only miss entries, never evict a newer
+    //   walk's. Relaxing single-flight would re-open that window (worst
+    //   case: extra misses until the next current walk restores, never
+    //   wrong output).
     if cache_full_walk && injection && mint_into_tracker {
         match_cache.sweep_layers(uri, kind, &touched_layer_hashes);
     }
@@ -2069,8 +2089,8 @@ mod tests {
         );
         rig.match_cache.store_layer(
             &rig.uri,
-            hash_v2,
             "locals",
+            hash_v2,
             0,
             std::sync::Arc::new(vec![crate::language::query_exec::MatchData {
                 pattern_index: 0,
@@ -2233,7 +2253,7 @@ mod tests {
     fn metadata_object_is_none_when_no_directives() {
         // Patterns without #set! must keep their pre-metadata wire shape —
         // an empty object would churn every delta lineage.
-        assert_eq!(metadata_object(vec![]), None);
+        assert_eq!(metadata_object(&[]), None);
     }
 
     #[test]
@@ -2242,7 +2262,7 @@ mod tests {
         // style); JSON true lets clients test for it, where Neovim's nil
         // assignment would make the key undetectable.
         let pairs = vec![("combined".to_string(), None)];
-        assert_eq!(metadata_object(pairs), Some(json!({ "combined": true })));
+        assert_eq!(metadata_object(&pairs), Some(json!({ "combined": true })));
     }
 
     #[test]
@@ -2253,7 +2273,7 @@ mod tests {
             ("kind".to_string(), Some("first".to_string())),
             ("kind".to_string(), Some("second".to_string())),
         ];
-        assert_eq!(metadata_object(pairs), Some(json!({ "kind": "second" })));
+        assert_eq!(metadata_object(&pairs), Some(json!({ "kind": "second" })));
     }
 
     #[test]

--- a/src/lsp/lsp_impl/kakehashi/captures_match_cache.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures_match_cache.rs
@@ -50,31 +50,50 @@ fn fnv1a(hash: &mut u64, bytes: &[u8]) {
     }
 }
 
+/// One included range as the cache key consumes it: byte span plus the
+/// COLUMNS tree-sitter was given for its endpoints. Rows are deliberately
+/// absent — a vertical shift changes rows but cannot change the parse — but
+/// columns can: an indentation-sensitive injected grammar (Python, YAML)
+/// parses differently when the range starts at a different column, and a
+/// gap's internal newline moving changes a later range's column without
+/// touching any hashed byte. See `content.rs`'s column-offset parse tests.
+pub(in crate::lsp::lsp_impl) struct KeyRange {
+    pub start_byte: usize,
+    pub end_byte: usize,
+    pub start_col: usize,
+    pub end_col: usize,
+}
+
 /// The cache key of one layer's walk: `(anchor, validity_hash)`.
 ///
 /// `anchor` is the layer's first included-range start — the offset cached
 /// matches are stored relative to, and the offset a hit re-adds. The hash
 /// folds the kind file name, the layer language, and each included range's
-/// anchor-relative geometry plus its text, so it is translation-invariant
-/// (an edit above the layer shifts the anchor, not the hash) but changes
-/// whenever the layer's visible bytes or its internal gap structure change.
+/// anchor-relative byte geometry, endpoint columns, and text, so it is
+/// invariant under VERTICAL translation (an edit on earlier lines shifts
+/// the anchor and rows, neither of which the parse can see) but changes
+/// whenever the layer's visible bytes, its internal gap structure, or its
+/// column placement change.
 ///
 /// Ranges are clamped to `text.len()` before hashing: a host tree parsed
 /// without explicit included ranges reports one `0..u32::MAX`-ish range.
 pub(in crate::lsp::lsp_impl) fn layer_cache_key(
     kind: &str,
     language: &str,
-    ranges: impl IntoIterator<Item = (usize, usize)>,
+    ranges: impl IntoIterator<Item = KeyRange>,
     text: &str,
 ) -> (usize, u64) {
     let mut hash = FNV_OFFSET;
     fnv1a(&mut hash, kind.as_bytes());
+    // Domain separator between the two variable-length prefix fields (kind
+    // is charset-validated and cannot contain 0xFF; language names cannot
+    // either, both being path components).
     fnv1a(&mut hash, &[0xFF]);
     fnv1a(&mut hash, language.as_bytes());
     let mut anchor = None;
-    for (start, end) in ranges {
-        let start = start.min(text.len());
-        let end = end.min(text.len());
+    for range in ranges {
+        let start = range.start_byte.min(text.len());
+        let end = range.end_byte.min(text.len());
         let anchor = *anchor.get_or_insert(start);
         // Separator + relative geometry: two range lists with the same
         // concatenated content but different gaps must not collide.
@@ -84,14 +103,18 @@ pub(in crate::lsp::lsp_impl) fn layer_cache_key(
             &(start.wrapping_sub(anchor) as u64).to_le_bytes(),
         );
         fnv1a(&mut hash, &(end.wrapping_sub(anchor) as u64).to_le_bytes());
+        fnv1a(&mut hash, &(range.start_col as u64).to_le_bytes());
+        fnv1a(&mut hash, &(range.end_col as u64).to_le_bytes());
+        // `start.min(end)` tolerates a (never observed) inverted range the
+        // same way the clamping above tolerates the host sentinel span.
         fnv1a(&mut hash, &text.as_bytes()[start.min(end)..end]);
     }
     (anchor.unwrap_or(0), hash)
 }
 
 /// [`layer_cache_key`] over a parsed layer tree — `Tree::included_ranges`
-/// recovers the exact absolute ranges the layer was parsed with (for a host
-/// tree, the whole document).
+/// recovers the exact absolute ranges (bytes AND points) the layer was
+/// parsed with (for a host tree, the whole document).
 pub(in crate::lsp::lsp_impl) fn tree_cache_key(
     kind: &str,
     language: &str,
@@ -101,9 +124,12 @@ pub(in crate::lsp::lsp_impl) fn tree_cache_key(
     layer_cache_key(
         kind,
         language,
-        tree.included_ranges()
-            .iter()
-            .map(|r| (r.start_byte, r.end_byte)),
+        tree.included_ranges().iter().map(|r| KeyRange {
+            start_byte: r.start_byte,
+            end_byte: r.end_byte,
+            start_col: r.start_point.column,
+            end_col: r.end_point.column,
+        }),
         text,
     )
 }
@@ -303,23 +329,33 @@ mod tests {
         Url::parse("file:///match_cache.md").unwrap()
     }
 
+    /// A `KeyRange` with column-0 endpoints — the common fence shape.
+    fn kr(start_byte: usize, end_byte: usize) -> KeyRange {
+        KeyRange {
+            start_byte,
+            end_byte,
+            start_col: 0,
+            end_col: 0,
+        }
+    }
+
     #[test]
     fn key_is_deterministic_and_separates_kind_and_language() {
         let text = "abcdefghij";
-        let base = layer_cache_key("highlights", "lua", [(2, 8)], text);
+        let base = layer_cache_key("highlights", "lua", [kr(2, 8)], text);
         assert_eq!(
             base,
-            layer_cache_key("highlights", "lua", [(2, 8)], text),
+            layer_cache_key("highlights", "lua", [kr(2, 8)], text),
             "same inputs -> same key"
         );
         assert_ne!(
             base.1,
-            layer_cache_key("locals", "lua", [(2, 8)], text).1,
+            layer_cache_key("locals", "lua", [kr(2, 8)], text).1,
             "kind separates"
         );
         assert_ne!(
             base.1,
-            layer_cache_key("highlights", "vim", [(2, 8)], text).1,
+            layer_cache_key("highlights", "vim", [kr(2, 8)], text).1,
             "language separates"
         );
     }
@@ -328,19 +364,60 @@ mod tests {
     fn key_is_translation_invariant_but_geometry_sensitive() {
         // Same content, shifted: the anchor moves, the hash does not — this
         // IS the cross-snapshot hit ("edit above the fence").
-        let (anchor_a, hash_a) = layer_cache_key("h", "lua", [(2, 5), (7, 9)], "..abc..de.");
-        let (anchor_b, hash_b) = layer_cache_key("h", "lua", [(5, 8), (10, 12)], ".....abc..de..");
+        let (anchor_a, hash_a) = layer_cache_key("h", "lua", [kr(2, 5), kr(7, 9)], "..abc..de.");
+        let (anchor_b, hash_b) =
+            layer_cache_key("h", "lua", [kr(5, 8), kr(10, 12)], ".....abc..de..");
         assert_eq!(hash_a, hash_b, "translated identical layer must hit");
         assert_eq!((anchor_a, anchor_b), (2, 5));
 
         // Same concatenated content ("abcde"), different gap: the layer tree
         // was parsed over different geometry, so the hash must differ.
-        let (_, gap_moved) = layer_cache_key("h", "lua", [(2, 6), (8, 9)], "..abcd..e.");
+        let (_, gap_moved) = layer_cache_key("h", "lua", [kr(2, 6), kr(8, 9)], "..abcd..e.");
         assert_ne!(hash_a, gap_moved, "gap geometry must separate");
 
         // Different content, same geometry.
-        let (_, content_changed) = layer_cache_key("h", "lua", [(2, 5), (7, 9)], "..abX..de.");
+        let (_, content_changed) = layer_cache_key("h", "lua", [kr(2, 5), kr(7, 9)], "..abX..de.");
         assert_ne!(hash_a, content_changed, "content must separate");
+    }
+
+    /// Endpoint columns are parse inputs for indentation-sensitive grammars
+    /// (and a gap's internal newline can move a later range's column without
+    /// touching any hashed byte) — same bytes at a different column must not
+    /// alias.
+    #[test]
+    fn key_separates_endpoint_columns() {
+        let text = "..abc..de.";
+        let base = layer_cache_key("h", "python", [kr(2, 5), kr(7, 9)], text);
+        let indented = layer_cache_key(
+            "h",
+            "python",
+            [
+                KeyRange {
+                    start_byte: 2,
+                    end_byte: 5,
+                    start_col: 4,
+                    end_col: 0,
+                },
+                kr(7, 9),
+            ],
+            text,
+        );
+        assert_ne!(base.1, indented.1, "first-range start column separates");
+        let gap_newline_moved = layer_cache_key(
+            "h",
+            "python",
+            [
+                kr(2, 5),
+                KeyRange {
+                    start_byte: 7,
+                    end_byte: 9,
+                    start_col: 2,
+                    end_col: 0,
+                },
+            ],
+            text,
+        );
+        assert_ne!(base.1, gap_newline_moved.1, "later-range column separates");
     }
 
     #[test]
@@ -348,8 +425,8 @@ mod tests {
         // A host tree parsed without explicit ranges reports ~0..u32::MAX;
         // the key must behave as "whole document".
         let text = "fn main() {}";
-        let clamped = layer_cache_key("h", "rust", [(0, u32::MAX as usize)], text);
-        let whole = layer_cache_key("h", "rust", [(0, text.len())], text);
+        let clamped = layer_cache_key("h", "rust", [kr(0, u32::MAX as usize)], text);
+        let whole = layer_cache_key("h", "rust", [kr(0, text.len())], text);
         assert_eq!(clamped, whole);
     }
 

--- a/src/lsp/lsp_impl/kakehashi/captures_match_cache.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures_match_cache.rs
@@ -59,20 +59,11 @@ fn fnv1a(hash: &mut u64, bytes: &[u8]) {
 
 /// One included range as the cache key consumes it: byte span plus the
 /// COLUMNS tree-sitter was given for its endpoints. Rows are deliberately
-/// absent — a vertical shift changes rows but cannot change the parse — but
-/// columns can: an indentation-sensitive injected grammar (Python, YAML)
-/// parses differently when the range starts at a different column, and a
-/// gap's internal newline moving changes a later range's column without
-/// touching any hashed byte (`content.rs` computes real column offsets for
-/// exactly this reason).
-///
-/// Gap BYTES between ranges stay unhashed. The parser never reads them,
-/// but query predicates slice the full host text by node span, so a node
-/// straddling a gap could observe them — the invariant relied on is that
-/// for every shipped gap source (blockquote/list prefixes), a gap byte
-/// cannot change without also changing the discovered ranges (the marker
-/// byte IS the construct; a space→tab change moves tab-stop indentation),
-/// which changes the hashed geometry or columns and misses.
+/// absent — a vertical shift changes rows but cannot change the parse or
+/// what predicates read — but columns can: an indentation-sensitive
+/// injected grammar (Python, YAML) parses differently when the range
+/// starts at a different column (`content.rs` computes real column
+/// offsets for exactly this reason).
 pub(in crate::lsp::lsp_impl) struct KeyRange {
     pub start_byte: usize,
     pub end_byte: usize,
@@ -84,12 +75,20 @@ pub(in crate::lsp::lsp_impl) struct KeyRange {
 ///
 /// `anchor` is the layer's first included-range start — the offset cached
 /// matches are stored relative to, and the offset a hit re-adds. The hash
-/// folds the kind file name, the layer language, and each included range's
-/// anchor-relative byte geometry, endpoint columns, and text, so it is
-/// invariant under VERTICAL translation (an edit on earlier lines shifts
-/// the anchor and rows, neither of which the parse can see) but changes
-/// whenever the layer's visible bytes, its internal gap structure, or its
-/// column placement change.
+/// folds the kind file name, the layer language, each included range's
+/// anchor-relative byte geometry and endpoint columns, and the layer's
+/// ENTIRE outer span text (first range start to last range end, gaps
+/// included, one contiguous pass). It is invariant under translation (an
+/// edit outside the span shifts the anchor and rows, neither of which the
+/// parse or the queries can see) but changes whenever any byte the walk
+/// could observe changes.
+///
+/// Gap bytes between ranges must be hashed even though the PARSER never
+/// reads them: query predicates (`#match?`, `#eq?`, `#lua-match?`, …)
+/// slice the full host text by node span, and a captured node straddling
+/// a gap observes the gap bytes — kind queries come from user-configurable
+/// search paths, so no grammar-level invariant can rule that out. One
+/// contiguous pass over the span is also cheaper than per-range slicing.
 ///
 /// Ranges are clamped to `text.len()` before hashing: a host tree parsed
 /// without explicit included ranges reports one `0..u32::MAX`-ish range.
@@ -107,12 +106,15 @@ pub(in crate::lsp::lsp_impl) fn layer_cache_key(
     fnv1a(&mut hash, &[0xFF]);
     fnv1a(&mut hash, language.as_bytes());
     let mut anchor = None;
+    let (mut span_start, mut span_end) = (usize::MAX, 0usize);
     for range in ranges {
         let start = range.start_byte.min(text.len());
         let end = range.end_byte.min(text.len());
         let anchor = *anchor.get_or_insert(start);
+        span_start = span_start.min(start.min(end));
+        span_end = span_end.max(end);
         // Separator + relative geometry: two range lists with the same
-        // concatenated content but different gaps must not collide.
+        // span content but different range boundaries must not collide.
         fnv1a(&mut hash, &[0xFE]);
         fnv1a(
             &mut hash,
@@ -121,9 +123,12 @@ pub(in crate::lsp::lsp_impl) fn layer_cache_key(
         fnv1a(&mut hash, &(end.wrapping_sub(anchor) as u64).to_le_bytes());
         fnv1a(&mut hash, &(range.start_col as u64).to_le_bytes());
         fnv1a(&mut hash, &(range.end_col as u64).to_le_bytes());
-        // `start.min(end)` tolerates a (never observed) inverted range the
-        // same way the clamping above tolerates the host sentinel span.
-        fnv1a(&mut hash, &text.as_bytes()[start.min(end)..end]);
+    }
+    // The whole outer span in ONE contiguous pass — gaps included, see the
+    // predicate note above. (`span_start` guards the degenerate empty-range
+    // iterator, where it stays at usize::MAX.)
+    if span_start < span_end {
+        fnv1a(&mut hash, &text.as_bytes()[span_start..span_end]);
     }
     (anchor.unwrap_or(0), hash)
 }
@@ -438,6 +443,18 @@ mod tests {
             text,
         );
         assert_ne!(base.1, gap_newline_moved.1, "later-range column separates");
+    }
+
+    /// Gap bytes are predicate-observable (a captured node straddling a gap
+    /// is sliced from the FULL host text), so a gap-only mutation that
+    /// leaves every included range's text, geometry, and columns identical
+    /// must still miss (codex review).
+    #[test]
+    fn key_separates_gap_bytes() {
+        let ranges = || [kr(2, 5), kr(7, 9)];
+        let (_, base) = layer_cache_key("h", "lua", ranges(), "..abc..de.");
+        let (_, gap_mutated) = layer_cache_key("h", "lua", ranges(), "..abcX.de.");
+        assert_ne!(base, gap_mutated, "gap-only mutation must separate");
     }
 
     #[test]

--- a/src/lsp/lsp_impl/kakehashi/captures_match_cache.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures_match_cache.rs
@@ -63,7 +63,16 @@ fn fnv1a(hash: &mut u64, bytes: &[u8]) {
 /// columns can: an indentation-sensitive injected grammar (Python, YAML)
 /// parses differently when the range starts at a different column, and a
 /// gap's internal newline moving changes a later range's column without
-/// touching any hashed byte. See `content.rs`'s column-offset parse tests.
+/// touching any hashed byte (`content.rs` computes real column offsets for
+/// exactly this reason).
+///
+/// Gap BYTES between ranges stay unhashed. The parser never reads them,
+/// but query predicates slice the full host text by node span, so a node
+/// straddling a gap could observe them — the invariant relied on is that
+/// for every shipped gap source (blockquote/list prefixes), a gap byte
+/// cannot change without also changing the discovered ranges (the marker
+/// byte IS the construct; a space→tab change moves tab-stop indentation),
+/// which changes the hashed geometry or columns and misses.
 pub(in crate::lsp::lsp_impl) struct KeyRange {
     pub start_byte: usize,
     pub end_byte: usize,
@@ -433,9 +442,29 @@ mod tests {
 
     #[test]
     fn key_clamps_ranges_to_text_length() {
-        // A host tree parsed without explicit ranges reports ~0..u32::MAX;
-        // the key must behave as "whole document".
+        // A host tree parsed without explicit ranges reports the sentinel
+        // range `0..u32::MAX` with `end_point (u32::MAX, u32::MAX)`. Bytes
+        // clamp to the text, so the hashed CONTENT is the whole document;
+        // columns are folded as-given (store and lookup both key off the
+        // same tree, so the sentinel end column is consistent) — the key
+        // must be deterministic for that real host shape.
         let text = "fn main() {}";
+        let host_sentinel = || KeyRange {
+            start_byte: 0,
+            end_byte: u32::MAX as usize,
+            start_col: 0,
+            end_col: u32::MAX as usize,
+        };
+        let key = layer_cache_key("h", "rust", [host_sentinel()], text);
+        assert_eq!(
+            key,
+            layer_cache_key("h", "rust", [host_sentinel()], text),
+            "the host sentinel shape keys deterministically"
+        );
+        assert_eq!(key.0, 0, "host anchors at 0");
+
+        // Byte clamping: an oversized end with the SAME columns hashes the
+        // same content as the exact span.
         let clamped = layer_cache_key("h", "rust", [kr(0, u32::MAX as usize)], text);
         let whole = layer_cache_key("h", "rust", [kr(0, text.len())], text);
         assert_eq!(clamped, whole);

--- a/src/lsp/lsp_impl/kakehashi/captures_match_cache.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures_match_cache.rs
@@ -1,0 +1,413 @@
+//! Cross-snapshot, content-addressed cache of per-layer captures query
+//! matches (`kakehashi/captures/*`).
+//!
+//! The captures walk re-executes every layer's kind query on every new
+//! snapshot, but a keystroke leaves most layers' *content* untouched — an
+//! edit above a fence only shifts it. This cache keys each layer's
+//! [`MatchData`] output by what the query result actually depends on: the
+//! kind file, the layer language, and the layer's included ranges (their
+//! text AND their geometry relative to the layer anchor). A layer whose
+//! content merely moved hits, and the walk skips `execute_query` for it.
+//!
+//! What is cached is deliberately the ID-free, pre-JSON stage
+//! ([`MatchData`]: byte offsets + capture names + `#set!` metadata), stored
+//! ANCHOR-RELATIVE. ULID minting, coordinate conversion, and wire shaping
+//! run per request in the walk exactly as on a fresh compute — the
+//! NodeTracker contract (currency-gated minting, post-walk reconciliation)
+//! is untouched, so a cache hit hands out byte-identical ids to the ones a
+//! fresh walk would mint. Node `kind`s inside [`MatchData`] are
+//! `&'static str` interned in the grammar's loaded library — the same
+//! process-lifetime assumption the `NodeTracker` already makes for its
+//! `(start, end, kind)` keys.
+//!
+//! Eviction mirrors the injection-token-cache discipline:
+//! - the host slot (depth 0) holds ONE entry per kind and self-replaces on
+//!   store — never more than the latest host content per kind;
+//! - injected-layer entries are swept per completed full-coverage walk
+//!   (`sweep_layers` retains only the hashes that walk touched, scoped to
+//!   its kind so other kinds' entries survive);
+//! - `clear_document` drops the document on didClose.
+//!
+//! The 64-bit validity hash accepts the same collision bound as
+//! `region_validity_hash` (semantic token cache): a collision requires two
+//! different layer contents in ONE document colliding under FNV-1a while
+//! also sharing kind and language — accepted there, accepted here.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use url::Url;
+
+use crate::language::query_exec::MatchData;
+
+const FNV_OFFSET: u64 = 0xcbf29ce484222325;
+const FNV_PRIME: u64 = 0x100000001b3;
+
+fn fnv1a(hash: &mut u64, bytes: &[u8]) {
+    for b in bytes {
+        *hash ^= u64::from(*b);
+        *hash = hash.wrapping_mul(FNV_PRIME);
+    }
+}
+
+/// The cache key of one layer's walk: `(anchor, validity_hash)`.
+///
+/// `anchor` is the layer's first included-range start — the offset cached
+/// matches are stored relative to, and the offset a hit re-adds. The hash
+/// folds the kind file name, the layer language, and each included range's
+/// anchor-relative geometry plus its text, so it is translation-invariant
+/// (an edit above the layer shifts the anchor, not the hash) but changes
+/// whenever the layer's visible bytes or its internal gap structure change.
+///
+/// Ranges are clamped to `text.len()` before hashing: a host tree parsed
+/// without explicit included ranges reports one `0..u32::MAX`-ish range.
+pub(in crate::lsp::lsp_impl) fn layer_cache_key(
+    kind: &str,
+    language: &str,
+    ranges: impl IntoIterator<Item = (usize, usize)>,
+    text: &str,
+) -> (usize, u64) {
+    let mut hash = FNV_OFFSET;
+    fnv1a(&mut hash, kind.as_bytes());
+    fnv1a(&mut hash, &[0xFF]);
+    fnv1a(&mut hash, language.as_bytes());
+    let mut anchor = None;
+    for (start, end) in ranges {
+        let start = start.min(text.len());
+        let end = end.min(text.len());
+        let anchor = *anchor.get_or_insert(start);
+        // Separator + relative geometry: two range lists with the same
+        // concatenated content but different gaps must not collide.
+        fnv1a(&mut hash, &[0xFE]);
+        fnv1a(
+            &mut hash,
+            &(start.wrapping_sub(anchor) as u64).to_le_bytes(),
+        );
+        fnv1a(&mut hash, &(end.wrapping_sub(anchor) as u64).to_le_bytes());
+        fnv1a(&mut hash, &text.as_bytes()[start.min(end)..end]);
+    }
+    (anchor.unwrap_or(0), hash)
+}
+
+/// [`layer_cache_key`] over a parsed layer tree — `Tree::included_ranges`
+/// recovers the exact absolute ranges the layer was parsed with (for a host
+/// tree, the whole document).
+pub(in crate::lsp::lsp_impl) fn tree_cache_key(
+    kind: &str,
+    language: &str,
+    tree: &tree_sitter::Tree,
+    text: &str,
+) -> (usize, u64) {
+    layer_cache_key(
+        kind,
+        language,
+        tree.included_ranges()
+            .iter()
+            .map(|r| (r.start_byte, r.end_byte)),
+        text,
+    )
+}
+
+/// Shift every capture offset down by `anchor`, in place. Returns `false`
+/// (leaving the matches untouched) if any capture starts below the anchor —
+/// a tree whose root node reaches outside its included ranges must simply
+/// not be cached, never corrupted by a wrapping subtraction.
+pub(in crate::lsp::lsp_impl) fn rebase_matches(matches: &mut [MatchData], anchor: usize) -> bool {
+    if matches
+        .iter()
+        .flat_map(|m| &m.captures)
+        .any(|c| c.start_byte < anchor)
+    {
+        return false;
+    }
+    for m in matches {
+        for c in &mut m.captures {
+            c.start_byte -= anchor;
+            c.end_byte = c.end_byte.saturating_sub(anchor);
+        }
+    }
+    true
+}
+
+/// One cached host-layer walk (depth 0). Keyed by kind in [`DocMatchCache`];
+/// the validity hash lives in the entry because the slot self-replaces —
+/// one host content per kind, no sweep needed.
+struct CachedHostMatches {
+    validity_hash: u64,
+    generation: u64,
+    matches: Arc<Vec<MatchData>>,
+}
+
+/// One cached injected-layer walk (depth > 0). Keyed by validity hash; the
+/// kind is carried for the per-kind sweep scope.
+struct CachedLayerMatches {
+    kind: String,
+    generation: u64,
+    matches: Arc<Vec<MatchData>>,
+}
+
+#[derive(Default)]
+struct DocMatchCache {
+    host: HashMap<String, CachedHostMatches>,
+    layers: HashMap<u64, CachedLayerMatches>,
+}
+
+/// See the module docs. One instance lives on the server, shared with the
+/// compute-pool walks by `Arc`.
+#[derive(Default)]
+pub(in crate::lsp::lsp_impl) struct CapturesMatchCache {
+    cache: dashmap::DashMap<Url, DocMatchCache>,
+}
+
+impl CapturesMatchCache {
+    pub(in crate::lsp::lsp_impl) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(in crate::lsp::lsp_impl) fn get_host(
+        &self,
+        uri: &Url,
+        kind: &str,
+        validity_hash: u64,
+        generation: u64,
+    ) -> Option<Arc<Vec<MatchData>>> {
+        let doc = self.cache.get(uri)?;
+        let hit = doc.host.get(kind)?;
+        (hit.validity_hash == validity_hash && hit.generation == generation)
+            .then(|| Arc::clone(&hit.matches))
+    }
+
+    pub(in crate::lsp::lsp_impl) fn store_host(
+        &self,
+        uri: &Url,
+        kind: &str,
+        validity_hash: u64,
+        generation: u64,
+        matches: Arc<Vec<MatchData>>,
+    ) {
+        let entry = CachedHostMatches {
+            validity_hash,
+            generation,
+            matches,
+        };
+        // get_mut before entry: the steady-state store hits an existing doc
+        // and skips the owned-key clone the entry API requires.
+        if let Some(mut doc) = self.cache.get_mut(uri) {
+            doc.host.insert(kind.to_string(), entry);
+            return;
+        }
+        self.cache
+            .entry(uri.clone())
+            .or_default()
+            .host
+            .insert(kind.to_string(), entry);
+    }
+
+    pub(in crate::lsp::lsp_impl) fn get_layer(
+        &self,
+        uri: &Url,
+        validity_hash: u64,
+        generation: u64,
+    ) -> Option<Arc<Vec<MatchData>>> {
+        let doc = self.cache.get(uri)?;
+        let hit = doc.layers.get(&validity_hash)?;
+        (hit.generation == generation).then(|| Arc::clone(&hit.matches))
+    }
+
+    pub(in crate::lsp::lsp_impl) fn store_layer(
+        &self,
+        uri: &Url,
+        validity_hash: u64,
+        kind: &str,
+        generation: u64,
+        matches: Arc<Vec<MatchData>>,
+    ) {
+        let entry = CachedLayerMatches {
+            kind: kind.to_string(),
+            generation,
+            matches,
+        };
+        if let Some(mut doc) = self.cache.get_mut(uri) {
+            doc.layers.insert(validity_hash, entry);
+            return;
+        }
+        self.cache
+            .entry(uri.clone())
+            .or_default()
+            .layers
+            .insert(validity_hash, entry);
+    }
+
+    /// Retain, for `kind`, only the layer entries a completed full-coverage
+    /// walk touched; other kinds' entries are untouched. The host slot needs
+    /// no sweep (it self-replaces per kind).
+    pub(in crate::lsp::lsp_impl) fn sweep_layers(
+        &self,
+        uri: &Url,
+        kind: &str,
+        touched: &HashSet<u64>,
+    ) {
+        if let Some(mut doc) = self.cache.get_mut(uri) {
+            doc.layers
+                .retain(|hash, entry| entry.kind != kind || touched.contains(hash));
+        }
+    }
+
+    pub(in crate::lsp::lsp_impl) fn clear_document(&self, uri: &Url) {
+        self.cache.remove(uri);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::language::query_exec::CapturedNode;
+
+    fn match_data(captures: &[(usize, usize)]) -> MatchData {
+        MatchData {
+            pattern_index: 0,
+            captures: captures
+                .iter()
+                .map(|&(start_byte, end_byte)| CapturedNode {
+                    name: "cap".to_string(),
+                    start_byte,
+                    end_byte,
+                    kind: "identifier",
+                    metadata: Vec::new(),
+                })
+                .collect(),
+            metadata: Vec::new(),
+        }
+    }
+
+    fn uri() -> Url {
+        Url::parse("file:///match_cache.md").unwrap()
+    }
+
+    #[test]
+    fn key_is_deterministic_and_separates_kind_and_language() {
+        let text = "abcdefghij";
+        let base = layer_cache_key("highlights", "lua", [(2, 8)], text);
+        assert_eq!(
+            base,
+            layer_cache_key("highlights", "lua", [(2, 8)], text),
+            "same inputs -> same key"
+        );
+        assert_ne!(
+            base.1,
+            layer_cache_key("locals", "lua", [(2, 8)], text).1,
+            "kind separates"
+        );
+        assert_ne!(
+            base.1,
+            layer_cache_key("highlights", "vim", [(2, 8)], text).1,
+            "language separates"
+        );
+    }
+
+    #[test]
+    fn key_is_translation_invariant_but_geometry_sensitive() {
+        // Same content, shifted: the anchor moves, the hash does not — this
+        // IS the cross-snapshot hit ("edit above the fence").
+        let (anchor_a, hash_a) = layer_cache_key("h", "lua", [(2, 5), (7, 9)], "..abc..de.");
+        let (anchor_b, hash_b) = layer_cache_key("h", "lua", [(5, 8), (10, 12)], ".....abc..de..");
+        assert_eq!(hash_a, hash_b, "translated identical layer must hit");
+        assert_eq!((anchor_a, anchor_b), (2, 5));
+
+        // Same concatenated content ("abcde"), different gap: the layer tree
+        // was parsed over different geometry, so the hash must differ.
+        let (_, gap_moved) = layer_cache_key("h", "lua", [(2, 6), (8, 9)], "..abcd..e.");
+        assert_ne!(hash_a, gap_moved, "gap geometry must separate");
+
+        // Different content, same geometry.
+        let (_, content_changed) = layer_cache_key("h", "lua", [(2, 5), (7, 9)], "..abX..de.");
+        assert_ne!(hash_a, content_changed, "content must separate");
+    }
+
+    #[test]
+    fn key_clamps_ranges_to_text_length() {
+        // A host tree parsed without explicit ranges reports ~0..u32::MAX;
+        // the key must behave as "whole document".
+        let text = "fn main() {}";
+        let clamped = layer_cache_key("h", "rust", [(0, u32::MAX as usize)], text);
+        let whole = layer_cache_key("h", "rust", [(0, text.len())], text);
+        assert_eq!(clamped, whole);
+    }
+
+    #[test]
+    fn rebase_shifts_offsets_and_rejects_sub_anchor_captures() {
+        let mut ok = vec![match_data(&[(10, 14), (12, 13)])];
+        assert!(rebase_matches(&mut ok, 10));
+        assert_eq!(ok[0].captures[0].start_byte, 0);
+        assert_eq!(ok[0].captures[0].end_byte, 4);
+        assert_eq!(ok[0].captures[1].start_byte, 2);
+
+        // A capture below the anchor (root node reaching outside the layer's
+        // included ranges) must refuse the rebase and leave data untouched.
+        let mut bad = vec![match_data(&[(10, 14)]), match_data(&[(4, 6)])];
+        assert!(!rebase_matches(&mut bad, 10));
+        assert_eq!(bad[0].captures[0].start_byte, 10, "untouched on refusal");
+    }
+
+    #[test]
+    fn host_slot_checks_hash_and_generation_and_self_replaces() {
+        let cache = CapturesMatchCache::new();
+        let uri = uri();
+        let matches = Arc::new(vec![match_data(&[(0, 3)])]);
+        cache.store_host(&uri, "highlights", 111, 7, Arc::clone(&matches));
+
+        assert!(cache.get_host(&uri, "highlights", 111, 7).is_some());
+        assert!(
+            cache.get_host(&uri, "highlights", 222, 7).is_none(),
+            "content hash mismatch must miss"
+        );
+        assert!(
+            cache.get_host(&uri, "highlights", 111, 8).is_none(),
+            "settings generation mismatch must miss"
+        );
+        assert!(
+            cache.get_host(&uri, "locals", 111, 7).is_none(),
+            "kinds have independent host slots"
+        );
+
+        // Self-replacement: the new content evicts the old, per kind.
+        cache.store_host(&uri, "highlights", 333, 7, matches);
+        assert!(cache.get_host(&uri, "highlights", 111, 7).is_none());
+        assert!(cache.get_host(&uri, "highlights", 333, 7).is_some());
+    }
+
+    #[test]
+    fn layer_entries_sweep_per_kind_by_touched_set() {
+        let cache = CapturesMatchCache::new();
+        let uri = uri();
+        let matches = Arc::new(vec![match_data(&[(0, 3)])]);
+        cache.store_layer(&uri, 1, "highlights", 7, Arc::clone(&matches));
+        cache.store_layer(&uri, 2, "highlights", 7, Arc::clone(&matches));
+        cache.store_layer(&uri, 3, "locals", 7, Arc::clone(&matches));
+
+        // A completed highlights walk touched only hash 1 (the fence at
+        // hash 2 was deleted): 2 goes, 1 stays, the other kind's 3 stays.
+        cache.sweep_layers(&uri, "highlights", &HashSet::from([1]));
+        assert!(cache.get_layer(&uri, 1, 7).is_some());
+        assert!(cache.get_layer(&uri, 2, 7).is_none(), "untouched swept");
+        assert!(cache.get_layer(&uri, 3, 7).is_some(), "other kind kept");
+
+        assert!(
+            cache.get_layer(&uri, 1, 8).is_none(),
+            "settings generation mismatch must miss"
+        );
+    }
+
+    #[test]
+    fn clear_document_drops_everything_for_the_uri() {
+        let cache = CapturesMatchCache::new();
+        let uri = uri();
+        let matches = Arc::new(vec![match_data(&[(0, 3)])]);
+        cache.store_host(&uri, "highlights", 1, 7, Arc::clone(&matches));
+        cache.store_layer(&uri, 2, "highlights", 7, matches);
+
+        cache.clear_document(&uri);
+        assert!(cache.get_host(&uri, "highlights", 1, 7).is_none());
+        assert!(cache.get_layer(&uri, 2, 7).is_none());
+    }
+}

--- a/src/lsp/lsp_impl/kakehashi/captures_match_cache.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures_match_cache.rs
@@ -248,23 +248,28 @@ impl CapturesMatchCache {
             doc.host.insert(kind.to_string(), entry);
             return;
         }
-        // Creating the doc slot needs a liveness check: an airborne walk
+        // Creating the doc slot needs a liveness handshake: an airborne walk
         // whose document was closed mid-flight must not resurrect the entry
         // `clear_document` just dropped — nothing would ever reclaim it (the
         // pre-existing walk memo shares this race; its entries are small,
-        // these hold full match sets). `doc_open` is consulted only on this
-        // create path, so the steady state pays nothing. A close landing
-        // between the check and the insert still resurrects — the same
-        // accepted micro-window as every deferred-epoch-class lifecycle
-        // race; it heals on reopen-close and costs memory, never staleness.
-        if !doc_open() {
-            return;
-        }
+        // these hold full match sets). INSERT-THEN-VERIFY, paired with
+        // didClose's `documents.remove` → `clear_document` ordering, closes
+        // the leak entirely (codex review): if the post-insert probe sees
+        // the document open, the remove has not run yet, so the close's
+        // later `clear_document` reclaims this insert; if it sees it
+        // closed, we drop the slot ourselves. (A probe-BEFORE-insert had a
+        // TOCTOU hole: close landing between check and insert leaked.) The
+        // self-remove can transiently drop a reopen-race walk's fresh
+        // entries — a recomputable miss, never staleness. `doc_open` runs
+        // only on this create path; the steady state never probes.
         self.cache
             .entry(uri.clone())
             .or_default()
             .host
             .insert(kind.to_string(), entry);
+        if !doc_open() {
+            self.cache.remove(uri);
+        }
     }
 
     pub(in crate::lsp::lsp_impl) fn get_layer(
@@ -296,16 +301,16 @@ impl CapturesMatchCache {
             doc.layers.insert(validity_hash, entry);
             return;
         }
-        // See `store_host`: create-path liveness check against the
-        // close-during-walk resurrection leak.
-        if !doc_open() {
-            return;
-        }
+        // See `store_host`: create-path insert-then-verify handshake
+        // against the close-during-walk resurrection leak.
         self.cache
             .entry(uri.clone())
             .or_default()
             .layers
             .insert(validity_hash, entry);
+        if !doc_open() {
+            self.cache.remove(uri);
+        }
     }
 
     /// Retain, for `kind`, only the layer entries a completed full-coverage
@@ -551,10 +556,11 @@ mod tests {
         );
     }
 
-    /// The close-during-walk resurrection guard: a store that would CREATE
-    /// the per-document slot consults `doc_open` and drops the store for a
-    /// closed document; a store into an EXISTING slot never probes (the
-    /// steady-state path stays closure-free).
+    /// The close-during-walk resurrection guard: a store that CREATES the
+    /// per-document slot verifies `doc_open` AFTER the insert and drops the
+    /// slot for a closed document (insert-then-verify — see `store_host`);
+    /// a store into an EXISTING slot never probes (the steady-state path
+    /// stays closure-free).
     #[test]
     fn store_into_missing_doc_slot_requires_liveness() {
         let cache = CapturesMatchCache::new();

--- a/src/lsp/lsp_impl/kakehashi/captures_match_cache.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures_match_cache.rs
@@ -184,6 +184,7 @@ impl CapturesMatchCache {
         validity_hash: u64,
         generation: u64,
         matches: Arc<Vec<MatchData>>,
+        doc_open: impl FnOnce() -> bool,
     ) {
         let entry = CachedHostMatches {
             validity_hash,
@@ -194,6 +195,18 @@ impl CapturesMatchCache {
         // and skips the owned-key clone the entry API requires.
         if let Some(mut doc) = self.cache.get_mut(uri) {
             doc.host.insert(kind.to_string(), entry);
+            return;
+        }
+        // Creating the doc slot needs a liveness check: an airborne walk
+        // whose document was closed mid-flight must not resurrect the entry
+        // `clear_document` just dropped — nothing would ever reclaim it (the
+        // pre-existing walk memo shares this race; its entries are small,
+        // these hold full match sets). `doc_open` is consulted only on this
+        // create path, so the steady state pays nothing. A close landing
+        // between the check and the insert still resurrects — the same
+        // accepted micro-window as every deferred-epoch-class lifecycle
+        // race; it heals on reopen-close and costs memory, never staleness.
+        if !doc_open() {
             return;
         }
         self.cache
@@ -221,6 +234,7 @@ impl CapturesMatchCache {
         kind: &str,
         generation: u64,
         matches: Arc<Vec<MatchData>>,
+        doc_open: impl FnOnce() -> bool,
     ) {
         let entry = CachedLayerMatches {
             kind: kind.to_string(),
@@ -229,6 +243,11 @@ impl CapturesMatchCache {
         };
         if let Some(mut doc) = self.cache.get_mut(uri) {
             doc.layers.insert(validity_hash, entry);
+            return;
+        }
+        // See `store_host`: create-path liveness check against the
+        // close-during-walk resurrection leak.
+        if !doc_open() {
             return;
         }
         self.cache
@@ -354,7 +373,7 @@ mod tests {
         let cache = CapturesMatchCache::new();
         let uri = uri();
         let matches = Arc::new(vec![match_data(&[(0, 3)])]);
-        cache.store_host(&uri, "highlights", 111, 7, Arc::clone(&matches));
+        cache.store_host(&uri, "highlights", 111, 7, Arc::clone(&matches), || true);
 
         assert!(cache.get_host(&uri, "highlights", 111, 7).is_some());
         assert!(
@@ -371,7 +390,7 @@ mod tests {
         );
 
         // Self-replacement: the new content evicts the old, per kind.
-        cache.store_host(&uri, "highlights", 333, 7, matches);
+        cache.store_host(&uri, "highlights", 333, 7, matches, || true);
         assert!(cache.get_host(&uri, "highlights", 111, 7).is_none());
         assert!(cache.get_host(&uri, "highlights", 333, 7).is_some());
     }
@@ -381,9 +400,9 @@ mod tests {
         let cache = CapturesMatchCache::new();
         let uri = uri();
         let matches = Arc::new(vec![match_data(&[(0, 3)])]);
-        cache.store_layer(&uri, 1, "highlights", 7, Arc::clone(&matches));
-        cache.store_layer(&uri, 2, "highlights", 7, Arc::clone(&matches));
-        cache.store_layer(&uri, 3, "locals", 7, Arc::clone(&matches));
+        cache.store_layer(&uri, 1, "highlights", 7, Arc::clone(&matches), || true);
+        cache.store_layer(&uri, 2, "highlights", 7, Arc::clone(&matches), || true);
+        cache.store_layer(&uri, 3, "locals", 7, Arc::clone(&matches), || true);
 
         // A completed highlights walk touched only hash 1 (the fence at
         // hash 2 was deleted): 2 goes, 1 stays, the other kind's 3 stays.
@@ -398,13 +417,39 @@ mod tests {
         );
     }
 
+    /// The close-during-walk resurrection guard: a store that would CREATE
+    /// the per-document slot consults `doc_open` and drops the store for a
+    /// closed document; a store into an EXISTING slot never probes (the
+    /// steady-state path stays closure-free).
+    #[test]
+    fn store_into_missing_doc_slot_requires_liveness() {
+        let cache = CapturesMatchCache::new();
+        let uri = uri();
+        let matches = Arc::new(vec![match_data(&[(0, 3)])]);
+
+        // Closed document (doc_open = false): neither store may resurrect.
+        cache.store_host(&uri, "highlights", 1, 7, Arc::clone(&matches), || false);
+        cache.store_layer(&uri, 2, "highlights", 7, Arc::clone(&matches), || false);
+        assert!(cache.get_host(&uri, "highlights", 1, 7).is_none());
+        assert!(cache.get_layer(&uri, 2, 7).is_none());
+
+        // Open document: the create path proceeds...
+        cache.store_host(&uri, "highlights", 1, 7, Arc::clone(&matches), || true);
+        assert!(cache.get_host(&uri, "highlights", 1, 7).is_some());
+        // ...and once the slot exists, stores skip the probe entirely.
+        cache.store_layer(&uri, 2, "highlights", 7, matches, || {
+            panic!("existing doc slot must not probe liveness")
+        });
+        assert!(cache.get_layer(&uri, 2, 7).is_some());
+    }
+
     #[test]
     fn clear_document_drops_everything_for_the_uri() {
         let cache = CapturesMatchCache::new();
         let uri = uri();
         let matches = Arc::new(vec![match_data(&[(0, 3)])]);
-        cache.store_host(&uri, "highlights", 1, 7, Arc::clone(&matches));
-        cache.store_layer(&uri, 2, "highlights", 7, matches);
+        cache.store_host(&uri, "highlights", 1, 7, Arc::clone(&matches), || true);
+        cache.store_layer(&uri, 2, "highlights", 7, matches, || true);
 
         cache.clear_document(&uri);
         assert!(cache.get_host(&uri, "highlights", 1, 7).is_none());

--- a/src/lsp/lsp_impl/kakehashi/captures_match_cache.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures_match_cache.rs
@@ -110,17 +110,14 @@ pub(in crate::lsp::lsp_impl) fn layer_cache_key(
     for range in ranges {
         let start = range.start_byte.min(text.len());
         let end = range.end_byte.min(text.len());
-        let anchor = *anchor.get_or_insert(start);
+        let base = *anchor.get_or_insert(start);
         span_start = span_start.min(start.min(end));
         span_end = span_end.max(end);
         // Separator + relative geometry: two range lists with the same
         // span content but different range boundaries must not collide.
         fnv1a(&mut hash, &[0xFE]);
-        fnv1a(
-            &mut hash,
-            &(start.wrapping_sub(anchor) as u64).to_le_bytes(),
-        );
-        fnv1a(&mut hash, &(end.wrapping_sub(anchor) as u64).to_le_bytes());
+        fnv1a(&mut hash, &(start.wrapping_sub(base) as u64).to_le_bytes());
+        fnv1a(&mut hash, &(end.wrapping_sub(base) as u64).to_le_bytes());
         fnv1a(&mut hash, &(range.start_col as u64).to_le_bytes());
         fnv1a(&mut hash, &(range.end_col as u64).to_le_bytes());
     }
@@ -243,9 +240,14 @@ impl CapturesMatchCache {
             matches,
         };
         // get_mut before entry: the steady-state store hits an existing doc
-        // and skips the owned-key clone the entry API requires.
+        // and skips the owned-key clones the entry APIs require (the `Url`
+        // here, the kind `String` below).
         if let Some(mut doc) = self.cache.get_mut(uri) {
-            doc.host.insert(kind.to_string(), entry);
+            if let Some(slot) = doc.host.get_mut(kind) {
+                *slot = entry;
+            } else {
+                doc.host.insert(kind.to_string(), entry);
+            }
             return;
         }
         // Creating the doc slot needs a liveness handshake: an airborne walk
@@ -292,15 +294,30 @@ impl CapturesMatchCache {
         matches: Arc<Vec<MatchData>>,
         doc_open: impl FnOnce() -> bool,
     ) {
+        if let Some(mut doc) = self.cache.get_mut(uri) {
+            // In-place refresh keeps the existing kind `String`: kind is
+            // folded into the validity hash, so a same-hash entry already
+            // carries this kind (modulo the accepted 64-bit bound).
+            if let Some(slot) = doc.layers.get_mut(&validity_hash) {
+                slot.generation = generation;
+                slot.matches = matches;
+            } else {
+                doc.layers.insert(
+                    validity_hash,
+                    CachedLayerMatches {
+                        kind: kind.to_string(),
+                        generation,
+                        matches,
+                    },
+                );
+            }
+            return;
+        }
         let entry = CachedLayerMatches {
             kind: kind.to_string(),
             generation,
             matches,
         };
-        if let Some(mut doc) = self.cache.get_mut(uri) {
-            doc.layers.insert(validity_hash, entry);
-            return;
-        }
         // See `store_host`: create-path insert-then-verify handshake
         // against the close-during-walk resurrection leak.
         self.cache

--- a/src/lsp/lsp_impl/kakehashi/captures_match_cache.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures_match_cache.rs
@@ -23,10 +23,17 @@
 //! Eviction mirrors the injection-token-cache discipline:
 //! - the host slot (depth 0) holds ONE entry per kind and self-replaces on
 //!   store — never more than the latest host content per kind;
-//! - injected-layer entries are swept per completed full-coverage walk
-//!   (`sweep_layers` retains only the hashes that walk touched, scoped to
-//!   its kind so other kinds' entries survive);
+//! - injected-layer entries are swept per completed, current-at-entry
+//!   full-coverage walk (`sweep_layers` retains only the hashes that walk
+//!   touched, scoped to its kind so other kinds' entries survive);
 //! - `clear_document` drops the document on didClose.
+//!
+//! Resident bound while a document is open: for each kind that was ever
+//! full-walked, its LAST live layer set (a kind the client stops requesting
+//! keeps that final set until didClose — kinds are bounded by real `.scm`
+//! files, not by client strings, since only `Loaded` queries store). A
+//! burst of stale-walk stores can transiently exceed the live set until
+//! the next current walk's sweep.
 //!
 //! The 64-bit validity hash accepts the same collision bound as
 //! `region_validity_hash` (semantic token cache): a collision requires two
@@ -137,7 +144,9 @@ pub(in crate::lsp::lsp_impl) fn tree_cache_key(
 /// Shift every capture offset down by `anchor`, in place. Returns `false`
 /// (leaving the matches untouched) if any capture starts below the anchor —
 /// a tree whose root node reaches outside its included ranges must simply
-/// not be cached, never corrupted by a wrapping subtraction.
+/// not be cached, never corrupted by a wrapping subtraction. Ignoring the
+/// verdict would cache un-rebased (absolute) offsets, hence `must_use`.
+#[must_use]
 pub(in crate::lsp::lsp_impl) fn rebase_matches(matches: &mut [MatchData], anchor: usize) -> bool {
     if matches
         .iter()
@@ -148,8 +157,10 @@ pub(in crate::lsp::lsp_impl) fn rebase_matches(matches: &mut [MatchData], anchor
     }
     for m in matches {
         for c in &mut m.captures {
+            // The guard above makes plain `-` safe for both offsets
+            // (end >= start >= anchor by construction).
             c.start_byte -= anchor;
-            c.end_byte = c.end_byte.saturating_sub(anchor);
+            c.end_byte -= anchor;
         }
     }
     true
@@ -256,8 +267,8 @@ impl CapturesMatchCache {
     pub(in crate::lsp::lsp_impl) fn store_layer(
         &self,
         uri: &Url,
-        validity_hash: u64,
         kind: &str,
+        validity_hash: u64,
         generation: u64,
         matches: Arc<Vec<MatchData>>,
         doc_open: impl FnOnce() -> bool,
@@ -477,9 +488,9 @@ mod tests {
         let cache = CapturesMatchCache::new();
         let uri = uri();
         let matches = Arc::new(vec![match_data(&[(0, 3)])]);
-        cache.store_layer(&uri, 1, "highlights", 7, Arc::clone(&matches), || true);
-        cache.store_layer(&uri, 2, "highlights", 7, Arc::clone(&matches), || true);
-        cache.store_layer(&uri, 3, "locals", 7, Arc::clone(&matches), || true);
+        cache.store_layer(&uri, "highlights", 1, 7, Arc::clone(&matches), || true);
+        cache.store_layer(&uri, "highlights", 2, 7, Arc::clone(&matches), || true);
+        cache.store_layer(&uri, "locals", 3, 7, Arc::clone(&matches), || true);
 
         // A completed highlights walk touched only hash 1 (the fence at
         // hash 2 was deleted): 2 goes, 1 stays, the other kind's 3 stays.
@@ -506,7 +517,7 @@ mod tests {
 
         // Closed document (doc_open = false): neither store may resurrect.
         cache.store_host(&uri, "highlights", 1, 7, Arc::clone(&matches), || false);
-        cache.store_layer(&uri, 2, "highlights", 7, Arc::clone(&matches), || false);
+        cache.store_layer(&uri, "highlights", 2, 7, Arc::clone(&matches), || false);
         assert!(cache.get_host(&uri, "highlights", 1, 7).is_none());
         assert!(cache.get_layer(&uri, 2, 7).is_none());
 
@@ -514,7 +525,7 @@ mod tests {
         cache.store_host(&uri, "highlights", 1, 7, Arc::clone(&matches), || true);
         assert!(cache.get_host(&uri, "highlights", 1, 7).is_some());
         // ...and once the slot exists, stores skip the probe entirely.
-        cache.store_layer(&uri, 2, "highlights", 7, matches, || {
+        cache.store_layer(&uri, "highlights", 2, 7, matches, || {
             panic!("existing doc slot must not probe liveness")
         });
         assert!(cache.get_layer(&uri, 2, 7).is_some());
@@ -526,7 +537,7 @@ mod tests {
         let uri = uri();
         let matches = Arc::new(vec![match_data(&[(0, 3)])]);
         cache.store_host(&uri, "highlights", 1, 7, Arc::clone(&matches), || true);
-        cache.store_layer(&uri, 2, "highlights", 7, matches, || true);
+        cache.store_layer(&uri, "highlights", 2, 7, matches, || true);
 
         cache.clear_document(&uri);
         assert!(cache.get_host(&uri, "highlights", 1, 7).is_none());

--- a/src/lsp/lsp_impl/text_document/did_close.rs
+++ b/src/lsp/lsp_impl/text_document/did_close.rs
@@ -37,6 +37,7 @@ impl Kakehashi {
             // full again", never to stale data.)
             self.captures_cache.retain(|key, _| key.0 != uri);
             self.captures_walk_cache.retain(|key, _| key.0 != uri);
+            self.captures_match_cache.clear_document(&uri);
             self.documents.remove(&uri);
         }
 

--- a/src/lsp/lsp_impl/text_document/did_close.rs
+++ b/src/lsp/lsp_impl/text_document/did_close.rs
@@ -37,8 +37,15 @@ impl Kakehashi {
             // full again", never to stale data.)
             self.captures_cache.retain(|key, _| key.0 != uri);
             self.captures_walk_cache.retain(|key, _| key.0 != uri);
-            self.captures_match_cache.clear_document(&uri);
             self.documents.remove(&uri);
+            // AFTER the document removal, deliberately: the match cache's
+            // store paths use an insert-then-verify handshake against this
+            // ordering — a straggler walk whose post-insert liveness probe
+            // saw the document open is guaranteed to have inserted before
+            // this clear runs, so the clear reclaims it; one that probes
+            // after the removal self-removes. Clearing BEFORE the removal
+            // would reopen the resurrection leak (codex review).
+            self.captures_match_cache.clear_document(&uri);
         }
 
         // Clean up all caches for this document (semantic tokens, injections, requests)


### PR DESCRIPTION
Implements the walk-side lever deferred from #558: the captures walk re-executed every layer's kind query on every new snapshot, but a keystroke leaves most layers' content untouched — an edit above a fence only translates it.

## Design

- **What is cached**: each layer's ID-free `execute_query` output (`MatchData`: byte offsets + capture names + `#set!` metadata), stored **anchor-relative** in a new `CapturesMatchCache` (per-URI, host slot per kind + injected-layer map).
- **Key**: FNV-1a over kind + language + each included range's anchor-relative byte geometry + endpoint columns + the layer's **entire outer span text in one contiguous pass** (gap bytes included — query predicates slice full host text by node span, and kind queries come from user-configurable search paths, so no grammar-level invariant can exclude them). Translation-invariant: an edit above the layer shifts the anchor, not the hash. Same 64-bit collision bound as `region_validity_hash`.
- **What still runs per request**: ULID minting (currency-gated tracker `get_or_create` / read-only lookup), byte→position mapping, JSON shaping — the `node.id` wire contract and the NodeTracker mint/reconciliation rules are untouched, so a hit hands out byte-identical ids to a fresh walk. **This needs no part of the deferred §3 tracker-mint reconciliation split** — only the pre-ID stage is cached.
- **Eviction**: host slots self-replace per kind; injected-layer entries sweep to the touched set after completed, current-at-entry full walks (single-flight winner guard held across walk+sweep); didClose clears via an insert-then-verify liveness handshake that makes close-during-walk stores leak-free; range walks bypass entirely (clipped results, both read and store gates).

## Measurements (release, `drive.py --captures --edits 1`, real 38KB/5,079-line corpus)

- Steady-state typing reuses ~all injected layers: **1152 reused / 2 executed** per walk (host + the edited paragraph's inline layer) — observable via the new per-walk `match-cache reused=/executed=` debug counters.
- Walk phase: median **100→90ms**, mean **111.5→97.7ms** vs origin/main. The remaining walk cost is the host-layer query + per-request shaping/minting of ~20k captures, which is ID-coupled and stays out of scope until the §3 identity work.

## Review pipeline

`/review` (10-perspective + fact-check, 2 rounds → SHIP) and codex (continued thread → clean, then a fresh session → clean on first response); every actionable finding fixed in its own commit:

- `80ebeb5d` M1: store create paths probe document liveness (close-during-walk resurrection).
- `9b1826da` L1: included-range endpoint columns folded into the key (indent-sensitive grammars; gap-newline moving a later range's column).
- `3e7b3c9f` L3/L4/L5 tidy: sweep-safety comment credits the single-flight guard correctly; `store_layer` parameter order matches `store_host`; `metadata_object` borrows (no shaping-path clones).
- `058e3a93` L6 tests: multi-range later-range exact reanchor, cancelled-walk-no-sweep, host-slot recurrence, range read gate.
- `94f71c75` round-2 advisories (docs + host-sentinel test shape).
- `347dde63` codex: hash the full outer span — gap bytes are predicate-visible (user queries can `#match?` a node straddling a gap).
- `ae3521be` codex round 2: insert-then-verify + didClose ordering (remove → clear) close the resurrection leak entirely; residual is a benign recomputable miss on a reopen race, never staleness.

Follow-up issue for the measured non-lever: #559 (incremental layer-tree reuse, layer build ≈35ms — below noise until the walk-side levers land).

🤖 Generated with [Claude Code](https://claude.com/claude-code)