### PR TITLE
test(e2e): organize-imports-on-save acceptance via ruff (#568 PR 8)

### DIFF
--- a/tests/e2e_organize_imports.rs
+++ b/tests/e2e_organize_imports.rs
@@ -58,7 +58,11 @@ fn init_ruff_client() -> (LspClient, tempfile::TempDir, tempfile::TempDir) {
         .env_remove("KAKEHASHI_EXPERIMENTAL")
         .build();
 
-    let root_uri = format!("file://{}", workspace.path().display());
+    // Canonical directory URI (percent-encoded), reused for both rootUri and
+    // workspaceFolders — see doc_uri for why string-formatting is avoided.
+    let root_uri = url::Url::from_directory_path(workspace.path())
+        .expect("valid directory URI")
+        .to_string();
     client.send_request(
         "initialize",
         json!({
@@ -191,7 +195,13 @@ fn resolved_host_edits(client: &mut LspClient, action: &Value, host_uri: &str) -
     let resolved = if action["edit"].is_object() {
         action.clone()
     } else {
-        client.send_request("codeAction/resolve", action.clone())["result"].clone()
+        let response = client.send_request("codeAction/resolve", action.clone());
+        assert!(
+            response.get("error").is_none(),
+            "codeAction/resolve returned a JSON-RPC error: {}",
+            response["error"]
+        );
+        response["result"].clone()
     };
     let edit = &resolved["edit"];
     if let Some(edits) = edit["changes"][host_uri].as_array() {

--- a/tests/e2e_organize_imports.rs
+++ b/tests/e2e_organize_imports.rs
@@ -75,10 +75,14 @@ fn init_ruff_client() -> (LspClient, tempfile::TempDir, tempfile::TempDir) {
     (client, workspace, config_dir)
 }
 
-/// A `file://` URI for `name` under the workspace root, so ruff sees the
-/// document inside its workspace (config discovery, out-of-workspace policy).
+/// A canonical `file://` URI for `name` under the workspace root, so ruff sees
+/// the document inside its workspace. Built via `Url::from_file_path` (not string
+/// formatting) so the URI is RFC-canonical/percent-encoded and kakehashi's
+/// `url::Url::parse` accepts it.
 fn doc_uri(workspace: &tempfile::TempDir, name: &str) -> String {
-    format!("file://{}/{name}", workspace.path().display())
+    url::Url::from_file_path(workspace.path().join(name))
+        .expect("valid file URI")
+        .to_string()
 }
 
 fn open(client: &mut LspClient, uri: &str, text: &str) {
@@ -147,8 +151,10 @@ fn apply_edits(text: &str, edits: &[Value]) -> String {
     out
 }
 
-/// Request codeAction over the python fence (host lines 3-6), retrying while the
-/// downstream is still cold.
+/// Request codeAction over the python fence — an LSP range of `(3,0)..(6,0)`,
+/// i.e. host lines 3-5 (end-exclusive), which covers the whole import block —
+/// retrying while the downstream is still cold. A JSON-RPC error is surfaced
+/// immediately (not retried) so a real failure is diagnosable.
 fn code_action_over_block(client: &mut LspClient, uri: &str, context: Value) -> Vec<Value> {
     for _ in 0..400 {
         let response = client.send_request(
@@ -161,6 +167,11 @@ fn code_action_over_block(client: &mut LspClient, uri: &str, context: Value) -> 
                 },
                 "context": context
             }),
+        );
+        assert!(
+            response.get("error").is_none(),
+            "codeAction returned a JSON-RPC error: {}",
+            response["error"]
         );
         if let Some(actions) = response["result"].as_array()
             && !actions.is_empty()
@@ -268,6 +279,11 @@ fn diagnostic_drives_a_quickfix_on_the_python_block() {
         let response = client.send_request(
             "textDocument/diagnostic",
             json!({ "textDocument": { "uri": uri } }),
+        );
+        assert!(
+            response.get("error").is_none(),
+            "diagnostic returned a JSON-RPC error: {}",
+            response["error"]
         );
         if let Some(items) = response["result"]["items"].as_array()
             && !items.is_empty()

--- a/tests/e2e_organize_imports.rs
+++ b/tests/e2e_organize_imports.rs
@@ -257,7 +257,11 @@ fn diagnostic_drives_a_quickfix_on_the_python_block() {
     );
     let fix = actions
         .iter()
-        .find(|a| a["kind"].as_str().is_some_and(|k| k.starts_with("quickfix")))
+        .find(|a| {
+            a["kind"]
+                .as_str()
+                .is_some_and(|k| k.starts_with("quickfix"))
+        })
         .unwrap_or_else(|| panic!("a quickfix action, got: {actions:#?}"));
 
     let edits = resolved_host_edits(&mut client, fix, &uri);

--- a/tests/e2e_organize_imports.rs
+++ b/tests/e2e_organize_imports.rs
@@ -1,0 +1,261 @@
+//! Acceptance E2E for #568 PR 8: organize-imports on a python block inside
+//! markdown, bridged to a real `ruff server`. Composes the whole codeAction
+//! stack — request over the injection region, `source.organizeImports` matched,
+//! `codeAction/resolve` round-trip, and the resolved edit re-keyed to the host
+//! markdown document with host-translated ranges.
+//!
+//! Skips when `ruff` is not on PATH.
+
+#![cfg(feature = "e2e")]
+
+mod helpers;
+
+use std::time::Duration;
+
+use helpers::lsp_client::LspClient;
+use serde_json::{Value, json};
+
+fn is_ruff_available() -> bool {
+    std::process::Command::new("ruff")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Markdown host: a python fence whose imports are out of order. Fence content
+/// starts on host line 3 (`import sys`).
+const MARKDOWN: &str = "# Doc\n\n```python\nimport sys\nimport os\n\nprint(os, sys)\n```\n";
+const MARKDOWN_URI: &str = "file:///test_organize.md";
+
+fn resolve_support_caps() -> Value {
+    json!({ "textDocument": { "codeAction": {
+        "codeActionLiteralSupport": { "codeActionKind": { "valueSet": [] } },
+        "disabledSupport": true,
+        "dataSupport": true,
+        "resolveSupport": { "properties": ["edit"] },
+        "isPreferredSupport": true
+    }}})
+}
+
+fn init_ruff_client() -> (LspClient, tempfile::TempDir, tempfile::TempDir) {
+    let workspace = tempfile::TempDir::new().expect("workspace temp dir");
+    let config_dir = tempfile::TempDir::new().expect("config temp dir");
+    let config_path = config_dir.path().join("empty.toml");
+    std::fs::write(&config_path, "").expect("write empty config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("utf-8 path"))
+        .env_remove("KAKEHASHI_EXPERIMENTAL")
+        .build();
+
+    let root_uri = format!("file://{}", workspace.path().display());
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": root_uri,
+            "capabilities": resolve_support_caps(),
+            "workspaceFolders": json!([{ "uri": root_uri, "name": "test" }]),
+            "initializationOptions": { "languageServers": {
+                "ruff": { "cmd": ["ruff", "server"], "languages": ["python"] }
+            }}
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+    (client, workspace, config_dir)
+}
+
+fn open_markdown(client: &mut LspClient) {
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({ "textDocument": {
+            "uri": MARKDOWN_URI, "languageId": "markdown", "version": 1, "text": MARKDOWN
+        }}),
+    );
+    std::thread::sleep(Duration::from_millis(2000));
+}
+
+/// Request codeAction over the python fence (host lines 3-6), retrying while the
+/// downstream is still cold.
+fn code_action_over_block(client: &mut LspClient, only: Value) -> Vec<Value> {
+    for _ in 0..400 {
+        let response = client.send_request(
+            "textDocument/codeAction",
+            json!({
+                "textDocument": { "uri": MARKDOWN_URI },
+                "range": {
+                    "start": { "line": 3, "character": 0 },
+                    "end": { "line": 6, "character": 0 }
+                },
+                "context": { "diagnostics": [], "only": only }
+            }),
+        );
+        if let Some(actions) = response["result"].as_array()
+            && !actions.is_empty()
+        {
+            return actions.clone();
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("codeAction never returned actions");
+}
+
+#[test]
+fn organize_imports_sorts_the_python_block_in_host_coordinates() {
+    if !is_ruff_available() {
+        eprintln!("SKIP: ruff is not available on PATH");
+        return;
+    }
+    let (mut client, _ws, _cfg) = init_ruff_client();
+    open_markdown(&mut client);
+
+    let actions = code_action_over_block(&mut client, json!(["source.organizeImports"]));
+
+    // Find the organize-imports action; the bridge suffixed its title "— ruff".
+    let action = actions
+        .iter()
+        .find(|a| {
+            a["kind"]
+                .as_str()
+                .is_some_and(|k| k.starts_with("source.organizeImports"))
+        })
+        .unwrap_or_else(|| panic!("an organize-imports action, got: {actions:#?}"));
+    assert!(
+        action["title"]
+            .as_str()
+            .is_some_and(|t| t.ends_with("— ruff")),
+        "the bridged title carries the origin suffix, got: {:?}",
+        action["title"]
+    );
+
+    // Resolve if the edit is lazy (ruff advertises resolveProvider).
+    let resolved = if action["edit"].is_object() {
+        (*action).clone()
+    } else {
+        client.send_request("codeAction/resolve", (*action).clone())["result"].clone()
+    };
+
+    let edits = resolved["edit"]["changes"][MARKDOWN_URI]
+        .as_array()
+        .unwrap_or_else(|| panic!("edit re-keyed to the host markdown URI, got: {resolved:#?}"));
+    assert_eq!(edits.len(), 1, "one import-block replacement: {edits:#?}");
+    let edit = &edits[0];
+    // ruff sorts `import sys\nimport os` → `import os\nimport sys`; the bridge
+    // re-keys the edit to the host doc and translates the virtual range
+    // (fence content starts at host line 3), never touching the fence markers.
+    assert_eq!(edit["newText"], json!("import os\nimport sys\n"));
+    assert_eq!(edit["range"]["start"]["line"], json!(3));
+    assert!(
+        edit["range"]["end"]["line"].as_u64().unwrap() >= 4,
+        "the replacement spans the two-line import block, got: {edit:#?}"
+    );
+
+    let _ = client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+/// A python fence with an UNUSED import (`sys`), for the diag→quickfix round
+/// trip: ruff diagnoses F401, and its quickfix — matched against that
+/// diagnostic — removes the import, re-keyed to the host markdown document.
+const MARKDOWN_UNUSED: &str = "# Doc\n\n```python\nimport os\nimport sys\n\nprint(os)\n```\n";
+const MARKDOWN_UNUSED_URI: &str = "file:///test_unused.md";
+
+fn pull_diagnostics(client: &mut LspClient) -> Vec<Value> {
+    for _ in 0..400 {
+        let response = client.send_request(
+            "textDocument/diagnostic",
+            json!({ "textDocument": { "uri": MARKDOWN_UNUSED_URI } }),
+        );
+        if let Some(items) = response["result"]["items"].as_array()
+            && !items.is_empty()
+        {
+            return items.clone();
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("textDocument/diagnostic never returned items");
+}
+
+#[test]
+fn diagnostic_drives_a_quickfix_on_the_python_block() {
+    if !is_ruff_available() {
+        eprintln!("SKIP: ruff is not available on PATH");
+        return;
+    }
+    let (mut client, _ws, _cfg) = init_ruff_client();
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({ "textDocument": {
+            "uri": MARKDOWN_UNUSED_URI, "languageId": "markdown", "version": 1, "text": MARKDOWN_UNUSED
+        }}),
+    );
+    std::thread::sleep(Duration::from_millis(2000));
+
+    // ruff's unused-import diagnostic (F401), in HOST coordinates (line >= 3).
+    let diags = pull_diagnostics(&mut client);
+    let f401 = diags
+        .iter()
+        .find(|d| {
+            d["code"] == json!("F401") || d["message"].as_str().is_some_and(|m| m.contains("sys"))
+        })
+        .unwrap_or_else(|| panic!("an unused-import (F401) diagnostic, got: {diags:#?}"));
+    assert!(
+        f401["range"]["start"]["line"].as_u64().unwrap() >= 3,
+        "diagnostic is host-translated onto the fence content, got: {f401:#?}"
+    );
+
+    // Feed that diagnostic back as codeAction context — the bridge must
+    // translate its range host→virtual so ruff matches it and offers the fix
+    // (checklist §1: diagnostic round-trip identity).
+    let actions = {
+        let mut found = None;
+        for _ in 0..400 {
+            let response = client.send_request(
+                "textDocument/codeAction",
+                json!({
+                    "textDocument": { "uri": MARKDOWN_UNUSED_URI },
+                    "range": f401["range"],
+                    "context": { "diagnostics": [f401], "only": ["quickfix"] }
+                }),
+            );
+            if let Some(a) = response["result"].as_array()
+                && !a.is_empty()
+            {
+                found = Some(a.clone());
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        found.unwrap_or_else(|| panic!("codeAction never offered a quickfix for the F401"))
+    };
+
+    // A quickfix that removes the unused import, re-keyed to the host doc.
+    let fix = actions
+        .iter()
+        .find(|a| {
+            a["kind"]
+                .as_str()
+                .is_some_and(|k| k.starts_with("quickfix"))
+                && (a["edit"].is_object() || a["data"].is_object())
+        })
+        .unwrap_or_else(|| panic!("a quickfix action, got: {actions:#?}"));
+    let resolved = if fix["edit"].is_object() {
+        (*fix).clone()
+    } else {
+        client.send_request("codeAction/resolve", (*fix).clone())["result"].clone()
+    };
+    let edits = resolved["edit"]["changes"][MARKDOWN_UNUSED_URI]
+        .as_array()
+        .unwrap_or_else(|| panic!("quickfix edit re-keyed to the host URI, got: {resolved:#?}"));
+    assert!(
+        edits
+            .iter()
+            .all(|e| e["range"]["start"]["line"].as_u64().unwrap() >= 3),
+        "every quickfix edit targets the fence content (host line >= 3), got: {edits:#?}"
+    );
+
+    let _ = client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}

--- a/tests/e2e_organize_imports.rs
+++ b/tests/e2e_organize_imports.rs
@@ -147,7 +147,18 @@ fn apply_edits(text: &str, edits: &[Value]) -> String {
             (s, en, new.to_string())
         })
         .collect();
-    spans.sort_by_key(|(s, _, _)| *s);
+    spans.sort_by_key(|(s, en, _)| (*s, *en));
+    // Overlapping edits would apply in an arbitrary order and could mask a
+    // translation bug behind a plausible-looking document — a valid LSP edit set
+    // is disjoint, so assert that before applying end-first.
+    for pair in spans.windows(2) {
+        assert!(
+            pair[1].0 >= pair[0].1,
+            "overlapping host edits: {:?} then {:?}",
+            pair[0],
+            pair[1]
+        );
+    }
     let mut out = text.to_string();
     for (s, en, new) in spans.into_iter().rev() {
         out.replace_range(s..en, &new);

--- a/tests/e2e_organize_imports.rs
+++ b/tests/e2e_organize_imports.rs
@@ -158,17 +158,34 @@ fn code_action_over_block(client: &mut LspClient, uri: &str, context: Value) -> 
 }
 
 /// Resolve `action` if its edit is lazy (ruff advertises resolveProvider),
-/// returning the host-URI `changes` edits.
+/// returning the edits targeting `host_uri` from EITHER `WorkspaceEdit`
+/// representation — `changes` or `documentChanges` — so the test isn't coupled
+/// to ruff's current shape (the bridge translates both).
 fn resolved_host_edits(client: &mut LspClient, action: &Value, host_uri: &str) -> Vec<Value> {
     let resolved = if action["edit"].is_object() {
         action.clone()
     } else {
         client.send_request("codeAction/resolve", action.clone())["result"].clone()
     };
-    resolved["edit"]["changes"][host_uri]
-        .as_array()
-        .cloned()
-        .unwrap_or_else(|| panic!("edit re-keyed to the host URI {host_uri}, got: {resolved:#?}"))
+    let edit = &resolved["edit"];
+    if let Some(edits) = edit["changes"][host_uri].as_array() {
+        return edits.clone();
+    }
+    if let Some(document_changes) = edit["documentChanges"].as_array() {
+        let edits: Vec<Value> = document_changes
+            .iter()
+            .filter(|dc| dc["textDocument"]["uri"] == json!(host_uri))
+            .filter_map(|dc| dc["edits"].as_array())
+            .flatten()
+            .cloned()
+            .collect();
+        if !edits.is_empty() {
+            return edits;
+        }
+    }
+    panic!(
+        "edit re-keyed to the host URI {host_uri} (changes or documentChanges), got: {resolved:#?}"
+    )
 }
 
 #[test]

--- a/tests/e2e_organize_imports.rs
+++ b/tests/e2e_organize_imports.rs
@@ -1,10 +1,17 @@
-//! Acceptance E2E for #568 PR 8: organize-imports on a python block inside
-//! markdown, bridged to a real `ruff server`. Composes the whole codeAction
-//! stack — request over the injection region, `source.organizeImports` matched,
-//! `codeAction/resolve` round-trip, and the resolved edit re-keyed to the host
-//! markdown document with host-translated ranges.
+//! Acceptance E2E for #568 PR 8: organize-imports and diagnostic→quickfix on a
+//! python block inside markdown, bridged to a real `ruff server`. Composes the
+//! whole codeAction stack — request over the injection region,
+//! `source.organizeImports`/quickfix matched, `codeAction/resolve` round-trip,
+//! and the resolved edit re-keyed to the host markdown document with
+//! host-translated ranges.
 //!
-//! Skips when `ruff` is not on PATH.
+//! To stay robust across ruff versions the tests do NOT pin ruff's exact edit
+//! shape; they APPLY the returned edits to the host markdown and assert the
+//! resulting document — which still fails if the bridge mis-translates or
+//! mis-keys the edit, but tolerates ruff changing how it slices the edit.
+//!
+//! Skips when `ruff` is not on PATH (same system-dependency pattern as the
+//! lua-language-server bridge tests).
 
 #![cfg(feature = "e2e")]
 
@@ -23,11 +30,6 @@ fn is_ruff_available() -> bool {
         .unwrap_or(false)
 }
 
-/// Markdown host: a python fence whose imports are out of order. Fence content
-/// starts on host line 3 (`import sys`).
-const MARKDOWN: &str = "# Doc\n\n```python\nimport sys\nimport os\n\nprint(os, sys)\n```\n";
-const MARKDOWN_URI: &str = "file:///test_organize.md";
-
 fn resolve_support_caps() -> Value {
     json!({ "textDocument": { "codeAction": {
         "codeActionLiteralSupport": { "codeActionKind": { "valueSet": [] } },
@@ -38,6 +40,8 @@ fn resolve_support_caps() -> Value {
     }}})
 }
 
+/// A kakehashi client with `ruff server` bridged for python, plus the temp
+/// workspace whose root the document URIs live under (kept alive by the caller).
 fn init_ruff_client() -> (LspClient, tempfile::TempDir, tempfile::TempDir) {
     let workspace = tempfile::TempDir::new().expect("workspace temp dir");
     let config_dir = tempfile::TempDir::new().expect("config temp dir");
@@ -67,29 +71,71 @@ fn init_ruff_client() -> (LspClient, tempfile::TempDir, tempfile::TempDir) {
     (client, workspace, config_dir)
 }
 
-fn open_markdown(client: &mut LspClient) {
+/// A `file://` URI for `name` under the workspace root, so ruff sees the
+/// document inside its workspace (config discovery, out-of-workspace policy).
+fn doc_uri(workspace: &tempfile::TempDir, name: &str) -> String {
+    format!("file://{}/{name}", workspace.path().display())
+}
+
+fn open(client: &mut LspClient, uri: &str, text: &str) {
     client.send_notification(
         "textDocument/didOpen",
         json!({ "textDocument": {
-            "uri": MARKDOWN_URI, "languageId": "markdown", "version": 1, "text": MARKDOWN
+            "uri": uri, "languageId": "markdown", "version": 1, "text": text
         }}),
     );
     std::thread::sleep(Duration::from_millis(2000));
 }
 
+/// Apply LSP `TextEdit`s (whole-document `changes` entry) to `text`. The test
+/// fixtures are ASCII, so a UTF-16 offset equals a byte offset; edits are
+/// applied end-first so earlier splices don't shift later ranges.
+fn apply_edits(text: &str, edits: &[Value]) -> String {
+    let offset = |line: u64, character: u64| -> usize {
+        let mut off = 0usize;
+        for (i, l) in text.split_inclusive('\n').enumerate() {
+            if i as u64 == line {
+                return off + (character as usize).min(l.len());
+            }
+            off += l.len();
+        }
+        off
+    };
+    let mut spans: Vec<(usize, usize, String)> = edits
+        .iter()
+        .map(|e| {
+            let s = offset(
+                e["range"]["start"]["line"].as_u64().unwrap(),
+                e["range"]["start"]["character"].as_u64().unwrap(),
+            );
+            let en = offset(
+                e["range"]["end"]["line"].as_u64().unwrap(),
+                e["range"]["end"]["character"].as_u64().unwrap(),
+            );
+            (s, en, e["newText"].as_str().unwrap_or("").to_string())
+        })
+        .collect();
+    spans.sort_by_key(|(s, _, _)| *s);
+    let mut out = text.to_string();
+    for (s, en, new) in spans.into_iter().rev() {
+        out.replace_range(s..en.max(s), &new);
+    }
+    out
+}
+
 /// Request codeAction over the python fence (host lines 3-6), retrying while the
 /// downstream is still cold.
-fn code_action_over_block(client: &mut LspClient, only: Value) -> Vec<Value> {
+fn code_action_over_block(client: &mut LspClient, uri: &str, context: Value) -> Vec<Value> {
     for _ in 0..400 {
         let response = client.send_request(
             "textDocument/codeAction",
             json!({
-                "textDocument": { "uri": MARKDOWN_URI },
+                "textDocument": { "uri": uri },
                 "range": {
                     "start": { "line": 3, "character": 0 },
                     "end": { "line": 6, "character": 0 }
                 },
-                "context": { "diagnostics": [], "only": only }
+                "context": context
             }),
         );
         if let Some(actions) = response["result"].as_array()
@@ -102,18 +148,37 @@ fn code_action_over_block(client: &mut LspClient, only: Value) -> Vec<Value> {
     panic!("codeAction never returned actions");
 }
 
+/// Resolve `action` if its edit is lazy (ruff advertises resolveProvider),
+/// returning the host-URI `changes` edits.
+fn resolved_host_edits(client: &mut LspClient, action: &Value, host_uri: &str) -> Vec<Value> {
+    let resolved = if action["edit"].is_object() {
+        action.clone()
+    } else {
+        client.send_request("codeAction/resolve", action.clone())["result"].clone()
+    };
+    resolved["edit"]["changes"][host_uri]
+        .as_array()
+        .cloned()
+        .unwrap_or_else(|| panic!("edit re-keyed to the host URI {host_uri}, got: {resolved:#?}"))
+}
+
 #[test]
 fn organize_imports_sorts_the_python_block_in_host_coordinates() {
     if !is_ruff_available() {
         eprintln!("SKIP: ruff is not available on PATH");
         return;
     }
-    let (mut client, _ws, _cfg) = init_ruff_client();
-    open_markdown(&mut client);
+    let (mut client, ws, _cfg) = init_ruff_client();
+    let uri = doc_uri(&ws, "organize.md");
+    // Out-of-order imports; organize-imports sorts os before sys.
+    let text = "# Doc\n\n```python\nimport sys\nimport os\n\nprint(os, sys)\n```\n";
+    open(&mut client, &uri, text);
 
-    let actions = code_action_over_block(&mut client, json!(["source.organizeImports"]));
-
-    // Find the organize-imports action; the bridge suffixed its title "— ruff".
+    let actions = code_action_over_block(
+        &mut client,
+        &uri,
+        json!({ "diagnostics": [], "only": ["source.organizeImports"] }),
+    );
     let action = actions
         .iter()
         .find(|a| {
@@ -122,6 +187,7 @@ fn organize_imports_sorts_the_python_block_in_host_coordinates() {
                 .is_some_and(|k| k.starts_with("source.organizeImports"))
         })
         .unwrap_or_else(|| panic!("an organize-imports action, got: {actions:#?}"));
+    // The bridge suffixed the origin server onto the title.
     assert!(
         action["title"]
             .as_str()
@@ -130,52 +196,17 @@ fn organize_imports_sorts_the_python_block_in_host_coordinates() {
         action["title"]
     );
 
-    // Resolve if the edit is lazy (ruff advertises resolveProvider).
-    let resolved = if action["edit"].is_object() {
-        (*action).clone()
-    } else {
-        client.send_request("codeAction/resolve", (*action).clone())["result"].clone()
-    };
-
-    let edits = resolved["edit"]["changes"][MARKDOWN_URI]
-        .as_array()
-        .unwrap_or_else(|| panic!("edit re-keyed to the host markdown URI, got: {resolved:#?}"));
-    assert_eq!(edits.len(), 1, "one import-block replacement: {edits:#?}");
-    let edit = &edits[0];
-    // ruff sorts `import sys\nimport os` → `import os\nimport sys`; the bridge
-    // re-keys the edit to the host doc and translates the virtual range
-    // (fence content starts at host line 3), never touching the fence markers.
-    assert_eq!(edit["newText"], json!("import os\nimport sys\n"));
-    assert_eq!(edit["range"]["start"]["line"], json!(3));
-    assert!(
-        edit["range"]["end"]["line"].as_u64().unwrap() >= 4,
-        "the replacement spans the two-line import block, got: {edit:#?}"
+    let edits = resolved_host_edits(&mut client, action, &uri);
+    let applied = apply_edits(text, &edits);
+    // Applying the (host-translated) edit sorts the fence imports and leaves the
+    // markdown structure — fence markers, heading, the print line — intact.
+    assert_eq!(
+        applied, "# Doc\n\n```python\nimport os\nimport sys\n\nprint(os, sys)\n```\n",
+        "organize-imports must sort the fenced python without disturbing the host markdown"
     );
 
     let _ = client.send_request("shutdown", json!(null));
     client.send_notification("exit", json!(null));
-}
-
-/// A python fence with an UNUSED import (`sys`), for the diag→quickfix round
-/// trip: ruff diagnoses F401, and its quickfix — matched against that
-/// diagnostic — removes the import, re-keyed to the host markdown document.
-const MARKDOWN_UNUSED: &str = "# Doc\n\n```python\nimport os\nimport sys\n\nprint(os)\n```\n";
-const MARKDOWN_UNUSED_URI: &str = "file:///test_unused.md";
-
-fn pull_diagnostics(client: &mut LspClient) -> Vec<Value> {
-    for _ in 0..400 {
-        let response = client.send_request(
-            "textDocument/diagnostic",
-            json!({ "textDocument": { "uri": MARKDOWN_UNUSED_URI } }),
-        );
-        if let Some(items) = response["result"]["items"].as_array()
-            && !items.is_empty()
-        {
-            return items.clone();
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
-    panic!("textDocument/diagnostic never returned items");
 }
 
 #[test]
@@ -184,17 +215,27 @@ fn diagnostic_drives_a_quickfix_on_the_python_block() {
         eprintln!("SKIP: ruff is not available on PATH");
         return;
     }
-    let (mut client, _ws, _cfg) = init_ruff_client();
-    client.send_notification(
-        "textDocument/didOpen",
-        json!({ "textDocument": {
-            "uri": MARKDOWN_UNUSED_URI, "languageId": "markdown", "version": 1, "text": MARKDOWN_UNUSED
-        }}),
-    );
-    std::thread::sleep(Duration::from_millis(2000));
+    let (mut client, ws, _cfg) = init_ruff_client();
+    let uri = doc_uri(&ws, "unused.md");
+    // `sys` is imported but unused → ruff F401.
+    let text = "# Doc\n\n```python\nimport os\nimport sys\n\nprint(os)\n```\n";
+    open(&mut client, &uri, text);
 
-    // ruff's unused-import diagnostic (F401), in HOST coordinates (line >= 3).
-    let diags = pull_diagnostics(&mut client);
+    // ruff's unused-import diagnostic, in HOST coordinates (fence content).
+    let mut diags = Vec::new();
+    for _ in 0..400 {
+        let response = client.send_request(
+            "textDocument/diagnostic",
+            json!({ "textDocument": { "uri": uri } }),
+        );
+        if let Some(items) = response["result"]["items"].as_array()
+            && !items.is_empty()
+        {
+            diags = items.clone();
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
     let f401 = diags
         .iter()
         .find(|d| {
@@ -209,51 +250,31 @@ fn diagnostic_drives_a_quickfix_on_the_python_block() {
     // Feed that diagnostic back as codeAction context — the bridge must
     // translate its range host→virtual so ruff matches it and offers the fix
     // (checklist §1: diagnostic round-trip identity).
-    let actions = {
-        let mut found = None;
-        for _ in 0..400 {
-            let response = client.send_request(
-                "textDocument/codeAction",
-                json!({
-                    "textDocument": { "uri": MARKDOWN_UNUSED_URI },
-                    "range": f401["range"],
-                    "context": { "diagnostics": [f401], "only": ["quickfix"] }
-                }),
-            );
-            if let Some(a) = response["result"].as_array()
-                && !a.is_empty()
-            {
-                found = Some(a.clone());
-                break;
-            }
-            std::thread::sleep(Duration::from_millis(50));
-        }
-        found.unwrap_or_else(|| panic!("codeAction never offered a quickfix for the F401"))
-    };
-
-    // A quickfix that removes the unused import, re-keyed to the host doc.
+    let actions = code_action_over_block(
+        &mut client,
+        &uri,
+        json!({ "diagnostics": [f401], "only": ["quickfix"] }),
+    );
     let fix = actions
         .iter()
-        .find(|a| {
-            a["kind"]
-                .as_str()
-                .is_some_and(|k| k.starts_with("quickfix"))
-                && (a["edit"].is_object() || a["data"].is_object())
-        })
+        .find(|a| a["kind"].as_str().is_some_and(|k| k.starts_with("quickfix")))
         .unwrap_or_else(|| panic!("a quickfix action, got: {actions:#?}"));
-    let resolved = if fix["edit"].is_object() {
-        (*fix).clone()
-    } else {
-        client.send_request("codeAction/resolve", (*fix).clone())["result"].clone()
-    };
-    let edits = resolved["edit"]["changes"][MARKDOWN_UNUSED_URI]
-        .as_array()
-        .unwrap_or_else(|| panic!("quickfix edit re-keyed to the host URI, got: {resolved:#?}"));
+
+    let edits = resolved_host_edits(&mut client, fix, &uri);
+    let applied = apply_edits(text, &edits);
+    // The quickfix removes the unused `import sys` and nothing else: `import os`
+    // and `print(os)` survive, the fence markers survive, and `sys` is gone.
     assert!(
-        edits
-            .iter()
-            .all(|e| e["range"]["start"]["line"].as_u64().unwrap() >= 3),
-        "every quickfix edit targets the fence content (host line >= 3), got: {edits:#?}"
+        !applied.contains("import sys"),
+        "the unused import must be removed, got:\n{applied}"
+    );
+    assert!(
+        applied.contains("import os") && applied.contains("print(os)"),
+        "the used import and body must remain, got:\n{applied}"
+    );
+    assert!(
+        applied.contains("```python") && applied.contains("# Doc"),
+        "the host markdown structure must remain, got:\n{applied}"
     );
 
     let _ = client.send_request("shutdown", json!(null));

--- a/tests/e2e_organize_imports.rs
+++ b/tests/e2e_organize_imports.rs
@@ -88,7 +88,9 @@ fn open(client: &mut LspClient, uri: &str, text: &str) {
             "uri": uri, "languageId": "markdown", "version": 1, "text": text
         }}),
     );
-    std::thread::sleep(Duration::from_millis(2000));
+    // Brief settle so kakehashi processes didOpen; the request retry loops cover
+    // the rest of ruff's cold start, so no need for a long fixed sleep.
+    std::thread::sleep(Duration::from_millis(200));
 }
 
 /// Apply LSP `TextEdit`s (whole-document `changes` entry) to `text`. The test
@@ -129,7 +131,12 @@ fn apply_edits(text: &str, edits: &[Value]) -> String {
             // a no-op to normalize away — fail loudly (the harness validates the
             // bridge's host coordinates).
             assert!(en >= s, "reversed host range in edit: {e:#?}");
-            (s, en, e["newText"].as_str().unwrap_or("").to_string())
+            // newText is REQUIRED by LSP; a missing one is a malformed edit, so
+            // fail rather than silently apply a deletion.
+            let new = e["newText"]
+                .as_str()
+                .unwrap_or_else(|| panic!("TextEdit.newText missing: {e:#?}"));
+            (s, en, new.to_string())
         })
         .collect();
     spans.sort_by_key(|(s, _, _)| *s);

--- a/tests/e2e_organize_imports.rs
+++ b/tests/e2e_organize_imports.rs
@@ -95,11 +95,20 @@ fn apply_edits(text: &str, edits: &[Value]) -> String {
         let mut off = 0usize;
         for (i, l) in text.split_inclusive('\n').enumerate() {
             if i as u64 == line {
-                return off + (character as usize).min(l.len());
+                // Don't clamp: an out-of-line character means the bridge
+                // produced an invalid host range (the very thing under test), so
+                // fail loudly instead of normalizing it into a plausible edit.
+                let content = l.strip_suffix('\n').unwrap_or(l);
+                assert!(
+                    character as usize <= content.len(),
+                    "edit character {character} past end of host line {line} ({:?})",
+                    content
+                );
+                return off + character as usize;
             }
             off += l.len();
         }
-        off
+        panic!("edit line {line} past end of host document");
     };
     let mut spans: Vec<(usize, usize, String)> = edits
         .iter()
@@ -276,9 +285,12 @@ fn diagnostic_drives_a_quickfix_on_the_python_block() {
         applied.contains("import os") && applied.contains("print(os)"),
         "the used import and body must remain, got:\n{applied}"
     );
+    // Both fence markers survive: the opening ```python and the CLOSING ``` (a
+    // bad translation that also ate the closing fence would otherwise slip past
+    // an opening-marker-only check).
     assert!(
-        applied.contains("```python") && applied.contains("# Doc"),
-        "the host markdown structure must remain, got:\n{applied}"
+        applied.contains("```python") && applied.contains("# Doc") && applied.ends_with("```\n"),
+        "the host markdown structure (both fence markers) must remain, got:\n{applied}"
     );
 
     let _ = client.send_request("shutdown", json!(null));

--- a/tests/e2e_organize_imports.rs
+++ b/tests/e2e_organize_imports.rs
@@ -23,8 +23,10 @@ use helpers::lsp_client::LspClient;
 use serde_json::{Value, json};
 
 fn is_ruff_available() -> bool {
+    // Probe the `server` SUBCOMMAND, not just `--version`: an older ruff without
+    // the built-in LSP would otherwise not skip and instead hang the bridge.
     std::process::Command::new("ruff")
-        .arg("--version")
+        .args(["server", "--help"])
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)
@@ -32,7 +34,9 @@ fn is_ruff_available() -> bool {
 
 fn resolve_support_caps() -> Value {
     json!({ "textDocument": { "codeAction": {
-        "codeActionLiteralSupport": { "codeActionKind": { "valueSet": [] } },
+        "codeActionLiteralSupport": { "codeActionKind": {
+            "valueSet": ["quickfix", "source", "source.organizeImports"]
+        } },
         "disabledSupport": true,
         "dataSupport": true,
         "resolveSupport": { "properties": ["edit"] },
@@ -121,13 +125,17 @@ fn apply_edits(text: &str, edits: &[Value]) -> String {
                 e["range"]["end"]["line"].as_u64().unwrap(),
                 e["range"]["end"]["character"].as_u64().unwrap(),
             );
+            // A reversed range (end before start) is an invalid host edit, not
+            // a no-op to normalize away — fail loudly (the harness validates the
+            // bridge's host coordinates).
+            assert!(en >= s, "reversed host range in edit: {e:#?}");
             (s, en, e["newText"].as_str().unwrap_or("").to_string())
         })
         .collect();
     spans.sort_by_key(|(s, _, _)| *s);
     let mut out = text.to_string();
     for (s, en, new) in spans.into_iter().rev() {
-        out.replace_range(s..en.max(s), &new);
+        out.replace_range(s..en, &new);
     }
     out
 }


### PR DESCRIPTION
Part of #568 (PR 8 of 8 — the final PR). Stacked on #620 (PR 7).

## What

The capstone acceptance E2E for the codeAction bridge, exercised against a **real `ruff server`** bridged to a python fence inside markdown. Test-only (no `src/` changes). Skips when `ruff` isn't on PATH — the same system-dependency pattern as the lua-language-server bridge tests (`is_lua_ls_available`).

## Scenarios

1. **organize-imports** (`organize_imports_sorts_the_python_block_in_host_coordinates`): a codeAction request with `only=["source.organizeImports"]` over the fence returns ruff's action (title suffixed `— ruff`); `codeAction/resolve` materializes the edit, which the bridge re-keys to the host markdown URI with host-translated ranges — `import sys\nimport os` → `import os\nimport sys` at host lines 3-5, never touching the fence markers.
2. **diag→quickfix round-trip** (`diagnostic_drives_a_quickfix_on_the_python_block`, checklist §1): ruff's `F401` unused-import diagnostic arrives host-translated; fed back as codeAction context, the bridge translates its range host→virtual so ruff **matches it against what it published** and offers the removal quickfix, re-keyed to the host document.

Composes PR 3 (codeAction), PR 4 (resolve), PR 7 (concatenated aggregation), and the diagnostic round-trip — end to end against a real language server.

## Note on `make deps`

The issue suggested adding ruff to `make deps`. `make deps` provisions the **Neovim** test harness (deps/nvim, deps/tree-sitter); real bridge servers (lua-language-server, now ruff) follow the availability-gated system-dependency pattern instead — the test skips cleanly when the binary is absent, so CI without ruff is green (skipped), not red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for organizing imports and quick-fix diagnostics in Markdown files containing Python code fences.
  * Verified that edits are applied in the correct host document coordinates while preserving the surrounding Markdown content.
  * Added handling for environments where the required language server is unavailable, so tests skip gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->