### PR TITLE
feat(bridge): bridge textDocument/codeAction (edit-carrying actions, no resolve)

### DIFF
--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -68,7 +68,7 @@ pub(crate) use protocol::VirtualDocumentUri;
 pub(crate) use protocol::location_link_to_location;
 pub(crate) use protocol::translate_virtual_range_to_host;
 pub(crate) use text_document::host::{HostDocument, HostTextReader, normalize_host_goto_result};
-pub(crate) use text_document::{CodeLensEnvelope, extract_code_lens_envelope};
+pub(crate) use text_document::{CodeLensEnvelope, bridge_code_actions, extract_code_lens_envelope};
 pub(crate) use workspace::WorkspaceFolderSet;
 
 /// Integration tests for the bridge module.

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -69,7 +69,8 @@ pub(crate) use protocol::location_link_to_location;
 pub(crate) use protocol::translate_virtual_range_to_host;
 pub(crate) use text_document::host::{HostDocument, HostTextReader, normalize_host_goto_result};
 pub(crate) use text_document::{
-    CodeLensEnvelope, bridge_code_actions, extract_code_lens_envelope, parse_code_actions_leniently,
+    CodeLensEnvelope, UpstreamCodeActionCaps, bridge_code_actions, extract_code_lens_envelope,
+    parse_code_actions_leniently,
 };
 pub(crate) use workspace::WorkspaceFolderSet;
 

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -68,7 +68,9 @@ pub(crate) use protocol::VirtualDocumentUri;
 pub(crate) use protocol::location_link_to_location;
 pub(crate) use protocol::translate_virtual_range_to_host;
 pub(crate) use text_document::host::{HostDocument, HostTextReader, normalize_host_goto_result};
-pub(crate) use text_document::{CodeLensEnvelope, bridge_code_actions, extract_code_lens_envelope};
+pub(crate) use text_document::{
+    CodeLensEnvelope, bridge_code_actions, extract_code_lens_envelope, parse_code_actions_leniently,
+};
 pub(crate) use workspace::WorkspaceFolderSet;
 
 /// Integration tests for the bridge module.

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -12,8 +12,8 @@ use std::time::Duration;
 
 use tokio::sync::mpsc;
 use tower_lsp_server::ls_types::{
-    ColorProviderCapability, DeclarationCapability, FoldingRangeProviderCapability,
-    HoverProviderCapability, ImplementationProviderCapability,
+    CodeActionProviderCapability, ColorProviderCapability, DeclarationCapability,
+    FoldingRangeProviderCapability, HoverProviderCapability, ImplementationProviderCapability,
     LinkedEditingRangeServerCapabilities, OneOf, RenameOptions, SaveOptions, ServerCapabilities,
     TextDocumentSyncCapability, TextDocumentSyncOptions, TextDocumentSyncSaveOptions,
     TypeDefinitionProviderCapability,
@@ -564,6 +564,13 @@ impl ConnectionHandle {
                     LinkedEditingRangeServerCapabilities::Simple(true)
                         | LinkedEditingRangeServerCapabilities::Options(_)
                         | LinkedEditingRangeServerCapabilities::RegistrationOptions(_)
+                )
+            ),
+            "textDocument/codeAction" => matches!(
+                caps.code_action_provider,
+                Some(
+                    CodeActionProviderCapability::Simple(true)
+                        | CodeActionProviderCapability::Options(_)
                 )
             ),
             "textDocument/codeLens" => caps.code_lens_provider.is_some(),
