### PR TITLE
fix(cli): reject uninstall language with --all

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -159,7 +159,7 @@ enum LanguageAction {
         force: bool,
 
         /// Remove all installed languages
-        #[arg(long)]
+        #[arg(long, conflicts_with = "language")]
         all: bool,
     },
 }

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -955,6 +955,11 @@ fn test_language_uninstall_rejects_language_with_all() {
         !output.status.success(),
         "Uninstall should reject a language with --all"
     );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--all") && stderr.contains("language"),
+        "Stderr should contain clap conflict error message. Got: {stderr}"
+    );
     assert!(
         test_dir
             .path()

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -916,6 +916,58 @@ fn test_language_uninstall_all() {
     assert!(queries.is_empty(), "All queries should be removed");
 }
 
+/// Test that language uninstall rejects a language together with --all
+#[test]
+fn test_language_uninstall_rejects_language_with_all() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+
+    fs::create_dir_all(test_dir.path().join("parser")).expect("Failed to create parser dir");
+    fs::create_dir_all(test_dir.path().join("queries/testlang"))
+        .expect("Failed to create queries dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    fs::write(
+        test_dir.path().join(format!("parser/testlang.{ext}")),
+        "fake",
+    )
+    .expect("Failed to write parser");
+    fs::write(
+        test_dir.path().join("queries/testlang/highlights.scm"),
+        "(comment) @comment",
+    )
+    .expect("Failed to write query");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "testlang",
+            "--all",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+            "--force",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(
+        !output.status.success(),
+        "Uninstall should reject a language with --all"
+    );
+    assert!(
+        test_dir
+            .path()
+            .join(format!("parser/testlang.{ext}"))
+            .exists(),
+        "Parser should not be removed when arguments are invalid"
+    );
+    assert!(
+        test_dir.path().join("queries/testlang").exists(),
+        "Queries directory should not be removed when arguments are invalid"
+    );
+}
+
 /// Test that --data-dir works as a top-level flag (before subcommand)
 #[test]
 fn test_data_dir_top_level_flag() {


### PR DESCRIPTION
## Summary
- make `language uninstall <lang> --all` invalid at clap argument parsing
- add a CLI regression test that verifies installed files are left untouched when the arguments conflict

Fixes #594

## Tests
- `cargo test --test test_cli test_language_uninstall_rejects_language_with_all`
- `cargo test --test test_cli`
- `cargo fmt --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `language uninstall` argument handling so `--force` can’t be used together with a specific language name.
  * Added CLI integration coverage to ensure invalid uninstall combinations are rejected and existing language data remains intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->