### PR TITLE
refactor(bridge): extract the WorkspaceEdit host transform for reuse

### DIFF
--- a/src/lsp/bridge/protocol.rs
+++ b/src/lsp/bridge/protocol.rs
@@ -18,6 +18,7 @@ mod request_id;
 mod response;
 mod translation;
 mod virtual_uri;
+mod workspace_edit;
 
 // Re-export all public items for external use
 pub(crate) use jsonrpc::{
@@ -29,3 +30,4 @@ pub(crate) use request_id::RequestId;
 pub(crate) use response::*;
 pub(crate) use translation::*;
 pub(crate) use virtual_uri::VirtualDocumentUri;
+pub(crate) use workspace_edit::transform_workspace_edit_to_host;

--- a/src/lsp/bridge/protocol.rs
+++ b/src/lsp/bridge/protocol.rs
@@ -5,10 +5,15 @@
 //!
 //! ## Module Structure
 //!
+//! - `client_capabilities` - Baseline client capabilities advertised downstream
+//! - `jsonrpc` - JSON-RPC message types and error inspection
+//! - `lifecycle` - Initialize/shutdown message builders
 //! - `request_id` - RequestId type for type-safe request ID handling
 //! - `virtual_uri` - VirtualDocumentUri type for encoding injection region references
 //! - `request` - Request builders for downstream language servers
 //! - `response` - Response transformers for coordinate translation
+//! - `translation` - Position/range translation between host and virtual coordinates
+//! - `workspace_edit` - WorkspaceEdit virtual→host transformation
 
 mod client_capabilities;
 mod jsonrpc;

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -8,7 +8,8 @@
 use std::collections::HashMap;
 
 use tower_lsp_server::ls_types::{
-    DocumentChangeOperation, DocumentChanges, OneOf, TextDocumentEdit, TextEdit, Uri, WorkspaceEdit,
+    DocumentChangeOperation, DocumentChanges, OneOf, ResourceOp, TextDocumentEdit, TextEdit, Uri,
+    WorkspaceEdit,
 };
 
 use super::translation::{RegionOffset, translate_virtual_range_to_host};
@@ -77,7 +78,10 @@ fn transform_changes_map(
 ///
 /// Handles both `Edits(Vec<TextDocumentEdit>)` and
 /// `Operations(Vec<DocumentChangeOperation>)` variants.
-/// File operations (CreateFile, RenameFile, DeleteFile) are preserved as-is.
+/// File operations (CreateFile, RenameFile, DeleteFile) on real files are
+/// preserved as-is; ones referencing virtual URIs are dropped — they cannot
+/// be expressed in host coordinates and would leak synthetic resources to
+/// the client.
 fn transform_document_changes(
     doc_changes: &mut DocumentChanges,
     request_virtual_uri: &str,
@@ -95,9 +99,21 @@ fn transform_document_changes(
                 DocumentChangeOperation::Edit(edit) => {
                     transform_text_document_edit(edit, request_virtual_uri, host_uri, offset)
                 }
-                DocumentChangeOperation::Op(_) => true, // File operations preserved
+                DocumentChangeOperation::Op(op) => resource_op_targets_real_files_only(op),
             });
         }
+    }
+}
+
+/// Whether a file operation references only real (non-virtual) URIs.
+fn resource_op_targets_real_files_only(op: &ResourceOp) -> bool {
+    match op {
+        ResourceOp::Create(create) => !VirtualDocumentUri::is_virtual_uri(create.uri.as_str()),
+        ResourceOp::Rename(rename) => {
+            !VirtualDocumentUri::is_virtual_uri(rename.old_uri.as_str())
+                && !VirtualDocumentUri::is_virtual_uri(rename.new_uri.as_str())
+        }
+        ResourceOp::Delete(delete) => !VirtualDocumentUri::is_virtual_uri(delete.uri.as_str()),
     }
 }
 
@@ -201,6 +217,46 @@ mod tests {
     }
 
     #[test]
