### PR TITLE
feat(bridge): bridge workspace/executeCommand (#568 PR 6)

### DIFF
--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -65,6 +65,7 @@ pub(crate) use progress_registry::{ProgressConnectionId, ProgressRegistry};
 pub(crate) use protocol::RegionOffset;
 pub(crate) use protocol::RequestId;
 pub(crate) use protocol::VirtualDocumentUri;
+pub(crate) use protocol::decode_command;
 pub(crate) use protocol::location_link_to_location;
 pub(crate) use protocol::transform_workspace_edit_to_host;
 pub(crate) use protocol::translate_virtual_range_to_host;

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -610,6 +610,11 @@ impl ConnectionHandle {
                 )
             }
             "textDocument/onTypeFormatting" => caps.document_on_type_formatting_provider.is_some(),
+            // A server handles executeCommand iff it advertises the provider.
+            // The specific command must be one it registered, but the bridge
+            // only forwards commands it surfaced FROM this server's actions, so
+            // provider presence is the right gate (#568 PR 6).
+            "workspace/executeCommand" => caps.execute_command_provider.is_some(),
             // willSave/willSaveWaitUntil live in `textDocumentSync`, and only its
             // `Options` form carries the flags — the bare `Kind` number form
             // advertises neither, so it correctly falls through to false. These

--- a/src/lsp/bridge/protocol.rs
+++ b/src/lsp/bridge/protocol.rs
@@ -6,6 +6,7 @@
 //! ## Module Structure
 //!
 //! - `client_capabilities` - Baseline client capabilities advertised downstream
+//! - `command_routing` - Encode/decode the origin server in a bridged command name
 //! - `jsonrpc` - JSON-RPC message types and error inspection
 //! - `lifecycle` - Initialize/shutdown message builders
 //! - `request_id` - RequestId type for type-safe request ID handling
@@ -16,6 +17,7 @@
 //! - `workspace_edit` - WorkspaceEdit virtual→host transformation
 
 mod client_capabilities;
+mod command_routing;
 mod jsonrpc;
 mod lifecycle;
 mod request;
@@ -26,6 +28,7 @@ mod virtual_uri;
 mod workspace_edit;
 
 // Re-export all public items for external use
+pub(crate) use command_routing::{decode_command, encode_command};
 pub(crate) use jsonrpc::{
     JsonRpcNotification, JsonRpcRequest, jsonrpc_error_summary, response_has_jsonrpc_error,
 };

