### PR TITLE
perf(captures): ADR §3 mint reconciliation + envelope move-construction (walk −55%)

### DIFF
--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -287,12 +287,14 @@ The decision therefore **separates three concerns that today all ride the tracke
   derives its region geometry, then maps that geometry to tracker ULIDs in one
   batch — reusing an existing id by position, minting a fresh one for a
   genuinely new region — with the latch re-checked under the tracker entry's
-  exclusive lock, the same lock the `didChange` edit-shift takes. (The check is
-  the tracker's own shift-latch rather than a `parsed_version == content_version`
-  comparison under `edit_lock`: the latch detects exactly the events that would
-  make the pass's coordinates stale — an edit-shift or a close/reopen — and
-  holding the mint inside the shifting lock is what makes the currency check and
-  the mint atomic.) A batch that passes is *correct-at-birth* — a later edit
+  exclusive lock, the same lock the `didChange` edit-shift takes. The latch is
+  necessary but not sufficient on its own: `didChange` shifts the tracker
+  BEFORE it bumps `content_version`, so the pass captures the latch **and**
+  validates liveness + lifetime + currency (incarnation and
+  `parsed_version == content_version`) in one critical section under
+  `edit_lock` (`populate_injections_on_pool`) — atomic against the shift/bump
+  pair — and everything landing after that section is what the latch re-check
+  inside the batch mint/commit catches. A batch that passes is *correct-at-birth* — a later edit
   shifts its ids like any live entry — so there is no purge machinery; a batch
   the latch refuses minted **nothing**: the stale pass withholds every
   region-id-bearing product and defers identity to the next current pass, the

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -551,12 +551,12 @@ inside the existing safety contracts at each step:
   parse-seed/external-scanner issue, not a query-cursor issue, and the read paths
   are already stale-offset-hardened), but readers **write** persistent caches. The
   whole-document token cache (in `semantic_cache` / `cache`, keyed by text hash) is
