### PR TITLE
perf(text): avoid avoidable O(n) copies/scans in injection/formatting/offset paths

### DIFF
--- a/src/analysis/offset_calculator.rs
+++ b/src/analysis/offset_calculator.rs
@@ -93,8 +93,12 @@ fn apply_offset_to_position(
     }
 
     // Start of the line containing byte_pos, found by scanning backward from
-    // byte_pos rather than forward from the document start.
-    let current_line_start = text[..byte_pos.min(text.len())]
+    // byte_pos rather than forward from the document start. Snap to a char
+    // boundary first: unlike the char_indices()-based scan this replaced,
+    // slicing at a raw byte_pos panics if it lands mid-codepoint (e.g. a
+    // stale tree-sitter offset) — the caller's later clamp/snap only applies
+    // to the *returned* value, not this internal slice.
+    let current_line_start = text[..floor_char_boundary(text, byte_pos.min(text.len()))]
         .rfind('\n')
         .map(|i| i + 1)
         .unwrap_or(0);
@@ -283,6 +287,17 @@ mod tests {
         // value against the whole-scan behavior this function replaced.
         let text = "line 1\nline 2";
         assert_eq!(apply_offset_to_position(text, 6, 5, 0), 7);
+    }
+
+    #[test]
+    fn test_apply_offset_to_position_mid_codepoint_byte_pos_does_not_panic() {
+        // A stale/malformed byte_pos landing inside a multi-byte character
+        // must not panic the internal line-start slice — it should behave as
+        // if snapped to the enclosing char boundary.
+        let text = "line 1\nあ\nline 3";
+        // Byte 8 is the second byte of "あ" (starts at byte 7, 3 bytes).
+        let _ = apply_offset_to_position(text, 8, 1, 0);
+        let _ = apply_offset_to_position(text, 8, -1, 0);
     }
 
     #[test]

