### PR TITLE
feat(aggregation): generic concatenated strategy for codeAction (#568 PR 7)

### DIFF
--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -61,9 +61,11 @@ fn default_language_servers() -> HashMap<String, BridgeServerConfig> {
 /// self-documenting — deleting any entry below never changes behavior:
 /// - `layers.aggregation` (cross-layer-aggregation): all three layers in
 ///   `["virt", "host", "native"]` priority, `Preferred` strategy except for
-///   formatting and diagnostics, which combine layers by `Concatenated`.
+///   formatting, diagnostics, and codeAction, which combine layers by
+///   `Concatenated`.
 /// - `bridge` (per-target server aggregation): all bridging enabled, `["*"]`
-///   fan-out, `Preferred` strategy except diagnostics (`Concatenated`).
+///   fan-out, `Preferred` strategy except diagnostics and codeAction
+///   (`Concatenated`).
 fn default_languages() -> HashMap<String, LanguageSettings> {
     HashMap::from([(
         WILDCARD_KEY.to_string(),
@@ -103,6 +105,16 @@ fn default_languages() -> HashMap<String, LanguageSettings> {
                             strategy: Some(AggregationStrategy::Concatenated),
                         },
                     ),
+                    (
+                        // codeAction menus merge across layers so every server's
+                        // (and the native layer's) actions show up at once (#568
+                        // PR 7); inherits the wildcard [virt, host, native] order.
+                        "textDocument/codeAction".to_string(),
+                        LayerAggregationConfig {
+                            priorities: None,
+                            strategy: Some(AggregationStrategy::Concatenated),
+                        },
+                    ),
                 ])),
             }),
             bridge: Some(HashMap::from([(
@@ -137,6 +149,17 @@ fn default_languages() -> HashMap<String, LanguageSettings> {
                                 // pulled on host events into the proactive cache
                                 // (push-propagation-diagnostic-forwarding).
                                 pull_fallback: Some(true),
+                                ..Default::default()
+                            },
+                        ),
+                        (
+                            // Every configured server's code actions are merged
+                            // (in priority order), not just the top server's
+                            // (#568 PR 7). The "{title} — {server}" suffix keeps
+                            // same-named actions distinguishable.
+                            "textDocument/codeAction".to_string(),
+                            AggregationConfig {
+                                strategy: Some(AggregationStrategy::Concatenated),
                                 ..Default::default()
                             },
                         ),
@@ -376,6 +399,7 @@ mod tests {
             "textDocument/formatting",
             "textDocument/diagnostic",
             "textDocument/publishDiagnostics",
+            "textDocument/codeAction",
         ] {
             let entry = agg
                 .get(method)

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -2971,13 +2971,22 @@ kind = "locals""#;
     }
 
     #[test]
-    fn default_strategy_is_concatenated_for_diagnostics() {
+    fn default_strategy_is_concatenated_for_diagnostics_and_code_action() {
         assert_eq!(
             default_aggregation_strategy_for_method("textDocument/diagnostic"),
             AggregationStrategy::Concatenated
         );
         assert_eq!(
             default_aggregation_strategy_for_method("textDocument/publishDiagnostics"),
+            AggregationStrategy::Concatenated
+        );
+        // #568 PR 7: codeAction concatenates at both levels by default.
+        assert_eq!(
+            default_aggregation_strategy_for_method("textDocument/codeAction"),
+            AggregationStrategy::Concatenated
+        );
+        assert_eq!(
+            default_layer_strategy_for_method("textDocument/codeAction"),
             AggregationStrategy::Concatenated
         );
     }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -246,9 +246,13 @@ impl ResolvedAggregationConfig {
 
 fn default_aggregation_strategy_for_method(method: &str) -> AggregationStrategy {
     match method {
-        "textDocument/diagnostic" | "textDocument/publishDiagnostics" => {
-            AggregationStrategy::Concatenated
-        }
+        // codeAction concatenates at BOTH levels (#568 PR 7): within a layer,
+        // every server's actions are merged; across layers, virt+host+native
+        // merge into one menu. Unlike formatting (competing whole-document
+        // edits), code actions from different servers are complementary.
+        "textDocument/diagnostic"
+        | "textDocument/publishDiagnostics"
+        | "textDocument/codeAction" => AggregationStrategy::Concatenated,
         _ => AggregationStrategy::Preferred,
     }
 }

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -284,9 +284,12 @@ pub(crate) async fn race_layers_preferred<R>(
 }
 
 /// Cross-layer `concatenated`: await ALL layers in `priorities` (a barrier,
-/// unlike [`race_layers_preferred`]'s first-wins) and merge their non-empty
-/// results in priority order via `combine`. A layer not in `priorities` is
-/// never awaited, so its future does no work. Errors (e.g. a cancelled layer)
+/// unlike [`race_layers_preferred`]'s first-wins) and merge every `Some(_)`
+/// contribution in priority order via `combine`. (It merges any `Some`, not
+/// only non-empty ones — it can't test `R` for emptiness generically; the
+/// codeAction layers already collapse empty→`None` before returning, so no
+/// `Some(empty)` reaches the fold.) A layer not in `priorities` is never
+/// awaited, so its future does no work. Errors (e.g. a cancelled layer)
 /// propagate. Ordering is stable by `priorities` regardless of which layer
 /// finishes first, so the merged menu keeps muscle-memory order.
 pub(crate) async fn race_layers_concatenated<R>(

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -1054,17 +1054,32 @@ impl Kakehashi {
             return Ok(None);
         };
         let layer_cfg = self.resolve_layer_config(&host_language, layer_method);
+        self.run_layer_race(race_layers_preferred(
+            &layer_cfg.priorities,
+            virt,
+            host,
+            native,
+            is_nonempty,
+        ))
+        .await
+    }
 
-        // Subscribe for the WHOLE walk before either arm runs: the arms'
-        // own subscribe attempts then find the id taken and proceed without
-        // a local receiver (logged at debug), and this select cancels the
-        // race — dropping both in-flight arms — the moment `$/cancelRequest`
-        // arrives, regardless of which arm would have held the subscription.
-        // Best-effort gap: between the race's completion and the next
-        // request there is no subscriber; a cancel landing there is only
-        // forwarded downstream via the upstream-request registry.
+    /// Run a pre-built layer race under a walk-wide cancel subscription, then
+    /// sweep the upstream registry — shared by [`Self::walk_layer_futures`] and
+    /// [`Self::walk_layers_by_strategy`].
+    ///
+    /// Subscribe for the WHOLE walk before the race runs: the arms' own
+    /// subscribe attempts then find the id taken and proceed without a local
+    /// receiver (logged at debug), and this select cancels the race — dropping
+    /// all in-flight arms — the moment `$/cancelRequest` arrives. Best-effort
+    /// gap: between the race's completion and the next request there is no
+    /// subscriber; a cancel landing there is only forwarded downstream via the
+    /// upstream-request registry.
+    async fn run_layer_race<R>(
+        &self,
+        race: impl Future<Output = tower_lsp_server::jsonrpc::Result<Option<R>>>,
+    ) -> tower_lsp_server::jsonrpc::Result<Option<R>> {
         let (cancel_rx, _cancel_guard) = self.subscribe_cancel(current_upstream_id().as_ref());
-        let race = race_layers_preferred(&layer_cfg.priorities, virt, host, native, is_nonempty);
         let result = match cancel_rx {
             Some(mut cancel_rx) => {
                 tokio::select! {
@@ -1075,23 +1090,24 @@ impl Kakehashi {
             }
             None => race.await,
         };
-        // Sweep upstream-registry entries a dropped (losing or cancelled)
-        // layer future did not get to unregister itself. Idempotent; a
-        // completed arm already cleaned up its own.
+        // Sweep upstream-registry entries a dropped (losing or cancelled) layer
+        // future did not get to unregister itself. Idempotent; a completed arm
+        // already cleaned up its own.
         self.bridge
             .pool_arc()
             .unregister_all_for_upstream_id(current_upstream_id().as_ref());
         result
     }
 
-    /// Cross-layer CONCATENATED walk: the barrier sibling of
-    /// [`Self::walk_layer_futures`]. Awaits all configured layers and merges
-    /// their non-empty results in priority order via `combine`, with the same
-    /// walk-wide cancel subscription and upstream-registry sweep. Used by
-    /// list-valued methods (codeAction) configured `strategy = concatenated`
-    /// at the `layers.aggregation` level (#568 PR 7).
+    /// Cross-layer walk that picks `preferred` (first-wins) vs `concatenated`
+    /// (barrier merge in priority order) from the SAME resolved layer config, so
+    /// the strategy and priorities can't come from two different settings
+    /// snapshots if a reload interleaves. `is_nonempty` gates the preferred race;
+    /// `combine` merges the concatenated race; whichever strategy is chosen only
+    /// the matching closure is used. Shares the walk-wide cancel subscription +
+    /// registry sweep with [`Self::walk_layer_futures`] (#568 PR 7).
     #[allow(clippy::too_many_arguments)]
-    pub(crate) async fn walk_layers_concatenated<R>(
+    pub(crate) async fn walk_layers_by_strategy<R>(
         &self,
         lsp_uri: &Uri,
         layer_method: &'static str,
@@ -1099,6 +1115,7 @@ impl Kakehashi {
         virt: impl Future<Output = tower_lsp_server::jsonrpc::Result<Option<R>>>,
         host: impl Future<Output = tower_lsp_server::jsonrpc::Result<Option<R>>>,
         native: impl Future<Output = tower_lsp_server::jsonrpc::Result<Option<R>>>,
+        is_nonempty: impl Fn(&R) -> bool,
         combine: impl Fn(R, R) -> R,
     ) -> tower_lsp_server::jsonrpc::Result<Option<R>> {
         let Ok(uri) = uri_to_url(lsp_uri) else {
@@ -1108,36 +1125,31 @@ impl Kakehashi {
         let Some(host_language) = self.document_language(&uri) else {
             return Ok(None);
         };
+        // ONE resolve for both the strategy decision and the priorities passed
+        // into the race — no torn read across a concurrent settings reload.
         let layer_cfg = self.resolve_layer_config(&host_language, layer_method);
-
-        // Same walk-wide cancel subscription as the preferred walk (see there).
-        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(current_upstream_id().as_ref());
-        let race = race_layers_concatenated(&layer_cfg.priorities, virt, host, native, combine);
-        let result = match cancel_rx {
-            Some(mut cancel_rx) => {
-                tokio::select! {
-                    biased;
-                    _ = &mut cancel_rx => Err(tower_lsp_server::jsonrpc::Error::request_cancelled()),
-                    result = race => result,
-                }
+        match layer_cfg.strategy {
+            AggregationStrategy::Preferred => {
+                self.run_layer_race(race_layers_preferred(
+                    &layer_cfg.priorities,
+                    virt,
+                    host,
+                    native,
+                    is_nonempty,
+                ))
+                .await
             }
-            None => race.await,
-        };
-        self.bridge
-            .pool_arc()
-            .unregister_all_for_upstream_id(current_upstream_id().as_ref());
-        result
-    }
-
-    /// The cross-layer aggregation strategy configured for `method` on this
-    /// document's host language (`layers.aggregation.<method>.strategy`),
-    /// defaulting to `preferred` when the document language can't be resolved.
-    pub(crate) fn cross_layer_strategy(&self, lsp_uri: &Uri, method: &str) -> AggregationStrategy {
-        uri_to_url(lsp_uri)
-            .ok()
-            .and_then(|uri| self.document_language(&uri))
-            .map(|lang| self.resolve_layer_config(&lang, method).strategy)
-            .unwrap_or(AggregationStrategy::Preferred)
+            AggregationStrategy::Concatenated => {
+                self.run_layer_race(race_layers_concatenated(
+                    &layer_cfg.priorities,
+                    virt,
+                    host,
+                    native,
+                    combine,
+                ))
+                .await
+            }
+        }
     }
 
     /// Resolve injection context for a bridge endpoint request (all matching servers).

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -283,6 +283,67 @@ pub(crate) async fn race_layers_preferred<R>(
     }
 }
 
+/// Cross-layer `concatenated`: await ALL layers in `priorities` (a barrier,
+/// unlike [`race_layers_preferred`]'s first-wins) and merge their non-empty
+/// results in priority order via `combine`. A layer not in `priorities` is
+/// never awaited, so its future does no work. Errors (e.g. a cancelled layer)
+/// propagate. Ordering is stable by `priorities` regardless of which layer
+/// finishes first, so the merged menu keeps muscle-memory order.
+pub(crate) async fn race_layers_concatenated<R>(
+    priorities: &[LayerSource],
+    virt: impl Future<Output = tower_lsp_server::jsonrpc::Result<Option<R>>>,
+    host: impl Future<Output = tower_lsp_server::jsonrpc::Result<Option<R>>>,
+    native: impl Future<Output = tower_lsp_server::jsonrpc::Result<Option<R>>>,
+    combine: impl Fn(R, R) -> R,
+) -> tower_lsp_server::jsonrpc::Result<Option<R>> {
+    // Only await a layer that's in `priorities`; a lazy future left un-awaited
+    // never runs, matching `race_layers_preferred`, which never consults an
+    // excluded layer. All included layers run concurrently under `join!`.
+    let virt_arm = async {
+        if priorities.contains(&LayerSource::Virt) {
+            virt.await
+        } else {
+            Ok(None)
+        }
+    };
+    let host_arm = async {
+        if priorities.contains(&LayerSource::Host) {
+            host.await
+        } else {
+            Ok(None)
+        }
+    };
+    let native_arm = async {
+        if priorities.contains(&LayerSource::Native) {
+            native.await
+        } else {
+            Ok(None)
+        }
+    };
+    let (virt_r, host_r, native_r) = tokio::join!(virt_arm, host_arm, native_arm);
+    let mut virt_r = virt_r?;
+    let mut host_r = host_r?;
+    let mut native_r = native_r?;
+
+    // Fold in priority order via `take()` so each layer contributes exactly
+    // once even if a (malformed) config lists it twice.
+    let mut acc: Option<R> = None;
+    for layer in priorities {
+        let contrib = match layer {
+            LayerSource::Virt => virt_r.take(),
+            LayerSource::Host => host_r.take(),
+            LayerSource::Native => native_r.take(),
+        };
+        if let Some(items) = contrib {
+            acc = Some(match acc {
+                Some(existing) => combine(existing, items),
+                None => items,
+            });
+        }
+    }
+    Ok(acc)
+}
+
 /// Deserialize a verbatim host-layer result into the handler's response
 /// type, logging (not erroring) on shape mismatch.
 pub(crate) fn parse_host_verbatim<R: serde::de::DeserializeOwned>(
@@ -1023,6 +1084,62 @@ impl Kakehashi {
         result
     }
 
+    /// Cross-layer CONCATENATED walk: the barrier sibling of
+    /// [`Self::walk_layer_futures`]. Awaits all configured layers and merges
+    /// their non-empty results in priority order via `combine`, with the same
+    /// walk-wide cancel subscription and upstream-registry sweep. Used by
+    /// list-valued methods (codeAction) configured `strategy = concatenated`
+    /// at the `layers.aggregation` level (#568 PR 7).
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn walk_layers_concatenated<R>(
+        &self,
+        lsp_uri: &Uri,
+        layer_method: &'static str,
+        request_method: &'static str,
+        virt: impl Future<Output = tower_lsp_server::jsonrpc::Result<Option<R>>>,
+        host: impl Future<Output = tower_lsp_server::jsonrpc::Result<Option<R>>>,
+        native: impl Future<Output = tower_lsp_server::jsonrpc::Result<Option<R>>>,
+        combine: impl Fn(R, R) -> R,
+    ) -> tower_lsp_server::jsonrpc::Result<Option<R>> {
+        let Ok(uri) = uri_to_url(lsp_uri) else {
+            log::warn!("Invalid URI in {}: {}", request_method, lsp_uri.as_str());
+            return Ok(None);
+        };
+        let Some(host_language) = self.document_language(&uri) else {
+            return Ok(None);
+        };
+        let layer_cfg = self.resolve_layer_config(&host_language, layer_method);
+
+        // Same walk-wide cancel subscription as the preferred walk (see there).
+        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(current_upstream_id().as_ref());
+        let race = race_layers_concatenated(&layer_cfg.priorities, virt, host, native, combine);
+        let result = match cancel_rx {
+            Some(mut cancel_rx) => {
+                tokio::select! {
+                    biased;
+                    _ = &mut cancel_rx => Err(tower_lsp_server::jsonrpc::Error::request_cancelled()),
+                    result = race => result,
+                }
+            }
+            None => race.await,
+        };
+        self.bridge
+            .pool_arc()
+            .unregister_all_for_upstream_id(current_upstream_id().as_ref());
+        result
+    }
+
+    /// The cross-layer aggregation strategy configured for `method` on this
+    /// document's host language (`layers.aggregation.<method>.strategy`),
+    /// defaulting to `preferred` when the document language can't be resolved.
+    pub(crate) fn cross_layer_strategy(&self, lsp_uri: &Uri, method: &str) -> AggregationStrategy {
+        uri_to_url(lsp_uri)
+            .ok()
+            .and_then(|uri| self.document_language(&uri))
+            .map(|lang| self.resolve_layer_config(&lang, method).strategy)
+            .unwrap_or(AggregationStrategy::Preferred)
+    }
+
     /// Resolve injection context for a bridge endpoint request (all matching servers).
     ///
     /// Delegates to the shared preamble, then looks up ALL bridge server configs
@@ -1200,6 +1317,78 @@ mod tests {
 
     fn pos(line: u32, character: u32) -> Position {
         Position { line, character }
+    }
+
+    fn concat_vec(mut a: Vec<i32>, b: Vec<i32>) -> Vec<i32> {
+        a.extend(b);
+        a
+    }
+
+    #[tokio::test]
+    async fn concatenated_merges_all_layers_in_priority_order() {
+        use std::future::ready;
+        let r = race_layers_concatenated(
+            &[LayerSource::Virt, LayerSource::Host, LayerSource::Native],
+            ready(Ok(Some(vec![1]))),
+            ready(Ok(Some(vec![2]))),
+            ready(Ok(None)),
+            concat_vec,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            r,
+            Some(vec![1, 2]),
+            "both non-empty layers appear, in order"
+        );
+    }
+
+    #[tokio::test]
+    async fn concatenated_order_follows_priorities_not_argument_order() {
+        use std::future::ready;
+        // Priorities put host BEFORE virt, so host's items lead even though virt
+        // is the first argument — proves ordering is by priority, not position.
+        let r = race_layers_concatenated(
+            &[LayerSource::Host, LayerSource::Virt],
+            ready(Ok(Some(vec![1]))), // virt
+            ready(Ok(Some(vec![2]))), // host
+            ready(Ok(None)),
+            concat_vec,
+        )
+        .await
+        .unwrap();
+        assert_eq!(r, Some(vec![2, 1]));
+    }
+
+    #[tokio::test]
+    async fn concatenated_drops_a_layer_absent_from_priorities() {
+        use std::future::ready;
+        // Only virt is in priorities; host's non-empty result is excluded.
+        let r = race_layers_concatenated(
+            &[LayerSource::Virt],
+            ready(Ok(Some(vec![1]))),
+            ready(Ok(Some(vec![99]))),
+            ready(Ok(None)),
+            concat_vec,
+        )
+        .await
+        .unwrap();
+        assert_eq!(r, Some(vec![1]));
+    }
+
+    #[tokio::test]
+    async fn concatenated_all_empty_is_none() {
+        use std::future::ready;
+        let r = race_layers_concatenated(
+            &[LayerSource::Virt, LayerSource::Host, LayerSource::Native],
+            ready(Ok(None::<Vec<i32>>)),
+            ready(Ok(None)),
+            ready(Ok(None)),
+            concat_vec,
+        )
+        .await
+        .unwrap();
+        assert_eq!(r, None);
     }
 
     #[test]

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -289,9 +289,11 @@ pub(crate) async fn race_layers_preferred<R>(
 /// only non-empty ones — it can't test `R` for emptiness generically; the
 /// codeAction layers already collapse empty→`None` before returning, so no
 /// `Some(empty)` reaches the fold.) A layer not in `priorities` is never
-/// awaited, so its future does no work. Errors (e.g. a cancelled layer)
-/// propagate. Ordering is stable by `priorities` regardless of which layer
-/// finishes first, so the merged menu keeps muscle-memory order.
+/// awaited, so its future does no work. The first layer error fails the
+/// aggregation fast, cancelling the other in-flight layers (a whole-request
+/// failure discards their results anyway), matching [`race_layers_preferred`].
+/// Ordering is stable by `priorities` regardless of which layer finishes
+/// first, so the merged menu keeps muscle-memory order.
 pub(crate) async fn race_layers_concatenated<R>(
     priorities: &[LayerSource],
     virt: impl Future<Output = tower_lsp_server::jsonrpc::Result<Option<R>>>,
@@ -301,7 +303,7 @@ pub(crate) async fn race_layers_concatenated<R>(
 ) -> tower_lsp_server::jsonrpc::Result<Option<R>> {
     // Only await a layer that's in `priorities`; a lazy future left un-awaited
     // never runs, matching `race_layers_preferred`, which never consults an
-    // excluded layer. All included layers run concurrently under `join!`.
+    // excluded layer. All included layers run concurrently under `try_join!`.
     let virt_arm = async {
         if priorities.contains(&LayerSource::Virt) {
             virt.await
@@ -323,10 +325,7 @@ pub(crate) async fn race_layers_concatenated<R>(
             Ok(None)
         }
     };
-    let (virt_r, host_r, native_r) = tokio::join!(virt_arm, host_arm, native_arm);
-    let mut virt_r = virt_r?;
-    let mut host_r = host_r?;
-    let mut native_r = native_r?;
+    let (mut virt_r, mut host_r, mut native_r) = tokio::try_join!(virt_arm, host_arm, native_arm)?;
 
     // Fold in priority order via `take()` so each layer contributes exactly
     // once even if a (malformed) config lists it twice.

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -18,8 +18,12 @@ use ulid::Ulid;
 use url::Url;
 
 use super::super::{Kakehashi, detect_document_language};
+use crate::config::settings::AggregationStrategy;
 use crate::language::InjectionResolver;
-use crate::lsp::aggregation::server::{FanInResult, dispatch_host_preferred, dispatch_preferred};
+use crate::lsp::aggregation::server::{
+    FanInResult, FanOutTask, HostFanOutTask, dispatch_concatenated, dispatch_host_concatenated,
+    dispatch_host_preferred, dispatch_preferred,
+};
 use crate::lsp::bridge::{
     CodeActionEnvelope, HostDocument, RegionOffset, UpstreamCodeActionCaps, bridge_code_actions,
     extract_code_action_envelope, parse_code_actions_leniently,
@@ -27,6 +31,16 @@ use crate::lsp::bridge::{
 use crate::text::PositionMapper;
 
 const METHOD: &str = "textDocument/codeAction";
+
+/// Flatten the per-server results of a `concatenated` dispatch into one response
+/// in priority order (`dispatch_concatenated` yields them ordered). Each server
+/// contributes `Option<CodeActionResponse>`; drop the `None`s, concatenate the
+/// action lists, and collapse an all-empty merge to `None` so the layer counts
+/// as "no result" for cross-layer aggregation (#568 PR 7).
+fn concat_merge(vecs: Vec<Option<CodeActionResponse>>) -> Option<CodeActionResponse> {
+    let merged: CodeActionResponse = vecs.into_iter().flatten().flatten().collect();
+    (!merged.is_empty()).then_some(merged)
+}
 
 impl Kakehashi {
     pub(crate) async fn code_action_impl(
@@ -207,37 +221,57 @@ impl Kakehashi {
 
         let pool = self.bridge.pool_arc();
         let range = ctx.range;
-        let result = dispatch_preferred(
-            &ctx.document,
-            pool.clone(),
-            |t| {
-                let context = context.clone();
-                async move {
-                    t.pool
-                        .send_code_action_request(
-                            &t.server_name,
-                            &t.server_config,
-                            &t.uri,
-                            range,
-                            context,
-                            &t.injection_language,
-                            &t.region_id,
-                            t.offset,
-                            &t.virtual_content,
-                            t.upstream_id,
-                            t.client_progress_token,
-                            upstream_caps,
-                        )
-                        .await
-                }
-            },
-            |opt| matches!(opt, Some(v) if !v.is_empty()),
-            cancel_rx,
-        )
-        .await;
+        // One fan-out closure, dispatched by the within-layer strategy
+        // (`bridge.<lang>.aggregation.<method>.strategy`): `preferred` returns
+        // the highest-priority non-empty server; `concatenated` merges every
+        // server's actions in priority order (#568 PR 7). The closure moves into
+        // exactly one arm.
+        let f = |t: FanOutTask| {
+            let context = context.clone();
+            async move {
+                t.pool
+                    .send_code_action_request(
+                        &t.server_name,
+                        &t.server_config,
+                        &t.uri,
+                        range,
+                        context,
+                        &t.injection_language,
+                        &t.region_id,
+                        t.offset,
+                        &t.virtual_content,
+                        t.upstream_id,
+                        t.client_progress_token,
+                        upstream_caps,
+                    )
+                    .await
+            }
+        };
+        let result = match ctx.document.strategy {
+            AggregationStrategy::Preferred => {
+                dispatch_preferred(
+                    &ctx.document,
+                    pool.clone(),
+                    f,
+                    |opt| matches!(opt, Some(v) if !v.is_empty()),
+                    cancel_rx,
+                )
+                .await
+                .handle(&self.client, "code action", None, Ok)
+                .await
+            }
+            AggregationStrategy::Concatenated => {
+                dispatch_concatenated(&ctx.document, pool.clone(), f, cancel_rx, None, None)
+                    .await
+                    .handle(&self.client, "code action", None, |vecs| {
+                        Ok(concat_merge(vecs))
+                    })
+                    .await
+            }
+        };
         pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
 
-        result.handle(&self.client, "code action", None, Ok).await
+        result
     }
 
     /// Host layer: forward the params verbatim to the host language's own
@@ -255,51 +289,74 @@ impl Kakehashi {
         };
         let (cancel_rx, _cancel_guard) = self.subscribe_cancel(ctx.upstream_request_id.as_ref());
         let pool = self.bridge.pool_arc();
-        let result = dispatch_host_preferred(
-            &ctx,
-            pool.clone(),
-            move |t| {
-                let params = raw_params.clone();
-                async move {
-                    let raw = t
-                        .pool
-                        .send_host_raw_request(
-                            &t.server_name,
-                            &t.server_config,
-                            &HostDocument {
-                                uri: &t.uri,
-                                language_id: &t.language_id,
-                                text: &t.text,
-                            },
-                            METHOD,
-                            params,
-                            t.upstream_id,
-                        )
-                        .await?;
-                    Ok(raw.and_then(|value| {
-                        let actions = parse_code_actions_leniently(value)?;
-                        Some(bridge_code_actions(
-                            actions,
-                            &t.server_name,
-                            t.uri.as_str(),
-                            upstream_caps,
-                            // Host-layer codeAction/resolve is not bridged, so
-                            // host lazy actions are never enveloped/resolved.
-                            false,
-                            None,
-                        ))
-                    }))
-                }
-            },
-            |opt| matches!(opt, Some(v) if !v.is_empty()),
-            cancel_rx,
-        )
-        .await;
+        // One fan-out closure, dispatched by the within-host-layer strategy
+        // (`bridge._self.aggregation.<method>.strategy`); moves into one arm.
+        let f = move |t: HostFanOutTask| {
+            let params = raw_params.clone();
+            async move {
+                let raw = t
+                    .pool
+                    .send_host_raw_request(
+                        &t.server_name,
+                        &t.server_config,
+                        &HostDocument {
+                            uri: &t.uri,
+                            language_id: &t.language_id,
+                            text: &t.text,
+                        },
+                        METHOD,
+                        params,
+                        t.upstream_id,
+                    )
+                    .await?;
+                Ok(raw.and_then(|value| {
+                    let actions = parse_code_actions_leniently(value)?;
+                    Some(bridge_code_actions(
+                        actions,
+                        &t.server_name,
+                        t.uri.as_str(),
+                        upstream_caps,
+                        // Host-layer codeAction/resolve is not bridged, so
+                        // host lazy actions are never enveloped/resolved.
+                        false,
+                        None,
+                    ))
+                }))
+            }
+        };
+        let result = match ctx.strategy {
+            AggregationStrategy::Preferred => {
+                let fan_in = dispatch_host_preferred(
+                    &ctx,
+                    pool.clone(),
+                    f,
+                    |opt| matches!(opt, Some(v) if !v.is_empty()),
+                    cancel_rx,
+                )
+                .await;
+                self.host_code_action_result(fan_in, |v| v).await
+            }
+            AggregationStrategy::Concatenated => {
+                let fan_in =
+                    dispatch_host_concatenated(&ctx, pool.clone(), f, cancel_rx, None, None).await;
+                self.host_code_action_result(fan_in, concat_merge).await
+            }
+        };
         pool.unregister_all_for_upstream_id(ctx.upstream_request_id.as_ref());
-        // Same quieting as the generic host arm: an all-empty host layer is
-        // the normal outcome whenever virt answers; only real failures log.
+        result
+    }
+
+    /// Fold a host-layer fan-in result into the handler's return, with the
+    /// host-arm quieting: an all-empty host layer is the normal outcome
+    /// whenever virt answers, so it stays SILENT (unlike [`FanInResult::handle`],
+    /// which logs a LOG-level message) and warns only on real failures.
+    async fn host_code_action_result<T>(
+        &self,
+        result: FanInResult<T>,
+        on_done: impl FnOnce(T) -> Option<CodeActionResponse>,
+    ) -> Result<Option<CodeActionResponse>> {
         match result {
-            FanInResult::Done(value) => Ok(value),
+            FanInResult::Done(value) => Ok(on_done(value)),
             FanInResult::NoResult { errors } => {
                 if errors > 0 {
                     self.client

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -7,7 +7,8 @@
 //! (host-document-bridge) bridges the host document itself. Both apply the
 //! `"{title} — {server}"` suffix, so the host arm cannot use the generic
 //! verbatim raw-value walk — it dispatches typed per server to keep the
-//! server name ([`Kakehashi::walk_layer_futures`]).
+//! server name ([`Kakehashi::walk_layers_by_strategy`], the strategy-aware walk
+//! codeAction uses instead of the generic `walk_layer_futures`).
 //!
 //! codeAction defaults to `concatenated` at both aggregation levels (#568 PR 7):
 //! within a layer, every server's actions are merged (`concat_merge`); across

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -11,7 +11,7 @@
 //!
 //! codeAction defaults to `concatenated` at both aggregation levels (#568 PR 7):
 //! within a layer, every server's actions are merged (`concat_merge`); across
-//! layers, [`Kakehashi::walk_layers_concatenated`] merges virt+host+native in
+//! layers, [`Kakehashi::walk_layers_by_strategy`] merges virt+host+native in
 //! priority order (the native layer is wired but contributes nothing yet — it
 //! resolves to `None`). Whichever cross-layer strategy applies, the final menu has
 //! its cross-source `isPreferred` collision collapsed once

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -11,8 +11,8 @@
 
 use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::{
-    CodeAction, CodeActionContext, CodeActionParams, CodeActionResponse, MessageType,
-    NumberOrString, Position, Range, Uri,
+    CodeAction, CodeActionContext, CodeActionOrCommand, CodeActionParams, CodeActionResponse,
+    MessageType, NumberOrString, Position, Range, Uri,
 };
 use ulid::Ulid;
 use url::Url;
@@ -42,6 +42,27 @@ fn concat_merge(vecs: Vec<Option<CodeActionResponse>>) -> Option<CodeActionRespo
     (!merged.is_empty()).then_some(merged)
 }
 
+/// Collapse the cross-server `isPreferred` collision on a concatenated menu:
+/// the client's auto-fix keybinding picks the FIRST `isPreferred: true`, so once
+/// several servers each mark their action preferred, keep only the first (the
+/// merge is in priority order, so that's the highest-priority server) and drop
+/// the rest to `false` (checklist §4). Per-action `isPreferredSupport` stripping
+/// already happened in `bridge_code_action`; this is the cross-set collapse.
+fn resolve_preferred_collision(actions: &mut CodeActionResponse) {
+    let mut kept = false;
+    for item in actions.iter_mut() {
+        if let CodeActionOrCommand::CodeAction(action) = item
+            && action.is_preferred == Some(true)
+        {
+            if kept {
+                action.is_preferred = Some(false);
+            } else {
+                kept = true;
+            }
+        }
+    }
+}
+
 impl Kakehashi {
     pub(crate) async fn code_action_impl(
         &self,
@@ -57,16 +78,44 @@ impl Kakehashi {
         let virt =
             self.code_action_virt_layer(&lsp_uri, range, context, work_done_token, upstream_caps);
         let host = self.code_action_host_layer(&lsp_uri, raw_params, upstream_caps);
-        self.walk_layer_futures(
-            &lsp_uri,
-            METHOD,
-            METHOD,
-            virt,
-            host,
-            std::future::ready(Ok(None)),
-            |actions: &CodeActionResponse| !actions.is_empty(),
-        )
-        .await
+        // Cross-layer strategy (`layers.aggregation."textDocument/codeAction"`):
+        // `preferred` returns the highest-priority non-empty layer; `concatenated`
+        // merges every layer's actions in priority order into one menu, then
+        // collapses the cross-server isPreferred collision (#568 PR 7).
+        match self.cross_layer_strategy(&lsp_uri, METHOD) {
+            AggregationStrategy::Preferred => {
+                self.walk_layer_futures(
+                    &lsp_uri,
+                    METHOD,
+                    METHOD,
+                    virt,
+                    host,
+                    std::future::ready(Ok(None)),
+                    |actions: &CodeActionResponse| !actions.is_empty(),
+                )
+                .await
+            }
+            AggregationStrategy::Concatenated => {
+                let merged = self
+                    .walk_layers_concatenated(
+                        &lsp_uri,
+                        METHOD,
+                        METHOD,
+                        virt,
+                        host,
+                        std::future::ready(Ok(None)),
+                        |mut acc: CodeActionResponse, next| {
+                            acc.extend(next);
+                            acc
+                        },
+                    )
+                    .await?;
+                Ok(merged.map(|mut actions| {
+                    resolve_preferred_collision(&mut actions);
+                    actions
+                }))
+            }
+        }
     }
 
     /// The upstream client's codeAction capabilities that gate the bridge
@@ -370,5 +419,81 @@ impl Kakehashi {
             }
             FanInResult::Cancelled => Err(tower_lsp_server::jsonrpc::Error::request_cancelled()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower_lsp_server::ls_types::Command;
+
+    fn action(title: &str, preferred: Option<bool>) -> CodeActionOrCommand {
+        CodeActionOrCommand::CodeAction(CodeAction {
+            title: title.to_string(),
+            is_preferred: preferred,
+            ..CodeAction::default()
+        })
+    }
+
+    fn command(title: &str) -> CodeActionOrCommand {
+        CodeActionOrCommand::Command(Command {
+            title: title.to_string(),
+            command: "c".to_string(),
+            arguments: None,
+        })
+    }
+
+    #[test]
+    fn concat_merge_flattens_in_order_and_drops_none() {
+        let merged = concat_merge(vec![
+            Some(vec![action("a", None)]),
+            None,
+            Some(vec![action("b", None), action("c", None)]),
+        ])
+        .expect("non-empty");
+        let titles: Vec<_> = merged
+            .iter()
+            .filter_map(|i| match i {
+                CodeActionOrCommand::CodeAction(a) => Some(a.title.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(titles, ["a", "b", "c"], "priority order preserved");
+    }
+
+    #[test]
+    fn concat_merge_all_empty_is_none() {
+        assert!(concat_merge(vec![None, Some(vec![]), None]).is_none());
+    }
+
+    #[test]
+    fn preferred_collision_keeps_only_the_first() {
+        // Two servers each marked their action preferred; after the collapse
+        // only the FIRST (highest-priority in the merged order) stays true.
+        let mut actions = vec![
+            action("x", Some(true)),
+            command("cmd"),
+            action("y", Some(true)),
+            action("z", None),
+        ];
+        resolve_preferred_collision(&mut actions);
+        let prefs: Vec<Option<bool>> = actions
+            .iter()
+            .filter_map(|i| match i {
+                CodeActionOrCommand::CodeAction(a) => Some(a.is_preferred),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(prefs, [Some(true), Some(false), None]);
+    }
+
+    #[test]
+    fn preferred_collision_leaves_a_single_preferred_untouched() {
+        let mut actions = vec![action("x", None), action("y", Some(true))];
+        resolve_preferred_collision(&mut actions);
+        let CodeActionOrCommand::CodeAction(y) = &actions[1] else {
+            unreachable!()
+        };
+        assert_eq!(y.is_preferred, Some(true));
     }
 }

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -8,6 +8,14 @@
 //! `"{title} — {server}"` suffix, so the host arm cannot use the generic
 //! verbatim raw-value walk — it dispatches typed per server to keep the
 //! server name ([`Kakehashi::walk_layer_futures`]).
+//!
+//! codeAction defaults to `concatenated` at both aggregation levels (#568 PR 7):
+//! within a layer, every server's actions are merged (`concat_merge`); across
+//! layers, [`Kakehashi::walk_layers_concatenated`] merges virt+host+native in
+//! priority order (the native layer is wired but contributes nothing yet — it
+//! resolves to `None`). Whichever cross-layer strategy applies, the final menu has
+//! its cross-source `isPreferred` collision collapsed once
+//! ([`resolve_preferred_collision`]).
 
 use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::{
@@ -80,9 +88,8 @@ impl Kakehashi {
         let host = self.code_action_host_layer(&lsp_uri, raw_params, upstream_caps);
         // Cross-layer strategy (`layers.aggregation."textDocument/codeAction"`):
         // `preferred` returns the highest-priority non-empty layer; `concatenated`
-        // merges every layer's actions in priority order into one menu, then
-        // collapses the cross-server isPreferred collision (#568 PR 7).
-        match self.cross_layer_strategy(&lsp_uri, METHOD) {
+        // merges every layer's actions in priority order into one menu (#568 PR 7).
+        let result = match self.cross_layer_strategy(&lsp_uri, METHOD) {
             AggregationStrategy::Preferred => {
                 self.walk_layer_futures(
                     &lsp_uri,
@@ -96,26 +103,32 @@ impl Kakehashi {
                 .await
             }
             AggregationStrategy::Concatenated => {
-                let merged = self
-                    .walk_layers_concatenated(
-                        &lsp_uri,
-                        METHOD,
-                        METHOD,
-                        virt,
-                        host,
-                        std::future::ready(Ok(None)),
-                        |mut acc: CodeActionResponse, next| {
-                            acc.extend(next);
-                            acc
-                        },
-                    )
-                    .await?;
-                Ok(merged.map(|mut actions| {
-                    resolve_preferred_collision(&mut actions);
-                    actions
-                }))
+                self.walk_layers_concatenated(
+                    &lsp_uri,
+                    METHOD,
+                    METHOD,
+                    virt,
+                    host,
+                    std::future::ready(Ok(None)),
+                    |mut acc: CodeActionResponse, next| {
+                        acc.extend(next);
+                        acc
+                    },
+                )
+                .await
             }
-        }
+        };
+        // Collapse the cross-source isPreferred collision on the FINAL menu,
+        // regardless of the cross-layer strategy: WITHIN-layer concatenation can
+        // merge several servers' actions into one layer even when the cross-layer
+        // strategy is `preferred` (that layer still wins as a unit), so several
+        // `isPreferred: true` actions can reach here without a cross-layer merge.
+        result.map(|maybe| {
+            maybe.map(|mut actions| {
+                resolve_preferred_collision(&mut actions);
+                actions
+            })
+        })
     }
 
     /// The upstream client's codeAction capabilities that gate the bridge

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -86,38 +86,25 @@ impl Kakehashi {
         let virt =
             self.code_action_virt_layer(&lsp_uri, range, context, work_done_token, upstream_caps);
         let host = self.code_action_host_layer(&lsp_uri, raw_params, upstream_caps);
-        // Cross-layer strategy (`layers.aggregation."textDocument/codeAction"`):
-        // `preferred` returns the highest-priority non-empty layer; `concatenated`
-        // merges every layer's actions in priority order into one menu (#568 PR 7).
-        let result = match self.cross_layer_strategy(&lsp_uri, METHOD) {
-            AggregationStrategy::Preferred => {
-                self.walk_layer_futures(
-                    &lsp_uri,
-                    METHOD,
-                    METHOD,
-                    virt,
-                    host,
-                    std::future::ready(Ok(None)),
-                    |actions: &CodeActionResponse| !actions.is_empty(),
-                )
-                .await
-            }
-            AggregationStrategy::Concatenated => {
-                self.walk_layers_concatenated(
-                    &lsp_uri,
-                    METHOD,
-                    METHOD,
-                    virt,
-                    host,
-                    std::future::ready(Ok(None)),
-                    |mut acc: CodeActionResponse, next| {
-                        acc.extend(next);
-                        acc
-                    },
-                )
-                .await
-            }
-        };
+        // Cross-layer strategy (`layers.aggregation."textDocument/codeAction"`),
+        // resolved once inside the walk: `preferred` returns the highest-priority
+        // non-empty layer; `concatenated` merges every layer's actions in priority
+        // order into one menu (#568 PR 7).
+        let result = self
+            .walk_layers_by_strategy(
+                &lsp_uri,
+                METHOD,
+                METHOD,
+                virt,
+                host,
+                std::future::ready(Ok(None)),
+                |actions: &CodeActionResponse| !actions.is_empty(),
+                |mut acc: CodeActionResponse, next| {
+                    acc.extend(next);
+                    acc
+                },
+            )
+            .await;
         // Collapse the cross-source isPreferred collision on the FINAL menu,
         // regardless of the cross-layer strategy: WITHIN-layer concatenation can
         // merge several servers' actions into one layer even when the cross-layer

--- a/tests/bin/mock_formatter.rs
+++ b/tests/bin/mock_formatter.rs
@@ -157,7 +157,7 @@ fn main() {
                         "codeLensProvider": { "resolveProvider": true },
                         "textDocumentSync": 1
                     }),
-                    "code-action" => json!({
+                    "code-action" | "code-action-preferred" => json!({
                         "codeActionProvider": true,
                         "executeCommandProvider": { "commands": ["mock.run"] },
                         "textDocumentSync": 1
@@ -512,6 +512,26 @@ fn main() {
                                 "title": "Lazy organize imports",
                                 "kind": "source.organizeImports",
                                 "data": { "mock": "lazy-1" }
+                            }])
+                        } else if mode == "code-action-preferred" {
+                            // One isPreferred quickfix — two of these servers let
+                            // a test prove the cross-source isPreferred collapse
+                            // runs even under cross-layer `preferred` (#568 PR 7).
+                            json!([{
+                                "title": "Preferred fix",
+                                "kind": "quickfix",
+                                "isPreferred": true,
+                                "edit": {
+                                    "changes": {
+                                        _uri: [{
+                                            "range": {
+                                                "start": { "line": 0, "character": 0 },
+                                                "end": { "line": 0, "character": 5 }
+                                            },
+                                            "newText": "fixed"
+                                        }]
+                                    }
+                                }
                             }])
                         } else {
                             // `code-action` mode: one edit-carrying quickfix (an

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -71,6 +71,36 @@ fn init_client_mode(
     (client, init_response, config_dir)
 }
 
+/// Two virt servers (`mock-a`, `mock-b`) both bridging the lua region in
+/// `code-action` mode — for the concatenated-aggregation test.
+fn init_client_two_servers(client_capabilities: Value) -> (LspClient, Value, tempfile::TempDir) {
+    let bin = mock_formatter_bin();
+    let config_dir = tempfile::TempDir::new().expect("Failed to create config temp dir");
+    let config_path = config_dir.path().join("code_action.toml");
+    std::fs::write(&config_path, "").expect("Failed to write config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("temp path should be UTF-8"))
+        .build();
+
+    let init_response = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": client_capabilities,
+            "workspaceFolders": null,
+            "initializationOptions": { "languageServers": {
+                "mock-a": { "cmd": [bin, "code-action"], "languages": ["lua"] },
+                "mock-b": { "cmd": [bin, "code-action"], "languages": ["lua"] }
+            }}
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+    (client, init_response, config_dir)
+}
+
 /// Client capabilities with codeActionLiteralSupport (required for the
 /// bridge to advertise codeActionProvider at all — it can only produce
 /// CodeAction literals), optionally with disabledSupport.
@@ -242,6 +272,32 @@ fn whole_document_range_reaches_the_injection_region() {
     assert_eq!(
         actions[0]["edit"]["changes"][MARKDOWN_URI][0]["range"]["start"]["line"],
         3
+    );
+
+    shutdown(&mut client);
+}
+
+#[test]
+fn concatenated_default_merges_actions_from_both_servers() {
+    // codeAction defaults to `concatenated` at both aggregation levels (#568
+    // PR 7), so BOTH virt servers' actions appear in one menu. Under the old
+    // `preferred` default only the highest-priority server's actions would
+    // survive — so this asserting both is the discriminating test.
+    let (mut client, init_response, _config_dir) =
+        init_client_two_servers(literal_support_caps(true));
+    assert_advertised(&init_response);
+    open_markdown(&mut client);
+
+    let actions = code_action_with_retry(&mut client);
+    let titles: Vec<&str> = actions.iter().filter_map(|a| a["title"].as_str()).collect();
+
+    assert!(
+        titles.iter().any(|t| t.ends_with("— mock-a")),
+        "mock-a's actions must appear, got: {titles:?}"
+    );
+    assert!(
+        titles.iter().any(|t| t.ends_with("— mock-b")),
+        "mock-b's actions must appear (dropped under preferred), got: {titles:?}"
     );
 
     shutdown(&mut client);

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -277,6 +277,76 @@ fn whole_document_range_reaches_the_injection_region() {
     shutdown(&mut client);
 }
 
+/// Two `code-action-preferred` servers with the CROSS-layer strategy forced to
+/// `preferred` (within-layer stays the default `concatenated`), so the virt
+/// layer concatenates both servers' preferred actions but the cross layer does
+/// not merge — exercising the isPreferred collapse on the preferred cross-layer
+/// path (#568 PR 7, codex finding).
+fn init_client_preferred_crosslayer_two_servers(
+    client_capabilities: Value,
+) -> (LspClient, Value, tempfile::TempDir) {
+    let bin = mock_formatter_bin();
+    let config_dir = tempfile::TempDir::new().expect("Failed to create config temp dir");
+    let config_path = config_dir.path().join("code_action.toml");
+    std::fs::write(
+        &config_path,
+        r#"[languages._.layers.aggregation."textDocument/codeAction"]
+strategy = "preferred"
+"#,
+    )
+    .expect("Failed to write config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("temp path should be UTF-8"))
+        .build();
+
+    let init_response = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": client_capabilities,
+            "workspaceFolders": null,
+            "initializationOptions": { "languageServers": {
+                "mock-a": { "cmd": [bin, "code-action-preferred"], "languages": ["lua"] },
+                "mock-b": { "cmd": [bin, "code-action-preferred"], "languages": ["lua"] }
+            }}
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+    (client, init_response, config_dir)
+}
+
+#[test]
+fn ispreferred_collapse_runs_even_under_crosslayer_preferred() {
+    // Cross-layer `preferred` + within-layer `concatenated`: the virt layer
+    // merges both servers' isPreferred quickfixes (two `isPreferred: true`), and
+    // the cross layer returns that virt result as a unit. The final menu must
+    // still collapse to exactly ONE preferred action — reverting the collapse to
+    // the concatenated-only arm would leave two.
+    // isPreferredSupport is required, else bridge_code_action strips is_preferred
+    // entirely and there's nothing to collapse.
+    let mut caps = literal_support_caps(true);
+    caps["textDocument"]["codeAction"]["isPreferredSupport"] = json!(true);
+    let (mut client, init_response, _config_dir) =
+        init_client_preferred_crosslayer_two_servers(caps);
+    assert_advertised(&init_response);
+    open_markdown(&mut client);
+
+    let actions = code_action_with_retry(&mut client);
+    let preferred_count = actions
+        .iter()
+        .filter(|a| a["isPreferred"] == json!(true))
+        .count();
+    assert_eq!(
+        preferred_count, 1,
+        "exactly one action stays preferred after the collapse, got: {actions:?}"
+    );
+
+    shutdown(&mut client);
+}
+
 #[test]
 fn concatenated_default_merges_actions_from_both_servers() {
     // codeAction defaults to `concatenated` at both aggregation levels (#568


### PR DESCRIPTION
> Recreates #620, which was falsely auto-marked *merged* by an accidental rebase+force-push (branches and commits restored unchanged).

---

Part of #568 (PR 7 of 8). Stacked on #619 (PR 6, executeCommand).

## What

Honors `strategy = "concatenated"` for `textDocument/codeAction` at **both** aggregation levels and makes it the default, so every configured server's (and eventually the native layer's) code actions show up in one menu — kept distinguishable by the `"{title} — {server}"` suffix — instead of only the highest-priority server's.

## How (3 commits)

1. **Within-layer strategy-aware dispatch** — the codeAction virt/host layers pick `dispatch_preferred` vs `dispatch_concatenated` / `dispatch_host_concatenated` by `bridge.<lang>.aggregation."textDocument/codeAction".strategy`, flattening the per-server `Option<CodeActionResponse>` lists in priority order.
2. **Cross-layer concatenated walk** — new `race_layers_concatenated` / `walk_layers_concatenated`, the **barrier** sibling of the first-wins `race_layers_preferred` / `walk_layer_futures`: await all configured layers and merge in priority order (stable, not completion order), same walk-wide cancel subscription + upstream-registry sweep. codeAction picks the walk by `layers.aggregation."textDocument/codeAction".strategy`, then collapses the cross-server `isPreferred` collision (keep the highest-priority preferred action, drop the rest to `false` — checklist §4).
3. **Default flip** — codeAction → concatenated at both levels in `default_settings` (the config-init template source) AND the runtime fallback `default_aggregation_strategy_for_method`, kept in lockstep.

## Deliberate scope decisions (challenge welcome)

- **Diagnostics NOT migrated** onto the new generic combiner — the issue said "optionally"; diagnostics has push/pull + per-region strategy + folded slots, and migrating risks regressing a converged subsystem for zero PR-7 value. `combine_layer_results` stays as the template, not the target.
- **Only codeAction is wired** to the concatenated walk. Single-result methods (hover, definition, …) stay on the preferred walk regardless of config, so a single-result method mis-configured `concatenated` **implicitly** falls back to preferred (no warning — they never consult the concatenated path). The formatting priorities-required guard is untouched.
- A layer absent from `priorities` is never awaited (its future does no work), matching `race_layers_preferred`.

## Tests

- Unit: `race_layers_concatenated` priority-order merge (proven to follow priorities, **not** argument/completion order), empty→None, excluded-layer drop; `concat_merge` flatten-in-order; `resolve_preferred_collision` keeps only the first preferred.
- E2E (discriminating): two virt servers both bridging the lua region now both surface their actions — dropped under `preferred`.

Gate: lib 2523, e2e_code_action 39, fmt/clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `textDocument/codeAction` now combines results from multiple language servers by default, so actions from all configured sources can appear together.
  * Preferred code actions are now resolved more consistently when multiple servers return them.

* **Bug Fixes**
  * Improved handling of code action aggregation so merged results respect server priority and avoid duplicate “preferred” flags.
  * Fixed default settings so code action behavior matches the documented aggregation mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->