### PR TITLE
perf(semantic): cache byte->UTF-16 column lookups per host line

### DIFF
--- a/src/analysis/semantic/token_collector.rs
+++ b/src/analysis/semantic/token_collector.rs
@@ -25,10 +25,9 @@ fn is_in_exclusion_range(node: &Node, ranges: &[(usize, usize)]) -> bool {
     })
 }
 
-/// Fetch `host_line`'s cached UTF-16 index, building it on first use for
-/// that line.
+/// Fetch `row`'s cached UTF-16 index, building it on first use for that row.
 ///
-/// A single host line commonly receives a start/end pair of `byte_to_utf16`
+/// A single line commonly receives a start/end pair of `byte_to_utf16`
 /// queries per capture, times however many captures land on that line.
 /// Returning the index (rather than resolving one column per call) lets a
 /// caller reuse a single lookup for both the start and end column of one
@@ -36,19 +35,25 @@ fn is_in_exclusion_range(node: &Node, ranges: &[(usize, usize)]) -> bool {
 /// O(line_len) rescan per query into one O(line_len) build plus O(log
 /// line_len) lookups.
 ///
-/// `host_line` is a dense index bounded by the host document's line count
-/// (never sparse/huge), so a `Vec<Option<_>>` indexed directly beats a
-/// `HashMap` here: O(1) with no hashing and better cache locality, at the
-/// cost of resizing to cover line numbers as they're first seen.
+/// `row` must be the CONTENT-local row (`start_pos.row` / the multiline
+/// loop's `row`), not the host-absolute line — this cache is scoped to one
+/// `collect_host_tokens` call, and an injection can start deep into a large
+/// host document. Indexing by the absolute host line would resize the
+/// vector to cover every line from 0 up to that point (e.g. a one-line
+/// injection at host line 10,000 forcing a 10,001-element vector) for a
+/// cache that only ever holds a handful of entries. The content-local row
+/// is dense and small (bounded by the content's own line count), which is
+/// what makes `Vec<Option<_>>` — O(1), no hashing, cache-friendly — a better
+/// fit here than a `HashMap`.
 fn cached_line_index<'a>(
     cache: &'a mut Vec<Option<Utf16LineIndex>>,
-    host_line: usize,
+    row: usize,
     line_text: &str,
 ) -> &'a Utf16LineIndex {
-    if host_line >= cache.len() {
-        cache.resize_with(host_line + 1, || None);
+    if row >= cache.len() {
+        cache.resize_with(row + 1, || None);
     }
-    cache[host_line].get_or_insert_with(|| Utf16LineIndex::new(line_text))
+    cache[row].get_or_insert_with(|| Utf16LineIndex::new(line_text))
 }
 
 /// Extract the `#set! priority N` value for a pattern, defaulting to 100.
@@ -419,7 +424,7 @@ pub(super) fn collect_host_tokens(
                 } else {
                     start_pos.column
                 };
-                let line_index = cached_line_index(&mut utf16_cache, host_line, host_line_text);
+                let line_index = cached_line_index(&mut utf16_cache, start_pos.row, host_line_text);
                 let start_utf16 = line_index.byte_to_utf16(byte_offset_in_host);
 
                 // For trailing newline case, use the line length as end position
@@ -461,7 +466,7 @@ pub(super) fn collect_host_tokens(
                         start_pos.column
                     };
                     let start_utf16 =
-                        cached_line_index(&mut utf16_cache, host_start_line, host_start_line_text)
+                        cached_line_index(&mut utf16_cache, start_pos.row, host_start_line_text)
                             .byte_to_utf16(start_byte_offset);
 
                     let mut total_length_utf16 = 0usize;
@@ -479,7 +484,7 @@ pub(super) fn collect_host_tokens(
                             &prefix_widths,
                         );
 
-                        let line_index = cached_line_index(&mut utf16_cache, host_row, line_text);
+                        let line_index = cached_line_index(&mut utf16_cache, row, line_text);
                         let line_start_utf16 = line_index.byte_to_utf16(line_start);
                         let line_end_utf16 = line_index.byte_to_utf16(line_end);
                         total_length_utf16 += line_end_utf16 - line_start_utf16;
