### PR TITLE
perf(bridge): capability prefilter for virt fan-out

### DIFF
--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -53,8 +53,14 @@ pub(crate) use coordinator::BridgeCoordinator;
 pub(crate) use coordinator::ResolvedServerConfig;
 pub(crate) use inbound_request_registry::InboundRequestRegistry;
 pub(crate) use pool::ConnectionKey;
+#[cfg(test)]
+pub(crate) use pool::ConnectionState;
 pub use pool::LanguageServerPool;
 pub(crate) use pool::UpstreamId;
+/// Re-exported for the capability-prefilter regression test in `lsp_impl`, which
+/// seeds a `Ready` downstream to exercise `collect_push_diagnostics`' filter.
+#[cfg(test)]
+pub(crate) use pool::test_helpers;
 pub(crate) use progress_registry::{ProgressConnectionId, ProgressRegistry};
 pub(crate) use protocol::RegionOffset;
 pub(crate) use protocol::RequestId;

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -626,19 +626,21 @@ impl LanguageServerPool {
             return std::collections::HashSet::new();
         }
         let connections = self.connections.lock().await;
-        // Tie the accumulated names to `candidates`' lifetime (not the lock
-        // guard) so the returned `String`s outlive the guard drop.
+        // `capable` / `has_ready` borrow server names from the connections map;
+        // the owned result is materialized below while the guard is still held,
+        // so they need not outlive it.
         let mut capable: std::collections::HashSet<&str> = std::collections::HashSet::new();
         let mut has_ready: std::collections::HashSet<&str> = std::collections::HashSet::new();
         for handle in connections.values() {
-            let Some(&candidate) = candidates.get(handle.key().server()) else {
+            let server = handle.key().server();
+            if !candidates.contains(server) {
                 continue;
-            };
+            }
             if handle.has_capability(method) {
-                capable.insert(candidate);
+                capable.insert(server);
             }
             if handle.state() == ConnectionState::Ready {
-                has_ready.insert(candidate);
+                has_ready.insert(server);
             }
         }
         candidates

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -22,7 +22,7 @@ mod message_sender;
 mod shutdown;
 mod shutdown_timeout;
 #[cfg(test)]
-pub(in crate::lsp::bridge) mod test_helpers;
+pub(crate) mod test_helpers;
 
 pub(crate) use connection_action::BridgeError;
 use connection_action::{ConnectionAction, decide_connection_action};
