### PR TITLE
feat(bridge): bridge host-layer codeAction/resolve (#627, #615)

### DIFF
--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -231,27 +231,36 @@ fn finalize_host_resolved_action(
     }
 
     // A materialized command must route back to the host server via
-    // executeCommand; drop it if the routing name can't be encoded.
-    if resolved
-        .command
-        .as_mut()
-        .and_then(|command| {
-            encode_command(&server_name, &envelope.host_uri, &command.command)
-                .map(|encoded| command.command = encoded)
-        })
-        .is_none()
-    {
-        resolved.command = None;
-    }
+    // executeCommand; drop it if the routing name can't be encoded. Remember
+    // whether a command was actually DROPPED (present but unencodable) — that is
+    // distinct from a resolve that never carried a command.
+    let command_dropped = match resolved.command.as_mut() {
+        Some(command) => match encode_command(&server_name, &envelope.host_uri, &command.command) {
+            Some(encoded) => {
+                command.command = encoded;
+                false
+            }
+            None => {
+                resolved.command = None;
+                true
+            }
+        },
+        None => false,
+    };
 
     // A resolved action with no command and no applicable edit is a no-op —
     // disable it as unresolvable (`REASON_RESOLVE`) rather than hand the client
     // an enabled action that applies nothing (mirrors the virt path's empty-edit
-    // policy). This also covers a command-only action whose routing name couldn't
-    // be encoded above (command dropped, edit absent): an absent edit is treated
-    // the same as an empty one. Without `disabledSupport`, fail soft to the
-    // unresolved action.
-    if resolved.command.is_none() && resolved.edit.as_ref().is_none_or(workspace_edit_is_empty) {
+    // policy). Two shapes qualify: a `Some`-but-empty edit (the server resolved
+    // to nothing), and a command-only action whose routing name couldn't be
+    // encoded above (command dropped, edit absent). A resolve that NEVER carried
+    // a command and has no edit is NOT a no-op — it is a still-lazy staged
+    // resolve, re-enveloped for a further pass below. Without `disabledSupport`,
+    // fail soft to the unresolved action.
+    if resolved.command.is_none()
+        && (resolved.edit.as_ref().is_some_and(workspace_edit_is_empty)
+            || (command_dropped && resolved.edit.is_none()))
+    {
         if !upstream_caps.disabled_support {
             re_envelope_action(&mut action, &envelope);
             return action;
@@ -2618,6 +2627,47 @@ mod tests {
         let route = crate::lsp::bridge::decode_command(&command.command).expect("routed name");
         assert_eq!(route.origin, "srv");
         assert_eq!(route.command, "server.fix");
+    }
+
+    #[test]
+    fn host_resolve_re_envelopes_still_lazy_result_with_no_command_and_no_edit() {
+        // A resolve that returns NEITHER a command NOR an edit (but never carried
+        // a command to begin with) is a still-lazy staged resolve, NOT a no-op:
+        // it must be re-enveloped for a further resolve pass, not disabled. This
+        // pins the #615 title-only host-lazy path against the dropped-command
+        // no-op guard.
+        let resolved: CodeAction =
+            serde_json::from_value(json!({ "title": "Organize imports" })).unwrap();
+        let action: CodeAction = serde_json::from_value(json!({
+            "title": "Organize imports — srv", "data": { "id": 1 }
+        }))
+        .unwrap();
+        let envelope: CodeActionEnvelope = serde_json::from_value(json!({
+            "origin": "srv",
+            "host_uri": "file:///test.md",
+            "region_id": "",
+            "injection_language": "",
+            "offset": { "line": 0, "column": 0 },
+            "original_title": "Organize imports",
+            "inner": null,
+            "host_layer": true
+        }))
+        .unwrap();
+
+        let out = finalize_host_resolved_action(
+            resolved,
+            action,
+            envelope,
+            "Organize imports — srv".to_string(),
+            caps_resolve(),
+        );
+
+        assert!(
+            out.disabled.is_none(),
+            "a still-lazy (no-command, no-edit) resolve must be re-enveloped, not disabled"
+        );
+        let env = extract_code_action_envelope(&out).expect("re-enveloped for a further resolve");
+        assert!(env.host_layer);
     }
 
     // -- resolve response parsing --------------------------------------------

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -595,6 +595,30 @@ impl LanguageServerPool {
             resolved.command = None;
         }
 
+        // An empty resolved edit with no command is a no-op — disable it as
+        // unresolvable (`REASON_RESOLVE`) rather than hand the client an enabled
+        // action that applies nothing (mirrors the virt path's empty-edit
+        // policy). Without `disabledSupport`, fail soft to the unresolved action.
+        if resolved.command.is_none() && resolved.edit.as_ref().is_some_and(workspace_edit_is_empty)
+        {
+            if !upstream_caps.disabled_support {
+                re_envelope_action(&mut action, &envelope);
+                return action;
+            }
+            resolved.title = resuffix_resolved_title(
+                std::mem::take(&mut resolved.title),
+                suffixed_title,
+                server_name,
+            );
+            resolved.edit = None;
+            resolved.data = None;
+            resolved.is_preferred = None;
+            resolved.disabled = Some(CodeActionDisabled {
+                reason: REASON_RESOLVE.to_string(),
+            });
+            return resolved;
+        }
+
         if !upstream_caps.is_preferred_support {
             resolved.is_preferred = None;
         }

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -188,6 +188,113 @@ fn re_envelope_action(action: &mut CodeAction, envelope: &CodeActionEnvelope) {
     }));
 }
 
+/// Shape a host server's `codeAction/resolve` RESPONSE for the client (host
+/// layer — coordinates are already host-relative, so no translation). `resolved`
+/// is the downstream's resolved action; `action`/`envelope` are the original
+/// unresolved action + its envelope (for fail-soft and lazy re-envelope);
+/// `suffixed_title` is the "` — {server}`"-suffixed title to re-apply.
+///
+/// Policy (mirrors the virt path): a disabled resolve is surfaced disabled; a
+/// materialized command is name-encoded for `executeCommand` routing (dropped
+/// if unencodable); a result with no command and no applicable edit is a no-op
+/// and is disabled as `REASON_RESOLVE`; a still-lazy result is re-enveloped for
+/// a further resolve. Without `disabledSupport` every disable path fails soft to
+/// the unresolved action instead.
+fn finalize_host_resolved_action(
+    mut resolved: CodeAction,
+    mut action: CodeAction,
+    mut envelope: CodeActionEnvelope,
+    suffixed_title: String,
+    upstream_caps: UpstreamCodeActionCaps,
+) -> CodeAction {
+    // Clone the origin so later `envelope` mutation (lazy re-envelope) doesn't
+    // conflict with the `&str` borrows below; resolve is a cold path.
+    let server_name = envelope.origin.clone();
+
+    // Disabled resolve → surface disabled (strip payload) with disabledSupport,
+    // else fail soft to the unresolved action.
+    if resolved.disabled.is_some() {
+        if !upstream_caps.disabled_support {
+            re_envelope_action(&mut action, &envelope);
+            return action;
+        }
+        resolved.title = resuffix_resolved_title(
+            std::mem::take(&mut resolved.title),
+            suffixed_title,
+            &server_name,
+        );
+        resolved.edit = None;
+        resolved.command = None;
+        resolved.data = None;
+        resolved.is_preferred = None;
+        return resolved;
+    }
+
+    // A materialized command must route back to the host server via
+    // executeCommand; drop it if the routing name can't be encoded.
+    if resolved
+        .command
+        .as_mut()
+        .and_then(|command| {
+            encode_command(&server_name, &envelope.host_uri, &command.command)
+                .map(|encoded| command.command = encoded)
+        })
+        .is_none()
+    {
+        resolved.command = None;
+    }
+
+    // A resolved action with no command and no applicable edit is a no-op —
+    // disable it as unresolvable (`REASON_RESOLVE`) rather than hand the client
+    // an enabled action that applies nothing (mirrors the virt path's empty-edit
+    // policy). This also covers a command-only action whose routing name couldn't
+    // be encoded above (command dropped, edit absent): an absent edit is treated
+    // the same as an empty one. Without `disabledSupport`, fail soft to the
+    // unresolved action.
+    if resolved.command.is_none() && resolved.edit.as_ref().is_none_or(workspace_edit_is_empty) {
+        if !upstream_caps.disabled_support {
+            re_envelope_action(&mut action, &envelope);
+            return action;
+        }
+        resolved.title = resuffix_resolved_title(
+            std::mem::take(&mut resolved.title),
+            suffixed_title,
+            &server_name,
+        );
+        resolved.edit = None;
+        resolved.data = None;
+        resolved.is_preferred = None;
+        resolved.disabled = Some(CodeActionDisabled {
+            reason: REASON_RESOLVE.to_string(),
+        });
+        return resolved;
+    }
+
+    if !upstream_caps.is_preferred_support {
+        resolved.is_preferred = None;
+    }
+
+    // The resolved edit is already in host coordinates — kept verbatim (no
+    // cross-region / translation concern the virt path guards against).
+    let server_title = std::mem::take(&mut resolved.title);
+    resolved.title = resuffix_resolved_title(server_title.clone(), suffixed_title, &server_name);
+
+    // Materialized (edit or command) → strip the envelope; still lazy →
+    // re-envelope for a further resolve, syncing a server-changed title.
+    if resolved.edit.is_some() || resolved.command.is_some() {
+        resolved.data = None;
+    } else {
+        if !server_title.is_empty() {
+            envelope.original_title = server_title;
+        }
+        if resolved.data.is_none() {
+            resolved.data = action.data.take();
+        }
+        re_envelope_action(&mut resolved, &envelope);
+    }
+    resolved
+}
+
 /// Whether a `WorkspaceEdit` carries no actual change. Checks the INNER edit
 /// vectors, not just the outer containers: a `changes` map whose every value
 /// is an empty `TextEdit[]`, or `documentChanges` whose every entry has empty
@@ -537,7 +644,7 @@ impl LanguageServerPool {
         &self,
         server_config: &BridgeServerConfig,
         mut action: CodeAction,
-        mut envelope: CodeActionEnvelope,
+        envelope: CodeActionEnvelope,
         upstream_caps: UpstreamCodeActionCaps,
         upstream_id: Option<UpstreamId>,
     ) -> CodeAction {
@@ -568,7 +675,7 @@ impl LanguageServerPool {
         let suffixed_title =
             std::mem::replace(&mut outgoing.title, envelope.original_title.clone());
 
-        let Some(mut resolved) = self
+        let Some(resolved) = self
             .send_code_action_resolve_on_handle(&handle, outgoing, upstream_id)
             .await
         else {
@@ -576,86 +683,7 @@ impl LanguageServerPool {
             return action;
         };
 
-        // Disabled resolve → surface disabled (strip payload) with
-        // disabledSupport, else fail soft to the unresolved action.
-        if resolved.disabled.is_some() {
-            if !upstream_caps.disabled_support {
-                re_envelope_action(&mut action, &envelope);
-                return action;
-            }
-            resolved.title = resuffix_resolved_title(
-                std::mem::take(&mut resolved.title),
-                suffixed_title,
-                server_name,
-            );
-            resolved.edit = None;
-            resolved.command = None;
-            resolved.data = None;
-            resolved.is_preferred = None;
-            return resolved;
-        }
-
-        // A materialized command must route back to the host server via
-        // executeCommand; drop it if the routing name can't be encoded.
-        if resolved
-            .command
-            .as_mut()
-            .and_then(|command| {
-                encode_command(server_name, &envelope.host_uri, &command.command)
-                    .map(|encoded| command.command = encoded)
-            })
-            .is_none()
-        {
-            resolved.command = None;
-        }
-
-        // An empty resolved edit with no command is a no-op — disable it as
-        // unresolvable (`REASON_RESOLVE`) rather than hand the client an enabled
-        // action that applies nothing (mirrors the virt path's empty-edit
-        // policy). Without `disabledSupport`, fail soft to the unresolved action.
-        if resolved.command.is_none() && resolved.edit.as_ref().is_some_and(workspace_edit_is_empty)
-        {
-            if !upstream_caps.disabled_support {
-                re_envelope_action(&mut action, &envelope);
-                return action;
-            }
-            resolved.title = resuffix_resolved_title(
-                std::mem::take(&mut resolved.title),
-                suffixed_title,
-                server_name,
-            );
-            resolved.edit = None;
-            resolved.data = None;
-            resolved.is_preferred = None;
-            resolved.disabled = Some(CodeActionDisabled {
-                reason: REASON_RESOLVE.to_string(),
-            });
-            return resolved;
-        }
-
-        if !upstream_caps.is_preferred_support {
-            resolved.is_preferred = None;
-        }
-
-        // The resolved edit is already in host coordinates — kept verbatim (no
-        // cross-region / translation concern the virt path guards against).
-        let server_title = std::mem::take(&mut resolved.title);
-        resolved.title = resuffix_resolved_title(server_title.clone(), suffixed_title, server_name);
-
-        // Materialized (edit or command) → strip the envelope; still lazy →
-        // re-envelope for a further resolve, syncing a server-changed title.
-        if resolved.edit.is_some() || resolved.command.is_some() {
-            resolved.data = None;
-        } else {
-            if !server_title.is_empty() {
-                envelope.original_title = server_title;
-            }
-            if resolved.data.is_none() {
-                resolved.data = action.data.take();
-            }
-            re_envelope_action(&mut resolved, &envelope);
-        }
-        resolved
+        finalize_host_resolved_action(resolved, action, envelope, suffixed_title, upstream_caps)
     }
 
     /// Reconnect to the origin `(server, root)`, restore the original title,
@@ -2499,6 +2527,97 @@ mod tests {
             ..CodeAction::default()
         };
         assert!(extract_code_action_envelope(&action).is_none());
+    }
+
+    // -- host resolve finalization -------------------------------------------
+
+    #[test]
+    fn host_resolve_disables_command_only_action_when_routing_name_unencodable() {
+        // A command-only resolved action whose routing name can't be encoded
+        // (origin contains the routing separator) must NOT surface as an enabled
+        // no-op: the command is dropped and, with no edit, the action is
+        // disabled as REASON_RESOLVE (regression for the dropped-command gap).
+        let resolved: CodeAction = serde_json::from_value(json!({
+            "title": "Run fix",
+            "command": { "title": "Run fix", "command": "server.fix" }
+        }))
+        .unwrap();
+        let action: CodeAction = serde_json::from_value(json!({
+            "title": "Run fix — srv", "data": { "id": 1 }
+        }))
+        .unwrap();
+        let envelope: CodeActionEnvelope = serde_json::from_value(json!({
+            "origin": "sr\u{1f}v", // contains SEP → encode_command fails
+            "host_uri": "file:///test.md",
+            "region_id": "",
+            "injection_language": "",
+            "offset": { "line": 0, "column": 0 },
+            "original_title": "Run fix",
+            "inner": null,
+            "host_layer": true
+        }))
+        .unwrap();
+
+        let out = finalize_host_resolved_action(
+            resolved,
+            action,
+            envelope,
+            "Run fix — sr\u{1f}v".to_string(),
+            caps_resolve(),
+        );
+
+        assert_eq!(
+            out.disabled
+                .as_ref()
+                .expect("must be disabled, not an enabled no-op")
+                .reason,
+            REASON_RESOLVE
+        );
+        assert!(out.command.is_none(), "unencodable command must be dropped");
+        assert!(out.edit.is_none());
+    }
+
+    #[test]
+    fn host_resolve_keeps_command_only_action_when_routing_name_encodable() {
+        // The happy path for the same shape: an encodable origin keeps the
+        // command (name-encoded) and stays enabled.
+        let resolved: CodeAction = serde_json::from_value(json!({
+            "title": "Run fix",
+            "command": { "title": "Run fix", "command": "server.fix" }
+        }))
+        .unwrap();
+        let action: CodeAction = serde_json::from_value(json!({
+            "title": "Run fix — srv", "data": { "id": 1 }
+        }))
+        .unwrap();
+        let envelope: CodeActionEnvelope = serde_json::from_value(json!({
+            "origin": "srv",
+            "host_uri": "file:///test.md",
+            "region_id": "",
+            "injection_language": "",
+            "offset": { "line": 0, "column": 0 },
+            "original_title": "Run fix",
+            "inner": null,
+            "host_layer": true
+        }))
+        .unwrap();
+
+        let out = finalize_host_resolved_action(
+            resolved,
+            action,
+            envelope,
+            "Run fix — srv".to_string(),
+            caps_resolve(),
+        );
+
+        assert!(
+            out.disabled.is_none(),
+            "an encodable command must stay enabled"
+        );
+        let command = out.command.expect("command kept");
+        let route = crate::lsp::bridge::decode_command(&command.command).expect("routed name");
+        assert_eq!(route.origin, "srv");
+        assert_eq!(route.command, "server.fix");
     }
 
     // -- resolve response parsing --------------------------------------------

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -658,9 +658,24 @@ impl LanguageServerPool {
         upstream_id: Option<UpstreamId>,
     ) -> CodeAction {
         let server_name = &envelope.origin;
-        let host_url = Url::parse(&envelope.host_uri).ok();
+        // `host_uri` comes from client-supplied `data` (the resolve params echo
+        // the action's envelope), so a malformed value must fail soft, NOT fall
+        // through to `get_or_create_connection(.., None)` — a `None` document
+        // hint routes to a rootless client-fallback / shared key that could run
+        // the resolve against the wrong workspace. The bridge only ever mints a
+        // valid `Url::as_str()` here, so a parse failure means a corrupt/foreign
+        // envelope.
+        let Ok(host_url) = Url::parse(&envelope.host_uri) else {
+            warn!(
+                target: "kakehashi::bridge",
+                "codeAction/resolve (host): envelope host_uri '{}' is not a valid URL; ignoring",
+                envelope.host_uri
+            );
+            re_envelope_action(&mut action, &envelope);
+            return action;
+        };
         let handle = match self
-            .get_or_create_connection(server_name, server_config, host_url.as_ref())
+            .get_or_create_connection(server_name, server_config, Some(&host_url))
             .await
         {
             Ok(h) => h,
@@ -709,9 +724,21 @@ impl LanguageServerPool {
         region_end: Position,
     ) -> CodeAction {
         let server_name = &envelope.origin;
-        let host_url = Url::parse(&envelope.host_uri).ok();
+        // Client-supplied `host_uri` (see the host path): a malformed value must
+        // fail soft, not connect with a `None` document hint that routes to a
+        // rootless client-fallback / shared key. The bridge only mints valid
+        // URLs here, so a parse failure means a corrupt/foreign envelope.
+        let Ok(host_url) = Url::parse(&envelope.host_uri) else {
+            warn!(
+                target: "kakehashi::bridge",
+                "codeAction/resolve: envelope host_uri '{}' is not a valid URL; ignoring",
+                envelope.host_uri
+            );
+            re_envelope_action(&mut action, &envelope);
+            return action;
+        };
         let handle = match self
-            .get_or_create_connection(server_name, server_config, host_url.as_ref())
+            .get_or_create_connection(server_name, server_config, Some(&host_url))
             .await
         {
             Ok(h) => h,
@@ -730,9 +757,7 @@ impl LanguageServerPool {
         }
 
         let offset = RegionOffset::from(&envelope.offset);
-        let host_uri_lsp = host_url
-            .as_ref()
-            .and_then(|u| crate::lsp::lsp_impl::url_to_uri(u).ok());
+        let host_uri_lsp = crate::lsp::lsp_impl::url_to_uri(&host_url).ok();
 
         // Forward with the ORIGINAL (unsuffixed) title restored and any
         // client-supplied ranges translated back to virtual coordinates. Keep

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -1152,7 +1152,7 @@ impl UpstreamCodeActionCaps {
     /// our envelope) and `resolveSupport` advertising `"edit"` (the client
     /// will actually resolve the edit). Otherwise the bridge must
     /// eager-resolve downstream instead.
-    fn can_envelope(&self) -> bool {
+    pub(crate) fn can_envelope(&self) -> bool {
         self.data_support && self.resolve_edit_support
     }
 }

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -86,10 +86,14 @@ pub(crate) struct CodeActionEnvelope {
 impl CodeActionEnvelope {
     /// Whether this is a genuine HOST-layer envelope: `host_layer` set AND no
     /// region identity. A host envelope is minted with an empty `region_id`
-    /// ([`envelope_host_action`]), so requiring that here means a client can't
-    /// flip `host_layer = true` on a VIRT envelope (which keeps its `region_id`)
-    /// to route it through the translation-free host path and skip the region
-    /// freshness / coordinate validation.
+    /// ([`envelope_host_action`]), so requiring both here means a CONFORMING
+    /// client that merely flips `host_layer = true` on a VIRT envelope (which
+    /// keeps its `region_id`) still can't route it through the translation-free
+    /// host path and skip the region freshness / coordinate validation. This is
+    /// not a security boundary: the envelope round-trips through client-supplied
+    /// `CodeAction.data` and is not integrity-protected, so a client could clear
+    /// `region_id` too — the check guards against ACCIDENTAL bypass, not a
+    /// malicious one (which the translation-free host path also fails soft on).
     pub(crate) fn is_host_layer(&self) -> bool {
         self.host_layer && self.region_id.is_empty()
     }
@@ -233,20 +237,18 @@ fn finalize_host_resolved_action(
     // A materialized command must route back to the host server via
     // executeCommand; drop it if the routing name can't be encoded. Remember
     // whether a command was actually DROPPED (present but unencodable) — that is
-    // distinct from a resolve that never carried a command.
-    let command_dropped = match resolved.command.as_mut() {
-        Some(command) => match encode_command(&server_name, &envelope.host_uri, &command.command) {
-            Some(encoded) => {
-                command.command = encoded;
-                false
-            }
-            None => {
-                resolved.command = None;
-                true
-            }
-        },
-        None => false,
-    };
+    // distinct from a resolve that never carried a command. Encode under the
+    // mutable borrow, then clear afterwards so the borrow is out of scope.
+    let mut command_dropped = false;
+    if let Some(command) = resolved.command.as_mut() {
+        match encode_command(&server_name, &envelope.host_uri, &command.command) {
+            Some(encoded) => command.command = encoded,
+            None => command_dropped = true,
+        }
+    }
+    if command_dropped {
+        resolved.command = None;
+    }
 
     // A resolved action with no command and no applicable edit is a no-op —
     // disable it as unresolvable (`REASON_RESOLVE`) rather than hand the client

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -74,6 +74,13 @@ pub(crate) struct CodeActionEnvelope {
     pub(crate) original_title: String,
     /// The downstream server's original `data` value (preserved verbatim).
     pub(crate) inner: Option<Value>,
+    /// Host-layer action (`bridge._self`): its edit/data are already in host
+    /// coordinates, so resolve routes to the host server VERBATIM — no virtual
+    /// URI, region, or offset translation. `region_id`/`injection_language`/
+    /// `offset` are unused for these. Defaults to `false` (virt layer) so
+    /// existing enveloped actions deserialize unchanged.
+    #[serde(default)]
+    pub(crate) host_layer: bool,
 }
 
 /// Everything needed to wrap an action's `data` in a routing envelope.
@@ -97,6 +104,32 @@ fn envelope_action_data(action: &mut CodeAction, ctx: &CodeActionEnvelopeContext
         offset: EnvelopeOffset::from(ctx.offset),
         original_title: action.title.clone(),
         inner,
+        host_layer: false,
+    };
+    action.data = Some(serde_json::json!({ ENVELOPE_KEY: envelope }));
+}
+
+/// Wrap a HOST-layer action's `data` in a routing envelope so a later
+/// `codeAction/resolve` routes back to the host server. The host document is
+/// forwarded verbatim, so no region/offset is captured (`host_layer = true`
+/// tells the resolve path to skip all coordinate translation). Captures the
+/// CURRENT (unsuffixed) title as `original_title`; call before suffixing.
+fn envelope_host_action(action: &mut CodeAction, server_name: &str, host_uri: &str) {
+    let inner = action.data.take();
+    let envelope = CodeActionEnvelope {
+        origin: server_name.to_string(),
+        host_uri: host_uri.to_string(),
+        region_id: String::new(),
+        injection_language: String::new(),
+        // Unused on the host path (resolve forwards verbatim); a zero offset.
+        offset: EnvelopeOffset {
+            line: 0,
+            column: 0,
+            line_column_offsets: None,
+        },
+        original_title: action.title.clone(),
+        inner,
+        host_layer: true,
     };
     action.data = Some(serde_json::json!({ ENVELOPE_KEY: envelope }));
 }
@@ -138,6 +171,7 @@ fn re_envelope_action(action: &mut CodeAction, envelope: &CodeActionEnvelope) {
             offset: envelope.offset.clone(),
             original_title: envelope.original_title.clone(),
             inner,
+            host_layer: envelope.host_layer,
         }
     }));
 }
@@ -453,6 +487,20 @@ impl LanguageServerPool {
             return action;
         };
 
+        // Host-layer actions are already in host coordinates — route their
+        // resolve to the host server VERBATIM (no translation, #627).
+        if envelope.host_layer {
+            return self
+                .send_host_code_action_resolve(
+                    &config,
+                    action,
+                    envelope,
+                    upstream_caps,
+                    upstream_id,
+                )
+                .await;
+        }
+
         self.send_code_action_resolve_request(
             &config,
             action,
@@ -462,6 +510,114 @@ impl LanguageServerPool {
             region_end,
         )
         .await
+    }
+
+    /// Route a HOST-layer `codeAction/resolve` back to its host server VERBATIM:
+    /// the action is already in host coordinates, so nothing is translated. Same
+    /// policy as [`Self::send_code_action_resolve_request`] (restore title →
+    /// forward → disable / command-route / isPreferred / suffix / strip-or-
+    /// re-envelope) MINUS coordinate translation and the host-ward edit
+    /// validation (a host edit needs neither). Fails soft (returns the action
+    /// unresolved, envelope restored) at every step.
+    async fn send_host_code_action_resolve(
+        &self,
+        server_config: &BridgeServerConfig,
+        mut action: CodeAction,
+        mut envelope: CodeActionEnvelope,
+        upstream_caps: UpstreamCodeActionCaps,
+        upstream_id: Option<UpstreamId>,
+    ) -> CodeAction {
+        let server_name = &envelope.origin;
+        let host_url = Url::parse(&envelope.host_uri).ok();
+        let handle = match self
+            .get_or_create_connection(server_name, server_config, host_url.as_ref())
+            .await
+        {
+            Ok(h) => h,
+            Err(e) => {
+                warn!(
+                    target: "kakehashi::bridge",
+                    "codeAction/resolve (host): failed to connect to {server_name}: {e}"
+                );
+                re_envelope_action(&mut action, &envelope);
+                return action;
+            }
+        };
+        if !handle.has_capability("codeAction/resolve") {
+            re_envelope_action(&mut action, &envelope);
+            return action;
+        }
+
+        // Forward with the ORIGINAL (unsuffixed) title restored; keep the
+        // suffixed title to re-apply. Host coordinates: no range translation.
+        let mut outgoing = action.clone();
+        let suffixed_title =
+            std::mem::replace(&mut outgoing.title, envelope.original_title.clone());
+
+        let Some(mut resolved) = self
+            .send_code_action_resolve_on_handle(&handle, outgoing, upstream_id)
+            .await
+        else {
+            re_envelope_action(&mut action, &envelope);
+            return action;
+        };
+
+        // Disabled resolve → surface disabled (strip payload) with
+        // disabledSupport, else fail soft to the unresolved action.
+        if resolved.disabled.is_some() {
+            if !upstream_caps.disabled_support {
+                re_envelope_action(&mut action, &envelope);
+                return action;
+            }
+            resolved.title = resuffix_resolved_title(
+                std::mem::take(&mut resolved.title),
+                suffixed_title,
+                server_name,
+            );
+            resolved.edit = None;
+            resolved.command = None;
+            resolved.data = None;
+            resolved.is_preferred = None;
+            return resolved;
+        }
+
+        // A materialized command must route back to the host server via
+        // executeCommand; drop it if the routing name can't be encoded.
+        if resolved
+            .command
+            .as_mut()
+            .and_then(|command| {
+                encode_command(server_name, &envelope.host_uri, &command.command)
+                    .map(|encoded| command.command = encoded)
+            })
+            .is_none()
+        {
+            resolved.command = None;
+        }
+
+        if !upstream_caps.is_preferred_support {
+            resolved.is_preferred = None;
+        }
+
+        // The resolved edit is already in host coordinates — kept verbatim (no
+        // cross-region / translation concern the virt path guards against).
+        let server_title = std::mem::take(&mut resolved.title);
+        resolved.title = resuffix_resolved_title(server_title.clone(), suffixed_title, server_name);
+
+        // Materialized (edit or command) → strip the envelope; still lazy →
+        // re-envelope for a further resolve, syncing a server-changed title.
+        if resolved.edit.is_some() || resolved.command.is_some() {
+            resolved.data = None;
+        } else {
+            if !server_title.is_empty() {
+                envelope.original_title = server_title;
+            }
+            if resolved.data.is_none() {
+                resolved.data = action.data.take();
+            }
+            re_envelope_action(&mut resolved, &envelope);
+        }
+        resolved
     }
 
     /// Reconnect to the origin `(server, root)`, restore the original title,
@@ -1056,27 +1212,32 @@ fn bridge_code_action(
             // disabled placeholder (the PR 3 behavior) rather than dropping it,
             // so `disabledSupport` clients see why it can't run.
             //
-            // Deliberate scope boundary: `data` presence is an intrinsic lazy
-            // signal needing no capability plumbing, so it is the host gate.
-            // Recognizing a TITLE-ONLY host lazy action (LSP 3.18) would require
-            // threading the host server's `resolveProvider` through
-            // `send_host_raw_request` — but the resulting placeholder could
-            // never be resolved (host resolve is unbridged), so it would be pure
-            // menu clutter. This matches PR 3 exactly (its `data.is_some() ||
-            // server_resolves` gate also dropped title-only host lazy actions)
-            // and is deferred alongside host-layer resolve support, not a
-            // regression.
+            // Now that host-layer resolve is bridged (#627), the host gate
+            // mirrors the virt one: a title-only action (LSP 3.18, no `data`)
+            // from a host server advertising `resolveProvider` is a resolvable
+            // lazy action, not clutter — `server_resolves` recognizes it. A
+            // `data`-carrying action stays lazy regardless (an intrinsic lazy
+            // signal), so a resolving server can complete it and a non-resolving
+            // one still surfaces it disabled below (#615 item 2).
             let is_lazy = match virt {
                 Some(_) => server_resolves,
-                None => action.data.is_some(),
+                None => action.data.is_some() || server_resolves,
             };
             if is_lazy {
-                // Envelope it (virt layer) if the client can resolve the edit,
-                // so a later `codeAction/resolve` routes back to the origin;
-                // otherwise it can never be completed — disable it (an
+                // Virt layer: envelope if the client can resolve the edit, so a
+                // later `codeAction/resolve` routes back to the origin (an
                 // eager-resolve pass already ran for non-envelope clients).
                 if let Some(virt) = virt.filter(|_| upstream_caps.can_envelope()) {
                     envelope_action_data(&mut action, &virt.envelope_ctx());
+                    action.title = suffix_title(action.title, server_name);
+                    return Some(CodeActionOrCommand::CodeAction(action));
+                }
+                // Host layer: if the host server advertises `resolveProvider`
+                // and the client can envelope, route resolve back to it VERBATIM
+                // (host coordinates, no translation — #627). Otherwise it can
+                // never be completed here, so disable it.
+                if virt.is_none() && server_resolves && upstream_caps.can_envelope() {
+                    envelope_host_action(&mut action, server_name, host_uri);
                     action.title = suffix_title(action.title, server_name);
                     return Some(CodeActionOrCommand::CodeAction(action));
                 }
@@ -1891,6 +2052,125 @@ mod tests {
         let route = crate::lsp::bridge::decode_command(&command.command).expect("routed name");
         assert_eq!(route.origin, "marksman");
         assert_eq!(route.command, "lint.run");
+    }
+
+    #[test]
+    fn host_lazy_action_is_enveloped_for_host_resolve_when_server_resolves() {
+        // A data-carrying host lazy action + a host server advertising resolve +
+        // an envelope-capable client → enveloped with `host_layer = true` so its
+        // resolve routes back to the host server, NOT disabled (#627).
+        let actions: Vec<CodeActionOrCommand> =
+            serde_json::from_value(json!([{ "title": "Organize imports", "data": { "id": 1 } }]))
+                .unwrap();
+        let bridged = bridge_code_actions(
+            actions,
+            "marksman",
+            "file:///test.md",
+            caps_resolve(),
+            true, // host server advertises codeAction/resolve
+            None, // host layer
+        );
+        assert_eq!(bridged.len(), 1);
+        let CodeActionOrCommand::CodeAction(action) = &bridged[0] else {
+            panic!("Expected CodeAction");
+        };
+        assert!(
+            action.disabled.is_none(),
+            "a resolvable host lazy action must be enveloped, not disabled"
+        );
+        assert_eq!(action.title, "Organize imports — marksman");
+        let env = extract_code_action_envelope(action).expect("host envelope present");
+        assert!(
+            env.host_layer,
+            "host_layer must be set for host-resolve routing"
+        );
+        assert_eq!(env.origin, "marksman");
+        assert_eq!(env.host_uri, "file:///test.md");
+        assert_eq!(env.original_title, "Organize imports");
+    }
+
+    #[test]
+    fn host_lazy_action_is_disabled_when_host_server_does_not_resolve() {
+        // Same action, but the host server does NOT advertise resolve → the
+        // bridge can't complete it, so it is disabled (pre-#627 behavior).
+        let actions: Vec<CodeActionOrCommand> =
+            serde_json::from_value(json!([{ "title": "Organize imports", "data": { "id": 1 } }]))
+                .unwrap();
+        let bridged = bridge_code_actions(
+            actions,
+            "marksman",
+            "file:///test.md",
+            caps_resolve(),
+            false, // host server does NOT advertise resolve
+            None,
+        );
+        let CodeActionOrCommand::CodeAction(action) = &bridged[0] else {
+            panic!("Expected CodeAction");
+        };
+        assert_eq!(action.disabled.as_ref().unwrap().reason, REASON_RESOLVE);
+        assert!(extract_code_action_envelope(action).is_none());
+    }
+
+    #[test]
+    fn envelope_without_host_layer_field_defaults_to_virt() {
+        // Backward compat: an envelope serialized before the field existed must
+        // deserialize as a virt-layer envelope (host_layer = false).
+        let env: CodeActionEnvelope = serde_json::from_value(json!({
+            "origin": "ruff",
+            "host_uri": "file:///x.md",
+            "region_id": "REGION",
+            "injection_language": "python",
+            "offset": { "line": 0, "column": 0 },
+            "original_title": "t",
+            "inner": null
+        }))
+        .expect("deserializes without host_layer");
+        assert!(!env.host_layer);
+    }
+
+    #[test]
+    fn title_only_host_lazy_action_is_enveloped_when_server_resolves() {
+        // #615 item 2: a TITLE-ONLY host action (no data/edit/command) from a
+        // host server advertising resolve is a resolvable lazy action —
+        // enveloped for host-resolve routing, not dropped as clutter.
+        let actions: Vec<CodeActionOrCommand> =
+            serde_json::from_value(json!([{ "title": "Fix all" }])).unwrap();
+        let bridged = bridge_code_actions(
+            actions,
+            "marksman",
+            "file:///test.md",
+            caps_resolve(),
+            true,
+            None,
+        );
+        assert_eq!(bridged.len(), 1);
+        let CodeActionOrCommand::CodeAction(action) = &bridged[0] else {
+            panic!("Expected CodeAction");
+        };
+        assert!(action.disabled.is_none(), "must be enveloped, not disabled");
+        let env = extract_code_action_envelope(action).expect("host envelope present");
+        assert!(env.host_layer);
+        assert_eq!(env.original_title, "Fix all");
+    }
+
+    #[test]
+    fn title_only_host_action_is_dropped_when_server_does_not_resolve() {
+        // Without host resolve support a title-only host action can never do
+        // anything, so it is dropped (not surfaced as menu clutter).
+        let actions: Vec<CodeActionOrCommand> =
+            serde_json::from_value(json!([{ "title": "Fix all" }])).unwrap();
+        let bridged = bridge_code_actions(
+            actions,
+            "marksman",
+            "file:///test.md",
+            caps_resolve(),
+            false,
+            None,
+        );
+        assert!(
+            bridged.is_empty(),
+            "a title-only non-resolvable host action is dropped"
+        );
     }
 
     // ==========================================================================

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -83,6 +83,18 @@ pub(crate) struct CodeActionEnvelope {
     pub(crate) host_layer: bool,
 }
 
+impl CodeActionEnvelope {
+    /// Whether this is a genuine HOST-layer envelope: `host_layer` set AND no
+    /// region identity. A host envelope is minted with an empty `region_id`
+    /// ([`envelope_host_action`]), so requiring that here means a client can't
+    /// flip `host_layer = true` on a VIRT envelope (which keeps its `region_id`)
+    /// to route it through the translation-free host path and skip the region
+    /// freshness / coordinate validation.
+    pub(crate) fn is_host_layer(&self) -> bool {
+        self.host_layer && self.region_id.is_empty()
+    }
+}
+
 /// Everything needed to wrap an action's `data` in a routing envelope.
 pub(crate) struct CodeActionEnvelopeContext<'a> {
     server_name: &'a str,
@@ -488,8 +500,10 @@ impl LanguageServerPool {
         };
 
         // Host-layer actions are already in host coordinates — route their
-        // resolve to the host server VERBATIM (no translation, #627).
-        if envelope.host_layer {
+        // resolve to the host server VERBATIM (no translation, #627). A genuine
+        // host envelope has no region identity; requiring that blocks a client
+        // flipping `host_layer` on a virt envelope to skip translation.
+        if envelope.is_host_layer() {
             return self
                 .send_host_code_action_resolve(
                     &config,
@@ -1229,12 +1243,11 @@ fn bridge_code_action(
             // LSP 3.18 allows a lazy action to be title-only, so the server's
             // capability is the deciding factor.
             //
-            // Host layer (`virt` is None): resolve is NOT bridged, so the
-            // bridge can't issue a resolve regardless of the server's
-            // capability. A `data`-carrying action is still a lazy action the
-            // server intends to be resolved — surface it as a `REASON_RESOLVE`
-            // disabled placeholder (the PR 3 behavior) rather than dropping it,
-            // so `disabledSupport` clients see why it can't run.
+            // Host layer (`virt` is None): host-layer `codeAction/resolve` is now
+            // bridged (#627), so a host lazy action from a resolving server is
+            // enveloped for resolve-routing (below); one from a non-resolving
+            // server is surfaced as a `REASON_RESOLVE` disabled placeholder so
+            // `disabledSupport` clients see why it can't run.
             //
             // Now that host-layer resolve is bridged (#627), the host gate
             // mirrors the virt one: a title-only action (LSP 3.18, no `data`)

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -2256,8 +2256,9 @@ mod tests {
 
     #[test]
     fn title_only_host_action_is_dropped_when_server_does_not_resolve() {
-        // Without host resolve support a title-only host action can never do
-        // anything, so it is dropped (not surfaced as menu clutter).
+        // When the host server does not advertise `codeAction/resolve`, a
+        // title-only host action can never do anything, so it is dropped (not
+        // surfaced as menu clutter).
         let actions: Vec<CodeActionOrCommand> =
             serde_json::from_value(json!([{ "title": "Fix all" }])).unwrap();
         let bridged = bridge_code_actions(

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -293,10 +293,13 @@ impl LanguageServerPool {
     }
 
     /// Whether the host server for `(server_name, uri)` advertises `method`
-    /// (e.g. `codeAction/resolve`). Queried on the cached connection — ~free
-    /// right after a request that already opened it — and fail-closed (`false`)
-    /// when the server can't be reached. Used to decide whether a host lazy
-    /// action can be resolve-routed rather than disabled (#627).
+    /// (e.g. `codeAction/resolve`). Reuses the existing connection when the
+    /// request that ran just before already opened it, but still goes through
+    /// `get_or_create_connection`, which re-resolves the marker/root and takes
+    /// the pool lock even on a cache hit — cheap, not free, so callers gate the
+    /// call when the answer can't change the outcome. Fail-closed (`false`) when
+    /// the server can't be reached. Used to decide whether a host lazy action can
+    /// be resolve-routed rather than disabled (#627).
     pub(crate) async fn host_server_advertises(
         &self,
         server_name: &str,

--- a/src/lsp/bridge/text_document/host.rs
+++ b/src/lsp/bridge/text_document/host.rs
@@ -292,6 +292,24 @@ impl LanguageServerPool {
         .await?
     }
 
+    /// Whether the host server for `(server_name, uri)` advertises `method`
+    /// (e.g. `codeAction/resolve`). Queried on the cached connection — ~free
+    /// right after a request that already opened it — and fail-closed (`false`)
+    /// when the server can't be reached. Used to decide whether a host lazy
+    /// action can be resolve-routed rather than disabled (#627).
+    pub(crate) async fn host_server_advertises(
+        &self,
+        server_name: &str,
+        server_config: &BridgeServerConfig,
+        uri: &url::Url,
+        method: &str,
+    ) -> bool {
+        self.get_or_create_connection(server_name, server_config, Some(uri))
+            .await
+            .map(|handle| handle.has_capability(method))
+            .unwrap_or(false)
+    }
+
     /// Send a host formatting request. Unlike [`Self::send_host_raw_request`],
     /// the response keeps formatting's LSP semantics, mirroring
     /// [`Self::send_formatting_request`]: a `null` result from a capable

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -381,10 +381,18 @@ impl Kakehashi {
                 // Whether this host server advertises `codeAction/resolve`, so a
                 // host lazy action can be enveloped for resolve-routing back to
                 // it (#627) rather than disabled. Queried on the just-opened
-                // connection — skipped when there are no actions, since
-                // `bridge_code_actions` returns empty regardless (avoids a
-                // redundant lock acquisition on the hot path).
-                let server_resolves = !actions.is_empty()
+                // connection — but only when at least one action could actually
+                // consume the answer. `bridge_code_actions` reads `server_resolves`
+                // ONLY for an action with no edit AND no command (a possibly-lazy
+                // action); a menu of purely materialized actions never looks at
+                // it, so the probe (and its lock acquisition) is skippable on that
+                // hot path. Probing whenever such an action exists — regardless of
+                // its `data`/`disabled` — keeps the result byte-identical.
+                let maybe_lazy = |item: &CodeActionOrCommand| match item {
+                    CodeActionOrCommand::CodeAction(a) => a.edit.is_none() && a.command.is_none(),
+                    CodeActionOrCommand::Command(_) => false,
+                };
+                let server_resolves = actions.iter().any(maybe_lazy)
                     && t.pool
                         .host_server_advertises(
                             &t.server_name,

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -385,20 +385,29 @@ impl Kakehashi {
                 // Whether this host server advertises `codeAction/resolve`, so a
                 // host lazy action can be enveloped for resolve-routing back to
                 // it (#627) rather than disabled. Queried on the just-opened
-                // connection — but only when at least one action could actually
-                // consume the answer. `bridge_code_action` reads `server_resolves`
-                // ONLY for a possibly-lazy action: no edit, no command, and NOT
-                // already disabled (a disabled action returns early, before the
-                // lazy gate). A menu of purely materialized/disabled actions never
-                // looks at it, so the probe (and its lock acquisition) is skippable
-                // on that hot path.
+                // connection — but only when the answer can actually change the
+                // outcome, so the probe (and its marker-root resolution + pool
+                // lock) is skippable on this hot `textDocument/codeAction` path:
+                //
+                // - `server_resolves` is read by `bridge_code_action` ONLY for a
+                //   possibly-lazy action (no edit, no command, and not already
+                //   disabled — a disabled action returns early, before the lazy
+                //   gate). No such action ⇒ never consulted.
+                // - Even with such an action, a HOST lazy action needs the CLIENT
+                //   to either envelope it (`can_envelope`) or show it disabled
+                //   (`disabled_support`); with NEITHER, it is dropped regardless
+                //   of `server_resolves` (envelope path gated on `can_envelope`,
+                //   `disable_action` returns `None` without `disabled_support`).
+                let client_can_use_resolve =
+                    upstream_caps.can_envelope() || upstream_caps.disabled_support;
                 let maybe_lazy = |item: &CodeActionOrCommand| match item {
                     CodeActionOrCommand::CodeAction(a) => {
                         a.edit.is_none() && a.command.is_none() && a.disabled.is_none()
                     }
                     CodeActionOrCommand::Command(_) => false,
                 };
-                let server_resolves = actions.iter().any(maybe_lazy)
+                let server_resolves = client_can_use_resolve
+                    && actions.iter().any(maybe_lazy)
                     && t.pool
                         .host_server_advertises(
                             &t.server_name,

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -167,10 +167,12 @@ impl Kakehashi {
         // edit so a stale/malformed one can't escape the region into unrelated
         // host text (see `translate_edit_host_ward_strict`).
         //
-        // Host-layer actions carry no region (verbatim, no translation), so the
-        // gate — which ULID-parses `region_id` and would fail on the empty host
-        // one — is skipped; `region_end` is unused on the host resolve path.
-        let region_end = if envelope.host_layer {
+        // A genuine host-layer action carries no region (verbatim, no
+        // translation), so the gate — which ULID-parses `region_id` and would
+        // fail on the empty host one — is skipped; `region_end` is unused on the
+        // host resolve path. `is_host_layer` requires the empty `region_id`, so a
+        // client can't flip `host_layer` on a virt envelope to skip the gate.
+        let region_end = if envelope.is_host_layer() {
             Position::default()
         } else {
             match self.code_action_region_end_if_fresh(&envelope) {

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -170,8 +170,12 @@ impl Kakehashi {
         // A genuine host-layer action carries no region (verbatim, no
         // translation), so the gate — which ULID-parses `region_id` and would
         // fail on the empty host one — is skipped; `region_end` is unused on the
-        // host resolve path. `is_host_layer` requires the empty `region_id`, so a
-        // client can't flip `host_layer` on a virt envelope to skip the gate.
+        // host resolve path. `is_host_layer` additionally requires the empty
+        // `region_id`, so a CONFORMING client can't skip the gate merely by
+        // toggling `host_layer` on a virt envelope. It is not a security boundary
+        // (the envelope round-trips through unprotected client `data`, so a client
+        // could clear `region_id` too) — it guards against accidental bypass, and
+        // the host path fails soft anyway.
         let region_end = if envelope.is_host_layer() {
             Position::default()
         } else {

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -166,13 +166,24 @@ impl Kakehashi {
         // the region's current host-document end, which bounds the resolved
         // edit so a stale/malformed one can't escape the region into unrelated
         // host text (see `translate_edit_host_ward_strict`).
-        let Some(region_end) = self.code_action_region_end_if_fresh(&envelope) else {
-            log::debug!(
-                target: "kakehashi::bridge",
-                "codeAction/resolve: region {} is stale; returning action unresolved",
-                envelope.region_id
-            );
-            return Ok(action);
+        //
+        // Host-layer actions carry no region (verbatim, no translation), so the
+        // gate — which ULID-parses `region_id` and would fail on the empty host
+        // one — is skipped; `region_end` is unused on the host resolve path.
+        let region_end = if envelope.host_layer {
+            Position::default()
+        } else {
+            match self.code_action_region_end_if_fresh(&envelope) {
+                Some(region_end) => region_end,
+                None => {
+                    log::debug!(
+                        target: "kakehashi::bridge",
+                        "codeAction/resolve: region {} is stale; returning action unresolved",
+                        envelope.region_id
+                    );
+                    return Ok(action);
+                }
+            }
         };
 
         let settings = self.settings_manager.load_settings();
@@ -359,19 +370,33 @@ impl Kakehashi {
                         t.upstream_id,
                     )
                     .await?;
-                Ok(raw.and_then(|value| {
-                    let actions = parse_code_actions_leniently(value)?;
-                    Some(bridge_code_actions(
-                        actions,
+                let Some(value) = raw else {
+                    return Ok(None);
+                };
+                let Some(actions) = parse_code_actions_leniently(value) else {
+                    return Ok(None);
+                };
+                // Whether this host server advertises `codeAction/resolve`, so a
+                // host lazy action can be enveloped for resolve-routing back to
+                // it (#627) rather than disabled. Queried on the just-opened
+                // connection.
+                let server_resolves = t
+                    .pool
+                    .host_server_advertises(
                         &t.server_name,
-                        t.uri.as_str(),
-                        upstream_caps,
-                        // Host-layer codeAction/resolve is not bridged, so
-                        // host lazy actions are never enveloped/resolved.
-                        false,
-                        None,
-                    ))
-                }))
+                        &t.server_config,
+                        &t.uri,
+                        "codeAction/resolve",
+                    )
+                    .await;
+                Ok(Some(bridge_code_actions(
+                    actions,
+                    &t.server_name,
+                    t.uri.as_str(),
+                    upstream_caps,
+                    server_resolves,
+                    None,
+                )))
             }
         };
         let result = match ctx.strategy {

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -386,14 +386,16 @@ impl Kakehashi {
                 // host lazy action can be enveloped for resolve-routing back to
                 // it (#627) rather than disabled. Queried on the just-opened
                 // connection — but only when at least one action could actually
-                // consume the answer. `bridge_code_actions` reads `server_resolves`
-                // ONLY for an action with no edit AND no command (a possibly-lazy
-                // action); a menu of purely materialized actions never looks at
-                // it, so the probe (and its lock acquisition) is skippable on that
-                // hot path. Probing whenever such an action exists — regardless of
-                // its `data`/`disabled` — keeps the result byte-identical.
+                // consume the answer. `bridge_code_action` reads `server_resolves`
+                // ONLY for a possibly-lazy action: no edit, no command, and NOT
+                // already disabled (a disabled action returns early, before the
+                // lazy gate). A menu of purely materialized/disabled actions never
+                // looks at it, so the probe (and its lock acquisition) is skippable
+                // on that hot path.
                 let maybe_lazy = |item: &CodeActionOrCommand| match item {
-                    CodeActionOrCommand::CodeAction(a) => a.edit.is_none() && a.command.is_none(),
+                    CodeActionOrCommand::CodeAction(a) => {
+                        a.edit.is_none() && a.command.is_none() && a.disabled.is_none()
+                    }
                     CodeActionOrCommand::Command(_) => false,
                 };
                 let server_resolves = actions.iter().any(maybe_lazy)

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -381,16 +381,18 @@ impl Kakehashi {
                 // Whether this host server advertises `codeAction/resolve`, so a
                 // host lazy action can be enveloped for resolve-routing back to
                 // it (#627) rather than disabled. Queried on the just-opened
-                // connection.
-                let server_resolves = t
-                    .pool
-                    .host_server_advertises(
-                        &t.server_name,
-                        &t.server_config,
-                        &t.uri,
-                        "codeAction/resolve",
-                    )
-                    .await;
+                // connection — skipped when there are no actions, since
+                // `bridge_code_actions` returns empty regardless (avoids a
+                // redundant lock acquisition on the hot path).
+                let server_resolves = !actions.is_empty()
+                    && t.pool
+                        .host_server_advertises(
+                            &t.server_name,
+                            &t.server_config,
+                            &t.uri,
+                            "codeAction/resolve",
+                        )
+                        .await;
                 Ok(Some(bridge_code_actions(
                     actions,
                     &t.server_name,

--- a/tests/e2e_host_bridge.rs
+++ b/tests/e2e_host_bridge.rs
@@ -1091,3 +1091,117 @@ enabled = true
 
     shutdown(&mut client);
 }
+
+#[test]
+fn e2e_host_bridge_codeaction_resolve_round_trips_verbatim() {
+    // #627: a HOST-layer (bridge._self) lazy code action is enveloped, and its
+    // codeAction/resolve routes back to the host server VERBATIM (no coordinate
+    // translation), materializing the edit on the host document. Guards against
+    // the resolve path being inert (the lsp_impl region-freshness gate must be
+    // skipped for host envelopes, which carry no region).
+    let config_dir = tempfile::TempDir::new().expect("temp dir");
+    let config_path = config_dir.path().join("host_ca.toml");
+    std::fs::write(
+        &config_path,
+        "[languages.markdown.bridge._self]\nenabled = true\n",
+    )
+    .expect("write config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("utf-8 path"))
+        .build();
+
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {
+                "textDocument": { "codeAction": {
+                    "codeActionLiteralSupport": { "codeActionKind": {
+                        "valueSet": ["quickfix", "source", "source.organizeImports"]
+                    } },
+                    "dataSupport": true,
+                    "resolveSupport": { "properties": ["edit"] },
+                    "disabledSupport": true,
+                    "isPreferredSupport": true
+                } }
+            },
+            "workspaceFolders": null,
+            "initializationOptions": {
+                "languageServers": {
+                    "mock-host": {
+                        "cmd": [mock_bin(), "code-action-lazy"],
+                        "languages": ["markdown"]
+                    }
+                }
+            }
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": MARKDOWN_URI,
+                "languageId": "markdown",
+                "version": 1,
+                "text": MARKDOWN
+            }
+        }),
+    );
+
+    // codeAction on the host document -> one lazy action, enveloped (host_layer)
+    // so it can be resolved. Retry while the host connection warms up.
+    let action = (0..300)
+        .find_map(|_| {
+            let resp = client.send_request(
+                "textDocument/codeAction",
+                json!({
+                    "textDocument": { "uri": MARKDOWN_URI },
+                    "range": {
+                        "start": { "line": 0, "character": 0 },
+                        "end": { "line": 0, "character": 1 }
+                    },
+                    "context": { "diagnostics": [] }
+                }),
+            );
+            let first = resp["result"].as_array().and_then(|a| a.first().cloned());
+            if first.is_none() {
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            first
+        })
+        .expect("host codeAction returns a lazy action");
+
+    assert_eq!(action["title"], "Lazy organize imports — mock-host");
+    assert!(action["edit"].is_null(), "the action is lazy (no edit yet)");
+    assert!(
+        action["data"].is_object(),
+        "a lazy host action carries a routing envelope, got: {action}"
+    );
+
+    // Resolve it -> routes to the host server verbatim; the edit materializes on
+    // the HOST document, and the mock's newText echoes the RESTORED (unsuffixed)
+    // original title.
+    let resolved = client.send_request("codeAction/resolve", action);
+    assert!(
+        resolved.get("error").is_none(),
+        "resolve errored: {resolved}"
+    );
+    let result = &resolved["result"];
+    assert_eq!(
+        result["title"], "Lazy organize imports — mock-host",
+        "resolved title is re-suffixed"
+    );
+    let edits = result["edit"]["changes"][MARKDOWN_URI]
+        .as_array()
+        .unwrap_or_else(|| panic!("resolved edit on the host doc, got: {result}"));
+    assert_eq!(
+        edits[0]["newText"], "organized:Lazy organize imports",
+        "host resolve routed with the original title restored and the edit verbatim"
+    );
+
+    shutdown(&mut client);
+}


### PR DESCRIPTION
Closes #627. Closes #615 (item 2; item 1 shipped in #630).

Host-layer (`bridge._self`) code actions carried no envelope, so their `codeAction/resolve` was never routed — data-carrying host lazy actions were disabled and title-only ones dropped. This bridges it, **verbatim** (host actions are already in host coordinates, so nothing is translated).

**What changed**
- `CodeActionEnvelope` gains `#[serde(default)] host_layer: bool` (existing virt envelopes deserialize unchanged); `envelope_host_action` mints a host envelope (origin + host_uri, no region/offset).
- The host dispatch now threads the host server's real `resolveProvider` (new `host_server_advertises`, probed on the just-opened connection) instead of a hardcoded `false`. A host lazy action from a resolving server + an envelope-capable client is enveloped for resolve-routing rather than disabled.
- `dispatch_code_action_resolve` routes a `host_layer` envelope to `send_host_code_action_resolve`, which forwards VERBATIM and applies the same disable / command-route / isPreferred / suffix / strip-or-re-envelope policy as the virt path **minus** coordinate translation and edit validation (a host edit is in real host coordinates — no cross-region/virtual-URI hazard).
- `code_action_resolve_impl` skips the virt-only region-freshness gate for host envelopes (they carry no region).
- The host lazy gate now mirrors the virt one (`data.is_some() || server_resolves`), so a title-only (LSP 3.18) host action from a resolving server is surfaced resolvable, not dropped (#615 item 2).

**Tests:** 5 unit tests (enveloping true/false, title-only true/false, serde-default backward compat) + an **e2e** (`e2e_host_bridge_codeaction_resolve_round_trips_verbatim`) proving the full round-trip: host lazy action → envelope → resolve routes to the host server → edit materializes on the host doc with the restored original title.

**Intended behaviors worth noting (not oversights):**
- The host aggregation has no eager-resolve fallback for non-envelope clients (only the virt aggregation wires `eager_resolve_lazy_actions`), so a host lazy action for a client that can't envelope is disabled, not materialized — consistent with the eager-resolve scope.
- A title-only host action + `disabledSupport` + non-envelope client is now surfaced *disabled* (`REASON_RESOLVE`) rather than dropped — the informative outcome, matching the virt layer. Clients without `disabledSupport` are unaffected (drop).

Reviewed locally + codex (which caught an inert-path bug — the region gate blocked the host branch — now fixed and covered by the e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Host-layer code actions can now be resolved directly on the originating server, preserving original document coordinates.
  * Host-layer lazy code actions are bridged or disabled based on whether the host server advertises `codeAction/resolve`.

* **Bug Fixes**
  * Improved host-layer resolve handling, including correct command routing behavior and better outcomes for “no edit/no command” cases.
  * Added backward-compatible envelope deserialization with a defaulted `host_layer` flag.

* **Tests**
  * Added/extended unit and end-to-end coverage for host-layer resolve round-trips, envelope behavior, and command-only/still-lazy scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->