### PR TITLE
feat(bridge): handle inbound workspace/applyEdit from downstream servers (#568 PR 5)

### DIFF
--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -66,8 +66,9 @@ pub(crate) use protocol::RegionOffset;
 pub(crate) use protocol::RequestId;
 pub(crate) use protocol::VirtualDocumentUri;
 pub(crate) use protocol::location_link_to_location;
-pub(crate) use protocol::translate_virtual_range_to_host;
 pub(crate) use protocol::transform_workspace_edit_to_host;
+pub(crate) use protocol::translate_virtual_range_to_host;
+pub(crate) use protocol::workspace_edit_within_region;
 pub(crate) use text_document::host::{HostDocument, HostTextReader, normalize_host_goto_result};
 pub(crate) use text_document::{
     CodeActionEnvelope, CodeLensEnvelope, UpstreamCodeActionCaps, bridge_code_actions,

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -67,6 +67,7 @@ pub(crate) use protocol::RequestId;
 pub(crate) use protocol::VirtualDocumentUri;
 pub(crate) use protocol::location_link_to_location;
 pub(crate) use protocol::translate_virtual_range_to_host;
+pub(crate) use protocol::transform_workspace_edit_to_host;
 pub(crate) use text_document::host::{HostDocument, HostTextReader, normalize_host_goto_result};
 pub(crate) use text_document::{
     CodeActionEnvelope, CodeLensEnvelope, UpstreamCodeActionCaps, bridge_code_actions,

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -174,6 +174,16 @@ pub(crate) enum UpstreamRequest {
         reply: oneshot::Sender<bool>,
         cancel: ForwardedRequestCancel,
     },
+    /// Forward a `workspace/applyEdit`; the editor's full response (`applied`,
+    /// `failureReason`, `failedChange`) is relayed back — the downstream acts
+    /// on the outcome. The forwarding loop translates virtual-document edits
+    /// back to host coordinates before the editor sees them, and answers
+    /// untranslatable edits `applied: false` locally (#568).
+    ApplyEdit {
+        params: tower_lsp_server::ls_types::ApplyWorkspaceEditParams,
+        reply: oneshot::Sender<tower_lsp_server::ls_types::ApplyWorkspaceEditResponse>,
+        cancel: ForwardedRequestCancel,
+    },
 }
 
 /// Cancellation context for a forwarded request: the originating connection and
@@ -232,9 +242,9 @@ pub(crate) struct ServerRequestDeps {
     /// dropped when full.
     pub(crate) window_tx: mpsc::Sender<UpstreamNotification>,
     /// Downstream-initiated requests forwarded to the editor with a response
-    /// relayed back (`window/showMessageRequest`, `window/showDocument`).
-    /// Unbounded: a dropped request would hang the downstream. See
-    /// [`UpstreamRequest`].
+    /// relayed back (`window/showMessageRequest`, `window/showDocument`,
+    /// `workspace/applyEdit`). Unbounded: a dropped request would hang the
+    /// downstream. See [`UpstreamRequest`].
     pub(crate) upstream_request_tx: mpsc::UnboundedSender<UpstreamRequest>,
     /// Tracks in-flight forwarded requests so a downstream `$/cancelRequest`
     /// (or connection death) can cancel the editor-bound request (#404).
@@ -908,6 +918,10 @@ async fn handle_server_request(
         }
         "window/showDocument" => {
             window::show_document::handle(&message, id, server_prefix, deps);
+            return;
+        }
+        "workspace/applyEdit" => {
+            workspace::apply_edit::handle(&message, id, server_prefix, deps);
             return;
         }
         _ => {}
@@ -3341,5 +3355,101 @@ mod tests {
         let response = recv_untracked(&mut response_rx).await;
         assert_eq!(response["id"], 12);
         assert_eq!(response["result"]["success"], false);
+    }
+
+    #[tokio::test]
+    async fn handle_message_apply_edit_relays_full_editor_response() {
+        let router = ResponseRouter::new();
+        let (deps, mut response_rx, mut request_rx) = server_request_deps_with_request_rx();
+
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 20,
+            "method": "workspace/applyEdit",
+            "params": {
+                "label": "organize imports",
+                "edit": { "changes": { "file:///p/main.rs": [] } }
+            }
+        });
+        handle_message(request, &router, "", &deps).await;
+
+        let UpstreamRequest::ApplyEdit { params, reply, .. } = request_rx
+            .recv()
+            .await
+            .expect("should forward an UpstreamRequest")
+        else {
+            panic!("expected ApplyEdit");
+        };
+        assert_eq!(params.label.as_deref(), Some("organize imports"));
+
+        // The editor rejected the edit: `applied`, `failureReason`, and
+        // `failedChange` must all reach the downstream — it acts on them.
+        reply
+            .send(
+                serde_json::from_value(json!({
+                    "applied": false,
+                    "failureReason": "user rejected",
+                    "failedChange": 1
+                }))
+                .unwrap(),
+            )
+            .expect("reply channel open");
+
+        let response = recv_untracked(&mut response_rx).await;
+        assert_eq!(response["id"], 20);
+        assert_eq!(response["result"]["applied"], false);
+        assert_eq!(response["result"]["failureReason"], "user rejected");
+        assert_eq!(response["result"]["failedChange"], 1);
+    }
+
+    #[tokio::test]
+    async fn handle_message_apply_edit_editor_drop_responds_applied_false() {
+        let router = ResponseRouter::new();
+        let (deps, mut response_rx, mut request_rx) = server_request_deps_with_request_rx();
+
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 21,
+            "method": "workspace/applyEdit",
+            "params": { "edit": {} }
+        });
+        handle_message(request, &router, "", &deps).await;
+
+        // Dropping the request (and its reply sender) simulates the editor
+        // failing to answer; the downstream must still get `applied: false`.
+        let request = request_rx.recv().await.expect("forwarded");
+        drop(request);
+
+        let response = recv_untracked(&mut response_rx).await;
+        assert_eq!(response["id"], 21);
+        assert_eq!(response["result"]["applied"], false);
+        assert!(
+            response["result"]["failureReason"].is_string(),
+            "a fabricated failure must carry a reason: {response}"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_message_apply_edit_invalid_params_responds_error() {
+        let router = ResponseRouter::new();
+        let (deps, mut response_rx, mut request_rx) = server_request_deps_with_request_rx();
+
+        // Missing the required `edit` field.
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 22,
+            "method": "workspace/applyEdit",
+            "params": { "label": "no edit" }
+        });
+        handle_message(request, &router, "", &deps).await;
+
+        let response = recv_untracked(&mut response_rx).await;
+        assert_eq!(response["id"], 22);
+        assert!(
+            response["error"].is_object(),
+            "invalid params should produce an error response: {response}"
+        );
+        // No request should have been forwarded to the editor.
+        assert!(request_rx.try_recv().is_err());
     }
 }

--- a/src/lsp/bridge/inbound_request_registry.rs
+++ b/src/lsp/bridge/inbound_request_registry.rs
@@ -1,5 +1,6 @@
 //! Cancellation registry for downstream-initiated requests forwarded to the
-//! editor (`window/showMessageRequest`, `window/showDocument`).
+//! editor (`window/showMessageRequest`, `window/showDocument`,
+//! `workspace/applyEdit`).
 //!
 //! When a downstream server sends `$/cancelRequest` for such a request — or its
 //! connection dies while one is in flight — the bridge must tell the editor to

