### PR TITLE
feat(lsp): opt into experimental features via KAKEHASHI_EXPERIMENTAL=true

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,6 @@ nix = { version = "0.31", features = ["signal", "process", "fs"] }
 
 [features]
 e2e = []
-experimental = []
 
 # Unix-only dev dependencies: pipe() for deterministic broken-pipe tests,
 # Signal::SIGPIPE for asserting the termination signal.

--- a/docs/language-features.md
+++ b/docs/language-features.md
@@ -225,8 +225,8 @@ differently.
 and [`textDocument/colorPresentation`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_colorPresentation)
 
 Shows color swatches and color picker presentations for embedded blocks.
-**Only available in experimental builds** — standard builds do not advertise color
-support.
+**Only available with the `KAKEHASHI_EXPERIMENTAL=true` environment variable** —
+without the opt-in the server does not advertise color support.
 
 ---
 

--- a/src/experimental.rs
+++ b/src/experimental.rs
@@ -1,8 +1,9 @@
 //! Runtime opt-in for experimental features.
 //!
-//! Experimental features (currently the native lexical-resolution layer)
-//! ship in every binary but stay dormant unless the server process is
-//! started with `KAKEHASHI_EXPERIMENTAL=true`. The variable is read once
+//! Experimental features (currently the native lexical-resolution layer
+//! and documentColor / colorPresentation bridging) ship in every binary but
+//! stay dormant unless the server process is started with
+//! `KAKEHASHI_EXPERIMENTAL=true`. The variable is read once
 //! per process; consumers that need per-instance test control (e.g.
 //! [`crate::lsp::Kakehashi`]) copy the value at construction instead of
 //! re-reading it.

