### PR TITLE
feat(bridge): bridge codeAction across all overlapping injection regions (#628)

### DIFF
--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -1205,39 +1205,49 @@ impl Kakehashi {
     }
 
     /// Range-overlap variant of [`Self::resolve_bridge_contexts_for_range`]:
-    /// bridge the FIRST region (document order) that intersects the range
-    /// and resolves to bridge server configs, clamping the request range to
-    /// that region so coordinate translation stays in-region — a range that
-    /// merely starts inside a region can still overshoot its end, and
-    /// save-time flows (`editor.codeActionsOnSave`) request with a
-    /// whole-document range starting at (0,0), outside any injection.
-    /// Unconfigured injections (e.g. `markdown_inline`) never shadow a
-    /// configured region further down. Only one region is bridged
-    /// (preferred semantics; multi-region merging is #568 stage 7).
-    pub(crate) async fn resolve_bridge_contexts_for_range_overlap(
+    /// bridge EVERY region (document order) that intersects the range and
+    /// resolves to bridge server configs, clamping the request range to each
+    /// region so coordinate translation stays in-region — a range that merely
+    /// starts inside a region can still overshoot its end, and save-time flows
+    /// (`editor.codeActionsOnSave`) request with a whole-document range starting
+    /// at (0,0), outside any injection. Unconfigured injections (e.g.
+    /// `markdown_inline`) contribute nothing but never shadow a configured region
+    /// further down. A range spanning several injection fences yields one context
+    /// per fence, and the caller merges their results into one menu (#628
+    /// multi-region). The common case (a range within a single fence) returns
+    /// exactly one context.
+    pub(crate) async fn resolve_bridge_contexts_for_all_overlapping_regions(
         &self,
         lsp_uri: &Uri,
         range: Range,
         method_name: &str,
-    ) -> Option<RangeRequestContext> {
+    ) -> Vec<RangeRequestContext> {
         self.ensure_fresh_tree_for_bridge(lsp_uri).await;
-        self.resolve_first_region_overlapping_range(lsp_uri, range, method_name)
+        self.resolve_all_regions_overlapping_range(lsp_uri, range, method_name)
             .await
     }
 
     /// Whole-document region scan behind
-    /// [`Self::resolve_bridge_contexts_for_range_overlap`]; the tree is
+    /// [`Self::resolve_bridge_contexts_for_all_overlapping_regions`]; the tree is
     /// already fresh (the caller awaited it).
-    async fn resolve_first_region_overlapping_range(
+    async fn resolve_all_regions_overlapping_range(
         &self,
         lsp_uri: &Uri,
         range: Range,
         method_name: &str,
-    ) -> Option<RangeRequestContext> {
-        let uri = uri_to_url(lsp_uri).ok()?;
-        let snapshot = self.documents.get(&uri)?.snapshot()?;
-        let language_name = self.document_language(&uri)?;
-        let injection_query = self.language.injection_query(&language_name)?;
+    ) -> Vec<RangeRequestContext> {
+        let Ok(uri) = uri_to_url(lsp_uri) else {
+            return Vec::new();
+        };
+        let Some(snapshot) = self.documents.get(&uri).and_then(|d| d.snapshot()) else {
+            return Vec::new();
+        };
+        let Some(language_name) = self.document_language(&uri) else {
+            return Vec::new();
+        };
+        let Some(injection_query) = self.language.injection_query(&language_name) else {
+            return Vec::new();
+        };
 
         let regions = crate::language::InjectionResolver::resolve_all(
             &self.language,
@@ -1248,10 +1258,8 @@ impl Kakehashi {
             injection_query.as_ref(),
         );
 
-        // First intersecting region that resolves to bridge server configs
-        // wins: unconfigured injections (e.g. markdown_inline) must not
-        // shadow a configured region further down the document.
         let mapper = PositionMapper::new(snapshot.text());
+        let mut contexts = Vec::new();
         for resolved in regions {
             // Clamp to the region so the translated range is in-region; skip a
             // region the range never touches.
@@ -1265,20 +1273,19 @@ impl Kakehashi {
                 language_name: language_name.clone(),
                 upstream_request_id: current_upstream_id(),
             };
-            // An intersecting region that resolves to no bridge config does not
-            // shadow a configured region further down: skip to the next.
+            // A region that resolves to no bridge config contributes nothing.
             let Some(document) = self
                 .preamble_to_document_context(preamble, method_name)
                 .await
             else {
                 continue;
             };
-            return Some(RangeRequestContext {
+            contexts.push(RangeRequestContext {
                 document,
                 range: clamped,
             });
         }
-        None
+        contexts
     }
 }
 

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -1258,6 +1258,13 @@ impl Kakehashi {
             injection_query.as_ref(),
         );
 
+        // One upstream request ID for the whole scan: every overlapping region's
+        // context shares it, and the virt codeAction path unregisters it ONCE
+        // (`unregister_all_for_upstream_id`) after fanning out to all regions.
+        // Hoisted out of the loop so that shared-ID invariant is explicit and
+        // can't drift if this scan is reused under a different request-id scope.
+        let upstream_request_id = current_upstream_id();
+
         let mapper = PositionMapper::new(snapshot.text());
         let mut contexts = Vec::new();
         for resolved in regions {
@@ -1271,7 +1278,7 @@ impl Kakehashi {
                 uri: uri.clone(),
                 resolved,
                 language_name: language_name.clone(),
-                upstream_request_id: current_upstream_id(),
+                upstream_request_id: upstream_request_id.clone(),
             };
             // A region that resolves to no bridge config contributes nothing.
             let Some(document) = self

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -26,6 +26,7 @@ use tower_lsp_server::ls_types::{
 use ulid::Ulid;
 use url::Url;
 
+use super::super::bridge_context::RangeRequestContext;
 use super::super::{Kakehashi, detect_document_language};
 use crate::config::settings::AggregationStrategy;
 use crate::language::InjectionResolver;
@@ -275,24 +276,74 @@ impl Kakehashi {
         client_progress_token: Option<NumberOrString>,
         upstream_caps: UpstreamCodeActionCaps,
     ) -> Result<Option<CodeActionResponse>> {
-        let Some(mut ctx) = self
-            .resolve_bridge_contexts_for_range_overlap(lsp_uri, range, METHOD)
-            .await
-        else {
+        // EVERY injection region the range overlaps (usually one). A range
+        // spanning several fences dispatches to each and the results are merged
+        // into one menu (#628 multi-region), in document order. Latency scales
+        // with the overlapped-region count (bounded by the document's injection
+        // count); the common case is a range within a single fence.
+        let contexts = self
+            .resolve_bridge_contexts_for_all_overlapping_regions(lsp_uri, range, METHOD)
+            .await;
+        if contexts.is_empty() {
             return Ok(None);
+        }
+
+        // All overlapping regions share THIS request's upstream id. Hold the
+        // pool registration cleanup ONCE for the whole walk (single
+        // `unregister_all` after the loop) rather than per region. The cancel
+        // subscription here is usually a redundant duplicate — the caller
+        // (`walk_layers_by_strategy` → `run_layer_race`) already subscribes the
+        // same id across the whole virt future, so this returns `None` and the
+        // outer race's `select!` cancels the loop. Keeping it makes the walk
+        // self-cancelling even if ever driven outside that race.
+        let upstream_id = contexts[0].document.upstream_request_id.clone();
+        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(upstream_id.as_ref());
+
+        let mut progress_token = client_progress_token;
+        let walk = async {
+            let mut merged: CodeActionResponse = Vec::new();
+            for mut ctx in contexts {
+                // The work-done progress token is single-use → first region only.
+                ctx.document.client_progress_token = progress_token.take();
+                if let Some(actions) = self
+                    .dispatch_virt_region_code_action(ctx, &context, upstream_caps)
+                    .await?
+                {
+                    merged.extend(actions);
+                }
+            }
+            Ok((!merged.is_empty()).then_some(merged))
         };
-        ctx.document.client_progress_token = client_progress_token;
 
-        let (cancel_rx, _cancel_guard) =
-            self.subscribe_cancel(ctx.document.upstream_request_id.as_ref());
+        // Cancel aborts the walk (dropping the in-flight region's dispatch).
+        let result = match cancel_rx {
+            Some(rx) => tokio::select! {
+                r = walk => r,
+                _ = rx => Ok(None),
+            },
+            None => walk.await,
+        };
+        self.bridge
+            .pool_arc()
+            .unregister_all_for_upstream_id(upstream_id.as_ref());
+        result
+    }
 
+    /// Fan out `textDocument/codeAction` across the servers bridging ONE
+    /// injection region, applying that region's within-layer strategy
+    /// (`bridge.<lang>.aggregation.<method>.strategy`): `preferred` returns the
+    /// highest-priority non-empty server; `concatenated` merges every server's
+    /// actions in priority order (#568 PR 7). One region of the multi-region
+    /// virt walk; cancellation and the upstream-id registration are held by the
+    /// caller for the whole walk, so this passes no `cancel_rx` of its own.
+    async fn dispatch_virt_region_code_action(
+        &self,
+        ctx: RangeRequestContext,
+        context: &CodeActionContext,
+        upstream_caps: UpstreamCodeActionCaps,
+    ) -> Result<Option<CodeActionResponse>> {
         let pool = self.bridge.pool_arc();
         let range = ctx.range;
-        // One fan-out closure, dispatched by the within-layer strategy
-        // (`bridge.<lang>.aggregation.<method>.strategy`): `preferred` returns
-        // the highest-priority non-empty server; `concatenated` merges every
-        // server's actions in priority order (#568 PR 7). The closure moves into
-        // exactly one arm.
         let f = |t: FanOutTask| {
             let context = context.clone();
             async move {
@@ -314,31 +365,30 @@ impl Kakehashi {
                     .await
             }
         };
-        let result = match ctx.document.strategy {
+        // No `cancel_rx` here: the caller holds a single cancel subscription for
+        // the whole multi-region walk and aborts it on cancel.
+        match ctx.document.strategy {
             AggregationStrategy::Preferred => {
                 dispatch_preferred(
                     &ctx.document,
                     pool.clone(),
                     f,
                     |opt| matches!(opt, Some(v) if !v.is_empty()),
-                    cancel_rx,
+                    None,
                 )
                 .await
                 .handle(&self.client, "code action", None, Ok)
                 .await
             }
             AggregationStrategy::Concatenated => {
-                dispatch_concatenated(&ctx.document, pool.clone(), f, cancel_rx, None, None)
+                dispatch_concatenated(&ctx.document, pool.clone(), f, None, None, None)
                     .await
                     .handle(&self.client, "code action", None, |vecs| {
                         Ok(concat_merge(vecs))
                     })
                     .await
             }
-        };
-        pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
-
-        result
+        }
     }
 
     /// Host layer: forward the params verbatim to the host language's own

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -315,11 +315,14 @@ impl Kakehashi {
             Ok((!merged.is_empty()).then_some(merged))
         };
 
-        // Cancel aborts the walk (dropping the in-flight region's dispatch).
+        // Cancel aborts the walk (dropping the in-flight region's dispatch) and
+        // surfaces `RequestCancelled` (-32800), matching how the outer
+        // `run_layer_race` reports cancellation — so a client `$/cancelRequest`
+        // is never masked as an empty result.
         let result = match cancel_rx {
             Some(rx) => tokio::select! {
                 r = walk => r,
-                _ = rx => Ok(None),
+                _ = rx => Err(tower_lsp_server::jsonrpc::Error::request_cancelled()),
             },
             None => walk.await,
         };

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -823,3 +823,63 @@ fn lazy_action_resolving_to_command_surfaces_it_routed() {
 
     shutdown(&mut client);
 }
+
+#[test]
+fn code_action_over_a_multi_fence_range_merges_actions_from_every_region() {
+    // #628 multi-region: a codeAction range spanning TWO injected lua fences
+    // bridges BOTH and merges their actions into one menu — previously only the
+    // first fence was bridged.
+    // Two lua fences: bodies on host lines 3 and 9.
+    const TWO_FENCE: &str = "# A\n\n```lua\nlocal x = 1\n```\n\n# B\n\n```lua\nlocal y = 2\n```\n";
+    let (mut client, init_response, _config_dir) = init_client(literal_support_caps(true));
+    assert_advertised(&init_response);
+
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": MARKDOWN_URI,
+                "languageId": "markdown",
+                "version": 1,
+                "text": TWO_FENCE
+            }
+        }),
+    );
+
+    // Range covering BOTH fence bodies (host line 3 through line 9).
+    let actions = (0..300)
+        .find_map(|_| {
+            let response = client.send_request(
+                "textDocument/codeAction",
+                json!({
+                    "textDocument": { "uri": MARKDOWN_URI },
+                    "range": {
+                        "start": { "line": 3, "character": 0 },
+                        "end": { "line": 9, "character": 5 }
+                    },
+                    "context": { "diagnostics": [] }
+                }),
+            );
+            let actions = response["result"].as_array().cloned().unwrap_or_default();
+            if actions.len() >= 4 {
+                return Some(actions);
+            }
+            std::thread::sleep(Duration::from_millis(50));
+            None
+        })
+        .expect("codeAction over a two-fence range returns actions from both fences");
+
+    // Each fence contributes an edit action (targeting its own host line) plus a
+    // bare command → 4 actions. The two edit actions target the two DIFFERENT
+    // fences (host lines 3 and 9), proving both regions were bridged and merged.
+    let edit_lines: Vec<u64> = actions
+        .iter()
+        .filter_map(|a| a["edit"]["changes"][MARKDOWN_URI][0]["range"]["start"]["line"].as_u64())
+        .collect();
+    assert!(
+        edit_lines.contains(&3) && edit_lines.contains(&9),
+        "edits must come from BOTH fences (host lines 3 and 9), got: {edit_lines:?}"
+    );
+
+    shutdown(&mut client);
+}

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -873,7 +873,7 @@ fn code_action_over_a_multi_fence_range_merges_actions_from_every_region() {
     // bare command → 4 actions. The two edit actions target the two DIFFERENT
     // fences (host lines 3 and 9), proving both regions were bridged and merged.
     let edit_lines: Vec<u64> = actions
-        .iter()
+        .into_iter()
         .filter_map(|a| a["edit"]["changes"][MARKDOWN_URI][0]["range"]["start"]["line"].as_u64())
         .collect();
     assert!(


### PR DESCRIPTION
Part of #628 (multi-region codeAction).

A `textDocument/codeAction` range spanning several injection fences bridged only the **first** intersecting region; actions from the others were dropped. Now it bridges **every** overlapping region and merges their actions into one menu (document order).

- `resolve_bridge_contexts_for_range_overlap` → `_for_all_overlapping_regions` returns `Vec<RangeRequestContext>` (one per fence the range touches, range clamped per region). The common single-fence case returns exactly one context.
- `code_action_virt_layer` dispatches per region (`dispatch_virt_region_code_action`, preserving each region's within-layer strategy) and concatenates the results; the work-done progress token goes to the first region only. The cross-source `isPreferred` collision is still collapsed once on the final menu.

**Cancellation / registration** are held once for the whole walk (single `unregister_all_for_upstream_id` after the loop; a defensive `select!` self-cancel). The outer `run_layer_race` already owns the cancel subscription across the whole virt future, so a client `$/cancelRequest` aborts the whole multi-region loop — no later region runs after cancel.

**Known / pre-existing (not introduced here):**
- **Latency scales with overlapped-region count** (bounded by the document's injection count); the common case is a single fence. No hard cap — a cap would silently omit valid regions.
- The host layer runs concurrently with the virt loop under the **same** `upstream_id`, and `unregister_all_for_upstream_id` is refcount-ignoring, so an early-finishing layer can coarsely clear an in-flight sibling's downstream cancel-forwarding registration. Pre-existing (single-region virt already ran concurrently with host); this widens the window but doesn't introduce the class. Fail-soft (only affects cancel-forwarding of a request whose response is discarded on cancel). Candidate follow-up: per-region sub-id or refcounted unregister.

**Tests:** e2e `code_action_over_a_multi_fence_range_merges_actions_from_every_region` (a range over two lua fences → actions from both, edits on each fence's host line); single-fence behavior unchanged (46 lib + 41 e2e code_action tests pass). Reviewed locally + codex (which flagged the cancel-span, now addressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Code actions now aggregate results across **all** overlapping injected regions within the selected range (instead of stopping at the first match), producing a single merged action menu.
  * Range-based bridge context resolution was corrected to include every intersecting region, improving multi-block selections.
* **Tests**
  * Added an end-to-end test covering `textDocument/codeAction` across a multi-fence selection, verifying edits from both embedded sections are merged into the results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->