@@ -643,9 +643,11 @@ impl LanguageServerPool {
     /// This allows tests to set up a pool with a known connection state
     /// without going through the full server spawn + handshake flow. The handle
     /// is keyed by its own `handle.key()` so lookups via the key (didChange,
-    /// cancel) agree with the map.
+    /// cancel) agree with the map. `pub(crate)` (not bridge-private) so the
+    /// capability-prefilter regression test in `lsp_impl` can seed a Ready
+    /// downstream (capability-prefilter-fanout).
     #[cfg(test)]
-    pub(in crate::lsp::bridge) async fn insert_connection(&self, handle: Arc<ConnectionHandle>) {
+    pub(crate) async fn insert_connection(&self, handle: Arc<ConnectionHandle>) {
         let mut connections = self.connections.lock().await;
         connections.insert(handle.key().clone(), handle);
     }

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -581,24 +581,42 @@ impl LanguageServerPool {
     /// Deliberately conservative — a candidate is returned ONLY when it has at
     /// least one `Ready` connection AND none of its connections advertises
     /// `method`. Concretely:
-    /// - **No live connection** → NOT returned. The capability is unknown until
-    ///   the server is spawned + handshaked, so the caller must keep it and let
-    ///   the request spawn it, exactly as before this filter existed.
+    /// - **No live connection at all** → NOT returned. The capability is unknown
+    ///   until the server is spawned + handshaked, so the caller keeps it and
+    ///   lets the request spawn it, exactly as before this filter existed.
     /// - **Only non-`Ready` connections** (`Initializing`, `Failed`, `Closing`,
-    ///   `Closed`) → NOT returned. Their `server_capabilities` may not be in yet
-    ///   (`has_capability` is a premature `false`), and today's
-    ///   `get_or_create_connection_wait_ready` waits for `Ready` before checking
-    ///   (or respawns a `Failed` one), so dropping here would change behavior
-    ///   (skip a server that will answer). A server with BOTH a `Ready`-lacking
-    ///   connection and a separate still-`Initializing` one IS returned — the
-    ///   `Ready` one already answers the capability; the same-binary static caps
-    ///   make the `Initializing` one redundant (see the across-roots note below).
+    ///   `Closed`) and no `Ready` one → NOT returned. `server_capabilities` may
+    ///   not be in yet (`has_capability` is a premature `false`), and
+    ///   `get_or_create_connection_wait_ready` waits for `Ready` (or respawns a
+    ///   `Failed` one) before checking, so dropping here would skip a server that
+    ///   will answer.
     ///
-    /// Classification is **by server name across roots**, reusing
-    /// `pull_driven_servers`' caveat verbatim: capability is a binary-level
-    /// property, so a server counts as capable if ANY of its `(server, root)`
-    /// connections advertises `method`; the only divergence is the exotic
-    /// per-instance *dynamic* registration, accepted there and here.
+    /// # Soundness boundary and the across-roots limitation
+    ///
+    /// Classification is **by server name across roots**: a server is capable if
+    /// ANY of its `(server, root)` connections advertises `method`, incapable if
+    /// it has a `Ready` connection and NONE does. This is exactly sound **iff the
+    /// capability is root-invariant** — the near-universal reality, since every
+    /// instance of one binary reports identical *static* `initialize`
+    /// capabilities (this is what makes a statically pull-incapable server like
+    /// basedpyright safe to drop on every root). It is NOT precise about the
+    /// serving root: if a `Ready` connection for `(server, rootA)` lacks `method`
+    /// while `(server, rootB)` would advertise it, a request in rootB is dropped
+    /// even though rootB has no connection yet or only an `Initializing` one — so
+    /// the "non-`Ready` is never dropped" rule above holds only when that is the
+    /// server's SOLE connection.
+    ///
+    /// That over-drop can fire only under genuine per-root capability
+    /// **divergence** (per-root `initializationOptions` that change advertised
+    /// static caps, or a per-instance *dynamic* registration) AND the serving
+    /// root having no `Ready`-capable connection. It is impossible in a
+    /// single-root workspace, and not permanent: any request via an exempt method
+    /// (see `capability_prefilter_applies`) or any other path spawns the
+    /// divergent root's instance and self-corrects the classification. Scoping to
+    /// the request's `(server, root)` would need a per-server marker resolution
+    /// (`resolve_marker_and_key`, filesystem I/O) on this hot path, which would
+    /// erode the win this filter exists for; the per-handler capability gate
+    /// remains authoritative for every server this does keep.
     pub(crate) async fn servers_known_incapable(
         &self,
         candidates: &std::collections::HashSet<&str>,

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -578,16 +578,21 @@ impl LanguageServerPool {
     /// request never spins up a task + connection lookup only to hit the
     /// per-handler capability gate and return an empty result.
     ///
-    /// Deliberately conservative — a candidate is returned ONLY when its
-    /// capability is *definitively* known-absent:
+    /// Deliberately conservative — a candidate is returned ONLY when it has at
+    /// least one `Ready` connection AND none of its connections advertises
+    /// `method`. Concretely:
     /// - **No live connection** → NOT returned. The capability is unknown until
     ///   the server is spawned + handshaked, so the caller must keep it and let
     ///   the request spawn it, exactly as before this filter existed.
-    /// - **A still-`Initializing` connection** → NOT returned. Its
-    ///   `server_capabilities` are not in yet (`has_capability` is a premature
-    ///   `false`); today's `get_or_create_connection_wait_ready` waits for it to
-    ///   become `Ready` before checking, so dropping it here would change
-    ///   behavior (skip a server that will answer).
+    /// - **Only non-`Ready` connections** (`Initializing`, `Failed`, `Closing`,
+    ///   `Closed`) → NOT returned. Their `server_capabilities` may not be in yet
+    ///   (`has_capability` is a premature `false`), and today's
+    ///   `get_or_create_connection_wait_ready` waits for `Ready` before checking
+    ///   (or respawns a `Failed` one), so dropping here would change behavior
+    ///   (skip a server that will answer). A server with BOTH a `Ready`-lacking
+    ///   connection and a separate still-`Initializing` one IS returned — the
+    ///   `Ready` one already answers the capability; the same-binary static caps
+    ///   make the `Initializing` one redundant (see the across-roots note below).
     ///
     /// Classification is **by server name across roots**, reusing
     /// `pull_driven_servers`' caveat verbatim: capability is a binary-level
@@ -5308,6 +5313,44 @@ mod tests {
         assert!(
             incapable.is_empty(),
             "a capable instance makes the whole server capable across roots"
+        );
+    }
+
+    /// A candidate whose only live connection is `Failed` or `Closing` — not
+    /// past a successful init — is NOT returned: its capability is not
+    /// known-absent (a `Failed` connection is evicted and respawned on the next
+    /// request, which may then advertise the method). Pins the strict
+    /// `state() == Ready` gate against a future widening (e.g. `!= Closed`) that
+    /// would silently over-drop such a server (capability-prefilter-fanout).
+    #[tokio::test]
+    async fn servers_known_incapable_keeps_failed_and_closing_only() {
+        use std::collections::HashSet;
+        use tower_lsp_server::ls_types::ServerCapabilities;
+
+        let pool = LanguageServerPool::new();
+
+        let failed =
+            create_handle_with_key(ConnectionState::Failed, ConnectionKey::for_server("failed"))
+                .await;
+        failed.set_server_capabilities(ServerCapabilities::default());
+        pool.insert_connection(failed).await;
+
+        let closing = create_handle_with_key(
+            ConnectionState::Closing,
+            ConnectionKey::for_server("closing"),
+        )
+        .await;
+        closing.set_server_capabilities(ServerCapabilities::default());
+        pool.insert_connection(closing).await;
+
+        let candidates = HashSet::from(["failed", "closing"]);
+        let incapable = pool
+            .servers_known_incapable(&candidates, "textDocument/hover")
+            .await;
+
+        assert!(
+            incapable.is_empty(),
+            "only a Ready connection is known-incapable; Failed/Closing are kept"
         );
     }
 

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -567,6 +567,64 @@ impl LanguageServerPool {
         pull_driven
     }
 
+    /// Among `candidates`, the server names **known** not to support `method`:
+    /// the server has at least one live connection past initialization (`Ready`)
+    /// and NONE of its live connections advertises `method` (via static
+    /// initialize caps or a dynamic registration) — checked WITHOUT creating a
+    /// connection (capability-prefilter-fanout).
+    ///
+    /// The inverse of `has_capability`: fan-out builders use this to drop a
+    /// server from a region's candidate set *before* spawning a task, so a
+    /// request never spins up a task + connection lookup only to hit the
+    /// per-handler capability gate and return an empty result.
+    ///
+    /// Deliberately conservative — a candidate is returned ONLY when its
+    /// capability is *definitively* known-absent:
+    /// - **No live connection** → NOT returned. The capability is unknown until
+    ///   the server is spawned + handshaked, so the caller must keep it and let
+    ///   the request spawn it, exactly as before this filter existed.
+    /// - **A still-`Initializing` connection** → NOT returned. Its
+    ///   `server_capabilities` are not in yet (`has_capability` is a premature
+    ///   `false`); today's `get_or_create_connection_wait_ready` waits for it to
+    ///   become `Ready` before checking, so dropping it here would change
+    ///   behavior (skip a server that will answer).
+    ///
+    /// Classification is **by server name across roots**, reusing
+    /// `pull_driven_servers`' caveat verbatim: capability is a binary-level
+    /// property, so a server counts as capable if ANY of its `(server, root)`
+    /// connections advertises `method`; the only divergence is the exotic
+    /// per-instance *dynamic* registration, accepted there and here.
+    pub(crate) async fn servers_known_incapable(
+        &self,
+        candidates: &std::collections::HashSet<&str>,
+        method: &str,
+    ) -> std::collections::HashSet<String> {
+        if candidates.is_empty() {
+            return std::collections::HashSet::new();
+        }
+        let connections = self.connections.lock().await;
+        // Tie the accumulated names to `candidates`' lifetime (not the lock
+        // guard) so the returned `String`s outlive the guard drop.
+        let mut capable: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        let mut has_ready: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        for handle in connections.values() {
+            let Some(&candidate) = candidates.get(handle.key().server()) else {
+                continue;
+            };
+            if handle.has_capability(method) {
+                capable.insert(candidate);
+            }
+            if handle.state() == ConnectionState::Ready {
+                has_ready.insert(candidate);
+            }
+        }
+        candidates
+            .iter()
+            .filter(|&&name| has_ready.contains(name) && !capable.contains(name))
+            .map(|&name| name.to_string())
+            .collect()
+    }
+
     /// Host-document sync state (host-document-bridge). Used by the host
     /// request path in `text_document/host.rs`.
     pub(super) async fn host_documents(
@@ -5158,6 +5216,108 @@ mod tests {
         let pool = LanguageServerPool::new();
         assert!(
             pool.pull_driven_servers(&HashSet::<&str>::new())
+                .await
+                .is_empty()
+        );
+    }
+
+    /// `servers_known_incapable` returns exactly the candidates whose capability
+    /// is *definitively* known-absent: a `Ready` connection lacking `method`.
+    /// A capable server, a still-`Initializing` one, and a name with no live
+    /// connection are all kept out of the result (capability-prefilter-fanout).
+    #[tokio::test]
+    async fn servers_known_incapable_returns_only_ready_and_lacking() {
+        use std::collections::HashSet;
+        use tower_lsp_server::ls_types::{HoverProviderCapability, ServerCapabilities};
+
+        let pool = LanguageServerPool::new();
+
+        // "capable" is Ready and advertises hover → NOT incapable.
+        let capable =
+            create_handle_with_key(ConnectionState::Ready, ConnectionKey::for_server("capable"))
+                .await;
+        capable.set_server_capabilities(ServerCapabilities {
+            hover_provider: Some(HoverProviderCapability::Simple(true)),
+            ..Default::default()
+        });
+        pool.insert_connection(capable).await;
+
+        // "lacking" is Ready with no hover capability → incapable (the one hit).
+        let lacking =
+            create_handle_with_key(ConnectionState::Ready, ConnectionKey::for_server("lacking"))
+                .await;
+        lacking.set_server_capabilities(ServerCapabilities::default());
+        pool.insert_connection(lacking).await;
+
+        // "warming" is still Initializing → capability unknown, must be kept.
+        let warming = create_handle_with_key(
+            ConnectionState::Initializing,
+            ConnectionKey::for_server("warming"),
+        )
+        .await;
+        pool.insert_connection(warming).await;
+
+        let candidates = HashSet::from([
+            "capable", "lacking", "warming", "ghost", // no live connection
+        ]);
+        let incapable = pool
+            .servers_known_incapable(&candidates, "textDocument/hover")
+            .await;
+
+        assert_eq!(
+            incapable,
+            HashSet::from(["lacking".to_string()]),
+            "only a Ready connection that lacks the capability is known-incapable"
+        );
+    }
+
+    /// A server counts as capable if ANY of its `(server, root)` connections
+    /// advertises `method`, so a Ready-but-lacking instance alongside a capable
+    /// one does not make the server incapable (across-roots caveat).
+    #[tokio::test]
+    async fn servers_known_incapable_capable_on_any_instance_wins() {
+        use std::collections::HashSet;
+        use tower_lsp_server::ls_types::{HoverProviderCapability, ServerCapabilities};
+
+        let pool = LanguageServerPool::new();
+
+        let root_a = create_handle_with_key(
+            ConnectionState::Ready,
+            ConnectionKey::new("srv", Some("/a".to_string())),
+        )
+        .await;
+        root_a.set_server_capabilities(ServerCapabilities::default());
+        pool.insert_connection(root_a).await;
+
+        let root_b = create_handle_with_key(
+            ConnectionState::Ready,
+            ConnectionKey::new("srv", Some("/b".to_string())),
+        )
+        .await;
+        root_b.set_server_capabilities(ServerCapabilities {
+            hover_provider: Some(HoverProviderCapability::Simple(true)),
+            ..Default::default()
+        });
+        pool.insert_connection(root_b).await;
+
+        let candidates = HashSet::from(["srv"]);
+        let incapable = pool
+            .servers_known_incapable(&candidates, "textDocument/hover")
+            .await;
+
+        assert!(
+            incapable.is_empty(),
+            "a capable instance makes the whole server capable across roots"
+        );
+    }
+
+    /// An empty candidate set short-circuits to empty without touching the pool.
+    #[tokio::test]
+    async fn servers_known_incapable_empty_candidates_returns_empty() {
+        use std::collections::HashSet;
+        let pool = LanguageServerPool::new();
+        assert!(
+            pool.servers_known_incapable(&HashSet::<&str>::new(), "textDocument/hover")
                 .await
                 .is_empty()
         );

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -626,23 +626,25 @@ impl LanguageServerPool {
             return std::collections::HashSet::new();
         }
         let connections = self.connections.lock().await;
-        // `capable` / `has_ready` borrow server names from the connections map;
-        // the owned result is materialized below while the guard is still held,
-        // so they need not outlive it.
+        // Accumulate into `candidates`-lifetime references (via `candidates.get`),
+        // NOT borrows of the `connections` map: that lets us drop the lock before
+        // the final owned materialization, so the `connections` mutex — contended
+        // by every bridge request — is held only for the scan, not the
+        // `candidates.iter()/collect()` pass below.
         let mut capable: std::collections::HashSet<&str> = std::collections::HashSet::new();
         let mut has_ready: std::collections::HashSet<&str> = std::collections::HashSet::new();
         for handle in connections.values() {
-            let server = handle.key().server();
-            if !candidates.contains(server) {
+            let Some(&candidate) = candidates.get(handle.key().server()) else {
                 continue;
-            }
+            };
             if handle.has_capability(method) {
-                capable.insert(server);
+                capable.insert(candidate);
             }
             if handle.state() == ConnectionState::Ready {
-                has_ready.insert(server);
+                has_ready.insert(candidate);
             }
         }
+        drop(connections);
         candidates
             .iter()
             .filter(|&&name| has_ready.contains(name) && !capable.contains(name))

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -603,7 +603,7 @@ impl Kakehashi {
     /// to resolve per-method aggregation priorities from the bridge language config.
     ///
     /// Returns `None` if no configs are found.
-    fn preamble_to_document_context(
+    async fn preamble_to_document_context(
         &self,
         preamble: PreambleResult,
         method_name: &str,
@@ -617,7 +617,7 @@ impl Kakehashi {
             return None;
         }
 
-        let configs = self.bridge_configs_for_injection_language(
+        let mut configs = self.bridge_configs_for_injection_language(
             &preamble.language_name,
             &preamble.resolved.injection_language,
         );
@@ -629,6 +629,32 @@ impl Kakehashi {
                 preamble.language_name
             );
             return None;
+        }
+
+        // Drop servers already known (a live, `Ready` connection) NOT to support
+        // this method, so the fan-out never spawns a task + connection lookup
+        // only to hit the per-handler capability gate and return empty
+        // (capability-prefilter-fanout). Uses the same `has_capability(method)`
+        // predicate as that gate, so a dropped server is observably equivalent
+        // to it having answered empty. Unknown / still-initializing servers are
+        // kept (spawned/awaited as before).
+        let candidates: std::collections::HashSet<&str> =
+            configs.iter().map(|c| c.server_name.as_str()).collect();
+        let incapable = self
+            .bridge
+            .pool_arc()
+            .servers_known_incapable(&candidates, method_name)
+            .await;
+        if !incapable.is_empty() {
+            configs.retain(|c| !incapable.contains(&c.server_name));
+            if configs.is_empty() {
+                log::debug!(
+                    "{}: all configured servers for {} are known-incapable; skipping virt layer",
+                    method_name,
+                    preamble.resolved.injection_language
+                );
+                return None;
+            }
         }
 
         let agg = self.resolve_aggregation_config(
@@ -911,7 +937,9 @@ impl Kakehashi {
         // would find `snapshot()` empty and return null after every edit.
         self.ensure_fresh_tree_for_bridge(lsp_uri).await;
         let preamble = self.resolve_bridge_preamble(lsp_uri, position, method_name)?;
-        let document = self.preamble_to_document_context(preamble, method_name)?;
+        let document = self
+            .preamble_to_document_context(preamble, method_name)
+            .await?;
 
         Some(PositionRequestContext { document, position })
     }
@@ -936,7 +964,9 @@ impl Kakehashi {
     ) -> Option<RangeRequestContext> {
         self.ensure_fresh_tree_for_bridge(lsp_uri).await;
         let preamble = self.resolve_bridge_preamble(lsp_uri, range.start, method_name)?;
-        let document = self.preamble_to_document_context(preamble, method_name)?;
+        let document = self
+            .preamble_to_document_context(preamble, method_name)
+            .await?;
 
         Some(RangeRequestContext { document, range })
     }

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -20,6 +20,22 @@ use crate::text::PositionMapper;
 
 use super::{Kakehashi, uri_to_url};
 
+/// Whether the capability prefilter (capability-prefilter-fanout) may drop a
+/// server known to lack `method` before fan-out.
+///
+/// The prefilter relies on `has_capability(method) == false` being observably
+/// equivalent to the handler returning an empty result. That holds for every
+/// routed method EXCEPT `textDocument/prepareRename`: its handler
+/// ([`send_prepare_rename_request`]) falls back to `DefaultBehavior` (rename
+/// stays enabled) when the server advertises `textDocument/rename` but not
+/// `prepareRename`, so dropping such a server here would silently disable
+/// rename in injected regions. Exempt it — the per-handler gate still runs.
+///
+/// [`send_prepare_rename_request`]: crate::lsp::bridge::LanguageServerPool::send_prepare_rename_request
+fn capability_prefilter_applies(method: &str) -> bool {
+    method != "textDocument/prepareRename"
+}
+
 /// All resolved context needed to send bridge requests to multiple servers.
 ///
 /// Produced by `Kakehashi::resolve_bridge_contexts`. Returns ALL matching server
@@ -637,23 +653,26 @@ impl Kakehashi {
         // (capability-prefilter-fanout). Uses the same `has_capability(method)`
         // predicate as that gate, so a dropped server is observably equivalent
         // to it having answered empty. Unknown / still-initializing servers are
-        // kept (spawned/awaited as before).
-        let candidates: std::collections::HashSet<&str> =
-            configs.iter().map(|c| c.server_name.as_str()).collect();
-        let incapable = self
-            .bridge
-            .pool_arc()
-            .servers_known_incapable(&candidates, method_name)
-            .await;
-        if !incapable.is_empty() {
-            configs.retain(|c| !incapable.contains(&c.server_name));
-            if configs.is_empty() {
-                log::debug!(
-                    "{}: all configured servers for {} are known-incapable; skipping virt layer",
-                    method_name,
-                    preamble.resolved.injection_language
-                );
-                return None;
+        // kept (spawned/awaited as before). Exempt methods whose capability-absent
+        // handler branch is NOT empty (see `capability_prefilter_applies`).
+        if capability_prefilter_applies(method_name) {
+            let candidates: std::collections::HashSet<&str> =
+                configs.iter().map(|c| c.server_name.as_str()).collect();
+            let incapable = self
+                .bridge
+                .pool_arc()
+                .servers_known_incapable(&candidates, method_name)
+                .await;
+            if !incapable.is_empty() {
+                configs.retain(|c| !incapable.contains(&c.server_name));
+                if configs.is_empty() {
+                    log::debug!(
+                        "{}: all configured servers for {} are known-incapable; skipping virt layer",
+                        method_name,
+                        preamble.resolved.injection_language
+                    );
+                    return None;
+                }
             }
         }
 
@@ -1837,5 +1856,28 @@ mod tests {
                 ("rust".to_string(), "python".to_string()),
             ]
         );
+    }
+
+    /// The capability prefilter applies to ordinary position/range methods but
+    /// is exempt for `textDocument/prepareRename`, whose capability-absent
+    /// handler branch is NOT empty (it falls back to `DefaultBehavior` when the
+    /// server advertises `textDocument/rename`). Dropping a rename-only server
+    /// here would silently disable rename in injected regions.
+    #[test]
+    fn capability_prefilter_exempts_prepare_rename_only() {
+        assert!(!capability_prefilter_applies("textDocument/prepareRename"));
+        for method in [
+            "textDocument/hover",
+            "textDocument/definition",
+            "textDocument/completion",
+            "textDocument/references",
+            "textDocument/rename",
+            "textDocument/documentColor",
+        ] {
+            assert!(
+                capability_prefilter_applies(method),
+                "{method} must be prefiltered"
+            );
+        }
     }
 }

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -25,15 +25,27 @@ use super::{Kakehashi, uri_to_url};
 ///
 /// The prefilter relies on `has_capability(method) == false` being observably
 /// equivalent to the handler returning an empty result. That holds for every
-/// routed method EXCEPT `textDocument/prepareRename`: its handler
-/// ([`send_prepare_rename_request`]) falls back to `DefaultBehavior` (rename
-/// stays enabled) when the server advertises `textDocument/rename` but not
-/// `prepareRename`, so dropping such a server here would silently disable
-/// rename in injected regions. Exempt it — the per-handler gate still runs.
+/// routed method EXCEPT the ones whose handler falls back to a *different*
+/// capability when the requested one is absent — dropping a server by the
+/// requested capability alone would then discard a server that would have
+/// answered via the fallback:
+/// - `textDocument/prepareRename` → `send_prepare_rename_request` returns
+///   `DefaultBehavior` (rename stays enabled) when the server advertises
+///   `textDocument/rename` but not `prepareRename`.
+/// - `textDocument/formatting` / `textDocument/rangeFormatting` → the
+///   Concatenated pipeline ([`pipeline_step_request_kind`]) uses a server that
+///   supports EITHER full OR range formatting, sending whichever it advertises;
+///   filtering by one alone would drop a server capable of the other.
 ///
-/// [`send_prepare_rename_request`]: crate::lsp::bridge::LanguageServerPool::send_prepare_rename_request
+/// For exempt methods the per-handler capability gate still runs and handles
+/// the fallback correctly.
+///
+/// [`pipeline_step_request_kind`]: crate::lsp::lsp_impl::text_document::formatting
 fn capability_prefilter_applies(method: &str) -> bool {
-    method != "textDocument/prepareRename"
+    !matches!(
+        method,
+        "textDocument/prepareRename" | "textDocument/formatting" | "textDocument/rangeFormatting"
+    )
 }
 
 /// All resolved context needed to send bridge requests to multiple servers.
@@ -612,6 +624,52 @@ impl Kakehashi {
             .allows(LayerSource::Virt)
     }
 
+    /// Shared capability prefilter (capability-prefilter-fanout): the set of
+    /// server names to drop from `method`'s virt fan-out across the given
+    /// `injection_languages` — those with a live `Ready` connection already
+    /// known to lack the capability (so the fan-out never spawns a task +
+    /// connection lookup only to hit the per-handler gate and return empty).
+    ///
+    /// One pool query for the whole request; every virt fan-out entry point
+    /// (per-region diagnostic loop, whole-document helper, documentSymbol /
+    /// documentColor, position/range preamble) routes through here so the drop
+    /// policy is uniform. Returns an empty set — a cheap no-op for callers —
+    /// when `method` is exempt (see [`capability_prefilter_applies`]) or nothing
+    /// is configured. `injection_languages` may repeat; it is deduped here.
+    ///
+    /// The owned `configs_by_lang` exists only so the candidate `&str`s can
+    /// borrow across the `await`; the per-language resolution is a cached lookup
+    /// and callers re-resolve their own per-region configs (same cached call).
+    pub(super) async fn incapable_virt_servers<'a>(
+        &self,
+        host_language: &str,
+        injection_languages: impl IntoIterator<Item = &'a str>,
+        method: &str,
+    ) -> std::collections::HashSet<String> {
+        if !capability_prefilter_applies(method) {
+            return std::collections::HashSet::new();
+        }
+        let mut langs: Vec<&str> = injection_languages.into_iter().collect();
+        langs.sort_unstable();
+        langs.dedup();
+        let configs_by_lang: Vec<_> = langs
+            .iter()
+            .map(|lang| self.bridge_configs_for_injection_language(host_language, lang))
+            .collect();
+        let candidates: std::collections::HashSet<&str> = configs_by_lang
+            .iter()
+            .flatten()
+            .map(|c| c.server_name.as_str())
+            .collect();
+        if candidates.is_empty() {
+            return std::collections::HashSet::new();
+        }
+        self.bridge
+            .pool_arc()
+            .servers_known_incapable(&candidates, method)
+            .await
+    }
+
     /// Convert a preamble result into a `DocumentRequestContext` by looking up
     /// bridge server configs for the injection language.
     ///
@@ -650,29 +708,23 @@ impl Kakehashi {
         // Drop servers already known (a live, `Ready` connection) NOT to support
         // this method, so the fan-out never spawns a task + connection lookup
         // only to hit the per-handler capability gate and return empty
-        // (capability-prefilter-fanout). Uses the same `has_capability(method)`
-        // predicate as that gate, so a dropped server is observably equivalent
-        // to it having answered empty. Unknown / still-initializing servers are
-        // kept (spawned/awaited as before). Exempt methods whose capability-absent
-        // handler branch is NOT empty (see `capability_prefilter_applies`).
-        if capability_prefilter_applies(method_name) {
-            let candidates: std::collections::HashSet<&str> =
-                configs.iter().map(|c| c.server_name.as_str()).collect();
-            let incapable = self
-                .bridge
-                .pool_arc()
-                .servers_known_incapable(&candidates, method_name)
-                .await;
-            if !incapable.is_empty() {
-                configs.retain(|c| !incapable.contains(&c.server_name));
-                if configs.is_empty() {
-                    log::debug!(
-                        "{}: all configured servers for {} are known-incapable; skipping virt layer",
-                        method_name,
-                        preamble.resolved.injection_language
-                    );
-                    return None;
-                }
+        // (capability-prefilter-fanout).
+        let incapable = self
+            .incapable_virt_servers(
+                &preamble.language_name,
+                std::iter::once(preamble.resolved.injection_language.as_str()),
+                method_name,
+            )
+            .await;
+        if !incapable.is_empty() {
+            configs.retain(|c| !incapable.contains(&c.server_name));
+            if configs.is_empty() {
+                log::debug!(
+                    "{}: all configured servers for {} are known-incapable; skipping virt layer",
+                    method_name,
+                    preamble.resolved.injection_language
+                );
+                return None;
             }
         }
 

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -1910,14 +1910,25 @@ mod tests {
         );
     }
 
-    /// The capability prefilter applies to ordinary position/range methods but
-    /// is exempt for `textDocument/prepareRename`, whose capability-absent
-    /// handler branch is NOT empty (it falls back to `DefaultBehavior` when the
-    /// server advertises `textDocument/rename`). Dropping a rename-only server
-    /// here would silently disable rename in injected regions.
+    /// The capability prefilter is exempt for the methods whose capability-absent
+    /// handler branch is NOT empty because it falls back to a different
+    /// capability: `prepareRename` (→ `rename`'s `DefaultBehavior`) and
+    /// `formatting`/`rangeFormatting` (→ the other formatting kind via the
+    /// Concatenated pipeline). Dropping a server by the requested capability
+    /// alone would discard one that would have answered via the fallback. All
+    /// other routed methods are prefiltered.
     #[test]
-    fn capability_prefilter_exempts_prepare_rename_only() {
-        assert!(!capability_prefilter_applies("textDocument/prepareRename"));
+    fn capability_prefilter_exempts_fallback_methods() {
+        for exempt in [
+            "textDocument/prepareRename",
+            "textDocument/formatting",
+            "textDocument/rangeFormatting",
+        ] {
+            assert!(
+                !capability_prefilter_applies(exempt),
+                "{exempt} must be exempt"
+            );
+        }
         for method in [
             "textDocument/hover",
             "textDocument/definition",
@@ -1925,6 +1936,9 @@ mod tests {
             "textDocument/references",
             "textDocument/rename",
             "textDocument/documentColor",
+            "textDocument/documentSymbol",
+            "textDocument/foldingRange",
+            "textDocument/diagnostic",
         ] {
             assert!(
                 capability_prefilter_applies(method),

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -33,14 +33,14 @@ use super::{Kakehashi, uri_to_url};
 ///   `DefaultBehavior` (rename stays enabled) when the server advertises
 ///   `textDocument/rename` but not `prepareRename`.
 /// - `textDocument/formatting` / `textDocument/rangeFormatting` → the
-///   Concatenated pipeline ([`pipeline_step_request_kind`]) uses a server that
-///   supports EITHER full OR range formatting, sending whichever it advertises;
-///   filtering by one alone would drop a server capable of the other.
+///   Concatenated pipeline (`pipeline_step_request_kind` in the
+///   [`formatting`](crate::lsp::lsp_impl::text_document::formatting) module) uses
+///   a server that supports EITHER full OR range formatting, sending whichever
+///   it advertises; filtering by one alone would drop a server capable of the
+///   other.
 ///
 /// For exempt methods the per-handler capability gate still runs and handles
 /// the fallback correctly.
-///
-/// [`pipeline_step_request_kind`]: crate::lsp::lsp_impl::text_document::formatting
 fn capability_prefilter_applies(method: &str) -> bool {
     !matches!(
         method,
@@ -653,7 +653,7 @@ impl Kakehashi {
         langs.sort_unstable();
         langs.dedup();
         let configs_by_lang: Vec<_> = langs
-            .iter()
+            .into_iter()
             .map(|lang| self.bridge_configs_for_injection_language(host_language, lang))
             .collect();
         let candidates: std::collections::HashSet<&str> = configs_by_lang

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -255,7 +255,9 @@ impl Kakehashi {
                 );
                 // Drop known-incapable servers before building the fan-out
                 // context (capability-prefilter-fanout).
-                configs.retain(|c| !incapable_servers.contains(&c.server_name));
+                if !incapable_servers.is_empty() {
+                    configs.retain(|c| !incapable_servers.contains(&c.server_name));
+                }
                 if configs.is_empty() {
                     continue;
                 }

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -228,16 +228,52 @@ impl Kakehashi {
             })
             .collect();
 
+        // Pre-filter servers already known (a live, `Ready` connection) NOT to
+        // answer pull diagnostics, so the per-region fan-out below never spawns a
+        // task + connection lookup only to hit the capability gate and return an
+        // empty layer (capability-prefilter-fanout). A push-only server like
+        // basedpyright, warmed by eager-open, is dropped here for EVERY region
+        // instead of once per (region × pull). One pool query for the whole
+        // request; the resulting set is a cheap lookup inside the region loop.
+        //
+        // Candidates: the distinct injection languages' configured servers.
+        // Configs are resolved here (cached) and kept owned so the candidate
+        // `&str`s borrow from them across the `await`.
+        let incapable_servers = {
+            let mut langs: Vec<&str> = virt_regions
+                .iter()
+                .map(|r| r.injection_language.as_str())
+                .collect();
+            langs.sort_unstable();
+            langs.dedup();
+            let configs_by_lang: Vec<_> = langs
+                .iter()
+                .map(|lang| self.bridge_configs_for_injection_language(&language_name, lang))
+                .collect();
+            let candidates: std::collections::HashSet<&str> = configs_by_lang
+                .iter()
+                .flatten()
+                .map(|c| c.server_name.as_str())
+                .collect();
+            self.bridge
+                .pool_arc()
+                .servers_known_incapable(&candidates, "textDocument/diagnostic")
+                .await
+        };
+
         // Virt layer: 2-level aggregation —
         //   Inner: dispatch per region (fans out to all servers for that region)
         //   Outer: collect across regions
         let virt_fut = async {
             let mut outer_join_set: JoinSet<Vec<Diagnostic>> = JoinSet::new();
             for resolved in virt_regions.iter() {
-                let configs = self.bridge_configs_for_injection_language(
+                let mut configs = self.bridge_configs_for_injection_language(
                     &language_name,
                     &resolved.injection_language,
                 );
+                // Drop known-incapable servers before building the fan-out
+                // context (capability-prefilter-fanout).
+                configs.retain(|c| !incapable_servers.contains(&c.server_name));
                 if configs.is_empty() {
                     continue;
                 }

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -235,33 +235,13 @@ impl Kakehashi {
         // basedpyright, warmed by eager-open, is dropped here for EVERY region
         // instead of once per (region × pull). One pool query for the whole
         // request; the resulting set is a cheap lookup inside the region loop.
-        //
-        // Candidates: the distinct injection languages' configured servers. The
-        // per-language config resolution is a cached lookup
-        // (`cached_configs_for_injection_language`); the owned `configs_by_lang`
-        // exists only so the candidate `&str`s can borrow from it across the
-        // `await`, and the region loop re-resolves (same cheap cached call).
-        let incapable_servers = {
-            let mut langs: Vec<&str> = virt_regions
-                .iter()
-                .map(|r| r.injection_language.as_str())
-                .collect();
-            langs.sort_unstable();
-            langs.dedup();
-            let configs_by_lang: Vec<_> = langs
-                .iter()
-                .map(|lang| self.bridge_configs_for_injection_language(&language_name, lang))
-                .collect();
-            let candidates: std::collections::HashSet<&str> = configs_by_lang
-                .iter()
-                .flatten()
-                .map(|c| c.server_name.as_str())
-                .collect();
-            self.bridge
-                .pool_arc()
-                .servers_known_incapable(&candidates, "textDocument/diagnostic")
-                .await
-        };
+        let incapable_servers = self
+            .incapable_virt_servers(
+                &language_name,
+                virt_regions.iter().map(|r| r.injection_language.as_str()),
+                "textDocument/diagnostic",
+            )
+            .await;
 
         // Virt layer: 2-level aggregation —
         //   Inner: dispatch per region (fans out to all servers for that region)

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -236,9 +236,11 @@ impl Kakehashi {
         // instead of once per (region × pull). One pool query for the whole
         // request; the resulting set is a cheap lookup inside the region loop.
         //
-        // Candidates: the distinct injection languages' configured servers.
-        // Configs are resolved here (cached) and kept owned so the candidate
-        // `&str`s borrow from them across the `await`.
+        // Candidates: the distinct injection languages' configured servers. The
+        // per-language config resolution is a cached lookup
+        // (`cached_configs_for_injection_language`); the owned `configs_by_lang`
+        // exists only so the candidate `&str`s can borrow from it across the
+        // `await`, and the region loop re-resolves (same cheap cached call).
         let incapable_servers = {
             let mut langs: Vec<&str> = virt_regions
                 .iter()

--- a/src/lsp/lsp_impl/text_document/document_color.rs
+++ b/src/lsp/lsp_impl/text_document/document_color.rs
@@ -124,7 +124,9 @@ impl Kakehashi {
                 &language_name,
                 &resolved.injection_language,
             );
-            configs.retain(|c| !incapable_servers.contains(&c.server_name));
+            if !incapable_servers.is_empty() {
+                configs.retain(|c| !incapable_servers.contains(&c.server_name));
+            }
             if configs.is_empty() {
                 continue;
             }

--- a/src/lsp/lsp_impl/text_document/document_color.rs
+++ b/src/lsp/lsp_impl/text_document/document_color.rs
@@ -107,12 +107,24 @@ impl Kakehashi {
         // Outer JoinSet: one task per injection region, all in parallel
         let mut outer_join_set: JoinSet<Vec<ColorInformation>> = JoinSet::new();
 
+        // Drop servers already known (a live, `Ready` connection) NOT to support
+        // this method before the per-region fan-out spawns their tasks
+        // (capability-prefilter-fanout). One pool query for the whole request.
+        let incapable_servers = self
+            .incapable_virt_servers(
+                &language_name,
+                all_regions.iter().map(|r| r.injection_language.as_str()),
+                "textDocument/documentColor",
+            )
+            .await;
+
         for resolved in all_regions.iter() {
             // Get ALL bridge server configs for this injection language
-            let configs = self.bridge_configs_for_injection_language(
+            let mut configs = self.bridge_configs_for_injection_language(
                 &language_name,
                 &resolved.injection_language,
             );
+            configs.retain(|c| !incapable_servers.contains(&c.server_name));
             if configs.is_empty() {
                 continue;
             }

--- a/src/lsp/lsp_impl/text_document/document_symbol.rs
+++ b/src/lsp/lsp_impl/text_document/document_symbol.rs
@@ -143,12 +143,24 @@ impl Kakehashi {
         });
         let mut cp_minted: Vec<NumberOrString> = Vec::new();
 
+        // Drop servers already known (a live, `Ready` connection) NOT to support
+        // this method before the per-region fan-out spawns their tasks
+        // (capability-prefilter-fanout). One pool query for the whole request.
+        let incapable_servers = self
+            .incapable_virt_servers(
+                &language_name,
+                all_regions.iter().map(|r| r.injection_language.as_str()),
+                METHOD,
+            )
+            .await;
+
         for resolved in all_regions.iter() {
             // Get ALL bridge server configs for this injection language
-            let configs = self.bridge_configs_for_injection_language(
+            let mut configs = self.bridge_configs_for_injection_language(
                 &language_name,
                 &resolved.injection_language,
             );
+            configs.retain(|c| !incapable_servers.contains(&c.server_name));
             if configs.is_empty() {
                 continue;
             }

--- a/src/lsp/lsp_impl/text_document/document_symbol.rs
+++ b/src/lsp/lsp_impl/text_document/document_symbol.rs
@@ -160,7 +160,9 @@ impl Kakehashi {
                 &language_name,
                 &resolved.injection_language,
             );
-            configs.retain(|c| !incapable_servers.contains(&c.server_name));
+            if !incapable_servers.is_empty() {
+                configs.retain(|c| !incapable_servers.contains(&c.server_name));
+            }
             if configs.is_empty() {
                 continue;
             }

--- a/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
@@ -180,3 +180,86 @@ pub(crate) async fn collect_push_diagnostics(
         &layer_cfg, virt_items, host_items,
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::settings::{AggregationStrategy, BridgeServerConfig};
+    use crate::language::injection::{CacheableInjectionRegion, ResolvedInjection};
+    use crate::lsp::bridge::ConnectionState;
+    use crate::lsp::bridge::ResolvedServerConfig;
+    use crate::lsp::bridge::test_helpers::create_handle_with_state;
+
+    fn virt_ctx_for_server(server: &str) -> DocumentRequestContext {
+        DocumentRequestContext {
+            uri: Url::parse("file:///t.md").unwrap(),
+            resolved: ResolvedInjection {
+                region: CacheableInjectionRegion {
+                    language: "python".to_string(),
+                    byte_range: 0..0,
+                    line_range: 0..0,
+                    start_column: 0,
+                    region_id: "r0".to_string(),
+                    content_hash: 0,
+                },
+                injection_language: "python".to_string(),
+                virtual_content: String::new(),
+                line_column_offsets: vec![],
+            },
+            configs: vec![ResolvedServerConfig {
+                server_name: server.to_string(),
+                config: Arc::new(BridgeServerConfig {
+                    cmd: vec![server.to_string()],
+                    languages: vec![],
+                    initialization_options: None,
+                    workspace_markers: None,
+                    on_type_formatting_triggers: None,
+                    prefer_shared_instance: None,
+                    enabled: None,
+                    settings: None,
+                }),
+            }],
+            upstream_request_id: None,
+            priorities: vec![],
+            strategy: AggregationStrategy::Preferred,
+            max_fan_out: None,
+            client_progress_token: None,
+        }
+    }
+
+    /// An all-incapable virt snapshot must still publish an (empty) pull layer,
+    /// NOT `Clear`: `has_contributors()` runs BEFORE the capability prefilter, so
+    /// dropping every server leaves the same empty publish the per-region
+    /// capability gate would have produced (capability-prefilter-fanout). Guards
+    /// the ordering against a refactor that filters ahead of that check (which
+    /// would turn a self-healing empty publish into a stale-clearing eviction).
+    #[tokio::test]
+    async fn all_incapable_virt_snapshot_publishes_empty_not_clear() {
+        let pool = Arc::new(LanguageServerPool::new());
+        // A `Ready` connection for server "test" with no advertised capabilities
+        // → known-incapable of `textDocument/diagnostic`, so the prefilter drops
+        // it and the region's config set empties.
+        let handle = create_handle_with_state(ConnectionState::Ready).await;
+        pool.insert_connection(handle).await;
+
+        let snapshot = DiagnosticSnapshot {
+            virt_contexts: vec![virt_ctx_for_server("test")],
+            host: None,
+            host_pull_enabled: false,
+            layer_cfg: ResolvedLayerConfig::with_defaults("textDocument/publishDiagnostics"),
+        };
+
+        let uri = Url::parse("file:///t.md").unwrap();
+        let outcome = collect_push_diagnostics(Some(snapshot), &pool, &uri, "test").await;
+
+        match outcome {
+            PullLayerOutcome::Publish(diags) => {
+                assert!(diags.is_empty(), "expected an empty publish");
+            }
+            PullLayerOutcome::Clear => {
+                panic!("all-incapable virt snapshot must Publish(empty), not Clear")
+            }
+            PullLayerOutcome::Skip => panic!("snapshot was Some, must not Skip"),
+        }
+    }
+}

--- a/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
@@ -105,11 +105,36 @@ pub(crate) async fn collect_push_diagnostics(
     // async blocks would otherwise rely on disjoint-field captures of
     // `snapshot`, which compiles but reads ambiguously).
     let DiagnosticSnapshot {
-        virt_contexts,
+        mut virt_contexts,
         host,
         host_pull_enabled,
         layer_cfg,
     } = snapshot;
+
+    // Drop servers already known (a live, `Ready` connection) NOT to answer pull
+    // diagnostics before spawning their per-region tasks
+    // (capability-prefilter-fanout). The proactive push path
+    // (didOpen/didSave/debounced didChange) fans out exactly like the editor's
+    // pull, so a push-only server (e.g. basedpyright, warmed by eager-open)
+    // would otherwise be re-dispatched once per region on every change. This is
+    // equivalence-preserving: the per-region `send_diagnostic_request` already
+    // returns an empty layer for such a server (its capability gate), so
+    // pre-dropping only removes the wasted task — the collected set is unchanged.
+    if !virt_contexts.is_empty() {
+        let candidates: std::collections::HashSet<&str> = virt_contexts
+            .iter()
+            .flat_map(|ctx| ctx.configs.iter().map(|c| c.server_name.as_str()))
+            .collect();
+        let incapable = pool
+            .servers_known_incapable(&candidates, "textDocument/diagnostic")
+            .await;
+        if !incapable.is_empty() {
+            for ctx in &mut virt_contexts {
+                ctx.configs.retain(|c| !incapable.contains(&c.server_name));
+            }
+            virt_contexts.retain(|ctx| !ctx.configs.is_empty());
+        }
+    }
 
     let virt_fut = async {
         let mut join_set = JoinSet::new();

--- a/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
@@ -116,10 +116,15 @@ pub(crate) async fn collect_push_diagnostics(
     // (capability-prefilter-fanout). The proactive push path
     // (didOpen/didSave/debounced didChange) fans out exactly like the editor's
     // pull, so a push-only server (e.g. basedpyright, warmed by eager-open)
-    // would otherwise be re-dispatched once per region on every change. This is
-    // equivalence-preserving: the per-region `send_diagnostic_request` already
-    // returns an empty layer for such a server (its capability gate), so
-    // pre-dropping only removes the wasted task — the collected set is unchanged.
+    // would otherwise be re-dispatched once per region on every change. The
+    // per-region `send_diagnostic_request` already returns an empty layer for
+    // such a server (its capability gate), so with the default (untruncated)
+    // `maxFanOut` pre-dropping only removes the wasted task — the collected set
+    // is unchanged. Under a configured `maxFanOut` this shares the same
+    // priority/truncation aggregation as the pull path, so dropping an incapable
+    // high-priority server can promote the next capable one into a kept slot —
+    // an answer where the region previously collected empty (the improvement
+    // noted in the PR description), never a regression.
     if !virt_contexts.is_empty() {
         let candidates: std::collections::HashSet<&str> = virt_contexts
             .iter()

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -167,7 +167,9 @@ impl Kakehashi {
                     &language_name,
                     &resolved.injection_language,
                 );
-                configs.retain(|c| !incapable_servers.contains(&c.server_name));
+                if !incapable_servers.is_empty() {
+                    configs.retain(|c| !incapable_servers.contains(&c.server_name));
+                }
                 if configs.is_empty() {
                     continue;
                 }

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -149,12 +149,25 @@ impl Kakehashi {
             });
             let mut cp_minted: Vec<NumberOrString> = Vec::new();
 
+            // Drop servers already known (a live, `Ready` connection) NOT to
+            // support this method before the per-region fan-out spawns their
+            // tasks (capability-prefilter-fanout). One pool query for the whole
+            // request; the resulting set is a cheap per-region lookup.
+            let incapable_servers = self
+                .incapable_virt_servers(
+                    &language_name,
+                    all_regions.iter().map(|r| r.injection_language.as_str()),
+                    method_name,
+                )
+                .await;
+
             for resolved in all_regions.iter() {
                 // Get ALL bridge server configs for this injection language
-                let configs = self.bridge_configs_for_injection_language(
+                let mut configs = self.bridge_configs_for_injection_language(
                     &language_name,
                     &resolved.injection_language,
                 );
+                configs.retain(|c| !incapable_servers.contains(&c.server_name));
                 if configs.is_empty() {
                     continue;
                 }


### PR DESCRIPTION
## Why

A markdown host with hundreds of injected code blocks made every bridged fan-out spray one task per **region × server**. For a push-only downstream (basedpyright, warmed by eager-open) that does not support pull diagnostics, each of those tasks spun up a connection lookup and readiness wait only to hit the per-handler capability gate and return empty — **~72,676 wasted dispatches in a single 2-minute session**, plus the tokio-runtime pressure of spawning them.

Root diagnosis (from `__ignored/log`): 18,941 `window/workDoneProgress/create` were basedpyright's own re-analysis of 308 open virtual Python docs; the bridge amplified the symptoms via a push→refresh→pull loop and the per-region×server fan-out. This PR removes the fan-out amplification.

## What

A **capability prefilter**: before spawning a downstream task for an injection region, drop any server already known — via a live `Ready` connection — not to support the requested method. Since every handler's capability-absent branch already returns an empty result, a dropped server is observably equivalent to it having answered empty; the difference is that no task/connection-wait is spent.

- `LanguageServerPool::servers_known_incapable(candidates, method)` — the inverse of `has_capability`, checked without spawning. Returns only servers with a `Ready` connection and **no** connection advertising the method; never a server with no connection or a still-`Initializing`/`Failed`/`Closing` one (those keep today's spawn-and-wait behavior).
- Shared helper `Kakehashi::incapable_virt_servers(host_language, injection_languages, method)` — one pool query per request, routed through by **every virt fan-out entry point**: pull-diagnostic loop, position/range preamble, whole-document fan-out (foldingRange/documentLink/codeLens, documentSymbol, documentColor), and the proactive push-diagnostic collection.
- `capability_prefilter_applies(method)` exempts the three methods whose capability-absent handler branch is **not** empty because it falls back to a different capability: `prepareRename` (→ `rename`'s `DefaultBehavior`) and `formatting`/`rangeFormatting` (→ the other formatting kind via the Concatenated pipeline). Filtering those by the requested capability alone would over-drop.

Out of scope by design: the **host layer** (single-target, no region multiplication) and the **CLI** one-shot path (just-spawned non-`Ready` connections → no-op).

## Behavioral notes

- Behavior-preserving on the common path (default `maxFanOut` is unset → no priority truncation → identical membership; incapable servers only ever contributed empty).
- Under a **configured `maxFanOut`**, dropping an incapable top-priority server promotes the next capable one into its slot — the editor gets an answer where it previously got an empty result (an improvement; noted in the feat commits).
- The by-server-name classification is sound iff capability is **root-invariant** (identical static `initialize` caps per binary — the near-universal case, and why basedpyright is safe on every root). A narrow, documented limitation exists for multi-root workspaces with genuine per-root capability divergence; the per-handler capability gate stays authoritative for every kept server. See the `servers_known_incapable` doc comment.

## Review

Went through the local `/revise` pipeline before this PR:
- **/review** (multi-perspective): found & fixed the `prepareRename` over-drop (would have silently disabled rename in injected regions), added Ready-gate and exemption tests, doc fixes.
- **codex** (3 continued rounds + 1 fresh session): found & fixed the whole-document bypass (extracted the shared helper), the proactive push-diagnostic bypass, and the `formatting`/`rangeFormatting` fallback hazard; added the `Publish(empty)`-not-`Clear` regression test. The fresh session's remaining two items (TOCTOU + across-roots) are accepted, inherent prefilter trade-offs, now honestly documented. (Final codex confirmation of the last refutation is pending an external usage limit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)