--- a/src/experimental.rs
+++ b/src/experimental.rs
@@ -1,0 +1,38 @@
+//! Runtime opt-in for experimental features.
+//!
+//! Experimental features (currently the native lexical-resolution layer)
+//! ship in every binary but stay dormant unless the server process is
+//! started with `KAKEHASHI_EXPERIMENTAL=true`. The variable is read once
+//! per process; consumers that need per-instance test control (e.g.
+//! [`crate::lsp::Kakehashi`]) copy the value at construction instead of
+//! re-reading it.
+
+use std::sync::OnceLock;
+
+static ENABLED: OnceLock<bool> = OnceLock::new();
+
+/// Whether experimental features are enabled for this process
+/// (`KAKEHASHI_EXPERIMENTAL=true`; read once, then cached).
+pub(crate) fn enabled() -> bool {
+    *ENABLED.get_or_init(|| parse(std::env::var("KAKEHASHI_EXPERIMENTAL").ok().as_deref()))
+}
+
+/// Only the exact value `true` opts in — an unset, empty, or any other
+/// value keeps experimental features off.
+fn parse(value: Option<&str>) -> bool {
+    value == Some("true")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse;
+
+    #[test]
+    fn only_the_exact_value_true_opts_in() {
+        assert!(parse(Some("true")));
+        assert!(!parse(Some("TRUE")));
+        assert!(!parse(Some("1")));
+        assert!(!parse(Some("")));
+        assert!(!parse(None));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub(crate) mod compute_pool;
 pub mod config;
 pub(crate) mod document;
 pub(crate) mod error;
+pub(crate) mod experimental;
 pub mod install;
 pub(crate) mod language;
 pub mod lsp;

--- a/src/lsp/bridge/pool/handshake.rs
+++ b/src/lsp/bridge/pool/handshake.rs
@@ -46,6 +46,7 @@ pub(super) async fn perform_lsp_handshake(
         workspace_folders,
         client_capabilities.as_ref(),
         advertise_configuration,
+        crate::experimental::enabled(),
     );
     handle
         .send_request(init_request, init_request_id)

--- a/src/lsp/bridge/pool/handshake.rs
+++ b/src/lsp/bridge/pool/handshake.rs
@@ -46,6 +46,10 @@ pub(super) async fn perform_lsp_handshake(
         workspace_folders,
         client_capabilities.as_ref(),
         advertise_configuration,
+        // Process-global opt-in, not Kakehashi's per-instance copy: the pool
+        // has no Kakehashi in scope, and both derive from the same one-shot
+        // env read (the per-instance AtomicBool exists only so unit tests can
+        // toggle Kakehashi-level gates; none of them reach this handshake).
         crate::experimental::enabled(),
     );
     handle

--- a/src/lsp/bridge/protocol/client_capabilities.rs
+++ b/src/lsp/bridge/protocol/client_capabilities.rs
@@ -7,8 +7,15 @@ use tower_lsp_server::ls_types::ClientCapabilities;
 
 /// Build the baseline client capabilities the bridge declares to downstream servers.
 ///
+/// `experimental` is the process-wide `KAKEHASHI_EXPERIMENTAL=true` opt-in
+/// (passed in so both variants stay testable); it adds the capabilities of
+/// experimental features (currently `colorProvider`).
+///
 /// Returns typed `ClientCapabilities` for use with [`merge_upstream_capabilities`].
-fn build_baseline_capabilities(advertise_configuration: bool) -> ClientCapabilities {
+fn build_baseline_capabilities(
+    advertise_configuration: bool,
+    experimental: bool,
+) -> ClientCapabilities {
     use tower_lsp_server::ls_types::{
         CompletionClientCapabilities, CompletionItemCapability, DiagnosticClientCapabilities,
         DiagnosticWorkspaceClientCapabilities, DocumentLinkClientCapabilities,
@@ -23,7 +30,6 @@ fn build_baseline_capabilities(advertise_configuration: bool) -> ClientCapabilit
         link_support: Some(true),
     });
 
-    #[allow(unused_mut)] // mutated only with "experimental" feature
     let mut text_document = TextDocumentClientCapabilities {
         hover: Some(HoverClientCapabilities {
             dynamic_registration: Some(false),
@@ -75,8 +81,7 @@ fn build_baseline_capabilities(advertise_configuration: bool) -> ClientCapabilit
         ..Default::default()
     };
 
-    #[cfg(feature = "experimental")]
-    {
+    if experimental {
         text_document.color_provider = Some(DynamicRegistrationClientCapabilities {
             dynamic_registration: Some(false),
         });
@@ -288,13 +293,15 @@ fn merge_upstream_capabilities(
 /// Build the client capabilities the bridge declares to downstream servers.
 ///
 /// Combines bridge baseline capabilities with upstream client capabilities.
-/// See [`merge_upstream_capabilities`] for merge semantics.
+/// See [`merge_upstream_capabilities`] for merge semantics and
+/// [`build_baseline_capabilities`] for the `experimental` opt-in.
 pub(super) fn build_bridge_client_capabilities(
     upstream: Option<&ClientCapabilities>,
     advertise_configuration: bool,
+    experimental: bool,
 ) -> ClientCapabilities {
     merge_upstream_capabilities(
-        build_baseline_capabilities(advertise_configuration),
+        build_baseline_capabilities(advertise_configuration, experimental),
         upstream,
     )
 }
@@ -303,25 +310,23 @@ pub(super) fn build_bridge_client_capabilities(
 mod tests {
     use super::*;
 
-    fn feature_suffix() -> &'static str {
-        if cfg!(feature = "experimental") {
-            "experimental"
-        } else {
-            "default"
+    /// Snapshot suffixes predate the runtime opt-in (they matched the old
+    /// "experimental" cargo feature); both variants now run in one process.
+    const EXPERIMENTAL_VARIANTS: [(bool, &str); 2] = [(false, "default"), (true, "experimental")];
+
+    #[test]
+    fn bridge_client_capabilities_snapshot() {
+        for (experimental, suffix) in EXPERIMENTAL_VARIANTS {
+            let capabilities = build_bridge_client_capabilities(None, true, experimental);
+            insta::with_settings!({snapshot_suffix => suffix}, {
+                insta::assert_json_snapshot!(capabilities);
+            });
         }
     }
 
     #[test]
-    fn bridge_client_capabilities_snapshot() {
-        let capabilities = build_bridge_client_capabilities(None, true);
-        insta::with_settings!({snapshot_suffix => feature_suffix()}, {
-            insta::assert_json_snapshot!(capabilities);
-        });
-    }
-
-    #[test]
     fn merge_with_none_upstream_equals_baseline() {
-        let base = build_baseline_capabilities(true);
+        let base = build_baseline_capabilities(true, false);
         let merged = merge_upstream_capabilities(base.clone(), None);
         // Serializing both should produce identical JSON
         assert_eq!(
@@ -342,7 +347,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let base = build_baseline_capabilities(true);
+        let base = build_baseline_capabilities(true, false);
         let base_json = serde_json::to_value(&base).unwrap();
         let merged = merge_upstream_capabilities(base, Some(&upstream));
         let merged_json = serde_json::to_value(&merged).unwrap();
@@ -398,7 +403,7 @@ mod tests {
             ..Default::default()
         };
 
-        let base = build_baseline_capabilities(true);
+        let base = build_baseline_capabilities(true, false);
         let merged = merge_upstream_capabilities(base, Some(&upstream));
         let item = merged
             .text_document
@@ -470,7 +475,7 @@ mod tests {
             ..Default::default()
         };
 
-        let base = build_baseline_capabilities(true);
+        let base = build_baseline_capabilities(true, false);
         let merged = merge_upstream_capabilities(base, Some(&upstream));
         let td = merged.text_document.as_ref().unwrap();
 
@@ -548,7 +553,7 @@ mod tests {
             ..Default::default()
         };
 
-        let base = build_baseline_capabilities(true);
+        let base = build_baseline_capabilities(true, false);
         let base_json = serde_json::to_value(&base).unwrap();
         let merged = merge_upstream_capabilities(base, Some(&upstream));
         let merged_json = serde_json::to_value(&merged).unwrap();
@@ -600,7 +605,7 @@ mod tests {
         use tower_lsp_server::ls_types::WindowClientCapabilities;
 
         // Baseline declares no window capability, so no upstream → none downstream.
-        let baseline = build_baseline_capabilities(true);
+        let baseline = build_baseline_capabilities(true, false);
         assert!(
             baseline.window.is_none(),
             "baseline must not advertise window.workDoneProgress on its own"
@@ -614,8 +619,10 @@ mod tests {
             }),
             ..Default::default()
         };
-        let merged =
-            merge_upstream_capabilities(build_baseline_capabilities(true), Some(&supporting));
+        let merged = merge_upstream_capabilities(
+            build_baseline_capabilities(true, false),
+            Some(&supporting),
+        );
         assert_eq!(
             merged.window.and_then(|w| w.work_done_progress),
             Some(true),
@@ -624,8 +631,10 @@ mod tests {
 
         // Upstream omits it → not advertised downstream (gated).
         let non_supporting = ClientCapabilities::default();
-        let merged =
-            merge_upstream_capabilities(build_baseline_capabilities(true), Some(&non_supporting));
+        let merged = merge_upstream_capabilities(
+            build_baseline_capabilities(true, false),
+            Some(&non_supporting),
+        );
         assert!(
             merged.window.and_then(|w| w.work_done_progress).is_none(),
             "must not invite progress the editor can't handle"
@@ -640,8 +649,10 @@ mod tests {
             }),
             ..Default::default()
         };
-        let merged =
-            merge_upstream_capabilities(build_baseline_capabilities(true), Some(&explicit_false));
+        let merged = merge_upstream_capabilities(
+            build_baseline_capabilities(true, false),
+            Some(&explicit_false),
+        );
         assert!(
             merged.window.is_none(),
             "explicit false must leave window unadvertised, not materialize workDoneProgress:false"
@@ -662,8 +673,10 @@ mod tests {
             }),
             ..Default::default()
         };
-        let merged =
-            merge_upstream_capabilities(build_baseline_capabilities(true), Some(&supporting));
+        let merged = merge_upstream_capabilities(
+            build_baseline_capabilities(true, false),
+            Some(&supporting),
+        );
         assert_eq!(
             merged
                 .window
@@ -681,8 +694,10 @@ mod tests {
             }),
             ..Default::default()
         };
-        let merged =
-            merge_upstream_capabilities(build_baseline_capabilities(true), Some(&unsupported));
+        let merged = merge_upstream_capabilities(
+            build_baseline_capabilities(true, false),
+            Some(&unsupported),
+        );
         assert!(
             merged.window.is_none(),
             "support=false must leave window unadvertised (bridge would only answer success:false)"
@@ -708,7 +723,7 @@ mod tests {
             ..Default::default()
         };
         let merged =
-            merge_upstream_capabilities(build_baseline_capabilities(true), Some(&upstream));
+            merge_upstream_capabilities(build_baseline_capabilities(true, false), Some(&upstream));
         assert_eq!(
             merged
                 .window
@@ -792,10 +807,12 @@ mod tests {
             ..Default::default()
         };
 
-        let merged = build_bridge_client_capabilities(Some(&upstream), true);
-        insta::with_settings!({snapshot_suffix => feature_suffix()}, {
-            insta::assert_json_snapshot!(merged);
-        });
+        for (experimental, suffix) in EXPERIMENTAL_VARIANTS {
+            let merged = build_bridge_client_capabilities(Some(&upstream), true, experimental);
+            insta::with_settings!({snapshot_suffix => suffix}, {
+                insta::assert_json_snapshot!(merged);
+            });
+        }
     }
 
     #[test]
@@ -804,13 +821,13 @@ mod tests {
         // (downstream-settings-propagation): otherwise an
         // initializationOptions-configured server would be flipped to pull and
         // answered `null`.
-        let advertised = build_bridge_client_capabilities(None, true);
+        let advertised = build_bridge_client_capabilities(None, true, false);
         assert_eq!(
             advertised.workspace.as_ref().and_then(|w| w.configuration),
             Some(true),
         );
 
-        let not_advertised = build_bridge_client_capabilities(None, false);
+        let not_advertised = build_bridge_client_capabilities(None, false, false);
         assert_eq!(
             not_advertised
                 .workspace

--- a/src/lsp/bridge/protocol/lifecycle.rs
+++ b/src/lsp/bridge/protocol/lifecycle.rs
@@ -18,7 +18,10 @@ use super::request_id::RequestId;
 /// Build an LSP initialize request.
 ///
 /// `root_uri` and `workspace_folders` are forwarded from the upstream client;
-/// `upstream_capabilities` are merged into the bridge defaults.
+/// `upstream_capabilities` are merged into the bridge defaults. `experimental`
+/// is the process-wide `KAKEHASHI_EXPERIMENTAL=true` opt-in, threaded through
+/// to the declared client capabilities.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn build_initialize_request(
     request_id: RequestId,
     initialization_options: Option<serde_json::Value>,
@@ -26,6 +29,7 @@ pub(crate) fn build_initialize_request(
     workspace_folders: Option<Vec<WorkspaceFolder>>,
     upstream_capabilities: Option<&ClientCapabilities>,
     advertise_configuration: bool,
+    experimental: bool,
 ) -> JsonRpcRequest<InitializeParams> {
     let root_path = root_uri.as_deref().and_then(|uri| {
         url::Url::parse(uri)
@@ -44,6 +48,7 @@ pub(crate) fn build_initialize_request(
         capabilities: build_bridge_client_capabilities(
             upstream_capabilities,
             advertise_configuration,
+            experimental,
         ),
         initialization_options,
         ..Default::default()
@@ -161,23 +166,29 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    fn feature_suffix() -> &'static str {
-        if cfg!(feature = "experimental") {
-            "experimental"
-        } else {
-            "default"
-        }
-    }
+    /// Snapshot suffixes predate the runtime opt-in (they matched the old
+    /// "experimental" cargo feature); both variants now run in one process.
+    const EXPERIMENTAL_VARIANTS: [(bool, &str); 2] = [(false, "default"), (true, "experimental")];
 
     #[test]
     fn initialize_request_has_correct_structure() {
-        let request = build_initialize_request(RequestId::new(1), None, None, None, None, true);
+        for (experimental, suffix) in EXPERIMENTAL_VARIANTS {
+            let request = build_initialize_request(
+                RequestId::new(1),
+                None,
+                None,
+                None,
+                None,
+                true,
+                experimental,
+            );
 
-        insta::with_settings!({snapshot_suffix => feature_suffix()}, {
-            insta::assert_json_snapshot!(request, {
-                ".params.processId" => "[PID]",
+            insta::with_settings!({snapshot_suffix => suffix}, {
+                insta::assert_json_snapshot!(request, {
+                    ".params.processId" => "[PID]",
+                });
             });
-        });
+        }
     }
 
     #[test]
@@ -189,20 +200,23 @@ mod tests {
                 }
             }
         });
-        let request = build_initialize_request(
-            RequestId::new(42),
-            Some(options.clone()),
-            None,
-            None,
-            None,
-            true,
-        );
+        for (experimental, suffix) in EXPERIMENTAL_VARIANTS {
+            let request = build_initialize_request(
+                RequestId::new(42),
+                Some(options.clone()),
+                None,
+                None,
+                None,
+                true,
+                experimental,
+            );
 
-        insta::with_settings!({snapshot_suffix => feature_suffix()}, {
-            insta::assert_json_snapshot!(request, {
-                ".params.processId" => "[PID]",
+            insta::with_settings!({snapshot_suffix => suffix}, {
+                insta::assert_json_snapshot!(request, {
+                    ".params.processId" => "[PID]",
+                });
             });
-        });
+        }
     }
 
     #[test]
@@ -215,6 +229,7 @@ mod tests {
             None,
             None,
             true,
+            false,
         );
 
         let json = serde_json::to_value(&request).unwrap();
@@ -223,7 +238,8 @@ mod tests {
 
     #[test]
     fn initialize_request_has_null_root_uri_when_not_provided() {
-        let request = build_initialize_request(RequestId::new(1), None, None, None, None, true);
+        let request =
+            build_initialize_request(RequestId::new(1), None, None, None, None, true, false);
 
         let json = serde_json::to_value(&request).unwrap();
         assert!(json["params"]["rootUri"].is_null());
@@ -235,19 +251,29 @@ mod tests {
             uri: Uri::from_str("file:///home/user/project").unwrap(),
             name: "project".to_string(),
         }];
-        let request =
-            build_initialize_request(RequestId::new(1), None, None, Some(folders), None, true);
+        for (experimental, suffix) in EXPERIMENTAL_VARIANTS {
+            let request = build_initialize_request(
+                RequestId::new(1),
+                None,
+                None,
+                Some(folders.clone()),
+                None,
+                true,
+                experimental,
+            );
 
-        insta::with_settings!({snapshot_suffix => feature_suffix()}, {
-            insta::assert_json_snapshot!(request, {
-                ".params.processId" => "[PID]",
+            insta::with_settings!({snapshot_suffix => suffix}, {
+                insta::assert_json_snapshot!(request, {
+                    ".params.processId" => "[PID]",
+                });
             });
-        });
+        }
     }
 
     #[test]
     fn initialize_request_has_null_workspace_folders_when_not_provided() {
-        let request = build_initialize_request(RequestId::new(1), None, None, None, None, true);
+        let request =
+            build_initialize_request(RequestId::new(1), None, None, None, None, true, false);
 
         let json = serde_json::to_value(&request).unwrap();
         assert!(json["params"]["workspaceFolders"].is_null());
@@ -263,6 +289,7 @@ mod tests {
             None,
             None,
             true,
+            false,
         );
 
         let json = serde_json::to_value(&request).unwrap();
@@ -271,7 +298,8 @@ mod tests {
 
     #[test]
     fn initialize_request_has_null_root_path_when_no_root_uri() {
-        let request = build_initialize_request(RequestId::new(1), None, None, None, None, true);
+        let request =
+            build_initialize_request(RequestId::new(1), None, None, None, None, true, false);
 
         let json = serde_json::to_value(&request).unwrap();
         assert!(json["params"]["rootPath"].is_null());
@@ -304,14 +332,23 @@ mod tests {
             ..Default::default()
         };
 
-        let request =
-            build_initialize_request(RequestId::new(1), None, None, None, Some(&upstream), true);
+        for (experimental, suffix) in EXPERIMENTAL_VARIANTS {
+            let request = build_initialize_request(
+                RequestId::new(1),
+                None,
+                None,
+                None,
+                Some(&upstream),
+                true,
+                experimental,
+            );
 
-        insta::with_settings!({snapshot_suffix => feature_suffix()}, {
-            insta::assert_json_snapshot!(request, {
-                ".params.processId" => "[PID]",
+            insta::with_settings!({snapshot_suffix => suffix}, {
+                insta::assert_json_snapshot!(request, {
+                    ".params.processId" => "[PID]",
+                });
             });
-        });
+        }
     }
 
     #[test]

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@experimental.snap
@@ -4,6 +4,8 @@ expression: merged
 ---
 {
   "workspace": {
+    "workspaceFolders": true,
+    "configuration": true,
     "diagnostics": {
       "refreshSupport": true
     }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@experimental.snap
@@ -4,6 +4,8 @@ expression: capabilities
 ---
 {
   "workspace": {
+    "workspaceFolders": true,
+    "configuration": true,
     "diagnostics": {
       "refreshSupport": true
     }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@experimental.snap
@@ -11,6 +11,8 @@ expression: request
     "rootUri": null,
     "capabilities": {
       "workspace": {
+        "workspaceFolders": true,
+        "configuration": true,
         "diagnostics": {
           "refreshSupport": true
         }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@experimental.snap
@@ -22,6 +22,8 @@ expression: request
     },
     "capabilities": {
       "workspace": {
+        "workspaceFolders": true,
+        "configuration": true,
         "diagnostics": {
           "refreshSupport": true
         }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@experimental.snap
@@ -11,6 +11,8 @@ expression: request
     "rootUri": null,
     "capabilities": {
       "workspace": {
+        "workspaceFolders": true,
+        "configuration": true,
         "diagnostics": {
           "refreshSupport": true
         }

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@experimental.snap
@@ -11,6 +11,8 @@ expression: request
     "rootUri": null,
     "capabilities": {
       "workspace": {
+        "workspaceFolders": true,
+        "configuration": true,
         "diagnostics": {
           "refreshSupport": true
         }

--- a/src/lsp/bridge/text_document.rs
+++ b/src/lsp/bridge/text_document.rs
@@ -6,7 +6,6 @@
 //! The structure mirrors `lsp_impl/text_document/` for consistency.
 
 mod code_lens;
-#[cfg(feature = "experimental")]
 mod color_presentation;
 
 pub(crate) use code_lens::{CodeLensEnvelope, extract_code_lens_envelope};
@@ -18,7 +17,6 @@ mod diagnostic;
 mod did_change;
 mod did_close;
 mod did_open;
-#[cfg(feature = "experimental")]
 mod document_color;
 mod document_highlight;
 mod document_link;

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -263,8 +263,9 @@ pub struct Kakehashi {
     cli_mode: std::sync::atomic::AtomicBool,
     /// Runtime opt-in for experimental features (`KAKEHASHI_EXPERIMENTAL=true`,
     /// see [`crate::experimental`]) — currently the native lexical-resolution
-    /// layer. Copied from the environment once at construction; atomic only so
-    /// tests can toggle it per instance.
+    /// layer and documentColor / colorPresentation (capability advertisement
+    /// and handlers). Copied from the environment once at construction; atomic
+    /// only so tests can toggle it per instance.
     experimental: std::sync::atomic::AtomicBool,
     /// Per-document coalescing scheduler for the off-ingress parse
     /// (per-document-parse-scheduler ADR): `did_change` applies the edit and clears the

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -32,7 +32,6 @@ use tower_lsp_server::ls_types::{
     SignatureHelpParams, TextDocumentPositionParams, TextEdit, Uri, WillSaveTextDocumentParams,
     WorkspaceEdit,
 };
-#[cfg(feature = "experimental")]
 use tower_lsp_server::ls_types::{
     ColorInformation, ColorPresentation, ColorPresentationParams, DocumentColorParams,
 };
@@ -764,12 +763,10 @@ impl LanguageServer for Kakehashi {
         self.linked_editing_range_impl(params).await
     }
 
-    #[cfg(feature = "experimental")]
     async fn document_color(&self, params: DocumentColorParams) -> Result<Vec<ColorInformation>> {
         self.document_color_impl(params).await
     }
 
-    #[cfg(feature = "experimental")]
     async fn color_presentation(
         &self,
         params: ColorPresentationParams,

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -262,6 +262,11 @@ pub struct Kakehashi {
     /// discards it), so `did_open_impl` skips the synthetic diagnostic task — that
     /// avoids both the wasted downstream pull and the abort-vs-`didClose` race (#489).
     cli_mode: std::sync::atomic::AtomicBool,
+    /// Runtime opt-in for experimental features (`KAKEHASHI_EXPERIMENTAL=true`,
+    /// see [`crate::experimental`]) — currently the native lexical-resolution
+    /// layer. Copied from the environment once at construction; atomic only so
+    /// tests can toggle it per instance.
+    experimental: std::sync::atomic::AtomicBool,
     /// Per-document coalescing scheduler for the off-ingress parse
     /// (per-document-parse-scheduler ADR): `did_change` applies the edit and clears the
     /// tree synchronously, then schedules the (re)parse here so the parse runs off
@@ -344,6 +349,7 @@ impl Kakehashi {
                 kakehashi::captures_match_cache::CapturesMatchCache::new(),
             ),
             cli_mode: std::sync::atomic::AtomicBool::new(false),
+            experimental: std::sync::atomic::AtomicBool::new(crate::experimental::enabled()),
             parse_scheduler: std::sync::Arc::new(parse_scheduler::ParseScheduler::default()),
         }
     }
@@ -358,6 +364,20 @@ impl Kakehashi {
     /// Whether this instance runs as a one-shot CLI rather than an LSP server.
     pub(crate) fn is_cli_mode(&self) -> bool {
         self.cli_mode.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Whether experimental features are enabled for this instance; see the
+    /// `experimental` field.
+    pub(crate) fn experimental_enabled(&self) -> bool {
+        self.experimental.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Toggle experimental features for this instance — tests only; the
+    /// production value comes from the environment at construction.
+    #[cfg(test)]
+    pub(crate) fn set_experimental(&self, enabled: bool) {
+        self.experimental
+            .store(enabled, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// Create a `ClientNotifier` for centralized client communication.

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use tower_lsp_server::Client;
 use tower_lsp_server::jsonrpc::Result;
-#[cfg(feature = "experimental")]
 use tower_lsp_server::ls_types::ColorProviderCapability;
 use tower_lsp_server::ls_types::{
     CodeLensOptions, CompletionOptions, DeclarationCapability, DeclarationOptions,
@@ -365,10 +364,9 @@ impl Kakehashi {
                 linked_editing_range_provider: Some(LinkedEditingRangeServerCapabilities::Simple(
                     true,
                 )),
-                #[cfg(feature = "experimental")]
-                color_provider: Some(ColorProviderCapability::Simple(true)),
-                #[cfg(not(feature = "experimental"))]
-                color_provider: None,
+                color_provider: self
+                    .experimental_enabled()
+                    .then_some(ColorProviderCapability::Simple(true)),
                 moniker_provider: Some(OneOf::Left(true)),
                 // pull-first-diagnostic-forwarding: Pull-first diagnostic forwarding
                 diagnostic_provider: Some(DiagnosticServerCapabilities::Options(

--- a/src/lsp/lsp_impl/text_document.rs
+++ b/src/lsp/lsp_impl/text_document.rs
@@ -1,7 +1,6 @@
 //! Text document related LSP methods.
 
 mod code_lens;
-#[cfg(feature = "experimental")]
 mod color_presentation;
 mod completion;
 mod completion_item;
@@ -12,7 +11,6 @@ mod did_change;
 mod did_close;
 mod did_open;
 mod did_save;
-#[cfg(feature = "experimental")]
 mod document_color;
 mod document_highlight;
 mod document_link;

--- a/src/lsp/lsp_impl/text_document/color_presentation.rs
+++ b/src/lsp/lsp_impl/text_document/color_presentation.rs
@@ -11,6 +11,12 @@ impl Kakehashi {
         &self,
         params: ColorPresentationParams,
     ) -> Result<Vec<ColorPresentation>> {
+        // Experimental (KAKEHASHI_EXPERIMENTAL=true): without the opt-in the
+        // capability is not advertised, so answer a compliant empty result to
+        // any client that calls regardless.
+        if !self.experimental_enabled() {
+            return Ok(Vec::new());
+        }
         let lsp_uri = params.text_document.uri;
         let range = params.range;
         let color = params.color;

--- a/src/lsp/lsp_impl/text_document/document_color.rs
+++ b/src/lsp/lsp_impl/text_document/document_color.rs
@@ -18,6 +18,12 @@ impl Kakehashi {
         &self,
         params: DocumentColorParams,
     ) -> Result<Vec<ColorInformation>> {
+        // Experimental (KAKEHASHI_EXPERIMENTAL=true): without the opt-in the
+        // capability is not advertised, so answer a compliant empty result to
+        // any client that calls regardless.
+        if !self.experimental_enabled() {
+            return Ok(Vec::new());
+        }
         let lsp_uri = params.text_document.uri;
 
         // Convert ls_types::Uri to url::Url for internal use

--- a/src/lsp/lsp_impl/text_document/native_bindings.rs
+++ b/src/lsp/lsp_impl/text_document/native_bindings.rs
@@ -71,6 +71,12 @@ impl Kakehashi {
         position: Position,
         f: impl FnOnce(NativeBindingsContext<'_>) -> Option<R>,
     ) -> Result<Option<R>> {
+        // Experimental gate (KAKEHASHI_EXPERIMENTAL=true): without the
+        // opt-in the native layer contributes nothing and the layer walk
+        // falls through to the bridge layers.
+        if !self.experimental_enabled() {
+            return Ok(None);
+        }
         let Ok(uri) = uri_to_url(lsp_uri) else {
             return Ok(None);
         };
@@ -428,6 +434,7 @@ mod tests {
     fn server_with_doc(text: &str) -> (LspService<Kakehashi>, Url, Uri) {
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();
+        server.set_experimental(true);
         server
             .language
             .language_registry_for_parallel()
@@ -472,6 +479,25 @@ mod tests {
         assert_eq!(links.len(), 1);
         assert_eq!(links[0].target_range.start, Position::new(0, 16));
         assert_eq!(links[0].target_range.end, Position::new(0, 22));
+    }
+
+    #[tokio::test]
+    async fn native_layer_stays_silent_without_the_experimental_opt_in() {
+        let text = "fn main() { let target = 1; target; }";
+        let (service, _url, uri) = server_with_doc(text);
+        let server = service.inner();
+        server.set_experimental(false);
+
+        let links = server
+            .native_bindings_answer(&uri, Position::new(0, 28), |ctx| {
+                native_definition(ctx, &uri)
+            })
+            .await
+            .unwrap();
+        assert!(
+            links.is_none(),
+            "the native layer must contribute nothing without the opt-in"
+        );
     }
 
     #[tokio::test]
@@ -633,6 +659,7 @@ mod tests {
     fn server_with_markdown_doc(text: &str) -> (LspService<Kakehashi>, Uri) {
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();
+        server.set_experimental(true);
         server
             .language
             .language_registry_for_parallel()

--- a/tests/e2e_lsp_capability.rs
+++ b/tests/e2e_lsp_capability.rs
@@ -50,30 +50,41 @@ fn e2e_capability_advertised(#[case] capability: &str) {
     shutdown_client(&mut client);
 }
 
-#[cfg(feature = "experimental")]
+/// Experimental capabilities follow the `KAKEHASHI_EXPERIMENTAL=true`
+/// runtime opt-in: advertised with it, absent (or `null`) without it —
+/// hermetically, even when the developer's shell exports the variable.
 #[rstest]
 #[case("colorProvider")]
-fn e2e_experimental_capability_advertised(#[case] capability: &str) {
-    let mut client = LspClient::new();
+fn e2e_experimental_capability_follows_the_env_opt_in(#[case] capability: &str) {
+    for (experimental, expected) in [(true, true), (false, false)] {
+        let builder = LspClient::builder();
+        let mut client = if experimental {
+            builder.env("KAKEHASHI_EXPERIMENTAL", "true")
+        } else {
+            builder.env_remove("KAKEHASHI_EXPERIMENTAL")
+        }
+        .build();
 
-    let init_response = client.send_request(
-        "initialize",
-        json!({
-            "processId": std::process::id(),
-            "rootUri": null,
-            "capabilities": {}
-        }),
-    );
+        let init_response = client.send_request(
+            "initialize",
+            json!({
+                "processId": std::process::id(),
+                "rootUri": null,
+                "capabilities": {}
+            }),
+        );
 
-    let capabilities = init_response
-        .get("result")
-        .and_then(|r| r.get("capabilities"))
-        .expect("Should have capabilities in init response");
+        let capabilities = init_response
+            .get("result")
+            .and_then(|r| r.get("capabilities"))
+            .expect("Should have capabilities in init response");
 
-    assert!(
-        capabilities.get(capability).is_some(),
-        "{capability} should be advertised in server capabilities"
-    );
+        let advertised = capabilities.get(capability).is_some_and(|v| !v.is_null());
+        assert_eq!(
+            advertised, expected,
+            "{capability} advertised={advertised} with KAKEHASHI_EXPERIMENTAL set to {experimental}"
+        );
 
-    shutdown_client(&mut client);
+        shutdown_client(&mut client);
+    }
 }

--- a/tests/e2e_lsp_lua_color_presentation.rs
+++ b/tests/e2e_lsp_lua_color_presentation.rs
@@ -17,7 +17,9 @@
 
 mod helpers;
 
-use helpers::lua_bridge::{create_lua_configured_client_experimental, shutdown_client};
+use helpers::lua_bridge::{
+    create_lua_configured_client_experimental, shutdown_client, skip_if_lua_ls_unavailable,
+};
 use serde_json::json;
 
 /// E2E test: colorPresentation request is handled without error
@@ -27,6 +29,9 @@ use serde_json::json;
 /// that the bridge infrastructure correctly handles the request.
 #[test]
 fn e2e_color_presentation_request_handled() {
+    if skip_if_lua_ls_unavailable() {
+        return;
+    }
     let (mut client, _config_dir) = create_lua_configured_client_experimental();
 
     // Open markdown document with Lua code block

--- a/tests/e2e_lsp_lua_color_presentation.rs
+++ b/tests/e2e_lsp_lua_color_presentation.rs
@@ -13,11 +13,11 @@
 //! **Note**: colorPresentation is typically called after documentColor returns colors.
 //! Since lua-ls doesn't return colors, we use mock values to test the infrastructure.
 
-#![cfg(all(feature = "e2e", feature = "experimental"))]
+#![cfg(feature = "e2e")]
 
 mod helpers;
 
-use helpers::lua_bridge::{create_lua_configured_client, shutdown_client};
+use helpers::lua_bridge::{create_lua_configured_client_experimental, shutdown_client};
 use serde_json::json;
 
 /// E2E test: colorPresentation request is handled without error
@@ -27,7 +27,7 @@ use serde_json::json;
 /// that the bridge infrastructure correctly handles the request.
 #[test]
 fn e2e_color_presentation_request_handled() {
-    let (mut client, _config_dir) = create_lua_configured_client();
+    let (mut client, _config_dir) = create_lua_configured_client_experimental();
 
     // Open markdown document with Lua code block
     let markdown_content = r##"# Test Document

--- a/tests/e2e_lsp_lua_document_color.rs
+++ b/tests/e2e_lsp_lua_document_color.rs
@@ -17,12 +17,17 @@
 
 mod helpers;
 
-use helpers::lua_bridge::{create_lua_configured_client_experimental, shutdown_client};
+use helpers::lua_bridge::{
+    create_lua_configured_client_experimental, shutdown_client, skip_if_lua_ls_unavailable,
+};
 use serde_json::json;
 
 /// E2E test: documentColor request is handled without error
 #[test]
 fn e2e_document_color_request_handled() {
+    if skip_if_lua_ls_unavailable() {
+        return;
+    }
     let (mut client, _config_dir) = create_lua_configured_client_experimental();
 
     // Open markdown document with Lua code block
@@ -126,6 +131,9 @@ More text.
 /// E2E test: documentColor for markdown without code blocks returns empty or null
 #[test]
 fn e2e_document_color_no_injections_returns_empty() {
+    if skip_if_lua_ls_unavailable() {
+        return;
+    }
     let (mut client, _config_dir) = create_lua_configured_client_experimental();
 
     // Open markdown document WITHOUT code blocks

--- a/tests/e2e_lsp_lua_document_color.rs
+++ b/tests/e2e_lsp_lua_document_color.rs
@@ -13,17 +13,17 @@
 //! **Note**: lua-language-server typically doesn't return color information for Lua code,
 //! so this test verifies the bridge infrastructure works correctly by accepting empty results.
 
-#![cfg(all(feature = "e2e", feature = "experimental"))]
+#![cfg(feature = "e2e")]
 
 mod helpers;
 
-use helpers::lua_bridge::{create_lua_configured_client, shutdown_client};
+use helpers::lua_bridge::{create_lua_configured_client_experimental, shutdown_client};
 use serde_json::json;
 
 /// E2E test: documentColor request is handled without error
 #[test]
 fn e2e_document_color_request_handled() {
-    let (mut client, _config_dir) = create_lua_configured_client();
+    let (mut client, _config_dir) = create_lua_configured_client_experimental();
 
     // Open markdown document with Lua code block
     // Note: lua-language-server typically doesn't provide colors for Lua code,
@@ -126,7 +126,7 @@ More text.
 /// E2E test: documentColor for markdown without code blocks returns empty or null
 #[test]
 fn e2e_document_color_no_injections_returns_empty() {
-    let (mut client, _config_dir) = create_lua_configured_client();
+    let (mut client, _config_dir) = create_lua_configured_client_experimental();
 
     // Open markdown document WITHOUT code blocks
     let markdown_content = r#"# Test Document

--- a/tests/e2e_native_definition.rs
+++ b/tests/e2e_native_definition.rs
@@ -28,8 +28,21 @@ fn init_options() -> serde_json::Value {
     })
 }
 
-fn client_with_open_doc() -> LspClient {
-    let mut client = LspClient::new();
+/// Spawn a client with the native layer enabled (`KAKEHASHI_EXPERIMENTAL=true`)
+/// or hermetically disabled (the variable removed even if the developer's
+/// shell exports it).
+fn experimental_client(enabled: bool) -> LspClient {
+    let builder = LspClient::builder();
+    if enabled {
+        builder.env("KAKEHASHI_EXPERIMENTAL", "true")
+    } else {
+        builder.env_remove("KAKEHASHI_EXPERIMENTAL")
+    }
+    .build()
+}
+
+fn client_with_open_doc(experimental: bool) -> LspClient {
+    let mut client = experimental_client(experimental);
     client.send_request(
         "initialize",
         json!({
@@ -61,7 +74,7 @@ fn use_position() -> serde_json::Value {
 
 #[test]
 fn native_definition_resolves_without_a_bridge_server() {
-    let mut client = client_with_open_doc();
+    let mut client = client_with_open_doc(true);
 
     let response = client.send_request(
         "textDocument/definition",
@@ -96,7 +109,7 @@ fn native_definition_resolves_without_a_bridge_server() {
 
 #[test]
 fn native_definition_resolves_inside_markdown_lua_block() {
-    let mut client = LspClient::new();
+    let mut client = experimental_client(true);
     client.send_request(
         "initialize",
         json!({
@@ -149,9 +162,34 @@ fn native_definition_resolves_inside_markdown_lua_block() {
     assert_eq!(range["start"]["character"], 6);
 }
 
+/// The native lexical-resolution layer is experimental: without
+/// `KAKEHASHI_EXPERIMENTAL=true` in the server's environment it must stay
+/// silent, even when a `bindings.scm` is served — with no bridge server
+/// configured, definition then answers `null`.
+#[test]
+fn native_definition_stays_silent_without_kakehashi_experimental() {
+    let mut client = client_with_open_doc(false);
+
+    let response = client.send_request(
+        "textDocument/definition",
+        json!({
+            "textDocument": { "uri": URI },
+            "position": use_position()
+        }),
+    );
+    assert!(
+        response.get("error").is_none(),
+        "definition must not error: {response:?}"
+    );
+    assert!(
+        response["result"].is_null(),
+        "native layer must stay silent without KAKEHASHI_EXPERIMENTAL=true: {response:?}"
+    );
+}
+
 #[test]
 fn native_references_and_rename_span_definition_and_use() {
-    let mut client = client_with_open_doc();
+    let mut client = client_with_open_doc(true);
 
     let response = client.send_request(
         "textDocument/references",

--- a/tests/helpers/lua_bridge.rs
+++ b/tests/helpers/lua_bridge.rs
@@ -116,7 +116,8 @@ fn init_lua_client_with(
     let mut client = if experimental {
         builder.env("KAKEHASHI_EXPERIMENTAL", "true")
     } else {
-        builder
+        // Hermetic even when the developer's shell exports the opt-in.
+        builder.env_remove("KAKEHASHI_EXPERIMENTAL")
     }
     .build();
 

--- a/tests/helpers/lua_bridge.rs
+++ b/tests/helpers/lua_bridge.rs
@@ -62,7 +62,15 @@ pub fn skip_if_lua_ls_unavailable() -> bool {
 /// Callers must keep the `TempDir` alive (e.g., `let (_client, _config_dir) = ...`)
 /// so the temp directory is not deleted while the server is running.
 pub fn create_lua_configured_client() -> (LspClient, tempfile::TempDir) {
-    let (client, config_dir) = init_lua_client(None);
+    let (client, config_dir) = init_lua_client_with(None, false);
+    (client, config_dir)
+}
+
+/// [`create_lua_configured_client`] with `KAKEHASHI_EXPERIMENTAL=true` set on
+/// the spawned server — for tests exercising experimental features
+/// (documentColor / colorPresentation bridging).
+pub fn create_lua_configured_client_experimental() -> (LspClient, tempfile::TempDir) {
+    let (client, config_dir) = init_lua_client_with(None, true);
     (client, config_dir)
 }
 
@@ -82,7 +90,7 @@ pub fn create_lua_configured_client() -> (LspClient, tempfile::TempDir) {
 pub fn create_lua_configured_client_with_workspace()
 -> (LspClient, tempfile::TempDir, tempfile::TempDir) {
     let workspace_dir = tempfile::TempDir::new().expect("Failed to create workspace temp dir");
-    let (client, config_dir) = init_lua_client(Some(&workspace_dir));
+    let (client, config_dir) = init_lua_client_with(Some(&workspace_dir), false);
     (client, workspace_dir, config_dir)
 }
 
@@ -90,7 +98,10 @@ pub fn create_lua_configured_client_with_workspace()
 ///
 /// When `workspace_dir` is `Some`, sets `rootUri` and `workspaceFolders` so lua-ls
 /// can index virtual documents. When `None`, uses `rootUri: null`.
-fn init_lua_client(workspace_dir: Option<&tempfile::TempDir>) -> (LspClient, tempfile::TempDir) {
+fn init_lua_client_with(
+    workspace_dir: Option<&tempfile::TempDir>,
+    experimental: bool,
+) -> (LspClient, tempfile::TempDir) {
     let config_dir = tempfile::TempDir::new().expect("Failed to create config temp dir");
     let config_path = config_dir.path().join("empty.toml");
     std::fs::write(&config_path, "").expect("Failed to write empty config");
@@ -99,10 +110,15 @@ fn init_lua_client(workspace_dir: Option<&tempfile::TempDir>) -> (LspClient, tem
         .expect("temp path should be valid UTF-8")
         .to_string();
 
-    let mut client = LspClient::builder()
+    let builder = LspClient::builder()
         .arg("--config-file")
-        .arg(&config_path_str)
-        .build();
+        .arg(&config_path_str);
+    let mut client = if experimental {
+        builder.env("KAKEHASHI_EXPERIMENTAL", "true")
+    } else {
+        builder
+    }
+    .build();
 
     let (root_uri, workspace_folders) = match workspace_dir {
         Some(dir) => {


### PR DESCRIPTION
## Summary

Unifies experimental-feature gating on a single runtime opt-in: the `KAKEHASHI_EXPERIMENTAL=true` environment variable (exact value, read once per process).

- **Native lexical-resolution layer** (bindings.scm, #556): now dormant unless the server is started with the opt-in. The gate sits on the feature's single entry point `native_bindings_answer` — not on `LayerSource::Native` in the layer-config resolution — so future native contributors to the layer walk (e.g. semanticTokens/foldingRange aggregation) are not conscripted into the gate.
- **`experimental` cargo feature removed**: documentColor / colorPresentation ship in every binary and follow the same env opt-in. `initialize` advertises `colorProvider` only with the opt-in; the handlers answer a compliant empty result to clients that call without it. The bridge's downstream client capabilities take an explicit `experimental: bool` (single production seam in the pool handshake).

## Details

- New `crate::experimental::enabled()` (OnceLock; only the exact value `true` opts in). `Kakehashi` copies the flag at construction into a per-instance AtomicBool so unit tests toggle it hermetically.
- Bridge capability snapshot tests now exercise **both** variants in one process (suffixes keep their historical `default`/`experimental` names). The `@experimental` snapshots were stale — regenerated only under the removed feature, missing the since-landed `workspaceFolders`/`configuration` capabilities — and are refreshed.
- The lua color e2e tests lose their feature cfg (they never ran in CI) and spawn the server with the variable via a new `lua_bridge` helper; `e2e_native_definition` gains a silent-without-opt-in case.
- Docs: `docs/language-features.md` documents the env variable instead of "experimental builds".

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --all-targets --features e2e -- -D warnings`
- [x] `cargo test --lib` — 2446 passed (new unit tests: gate silence, env-value parsing)
- [x] Full e2e suite — 55 binaries / 1579 tests passed (one known `e2e_selection_range` load flake recovered on serial retry)
- [x] TDD: RED e2e commits precede each GREEN (native gate; colorProvider opt-in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)