### PR TITLE
fix(completion): preserve incomplete empty results

### DIFF
--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -201,6 +201,14 @@ pub(crate) fn is_empty_layer_value(value: &serde_json::Value) -> bool {
     if let Some(object) = value.as_object() {
         for key in ["items", "signatures", "ranges"] {
             if let Some(list) = object.get(key).and_then(serde_json::Value::as_array) {
+                if key == "items"
+                    && object
+                        .get("isIncomplete")
+                        .and_then(serde_json::Value::as_bool)
+                        .unwrap_or(false)
+                {
+                    return false;
+                }
                 return list.is_empty();
             }
         }
@@ -2371,5 +2379,25 @@ mod tests {
                 "{method} must be prefiltered"
             );
         }
+    }
+
+    #[test]
+    fn incomplete_empty_completion_list_is_not_empty_layer_value() {
+        let value = serde_json::json!({
+            "isIncomplete": true,
+            "items": []
+        });
+
+        assert!(!is_empty_layer_value(&value));
+    }
+
+    #[test]
+    fn complete_empty_completion_list_is_empty_layer_value() {
+        let value = serde_json::json!({
+            "isIncomplete": false,
+            "items": []
+        });
+
+        assert!(is_empty_layer_value(&value));
     }
 }

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -186,9 +186,11 @@ pub(crate) fn resolve_layer_config_from_settings(
 
 /// Generic emptiness check for raw host-layer results in the `preferred`
 /// fan-in: `null` and `[]` are "no result", as are the object-shaped
-/// "empty but valid" responses whose single canonical list field is empty —
-/// `CompletionList.items`, `SignatureHelp.signatures`,
-/// `LinkedEditingRanges.ranges`. Without the object shapes, a
+/// "empty but valid" responses whose single canonical list field is empty:
+/// `CompletionList.items` when `isIncomplete` is not true,
+/// `SignatureHelp.signatures`, and `LinkedEditingRanges.ranges`. Keep the
+/// completion-list rule in sync with `completion_list_has_result` in the
+/// completion handler. Without the object shapes, a
 /// higher-priority host server's empty list would prematurely win the
 /// fan-in over a lower-priority server with actual results.
 pub(crate) fn is_empty_layer_value(value: &serde_json::Value) -> bool {

--- a/src/lsp/lsp_impl/text_document/completion.rs
+++ b/src/lsp/lsp_impl/text_document/completion.rs
@@ -99,6 +99,8 @@ fn completion_response_has_result(resp: &CompletionResponse) -> bool {
 }
 
 fn completion_list_has_result(list: &CompletionList) -> bool {
+    // Keep the incomplete-empty rule in sync with `is_empty_layer_value`,
+    // which applies the same LSP CompletionList semantics to raw JSON.
     list.is_incomplete || !list.items.is_empty()
 }
 

--- a/src/lsp/lsp_impl/text_document/completion.rs
+++ b/src/lsp/lsp_impl/text_document/completion.rs
@@ -3,8 +3,9 @@
 //! Walks the resolved layer order (cross-layer-aggregation): the virt layer
 //! bridges the injection region under the cursor, the host layer
 //! (host-document-bridge) bridges the host document itself with the real URI
-//! and the response verbatim. The first layer producing a non-empty result
-//! wins (`preferred`).
+//! and the response verbatim. The first layer producing completion items, or an
+//! incomplete `CompletionList` that asks the client to re-query, wins
+//! (`preferred`).
 
 use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::{

--- a/src/lsp/lsp_impl/text_document/completion.rs
+++ b/src/lsp/lsp_impl/text_document/completion.rs
@@ -7,7 +7,9 @@
 //! wins (`preferred`).
 
 use tower_lsp_server::jsonrpc::Result;
-use tower_lsp_server::ls_types::{CompletionParams, CompletionResponse, Position, Uri};
+use tower_lsp_server::ls_types::{
+    CompletionList, CompletionParams, CompletionResponse, Position, Uri,
+};
 
 use super::super::Kakehashi;
 use crate::lsp::aggregation::server::dispatch_preferred;
@@ -32,10 +34,7 @@ impl Kakehashi {
             raw_params,
             virt,
             parse_host_verbatim::<CompletionResponse>,
-            |resp: &CompletionResponse| match resp {
-                CompletionResponse::Array(items) => !items.is_empty(),
-                CompletionResponse::List(list) => !list.items.is_empty(),
-            },
+            completion_response_has_result,
         )
         .await
     }
@@ -78,7 +77,7 @@ impl Kakehashi {
                     )
                     .await
             },
-            |opt| matches!(opt, Some(list) if !list.items.is_empty()),
+            |opt| opt.as_ref().is_some_and(completion_list_has_result),
             cancel_rx,
         )
         .await;
@@ -89,5 +88,41 @@ impl Kakehashi {
                 Ok(v.map(CompletionResponse::List))
             })
             .await
+    }
+}
+
+fn completion_response_has_result(resp: &CompletionResponse) -> bool {
+    match resp {
+        CompletionResponse::Array(items) => !items.is_empty(),
+        CompletionResponse::List(list) => completion_list_has_result(list),
+    }
+}
+
+fn completion_list_has_result(list: &CompletionList) -> bool {
+    list.is_incomplete || !list.items.is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn incomplete_empty_completion_list_counts_as_result() {
+        let response = CompletionResponse::List(CompletionList {
+            is_incomplete: true,
+            items: vec![],
+        });
+
+        assert!(completion_response_has_result(&response));
+    }
+
+    #[test]
+    fn complete_empty_completion_list_counts_as_empty() {
+        let response = CompletionResponse::List(CompletionList {
+            is_incomplete: false,
+            items: vec![],
+        });
+
+        assert!(!completion_response_has_result(&response));
     }
 }


### PR DESCRIPTION
## Summary
- treat `CompletionList { isIncomplete: true, items: [] }` as a valid preferred result
- apply the same rule to raw host-layer completion-list values
- add focused regression tests for complete and incomplete empty completion lists

Fixes #591

## Tests
- `cargo test lsp::lsp_impl::text_document::completion::tests`
- `cargo test completion_list_is`
- `cargo fmt --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated completion result detection so **incomplete** suggestion lists are treated as valid results even when they contain zero items.
  * Ensured **completed** suggestion lists with an empty items array are still treated as empty results.
  * Aligned completion-layer handling for consistent “has results” behavior across completion flows.
  * Added unit tests covering both `isIncomplete: true` (non-empty result) and `isIncomplete: false` (empty result).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->