--- a/src/lsp/bridge/protocol/client_capabilities.rs
+++ b/src/lsp/bridge/protocol/client_capabilities.rs
@@ -131,6 +131,13 @@ fn build_baseline_capabilities(
             // "extract into function") instead of assuming the client can't
             // apply edits.
             apply_edit: Some(true),
+            // The bridge executes a surfaced command via `workspace/executeCommand`
+            // (#568 PR 6), so advertise the client capability — a spec-compliant
+            // server may withhold command-carrying actions otherwise. No dynamic
+            // registration (the bridge routes by the static command name).
+            execute_command: Some(DynamicRegistrationClientCapabilities {
+                dynamic_registration: Some(false),
+            }),
             diagnostics: Some(DiagnosticWorkspaceClientCapabilities {
                 refresh_support: Some(true),
             }),

--- a/src/lsp/bridge/protocol/command_routing.rs
+++ b/src/lsp/bridge/protocol/command_routing.rs
@@ -58,8 +58,10 @@ pub(crate) fn encode_command(origin: &str, host_uri: &str, command: &str) -> Str
 /// name fails soft at the call site.
 pub(crate) fn decode_command(name: &str) -> Option<CommandRoute<'_>> {
     let rest = name.strip_prefix(COMMAND_PREFIX)?.strip_prefix(SEP)?;
-    // Exactly three fields; the command id is the remainder (it may contain
-    // anything except the separator, which the encoder never emits inside it).
+    // Split into exactly three fields: origin, host_uri, and the command as the
+    // REMAINDER. Only the origin/host_uri boundaries need to be separator-free
+    // (they are — a config key and a URL); a separator inside the command id
+    // rejoins into the remainder unharmed.
     let mut parts = rest.splitn(3, SEP);
     let origin = parts.next()?;
     let host_uri = parts.next()?;

--- a/src/lsp/bridge/protocol/command_routing.rs
+++ b/src/lsp/bridge/protocol/command_routing.rs
@@ -18,9 +18,12 @@
 //! (realistic once concatenated aggregation lands, #568 PR 7) encode to
 //! distinct names and route correctly.
 //!
-//! The separator is the ASCII Unit Separator (`0x1f`), which cannot appear in a
-//! TOML config server name, a `file://` URI, or a real command identifier, so
-//! the split is unambiguous. Decoding is total: any name that isn't a
+//! The separator is the ASCII Unit Separator (`0x1f`). The routing invariant is
+//! that it must not appear in the FIRST two segments — `origin` (a TOML config
+//! key) and `host_uri` (a URL) are both control-char-free, so those boundaries
+//! are unambiguous. The `command` is the final segment and taken as the
+//! `splitn(3)` remainder, so even an (LSP-legal but unheard-of) separator inside
+//! a command id round-trips faithfully. Decoding is total: any name that isn't a
 //! well-formed bridge command yields `None`, and the handler fails that command
 //! soft rather than panicking.
 //!
@@ -31,8 +34,9 @@
 
 /// Marker that identifies a bridge-minted command name.
 const COMMAND_PREFIX: &str = "kakehashi";
-/// ASCII Unit Separator — cannot occur in a config server name, a URI, or a
-/// command id.
+/// ASCII Unit Separator — cannot occur in the `origin` (a config server name)
+/// or `host_uri` segments, which is the only invariant the split needs (the
+/// `command` is the `splitn(3)` remainder, so a separator there is harmless).
 const SEP: char = '\u{1f}';
 
 /// A decoded bridge command name: the origin server, the host document it was
@@ -89,6 +93,18 @@ mod tests {
         assert_eq!(route.origin, "py.ruff-lsp");
         assert_eq!(route.host_uri, "file:///x");
         assert_eq!(route.command, "cmd:with:colons");
+    }
+
+    #[test]
+    fn a_separator_inside_the_command_segment_round_trips() {
+        // LSP command ids are arbitrary strings; a (theoretical) separator in
+        // the command is harmless because it's the splitn(3) remainder — only
+        // the origin/host_uri boundaries must be separator-free.
+        let encoded = encode_command("srv", "file:///x", "weird\u{1f}cmd");
+        let route = decode_command(&encoded).expect("well-formed");
+        assert_eq!(route.origin, "srv");
+        assert_eq!(route.host_uri, "file:///x");
+        assert_eq!(route.command, "weird\u{1f}cmd");
     }
 
     #[test]

--- a/src/lsp/bridge/protocol/command_routing.rs
+++ b/src/lsp/bridge/protocol/command_routing.rs
@@ -20,8 +20,11 @@
 //!
 //! The separator is the ASCII Unit Separator (`0x1f`). The routing invariant is
 //! that it must not appear in the FIRST two segments — `origin` (a TOML config
-//! key) and `host_uri` (a URL) are both control-char-free, so those boundaries
-//! are unambiguous. The `command` is the final segment and taken as the
+//! key) and `host_uri` (a URL) — so those boundaries are unambiguous. `host_uri`
+//! is control-char-free by construction (a URL), but `origin` is an unvalidated
+//! config key, so [`encode_command`] ENFORCES the invariant: it fails closed
+//! (`None`) rather than mint an ambiguous name, and the caller drops the
+//! unroutable command. The `command` is the final segment and taken as the
 //! `splitn(3)` remainder, so even an (LSP-legal but unheard-of) separator inside
 //! a command id round-trips faithfully. Decoding is total: any name that isn't a
 //! well-formed bridge command yields `None`, and the handler fails that command
@@ -49,8 +52,22 @@ pub(crate) struct CommandRoute<'a> {
 
 /// Encode `command` as a bridge-routed name carrying its `origin` server and
 /// `host_uri`: `"kakehashi\u{1f}{origin}\u{1f}{host_uri}\u{1f}{command}"`.
-pub(crate) fn encode_command(origin: &str, host_uri: &str, command: &str) -> String {
-    format!("{COMMAND_PREFIX}{SEP}{origin}{SEP}{host_uri}{SEP}{command}")
+///
+/// Fails closed (`None`) when `origin` or `host_uri` contains the separator: the
+/// `splitn(3)` decode relies on those two segments being separator-free. A
+/// `host_uri` is a URL (control chars are percent-encoded), but `origin` is an
+/// unvalidated TOML config key — a stray separator there would make
+/// [`decode_command`] mis-split and route execution to the WRONG server/root.
+/// Better to drop the (unroutable) command at the call site than to mint an
+/// ambiguous name. `command` may contain the separator freely (it's the
+/// remainder).
+pub(crate) fn encode_command(origin: &str, host_uri: &str, command: &str) -> Option<String> {
+    if origin.contains(SEP) || host_uri.contains(SEP) {
+        return None;
+    }
+    Some(format!(
+        "{COMMAND_PREFIX}{SEP}{origin}{SEP}{host_uri}{SEP}{command}"
+    ))
 }
 
 /// Decode a bridge-routed command name, or `None` if `name` was not minted by
@@ -79,7 +96,8 @@ mod tests {
 
     #[test]
     fn round_trips_all_three_fields() {
-        let encoded = encode_command("ruff", "file:///w/a.md", "ruff.applyOrganizeImports");
+        let encoded =
+            encode_command("ruff", "file:///w/a.md", "ruff.applyOrganizeImports").expect("valid");
         let route = decode_command(&encoded).expect("well-formed");
         assert_eq!(route.origin, "ruff");
         assert_eq!(route.host_uri, "file:///w/a.md");
@@ -90,7 +108,7 @@ mod tests {
     fn round_trips_a_server_name_with_dots_and_a_command_with_colons() {
         // Config server names are arbitrary TOML keys and command ids often
         // contain colons/dots; the separator must not collide with any of them.
-        let encoded = encode_command("py.ruff-lsp", "file:///x", "cmd:with:colons");
+        let encoded = encode_command("py.ruff-lsp", "file:///x", "cmd:with:colons").expect("valid");
         let route = decode_command(&encoded).expect("well-formed");
         assert_eq!(route.origin, "py.ruff-lsp");
         assert_eq!(route.host_uri, "file:///x");
@@ -102,11 +120,21 @@ mod tests {
         // LSP command ids are arbitrary strings; a (theoretical) separator in
         // the command is harmless because it's the splitn(3) remainder — only
         // the origin/host_uri boundaries must be separator-free.
-        let encoded = encode_command("srv", "file:///x", "weird\u{1f}cmd");
+        let encoded = encode_command("srv", "file:///x", "weird\u{1f}cmd").expect("valid");
         let route = decode_command(&encoded).expect("well-formed");
         assert_eq!(route.origin, "srv");
         assert_eq!(route.host_uri, "file:///x");
         assert_eq!(route.command, "weird\u{1f}cmd");
+    }
+
+    #[test]
+    fn encode_fails_closed_when_origin_or_host_uri_contains_the_separator() {
+        // A separator in `origin` or `host_uri` would make `decode_command`
+        // mis-split and route to the wrong server/root, so refuse to encode.
+        assert!(encode_command("sr\u{1f}v", "file:///x", "cmd").is_none());
+        assert!(encode_command("srv", "file:///x\u{1f}y", "cmd").is_none());
+        // The command segment may contain it freely (it's the remainder).
+        assert!(encode_command("srv", "file:///x", "c\u{1f}md").is_some());
     }
 
     #[test]

--- a/src/lsp/bridge/protocol/command_routing.rs
+++ b/src/lsp/bridge/protocol/command_routing.rs
@@ -1,0 +1,104 @@
+//! Command-name routing for bridged `workspace/executeCommand` (#568 PR 6).
+//!
+//! A downstream `Command` (bare, or embedded in a `CodeAction`) is executed by
+//! the client via `workspace/executeCommand`, which carries only `command` +
+//! `arguments` — no `data` envelope. So the origin server can't ride along in
+//! `data` the way `codeAction/resolve` routes (that path DOES get `data`).
+//!
+//! Instead the command NAME itself is the routing key: when the bridge surfaces
+//! a downstream command it rewrites the name to encode the origin server AND the
+//! host document it came from, and the bridged `executeCommand` decodes both to
+//! reach the exact `(server, root)` connection that has the (virtual or host)
+//! document open. The `arguments` stay verbatim — they are the downstream's own
+//! coordinate system (checklist §10). Rewriting the name (which the bridge
+//! minted when it surfaced the action) does not violate that.
+//!
+//! Encoding is stateless (no cross-request registry to populate/evict) and
+//! therefore collision-safe: two servers advertising the same command name
+//! (realistic once concatenated aggregation lands, #568 PR 7) encode to
+//! distinct names and route correctly.
+//!
+//! The separator is the ASCII Unit Separator (`0x1f`), which cannot appear in a
+//! TOML config server name, a `file://` URI, or a real command identifier, so
+//! the split is unambiguous. Decoding is total: any name that isn't a
+//! well-formed bridge command yields `None`, and the handler fails that command
+//! soft rather than panicking.
+//!
+//! NOTE: this reaches only commands surfaced through a bridged action. Commands
+//! the client fires WITHOUT an action context (from a palette, keyed off the
+//! advertised `executeCommandProvider.commands` list) need real advertised
+//! names + dynamic registration and are a deliberate follow-up (see #568 PR 6).
+
+/// Marker that identifies a bridge-minted command name.
+const COMMAND_PREFIX: &str = "kakehashi";
+/// ASCII Unit Separator — cannot occur in a config server name, a URI, or a
+/// command id.
+const SEP: char = '\u{1f}';
+
+/// A decoded bridge command name: the origin server, the host document it was
+/// surfaced from, and the downstream's own command id (forwarded verbatim).
+pub(crate) struct CommandRoute<'a> {
+    pub(crate) origin: &'a str,
+    pub(crate) host_uri: &'a str,
+    pub(crate) command: &'a str,
+}
+
+/// Encode `command` as a bridge-routed name carrying its `origin` server and
+/// `host_uri`: `"kakehashi\u{1f}{origin}\u{1f}{host_uri}\u{1f}{command}"`.
+pub(crate) fn encode_command(origin: &str, host_uri: &str, command: &str) -> String {
+    format!("{COMMAND_PREFIX}{SEP}{origin}{SEP}{host_uri}{SEP}{command}")
+}
+
+/// Decode a bridge-routed command name, or `None` if `name` was not minted by
+/// [`encode_command`]. Total: never panics, so a malformed or foreign command
+/// name fails soft at the call site.
+pub(crate) fn decode_command(name: &str) -> Option<CommandRoute<'_>> {
+    let rest = name.strip_prefix(COMMAND_PREFIX)?.strip_prefix(SEP)?;
+    // Exactly three fields; the command id is the remainder (it may contain
+    // anything except the separator, which the encoder never emits inside it).
+    let mut parts = rest.splitn(3, SEP);
+    let origin = parts.next()?;
+    let host_uri = parts.next()?;
+    let command = parts.next()?;
+    Some(CommandRoute {
+        origin,
+        host_uri,
+        command,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_all_three_fields() {
+        let encoded = encode_command("ruff", "file:///w/a.md", "ruff.applyOrganizeImports");
+        let route = decode_command(&encoded).expect("well-formed");
+        assert_eq!(route.origin, "ruff");
+        assert_eq!(route.host_uri, "file:///w/a.md");
+        assert_eq!(route.command, "ruff.applyOrganizeImports");
+    }
+
+    #[test]
+    fn round_trips_a_server_name_with_dots_and_a_command_with_colons() {
+        // Config server names are arbitrary TOML keys and command ids often
+        // contain colons/dots; the separator must not collide with any of them.
+        let encoded = encode_command("py.ruff-lsp", "file:///x", "cmd:with:colons");
+        let route = decode_command(&encoded).expect("well-formed");
+        assert_eq!(route.origin, "py.ruff-lsp");
+        assert_eq!(route.host_uri, "file:///x");
+        assert_eq!(route.command, "cmd:with:colons");
+    }
+
+    #[test]
+    fn decode_rejects_a_foreign_or_truncated_command_name() {
+        // A command the bridge did not mint (e.g. a client-side command) must
+        // not be mistaken for a routed one, nor may a truncated one panic.
+        assert!(decode_command("rust-analyzer.runSingle").is_none());
+        assert!(decode_command("kakehashi").is_none());
+        assert!(decode_command("kakehashi\u{1f}only-server").is_none());
+        assert!(decode_command("kakehashi\u{1f}server\u{1f}uri-no-command").is_none());
+        assert!(decode_command("").is_none());
+    }
+}

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@default.snap
@@ -5,6 +5,9 @@ expression: merged
 {
   "workspace": {
     "applyEdit": true,
+    "executeCommand": {
+      "dynamicRegistration": false
+    },
     "workspaceFolders": true,
     "configuration": true,
     "diagnostics": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@experimental.snap
@@ -5,6 +5,9 @@ expression: merged
 {
   "workspace": {
     "applyEdit": true,
+    "executeCommand": {
+      "dynamicRegistration": false
+    },
     "workspaceFolders": true,
     "configuration": true,
     "diagnostics": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@default.snap
@@ -5,6 +5,9 @@ expression: capabilities
 {
   "workspace": {
     "applyEdit": true,
+    "executeCommand": {
+      "dynamicRegistration": false
+    },
     "workspaceFolders": true,
     "configuration": true,
     "diagnostics": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@experimental.snap
@@ -5,6 +5,9 @@ expression: capabilities
 {
   "workspace": {
     "applyEdit": true,
+    "executeCommand": {
+      "dynamicRegistration": false
+    },
     "workspaceFolders": true,
     "configuration": true,
     "diagnostics": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@default.snap
@@ -12,6 +12,9 @@ expression: request
     "capabilities": {
       "workspace": {
         "applyEdit": true,
+        "executeCommand": {
+          "dynamicRegistration": false
+        },
         "workspaceFolders": true,
         "configuration": true,
         "diagnostics": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@experimental.snap
@@ -12,6 +12,9 @@ expression: request
     "capabilities": {
       "workspace": {
         "applyEdit": true,
+        "executeCommand": {
+          "dynamicRegistration": false
+        },
         "workspaceFolders": true,
         "configuration": true,
         "diagnostics": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@default.snap
@@ -23,6 +23,9 @@ expression: request
     "capabilities": {
       "workspace": {
         "applyEdit": true,
+        "executeCommand": {
+          "dynamicRegistration": false
+        },
         "workspaceFolders": true,
         "configuration": true,
         "diagnostics": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@experimental.snap
@@ -23,6 +23,9 @@ expression: request
     "capabilities": {
       "workspace": {
         "applyEdit": true,
+        "executeCommand": {
+          "dynamicRegistration": false
+        },
         "workspaceFolders": true,
         "configuration": true,
         "diagnostics": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@default.snap
@@ -12,6 +12,9 @@ expression: request
     "capabilities": {
       "workspace": {
         "applyEdit": true,
+        "executeCommand": {
+          "dynamicRegistration": false
+        },
         "workspaceFolders": true,
         "configuration": true,
         "diagnostics": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@experimental.snap
@@ -12,6 +12,9 @@ expression: request
     "capabilities": {
       "workspace": {
         "applyEdit": true,
+        "executeCommand": {
+          "dynamicRegistration": false
+        },
         "workspaceFolders": true,
         "configuration": true,
         "diagnostics": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@default.snap
@@ -12,6 +12,9 @@ expression: request
     "capabilities": {
       "workspace": {
         "applyEdit": true,
+        "executeCommand": {
+          "dynamicRegistration": false
+        },
         "workspaceFolders": true,
         "configuration": true,
         "diagnostics": {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@experimental.snap
@@ -12,6 +12,9 @@ expression: request
     "capabilities": {
       "workspace": {
         "applyEdit": true,
+        "executeCommand": {
+          "dynamicRegistration": false
+        },
         "workspaceFolders": true,
         "configuration": true,
         "diagnostics": {

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -33,10 +33,10 @@ use url::Url;
 
 use super::super::pool::{ConnectionHandle, LanguageServerPool, UpstreamId};
 use super::super::protocol::{
-    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, host_position_within_region,
-    response_has_jsonrpc_error, transform_workspace_edit_to_host, translate_host_range_to_virtual,
-    translate_virtual_position_to_host, translate_virtual_range_to_host, virtual_uri_to_lsp_uri,
-    workspace_edit_within_region,
+    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, encode_command,
+    host_position_within_region, response_has_jsonrpc_error, transform_workspace_edit_to_host,
+    translate_host_range_to_virtual, translate_virtual_position_to_host,
+    translate_virtual_range_to_host, virtual_uri_to_lsp_uri, workspace_edit_within_region,
 };
 use super::completion::EnvelopeOffset;
 
@@ -333,6 +333,7 @@ impl LanguageServerPool {
         Ok(Some(bridge_code_actions(
             actions,
             server_name,
+            host_uri.as_str(),
             upstream_caps,
             handle.has_capability("codeAction/resolve"),
             Some(&virt),
@@ -535,14 +536,13 @@ impl LanguageServerPool {
             return resolved;
         }
 
-        // A resolve that materializes a `command` (or edit+command) can't be
-        // honored — command execution is unbridged, and applying only the edit
-        // half is worse than none (the initial codeAction path disables such
-        // actions). Fail soft: return the original action unresolved rather
-        // than hand the editor an executable downstream command.
-        if resolved.command.is_some() {
-            re_envelope_action(&mut action, &envelope);
-            return action;
+        // A resolve that materializes a `command` (or edit+command) is now
+        // executable: rewrite the command name to encode the origin server so
+        // the bridged executeCommand routes back to it (mirrors the initial
+        // codeAction path). An edit+command action keeps both — the edit is
+        // translated below, then the client executes the command.
+        if let Some(command) = &mut resolved.command {
+            command.command = encode_command(server_name, &envelope.host_uri, &command.command);
         }
 
         // isPreferred is its own client capability (LSP 3.15); the downstream
@@ -603,14 +603,14 @@ impl LanguageServerPool {
         let server_title = std::mem::take(&mut resolved.title);
         resolved.title = resuffix_resolved_title(server_title.clone(), suffixed_title, server_name);
 
-        // Once resolve has materialized an edit, the action is complete and
-        // its edit is host-translated. Re-enveloping it would let a second
-        // resolve forward that host-coordinate edit back downstream (no
-        // inverse transform) — so strip the data instead, mirroring the
-        // initial-response policy for edit-carrying actions. Only a still-lazy
-        // resolved action (no edit) keeps a routing envelope for a further
-        // resolve.
-        if resolved.edit.is_some() {
+        // Once resolve has materialized an edit OR a command, the action is
+        // complete (the edit is host-translated; the command name is routed).
+        // Re-enveloping it would let a second resolve forward that host-
+        // coordinate edit back downstream (no inverse transform) — so strip the
+        // data instead, mirroring the initial-response policy. Only a still-lazy
+        // resolved action (no edit, no command) keeps a routing envelope for a
+        // further resolve.
+        if resolved.edit.is_some() || resolved.command.is_some() {
             resolved.data = None;
         } else {
             // Still lazy: a future resolve restores `envelope.original_title`
@@ -881,6 +881,7 @@ impl UpstreamCodeActionCaps {
 pub(crate) fn bridge_code_actions(
     actions: Vec<CodeActionOrCommand>,
     server_name: &str,
+    host_uri: &str,
     upstream_caps: UpstreamCodeActionCaps,
     server_resolves: bool,
     virt: Option<&VirtLayerContext<'_>>,
@@ -888,33 +889,39 @@ pub(crate) fn bridge_code_actions(
     actions
         .into_iter()
         .filter_map(|item| {
-            bridge_code_action(item, server_name, upstream_caps, server_resolves, virt)
+            bridge_code_action(
+                item,
+                server_name,
+                host_uri,
+                upstream_caps,
+                server_resolves,
+                virt,
+            )
         })
         .collect()
 }
 
-const REASON_COMMANDS: &str = "kakehashi does not bridge command execution yet";
 const REASON_RESOLVE: &str = "this action could not be resolved to an applicable edit";
 const REASON_CROSS_REGION: &str = "the edit cannot be represented in the host document";
 
 fn bridge_code_action(
     item: CodeActionOrCommand,
     server_name: &str,
+    host_uri: &str,
     upstream_caps: UpstreamCodeActionCaps,
     server_resolves: bool,
     virt: Option<&VirtLayerContext<'_>>,
 ) -> Option<CodeActionOrCommand> {
     let mut action = match item {
-        // A bare Command cannot carry `disabled`; represent it as a disabled
-        // CodeAction so the user still sees it exists (checklist: never
-        // silently drop when the client can render why).
-        CodeActionOrCommand::Command(command) => {
-            return disabled_placeholder(
-                command.title,
-                REASON_COMMANDS,
-                server_name,
-                upstream_caps,
-            );
+        // A bare Command is executable via workspace/executeCommand once its
+        // name encodes the origin server + host document (the client sends only
+        // command+arguments on execute — no data envelope to route by).
+        // Arguments stay verbatim (checklist §10); suffix the title like every
+        // bridged action.
+        CodeActionOrCommand::Command(mut command) => {
+            command.command = encode_command(server_name, host_uri, &command.command);
+            command.title = suffix_title(command.title, server_name);
+            return Some(CodeActionOrCommand::Command(command));
         }
         CodeActionOrCommand::CodeAction(action) => action,
     };
@@ -954,12 +961,18 @@ fn bridge_code_action(
         action.is_preferred = None;
     }
 
-    // Commands are not executable until executeCommand is bridged; applying
-    // only the edit half of an edit+command action would be worse than
-    // disabling the whole action.
-    if action.command.is_some() {
-        return disable_action(action, REASON_COMMANDS, server_name, upstream_caps);
-    }
+    // A command makes the action executable via workspace/executeCommand.
+    // Rewrite the command name to encode its origin server so the bridged
+    // executeCommand routes it back (the client sends only command+arguments on
+    // execute — no data envelope). Arguments pass through verbatim (they are the
+    // downstream's own coordinate system, checklist §10). An edit+command action
+    // keeps BOTH: the client applies the (translated) edit, then executes.
+    let has_command = if let Some(command) = &mut action.command {
+        command.command = encode_command(server_name, host_uri, &command.command);
+        true
+    } else {
+        false
+    };
 
     match &mut action.edit {
         Some(edit) => {
@@ -981,6 +994,14 @@ fn bridge_code_action(
             }
         }
         None => {
+            // Command-only action: executable via the bridged executeCommand
+            // (its name was rewritten above), no edit to translate. Strip the
+            // resolve `data` and surface it suffixed.
+            if has_command {
+                action.data = None;
+                action.title = suffix_title(action.title, server_name);
+                return Some(CodeActionOrCommand::CodeAction(action));
+            }
             // No edit, no command: is this a lazy (resolve-deferred) action?
             //
             // Virt layer: the *bridge* issues the `codeAction/resolve`, so the
@@ -1138,24 +1159,6 @@ fn disable_action(
         reason: reason.to_string(),
     });
     Some(CodeActionOrCommand::CodeAction(action))
-}
-
-fn disabled_placeholder(
-    title: String,
-    reason: &str,
-    server_name: &str,
-    upstream_caps: UpstreamCodeActionCaps,
-) -> Option<CodeActionOrCommand> {
-    if !upstream_caps.disabled_support {
-        return None;
-    }
-    Some(CodeActionOrCommand::CodeAction(CodeAction {
-        title: suffix_title(title, server_name),
-        disabled: Some(CodeActionDisabled {
-            reason: reason.to_string(),
-        }),
-        ..CodeAction::default()
-    }))
 }
 
 #[cfg(test)]
@@ -1460,6 +1463,7 @@ mod tests {
         Some(bridge_code_actions(
             actions,
             "ruff",
+            "file:///test.md",
             upstream_caps,
             server_resolves,
             Some(&virt),
@@ -1551,33 +1555,41 @@ mod tests {
     }
 
     #[test]
-    fn bare_command_becomes_disabled_placeholder() {
+    fn bare_command_is_surfaced_with_a_routed_name() {
+        use crate::lsp::bridge::decode_command;
         let actions = transform(
             json!([{ "title": "Run organize imports", "command": "ruff.organizeImports" }]),
             caps(true),
         )
         .unwrap();
 
-        let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
-            panic!("Expected CodeAction placeholder");
+        let CodeActionOrCommand::Command(command) = &actions[0] else {
+            panic!("Expected an executable Command");
         };
-        assert_eq!(action.title, "Run organize imports — ruff");
-        assert_eq!(action.disabled.as_ref().unwrap().reason, REASON_COMMANDS);
-        assert!(action.command.is_none() && action.edit.is_none());
+        assert_eq!(command.title, "Run organize imports — ruff");
+        // The command name encodes the origin server + host document so
+        // executeCommand routes back to it; arguments (none here) stay verbatim.
+        let route = decode_command(&command.command).expect("routed name");
+        assert_eq!(route.origin, "ruff");
+        assert_eq!(route.host_uri, "file:///test.md");
+        assert_eq!(route.command, "ruff.organizeImports");
     }
 
     #[test]
-    fn bare_command_is_dropped_without_disabled_support() {
+    fn bare_command_is_surfaced_even_without_disabled_support() {
+        // A command is executable, not disabled, so disabledSupport is
+        // irrelevant — it must still be surfaced.
         let actions = transform(
             json!([{ "title": "Run organize imports", "command": "ruff.organizeImports" }]),
             caps(false),
         )
         .unwrap();
-        assert!(actions.is_empty());
+        assert!(matches!(actions[0], CodeActionOrCommand::Command(_)));
     }
 
     #[test]
-    fn command_carrying_action_is_disabled_with_payload_stripped() {
+    fn edit_command_action_keeps_both_with_a_routed_command() {
+        use crate::lsp::bridge::decode_command;
         let mut action = edit_carrying_action("Fix all");
         action["command"] = json!({ "title": "post", "command": "ruff.postFix" });
         let actions = transform(json!([action]), caps(true)).unwrap();
@@ -1585,12 +1597,13 @@ mod tests {
         let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
             panic!("Expected CodeAction");
         };
-        assert_eq!(action.disabled.as_ref().unwrap().reason, REASON_COMMANDS);
-        assert!(
-            action.edit.is_none() && action.command.is_none(),
-            "an edit+command action must not ship a half-appliable payload"
-        );
         assert_eq!(action.title, "Fix all — ruff");
+        // The client applies the (translated) edit, then executes the routed
+        // command — both halves survive.
+        assert!(action.edit.is_some(), "the translated edit is kept");
+        let route = decode_command(&action.command.as_ref().unwrap().command).expect("routed name");
+        assert_eq!(route.origin, "ruff");
+        assert_eq!(route.command, "ruff.postFix");
     }
 
     #[test]
@@ -1789,7 +1802,14 @@ mod tests {
         ]))
         .unwrap();
 
-        let bridged = bridge_code_actions(actions, "marksman", caps(true), false, None);
+        let bridged = bridge_code_actions(
+            actions,
+            "marksman",
+            "file:///test.md",
+            caps(true),
+            false,
+            None,
+        );
         assert_eq!(bridged.len(), 2);
         let CodeActionOrCommand::CodeAction(action) = &bridged[0] else {
             panic!("Expected CodeAction");
@@ -1798,13 +1818,15 @@ mod tests {
         let changes = action.edit.as_ref().unwrap().changes.as_ref().unwrap();
         let edits = changes.get(&make_host_uri()).unwrap();
         assert_eq!(edits[0].range.start.line, 50, "host edits stay verbatim");
-        let CodeActionOrCommand::CodeAction(placeholder) = &bridged[1] else {
-            panic!("Expected disabled placeholder");
+        // The bare command is surfaced executable (host layer routes back to
+        // the host server, whose arguments reference the real URI).
+        let CodeActionOrCommand::Command(command) = &bridged[1] else {
+            panic!("Expected an executable Command");
         };
-        assert_eq!(
-            placeholder.disabled.as_ref().unwrap().reason,
-            REASON_COMMANDS
-        );
+        assert_eq!(command.title, "Run linter — marksman");
+        let route = crate::lsp::bridge::decode_command(&command.command).expect("routed name");
+        assert_eq!(route.origin, "marksman");
+        assert_eq!(route.command, "lint.run");
     }
 
     // ==========================================================================

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -542,8 +542,18 @@ impl LanguageServerPool {
         // the bridged executeCommand routes back to it (mirrors the initial
         // codeAction path). An edit+command action keeps both — the edit is
         // translated below, then the client executes the command.
-        if let Some(command) = &mut resolved.command {
-            command.command = encode_command(server_name, &envelope.host_uri, &command.command);
+        // Drop the command if its routing name can't be encoded (unroutable);
+        // an accompanying edit is still applied.
+        if resolved
+            .command
+            .as_mut()
+            .and_then(|command| {
+                encode_command(server_name, &envelope.host_uri, &command.command)
+                    .map(|encoded| command.command = encoded)
+            })
+            .is_none()
+        {
+            resolved.command = None;
         }
 
         // isPreferred is its own client capability (LSP 3.15); the downstream
@@ -920,7 +930,10 @@ fn bridge_code_action(
         // Arguments stay verbatim (checklist §10); suffix the title like every
         // bridged action.
         CodeActionOrCommand::Command(mut command) => {
-            command.command = encode_command(server_name, host_uri, &command.command);
+            // Drop a bare command we can't mint an unambiguous routing name for
+            // (pathological: a separator in the server name) — routed back it
+            // would reach the wrong server, and un-routed it executes to nothing.
+            command.command = encode_command(server_name, host_uri, &command.command)?;
             command.title = suffix_title(command.title, server_name);
             return Some(CodeActionOrCommand::Command(command));
         }
@@ -968,12 +981,20 @@ fn bridge_code_action(
     // execute — no data envelope). Arguments pass through verbatim (they are the
     // downstream's own coordinate system, checklist §10). An edit+command action
     // keeps BOTH: the client applies the (translated) edit, then executes.
-    let has_command = if let Some(command) = &mut action.command {
-        command.command = encode_command(server_name, host_uri, &command.command);
-        true
-    } else {
-        false
-    };
+    let has_command = action
+        .command
+        .as_mut()
+        .and_then(|command| {
+            encode_command(server_name, host_uri, &command.command)
+                .map(|encoded| command.command = encoded)
+        })
+        .is_some();
+    // A command whose name couldn't be encoded (unroutable) is dropped; an
+    // accompanying edit is still applied below, else the action is dropped as a
+    // no-op. Assigning None when there was no command is a harmless no-op.
+    if !has_command {
+        action.command = None;
+    }
 
     match &mut action.edit {
         Some(edit) => {

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -4,9 +4,10 @@
 //! `codeAction/resolve` is routed back to the origin server via the
 //! `CodeActionEnvelope` in `CodeAction.data` (PR 4), or eagerly resolved
 //! downstream when the upstream client lacks `dataSupport`/`resolveSupport`.
-//! Only `Command` execution remains unbridged — command-carrying actions
-//! surface as `disabled: { reason }` when the client supports it and are
-//! dropped otherwise (LSP 3.16 `disabledSupport`).
+//! Command-carrying actions are executable: the command name is rewritten to
+//! encode its origin server + host document, so the bridged
+//! `workspace/executeCommand` routes it back (PR 6, see
+//! [`command_routing`](super::super::protocol)).
 //!
 //! Every bridged action title gets the `"{title} — {server}"` suffix so
 //! users can see which downstream server each action comes from.

--- a/src/lsp/bridge/workspace.rs
+++ b/src/lsp/bridge/workspace.rs
@@ -17,6 +17,10 @@
 pub(in crate::lsp::bridge) mod apply_edit;
 pub(in crate::lsp::bridge) mod configuration;
 pub(in crate::lsp::bridge) mod diagnostic_refresh;
+// The one OUTBOUND method in this namespace (editor → bridge → downstream):
+// routes a bridged command back to its origin server. Kept here so the
+// `workspace/*` surface stays in one directory.
+pub(in crate::lsp::bridge) mod execute_command;
 mod folder_set;
 pub(in crate::lsp::bridge) mod workspace_folders;
 

--- a/src/lsp/bridge/workspace/execute_command.rs
+++ b/src/lsp/bridge/workspace/execute_command.rs
@@ -144,15 +144,41 @@ impl LanguageServerPool {
         let request = JsonRpcRequest::new(request_id.as_i64(), METHOD, &params);
         let mut router_guard = RouterCleanupGuard::new(Arc::clone(handle.router()), request_id);
 
-        if let Err(e) = handle.send_request(request, request_id) {
-            warn!(
-                target: "kakehashi::bridge",
-                "executeCommand: failed to send request: {e}"
-            );
-            if let Some(ref id) = upstream_id {
-                self.unregister_upstream_request(id, connection_key);
+        // Verify `handle` is still the pool's LIVE connection for its key before
+        // sending, under the `connections` lock: `handle` was fetched earlier
+        // (get_or_create), and a concurrent respawn could have replaced it. Both
+        // the check and the enqueue must hold the lock so the swap can't
+        // interleave — the same guard `execute_bridge_request_with_handle` uses.
+        // Sending on a stale handle would route the request (and its cancel
+        // bookkeeping) to a dead/outdated process. On failure `router_guard`
+        // drops (cleaning the router entry).
+        {
+            let connections = self.connections().await;
+            if !connections
+                .get(connection_key)
+                .is_some_and(|current| Arc::ptr_eq(current, handle))
+            {
+                drop(connections);
+                warn!(
+                    target: "kakehashi::bridge",
+                    "executeCommand: connection {connection_key} was replaced before send"
+                );
+                if let Some(ref id) = upstream_id {
+                    self.unregister_upstream_request(id, connection_key);
+                }
+                return None;
             }
-            return None;
+            if let Err(e) = handle.send_request(request, request_id) {
+                drop(connections);
+                warn!(
+                    target: "kakehashi::bridge",
+                    "executeCommand: failed to send request: {e}"
+                );
+                if let Some(ref id) = upstream_id {
+                    self.unregister_upstream_request(id, connection_key);
+                }
+                return None;
+            }
         }
 
         let response = handle.wait_for_response(request_id, response_rx).await;

--- a/src/lsp/bridge/workspace/execute_command.rs
+++ b/src/lsp/bridge/workspace/execute_command.rs
@@ -73,9 +73,19 @@ impl LanguageServerPool {
             merge_bridge_server_configs,
         )?;
 
-        let host_url = Url::parse(&host_uri).ok();
+        // A malformed host_uri must REJECT, not fall through to a client-root
+        // fallback connection (which could execute the command against the
+        // wrong root). The bridge only ever mints a valid `Url::as_str()` here,
+        // so a parse failure means a foreign/corrupt command — fail soft.
+        let Ok(host_url) = Url::parse(&host_uri) else {
+            warn!(
+                target: "kakehashi::bridge",
+                "executeCommand: routed host_uri '{host_uri}' is not a valid URL; ignoring"
+            );
+            return None;
+        };
         let handle = match self
-            .get_or_create_connection(&origin, &config, host_url.as_ref())
+            .get_or_create_connection(&origin, &config, Some(&host_url))
             .await
         {
             Ok(handle) => handle,

--- a/src/lsp/bridge/workspace/execute_command.rs
+++ b/src/lsp/bridge/workspace/execute_command.rs
@@ -1,0 +1,169 @@
+//! `workspace/executeCommand` routing (#568 PR 6).
+//!
+//! Outbound (editor → bridge → downstream). A `Command` the bridge surfaced in
+//! a code action (bare or embedded) is executed by the client via
+//! `workspace/executeCommand`, which carries only `command` + `arguments` — no
+//! `data` envelope. The origin server + host document are encoded in the command
+//! NAME instead (see [`command_routing`](crate::lsp::bridge::protocol)), so this
+//! handler decodes them, reconnects to the exact `(server, root)` connection
+//! that has the document open, and forwards the request with the downstream's
+//! ORIGINAL command name and verbatim arguments (checklist §10).
+//!
+//! The server's result is relayed verbatim. Most command-style servers answer
+//! executeCommand by sending a `workspace/applyEdit` back (handled inbound by
+//! [`apply_edit`](super::apply_edit)) and returning a null result — the two
+//! paths compose: execute → server-applyEdit → editor applies → execute-result.
+//!
+//! Fails soft at every step: a command that doesn't decode as a bridge command,
+//! an unspawnable/unresolvable origin, a dead connection, or a server error all
+//! yield `None` (a null result to the client) rather than an error dialog.
+
+use std::sync::Arc;
+
+use log::warn;
+use serde_json::Value;
+
+use crate::config::settings::WorkspaceSettings;
+use crate::config::{merge_bridge_server_configs, resolve_with_wildcard};
+use crate::lsp::bridge::actor::RouterCleanupGuard;
+use crate::lsp::bridge::decode_command;
+use crate::lsp::bridge::pool::{ConnectionHandle, LanguageServerPool, UpstreamId};
+use crate::lsp::bridge::protocol::{JsonRpcRequest, response_has_jsonrpc_error};
+use tower_lsp_server::ls_types::ExecuteCommandParams;
+use url::Url;
+
+const METHOD: &str = "workspace/executeCommand";
+
+impl LanguageServerPool {
+    /// Route a bridged `workspace/executeCommand` back to the origin downstream
+    /// server encoded in the command name. Returns the server's result relayed
+    /// verbatim, or `None` on any failure (fail soft).
+    pub(crate) async fn dispatch_execute_command(
+        &self,
+        params: ExecuteCommandParams,
+        settings: &WorkspaceSettings,
+        upstream_id: Option<UpstreamId>,
+    ) -> Option<Value> {
+        // Decode into owned strings first so `params.arguments` can move into
+        // the outgoing request without a partial-borrow conflict.
+        let (origin, host_uri, command) = match decode_command(&params.command) {
+            Some(route) => (
+                route.origin.to_string(),
+                route.host_uri.to_string(),
+                route.command.to_string(),
+            ),
+            None => {
+                // Not a bridge-minted command (a client-side or foreign command)
+                // — the bridge has no origin to route it to.
+                warn!(
+                    target: "kakehashi::bridge",
+                    "executeCommand: '{}' is not a bridged command; ignoring",
+                    params.command
+                );
+                return None;
+            }
+        };
+
+        if !crate::config::is_server_spawnable(&settings.language_servers, &origin) {
+            return None;
+        }
+        let config = resolve_with_wildcard(
+            &settings.language_servers,
+            &origin,
+            merge_bridge_server_configs,
+        )?;
+
+        let host_url = Url::parse(&host_uri).ok();
+        let handle = match self
+            .get_or_create_connection(&origin, &config, host_url.as_ref())
+            .await
+        {
+            Ok(handle) => handle,
+            Err(e) => {
+                warn!(
+                    target: "kakehashi::bridge",
+                    "executeCommand: failed to connect to {origin}: {e}"
+                );
+                return None;
+            }
+        };
+        if !handle.has_capability(METHOD) {
+            return None;
+        }
+
+        // Forward with the downstream's ORIGINAL command name and its own
+        // arguments untouched (they reference the downstream's coordinate
+        // system — its virtual or host document — checklist §10).
+        let outgoing = ExecuteCommandParams {
+            command,
+            arguments: params.arguments,
+            work_done_progress_params: params.work_done_progress_params,
+        };
+        self.send_execute_command_on_handle(&handle, outgoing, upstream_id)
+            .await
+    }
+
+    /// Send a `workspace/executeCommand` on an already-connected handle and
+    /// return the raw `result` (null normalized to `None`). Returns `None` on
+    /// any failure (register/send/wait/error) so the caller fails soft.
+    async fn send_execute_command_on_handle(
+        &self,
+        handle: &Arc<ConnectionHandle>,
+        params: ExecuteCommandParams,
+        upstream_id: Option<UpstreamId>,
+    ) -> Option<Value> {
+        let connection_key = handle.key();
+        if let Some(ref id) = upstream_id {
+            self.register_upstream_request(id.clone(), connection_key);
+        }
+        let (request_id, response_rx) =
+            match handle.register_request_with_upstream(upstream_id.clone()) {
+                Ok(pair) => pair,
+                Err(e) => {
+                    warn!(
+                        target: "kakehashi::bridge",
+                        "executeCommand: failed to register request: {e}"
+                    );
+                    if let Some(ref id) = upstream_id {
+                        self.unregister_upstream_request(id, connection_key);
+                    }
+                    return None;
+                }
+            };
+
+        let request = JsonRpcRequest::new(request_id.as_i64(), METHOD, &params);
+        let mut router_guard = RouterCleanupGuard::new(Arc::clone(handle.router()), request_id);
+
+        if let Err(e) = handle.send_request(request, request_id) {
+            warn!(
+                target: "kakehashi::bridge",
+                "executeCommand: failed to send request: {e}"
+            );
+            if let Some(ref id) = upstream_id {
+                self.unregister_upstream_request(id, connection_key);
+            }
+            return None;
+        }
+
+        let response = handle.wait_for_response(request_id, response_rx).await;
+        router_guard.disarm();
+        if let Some(ref id) = upstream_id {
+            self.unregister_upstream_request(id, connection_key);
+        }
+
+        parse_execute_command_response(response.ok()?)
+    }
+}
+
+/// Parse a JSON-RPC `workspace/executeCommand` response into its `result`,
+/// relayed verbatim. Returns `None` for errors and a null result.
+fn parse_execute_command_response(mut response: Value) -> Option<Value> {
+    if response_has_jsonrpc_error(&response, METHOD) {
+        return None;
+    }
+    let result = response.get_mut("result").map(Value::take)?;
+    if result.is_null() {
+        return None;
+    }
+    Some(result)
+}

--- a/src/lsp/bridge/workspace/execute_command.rs
+++ b/src/lsp/bridge/workspace/execute_command.rs
@@ -98,6 +98,13 @@ impl LanguageServerPool {
             }
         };
         if !handle.has_capability(METHOD) {
+            // Should be unreachable — the bridge only mints commands from servers
+            // it bridged — but if it happens, a log entry beats a silent drop
+            // (every other failure branch here warns).
+            warn!(
+                target: "kakehashi::bridge",
+                "executeCommand: {origin} does not advertise executeCommandProvider; ignoring '{command}'"
+            );
             return None;
         }
 
@@ -187,7 +194,20 @@ impl LanguageServerPool {
             self.unregister_upstream_request(id, connection_key);
         }
 
-        parse_execute_command_response(response.ok()?)
+        // Fail soft, but not silently: surface timeouts / channel-closed like the
+        // other branches so execute-time issues are debuggable (sibling sweep of
+        // the codeAction/resolve logging fix).
+        let response = match response {
+            Ok(r) => r,
+            Err(e) => {
+                warn!(
+                    target: "kakehashi::bridge",
+                    "executeCommand: wait for response failed on {connection_key:?}: {e}"
+                );
+                return None;
+            }
+        };
+        parse_execute_command_response(response)
     }
 }
 

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -25,14 +25,15 @@ use tower_lsp_server::ls_types::{
     DidSaveTextDocumentParams, DocumentDiagnosticParams, DocumentDiagnosticReportResult,
     DocumentFormattingParams, DocumentHighlight, DocumentHighlightParams, DocumentLink,
     DocumentLinkParams, DocumentOnTypeFormattingParams, DocumentRangeFormattingParams,
-    DocumentSymbolParams, DocumentSymbolResponse, FoldingRange, FoldingRangeParams,
-    GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams, InitializeParams,
-    InitializeResult, InitializedParams, InlayHint, InlayHintParams, LinkedEditingRangeParams,
-    LinkedEditingRanges, Location, Moniker, MonikerParams, PrepareRenameResponse, ReferenceParams,
-    RenameParams, SelectionRange, SelectionRangeParams, SemanticTokensDeltaParams,
-    SemanticTokensFullDeltaResult, SemanticTokensParams, SemanticTokensRangeParams,
-    SemanticTokensRangeResult, SemanticTokensResult, SignatureHelp, SignatureHelpParams,
-    TextDocumentPositionParams, TextEdit, Uri, WillSaveTextDocumentParams, WorkspaceEdit,
+    DocumentSymbolParams, DocumentSymbolResponse, ExecuteCommandParams, FoldingRange,
+    FoldingRangeParams, GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams,
+    InitializeParams, InitializeResult, InitializedParams, InlayHint, InlayHintParams,
+    LinkedEditingRangeParams, LinkedEditingRanges, Location, Moniker, MonikerParams,
+    PrepareRenameResponse, ReferenceParams, RenameParams, SelectionRange, SelectionRangeParams,
+    SemanticTokensDeltaParams, SemanticTokensFullDeltaResult, SemanticTokensParams,
+    SemanticTokensRangeParams, SemanticTokensRangeResult, SemanticTokensResult, SignatureHelp,
+    SignatureHelpParams, TextDocumentPositionParams, TextEdit, Uri, WillSaveTextDocumentParams,
+    WorkspaceEdit,
 };
 use tower_lsp_server::ls_types::{
     ColorInformation, ColorPresentation, ColorPresentationParams, DocumentColorParams,
@@ -736,6 +737,13 @@ impl LanguageServer for Kakehashi {
 
     async fn code_action_resolve(&self, params: CodeAction) -> Result<CodeAction> {
         self.code_action_resolve_impl(params).await
+    }
+
+    async fn execute_command(
+        &self,
+        params: ExecuteCommandParams,
+    ) -> Result<Option<serde_json::Value>> {
+        self.execute_command_impl(params).await
     }
 
     async fn formatting(&self, params: DocumentFormattingParams) -> Result<Option<Vec<TextEdit>>> {

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -10,14 +10,15 @@ use tower_lsp_server::ls_types::{
     DeclarationCapability, DeclarationOptions, DefinitionOptions, DiagnosticOptions,
     DiagnosticServerCapabilities, DocumentFormattingOptions, DocumentLinkOptions,
     DocumentOnTypeFormattingOptions, DocumentRangeFormattingOptions, DocumentSymbolOptions,
-    FoldingRangeProviderCapability, HoverProviderCapability, ImplementationProviderCapability,
-    InitializeParams, InitializeResult, InitializedParams, InlayHintOptions,
-    InlayHintServerCapabilities, LinkedEditingRangeServerCapabilities, OneOf, ReferenceOptions,
-    RenameOptions, SaveOptions, SelectionRangeProviderCapability, SemanticTokenModifier,
-    SemanticTokenType, SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
-    SemanticTokensServerCapabilities, ServerCapabilities, ServerInfo, SignatureHelpOptions,
-    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
-    TextDocumentSyncSaveOptions, TypeDefinitionProviderCapability, Uri, WorkDoneProgressOptions,
+    ExecuteCommandOptions, FoldingRangeProviderCapability, HoverProviderCapability,
+    ImplementationProviderCapability, InitializeParams, InitializeResult, InitializedParams,
+    InlayHintOptions, InlayHintServerCapabilities, LinkedEditingRangeServerCapabilities, OneOf,
+    ReferenceOptions, RenameOptions, SaveOptions, SelectionRangeProviderCapability,
+    SemanticTokenModifier, SemanticTokenType, SemanticTokensFullOptions, SemanticTokensLegend,
+    SemanticTokensOptions, SemanticTokensServerCapabilities, ServerCapabilities, ServerInfo,
+    SignatureHelpOptions, TextDocumentSyncCapability, TextDocumentSyncKind,
+    TextDocumentSyncOptions, TextDocumentSyncSaveOptions, TypeDefinitionProviderCapability, Uri,
+    WorkDoneProgressOptions,
 };
 use url::Url;
 
@@ -355,6 +356,22 @@ impl Kakehashi {
                 ),
                 code_lens_provider: Some(CodeLensOptions {
                     resolve_provider: Some(true),
+                }),
+                // Bridged commands (a `Command` surfaced in a code action) are
+                // executed via `workspace/executeCommand`, routed back to their
+                // origin server by the encoded command name (#568 PR 6). Gated
+                // on the same literal-support condition as `code_action_provider`
+                // — commands only reach the bridge through a bridged code action.
+                // No advertised `commands`: downstream servers connect lazily so
+                // their command names aren't known at initialize; the capability's
+                // presence is what lets clients execute action-embedded commands.
+                // Palette-fired commands (from the advertised list) need dynamic
+                // registration and are a deferred follow-up.
+                execute_command_provider: client_supports_code_action_literals.then(|| {
+                    ExecuteCommandOptions {
+                        commands: vec![],
+                        work_done_progress_options: Default::default(),
+                    }
                 }),
                 rename_provider: Some(OneOf::Right(RenameOptions {
                     prepare_provider: Some(true),

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -363,10 +363,15 @@ impl Kakehashi {
                 // on the same literal-support condition as `code_action_provider`
                 // — commands only reach the bridge through a bridged code action.
                 // No advertised `commands`: downstream servers connect lazily so
-                // their command names aren't known at initialize; the capability's
-                // presence is what lets clients execute action-embedded commands.
-                // Palette-fired commands (from the advertised list) need dynamic
-                // registration and are a deferred follow-up.
+                // their command names aren't known at initialize (and each routed
+                // name embeds a per-document host_uri, so it could never be a
+                // stable advertised entry anyway). A client that dispatches an
+                // action's command on provider PRESENCE (Neovim's built-in client)
+                // executes it regardless; a client that only dispatches command
+                // ids from the advertised `commands` list (VS Code's
+                // vscode-languageclient) would show the action but not run it —
+                // reaching those needs dynamic registration of real names, the
+                // same deferred follow-up as palette-fired commands.
                 execute_command_provider: client_supports_code_action_literals.then(|| {
                     ExecuteCommandOptions {
                         commands: vec![],

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -281,6 +281,7 @@ impl Kakehashi {
                         Some(bridge_code_actions(
                             actions,
                             &t.server_name,
+                            t.uri.as_str(),
                             upstream_caps,
                             // Host-layer codeAction/resolve is not bridged, so
                             // host lazy actions are never enveloped/resolved.

--- a/src/lsp/lsp_impl/workspace.rs
+++ b/src/lsp/lsp_impl/workspace.rs
@@ -1,3 +1,4 @@
 //! Workspace related LSP methods.
 
 mod did_change_configuration;
+mod execute_command;

--- a/src/lsp/lsp_impl/workspace/execute_command.rs
+++ b/src/lsp/lsp_impl/workspace/execute_command.rs
@@ -1,0 +1,28 @@
+//! `workspace/executeCommand` method for Kakehashi (#568 PR 6).
+//!
+//! A `Command` the bridge surfaced in a code action is executed here: the
+//! origin server + host document are encoded in the command NAME, so the pool
+//! decodes them and routes the request back to that server (see
+//! [`dispatch_execute_command`](crate::lsp::bridge::pool::LanguageServerPool)).
+//! The server's result is relayed verbatim; a command the bridge didn't mint,
+//! or any downstream failure, yields a null result (fail soft).
+
+use serde_json::Value;
+use tower_lsp_server::jsonrpc::Result;
+use tower_lsp_server::ls_types::ExecuteCommandParams;
+
+use super::super::Kakehashi;
+
+impl Kakehashi {
+    pub(crate) async fn execute_command_impl(
+        &self,
+        params: ExecuteCommandParams,
+    ) -> Result<Option<Value>> {
+        let settings = self.settings_manager.load_settings();
+        let upstream_id = crate::lsp::current_upstream_id();
+        let pool = self.bridge.pool_arc();
+        Ok(pool
+            .dispatch_execute_command(params, &settings, upstream_id)
+            .await)
+    }
+}

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -756,15 +756,17 @@ fn main() {
                     // bridge) before completing executeCommand — real servers
                     // sequence it this way, and it makes the applyEdit reach the
                     // client strictly before this command's response. During
-                    // executeCommand handling the ONLY inbound message is that
-                    // response (id 4000), so this consumes nothing else; if the
-                    // client never answers, the mock parks here and the e2e
-                    // client's response timeout fails the test (it can't hang the
-                    // suite).
-                    while let Some(reply) = read_message(&mut reader) {
-                        if reply.get("id").and_then(Value::as_i64) == Some(4000) {
-                            break;
-                        }
+                    // executeCommand handling the applyEdit response (id 4000) is
+                    // the only message the bridge sends back, so read exactly one
+                    // and FAIL FAST on anything else rather than silently
+                    // swallowing an interleaved request/notification.
+                    match read_message(&mut reader) {
+                        Some(reply)
+                            if reply.get("id").and_then(Value::as_i64) == Some(4000) => {}
+                        other => panic!(
+                            "mock executeCommand: expected the applyEdit response (id 4000), \
+                             got {other:?}"
+                        ),
                     }
                 }
                 respond(&mut writer, id, json!({ "executed": command }));

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -159,6 +159,7 @@ fn main() {
                     }),
                     "code-action" => json!({
                         "codeActionProvider": true,
+                        "executeCommandProvider": { "commands": ["mock.run"] },
                         "textDocumentSync": 1
                     }),
                     // `code-action-lazy`: advertises resolveProvider and
@@ -167,8 +168,8 @@ fn main() {
                     // rust-analyzer shape that motivates PR 4 (#568).
                     // `code-action-lazy-cmd` is like `code-action-lazy` but its
                     // resolve materializes a COMMAND (not an edit) — the bridge
-                    // must fail soft (command execution is unbridged), never
-                    // handing the command to the editor.
+                    // rewrites the command name to route executeCommand back to
+                    // this server (#568 PR 6) and surfaces it executable.
                     // `code-action-lazy-retitle` is like `code-action-lazy` but
                     // its resolve returns a CHANGED title (LSP lets a server
                     // rewrite the title on resolve) — the bridge must surface
@@ -187,6 +188,7 @@ fn main() {
                     | "code-action-lazy-oob" => {
                         json!({
                             "codeActionProvider": { "resolveProvider": true },
+                            "executeCommandProvider": { "commands": ["mock.run"] },
                             "textDocumentSync": 1
                         })
                     }
@@ -514,9 +516,9 @@ fn main() {
                         } else {
                             // `code-action` mode: one edit-carrying quickfix (an
                             // edit on the requested document at virtual line 0)
-                            // plus one bare Command action (not executable until
-                            // executeCommand is bridged — must surface as
-                            // disabled/dropped, never verbatim).
+                            // plus one bare Command action, surfaced executable
+                            // with a routed command name (#568 PR 6). Executing
+                            // it drives executeCommand back to this server.
                             json!([
                                 {
                                     "title": "Replace with fixed",
@@ -562,9 +564,9 @@ fn main() {
                 // the mock received its URI via didOpen (single-doc tests).
                 let target_uri = documents.keys().next().cloned().unwrap_or_default();
                 if mode == "code-action-lazy-cmd" {
-                    // Resolve to a COMMAND instead of an edit: command execution
-                    // is unbridged, so the bridge must fail soft and never hand
-                    // this command to the editor.
+                    // Resolve to a COMMAND instead of an edit: the bridge routes
+                    // it (rewrites the name, strips data) and surfaces it
+                    // executable (#568 PR 6).
                     respond(
                         &mut writer,
                         id,
@@ -719,6 +721,48 @@ fn main() {
                         }
                     }),
                 );
+            }
+            "workspace/executeCommand" => {
+                // The bridge stripped its routing prefix, so we see our OWN
+                // command name (`mock.run`). Prove execute → applyEdit → relay
+                // composes with PR 5: ask the client to apply an edit on our
+                // virtual document (the bridge translates it host-ward), then
+                // answer the executeCommand with a verbatim-relayed result.
+                let command = message
+                    .pointer("/params/command")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                if command == "mock.run" {
+                    let target_uri = documents.keys().next().cloned().unwrap_or_default();
+                    request_with_params(
+                        &mut writer,
+                        json!(4000),
+                        "workspace/applyEdit",
+                        json!({
+                            "edit": {
+                                "changes": {
+                                    target_uri: [{
+                                        "range": {
+                                            "start": { "line": 0, "character": 0 },
+                                            "end": { "line": 0, "character": 5 }
+                                        },
+                                        "newText": "executed"
+                                    }]
+                                }
+                            }
+                        }),
+                    );
+                    // Wait for the client's applyEdit response (relayed by the
+                    // bridge) before completing executeCommand — real servers
+                    // sequence it this way, and it makes the applyEdit reach the
+                    // client strictly before this command's response.
+                    while let Some(reply) = read_message(&mut reader) {
+                        if reply.get("id").and_then(Value::as_i64) == Some(4000) {
+                            break;
+                        }
+                    }
+                }
+                respond(&mut writer, id, json!({ "executed": command }));
             }
             "textDocument/diagnostic" => {
                 if mode == "diagnostics-fail" {
@@ -932,6 +976,15 @@ fn push_diagnostics(uri: &str, present: bool) -> Value {
 /// no params) to the bridge — e.g. an unsolicited `workspace/diagnostic/refresh`.
 fn request<W: Write>(writer: &mut W, id: Value, method: &str) {
     let body = json!({ "jsonrpc": "2.0", "id": id, "method": method }).to_string();
+    let _ = write!(writer, "Content-Length: {}\r\n\r\n{body}", body.len());
+    let _ = writer.flush();
+}
+
+/// Send a server→client **request** carrying `params` — e.g. a
+/// `workspace/applyEdit` issued while handling an `executeCommand`.
+fn request_with_params<W: Write>(writer: &mut W, id: Value, method: &str, params: Value) {
+    let body =
+        json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params }).to_string();
     let _ = write!(writer, "Content-Length: {}\r\n\r\n{body}", body.len());
     let _ = writer.flush();
 }

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -755,7 +755,12 @@ fn main() {
                     // Wait for the client's applyEdit response (relayed by the
                     // bridge) before completing executeCommand — real servers
                     // sequence it this way, and it makes the applyEdit reach the
-                    // client strictly before this command's response.
+                    // client strictly before this command's response. During
+                    // executeCommand handling the ONLY inbound message is that
+                    // response (id 4000), so this consumes nothing else; if the
+                    // client never answers, the mock parks here and the e2e
+                    // client's response timeout fails the test (it can't hang the
+                    // suite).
                     while let Some(reply) = read_message(&mut reader) {
                         if reply.get("id").and_then(Value::as_i64) == Some(4000) {
                             break;

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -761,8 +761,7 @@ fn main() {
                     // and FAIL FAST on anything else rather than silently
                     // swallowing an interleaved request/notification.
                     match read_message(&mut reader) {
-                        Some(reply)
-                            if reply.get("id").and_then(Value::as_i64) == Some(4000) => {}
+                        Some(reply) if reply.get("id").and_then(Value::as_i64) == Some(4000) => {}
                         other => panic!(
                             "mock executeCommand: expected the applyEdit response (id 4000), \
                              got {other:?}"

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -194,7 +194,11 @@ fn code_action_edit_is_host_translated_and_suffixed() {
         .expect("the executable command action");
     assert_eq!(command["title"], "Run mock command — mock-codeaction");
     assert!(
-        is_routed_command(command["command"].as_str().unwrap(), "mock-codeaction", "mock.run"),
+        is_routed_command(
+            command["command"].as_str().unwrap(),
+            "mock-codeaction",
+            "mock.run"
+        ),
         "command name must encode the origin server, got: {command:?}"
     );
 
@@ -284,7 +288,11 @@ fn command_action_surfaces_as_executable_with_a_routed_name() {
         "an executable command is not disabled, got: {command:?}"
     );
     assert!(
-        is_routed_command(command["command"].as_str().unwrap(), "mock-codeaction", "mock.run"),
+        is_routed_command(
+            command["command"].as_str().unwrap(),
+            "mock-codeaction",
+            "mock.run"
+        ),
         "command name must encode the origin server, got: {command:?}"
     );
 

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -102,6 +102,15 @@ fn assert_advertised(init_response: &Value) {
         json!(true),
         "codeActionProvider{{resolveProvider}} must be advertised for literal-support clients (#568)"
     );
+    // PR 6: executeCommand must be advertised (empty command list) so a real
+    // client actually fires action-embedded commands — the one thing the mock
+    // harness cannot gate on, since LspClient sends regardless.
+    let execute = &init_response["result"]["capabilities"]["executeCommandProvider"];
+    assert_eq!(
+        execute["commands"],
+        json!([]),
+        "executeCommandProvider must be advertised with an empty command list (#568 PR 6)"
+    );
 }
 
 /// Markdown host: the lua fence content sits on host line 3.
@@ -244,6 +253,14 @@ fn code_action_not_advertised_without_literal_support() {
         init_response["result"]["capabilities"]["codeActionProvider"],
         Value::Null,
         "codeActionProvider must be withheld without literal support"
+    );
+    // executeCommand is gated on the same condition — commands only reach the
+    // bridge through a bridged code action, so it must be withheld too (pins
+    // the gating expression, not just the capability's presence).
+    assert_eq!(
+        init_response["result"]["capabilities"]["executeCommandProvider"],
+        Value::Null,
+        "executeCommandProvider must be withheld without literal support"
     );
     shutdown(&mut client);
 }

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -8,8 +8,10 @@
 //! - The request range is translated host→virtual, the returned edit is
 //!   re-keyed to the host URI with host-translated ranges, and the title
 //!   carries the `"{title} — {server}"` suffix.
-//! - A bare Command action surfaces as a disabled placeholder for a client
-//!   with `disabledSupport`, and is dropped for a client without it.
+//! - A bare Command action surfaces as an EXECUTABLE command with a routed
+//!   name (regardless of `disabledSupport`); executing it drives a bridged
+//!   `workspace/executeCommand` back to the origin server, which answers by
+//!   asking the client to apply an edit (PR 5 + PR 6 compose).
 //! - A lazy action is enveloped and resolved via `codeAction/resolve` for a
 //!   resolve-capable client, and eager-resolved downstream (edit inline) for a
 //!   client lacking resolve/data support (PR 4).
@@ -25,6 +27,14 @@ use serde_json::{Value, json};
 
 fn mock_formatter_bin() -> &'static str {
     env!("CARGO_BIN_EXE_mock-lsp-formatter")
+}
+
+/// A bridged command name encodes `kakehashi\u{1f}{origin}\u{1f}{host_uri}\u{1f}{command}`
+/// (see `bridge::protocol::command_routing`). Assert the routing key without
+/// depending on the exact host-URI field.
+fn is_routed_command(name: &str, origin: &str, command: &str) -> bool {
+    name.starts_with(&format!("kakehashi\u{1f}{origin}\u{1f}"))
+        && name.ends_with(&format!("\u{1f}{command}"))
 }
 
 fn init_client(client_capabilities: Value) -> (LspClient, Value, tempfile::TempDir) {
@@ -145,21 +155,20 @@ fn code_action_with_retry(client: &mut LspClient) -> Vec<Value> {
 
 #[test]
 fn code_action_edit_is_host_translated_and_suffixed() {
-    // No disabledSupport: the bare Command action must be dropped entirely.
+    // Even without disabledSupport, the bare Command surfaces (executable, not
+    // disabled): the edit action + the command action both come back.
     let (mut client, init_response, _config_dir) = init_client(literal_support_caps(false));
     assert_advertised(&init_response);
     open_markdown(&mut client);
 
     let actions = code_action_with_retry(&mut client);
 
-    assert_eq!(
-        actions.len(),
-        1,
-        "the Command action must be dropped without disabledSupport, got: {actions:?}"
-    );
-    let action = &actions[0];
+    assert_eq!(actions.len(), 2, "edit + command action, got: {actions:?}");
+    let action = actions
+        .iter()
+        .find(|a| a["kind"] == "quickfix")
+        .expect("the edit-carrying quickfix");
     assert_eq!(action["title"], "Replace with fixed — mock-codeaction");
-    assert_eq!(action["kind"], "quickfix");
     let edits = &action["edit"]["changes"][MARKDOWN_URI];
     assert!(
         edits.is_array(),
@@ -168,6 +177,17 @@ fn code_action_edit_is_host_translated_and_suffixed() {
     // Virtual line 0 = host line 3 (fence content line).
     assert_eq!(edits[0]["range"]["start"]["line"], 3);
     assert_eq!(edits[0]["newText"], "fixed");
+
+    // The bare Command carries a routed name that encodes the origin server.
+    let command = actions
+        .iter()
+        .find(|a| a["command"].is_string())
+        .expect("the executable command action");
+    assert_eq!(command["title"], "Run mock command — mock-codeaction");
+    assert!(
+        is_routed_command(command["command"].as_str().unwrap(), "mock-codeaction", "mock.run"),
+        "command name must encode the origin server, got: {command:?}"
+    );
 
     shutdown(&mut client);
 }
@@ -229,7 +249,7 @@ fn code_action_not_advertised_without_literal_support() {
 }
 
 #[test]
-fn command_action_surfaces_as_disabled_with_disabled_support() {
+fn command_action_surfaces_as_executable_with_a_routed_name() {
     let (mut client, init_response, _config_dir) = init_client(literal_support_caps(true));
     assert_advertised(&init_response);
     open_markdown(&mut client);
@@ -237,15 +257,70 @@ fn command_action_surfaces_as_disabled_with_disabled_support() {
     let actions = code_action_with_retry(&mut client);
 
     assert_eq!(actions.len(), 2, "got: {actions:?}");
-    let disabled: Vec<&Value> = actions
+    let command = actions
         .iter()
-        .filter(|a| a["disabled"].is_object())
-        .collect();
-    assert_eq!(disabled.len(), 1, "exactly one disabled placeholder");
-    assert_eq!(disabled[0]["title"], "Run mock command — mock-codeaction");
+        .find(|a| a["command"].is_string())
+        .expect("the executable command action");
+    assert_eq!(command["title"], "Run mock command — mock-codeaction");
     assert!(
-        disabled[0]["command"].is_null() && disabled[0]["edit"].is_null(),
-        "a disabled placeholder must not carry an executable payload"
+        command["disabled"].is_null(),
+        "an executable command is not disabled, got: {command:?}"
+    );
+    assert!(
+        is_routed_command(command["command"].as_str().unwrap(), "mock-codeaction", "mock.run"),
+        "command name must encode the origin server, got: {command:?}"
+    );
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn executing_a_bridged_command_routes_back_and_relays_the_server_applyedit() {
+    // The full PR 5 + PR 6 composition: the client executes a surfaced command;
+    // the bridge decodes its routed name, forwards executeCommand to the origin
+    // server with the ORIGINAL name; the server answers by asking the client to
+    // apply an edit (host-translated by the bridge) and returns a result the
+    // bridge relays verbatim.
+    let (mut client, init_response, _config_dir) = init_client(literal_support_caps(true));
+    assert_advertised(&init_response);
+    open_markdown(&mut client);
+
+    let actions = code_action_with_retry(&mut client);
+    let routed = actions
+        .iter()
+        .find(|a| a["command"].is_string())
+        .expect("the executable command action")["command"]
+        .as_str()
+        .expect("command name")
+        .to_string();
+
+    // Fire executeCommand without blocking — the server's applyEdit request
+    // interleaves before the executeCommand response arrives.
+    let exec_id = client.send_request_async(
+        "workspace/executeCommand",
+        json!({ "command": routed, "arguments": [] }),
+    );
+
+    // The server's applyEdit reaches the client, re-keyed to the host URI and
+    // its virtual line 0 translated to host line 3.
+    let (apply_id, apply_params) = client
+        .wait_for_server_request("workspace/applyEdit", Duration::from_secs(5))
+        .expect("the server's applyEdit must reach the client");
+    let edits = &apply_params["edit"]["changes"][MARKDOWN_URI];
+    assert!(
+        edits.is_array(),
+        "applyEdit must be re-keyed to the host URI, got: {apply_params:?}"
+    );
+    assert_eq!(edits[0]["range"]["start"]["line"], 3);
+    assert_eq!(edits[0]["newText"], "executed");
+    client.send_response(apply_id, json!({ "applied": true }));
+
+    // The executeCommand result is relayed verbatim; the server saw its own
+    // ORIGINAL command name (the routing prefix was stripped).
+    let response = client.receive_response_for_id_public(exec_id);
+    assert_eq!(
+        response["result"]["executed"], "mock.run",
+        "the origin server must receive its original command name, got: {response:?}"
     );
 
     shutdown(&mut client);
@@ -559,11 +634,10 @@ fn lazy_action_is_eager_resolved_without_resolve_support() {
 }
 
 #[test]
-fn lazy_action_resolving_to_command_fails_soft() {
-    // A lazy action whose resolve materializes a COMMAND (not an edit) must
-    // not hand that command to the editor — command execution is unbridged.
-    // The bridge fails soft: the resolved action comes back unresolved, with
-    // no command and its routing envelope intact.
+fn lazy_action_resolving_to_command_surfaces_it_routed() {
+    // A lazy action whose resolve materializes a COMMAND (not an edit) is now
+    // executable (#568 PR 6): the resolved action comes back with a routed
+    // command name and no `data` (a command-complete action is not re-resolved).
     let (mut client, init_response, _config_dir) =
         init_client_mode("code-action-lazy-cmd", resolve_support_caps());
     assert_advertised(&init_response);
@@ -577,16 +651,20 @@ fn lazy_action_resolving_to_command_fails_soft() {
     let resolved = client.send_request("codeAction/resolve", lazy.clone());
     let resolved = &resolved["result"];
     assert!(
-        resolved["command"].is_null(),
-        "an unbridged command must never reach the editor, got: {resolved:?}"
+        is_routed_command(
+            resolved["command"]["command"].as_str().unwrap_or_default(),
+            "mock-codeaction",
+            "mock.run"
+        ),
+        "the resolved command must carry a routed name, got: {resolved:?}"
     );
     assert!(
         resolved["edit"].is_null(),
-        "the action stays unresolved (no edit), got: {resolved:?}"
+        "a command-only resolve carries no edit, got: {resolved:?}"
     );
-    assert_eq!(
-        resolved["data"]["kakehashi"]["origin"], "mock-codeaction",
-        "the routing envelope is preserved on the fail-soft path"
+    assert!(
+        resolved["data"].is_null(),
+        "a command-complete action is not re-resolved (data stripped), got: {resolved:?}"
     );
 
     shutdown(&mut client);


### PR DESCRIPTION
> Recreates #619, which was falsely auto-marked *merged* by an accidental rebase+force-push (branches and commits restored unchanged).

---

Part of #568 (PR 6 of the 8-PR sequence). Stacked on #617 (PR 5, applyEdit).

## What

Bridges `workspace/executeCommand` so a downstream `Command` surfaced in a code action becomes **executable** instead of disabled. Removes the PR 3 `REASON_COMMANDS` disabled placeholder at both command sites.

## Routing: the command name IS the routing key

`workspace/executeCommand` carries only `command` + `arguments` — no `data` envelope. So the bridge rewrites a surfaced command's name to encode its origin server + host document:

```
kakehashi␟{origin}␟{host_uri}␟{command}     (␟ = ASCII Unit Separator, 0x1f)
```

The handler decodes it, resolves the server config by name (`resolve_with_wildcard`), reconnects to the exact `(server, root)` via `get_or_create_connection(origin, config, host_url)`, and forwards executeCommand with the downstream's **original** command name and **verbatim** arguments (checklist §10). The result is relayed verbatim (null → no result).

**Deviation from the issue's sketch (deliberate):** the issue suggested a server-name→origin *registry*. Name-encoding is strictly better — stateless (no registry to populate/evict), collision-safe (two servers with the same command name route correctly, which matters once concatenated aggregation lands in PR 7), and it reuses the exact `(server, root)` reconnection path that `codeAction/resolve` already uses. Encoding `host_uri` (not just origin) gives precise multi-root routing. `Command.command` is ours to mint, so §10 (arguments verbatim) is unaffected.

## Composes with PR 5

Most command-style servers answer executeCommand by sending `workspace/applyEdit` back (server-initiated) and returning a null result. That inbound applyEdit is handled by PR 5's independent reader task. The E2E exercises the full loop: execute → server applyEdit (host-translated) → client applies → execute result relayed.

## Also

- Advertises `execute_command_provider` upstream (empty `commands` list) gated on the same codeAction-literal-support condition; `has_capability` arm; downstream `execute_command` client cap.
- The resolve path (a resolve that materializes a command) encodes the command too, and the "edit OR command complete → strip data" gate stops a command-complete action from being re-resolved.

## Fail-soft

Every failure path (foreign/malformed command name, malformed encoded host_uri, unspawnable/unresolvable origin, dead connection, server error) returns a null result — never a panic. `decode_command` is total.

## Scope / known limitations (challenge welcome)

- **Verified via the mock harness; real-client action-command execution is not exercised** (the Rust test client sends executeCommand regardless of the advertised capability — the advertise itself is asserted separately in both directions).
- **List-gated clients** (VS Code's vscode-languageclient) only dispatch command ids from the advertised `commands` list, so they'd show the action but not run it. Neovim's built-in client dispatches on provider *presence* and works. Reaching list-gated clients needs dynamic registration of real names — the same deferred follow-up as **palette-fired commands** (fired without an action context).

## Review

Local multi-perspective `/review` + two codex passes (continued + fresh) converged. codex caught a real fail-soft gap — a malformed encoded `host_uri` fell through to a client-root fallback connection — now fixed (rejects, matching how resolve gates a malformed envelope host_uri).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Code actions can now surface executable commands instead of disabled placeholders.
  * Routed command handling now works end-to-end, including returning edits from the originating language server.

* **Bug Fixes**
  * Improved command execution support for bridged code actions.
  * Fixed handling so command-related actions are preserved when edits are available.
  * Better routing ensures actions and follow-up edits map back to the correct document context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->