### PR TITLE
fix(bridge): drop the virtual doc version when re-keying rename edits

### DIFF
--- a/src/lsp/bridge/text_document/rename.rs
+++ b/src/lsp/bridge/text_document/rename.rs
@@ -636,6 +636,7 @@ mod tests {
 
         match edit.document_changes.unwrap() {
             DocumentChanges::Edits(edits) => {
+                assert_eq!(edits.len(), 1);
                 assert_eq!(edits[0].text_document.uri, host_uri);
                 assert_eq!(
                     edits[0].text_document.version, None,

--- a/src/lsp/bridge/text_document/rename.rs
+++ b/src/lsp/bridge/text_document/rename.rs
@@ -234,6 +234,9 @@ fn transform_text_document_edit(
     // Case 2: Same virtual URI → transform
     if uri_str == request_virtual_uri {
         edit.text_document.uri = host_uri.clone();
+        // The version counted the virtual document; against the host URI it
+        // would make clients reject the edit as stale.
+        edit.text_document.version = None;
         for one_of in &mut edit.edits {
             let text_edit = match one_of {
                 OneOf::Left(text_edit) => text_edit,
@@ -590,6 +593,54 @@ mod tests {
                     }
                     OneOf::Right(_) => panic!("Expected Left(TextEdit)"),
                 }
+            }
+            DocumentChanges::Operations(_) => panic!("Expected Edits variant"),
+        }
+    }
+
+    #[test]
+    fn workspace_edit_document_changes_drops_virtual_doc_version() {
+        // The downstream's version counts the VIRTUAL document, not the host
+        // document. Re-keying the URI to the host while keeping that version
+        // makes clients reject the whole WorkspaceEdit as stale whenever the
+        // two counters disagree. The version must be dropped with the URI.
+        let virtual_uri = make_virtual_uri_string();
+        let host_uri = make_host_uri();
+
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 42,
+            "result": {
+                "documentChanges": [
+                    {
+                        "textDocument": { "uri": virtual_uri, "version": 7 },
+                        "edits": [{
+                            "range": {
+                                "start": { "line": 0, "character": 0 },
+                                "end": { "line": 0, "character": 5 }
+                            },
+                            "newText": "newName"
+                        }]
+                    }
+                ]
+            }
+        });
+
+        let edit = transform_workspace_edit_response_to_host(
+            response,
+            &virtual_uri,
+            &host_uri,
+            &RegionOffset::new(10, 0),
+        )
+        .unwrap();
+
+        match edit.document_changes.unwrap() {
+            DocumentChanges::Edits(edits) => {
+                assert_eq!(edits[0].text_document.uri, host_uri);
+                assert_eq!(
+                    edits[0].text_document.version, None,
+                    "virtual doc version must not survive re-keying to the host URI"
+                );
             }
             DocumentChanges::Operations(_) => panic!("Expected Edits variant"),
         }


### PR DESCRIPTION
## Problem

`transform_text_document_edit` (src/lsp/bridge/text_document/rename.rs) rewrites the `documentChanges` URI from the virtual document to the host document, but keeps the downstream server's `OptionalVersionedTextDocumentIdentifier.version`.

That version counts `didChange` notifications on the **virtual** document. Against the host URI it is wrong whenever the two counters disagree, so version-checking clients reject the whole `WorkspaceEdit` as stale and the rename silently does nothing.

## Fix

Null the version alongside the URI rewrite. Per LSP, a `null` version tells the client to apply the edit against its current buffer — exactly the semantics the translated edit has.

Found while designing `textDocument/codeAction` bridge support, which will reuse `transform_workspace_edit_response_to_host`; landing the fix first so codeAction inherits correct version handling.

## Testing

- New unit test `workspace_edit_document_changes_drops_virtual_doc_version` (red before the fix: version `Some(7)` survived the re-key).
- Full gate green: clippy `-D warnings`, `cargo fmt --check`, 2447 lib tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)