### PR TITLE
feat(bridge): open the origin server's docs before a bridged executeCommand

### DIFF
--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -1452,19 +1452,14 @@ mod tests {
                 ..Default::default()
             },
         );
+        // Use a blocking devnull command (not a real binary like `ruff`): if the
+        // filter regressed and DID attempt to spawn, the handshake would hang and
+        // the 2s timeout below would fire — a real binary could instead fail-fast
+        // on a missing runner and let the test pass without proving no-spawn.
         let mut servers = HashMap::new();
         servers.insert(
             "ruff".to_string(),
-            BridgeServerConfig {
-                cmd: vec!["ruff".to_string()],
-                languages: vec!["python".to_string()],
-                initialization_options: None,
-                workspace_markers: None,
-                on_type_formatting_triggers: None,
-                prefer_shared_instance: None,
-                enabled: None,
-                settings: None,
-            },
+            crate::lsp::bridge::pool::test_helpers::devnull_config_for_language("python"),
         );
         let settings = WorkspaceSettings {
             languages,

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -328,6 +328,15 @@ impl BridgeCoordinator {
     /// (FIFO → didOpen first). A no-op when the docs are already open
     /// (idempotent claim), and when no injection maps to `server_name`
     /// (e.g. a host-layer command — host-layer sync is a separate follow-up).
+    ///
+    /// This heals MISSING document state (a purged tracker), not stale content —
+    /// it never sends `didChange` (that is the edit path's job). And it is
+    /// best-effort against a *concurrent* respawn: if the downstream is replaced
+    /// in the narrow gap between this open and the caller's own connection
+    /// acquisition, the command can still execute against missing state (the
+    /// fresh server may error, no-op, or act on incomplete state); any failure
+    /// is handled fail-soft by the existing dispatch path. Still a far smaller
+    /// window than the codeAction↔executeCommand gap this closes.
     pub(crate) async fn ensure_server_documents_open(
         &self,
         settings: &WorkspaceSettings,
@@ -336,19 +345,8 @@ impl BridgeCoordinator {
         injections: Vec<BridgeInjection>,
         server_name: &str,
     ) {
-        let mut config: Option<Arc<BridgeServerConfig>> = None;
-        let for_server: Vec<BridgeInjection> = injections
-            .into_iter()
-            .filter(|inj| {
-                match self.get_config_for_language(settings, host_language, &inj.language) {
-                    Some(resolved) if resolved.server_name == server_name => {
-                        config.get_or_insert(resolved.config);
-                        true
-                    }
-                    _ => false,
-                }
-            })
-            .collect();
+        let (for_server, config) =
+            self.injections_for_server(settings, host_language, injections, server_name);
         let Some(config) = config else {
             return; // no injected region on this host bridges to `server_name`
         };
@@ -358,6 +356,40 @@ impl BridgeCoordinator {
         self.pool
             .eager_open_virtual_documents(server_name, &config, host_uri, &host_uri_lsp, for_server)
             .await;
+    }
+
+    /// The injections whose language bridges to `server_name`, plus that server's
+    /// resolved config. A codeAction fans out to ALL servers bridging an
+    /// injection language, so the command's origin may be ANY of them — match by
+    /// name against the full set ([`Self::get_all_configs_for_language`]), not
+    /// [`Self::get_config_for_language`]'s single first pick (which would miss
+    /// the origin when e.g. both ruff and pyright bridge python and the command
+    /// came from ruff). Pure; the async open is separate so it is unit-testable.
+    fn injections_for_server(
+        &self,
+        settings: &WorkspaceSettings,
+        host_language: &str,
+        injections: Vec<BridgeInjection>,
+        server_name: &str,
+    ) -> (Vec<BridgeInjection>, Option<Arc<BridgeServerConfig>>) {
+        let mut config: Option<Arc<BridgeServerConfig>> = None;
+        let for_server = injections
+            .into_iter()
+            .filter(|inj| {
+                match self
+                    .get_all_configs_for_language(settings, host_language, &inj.language)
+                    .into_iter()
+                    .find(|r| r.server_name == server_name)
+                {
+                    Some(resolved) => {
+                        config.get_or_insert(resolved.config);
+                        true
+                    }
+                    None => false,
+                }
+            })
+            .collect();
+        (for_server, config)
     }
 
     pub(crate) fn get_config_for_language(
@@ -1327,6 +1359,73 @@ mod tests {
             result.is_none(),
             "rust should be blocked by markdown's bridge filter"
         );
+    }
+
+    #[test]
+    fn injections_for_server_matches_any_fan_out_server_not_just_the_first() {
+        // python bridges to BOTH ruff and pyright (codeAction fans out to all).
+        // A command routed to either must still select the python injection —
+        // get_config_for_language's single first pick would miss whichever the
+        // command did NOT come from.
+        let coordinator = BridgeCoordinator::new();
+
+        let mut bridge_filter = HashMap::new();
+        bridge_filter.insert(
+            "python".to_string(),
+            BridgeLanguageConfig {
+                enabled: Some(true),
+                ..Default::default()
+            },
+        );
+        let mut languages = HashMap::new();
+        languages.insert(
+            "markdown".to_string(),
+            LanguageSettings {
+                bridge: Some(bridge_filter),
+                ..Default::default()
+            },
+        );
+        let server = |cmd: &str| BridgeServerConfig {
+            cmd: vec![cmd.to_string()],
+            languages: vec!["python".to_string()],
+            initialization_options: None,
+            workspace_markers: None,
+            on_type_formatting_triggers: None,
+            prefer_shared_instance: None,
+            enabled: None,
+            settings: None,
+        };
+        let mut servers = HashMap::new();
+        servers.insert("ruff".to_string(), server("ruff"));
+        servers.insert("pyright".to_string(), server("pyright"));
+        let settings = WorkspaceSettings {
+            languages,
+            auto_install: false,
+            language_servers: servers,
+            ..Default::default()
+        };
+
+        let injections = vec![BridgeInjection {
+            language: "python".to_string(),
+            region_id: "region-0".to_string(),
+            content: "import os\n".to_string(),
+        }];
+
+        for (name, cmd) in [("ruff", "ruff"), ("pyright", "pyright")] {
+            let (kept, config) =
+                coordinator.injections_for_server(&settings, "markdown", injections.clone(), name);
+            assert_eq!(kept.len(), 1, "{name} must self-heal its python injection");
+            assert_eq!(
+                config.expect("config for matched server").cmd,
+                vec![cmd.to_string()]
+            );
+        }
+
+        // A server that does not bridge python selects nothing.
+        let (kept, config) =
+            coordinator.injections_for_server(&settings, "markdown", injections, "gopls");
+        assert!(kept.is_empty());
+        assert!(config.is_none());
     }
 
     #[tokio::test]

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -337,7 +337,7 @@ impl BridgeCoordinator {
     /// window than the codeAction↔executeCommand gap this closes.
     pub(crate) async fn ensure_server_documents_open(
         &self,
-        settings: &WorkspaceSettings,
+        settings: &Arc<WorkspaceSettings>,
         host_language: &str,
         host_uri: &Url,
         injections: Vec<BridgeInjection>,
@@ -365,26 +365,23 @@ impl BridgeCoordinator {
     /// came from ruff). Pure; the async open is separate so it is unit-testable.
     fn injections_for_server(
         &self,
-        settings: &WorkspaceSettings,
+        settings: &Arc<WorkspaceSettings>,
         host_language: &str,
         injections: Vec<BridgeInjection>,
         server_name: &str,
     ) -> (Vec<BridgeInjection>, Option<Arc<BridgeServerConfig>>) {
         let mut config: Option<Arc<BridgeServerConfig>> = None;
-        // Injections commonly share an injection language (many fences of the
-        // same kind), so memoize the per-language resolution: `get_all_configs_
-        // for_language` scans/merges/sorts server configs, and this runs on the
-        // user-facing executeCommand path. Cache whether `server_name` bridges
-        // each language once, folding its config in on the first match.
-        let mut matched_by_language: HashMap<String, bool> = HashMap::new();
+        // Resolve via the per-settings-snapshot memo
+        // ([`Self::cached_configs_for_injection_language`]): several injections
+        // commonly share an injection language, and the cache also spans repeated
+        // executeCommands on the same snapshot, so the scan/merge/sort runs once
+        // per (host, injection) language rather than once per injection — this is
+        // on the user-facing executeCommand path.
         let for_server = injections
             .into_iter()
             .filter(|inj| {
-                if let Some(&matched) = matched_by_language.get(&inj.language) {
-                    return matched;
-                }
-                let matched = match self
-                    .get_all_configs_for_language(settings, host_language, &inj.language)
+                match self
+                    .cached_configs_for_injection_language(settings, host_language, &inj.language)
                     .into_iter()
                     .find(|r| r.server_name == server_name)
                 {
@@ -393,9 +390,7 @@ impl BridgeCoordinator {
                         true
                     }
                     None => false,
-                };
-                matched_by_language.insert(inj.language.clone(), matched);
-                matched
+                }
             })
             .collect();
         (for_server, config)
@@ -1413,12 +1408,12 @@ mod tests {
         let mut servers = HashMap::new();
         servers.insert("ruff".to_string(), server("ruff"));
         servers.insert("pyright".to_string(), server("pyright"));
-        let settings = WorkspaceSettings {
+        let settings = Arc::new(WorkspaceSettings {
             languages,
             auto_install: false,
             language_servers: servers,
             ..Default::default()
-        };
+        });
 
         let injections = vec![BridgeInjection {
             language: "python".to_string(),
@@ -1476,12 +1471,12 @@ mod tests {
             "ruff".to_string(),
             crate::lsp::bridge::pool::test_helpers::devnull_config_for_language("python"),
         );
-        let settings = WorkspaceSettings {
+        let settings = Arc::new(WorkspaceSettings {
             languages,
             auto_install: false,
             language_servers: servers,
             ..Default::default()
-        };
+        });
 
         let host_uri = Url::parse("file:///doc.md").unwrap();
         let injections = vec![BridgeInjection {

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -312,12 +312,6 @@ impl BridgeCoordinator {
     // Config lookup (moved from Kakehashi)
     // ========================================
 
-    /// Resolve `bridge.servers` for `injection_language`, returning the
-    /// `ResolvedServerConfig` (server name for pooling + spawn config) or
-    /// `None` when no server matches, or the host's bridge filter excludes
-    /// this injection. Host lookup uses wildcard resolution (wildcard-config-inheritance):
-    /// undefined hosts inherit `languages._`, letting one default filter apply
-    /// to every host.
     /// Await eager-opening ONLY `server_name`'s virtual documents for `host_uri`,
     /// so a bridged `workspace/executeCommand` routed to a respawned downstream
     /// (whose doc tracker was purged) doesn't compute against missing document
@@ -392,6 +386,12 @@ impl BridgeCoordinator {
         (for_server, config)
     }
 
+    /// Resolve `bridge.servers` for `injection_language`, returning the
+    /// `ResolvedServerConfig` (server name for pooling + spawn config) or
+    /// `None` when no server matches, or the host's bridge filter excludes
+    /// this injection. Host lookup uses wildcard resolution (wildcard-config-inheritance):
+    /// undefined hosts inherit `languages._`, letting one default filter apply
+    /// to every host.
     pub(crate) fn get_config_for_language(
         &self,
         settings: &WorkspaceSettings,

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -317,11 +317,15 @@ impl BridgeCoordinator {
     /// (whose doc tracker was purged) doesn't compute against missing document
     /// state. Unlike the request path, executeCommand has no
     /// `ensure_document_opened` step; unlike [`Self::eager_spawn_and_open_documents`]
-    /// (fire-and-forget), this is AWAITED so the `didOpen` is enqueued on the
-    /// shared single-writer connection BEFORE the caller sends the command
-    /// (FIFO → didOpen first). A no-op when the docs are already open
-    /// (idempotent claim), and when no injection maps to `server_name`
-    /// (e.g. a host-layer command — host-layer sync is a separate follow-up).
+    /// (fire-and-forget), this is AWAITED so that, WHEN a `didOpen` is enqueued,
+    /// it lands on the shared single-writer connection before the caller sends
+    /// the command (FIFO → didOpen first). The open is best-effort:
+    /// `eager_open_virtual_documents` may skip or return early (downstream not
+    /// ready, outbound queue full), in which case no `didOpen` is queued and the
+    /// command simply proceeds without it (handled fail-soft by dispatch). A
+    /// no-op when the docs are already open (idempotent claim), and when no
+    /// injection maps to `server_name` (e.g. a host-layer command — host-layer
+    /// sync is a separate follow-up).
     ///
     /// This heals MISSING document state (a purged tracker), not stale content —
     /// it never sends `didChange` (that is the edit path's job). And it is
@@ -367,10 +371,19 @@ impl BridgeCoordinator {
         server_name: &str,
     ) -> (Vec<BridgeInjection>, Option<Arc<BridgeServerConfig>>) {
         let mut config: Option<Arc<BridgeServerConfig>> = None;
+        // Injections commonly share an injection language (many fences of the
+        // same kind), so memoize the per-language resolution: `get_all_configs_
+        // for_language` scans/merges/sorts server configs, and this runs on the
+        // user-facing executeCommand path. Cache whether `server_name` bridges
+        // each language once, folding its config in on the first match.
+        let mut matched_by_language: HashMap<String, bool> = HashMap::new();
         let for_server = injections
             .into_iter()
             .filter(|inj| {
-                match self
+                if let Some(&matched) = matched_by_language.get(&inj.language) {
+                    return matched;
+                }
+                let matched = match self
                     .get_all_configs_for_language(settings, host_language, &inj.language)
                     .into_iter()
                     .find(|r| r.server_name == server_name)
@@ -380,7 +393,9 @@ impl BridgeCoordinator {
                         true
                     }
                     None => false,
-                }
+                };
+                matched_by_language.insert(inj.language.clone(), matched);
+                matched
             })
             .collect();
         (for_server, config)

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -318,6 +318,48 @@ impl BridgeCoordinator {
     /// this injection. Host lookup uses wildcard resolution (wildcard-config-inheritance):
     /// undefined hosts inherit `languages._`, letting one default filter apply
     /// to every host.
+    /// Await eager-opening ONLY `server_name`'s virtual documents for `host_uri`,
+    /// so a bridged `workspace/executeCommand` routed to a respawned downstream
+    /// (whose doc tracker was purged) doesn't compute against missing document
+    /// state. Unlike the request path, executeCommand has no
+    /// `ensure_document_opened` step; unlike [`Self::eager_spawn_and_open_documents`]
+    /// (fire-and-forget), this is AWAITED so the `didOpen` is enqueued on the
+    /// shared single-writer connection BEFORE the caller sends the command
+    /// (FIFO → didOpen first). A no-op when the docs are already open
+    /// (idempotent claim), and when no injection maps to `server_name`
+    /// (e.g. a host-layer command — host-layer sync is a separate follow-up).
+    pub(crate) async fn ensure_server_documents_open(
+        &self,
+        settings: &WorkspaceSettings,
+        host_language: &str,
+        host_uri: &Url,
+        injections: Vec<BridgeInjection>,
+        server_name: &str,
+    ) {
+        let mut config: Option<Arc<BridgeServerConfig>> = None;
+        let for_server: Vec<BridgeInjection> = injections
+            .into_iter()
+            .filter(|inj| {
+                match self.get_config_for_language(settings, host_language, &inj.language) {
+                    Some(resolved) if resolved.server_name == server_name => {
+                        config.get_or_insert(resolved.config);
+                        true
+                    }
+                    _ => false,
+                }
+            })
+            .collect();
+        let Some(config) = config else {
+            return; // no injected region on this host bridges to `server_name`
+        };
+        let Ok(host_uri_lsp) = crate::lsp::lsp_impl::url_to_uri(host_uri) else {
+            return;
+        };
+        self.pool
+            .eager_open_virtual_documents(server_name, &config, host_uri, &host_uri_lsp, for_server)
+            .await;
+    }
+
     pub(crate) fn get_config_for_language(
         &self,
         settings: &WorkspaceSettings,
@@ -1285,6 +1327,73 @@ mod tests {
             result.is_none(),
             "rust should be blocked by markdown's bridge filter"
         );
+    }
+
+    #[tokio::test]
+    async fn ensure_server_documents_open_short_circuits_for_a_non_matching_server() {
+        // A command whose host injections bridge to another server must not
+        // trigger a connect/spawn for `server_name`: the filter drops every
+        // injection, so the method returns before touching the pool. Asserted
+        // via a timeout — a spawn attempt would block on the init handshake.
+        let coordinator = BridgeCoordinator::new();
+
+        let mut bridge_filter = HashMap::new();
+        bridge_filter.insert(
+            "python".to_string(),
+            BridgeLanguageConfig {
+                enabled: Some(true),
+                ..Default::default()
+            },
+        );
+        let mut languages = HashMap::new();
+        languages.insert(
+            "markdown".to_string(),
+            LanguageSettings {
+                bridge: Some(bridge_filter),
+                ..Default::default()
+            },
+        );
+        let mut servers = HashMap::new();
+        servers.insert(
+            "ruff".to_string(),
+            BridgeServerConfig {
+                cmd: vec!["ruff".to_string()],
+                languages: vec!["python".to_string()],
+                initialization_options: None,
+                workspace_markers: None,
+                on_type_formatting_triggers: None,
+                prefer_shared_instance: None,
+                enabled: None,
+                settings: None,
+            },
+        );
+        let settings = WorkspaceSettings {
+            languages,
+            auto_install: false,
+            language_servers: servers,
+            ..Default::default()
+        };
+
+        let host_uri = Url::parse("file:///doc.md").unwrap();
+        let injections = vec![BridgeInjection {
+            language: "python".to_string(),
+            region_id: "region-0".to_string(),
+            content: "import os\n".to_string(),
+        }];
+
+        // `python` bridges to "ruff", not "other-server" → no match → no-op.
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            coordinator.ensure_server_documents_open(
+                &settings,
+                "markdown",
+                &host_uri,
+                injections,
+                "other-server",
+            ),
+        )
+        .await
+        .expect("a non-matching server must short-circuit, not attempt a spawn");
     }
 
     #[test]

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -335,6 +335,16 @@ impl InjectionCoordinator {
         detect_document_language(&self.language, &self.documents, uri)
     }
 
+    /// The host language and resolved bridge injections for `uri`, or `None`
+    /// when the document has no detectable language. Lets a caller re-derive the
+    /// injected regions on demand (executeCommand doc-sync), mirroring the
+    /// didOpen/didChange discovery.
+    pub(crate) fn bridge_injections(&self, uri: &Url) -> Option<(String, Vec<BridgeInjection>)> {
+        let host_language = self.get_language_for_document(uri)?;
+        let injections = self.resolve_injection_data(uri, &host_language);
+        Some((host_language, injections))
+    }
+
     fn install_coordinator(&self) -> InstallCoordinator {
         InstallCoordinator::from_parts(InstallCoordinatorDeps {
             client: self.client.clone(),

--- a/src/lsp/lsp_impl/workspace/execute_command.rs
+++ b/src/lsp/lsp_impl/workspace/execute_command.rs
@@ -68,7 +68,7 @@ impl Kakehashi {
         // open) returns immediately, and dispatch uses the fail-fast connection
         // variant, so a slow downstream can't block command execution here.
         const SYNC_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
-        let _ = tokio::time::timeout(
+        if tokio::time::timeout(
             SYNC_TIMEOUT,
             self.bridge.ensure_server_documents_open(
                 settings,
@@ -78,6 +78,17 @@ impl Kakehashi {
                 route.origin,
             ),
         )
-        .await;
+        .await
+        .is_err()
+        {
+            // Timed out waiting for the downstream to open its documents; dispatch
+            // anyway (fail-fast connection variant). Logged so an intermittent
+            // "downstream never saw didOpen before the command" is diagnosable.
+            log::debug!(
+                target: "kakehashi::bridge",
+                "executeCommand: pre-sync of origin '{}' documents timed out after {SYNC_TIMEOUT:?}; dispatching anyway",
+                route.origin
+            );
+        }
     }
 }

--- a/src/lsp/lsp_impl/workspace/execute_command.rs
+++ b/src/lsp/lsp_impl/workspace/execute_command.rs
@@ -20,9 +20,55 @@ impl Kakehashi {
     ) -> Result<Option<Value>> {
         let settings = self.settings_manager.load_settings();
         let upstream_id = crate::lsp::current_upstream_id();
+
+        // Self-heal document state before routing. A bridged command assumes the
+        // origin server has the (virtual) document open, but a downstream respawn
+        // between the codeAction that surfaced the command and this executeCommand
+        // purges that connection's doc tracker — and, unlike the request path,
+        // executeCommand has no `ensure_document_opened` step. Re-open the origin's
+        // injected docs first (awaited, so the didOpen is enqueued before the
+        // command on the shared connection). Fail-soft: any gap (foreign command,
+        // unparseable host URI, undetectable host language, no matching injection)
+        // just skips the sync and dispatches as before.
+        self.sync_origin_documents_before_execute(&params, &settings)
+            .await;
+
         let pool = self.bridge.pool_arc();
         Ok(pool
             .dispatch_execute_command(params, &settings, upstream_id)
             .await)
+    }
+
+    /// Best-effort re-open of the routed command's origin-server documents (see
+    /// [`Self::execute_command_impl`]). Scoped to virt-layer injected documents;
+    /// a host-layer command resolves to no injection and is left to dispatch.
+    async fn sync_origin_documents_before_execute(
+        &self,
+        params: &ExecuteCommandParams,
+        settings: &crate::config::WorkspaceSettings,
+    ) {
+        let Some(route) = crate::lsp::bridge::decode_command(&params.command) else {
+            return;
+        };
+        let Ok(host_url) = url::Url::parse(route.host_uri) else {
+            return;
+        };
+        let Some((host_language, injections)) =
+            self.injection_coordinator().bridge_injections(&host_url)
+        else {
+            return;
+        };
+        if injections.is_empty() {
+            return;
+        }
+        self.bridge
+            .ensure_server_documents_open(
+                settings,
+                &host_language,
+                &host_url,
+                injections,
+                route.origin,
+            )
+            .await;
     }
 }

--- a/src/lsp/lsp_impl/workspace/execute_command.rs
+++ b/src/lsp/lsp_impl/workspace/execute_command.rs
@@ -46,7 +46,7 @@ impl Kakehashi {
     async fn sync_origin_documents_before_execute(
         &self,
         params: &ExecuteCommandParams,
-        settings: &crate::config::WorkspaceSettings,
+        settings: &std::sync::Arc<crate::config::WorkspaceSettings>,
     ) {
         let Some(route) = crate::lsp::bridge::decode_command(&params.command) else {
             return;

--- a/src/lsp/lsp_impl/workspace/execute_command.rs
+++ b/src/lsp/lsp_impl/workspace/execute_command.rs
@@ -26,10 +26,11 @@ impl Kakehashi {
         // between the codeAction that surfaced the command and this executeCommand
         // purges that connection's doc tracker — and, unlike the request path,
         // executeCommand has no `ensure_document_opened` step. Re-open the origin's
-        // injected docs first (awaited, so the didOpen is enqueued before the
-        // command on the shared connection). Fail-soft: any gap (foreign command,
-        // unparseable host URI, undetectable host language, no matching injection)
-        // just skips the sync and dispatches as before.
+        // injected docs first (awaited, so that WHEN a didOpen is queued it
+        // precedes the command on the shared connection; the open is best-effort
+        // and may queue nothing). Fail-soft: any gap (foreign command, unparseable
+        // host URI, undetectable host language, no matching injection) just skips
+        // the sync and dispatches as before.
         self.sync_origin_documents_before_execute(&params, &settings)
             .await;
 

--- a/src/lsp/lsp_impl/workspace/execute_command.rs
+++ b/src/lsp/lsp_impl/workspace/execute_command.rs
@@ -61,14 +61,23 @@ impl Kakehashi {
         if injections.is_empty() {
             return;
         }
-        self.bridge
-            .ensure_server_documents_open(
+        // Bound the best-effort pre-sync: `eager_open_virtual_documents` can wait
+        // up to the init timeout for a cold/stuck downstream to reach Ready, and
+        // this sits on the user-facing executeCommand path. If it doesn't finish
+        // quickly, skip it and dispatch anyway — the happy path (doc already
+        // open) returns immediately, and dispatch uses the fail-fast connection
+        // variant, so a slow downstream can't block command execution here.
+        const SYNC_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+        let _ = tokio::time::timeout(
+            SYNC_TIMEOUT,
+            self.bridge.ensure_server_documents_open(
                 settings,
                 &host_language,
                 &host_url,
                 injections,
                 route.origin,
-            )
-            .await;
+            ),
+        )
+        .await;
     }
 }


### PR DESCRIPTION
Part of #628. Addresses the qodo "executeCommand skips document sync" finding from #625.

A bridged `workspace/executeCommand` assumes the origin downstream has the (virtual) document open, but a respawn between the codeAction that surfaced the command and its execution purges that connection's document tracker — and, unlike the request path, executeCommand has no `ensure_document_opened` step. So a command routed to a respawned server computed against no document.

`execute_command_impl` now re-opens the routed command's origin-server injected documents before dispatch, via `BridgeCoordinator::ensure_server_documents_open`. It is **awaited** (not the fire-and-forget `eager_spawn_and_open_documents`) so the `didOpen` is enqueued on the shared single-writer connection **before** the command is sent (FIFO ⇒ didOpen first), reusing the same tested `eager_open_virtual_documents` self-heal path — a true no-op when the docs are already open. Fail-soft on every gap (foreign command, unparseable host URI, undetectable host language, no injection bridged to the origin).

**Scope / honest limits** (both surfaced in review):
- **Fan-out matching**: the origin is matched against *all* servers bridging an injection language (`get_all_configs_for_language`), not `get_config_for_language`'s single first pick — so a command from `ruff` self-heals even when `python` also bridges to `pyright`. Covered by a discriminating two-server test.
- **Concurrent respawn is best-effort**: a respawn landing in the narrow gap between the open and dispatch's own connection acquisition can still execute against missing state (handled fail-soft by dispatch). This shrinks the exposure from the whole codeAction↔executeCommand gap to a tiny inter-await window; fully closing it needs the ensure to move onto dispatch's exact send handle (pool-layer change) — a follow-up.
- **Virt-layer scope**: host-layer command sync resolves to no injection and is left to dispatch (tracked with host-layer resolve, #627).

Tests: existing executeCommand round-trip e2e still passes (no-op sync on the happy path); new unit tests for the fan-out selection and the non-matching short-circuit. Reviewed locally + codex (fan-out fix + residual-window wording from its findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved command execution on bridged documents by best-effort ensuring the correct virtual documents are opened on the backing server before dispatch.
  * Enhanced injection-to-server routing to correctly fan out across multiple target servers.
* **Bug Fixes**
  * Reduced command failures caused by missing document-open tracking on targeted servers.
  * Added safer behavior when routing data can’t be decoded, URIs can’t be parsed, language/injections can’t be determined, or when no matching server target exists (including timeout-based no-op).
* **Tests**
  * Added coverage for multi-server fan-out selection and for early no-op behavior when there’s no matching server target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->