--- a/src/analysis/offset_calculator.rs
+++ b/src/analysis/offset_calculator.rs
@@ -98,7 +98,7 @@ fn apply_offset_to_position(
     // slicing at a raw byte_pos panics if it lands mid-codepoint (e.g. a
     // stale tree-sitter offset) — the caller's later clamp/snap only applies
     // to the *returned* value, not this internal slice.
-    let current_line_start = text[..floor_char_boundary(text, byte_pos.min(text.len()))]
+    let current_line_start = text[..floor_char_boundary(text, byte_pos)]
         .rfind('\n')
         .map(|i| i + 1)
         .unwrap_or(0);

--- a/src/analysis/offset_calculator.rs
+++ b/src/analysis/offset_calculator.rs
@@ -75,6 +75,12 @@ pub fn calculate_effective_range(
 }
 
 /// Apply row and column offset to a byte position in text
+///
+/// Walks only the span between `byte_pos` and the target line, in whichever
+/// direction `row_offset` points — never the whole document. `#offset!` rows
+/// are small (typically ±1, e.g. skipping a fence/frontmatter delimiter), so
+/// this is O(distance moved) rather than the O(document) two-full-scan
+/// approach it replaced.
 fn apply_offset_to_position(
     text: &str,
     byte_pos: usize,
@@ -86,59 +92,37 @@ fn apply_offset_to_position(
         return (byte_pos as i32 + col_offset).max(0) as usize;
     }
 
-    // Find the line containing the byte position
-    let mut current_line = 0;
-    let mut line_start_byte = 0;
+    // Start of the line containing byte_pos, found by scanning backward from
+    // byte_pos rather than forward from the document start.
+    let current_line_start = text[..byte_pos.min(text.len())]
+        .rfind('\n')
+        .map(|i| i + 1)
+        .unwrap_or(0);
 
-    for (i, ch) in text.char_indices() {
-        if i >= byte_pos {
-            // Found the line containing our position
-            break;
-        }
-        if ch == '\n' {
-            current_line += 1;
-            line_start_byte = i + 1;
-        }
-    }
-
-    // Now find the target line (current_line + row_offset)
-    let target_line = (current_line as i32 + row_offset).max(0) as usize;
-
-    if row_offset > 0 {
-        // Moving forward - find the target line
-        let mut lines_seen = current_line;
-        let mut target_line_start = line_start_byte;
-
-        for (i, ch) in text[line_start_byte..].char_indices() {
-            if lines_seen == target_line {
-                break;
-            }
-            if ch == '\n' {
-                lines_seen += 1;
-                target_line_start = line_start_byte + i + 1;
+    let target_line_start = if row_offset > 0 {
+        // Overshooting the last line stops at that line's start (matching the
+        // original whole-scan behavior), not the document end.
+        let mut pos = current_line_start;
+        for _ in 0..row_offset {
+            match text[pos..].find('\n') {
+                Some(nl) => pos += nl + 1,
+                None => break,
             }
         }
-
-        // Apply column offset from the start of the target line
-        (target_line_start as i32 + col_offset).max(0) as usize
+        pos
     } else {
-        // Moving backward - count lines from the beginning
-        let mut lines_seen = 0;
-        let mut target_line_start = 0;
-
-        for (i, ch) in text.char_indices() {
-            if lines_seen == target_line {
-                target_line_start = i;
+        let mut pos = current_line_start;
+        for _ in 0..row_offset.unsigned_abs() {
+            if pos == 0 {
                 break;
             }
-            if ch == '\n' {
-                lines_seen += 1;
-            }
+            pos = text[..pos - 1].rfind('\n').map(|i| i + 1).unwrap_or(0);
         }
+        pos
+    };
 
-        // Apply column offset from the start of the target line
-        (target_line_start as i32 + col_offset).max(0) as usize
-    }
+    // Apply column offset from the start of the target line
+    (target_line_start as i32 + col_offset).max(0) as usize
 }
 
 #[cfg(test)]
@@ -290,6 +274,15 @@ mod tests {
         assert_eq!(effective.end, 13);
         // Slicing should be safe
         let _ = &text[effective.start..effective.end];
+    }
+
+    #[test]
+    fn test_apply_offset_to_position_positive_row_overshoot_clamps_to_last_line_start() {
+        // A row_offset overshooting the last line must clamp to that last
+        // line's start, not the document end — pins the exact overshoot
+        // value against the whole-scan behavior this function replaced.
+        let text = "line 1\nline 2";
+        assert_eq!(apply_offset_to_position(text, 6, 5, 0), 7);
     }
 
     #[test]

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -135,7 +135,7 @@ impl InjectionCoordinator {
         let Some(tree) = doc.tree().cloned() else {
             return Vec::new();
         };
-        let text = doc.text().to_string();
+        let text = doc.text_arc();
         drop(doc);
 
         let Some(regions) =

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -133,7 +133,7 @@ impl Kakehashi {
         let upstream_request_id = crate::lsp::current_upstream_id();
         let mut cancel_state = self.setup_formatting_cancel_token(upstream_request_id.as_ref());
         cancel_state.request_error_sink = request_error_sink;
-        let original = snapshot.text().to_string();
+        let original = snapshot.text_arc();
 
         let result = match layer_cfg.strategy {
             AggregationStrategy::Preferred => {
@@ -168,13 +168,13 @@ impl Kakehashi {
                 // default order (virt before host) satisfies this; an order
                 // placing virt after a producing host is skipped with a
                 // warning rather than formatting against stale regions.
-                let mut current = original.clone();
+                let mut current = original.to_string();
                 let mut producers = 0usize;
                 let mut sole_edits: Option<Vec<TextEdit>> = None;
                 for layer in &layer_cfg.priorities {
                     let edits = match layer {
                         LayerSource::Virt => {
-                            if current != original {
+                            if current.as_str() != &*original {
                                 log::warn!(
                                     target: "kakehashi::formatting",
                                     "cross-layer concatenated formatting: virt placed after a \

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -168,13 +168,13 @@ impl Kakehashi {
                 // default order (virt before host) satisfies this; an order
                 // placing virt after a producing host is skipped with a
                 // warning rather than formatting against stale regions.
-                let mut current = original.to_string();
+                let mut current: std::borrow::Cow<'_, str> = std::borrow::Cow::Borrowed(&original);
                 let mut producers = 0usize;
                 let mut sole_edits: Option<Vec<TextEdit>> = None;
                 for layer in &layer_cfg.priorities {
                     let edits = match layer {
                         LayerSource::Virt => {
-                            if current.as_str() != &*original {
+                            if current.as_ref() != &*original {
                                 log::warn!(
                                     target: "kakehashi::formatting",
                                     "cross-layer concatenated formatting: virt placed after a \
@@ -203,7 +203,9 @@ impl Kakehashi {
                     if let Some(edits) = edits
                         && !edits.is_empty()
                     {
-                        current = crate::text::edit::apply_text_edits(&current, &edits);
+                        current = std::borrow::Cow::Owned(crate::text::edit::apply_text_edits(
+                            &current, &edits,
+                        ));
                         producers += 1;
                         sole_edits = Some(edits);
                     }


### PR DESCRIPTION
## Summary
- `injection.rs` / `formatting.rs`: replace `text().to_string()` with `text_arc()` (refcount bump) at two read-only call sites; the Concatenated-formatting pipeline now only pays for an owned `String` when it actually mutates text.
- `offset_calculator.rs`: `apply_offset_to_position` (`#offset!` row handling) now walks only the span between the byte position and the target line, bounded by the row-offset distance, instead of two full-document scans. Pinned the existing overshoot-clamps-to-last-line behavior with a new test.
- Skipped the `text_sync.rs` per-change `PositionMapper` rebuild sub-item: the suggested descending-sort/splice fix changes behavior under LSP's sequential content-change semantics (a later range in a batch can depend on line shifts from an earlier one). Commented on the issue with a counterexample; left as a follow-up candidate.

Closes part of #581 (item 2 remains open, see issue comment).

## Test plan
- [x] `cargo test --lib` (2461 passed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] full e2e suite via pre-commit gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved position/line offset handling: overshoots clamp to the last line start, and offset computations now safely handle byte positions that land mid–multi-byte character.
* **Performance**
  * Reduced unnecessary text copying during formatting and injection resolution by reusing shared document text snapshots.
  * Optimized offset calculations to work relative to nearby line movement rather than scanning the full document.
* **Tests**
  * Added edge-case coverage for clamping and non-panicking behavior with mid-character starting positions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->