--- a/src/lsp/bridge/protocol/client_capabilities.rs
+++ b/src/lsp/bridge/protocol/client_capabilities.rs
@@ -124,6 +124,13 @@ fn build_baseline_capabilities(
     ClientCapabilities {
         text_document: Some(text_document),
         workspace: Some(WorkspaceClientCapabilities {
+            // The bridge handles inbound `workspace/applyEdit` (#568 PR 5),
+            // translating virtual-document edits to the host document and
+            // relaying the editor's response. Advertise it so a spec-compliant
+            // downstream server actually issues applyEdit (e.g. rust-analyzer's
+            // "extract into function") instead of assuming the client can't
+            // apply edits.
+            apply_edit: Some(true),
             diagnostics: Some(DiagnosticWorkspaceClientCapabilities {
                 refresh_support: Some(true),
             }),

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@default.snap
@@ -4,6 +4,7 @@ expression: merged
 ---
 {
   "workspace": {
+    "applyEdit": true,
     "workspaceFolders": true,
     "configuration": true,
     "diagnostics": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@experimental.snap
@@ -4,6 +4,7 @@ expression: merged
 ---
 {
   "workspace": {
+    "applyEdit": true,
     "workspaceFolders": true,
     "configuration": true,
     "diagnostics": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@default.snap
@@ -4,6 +4,7 @@ expression: capabilities
 ---
 {
   "workspace": {
+    "applyEdit": true,
     "workspaceFolders": true,
     "configuration": true,
     "diagnostics": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@experimental.snap
@@ -4,6 +4,7 @@ expression: capabilities
 ---
 {
   "workspace": {
+    "applyEdit": true,
     "workspaceFolders": true,
     "configuration": true,
     "diagnostics": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@default.snap
@@ -11,6 +11,7 @@ expression: request
     "rootUri": null,
     "capabilities": {
       "workspace": {
+        "applyEdit": true,
         "workspaceFolders": true,
         "configuration": true,
         "diagnostics": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@experimental.snap
@@ -11,6 +11,7 @@ expression: request
     "rootUri": null,
     "capabilities": {
       "workspace": {
+        "applyEdit": true,
         "workspaceFolders": true,
         "configuration": true,
         "diagnostics": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@default.snap
@@ -22,6 +22,7 @@ expression: request
     },
     "capabilities": {
       "workspace": {
+        "applyEdit": true,
         "workspaceFolders": true,
         "configuration": true,
         "diagnostics": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@experimental.snap
@@ -22,6 +22,7 @@ expression: request
     },
     "capabilities": {
       "workspace": {
+        "applyEdit": true,
         "workspaceFolders": true,
         "configuration": true,
         "diagnostics": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@default.snap
@@ -11,6 +11,7 @@ expression: request
     "rootUri": null,
     "capabilities": {
       "workspace": {
+        "applyEdit": true,
         "workspaceFolders": true,
         "configuration": true,
         "diagnostics": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@experimental.snap
@@ -11,6 +11,7 @@ expression: request
     "rootUri": null,
     "capabilities": {
       "workspace": {
+        "applyEdit": true,
         "workspaceFolders": true,
         "configuration": true,
         "diagnostics": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@default.snap
@@ -11,6 +11,7 @@ expression: request
     "rootUri": null,
     "capabilities": {
       "workspace": {
+        "applyEdit": true,
         "workspaceFolders": true,
         "configuration": true,
         "diagnostics": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@experimental.snap
@@ -11,6 +11,7 @@ expression: request
     "rootUri": null,
     "capabilities": {
       "workspace": {
+        "applyEdit": true,
         "workspaceFolders": true,
         "configuration": true,
         "diagnostics": {

--- a/src/lsp/bridge/workspace.rs
+++ b/src/lsp/bridge/workspace.rs
@@ -1,10 +1,10 @@
 //! Inbound `workspace/*` server-request handlers.
 //!
 //! The `workspace` LSP namespace is inbound here (downstream → bridge): a
-//! downstream server asks the client (the bridge) to re-pull diagnostics, or
-//! pulls the workspace folders it serves. Each method has its own file so the
-//! directory listing maps to the supported surface, mirroring
-//! [`text_document`](super::text_document).
+//! downstream server asks the client (the bridge) to apply a workspace edit
+//! or re-pull diagnostics, or pulls the workspace folders it serves. Each
+//! method has its own file so the directory listing maps to the supported
+//! surface, mirroring [`text_document`](super::text_document).
 //!
 //! [`folder_set`] holds the per-connection [`WorkspaceFolderSet`] *data type*
 //! that [`workspace_folders`] answers pulls from; keeping the type and its
@@ -14,6 +14,7 @@
 //! The dispatcher in [`actor::reader`](super::actor) owns the shared transport
 //! and routes each method here.
 
+pub(in crate::lsp::bridge) mod apply_edit;
 pub(in crate::lsp::bridge) mod configuration;
 pub(in crate::lsp::bridge) mod diagnostic_refresh;
 mod folder_set;

--- a/src/lsp/bridge/workspace/apply_edit.rs
+++ b/src/lsp/bridge/workspace/apply_edit.rs
@@ -89,8 +89,13 @@ pub(in crate::lsp::bridge) fn handle(
                 .await
                 .unwrap_or_else(|_| ApplyWorkspaceEditResponse {
                     applied: false,
+                    // `reply_rx` drops for BOTH a lost editor response AND a
+                    // never-forwarded request (forwarding loop gone / enqueue
+                    // failed). Keep the single unified drop path (see below) but
+                    // word the reason neutrally so a transport failure isn't
+                    // misattributed to the editor.
                     failure_reason: Some(
-                        "kakehashi: the editor did not answer workspace/applyEdit".to_string(),
+                        "kakehashi: no workspace/applyEdit response was produced".to_string(),
                     ),
                     failed_change: None,
                 });

--- a/src/lsp/bridge/workspace/apply_edit.rs
+++ b/src/lsp/bridge/workspace/apply_edit.rs
@@ -84,15 +84,16 @@ pub(in crate::lsp::bridge) fn handle(
     // response without a special-cased "loop gone" reply path.
     let response_id = id.clone();
     tokio::spawn(async move {
-        let result: ApplyWorkspaceEditResponse = reply_rx.await.unwrap_or_else(|_| {
-            ApplyWorkspaceEditResponse {
-                applied: false,
-                failure_reason: Some(
-                    "kakehashi: the editor did not answer workspace/applyEdit".to_string(),
-                ),
-                failed_change: None,
-            }
-        });
+        let result: ApplyWorkspaceEditResponse =
+            reply_rx
+                .await
+                .unwrap_or_else(|_| ApplyWorkspaceEditResponse {
+                    applied: false,
+                    failure_reason: Some(
+                        "kakehashi: the editor did not answer workspace/applyEdit".to_string(),
+                    ),
+                    failed_change: None,
+                });
         // The typed struct serializes infallibly in practice; the fallback keeps
         // the no-panic guarantee with the same protocol default.
         let result = serde_json::to_value(result)

--- a/src/lsp/bridge/workspace/apply_edit.rs
+++ b/src/lsp/bridge/workspace/apply_edit.rs
@@ -1,0 +1,122 @@
+//! `workspace/applyEdit` server-request handler (#568).
+//!
+//! Inbound (downstream → bridge → editor → downstream). A downstream asks the
+//! client to apply a [`WorkspaceEdit`]; the bridge forwards it to the editor
+//! and relays the editor's full [`ApplyWorkspaceEditResponse`] (`applied`,
+//! `failureReason`, `failedChange`) back — it is a **request**, not a
+//! notification: the downstream acts on the outcome.
+//!
+//! **Edit translation happens downstream of this handler:** the forwarding
+//! loop rewrites virtual-document URIs + ranges back to the host document
+//! (see `ApplyEditTranslator` in `lsp_impl::apply_edit_translation`) before
+//! sending the edit to the editor, and answers untranslatable edits
+//! `applied: false` locally. This handler stays transport-only, exactly like
+//! [`show_document`](crate::lsp::bridge::window::show_document).
+//!
+//! Like the other deferred handlers this **defers** its response on a spawned
+//! task so neither the read loop nor the global forwarding loop blocks. If the
+//! editor errors, or the downstream dies before an answer (the reply channel
+//! drops), the downstream receives `applied: false` with a `failureReason`.
+//!
+//! [`WorkspaceEdit`]: tower_lsp_server::ls_types::WorkspaceEdit
+//! [`ApplyWorkspaceEditResponse`]: tower_lsp_server::ls_types::ApplyWorkspaceEditResponse
+
+use log::{debug, warn};
+use serde::Deserialize;
+use tokio::sync::oneshot;
+use tower_lsp_server::jsonrpc;
+use tower_lsp_server::ls_types::{ApplyWorkspaceEditParams, ApplyWorkspaceEditResponse};
+
+use crate::lsp::bridge::actor::{
+    ForwardedRequestCancel, ServerRequestDeps, UpstreamRequest, send_server_response,
+};
+
+const METHOD: &str = "workspace/applyEdit";
+
+/// Handle a `workspace/applyEdit` request, relaying the editor's
+/// `ApplyWorkspaceEditResponse` back to the downstream asynchronously.
+pub(in crate::lsp::bridge) fn handle(
+    message: &serde_json::Value,
+    id: jsonrpc::Id,
+    server_prefix: &str,
+    deps: &ServerRequestDeps,
+) {
+    let response_tx = deps.response_tx.clone();
+    let server_prefix_owned = server_prefix.to_string();
+
+    let params = match ApplyWorkspaceEditParams::deserialize(&message["params"]) {
+        Ok(params) => params,
+        Err(e) => {
+            warn!(
+                target: "kakehashi::bridge::reader",
+                "{}Rejecting {} with InvalidParams (unparseable params): {}",
+                server_prefix, METHOD, e
+            );
+            tokio::spawn(async move {
+                let response = jsonrpc::Response::from_error(
+                    id,
+                    jsonrpc::Error::invalid_params(format!("Invalid params: {e}")),
+                );
+                send_server_response(&response_tx, response, &server_prefix_owned, METHOD).await;
+            });
+            return;
+        }
+    };
+
+    // Register the in-flight request BEFORE enqueueing it so a racing downstream
+    // `$/cancelRequest` can't miss it (#404). See `show_message_request`.
+    let connection_id = deps.progress_connection_id;
+    let (token, generation) = deps
+        .inbound_request_registry
+        .register(connection_id, id.clone());
+    let cancel = ForwardedRequestCancel {
+        connection_id,
+        request_id: id.clone(),
+        token,
+        generation,
+    };
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+
+    // Spawn the responder first; it owns `reply_rx`. If the request below fails
+    // to enqueue (forwarding loop gone), `reply_tx` drops and `reply_rx` resolves
+    // to `Err`, which maps to `applied: false` — so the downstream always gets a
+    // response without a special-cased "loop gone" reply path.
+    let response_id = id.clone();
+    tokio::spawn(async move {
+        let result: ApplyWorkspaceEditResponse = reply_rx.await.unwrap_or_else(|_| {
+            ApplyWorkspaceEditResponse {
+                applied: false,
+                failure_reason: Some(
+                    "kakehashi: the editor did not answer workspace/applyEdit".to_string(),
+                ),
+                failed_change: None,
+            }
+        });
+        // The typed struct serializes infallibly in practice; the fallback keeps
+        // the no-panic guarantee with the same protocol default.
+        let result = serde_json::to_value(result)
+            .unwrap_or_else(|_| serde_json::json!({ "applied": false }));
+        let response = jsonrpc::Response::from_ok(response_id, result);
+        send_server_response(&response_tx, response, &server_prefix_owned, METHOD).await;
+    });
+
+    if deps
+        .upstream_request_tx
+        .send(UpstreamRequest::ApplyEdit {
+            params,
+            reply: reply_tx,
+            cancel,
+        })
+        .is_err()
+    {
+        // Forwarding loop gone (shutdown): drop the registry entry we just made.
+        deps.inbound_request_registry
+            .unregister(connection_id, &id, generation);
+        debug!(
+            target: "kakehashi::bridge::reader",
+            "{}Forwarding loop gone; answering {} with applied:false",
+            server_prefix, METHOD
+        );
+    }
+}

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -5,6 +5,7 @@ pub(crate) use coordinator::DiagnosticPublisher;
 pub(crate) mod kakehashi;
 mod lifecycle;
 mod parse_scheduler;
+mod region_offset;
 mod show_document_translation;
 mod snapshot_read;
 pub(crate) mod text_document;

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -1,3 +1,4 @@
+mod apply_edit_translation;
 pub(crate) mod bridge_context;
 mod cli;
 mod coordinator;

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -159,6 +159,13 @@ fn transform_params_to_host(
 /// `changes` map, `documentChanges` text edits, and file-operation URIs.
 /// Deduplicated (a URI appearing in both shapes counts once); order follows
 /// discovery and is only meaningful for the single-element case.
+///
+/// A text-edit entry (`changes` value or a `TextDocumentEdit`) with an EMPTY
+/// edit vector is a no-op and does NOT count as touching its URI: an edit that
+/// is real-file-only but carries a stray empty virtual entry must forward
+/// verbatim, not be routed down the virtual-translation path (and then fail
+/// `applied: false`). File operations always count — a create/rename/delete is
+/// a real change even with no accompanying text edits.
 fn collect_virtual_uris(edit: &WorkspaceEdit) -> Vec<String> {
     let mut uris: Vec<String> = Vec::new();
     let mut push = |uri: &str| {
@@ -168,20 +175,27 @@ fn collect_virtual_uris(edit: &WorkspaceEdit) -> Vec<String> {
     };
 
     if let Some(changes) = &edit.changes {
-        for uri in changes.keys() {
-            push(uri.as_str());
+        for (uri, edits) in changes {
+            if !edits.is_empty() {
+                push(uri.as_str());
+            }
         }
     }
     match &edit.document_changes {
         Some(DocumentChanges::Edits(edits)) => {
             for edit in edits {
-                push(edit.text_document.uri.as_str());
+                if !edit.edits.is_empty() {
+                    push(edit.text_document.uri.as_str());
+                }
             }
         }
         Some(DocumentChanges::Operations(ops)) => {
             for op in ops {
                 match op {
-                    DocumentChangeOperation::Edit(edit) => push(edit.text_document.uri.as_str()),
+                    DocumentChangeOperation::Edit(edit) if !edit.edits.is_empty() => {
+                        push(edit.text_document.uri.as_str())
+                    }
+                    DocumentChangeOperation::Edit(_) => {}
                     DocumentChangeOperation::Op(ResourceOp::Create(create)) => {
                         push(create.uri.as_str())
                     }
@@ -414,5 +428,43 @@ mod tests {
         }))
         .unwrap();
         assert_eq!(collect_virtual_uris(&edit), vec![uri]);
+    }
+
+    #[test]
+    fn collect_virtual_uris_ignores_empty_text_edit_entries() {
+        // An edit with real-file changes plus a STRAY EMPTY virtual entry must
+        // not be routed down the virtual-translation path: the empty virtual
+        // entry is a no-op, so it doesn't count as touching a virtual document.
+        let uri = virtual_uri("01ARZ3NDEKTSV4RRFFQ69G5FAV");
+        let changes_edit: WorkspaceEdit = serde_json::from_value(json!({
+            "changes": {
+                uri.clone(): [],
+                "file:///real.lua": [text_edit(0)]
+            }
+        }))
+        .unwrap();
+        assert!(
+            collect_virtual_uris(&changes_edit).is_empty(),
+            "an empty virtual `changes` entry must not count as touched"
+        );
+
+        // Same for a `documentChanges` TextDocumentEdit with no edits.
+        let doc_changes_edit: WorkspaceEdit = serde_json::from_value(json!({
+            "documentChanges": [
+                { "textDocument": { "uri": uri.clone(), "version": null }, "edits": [] }
+            ]
+        }))
+        .unwrap();
+        assert!(
+            collect_virtual_uris(&doc_changes_edit).is_empty(),
+            "an empty virtual `documentChanges` edit must not count as touched"
+        );
+
+        // A NON-empty virtual entry still counts.
+        let non_empty: WorkspaceEdit = serde_json::from_value(json!({
+            "changes": { uri.clone(): [text_edit(0)] }
+        }))
+        .unwrap();
+        assert_eq!(collect_virtual_uris(&non_empty), vec![uri]);
     }
 }

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -31,7 +31,7 @@
 use std::sync::Arc;
 
 use tower_lsp_server::ls_types::{
-    ApplyWorkspaceEditParams, DocumentChangeOperation, DocumentChanges, ResourceOp, Uri,
+    ApplyWorkspaceEditParams, DocumentChangeOperation, DocumentChanges, Position, ResourceOp, Uri,
     WorkspaceEdit,
 };
 
@@ -39,6 +39,7 @@ use crate::document::DocumentStore;
 use crate::language::LanguageCoordinator;
 use crate::lsp::bridge::{
     BridgeCoordinator, RegionOffset, VirtualDocumentUri, transform_workspace_edit_to_host,
+    workspace_edit_within_region,
 };
 
 use super::region_offset::resolve_region_offset;
@@ -88,16 +89,13 @@ impl ApplyEditTranslator {
             // different transforms. A partially-applied edit is worse than
             // none, so reject the whole edit.
             _ => {
-                return Err(
-                    "kakehashi: the edit spans multiple injected regions; \
+                return Err("kakehashi: the edit spans multiple injected regions; \
                      it cannot be applied to the host document"
-                        .to_string(),
-                );
+                    .to_string());
             }
         };
 
-        let Some((host_url, region_id)) = self.bridge.resolve_virtual_uri(virtual_uri).await
-        else {
+        let Some((host_url, region_id)) = self.bridge.resolve_virtual_uri(virtual_uri).await else {
             return Err(format!(
                 "kakehashi: the edit targets an unknown virtual document: {virtual_uri}"
             ));
@@ -107,7 +105,7 @@ impl ApplyEditTranslator {
                 "kakehashi: the virtual document's host URI is unmappable: {host_url}"
             ));
         };
-        let Some(offset) = resolve_region_offset(
+        let Some((offset, region_end)) = resolve_region_offset(
             &self.documents,
             &self.language,
             &self.bridge,
@@ -123,7 +121,7 @@ impl ApplyEditTranslator {
             );
         };
 
-        transform_params_to_host(&mut params, virtual_uri, &host_uri, &offset)?;
+        transform_params_to_host(&mut params, virtual_uri, &host_uri, &offset, region_end)?;
         Ok(params)
     }
 }
@@ -131,16 +129,27 @@ impl ApplyEditTranslator {
 /// Rewrite `params.edit` to host coordinates via the shared WorkspaceEdit
 /// transform. Pure mutation, split out so it can be unit-tested without a live
 /// parse. `Err` when the edit performs file operations on a virtual document
-/// (the transform's whole-edit reject).
+/// (the transform's whole-edit reject) or when a translated range escapes the
+/// region end (`region_end`) — a stale/malformed downstream edit whose range
+/// runs past the region would otherwise land in unrelated host text after the
+/// fence and corrupt the buffer.
 fn transform_params_to_host(
     params: &mut ApplyWorkspaceEditParams,
     virtual_uri: &str,
     host_uri: &Uri,
     offset: &RegionOffset,
+    region_end: Position,
 ) -> Result<(), String> {
     if !transform_workspace_edit_to_host(&mut params.edit, virtual_uri, host_uri, offset) {
         return Err(
             "kakehashi: the edit performs file operations on a virtual document".to_string(),
+        );
+    }
+    if !workspace_edit_within_region(&params.edit, host_uri, region_end) {
+        return Err(
+            "kakehashi: the edit extends past the injected region; it cannot be applied to the \
+             host document without corrupting surrounding text"
+                .to_string(),
         );
     }
     Ok(())
@@ -314,8 +323,16 @@ mod tests {
         .unwrap();
         let host = host_uri();
 
-        transform_params_to_host(&mut params, &uri, &host, &RegionOffset::new(10, 2))
-            .expect("text-only edit must transform");
+        // Generous region end: this test exercises translation + annotation
+        // passthrough, not the region-bounds guard (which has its own test).
+        transform_params_to_host(
+            &mut params,
+            &uri,
+            &host,
+            &RegionOffset::new(10, 2),
+            Position::new(u32::MAX, u32::MAX),
+        )
+        .expect("text-only edit must transform");
 
         assert_eq!(params.label.as_deref(), Some("extract function"));
         let changes = params.edit.changes.expect("changes survive");
@@ -341,11 +358,48 @@ mod tests {
             ]
         }));
 
-        let reason =
-            transform_params_to_host(&mut params, &uri, &host_uri(), &RegionOffset::new(10, 0))
-                .expect_err("virtual-URI file ops must reject the whole edit");
+        let reason = transform_params_to_host(
+            &mut params,
+            &uri,
+            &host_uri(),
+            &RegionOffset::new(10, 0),
+            Position::default(),
+        )
+        .expect_err("virtual-URI file ops must reject the whole edit");
         assert!(
             reason.contains("file operations on a virtual document"),
+            "reason should name the failure: {reason}"
+        );
+    }
+
+    #[test]
+    fn transform_params_to_host_rejects_edit_past_region_end() {
+        // The region occupies a single host line (offset line 10). An edit whose
+        // virtual range runs onto virtual line 3 translates to host line 13 —
+        // past the region end — and would corrupt unrelated host text. It must
+        // be rejected, not forwarded.
+        let uri = virtual_uri("01ARZ3NDEKTSV4RRFFQ69G5FAV");
+        let mut params = params_with_edit(json!({
+            "changes": { uri.clone(): [{
+                "range": {
+                    "start": { "line": 3, "character": 0 },
+                    "end": { "line": 3, "character": 4 }
+                },
+                "newText": "oops"
+            }] }
+        }));
+        // Region end is host line 10 (a one-line region at the offset line).
+        let region_end = Position::new(10, 11);
+        let reason = transform_params_to_host(
+            &mut params,
+            &uri,
+            &host_uri(),
+            &RegionOffset::new(10, 0),
+            region_end,
+        )
+        .expect_err("an edit past the region end must reject the whole edit");
+        assert!(
+            reason.contains("past the injected region"),
             "reason should name the failure: {reason}"
         );
     }

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -145,9 +145,13 @@ fn transform_params_to_host(
             "kakehashi: the edit performs file operations on a virtual document".to_string(),
         );
     }
-    if !workspace_edit_within_region(&params.edit, host_uri, region_end) {
+    // Region host start = where a translated virtual (0,0) lands; bound the
+    // edit on BOTH ends so a pass-through host-URI edit can't reach host text
+    // above OR below the injected region.
+    let region_start = Position::new(offset.line(), offset.column_for_line(0));
+    if !workspace_edit_within_region(&params.edit, host_uri, region_start, region_end) {
         return Err(
-            "kakehashi: the edit extends past the injected region; it cannot be applied to the \
+            "kakehashi: the edit extends outside the injected region; it cannot be applied to the \
              host document without corrupting surrounding text"
                 .to_string(),
         );
@@ -413,7 +417,38 @@ mod tests {
         )
         .expect_err("an edit past the region end must reject the whole edit");
         assert!(
-            reason.contains("past the injected region"),
+            reason.contains("outside the injected region"),
+            "reason should name the failure: {reason}"
+        );
+    }
+
+    #[test]
+    fn transform_params_to_host_rejects_edit_before_region_start() {
+        // A pass-through host-URI edit above the region: keyed to the HOST doc
+        // (not the virtual URI), so the transform leaves it untranslated. Its
+        // range sits before the region start — must be rejected, not forwarded.
+        let mut params = params_with_edit(json!({
+            "changes": { "file:///project/doc.md": [{
+                "range": {
+                    "start": { "line": 0, "character": 0 },
+                    "end": { "line": 2, "character": 0 }
+                },
+                "newText": "sneaky"
+            }] }
+        }));
+        // Region starts at host line 10; the host edit above it (lines 0-2) is
+        // fully below the region start.
+        let uri = virtual_uri("01ARZ3NDEKTSV4RRFFQ69G5FAV");
+        let reason = transform_params_to_host(
+            &mut params,
+            &uri,
+            &host_uri(),
+            &RegionOffset::new(10, 0),
+            Position::new(10, 11),
+        )
+        .expect_err("a host edit before the region start must reject the whole edit");
+        assert!(
+            reason.contains("outside the injected region"),
             "reason should name the failure: {reason}"
         );
     }

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -1,0 +1,364 @@
+//! Virtual→host translation for inbound `workspace/applyEdit` requests (#568).
+//!
+//! A bridged downstream server only knows the *virtual* document it was handed,
+//! so a `workspace/applyEdit` it issues may carry edits keyed by a virtual URI
+//! in virtual coordinates. Before the bridge forwards the request to the
+//! editor, [`ApplyEditTranslator`] rewrites those edits back to the host
+//! document via the shared
+//! [`transform_workspace_edit_to_host`] (the same transform rename responses
+//! use), so the editor applies the edit to the real file at the right spot.
+//!
+//! The host/virt distinction is made from the edit itself, not the connection:
+//! an edit that touches **no** virtual URIs (every edit from a host-layer
+//! connection, and real-file-only edits from virt connections) is forwarded
+//! verbatim. An edit that touches exactly one virtual document is translated
+//! against that region's live offset (rebuilt exactly as goto/showDocument do,
+//! via [`resolve_region_offset`](super::region_offset::resolve_region_offset)).
+//!
+//! Unlike `window/showDocument` — which degrades by dropping the selection —
+//! an applyEdit whose coordinates can't be trusted must **not** be forwarded:
+//! a mistranslated edit corrupts the user's buffer. Untranslatable edits
+//! (unknown/stale virtual URI, region invalidated by edits, file operations on
+//! a virtual document, or an edit spanning multiple virtual documents) are
+//! rejected with `Err(failure_reason)`; the caller answers the downstream
+//! `applied: false` locally without contacting the editor.
+//!
+//! `label` and `changeAnnotations` pass through untouched (the transform only
+//! rewrites URIs/ranges/versions).
+//!
+//! [`transform_workspace_edit_to_host`]: crate::lsp::bridge::transform_workspace_edit_to_host
+
+use std::sync::Arc;
+
+use tower_lsp_server::ls_types::{
+    ApplyWorkspaceEditParams, DocumentChangeOperation, DocumentChanges, ResourceOp, Uri,
+    WorkspaceEdit,
+};
+
+use crate::document::DocumentStore;
+use crate::language::LanguageCoordinator;
+use crate::lsp::bridge::{
+    BridgeCoordinator, RegionOffset, VirtualDocumentUri, transform_workspace_edit_to_host,
+};
+
+use super::region_offset::resolve_region_offset;
+
+/// Translates `workspace/applyEdit` params whose edit targets a virtual
+/// document back to the host document + host coordinates. Holds shared
+/// (cheaply cloneable) handles to the document store, language coordinator,
+/// and bridge so it can run off the forwarding loop without the `Kakehashi`
+/// receiver — same shape as
+/// [`ShowDocumentTranslator`](super::show_document_translation::ShowDocumentTranslator).
+pub(super) struct ApplyEditTranslator {
+    documents: Arc<DocumentStore>,
+    language: Arc<LanguageCoordinator>,
+    bridge: Arc<BridgeCoordinator>,
+}
+
+impl ApplyEditTranslator {
+    pub(super) fn new(
+        documents: Arc<DocumentStore>,
+        language: Arc<LanguageCoordinator>,
+        bridge: Arc<BridgeCoordinator>,
+    ) -> Self {
+        Self {
+            documents,
+            language,
+            bridge,
+        }
+    }
+
+    /// Translate a virtual-document applyEdit to host coordinates; forward
+    /// `params` unchanged when the edit touches no virtual URIs. `Err` carries
+    /// the `failureReason` for a local `applied: false` answer — the edit must
+    /// not reach the editor. See the module docs for the exact behavior.
+    pub(super) async fn translate(
+        &self,
+        mut params: ApplyWorkspaceEditParams,
+    ) -> Result<ApplyWorkspaceEditParams, String> {
+        let virtual_uris = collect_virtual_uris(&params.edit);
+        let virtual_uri = match virtual_uris.as_slice() {
+            // No virtual URIs: a host-layer connection's edit (real URIs
+            // throughout), or a virt connection editing only real files.
+            [] => return Ok(params),
+            [uri] => uri,
+            // The shared transform is scoped to one region (it filters other
+            // virtual URIs as cross-region); translating each region against
+            // its own offset would still interleave documentChanges from
+            // different transforms. A partially-applied edit is worse than
+            // none, so reject the whole edit.
+            _ => {
+                return Err(
+                    "kakehashi: the edit spans multiple injected regions; \
+                     it cannot be applied to the host document"
+                        .to_string(),
+                );
+            }
+        };
+
+        let Some((host_url, region_id)) = self.bridge.resolve_virtual_uri(virtual_uri).await
+        else {
+            return Err(format!(
+                "kakehashi: the edit targets an unknown virtual document: {virtual_uri}"
+            ));
+        };
+        let Ok(host_uri) = super::url_to_uri(&host_url) else {
+            return Err(format!(
+                "kakehashi: the virtual document's host URI is unmappable: {host_url}"
+            ));
+        };
+        let Some(offset) = resolve_region_offset(
+            &self.documents,
+            &self.language,
+            &self.bridge,
+            &host_url,
+            &region_id,
+        ) else {
+            // The region moved or was removed since the downstream produced
+            // the edit; translating against a stale offset would edit the
+            // wrong host text.
+            return Err(
+                "kakehashi: the injected region changed before the edit could be applied"
+                    .to_string(),
+            );
+        };
+
+        transform_params_to_host(&mut params, virtual_uri, &host_uri, &offset)?;
+        Ok(params)
+    }
+}
+
+/// Rewrite `params.edit` to host coordinates via the shared WorkspaceEdit
+/// transform. Pure mutation, split out so it can be unit-tested without a live
+/// parse. `Err` when the edit performs file operations on a virtual document
+/// (the transform's whole-edit reject).
+fn transform_params_to_host(
+    params: &mut ApplyWorkspaceEditParams,
+    virtual_uri: &str,
+    host_uri: &Uri,
+    offset: &RegionOffset,
+) -> Result<(), String> {
+    if !transform_workspace_edit_to_host(&mut params.edit, virtual_uri, host_uri, offset) {
+        return Err(
+            "kakehashi: the edit performs file operations on a virtual document".to_string(),
+        );
+    }
+    Ok(())
+}
+
+/// Collect the distinct virtual-document URIs an edit touches, across the
+/// `changes` map, `documentChanges` text edits, and file-operation URIs.
+/// Deduplicated (a URI appearing in both shapes counts once); order follows
+/// discovery and is only meaningful for the single-element case.
+fn collect_virtual_uris(edit: &WorkspaceEdit) -> Vec<String> {
+    let mut uris: Vec<String> = Vec::new();
+    let mut push = |uri: &str| {
+        if VirtualDocumentUri::is_virtual_uri(uri) && !uris.iter().any(|u| u == uri) {
+            uris.push(uri.to_string());
+        }
+    };
+
+    if let Some(changes) = &edit.changes {
+        for uri in changes.keys() {
+            push(uri.as_str());
+        }
+    }
+    match &edit.document_changes {
+        Some(DocumentChanges::Edits(edits)) => {
+            for edit in edits {
+                push(edit.text_document.uri.as_str());
+            }
+        }
+        Some(DocumentChanges::Operations(ops)) => {
+            for op in ops {
+                match op {
+                    DocumentChangeOperation::Edit(edit) => push(edit.text_document.uri.as_str()),
+                    DocumentChangeOperation::Op(ResourceOp::Create(create)) => {
+                        push(create.uri.as_str())
+                    }
+                    DocumentChangeOperation::Op(ResourceOp::Rename(rename)) => {
+                        push(rename.old_uri.as_str());
+                        push(rename.new_uri.as_str());
+                    }
+                    DocumentChangeOperation::Op(ResourceOp::Delete(delete)) => {
+                        push(delete.uri.as_str())
+                    }
+                }
+            }
+        }
+        None => {}
+    }
+    uris
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::str::FromStr;
+
+    fn translator() -> ApplyEditTranslator {
+        ApplyEditTranslator::new(
+            Arc::new(DocumentStore::new()),
+            Arc::new(LanguageCoordinator::new()),
+            Arc::new(BridgeCoordinator::new()),
+        )
+    }
+
+    fn host_uri() -> Uri {
+        Uri::from_str("file:///project/doc.md").unwrap()
+    }
+
+    fn virtual_uri(region_id: &str) -> String {
+        VirtualDocumentUri::new(&host_uri(), "lua", region_id).to_uri_string()
+    }
+
+    fn params_with_edit(edit: serde_json::Value) -> ApplyWorkspaceEditParams {
+        serde_json::from_value(json!({ "edit": edit })).unwrap()
+    }
+
+    fn text_edit(line: u32) -> serde_json::Value {
+        json!({
+            "range": {
+                "start": { "line": line, "character": 0 },
+                "end": { "line": line, "character": 5 }
+            },
+            "newText": "newName"
+        })
+    }
+
+    #[tokio::test]
+    async fn passes_through_edit_touching_only_real_files() {
+        // Host-layer connections (and virt connections editing real files)
+        // produce edits with real URIs throughout: forwarded verbatim.
+        let original: ApplyWorkspaceEditParams = serde_json::from_value(json!({
+            "label": "quickfix",
+            "edit": { "changes": { "file:///project/main.rs": [text_edit(3)] } }
+        }))
+        .unwrap();
+        let out = translator()
+            .translate(original.clone())
+            .await
+            .expect("real-file edit must pass through");
+        assert_eq!(out, original);
+    }
+
+    #[tokio::test]
+    async fn rejects_edit_for_unknown_virtual_document() {
+        // A well-formed virtual URI no open document maps to: forwarding it
+        // would hand the editor a URI it can't apply — answer locally.
+        let uri = virtual_uri("01ARZ3NDEKTSV4RRFFQ69G5FAV");
+        let original = params_with_edit(json!({ "changes": { uri.clone(): [text_edit(0)] } }));
+        let reason = translator()
+            .translate(original)
+            .await
+            .expect_err("unknown virtual document must be rejected");
+        assert!(
+            reason.contains("unknown virtual document"),
+            "reason should name the failure: {reason}"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_edit_spanning_multiple_virtual_documents() {
+        let uri_a = virtual_uri("01ARZ3NDEKTSV4RRFFQ69G5FAV");
+        let uri_b = virtual_uri("01BX5ZZKBKACTAV9WEVGEMMVRZ");
+        let original = params_with_edit(json!({
+            "changes": {
+                uri_a: [text_edit(0)],
+                uri_b: [text_edit(1)]
+            }
+        }));
+        let reason = translator()
+            .translate(original)
+            .await
+            .expect_err("multi-region edit must be rejected");
+        assert!(
+            reason.contains("multiple injected regions"),
+            "reason should name the failure: {reason}"
+        );
+    }
+
+    #[tokio::test]
+    async fn same_virtual_uri_in_both_shapes_counts_as_one_region() {
+        // The same virtual URI in `changes` AND `documentChanges` must dedup to
+        // the single-region path (here it then fails resolution — empty bridge —
+        // which proves it got past the multi-region reject).
+        let uri = virtual_uri("01ARZ3NDEKTSV4RRFFQ69G5FAV");
+        let original = params_with_edit(json!({
+            "changes": { uri.clone(): [text_edit(0)] },
+            "documentChanges": [{
+                "textDocument": { "uri": uri, "version": 2 },
+                "edits": [text_edit(1)]
+            }]
+        }));
+        let reason = translator().translate(original).await.unwrap_err();
+        assert!(
+            reason.contains("unknown virtual document"),
+            "dedup must reach the single-region path, not the multi-region reject: {reason}"
+        );
+    }
+
+    #[test]
+    fn transform_params_to_host_translates_and_preserves_annotations() {
+        let uri = virtual_uri("01ARZ3NDEKTSV4RRFFQ69G5FAV");
+        let mut params: ApplyWorkspaceEditParams = serde_json::from_value(json!({
+            "label": "extract function",
+            "edit": {
+                "changes": { uri.clone(): [text_edit(0)] },
+                "changeAnnotations": {
+                    "refactor": { "label": "Extract", "needsConfirmation": true }
+                }
+            }
+        }))
+        .unwrap();
+        let host = host_uri();
+
+        transform_params_to_host(&mut params, &uri, &host, &RegionOffset::new(10, 2))
+            .expect("text-only edit must transform");
+
+        assert_eq!(params.label.as_deref(), Some("extract function"));
+        let changes = params.edit.changes.expect("changes survive");
+        let edits = changes.get(&host).expect("re-keyed to the host URI");
+        assert_eq!(
+            edits[0].range.start,
+            tower_lsp_server::ls_types::Position::new(10, 2),
+            "line-0 edit shifts by the region's (line, column) offset"
+        );
+        let annotations = params
+            .edit
+            .change_annotations
+            .expect("changeAnnotations pass through untouched");
+        assert!(annotations.contains_key("refactor"));
+    }
+
+    #[test]
+    fn transform_params_to_host_rejects_virtual_file_ops() {
+        let uri = virtual_uri("01ARZ3NDEKTSV4RRFFQ69G5FAV");
+        let mut params = params_with_edit(json!({
+            "documentChanges": [
+                { "kind": "rename", "oldUri": uri.clone(), "newUri": "file:///renamed.lua" }
+            ]
+        }));
+
+        let reason =
+            transform_params_to_host(&mut params, &uri, &host_uri(), &RegionOffset::new(10, 0))
+                .expect_err("virtual-URI file ops must reject the whole edit");
+        assert!(
+            reason.contains("file operations on a virtual document"),
+            "reason should name the failure: {reason}"
+        );
+    }
+
+    #[test]
+    fn collect_virtual_uris_covers_file_operation_uris() {
+        let uri = virtual_uri("01ARZ3NDEKTSV4RRFFQ69G5FAV");
+        let edit: WorkspaceEdit = serde_json::from_value(json!({
+            "documentChanges": [
+                { "kind": "rename", "oldUri": "file:///a.lua", "newUri": uri }
+            ]
+        }))
+        .unwrap();
+        assert_eq!(collect_virtual_uris(&edit), vec![uri]);
+    }
+}

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -145,11 +145,10 @@ fn transform_params_to_host(
             "kakehashi: the edit performs file operations on a virtual document".to_string(),
         );
     }
-    // Region host start = where a translated virtual (0,0) lands; bound the
-    // edit on BOTH ends so a pass-through host-URI edit can't reach host text
-    // above OR below the injected region.
-    let region_start = Position::new(offset.line(), offset.column_for_line(0));
-    if !workspace_edit_within_region(&params.edit, host_uri, region_start, region_end) {
+    // Bound the edit to the region on both ends, per line, so a pass-through
+    // host-URI edit can't reach host text above/below the region or into a
+    // line's prefix (blockquote `> `).
+    if !workspace_edit_within_region(&params.edit, host_uri, offset, region_end) {
         return Err(
             "kakehashi: the edit extends outside the injected region; it cannot be applied to the \
              host document without corrupting surrounding text"

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1121,8 +1121,7 @@ fn spawn_upstream_request(
                     },
                     Ok(params) => {
                         let id = client.next_request_id();
-                        let value =
-                            serde_json::to_value(params).unwrap_or(serde_json::Value::Null);
+                        let value = serde_json::to_value(params).unwrap_or(serde_json::Value::Null);
                         forward_with_cancel(
                             &client,
                             id,
@@ -2786,7 +2785,10 @@ mod tests {
         assert_eq!(req.method(), "workspace/applyEdit");
         let id = req.id().expect("request has an id").clone();
         let _ = responses
-            .send(Response::from_ok(id, serde_json::json!({ "applied": true })))
+            .send(Response::from_ok(
+                id,
+                serde_json::json!({ "applied": true }),
+            ))
             .await;
 
         let response = reply_rx.await.expect("reply delivered");

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1131,12 +1131,13 @@ fn spawn_upstream_request(
                         )
                         .await
                         .and_then(|v| serde_json::from_value::<ApplyWorkspaceEditResponse>(v).ok())
-                        // Editor error/cancel/unparseable response: the protocol
-                        // default — the edit was not applied.
+                        // Editor error/cancel, or a response that didn't parse
+                        // as an ApplyWorkspaceEditResponse: the protocol default
+                        // — the edit was not applied.
                         .unwrap_or(ApplyWorkspaceEditResponse {
                             applied: false,
                             failure_reason: Some(
-                                "kakehashi: the editor returned no workspace/applyEdit response"
+                                "kakehashi: no valid workspace/applyEdit response from the editor"
                                     .to_string(),
                             ),
                             failed_change: None,

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -26,8 +26,18 @@ use crate::config::WorkspaceSettings;
 use crate::lsp::client::check_semantic_tokens_refresh_support;
 use crate::lsp::{SettingsSource, load_settings};
 
+use super::apply_edit_translation::ApplyEditTranslator;
 use super::show_document_translation::ShowDocumentTranslator;
 use super::{Kakehashi, uri_to_url};
+
+/// Translators for downstream-initiated request payloads that carry
+/// virtual-document coordinates, bundled so the forwarding loop threads one
+/// handle. Both are built from the same shared (cheaply cloneable) service
+/// handles; `None` for the whole bundle means "forward verbatim" (test loops).
+struct UpstreamRequestTranslators {
+    show_document: ShowDocumentTranslator,
+    apply_edit: ApplyEditTranslator,
+}
 
 fn lsp_legend_types() -> Vec<SemanticTokenType> {
     LEGEND_TYPES
@@ -415,20 +425,29 @@ impl Kakehashi {
         //   window/showMessage, and telemetry/event.
         // - unbounded `upstream_request_rx` (loss-intolerant): downstream
         //   requests forwarded with a response relayed back
-        //   (window/showMessageRequest, window/showDocument).
+        //   (window/showMessageRequest, window/showDocument, workspace/applyEdit).
         if let Some(upstream_rx) = self.bridge.take_upstream_rx()
             && let Some(window_rx) = self.bridge.take_window_rx()
             && let Some(upstream_request_rx) = self.bridge.take_upstream_request_rx()
         {
             let client = self.client.clone();
             let token = self.shutdown_token.clone();
-            // Translates downstream-initiated window/showDocument virtual URIs +
-            // selections back to host coordinates before forwarding (#403).
-            let show_document_translator = Some(Arc::new(ShowDocumentTranslator::new(
-                Arc::clone(&self.documents),
-                Arc::clone(&self.language),
-                Arc::clone(&self.bridge),
-            )));
+            // Translates downstream-initiated payloads carrying virtual-document
+            // coordinates back to the host document before forwarding:
+            // window/showDocument URIs + selections (#403) and
+            // workspace/applyEdit edits (#568).
+            let translators = Some(Arc::new(UpstreamRequestTranslators {
+                show_document: ShowDocumentTranslator::new(
+                    Arc::clone(&self.documents),
+                    Arc::clone(&self.language),
+                    Arc::clone(&self.bridge),
+                ),
+                apply_edit: ApplyEditTranslator::new(
+                    Arc::clone(&self.documents),
+                    Arc::clone(&self.language),
+                    Arc::clone(&self.bridge),
+                ),
+            }));
             let inbound_request_registry = self.bridge.pool().inbound_request_registry();
             // The single proactive diagnostics publisher: region pushes routed up
             // by the reader resolve to a host + region and republish the merged
@@ -440,7 +459,7 @@ impl Kakehashi {
                 upstream_rx,
                 window_rx,
                 upstream_request_rx,
-                show_document_translator,
+                translators,
                 inbound_request_registry,
                 client,
                 diagnostic_publisher,
@@ -661,7 +680,7 @@ async fn upstream_forwarding_loop(
     mut upstream_request_rx: tokio::sync::mpsc::UnboundedReceiver<
         crate::lsp::bridge::UpstreamRequest,
     >,
-    show_document_translator: Option<Arc<ShowDocumentTranslator>>,
+    translators: Option<Arc<UpstreamRequestTranslators>>,
     inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry,
     client: Client,
     diagnostic_publisher: Option<Arc<crate::lsp::lsp_impl::coordinator::DiagnosticPublisher>>,
@@ -747,7 +766,7 @@ async fn upstream_forwarding_loop(
                     Some(request) => {
                         spawn_upstream_request(
                             inbound_request_registry.clone(),
-                            show_document_translator.clone(),
+                            translators.clone(),
                             &client,
                             request,
                         )
@@ -1006,7 +1025,7 @@ async fn forward_with_cancel(
 
 fn spawn_upstream_request(
     inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry,
-    show_document_translator: Option<Arc<ShowDocumentTranslator>>,
+    translators: Option<Arc<UpstreamRequestTranslators>>,
     client: &Client,
     request: crate::lsp::bridge::UpstreamRequest,
 ) {
@@ -1059,8 +1078,8 @@ fn spawn_upstream_request(
                 // used (selection translated, or dropped if the offset can't be
                 // rebuilt); only a non-virtual/unresolvable URI is forwarded
                 // unchanged. See `ShowDocumentTranslator::translate`.
-                let params = match &show_document_translator {
-                    Some(translator) => translator.translate(params).await,
+                let params = match &translators {
+                    Some(translators) => translators.show_document.translate(params).await,
                     None => params,
                 };
                 let id = client.next_request_id();
@@ -1077,6 +1096,60 @@ fn spawn_upstream_request(
                     cancel.generation,
                 );
                 let _ = reply.send(success);
+            }
+            UpstreamRequest::ApplyEdit {
+                params,
+                reply,
+                cancel,
+            } => {
+                use tower_lsp_server::ls_types::ApplyWorkspaceEditResponse;
+                // Translate virtual-document edits back to host coordinates
+                // before forwarding (#568). Unlike showDocument there is no
+                // safe degraded forward: an untranslatable edit (unknown/stale
+                // region, virtual-URI file ops, multi-region edit) is answered
+                // `applied: false` locally with a failureReason, never sent to
+                // the editor. See `ApplyEditTranslator::translate`.
+                let params = match &translators {
+                    Some(translators) => translators.apply_edit.translate(params).await,
+                    None => Ok(params),
+                };
+                let response = match params {
+                    Err(failure_reason) => ApplyWorkspaceEditResponse {
+                        applied: false,
+                        failure_reason: Some(failure_reason),
+                        failed_change: None,
+                    },
+                    Ok(params) => {
+                        let id = client.next_request_id();
+                        let value =
+                            serde_json::to_value(params).unwrap_or(serde_json::Value::Null);
+                        forward_with_cancel(
+                            &client,
+                            id,
+                            "workspace/applyEdit",
+                            value,
+                            &cancel.token,
+                        )
+                        .await
+                        .and_then(|v| serde_json::from_value::<ApplyWorkspaceEditResponse>(v).ok())
+                        // Editor error/cancel/unparseable response: the protocol
+                        // default — the edit was not applied.
+                        .unwrap_or(ApplyWorkspaceEditResponse {
+                            applied: false,
+                            failure_reason: Some(
+                                "kakehashi: the editor returned no workspace/applyEdit response"
+                                    .to_string(),
+                            ),
+                            failed_change: None,
+                        })
+                    }
+                };
+                inbound_request_registry.unregister(
+                    cancel.connection_id,
+                    &cancel.request_id,
+                    cancel.generation,
+                );
+                let _ = reply.send(response);
             }
         }
     });
@@ -2667,6 +2740,134 @@ mod tests {
             .await;
 
         assert!(reply_rx.await.expect("reply delivered"));
+
+        cancel.cancel();
+        let _ = loop_handle.await;
+    }
+
+    #[tokio::test]
+    async fn forwarding_loop_relays_apply_edit_response() {
+        use crate::lsp::bridge::UpstreamRequest;
+        use futures::{SinkExt, StreamExt};
+        use tower_lsp_server::jsonrpc::Response;
+
+        let (client, mut requests, mut responses) = init_client_and_socket().await;
+
+        // `_upstream_tx`/`_window_tx` kept alive so those channels stay open and
+        // the loop doesn't exit early; this test drives only the request channel.
+        let (_upstream_tx, upstream_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (_window_tx, window_rx) = tokio::sync::mpsc::channel(16);
+        let (request_tx, request_rx) = tokio::sync::mpsc::unbounded_channel();
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let loop_handle = tokio::spawn(upstream_forwarding_loop(
+            upstream_rx,
+            window_rx,
+            request_rx,
+            None,
+            crate::lsp::bridge::InboundRequestRegistry::default(),
+            client,
+            None,
+            cancel.clone(),
+        ));
+
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        request_tx
+            .send(UpstreamRequest::ApplyEdit {
+                params: serde_json::from_value(serde_json::json!({
+                    "edit": { "changes": { "file:///x.rs": [] } }
+                }))
+                .unwrap(),
+                reply: reply_tx,
+                cancel: test_forwarded_cancel(),
+            })
+            .unwrap();
+
+        let req = requests.next().await.expect("applyEdit emitted");
+        assert_eq!(req.method(), "workspace/applyEdit");
+        let id = req.id().expect("request has an id").clone();
+        let _ = responses
+            .send(Response::from_ok(id, serde_json::json!({ "applied": true })))
+            .await;
+
+        let response = reply_rx.await.expect("reply delivered");
+        assert!(response.applied);
+        assert_eq!(response.failure_reason, None);
+
+        cancel.cancel();
+        let _ = loop_handle.await;
+    }
+
+    /// An applyEdit whose edit can't be translated to host coordinates (here: a
+    /// virtual URI no open document maps to) must be answered `applied: false`
+    /// locally — the editor must never see the corrupted edit (#568).
+    #[tokio::test]
+    async fn forwarding_loop_answers_untranslatable_apply_edit_locally() {
+        use crate::lsp::bridge::{BridgeCoordinator, UpstreamRequest, VirtualDocumentUri};
+        use std::str::FromStr;
+        use std::time::Duration;
+        use tokio::time::timeout;
+
+        let (client, _requests, _responses) = init_client_and_socket().await;
+
+        let (_upstream_tx, upstream_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (_window_tx, window_rx) = tokio::sync::mpsc::channel(16);
+        let (request_tx, request_rx) = tokio::sync::mpsc::unbounded_channel();
+        let cancel = tokio_util::sync::CancellationToken::new();
+        // Real translators over empty stores: the virtual URI resolves to no
+        // open document, so translation rejects the edit.
+        let translators = Some(Arc::new(UpstreamRequestTranslators {
+            show_document: ShowDocumentTranslator::new(
+                Arc::new(crate::document::DocumentStore::new()),
+                Arc::new(crate::language::LanguageCoordinator::new()),
+                Arc::new(BridgeCoordinator::new()),
+            ),
+            apply_edit: ApplyEditTranslator::new(
+                Arc::new(crate::document::DocumentStore::new()),
+                Arc::new(crate::language::LanguageCoordinator::new()),
+                Arc::new(BridgeCoordinator::new()),
+            ),
+        }));
+        let loop_handle = tokio::spawn(upstream_forwarding_loop(
+            upstream_rx,
+            window_rx,
+            request_rx,
+            translators,
+            crate::lsp::bridge::InboundRequestRegistry::default(),
+            client,
+            None,
+            cancel.clone(),
+        ));
+
+        let host = tower_lsp_server::ls_types::Uri::from_str("file:///project/doc.md").unwrap();
+        let virtual_uri =
+            VirtualDocumentUri::new(&host, "lua", "01ARZ3NDEKTSV4RRFFQ69G5FAV").to_uri_string();
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        request_tx
+            .send(UpstreamRequest::ApplyEdit {
+                params: serde_json::from_value(serde_json::json!({
+                    "edit": { "changes": { virtual_uri: [] } }
+                }))
+                .unwrap(),
+                reply: reply_tx,
+                cancel: test_forwarded_cancel(),
+            })
+            .unwrap();
+
+        // The reply arrives without the editor (`_requests` never serviced)
+        // answering anything — proof the loop answered locally.
+        let response = timeout(Duration::from_secs(5), reply_rx)
+            .await
+            .expect("locally-answered reply must not pend on the editor")
+            .expect("reply delivered");
+        assert!(!response.applied);
+        assert!(
+            response
+                .failure_reason
+                .as_deref()
+                .is_some_and(|r| r.contains("unknown virtual document")),
+            "failureReason should name the failure: {:?}",
+            response.failure_reason
+        );
 
         cancel.cancel();
         let _ = loop_handle.await;

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1119,30 +1119,44 @@ fn spawn_upstream_request(
                         failure_reason: Some(failure_reason),
                         failed_change: None,
                     },
-                    Ok(params) => {
-                        let id = client.next_request_id();
-                        let value = serde_json::to_value(params).unwrap_or(serde_json::Value::Null);
-                        forward_with_cancel(
-                            &client,
-                            id,
-                            "workspace/applyEdit",
-                            value,
-                            &cancel.token,
-                        )
-                        .await
-                        .and_then(|v| serde_json::from_value::<ApplyWorkspaceEditResponse>(v).ok())
-                        // Editor error/cancel, or a response that didn't parse
-                        // as an ApplyWorkspaceEditResponse: the protocol default
-                        // — the edit was not applied.
-                        .unwrap_or(ApplyWorkspaceEditResponse {
+                    // Serializing the (typed) translated params ~never fails,
+                    // but forwarding `params: null` on the off chance it did
+                    // would send the editor an invalid request; answer local
+                    // applied:false with a serialization reason instead.
+                    Ok(params) => match serde_json::to_value(params) {
+                        Ok(value) => {
+                            let id = client.next_request_id();
+                            forward_with_cancel(
+                                &client,
+                                id,
+                                "workspace/applyEdit",
+                                value,
+                                &cancel.token,
+                            )
+                            .await
+                            .and_then(|v| {
+                                serde_json::from_value::<ApplyWorkspaceEditResponse>(v).ok()
+                            })
+                            // Editor error/cancel, or a response that didn't
+                            // parse as an ApplyWorkspaceEditResponse: the
+                            // protocol default — the edit was not applied.
+                            .unwrap_or(ApplyWorkspaceEditResponse {
+                                applied: false,
+                                failure_reason: Some(
+                                    "kakehashi: no valid workspace/applyEdit response from the editor"
+                                        .to_string(),
+                                ),
+                                failed_change: None,
+                            })
+                        }
+                        Err(e) => ApplyWorkspaceEditResponse {
                             applied: false,
-                            failure_reason: Some(
-                                "kakehashi: no valid workspace/applyEdit response from the editor"
-                                    .to_string(),
-                            ),
+                            failure_reason: Some(format!(
+                                "kakehashi: could not serialize the workspace/applyEdit request: {e}"
+                            )),
                             failed_change: None,
-                        })
-                    }
+                        },
+                    },
                 };
                 inbound_request_registry.unregister(
                     cancel.connection_id,

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1142,9 +1142,12 @@ fn spawn_upstream_request(
                             // protocol default — the edit was not applied.
                             .unwrap_or(ApplyWorkspaceEditResponse {
                                 applied: false,
+                                // Covers editor error, cancellation, AND an
+                                // unparseable response — neutral wording (like
+                                // the reader drop-path) so a cancel/transport
+                                // failure isn't misattributed to the editor.
                                 failure_reason: Some(
-                                    "kakehashi: no valid workspace/applyEdit response from the editor"
-                                        .to_string(),
+                                    "kakehashi: no valid workspace/applyEdit response".to_string(),
                                 ),
                                 failed_change: None,
                             })

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -2847,8 +2847,17 @@ mod tests {
         let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
         request_tx
             .send(UpstreamRequest::ApplyEdit {
+                // A NON-empty edit against a virtual URI that resolves to no open
+                // document: the translator can't map it, so the loop must reject
+                // it locally. (An empty edit array would be a no-op forwarded
+                // verbatim — see `collect_virtual_uris`.)
                 params: serde_json::from_value(serde_json::json!({
-                    "edit": { "changes": { virtual_uri: [] } }
+                    "edit": { "changes": { virtual_uri: [
+                        { "range": {
+                            "start": { "line": 0, "character": 0 },
+                            "end": { "line": 0, "character": 1 }
+                        }, "newText": "x" }
+                    ] } }
                 }))
                 .unwrap(),
                 reply: reply_tx,

--- a/src/lsp/lsp_impl/region_offset.rs
+++ b/src/lsp/lsp_impl/region_offset.rs
@@ -1,0 +1,66 @@
+//! Rebuild an injection region's current host offset from the live parse.
+//!
+//! Shared by translators of inbound (downstream → editor) payloads that must
+//! map virtual-document coordinates back to the host document — today
+//! `window/showDocument` ([`ShowDocumentTranslator`]). The offset is rebuilt
+//! exactly as the goto request path does (`region_id → node byte range →
+//! resolve injection → RegionOffset`), so inbound translation can't disagree
+//! with goto on the same region.
+//!
+//! [`ShowDocumentTranslator`]: super::show_document_translation::ShowDocumentTranslator
+
+use std::sync::Arc;
+
+use url::Url;
+
+use crate::document::DocumentStore;
+use crate::language::{InjectionResolver, LanguageCoordinator};
+use crate::lsp::bridge::{BridgeCoordinator, RegionOffset};
+
+/// Rebuild the region's current host offset from the live parse, keyed by its
+/// `region_id` (a ULID in production). Returns `None` when the offset can't be
+/// rebuilt: region invalidated by edits (`lookup_node` misses), a `region_id`
+/// that no longer matches the live parse at that byte (edit race), or a missing
+/// document/snapshot/language/query.
+pub(super) fn resolve_region_offset(
+    documents: &DocumentStore,
+    language: &Arc<LanguageCoordinator>,
+    bridge: &BridgeCoordinator,
+    host_url: &Url,
+    region_id: &str,
+) -> Option<RegionOffset> {
+    let ulid = ulid::Ulid::from_string(region_id).ok()?;
+    let (start_byte, _end, _kind, _layer) = bridge.node_tracker().lookup_node(host_url, &ulid)?;
+    // Snapshot is owned, so the document handle (a store lock) is released
+    // before `detect_document_language` reaches back into the store.
+    let snapshot = documents.get(host_url)?.snapshot()?;
+    let language_name = super::detect_document_language(language, documents, host_url)?;
+    let injection_query = language.injection_query(&language_name)?;
+    let resolved = InjectionResolver::resolve_at_byte_offset(
+        language,
+        bridge.node_tracker(),
+        host_url,
+        snapshot.tree(),
+        snapshot.text(),
+        injection_query.as_ref(),
+        start_byte,
+    )?;
+    // `region_id`/`start_byte` came from the tracker + node map, but
+    // `resolved` came from a separately-fetched snapshot. If an edit landed
+    // in between, `start_byte` could fall inside a *different* live region —
+    // `resolve_at_byte_offset` returns whichever region contains the byte. A
+    // mismatched `region_id` means we'd translate coordinates against the
+    // wrong region, so return `None` (no offset); callers fall back to their
+    // safe default rather than risk a wrong translation. (The goto path can't
+    // hit this: there `resolved` and `region_id` come from one call.)
+    if resolved.region.region_id != region_id {
+        return None;
+    }
+    // `start` is `Copy`; move `line_column_offsets` out (no clone — `resolved`
+    // is dropped after this).
+    let start_line = resolved.region.line_range.start;
+    Some(RegionOffset::with_per_line_offsets(
+        start_line,
+        resolved.line_column_offsets,
+    ))
+}

--- a/src/lsp/lsp_impl/region_offset.rs
+++ b/src/lsp/lsp_impl/region_offset.rs
@@ -1,13 +1,16 @@
 //! Rebuild an injection region's current host offset from the live parse.
 //!
 //! Shared by translators of inbound (downstream → editor) payloads that must
-//! map virtual-document coordinates back to the host document — today
-//! `window/showDocument` ([`ShowDocumentTranslator`]). The offset is rebuilt
-//! exactly as the goto request path does (`region_id → node byte range →
-//! resolve injection → RegionOffset`), so inbound translation can't disagree
-//! with goto on the same region.
+//! map virtual-document coordinates back to the host document —
+//! `window/showDocument` ([`ShowDocumentTranslator`]) and `workspace/applyEdit`
+//! ([`ApplyEditTranslator`]). The offset is rebuilt exactly as the goto request
+//! path does (`region_id → node byte range → resolve injection → RegionOffset`),
+//! so inbound translation can't disagree with goto on the same region. The
+//! region's content-precise host end is returned alongside so an edit translator
+//! can reject a range that escapes the region.
 //!
 //! [`ShowDocumentTranslator`]: super::show_document_translation::ShowDocumentTranslator
+//! [`ApplyEditTranslator`]: super::apply_edit_translation::ApplyEditTranslator
 
 use std::sync::Arc;
 

--- a/src/lsp/lsp_impl/region_offset.rs
+++ b/src/lsp/lsp_impl/region_offset.rs
@@ -11,11 +11,13 @@
 
 use std::sync::Arc;
 
+use tower_lsp_server::ls_types::Position;
 use url::Url;
 
 use crate::document::DocumentStore;
 use crate::language::{InjectionResolver, LanguageCoordinator};
 use crate::lsp::bridge::{BridgeCoordinator, RegionOffset};
+use crate::text::PositionMapper;
 
 /// Rebuild the region's current host offset from the live parse, keyed by its
 /// `region_id` (a ULID in production). Returns `None` when the offset can't be
@@ -28,7 +30,7 @@ pub(super) fn resolve_region_offset(
     bridge: &BridgeCoordinator,
     host_url: &Url,
     region_id: &str,
-) -> Option<RegionOffset> {
+) -> Option<(RegionOffset, Position)> {
     let ulid = ulid::Ulid::from_string(region_id).ok()?;
     let (start_byte, _end, _kind, _layer) = bridge.node_tracker().lookup_node(host_url, &ulid)?;
     // Snapshot is owned, so the document handle (a store lock) is released
@@ -56,11 +58,17 @@ pub(super) fn resolve_region_offset(
     if resolved.region.region_id != region_id {
         return None;
     }
+    // The region's exclusive host-document end, content-precise (the injection
+    // region's own byte range mapped through the live host text). Callers that
+    // translate an inbound edit use it to reject a range that runs past the
+    // region into unrelated host text.
+    let region_end =
+        PositionMapper::new(snapshot.text()).byte_to_position(resolved.region.byte_range.end)?;
     // `start` is `Copy`; move `line_column_offsets` out (no clone — `resolved`
     // is dropped after this).
     let start_line = resolved.region.line_range.start;
-    Some(RegionOffset::with_per_line_offsets(
-        start_line,
-        resolved.line_column_offsets,
+    Some((
+        RegionOffset::with_per_line_offsets(start_line, resolved.line_column_offsets),
+        region_end,
     ))
 }

--- a/src/lsp/lsp_impl/show_document_translation.rs
+++ b/src/lsp/lsp_impl/show_document_translation.rs
@@ -117,7 +117,9 @@ impl ShowDocumentTranslator {
 
     /// Rebuild the region's current host offset from the live parse via the
     /// shared [`resolve_region_offset`]. On `None` the caller opens the host
-    /// document without a selection rather than risk a wrong one.
+    /// document without a selection rather than risk a wrong one. showDocument
+    /// only needs the offset (it translates a single selection position, not an
+    /// edit), so the region-end bound is discarded.
     fn region_offset(&self, host_url: &Url, region_id: &str) -> Option<RegionOffset> {
         resolve_region_offset(
             &self.documents,
@@ -126,6 +128,7 @@ impl ShowDocumentTranslator {
             host_url,
             region_id,
         )
+        .map(|(offset, _region_end)| offset)
     }
 }
 

--- a/src/lsp/lsp_impl/show_document_translation.rs
+++ b/src/lsp/lsp_impl/show_document_translation.rs
@@ -10,8 +10,9 @@
 //! the right spot.
 //!
 //! The offset is rebuilt from the live parse exactly as the goto path does
-//! (`region_id → node byte range → resolve injection → RegionOffset`), so a
-//! showDocument-to-a-region can't disagree with goto on the same region.
+//! (`region_id → node byte range → resolve injection → RegionOffset`, via the
+//! shared [`resolve_region_offset`](super::region_offset::resolve_region_offset)),
+//! so a showDocument-to-a-region can't disagree with goto on the same region.
 //!
 //! Once the URI resolves to a currently-open virtual document, the editor always
 //! gets the **host** document URI. The selection is translated when the region
@@ -34,8 +35,10 @@ use tower_lsp_server::ls_types::ShowDocumentParams;
 use url::Url;
 
 use crate::document::DocumentStore;
-use crate::language::{InjectionResolver, LanguageCoordinator};
+use crate::language::LanguageCoordinator;
 use crate::lsp::bridge::{BridgeCoordinator, RegionOffset, translate_virtual_range_to_host};
+
+use super::region_offset::resolve_region_offset;
 
 /// Translates `window/showDocument` params whose URI is a virtual document back
 /// to the host document + host coordinates. Holds shared (cheaply cloneable)
@@ -112,47 +115,17 @@ impl ShowDocumentTranslator {
         params
     }
 
-    /// Rebuild the region's current host offset from the live parse, keyed by its
-    /// `region_id` (a ULID in production). Mirrors the goto request path's offset
-    /// construction.
+    /// Rebuild the region's current host offset from the live parse via the
+    /// shared [`resolve_region_offset`]. On `None` the caller opens the host
+    /// document without a selection rather than risk a wrong one.
     fn region_offset(&self, host_url: &Url, region_id: &str) -> Option<RegionOffset> {
-        let ulid = ulid::Ulid::from_string(region_id).ok()?;
-        let (start_byte, _end, _kind, _layer) =
-            self.bridge.node_tracker().lookup_node(host_url, &ulid)?;
-        // Snapshot is owned, so the document handle (a store lock) is released
-        // before `detect_document_language` reaches back into the store.
-        let snapshot = self.documents.get(host_url)?.snapshot()?;
-        let language_name =
-            super::detect_document_language(&self.language, &self.documents, host_url)?;
-        let injection_query = self.language.injection_query(&language_name)?;
-        let resolved = InjectionResolver::resolve_at_byte_offset(
+        resolve_region_offset(
+            &self.documents,
             &self.language,
-            self.bridge.node_tracker(),
+            &self.bridge,
             host_url,
-            snapshot.tree(),
-            snapshot.text(),
-            injection_query.as_ref(),
-            start_byte,
-        )?;
-        // `region_id`/`start_byte` came from the tracker + node map, but
-        // `resolved` came from a separately-fetched snapshot. If an edit landed
-        // in between, `start_byte` could fall inside a *different* live region —
-        // `resolve_at_byte_offset` returns whichever region contains the byte. A
-        // mismatched `region_id` means we'd translate the selection against the
-        // wrong region, so return `None` (no offset); the caller then opens the
-        // host document without a selection rather than risk a wrong one. (The
-        // goto path can't hit this: there `resolved` and `region_id` come from
-        // one call.)
-        if resolved.region.region_id != region_id {
-            return None;
-        }
-        // `start` is `Copy`; move `line_column_offsets` out (no clone — `resolved`
-        // is dropped after this).
-        let start_line = resolved.region.line_range.start;
-        Some(RegionOffset::with_per_line_offsets(
-            start_line,
-            resolved.line_column_offsets,
-        ))
+            region_id,
+        )
     }
 }
 

--- a/src/lsp/lsp_impl/show_document_translation.rs
+++ b/src/lsp/lsp_impl/show_document_translation.rs
@@ -10,8 +10,8 @@
 //! the right spot.
 //!
 //! The offset is rebuilt from the live parse exactly as the goto path does
-//! (`region_id → node byte range → resolve injection → RegionOffset`, via the
-//! shared [`resolve_region_offset`](super::region_offset::resolve_region_offset)),
+//! (`region_id → node byte range → resolve injection → RegionOffset`) via the
+//! shared [`resolve_region_offset`](super::region_offset::resolve_region_offset),
 //! so a showDocument-to-a-region can't disagree with goto on the same region.
 //!
 //! Once the URI resolves to a currently-open virtual document, the editor always


### PR DESCRIPTION
> Recreates #617, which was falsely auto-marked *merged* by an accidental rebase+force-push (branches and commits restored unchanged).

---

PR 5 of the #568 sequence, **stacked on #610** (codeAction/resolve). Adds the inbound `workspace/applyEdit` server→client request path so a bridged downstream server can ask the editor to apply an edit — the last genuinely new server-initiated path (checklist item 9/10).

## What it does
A downstream server issues `workspace/applyEdit`. The bridge:
1. **Translates** virtual-document edits back to the host document (`ApplyEditTranslator`, `lsp_impl/apply_edit_translation.rs`), reusing the shared `transform_workspace_edit_to_host` — the same transform rename responses use.
2. **Forwards** the translated request to the editor and **relays the full `ApplyWorkspaceEditResponse`** (`applied` / `failureReason` / `failedChange`) back to the downstream — it's a request, not a notification.
3. **Fails closed on untranslatable edits**: unlike `window/showDocument` (which degrades by dropping the selection), a mistranslated edit would corrupt the buffer, so an edit that is unknown/stale-region, a virtual-URI file op, or spans multiple injected regions is answered `applied: false` **locally** with a `failureReason`, never sent to the editor.

Host/virt is decided from the **edit itself**, not the connection: an edit touching no virtual URIs (host-layer, or real-file-only) forwards verbatim; an edit touching exactly one virtual document is translated against that region's live offset (rebuilt exactly as goto/showDocument do). `label` and `changeAnnotations` pass through untouched.

## Structure
- `bridge/workspace/apply_edit.rs` — transport-only handler (mirrors `window/show_document`): parses params, registers for `$/cancelRequest`, defers the response on a spawned task, enqueues `UpstreamRequest::ApplyEdit`. A dropped reply channel (downstream died / forwarding loop gone) answers `applied: false`.
- `lsp_impl/apply_edit_translation.rs` — `ApplyEditTranslator` (virtual→host).
- `lsp_impl/region_offset.rs` — region-offset resolution extracted from `ShowDocumentTranslator` into a shared function so both inbound translators build offsets identically to the goto path (pure move, no behavior change).
- `bridge/actor/reader.rs` — dispatch `workspace/applyEdit` to the handler.
- `lsp_impl/lifecycle.rs` — the forwarding loop translates → forwards-with-cancel → relays.

## Test plan
- [x] `cargo clippy --lib --tests --features e2e -- -D warnings` clean, `cargo fmt --check` clean
- [x] Full lib suite: **2507 passed** (+12): applyEdit invalid-params/relay reader tests; translation unit tests (pass-through real files, reject unknown/stale/multi-region, virtual-URI file ops rejected, translate+preserve annotations, same-URI-both-shapes counts as one region); forwarding-loop relay + untranslatable-local tests.

E2E for the full apply flow lands with the organize-imports-on-save acceptance test (PR 8). Part of #568.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app can now forward `workspace/applyEdit` requests from connected language servers to the editor.
  * Edits targeting virtual documents are translated to the correct host-document locations before being applied.
  * The bridge now reports support for this request type to downstream servers.

* **Bug Fixes**
  * Invalid or unsupported edit requests now fail safely instead of sending incorrect changes.
  * Response handling is more reliable when the editor is unavailable or returns an unexpected result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->