@@ -523,8 +528,7 @@ pub(super) fn collect_host_tokens(
                             &prefix_widths,
                         );
 
-                        let line_index =
-                            cached_line_index(&mut utf16_cache, host_row, host_line_text);
+                        let line_index = cached_line_index(&mut utf16_cache, row, host_line_text);
                         let start_utf16 = line_index.byte_to_utf16(line_start_byte);
                         let end_utf16 = line_index.byte_to_utf16(line_end_byte);
 

--- a/src/analysis/semantic/token_collector.rs
+++ b/src/analysis/semantic/token_collector.rs
@@ -3,8 +3,10 @@
 //! This module handles the collection of raw tokens from a single document's
 //! highlight query, including multiline token handling and byte-to-UTF16 conversion.
 
+use std::collections::HashMap;
+
 use crate::config::CaptureMappings;
-use crate::text::position::byte_to_utf16_col;
+use crate::text::position::Utf16LineIndex;
 use tree_sitter::{Node, Query, QueryCursor, StreamingIterator, Tree};
 
 use super::legend::{CaptureResult, resolve_capture};
@@ -23,6 +25,25 @@ fn is_in_exclusion_range(node: &Node, ranges: &[(usize, usize)]) -> bool {
             && node_end <= range_end
             && (node_start != range_start || node_end != range_end)
     })
+}
+
+/// Resolve a byte column to a UTF-16 column against `host_line`'s cached
+/// index, building the index on first use for that line.
+///
+/// A single host line commonly receives several `byte_to_utf16` queries (one
+/// pair of start/end per capture, times however many captures land on that
+/// line), so caching by line number turns what would be an O(line_len)
+/// rescan per query into one O(line_len) build plus O(log line_len) lookups.
+fn cached_utf16_col(
+    cache: &mut HashMap<usize, Utf16LineIndex>,
+    host_line: usize,
+    line_text: &str,
+    byte_col: usize,
+) -> usize {
+    cache
+        .entry(host_line)
+        .or_insert_with(|| Utf16LineIndex::new(line_text))
+        .byte_to_utf16(byte_col)
 }
 
 /// Extract the `#set! priority N` value for a pattern, defaulting to 100.