+    fn document_changes_operations_filters_file_ops_on_virtual_uris() {
+        let virtual_uri = make_virtual_uri_string();
+        let host_uri = make_host_uri();
+        // A file op against a virtual URI would leak the synthetic
+        // kakehashi:// resource to the client; none of create/rename/delete
+        // can be expressed in host coordinates, so each must be dropped.
+        let mut edit = parse_workspace_edit(json!({
+            "documentChanges": [
+                { "kind": "create", "uri": virtual_uri },
+                { "kind": "rename", "oldUri": virtual_uri, "newUri": "file:///renamed.lua" },
+                { "kind": "delete", "uri": "file:///obsolete.lua" }
+            ]
+        }));
+
+        transform_workspace_edit_to_host(
+            &mut edit,
+            &virtual_uri,
+            &host_uri,
+            &RegionOffset::new(10, 0),
+        );
+
+        match edit.document_changes.unwrap() {
+            DocumentChanges::Operations(ops) => {
+                assert_eq!(
+                    ops.len(),
+                    1,
+                    "file ops referencing virtual URIs must be dropped"
+                );
+                match &ops[0] {
+                    DocumentChangeOperation::Op(ResourceOp::Delete(delete)) => {
+                        assert_eq!(delete.uri.as_str(), "file:///obsolete.lua");
+                    }
+                    other => panic!("Expected the real-file delete to survive, got {other:?}"),
+                }
+            }
+            DocumentChanges::Edits(_) => panic!("Expected Operations variant"),
+        }
+    }
+
+    #[test]
     fn document_changes_translates_annotated_edits() {
         use tower_lsp_server::ls_types::{
             AnnotatedTextEdit, OptionalVersionedTextDocumentIdentifier, Position, Range,
@@ -209,7 +265,10 @@ mod tests {
         let virtual_uri = make_virtual_uri_string();
         let host_uri = make_host_uri();
         // Constructed in code: serde's untagged OneOf parses annotated edits as
-        // plain TextEdits (unknown fields are ignored), so JSON can't reach Right.
+        // plain TextEdits (unknown fields are ignored), so responses
+        // deserialized from JSON never reach Right and silently lose their
+        // annotationId (an upstream ls-types limitation, tracked in #568
+        // checklist item 7). This pins the arm for typed construction.
         let mut edit = WorkspaceEdit {
             document_changes: Some(DocumentChanges::Edits(vec![TextDocumentEdit {
                 text_document: OptionalVersionedTextDocumentIdentifier {

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -136,3 +136,166 @@ fn transform_text_document_edit(
     // Case 3: Cross-region → filter out
     false
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn make_host_uri() -> Uri {
+        crate::lsp::lsp_impl::url_to_uri(&url::Url::parse("file:///test.md").unwrap()).unwrap()
+    }
+
+    fn make_virtual_uri_string() -> String {
+        VirtualDocumentUri::new(&make_host_uri(), "lua", "region-0").to_uri_string()
+    }
+
+    fn parse_workspace_edit(value: serde_json::Value) -> WorkspaceEdit {
+        serde_json::from_value(value).unwrap()
+    }
+
+    #[test]
+    fn document_changes_operations_preserves_file_ops_and_transforms_edits() {
+        let virtual_uri = make_virtual_uri_string();
+        let host_uri = make_host_uri();
+        let mut edit = parse_workspace_edit(json!({
+            "documentChanges": [
+                { "kind": "create", "uri": "file:///new.lua" },
+                {
+                    "textDocument": { "uri": virtual_uri, "version": 3 },
+                    "edits": [{
+                        "range": {
+                            "start": { "line": 0, "character": 0 },
+                            "end": { "line": 0, "character": 5 }
+                        },
+                        "newText": "newName"
+                    }]
+                }
+            ]
+        }));
+
+        transform_workspace_edit_to_host(
+            &mut edit,
+            &virtual_uri,
+            &host_uri,
+            &RegionOffset::new(10, 0),
+        );
+
+        match edit.document_changes.unwrap() {
+            DocumentChanges::Operations(ops) => {
+                assert_eq!(ops.len(), 2, "file op and edit must both survive");
+                assert!(
+                    matches!(&ops[0], DocumentChangeOperation::Op(_)),
+                    "file operation must pass through untouched"
+                );
+                match &ops[1] {
+                    DocumentChangeOperation::Edit(edit) => {
+                        assert_eq!(edit.text_document.uri, host_uri);
+                        assert_eq!(edit.text_document.version, None);
+                    }
+                    DocumentChangeOperation::Op(_) => panic!("Expected Edit operation"),
+                }
+            }
+            DocumentChanges::Edits(_) => panic!("Expected Operations variant"),
+        }
+    }
+
+    #[test]
+    fn document_changes_translates_annotated_edits() {
+        use tower_lsp_server::ls_types::{
+            AnnotatedTextEdit, OptionalVersionedTextDocumentIdentifier, Position, Range,
+        };
+
+        let virtual_uri = make_virtual_uri_string();
+        let host_uri = make_host_uri();
+        // Constructed in code: serde's untagged OneOf parses annotated edits as
+        // plain TextEdits (unknown fields are ignored), so JSON can't reach Right.
+        let mut edit = WorkspaceEdit {
+            document_changes: Some(DocumentChanges::Edits(vec![TextDocumentEdit {
+                text_document: OptionalVersionedTextDocumentIdentifier {
+                    uri: virtual_uri.parse().unwrap(),
+                    version: Some(1),
+                },
+                edits: vec![OneOf::Right(AnnotatedTextEdit {
+                    text_edit: TextEdit {
+                        range: Range {
+                            start: Position {
+                                line: 2,
+                                character: 0,
+                            },
+                            end: Position {
+                                line: 2,
+                                character: 5,
+                            },
+                        },
+                        new_text: "newName".to_string(),
+                    },
+                    annotation_id: "refactor".to_string(),
+                })],
+            }])),
+            ..Default::default()
+        };
+
+        transform_workspace_edit_to_host(
+            &mut edit,
+            &virtual_uri,
+            &host_uri,
+            &RegionOffset::new(10, 0),
+        );
+
+        match edit.document_changes.unwrap() {
+            DocumentChanges::Edits(edits) => match &edits[0].edits[0] {
+                OneOf::Right(annotated) => {
+                    assert_eq!(annotated.text_edit.range.start.line, 12); // 2 + 10
+                    assert_eq!(annotated.annotation_id, "refactor");
+                }
+                OneOf::Left(_) => panic!("Expected Right(AnnotatedTextEdit)"),
+            },
+            DocumentChanges::Operations(_) => panic!("Expected Edits variant"),
+        }
+    }
+
+    #[test]
+    fn document_changes_real_file_edit_preserved_untouched() {
+        let virtual_uri = make_virtual_uri_string();
+        let host_uri = make_host_uri();
+        let real_uri = "file:///usr/local/lib/types.lua";
+        let mut edit = parse_workspace_edit(json!({
+            "documentChanges": [{
+                "textDocument": { "uri": real_uri, "version": 5 },
+                "edits": [{
+                    "range": {
+                        "start": { "line": 50, "character": 0 },
+                        "end": { "line": 50, "character": 5 }
+                    },
+                    "newText": "newName"
+                }]
+            }]
+        }));
+
+        transform_workspace_edit_to_host(
+            &mut edit,
+            &virtual_uri,
+            &host_uri,
+            &RegionOffset::new(10, 0),
+        );
+
+        match edit.document_changes.unwrap() {
+            DocumentChanges::Edits(edits) => {
+                assert_eq!(edits[0].text_document.uri.as_str(), real_uri);
+                assert_eq!(
+                    edits[0].text_document.version,
+                    Some(5),
+                    "real-file version must survive untouched"
+                );
+                match &edits[0].edits[0] {
+                    OneOf::Left(text_edit) => {
+                        assert_eq!(text_edit.range.start.line, 50, "real-file range untouched");
+                    }
+                    OneOf::Right(_) => panic!("Expected Left(TextEdit)"),
+                }
+            }
+            DocumentChanges::Operations(_) => panic!("Expected Edits variant"),
+        }
+    }
+}

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -1,0 +1,138 @@
+//! WorkspaceEdit coordinate transformation from virtual to host documents.
+//!
+//! Shared by response paths that carry a `WorkspaceEdit` produced against a
+//! virtual document (rename today; codeAction and workspace/applyEdit reuse
+//! it). Per LSP spec a WorkspaceEdit may carry edits via `changes`
+//! (URI→TextEdit map) or `documentChanges`; both are handled.
+
+use std::collections::HashMap;
+
+use tower_lsp_server::ls_types::{
+    DocumentChangeOperation, DocumentChanges, OneOf, TextDocumentEdit, TextEdit, Uri, WorkspaceEdit,
+};
+
+use super::translation::{RegionOffset, translate_virtual_range_to_host};
+use super::virtual_uri::VirtualDocumentUri;
+
+/// Transform a WorkspaceEdit in place from virtual to host document coordinates.
+///
+/// For each URI: real files pass through, the request's own virtual URI is
+/// re-keyed to the host URI (ranges translated, stale virtual-doc versions
+/// dropped), and other (cross-region) virtual URIs are filtered out.
+pub(crate) fn transform_workspace_edit_to_host(
+    edit: &mut WorkspaceEdit,
+    request_virtual_uri: &str,
+    host_uri: &Uri,
+    offset: &RegionOffset,
+) {
+    // Transform changes map: { [uri: string]: TextEdit[] }
+    if let Some(changes) = &mut edit.changes {
+        transform_changes_map(changes, request_virtual_uri, host_uri, offset);
+    }
+
+    // Transform documentChanges array
+    if let Some(doc_changes) = &mut edit.document_changes {
+        transform_document_changes(doc_changes, request_virtual_uri, host_uri, offset);
+    }
+}
+
+/// Transform the `changes` map in a WorkspaceEdit.
+///
+/// Re-keys virtual URIs to host URI and transforms TextEdit ranges.
+/// Cross-region virtual URIs are removed entirely.
+fn transform_changes_map(
+    changes: &mut HashMap<Uri, Vec<TextEdit>>,
+    request_virtual_uri: &str,
+    host_uri: &Uri,
+    offset: &RegionOffset,
+) {
+    // Collect keys to process (can't modify HashMap keys in-place)
+    let keys: Vec<Uri> = changes.keys().cloned().collect();
+
+    for key in keys {
+        let uri_str = key.as_str();
+
+        // Case 1: Real file URI → keep as-is
+        if !VirtualDocumentUri::is_virtual_uri(uri_str) {
+            continue;
+        }
+
+        // Case 2: Same virtual URI → transform ranges, re-key to host URI
+        if uri_str == request_virtual_uri {
+            if let Some(mut edits) = changes.remove(&key) {
+                for edit in &mut edits {
+                    translate_virtual_range_to_host(&mut edit.range, offset);
+                }
+                changes.entry(host_uri.clone()).or_default().extend(edits);
+            }
+            continue;
+        }
+
+        // Case 3: Different virtual URI (cross-region) → filter out
+        changes.remove(&key);
+    }
+}
+
+/// Transform the `documentChanges` array in a WorkspaceEdit.
+///
+/// Handles both `Edits(Vec<TextDocumentEdit>)` and
+/// `Operations(Vec<DocumentChangeOperation>)` variants.
+/// File operations (CreateFile, RenameFile, DeleteFile) are preserved as-is.
+fn transform_document_changes(
+    doc_changes: &mut DocumentChanges,
+    request_virtual_uri: &str,
+    host_uri: &Uri,
+    offset: &RegionOffset,
+) {
+    match doc_changes {
+        DocumentChanges::Edits(edits) => {
+            edits.retain_mut(|edit| {
+                transform_text_document_edit(edit, request_virtual_uri, host_uri, offset)
+            });
+        }
+        DocumentChanges::Operations(ops) => {
+            ops.retain_mut(|op| match op {
+                DocumentChangeOperation::Edit(edit) => {
+                    transform_text_document_edit(edit, request_virtual_uri, host_uri, offset)
+                }
+                DocumentChangeOperation::Op(_) => true, // File operations preserved
+            });
+        }
+    }
+}
+
+/// Transform a single TextDocumentEdit's URI and edit ranges.
+///
+/// Returns `true` if the edit should be kept, `false` if it should be filtered out.
+fn transform_text_document_edit(
+    edit: &mut TextDocumentEdit,
+    request_virtual_uri: &str,
+    host_uri: &Uri,
+    offset: &RegionOffset,
+) -> bool {
+    let uri_str = edit.text_document.uri.as_str();
+
+    // Case 1: Real file URI → keep as-is
+    if !VirtualDocumentUri::is_virtual_uri(uri_str) {
+        return true;
+    }
+
+    // Case 2: Same virtual URI → transform
+    if uri_str == request_virtual_uri {
+        edit.text_document.uri = host_uri.clone();
+        // The version counted the virtual document; against the host URI it
+        // would make clients reject the edit as stale.
+        edit.text_document.version = None;
+        for one_of in &mut edit.edits {
+            let text_edit = match one_of {
+                OneOf::Left(text_edit) => text_edit,
+                OneOf::Right(annotated_edit) => &mut annotated_edit.text_edit,
+            };
+            translate_virtual_range_to_host(&mut text_edit.range, offset);
+        }
+        return true;
+    }
+
+    // Case 3: Cross-region → filter out
+    false
+}

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -1,8 +1,8 @@
 //! WorkspaceEdit coordinate transformation from virtual to host documents.
 //!
 //! Shared by response paths that carry a `WorkspaceEdit` produced against a
-//! virtual document (rename today; codeAction and workspace/applyEdit reuse
-//! it). Per LSP spec a WorkspaceEdit may carry edits via `changes`
+//! virtual document — rename today; codeAction and workspace/applyEdit will
+//! reuse it (#568). Per LSP spec a WorkspaceEdit may carry edits via `changes`
 //! (URI→TextEdit map) or `documentChanges`; both are handled.
 
 use std::collections::HashMap;

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -17,9 +17,10 @@ use super::virtual_uri::VirtualDocumentUri;
 
 /// Transform a WorkspaceEdit in place from virtual to host document coordinates.
 ///
-/// For each URI: real files pass through, the request's own virtual URI is
-/// re-keyed to the host URI (ranges translated, stale virtual-doc versions
-/// dropped), and other (cross-region) virtual URIs are filtered out.
+/// For text edits: real-file URIs pass through, the request's own virtual URI
+/// is re-keyed to the host URI (ranges translated, stale virtual-doc versions
+/// dropped), and other (cross-region) virtual URIs are filtered out. File
+/// operations referencing any virtual URI are filtered out entirely.
 pub(crate) fn transform_workspace_edit_to_host(
     edit: &mut WorkspaceEdit,
     request_virtual_uri: &str,

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -65,30 +65,37 @@ fn transform_changes_map(
     host_uri: &Uri,
     offset: &RegionOffset,
 ) {
-    // Collect keys to process (can't modify HashMap keys in-place)
-    let keys: Vec<Uri> = changes.keys().cloned().collect();
-
-    for key in keys {
+    // Filter and translate in one allocation-free pass, extracting the
+    // request's own edits for re-keying afterwards (keys can't change in place).
+    let mut rekeyed_edits: Option<Vec<TextEdit>> = None;
+    changes.retain(|key, edits| {
         let uri_str = key.as_str();
 
         // Case 1: Real file URI → keep as-is
         if !VirtualDocumentUri::is_virtual_uri(uri_str) {
-            continue;
+            return true;
         }
 
         // Case 2: Same virtual URI → transform ranges, re-key to host URI
         if uri_str == request_virtual_uri {
-            if let Some(mut edits) = changes.remove(&key) {
-                for edit in &mut edits {
-                    translate_virtual_range_to_host(&mut edit.range, offset);
-                }
-                changes.entry(host_uri.clone()).or_default().extend(edits);
+            for edit in edits.iter_mut() {
+                translate_virtual_range_to_host(&mut edit.range, offset);
             }
-            continue;
+            rekeyed_edits = Some(std::mem::take(edits));
+            return false;
         }
 
         // Case 3: Different virtual URI (cross-region) → filter out
-        changes.remove(&key);
+        false
+    });
+
+    if let Some(edits) = rekeyed_edits {
+        // get_mut before insert: clone the host key only on the miss path.
+        if let Some(existing) = changes.get_mut(host_uri) {
+            existing.extend(edits);
+        } else {
+            changes.insert(host_uri.clone(), edits);
+        }
     }
 }
 

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -19,14 +19,29 @@ use super::virtual_uri::VirtualDocumentUri;
 ///
 /// For text edits: real-file URIs pass through, the request's own virtual URI
 /// is re-keyed to the host URI (ranges translated, stale virtual-doc versions
-/// dropped), and other (cross-region) virtual URIs are filtered out. File
-/// operations referencing any virtual URI are filtered out entirely.
+/// dropped), and other (cross-region) virtual URIs are filtered out.
+///
+/// Returns `false` when the edit cannot be represented in host coordinates:
+/// a file operation (create/rename/delete) references a virtual URI. The
+/// spec applies `documentChanges` in order, so dropping just the op (e.g. a
+/// virtual→real rename) would misdirect later edits at an unrelated existing
+/// file — the caller must discard the whole edit instead.
 pub(crate) fn transform_workspace_edit_to_host(
     edit: &mut WorkspaceEdit,
     request_virtual_uri: &str,
     host_uri: &Uri,
     offset: &RegionOffset,
-) {
+) -> bool {
+    if let Some(DocumentChanges::Operations(ops)) = &edit.document_changes {
+        let has_virtual_file_op = ops.iter().any(|op| match op {
+            DocumentChangeOperation::Op(op) => !resource_op_targets_real_files_only(op),
+            DocumentChangeOperation::Edit(_) => false,
+        });
+        if has_virtual_file_op {
+            return false;
+        }
+    }
+
     // Transform changes map: { [uri: string]: TextEdit[] }
     if let Some(changes) = &mut edit.changes {
         transform_changes_map(changes, request_virtual_uri, host_uri, offset);
@@ -36,6 +51,8 @@ pub(crate) fn transform_workspace_edit_to_host(
     if let Some(doc_changes) = &mut edit.document_changes {
         transform_document_changes(doc_changes, request_virtual_uri, host_uri, offset);
     }
+
+    true
 }
 
 /// Transform the `changes` map in a WorkspaceEdit.
@@ -79,10 +96,9 @@ fn transform_changes_map(
 ///
 /// Handles both `Edits(Vec<TextDocumentEdit>)` and
 /// `Operations(Vec<DocumentChangeOperation>)` variants.
-/// File operations (CreateFile, RenameFile, DeleteFile) on real files are
-/// preserved as-is; ones referencing virtual URIs are dropped — they cannot
-/// be expressed in host coordinates and would leak synthetic resources to
-/// the client.
+/// File operations (CreateFile, RenameFile, DeleteFile) are preserved as-is;
+/// the caller has already rejected edits whose file ops reference virtual
+/// URIs.
 fn transform_document_changes(
     doc_changes: &mut DocumentChanges,
     request_virtual_uri: &str,
@@ -100,7 +116,7 @@ fn transform_document_changes(
                 DocumentChangeOperation::Edit(edit) => {
                     transform_text_document_edit(edit, request_virtual_uri, host_uri, offset)
                 }
-                DocumentChangeOperation::Op(op) => resource_op_targets_real_files_only(op),
+                DocumentChangeOperation::Op(_) => true, // Pre-validated real-file ops
             });
         }
     }
@@ -218,43 +234,67 @@ mod tests {
     }
 
     #[test]
-    fn document_changes_operations_filters_file_ops_on_virtual_uris() {
+    fn document_changes_rejects_whole_edit_on_virtual_uri_file_ops() {
         let virtual_uri = make_virtual_uri_string();
         let host_uri = make_host_uri();
-        // A file op against a virtual URI would leak the synthetic
-        // kakehashi:// resource to the client; none of create/rename/delete
-        // can be expressed in host coordinates, so each must be dropped.
+        // A file op against a virtual URI would leak the synthetic resource
+        // to the client, and documentChanges apply IN ORDER — dropping just
+        // the op (e.g. a virtual→real rename) would misdirect later edits at
+        // an unrelated existing file. The whole edit must be rejected.
         let mut edit = parse_workspace_edit(json!({
             "documentChanges": [
-                { "kind": "create", "uri": virtual_uri },
                 { "kind": "rename", "oldUri": virtual_uri, "newUri": "file:///renamed.lua" },
-                { "kind": "delete", "uri": "file:///obsolete.lua" }
+                {
+                    "textDocument": { "uri": "file:///renamed.lua", "version": null },
+                    "edits": [{
+                        "range": {
+                            "start": { "line": 0, "character": 0 },
+                            "end": { "line": 0, "character": 5 }
+                        },
+                        "newText": "dependsOnRename"
+                    }]
+                }
             ]
         }));
 
-        transform_workspace_edit_to_host(
+        let representable = transform_workspace_edit_to_host(
             &mut edit,
             &virtual_uri,
             &host_uri,
             &RegionOffset::new(10, 0),
         );
 
-        match edit.document_changes.unwrap() {
-            DocumentChanges::Operations(ops) => {
-                assert_eq!(
-                    ops.len(),
-                    1,
-                    "file ops referencing virtual URIs must be dropped"
-                );
-                match &ops[0] {
-                    DocumentChangeOperation::Op(ResourceOp::Delete(delete)) => {
-                        assert_eq!(delete.uri.as_str(), "file:///obsolete.lua");
-                    }
-                    other => panic!("Expected the real-file delete to survive, got {other:?}"),
-                }
+        assert!(
+            !representable,
+            "a virtual-URI file op must reject the whole WorkspaceEdit"
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::create(json!({ "kind": "create", "uri": "kakehashi://virtual" }))]
+    #[case::rename_new(
+        json!({ "kind": "rename", "oldUri": "file:///a.lua", "newUri": "kakehashi://virtual" })
+    )]
+    #[case::delete(json!({ "kind": "delete", "uri": "kakehashi://virtual" }))]
+    fn document_changes_rejects_each_virtual_file_op_kind(#[case] mut op: serde_json::Value) {
+        let virtual_uri = make_virtual_uri_string();
+        let host_uri = make_host_uri();
+        // Substitute a well-formed virtual URI for the placeholder
+        for key in ["uri", "oldUri", "newUri"] {
+            if op.get(key).is_some_and(|v| v == "kakehashi://virtual") {
+                op[key] = json!(virtual_uri.clone());
             }
-            DocumentChanges::Edits(_) => panic!("Expected Operations variant"),
         }
+        let mut edit = parse_workspace_edit(json!({ "documentChanges": [op] }));
+
+        let representable = transform_workspace_edit_to_host(
+            &mut edit,
+            &virtual_uri,
+            &host_uri,
+            &RegionOffset::new(10, 0),
+        );
+
+        assert!(!representable);
     }
 
     #[test]

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -232,6 +232,15 @@ mod tests {
                     DocumentChangeOperation::Edit(edit) => {
                         assert_eq!(edit.text_document.uri, host_uri);
                         assert_eq!(edit.text_document.version, None);
+                        match &edit.edits[0] {
+                            OneOf::Left(text_edit) => {
+                                assert_eq!(
+                                    text_edit.range.start.line, 10,
+                                    "range must be translated by the region offset (0 + 10)"
+                                );
+                            }
+                            OneOf::Right(_) => panic!("Expected Left(TextEdit)"),
+                        }
                     }
                     DocumentChangeOperation::Op(_) => panic!("Expected Edit operation"),
                 }

--- a/src/lsp/bridge/text_document/rename.rs
+++ b/src/lsp/bridge/text_document/rename.rs
@@ -132,7 +132,9 @@ fn transform_workspace_edit_response_to_host(
     // Parse into typed WorkspaceEdit
     let mut edit: WorkspaceEdit = serde_json::from_value(result).ok()?;
 
-    transform_workspace_edit_to_host(&mut edit, request_virtual_uri, host_uri, offset);
+    if !transform_workspace_edit_to_host(&mut edit, request_virtual_uri, host_uri, offset) {
+        return None;
+    }
 
     Some(edit)
 }

--- a/src/lsp/bridge/text_document/rename.rs
+++ b/src/lsp/bridge/text_document/rename.rs
@@ -10,22 +10,19 @@
 
 use std::io;
 
-use std::collections::HashMap;
-
 use crate::config::settings::BridgeServerConfig;
 use tower_lsp_server::ls_types::{
-    DocumentChangeOperation, DocumentChanges, NumberOrString, OneOf, Position, TextDocumentEdit,
-    TextEdit, Uri, WorkDoneProgressParams, WorkspaceEdit,
+    NumberOrString, Position, Uri, WorkDoneProgressParams, WorkspaceEdit,
 };
 use url::Url;
 
 use super::super::pool::{LanguageServerPool, UpstreamId};
 use tower_lsp_server::ls_types::RenameParams;
 
-use super::super::protocol::translate_virtual_range_to_host;
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri,
     build_text_document_position_params, response_has_jsonrpc_error,
+    transform_workspace_edit_to_host,
 };
 
 impl LanguageServerPool {
@@ -115,10 +112,8 @@ fn build_rename_request(
 
 /// Transform a WorkspaceEdit response from virtual to host document coordinates.
 ///
-/// Per LSP spec a WorkspaceEdit may carry edits via `changes` (URI→TextEdit map) or
-/// `documentChanges`; both are handled. For each URI: real files pass through, the
-/// request's own virtual URI is translated, and other (cross-region) virtual URIs are
-/// filtered out.
+/// Unwraps the JSON-RPC response, then delegates the coordinate transformation
+/// to [`transform_workspace_edit_to_host`].
 fn transform_workspace_edit_response_to_host(
     mut response: serde_json::Value,
     request_virtual_uri: &str,
@@ -137,118 +132,9 @@ fn transform_workspace_edit_response_to_host(
     // Parse into typed WorkspaceEdit
     let mut edit: WorkspaceEdit = serde_json::from_value(result).ok()?;
 
-    // Transform changes map: { [uri: string]: TextEdit[] }
-    if let Some(changes) = &mut edit.changes {
-        transform_changes_map(changes, request_virtual_uri, host_uri, offset);
-    }
-
-    // Transform documentChanges array
-    if let Some(doc_changes) = &mut edit.document_changes {
-        transform_document_changes(doc_changes, request_virtual_uri, host_uri, offset);
-    }
+    transform_workspace_edit_to_host(&mut edit, request_virtual_uri, host_uri, offset);
 
     Some(edit)
-}
-
-/// Transform the `changes` map in a WorkspaceEdit.
-///
-/// Re-keys virtual URIs to host URI and transforms TextEdit ranges.
-/// Cross-region virtual URIs are removed entirely.
-fn transform_changes_map(
-    changes: &mut HashMap<Uri, Vec<TextEdit>>,
-    request_virtual_uri: &str,
-    host_uri: &Uri,
-    offset: &RegionOffset,
-) {
-    // Collect keys to process (can't modify HashMap keys in-place)
-    let keys: Vec<Uri> = changes.keys().cloned().collect();
-
-    for key in keys {
-        let uri_str = key.as_str();
-
-        // Case 1: Real file URI → keep as-is
-        if !VirtualDocumentUri::is_virtual_uri(uri_str) {
-            continue;
-        }
-
-        // Case 2: Same virtual URI → transform ranges, re-key to host URI
-        if uri_str == request_virtual_uri {
-            if let Some(mut edits) = changes.remove(&key) {
-                for edit in &mut edits {
-                    translate_virtual_range_to_host(&mut edit.range, offset);
-                }
-                changes.entry(host_uri.clone()).or_default().extend(edits);
-            }
-            continue;
-        }
-
-        // Case 3: Different virtual URI (cross-region) → filter out
-        changes.remove(&key);
-    }
-}
-
-/// Transform the `documentChanges` array in a WorkspaceEdit.
-///
-/// Handles both `Edits(Vec<TextDocumentEdit>)` and
-/// `Operations(Vec<DocumentChangeOperation>)` variants.
-/// File operations (CreateFile, RenameFile, DeleteFile) are preserved as-is.
-fn transform_document_changes(
-    doc_changes: &mut DocumentChanges,
-    request_virtual_uri: &str,
-    host_uri: &Uri,
-    offset: &RegionOffset,
-) {
-    match doc_changes {
-        DocumentChanges::Edits(edits) => {
-            edits.retain_mut(|edit| {
-                transform_text_document_edit(edit, request_virtual_uri, host_uri, offset)
-            });
-        }
-        DocumentChanges::Operations(ops) => {
-            ops.retain_mut(|op| match op {
-                DocumentChangeOperation::Edit(edit) => {
-                    transform_text_document_edit(edit, request_virtual_uri, host_uri, offset)
-                }
-                DocumentChangeOperation::Op(_) => true, // File operations preserved
-            });
-        }
-    }
-}
-
-/// Transform a single TextDocumentEdit's URI and edit ranges.
-///
-/// Returns `true` if the edit should be kept, `false` if it should be filtered out.
-fn transform_text_document_edit(
-    edit: &mut TextDocumentEdit,
-    request_virtual_uri: &str,
-    host_uri: &Uri,
-    offset: &RegionOffset,
-) -> bool {
-    let uri_str = edit.text_document.uri.as_str();
-
-    // Case 1: Real file URI → keep as-is
-    if !VirtualDocumentUri::is_virtual_uri(uri_str) {
-        return true;
-    }
-
-    // Case 2: Same virtual URI → transform
-    if uri_str == request_virtual_uri {
-        edit.text_document.uri = host_uri.clone();
-        // The version counted the virtual document; against the host URI it
-        // would make clients reject the edit as stale.
-        edit.text_document.version = None;
-        for one_of in &mut edit.edits {
-            let text_edit = match one_of {
-                OneOf::Left(text_edit) => text_edit,
-                OneOf::Right(annotated_edit) => &mut annotated_edit.text_edit,
-            };
-            translate_virtual_range_to_host(&mut text_edit.range, offset);
-        }
-        return true;
-    }
-
-    // Case 3: Cross-region → filter out
-    false
 }
 
 #[cfg(test)]
@@ -257,6 +143,7 @@ mod tests {
     use super::*;
     use rstest::rstest;
     use serde_json::json;
+    use tower_lsp_server::ls_types::{DocumentChanges, OneOf};
 
     // ==========================================================================
     // Rename request builder tests


### PR DESCRIPTION
## Summary

PR 2 of the #568 sequence (see the PR plan there). The first commit is a pure structural move; review rounds then hardened the shared transform with two behavior fixes.

**Structural move (42d74356):**
- Move the virtual→host `WorkspaceEdit` transformation core (`transform_changes_map` / `transform_document_changes` / `transform_text_document_edit`) out of `bridge/text_document/rename.rs` into a new shared `bridge/protocol/workspace_edit.rs`, exposed as `transform_workspace_edit_to_host`.
- `rename.rs` keeps the JSON-RPC unwrapping wrapper (`transform_workspace_edit_response_to_host`) and delegates the coordinate work.

**Behavior fixes found in review (they change rename's observable behavior — deliberately):**
- `transform_workspace_edit_to_host` is now **fallible**: if `documentChanges` contains a file operation (create/rename/delete) referencing a virtual URI, the whole edit is rejected and rename returns `null`. Previously such ops were passed through verbatim, leaking synthetic `kakehashi` virtual URIs to the client; and per-op filtering is unsafe because `documentChanges` apply in order (a dropped virtual→real rename would misdirect later edits at an unrelated existing file). Aligns with the #568 decision that virtual-URI file ops invalidate the whole action.
- `transform_changes_map` rewritten allocation-free (`HashMap::retain` + `mem::take`; host key cloned only on the miss path).

**New tests:** the module owns direct unit tests for the previously never-covered paths: `DocumentChanges::Operations` (file-op passthrough + edit transform), virtual-URI file-op rejection (ordering-hazard case + one rstest case per op kind), `OneOf::Right` annotated edits (typed construction — serde's untagged `OneOf` can't reach `Right` from JSON), and real-file `documentChanges` passthrough.

## Why

The upcoming `textDocument/codeAction` bridge (PR 3) transforms `CodeAction.edit` — already a typed `WorkspaceEdit`, not a JSON-RPC response — and `workspace/applyEdit` (PR 5) reuses the same transform. The typed-in-place split is exactly the reuse boundary both need.

## Test plan

- [x] `cargo clippy --lib --tests -- -D warnings` clean
- [x] Full lib suite: 2454 passed (rename wrapper tests + new direct module tests)

Part of #568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bridged support for `textDocument/codeAction` and `codeAction/resolve`, including correct edit/command routing and title/aggregation behavior across servers.

* **Bug Fixes**
  * Workspace edits originating from virtual documents (including rename-based edits) are now translated to host document coordinates, with proper region scoping.
  * Multi-file and cross-region edits are handled safely: real file edits are preserved, while unsupported virtual file operations or out-of-region edits are rejected/disabled instead of being applied.
  * Added forwarding and relaying for `workspace/applyEdit`, improving fail-soft behavior and response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->