-  closed by keying off the snapshot's text. The **injection-token cache** (keyed
-  `(Url, region_id)`) and the **node-tracker ULIDs** are *not* closed by
-  text-keying — they are closed only by moving region minting into the snapshot's
-  `populate` (§3) so a stale read consumes stale-but-consistent ids and mints
-  nothing. Naive stale-serve does neither and poisons both permanently (no
-  generation bump, no refresh today).
+  closed by keying off the snapshot's text. The **injection-token cache** and
+  the **node-tracker ULIDs** are *not* closed by text-keying — they are closed
+  by the content-addressed token-cache key and the §3 latch-gated mint
+  reconciliation (both now in) so a stale read consumes stale-but-consistent
+  ids and mints nothing. Naive stale-serve does neither and poisons both
+  permanently (no generation bump, no refresh today).
 - **A text-owning parse actor (per-document-parse-scheduler's Option 4).** Still
   rejected for the reason recorded there: reads bypass the owner, so owning the
   text buys nothing while resurrection-safety must still guard every reader
@@ -692,13 +692,17 @@ removed — `get_tree_with_wait`, `wait_for_epoch`, and the on-demand parse in
 
 Two Stage-2 pieces remain deliberately open:
 
-- The **§3 identity split** (snapshot-owned region ordinals + the
-  current-version tracker reconciliation, and the companion
-  injection-token-cache key rework). Until it lands, the readers whose region
-  resolution mints tracker ULIDs — the whole-document fan-out family and the
-  bridge-context requests — require a **current** snapshot (bounded wait,
-  degrade on staleness) instead of serving stale: a stale read must never
-  mint, and currency is the interim way to guarantee that.
+- The **reader-side remainder of the §3 identity split**. The writer half is
+  in: the tracker reconciliation is the latch-gated batch mint
+  (`mint_batch_if_unshifted`, see §3 above) in `populate` and the captures
+  walk, and the injection-token-cache key rework is content-addressed. What
+  stays open is the readers whose *inline* region resolution (the
+  non-prebuilt fallback) still mints tracker ULIDs — the whole-document
+  fan-out family and the bridge-context requests — which therefore still
+  require a **current** snapshot (bounded wait, degrade on staleness) instead
+  of serving stale: a stale read must never mint, and currency remains the
+  way to guarantee that until those readers consume snapshot-owned region
+  identity instead of minting.
 - Several notification-path consumers (pull diagnostics, `did_save`,
   `documentSymbol`/`documentColor`) still read the legacy store tree after the
   bounded current-wait; they migrate to `latest_snapshot` with the Stage-3

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -310,8 +310,10 @@ snapshot and touches no shared identity index (the mint-race and the
 undefined-id-on-gate-failure both vanish); token reuse is content-keyed; and the
 one identity that genuinely needs cross-edit stability (the bridge's) keeps the
 tracker that already provides it. This ADR commits only to *not* mutating shared
-identities from a **stale** parse pass or any read path — the current-version
-reconciliation above is the one place a parse still mints them.
+identities from a **stale** parse pass or any **stale** read path — the
+latch-gated reconciliation above is where a parse mints them, and the
+currency-gated inline readers (the Stage-2 remainder below) still mint on
+their current-snapshot path.
 
 Any reader that must resolve against **live** positions is position-critical
 (below).

--- a/docs/architecture-decisions/parse-snapshot-architecture.md
+++ b/docs/architecture-decisions/parse-snapshot-architecture.md
@@ -281,20 +281,29 @@ The decision therefore **separates three concerns that today all ride the tracke
 - **Cross-edit bridge / virtual-document identity** — the stable handle a
   downstream language server's virtual document is keyed by — **remains the shared `NodeTracker` ULID**, a live-position (`content_version`) concern. Because regions
   are only *discovered* by a parse, minting still originates from a parse pass, but
-  as a distinct **current-version reconciliation step**, not off the stale-read
-  path: the tracker ULID mint that `populate_injections` performs inline today
-  **moves out of `populate` into a distinct reconciliation step**. When a pass
-  completes and (under `edit_lock`) its `parsed_version` still equals
-  `content_version`, that step maps the snapshot's region geometry to tracker ULIDs
-  — reusing an existing id by position, minting a fresh one for a genuinely new
-  region — exactly what the mint discovery does today, just gated and relocated. If the
-  pass is stale (`content_version` moved on), reconciliation is skipped and deferred
-  to the next current pass; the tracker is meanwhile kept live by the ordinary
-  `didChange` edit-shift (`apply_input_edits`), so the bridge always resolves
-  against a `content_version`-consistent index. A *stale-tree read* still never
-  mints or mutates it — only the current-version reconciliation does. So `populate`
-  splits into two: derive the snapshot-owned ordinals + geometry (always), and (only
-  at current version) reconcile tracker ULIDs.
+  as a distinct **reconciliation step**, not an inline per-region mint off the
+  stale-read path. **Implemented** (`NodeTracker::mint_batch_if_unshifted`):
+  the pass latches the tracker's (shift generation, cleanup epoch) at entry,
+  derives its region geometry, then maps that geometry to tracker ULIDs in one
+  batch — reusing an existing id by position, minting a fresh one for a
+  genuinely new region — with the latch re-checked under the tracker entry's
+  exclusive lock, the same lock the `didChange` edit-shift takes. (The check is
+  the tracker's own shift-latch rather than a `parsed_version == content_version`
+  comparison under `edit_lock`: the latch detects exactly the events that would
+  make the pass's coordinates stale — an edit-shift or a close/reopen — and
+  holding the mint inside the shifting lock is what makes the currency check and
+  the mint atomic.) A batch that passes is *correct-at-birth* — a later edit
+  shifts its ids like any live entry — so there is no purge machinery; a batch
+  the latch refuses minted **nothing**: the stale pass withholds every
+  region-id-bearing product and defers identity to the next current pass, the
+  tracker meanwhile kept live by the ordinary `didChange` edit-shift
+  (`apply_input_edits`), so the bridge always resolves against a
+  `content_version`-consistent index. A *stale-tree read* still never mints or
+  mutates it — only the latch-gated reconciliation does. So `populate` splits in
+  two: derive the snapshot-owned geometry (always), and (only while unshifted)
+  reconcile tracker ULIDs. The captures walk applies the same primitive
+  per layer — one latch-gated batch per visited layer instead of one tracker
+  lock acquisition per capture.
 
 So a stale-tree reader reads self-consistent ordinals + geometry from its own
 snapshot and touches no shared identity index (the mint-race and the
@@ -492,8 +501,8 @@ inside the existing safety contracts at each step:
   `latest_snapshot` retains a servable tree across an edit's `tree.take()`; the two
   stores may transiently sit at different versions (a lost legacy CAS just reseeds
   next pass), but no **reader** sees the difference because every reader reads the
-  snapshot, not the legacy tree. Split `populate` into ordinal/geometry derivation
-  (snapshot-owned) and the current-version tracker reconciliation (§3). Take the
+  snapshot, not the legacy tree. `populate`'s split into geometry derivation and
+  the latch-gated tracker reconciliation (§3) is **already in**. Take the
   grammar auto-install off the read handlers (`compute_captures` no longer triggers
   `ensure_injection_languages_loaded_for_document` inline): the parse loop
   *detects* a missing injected grammar and spawns the install as a **detached
@@ -501,7 +510,7 @@ inside the existing safety contracts at each step:
   **never on the ingress path and never under `edit_lock`** — only the O(1)
   detect-and-spawn is near the lock, and even that need not hold it. The region is
   re-minted on a later reconciliation once the grammar lands. Only the fast
-  tracker-mint itself runs under `edit_lock`. Convert
+  latch-gated tracker-mint itself runs inside the tracker's shifting lock. Convert
   `semanticTokens` full/delta and `captures/full` to the serve-current parked
   wait (the latter reserving
   `null` for no-snapshot / no-lineage / the settle backstop); the whole-document

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -73,10 +73,11 @@ pub(crate) struct InjectionCacheCtx<'a> {
     ///
     /// Accepted residual: an edit landing DURING the fan-out can still let
     /// this pass mint from a just-staled snapshot. Unlike the captures walk
-    /// (whose ids go out on the wire and get a post-walk purge), region ids
+    /// (whose ids go out on the wire, so its mints run through the
+    /// latch-gated `mint_batch_if_unshifted` reconciliation), region ids
     /// stay internal cache keys — a phantom entry is orphaned, never
     /// resolved, and the token cache stays correct via its content-hash
-    /// validity gate — so the purge machinery is not worth its cost here.
+    /// validity gate — so the latch gating is not worth its cost here.
     pub mint_regions: bool,
     /// Owned discovery for this tree (#529), or `None`. Reused — skipping the
     /// injection query — only when its `generation` still matches `generation`

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -542,6 +542,25 @@ impl DocumentStore {
         self.edit_locks.remove(uri);
     }
 
+    /// [`remove_edit_lock`](Self::remove_edit_lock), but only while the map
+    /// still holds the exact `Arc` the caller acquired AND nobody else
+    /// holds a clone — for miss paths that probe liveness some time after
+    /// their `edit_lock()` call. A close+reopen in that gap can hand the
+    /// SAME entry to the new lifetime's first edit (`edit_lock`
+    /// get-or-inserts), and removing it from under that queued edit would
+    /// let the lifetime's next edit mint a fresh mutex and run
+    /// concurrently. The strong count identifies the safe case: exactly 2
+    /// means the caller's clone plus the map's copy and no queued waiter
+    /// (every waiter cloned via `edit_lock`, whose or-insert serializes
+    /// with this predicate on the entry's shard lock, so a pre-predicate
+    /// clone is always visible in the count). On a waiter, the entry stays
+    /// — it is in live use, not a leak.
+    pub(crate) fn remove_edit_lock_if_unshared(&self, uri: &Url, held: &Arc<Mutex<()>>) {
+        self.edit_locks.remove_if(uri, |_, current| {
+            Arc::ptr_eq(current, held) && Arc::strong_count(current) == 2
+        });
+    }
+
     /// Ensure a watermark channel exists for `uri` carrying the current lifetime's
     /// `incarnation`, created at ticket 0. Called when a document is registered or
     /// edited so the watermark's lifetime tracks the document's — it exists exactly

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -670,10 +670,25 @@ impl NodeTracker {
     /// `shift_gen` back at 0) and passes against the not-yet-bumped epoch,
     /// leaving stale-lifetime coordinates alive in a reopened document's
     /// index with nothing left to reclaim them.
-    pub(crate) fn cleanup(&self, uri: &Url) {
+    ///
+    /// `reopened` guards the removal against the inverse race: didClose
+    /// runs this AFTER removing the document and OUTSIDE `edit_lock`, so a
+    /// fast reopen's parse may already have minted the NEW lifetime's ids
+    /// into this entry — an unconditional wipe would publish a snapshot
+    /// whose ids immediately resolve `null`. The probe is evaluated under
+    /// the entry's exclusive lock: probe-sees-open ⇒ the entry is the
+    /// reopened document's live index, keep it (the epoch bump above still
+    /// refuses any old-lifetime latch; old-lifetime entries it may carry
+    /// are position-keyed and bounded, invalidated by the new lifetime's
+    /// edits like any other). Probe-sees-closed ⇒ no new-lifetime mint can
+    /// have happened — mints are liveness-gated on the reopened snapshot,
+    /// whose insert happens-before any mint that passed the gate, which
+    /// happens-before this probe under the same entry lock — so the removal
+    /// reclaims only old-lifetime state.
+    pub(crate) fn cleanup(&self, uri: &Url, reopened: impl FnOnce() -> bool) {
         self.cleanup_epoch
             .fetch_add(1, std::sync::atomic::Ordering::Release);
-        self.entries.remove(uri);
+        self.entries.remove_if(uri, |_, _| !reopened());
     }
 
     /// Run `commit` only if `uri`'s (shift generation, cleanup epoch) still
@@ -855,6 +870,31 @@ mod tests {
         );
     }
 
+    /// A close raced by a completed reopen (the probe sees the document
+    /// open again) keeps the reopened lifetime's index — its freshly minted
+    /// ids must survive — while the epoch bump still refuses any
+    /// old-lifetime latch.
+    #[test]
+    fn cleanup_keeps_reopened_index_but_still_bumps_epoch() {
+        let tracker = NodeTracker::new();
+        let uri = test_uri("cleanup_reopen");
+        // Stands in for the reopened lifetime's first mint, which the raced
+        // didClose's cleanup must not wipe.
+        let id = tracker.get_or_create_in_layer(&uri, 0, 4, "word", 0);
+        let pre_close_latch = tracker.mint_epoch(&uri);
+        tracker.cleanup(&uri, || true);
+        assert_eq!(
+            tracker.lookup_in_layer(&uri, 0, 4, "word", 0),
+            Some(id),
+            "a reopened document's index survives the raced close"
+        );
+        assert_eq!(
+            tracker.mint_batch_if_unshifted(&uri, pre_close_latch, [(10, 14, "word", 0)]),
+            None,
+            "the epoch bump still refuses latches taken before the close"
+        );
+    }
+
     /// A close (any document's) bumps the global cleanup epoch, so a latch
     /// taken before it refuses — the close/reopen ABA guard the per-URI
     /// generation alone cannot provide.
@@ -864,7 +904,7 @@ mod tests {
         let uri = test_uri("batch_mint_cleanup");
         let other = test_uri("batch_mint_other");
         let latch = tracker.mint_epoch(&uri);
-        tracker.cleanup(&other);
+        tracker.cleanup(&other, || false);
         assert_eq!(
             tracker.mint_batch_if_unshifted(&uri, latch, [(0, 4, "word", 0)]),
             None
@@ -909,7 +949,7 @@ mod tests {
         // to a post-reopen observation — including for a URI that never
         // tracked a node.
         let (_, epoch_before) = tracker.mint_epoch(&uri);
-        tracker.cleanup(&uri);
+        tracker.cleanup(&uri, || false);
         let (gen_after, epoch_after) = tracker.mint_epoch(&uri);
         assert_eq!(gen_after, 0, "the fresh index restarts at generation 0");
         assert!(
@@ -1059,7 +1099,7 @@ mod tests {
         let ulid_before = tracker.get_or_create(&uri, 0, 10, "code_block");
 
         // Cleanup
-        tracker.cleanup(&uri);
+        tracker.cleanup(&uri, || false);
 
         // After cleanup, same key should create NEW ULID
         let ulid_after = tracker.get_or_create(&uri, 0, 10, "code_block");
@@ -1081,7 +1121,7 @@ mod tests {
         let _ulid2 = tracker.get_or_create(&uri2, 0, 10, "code_block");
 
         // Cleanup only uri2
-        tracker.cleanup(&uri2);
+        tracker.cleanup(&uri2, || false);
 
         // uri1 should still have its ULID
         let ulid1_after = tracker.get_or_create(&uri1, 0, 10, "code_block");
@@ -1129,7 +1169,7 @@ mod tests {
         let ulid = tracker.get_or_create(&uri, 10, 20, "block");
         assert!(tracker.lookup_position(&uri, &ulid).is_some());
 
-        tracker.cleanup(&uri);
+        tracker.cleanup(&uri, || false);
 
         assert_eq!(
             tracker.lookup_position(&uri, &ulid),

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -741,7 +741,27 @@ impl NodeTracker {
         expected: (u64, u64),
         keys: impl IntoIterator<Item = (usize, usize, &'static str, usize)>,
     ) -> Option<Vec<Ulid>> {
+        // `get_mut` first: the hot path (index already exists — every batch
+        // after a document's first) avoids the `Url` clone `entry()` needs
+        // for its owned key. The absent-entry `entry().or_default()`
+        // fallback stays load-bearing: it serializes the latch check with a
+        // concurrent FIRST edit on a never-minted URI.
+        if let Some(mut entry) = self.entries.get_mut(uri) {
+            return self.mint_batch_in_entry(&mut entry, expected, keys);
+        }
         let mut entry = self.entries.entry(uri.clone()).or_default();
+        self.mint_batch_in_entry(&mut entry, expected, keys)
+    }
+
+    /// The latch check + mint body of
+    /// [`mint_batch_if_unshifted`](Self::mint_batch_if_unshifted), run while
+    /// the caller holds `entry`'s exclusive lock.
+    fn mint_batch_in_entry(
+        &self,
+        entry: &mut UriEntries,
+        expected: (u64, u64),
+        keys: impl IntoIterator<Item = (usize, usize, &'static str, usize)>,
+    ) -> Option<Vec<Ulid>> {
         let epoch = self
             .cleanup_epoch
             .load(std::sync::atomic::Ordering::Acquire);

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -680,7 +680,15 @@ impl NodeTracker {
     /// reopened document's live index, keep it (the epoch bump above still
     /// refuses any old-lifetime latch; old-lifetime entries it may carry
     /// are position-keyed and bounded, invalidated by the new lifetime's
-    /// edits like any other). Probe-sees-closed ⇒ no new-lifetime mint can
+    /// edits like any other). ACCEPTED residual of that keep: a pre-close
+    /// id can stay resolvable against the reopened document instead of
+    /// degrading to `null` — this is the didOpen-racing-didClose lifecycle
+    /// class the close path deliberately defers to a per-document
+    /// lifecycle-epoch gate (see the residual notes in `did_close.rs`);
+    /// separating the lifetimes here would need incarnation-tagged
+    /// entries, while the alternative (unconditional wipe) nulls the
+    /// reopened snapshot's ENTIRE id set — strictly worse.
+    /// Probe-sees-closed ⇒ no new-lifetime mint can
     /// have happened — mints are liveness-gated on the reopened snapshot,
     /// whose insert happens-before any mint that passed the gate, which
     /// happens-before this probe under the same entry lock — so the removal

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -721,7 +721,18 @@ impl NodeTracker {
     /// (its coordinates match the live text at mint time; later edits shift
     /// it like any live entry), which is why callers need no post-pass purge
     /// set: a refused batch (`None`) minted **nothing** — the stale pass
-    /// simply defers identity to the next current pass.
+    /// simply defers identity to the next current pass. Correct-at-birth is
+    /// **relative to the latch**: the batch only proves no shift happened
+    /// since `expected` was read, so callers must take it (via
+    /// [`mint_epoch`](Self::mint_epoch)) at or before validating that the
+    /// coordinates they are about to mint belong to the live text.
+    ///
+    /// `keys` is consumed while this method holds the entry's exclusive
+    /// lock — like `commit_if_unshifted`'s closure, it MUST NOT touch this
+    /// tracker (a re-entrant access to the same URI or shard would
+    /// self-deadlock). An entry materialized only to fail the check stays
+    /// behind as an empty index — the same bounded residue
+    /// [`commit_if_unshifted`](Self::commit_if_unshifted) documents.
     ///
     /// Returns the ids aligned with `keys`' iteration order.
     pub(crate) fn mint_batch_if_unshifted(
@@ -832,9 +843,10 @@ mod tests {
         );
     }
 
-    /// Every edit application advances the shift generation — including on a
-    /// URI with no entries yet — so a latch taken before the edit refuses a
-    /// later batch, while a latch taken AFTER it mints.
+    /// Edit application advances the shift generation — including on a URI
+    /// with no entries yet — and a latch taken AFTER the edit still mints.
+    /// (That a latch taken BEFORE the edit refuses is pinned separately by
+    /// `batch_mint_refuses_shifted_latch_and_mints_nothing`.)
     #[test]
     fn shift_generation_advances_on_every_edit_even_without_entries() {
         let tracker = NodeTracker::new();

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -656,14 +656,24 @@ impl NodeTracker {
     ///
     /// Called on didClose to prevent memory leaks. The removal resets the
     /// URI's `shift_gen`, so the global [`cleanup_epoch`](Self::cleanup_epoch)
-    /// is bumped instead: the serve-stale walks fold it into their latch
+    /// is bumped instead: the latch-gated passes fold it into their latch
     /// ([`mint_epoch`](Self::mint_epoch)), making an old-lifetime latch
     /// unequal to any post-close/reopen observation without retaining any
     /// per-closed-URI state.
+    ///
+    /// The bump runs BEFORE the removal, and the order is load-bearing: a
+    /// latch check that passes reads the pre-bump epoch, so it strictly
+    /// precedes this close in epoch order, and whatever it minted is wiped
+    /// by the removal that follows — a closed document still leaves no
+    /// state. Removing FIRST would open a gap where a pre-close latch
+    /// `(0, E)` re-materializes the just-removed entry (`or_default`,
+    /// `shift_gen` back at 0) and passes against the not-yet-bumped epoch,
+    /// leaving stale-lifetime coordinates alive in a reopened document's
+    /// index with nothing left to reclaim them.
     pub(crate) fn cleanup(&self, uri: &Url) {
-        self.entries.remove(uri);
         self.cleanup_epoch
             .fetch_add(1, std::sync::atomic::Ordering::Release);
+        self.entries.remove(uri);
     }
 
     /// Run `commit` only if `uri`'s (shift generation, cleanup epoch) still

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -700,6 +700,18 @@ impl NodeTracker {
     /// held — the document-store read the didClose probe performs is fine
     /// (the store never re-enters the tracker under its own locks); a future
     /// probe must preserve that one-way ordering.
+    ///
+    /// Memory-ordering note (why `Release` on the bump suffices, no
+    /// `SeqCst` needed): the only way another thread can OBSERVE the
+    /// removal is through the entry's shard lock (`get_mut` /
+    /// `entry().or_default()`), and that lock's release/acquire pair makes
+    /// every write sequenced before the removal — including this bump —
+    /// visible to the observer, so a check that finds the entry gone always
+    /// reads the bumped epoch and refuses. A check that instead wins the
+    /// shard lock BEFORE the removal may still read the pre-bump epoch and
+    /// pass, but it then minted into the still-present entry, which the
+    /// removal (queued behind that same lock) wipes — a closed document
+    /// leaves no state on either interleaving.
     pub(crate) fn cleanup(&self, uri: &Url, reopened: impl FnOnce() -> bool) {
         self.cleanup_epoch
             .fetch_add(1, std::sync::atomic::Ordering::Release);

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -63,22 +63,13 @@ struct UriEntries {
 impl UriEntries {
     /// Get or insert a ULID for a position key, keeping both maps in sync.
     fn get_or_insert(&mut self, key: PositionKey) -> Ulid {
-        self.get_or_insert_tracked(key).0
-    }
-
-    /// [`get_or_insert`](Self::get_or_insert) that also reports whether this
-    /// call CREATED the id (`true`) or found an existing one (`false`) — an
-    /// atomic distinction the serve-stale purge needs: a separate
-    /// lookup-then-create races a concurrent creator, mis-attributing (and
-    /// then wrongly purging) an id another, still-current request handed out.
-    fn get_or_insert_tracked(&mut self, key: PositionKey) -> (Ulid, bool, u64) {
         if let Some(existing) = self.forward.get(&key) {
-            return (*existing, false, self.shift_gen);
+            return *existing;
         }
         let ulid = Ulid::new();
         self.forward.insert(key, ulid);
         self.reverse.insert(ulid, key);
-        (ulid, true, self.shift_gen)
+        ulid
     }
 
     /// Lookup a position key by ULID.
@@ -338,40 +329,11 @@ impl NodeTracker {
         entry.get_or_insert(key)
     }
 
-    /// [`get_or_create_in_layer`](Self::get_or_create_in_layer) that also
-    /// reports whether this call CREATED the id — atomically under the same
-    /// entry lock, so a concurrent creator can never be mis-attributed. The
-    /// serve-stale captures walk purges only ids it created itself; purging
-    /// on a lookup-then-create basis would race another, still-current
-    /// request into handing out an id this walk then deletes. The third
-    /// element is the [`shift generation`](Self::shift_generation) observed
-    /// atomically with the insert: a creation whose generation equals the
-    /// one latched alongside the walk's currency check is correct-at-birth
-    /// (no edit shift intervened); a mismatch marks the entry as minted in a
-    /// superseded coordinate space.
-    pub(crate) fn get_or_create_in_layer_tracked(
-        &self,
-        uri: &Url,
-        start: usize,
-        end: usize,
-        kind: &'static str,
-        layer: usize,
-    ) -> (Ulid, bool, u64) {
-        let key = PositionKey::new(start, end, kind, layer);
-        // `get_mut` first: the hot path (index already exists) avoids the
-        // `Url` clone `entry()` needs for its owned key.
-        if let Some(mut entry) = self.entries.get_mut(uri) {
-            return entry.get_or_insert_tracked(key);
-        }
-        let mut entry = self.entries.entry(uri.clone()).or_default();
-        entry.get_or_insert_tracked(key)
-    }
-
     /// The count of coordinate shifts (edit applications) `uri`'s index has
-    /// received — see `get_or_create_in_layer_tracked` for the atomicity
-    /// contract. `0` for an index no edit has touched yet (edits bump the
-    /// generation even for a URI with no entries, so a latch taken before
-    /// the first mint still detects an intervening shift).
+    /// received — see [`mint_batch_if_unshifted`](Self::mint_batch_if_unshifted)
+    /// for the atomicity contract. `0` for an index no edit has touched yet
+    /// (edits bump the generation even for a URI with no entries, so a latch
+    /// taken before the first mint still detects an intervening shift).
     pub(crate) fn shift_generation(&self, uri: &Url) -> u64 {
         self.entries.get(uri).map(|e| e.shift_gen).unwrap_or(0)
     }
@@ -409,24 +371,6 @@ impl NodeTracker {
         let entries = self.entries.get(uri)?;
         let key = entries.lookup(ulid)?;
         Some((key.start_byte, key.end_byte, key.kind, key.layer))
-    }
-
-    /// Remove `ulid` from `uri`'s index (both directions).
-    ///
-    /// Used by the serve-stale walks' post-walk reconciliation: an id whose
-    /// creation observed a shift generation different from the one latched
-    /// with the walk's currency check was minted in a superseded coordinate
-    /// space (it missed at least one edit's correction — coordinate
-    /// comparison cannot detect this once a LATER edit moves the entry
-    /// again) and must not persist as live. The removed id then resolves
-    /// like a never-issued one — the captures protocol's re-sync signal (no
-    /// tombstone, per lazy-node-identity-tracking).
-    pub(crate) fn remove_id(&self, uri: &Url, ulid: &Ulid) {
-        if let Some(mut entries) = self.entries.get_mut(uri)
-            && let Some(key) = entries.reverse.remove(ulid)
-        {
-            entries.forward.remove(&key);
-        }
     }
 
     /// Get the ULID for a position in a layer if it exists, without creating
@@ -877,38 +821,9 @@ mod tests {
         );
     }
 
-    /// The tracked mint reports created-vs-reused and the observed shift
-    /// generation atomically; `remove_id` erases both directions with no
-    /// tombstone (a later mint draws a fresh id).
-    #[test]
-    fn tracked_mint_reports_creation_and_shift_generation_atomically() {
-        let tracker = NodeTracker::new();
-        let uri = test_uri("purge");
-        let (id, created, observed_gen) =
-            tracker.get_or_create_in_layer_tracked(&uri, 0, 4, "word", 1);
-        assert!(created, "first mint creates");
-        assert_eq!(observed_gen, 0, "no edit has shifted this index yet");
-        let (again, created_again, _) =
-            tracker.get_or_create_in_layer_tracked(&uri, 0, 4, "word", 1);
-        assert_eq!(again, id);
-        assert!(!created_again, "re-mint reuses, atomically attributed");
-
-        tracker.remove_id(&uri, &id);
-        assert!(tracker.lookup_node(&uri, &id).is_none(), "reverse purged");
-        assert_eq!(
-            tracker.lookup_in_layer(&uri, 0, 4, "word", 1),
-            None,
-            "forward purged"
-        );
-
-        let fresh = tracker.get_or_create_in_layer(&uri, 0, 4, "word", 1);
-        assert_ne!(fresh, id, "re-mint draws a fresh id");
-    }
-
     /// Every edit application advances the shift generation — including on a
-    /// URI with no entries yet — and a post-edit mint observes the advanced
-    /// generation, marking it as minted in a superseded coordinate space
-    /// relative to a pre-edit latch.
+    /// URI with no entries yet — so a latch taken before the edit refuses a
+    /// later batch, while a latch taken AFTER it mints.
     #[test]
     fn shift_generation_advances_on_every_edit_even_without_entries() {
         let tracker = NodeTracker::new();
@@ -923,12 +838,12 @@ mod tests {
             "the latch-before-first-mint case must detect this edit"
         );
 
-        let (_, created, observed_gen) =
-            tracker.get_or_create_in_layer_tracked(&uri, 10, 14, "word", 0);
-        assert!(created);
-        assert_eq!(
-            observed_gen, 1,
-            "a post-edit mint observes the advanced generation"
+        let post_edit_latch = tracker.mint_epoch(&uri);
+        assert!(
+            tracker
+                .mint_batch_if_unshifted(&uri, post_edit_latch, [(10, 14, "word", 0)])
+                .is_some(),
+            "a latch taken after the edit mints"
         );
 
         let _ = tracker.apply_text_diff(&uri, "aaaa aaaa aaaa", "aaaa aaaa bbbb aaaa");

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -778,11 +778,19 @@ impl NodeTracker {
     }
 
     /// The (per-URI shift generation, global cleanup epoch) pair a pass
-    /// latches at entry, alongside its currency check, and hands to
+    /// latches at entry and hands to
     /// [`mint_batch_if_unshifted`](Self::mint_batch_if_unshifted): a
     /// mismatch in either half means the pass's coordinates were superseded
     /// (an edit shifted the index, or a close/reopen replaced it) and the
     /// batch refuses to mint.
+    ///
+    /// The two halves are read WITHOUT mutual synchronization, so a
+    /// close+reopen completing between them yields a mixed
+    /// `(old_gen, new_epoch)` latch that can match the reopened index.
+    /// Callers therefore must latch FIRST and validate the pass's
+    /// liveness/currency (incarnation, snapshot version) AFTER — only a
+    /// post-latch check is guaranteed to observe the lifetime change that
+    /// produced the mixed latch and bail before minting under it.
     pub(crate) fn mint_epoch(&self, uri: &Url) -> (u64, u64) {
         (
             self.shift_generation(uri),

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -754,6 +754,44 @@ impl NodeTracker {
         Some(commit())
     }
 
+    /// Mint every `(start, end, kind, layer)` key — reusing an existing id
+    /// by position, drawing a fresh ULID for a genuinely new key — under ONE
+    /// acquisition of the URI's entry lock, but only if the (shift
+    /// generation, cleanup epoch) latch still equals `expected`.
+    ///
+    /// This is the mint half of the parse-snapshot ADR §3 **reconciliation
+    /// step**: the latch is checked while HOLDING the entry's exclusive lock
+    /// — the same lock coordinate shifts (`apply_*_edits`) and `cleanup`
+    /// acquire — so a batch that passes serializes strictly before any
+    /// concurrent shift. Every id it mints is therefore *correct-at-birth*
+    /// (its coordinates match the live text at mint time; later edits shift
+    /// it like any live entry), which is why callers need no post-pass purge
+    /// set: a refused batch (`None`) minted **nothing** — the stale pass
+    /// simply defers identity to the next current pass.
+    ///
+    /// Returns the ids aligned with `keys`' iteration order.
+    pub(crate) fn mint_batch_if_unshifted(
+        &self,
+        uri: &Url,
+        expected: (u64, u64),
+        keys: impl IntoIterator<Item = (usize, usize, &'static str, usize)>,
+    ) -> Option<Vec<Ulid>> {
+        let mut entry = self.entries.entry(uri.clone()).or_default();
+        let epoch = self
+            .cleanup_epoch
+            .load(std::sync::atomic::Ordering::Acquire);
+        if (entry.shift_gen, epoch) != expected {
+            return None;
+        }
+        Some(
+            keys.into_iter()
+                .map(|(start, end, kind, layer)| {
+                    entry.get_or_insert(PositionKey::new(start, end, kind, layer))
+                })
+                .collect(),
+        )
+    }
+
     /// The (per-URI shift generation, global cleanup epoch) pair the
     /// serve-stale walks latch alongside their currency check and compare at
     /// exit: a mismatch in either half means the mint landed in a superseded
@@ -780,6 +818,63 @@ mod tests {
 
     fn test_uri(name: &str) -> Url {
         Url::parse(&format!("file:///test/{}.md", name)).unwrap()
+    }
+
+    /// The batch reconciliation mint reuses an existing id by position and
+    /// mints fresh ids for genuinely new keys — all under one entry lock,
+    /// gated on the latch (parse-snapshot ADR §3 reconciliation).
+    #[test]
+    fn batch_mint_reuses_by_position_and_mints_new_under_one_latch() {
+        let tracker = NodeTracker::new();
+        let uri = test_uri("batch_mint");
+        let existing = tracker.get_or_create_in_layer(&uri, 0, 4, "word", 0);
+        let latch = tracker.mint_epoch(&uri);
+        let ulids = tracker
+            .mint_batch_if_unshifted(&uri, latch, [(0, 4, "word", 0), (10, 14, "word", 1)])
+            .expect("an unshifted latch mints");
+        assert_eq!(ulids[0], existing, "existing position reuses its id");
+        assert_eq!(
+            tracker.lookup_in_layer(&uri, 10, 14, "word", 1),
+            Some(ulids[1]),
+            "new position minted live"
+        );
+    }
+
+    /// A latch an edit has shifted refuses the whole batch — nothing is
+    /// minted (the stale pass defers to the next current pass; there is no
+    /// purge because there is nothing to purge).
+    #[test]
+    fn batch_mint_refuses_shifted_latch_and_mints_nothing() {
+        let tracker = NodeTracker::new();
+        let uri = test_uri("batch_mint_shifted");
+        let latch = tracker.mint_epoch(&uri);
+        let _ = tracker.apply_input_edits(&uri, &[EditInfo::new(0, 0, 3)]);
+        assert_eq!(
+            tracker.mint_batch_if_unshifted(&uri, latch, [(0, 4, "word", 0)]),
+            None,
+            "a shifted latch refuses"
+        );
+        assert_eq!(
+            tracker.lookup_in_layer(&uri, 0, 4, "word", 0),
+            None,
+            "the refused batch minted nothing"
+        );
+    }
+
+    /// A close (any document's) bumps the global cleanup epoch, so a latch
+    /// taken before it refuses — the close/reopen ABA guard the per-URI
+    /// generation alone cannot provide.
+    #[test]
+    fn batch_mint_refuses_after_cleanup_epoch_bump() {
+        let tracker = NodeTracker::new();
+        let uri = test_uri("batch_mint_cleanup");
+        let other = test_uri("batch_mint_other");
+        let latch = tracker.mint_epoch(&uri);
+        tracker.cleanup(&other);
+        assert_eq!(
+            tracker.mint_batch_if_unshifted(&uri, latch, [(0, 4, "word", 0)]),
+            None
+        );
     }
 
     /// The tracked mint reports created-vs-reused and the observed shift

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -30,12 +30,13 @@ use url::Url;
 pub(crate) struct NodeTracker {
     entries: DashMap<Url, UriEntries>,
     /// Bumped by every [`cleanup`](Self::cleanup) (didClose). Folded into the
-    /// serve-stale walks' generation latch so a close/reopen — which removes
-    /// the per-URI index and would reset its `shift_gen` to 0 (ABA) — can
-    /// never make an old-lifetime latch compare equal. Global (not per-URI)
-    /// so closed documents leave NO retained state; the cost is that a close
-    /// of any document mid-walk purges that walk's own mints — a rare event
-    /// with a one-null-re-sync consequence.
+    /// mint latch ([`mint_epoch`](Self::mint_epoch)) so a close/reopen —
+    /// which removes the per-URI index and would reset its `shift_gen` to 0
+    /// (ABA) — can never make an old-lifetime latch compare equal. Global
+    /// (not per-URI) so closed documents leave NO retained state; the cost
+    /// is that a close of any document mid-pass refuses that pass's
+    /// remaining mint batches — a rare event with a one-null-re-sync
+    /// consequence.
     cleanup_epoch: std::sync::atomic::AtomicU64,
 }
 
@@ -51,12 +52,11 @@ struct UriEntries {
     reverse: HashMap<Ulid, PositionKey>,
     /// Count of coordinate shifts (edit applications) this index has
     /// received. Read/written under the same DashMap entry lock as the maps,
-    /// so a mint that records the generation it observed can atomically
-    /// prove "no shift intervened between my snapshot's currency check and
-    /// this insert" — the serve-stale purge's correct-at-birth predicate
-    /// (coordinate comparison alone cannot: with two mid-walk edits, an
-    /// entry minted between them is shifted by the second yet still missed
-    /// the first).
+    /// so [`mint_batch_if_unshifted`](NodeTracker::mint_batch_if_unshifted)
+    /// can atomically prove "no shift intervened between the pass's latch
+    /// and this batch" — the correct-at-birth predicate (coordinate
+    /// comparison alone cannot: with two mid-pass edits, an entry minted
+    /// between them is shifted by the second yet still missed the first).
     shift_gen: u64,
 }
 
@@ -736,11 +736,12 @@ impl NodeTracker {
         )
     }
 
-    /// The (per-URI shift generation, global cleanup epoch) pair the
-    /// serve-stale walks latch alongside their currency check and compare at
-    /// exit: a mismatch in either half means the mint landed in a superseded
-    /// coordinate space (an edit shifted the index, or a close/reopen
-    /// replaced it) and must be purged.
+    /// The (per-URI shift generation, global cleanup epoch) pair a pass
+    /// latches at entry, alongside its currency check, and hands to
+    /// [`mint_batch_if_unshifted`](Self::mint_batch_if_unshifted): a
+    /// mismatch in either half means the pass's coordinates were superseded
+    /// (an edit shifted the index, or a close/reopen replaced it) and the
+    /// batch refuses to mint.
     pub(crate) fn mint_epoch(&self, uri: &Url) -> (u64, u64) {
         (
             self.shift_generation(uri),

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -693,6 +693,13 @@ impl NodeTracker {
     /// whose insert happens-before any mint that passed the gate, which
     /// happens-before this probe under the same entry lock — so the removal
     /// reclaims only old-lifetime state.
+    ///
+    /// Lock-order contract: `reopened` runs while this method holds `uri`'s
+    /// entry (shard) lock, so it MUST NOT touch this tracker (self-deadlock)
+    /// and may only take locks that never call back into the tracker while
+    /// held — the document-store read the didClose probe performs is fine
+    /// (the store never re-enters the tracker under its own locks); a future
+    /// probe must preserve that one-way ordering.
     pub(crate) fn cleanup(&self, uri: &Url, reopened: impl FnOnce() -> bool) {
         self.cleanup_epoch
             .fetch_add(1, std::sync::atomic::Ordering::Release);

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -575,9 +575,11 @@ impl BridgeCoordinator {
 
     /// Remove all tracked regions for a document.
     ///
-    /// Called on didClose to prevent memory leaks.
-    pub(crate) fn cleanup(&self, uri: &Url) {
-        self.node_tracker.cleanup(uri)
+    /// Called on didClose to prevent memory leaks. `reopened` is the
+    /// raced-reopen probe forwarded to [`NodeTracker::cleanup`] — see the
+    /// removal guard there.
+    pub(crate) fn cleanup(&self, uri: &Url, reopened: impl FnOnce() -> bool) {
+        self.node_tracker.cleanup(uri, reopened)
     }
 
     // ========================================

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -182,6 +182,17 @@ impl CacheCoordinator {
     /// would let a close+reopen completing between the two `mint_epoch`
     /// reads produce a `(0, new_epoch)` latch that matches the reopened
     /// index and mints this pass's old-lifetime coordinates into it.
+    ///
+    /// Returns `None` when the latch REFUSED the pass (at the batch mint or
+    /// the final commit) — the pass was outrun and produced nothing, so the
+    /// snapshot must ride with `None` region fields and every reader falls
+    /// back to inline resolution. This is distinct from
+    /// `Some(PopulatedInjections::empty(..))`, which means the pass RAN and
+    /// found no injections — consumers then skip injection work outright.
+    /// Conflating the two would let a refused pass (e.g. any document's
+    /// close bumping the global cleanup epoch mid-populate) publish "no
+    /// injections" and blank the document's injections until the next
+    /// parse.
     #[must_use]
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn populate_injections(
@@ -194,7 +205,7 @@ impl CacheCoordinator {
         tracker: &NodeTracker,
         entry_mint_epoch: (u64, u64),
         build_bridge_regions: bool,
-    ) -> PopulatedInjections {
+    ) -> Option<PopulatedInjections> {
         // Snapshot the generation FIRST — before reading the injection query or
         // resolving any language below — so the stamp can never be *newer* than
         // the queries the discovery was built with. A reload swaps queries and
@@ -227,7 +238,7 @@ impl CacheCoordinator {
                     self.injection_map.clear(uri);
                     self.injection_token_cache.clear_document(uri);
                 });
-                return PopulatedInjections::empty(generation);
+                return Some(PopulatedInjections::empty(generation));
             }
         };
 
@@ -242,7 +253,7 @@ impl CacheCoordinator {
                     self.injection_map.clear(uri);
                     self.injection_token_cache.clear_document(uri);
                 });
-                return PopulatedInjections::empty(generation);
+                return Some(PopulatedInjections::empty(generation));
             }
 
             // Mint reconciliation step (parse-snapshot ADR §3): map the
@@ -258,7 +269,7 @@ impl CacheCoordinator {
             // pre-lever path) and defer identity to the next current pass —
             // the tracker is meanwhile kept live by the ordinary didChange
             // edit-shift.
-            let Some(region_ids) = tracker.mint_batch_if_unshifted(
+            let region_ids = tracker.mint_batch_if_unshifted(
                 uri,
                 entry_mint_epoch,
                 regions.iter().map(|info| {
@@ -269,9 +280,7 @@ impl CacheCoordinator {
                         0,
                     )
                 }),
-            ) else {
-                return PopulatedInjections::empty(generation);
-            };
+            )?;
 
             // Convert to CacheableInjectionRegion pairing each region with
             // its reconciled ULID (index-aligned with `regions` by the batch
@@ -397,18 +406,16 @@ impl CacheCoordinator {
                 self.injection_token_cache
                     .retain_document(uri, &live_hashes);
             });
-            if committed.is_none() {
-                return PopulatedInjections::empty(generation);
-            }
-            return PopulatedInjections {
+            committed?;
+            return Some(PopulatedInjections {
                 discovery,
                 bridge_regions,
                 resolved_regions,
                 generation,
-            };
+            });
         }
 
-        PopulatedInjections::empty(generation)
+        Some(PopulatedInjections::empty(generation))
     }
 
     /// Get all injection regions for a document (test helper).

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -174,6 +174,14 @@ impl CacheCoordinator {
     /// no/empty regions, below the region-count gate, an `injection.combined`
     /// group, or a not-yet-loaded parser). The discovery query (`Q`) is run
     /// **once** here and shared; the request path never re-runs it.
+    ///
+    /// `entry_mint_epoch` is the tracker latch ([`NodeTracker::mint_epoch`])
+    /// the CALLER captured **before** validating the pass's
+    /// liveness/lifetime, and every tracker-mutating step below re-checks it
+    /// (latch-then-validate): capturing it here, after the caller's check,
+    /// would let a close+reopen completing between the two `mint_epoch`
+    /// reads produce a `(0, new_epoch)` latch that matches the reopened
+    /// index and mints this pass's old-lifetime coordinates into it.
     #[must_use]
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn populate_injections(
@@ -184,6 +192,7 @@ impl CacheCoordinator {
         language_name: &str,
         language: &LanguageCoordinator,
         tracker: &NodeTracker,
+        entry_mint_epoch: (u64, u64),
         build_bridge_regions: bool,
     ) -> PopulatedInjections {
         // Snapshot the generation FIRST — before reading the injection query or
@@ -200,11 +209,11 @@ impl CacheCoordinator {
         // Entry half of the mint reconciliation (parse-snapshot ADR §3):
         // populate runs post-CAS but an edit can land DURING this pass and
         // shift the live-coordinate NodeTracker, making this pass's tree
-        // coordinates stale. The latch is re-checked inside every
-        // tracker-mutating step below (the batch mint and the commit), so a
-        // stale pass mints nothing and clobbers nothing — identity defers to
-        // the next current pass.
-        let entry_mint_epoch = tracker.mint_epoch(uri);
+        // coordinates stale. `entry_mint_epoch` (latched by the caller,
+        // BEFORE its liveness validation — see the doc comment) is
+        // re-checked inside every tracker-mutating step below (the batch
+        // mint and the commit), so a stale pass mints nothing and clobbers
+        // nothing — identity defers to the next current pass.
 
         // Get the injection query for this language
         let injection_query = match language.injection_query(language_name) {
@@ -821,6 +830,7 @@ print("hello")
             "markdown",
             &coordinator,
             &tracker,
+            tracker.mint_epoch(&uri),
             true,
         );
 
@@ -881,6 +891,7 @@ print("hello")
             "markdown",
             &coordinator,
             &tracker,
+            tracker.mint_epoch(&uri),
             true,
         );
 
@@ -955,6 +966,7 @@ print("hello")
             "markdown",
             &coordinator,
             &tracker,
+            tracker.mint_epoch(&uri),
             true,
         );
 
@@ -999,6 +1011,7 @@ print("goodbye")
             "markdown",
             &coordinator,
             &tracker,
+            tracker.mint_epoch(&uri),
             true,
         );
 

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -233,11 +233,14 @@ impl CacheCoordinator {
                 // No injection query = no injections to track. Clear any
                 // stale injection caches — but only when no edit landed
                 // during this pass (a stale pass must not clobber state the
-                // newer text's own populate maintains).
-                let _ = tracker.commit_if_unshifted(uri, entry_mint_epoch, || {
+                // newer text's own populate maintains). A refused clear
+                // aborts the pass (`None`): reporting ran-and-empty while
+                // the old entries survive would leave them unreclaimed
+                // until another parse.
+                tracker.commit_if_unshifted(uri, entry_mint_epoch, || {
                     self.injection_map.clear(uri);
                     self.injection_token_cache.clear_document(uri);
-                });
+                })?;
                 return Some(PopulatedInjections::empty(generation));
             }
         };
@@ -248,11 +251,13 @@ impl CacheCoordinator {
         {
             if regions.is_empty() {
                 // Clear any existing regions and caches for this document —
-                // epoch-gated like the commit below.
-                let _ = tracker.commit_if_unshifted(uri, entry_mint_epoch, || {
+                // epoch-gated like the commit below, and aborting (`None`)
+                // on refusal like it too: ran-and-empty must only be
+                // reported after the clear actually landed.
+                tracker.commit_if_unshifted(uri, entry_mint_epoch, || {
                     self.injection_map.clear(uri);
                     self.injection_token_cache.clear_document(uri);
-                });
+                })?;
                 return Some(PopulatedInjections::empty(generation));
             }
 

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -197,14 +197,14 @@ impl CacheCoordinator {
         // re-discovers inline — the "snapshot generation at the top" discipline
         // the token handlers use.
         let generation = self.semantic_token_generation();
-        // Entry half of the mint reconciliation (the captures walk's #554
-        // pattern, applied to the WRITER): populate runs post-CAS but an edit
-        // can land DURING this pass, shift the live-coordinate NodeTracker,
-        // and leave this pass minting the old tree's coordinates into it. The
-        // exit check below purges this pass's own creations and withholds
-        // every region-id-bearing product when the latch no longer matches.
+        // Entry half of the mint reconciliation (parse-snapshot ADR §3):
+        // populate runs post-CAS but an edit can land DURING this pass and
+        // shift the live-coordinate NodeTracker, making this pass's tree
+        // coordinates stale. The latch is re-checked inside every
+        // tracker-mutating step below (the batch mint and the commit), so a
+        // stale pass mints nothing and clobbers nothing — identity defers to
+        // the next current pass.
         let entry_mint_epoch = tracker.mint_epoch(uri);
-        let mut minted_ids: Vec<ulid::Ulid> = Vec::new();
 
         // Get the injection query for this language
         let injection_query = match language.injection_query(language_name) {
@@ -236,23 +236,41 @@ impl CacheCoordinator {
                 return PopulatedInjections::empty(generation);
             }
 
-            // Convert to CacheableInjectionRegion using position-based ULIDs
-            // NodeTracker provides stable IDs based on (uri, start_byte, end_byte, kind)
-            let cacheable_regions: Vec<CacheableInjectionRegion> = regions
-                .iter()
-                .map(|info| {
-                    // Get position-based ULID from tracker, recording
-                    // creations for the exit reconciliation's purge set.
-                    let (ulid, created, _) = tracker.get_or_create_in_layer_tracked(
-                        uri,
+            // Mint reconciliation step (parse-snapshot ADR §3): map the
+            // pass's region geometry to tracker ULIDs in ONE latch-gated
+            // batch — reusing an existing id by position, minting a fresh
+            // one for a genuinely new region — instead of an inline
+            // per-region mint. The latch check runs under the tracker
+            // entry's exclusive lock (the lock the didChange edit-shift also
+            // takes), so a passing batch is correct-at-birth and needs no
+            // purge set; a refused batch minted NOTHING. Refusal means an
+            // edit outran this pass: withhold every region-id-bearing
+            // product (readers fall back inline, byte-identically to the
+            // pre-lever path) and defer identity to the next current pass —
+            // the tracker is meanwhile kept live by the ordinary didChange
+            // edit-shift.
+            let Some(region_ids) = tracker.mint_batch_if_unshifted(
+                uri,
+                entry_mint_epoch,
+                regions.iter().map(|info| {
+                    (
                         info.content_node.start_byte(),
                         info.content_node.end_byte(),
                         info.content_node.kind(),
                         0,
-                    );
-                    if created {
-                        minted_ids.push(ulid);
-                    }
+                    )
+                }),
+            ) else {
+                return PopulatedInjections::empty(generation);
+            };
+
+            // Convert to CacheableInjectionRegion pairing each region with
+            // its reconciled ULID (index-aligned with `regions` by the batch
+            // contract).
+            let cacheable_regions: Vec<CacheableInjectionRegion> = regions
+                .iter()
+                .zip(&region_ids)
+                .map(|(info, ulid)| {
                     let region_id = ulid.to_string();
                     CacheableInjectionRegion::from_region_info(info, &region_id, text)
                 })
@@ -344,19 +362,20 @@ impl CacheCoordinator {
                 .unwrap_or_default();
 
             // Exit half of the mint reconciliation, atomic with coordinate
-            // shifts: the commit runs under the tracker entry's shared lock
-            // and only while the (shift generation, cleanup epoch) latch
-            // still matches — an edit (or close/reopen) that landed during
-            // this pass fails the check INSIDE the lock, so a shift can
-            // never interleave between check and commit. On mismatch, purge
-            // exactly this pass's tracker creations (the base invariant: a
-            // stale pass never leaves wrong-space entries as live), keep the
-            // injection map's previous entry (the newer text's own populate
-            // replaces it), and withhold the region-id-bearing products; the
-            // snapshot then rides without regions and every reader falls
-            // back inline, byte-identically to the pre-lever path. The
-            // token-cache sweep runs inside the commit closure, so a stale
-            // pass performs no eviction at all.
+            // shifts: the commit runs under the tracker entry's exclusive
+            // lock and only while the (shift generation, cleanup epoch)
+            // latch still matches — an edit (or close/reopen) that landed
+            // during this pass fails the check INSIDE the lock, so a shift
+            // can never interleave between check and commit. On mismatch,
+            // keep the injection map's previous entry (the newer text's own
+            // populate replaces it) and withhold the region-id-bearing
+            // products; the snapshot then rides without regions and every
+            // reader falls back inline, byte-identically to the pre-lever
+            // path. No tracker purge is needed: the batch mint above was
+            // latch-gated too, so every id this pass minted was
+            // correct-at-birth — the intervening edit shifts it like any
+            // live entry. The token-cache sweep runs inside the commit
+            // closure, so a stale pass performs no eviction at all.
             let committed = tracker.commit_if_unshifted(uri, entry_mint_epoch, || {
                 // Commit point: record the committed pass's region set (test
                 // observability today; no production reader since token
@@ -370,9 +389,6 @@ impl CacheCoordinator {
                     .retain_document(uri, &live_hashes);
             });
             if committed.is_none() {
-                for id in &minted_ids {
-                    tracker.remove_id(uri, id);
-                }
                 return PopulatedInjections::empty(generation);
             }
             return PopulatedInjections {

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -442,6 +442,7 @@ mod tests {
             server.bridge.node_tracker_arc().mint_epoch(&uri),
             true,
         );
+        let populated = populated.expect("current pass populates");
         let bridge_regions = populated.bridge_regions.expect("gate was true");
         server
             .documents

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -439,6 +439,7 @@ mod tests {
             "markdown",
             &server.language,
             &server.bridge.node_tracker_arc(),
+            server.bridge.node_tracker_arc().mint_epoch(&uri),
             true,
         );
         let bridge_regions = populated.bridge_regions.expect("gate was true");

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -317,9 +317,14 @@ impl ParseCoordinator {
                 // The edit_lock() accessor above materializes a lock entry
                 // even for a document a didClose already removed — drop it
                 // so raced closes can't grow the map (the did_change stray
-                // rule).
+                // rule). Identity- AND share-checked: a reopen racing this
+                // probe may already be reusing this very entry (or have
+                // installed a new one) for the new lifetime's edits, and
+                // removing it from under a queued edit would let the next
+                // edit mint a fresh mutex and run concurrently.
                 if self.documents.latest_snapshot(&uri).is_none() {
-                    self.documents.remove_edit_lock(&uri);
+                    self.documents
+                        .remove_edit_lock_if_unshared(&uri, &edit_lock);
                 }
                 return PopulatedSnapshotRegions::default();
             }

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -340,7 +340,13 @@ impl ParseCoordinator {
             .any_bridge_server_runnable();
         self.compute_pool
             .run(None, move || {
-                let populated = cache.populate_injections(
+                // A refused pass (`None`) maps to all-`None` region fields —
+                // the snapshot then rides WITHOUT regions and readers fall
+                // back to inline resolution. Mapping it to the ran-and-empty
+                // shape instead would publish "no injections" for a pass
+                // that never derived anything, blanking the document's
+                // injections until the next parse.
+                let Some(populated) = cache.populate_injections(
                     &uri,
                     &text,
                     &tree,
@@ -349,7 +355,9 @@ impl ParseCoordinator {
                     &tracker,
                     entry_mint_epoch,
                     build_bridge_regions,
-                );
+                ) else {
+                    return PopulatedSnapshotRegions::default();
+                };
                 PopulatedSnapshotRegions {
                     discovery: populated.discovery.map(std::sync::Arc::new),
                     bridge_regions: populated

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -279,11 +279,52 @@ impl ParseCoordinator {
         tree: tree_sitter::Tree,
         language_name: String,
         incarnation: u64,
+        content_version: u64,
     ) -> PopulatedSnapshotRegions {
         let cache = std::sync::Arc::clone(&self.cache);
         let language = std::sync::Arc::clone(&self.language);
         let tracker = self.bridge.node_tracker_arc();
-        let documents = std::sync::Arc::clone(&self.documents);
+        // Latch + at-mint validity gate, taken UNDER this document's edit
+        // lock so the pair is atomic against `did_change` (which holds the
+        // same lock across its tracker edit-shift AND its
+        // `content_version` bump — the ADR's "only the fast tracker-mint
+        // runs under edit_lock" obligation). Lock-free latch-then-validate
+        // is NOT enough here: didChange shifts the tracker BEFORE it bumps
+        // the version, so a latch taken after the shift with a version read
+        // before the bump would look current on both counts and let this
+        // pass mint its old-tree coordinates into the shifted index as
+        // correct-at-birth. Under the lock, the gate checks:
+        // - liveness + lifetime (a didClose that ran to COMPLETION leaves
+        //   the tracker at `(0, epoch+1)` — indistinguishable from a
+        //   reopen's first mint, so the latch alone cannot refuse it; the
+        //   reopen case fails the incarnation check);
+        // - currency (`content_version` unchanged since the parse's CAS —
+        //   an edit that already landed makes this pass's tree stale).
+        // Anything landing AFTER the lock drops is caught by the latch
+        // re-check inside the batch mint / commit (`cleanup` bumps the
+        // epoch before it removes; an edit-shift bumps the generation).
+        // Skipping populate matches the stale/closed outcome everywhere
+        // else: the snapshot (if it still publishes) rides without regions.
+        let entry_mint_epoch = {
+            let edit_lock = self.documents.edit_lock(&uri);
+            let _edit_guard = edit_lock.lock().await;
+            let latch = tracker.mint_epoch(&uri);
+            let valid = self.documents.latest_snapshot(&uri).is_some_and(|view| {
+                view.slot.current_incarnation == incarnation
+                    && view.content_version == content_version
+            });
+            if !valid {
+                // The edit_lock() accessor above materializes a lock entry
+                // even for a document a didClose already removed — drop it
+                // so raced closes can't grow the map (the did_change stray
+                // rule).
+                if self.documents.latest_snapshot(&uri).is_none() {
+                    self.documents.remove_edit_lock(&uri);
+                }
+                return PopulatedSnapshotRegions::default();
+            }
+            latch
+        };
         // Coarse per-parse gate: with no runnable bridge server configured,
         // the bridge-region build (per-region content copies) is pure waste
         // on the pre-publish critical path. `None` on the snapshot makes a
@@ -294,32 +335,6 @@ impl ParseCoordinator {
             .any_bridge_server_runnable();
         self.compute_pool
             .run(None, move || {
-                // Latch FIRST, validate liveness SECOND — the captures
-                // walk's ordering, and it is load-bearing: `mint_epoch` is
-                // two unsynchronized reads, so a close+reopen completing
-                // between them yields `(old_gen, new_epoch)`; only a
-                // liveness check taken AFTER the latch is guaranteed to see
-                // that reopen's new incarnation and bail before anything
-                // mints under the mixed latch.
-                let entry_mint_epoch = tracker.mint_epoch(&uri);
-                // At-mint liveness gate (the captures walk's
-                // `mint_into_tracker` discipline, applied to the writer): a
-                // didClose that ran to COMPLETION after this parse's CAS
-                // leaves the tracker's post-cleanup state — `(0, epoch+1)` —
-                // indistinguishable from a reopen's legitimate first mint,
-                // so populate's shift latch alone cannot refuse this pass.
-                // Gate on the document still being open in this same
-                // lifetime before minting anything; a close landing AFTER
-                // this check is caught by the latch instead (`cleanup` bumps
-                // the epoch before it removes). Skipping populate here
-                // matches the closed-document outcome everywhere else: the
-                // snapshot (if it still publishes) rides without regions.
-                if documents
-                    .latest_snapshot(&uri)
-                    .is_none_or(|view| view.slot.current_incarnation != incarnation)
-                {
-                    return PopulatedSnapshotRegions::default();
-                }
                 let populated = cache.populate_injections(
                     &uri,
                     &text,
@@ -542,6 +557,7 @@ impl ParseCoordinator {
                         tree.clone(),
                         language_name.clone(),
                         incarnation,
+                        content_version,
                     )
                     .await
                 } else {
@@ -799,6 +815,7 @@ impl ParseCoordinator {
                     tree.clone(),
                     language_name.clone(),
                     expected_incarnation,
+                    content_version,
                 )
                 .await
             } else {
@@ -993,6 +1010,7 @@ impl ParseCoordinator {
                     tree.clone(),
                     language_name.clone(),
                     incarnation,
+                    content_version,
                 )
                 .await
             } else {

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -278,10 +278,12 @@ impl ParseCoordinator {
         text: std::sync::Arc<str>,
         tree: tree_sitter::Tree,
         language_name: String,
+        incarnation: u64,
     ) -> PopulatedSnapshotRegions {
         let cache = std::sync::Arc::clone(&self.cache);
         let language = std::sync::Arc::clone(&self.language);
         let tracker = self.bridge.node_tracker_arc();
+        let documents = std::sync::Arc::clone(&self.documents);
         // Coarse per-parse gate: with no runnable bridge server configured,
         // the bridge-region build (per-region content copies) is pure waste
         // on the pre-publish critical path. `None` on the snapshot makes a
@@ -292,6 +294,24 @@ impl ParseCoordinator {
             .any_bridge_server_runnable();
         self.compute_pool
             .run(None, move || {
+                // At-mint liveness gate (the captures walk's
+                // `mint_into_tracker` discipline, applied to the writer): a
+                // didClose that ran to COMPLETION after this parse's CAS
+                // leaves the tracker's post-cleanup state — `(0, epoch+1)` —
+                // indistinguishable from a reopen's legitimate first mint,
+                // so populate's shift latch alone cannot refuse this pass.
+                // Gate on the document still being open in this same
+                // lifetime before minting anything; a close landing AFTER
+                // this check is caught by the latch instead (`cleanup` bumps
+                // the epoch before it removes). Skipping populate here
+                // matches the closed-document outcome everywhere else: the
+                // snapshot (if it still publishes) rides without regions.
+                if documents
+                    .latest_snapshot(&uri)
+                    .is_none_or(|view| view.slot.current_incarnation != incarnation)
+                {
+                    return PopulatedSnapshotRegions::default();
+                }
                 let populated = cache.populate_injections(
                     &uri,
                     &text,
@@ -512,6 +532,7 @@ impl ParseCoordinator {
                         text.clone(),
                         tree.clone(),
                         language_name.clone(),
+                        incarnation,
                     )
                     .await
                 } else {
@@ -768,6 +789,7 @@ impl ParseCoordinator {
                     text.clone(),
                     tree.clone(),
                     language_name.clone(),
+                    expected_incarnation,
                 )
                 .await
             } else {
@@ -961,6 +983,7 @@ impl ParseCoordinator {
                     text.clone(),
                     tree.clone(),
                     language_name.clone(),
+                    incarnation,
                 )
                 .await
             } else {

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -309,7 +309,8 @@ impl ParseCoordinator {
             let edit_lock = self.documents.edit_lock(&uri);
             let _edit_guard = edit_lock.lock().await;
             let latch = tracker.mint_epoch(&uri);
-            let valid = self.documents.latest_snapshot(&uri).is_some_and(|view| {
+            let latest = self.documents.latest_snapshot(&uri);
+            let valid = latest.as_ref().is_some_and(|view| {
                 view.slot.current_incarnation == incarnation
                     && view.content_version == content_version
             });
@@ -322,7 +323,7 @@ impl ParseCoordinator {
                 // installed a new one) for the new lifetime's edits, and
                 // removing it from under a queued edit would let the next
                 // edit mint a fresh mutex and run concurrently.
-                if self.documents.latest_snapshot(&uri).is_none() {
+                if latest.is_none() {
                     self.documents
                         .remove_edit_lock_if_unshared(&uri, &edit_lock);
                 }

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -294,6 +294,14 @@ impl ParseCoordinator {
             .any_bridge_server_runnable();
         self.compute_pool
             .run(None, move || {
+                // Latch FIRST, validate liveness SECOND — the captures
+                // walk's ordering, and it is load-bearing: `mint_epoch` is
+                // two unsynchronized reads, so a close+reopen completing
+                // between them yields `(old_gen, new_epoch)`; only a
+                // liveness check taken AFTER the latch is guaranteed to see
+                // that reopen's new incarnation and bail before anything
+                // mints under the mixed latch.
+                let entry_mint_epoch = tracker.mint_epoch(&uri);
                 // At-mint liveness gate (the captures walk's
                 // `mint_into_tracker` discipline, applied to the writer): a
                 // didClose that ran to COMPLETION after this parse's CAS
@@ -319,6 +327,7 @@ impl ParseCoordinator {
                     &language_name,
                     &language,
                     &tracker,
+                    entry_mint_epoch,
                     build_bridge_regions,
                 );
                 PopulatedSnapshotRegions {

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -1333,6 +1333,16 @@ fn execute_captures_walk(
             }
             matches.push(Value::Object(envelope));
         }
+        // The alignment contract the unchecked indexing above relies on:
+        // `capture_keys()` and the shaping loop enumerate the same captures
+        // in the same order, so the loop consumes EXACTLY the batch. A
+        // future divergence (a filter on one side but not the other) trips
+        // this in tests instead of panicking on an index in production.
+        debug_assert_eq!(
+            capture_idx,
+            layer_ulids.len(),
+            "capture_keys() and the shaping loop must enumerate the same captures"
+        );
     };
 
     if injection {

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -171,6 +171,16 @@ fn metadata_object(pairs: &[(String, Option<String>)]) -> Option<Value> {
     Some(Value::Object(map))
 }
 
+/// Shape an LSP `Position` as its wire object by direct construction —
+/// `{"line": .., "character": ..}` — avoiding the serde round-trip a `json!`
+/// expression embed would pay per capture endpoint on the walk hot path.
+fn position_value(position: tower_lsp_server::ls_types::Position) -> Value {
+    let mut map = serde_json::Map::with_capacity(2);
+    map.insert("line".to_owned(), Value::from(position.line));
+    map.insert("character".to_owned(), Value::from(position.character));
+    Value::Object(map)
+}
+
 /// A memoized full-mode captures walk result, tagged with the exact inputs
 /// it was computed from: the snapshot identity `(parsed_version,
 /// incarnation)` and the settings `generation`. Named fields (three adjacent
@@ -1274,18 +1284,30 @@ fn execute_captures_walk(
                     let end_byte = c.end_byte + anchor;
                     let start = mapper.byte_to_position(start_byte)?;
                     let end = mapper.byte_to_position(end_byte)?;
-                    let node = json!({ "id": ulid.to_string(), "kind": c.kind });
-                    let mut capture = json!({
-                        "name": c.name,
-                        "node": node,
-                        "range": { "start": start, "end": end },
-                    });
+                    // Direct Map construction, MOVING every sub-value: a
+                    // `json!` literal with non-literal expressions funnels
+                    // them through `to_value(&expr)` — a full re-serialization
+                    // (deep copy) of each nested Value plus the drop of the
+                    // original, which profiling showed as ~37% of the walk on
+                    // an injection-heavy document. The field order below IS
+                    // the wire shape (`envelope_wire_shape_is_stable`).
+                    let mut node = serde_json::Map::with_capacity(2);
+                    node.insert("id".to_owned(), Value::String(ulid.to_string()));
+                    node.insert("kind".to_owned(), Value::String(c.kind.to_owned()));
+                    let mut range = serde_json::Map::with_capacity(2);
+                    range.insert("start".to_owned(), position_value(start));
+                    range.insert("end".to_owned(), position_value(end));
+                    let has_meta = !c.metadata.is_empty();
+                    let mut capture = serde_json::Map::with_capacity(3 + usize::from(has_meta));
+                    capture.insert("name".to_owned(), Value::String(c.name.clone()));
+                    capture.insert("node".to_owned(), Value::Object(node));
+                    capture.insert("range".to_owned(), Value::Object(range));
                     // Capture-scoped `#set! @cap key value` metadata,
                     // only when the capture was annotated.
                     if let Some(meta) = metadata_object(&c.metadata) {
-                        capture["metadata"] = meta;
+                        capture.insert("metadata".to_owned(), meta);
                     }
-                    Some(capture)
+                    Some(Value::Object(capture))
                 })
                 .collect();
             // Mirror execute_query's invariant: clients never see an empty
@@ -1293,18 +1315,21 @@ fn execute_captures_walk(
             if captures.is_empty() {
                 continue;
             }
-            let mut envelope = json!({
-                "patternIndex": m.pattern_index,
-                "language": layer_language,
-                "captures": captures,
-            });
+            let mut envelope =
+                serde_json::Map::with_capacity(3 + usize::from(match_metadata.is_some()));
+            envelope.insert("patternIndex".to_owned(), Value::from(m.pattern_index));
+            envelope.insert(
+                "language".to_owned(),
+                Value::String(layer_language.to_owned()),
+            );
+            envelope.insert("captures".to_owned(), Value::Array(captures));
             // Match-level `#set!` metadata, only when the pattern set any
             // (treesitter-directive-set!) — absent otherwise, so patterns
             // without directives keep their pre-metadata wire shape.
             if let Some(meta) = match_metadata {
-                envelope["metadata"] = meta;
+                envelope.insert("metadata".to_owned(), meta);
             }
-            matches.push(envelope);
+            matches.push(Value::Object(envelope));
         }
     };
 
@@ -2111,6 +2136,31 @@ mod tests {
             seen >= 4,
             "host and layer captures should both contribute (got {seen})"
         );
+    }
+
+    /// The wire shape of a match envelope, pinned byte-for-byte — field
+    /// order included. The shaping loop builds envelopes by direct Map
+    /// construction (moving sub-values instead of re-serializing them
+    /// through the json! macro), and this serialization is what keeps that
+    /// construction from drifting the JSON the captures protocol documents.
+    #[test]
+    fn envelope_wire_shape_is_stable() {
+        let text = "fn x() {}\n";
+        let rig = MatchCacheRig::new("file:///wire_shape.rs", text);
+        let (matches, _) = rig
+            .walk(text, &[], 0, None)
+            .expect("kind query should load");
+        assert_eq!(matches.len(), 1, "one identifier expected");
+        let m = &matches[0];
+        let id = m["captures"][0]["node"]["id"].as_str().unwrap().to_owned();
+        let expected = format!(
+            "{{\"patternIndex\":0,\"language\":\"rust\",\"captures\":[\
+             {{\"name\":\"local.reference\",\
+             \"node\":{{\"id\":\"{id}\",\"kind\":\"identifier\"}},\
+             \"range\":{{\"start\":{{\"line\":0,\"character\":3}},\
+             \"end\":{{\"line\":0,\"character\":4}}}}}}]}}"
+        );
+        assert_eq!(serde_json::to_string(m).unwrap(), expected);
     }
 
     fn capture_names(matches: &[Value]) -> Vec<String> {

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -1268,7 +1268,6 @@ fn execute_captures_walk(
         });
         let mut capture_idx = 0usize;
         for m in layer_matches.iter() {
-            let match_metadata = metadata_object(&m.metadata);
             let captures: Vec<Value> = m
                 .captures
                 .iter()
@@ -1315,6 +1314,9 @@ fn execute_captures_walk(
             if captures.is_empty() {
                 continue;
             }
+            // Shaped after the empty-captures bail so a skipped envelope
+            // allocates nothing.
+            let match_metadata = metadata_object(&m.metadata);
             let mut envelope =
                 serde_json::Map::with_capacity(3 + usize::from(match_metadata.is_some()));
             envelope.insert("patternIndex".to_owned(), Value::from(m.pattern_index));

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -1074,21 +1074,20 @@ fn execute_captures_walk(
     // current-snapshot request mints real ones. Checked here inside the
     // work-unit so the entry window is the walk itself, not the pool-queue
     // wait; the walk-duration residual — an edit landing DURING the walk —
-    // is closed by the post-walk reconciliation below, which purges this
-    // walk's own mints when the snapshot is no longer current on exit.
+    // is closed by the mint itself: each layer's ids are reconciled in ONE
+    // latch-gated batch (`mint_batch_if_unshifted`), whose latch check runs
+    // under the tracker entry's exclusive lock, so every id it mints is
+    // correct-at-birth and no purge set is needed — a batch the mid-walk
+    // edit outran refuses wholesale (minting nothing) and the layer falls
+    // back to the same read-only resolution as a stale-at-entry serve.
     // Latched BEFORE the currency check: an edit landing between the two
-    // bumps the generation (making later mints purge-eligible) or fails the
-    // currency check itself — either way no wrong-space mint survives. The
-    // epoch half covers close/reopen, which REPLACES the per-URI index (its
-    // generation restarts at 0).
-    let (entry_shift_gen, entry_cleanup_epoch) = tracker.mint_epoch(uri);
+    // fails the batch latch or the currency check itself — either way no
+    // wrong-space mint EXISTS, ever. The epoch half covers close/reopen,
+    // which REPLACES the per-URI index (its generation restarts at 0).
+    let entry_mint_epoch = tracker.mint_epoch(uri);
     let mint_into_tracker = documents.latest_snapshot(uri).is_some_and(|view| {
         view.slot.current_incarnation == incarnation && view.content_version == parsed_version
     });
-    // Ids THIS walk created (as opposed to reused), with the shift
-    // generation each creation observed — the purge set for the post-walk
-    // reconciliation.
-    let mut minted_ids: Vec<(ulid::Ulid, u64)> = Vec::new();
     let mapper = PositionMapper::new(text);
 
     // Range scoping: clamped conversion (like other viewport-shaped
@@ -1217,48 +1216,64 @@ fn execute_captures_walk(
                 (arc, 0)
             }
         };
+        // Per-layer id reconciliation (the §3 walk lever): resolve every
+        // capture's ULID in ONE tracker entry-lock acquisition instead of
+        // one per capture (~20k on an injection-heavy document). Minted in
+        // the layer's depth, so the id resolves in its minting layer via
+        // kakehashi/node/* (per-layer Scope rule). The batch is keyed on the
+        // walk's entry latch: a mid-walk edit refuses it wholesale (nothing
+        // minted — no wrong-space entries, no purge), and the layer degrades
+        // to the stale serve's read-only resolution below. Ids are minted
+        // for every capture, including one whose span later fails position
+        // mapping and is dropped from the response — under a current
+        // snapshot every span maps by construction, so the difference is
+        // theoretical; the alignment (one id per capture, match order) is
+        // what the shaping loop indexes by.
+        let capture_keys = || {
+            layer_matches.iter().flat_map(|m| {
+                m.captures
+                    .iter()
+                    .map(|c| (c.start_byte + anchor, c.end_byte + anchor, c.kind, depth))
+            })
+        };
+        let layer_ulids: Vec<ulid::Ulid> = if mint_into_tracker {
+            tracker.mint_batch_if_unshifted(uri, entry_mint_epoch, capture_keys())
+        } else {
+            None
+        }
+        .unwrap_or_else(|| {
+            // Read-only resolution (stale-at-entry serve, or a mid-walk edit
+            // refusing the batch): a position the intervening edits did not
+            // shift reuses its live id; an unknown position gets a fresh
+            // UNREGISTERED id — NOT Ulid::default() (the nil id), since
+            // unregistered ids must still be unique per capture.
+            capture_keys()
+                .map(|(start, end, kind, layer)| {
+                    match tracker.lookup_in_layer(uri, start, end, kind, layer) {
+                        Some(live) => live,
+                        None => ulid::Ulid::new(),
+                    }
+                })
+                .collect()
+        });
+        let mut capture_idx = 0usize;
         for m in layer_matches.iter() {
             let match_metadata = metadata_object(&m.metadata);
             let captures: Vec<Value> = m
                 .captures
                 .iter()
                 .filter_map(|c| {
+                    // Consume this capture's reconciled id FIRST (the batch
+                    // is aligned one-id-per-capture in match order), so a
+                    // dropped capture cannot shift later captures' ids.
+                    let ulid = layer_ulids[capture_idx];
+                    capture_idx += 1;
                     // A capture whose bytes don't map to positions (corrupt
                     // span) is dropped rather than failing the whole request.
                     let start_byte = c.start_byte + anchor;
                     let end_byte = c.end_byte + anchor;
                     let start = mapper.byte_to_position(start_byte)?;
                     let end = mapper.byte_to_position(end_byte)?;
-                    // Minted in the layer's depth, so the id resolves in
-                    // its minting layer via kakehashi/node/* (per-layer
-                    // Scope rule). Same mint as `mint_node_info`, done via
-                    // the tracker handle since this runs off `self`. On a
-                    // stale serve the tracker is read-only (see the
-                    // currency gate above).
-                    let ulid = if mint_into_tracker {
-                        let (ulid, created, shift_gen) = tracker.get_or_create_in_layer_tracked(
-                            uri, start_byte, end_byte, c.kind, depth,
-                        );
-                        // Recorded for the post-walk purge: if an edit lands
-                        // mid-walk, entries created after its shift were
-                        // minted in a superseded coordinate space and must
-                        // not persist. Both `created` and the observed
-                        // generation are determined atomically under the
-                        // tracker's entry lock, so an id a concurrent,
-                        // still-current request created (and handed out) is
-                        // never mis-attributed here and wrongly purged.
-                        if created {
-                            minted_ids.push((ulid, shift_gen));
-                        }
-                        ulid
-                    } else {
-                        match tracker.lookup_in_layer(uri, start_byte, end_byte, c.kind, depth) {
-                            Some(live) => live,
-                            // NOT Ulid::default() (the nil id): unregistered
-                            // ids must still be unique per capture.
-                            None => ulid::Ulid::new(),
-                        }
-                    };
                     let node = json!({ "id": ulid.to_string(), "kind": c.kind });
                     let mut capture = json!({
                         "name": c.name,
@@ -1328,33 +1343,10 @@ fn execute_captures_walk(
         visit(language_id, tree, 0);
     }
 
-    // Post-walk reconciliation, the other half of the currency gate: the
-    // entry latch cannot see an edit (or close/reopen) that lands DURING the
-    // walk. A creation whose observed shift generation still equals the
-    // entry latch — with the cleanup epoch also unchanged — is
-    // correct-at-birth: no edit intervened, and later edits shift it like
-    // any live entry. A generation mismatch means the mint landed AFTER some
-    // edit's shift, i.e. in a superseded coordinate space — coordinate
-    // comparison could not detect this once a second edit moves the
-    // wrong-space entry again. An epoch mismatch means a close/reopen
-    // replaced some index mid-walk (per-URI generations restart at 0, so
-    // the generation alone could ABA); purging our own mints then is
-    // conservative but bounded — one null re-sync. The response still
-    // carries purged ids, which resolve `null` (the protocol's re-sync
-    // signal), the same degradation as a stale-at-entry serve.
-    if !minted_ids.is_empty() {
-        let (_, exit_cleanup_epoch) = tracker.mint_epoch(uri);
-        for (id, shift_gen) in &minted_ids {
-            if *shift_gen != entry_shift_gen || exit_cleanup_epoch != entry_cleanup_epoch {
-                tracker.remove_id(uri, id);
-            }
-        }
-    }
-
     // A cancelled walk must not shape a partial result: the caller answers
     // the protocol cancellation, and nothing may reach the walk memo. The
-    // minted-id reconciliation above still ran, so entries minted before the
-    // bail were purged/kept under the same rules as a completed walk — only
+    // per-layer batch mints that ran before the bail were latch-gated
+    // (correct-at-birth), so no post-walk reconciliation is needed — only
     // the response is discarded.
     if crate::cancel::is_cancelled(cancel) {
         return None;
@@ -2068,6 +2060,57 @@ mod tests {
                 cancel,
             )
         }
+    }
+
+    /// Batch id reconciliation alignment: every capture in a current serve
+    /// carries the id of ITS OWN span — resolvable via `lookup_node` to
+    /// exactly the byte range and kind the response reports for it. An
+    /// off-by-one in the one-id-per-capture alignment (e.g. a dropped
+    /// capture shifting later ids) would pair some capture with a
+    /// neighbor's id and fail the span equality.
+    #[test]
+    fn current_serve_ids_align_one_per_capture_with_their_own_spans() {
+        let code = "let alpha = beta + gamma;\n";
+        let text = format!("AAAA\n{code}");
+        let start = text.find(code).unwrap();
+        let rig = MatchCacheRig::new("file:///batch_align.rs", &text);
+        let layer = rust_layer(&text, start, text.len());
+        let (matches, _) = rig
+            .walk(&text, &[layer], 0, None)
+            .expect("kind query should load");
+        let mapper = PositionMapper::new(&text);
+        let to_pos = |p: &Value| {
+            tower_lsp_server::ls_types::Position::new(
+                u32::try_from(p["line"].as_u64().unwrap()).unwrap(),
+                u32::try_from(p["character"].as_u64().unwrap()).unwrap(),
+            )
+        };
+        let mut seen = 0;
+        for m in &matches {
+            for c in m["captures"].as_array().unwrap() {
+                let id: ulid::Ulid = c["node"]["id"].as_str().unwrap().parse().unwrap();
+                let (s, e, kind, _layer) = rig
+                    .tracker
+                    .lookup_node(&rig.uri, &id)
+                    .expect("a current serve mints resolvable ids");
+                assert_eq!(
+                    mapper.position_to_byte_clamped(to_pos(&c["range"]["start"])),
+                    s,
+                    "capture start must be the id's own tracked start"
+                );
+                assert_eq!(
+                    mapper.position_to_byte_clamped(to_pos(&c["range"]["end"])),
+                    e,
+                    "capture end must be the id's own tracked end"
+                );
+                assert_eq!(c["node"]["kind"].as_str().unwrap(), kind);
+                seen += 1;
+            }
+        }
+        assert!(
+            seen >= 4,
+            "host and layer captures should both contribute (got {seen})"
+        );
     }
 
     fn capture_names(matches: &[Value]) -> Vec<String> {

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -2007,15 +2007,15 @@ mod tests {
 
     impl MatchCacheRig {
         fn new(uri: &str, text: &str) -> Self {
+            Self::new_with_query(uri, text, "(identifier) @local.reference\n")
+        }
+
+        fn new_with_query(uri: &str, text: &str, locals_scm: &str) -> Self {
             use crate::config::WorkspaceSettings;
             let dir = tempfile::tempdir().unwrap();
             let query_dir = dir.path().join("queries/rust");
             std::fs::create_dir_all(&query_dir).unwrap();
-            std::fs::write(
-                query_dir.join("locals.scm"),
-                "(identifier) @local.reference\n",
-            )
-            .unwrap();
+            std::fs::write(query_dir.join("locals.scm"), locals_scm).unwrap();
             let coordinator = std::sync::Arc::new(crate::language::LanguageCoordinator::new());
             coordinator.load_settings(&WorkspaceSettings {
                 search_paths: vec![dir.path().to_string_lossy().into_owned()],
@@ -2044,7 +2044,7 @@ mod tests {
             parsed_version: u64,
             lsp_range: Option<Range>,
         ) -> Option<(Vec<Value>, Vec<Value>)> {
-            self.walk_with(text, layers, parsed_version, lsp_range, true, None)
+            self.walk_with(text, layers, parsed_version, lsp_range, true, None, 0)
         }
 
         #[allow(clippy::too_many_arguments)]
@@ -2056,6 +2056,11 @@ mod tests {
             lsp_range: Option<Range>,
             injection: bool,
             cancel: Option<&crate::cancel::CancelToken>,
+            // The kind-query compile cache is PROCESS-WIDE, keyed
+            // (language, kind file, generation) — a rig with a custom
+            // locals.scm must walk under a generation no other test uses,
+            // or it silently serves another rig's compiled query.
+            generation: u64,
         ) -> Option<(Vec<Value>, Vec<Value>)> {
             let mut parser = tree_sitter::Parser::new();
             parser
@@ -2082,7 +2087,7 @@ mod tests {
                 &self.store,
                 parsed_version,
                 incarnation,
-                0,
+                generation,
                 &self.match_cache,
                 cancel,
             )
@@ -2161,6 +2166,101 @@ mod tests {
              \"node\":{{\"id\":\"{id}\",\"kind\":\"identifier\"}},\
              \"range\":{{\"start\":{{\"line\":0,\"character\":3}},\
              \"end\":{{\"line\":0,\"character\":4}}}}}}]}}"
+        );
+        assert_eq!(serde_json::to_string(m).unwrap(), expected);
+    }
+
+    /// The dropped-capture half of the alignment invariant: a capture whose
+    /// span fails position mapping is dropped from the response, and the
+    /// SURVIVING captures must keep their own ids — consuming the batch
+    /// index after the drop (instead of before) would hand the survivor the
+    /// dropped capture's id. Unmappable spans cannot come from a real tree,
+    /// so one is planted as a cached-matches sentinel (the walk trusts the
+    /// content-addressed cache).
+    #[test]
+    fn dropped_capture_does_not_shift_surviving_capture_ids() {
+        let text = "fn x() {}\n";
+        let rig = MatchCacheRig::new("file:///drop_align.rs", text);
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let tree = parser.parse(text, None).unwrap();
+        let (anchor, hash) =
+            super::super::captures_match_cache::tree_cache_key("locals", "rust", &tree, text);
+        assert_eq!(anchor, 0, "host layer anchors at 0");
+        rig.match_cache.store_host(
+            &rig.uri,
+            "locals",
+            hash,
+            0,
+            std::sync::Arc::new(vec![crate::language::query_exec::MatchData {
+                pattern_index: 0,
+                captures: vec![
+                    // Unmappable span (beyond EOF): dropped by the position
+                    // filter AFTER its id was consumed from the batch.
+                    crate::language::query_exec::CapturedNode {
+                        name: "dropped".to_string(),
+                        start_byte: text.len() + 10,
+                        end_byte: text.len() + 12,
+                        kind: "identifier",
+                        metadata: Vec::new(),
+                    },
+                    crate::language::query_exec::CapturedNode {
+                        name: "survivor".to_string(),
+                        start_byte: 3,
+                        end_byte: 4,
+                        kind: "identifier",
+                        metadata: Vec::new(),
+                    },
+                ],
+                metadata: Vec::new(),
+            }]),
+            || true,
+        );
+
+        let (matches, _) = rig
+            .walk(text, &[], 0, None)
+            .expect("kind query should load");
+        let envelope = &matches[0];
+        let captures = envelope["captures"].as_array().unwrap();
+        assert_eq!(captures.len(), 1, "the unmappable capture is dropped");
+        assert_eq!(captures[0]["name"], "survivor");
+        let id: ulid::Ulid = captures[0]["node"]["id"].as_str().unwrap().parse().unwrap();
+        assert_eq!(
+            rig.tracker.lookup_node(&rig.uri, &id),
+            Some((3, 4, "identifier", 0)),
+            "the survivor must keep ITS OWN id, not inherit the dropped capture's"
+        );
+    }
+
+    /// Wire position of the optional `metadata` field, pinned byte-for-byte
+    /// at both levels: last key of the capture object and last key of the
+    /// match envelope (the `#set!` directives' documented shape).
+    #[test]
+    fn metadata_wire_position_is_stable() {
+        let text = "fn x() {}\n";
+        let rig = MatchCacheRig::new_with_query(
+            "file:///wire_shape_meta.rs",
+            text,
+            "((identifier) @local.reference\n  (#set! @local.reference ck \"cv\")\n  (#set! mk \"mv\"))\n",
+        );
+        // Unique generation: the process-wide kind-query compile cache would
+        // otherwise serve another rig's plain locals.scm (see walk_with).
+        let (matches, _) = rig
+            .walk_with(text, &[], 0, None, true, None, 7777)
+            .expect("kind query should load");
+        assert_eq!(matches.len(), 1, "one identifier expected");
+        let m = &matches[0];
+        let id = m["captures"][0]["node"]["id"].as_str().unwrap().to_owned();
+        let expected = format!(
+            "{{\"patternIndex\":0,\"language\":\"rust\",\"captures\":[\
+             {{\"name\":\"local.reference\",\
+             \"node\":{{\"id\":\"{id}\",\"kind\":\"identifier\"}},\
+             \"range\":{{\"start\":{{\"line\":0,\"character\":3}},\
+             \"end\":{{\"line\":0,\"character\":4}}}},\
+             \"metadata\":{{\"ck\":\"cv\"}}}}],\
+             \"metadata\":{{\"mk\":\"mv\"}}}}"
         );
         assert_eq!(serde_json::to_string(m).unwrap(), expected);
     }
@@ -2478,6 +2578,7 @@ mod tests {
             None,
             true,
             Some(&cancel),
+            0,
         );
         assert!(cancelled.is_none(), "a cancelled walk serves nothing");
         assert!(
@@ -2493,7 +2594,7 @@ mod tests {
     fn host_slot_serves_on_content_recurrence() {
         let text = "let a = 1;\n";
         let rig = MatchCacheRig::new("file:///match_cache_host.rs", text);
-        rig.walk_with(text, &[], 0, None, false, None)
+        rig.walk_with(text, &[], 0, None, false, None, 0)
             .expect("kind query should load");
 
         // Host key for the same content: parse without included ranges.
@@ -2532,7 +2633,7 @@ mod tests {
 
         // Same content again (undo/redo shape): must serve the host slot.
         let (matches, _) = rig
-            .walk_with(text, &[], 0, None, false, None)
+            .walk_with(text, &[], 0, None, false, None, 0)
             .expect("kind query should load");
         assert!(
             capture_names(&matches)

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -904,6 +904,39 @@ impl Kakehashi {
         let snapshot_for_layers = std::sync::Arc::clone(&snapshot);
         let walk_cancel = cancel_token.clone();
         let inner_cancel = cancel_token.clone();
+        // Mint latch + currency gate, taken atomically UNDER the document's
+        // edit lock (populate's discipline, see
+        // `populate_injections_on_pool`): `did_change` shifts the tracker
+        // BEFORE it bumps `content_version` under this same lock, so a
+        // lock-free latch + version check could observe the intermediate
+        // state — latch matching the already-shifted tracker, version not
+        // yet bumped — and let the walk's per-layer batches mint
+        // old-snapshot coordinates as correct-at-birth. Under the lock the
+        // pair is atomic; an edit (or close) landing after the lock drops
+        // fails the per-layer batch latch instead, degrading that layer to
+        // the read-only fallback. Taken before the pool dispatch: an edit
+        // during the queue wait now refuses the batches rather than
+        // flipping the gate, the same read-only outcome; the sweep it
+        // permits stays bounded by the single-flight winner guard (see the
+        // sweep note in `execute_captures_walk`).
+        let (entry_mint_epoch, mint_into_tracker) = {
+            let edit_lock = self.documents.edit_lock(&uri);
+            let _edit_guard = edit_lock.lock().await;
+            let latch = tracker.mint_epoch(&uri);
+            let latest = self.documents.latest_snapshot(&uri);
+            let current = latest.as_ref().is_some_and(|view| {
+                view.slot.current_incarnation == incarnation
+                    && view.content_version == parsed_version
+            });
+            if latest.is_none() {
+                // Reclaim the lock entry edit_lock() materialized for a
+                // closed document (identity+share-checked — see
+                // `remove_edit_lock_if_unshared`).
+                self.documents
+                    .remove_edit_lock_if_unshared(&uri, &edit_lock);
+            }
+            (latch, current)
+        };
         let walk_future = self
             .compute_pool
             .run(Some(cancel_token.clone()), move || {
@@ -965,8 +998,8 @@ impl Kakehashi {
                     &language,
                     &tracker,
                     &documents,
-                    parsed_version,
-                    incarnation,
+                    entry_mint_epoch,
+                    mint_into_tracker,
                     generation,
                     &match_cache,
                     Some(&inner_cancel),
@@ -1062,8 +1095,8 @@ fn execute_captures_walk(
     language: &crate::language::LanguageCoordinator,
     tracker: &crate::language::NodeTracker,
     documents: &crate::document::DocumentStore,
-    parsed_version: u64,
-    incarnation: u64,
+    entry_mint_epoch: (u64, u64),
+    mint_into_tracker: bool,
     generation: u64,
     match_cache: &super::captures_match_cache::CapturesMatchCache,
     cancel: Option<&crate::cancel::CancelToken>,
@@ -1072,32 +1105,24 @@ fn execute_captures_walk(
     // index (didChange shifts every entry before the reparse), so a trailing
     // snapshot's byte offsets must never be written into it — they would be
     // wrong-space entries that later edits keep shifting as if they were live
-    // (the "a stale read never mints" invariant, see snapshot_read.rs). The
-    // handler resolves a CURRENT snapshot (serve-current park), but an edit
-    // can land between that resolution and this work-unit reaching the front
-    // of the pool queue; a walk that starts outrun still returns matches
-    // (voided later by the lineage gate) but goes READ-ONLY on the tracker: a
-    // position the intervening edits did not shift reuses its live id (so
-    // the delta lineage stays a minimal diff), and an unknown position gets
-    // an unregistered id — resolving one via `kakehashi/node/*` yields
-    // `null`, the protocol's re-sync signal, and the client's next
-    // current-snapshot request mints real ones. Checked here inside the
-    // work-unit so the entry window is the walk itself, not the pool-queue
-    // wait; the walk-duration residual — an edit landing DURING the walk —
-    // is closed by the mint itself: each layer's ids are reconciled in ONE
-    // latch-gated batch (`mint_batch_if_unshifted`), whose latch check runs
-    // under the tracker entry's exclusive lock, so every id it mints is
-    // correct-at-birth and no purge set is needed — a batch the mid-walk
-    // edit outran refuses wholesale (minting nothing) and the layer falls
-    // back to the same read-only resolution as a stale-at-entry serve.
-    // Latched BEFORE the currency check: an edit landing between the two
-    // fails the batch latch or the currency check itself — either way no
-    // wrong-space mint EXISTS, ever. The epoch half covers close/reopen,
-    // which REPLACES the per-URI index (its generation restarts at 0).
-    let entry_mint_epoch = tracker.mint_epoch(uri);
-    let mint_into_tracker = documents.latest_snapshot(uri).is_some_and(|view| {
-        view.slot.current_incarnation == incarnation && view.content_version == parsed_version
-    });
+    // (the "a stale read never mints" invariant, see snapshot_read.rs).
+    // `entry_mint_epoch` + `mint_into_tracker` are captured by the CALLER,
+    // atomically under the document's edit lock (see `compute_captures`) —
+    // `did_change` shifts the tracker BEFORE it bumps `content_version`
+    // under that lock, so computing the pair lock-free here could observe
+    // the intermediate state and mint old-snapshot coordinates as
+    // correct-at-birth. A stale-at-entry serve (`mint_into_tracker` false)
+    // goes READ-ONLY on the tracker: a position the intervening edits did
+    // not shift reuses its live id (so the delta lineage stays a minimal
+    // diff), and an unknown position gets an unregistered id — resolving
+    // one via `kakehashi/node/*` yields `null`, the protocol's re-sync
+    // signal, and the client's next current-snapshot request mints real
+    // ones. An edit landing AFTER the caller's gate — during the pool-queue
+    // wait or the walk itself — fails the per-layer batch latch instead
+    // (`mint_batch_if_unshifted` re-checks it under the tracker entry's
+    // exclusive lock; the epoch half covers close/reopen, whose per-URI
+    // generation restarts at 0), degrading those layers to the same
+    // read-only resolution. Either way no wrong-space mint EXISTS, ever.
     let mapper = PositionMapper::new(text);
 
     // Range scoping: clamped conversion (like other viewport-shaped
@@ -1865,13 +1890,7 @@ mod tests {
         let store = DocumentStore::new();
         let uri = Url::parse("file:///stale_mint.rs").unwrap();
         store.insert(uri.clone(), text.to_string(), Some("rust".into()), None);
-        let incarnation = store
-            .latest_snapshot(&uri)
-            .unwrap()
-            .slot
-            .current_incarnation;
-
-        // Current (parsed_version == content_version == 0): minting is live.
+        // Current serve: the caller-computed gate is true (minting live).
         let tracker = NodeTracker::new();
         let match_cache = super::super::captures_match_cache::CapturesMatchCache::new();
         let (matches, _) = execute_captures_walk(
@@ -1886,8 +1905,8 @@ mod tests {
             &coordinator,
             &tracker,
             &store,
-            0,
-            incarnation,
+            tracker.mint_epoch(&uri),
+            true,
             0,
             &match_cache,
             None,
@@ -1916,8 +1935,8 @@ mod tests {
             &coordinator,
             &tracker,
             &store,
-            0,
-            incarnation,
+            tracker.mint_epoch(&uri),
+            false,
             0,
             &match_cache,
             None,
@@ -1948,8 +1967,8 @@ mod tests {
             &coordinator,
             &stale_tracker,
             &store,
-            0,
-            incarnation,
+            stale_tracker.mint_epoch(&uri),
+            false,
             0,
             &match_cache,
             None,
@@ -2083,6 +2102,13 @@ mod tests {
                 .unwrap()
                 .slot
                 .current_incarnation;
+            // Latch-then-validate, mirroring the production caller
+            // (`compute_captures` takes both under the edit lock).
+            let entry_mint_epoch = self.tracker.mint_epoch(&self.uri);
+            let mint_into_tracker = self.store.latest_snapshot(&self.uri).is_some_and(|view| {
+                view.slot.current_incarnation == incarnation
+                    && view.content_version == parsed_version
+            });
             execute_captures_walk(
                 &self.uri,
                 "locals",
@@ -2095,8 +2121,8 @@ mod tests {
                 &self.coordinator,
                 &self.tracker,
                 &self.store,
-                parsed_version,
-                incarnation,
+                entry_mint_epoch,
+                mint_into_tracker,
                 generation,
                 &self.match_cache,
                 cancel,

--- a/src/lsp/lsp_impl/text_document/did_close.rs
+++ b/src/lsp/lsp_impl/text_document/did_close.rs
@@ -51,8 +51,15 @@ impl Kakehashi {
         // Clean up all caches for this document (semantic tokens, injections, requests)
         self.cache.remove_document(&uri);
 
-        // Clean up region ID mappings for this document (lazy-node-identity-tracking)
-        self.bridge.cleanup(&uri);
+        // Clean up region ID mappings for this document
+        // (lazy-node-identity-tracking). This runs AFTER the removal above
+        // and outside the edit-lock section, so a fast reopen's parse may
+        // already have minted the NEW lifetime's ids — the probe (evaluated
+        // under the tracker entry's lock) skips the removal in that case
+        // instead of wiping a live index whose published ids would then
+        // resolve null. See NodeTracker::cleanup.
+        self.bridge
+            .cleanup(&uri, || self.documents.latest_snapshot(&uri).is_some());
 
         // Abort any in-progress synthetic diagnostic task for this document (pull-first-diagnostic-forwarding Phase 2)
         self.synthetic_diagnostics.remove_document(&uri);


### PR DESCRIPTION
## What

Two coupled levers on the captures/populate hot path, follow-up to #560 (`docs/architecture-decisions/parse-snapshot-architecture.md` §3, third concern):

### 1. Mint reconciliation (`NodeTracker::mint_batch_if_unshifted`)

The tracker ULID mint moves out of inline per-region (`populate_injections`) and per-capture (captures walk, ~20k entry-lock acquisitions per request) call sites into a **latch-gated batch**: one exclusive entry-lock acquisition per pass/layer, with the (shift generation, cleanup epoch) latch re-checked *inside* the lock the `didChange` edit-shift takes.

- A passing batch is **correct-at-birth** — a later edit shifts its ids like any live entry — so the whole post-pass purge machinery (`get_or_create_in_layer_tracked`, `remove_id`, minted-id sets in populate and the walk) is **deleted**.
- A refused batch mints **nothing**: `populate_injections` now returns `Option` (`None` = refused pass → the snapshot rides without regions and readers fall back inline; `Some(empty)` = ran-and-found-none).
- populate's caller captures the latch **atomically with a liveness/lifetime/currency gate under the document's `edit_lock`** — necessary because `didChange` shifts the tracker before it bumps `content_version`, so a lock-free latch-then-validate could pass on both counts while minting old-tree coordinates.
- Close/reopen lifecycle hardening that the reviews surfaced: `cleanup` bumps the epoch **before** removing the entry; the removal is guarded by a reopen probe (a raced reopen's freshly minted ids survive; accepted residual documented at the code site → #569); stray edit-lock reclamation is identity+share-checked.

### 2. Envelope move-construction

Profiling (samply, markdown size-600 corpus, ~30k matches/walk) showed **~37% of walk time inside `json!`'s hidden deep copies** — a non-literal expression embedded in a `json!` literal goes through `to_value(&expr)`, a full re-serialization of the nested `Value` plus the drop of the original. Position mapping was ~1%, the batch mint ~5% — which also refuted the previously-planned shaped-JSON/ULID caching levers (a cache hit's `Value` deep-clone repays the same allocation bill as construction).

The shaping loop now builds envelope/capture/node/range maps directly and **moves** every sub-value; the wire shape is pinned byte-for-byte (field order included) by `envelope_wire_shape_is_stable` and `metadata_wire_position_is_stable`.

## Measured

Interleaved A/B, `benches/profile/drive.py --captures --edits 1 --lang markdown --size 600`, 25 requests (isolated data dir + empty `XDG_CONFIG_HOME`):

| | main | branch |
|---|---|---|
| captures walk median | 178–219 ms | **68–71 ms** |
| end-to-end request cycle | 1198 ms/req | 1013 ms/req |

(Machine under external load ~96 loadavg; interleaved rounds sign-consistent. Post-review-fix sanity run: walk median 69 ms.)

## Review

Converged through /review ×2 (M1 cleanup ordering, ADR contradiction, doc contracts, alloc trims, dropped-capture alignment + metadata wire tests) and four codex sessions (latch-then-validate ordering, edit_lock-atomic gate, refused-pass `None` shape, refused-clear propagation, share-checked lock reclamation); final fresh codex session clean on first response. Accepted residuals are documented at the code sites (#569; did_close lifecycle-epoch deferrals; the walk's microsecond shift-vs-bump window shared with main).

Follow-ups filed: #564 (response-side Value materialization), #565 (walk-memo insert liveness), #569 (incarnation-tagged tracker entries); #559 got fresh measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)