@@ -342,6 +363,10 @@ pub(super) fn collect_host_tokens(
     // Split content text into lines for byte offset calculations
     let content_lines: Vec<&str> = text.lines().collect();
 
+    // Lazily-built byte->UTF-16 lookup per host line, shared across every
+    // capture below. See `cached_utf16_col`.
+    let mut utf16_cache: HashMap<usize, Utf16LineIndex> = HashMap::new();
+
     // Collect tokens from this document's highlight query
     let mut cursor = QueryCursor::new();
     let mut matches = cursor.matches(query, tree.root_node(), text.as_bytes());
@@ -389,7 +414,12 @@ pub(super) fn collect_host_tokens(
                 } else {
                     start_pos.column
                 };
-                let start_utf16 = byte_to_utf16_col(host_line_text, byte_offset_in_host);
+                let start_utf16 = cached_utf16_col(
+                    &mut utf16_cache,
+                    host_line,
+                    host_line_text,
+                    byte_offset_in_host,
+                );
 
                 // For trailing newline case, use the line length as end position
                 let end_byte_offset_in_host = if is_trailing_newline {
@@ -399,7 +429,12 @@ pub(super) fn collect_host_tokens(
                 } else {
                     end_pos.column
                 };
-                let end_utf16 = byte_to_utf16_col(host_line_text, end_byte_offset_in_host);
+                let end_utf16 = cached_utf16_col(
+                    &mut utf16_cache,
+                    host_line,
+                    host_line_text,
+                    end_byte_offset_in_host,
+                );
 
                 all_tokens.push(RawToken {
                     line: host_line,
@@ -429,7 +464,12 @@ pub(super) fn collect_host_tokens(
                     } else {
                         start_pos.column
                     };
-                    let start_utf16 = byte_to_utf16_col(host_start_line_text, start_byte_offset);
+                    let start_utf16 = cached_utf16_col(
+                        &mut utf16_cache,
+                        host_start_line,
+                        host_start_line_text,
+                        start_byte_offset,
+                    );
 
                     let mut total_length_utf16 = 0usize;
                     for row in start_pos.row..=end_pos.row {
@@ -446,8 +486,10 @@ pub(super) fn collect_host_tokens(
                             &prefix_widths,
                         );
 
-                        let line_start_utf16 = byte_to_utf16_col(line_text, line_start);
-                        let line_end_utf16 = byte_to_utf16_col(line_text, line_end);
+                        let line_start_utf16 =
+                            cached_utf16_col(&mut utf16_cache, host_row, line_text, line_start);
+                        let line_end_utf16 =
+                            cached_utf16_col(&mut utf16_cache, host_row, line_text, line_end);
                         total_length_utf16 += line_end_utf16 - line_start_utf16;
 
                         if row < end_pos.row {
@@ -489,8 +531,18 @@ pub(super) fn collect_host_tokens(
                             &prefix_widths,
                         );
 
-                        let start_utf16 = byte_to_utf16_col(host_line_text, line_start_byte);
-                        let end_utf16 = byte_to_utf16_col(host_line_text, line_end_byte);
+                        let start_utf16 = cached_utf16_col(
+                            &mut utf16_cache,
+                            host_row,
+                            host_line_text,
+                            line_start_byte,
+                        );
+                        let end_utf16 = cached_utf16_col(
+                            &mut utf16_cache,
+                            host_row,
+                            host_line_text,
+                            line_end_byte,
+                        );
 
                         if end_utf16 > start_utf16 {
                             all_tokens.push(RawToken {
@@ -775,6 +827,50 @@ mod tests {
         assert!(
             !tokens.is_empty(),
             "Token with exact-match exclusion range should NOT be suppressed"
+        );
+    }
+
+    #[test]
+    fn collect_host_tokens_utf16_columns_correct_for_multiple_tokens_after_cjk_prefix() {
+        // Two identifiers on the same line, with a 3-char CJK string literal
+        // between them, so both byte->UTF-16 conversions land on the SAME
+        // host_line (exercising the Utf16LineIndex cache across two lookups
+        // on one line) and the second identifier's byte and UTF-16 columns
+        // genuinely diverge (each CJK char is 3 bytes but 1 UTF-16 unit).
+        let code = "let x = \"あいう\"; let y = 1;";
+        let tree = parse_rust_tree(code);
+        let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        let query = tree_sitter::Query::new(&language, "(identifier) @variable").unwrap();
+        let lines: Vec<&str> = code.lines().collect();
+
+        let mut tokens = Vec::new();
+        collect_host_tokens(
+            code,
+            &tree,
+            &query,
+            Some("rust"),
+            None,
+            code,
+            &lines,
+            &build_line_start_bytes(code),
+            0,
+            0,
+            false,
+            &[],
+            &[],
+            &mut tokens,
+        );
+
+        assert_eq!(tokens.len(), 2);
+        assert_eq!(
+            (tokens[0].column, tokens[0].length),
+            (4, 1),
+            "x: byte col 4 == utf16 col 4 (pure ASCII prefix)"
+        );
+        assert_eq!(
+            (tokens[1].column, tokens[1].length),
+            (19, 1),
+            "y: byte col 25, but utf16 col 19 (three 3-byte CJK chars each collapse to 1 utf16 unit)"
         );
     }
 

--- a/src/analysis/semantic/token_collector.rs
+++ b/src/analysis/semantic/token_collector.rs
@@ -3,8 +3,6 @@
 //! This module handles the collection of raw tokens from a single document's
 //! highlight query, including multiline token handling and byte-to-UTF16 conversion.
 
-use std::collections::HashMap;
-
 use crate::config::CaptureMappings;
 use crate::text::position::Utf16LineIndex;
 use tree_sitter::{Node, Query, QueryCursor, StreamingIterator, Tree};
@@ -33,18 +31,24 @@ fn is_in_exclusion_range(node: &Node, ranges: &[(usize, usize)]) -> bool {
 /// A single host line commonly receives a start/end pair of `byte_to_utf16`
 /// queries per capture, times however many captures land on that line.
 /// Returning the index (rather than resolving one column per call) lets a
-/// caller reuse a single `HashMap` lookup for both the start and end column
-/// of one token, on top of caching by line number turning what would be an
+/// caller reuse a single lookup for both the start and end column of one
+/// token, on top of caching by line number turning what would be an
 /// O(line_len) rescan per query into one O(line_len) build plus O(log
 /// line_len) lookups.
+///
+/// `host_line` is a dense index bounded by the host document's line count
+/// (never sparse/huge), so a `Vec<Option<_>>` indexed directly beats a
+/// `HashMap` here: O(1) with no hashing and better cache locality, at the
+/// cost of resizing to cover line numbers as they're first seen.
 fn cached_line_index<'a>(
-    cache: &'a mut HashMap<usize, Utf16LineIndex>,
+    cache: &'a mut Vec<Option<Utf16LineIndex>>,
     host_line: usize,
     line_text: &str,
 ) -> &'a Utf16LineIndex {
-    cache
-        .entry(host_line)
-        .or_insert_with(|| Utf16LineIndex::new(line_text))
+    if host_line >= cache.len() {
+        cache.resize_with(host_line + 1, || None);
+    }
+    cache[host_line].get_or_insert_with(|| Utf16LineIndex::new(line_text))
 }
 
 /// Extract the `#set! priority N` value for a pattern, defaulting to 100.
@@ -366,7 +370,7 @@ pub(super) fn collect_host_tokens(
 
     // Lazily-built byte->UTF-16 lookup per host line, shared across every
     // capture below. See `cached_line_index`.
-    let mut utf16_cache: HashMap<usize, Utf16LineIndex> = HashMap::new();
+    let mut utf16_cache: Vec<Option<Utf16LineIndex>> = Vec::new();
 
     // Collect tokens from this document's highlight query
     let mut cursor = QueryCursor::new();

--- a/src/analysis/semantic/token_collector.rs
+++ b/src/analysis/semantic/token_collector.rs
@@ -27,23 +27,24 @@ fn is_in_exclusion_range(node: &Node, ranges: &[(usize, usize)]) -> bool {
     })
 }
 
-/// Resolve a byte column to a UTF-16 column against `host_line`'s cached
-/// index, building the index on first use for that line.
+/// Fetch `host_line`'s cached UTF-16 index, building it on first use for
+/// that line.
 ///
-/// A single host line commonly receives several `byte_to_utf16` queries (one
-/// pair of start/end per capture, times however many captures land on that
-/// line), so caching by line number turns what would be an O(line_len)
-/// rescan per query into one O(line_len) build plus O(log line_len) lookups.
-fn cached_utf16_col(
-    cache: &mut HashMap<usize, Utf16LineIndex>,
+/// A single host line commonly receives a start/end pair of `byte_to_utf16`
+/// queries per capture, times however many captures land on that line.
+/// Returning the index (rather than resolving one column per call) lets a
+/// caller reuse a single `HashMap` lookup for both the start and end column
+/// of one token, on top of caching by line number turning what would be an
+/// O(line_len) rescan per query into one O(line_len) build plus O(log
+/// line_len) lookups.
+fn cached_line_index<'a>(
+    cache: &'a mut HashMap<usize, Utf16LineIndex>,
     host_line: usize,
     line_text: &str,
-    byte_col: usize,
-) -> usize {
+) -> &'a Utf16LineIndex {
     cache
         .entry(host_line)
         .or_insert_with(|| Utf16LineIndex::new(line_text))
-        .byte_to_utf16(byte_col)
 }
 
 /// Extract the `#set! priority N` value for a pattern, defaulting to 100.
@@ -364,7 +365,7 @@ pub(super) fn collect_host_tokens(
     let content_lines: Vec<&str> = text.lines().collect();
 
     // Lazily-built byte->UTF-16 lookup per host line, shared across every
-    // capture below. See `cached_utf16_col`.
+    // capture below. See `cached_line_index`.
     let mut utf16_cache: HashMap<usize, Utf16LineIndex> = HashMap::new();
 
     // Collect tokens from this document's highlight query
@@ -414,12 +415,8 @@ pub(super) fn collect_host_tokens(
                 } else {
                     start_pos.column
                 };
-                let start_utf16 = cached_utf16_col(
-                    &mut utf16_cache,
-                    host_line,
-                    host_line_text,
-                    byte_offset_in_host,
-                );
+                let line_index = cached_line_index(&mut utf16_cache, host_line, host_line_text);
+                let start_utf16 = line_index.byte_to_utf16(byte_offset_in_host);
 
                 // For trailing newline case, use the line length as end position
                 let end_byte_offset_in_host = if is_trailing_newline {
@@ -429,12 +426,7 @@ pub(super) fn collect_host_tokens(
                 } else {
                     end_pos.column
                 };
-                let end_utf16 = cached_utf16_col(
-                    &mut utf16_cache,
-                    host_line,
-                    host_line_text,
-                    end_byte_offset_in_host,
-                );
+                let end_utf16 = line_index.byte_to_utf16(end_byte_offset_in_host);
 
                 all_tokens.push(RawToken {
                     line: host_line,
@@ -464,12 +456,9 @@ pub(super) fn collect_host_tokens(
                     } else {
                         start_pos.column
                     };
-                    let start_utf16 = cached_utf16_col(
-                        &mut utf16_cache,
-                        host_start_line,
-                        host_start_line_text,
-                        start_byte_offset,
-                    );
+                    let start_utf16 =
+                        cached_line_index(&mut utf16_cache, host_start_line, host_start_line_text)
+                            .byte_to_utf16(start_byte_offset);
 
                     let mut total_length_utf16 = 0usize;
                     for row in start_pos.row..=end_pos.row {
@@ -486,10 +475,9 @@ pub(super) fn collect_host_tokens(
                             &prefix_widths,
                         );
 
-                        let line_start_utf16 =
-                            cached_utf16_col(&mut utf16_cache, host_row, line_text, line_start);
-                        let line_end_utf16 =
-                            cached_utf16_col(&mut utf16_cache, host_row, line_text, line_end);
+                        let line_index = cached_line_index(&mut utf16_cache, host_row, line_text);
+                        let line_start_utf16 = line_index.byte_to_utf16(line_start);
+                        let line_end_utf16 = line_index.byte_to_utf16(line_end);
                         total_length_utf16 += line_end_utf16 - line_start_utf16;
 
                         if row < end_pos.row {
@@ -531,18 +519,10 @@ pub(super) fn collect_host_tokens(
                             &prefix_widths,
                         );
 
-                        let start_utf16 = cached_utf16_col(
-                            &mut utf16_cache,
-                            host_row,
-                            host_line_text,
-                            line_start_byte,
-                        );
-                        let end_utf16 = cached_utf16_col(
-                            &mut utf16_cache,
-                            host_row,
-                            host_line_text,
-                            line_end_byte,
-                        );
+                        let line_index =
+                            cached_line_index(&mut utf16_cache, host_row, host_line_text);
+                        let start_utf16 = line_index.byte_to_utf16(line_start_byte);
+                        let end_utf16 = line_index.byte_to_utf16(line_end_byte);
 
                         if end_utf16 > start_utf16 {
                             all_tokens.push(RawToken {
@@ -860,6 +840,11 @@ mod tests {
             &[],
             &mut tokens,
         );
+
+        // collect_host_tokens doesn't guarantee match/emission order, so sort
+        // by column before asserting rather than relying on tree-sitter's
+        // query-iteration order to place x before y.
+        tokens.sort_by_key(|t| t.column);
 
         assert_eq!(tokens.len(), 2);
         assert_eq!(

--- a/src/text/position.rs
+++ b/src/text/position.rs
@@ -171,6 +171,56 @@ pub fn convert_byte_to_utf16_in_line(line_text: &str, byte_pos: usize) -> Option
     }
 }
 
+/// Per-line byte→UTF-16 column lookup, amortizing the cost of repeated
+/// `byte_to_utf16_col` calls against the same line across multiple tokens.
+///
+/// ASCII lines keep `byte_to_utf16_col`'s fast path (byte offset == UTF-16
+/// offset, clamped to the line length) with no allocation. Non-ASCII lines
+/// build a sorted `(byte, utf16)` boundary table once, O(line_len), then
+/// resolve each query via binary search, O(log line_len) — replacing the
+/// O(line_len) per-char decode loop `byte_to_utf16_col` would otherwise
+/// re-run from column 0 on every call against that line.
+pub(crate) struct Utf16LineIndex {
+    line_len: usize,
+    // None for ASCII lines (fast path needs no table). Always starts at
+    // (0, 0) and ends with (line_len, total_utf16_width) for non-ASCII lines.
+    boundaries: Option<Vec<(usize, usize)>>,
+}
+
+impl Utf16LineIndex {
+    pub(crate) fn new(line: &str) -> Self {
+        if line.as_bytes().is_ascii() {
+            return Self {
+                line_len: line.len(),
+                boundaries: None,
+            };
+        }
+
+        let mut boundaries = Vec::with_capacity(line.len() + 1);
+        let mut utf16_offset = 0;
+        for (byte, ch) in line.char_indices() {
+            boundaries.push((byte, utf16_offset));
+            utf16_offset += ch.len_utf16();
+        }
+        boundaries.push((line.len(), utf16_offset));
+        Self {
+            line_len: line.len(),
+            boundaries: Some(boundaries),
+        }
+    }
+
+    /// Same semantics as `byte_to_utf16_col`: an out-of-bounds or
+    /// mid-codepoint `byte_col` resolves to the nearest valid boundary at or
+    /// before it.
+    pub(crate) fn byte_to_utf16(&self, byte_col: usize) -> usize {
+        let Some(boundaries) = &self.boundaries else {
+            return byte_col.min(self.line_len);
+        };
+        let idx = boundaries.partition_point(|&(b, _)| b <= byte_col);
+        boundaries[idx.saturating_sub(1)].1
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -220,6 +270,77 @@ mod tests {
         assert_eq!(byte_to_utf16_col(line, 2), 1);
         // byte 3 is mid-emoji → falls back to 1
         assert_eq!(byte_to_utf16_col(line, 3), 1);
+    }
+
+    #[test]
+    fn utf16_line_index_matches_byte_to_utf16_col_ascii() {
+        let line = "hello world";
+        let index = Utf16LineIndex::new(line);
+        for byte_col in [0, 5, 11] {
+            assert_eq!(
+                index.byte_to_utf16(byte_col),
+                byte_to_utf16_col(line, byte_col)
+            );
+        }
+    }
+
+    #[test]
+    fn utf16_line_index_matches_byte_to_utf16_col_japanese() {
+        let line = "こんにちは";
+        let index = Utf16LineIndex::new(line);
+        for byte_col in [0, 3, 6, 15] {
+            assert_eq!(
+                index.byte_to_utf16(byte_col),
+                byte_to_utf16_col(line, byte_col)
+            );
+        }
+    }
+
+    #[test]
+    fn utf16_line_index_matches_byte_to_utf16_col_mixed_ascii_and_japanese() {
+        let line = "let x = \"あいうえお\"";
+        let index = Utf16LineIndex::new(line);
+        for byte_col in [0, 8, 9, 12, 24] {
+            assert_eq!(
+                index.byte_to_utf16(byte_col),
+                byte_to_utf16_col(line, byte_col)
+            );
+        }
+    }
+
+    #[test]
+    fn utf16_line_index_matches_byte_to_utf16_col_mid_character_fallback() {
+        let line = "こんにちは";
+        let index = Utf16LineIndex::new(line);
+        for byte_col in [1, 2, 4] {
+            assert_eq!(
+                index.byte_to_utf16(byte_col),
+                byte_to_utf16_col(line, byte_col)
+            );
+        }
+
+        let line = "a👋b";
+        let index = Utf16LineIndex::new(line);
+        for byte_col in [2, 3] {
+            assert_eq!(
+                index.byte_to_utf16(byte_col),
+                byte_to_utf16_col(line, byte_col)
+            );
+        }
+    }
+
+    #[test]
+    fn utf16_line_index_matches_byte_to_utf16_col_out_of_bounds() {
+        // Past the end of the line, on both ASCII and non-ASCII content —
+        // exercises the "no boundary found" fallback that clamps to line_len.
+        for line in ["hello", "こんにちは", "a👋b"] {
+            let index = Utf16LineIndex::new(line);
+            let past_end = line.len() + 5;
+            assert_eq!(
+                index.byte_to_utf16(past_end),
+                byte_to_utf16_col(line, past_end)
+            );
+        }
     }
 
     #[test]

--- a/src/text/position.rs
+++ b/src/text/position.rs
@@ -332,7 +332,10 @@ mod tests {
     #[test]
     fn utf16_line_index_matches_byte_to_utf16_col_out_of_bounds() {
         // Past the end of the line, on both ASCII and non-ASCII content —
-        // exercises the "no boundary found" fallback that clamps to line_len.
+        // exercises the "no boundary found" fallback, which clamps to the
+        // line's end: byte length for ASCII (byte offset == UTF-16 offset),
+        // but the line's UTF-16 WIDTH for non-ASCII (e.g. "こんにちは" is
+        // 15 bytes but clamps to UTF-16 column 5).
         for line in ["hello", "こんにちは", "a👋b"] {
             let index = Utf16LineIndex::new(line);
             let past_end = line.len() + 5;


### PR DESCRIPTION
## Summary
- `collect_host_tokens` converted each token's byte column to UTF-16 independently via `byte_to_utf16_col`, rescanning the line from column 0 every call. The ASCII fast path keeps this cheap; any non-ASCII line falls to a per-char decode loop, so a line with k tokens paid O(line_len) k times over — true O(tokens × line_len) per line.
- Long CJK/emoji lines with many captures compound with the O(k²) overlap split fixed in #577.
- Added `Utf16LineIndex`: ASCII lines keep the zero-allocation fast path; non-ASCII lines build a sorted `(byte, utf16)` boundary table once (O(line_len)) then resolve each query via binary search (O(log line_len)). Reproduces `byte_to_utf16_col`'s exact fallback semantics.
- Wired in via a `Vec<Option<Utf16LineIndex>>` built lazily and shared across every capture on that line. Keyed by the content-local row (not the host-absolute line), so an injection deep in a large host document only allocates up to its own small line count, not the host's; captures arrive in tree-sitter match order, not sorted by column, so a single forward sweep isn't safe in general.

## Test plan
- [x] `Utf16LineIndex` tests mirror every existing `byte_to_utf16_col` test case (ascii, japanese, mixed, mid-character fallback, out-of-bounds)
- [x] New `collect_host_tokens` test with two identifiers straddling a 3-char CJK string literal on one line, pinning that byte/UTF-16 columns diverge correctly and the cache is shared across both lookups
- [x] `cargo test --lib` (2468 tests) all pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Full e2e suite green

Closes #579

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-16 cursor and token column/length accuracy for non-ASCII text, including Japanese/CJK and mixed-content lines.
  * Fixed incorrect token column/length reporting when multiple tokens appear after CJK literals on the same line.
  * Improved correctness for boundary-adjacent positions (including emoji) and for multiline tokens spanning multiple lines.
* **Tests**
  * Added unit coverage to validate UTF-16 column/length for multiple tokens after CJK prefixes, plus boundary and out-of-range edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->