### PR TITLE
test(e2e): drop the fixed 1s didOpen sleep in the codeAction e2e

### DIFF
--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -164,7 +164,10 @@ fn open_markdown(client: &mut LspClient) {
             }
         }),
     );
-    std::thread::sleep(Duration::from_millis(1000));
+    // No fixed settle sleep: every caller drives the codeAction request through
+    // a retry loop (`code_action_with_retry` / `code_action_over_fence`, 300 ×
+    // 50ms, waiting for a non-empty result), which already absorbs the cold
+    // downstream handshake — a hard 1s sleep was pure per-test latency.
 }
 
 /// Issue `textDocument/codeAction` over the lua fence line, retrying while


### PR DESCRIPTION
Part of #628 (codeAction follow-up cleanups).

`open_markdown` slept a hard `1s` after `didOpen`, but every caller then drives the `textDocument/codeAction` request through a retry loop (`code_action_with_retry` / `code_action_over_fence` / an inline `0..300` loop: 300 × 50 ms, returning only on a non-empty result) that already absorbs the cold-downstream handshake. The fixed sleep was therefore pure per-test latency.

**Effect:** the full `e2e_code_action` suite (40 tests) now runs in **~1.5 s** instead of ~40 s. Same fixed-sleep-vs-retry-loop cleanup already applied in #568 PR 8's e2e.

All 40 `e2e_code_action` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by removing an unnecessary fixed pause and relying on existing retry behavior instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->