### PR TITLE
fix(config): parse wrapped didChange settings

### DIFF
--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -609,7 +609,7 @@ pub(crate) fn infer_query_kind(path: &str) -> Option<QueryKind> {
     }
 }
 
-#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RawWorkspaceSettings {
     /// Directories to search for Tree-sitter parser libraries and query files.
@@ -629,6 +629,12 @@ pub struct RawWorkspaceSettings {
     /// Language servers for bridging LSP requests to injection regions.
     /// Map of server name to server configuration.
     pub language_servers: Option<HashMap<String, BridgeServerConfig>>,
+}
+
+impl RawWorkspaceSettings {
+    pub fn is_effectively_empty(&self) -> bool {
+        self == &Self::default()
+    }
 }
 
 /// Generate JSON Schema for the workspace configuration.

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -1,5 +1,8 @@
 //! didChangeConfiguration notification handler for Kakehashi.
 
+use std::collections::HashSet;
+use std::sync::OnceLock;
+
 use tower_lsp_server::ls_types::DidChangeConfigurationParams;
 
 use crate::config::{RawWorkspaceSettings, WorkspaceSettings, merge_workspace_settings};
@@ -208,15 +211,24 @@ fn has_known_configuration_key(value: &serde_json::Value) -> bool {
 }
 
 fn is_known_configuration_key(key: &str) -> bool {
-    matches!(
-        key,
-        "searchPaths"
-            | "languages"
-            | "captureMappings"
-            | "autoInstall"
-            | "diagnosticsDebounceMs"
-            | "languageServers"
-    )
+    known_configuration_keys().contains(key)
+}
+
+fn known_configuration_keys() -> &'static HashSet<String> {
+    static KEYS: OnceLock<HashSet<String>> = OnceLock::new();
+
+    KEYS.get_or_init(|| {
+        let schema = serde_json::to_value(crate::config::json_schema()).unwrap_or_else(|err| {
+            log::warn!("failed to serialize RawWorkspaceSettings schema: {err}");
+            serde_json::Value::Null
+        });
+
+        schema
+            .get("properties")
+            .and_then(|properties| properties.as_object())
+            .map(|properties| properties.keys().cloned().collect())
+            .unwrap_or_default()
+    })
 }
 
 fn raw_workspace_settings_is_empty(settings: &RawWorkspaceSettings) -> bool {
@@ -349,6 +361,23 @@ mod tests {
 
         assert!(raw_workspace_settings_is_empty(&update.settings));
         assert!(update.warnings.is_empty());
+    }
+
+    #[test]
+    fn known_configuration_keys_come_from_schema_properties() {
+        let schema = serde_json::to_value(crate::config::json_schema())
+            .expect("RawWorkspaceSettings schema should serialize");
+        let expected: HashSet<_> = schema
+            .get("properties")
+            .and_then(|properties| properties.as_object())
+            .expect("schema should define top-level properties")
+            .keys()
+            .cloned()
+            .collect();
+
+        assert_eq!(known_configuration_keys(), &expected);
+        assert!(is_known_configuration_key("autoInstall"));
+        assert!(!is_known_configuration_key("autoInstal"));
     }
 
     #[test]

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -38,11 +38,13 @@ impl Kakehashi {
             }
         };
 