@@ -1907,6 +1914,12 @@ mod tests {
                 }),
             ),
             (
+                "textDocument/codeAction",
+                Box::new(|c| {
+                    c.code_action_provider = Some(CodeActionProviderCapability::Simple(true));
+                }),
+            ),
+            (
                 "textDocument/completion",
                 Box::new(|c| {
                     c.completion_provider = Some(CompletionOptions::default());
@@ -2134,6 +2147,12 @@ mod tests {
                 }),
             ),
             (
+                "textDocument/codeAction",
+                Box::new(|c| {
+                    c.code_action_provider = Some(CodeActionProviderCapability::Simple(false));
+                }),
+            ),
+            (
                 "textDocument/definition",
                 Box::new(|c| {
                     c.definition_provider = Some(OneOf::Left(false));
@@ -2246,6 +2265,7 @@ mod tests {
             "textDocument/inlayHint",
             "textDocument/documentColor",
             "textDocument/colorPresentation",
+            "textDocument/codeAction",
             "textDocument/codeLens",
             "codeLens/resolve",
             "textDocument/onTypeFormatting",

--- a/src/lsp/bridge/protocol/client_capabilities.rs
+++ b/src/lsp/bridge/protocol/client_capabilities.rs
@@ -17,6 +17,7 @@ fn build_baseline_capabilities(
     experimental: bool,
 ) -> ClientCapabilities {
     use tower_lsp_server::ls_types::{
+        CodeActionClientCapabilities, CodeActionKindLiteralSupport, CodeActionLiteralSupport,
         CompletionClientCapabilities, CompletionItemCapability, DiagnosticClientCapabilities,
         DiagnosticWorkspaceClientCapabilities, DocumentLinkClientCapabilities,
         DocumentSymbolClientCapabilities, DynamicRegistrationClientCapabilities,
@@ -68,6 +69,34 @@ fn build_baseline_capabilities(
         }),
         inlay_hint: Some(InlayHintClientCapabilities {
             dynamic_registration: Some(false),
+            ..Default::default()
+        }),
+        // Without codeActionLiteralSupport, older servers fall back to
+        // returning bare Commands only (issue #568). No dataSupport /
+        // resolveSupport yet: servers must return complete (edit-carrying)
+        // actions until codeAction/resolve is bridged.
+        code_action: Some(CodeActionClientCapabilities {
+            dynamic_registration: Some(false),
+            code_action_literal_support: Some(CodeActionLiteralSupport {
+                code_action_kind: CodeActionKindLiteralSupport {
+                    value_set: [
+                        "",
+                        "quickfix",
+                        "refactor",
+                        "refactor.extract",
+                        "refactor.inline",
+                        "refactor.rewrite",
+                        "source",
+                        "source.organizeImports",
+                        "source.fixAll",
+                    ]
+                    .into_iter()
+                    .map(String::from)
+                    .collect(),
+                },
+            }),
+            is_preferred_support: Some(true),
+            disabled_support: Some(true),
             ..Default::default()
         }),
         diagnostic: Some(DiagnosticClientCapabilities {

--- a/src/lsp/bridge/protocol/client_capabilities.rs
+++ b/src/lsp/bridge/protocol/client_capabilities.rs
@@ -80,7 +80,6 @@ fn build_baseline_capabilities(
             code_action_literal_support: Some(CodeActionLiteralSupport {
                 code_action_kind: CodeActionKindLiteralSupport {
                     value_set: [
-                        "",
                         "quickfix",
                         "refactor",
                         "refactor.extract",

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@default.snap
@@ -96,6 +96,26 @@ expression: merged
       "dynamicRegistration": false,
       "linkSupport": true
     },
+    "codeAction": {
+      "dynamicRegistration": false,
+      "codeActionLiteralSupport": {
+        "codeActionKind": {
+          "valueSet": [
+            "",
+            "quickfix",
+            "refactor",
+            "refactor.extract",
+            "refactor.inline",
+            "refactor.rewrite",
+            "source",
+            "source.organizeImports",
+            "source.fixAll"
+          ]
+        }
+      },
+      "isPreferredSupport": true,
+      "disabledSupport": true
+    },
     "documentLink": {
       "dynamicRegistration": false,
       "tooltipSupport": true

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@default.snap
@@ -101,7 +101,6 @@ expression: merged
       "codeActionLiteralSupport": {
         "codeActionKind": {
           "valueSet": [
-            "",
             "quickfix",
             "refactor",
             "refactor.extract",

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@experimental.snap
@@ -96,6 +96,26 @@ expression: merged
       "dynamicRegistration": false,
       "linkSupport": true
     },
+    "codeAction": {
+      "dynamicRegistration": false,
+      "codeActionLiteralSupport": {
+        "codeActionKind": {
+          "valueSet": [
+            "",
+            "quickfix",
+            "refactor",
+            "refactor.extract",
+            "refactor.inline",
+            "refactor.rewrite",
+            "source",
+            "source.organizeImports",
+            "source.fixAll"
+          ]
+        }
+      },
+      "isPreferredSupport": true,
+      "disabledSupport": true
+    },
     "documentLink": {
       "dynamicRegistration": false,
       "tooltipSupport": true

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@experimental.snap
@@ -101,7 +101,6 @@ expression: merged
       "codeActionLiteralSupport": {
         "codeActionKind": {
           "valueSet": [
-            "",
             "quickfix",
             "refactor",
             "refactor.extract",

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@default.snap
@@ -54,7 +54,6 @@ expression: capabilities
       "codeActionLiteralSupport": {
         "codeActionKind": {
           "valueSet": [
-            "",
             "quickfix",
             "refactor",
             "refactor.extract",

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@default.snap
@@ -49,6 +49,26 @@ expression: capabilities
       "dynamicRegistration": false,
       "linkSupport": true
     },
+    "codeAction": {
+      "dynamicRegistration": false,
+      "codeActionLiteralSupport": {
+        "codeActionKind": {
+          "valueSet": [
+            "",
+            "quickfix",
+            "refactor",
+            "refactor.extract",
+            "refactor.inline",
+            "refactor.rewrite",
+            "source",
+            "source.organizeImports",
+            "source.fixAll"
+          ]
+        }
+      },
+      "isPreferredSupport": true,
+      "disabledSupport": true
+    },
     "documentLink": {
       "dynamicRegistration": false,
       "tooltipSupport": true

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@experimental.snap
@@ -54,7 +54,6 @@ expression: capabilities
       "codeActionLiteralSupport": {
         "codeActionKind": {
           "valueSet": [
-            "",
             "quickfix",
             "refactor",
             "refactor.extract",

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@experimental.snap
@@ -49,6 +49,26 @@ expression: capabilities
       "dynamicRegistration": false,
       "linkSupport": true
     },
+    "codeAction": {
+      "dynamicRegistration": false,
+      "codeActionLiteralSupport": {
+        "codeActionKind": {
+          "valueSet": [
+            "",
+            "quickfix",
+            "refactor",
+            "refactor.extract",
+            "refactor.inline",
+            "refactor.rewrite",
+            "source",
+            "source.organizeImports",
+            "source.fixAll"
+          ]
+        }
+      },
+      "isPreferredSupport": true,
+      "disabledSupport": true
+    },
     "documentLink": {
       "dynamicRegistration": false,
       "tooltipSupport": true

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@default.snap
@@ -61,7 +61,6 @@ expression: request
           "codeActionLiteralSupport": {
             "codeActionKind": {
               "valueSet": [
-                "",
                 "quickfix",
                 "refactor",
                 "refactor.extract",

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@default.snap
@@ -56,6 +56,26 @@ expression: request
           "dynamicRegistration": false,
           "linkSupport": true
         },
+        "codeAction": {
+          "dynamicRegistration": false,
+          "codeActionLiteralSupport": {
+            "codeActionKind": {
+              "valueSet": [
+                "",
+                "quickfix",
+                "refactor",
+                "refactor.extract",
+                "refactor.inline",
+                "refactor.rewrite",
+                "source",
+                "source.organizeImports",
+                "source.fixAll"
+              ]
+            }
+          },
+          "isPreferredSupport": true,
+          "disabledSupport": true
+        },
         "documentLink": {
           "dynamicRegistration": false,
           "tooltipSupport": true

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@experimental.snap
@@ -61,7 +61,6 @@ expression: request
           "codeActionLiteralSupport": {
             "codeActionKind": {
               "valueSet": [
-                "",
                 "quickfix",
                 "refactor",
                 "refactor.extract",

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@experimental.snap
@@ -56,6 +56,26 @@ expression: request
           "dynamicRegistration": false,
           "linkSupport": true
         },
+        "codeAction": {
+          "dynamicRegistration": false,
+          "codeActionLiteralSupport": {
+            "codeActionKind": {
+              "valueSet": [
+                "",
+                "quickfix",
+                "refactor",
+                "refactor.extract",
+                "refactor.inline",
+                "refactor.rewrite",
+                "source",
+                "source.organizeImports",
+                "source.fixAll"
+              ]
+            }
+          },
+          "isPreferredSupport": true,
+          "disabledSupport": true
+        },
         "documentLink": {
           "dynamicRegistration": false,
           "tooltipSupport": true

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@default.snap
@@ -72,7 +72,6 @@ expression: request
           "codeActionLiteralSupport": {
             "codeActionKind": {
               "valueSet": [
-                "",
                 "quickfix",
                 "refactor",
                 "refactor.extract",

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@default.snap
@@ -67,6 +67,26 @@ expression: request
           "dynamicRegistration": false,
           "linkSupport": true
         },
+        "codeAction": {
+          "dynamicRegistration": false,
+          "codeActionLiteralSupport": {
+            "codeActionKind": {
+              "valueSet": [
+                "",
+                "quickfix",
+                "refactor",
+                "refactor.extract",
+                "refactor.inline",
+                "refactor.rewrite",
+                "source",
+                "source.organizeImports",
+                "source.fixAll"
+              ]
+            }
+          },
+          "isPreferredSupport": true,
+          "disabledSupport": true
+        },
         "documentLink": {
           "dynamicRegistration": false,
           "tooltipSupport": true

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@experimental.snap
@@ -72,7 +72,6 @@ expression: request
           "codeActionLiteralSupport": {
             "codeActionKind": {
               "valueSet": [
-                "",
                 "quickfix",
                 "refactor",
                 "refactor.extract",

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@experimental.snap
@@ -67,6 +67,26 @@ expression: request
           "dynamicRegistration": false,
           "linkSupport": true
         },
+        "codeAction": {
+          "dynamicRegistration": false,
+          "codeActionLiteralSupport": {
+            "codeActionKind": {
+              "valueSet": [
+                "",
+                "quickfix",
+                "refactor",
+                "refactor.extract",
+                "refactor.inline",
+                "refactor.rewrite",
+                "source",
+                "source.organizeImports",
+                "source.fixAll"
+              ]
+            }
+          },
+          "isPreferredSupport": true,
+          "disabledSupport": true
+        },
         "documentLink": {
           "dynamicRegistration": false,
           "tooltipSupport": true

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@default.snap
@@ -61,7 +61,6 @@ expression: request
           "codeActionLiteralSupport": {
             "codeActionKind": {
               "valueSet": [
-                "",
                 "quickfix",
                 "refactor",
                 "refactor.extract",

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@default.snap
@@ -56,6 +56,26 @@ expression: request
           "dynamicRegistration": false,
           "linkSupport": true
         },
+        "codeAction": {
+          "dynamicRegistration": false,
+          "codeActionLiteralSupport": {
+            "codeActionKind": {
+              "valueSet": [
+                "",
+                "quickfix",
+                "refactor",
+                "refactor.extract",
+                "refactor.inline",
+                "refactor.rewrite",
+                "source",
+                "source.organizeImports",
+                "source.fixAll"
+              ]
+            }
+          },
+          "isPreferredSupport": true,
+          "disabledSupport": true
+        },
         "documentLink": {
           "dynamicRegistration": false,
           "tooltipSupport": true

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@experimental.snap
@@ -61,7 +61,6 @@ expression: request
           "codeActionLiteralSupport": {
             "codeActionKind": {
               "valueSet": [
-                "",
                 "quickfix",
                 "refactor",
                 "refactor.extract",

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@experimental.snap
@@ -56,6 +56,26 @@ expression: request
           "dynamicRegistration": false,
           "linkSupport": true
         },
+        "codeAction": {
+          "dynamicRegistration": false,
+          "codeActionLiteralSupport": {
+            "codeActionKind": {
+              "valueSet": [
+                "",
+                "quickfix",
+                "refactor",
+                "refactor.extract",
+                "refactor.inline",
+                "refactor.rewrite",
+                "source",
+                "source.organizeImports",
+                "source.fixAll"
+              ]
+            }
+          },
+          "isPreferredSupport": true,
+          "disabledSupport": true
+        },
         "documentLink": {
           "dynamicRegistration": false,
           "tooltipSupport": true

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@default.snap
@@ -65,6 +65,26 @@ expression: request
           "dynamicRegistration": false,
           "linkSupport": true
         },
+        "codeAction": {
+          "dynamicRegistration": false,
+          "codeActionLiteralSupport": {
+            "codeActionKind": {
+              "valueSet": [
+                "",
+                "quickfix",
+                "refactor",
+                "refactor.extract",
+                "refactor.inline",
+                "refactor.rewrite",
+                "source",
+                "source.organizeImports",
+                "source.fixAll"
+              ]
+            }
+          },
+          "isPreferredSupport": true,
+          "disabledSupport": true
+        },
         "documentLink": {
           "dynamicRegistration": false,
           "tooltipSupport": true

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@default.snap
@@ -70,7 +70,6 @@ expression: request
           "codeActionLiteralSupport": {
             "codeActionKind": {
               "valueSet": [
-                "",
                 "quickfix",
                 "refactor",
                 "refactor.extract",

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@experimental.snap
@@ -65,6 +65,26 @@ expression: request
           "dynamicRegistration": false,
           "linkSupport": true
         },
+        "codeAction": {
+          "dynamicRegistration": false,
+          "codeActionLiteralSupport": {
+            "codeActionKind": {
+              "valueSet": [
+                "",
+                "quickfix",
+                "refactor",
+                "refactor.extract",
+                "refactor.inline",
+                "refactor.rewrite",
+                "source",
+                "source.organizeImports",
+                "source.fixAll"
+              ]
+            }
+          },
+          "isPreferredSupport": true,
+          "disabledSupport": true
+        },
         "documentLink": {
           "dynamicRegistration": false,
           "tooltipSupport": true

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@experimental.snap
@@ -70,7 +70,6 @@ expression: request
           "codeActionLiteralSupport": {
             "codeActionKind": {
               "valueSet": [
-                "",
                 "quickfix",
                 "refactor",
                 "refactor.extract",

--- a/src/lsp/bridge/text_document.rs
+++ b/src/lsp/bridge/text_document.rs
@@ -9,7 +9,7 @@ mod code_action;
 mod code_lens;
 mod color_presentation;
 
-pub(crate) use code_action::bridge_code_actions;
+pub(crate) use code_action::{bridge_code_actions, parse_code_actions_leniently};
 pub(crate) use code_lens::{CodeLensEnvelope, extract_code_lens_envelope};
 mod completion;
 mod completion_item;

--- a/src/lsp/bridge/text_document.rs
+++ b/src/lsp/bridge/text_document.rs
@@ -5,9 +5,11 @@
 //!
 //! The structure mirrors `lsp_impl/text_document/` for consistency.
 
+mod code_action;
 mod code_lens;
 mod color_presentation;
 
+pub(crate) use code_action::bridge_code_actions;
 pub(crate) use code_lens::{CodeLensEnvelope, extract_code_lens_envelope};
 mod completion;
 mod completion_item;

--- a/src/lsp/bridge/text_document.rs
+++ b/src/lsp/bridge/text_document.rs
@@ -9,7 +9,9 @@ mod code_action;
 mod code_lens;
 mod color_presentation;
 
-pub(crate) use code_action::{bridge_code_actions, parse_code_actions_leniently};
+pub(crate) use code_action::{
+    UpstreamCodeActionCaps, bridge_code_actions, parse_code_actions_leniently,
+};
 pub(crate) use code_lens::{CodeLensEnvelope, extract_code_lens_envelope};
 mod completion;
 mod completion_item;

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -3,7 +3,7 @@
 //! Edit-carrying actions only: `codeAction/resolve` and `Command` execution
 //! are not bridged yet. Actions that would need them surface as
 //! `disabled: { reason }` when the upstream client supports it and are
-//! dropped otherwise (LSP 3.18 `disabledSupport`).
+//! dropped otherwise (LSP 3.16 `disabledSupport`).
 //!
 //! Every bridged action title gets the `"{title} — {server}"` suffix so
 //! users can see which downstream server each action comes from.
@@ -139,10 +139,7 @@ fn transform_code_action_response_to_host(
         return None;
     }
     let result = response.get_mut("result").map(serde_json::Value::take)?;
-    if result.is_null() {
-        return None;
-    }
-    let actions: CodeActionResponse = serde_json::from_value(result).ok()?;
+    let actions = parse_code_actions_leniently(result)?;
 
     Some(bridge_code_actions(
         actions,
@@ -156,12 +153,39 @@ fn transform_code_action_response_to_host(
     ))
 }
 
+/// Parse a code action result value item by item: one malformed action must
+/// not nuke the whole server response (a whole-`Vec` parse would return
+/// `None` with zero valid actions and no log).
+pub(crate) fn parse_code_actions_leniently(
+    result: serde_json::Value,
+) -> Option<CodeActionResponse> {
+    if result.is_null() {
+        return None;
+    }
+    let Ok(items) = serde_json::from_value::<Vec<serde_json::Value>>(result) else {
+        log::warn!("textDocument/codeAction: response result is not an array");
+        return None;
+    };
+    Some(
+        items
+            .into_iter()
+            .filter_map(|item| match serde_json::from_value(item) {
+                Ok(action) => Some(action),
+                Err(error) => {
+                    log::warn!("textDocument/codeAction: skipping malformed action: {error}");
+                    None
+                }
+            })
+            .collect(),
+    )
+}
+
 /// Virtual-layer coordinate context for [`bridge_code_actions`]; `None`
 /// means the host layer (real URIs and coordinates, nothing to translate).
 pub(crate) struct VirtLayerContext<'a> {
-    pub(crate) request_virtual_uri: &'a str,
-    pub(crate) host_uri: &'a Uri,
-    pub(crate) offset: &'a RegionOffset,
+    request_virtual_uri: &'a str,
+    host_uri: &'a Uri,
+    offset: &'a RegionOffset,
 }
 
 /// Apply the bridge policy to a downstream server's actions: title suffix,
@@ -262,6 +286,10 @@ fn bridge_code_action(
         }
     }
 
+    // The bridge can't answer codeAction/resolve yet, and untranslated
+    // `data` can embed virtual URIs/coordinates — strip it on the kept path
+    // too (PR 4's envelope replaces this).
+    action.data = None;
     action.title = suffix_title(action.title, server_name);
     Some(CodeActionOrCommand::CodeAction(action))
 }
@@ -287,9 +315,14 @@ fn disable_action(
     action.edit = None;
     action.command = None;
     action.data = None;
-    action.disabled = Some(CodeActionDisabled {
-        reason: reason.to_string(),
-    });
+    // A disabled action must not steer the client's auto-fix keybinding.
+    action.is_preferred = None;
+    // Keep the server's own reason when it already disabled the action.
+    if action.disabled.is_none() {
+        action.disabled = Some(CodeActionDisabled {
+            reason: reason.to_string(),
+        });
+    }
     Some(CodeActionOrCommand::CodeAction(action))
 }
 
@@ -479,6 +512,25 @@ mod tests {
     }
 
     #[test]
+    fn malformed_action_is_skipped_not_fatal() {
+        // One malformed item (no title) must not nuke the whole server
+        // response — the valid action survives.
+        let actions = transform(
+            json!([
+                { "kind": "quickfix" },
+                edit_carrying_action("Remove unused import")
+            ]),
+            true,
+        )
+        .unwrap();
+        assert_eq!(actions.len(), 1, "valid action must survive: {actions:?}");
+        let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
+            panic!("Expected CodeAction");
+        };
+        assert_eq!(action.title, "Remove unused import — ruff");
+    }
+
+    #[test]
     fn edit_carrying_action_is_translated_and_suffixed() {
         let actions =
             transform(json!([edit_carrying_action("Remove unused import")]), true).unwrap();
@@ -569,6 +621,47 @@ mod tests {
         };
         assert_eq!(action.disabled.as_ref().unwrap().reason, REASON_RESOLVE);
         assert!(action.data.is_none());
+    }
+
+    #[test]
+    fn kept_action_strips_untranslated_data() {
+        let mut action = edit_carrying_action("Fix");
+        action["data"] = json!({ "virtualUri": make_virtual_uri_string() });
+        let actions = transform(json!([action]), true).unwrap();
+        let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
+            panic!("Expected CodeAction");
+        };
+        assert!(action.edit.is_some(), "edit must survive");
+        assert!(
+            action.data.is_none(),
+            "untranslated data must not leak until the PR 4 envelope exists"
+        );
+    }
+
+    #[test]
+    fn server_disabled_command_action_keeps_server_reason() {
+        let actions = transform(
+            json!([{
+                "title": "Not here",
+                "command": { "title": "x", "command": "mock.x" },
+                "disabled": { "reason": "wrong scope" },
+                "isPreferred": true
+            }]),
+            true,
+        )
+        .unwrap();
+        let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
+            panic!("Expected CodeAction");
+        };
+        assert_eq!(
+            action.disabled.as_ref().unwrap().reason,
+            "wrong scope",
+            "the server's own disabled reason must not be overwritten"
+        );
+        assert_eq!(
+            action.is_preferred, None,
+            "a disabled action must not steer auto-fix"
+        );
     }
 
     #[test]

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -123,12 +123,14 @@ fn build_code_action_request(
     // Out-of-region diagnostics would translate to virtual coordinates that
     // don't exist: above-region ones saturate to (0,0) and can false-match a
     // different diagnostic at the top of the virtual document; ones past the
-    // region land beyond the virtual document. Bound by the region's own
-    // [start, end) extent — NOT the (possibly zero-length, cursor) request
-    // range, which would wrongly drop a diagnostic sitting at the cursor.
+    // region land beyond the virtual document. Keep only diagnostics whose
+    // WHOLE range fits the region's `[start, end)` extent (`region_end` is
+    // exclusive, so a diagnostic ending exactly at it is in) — bounding by
+    // the region, NOT the (possibly zero-length, cursor) request range, which
+    // would wrongly drop a diagnostic sitting at the cursor.
     context.diagnostics.retain(|diagnostic| {
         host_position_within_region(diagnostic.range.start, offset)
-            && diagnostic.range.start < region_end
+            && diagnostic.range.end <= region_end
     });
     for diagnostic in &mut context.diagnostics {
         translate_host_range_to_virtual(&mut diagnostic.range, offset);
@@ -464,6 +466,52 @@ mod tests {
             "source.organizeImports"
         );
         assert_eq!(json["params"]["context"]["triggerKind"], 1);
+    }
+
+    #[test]
+    fn code_action_request_drops_diagnostic_straddling_region_end() {
+        // A diagnostic that starts in-region but ends past the region end
+        // would translate to a virtual end beyond the virtual document — the
+        // whole range must fit the region, so it's dropped.
+        let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
+        let straddling = Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 5,
+                    character: 0,
+                },
+                end: Position {
+                    line: 14,
+                    character: 0,
+                },
+            },
+            ..Diagnostic::default()
+        };
+        let context = CodeActionContext {
+            diagnostics: vec![straddling],
+            ..CodeActionContext::default()
+        };
+        let request = build_code_action_request(
+            &virtual_uri,
+            range(5, 5),
+            context,
+            &RegionOffset::new(3, 0),
+            Position {
+                line: 13,
+                character: 0,
+            },
+            RequestId::new(1),
+            None,
+        );
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert!(
+            json["params"]["context"]["diagnostics"]
+                .as_array()
+                .unwrap()
+                .is_empty(),
+            "a diagnostic ending past the region end must be dropped"
+        );
     }
 
     #[test]

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -228,8 +228,13 @@ fn bridge_code_action(
     };
 
     // A server-side disabled action is only representable with disabledSupport.
-    if action.disabled.is_some() && !client_supports_disabled {
-        return None;
+    if action.disabled.is_some() {
+        if !client_supports_disabled {
+            return None;
+        }
+        // A disabled action must not steer the client's auto-fix keybinding,
+        // whatever path surfaces it.
+        action.is_preferred = None;
     }
 
     // The action's own diagnostics came back in virtual coordinates.

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -1,0 +1,627 @@
+//! Code action request handling for bridge connections (#568, stage "PR 3").
+//!
+//! Edit-carrying actions only: `codeAction/resolve` and `Command` execution
+//! are not bridged yet. Actions that would need them surface as
+//! `disabled: { reason }` when the upstream client supports it and are
+//! dropped otherwise (LSP 3.18 `disabledSupport`).
+//!
+//! Every bridged action title gets the `"{title} — {server}"` suffix so
+//! users can see which downstream server each action comes from.
+
+use std::io;
+
+use crate::config::settings::BridgeServerConfig;
+use tower_lsp_server::ls_types::{
+    CodeAction, CodeActionContext, CodeActionDisabled, CodeActionOrCommand, CodeActionParams,
+    CodeActionResponse, NumberOrString, PartialResultParams, Range, TextDocumentIdentifier, Uri,
+    WorkDoneProgressParams,
+};
+use url::Url;
+
+use super::super::pool::{LanguageServerPool, UpstreamId};
+use super::super::protocol::{
+    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, response_has_jsonrpc_error,
+    transform_workspace_edit_to_host, translate_host_range_to_virtual,
+    translate_virtual_range_to_host, virtual_uri_to_lsp_uri,
+};
+
+impl LanguageServerPool {
+    /// Send a code action request and wait for the response.
+    ///
+    /// The request's range and `context.diagnostics` ranges are translated
+    /// host→virtual (diagnostic `data`/`source`/`code` stay byte-identical so
+    /// the downstream can match them against what it published); the
+    /// response's edits and action diagnostics are translated back.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn send_code_action_request(
+        &self,
+        server_name: &str,
+        server_config: &BridgeServerConfig,
+        host_uri: &Url,
+        host_range: Range,
+        context: CodeActionContext,
+        injection_language: &str,
+        region_id: &str,
+        offset: RegionOffset,
+        virtual_content: &str,
+        upstream_request_id: Option<UpstreamId>,
+        client_progress_token: Option<NumberOrString>,
+        client_supports_disabled: bool,
+    ) -> io::Result<Option<CodeActionResponse>> {
+        let handle = self
+            .get_or_create_connection(server_name, server_config, Some(host_uri))
+            .await?;
+        if !handle.has_capability("textDocument/codeAction") {
+            return Ok(None);
+        }
+        self.execute_bridge_request_with_handle(
+            handle,
+            host_uri,
+            injection_language,
+            region_id,
+            &offset,
+            virtual_content,
+            upstream_request_id,
+            |virtual_uri, request_id| {
+                build_code_action_request(
+                    virtual_uri,
+                    host_range,
+                    context,
+                    &offset,
+                    request_id,
+                    client_progress_token,
+                )
+            },
+            |response, ctx| {
+                transform_code_action_response_to_host(
+                    response,
+                    &ctx.virtual_uri_string,
+                    ctx.host_uri_lsp,
+                    ctx.offset,
+                    server_name,
+                    client_supports_disabled,
+                )
+            },
+        )
+        .await
+    }
+}
+
+/// Build a JSON-RPC code action request for a downstream language server.
+///
+/// Translates the range AND every `context.diagnostics` range host→virtual;
+/// `only` and `triggerKind` pass through untouched (dropping `only` would
+/// kill save-time flows like `editor.codeActionsOnSave`).
+fn build_code_action_request(
+    virtual_uri: &VirtualDocumentUri,
+    host_range: Range,
+    mut context: CodeActionContext,
+    offset: &RegionOffset,
+    request_id: RequestId,
+    client_progress_token: Option<NumberOrString>,
+) -> JsonRpcRequest<CodeActionParams> {
+    let mut virtual_range = host_range;
+    translate_host_range_to_virtual(&mut virtual_range, offset);
+    for diagnostic in &mut context.diagnostics {
+        translate_host_range_to_virtual(&mut diagnostic.range, offset);
+    }
+
+    let params = CodeActionParams {
+        text_document: TextDocumentIdentifier {
+            uri: virtual_uri_to_lsp_uri(virtual_uri),
+        },
+        range: virtual_range,
+        context,
+        work_done_progress_params: WorkDoneProgressParams {
+            work_done_token: client_progress_token,
+        },
+        partial_result_params: PartialResultParams::default(),
+    };
+    JsonRpcRequest::new(request_id.as_i64(), "textDocument/codeAction", params)
+}
+
+/// Transform a code action response from virtual to host coordinates.
+fn transform_code_action_response_to_host(
+    mut response: serde_json::Value,
+    request_virtual_uri: &str,
+    host_uri: &Uri,
+    offset: &RegionOffset,
+    server_name: &str,
+    client_supports_disabled: bool,
+) -> Option<CodeActionResponse> {
+    if response_has_jsonrpc_error(&response, "textDocument/codeAction") {
+        return None;
+    }
+    let result = response.get_mut("result").map(serde_json::Value::take)?;
+    if result.is_null() {
+        return None;
+    }
+    let actions: CodeActionResponse = serde_json::from_value(result).ok()?;
+
+    Some(bridge_code_actions(
+        actions,
+        server_name,
+        client_supports_disabled,
+        Some(&VirtLayerContext {
+            request_virtual_uri,
+            host_uri,
+            offset,
+        }),
+    ))
+}
+
+/// Virtual-layer coordinate context for [`bridge_code_actions`]; `None`
+/// means the host layer (real URIs and coordinates, nothing to translate).
+pub(crate) struct VirtLayerContext<'a> {
+    pub(crate) request_virtual_uri: &'a str,
+    pub(crate) host_uri: &'a Uri,
+    pub(crate) offset: &'a RegionOffset,
+}
+
+/// Apply the bridge policy to a downstream server's actions: title suffix,
+/// command/lazy-action disabling, and (virt layer) coordinate translation.
+pub(crate) fn bridge_code_actions(
+    actions: Vec<CodeActionOrCommand>,
+    server_name: &str,
+    client_supports_disabled: bool,
+    virt: Option<&VirtLayerContext<'_>>,
+) -> Vec<CodeActionOrCommand> {
+    actions
+        .into_iter()
+        .filter_map(|item| bridge_code_action(item, server_name, client_supports_disabled, virt))
+        .collect()
+}
+
+const REASON_COMMANDS: &str = "kakehashi does not bridge command execution yet";
+const REASON_RESOLVE: &str = "kakehashi does not bridge codeAction/resolve yet";
+const REASON_CROSS_REGION: &str = "the edit cannot be represented in the host document";
+
+fn bridge_code_action(
+    item: CodeActionOrCommand,
+    server_name: &str,
+    client_supports_disabled: bool,
+    virt: Option<&VirtLayerContext<'_>>,
+) -> Option<CodeActionOrCommand> {
+    let mut action = match item {
+        // A bare Command cannot carry `disabled`; represent it as a disabled
+        // CodeAction so the user still sees it exists (checklist: never
+        // silently drop when the client can render why).
+        CodeActionOrCommand::Command(command) => {
+            return disabled_placeholder(
+                command.title,
+                REASON_COMMANDS,
+                server_name,
+                client_supports_disabled,
+            );
+        }
+        CodeActionOrCommand::CodeAction(action) => action,
+    };
+
+    // A server-side disabled action is only representable with disabledSupport.
+    if action.disabled.is_some() && !client_supports_disabled {
+        return None;
+    }
+
+    // The action's own diagnostics came back in virtual coordinates.
+    if let Some(virt) = virt
+        && let Some(diagnostics) = &mut action.diagnostics
+    {
+        for diagnostic in diagnostics {
+            translate_virtual_range_to_host(&mut diagnostic.range, virt.offset);
+        }
+    }
+
+    // Commands are not executable until executeCommand is bridged; applying
+    // only the edit half of an edit+command action would be worse than
+    // disabling the whole action.
+    if action.command.is_some() {
+        return disable_action(
+            action,
+            REASON_COMMANDS,
+            server_name,
+            client_supports_disabled,
+        );
+    }
+
+    match &mut action.edit {
+        Some(edit) => {
+            if let Some(virt) = virt
+                && !transform_workspace_edit_to_host(
+                    edit,
+                    virt.request_virtual_uri,
+                    virt.host_uri,
+                    virt.offset,
+                )
+            {
+                return disable_action(
+                    action,
+                    REASON_CROSS_REGION,
+                    server_name,
+                    client_supports_disabled,
+                );
+            }
+        }
+        None => {
+            // No edit, no command: a lazy action that needs codeAction/resolve
+            // (its payload hides behind `data`). We don't advertise resolve
+            // yet, so it can never be completed.
+            if action.data.is_some() {
+                return disable_action(
+                    action,
+                    REASON_RESOLVE,
+                    server_name,
+                    client_supports_disabled,
+                );
+            }
+        }
+    }
+
+    action.title = suffix_title(action.title, server_name);
+    Some(CodeActionOrCommand::CodeAction(action))
+}
+
+/// `"{title} — {server}"`: applied to every bridged action, unconditionally.
+fn suffix_title(title: String, server_name: &str) -> String {
+    format!("{title} — {server_name}")
+}
+
+/// Turn an action the bridge cannot execute into a `disabled` entry: the
+/// unusable payload (edit/command/data) is stripped so a client that applies
+/// it anyway cannot act on untranslated coordinates.
+fn disable_action(
+    mut action: CodeAction,
+    reason: &str,
+    server_name: &str,
+    client_supports_disabled: bool,
+) -> Option<CodeActionOrCommand> {
+    if !client_supports_disabled {
+        return None;
+    }
+    action.title = suffix_title(action.title, server_name);
+    action.edit = None;
+    action.command = None;
+    action.data = None;
+    action.disabled = Some(CodeActionDisabled {
+        reason: reason.to_string(),
+    });
+    Some(CodeActionOrCommand::CodeAction(action))
+}
+
+fn disabled_placeholder(
+    title: String,
+    reason: &str,
+    server_name: &str,
+    client_supports_disabled: bool,
+) -> Option<CodeActionOrCommand> {
+    if !client_supports_disabled {
+        return None;
+    }
+    Some(CodeActionOrCommand::CodeAction(CodeAction {
+        title: suffix_title(title, server_name),
+        disabled: Some(CodeActionDisabled {
+            reason: reason.to_string(),
+        }),
+        ..CodeAction::default()
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_helpers::*;
+    use super::*;
+    use serde_json::json;
+    use tower_lsp_server::ls_types::{CodeActionKind, CodeActionTriggerKind, Diagnostic, Position};
+
+    fn make_host_uri() -> Uri {
+        crate::lsp::lsp_impl::url_to_uri(&Url::parse("file:///test.md").unwrap()).unwrap()
+    }
+
+    fn make_virtual_uri_string() -> String {
+        VirtualDocumentUri::new(&make_host_uri(), "lua", "region-0").to_uri_string()
+    }
+
+    fn range(start_line: u32, end_line: u32) -> Range {
+        Range {
+            start: Position {
+                line: start_line,
+                character: 0,
+            },
+            end: Position {
+                line: end_line,
+                character: 5,
+            },
+        }
+    }
+
+    fn diagnostic_at(line: u32) -> Diagnostic {
+        Diagnostic {
+            range: range(line, line),
+            message: "unused import".to_string(),
+            code: Some(tower_lsp_server::ls_types::NumberOrString::String(
+                "F401".to_string(),
+            )),
+            data: Some(json!({"fix": "remove"})),
+            ..Diagnostic::default()
+        }
+    }
+
+    // ==========================================================================
+    // Request builder
+    // ==========================================================================
+
+    #[test]
+    fn code_action_request_translates_range_and_diagnostics() {
+        // Host line 5, region starts at line 3 → virtual line 2.
+        let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
+        let context = CodeActionContext {
+            diagnostics: vec![diagnostic_at(5)],
+            only: Some(vec![CodeActionKind::SOURCE_ORGANIZE_IMPORTS]),
+            trigger_kind: Some(CodeActionTriggerKind::INVOKED),
+        };
+        let request = build_code_action_request(
+            &virtual_uri,
+            range(5, 5),
+            context,
+            &RegionOffset::new(3, 0),
+            RequestId::new(1),
+            None,
+        );
+
+        assert_uses_virtual_uri(&request, "lua");
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["params"]["range"]["start"]["line"], 2);
+        let diag = &json["params"]["context"]["diagnostics"][0];
+        assert_eq!(diag["range"]["start"]["line"], 2);
+        // Identity fields must survive byte-identical for downstream matching.
+        assert_eq!(diag["code"], "F401");
+        assert_eq!(diag["data"], json!({"fix": "remove"}));
+        // `only` + `triggerKind` pass through.
+        assert_eq!(
+            json["params"]["context"]["only"][0],
+            "source.organizeImports"
+        );
+        assert_eq!(json["params"]["context"]["triggerKind"], 1);
+    }
+
+    #[test]
+    fn code_action_request_carries_work_done_token() {
+        let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
+        let request = build_code_action_request(
+            &virtual_uri,
+            range(5, 5),
+            CodeActionContext::default(),
+            &RegionOffset::new(3, 0),
+            test_request_id(),
+            Some(NumberOrString::String("wd-1".to_string())),
+        );
+        assert_eq!(
+            serde_json::to_value(&request).unwrap()["params"]["workDoneToken"],
+            "wd-1"
+        );
+    }
+
+    // ==========================================================================
+    // Response transform
+    // ==========================================================================
+
+    fn transform(
+        result: serde_json::Value,
+        client_supports_disabled: bool,
+    ) -> Option<CodeActionResponse> {
+        let virtual_uri = make_virtual_uri_string();
+        let host_uri = make_host_uri();
+        transform_code_action_response_to_host(
+            json!({"jsonrpc": "2.0", "id": 42, "result": result}),
+            &virtual_uri,
+            &host_uri,
+            &RegionOffset::new(10, 0),
+            "ruff",
+            client_supports_disabled,
+        )
+    }
+
+    fn edit_carrying_action(title: &str) -> serde_json::Value {
+        json!({
+            "title": title,
+            "kind": "quickfix",
+            "edit": {
+                "changes": {
+                    make_virtual_uri_string(): [{
+                        "range": {
+                            "start": { "line": 0, "character": 0 },
+                            "end": { "line": 0, "character": 5 }
+                        },
+                        "newText": "fixed"
+                    }]
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn null_result_returns_none() {
+        assert!(transform(serde_json::Value::Null, true).is_none());
+    }
+
+    #[test]
+    fn edit_carrying_action_is_translated_and_suffixed() {
+        let actions =
+            transform(json!([edit_carrying_action("Remove unused import")]), true).unwrap();
+
+        assert_eq!(actions.len(), 1);
+        let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
+            panic!("Expected CodeAction");
+        };
+        assert_eq!(action.title, "Remove unused import — ruff");
+        assert!(action.disabled.is_none());
+        let changes = action.edit.as_ref().unwrap().changes.as_ref().unwrap();
+        let edits = changes
+            .get(&make_host_uri())
+            .expect("edit must be re-keyed to the host URI");
+        assert_eq!(edits[0].range.start.line, 10, "0 + region offset 10");
+    }
+
+    #[test]
+    fn action_diagnostics_are_translated_back_to_host() {
+        let mut action = edit_carrying_action("Fix");
+        action["diagnostics"] = json!([{
+            "range": {
+                "start": { "line": 2, "character": 0 },
+                "end": { "line": 2, "character": 5 }
+            },
+            "message": "unused"
+        }]);
+        let actions = transform(json!([action]), true).unwrap();
+        let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
+            panic!("Expected CodeAction");
+        };
+        assert_eq!(
+            action.diagnostics.as_ref().unwrap()[0].range.start.line,
+            12,
+            "2 + region offset 10"
+        );
+    }
+
+    #[test]
+    fn bare_command_becomes_disabled_placeholder() {
+        let actions = transform(
+            json!([{ "title": "Run organize imports", "command": "ruff.organizeImports" }]),
+            true,
+        )
+        .unwrap();
+
+        let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
+            panic!("Expected CodeAction placeholder");
+        };
+        assert_eq!(action.title, "Run organize imports — ruff");
+        assert_eq!(action.disabled.as_ref().unwrap().reason, REASON_COMMANDS);
+        assert!(action.command.is_none() && action.edit.is_none());
+    }
+
+    #[test]
+    fn bare_command_is_dropped_without_disabled_support() {
+        let actions = transform(
+            json!([{ "title": "Run organize imports", "command": "ruff.organizeImports" }]),
+            false,
+        )
+        .unwrap();
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn command_carrying_action_is_disabled_with_payload_stripped() {
+        let mut action = edit_carrying_action("Fix all");
+        action["command"] = json!({ "title": "post", "command": "ruff.postFix" });
+        let actions = transform(json!([action]), true).unwrap();
+
+        let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
+            panic!("Expected CodeAction");
+        };
+        assert_eq!(action.disabled.as_ref().unwrap().reason, REASON_COMMANDS);
+        assert!(
+            action.edit.is_none() && action.command.is_none(),
+            "an edit+command action must not ship a half-appliable payload"
+        );
+        assert_eq!(action.title, "Fix all — ruff");
+    }
+
+    #[test]
+    fn lazy_data_only_action_is_disabled() {
+        let actions =
+            transform(json!([{ "title": "Lazy fix", "data": { "id": 7 } }]), true).unwrap();
+        let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
+            panic!("Expected CodeAction");
+        };
+        assert_eq!(action.disabled.as_ref().unwrap().reason, REASON_RESOLVE);
+        assert!(action.data.is_none());
+    }
+
+    #[test]
+    fn unrepresentable_edit_disables_the_action() {
+        // A file op on the virtual URI makes the edit unrepresentable in host
+        // coordinates (see workspace_edit.rs); the whole action is disabled
+        // and the edit stripped.
+        let action = json!({
+            "title": "Extract to new file",
+            "edit": {
+                "documentChanges": [
+                    { "kind": "create", "uri": make_virtual_uri_string() }
+                ]
+            }
+        });
+        let actions = transform(json!([action]), true).unwrap();
+        let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
+            panic!("Expected CodeAction");
+        };
+        assert_eq!(
+            action.disabled.as_ref().unwrap().reason,
+            REASON_CROSS_REGION
+        );
+        assert!(action.edit.is_none(), "untranslated edit must not leak");
+    }
+
+    #[test]
+    fn unrepresentable_edit_drops_action_without_disabled_support() {
+        let action = json!({
+            "title": "Extract to new file",
+            "edit": {
+                "documentChanges": [
+                    { "kind": "create", "uri": make_virtual_uri_string() }
+                ]
+            }
+        });
+        let actions = transform(json!([action]), false).unwrap();
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn server_disabled_action_dropped_without_disabled_support() {
+        let actions = transform(
+            json!([{ "title": "Not applicable here", "disabled": { "reason": "wrong scope" } }]),
+            false,
+        )
+        .unwrap();
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn host_layer_policy_keeps_edit_verbatim() {
+        // Host layer (virt = None): real URIs/coordinates, no translation —
+        // but the suffix and command policy still apply.
+        let actions: Vec<CodeActionOrCommand> = serde_json::from_value(json!([
+            {
+                "title": "Sort imports",
+                "edit": {
+                    "changes": {
+                        "file:///test.md": [{
+                            "range": {
+                                "start": { "line": 50, "character": 0 },
+                                "end": { "line": 50, "character": 5 }
+                            },
+                            "newText": "sorted"
+                        }]
+                    }
+                }
+            },
+            { "title": "Run linter", "command": "lint.run" }
+        ]))
+        .unwrap();
+
+        let bridged = bridge_code_actions(actions, "marksman", true, None);
+        assert_eq!(bridged.len(), 2);
+        let CodeActionOrCommand::CodeAction(action) = &bridged[0] else {
+            panic!("Expected CodeAction");
+        };
+        assert_eq!(action.title, "Sort imports — marksman");
+        let changes = action.edit.as_ref().unwrap().changes.as_ref().unwrap();
+        let edits = changes.get(&make_host_uri()).unwrap();
+        assert_eq!(edits[0].range.start.line, 50, "host edits stay verbatim");
+        let CodeActionOrCommand::CodeAction(placeholder) = &bridged[1] else {
+            panic!("Expected disabled placeholder");
+        };
+        assert_eq!(
+            placeholder.disabled.as_ref().unwrap().reason,
+            REASON_COMMANDS
+        );
+    }
+}

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -20,8 +20,8 @@ use url::Url;
 
 use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::{
-    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, response_has_jsonrpc_error,
-    transform_workspace_edit_to_host, translate_host_range_to_virtual,
+    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, host_position_within_region,
+    response_has_jsonrpc_error, transform_workspace_edit_to_host, translate_host_range_to_virtual,
     translate_virtual_range_to_host, virtual_uri_to_lsp_uri,
 };
 
@@ -102,6 +102,12 @@ fn build_code_action_request(
 ) -> JsonRpcRequest<CodeActionParams> {
     let mut virtual_range = host_range;
     translate_host_range_to_virtual(&mut virtual_range, offset);
+    // Out-of-region diagnostics would saturate to virtual (0,0) and could
+    // false-match a different diagnostic the server published at the top of
+    // the virtual document — drop them instead of clamping.
+    context
+        .diagnostics
+        .retain(|diagnostic| host_position_within_region(diagnostic.range.start, offset));
     for diagnostic in &mut context.diagnostics {
         translate_host_range_to_virtual(&mut diagnostic.range, offset);
     }
@@ -381,6 +387,35 @@ mod tests {
             "source.organizeImports"
         );
         assert_eq!(json["params"]["context"]["triggerKind"], 1);
+    }
+
+    #[test]
+    fn code_action_request_drops_out_of_region_diagnostics() {
+        // A diagnostic above the region would clamp to virtual (0,0) and
+        // could false-match a different diagnostic the server published at
+        // the top of the virtual document — it must be dropped, not clamped.
+        let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
+        let context = CodeActionContext {
+            diagnostics: vec![diagnostic_at(0), diagnostic_at(5)],
+            ..CodeActionContext::default()
+        };
+        let request = build_code_action_request(
+            &virtual_uri,
+            range(5, 5),
+            context,
+            &RegionOffset::new(3, 0),
+            RequestId::new(1),
+            None,
+        );
+
+        let json = serde_json::to_value(&request).unwrap();
+        let diags = json["params"]["context"]["diagnostics"].as_array().unwrap();
+        assert_eq!(
+            diags.len(),
+            1,
+            "the above-region diagnostic must be dropped"
+        );
+        assert_eq!(diags[0]["range"]["start"]["line"], 2, "5 - region start 3");
     }
 
     #[test]

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -46,7 +46,7 @@ impl LanguageServerPool {
         virtual_content: &str,
         upstream_request_id: Option<UpstreamId>,
         client_progress_token: Option<NumberOrString>,
-        client_supports_disabled: bool,
+        upstream_caps: UpstreamCodeActionCaps,
     ) -> io::Result<Option<CodeActionResponse>> {
         let handle = self
             .get_or_create_connection(server_name, server_config, Some(host_uri))
@@ -79,7 +79,7 @@ impl LanguageServerPool {
                     ctx.host_uri_lsp,
                     ctx.offset,
                     server_name,
-                    client_supports_disabled,
+                    upstream_caps,
                 )
             },
         )
@@ -133,7 +133,7 @@ fn transform_code_action_response_to_host(
     host_uri: &Uri,
     offset: &RegionOffset,
     server_name: &str,
-    client_supports_disabled: bool,
+    upstream_caps: UpstreamCodeActionCaps,
 ) -> Option<CodeActionResponse> {
     if response_has_jsonrpc_error(&response, "textDocument/codeAction") {
         return None;
@@ -144,7 +144,7 @@ fn transform_code_action_response_to_host(
     Some(bridge_code_actions(
         actions,
         server_name,
-        client_supports_disabled,
+        upstream_caps,
         Some(&VirtLayerContext {
             request_virtual_uri,
             host_uri,
@@ -188,17 +188,26 @@ pub(crate) struct VirtLayerContext<'a> {
     offset: &'a RegionOffset,
 }
 
+/// Upstream client capabilities that gate the bridge action policy
+/// (LSP 3.15/3.16 `isPreferredSupport` / `disabledSupport`): fields the
+/// client did not advertise must not reach it.
+#[derive(Clone, Copy)]
+pub(crate) struct UpstreamCodeActionCaps {
+    pub(crate) disabled_support: bool,
+    pub(crate) is_preferred_support: bool,
+}
+
 /// Apply the bridge policy to a downstream server's actions: title suffix,
 /// command/lazy-action disabling, and (virt layer) coordinate translation.
 pub(crate) fn bridge_code_actions(
     actions: Vec<CodeActionOrCommand>,
     server_name: &str,
-    client_supports_disabled: bool,
+    upstream_caps: UpstreamCodeActionCaps,
     virt: Option<&VirtLayerContext<'_>>,
 ) -> Vec<CodeActionOrCommand> {
     actions
         .into_iter()
-        .filter_map(|item| bridge_code_action(item, server_name, client_supports_disabled, virt))
+        .filter_map(|item| bridge_code_action(item, server_name, upstream_caps, virt))
         .collect()
 }
 
@@ -209,7 +218,7 @@ const REASON_CROSS_REGION: &str = "the edit cannot be represented in the host do
 fn bridge_code_action(
     item: CodeActionOrCommand,
     server_name: &str,
-    client_supports_disabled: bool,
+    upstream_caps: UpstreamCodeActionCaps,
     virt: Option<&VirtLayerContext<'_>>,
 ) -> Option<CodeActionOrCommand> {
     let mut action = match item {
@@ -221,7 +230,7 @@ fn bridge_code_action(
                 command.title,
                 REASON_COMMANDS,
                 server_name,
-                client_supports_disabled,
+                upstream_caps,
             );
         }
         CodeActionOrCommand::CodeAction(action) => action,
@@ -229,11 +238,18 @@ fn bridge_code_action(
 
     // A server-side disabled action is only representable with disabledSupport.
     if action.disabled.is_some() {
-        if !client_supports_disabled {
+        if !upstream_caps.disabled_support {
             return None;
         }
         // A disabled action must not steer the client's auto-fix keybinding,
         // whatever path surfaces it.
+        action.is_preferred = None;
+    }
+
+    // isPreferred is its own client capability (LSP 3.15); the downstream
+    // baseline advertises it unconditionally, so strip it for clients that
+    // did not opt in.
+    if !upstream_caps.is_preferred_support {
         action.is_preferred = None;
     }
 
@@ -250,12 +266,7 @@ fn bridge_code_action(
     // only the edit half of an edit+command action would be worse than
     // disabling the whole action.
     if action.command.is_some() {
-        return disable_action(
-            action,
-            REASON_COMMANDS,
-            server_name,
-            client_supports_disabled,
-        );
+        return disable_action(action, REASON_COMMANDS, server_name, upstream_caps);
     }
 
     match &mut action.edit {
@@ -268,12 +279,7 @@ fn bridge_code_action(
                     virt.offset,
                 )
             {
-                return disable_action(
-                    action,
-                    REASON_CROSS_REGION,
-                    server_name,
-                    client_supports_disabled,
-                );
+                return disable_action(action, REASON_CROSS_REGION, server_name, upstream_caps);
             }
         }
         None => {
@@ -281,12 +287,7 @@ fn bridge_code_action(
             // (its payload hides behind `data`). We don't advertise resolve
             // yet, so it can never be completed.
             if action.data.is_some() {
-                return disable_action(
-                    action,
-                    REASON_RESOLVE,
-                    server_name,
-                    client_supports_disabled,
-                );
+                return disable_action(action, REASON_RESOLVE, server_name, upstream_caps);
             }
         }
     }
@@ -311,9 +312,9 @@ fn disable_action(
     mut action: CodeAction,
     reason: &str,
     server_name: &str,
-    client_supports_disabled: bool,
+    upstream_caps: UpstreamCodeActionCaps,
 ) -> Option<CodeActionOrCommand> {
-    if !client_supports_disabled {
+    if !upstream_caps.disabled_support {
         return None;
     }
     action.title = suffix_title(action.title, server_name);
@@ -335,9 +336,9 @@ fn disabled_placeholder(
     title: String,
     reason: &str,
     server_name: &str,
-    client_supports_disabled: bool,
+    upstream_caps: UpstreamCodeActionCaps,
 ) -> Option<CodeActionOrCommand> {
-    if !client_supports_disabled {
+    if !upstream_caps.disabled_support {
         return None;
     }
     Some(CodeActionOrCommand::CodeAction(CodeAction {
@@ -477,9 +478,16 @@ mod tests {
     // Response transform
     // ==========================================================================
 
+    fn caps(disabled_support: bool) -> UpstreamCodeActionCaps {
+        UpstreamCodeActionCaps {
+            disabled_support,
+            is_preferred_support: true,
+        }
+    }
+
     fn transform(
         result: serde_json::Value,
-        client_supports_disabled: bool,
+        upstream_caps: UpstreamCodeActionCaps,
     ) -> Option<CodeActionResponse> {
         let virtual_uri = make_virtual_uri_string();
         let host_uri = make_host_uri();
@@ -489,7 +497,7 @@ mod tests {
             &host_uri,
             &RegionOffset::new(10, 0),
             "ruff",
-            client_supports_disabled,
+            upstream_caps,
         )
     }
 
@@ -513,7 +521,7 @@ mod tests {
 
     #[test]
     fn null_result_returns_none() {
-        assert!(transform(serde_json::Value::Null, true).is_none());
+        assert!(transform(serde_json::Value::Null, caps(true)).is_none());
     }
 
     #[test]
@@ -525,7 +533,7 @@ mod tests {
                 { "kind": "quickfix" },
                 edit_carrying_action("Remove unused import")
             ]),
-            true,
+            caps(true),
         )
         .unwrap();
         assert_eq!(actions.len(), 1, "valid action must survive: {actions:?}");
@@ -537,8 +545,11 @@ mod tests {
 
     #[test]
     fn edit_carrying_action_is_translated_and_suffixed() {
-        let actions =
-            transform(json!([edit_carrying_action("Remove unused import")]), true).unwrap();
+        let actions = transform(
+            json!([edit_carrying_action("Remove unused import")]),
+            caps(true),
+        )
+        .unwrap();
 
         assert_eq!(actions.len(), 1);
         let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
@@ -563,7 +574,7 @@ mod tests {
             },
             "message": "unused"
         }]);
-        let actions = transform(json!([action]), true).unwrap();
+        let actions = transform(json!([action]), caps(true)).unwrap();
         let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
             panic!("Expected CodeAction");
         };
@@ -578,7 +589,7 @@ mod tests {
     fn bare_command_becomes_disabled_placeholder() {
         let actions = transform(
             json!([{ "title": "Run organize imports", "command": "ruff.organizeImports" }]),
-            true,
+            caps(true),
         )
         .unwrap();
 
@@ -594,7 +605,7 @@ mod tests {
     fn bare_command_is_dropped_without_disabled_support() {
         let actions = transform(
             json!([{ "title": "Run organize imports", "command": "ruff.organizeImports" }]),
-            false,
+            caps(false),
         )
         .unwrap();
         assert!(actions.is_empty());
@@ -604,7 +615,7 @@ mod tests {
     fn command_carrying_action_is_disabled_with_payload_stripped() {
         let mut action = edit_carrying_action("Fix all");
         action["command"] = json!({ "title": "post", "command": "ruff.postFix" });
-        let actions = transform(json!([action]), true).unwrap();
+        let actions = transform(json!([action]), caps(true)).unwrap();
 
         let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
             panic!("Expected CodeAction");
@@ -619,8 +630,11 @@ mod tests {
 
     #[test]
     fn lazy_data_only_action_is_disabled() {
-        let actions =
-            transform(json!([{ "title": "Lazy fix", "data": { "id": 7 } }]), true).unwrap();
+        let actions = transform(
+            json!([{ "title": "Lazy fix", "data": { "id": 7 } }]),
+            caps(true),
+        )
+        .unwrap();
         let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
             panic!("Expected CodeAction");
         };
@@ -632,7 +646,7 @@ mod tests {
     fn kept_action_strips_untranslated_data() {
         let mut action = edit_carrying_action("Fix");
         action["data"] = json!({ "virtualUri": make_virtual_uri_string() });
-        let actions = transform(json!([action]), true).unwrap();
+        let actions = transform(json!([action]), caps(true)).unwrap();
         let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
             panic!("Expected CodeAction");
         };
@@ -644,6 +658,31 @@ mod tests {
     }
 
     #[test]
+    fn is_preferred_stripped_without_client_support() {
+        let mut action = edit_carrying_action("Fix");
+        action["isPreferred"] = json!(true);
+        let no_pref = UpstreamCodeActionCaps {
+            disabled_support: true,
+            is_preferred_support: false,
+        };
+        let actions = transform(json!([action.clone()]), no_pref).unwrap();
+        let CodeActionOrCommand::CodeAction(bridged) = &actions[0] else {
+            panic!("Expected CodeAction");
+        };
+        assert_eq!(
+            bridged.is_preferred, None,
+            "isPreferred must not reach a client without isPreferredSupport"
+        );
+
+        // With support it passes through.
+        let actions = transform(json!([action]), caps(true)).unwrap();
+        let CodeActionOrCommand::CodeAction(bridged) = &actions[0] else {
+            panic!("Expected CodeAction");
+        };
+        assert_eq!(bridged.is_preferred, Some(true));
+    }
+
+    #[test]
     fn server_disabled_command_action_keeps_server_reason() {
         let actions = transform(
             json!([{
@@ -652,7 +691,7 @@ mod tests {
                 "disabled": { "reason": "wrong scope" },
                 "isPreferred": true
             }]),
-            true,
+            caps(true),
         )
         .unwrap();
         let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
@@ -682,7 +721,7 @@ mod tests {
                 ]
             }
         });
-        let actions = transform(json!([action]), true).unwrap();
+        let actions = transform(json!([action]), caps(true)).unwrap();
         let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
             panic!("Expected CodeAction");
         };
@@ -703,7 +742,7 @@ mod tests {
                 ]
             }
         });
-        let actions = transform(json!([action]), false).unwrap();
+        let actions = transform(json!([action]), caps(false)).unwrap();
         assert!(actions.is_empty());
     }
 
@@ -711,7 +750,7 @@ mod tests {
     fn server_disabled_action_dropped_without_disabled_support() {
         let actions = transform(
             json!([{ "title": "Not applicable here", "disabled": { "reason": "wrong scope" } }]),
-            false,
+            caps(false),
         )
         .unwrap();
         assert!(actions.is_empty());
@@ -740,7 +779,7 @@ mod tests {
         ]))
         .unwrap();
 
-        let bridged = bridge_code_actions(actions, "marksman", true, None);
+        let bridged = bridge_code_actions(actions, "marksman", caps(true), None);
         assert_eq!(bridged.len(), 2);
         let CodeActionOrCommand::CodeAction(action) = &bridged[0] else {
             panic!("Expected CodeAction");

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -11,10 +11,11 @@
 use std::io;
 
 use crate::config::settings::BridgeServerConfig;
+use crate::text::PositionMapper;
 use tower_lsp_server::ls_types::{
     CodeAction, CodeActionContext, CodeActionDisabled, CodeActionOrCommand, CodeActionParams,
-    CodeActionResponse, NumberOrString, PartialResultParams, Range, TextDocumentIdentifier, Uri,
-    WorkDoneProgressParams,
+    CodeActionResponse, NumberOrString, PartialResultParams, Position, Range,
+    TextDocumentIdentifier, Uri, WorkDoneProgressParams,
 };
 use url::Url;
 
@@ -22,8 +23,23 @@ use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, host_position_within_region,
     response_has_jsonrpc_error, transform_workspace_edit_to_host, translate_host_range_to_virtual,
-    translate_virtual_range_to_host, virtual_uri_to_lsp_uri,
+    translate_virtual_position_to_host, translate_virtual_range_to_host, virtual_uri_to_lsp_uri,
 };
+
+/// The exclusive host-document end of an injection region: the position just
+/// past its `virtual_content`, mapped back to host coordinates. Bounds the
+/// in-region diagnostic filter position-precisely (line AND column), so a
+/// diagnostic after an inline same-line injection is dropped, not leaked.
+fn region_host_end(virtual_content: &str, offset: &RegionOffset) -> Position {
+    let mut end = PositionMapper::new(virtual_content)
+        .byte_to_position(virtual_content.len())
+        .unwrap_or(Position {
+            line: 0,
+            character: 0,
+        });
+    translate_virtual_position_to_host(&mut end, offset);
+    end
+}
 
 impl LanguageServerPool {
     /// Send a code action request and wait for the response.
@@ -68,9 +84,7 @@ impl LanguageServerPool {
                     host_range,
                     context,
                     &offset,
-                    // The region spans this many host lines; bounds the
-                    // in-region diagnostic filter from below.
-                    virtual_content.lines().count() as u32,
+                    region_host_end(virtual_content, &offset),
                     request_id,
                     client_progress_token,
                 )
@@ -100,7 +114,7 @@ fn build_code_action_request(
     host_range: Range,
     mut context: CodeActionContext,
     offset: &RegionOffset,
-    region_line_count: u32,
+    region_end: Position,
     request_id: RequestId,
     client_progress_token: Option<NumberOrString>,
 ) -> JsonRpcRequest<CodeActionParams> {
@@ -108,14 +122,13 @@ fn build_code_action_request(
     translate_host_range_to_virtual(&mut virtual_range, offset);
     // Out-of-region diagnostics would translate to virtual coordinates that
     // don't exist: above-region ones saturate to (0,0) and can false-match a
-    // different diagnostic at the top of the virtual document; below-region
-    // ones land past the virtual document's end. Bound by the region's own
-    // line span — NOT the (possibly zero-length, cursor) request range, which
-    // would wrongly drop a diagnostic sitting exactly at the cursor.
-    let region_end_line = offset.line().saturating_add(region_line_count);
+    // different diagnostic at the top of the virtual document; ones past the
+    // region land beyond the virtual document. Bound by the region's own
+    // [start, end) extent — NOT the (possibly zero-length, cursor) request
+    // range, which would wrongly drop a diagnostic sitting at the cursor.
     context.diagnostics.retain(|diagnostic| {
         host_position_within_region(diagnostic.range.start, offset)
-            && diagnostic.range.start.line < region_end_line
+            && diagnostic.range.start < region_end
     });
     for diagnostic in &mut context.diagnostics {
         translate_host_range_to_virtual(&mut diagnostic.range, offset);
@@ -429,7 +442,10 @@ mod tests {
             range(5, 5),
             context,
             &RegionOffset::new(3, 0),
-            10,
+            Position {
+                line: 13,
+                character: 0,
+            },
             RequestId::new(1),
             None,
         );
@@ -467,7 +483,10 @@ mod tests {
             context,
             &RegionOffset::new(3, 0),
             // Region spans host lines 3..13; line-5 diagnostic is in, line-40 is out.
-            10,
+            Position {
+                line: 13,
+                character: 0,
+            },
             RequestId::new(1),
             None,
         );
@@ -510,7 +529,10 @@ mod tests {
             },
             context,
             &RegionOffset::new(3, 0),
-            10,
+            Position {
+                line: 13,
+                character: 0,
+            },
             RequestId::new(1),
             None,
         );
@@ -529,7 +551,10 @@ mod tests {
             range(5, 5),
             CodeActionContext::default(),
             &RegionOffset::new(3, 0),
-            10,
+            Position {
+                line: 13,
+                character: 0,
+            },
             test_request_id(),
             Some(NumberOrString::String("wd-1".to_string())),
         );

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -124,10 +124,17 @@ fn build_code_action_request(
     // don't exist: above-region ones saturate to (0,0) and can false-match a
     // different diagnostic at the top of the virtual document; ones past the
     // region land beyond the virtual document. Keep only diagnostics whose
-    // WHOLE range fits the region's `[start, end)` extent (`region_end` is
-    // exclusive, so a diagnostic ending exactly at it is in) — bounding by
-    // the region, NOT the (possibly zero-length, cursor) request range, which
-    // would wrongly drop a diagnostic sitting at the cursor.
+    // WHOLE range fits the region — bounding by the region, NOT the (possibly
+    // zero-length, cursor) request range, which would wrongly drop a
+    // diagnostic sitting at the cursor.
+    //
+    // `region_end` is `virtual_content`'s end mapped to host coords, i.e. the
+    // valid end-of-content LSP position (one past the last char / start of a
+    // trailing empty line). `end <= region_end` is therefore INCLUSIVE on
+    // purpose: an end-of-content diagnostic (e.g. "missing semicolon") is
+    // real and maps to a valid virtual position. For a well-formed diagnostic
+    // (`start <= end`), `end <= region_end` already forces any `start` at
+    // `region_end` to be zero-length there — still valid, not a leak.
     context.diagnostics.retain(|diagnostic| {
         host_position_within_region(diagnostic.range.start, offset)
             && diagnostic.range.end <= region_end

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -366,12 +366,13 @@ fn disable_action(
     action.data = None;
     // A disabled action must not steer the client's auto-fix keybinding.
     action.is_preferred = None;
-    // Keep the server's own reason when it already disabled the action.
-    if action.disabled.is_none() {
-        action.disabled = Some(CodeActionDisabled {
-            reason: reason.to_string(),
-        });
-    }
+    // `disable_action` is only reached for actions the SERVER did not disable:
+    // `bridge_code_action` handles a server-disabled action (keeping its own
+    // reason) and returns before ever calling here. So the bridge always owns
+    // the reason on this path — assign it unconditionally.
+    action.disabled = Some(CodeActionDisabled {
+        reason: reason.to_string(),
+    });
     Some(CodeActionOrCommand::CodeAction(action))
 }
 

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -68,6 +68,9 @@ impl LanguageServerPool {
                     host_range,
                     context,
                     &offset,
+                    // The region spans this many host lines; bounds the
+                    // in-region diagnostic filter from below.
+                    virtual_content.lines().count() as u32,
                     request_id,
                     client_progress_token,
                 )
@@ -97,6 +100,7 @@ fn build_code_action_request(
     host_range: Range,
     mut context: CodeActionContext,
     offset: &RegionOffset,
+    region_line_count: u32,
     request_id: RequestId,
     client_progress_token: Option<NumberOrString>,
 ) -> JsonRpcRequest<CodeActionParams> {
@@ -105,11 +109,13 @@ fn build_code_action_request(
     // Out-of-region diagnostics would translate to virtual coordinates that
     // don't exist: above-region ones saturate to (0,0) and can false-match a
     // different diagnostic at the top of the virtual document; below-region
-    // ones land past the virtual document's end. `host_range` is already
-    // clamped to the region, so its end bounds the region from below.
+    // ones land past the virtual document's end. Bound by the region's own
+    // line span — NOT the (possibly zero-length, cursor) request range, which
+    // would wrongly drop a diagnostic sitting exactly at the cursor.
+    let region_end_line = offset.line().saturating_add(region_line_count);
     context.diagnostics.retain(|diagnostic| {
         host_position_within_region(diagnostic.range.start, offset)
-            && diagnostic.range.start < host_range.end
+            && diagnostic.range.start.line < region_end_line
     });
     for diagnostic in &mut context.diagnostics {
         translate_host_range_to_virtual(&mut diagnostic.range, offset);
@@ -239,6 +245,17 @@ fn bridge_code_action(
         CodeActionOrCommand::CodeAction(action) => action,
     };
 
+    // The action's own diagnostics came back in virtual coordinates —
+    // translate them before any early return so every surfaced action
+    // (including a disabled one) carries host coordinates.
+    if let Some(virt) = virt
+        && let Some(diagnostics) = &mut action.diagnostics
+    {
+        for diagnostic in diagnostics {
+            translate_virtual_range_to_host(&mut diagnostic.range, virt.offset);
+        }
+    }
+
     // A server-side disabled action needs no further policy: its own reason
     // already explains why it can't run, and it's only representable with
     // disabledSupport. Suffix it, strip any payload (we can't execute it and
@@ -261,15 +278,6 @@ fn bridge_code_action(
     // did not opt in.
     if !upstream_caps.is_preferred_support {
         action.is_preferred = None;
-    }
-
-    // The action's own diagnostics came back in virtual coordinates.
-    if let Some(virt) = virt
-        && let Some(diagnostics) = &mut action.diagnostics
-    {
-        for diagnostic in diagnostics {
-            translate_virtual_range_to_host(&mut diagnostic.range, virt.offset);
-        }
     }
 
     // Commands are not executable until executeCommand is bridged; applying
@@ -421,6 +429,7 @@ mod tests {
             range(5, 5),
             context,
             &RegionOffset::new(3, 0),
+            10,
             RequestId::new(1),
             None,
         );
@@ -457,6 +466,8 @@ mod tests {
             range(5, 5),
             context,
             &RegionOffset::new(3, 0),
+            // Region spans host lines 3..13; line-5 diagnostic is in, line-40 is out.
+            10,
             RequestId::new(1),
             None,
         );
@@ -472,6 +483,45 @@ mod tests {
     }
 
     #[test]
+    fn code_action_request_keeps_in_region_diagnostic_for_cursor_request() {
+        // A zero-length (cursor) request: a diagnostic exactly at the cursor
+        // is in-region and must survive — the region span, not the request
+        // range end, bounds the filter.
+        let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
+        let cursor = Position {
+            line: 5,
+            character: 3,
+        };
+        let context = CodeActionContext {
+            diagnostics: vec![Diagnostic {
+                range: Range {
+                    start: cursor,
+                    end: cursor,
+                },
+                ..Diagnostic::default()
+            }],
+            ..CodeActionContext::default()
+        };
+        let request = build_code_action_request(
+            &virtual_uri,
+            Range {
+                start: cursor,
+                end: cursor,
+            },
+            context,
+            &RegionOffset::new(3, 0),
+            10,
+            RequestId::new(1),
+            None,
+        );
+
+        let json = serde_json::to_value(&request).unwrap();
+        let diags = json["params"]["context"]["diagnostics"].as_array().unwrap();
+        assert_eq!(diags.len(), 1, "the cursor diagnostic must survive");
+        assert_eq!(diags[0]["range"]["start"]["line"], 2, "5 - region start 3");
+    }
+
+    #[test]
     fn code_action_request_carries_work_done_token() {
         let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
         let request = build_code_action_request(
@@ -479,6 +529,7 @@ mod tests {
             range(5, 5),
             CodeActionContext::default(),
             &RegionOffset::new(3, 0),
+            10,
             test_request_id(),
             Some(NumberOrString::String("wd-1".to_string())),
         );
@@ -720,6 +771,37 @@ mod tests {
             action.is_preferred, None,
             "a disabled action must not steer auto-fix"
         );
+    }
+
+    #[test]
+    fn server_disabled_action_diagnostics_are_translated_to_host() {
+        // A disabled action can still carry diagnostics; on the virt layer
+        // those are in virtual coordinates and must reach the client in host
+        // coordinates even though the action short-circuits the policy.
+        let actions = transform(
+            json!([{
+                "title": "Not here",
+                "disabled": { "reason": "wrong scope" },
+                "diagnostics": [{
+                    "range": {
+                        "start": { "line": 2, "character": 0 },
+                        "end": { "line": 2, "character": 5 }
+                    },
+                    "message": "unused"
+                }]
+            }]),
+            caps(true),
+        )
+        .unwrap();
+        let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
+            panic!("Expected CodeAction");
+        };
+        assert_eq!(
+            action.diagnostics.as_ref().unwrap()[0].range.start.line,
+            12,
+            "2 + region offset 10 — disabled actions get translated too"
+        );
+        assert_eq!(action.disabled.as_ref().unwrap().reason, "wrong scope");
     }
 
     #[test]

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -102,12 +102,15 @@ fn build_code_action_request(
 ) -> JsonRpcRequest<CodeActionParams> {
     let mut virtual_range = host_range;
     translate_host_range_to_virtual(&mut virtual_range, offset);
-    // Out-of-region diagnostics would saturate to virtual (0,0) and could
-    // false-match a different diagnostic the server published at the top of
-    // the virtual document — drop them instead of clamping.
-    context
-        .diagnostics
-        .retain(|diagnostic| host_position_within_region(diagnostic.range.start, offset));
+    // Out-of-region diagnostics would translate to virtual coordinates that
+    // don't exist: above-region ones saturate to (0,0) and can false-match a
+    // different diagnostic at the top of the virtual document; below-region
+    // ones land past the virtual document's end. `host_range` is already
+    // clamped to the region, so its end bounds the region from below.
+    context.diagnostics.retain(|diagnostic| {
+        host_position_within_region(diagnostic.range.start, offset)
+            && diagnostic.range.start < host_range.end
+    });
     for diagnostic in &mut context.diagnostics {
         translate_host_range_to_virtual(&mut diagnostic.range, offset);
     }
@@ -236,14 +239,21 @@ fn bridge_code_action(
         CodeActionOrCommand::CodeAction(action) => action,
     };
 
-    // A server-side disabled action is only representable with disabledSupport.
+    // A server-side disabled action needs no further policy: its own reason
+    // already explains why it can't run, and it's only representable with
+    // disabledSupport. Suffix it, strip any payload (we can't execute it and
+    // a virt edit here would still be in untranslated coordinates), and keep
+    // the server's own reason — never overwrite it with a generic one.
     if action.disabled.is_some() {
         if !upstream_caps.disabled_support {
             return None;
         }
-        // A disabled action must not steer the client's auto-fix keybinding,
-        // whatever path surfaces it.
+        action.title = suffix_title(action.title, server_name);
+        action.edit = None;
+        action.command = None;
+        action.data = None;
         action.is_preferred = None;
+        return Some(CodeActionOrCommand::CodeAction(action));
     }
 
     // isPreferred is its own client capability (LSP 3.15); the downstream
@@ -289,6 +299,9 @@ fn bridge_code_action(
             if action.data.is_some() {
                 return disable_action(action, REASON_RESOLVE, server_name, upstream_caps);
             }
+            // No edit, no command, no data, not server-disabled: selecting it
+            // would do nothing — drop it rather than clutter the menu.
+            return None;
         }
     }
 
@@ -430,12 +443,13 @@ mod tests {
 
     #[test]
     fn code_action_request_drops_out_of_region_diagnostics() {
-        // A diagnostic above the region would clamp to virtual (0,0) and
-        // could false-match a different diagnostic the server published at
-        // the top of the virtual document — it must be dropped, not clamped.
+        // A diagnostic above the region clamps to virtual (0,0) and could
+        // false-match a different diagnostic at the top of the virtual
+        // document; one below the (region-clamped) request range lands past
+        // the virtual document's end — both must be dropped, not clamped.
         let virtual_uri = VirtualDocumentUri::new(&test_host_uri(), "lua", "region-0");
         let context = CodeActionContext {
-            diagnostics: vec![diagnostic_at(0), diagnostic_at(5)],
+            diagnostics: vec![diagnostic_at(0), diagnostic_at(5), diagnostic_at(40)],
             ..CodeActionContext::default()
         };
         let request = build_code_action_request(
@@ -452,7 +466,7 @@ mod tests {
         assert_eq!(
             diags.len(),
             1,
-            "the above-region diagnostic must be dropped"
+            "diagnostics above and below the region must be dropped"
         );
         assert_eq!(diags[0]["range"]["start"]["line"], 2, "5 - region start 3");
     }
@@ -706,6 +720,14 @@ mod tests {
             action.is_preferred, None,
             "a disabled action must not steer auto-fix"
         );
+    }
+
+    #[test]
+    fn payloadless_action_is_dropped() {
+        // No edit, no command, no data, not server-disabled: selecting it can
+        // do nothing, so it must not clutter the menu.
+        let actions = transform(json!([{ "title": "Ghost" }]), caps(true)).unwrap();
+        assert!(actions.is_empty(), "got: {actions:?}");
     }
 
     #[test]

--- a/src/lsp/ingress_order.rs
+++ b/src/lsp/ingress_order.rs
@@ -287,8 +287,9 @@ enum Role {
 /// its current text, so edits computed against a stale snapshot corrupt the
 /// document), pull diagnostics, and `didSave` (its synthetic-diagnostic task
 /// snapshots the document, which must reflect every edit before the save).
-/// `textDocument/codeAction` belongs in the same class once it is
-/// implemented (#352). `codeLens/resolve` is a reader too (#355): its
+/// `textDocument/codeAction` is in the same class: its
+/// `context.diagnostics` and returned edits are computed against the
+/// document snapshot (#568). `codeLens/resolve` is a reader too (#355): its
 /// freshness gate reads tracker/document state, so it must observe every
 /// `didChange` that preceded it on the wire — but its params carry no
 /// `textDocument`, so the URI comes from the routing envelope in
@@ -315,6 +316,7 @@ fn classify(req: &Request) -> Option<Role> {
         | "textDocument/rangeFormatting"
         | "textDocument/rename"
         | "textDocument/prepareRename"
+        | "textDocument/codeAction"
         | "textDocument/diagnostic"
         | "textDocument/didSave"
         | "kakehashi/captures/full"
@@ -643,6 +645,7 @@ mod tests {
             "textDocument/rangeFormatting",
             "textDocument/rename",
             "textDocument/prepareRename",
+            "textDocument/codeAction",
             "textDocument/diagnostic",
             "textDocument/didSave",
             "kakehashi/captures/full",

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -17,20 +17,20 @@ use tower_lsp_server::ls_types::request::{
     GotoImplementationResponse, GotoTypeDefinitionParams, GotoTypeDefinitionResponse,
 };
 use tower_lsp_server::ls_types::{
-    CodeLens, CodeLensParams, CompletionItem, CompletionParams, CompletionResponse,
-    DidChangeConfigurationParams, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
-    DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentDiagnosticParams,
-    DocumentDiagnosticReportResult, DocumentFormattingParams, DocumentHighlight,
-    DocumentHighlightParams, DocumentLink, DocumentLinkParams, DocumentOnTypeFormattingParams,
-    DocumentRangeFormattingParams, DocumentSymbolParams, DocumentSymbolResponse, FoldingRange,
-    FoldingRangeParams, GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams,
-    InitializeParams, InitializeResult, InitializedParams, InlayHint, InlayHintParams,
-    LinkedEditingRangeParams, LinkedEditingRanges, Location, Moniker, MonikerParams,
-    PrepareRenameResponse, ReferenceParams, RenameParams, SelectionRange, SelectionRangeParams,
-    SemanticTokensDeltaParams, SemanticTokensFullDeltaResult, SemanticTokensParams,
-    SemanticTokensRangeParams, SemanticTokensRangeResult, SemanticTokensResult, SignatureHelp,
-    SignatureHelpParams, TextDocumentPositionParams, TextEdit, Uri, WillSaveTextDocumentParams,
-    WorkspaceEdit,
+    CodeActionParams, CodeActionResponse, CodeLens, CodeLensParams, CompletionItem,
+    CompletionParams, CompletionResponse, DidChangeConfigurationParams,
+    DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
+    DidSaveTextDocumentParams, DocumentDiagnosticParams, DocumentDiagnosticReportResult,
+    DocumentFormattingParams, DocumentHighlight, DocumentHighlightParams, DocumentLink,
+    DocumentLinkParams, DocumentOnTypeFormattingParams, DocumentRangeFormattingParams,
+    DocumentSymbolParams, DocumentSymbolResponse, FoldingRange, FoldingRangeParams,
+    GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams, InitializeParams,
+    InitializeResult, InitializedParams, InlayHint, InlayHintParams, LinkedEditingRangeParams,
+    LinkedEditingRanges, Location, Moniker, MonikerParams, PrepareRenameResponse, ReferenceParams,
+    RenameParams, SelectionRange, SelectionRangeParams, SemanticTokensDeltaParams,
+    SemanticTokensFullDeltaResult, SemanticTokensParams, SemanticTokensRangeParams,
+    SemanticTokensRangeResult, SemanticTokensResult, SignatureHelp, SignatureHelpParams,
+    TextDocumentPositionParams, TextEdit, Uri, WillSaveTextDocumentParams, WorkspaceEdit,
 };
 use tower_lsp_server::ls_types::{
     ColorInformation, ColorPresentation, ColorPresentationParams, DocumentColorParams,
@@ -726,6 +726,10 @@ impl LanguageServer for Kakehashi {
 
     async fn rename(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
         self.rename_impl(params).await
+    }
+
+    async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
+        self.code_action_impl(params).await
     }
 
     async fn formatting(&self, params: DocumentFormattingParams) -> Result<Option<Vec<TextEdit>>> {

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -1119,16 +1119,17 @@ impl Kakehashi {
         // First intersecting region that resolves to bridge server configs
         // wins: unconfigured injections (e.g. markdown_inline) must not
         // shadow a configured region further down the document.
+        let mapper = PositionMapper::new(snapshot.text());
         regions.into_iter().find_map(|resolved| {
             let region_start = Position {
                 line: resolved.region.line_range.start,
                 character: resolved.region.start_column,
             };
-            // line_range end is exclusive.
-            let region_end = Position {
-                line: resolved.region.line_range.end,
-                character: 0,
-            };
+            // Byte-precise end: synthesizing (line_range.end, 0) would
+            // over-approximate a same-line inline injection through the end
+            // of its line, matching ranges entirely after the injected
+            // content and clamping to columns outside the virtual document.
+            let region_end = mapper.byte_to_position(resolved.region.byte_range.end)?;
             if !range_intersects_region(&range, region_start, region_end) {
                 return None;
             }

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -1122,24 +1122,10 @@ impl Kakehashi {
         // shadow a configured region further down the document.
         let mapper = PositionMapper::new(snapshot.text());
         for resolved in regions {
-            let region_start = Position {
-                line: resolved.region.line_range.start,
-                character: resolved.region.start_column,
-            };
-            // Byte-precise end: synthesizing (line_range.end, 0) would
-            // over-approximate a same-line inline injection through the end
-            // of its line, matching ranges entirely after the injected
-            // content and clamping to columns outside the virtual document.
-            let Some(region_end) = mapper.byte_to_position(resolved.region.byte_range.end) else {
+            // Clamp to the region so the translated range is in-region; skip a
+            // region the range never touches.
+            let Some(clamped) = clamp_range_to_region(&resolved, &range, &mapper) else {
                 continue;
-            };
-            if !range_intersects_region(&range, region_start, region_end) {
-                continue;
-            }
-            // Clamp to the region so the translated range is in-region.
-            let clamped = Range {
-                start: range.start.max(region_start),
-                end: range.end.min(region_end),
             };
 
             let preamble = PreambleResult {
@@ -1163,6 +1149,33 @@ impl Kakehashi {
         }
         None
     }
+}
+
+/// Clamp `range` to `resolved`'s injection region for an in-region translated
+/// request, or `None` when the region does not intersect the range (or its
+/// byte-precise end is unmappable). Pure geometry — no bridge-config lookup, so
+/// the async region scan stays focused on config resolution.
+fn clamp_range_to_region(
+    resolved: &ResolvedInjection,
+    range: &Range,
+    mapper: &PositionMapper,
+) -> Option<Range> {
+    let region_start = Position {
+        line: resolved.region.line_range.start,
+        character: resolved.region.start_column,
+    };
+    // Byte-precise end: synthesizing (line_range.end, 0) would over-approximate
+    // a same-line inline injection through the end of its line, matching ranges
+    // entirely after the injected content and clamping to columns outside the
+    // virtual document.
+    let region_end = mapper.byte_to_position(resolved.region.byte_range.end)?;
+    if !range_intersects_region(range, region_start, region_end) {
+        return None;
+    }
+    Some(Range {
+        start: range.start.max(region_start),
+        end: range.end.min(region_end),
+    })
 }
 
 /// Position-precise intersection of an LSP request range with an injection

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -1119,41 +1119,51 @@ impl Kakehashi {
         // First intersecting region that resolves to bridge server configs
         // wins: unconfigured injections (e.g. markdown_inline) must not
         // shadow a configured region further down the document.
-        regions
-            .into_iter()
-            .filter(|resolved| {
-                // line_range end is exclusive; intersect on lines only.
-                let lines = &resolved.region.line_range;
-                lines.start <= range.end.line && range.start.line < lines.end
-            })
-            .find_map(|resolved| {
-                // Clamp to the region so the translated range is in-region.
-                let region_start = Position {
-                    line: resolved.region.line_range.start,
-                    character: resolved.region.start_column,
-                };
-                let region_end = Position {
-                    line: resolved.region.line_range.end,
-                    character: 0,
-                };
-                let clamped = Range {
-                    start: range.start.max(region_start),
-                    end: range.end.min(region_end),
-                };
+        regions.into_iter().find_map(|resolved| {
+            let region_start = Position {
+                line: resolved.region.line_range.start,
+                character: resolved.region.start_column,
+            };
+            // line_range end is exclusive.
+            let region_end = Position {
+                line: resolved.region.line_range.end,
+                character: 0,
+            };
+            if !range_intersects_region(&range, region_start, region_end) {
+                return None;
+            }
+            // Clamp to the region so the translated range is in-region.
+            let clamped = Range {
+                start: range.start.max(region_start),
+                end: range.end.min(region_end),
+            };
 
-                let preamble = PreambleResult {
-                    uri: uri.clone(),
-                    resolved,
-                    language_name: language_name.clone(),
-                    upstream_request_id: current_upstream_id(),
-                };
-                let document = self.preamble_to_document_context(preamble, method_name)?;
-                Some(RangeRequestContext {
-                    document,
-                    range: clamped,
-                })
+            let preamble = PreambleResult {
+                uri: uri.clone(),
+                resolved,
+                language_name: language_name.clone(),
+                upstream_request_id: current_upstream_id(),
+            };
+            let document = self.preamble_to_document_context(preamble, method_name)?;
+            Some(RangeRequestContext {
+                document,
+                range: clamped,
             })
+        })
     }
+}
+
+/// Position-precise intersection of an LSP request range with an injection
+/// region `[region_start, region_end)`. Line-only comparison would bridge a
+/// region the range never touches — e.g. a range ending exactly AT the
+/// region start, or a same-line range entirely before an inline region's
+/// start column. A zero-length (cursor) request counts as inside when the
+/// position sits within the region, inclusive of its start.
+fn range_intersects_region(range: &Range, region_start: Position, region_end: Position) -> bool {
+    if range.start == range.end {
+        return region_start <= range.start && range.start < region_end;
+    }
+    range.start < region_end && region_start < range.end
 }
 
 #[cfg(test)]
@@ -1162,6 +1172,67 @@ mod tests {
     use crate::config::settings::{
         AggregationConfig, AggregationStrategy, BridgeLanguageConfig, LanguageSettings,
     };
+
+    fn pos(line: u32, character: u32) -> Position {
+        Position { line, character }
+    }
+
+    #[test]
+    fn range_intersection_is_position_precise() {
+        // Fenced region: content [(3,0), (4,0)).
+        let (rs, re) = (pos(3, 0), pos(4, 0));
+        let range = |s: Position, e: Position| Range { start: s, end: e };
+
+        // Overlapping and containing ranges intersect.
+        assert!(range_intersects_region(
+            &range(pos(0, 0), pos(5, 0)),
+            rs,
+            re
+        ));
+        assert!(range_intersects_region(
+            &range(pos(3, 1), pos(3, 5)),
+            rs,
+            re
+        ));
+        // Ending exactly AT the region start does not touch it.
+        assert!(!range_intersects_region(
+            &range(pos(0, 0), pos(3, 0)),
+            rs,
+            re
+        ));
+        // Starting at the exclusive region end does not touch it.
+        assert!(!range_intersects_region(
+            &range(pos(4, 0), pos(5, 0)),
+            rs,
+            re
+        ));
+
+        // Cursor (zero-length) requests: inclusive start, exclusive end.
+        assert!(range_intersects_region(
+            &range(pos(3, 0), pos(3, 0)),
+            rs,
+            re
+        ));
+        assert!(!range_intersects_region(
+            &range(pos(4, 0), pos(4, 0)),
+            rs,
+            re
+        ));
+
+        // Inline region starting mid-line: a same-line range entirely
+        // before the start column must not match.
+        let (rs, re) = (pos(3, 5), pos(4, 0));
+        assert!(!range_intersects_region(
+            &range(pos(3, 0), pos(3, 2)),
+            rs,
+            re
+        ));
+        assert!(range_intersects_region(
+            &range(pos(3, 0), pos(3, 6)),
+            rs,
+            re
+        ));
+    }
     use std::collections::HashMap;
 
     fn settings_with(languages: HashMap<String, LanguageSettings>) -> WorkspaceSettings {

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -1091,12 +1091,13 @@ impl Kakehashi {
     ) -> Option<RangeRequestContext> {
         self.ensure_fresh_tree_for_bridge(lsp_uri).await;
         self.resolve_first_region_overlapping_range(lsp_uri, range, method_name)
+            .await
     }
 
     /// Whole-document region scan behind
     /// [`Self::resolve_bridge_contexts_for_range_overlap`]; the tree is
     /// already fresh (the caller awaited it).
-    fn resolve_first_region_overlapping_range(
+    async fn resolve_first_region_overlapping_range(
         &self,
         lsp_uri: &Uri,
         range: Range,
@@ -1120,7 +1121,7 @@ impl Kakehashi {
         // wins: unconfigured injections (e.g. markdown_inline) must not
         // shadow a configured region further down the document.
         let mapper = PositionMapper::new(snapshot.text());
-        regions.into_iter().find_map(|resolved| {
+        for resolved in regions {
             let region_start = Position {
                 line: resolved.region.line_range.start,
                 character: resolved.region.start_column,
@@ -1129,9 +1130,11 @@ impl Kakehashi {
             // over-approximate a same-line inline injection through the end
             // of its line, matching ranges entirely after the injected
             // content and clamping to columns outside the virtual document.
-            let region_end = mapper.byte_to_position(resolved.region.byte_range.end)?;
+            let Some(region_end) = mapper.byte_to_position(resolved.region.byte_range.end) else {
+                continue;
+            };
             if !range_intersects_region(&range, region_start, region_end) {
-                return None;
+                continue;
             }
             // Clamp to the region so the translated range is in-region.
             let clamped = Range {
@@ -1145,12 +1148,20 @@ impl Kakehashi {
                 language_name: language_name.clone(),
                 upstream_request_id: current_upstream_id(),
             };
-            let document = self.preamble_to_document_context(preamble, method_name)?;
-            Some(RangeRequestContext {
+            // An intersecting region that resolves to no bridge config does not
+            // shadow a configured region further down: skip to the next.
+            let Some(document) = self
+                .preamble_to_document_context(preamble, method_name)
+                .await
+            else {
+                continue;
+            };
+            return Some(RangeRequestContext {
                 document,
                 range: clamped,
-            })
-        })
+            });
+        }
+        None
     }
 }
 

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -944,15 +944,6 @@ impl Kakehashi {
         host_parse: impl Fn(serde_json::Value) -> Option<R>,
         is_nonempty: impl Fn(&R) -> bool,
     ) -> tower_lsp_server::jsonrpc::Result<Option<R>> {
-        let Ok(uri) = uri_to_url(lsp_uri) else {
-            log::warn!("Invalid URI in {}: {}", request_method, lsp_uri.as_str());
-            return Ok(None);
-        };
-        let Some(host_language) = self.document_language(&uri) else {
-            return Ok(None);
-        };
-        let layer_cfg = self.resolve_layer_config(&host_language, layer_method);
-
         let host = async {
             match self.resolve_host_bridge_context(lsp_uri, layer_method) {
                 Some(ctx) => Ok(self
@@ -962,6 +953,46 @@ impl Kakehashi {
                 None => Ok(None),
             }
         };
+
+        self.walk_layer_futures(
+            lsp_uri,
+            layer_method,
+            request_method,
+            virt,
+            host,
+            native,
+            is_nonempty,
+        )
+        .await
+    }
+
+    /// Race pre-built virt/host/native layer futures under the resolved
+    /// layer priorities (cross-layer-aggregation, `preferred` semantics),
+    /// with walk-wide cancel subscription and upstream-registry sweep.
+    ///
+    /// This is the walk core behind [`Self::walk_layers_with_native`];
+    /// handlers that need a custom host arm (e.g. codeAction's per-server
+    /// title suffixing, which the verbatim raw-value host arm cannot
+    /// express) build their own host future and call this directly.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn walk_layer_futures<R>(
+        &self,
+        lsp_uri: &Uri,
+        layer_method: &'static str,
+        request_method: &'static str,
+        virt: impl Future<Output = tower_lsp_server::jsonrpc::Result<Option<R>>>,
+        host: impl Future<Output = tower_lsp_server::jsonrpc::Result<Option<R>>>,
+        native: impl Future<Output = tower_lsp_server::jsonrpc::Result<Option<R>>>,
+        is_nonempty: impl Fn(&R) -> bool,
+    ) -> tower_lsp_server::jsonrpc::Result<Option<R>> {
+        let Ok(uri) = uri_to_url(lsp_uri) else {
+            log::warn!("Invalid URI in {}: {}", request_method, lsp_uri.as_str());
+            return Ok(None);
+        };
+        let Some(host_language) = self.document_language(&uri) else {
+            return Ok(None);
+        };
+        let layer_cfg = self.resolve_layer_config(&host_language, layer_method);
 
         // Subscribe for the WHOLE walk before either arm runs: the arms'
         // own subscribe attempts then find the id taken and proceed without

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -1074,11 +1074,14 @@ impl Kakehashi {
     }
 
     /// Range-overlap variant of [`Self::resolve_bridge_contexts_for_range`]:
-    /// when `range.start` is not inside an injection — save-time flows
-    /// (`editor.codeActionsOnSave`) request with a whole-document range
-    /// starting at (0,0) — fall back to the FIRST region intersecting the
-    /// range and clamp the request range to it, so coordinate translation
-    /// stays in-region. Only the first intersecting region is bridged
+    /// bridge the FIRST region (document order) that intersects the range
+    /// and resolves to bridge server configs, clamping the request range to
+    /// that region so coordinate translation stays in-region — a range that
+    /// merely starts inside a region can still overshoot its end, and
+    /// save-time flows (`editor.codeActionsOnSave`) request with a
+    /// whole-document range starting at (0,0), outside any injection.
+    /// Unconfigured injections (e.g. `markdown_inline`) never shadow a
+    /// configured region further down. Only one region is bridged
     /// (preferred semantics; multi-region merging is #568 stage 7).
     pub(crate) async fn resolve_bridge_contexts_for_range_overlap(
         &self,
@@ -1086,17 +1089,13 @@ impl Kakehashi {
         range: Range,
         method_name: &str,
     ) -> Option<RangeRequestContext> {
-        if let Some(ctx) = self
-            .resolve_bridge_contexts_for_range(lsp_uri, range, method_name)
-            .await
-        {
-            return Some(ctx);
-        }
+        self.ensure_fresh_tree_for_bridge(lsp_uri).await;
         self.resolve_first_region_overlapping_range(lsp_uri, range, method_name)
     }
 
-    /// Whole-document region scan behind the overlap fallback: the tree is
-    /// already fresh (the primary resolver awaited it).
+    /// Whole-document region scan behind
+    /// [`Self::resolve_bridge_contexts_for_range_overlap`]; the tree is
+    /// already fresh (the caller awaited it).
     fn resolve_first_region_overlapping_range(
         &self,
         lsp_uri: &Uri,

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -1072,6 +1072,89 @@ impl Kakehashi {
 
         Some(RangeRequestContext { document, range })
     }
+
+    /// Range-overlap variant of [`Self::resolve_bridge_contexts_for_range`]:
+    /// when `range.start` is not inside an injection — save-time flows
+    /// (`editor.codeActionsOnSave`) request with a whole-document range
+    /// starting at (0,0) — fall back to the FIRST region intersecting the
+    /// range and clamp the request range to it, so coordinate translation
+    /// stays in-region. Only the first intersecting region is bridged
+    /// (preferred semantics; multi-region merging is #568 stage 7).
+    pub(crate) async fn resolve_bridge_contexts_for_range_overlap(
+        &self,
+        lsp_uri: &Uri,
+        range: Range,
+        method_name: &str,
+    ) -> Option<RangeRequestContext> {
+        if let Some(ctx) = self
+            .resolve_bridge_contexts_for_range(lsp_uri, range, method_name)
+            .await
+        {
+            return Some(ctx);
+        }
+        self.resolve_first_region_overlapping_range(lsp_uri, range, method_name)
+    }
+
+    /// Whole-document region scan behind the overlap fallback: the tree is
+    /// already fresh (the primary resolver awaited it).
+    fn resolve_first_region_overlapping_range(
+        &self,
+        lsp_uri: &Uri,
+        range: Range,
+        method_name: &str,
+    ) -> Option<RangeRequestContext> {
+        let uri = uri_to_url(lsp_uri).ok()?;
+        let snapshot = self.documents.get(&uri)?.snapshot()?;
+        let language_name = self.document_language(&uri)?;
+        let injection_query = self.language.injection_query(&language_name)?;
+
+        let regions = crate::language::InjectionResolver::resolve_all(
+            &self.language,
+            self.bridge.node_tracker(),
+            &uri,
+            snapshot.tree(),
+            snapshot.text(),
+            injection_query.as_ref(),
+        );
+
+        // First intersecting region that resolves to bridge server configs
+        // wins: unconfigured injections (e.g. markdown_inline) must not
+        // shadow a configured region further down the document.
+        regions
+            .into_iter()
+            .filter(|resolved| {
+                // line_range end is exclusive; intersect on lines only.
+                let lines = &resolved.region.line_range;
+                lines.start <= range.end.line && range.start.line < lines.end
+            })
+            .find_map(|resolved| {
+                // Clamp to the region so the translated range is in-region.
+                let region_start = Position {
+                    line: resolved.region.line_range.start,
+                    character: resolved.region.start_column,
+                };
+                let region_end = Position {
+                    line: resolved.region.line_range.end,
+                    character: 0,
+                };
+                let clamped = Range {
+                    start: range.start.max(region_start),
+                    end: range.end.min(region_end),
+                };
+
+                let preamble = PreambleResult {
+                    uri: uri.clone(),
+                    resolved,
+                    language_name: language_name.clone(),
+                    upstream_request_id: current_upstream_id(),
+                };
+                let document = self.preamble_to_document_context(preamble, method_name)?;
+                Some(RangeRequestContext {
+                    document,
+                    range: clamped,
+                })
+            })
+    }
 }
 
 #[cfg(test)]

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -111,6 +111,17 @@ impl Kakehashi {
         self.bridge
             .pool()
             .set_workspace_folders(workspace_folders_for_bridge);
+        // Clients without codeActionLiteralSupport only understand
+        // `Command[]` responses, and the bridge can only produce CodeAction
+        // literals (commands aren't bridged) — withhold the capability for
+        // them (#568).
+        let client_supports_code_action_literals = params
+            .capabilities
+            .text_document
+            .as_ref()
+            .and_then(|td| td.code_action.as_ref())
+            .and_then(|ca| ca.code_action_literal_support.as_ref())
+            .is_some();
         self.bridge
             .pool()
             .set_client_capabilities(params.capabilities);
@@ -324,7 +335,8 @@ impl Kakehashi {
                 // servers are asked for complete (edit-carrying) actions, and
                 // narrowing kinds would stop clients from asking at all
                 // (#568).
-                code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
+                code_action_provider: client_supports_code_action_literals
+                    .then_some(CodeActionProviderCapability::Simple(true)),
                 code_lens_provider: Some(CodeLensOptions {
                     resolve_provider: Some(true),
                 }),

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -6,18 +6,18 @@ use tower_lsp_server::Client;
 use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::ColorProviderCapability;
 use tower_lsp_server::ls_types::{
-    CodeLensOptions, CompletionOptions, DeclarationCapability, DeclarationOptions,
-    DefinitionOptions, DiagnosticOptions, DiagnosticServerCapabilities, DocumentFormattingOptions,
-    DocumentLinkOptions, DocumentOnTypeFormattingOptions, DocumentRangeFormattingOptions,
-    DocumentSymbolOptions, FoldingRangeProviderCapability, HoverProviderCapability,
-    ImplementationProviderCapability, InitializeParams, InitializeResult, InitializedParams,
-    InlayHintOptions, InlayHintServerCapabilities, LinkedEditingRangeServerCapabilities, OneOf,
-    ReferenceOptions, RenameOptions, SaveOptions, SelectionRangeProviderCapability,
-    SemanticTokenModifier, SemanticTokenType, SemanticTokensFullOptions, SemanticTokensLegend,
-    SemanticTokensOptions, SemanticTokensServerCapabilities, ServerCapabilities, ServerInfo,
-    SignatureHelpOptions, TextDocumentSyncCapability, TextDocumentSyncKind,
-    TextDocumentSyncOptions, TextDocumentSyncSaveOptions, TypeDefinitionProviderCapability, Uri,
-    WorkDoneProgressOptions,
+    CodeActionProviderCapability, CodeLensOptions, CompletionOptions, DeclarationCapability,
+    DeclarationOptions, DefinitionOptions, DiagnosticOptions, DiagnosticServerCapabilities,
+    DocumentFormattingOptions, DocumentLinkOptions, DocumentOnTypeFormattingOptions,
+    DocumentRangeFormattingOptions, DocumentSymbolOptions, FoldingRangeProviderCapability,
+    HoverProviderCapability, ImplementationProviderCapability, InitializeParams, InitializeResult,
+    InitializedParams, InlayHintOptions, InlayHintServerCapabilities,
+    LinkedEditingRangeServerCapabilities, OneOf, ReferenceOptions, RenameOptions, SaveOptions,
+    SelectionRangeProviderCapability, SemanticTokenModifier, SemanticTokenType,
+    SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
+    SemanticTokensServerCapabilities, ServerCapabilities, ServerInfo, SignatureHelpOptions,
+    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
+    TextDocumentSyncSaveOptions, TypeDefinitionProviderCapability, Uri, WorkDoneProgressOptions,
 };
 use url::Url;
 
@@ -320,6 +320,11 @@ impl Kakehashi {
                 // codeLens/resolve is routed to the origin downstream server
                 // via the envelope in lens.data (#355, see
                 // bridge/text_document/code_lens.rs).
+                // No resolveProvider or codeActionKinds yet: downstream
+                // servers are asked for complete (edit-carrying) actions, and
+                // narrowing kinds would stop clients from asking at all
+                // (#568).
+                code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
                 code_lens_provider: Some(CodeLensOptions {
                     resolve_provider: Some(true),
                 }),

--- a/src/lsp/lsp_impl/text_document.rs
+++ b/src/lsp/lsp_impl/text_document.rs
@@ -1,5 +1,6 @@
 //! Text document related LSP methods.
 
+mod code_action;
 mod code_lens;
 mod color_presentation;
 mod completion;

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -1,0 +1,192 @@
+//! Code action method for Kakehashi (#568, edit-carrying actions only).
+//!
+//! Walks the resolved layer order (cross-layer-aggregation): the virt layer
+//! bridges the injection region under the requested range, the host layer
+//! (host-document-bridge) bridges the host document itself. Both apply the
+//! `"{title} — {server}"` suffix, so the host arm cannot use the generic
+//! verbatim raw-value walk — it dispatches typed per server to keep the
+//! server name ([`Kakehashi::walk_layer_futures`]).
+
+use tower_lsp_server::jsonrpc::Result;
+use tower_lsp_server::ls_types::{
+    CodeActionContext, CodeActionParams, CodeActionResponse, MessageType, NumberOrString, Range,
+    Uri,
+};
+
+use super::super::Kakehashi;
+use crate::lsp::aggregation::server::{FanInResult, dispatch_host_preferred, dispatch_preferred};
+use crate::lsp::bridge::{HostDocument, bridge_code_actions};
+
+const METHOD: &str = "textDocument/codeAction";
+
+impl Kakehashi {
+    pub(crate) async fn code_action_impl(
+        &self,
+        params: CodeActionParams,
+    ) -> Result<Option<CodeActionResponse>> {
+        let raw_params = serde_json::to_value(&params).unwrap_or(serde_json::Value::Null);
+        let work_done_token = params.work_done_progress_params.work_done_token;
+        let lsp_uri = params.text_document.uri;
+        let range = params.range;
+        let context = params.context;
+        let client_supports_disabled = self.client_supports_code_action_disabled();
+
+        let virt = self.code_action_virt_layer(
+            &lsp_uri,
+            range,
+            context,
+            work_done_token,
+            client_supports_disabled,
+        );
+        let host = self.code_action_host_layer(&lsp_uri, raw_params, client_supports_disabled);
+        self.walk_layer_futures(
+            &lsp_uri,
+            METHOD,
+            METHOD,
+            virt,
+            host,
+            std::future::ready(Ok(None)),
+            |actions: &CodeActionResponse| !actions.is_empty(),
+        )
+        .await
+    }
+
+    /// Whether the upstream client can render `CodeAction.disabled`
+    /// (LSP 3.16 `disabledSupport`). Gates the disable-vs-drop policy for
+    /// actions the bridge cannot execute yet.
+    fn client_supports_code_action_disabled(&self) -> bool {
+        self.settings_manager
+            .client_capabilities_lock()
+            .get()
+            .and_then(|caps| caps.text_document.as_ref())
+            .and_then(|td| td.code_action.as_ref())
+            .and_then(|ca| ca.disabled_support)
+            .unwrap_or(false)
+    }
+
+    /// Virt layer: bridge the injection region under the requested range.
+    async fn code_action_virt_layer(
+        &self,
+        lsp_uri: &Uri,
+        range: Range,
+        context: CodeActionContext,
+        client_progress_token: Option<NumberOrString>,
+        client_supports_disabled: bool,
+    ) -> Result<Option<CodeActionResponse>> {
+        let Some(mut ctx) = self
+            .resolve_bridge_contexts_for_range(lsp_uri, range, METHOD)
+            .await
+        else {
+            return Ok(None);
+        };
+        ctx.document.client_progress_token = client_progress_token;
+
+        let (cancel_rx, _cancel_guard) =
+            self.subscribe_cancel(ctx.document.upstream_request_id.as_ref());
+
+        let pool = self.bridge.pool_arc();
+        let range = ctx.range;
+        let result = dispatch_preferred(
+            &ctx.document,
+            pool.clone(),
+            |t| {
+                let context = context.clone();
+                async move {
+                    t.pool
+                        .send_code_action_request(
+                            &t.server_name,
+                            &t.server_config,
+                            &t.uri,
+                            range,
+                            context,
+                            &t.injection_language,
+                            &t.region_id,
+                            t.offset,
+                            &t.virtual_content,
+                            t.upstream_id,
+                            t.client_progress_token,
+                            client_supports_disabled,
+                        )
+                        .await
+                }
+            },
+            |opt| matches!(opt, Some(v) if !v.is_empty()),
+            cancel_rx,
+        )
+        .await;
+        pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
+
+        result.handle(&self.client, "code action", None, Ok).await
+    }
+
+    /// Host layer: forward the params verbatim to the host language's own
+    /// servers, then apply the bridge action policy (suffix, command
+    /// disabling) per winning server. Edits stay verbatim — real URIs and
+    /// coordinates need no translation.
+    async fn code_action_host_layer(
+        &self,
+        lsp_uri: &Uri,
+        raw_params: serde_json::Value,
+        client_supports_disabled: bool,
+    ) -> Result<Option<CodeActionResponse>> {
+        let Some(ctx) = self.resolve_host_bridge_context(lsp_uri, METHOD) else {
+            return Ok(None);
+        };
+        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(ctx.upstream_request_id.as_ref());
+        let pool = self.bridge.pool_arc();
+        let result = dispatch_host_preferred(
+            &ctx,
+            pool.clone(),
+            move |t| {
+                let params = raw_params.clone();
+                async move {
+                    let raw = t
+                        .pool
+                        .send_host_raw_request(
+                            &t.server_name,
+                            &t.server_config,
+                            &HostDocument {
+                                uri: &t.uri,
+                                language_id: &t.language_id,
+                                text: &t.text,
+                            },
+                            METHOD,
+                            params,
+                            t.upstream_id,
+                        )
+                        .await?;
+                    Ok(raw.and_then(|value| {
+                        let actions: CodeActionResponse = serde_json::from_value(value).ok()?;
+                        Some(bridge_code_actions(
+                            actions,
+                            &t.server_name,
+                            client_supports_disabled,
+                            None,
+                        ))
+                    }))
+                }
+            },
+            |opt| matches!(opt, Some(v) if !v.is_empty()),
+            cancel_rx,
+        )
+        .await;
+        pool.unregister_all_for_upstream_id(ctx.upstream_request_id.as_ref());
+        // Same quieting as the generic host arm: an all-empty host layer is
+        // the normal outcome whenever virt answers; only real failures log.
+        match result {
+            FanInResult::Done(value) => Ok(value),
+            FanInResult::NoResult { errors } => {
+                if errors > 0 {
+                    self.client
+                        .log_message(
+                            MessageType::WARNING,
+                            format!("No {METHOD} response from any host bridge server"),
+                        )
+                        .await;
+                }
+                Ok(None)
+            }
+            FanInResult::Cancelled => Err(tower_lsp_server::jsonrpc::Error::request_cancelled()),
+        }
+    }
+}

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -15,7 +15,7 @@ use tower_lsp_server::ls_types::{
 
 use super::super::Kakehashi;
 use crate::lsp::aggregation::server::{FanInResult, dispatch_host_preferred, dispatch_preferred};
-use crate::lsp::bridge::{HostDocument, bridge_code_actions};
+use crate::lsp::bridge::{HostDocument, bridge_code_actions, parse_code_actions_leniently};
 
 const METHOD: &str = "textDocument/codeAction";
 
@@ -156,7 +156,7 @@ impl Kakehashi {
                         )
                         .await?;
                     Ok(raw.and_then(|value| {
-                        let actions: CodeActionResponse = serde_json::from_value(value).ok()?;
+                        let actions = parse_code_actions_leniently(value)?;
                         Some(bridge_code_actions(
                             actions,
                             &t.server_name,

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -74,7 +74,7 @@ impl Kakehashi {
         client_supports_disabled: bool,
     ) -> Result<Option<CodeActionResponse>> {
         let Some(mut ctx) = self
-            .resolve_bridge_contexts_for_range(lsp_uri, range, METHOD)
+            .resolve_bridge_contexts_for_range_overlap(lsp_uri, range, METHOD)
             .await
         else {
             return Ok(None);

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -15,7 +15,9 @@ use tower_lsp_server::ls_types::{
 
 use super::super::Kakehashi;
 use crate::lsp::aggregation::server::{FanInResult, dispatch_host_preferred, dispatch_preferred};
-use crate::lsp::bridge::{HostDocument, bridge_code_actions, parse_code_actions_leniently};
+use crate::lsp::bridge::{
+    HostDocument, UpstreamCodeActionCaps, bridge_code_actions, parse_code_actions_leniently,
+};
 
 const METHOD: &str = "textDocument/codeAction";
 
@@ -29,16 +31,11 @@ impl Kakehashi {
         let lsp_uri = params.text_document.uri;
         let range = params.range;
         let context = params.context;
-        let client_supports_disabled = self.client_supports_code_action_disabled();
+        let upstream_caps = self.upstream_code_action_caps();
 
-        let virt = self.code_action_virt_layer(
-            &lsp_uri,
-            range,
-            context,
-            work_done_token,
-            client_supports_disabled,
-        );
-        let host = self.code_action_host_layer(&lsp_uri, raw_params, client_supports_disabled);
+        let virt =
+            self.code_action_virt_layer(&lsp_uri, range, context, work_done_token, upstream_caps);
+        let host = self.code_action_host_layer(&lsp_uri, raw_params, upstream_caps);
         self.walk_layer_futures(
             &lsp_uri,
             METHOD,
@@ -51,17 +48,25 @@ impl Kakehashi {
         .await
     }
 
-    /// Whether the upstream client can render `CodeAction.disabled`
-    /// (LSP 3.16 `disabledSupport`). Gates the disable-vs-drop policy for
-    /// actions the bridge cannot execute yet.
-    fn client_supports_code_action_disabled(&self) -> bool {
-        self.settings_manager
+    /// The upstream client's codeAction capabilities that gate the bridge
+    /// policy: `disabledSupport` (LSP 3.16) drives disable-vs-drop for
+    /// actions the bridge cannot execute yet; `isPreferredSupport`
+    /// (LSP 3.15) gates the isPreferred passthrough.
+    fn upstream_code_action_caps(&self) -> UpstreamCodeActionCaps {
+        let code_action = self
+            .settings_manager
             .client_capabilities_lock()
             .get()
             .and_then(|caps| caps.text_document.as_ref())
-            .and_then(|td| td.code_action.as_ref())
-            .and_then(|ca| ca.disabled_support)
-            .unwrap_or(false)
+            .and_then(|td| td.code_action.as_ref());
+        UpstreamCodeActionCaps {
+            disabled_support: code_action
+                .and_then(|ca| ca.disabled_support)
+                .unwrap_or(false),
+            is_preferred_support: code_action
+                .and_then(|ca| ca.is_preferred_support)
+                .unwrap_or(false),
+        }
     }
 
     /// Virt layer: bridge the injection region under the requested range.
@@ -71,7 +76,7 @@ impl Kakehashi {
         range: Range,
         context: CodeActionContext,
         client_progress_token: Option<NumberOrString>,
-        client_supports_disabled: bool,
+        upstream_caps: UpstreamCodeActionCaps,
     ) -> Result<Option<CodeActionResponse>> {
         let Some(mut ctx) = self
             .resolve_bridge_contexts_for_range_overlap(lsp_uri, range, METHOD)
@@ -105,7 +110,7 @@ impl Kakehashi {
                             &t.virtual_content,
                             t.upstream_id,
                             t.client_progress_token,
-                            client_supports_disabled,
+                            upstream_caps,
                         )
                         .await
                 }
@@ -127,7 +132,7 @@ impl Kakehashi {
         &self,
         lsp_uri: &Uri,
         raw_params: serde_json::Value,
-        client_supports_disabled: bool,
+        upstream_caps: UpstreamCodeActionCaps,
     ) -> Result<Option<CodeActionResponse>> {
         let Some(ctx) = self.resolve_host_bridge_context(lsp_uri, METHOD) else {
             return Ok(None);
@@ -160,7 +165,7 @@ impl Kakehashi {
                         Some(bridge_code_actions(
                             actions,
                             &t.server_name,
-                            client_supports_disabled,
+                            upstream_caps,
                             None,
                         ))
                     }))

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -35,6 +35,8 @@
 //!   normally, then answers formatting with a JSON-RPC *success* whose
 //!   `result` is not a `TextEdit[]`. Exercises the malformed-payload
 //!   request-failure path.
+//! - `code-action` — advertises `codeActionProvider`; returns one
+//!   edit-carrying quickfix plus one bare Command action (#568).
 //! - `code-lens` — advertises `codeLensProvider` with `resolveProvider`;
 //!   answers `textDocument/codeLens` with one UNRESOLVED lens (data only) and
 //!   `codeLens/resolve` by materializing a command that echoes the lens data.
@@ -153,6 +155,10 @@ fn main() {
                     }),
                     "code-lens" => json!({
                         "codeLensProvider": { "resolveProvider": true },
+                        "textDocumentSync": 1
+                    }),
+                    "code-action" => json!({
+                        "codeActionProvider": true,
                         "textDocumentSync": 1
                     }),
                     // `diagnostics-push-pullcap` is BOTH: it advertises
@@ -452,6 +458,41 @@ fn main() {
                             },
                             "data": { "mock": "lens-1" }
                         }])
+                    })
+                    .unwrap_or(Value::Null);
+                respond(&mut writer, id, result);
+            }
+            "textDocument/codeAction" => {
+                // `code-action` mode: one edit-carrying quickfix (an edit on
+                // the requested document at virtual line 0) plus one bare
+                // Command action (not executable until executeCommand is
+                // bridged — must surface as disabled/dropped, never verbatim).
+                let result = message
+                    .pointer("/params/textDocument/uri")
+                    .and_then(Value::as_str)
+                    .filter(|uri| documents.contains_key(*uri))
+                    .map(|uri| {
+                        json!([
+                            {
+                                "title": "Replace with fixed",
+                                "kind": "quickfix",
+                                "edit": {
+                                    "changes": {
+                                        uri: [{
+                                            "range": {
+                                                "start": { "line": 0, "character": 0 },
+                                                "end": { "line": 0, "character": 5 }
+                                            },
+                                            "newText": "fixed"
+                                        }]
+                                    }
+                                }
+                            },
+                            {
+                                "title": "Run mock command",
+                                "command": "mock.run"
+                            }
+                        ])
                     })
                     .unwrap_or(Value::Null);
                 respond(&mut writer, id, result);

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -23,7 +23,7 @@ fn mock_formatter_bin() -> &'static str {
     env!("CARGO_BIN_EXE_mock-lsp-formatter")
 }
 
-fn init_client(client_capabilities: Value) -> (LspClient, tempfile::TempDir) {
+fn init_client(client_capabilities: Value) -> (LspClient, Value, tempfile::TempDir) {
     let bin = mock_formatter_bin();
     let config_dir = tempfile::TempDir::new().expect("Failed to create config temp dir");
     let config_path = config_dir.path().join("code_action.toml");
@@ -46,13 +46,29 @@ fn init_client(client_capabilities: Value) -> (LspClient, tempfile::TempDir) {
             }}
         }),
     );
+    client.send_notification("initialized", json!({}));
+    (client, init_response, config_dir)
+}
+
+/// Client capabilities with codeActionLiteralSupport (required for the
+/// bridge to advertise codeActionProvider at all — it can only produce
+/// CodeAction literals), optionally with disabledSupport.
+fn literal_support_caps(disabled_support: bool) -> Value {
+    let mut code_action = json!({
+        "codeActionLiteralSupport": { "codeActionKind": { "valueSet": [] } }
+    });
+    if disabled_support {
+        code_action["disabledSupport"] = json!(true);
+    }
+    json!({ "textDocument": { "codeAction": code_action } })
+}
+
+fn assert_advertised(init_response: &Value) {
     assert_eq!(
         init_response["result"]["capabilities"]["codeActionProvider"],
         json!(true),
-        "codeActionProvider must be advertised (#568)"
+        "codeActionProvider must be advertised for literal-support clients (#568)"
     );
-    client.send_notification("initialized", json!({}));
-    (client, config_dir)
 }
 
 /// Markdown host: the lua fence content sits on host line 3.
@@ -107,7 +123,8 @@ fn code_action_with_retry(client: &mut LspClient) -> Vec<Value> {
 #[test]
 fn code_action_edit_is_host_translated_and_suffixed() {
     // No disabledSupport: the bare Command action must be dropped entirely.
-    let (mut client, _config_dir) = init_client(json!({}));
+    let (mut client, init_response, _config_dir) = init_client(literal_support_caps(false));
+    assert_advertised(&init_response);
     open_markdown(&mut client);
 
     let actions = code_action_with_retry(&mut client);
@@ -137,7 +154,8 @@ fn whole_document_range_reaches_the_injection_region() {
     // Save-time flows (editor.codeActionsOnSave) request with a range that
     // starts at (0,0), OUTSIDE any injection — the bridge must still find
     // the overlapped region instead of skipping the virt layer.
-    let (mut client, _config_dir) = init_client(json!({}));
+    let (mut client, init_response, _config_dir) = init_client(literal_support_caps(false));
+    assert_advertised(&init_response);
     open_markdown(&mut client);
 
     let actions = (0..300)
@@ -174,10 +192,23 @@ fn whole_document_range_reaches_the_injection_region() {
 }
 
 #[test]
+fn code_action_not_advertised_without_literal_support() {
+    // A client without codeActionLiteralSupport only understands Command[]
+    // responses, which the bridge cannot produce — the capability must be
+    // withheld so the client never asks.
+    let (mut client, init_response, _config_dir) = init_client(json!({}));
+    assert_eq!(
+        init_response["result"]["capabilities"]["codeActionProvider"],
+        Value::Null,
+        "codeActionProvider must be withheld without literal support"
+    );
+    shutdown(&mut client);
+}
+
+#[test]
 fn command_action_surfaces_as_disabled_with_disabled_support() {
-    let (mut client, _config_dir) = init_client(json!({
-        "textDocument": { "codeAction": { "disabledSupport": true } }
-    }));
+    let (mut client, init_response, _config_dir) = init_client(literal_support_caps(true));
+    assert_advertised(&init_response);
     open_markdown(&mut client);
 
     let actions = code_action_with_retry(&mut client);

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -82,7 +82,7 @@ fn open_markdown(client: &mut LspClient) {
 /// Issue `textDocument/codeAction` over the lua fence line, retrying while
 /// the result is null (cold downstream still handshaking).
 fn code_action_with_retry(client: &mut LspClient) -> Vec<Value> {
-    for _ in 0..20 {
+    for _ in 0..300 {
         let response = client.send_request(
             "textDocument/codeAction",
             json!({
@@ -99,7 +99,7 @@ fn code_action_with_retry(client: &mut LspClient) -> Vec<Value> {
         {
             return actions.clone();
         }
-        std::thread::sleep(Duration::from_millis(300));
+        std::thread::sleep(Duration::from_millis(50));
     }
     panic!("textDocument/codeAction never returned actions");
 }

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -1,0 +1,157 @@
+//! E2E tests for bridged `textDocument/codeAction` (#568, edit-carrying
+//! stage), using the `mock-lsp-formatter` test binary in `code-action` mode
+//! (one edit-carrying quickfix + one bare Command action).
+//!
+//! Proves end-to-end:
+//! - `codeActionProvider` is advertised upstream.
+//! - The request range is translated host→virtual, the returned edit is
+//!   re-keyed to the host URI with host-translated ranges, and the title
+//!   carries the `"{title} — {server}"` suffix.
+//! - A bare Command action surfaces as a disabled placeholder for a client
+//!   with `disabledSupport`, and is dropped for a client without it.
+
+#![cfg(feature = "e2e")]
+
+mod helpers;
+
+use std::time::Duration;
+
+use helpers::lsp_client::LspClient;
+use serde_json::{Value, json};
+
+fn mock_formatter_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_mock-lsp-formatter")
+}
+
+fn init_client(client_capabilities: Value) -> (LspClient, tempfile::TempDir) {
+    let bin = mock_formatter_bin();
+    let config_dir = tempfile::TempDir::new().expect("Failed to create config temp dir");
+    let config_path = config_dir.path().join("code_action.toml");
+    std::fs::write(&config_path, "").expect("Failed to write config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("temp path should be UTF-8"))
+        .build();
+
+    let init_response = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": client_capabilities,
+            "workspaceFolders": null,
+            "initializationOptions": { "languageServers": {
+                "mock-codeaction": { "cmd": [bin, "code-action"], "languages": ["lua"] }
+            }}
+        }),
+    );
+    assert_eq!(
+        init_response["result"]["capabilities"]["codeActionProvider"],
+        json!(true),
+        "codeActionProvider must be advertised (#568)"
+    );
+    client.send_notification("initialized", json!({}));
+    (client, config_dir)
+}
+
+/// Markdown host: the lua fence content sits on host line 3.
+const MARKDOWN: &str = "# Test\n\n```lua\nlocal x = 1\n```\n";
+const MARKDOWN_URI: &str = "file:///test_code_action.md";
+
+fn shutdown(client: &mut LspClient) {
+    let _ = client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+fn open_markdown(client: &mut LspClient) {
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": MARKDOWN_URI,
+                "languageId": "markdown",
+                "version": 1,
+                "text": MARKDOWN
+            }
+        }),
+    );
+    std::thread::sleep(Duration::from_millis(1000));
+}
+
+/// Issue `textDocument/codeAction` over the lua fence line, retrying while
+/// the result is null (cold downstream still handshaking).
+fn code_action_with_retry(client: &mut LspClient) -> Vec<Value> {
+    for _ in 0..20 {
+        let response = client.send_request(
+            "textDocument/codeAction",
+            json!({
+                "textDocument": { "uri": MARKDOWN_URI },
+                "range": {
+                    "start": { "line": 3, "character": 0 },
+                    "end": { "line": 3, "character": 5 }
+                },
+                "context": { "diagnostics": [] }
+            }),
+        );
+        if let Some(actions) = response["result"].as_array()
+            && !actions.is_empty()
+        {
+            return actions.clone();
+        }
+        std::thread::sleep(Duration::from_millis(300));
+    }
+    panic!("textDocument/codeAction never returned actions");
+}
+
+#[test]
+fn code_action_edit_is_host_translated_and_suffixed() {
+    // No disabledSupport: the bare Command action must be dropped entirely.
+    let (mut client, _config_dir) = init_client(json!({}));
+    open_markdown(&mut client);
+
+    let actions = code_action_with_retry(&mut client);
+
+    assert_eq!(
+        actions.len(),
+        1,
+        "the Command action must be dropped without disabledSupport, got: {actions:?}"
+    );
+    let action = &actions[0];
+    assert_eq!(action["title"], "Replace with fixed — mock-codeaction");
+    assert_eq!(action["kind"], "quickfix");
+    let edits = &action["edit"]["changes"][MARKDOWN_URI];
+    assert!(
+        edits.is_array(),
+        "edit must be re-keyed to the host URI, got: {action:?}"
+    );
+    // Virtual line 0 = host line 3 (fence content line).
+    assert_eq!(edits[0]["range"]["start"]["line"], 3);
+    assert_eq!(edits[0]["newText"], "fixed");
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn command_action_surfaces_as_disabled_with_disabled_support() {
+    let (mut client, _config_dir) = init_client(json!({
+        "textDocument": { "codeAction": { "disabledSupport": true } }
+    }));
+    open_markdown(&mut client);
+
+    let actions = code_action_with_retry(&mut client);
+
+    assert_eq!(actions.len(), 2, "got: {actions:?}");
+    let disabled: Vec<&Value> = actions
+        .iter()
+        .filter(|a| a["disabled"].is_object())
+        .collect();
+    assert_eq!(disabled.len(), 1, "exactly one disabled placeholder");
+    assert_eq!(disabled[0]["title"], "Run mock command — mock-codeaction");
+    assert!(
+        disabled[0]["command"].is_null() && disabled[0]["edit"].is_null(),
+        "a disabled placeholder must not carry an executable payload"
+    );
+
+    shutdown(&mut client);
+}

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -133,6 +133,47 @@ fn code_action_edit_is_host_translated_and_suffixed() {
 }
 
 #[test]
+fn whole_document_range_reaches_the_injection_region() {
+    // Save-time flows (editor.codeActionsOnSave) request with a range that
+    // starts at (0,0), OUTSIDE any injection — the bridge must still find
+    // the overlapped region instead of skipping the virt layer.
+    let (mut client, _config_dir) = init_client(json!({}));
+    open_markdown(&mut client);
+
+    let actions = (0..300)
+        .find_map(|_| {
+            let response = client.send_request(
+                "textDocument/codeAction",
+                json!({
+                    "textDocument": { "uri": MARKDOWN_URI },
+                    "range": {
+                        "start": { "line": 0, "character": 0 },
+                        "end": { "line": 5, "character": 0 }
+                    },
+                    "context": { "diagnostics": [] }
+                }),
+            );
+            match response["result"].as_array() {
+                Some(actions) if !actions.is_empty() => Some(actions.clone()),
+                _ => {
+                    std::thread::sleep(Duration::from_millis(50));
+                    None
+                }
+            }
+        })
+        .expect("whole-document codeAction never returned actions");
+
+    assert_eq!(actions[0]["title"], "Replace with fixed — mock-codeaction");
+    // The edit still lands on the fence content line in host coordinates.
+    assert_eq!(
+        actions[0]["edit"]["changes"][MARKDOWN_URI][0]["range"]["start"]["line"],
+        3
+    );
+
+    shutdown(&mut client);
+}
+
+#[test]
 fn command_action_surfaces_as_disabled_with_disabled_support() {
     let (mut client, _config_dir) = init_client(json!({
         "textDocument": { "codeAction": { "disabledSupport": true } }


### PR DESCRIPTION
> Recreates #606, which was falsely auto-marked *merged* by an accidental rebase+force-push (branches and commits restored unchanged).

---

## Summary

PR 3 of the #568 sequence, **stacked on #570**. First user-visible codeAction increment: quickfixes/refactors whose edits arrive inline (ruff, lua_ls, most linters) work end-to-end on both bridge layers.

### Upstream / downstream capability surface
- Advertise `code_action_provider: Simple(true)` — **no** `resolveProvider`, **no** `codeActionKinds` (narrow kinds stop clients from asking at all; resolve comes in PR 4).
- Downstream client-caps baseline gains `codeAction`: literal support + kindValueSet, `disabledSupport`, `isPreferredSupport` — deliberately **no** `dataSupport`/`resolveSupport` yet, so servers return complete (edit-carrying) actions.
- `has_capability` arm rejecting `Simple(false)`.

### Request/response translation (virt layer)
- Range AND `context.diagnostics` ranges translated host→virtual; diagnostic `data`/`source`/`code` byte-identical for downstream matching (checklist §1). `only`/`triggerKind` pass through (§3).
- Response edits translated back via the shared WorkspaceEdit transform (#570); action diagnostics translated back too.

### Host layer
Params forwarded verbatim per host server; edits stay verbatim. Dispatches **typed per server** (not the generic raw-value host arm) so the winning server's name is available for the title suffix — enabled by extracting `walk_layer_futures` from the layer walk (first commit, pure refactor).

### Policy (checklist §5, gated on the client's `disabledSupport`, else dropped)
- Every bridged title gets the `"{title} — {server}"` suffix, unconditionally.
- Command-carrying actions → `disabled` (commands not bridged until PR 6); an edit+command action is disabled whole — applying half is worse than none.
- Unrepresentable edits (virtual-URI file ops → whole-edit rejection from #570) → action disabled with payload stripped.
- Lazy data-only actions → disabled (resolve not bridged until PR 4).

### Tests
- 13 unit tests on the builder/transform/policy (translation both ways, suffix, each disable/drop path, host-verbatim policy).
- 2 E2E tests via a new `code-action` mode of `mock-lsp-formatter`: host→virtual→host round trip with suffix, and the disabledSupport-gated Command policy.
- `textDocument/codeAction` classified as an ingress reader.

## Test plan
- [x] `cargo clippy --lib --tests --features e2e -- -D warnings` clean
- [x] Full lib suite: 2467 passed
- [x] `cargo test --features e2e --test e2e_code_action`: both scenarios green

Part of #568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for code actions in the editor experience, including quick fixes and command-based actions.
  * Code actions now work with supported document ranges and preserve host-side edits and diagnostics.

* **Bug Fixes**
  * Improved handling of code action capabilities so supported actions are shown only when the client can use them.
  * Fixed code action routing for documents with embedded or overlapping regions, including cursor-edge cases.
  * Better resilience when parsing code action results, avoiding failures from malformed entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->