-        for warning in &parsed.warnings {
+        let ClientConfigurationUpdate { settings, warnings } = parsed;
+
+        for warning in warnings {
             self.notifier().log_warning(warning).await;
         }
 
-        if raw_workspace_settings_is_empty(&parsed.settings) {
+        if raw_workspace_settings_is_empty(&settings) {
             return;
         }
 
@@ -52,8 +54,7 @@ impl Kakehashi {
         let current_ts = self.settings_manager.load_raw_settings();
         // SAFETY: merge_workspace_settings(Some, Some) always returns Some, so unwrap_or_return is
         // defensive only — the None branch is unreachable under the current implementation.
-        let Some(merged_ts) =
-            merge_workspace_settings(Some((*current_ts).clone()), Some(parsed.settings))
+        let Some(merged_ts) = merge_workspace_settings(Some((*current_ts).clone()), Some(settings))
         else {
             log::warn!(
                 "merge_workspace_settings returned None despite two Some inputs; skipping configuration update"

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -122,20 +122,28 @@ fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientCon
         let top_level_flat = flat_configuration_without_wrappers(&value);
         let settings_root_has_signal = has_configuration_signal(settings_root);
         let top_level_flat_has_signal = has_configuration_signal(&top_level_flat);
-        let top_level_flat_ignored = ignored_keys(&top_level_flat);
-        let (raw_value, has_signal) = if settings_root_has_signal {
-            (settings_root.clone(), true)
-        } else if top_level_flat_has_signal {
+        if settings_root_has_signal {
+            let mut ignored = ignored_keys(settings_root);
+            let mut raw_value = settings_root.clone();
+            if let Some(raw_object) = raw_value.as_object_mut()
+                && let Some(top_level_object) = top_level_flat.as_object()
+            {
+                merge_flat_sibling_settings(raw_object, &mut ignored, top_level_object);
+            }
+            let warnings = ignored_key_warnings_from_keys(ignored);
+            return NormalizedClientConfiguration {
+                raw_value,
+                warnings,
+            };
+        }
+
+        let (raw_value, has_signal) = if top_level_flat_has_signal {
             (top_level_flat, true)
         } else {
             (settings_root.clone(), false)
         };
         let warnings = if has_signal {
-            let mut ignored = ignored_keys(&raw_value);
-            if settings_root_has_signal {
-                ignored.extend(top_level_flat_ignored);
-            }
-            ignored_key_warnings_from_keys(ignored)
+            ignored_key_warnings_from_keys(ignored_keys(&raw_value))
         } else {
             Vec::new()
         };
@@ -507,6 +515,22 @@ mod tests {
             update.warnings,
             vec!["Ignored unknown client configuration key(s): autoInstal"]
         );
+    }
+
+    #[test]
+    fn merges_known_top_level_keys_with_settings_root() {
+        let update = parse_client_configuration(serde_json::json!({
+            "settings": {
+                "autoInstall": false
+            },
+            "autoInstall": true,
+            "diagnosticsDebounceMs": 250
+        }))
+        .expect("settings-root payload with top-level known keys should parse");
+
+        assert_eq!(update.settings.auto_install, Some(false));
+        assert_eq!(update.settings.diagnostics_debounce_ms, Some(250));
+        assert!(update.warnings.is_empty());
     }
 
     #[test]

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -9,11 +9,21 @@ use super::super::Kakehashi;
 impl Kakehashi {
     /// Handle workspace/didChangeConfiguration notification.
     pub(crate) async fn did_change_configuration_impl(&self, params: DidChangeConfigurationParams) {
+        let parsed = match parse_client_configuration(params.settings) {
+            Ok(update) => update,
+            Err(err) => {
+                self.notifier()
+                    .log_warning(format!("Failed to parse client configuration: {}", err))
+                    .await;
+                return;
+            }
+        };
+
         // Nudge users off the deprecated `rootMarkers` key if this push carries
         // it. Detect from the raw value before serde's alias erases which key
         // was used; the claim guard shares the once-per-session slot with the
         // initialize path.
-        if crate::config::deprecation::json_uses_deprecated_root_markers(&params.settings)
+        if crate::config::deprecation::json_uses_deprecated_root_markers(&parsed.raw_value)
             && self
                 .settings_manager
                 .claim_root_markers_deprecation_warning()
@@ -23,16 +33,9 @@ impl Kakehashi {
                 .await;
         }
 
-        // Parse the incoming settings
-        let parsed = match serde_json::from_value::<RawWorkspaceSettings>(params.settings) {
-            Ok(settings) => settings,
-            Err(err) => {
-                self.notifier()
-                    .log_warning(format!("Failed to parse client configuration: {}", err))
-                    .await;
-                return;
-            }
-        };
+        for warning in &parsed.warnings {
+            self.notifier().log_warning(warning).await;
+        }
 
         // Merge onto current effective settings (not from scratch).
         // The current settings already reflect defaults < user < project < initializationOptions,
@@ -40,7 +43,8 @@ impl Kakehashi {
         let current_ts = self.settings_manager.load_raw_settings();
         // SAFETY: merge_workspace_settings(Some, Some) always returns Some, so unwrap_or_return is
         // defensive only — the None branch is unreachable under the current implementation.
-        let Some(merged_ts) = merge_workspace_settings(Some((*current_ts).clone()), Some(parsed))
+        let Some(merged_ts) =
+            merge_workspace_settings(Some((*current_ts).clone()), Some(parsed.settings))
         else {
             log::warn!(
                 "merge_workspace_settings returned None despite two Some inputs; skipping configuration update"
@@ -66,5 +70,101 @@ impl Kakehashi {
                 self.notifier().log_settings_events(&[event]).await;
             }
         }
+    }
+}
+
+struct ClientConfigurationUpdate {
+    settings: RawWorkspaceSettings,
+    raw_value: serde_json::Value,
+    warnings: Vec<String>,
+}
+
+fn parse_client_configuration(
+    value: serde_json::Value,
+) -> Result<ClientConfigurationUpdate, serde_json::Error> {
+    let raw_value = unwrap_kakehashi_settings(value);
+    let warnings = ignored_key_warnings(&raw_value);
+    let settings = serde_json::from_value::<RawWorkspaceSettings>(raw_value.clone())?;
+
+    Ok(ClientConfigurationUpdate {
+        settings,
+        raw_value,
+        warnings,
+    })
+}
+
+fn unwrap_kakehashi_settings(value: serde_json::Value) -> serde_json::Value {
+    value
+        .get("settings")
+        .and_then(|settings| settings.get("kakehashi"))
+        .cloned()
+        .or_else(|| value.get("kakehashi").cloned())
+        .unwrap_or(value)
+}
+
+fn ignored_key_warnings(value: &serde_json::Value) -> Vec<String> {
+    let Some(object) = value.as_object() else {
+        return Vec::new();
+    };
+
+    let mut ignored: Vec<_> = object
+        .keys()
+        .filter(|key| {
+            !matches!(
+                key.as_str(),
+                "searchPaths"
+                    | "languages"
+                    | "captureMappings"
+                    | "autoInstall"
+                    | "diagnosticsDebounceMs"
+                    | "languageServers"
+            )
+        })
+        .cloned()
+        .collect();
+    ignored.sort();
+
+    if ignored.is_empty() {
+        Vec::new()
+    } else {
+        vec![format!(
+            "Ignored unknown client configuration key(s): {}",
+            ignored.join(", ")
+        )]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_section_wrapped_kakehashi_settings() {
+        let update = parse_client_configuration(serde_json::json!({
+            "settings": {
+                "kakehashi": {
+                    "autoInstall": false
+                }
+            }
+        }))
+        .expect("section-wrapped settings should parse");
+
+        assert_eq!(update.settings.auto_install, Some(false));
+        assert!(update.warnings.is_empty());
+    }
+
+    #[test]
+    fn warns_about_unknown_flat_keys() {
+        let update = parse_client_configuration(serde_json::json!({
+            "autoInstal": false,
+            "autoInstall": true
+        }))
+        .expect("settings with unknown keys should still parse");
+
+        assert_eq!(update.settings.auto_install, Some(true));
+        assert_eq!(
+            update.warnings,
+            vec!["Ignored unknown client configuration key(s): autoInstal"]
+        );
     }
 }

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -144,9 +144,7 @@ fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientCon
     let mut raw_value = inner.clone();
 
     if let Some(raw_object) = raw_value.as_object_mut() {
-        if value.get("settings").is_some()
-            && let Some(settings_object) = settings_root.as_object()
-        {
+        if let Some(settings_object) = value["settings"].as_object() {
             merge_flat_sibling_settings(raw_object, &mut warnings, settings_object);
         }
 

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -122,6 +122,7 @@ fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientCon
         let top_level_flat = flat_configuration_without_wrappers(&value);
         let settings_root_has_signal = has_configuration_signal(settings_root);
         let top_level_flat_has_signal = has_configuration_signal(&top_level_flat);
+        let top_level_flat_ignored = ignored_keys(&top_level_flat);
         let (raw_value, has_signal) = if settings_root_has_signal {
             (settings_root.clone(), true)
         } else if top_level_flat_has_signal {
@@ -130,7 +131,11 @@ fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientCon
             (settings_root.clone(), false)
         };
         let warnings = if has_signal {
-            ignored_key_warnings(&raw_value)
+            let mut ignored = ignored_keys(&raw_value);
+            if settings_root_has_signal {
+                ignored.extend(top_level_flat_ignored);
+            }
+            ignored_key_warnings_from_keys(ignored)
         } else {
             Vec::new()
         };
@@ -173,8 +178,9 @@ fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientCon
     }
 }
 
-fn ignored_key_warnings(value: &serde_json::Value) -> Vec<String> {
-    let ignored = ignored_keys(value);
+fn ignored_key_warnings_from_keys(mut ignored: Vec<String>) -> Vec<String> {
+    ignored.sort();
+    ignored.dedup();
     if ignored.is_empty() {
         Vec::new()
     } else {
@@ -484,6 +490,23 @@ mod tests {
 
         assert_eq!(update.settings.auto_install, Some(false));
         assert!(update.warnings.is_empty());
+    }
+
+    #[test]
+    fn warns_about_unknown_top_level_keys_dropped_for_settings_root() {
+        let update = parse_client_configuration(serde_json::json!({
+            "settings": {
+                "autoInstall": false
+            },
+            "autoInstal": true
+        }))
+        .expect("settings-root payload with top-level typo should parse");
+
+        assert_eq!(update.settings.auto_install, Some(false));
+        assert_eq!(
+            update.warnings,
+            vec!["Ignored unknown client configuration key(s): autoInstal"]
+        );
     }
 
     #[test]

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -9,21 +9,13 @@ use super::super::Kakehashi;
 impl Kakehashi {
     /// Handle workspace/didChangeConfiguration notification.
     pub(crate) async fn did_change_configuration_impl(&self, params: DidChangeConfigurationParams) {
-        let parsed = match parse_client_configuration(params.settings) {
-            Ok(update) => update,
-            Err(err) => {
-                self.notifier()
-                    .log_warning(format!("Failed to parse client configuration: {}", err))
-                    .await;
-                return;
-            }
-        };
+        let normalized = normalize_kakehashi_settings(params.settings);
 
         // Nudge users off the deprecated `rootMarkers` key if this push carries
         // it. Detect from the raw value before serde's alias erases which key
         // was used; the claim guard shares the once-per-session slot with the
         // initialize path.
-        if crate::config::deprecation::json_uses_deprecated_root_markers(&parsed.raw_value)
+        if crate::config::deprecation::json_uses_deprecated_root_markers(&normalized.raw_value)
             && self
                 .settings_manager
                 .claim_root_markers_deprecation_warning()
@@ -32,6 +24,16 @@ impl Kakehashi {
                 .show_warning(crate::config::deprecation::ROOT_MARKERS_DEPRECATION_NOTICE)
                 .await;
         }
+
+        let parsed = match parse_normalized_client_configuration(normalized) {
+            Ok(update) => update,
+            Err(err) => {
+                self.notifier()
+                    .log_warning(format!("Failed to parse client configuration: {}", err))
+                    .await;
+                return;
+            }
+        };
 
         for warning in &parsed.warnings {
             self.notifier().log_warning(warning).await;
@@ -79,31 +81,43 @@ impl Kakehashi {
 
 struct ClientConfigurationUpdate {
     settings: RawWorkspaceSettings,
+    warnings: Vec<String>,
+}
+
+struct NormalizedClientConfiguration {
     raw_value: serde_json::Value,
     warnings: Vec<String>,
 }
 
+#[cfg(test)]
 fn parse_client_configuration(
     value: serde_json::Value,
 ) -> Result<ClientConfigurationUpdate, serde_json::Error> {
-    let (raw_value, warnings) = normalize_kakehashi_settings(value);
-    let settings = serde_json::from_value::<RawWorkspaceSettings>(raw_value.clone())?;
+    parse_normalized_client_configuration(normalize_kakehashi_settings(value))
+}
+
+fn parse_normalized_client_configuration(
+    normalized: NormalizedClientConfiguration,
+) -> Result<ClientConfigurationUpdate, serde_json::Error> {
+    let settings = serde_json::from_value::<RawWorkspaceSettings>(normalized.raw_value.clone())?;
 
     Ok(ClientConfigurationUpdate {
         settings,
-        raw_value,
-        warnings,
+        warnings: normalized.warnings,
     })
 }
 
-fn normalize_kakehashi_settings(value: serde_json::Value) -> (serde_json::Value, Vec<String>) {
+fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientConfiguration {
     let Some(inner) = value
         .get("settings")
         .and_then(|settings| settings.get("kakehashi"))
         .or_else(|| value.get("kakehashi"))
     else {
         let warnings = ignored_key_warnings(&value);
-        return (value, warnings);
+        return NormalizedClientConfiguration {
+            raw_value: value,
+            warnings,
+        };
     };
 
     let mut warnings = Vec::new();
@@ -132,15 +146,18 @@ fn normalize_kakehashi_settings(value: serde_json::Value) -> (serde_json::Value,
     warnings.dedup();
 
     if warnings.is_empty() {
-        (raw_value, Vec::new())
-    } else {
-        (
+        NormalizedClientConfiguration {
             raw_value,
-            vec![format!(
+            warnings: Vec::new(),
+        }
+    } else {
+        NormalizedClientConfiguration {
+            raw_value,
+            warnings: vec![format!(
                 "Ignored unknown client configuration key(s): {}",
                 warnings.join(", ")
             )],
-        )
+        }
     }
 }
 
@@ -282,5 +299,22 @@ mod tests {
         .expect("empty languageServers should parse");
 
         assert!(!raw_workspace_settings_is_empty(&update.settings));
+    }
+
+    #[test]
+    fn normalization_preserves_deprecated_root_markers_before_parse_error() {
+        let normalized = normalize_kakehashi_settings(serde_json::json!({
+            "languageServers": {
+                "rust-analyzer": {
+                    "rootMarkers": [".git"],
+                    "cmd": "rust-analyzer"
+                }
+            }
+        }));
+
+        assert!(
+            crate::config::deprecation::json_uses_deprecated_root_markers(&normalized.raw_value)
+        );
+        assert!(parse_normalized_client_configuration(normalized).is_err());
     }
 }

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -124,13 +124,21 @@ fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientCon
         .or_else(|| value.get("kakehashi"))
         .filter(|value| value.is_object())
     else {
-        let warnings = if has_known_configuration_key(&settings_root) {
-            ignored_key_warnings(&settings_root)
+        let top_level_flat = flat_configuration_without_wrappers(&value);
+        let raw_value = if has_configuration_signal(&settings_root) {
+            settings_root
+        } else if has_configuration_signal(&top_level_flat) {
+            top_level_flat
+        } else {
+            settings_root
+        };
+        let warnings = if has_configuration_signal(&raw_value) {
+            ignored_key_warnings(&raw_value)
         } else {
             Vec::new()
         };
         return NormalizedClientConfiguration {
-            raw_value: settings_root,
+            raw_value,
             warnings,
         };
     };
@@ -138,21 +146,15 @@ fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientCon
     let mut warnings = Vec::new();
     let mut raw_value = inner.clone();
 
-    if let Some(raw_object) = raw_value.as_object_mut()
-        && let Some(root_object) = value.as_object()
-    {
-        for (key, candidate) in root_object {
-            if key == "settings" || key == "kakehashi" {
-                continue;
-            }
+    if let Some(raw_object) = raw_value.as_object_mut() {
+        if let Some(root_object) = value.as_object() {
+            merge_flat_sibling_settings(raw_object, &mut warnings, root_object);
+        }
 
-            if is_known_configuration_key(key) {
-                raw_object
-                    .entry(key.clone())
-                    .or_insert_with(|| candidate.clone());
-            } else {
-                warnings.push(key.clone());
-            }
+        if value.get("settings").is_some()
+            && let Some(settings_object) = settings_root.as_object()
+        {
+            merge_flat_sibling_settings(raw_object, &mut warnings, settings_object);
         }
     }
 
@@ -194,12 +196,50 @@ fn ignored_keys(value: &serde_json::Value) -> Vec<String> {
     };
 
     let mut ignored: Vec<_> = object
-        .keys()
-        .filter(|key| !is_known_configuration_key(key))
-        .cloned()
+        .iter()
+        .filter(|(key, value)| should_warn_unknown_key(key, value))
+        .map(|(key, _)| key.clone())
         .collect();
     ignored.sort();
     ignored
+}
+
+fn flat_configuration_without_wrappers(value: &serde_json::Value) -> serde_json::Value {
+    let Some(object) = value.as_object() else {
+        return serde_json::Value::Object(serde_json::Map::new());
+    };
+
+    serde_json::Value::Object(
+        object
+            .iter()
+            .filter(|(key, _)| key.as_str() != "settings" && key.as_str() != "kakehashi")
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect(),
+    )
+}
+
+fn merge_flat_sibling_settings(
+    raw_object: &mut serde_json::Map<String, serde_json::Value>,
+    warnings: &mut Vec<String>,
+    siblings: &serde_json::Map<String, serde_json::Value>,
+) {
+    for (key, candidate) in siblings {
+        if key == "settings" || key == "kakehashi" {
+            continue;
+        }
+
+        if is_known_configuration_key(key) {
+            raw_object
+                .entry(key.clone())
+                .or_insert_with(|| candidate.clone());
+        } else if should_warn_unknown_key(key, candidate) {
+            warnings.push(key.clone());
+        }
+    }
+}
+
+fn has_configuration_signal(value: &serde_json::Value) -> bool {
+    has_known_configuration_key(value) || has_probable_unknown_configuration_key(value)
 }
 
 fn has_known_configuration_key(value: &serde_json::Value) -> bool {
@@ -208,6 +248,22 @@ fn has_known_configuration_key(value: &serde_json::Value) -> bool {
             .keys()
             .any(|key| is_known_configuration_key(key.as_str()))
     })
+}
+
+fn has_probable_unknown_configuration_key(value: &serde_json::Value) -> bool {
+    value.as_object().is_some_and(|object| {
+        object
+            .iter()
+            .any(|(key, value)| should_warn_unknown_key(key, value))
+    })
+}
+
+fn should_warn_unknown_key(key: &str, value: &serde_json::Value) -> bool {
+    !is_known_configuration_key(key)
+        && key != "settings"
+        && key != "kakehashi"
+        && !key.contains('.')
+        && !value.is_object()
 }
 
 fn is_known_configuration_key(key: &str) -> bool {
@@ -295,6 +351,27 @@ mod tests {
     }
 
     #[test]
+    fn merges_settings_root_flat_siblings_with_wrapped_settings() {
+        let update = parse_client_configuration(serde_json::json!({
+            "settings": {
+                "kakehashi": {
+                    "autoInstall": false
+                },
+                "diagnosticsDebounceMs": 250,
+                "editorSetting": true
+            }
+        }))
+        .expect("settings-root mixed wrapped and flat settings should parse");
+
+        assert_eq!(update.settings.auto_install, Some(false));
+        assert_eq!(update.settings.diagnostics_debounce_ms, Some(250));
+        assert_eq!(
+            update.warnings,
+            vec!["Ignored unknown client configuration key(s): editorSetting"]
+        );
+    }
+
+    #[test]
     fn warns_about_unknown_wrapped_keys() {
         let update = parse_client_configuration(serde_json::json!({
             "kakehashi": {
@@ -319,7 +396,10 @@ mod tests {
         .expect("unknown-only settings should still parse");
 
         assert!(raw_workspace_settings_is_empty(&update.settings));
-        assert!(update.warnings.is_empty());
+        assert_eq!(
+            update.warnings,
+            vec!["Ignored unknown client configuration key(s): autoInstal"]
+        );
     }
 
     #[test]
@@ -336,6 +416,22 @@ mod tests {
     }
 
     #[test]
+    fn parses_top_level_known_keys_when_settings_contains_other_servers() {
+        let update = parse_client_configuration(serde_json::json!({
+            "settings": {
+                "gopls": {
+                    "usePlaceholders": true
+                }
+            },
+            "autoInstall": false
+        }))
+        .expect("top-level known settings should parse beside other server settings");
+
+        assert_eq!(update.settings.auto_install, Some(false));
+        assert!(update.warnings.is_empty());
+    }
+
+    #[test]
     fn ignores_other_servers_settings_without_warning() {
         let update = parse_client_configuration(serde_json::json!({
             "settings": {
@@ -345,6 +441,20 @@ mod tests {
             }
         }))
         .expect("other servers' settings should parse as an empty update");
+
+        assert!(raw_workspace_settings_is_empty(&update.settings));
+        assert!(update.warnings.is_empty());
+    }
+
+    #[test]
+    fn ignores_dotted_editor_settings_without_warning() {
+        let update = parse_client_configuration(serde_json::json!({
+            "editor.fontSize": 14,
+            "gopls": {
+                "usePlaceholders": true
+            }
+        }))
+        .expect("editor settings should parse as an empty update");
 
         assert!(raw_workspace_settings_is_empty(&update.settings));
         assert!(update.warnings.is_empty());

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -37,6 +37,10 @@ impl Kakehashi {
             self.notifier().log_warning(warning).await;
         }
 
+        if raw_workspace_settings_is_empty(&parsed.settings) {
+            return;
+        }
+
         // Merge onto current effective settings (not from scratch).
         // The current settings already reflect defaults < user < project < initializationOptions,
         // so merging preserves languages and other fields set during initialize.
@@ -82,8 +86,7 @@ struct ClientConfigurationUpdate {
 fn parse_client_configuration(
     value: serde_json::Value,
 ) -> Result<ClientConfigurationUpdate, serde_json::Error> {
-    let raw_value = unwrap_kakehashi_settings(value);
-    let warnings = ignored_key_warnings(&raw_value);
+    let (raw_value, warnings) = normalize_kakehashi_settings(value);
     let settings = serde_json::from_value::<RawWorkspaceSettings>(raw_value.clone())?;
 
     Ok(ClientConfigurationUpdate {
@@ -93,37 +96,56 @@ fn parse_client_configuration(
     })
 }
 
-fn unwrap_kakehashi_settings(value: serde_json::Value) -> serde_json::Value {
-    value
+fn normalize_kakehashi_settings(value: serde_json::Value) -> (serde_json::Value, Vec<String>) {
+    let Some(inner) = value
         .get("settings")
         .and_then(|settings| settings.get("kakehashi"))
-        .cloned()
-        .or_else(|| value.get("kakehashi").cloned())
-        .unwrap_or(value)
+        .or_else(|| value.get("kakehashi"))
+    else {
+        let warnings = ignored_key_warnings(&value);
+        return (value, warnings);
+    };
+
+    let mut warnings = Vec::new();
+    let mut raw_value = inner.clone();
+
+    if let Some(raw_object) = raw_value.as_object_mut() {
+        if let Some(root_object) = value.as_object() {
+            for (key, candidate) in root_object {
+                if key == "settings" || key == "kakehashi" {
+                    continue;
+                }
+
+                if is_known_configuration_key(key) {
+                    raw_object
+                        .entry(key.clone())
+                        .or_insert_with(|| candidate.clone());
+                } else {
+                    warnings.push(key.clone());
+                }
+            }
+        }
+    }
+
+    warnings.extend(ignored_keys(&raw_value));
+    warnings.sort();
+    warnings.dedup();
+
+    if warnings.is_empty() {
+        (raw_value, Vec::new())
+    } else {
+        (
+            raw_value,
+            vec![format!(
+                "Ignored unknown client configuration key(s): {}",
+                warnings.join(", ")
+            )],
+        )
+    }
 }
 
 fn ignored_key_warnings(value: &serde_json::Value) -> Vec<String> {
-    let Some(object) = value.as_object() else {
-        return Vec::new();
-    };
-
-    let mut ignored: Vec<_> = object
-        .keys()
-        .filter(|key| {
-            !matches!(
-                key.as_str(),
-                "searchPaths"
-                    | "languages"
-                    | "captureMappings"
-                    | "autoInstall"
-                    | "diagnosticsDebounceMs"
-                    | "languageServers"
-            )
-        })
-        .cloned()
-        .collect();
-    ignored.sort();
-
+    let ignored = ignored_keys(value);
     if ignored.is_empty() {
         Vec::new()
     } else {
@@ -132,6 +154,41 @@ fn ignored_key_warnings(value: &serde_json::Value) -> Vec<String> {
             ignored.join(", ")
         )]
     }
+}
+
+fn ignored_keys(value: &serde_json::Value) -> Vec<String> {
+    let Some(object) = value.as_object() else {
+        return Vec::new();
+    };
+
+    let mut ignored: Vec<_> = object
+        .keys()
+        .filter(|key| !is_known_configuration_key(key))
+        .cloned()
+        .collect();
+    ignored.sort();
+    ignored
+}
+
+fn is_known_configuration_key(key: &str) -> bool {
+    matches!(
+        key,
+        "searchPaths"
+            | "languages"
+            | "captureMappings"
+            | "autoInstall"
+            | "diagnosticsDebounceMs"
+            | "languageServers"
+    )
+}
+
+fn raw_workspace_settings_is_empty(settings: &RawWorkspaceSettings) -> bool {
+    settings.search_paths.is_none()
+        && settings.languages.is_empty()
+        && settings.capture_mappings.is_empty()
+        && settings.auto_install.is_none()
+        && settings.diagnostics_debounce_ms.is_none()
+        && settings.language_servers.is_none()
 }
 
 #[cfg(test)]
@@ -154,6 +211,41 @@ mod tests {
     }
 
     #[test]
+    fn parses_top_level_wrapped_kakehashi_settings() {
+        let update = parse_client_configuration(serde_json::json!({
+            "kakehashi": {
+                "autoInstall": false
+            }
+        }))
+        .expect("top-level wrapped settings should parse");
+
+        assert_eq!(update.settings.auto_install, Some(false));
+        assert!(update.warnings.is_empty());
+    }
+
+    #[test]
+    fn merges_known_flat_siblings_with_wrapped_settings() {
+        let update = parse_client_configuration(serde_json::json!({
+            "settings": {
+                "kakehashi": {
+                    "autoInstall": false
+                }
+            },
+            "autoInstall": true,
+            "diagnosticsDebounceMs": 250,
+            "editorSetting": true
+        }))
+        .expect("mixed wrapped and flat settings should parse");
+
+        assert_eq!(update.settings.auto_install, Some(false));
+        assert_eq!(update.settings.diagnostics_debounce_ms, Some(250));
+        assert_eq!(
+            update.warnings,
+            vec!["Ignored unknown client configuration key(s): editorSetting"]
+        );
+    }
+
+    #[test]
     fn warns_about_unknown_flat_keys() {
         let update = parse_client_configuration(serde_json::json!({
             "autoInstal": false,
@@ -166,5 +258,29 @@ mod tests {
             update.warnings,
             vec!["Ignored unknown client configuration key(s): autoInstal"]
         );
+    }
+
+    #[test]
+    fn recognizes_empty_client_configuration() {
+        let update = parse_client_configuration(serde_json::json!({
+            "autoInstal": false
+        }))
+        .expect("unknown-only settings should still parse");
+
+        assert!(raw_workspace_settings_is_empty(&update.settings));
+        assert_eq!(
+            update.warnings,
+            vec!["Ignored unknown client configuration key(s): autoInstal"]
+        );
+    }
+
+    #[test]
+    fn language_servers_empty_map_is_effective_configuration() {
+        let update = parse_client_configuration(serde_json::json!({
+            "languageServers": {}
+        }))
+        .expect("empty languageServers should parse");
+
+        assert!(!raw_workspace_settings_is_empty(&update.settings));
     }
 }

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -123,20 +123,20 @@ fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientCon
     let mut warnings = Vec::new();
     let mut raw_value = inner.clone();
 
-    if let Some(raw_object) = raw_value.as_object_mut() {
-        if let Some(root_object) = value.as_object() {
-            for (key, candidate) in root_object {
-                if key == "settings" || key == "kakehashi" {
-                    continue;
-                }
+    if let Some(raw_object) = raw_value.as_object_mut()
+        && let Some(root_object) = value.as_object()
+    {
+        for (key, candidate) in root_object {
+            if key == "settings" || key == "kakehashi" {
+                continue;
+            }
 
-                if is_known_configuration_key(key) {
-                    raw_object
-                        .entry(key.clone())
-                        .or_insert_with(|| candidate.clone());
-                } else {
-                    warnings.push(key.clone());
-                }
+            if is_known_configuration_key(key) {
+                raw_object
+                    .entry(key.clone())
+                    .or_insert_with(|| candidate.clone());
+            } else {
+                warnings.push(key.clone());
             }
         }
     }

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -263,11 +263,59 @@ fn should_warn_unknown_key(key: &str, value: &serde_json::Value) -> bool {
         && key != "settings"
         && key != "kakehashi"
         && !key.contains('.')
-        && (!value.is_object() || key.chars().any(|ch| ch.is_ascii_uppercase()))
+        && (!value.is_object()
+            || key.chars().any(|ch| ch.is_ascii_uppercase())
+            || is_one_edit_from_known_configuration_key(key))
 }
 
 fn is_known_configuration_key(key: &str) -> bool {
     known_configuration_keys().contains(key)
+}
+
+fn is_one_edit_from_known_configuration_key(key: &str) -> bool {
+    known_configuration_keys()
+        .iter()
+        .any(|known| is_one_edit_apart(key, known))
+}
+
+fn is_one_edit_apart(left: &str, right: &str) -> bool {
+    let left = left.as_bytes();
+    let right = right.as_bytes();
+    let len_diff = left.len().abs_diff(right.len());
+    if len_diff > 1 {
+        return false;
+    }
+
+    if len_diff == 0 {
+        return left
+            .iter()
+            .zip(right.iter())
+            .filter(|(left, right)| left != right)
+            .count()
+            == 1;
+    }
+
+    let (shorter, longer) = if left.len() < right.len() {
+        (left, right)
+    } else {
+        (right, left)
+    };
+    let mut short_index = 0;
+    let mut long_index = 0;
+    let mut edits = 0;
+    while short_index < shorter.len() && long_index < longer.len() {
+        if shorter[short_index] == longer[long_index] {
+            short_index += 1;
+        } else {
+            edits += 1;
+            if edits > 1 {
+                return false;
+            }
+        }
+        long_index += 1;
+    }
+
+    true
 }
 
 fn known_configuration_keys() -> &'static HashSet<String> {
@@ -472,6 +520,20 @@ mod tests {
         assert_eq!(
             update.warnings,
             vec!["Ignored unknown client configuration key(s): languageServerss"]
+        );
+    }
+
+    #[test]
+    fn warns_about_lowercase_object_typos_near_known_keys() {
+        let update = parse_client_configuration(serde_json::json!({
+            "languagess": {}
+        }))
+        .expect("lowercase object-valued config typo should still parse");
+
+        assert!(raw_workspace_settings_is_empty(&update.settings));
+        assert_eq!(
+            update.warnings,
+            vec!["Ignored unknown client configuration key(s): languagess"]
         );
     }
 

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -112,10 +112,7 @@ fn parse_normalized_client_configuration(
 }
 
 fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientConfiguration {
-    let settings_root = value
-        .get("settings")
-        .cloned()
-        .unwrap_or_else(|| value.clone());
+    let settings_root = value.get("settings").unwrap_or(&value);
     let Some(inner) = settings_root
         .get("settings")
         .and_then(|settings| settings.get("kakehashi"))
@@ -126,14 +123,16 @@ fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientCon
         .filter(|value| value.is_object())
     else {
         let top_level_flat = flat_configuration_without_wrappers(&value);
-        let raw_value = if has_configuration_signal(&settings_root) {
-            settings_root
-        } else if has_configuration_signal(&top_level_flat) {
-            top_level_flat
+        let settings_root_has_signal = has_configuration_signal(settings_root);
+        let top_level_flat_has_signal = has_configuration_signal(&top_level_flat);
+        let (raw_value, has_signal) = if settings_root_has_signal {
+            (settings_root.clone(), true)
+        } else if top_level_flat_has_signal {
+            (top_level_flat, true)
         } else {
-            settings_root
+            (settings_root.clone(), false)
         };
-        let warnings = if has_configuration_signal(&raw_value) {
+        let warnings = if has_signal {
             ignored_key_warnings(&raw_value)
         } else {
             Vec::new()

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -99,7 +99,7 @@ fn parse_client_configuration(
 fn parse_normalized_client_configuration(
     normalized: NormalizedClientConfiguration,
 ) -> Result<ClientConfigurationUpdate, serde_json::Error> {
-    let settings = serde_json::from_value::<RawWorkspaceSettings>(normalized.raw_value.clone())?;
+    let settings = serde_json::from_value::<RawWorkspaceSettings>(normalized.raw_value)?;
 
     Ok(ClientConfigurationUpdate {
         settings,
@@ -108,14 +108,26 @@ fn parse_normalized_client_configuration(
 }
 
 fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientConfiguration {
-    let Some(inner) = value
+    let settings_root = value
+        .get("settings")
+        .cloned()
+        .unwrap_or_else(|| value.clone());
+    let Some(inner) = settings_root
         .get("settings")
         .and_then(|settings| settings.get("kakehashi"))
+        .filter(|value| value.is_object())
+        .or_else(|| settings_root.get("kakehashi"))
+        .filter(|value| value.is_object())
         .or_else(|| value.get("kakehashi"))
+        .filter(|value| value.is_object())
     else {
-        let warnings = ignored_key_warnings(&value);
+        let warnings = if has_known_configuration_key(&settings_root) {
+            ignored_key_warnings(&settings_root)
+        } else {
+            Vec::new()
+        };
         return NormalizedClientConfiguration {
-            raw_value: value,
+            raw_value: settings_root,
             warnings,
         };
     };
@@ -185,6 +197,14 @@ fn ignored_keys(value: &serde_json::Value) -> Vec<String> {
         .collect();
     ignored.sort();
     ignored
+}
+
+fn has_known_configuration_key(value: &serde_json::Value) -> bool {
+    value.as_object().is_some_and(|object| {
+        object
+            .keys()
+            .any(|key| is_known_configuration_key(key.as_str()))
+    })
 }
 
 fn is_known_configuration_key(key: &str) -> bool {
@@ -263,10 +283,12 @@ mod tests {
     }
 
     #[test]
-    fn warns_about_unknown_flat_keys() {
+    fn warns_about_unknown_wrapped_keys() {
         let update = parse_client_configuration(serde_json::json!({
-            "autoInstal": false,
-            "autoInstall": true
+            "kakehashi": {
+                "autoInstal": false,
+                "autoInstall": true
+            }
         }))
         .expect("settings with unknown keys should still parse");
 
@@ -285,10 +307,48 @@ mod tests {
         .expect("unknown-only settings should still parse");
 
         assert!(raw_workspace_settings_is_empty(&update.settings));
-        assert_eq!(
-            update.warnings,
-            vec!["Ignored unknown client configuration key(s): autoInstal"]
-        );
+        assert!(update.warnings.is_empty());
+    }
+
+    #[test]
+    fn parses_settings_root_known_keys() {
+        let update = parse_client_configuration(serde_json::json!({
+            "settings": {
+                "autoInstall": false
+            }
+        }))
+        .expect("settings-root payload should parse");
+
+        assert_eq!(update.settings.auto_install, Some(false));
+        assert!(update.warnings.is_empty());
+    }
+
+    #[test]
+    fn ignores_other_servers_settings_without_warning() {
+        let update = parse_client_configuration(serde_json::json!({
+            "settings": {
+                "gopls": {
+                    "usePlaceholders": true
+                }
+            }
+        }))
+        .expect("other servers' settings should parse as an empty update");
+
+        assert!(raw_workspace_settings_is_empty(&update.settings));
+        assert!(update.warnings.is_empty());
+    }
+
+    #[test]
+    fn non_object_kakehashi_settings_are_empty() {
+        let update = parse_client_configuration(serde_json::json!({
+            "settings": {
+                "kakehashi": null
+            }
+        }))
+        .expect("non-object wrapped settings should parse as an empty update");
+
+        assert!(raw_workspace_settings_is_empty(&update.settings));
+        assert!(update.warnings.is_empty());
     }
 
     #[test]

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -147,14 +147,14 @@ fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientCon
     let mut raw_value = inner.clone();
 
     if let Some(raw_object) = raw_value.as_object_mut() {
-        if let Some(root_object) = value.as_object() {
-            merge_flat_sibling_settings(raw_object, &mut warnings, root_object);
-        }
-
         if value.get("settings").is_some()
             && let Some(settings_object) = settings_root.as_object()
         {
             merge_flat_sibling_settings(raw_object, &mut warnings, settings_object);
+        }
+
+        if let Some(root_object) = value.as_object() {
+            merge_flat_sibling_settings(raw_object, &mut warnings, root_object);
         }
     }
 
@@ -417,6 +417,21 @@ mod tests {
             update.warnings,
             vec!["Ignored unknown client configuration key(s): editorSetting"]
         );
+    }
+
+    #[test]
+    fn settings_root_flat_siblings_precede_top_level_siblings() {
+        let update = parse_client_configuration(serde_json::json!({
+            "settings": {
+                "kakehashi": {},
+                "autoInstall": false
+            },
+            "autoInstall": true
+        }))
+        .expect("conflicting mixed settings should parse");
+
+        assert_eq!(update.settings.auto_install, Some(false));
+        assert!(update.warnings.is_empty());
     }
 
     #[test]

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -263,7 +263,7 @@ fn should_warn_unknown_key(key: &str, value: &serde_json::Value) -> bool {
         && key != "settings"
         && key != "kakehashi"
         && !key.contains('.')
-        && !value.is_object()
+        && (!value.is_object() || key.chars().any(|ch| ch.is_ascii_uppercase()))
 }
 
 fn is_known_configuration_key(key: &str) -> bool {
@@ -458,6 +458,21 @@ mod tests {
 
         assert!(raw_workspace_settings_is_empty(&update.settings));
         assert!(update.warnings.is_empty());
+    }
+
+    #[test]
+    fn warns_about_object_valued_camel_case_typos() {
+        let update = parse_client_configuration(serde_json::json!({
+            "languageServerss": {},
+            "autoInstall": true
+        }))
+        .expect("object-valued config typo should still parse");
+
+        assert_eq!(update.settings.auto_install, Some(true));
+        assert_eq!(
+            update.warnings,
+            vec!["Ignored unknown client configuration key(s): languageServerss"]
+        );
     }
 
     #[test]

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -114,10 +114,7 @@ fn parse_normalized_client_configuration(
 fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientConfiguration {
     let settings_root = value.get("settings").unwrap_or(&value);
     let Some(inner) = settings_root
-        .get("settings")
-        .and_then(|settings| settings.get("kakehashi"))
-        .filter(|value| value.is_object())
-        .or_else(|| settings_root.get("kakehashi"))
+        .get("kakehashi")
         .filter(|value| value.is_object())
         .or_else(|| value.get("kakehashi"))
         .filter(|value| value.is_object())
@@ -426,6 +423,24 @@ mod tests {
         .expect("conflicting mixed settings should parse");
 
         assert_eq!(update.settings.auto_install, Some(false));
+        assert!(update.warnings.is_empty());
+    }
+
+    #[test]
+    fn ignores_double_wrapped_kakehashi_settings() {
+        let update = parse_client_configuration(serde_json::json!({
+            "settings": {
+                "settings": {
+                    "kakehashi": {
+                        "autoInstall": false
+                    },
+                    "diagnosticsDebounceMs": 250
+                }
+            }
+        }))
+        .expect("unsupported double-wrapped settings should parse as an empty update");
+
+        assert!(raw_workspace_settings_is_empty(&update.settings));
         assert!(update.warnings.is_empty());
     }
 

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -336,12 +336,7 @@ fn known_configuration_keys() -> &'static HashSet<String> {
 }
 
 fn raw_workspace_settings_is_empty(settings: &RawWorkspaceSettings) -> bool {
-    settings.search_paths.is_none()
-        && settings.languages.is_empty()
-        && settings.capture_mappings.is_empty()
-        && settings.auto_install.is_none()
-        && settings.diagnostics_debounce_ms.is_none()
-        && settings.language_servers.is_none()
+    settings.is_effectively_empty()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- parse `workspace/didChangeConfiguration` payloads wrapped as `settings.kakehashi` or `kakehashi`
- preserve deprecation scanning on the unwrapped kakehashi config value
- warn when client config contains ignored unknown top-level keys

Fixes #595

## Tests
- `cargo test lsp::lsp_impl::workspace::did_change_configuration::tests`
- `cargo fmt --check`
- `cargo test --test e2e_config_file did_change` (0 tests matched in this build)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of workspace configuration updates by normalizing nested or partially provided settings before applying them.
  * Added more reliable warnings for unknown configuration keys and better detection of “effectively empty” updates to avoid unintended changes.
  * Preserved deprecated `rootMarkers` settings so prior behavior remains consistent.

* **Tests**
  * Added unit tests covering top-level vs section-wrapped parsing, settings merging, unknown-key warnings, effectively empty updates (including the `languageServers` edge case), and deprecated-field preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->