### PR TITLE
feat(bridge): bridge palette-fired workspace/executeCommand (#628)

### DIFF
--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -184,6 +184,11 @@ pub(crate) enum UpstreamRequest {
         reply: oneshot::Sender<tower_lsp_server::ls_types::ApplyWorkspaceEditResponse>,
         cancel: ForwardedRequestCancel,
     },
+    /// Advertise a downstream server's `workspace/executeCommand` command names
+    /// to the editor via `client/registerCapability`, so its palette lists them
+    /// and fires them by raw name (#628 palette-fired commands). Fire-and-forget:
+    /// no reply/cancel (the editor's ack is ignored; routing fails soft anyway).
+    RegisterCommands { commands: Vec<String> },
 }
 
 /// Cancellation context for a forwarded request: the originating connection and

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -152,9 +152,12 @@ pub(crate) enum UpstreamNotification {
 /// are user-interactive and can pend indefinitely, so awaiting one inline would
 /// freeze forwarding for every bridged server.
 ///
-/// Each variant carries a [`ForwardedRequestCancel`] so the forwarding loop can
-/// observe a downstream `$/cancelRequest` (or connection death) and forward the
-/// cancel to the editor — see [`InboundRequestRegistry`].
+/// Each *reply-bearing* variant carries a [`ForwardedRequestCancel`] so the
+/// forwarding loop can observe a downstream `$/cancelRequest` (or connection
+/// death) and forward the cancel to the editor — see [`InboundRequestRegistry`].
+/// The one exception is [`RegisterCommands`](Self::RegisterCommands), which is
+/// fire-and-forget: it advertises capability names to the editor, expects no
+/// reply, and so carries neither a `reply` sender nor a `cancel`.
 ///
 /// [`InboundRequestRegistry`]: crate::lsp::bridge::InboundRequestRegistry
 pub(crate) enum UpstreamRequest {

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1712,7 +1712,7 @@ impl LanguageServerPool {
                     // the whole session, so a respawn / second root re-registers
                     // nothing new.
                     if let Some(commands) = palette_commands {
-                        let added = command_origins.register(&command_registration_key, &commands);
+                        let added = command_origins.register(&command_registration_key, commands);
                         // Advertise the NEWLY-added names upstream so the editor's
                         // palette lists them. Fire-and-forget; skipped when the
                         // client can't accept a dynamic registration.

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1717,8 +1717,15 @@ impl LanguageServerPool {
                         // palette lists them. Fire-and-forget; skipped when the
                         // client can't accept a dynamic registration.
                         if !added.is_empty() && supports_dynamic_command_registration {
-                            let _ = upstream_request_tx
-                                .send(UpstreamRequest::RegisterCommands { commands: added });
+                            if let Err(e) = upstream_request_tx
+                                .send(UpstreamRequest::RegisterCommands { commands: added })
+                            {
+                                log::warn!(
+                                    target: "kakehashi::bridge",
+                                    "Failed to queue palette-command registration \
+                                     (forwarding loop gone): {e}"
+                                );
+                            }
                         }
                     }
                     Ok(())

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -334,9 +334,23 @@ impl LanguageServerPool {
     }
 
     /// Registry mapping a downstream server's advertised palette command names to
-    /// their origin server (#628 palette-fired `workspace/executeCommand`).
+    /// the connection that advertised them (#628 palette-fired executeCommand).
     pub(crate) fn command_origins(&self) -> &CommandOriginRegistry {
         &self.command_origins
+    }
+
+    /// The existing `Ready` connection for `key`, if one is live. Used to route a
+    /// palette command back to the exact connection that advertised it (right
+    /// workspace root/context) rather than spawning a fresh client-root one.
+    pub(crate) async fn ready_connection_by_key(
+        &self,
+        key: &ConnectionKey,
+    ) -> Option<Arc<ConnectionHandle>> {
+        let connections = self.connections.lock().await;
+        connections
+            .get(key)
+            .filter(|handle| handle.state() == ConnectionState::Ready)
+            .map(Arc::clone)
     }
 
     /// Shared registry of in-flight forwarded requests, handed to the forwarding
@@ -1622,6 +1636,7 @@ impl LanguageServerPool {
         let handle_for_handshake = Arc::clone(&handle);
         let server_name_for_log = server_name.to_string();
         let command_origins = Arc::clone(&self.command_origins);
+        let command_registration_key = connection_key.clone();
         let upstream_request_tx = self.upstream_request_tx.clone();
         // The editor accepts a dynamic `workspace/executeCommand` registration
         // only if it advertised `dynamicRegistration` (LSP spec). Compute once.
@@ -1656,21 +1671,13 @@ impl LanguageServerPool {
                         "[{}] LSP handshake completed successfully",
                         server_name_for_log
                     );
-                    // Record this server's advertised palette command names so a
-                    // command fired without an action context (raw name) can route
-                    // back (#628). Dedup is by name across the whole session, so a
-                    // respawn / second root re-registers nothing new.
-                    if let Some(options) = capabilities.execute_command_provider.as_ref() {
-                        let added =
-                            command_origins.register(&server_name_for_log, &options.commands);
-                        // Advertise the NEWLY-added names upstream so the editor's
-                        // palette lists them (#628). Fire-and-forget; skipped when
-                        // the client can't accept a dynamic registration.
-                        if !added.is_empty() && supports_dynamic_command_registration {
-                            let _ = upstream_request_tx
-                                .send(UpstreamRequest::RegisterCommands { commands: added });
-                        }
-                    }
+                    // Extract this server's advertised palette command names
+                    // before `capabilities` is moved; they're registered AFTER
+                    // the Ready flip below.
+                    let palette_commands = capabilities
+                        .execute_command_provider
+                        .as_ref()
+                        .map(|options| options.commands.clone());
                     handle_for_handshake.set_server_capabilities(capabilities);
                     // Path a: push this server's settings now that `initialized`
                     // has been sent, so push-model servers are configured even
@@ -1699,6 +1706,21 @@ impl LanguageServerPool {
                         );
                     }
                     handle_for_handshake.set_state(ConnectionState::Ready);
+                    // Record advertised palette command names AFTER Ready, so a
+                    // command fired without an action context (raw name) routes
+                    // back to a Ready connection (#628). Dedup is by name across
+                    // the whole session, so a respawn / second root re-registers
+                    // nothing new.
+                    if let Some(commands) = palette_commands {
+                        let added = command_origins.register(&command_registration_key, &commands);
+                        // Advertise the NEWLY-added names upstream so the editor's
+                        // palette lists them. Fire-and-forget; skipped when the
+                        // client can't accept a dynamic registration.
+                        if !added.is_empty() && supports_dynamic_command_registration {
+                            let _ = upstream_request_tx
+                                .send(UpstreamRequest::RegisterCommands { commands: added });
+                        }
+                    }
                     Ok(())
                 }
                 Ok(Err(e)) => {

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -9,6 +9,7 @@
 //! [`LanguageServerPool`] manages the connections; [`ConnectionHandle`]
 //! (ls-bridge-async-connection) and [`ConnectionState`] track each connection's lifecycle.
 
+mod command_origin_registry;
 mod connection_action;
 mod connection_handle;
 mod connection_key;
@@ -24,6 +25,7 @@ mod shutdown_timeout;
 #[cfg(test)]
 pub(crate) mod test_helpers;
 
+pub(crate) use command_origin_registry::CommandOriginRegistry;
 pub(crate) use connection_action::BridgeError;
 use connection_action::{ConnectionAction, decide_connection_action};
 use handshake::perform_lsp_handshake;
@@ -286,6 +288,8 @@ pub struct LanguageServerPool {
     /// `upstream_request_registry`, which is the *outbound* (editor → downstream)
     /// cancel direction.
     inbound_request_registry: super::InboundRequestRegistry,
+    /// Palette command name → origin server (#628 palette-fired executeCommand).
+    command_origins: Arc<CommandOriginRegistry>,
 }
 
 impl Default for LanguageServerPool {
@@ -325,7 +329,14 @@ impl LanguageServerPool {
             progress_registry: Arc::new(super::ProgressRegistry::new()),
             client_progress_registry: Arc::new(super::ClientProgressRegistry::new()),
             inbound_request_registry: super::InboundRequestRegistry::default(),
+            command_origins: Arc::new(CommandOriginRegistry::default()),
         }
+    }
+
+    /// Registry mapping a downstream server's advertised palette command names to
+    /// their origin server (#628 palette-fired `workspace/executeCommand`).
+    pub(crate) fn command_origins(&self) -> &CommandOriginRegistry {
+        &self.command_origins
     }
 
     /// Shared registry of in-flight forwarded requests, handed to the forwarding
@@ -1610,6 +1621,7 @@ impl LanguageServerPool {
         let advertise_configuration = server_config.settings.is_some();
         let handle_for_handshake = Arc::clone(&handle);
         let server_name_for_log = server_name.to_string();
+        let command_origins = Arc::clone(&self.command_origins);
         let handshake_task = tokio::spawn(async move {
             let init_result = tokio::time::timeout(
                 timeout,
@@ -1635,6 +1647,13 @@ impl LanguageServerPool {
                         "[{}] LSP handshake completed successfully",
                         server_name_for_log
                     );
+                    // Record this server's advertised palette command names so a
+                    // command fired without an action context (raw name) can route
+                    // back (#628). Dedup is by name across the whole session, so a
+                    // respawn / second root re-registers nothing new.
+                    if let Some(options) = capabilities.execute_command_provider.as_ref() {
+                        command_origins.register(&server_name_for_log, &options.commands);
+                    }
                     handle_for_handshake.set_server_capabilities(capabilities);
                     // Path a: push this server's settings now that `initialized`
                     // has been sent, so push-model servers are configured even

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1622,6 +1622,15 @@ impl LanguageServerPool {
         let handle_for_handshake = Arc::clone(&handle);
         let server_name_for_log = server_name.to_string();
         let command_origins = Arc::clone(&self.command_origins);
+        let upstream_request_tx = self.upstream_request_tx.clone();
+        // The editor accepts a dynamic `workspace/executeCommand` registration
+        // only if it advertised `dynamicRegistration` (LSP spec). Compute once.
+        let supports_dynamic_command_registration = self
+            .client_capabilities()
+            .and_then(|caps| caps.workspace)
+            .and_then(|ws| ws.execute_command)
+            .and_then(|ec| ec.dynamic_registration)
+            .unwrap_or(false);
         let handshake_task = tokio::spawn(async move {
             let init_result = tokio::time::timeout(
                 timeout,
@@ -1652,7 +1661,15 @@ impl LanguageServerPool {
                     // back (#628). Dedup is by name across the whole session, so a
                     // respawn / second root re-registers nothing new.
                     if let Some(options) = capabilities.execute_command_provider.as_ref() {
-                        command_origins.register(&server_name_for_log, &options.commands);
+                        let added =
+                            command_origins.register(&server_name_for_log, &options.commands);
+                        // Advertise the NEWLY-added names upstream so the editor's
+                        // palette lists them (#628). Fire-and-forget; skipped when
+                        // the client can't accept a dynamic registration.
+                        if !added.is_empty() && supports_dynamic_command_registration {
+                            let _ = upstream_request_tx
+                                .send(UpstreamRequest::RegisterCommands { commands: added });
+                        }
                     }
                     handle_for_handshake.set_server_capabilities(capabilities);
                     // Path a: push this server's settings now that `initialized`

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1716,16 +1716,16 @@ impl LanguageServerPool {
                         // Advertise the NEWLY-added names upstream so the editor's
                         // palette lists them. Fire-and-forget; skipped when the
                         // client can't accept a dynamic registration.
-                        if !added.is_empty() && supports_dynamic_command_registration {
-                            if let Err(e) = upstream_request_tx
+                        if !added.is_empty()
+                            && supports_dynamic_command_registration
+                            && let Err(e) = upstream_request_tx
                                 .send(UpstreamRequest::RegisterCommands { commands: added })
-                            {
-                                log::warn!(
-                                    target: "kakehashi::bridge",
-                                    "Failed to queue palette-command registration \
-                                     (forwarding loop gone): {e}"
-                                );
-                            }
+                        {
+                            log::warn!(
+                                target: "kakehashi::bridge",
+                                "Failed to queue palette-command registration \
+                                 (forwarding loop gone): {e}"
+                            );
                         }
                     }
                     Ok(())

--- a/src/lsp/bridge/pool/command_origin_registry.rs
+++ b/src/lsp/bridge/pool/command_origin_registry.rs
@@ -27,9 +27,14 @@ pub(crate) struct CommandOriginRegistry {
 
 impl CommandOriginRegistry {
     /// Record `commands` as advertised by the connection `key`, returning the
-    /// subset that was NEWLY added (not already registered under any connection).
-    /// The caller advertises only the new names upstream, so a server respawn or
-    /// a second root re-advertises nothing (dedup by construction).
+    /// subset that is NEWLY seen (never registered before).
+    ///
+    /// The routing target is ALWAYS updated to `key` — a server respawned under a
+    /// different root, or a different server that later advertises the same name,
+    /// must route to the CURRENT live connection, not a stale one. Only the
+    /// genuinely-new names are returned, though: the command NAME is already
+    /// registered with the editor, so re-advertising it would be a duplicate
+    /// registration.
     pub(crate) fn register(&self, key: &ConnectionKey, commands: &[String]) -> Vec<String> {
         let mut origins = self
             .origins
@@ -37,7 +42,11 @@ impl CommandOriginRegistry {
             .recover_poison("CommandOriginRegistry::register");
         let mut added = Vec::new();
         for command in commands {
-            if !origins.contains_key(command) {
+            if let Some(existing) = origins.get_mut(command) {
+                // Re-point routing to the current owner; don't re-advertise (and
+                // don't clone the key string — the entry already exists).
+                *existing = key.clone();
+            } else {
                 origins.insert(command.clone(), key.clone());
                 added.push(command.clone());
             }
@@ -60,27 +69,27 @@ mod tests {
     use super::*;
 
     #[test]
-    fn register_dedups_and_reports_only_new_names() {
+    fn register_reports_only_new_names_but_always_updates_routing() {
         let reg = CommandOriginRegistry::default();
-        let ruff = ConnectionKey::new("ruff", Some("/w".to_string()));
-        let pyright = ConnectionKey::new("pyright", Some("/w".to_string()));
+        let ruff_a = ConnectionKey::new("ruff", Some("/w/a".to_string()));
+        let ruff_b = ConnectionKey::new("ruff", Some("/w/b".to_string()));
 
         assert_eq!(
-            reg.register(&ruff, &["ruff.fix".to_string(), "ruff.sort".to_string()]),
+            reg.register(&ruff_a, &["ruff.fix".to_string(), "ruff.sort".to_string()]),
             vec!["ruff.fix".to_string(), "ruff.sort".to_string()]
         );
-        // A respawn / second root re-registers nothing new.
-        assert!(reg.register(&ruff, &["ruff.fix".to_string()]).is_empty());
-        // A different server contributes only its unseen names.
+        assert_eq!(reg.route("ruff.fix").as_ref(), Some(&ruff_a));
+
+        // A respawn under a DIFFERENT root re-advertises nothing new (the name is
+        // already registered with the editor) but RE-POINTS routing to the live
+        // connection, so a palette command reaches the current process.
+        assert!(reg.register(&ruff_b, &["ruff.fix".to_string()]).is_empty());
         assert_eq!(
-            reg.register(
-                &pyright,
-                &["ruff.fix".to_string(), "pyright.org".to_string()]
-            ),
-            vec!["pyright.org".to_string()]
+            reg.route("ruff.fix").as_ref(),
+            Some(&ruff_b),
+            "routing must follow the current owner, not stay on the stale root"
         );
-        assert_eq!(reg.route("ruff.fix").as_ref(), Some(&ruff));
-        assert_eq!(reg.route("pyright.org").as_ref(), Some(&pyright));
+
         assert_eq!(reg.route("unknown.cmd"), None);
     }
 }

--- a/src/lsp/bridge/pool/command_origin_registry.rs
+++ b/src/lsp/bridge/pool/command_origin_registry.rs
@@ -1,12 +1,13 @@
 //! Maps a downstream server's advertised `workspace/executeCommand` command
-//! names to their origin server (#628 palette-fired commands).
+//! names to the CONNECTION that advertised them (#628 palette-fired commands).
 //!
 //! A command surfaced in a bridged code action routes by its NAME-encoded
 //! envelope (`command_routing`). But a command the client fires WITHOUT an
 //! action context — from the command palette, keyed off the advertised
 //! `executeCommandProvider.commands` list — arrives as the RAW downstream name.
 //! This registry lets `dispatch_execute_command` resolve that raw name back to
-//! the server that advertised it.
+//! the exact `(server, root)` connection that advertised it, so the command runs
+//! in the same workspace context (not a fresh client-root connection).
 //!
 //! Global to the editor↔Kakehashi session (one instance on the pool) and keyed
 //! by command name. Two servers advertising the same command name collide to a
@@ -16,19 +17,20 @@
 use std::collections::HashMap;
 use std::sync::Mutex;
 
+use super::ConnectionKey;
 use crate::error::LockResultExt;
 
 #[derive(Default)]
 pub(crate) struct CommandOriginRegistry {
-    origins: Mutex<HashMap<String, String>>,
+    origins: Mutex<HashMap<String, ConnectionKey>>,
 }
 
 impl CommandOriginRegistry {
-    /// Record `commands` as owned by `server_name`, returning the subset that was
-    /// NEWLY added (not already registered under any server). The caller
-    /// advertises only the new names upstream, so a server respawn or a second
-    /// root for the same server re-advertises nothing (dedup by construction).
-    pub(crate) fn register(&self, server_name: &str, commands: &[String]) -> Vec<String> {
+    /// Record `commands` as advertised by the connection `key`, returning the
+    /// subset that was NEWLY added (not already registered under any connection).
+    /// The caller advertises only the new names upstream, so a server respawn or
+    /// a second root re-advertises nothing (dedup by construction).
+    pub(crate) fn register(&self, key: &ConnectionKey, commands: &[String]) -> Vec<String> {
         let mut origins = self
             .origins
             .lock()
@@ -36,18 +38,18 @@ impl CommandOriginRegistry {
         let mut added = Vec::new();
         for command in commands {
             if !origins.contains_key(command) {
-                origins.insert(command.clone(), server_name.to_string());
+                origins.insert(command.clone(), key.clone());
                 added.push(command.clone());
             }
         }
         added
     }
 
-    /// The origin server for a palette command name, if one advertised it.
-    pub(crate) fn origin(&self, command: &str) -> Option<String> {
+    /// The connection that advertised a palette command name, if one did.
+    pub(crate) fn route(&self, command: &str) -> Option<ConnectionKey> {
         self.origins
             .lock()
-            .recover_poison("CommandOriginRegistry::origin")
+            .recover_poison("CommandOriginRegistry::route")
             .get(command)
             .cloned()
     }
@@ -60,22 +62,25 @@ mod tests {
     #[test]
     fn register_dedups_and_reports_only_new_names() {
         let reg = CommandOriginRegistry::default();
+        let ruff = ConnectionKey::new("ruff", Some("/w".to_string()));
+        let pyright = ConnectionKey::new("pyright", Some("/w".to_string()));
+
         assert_eq!(
-            reg.register("ruff", &["ruff.fix".to_string(), "ruff.sort".to_string()]),
+            reg.register(&ruff, &["ruff.fix".to_string(), "ruff.sort".to_string()]),
             vec!["ruff.fix".to_string(), "ruff.sort".to_string()]
         );
         // A respawn / second root re-registers nothing new.
-        assert!(reg.register("ruff", &["ruff.fix".to_string()]).is_empty());
+        assert!(reg.register(&ruff, &["ruff.fix".to_string()]).is_empty());
         // A different server contributes only its unseen names.
         assert_eq!(
             reg.register(
-                "pyright",
+                &pyright,
                 &["ruff.fix".to_string(), "pyright.org".to_string()]
             ),
             vec!["pyright.org".to_string()]
         );
-        assert_eq!(reg.origin("ruff.fix").as_deref(), Some("ruff"));
-        assert_eq!(reg.origin("pyright.org").as_deref(), Some("pyright"));
-        assert_eq!(reg.origin("unknown.cmd"), None);
+        assert_eq!(reg.route("ruff.fix").as_ref(), Some(&ruff));
+        assert_eq!(reg.route("pyright.org").as_ref(), Some(&pyright));
+        assert_eq!(reg.route("unknown.cmd"), None);
     }
 }

--- a/src/lsp/bridge/pool/command_origin_registry.rs
+++ b/src/lsp/bridge/pool/command_origin_registry.rs
@@ -1,0 +1,81 @@
+//! Maps a downstream server's advertised `workspace/executeCommand` command
+//! names to their origin server (#628 palette-fired commands).
+//!
+//! A command surfaced in a bridged code action routes by its NAME-encoded
+//! envelope (`command_routing`). But a command the client fires WITHOUT an
+//! action context — from the command palette, keyed off the advertised
+//! `executeCommandProvider.commands` list — arrives as the RAW downstream name.
+//! This registry lets `dispatch_execute_command` resolve that raw name back to
+//! the server that advertised it.
+//!
+//! Global to the editor↔Kakehashi session (one instance on the pool) and keyed
+//! by command name. Two servers advertising the same command name collide to a
+//! single origin — an accepted limitation (bridged-action commands, which embed
+//! the origin, don't have this ambiguity).
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use crate::error::LockResultExt;
+
+#[derive(Default)]
+pub(crate) struct CommandOriginRegistry {
+    origins: Mutex<HashMap<String, String>>,
+}
+
+impl CommandOriginRegistry {
+    /// Record `commands` as owned by `server_name`, returning the subset that was
+    /// NEWLY added (not already registered under any server). The caller
+    /// advertises only the new names upstream, so a server respawn or a second
+    /// root for the same server re-advertises nothing (dedup by construction).
+    pub(crate) fn register(&self, server_name: &str, commands: &[String]) -> Vec<String> {
+        let mut origins = self
+            .origins
+            .lock()
+            .recover_poison("CommandOriginRegistry::register");
+        let mut added = Vec::new();
+        for command in commands {
+            if !origins.contains_key(command) {
+                origins.insert(command.clone(), server_name.to_string());
+                added.push(command.clone());
+            }
+        }
+        added
+    }
+
+    /// The origin server for a palette command name, if one advertised it.
+    pub(crate) fn origin(&self, command: &str) -> Option<String> {
+        self.origins
+            .lock()
+            .recover_poison("CommandOriginRegistry::origin")
+            .get(command)
+            .cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_dedups_and_reports_only_new_names() {
+        let reg = CommandOriginRegistry::default();
+        assert_eq!(
+            reg.register("ruff", &["ruff.fix".to_string(), "ruff.sort".to_string()]),
+            vec!["ruff.fix".to_string(), "ruff.sort".to_string()]
+        );
+        // A respawn / second root re-registers nothing new.
+        assert!(reg.register("ruff", &["ruff.fix".to_string()]).is_empty());
+        // A different server contributes only its unseen names.
+        assert_eq!(
+            reg.register(
+                "pyright",
+                &["ruff.fix".to_string(), "pyright.org".to_string()]
+            ),
+            vec!["pyright.org".to_string()]
+        );
+        assert_eq!(reg.origin("ruff.fix").as_deref(), Some("ruff"));
+        assert_eq!(reg.origin("pyright.org").as_deref(), Some("pyright"));
+        assert_eq!(reg.origin("unknown.cmd"), None);
+    }
+}

--- a/src/lsp/bridge/pool/command_origin_registry.rs
+++ b/src/lsp/bridge/pool/command_origin_registry.rs
@@ -35,20 +35,21 @@ impl CommandOriginRegistry {
     /// genuinely-new names are returned, though: the command NAME is already
     /// registered with the editor, so re-advertising it would be a duplicate
     /// registration.
-    pub(crate) fn register(&self, key: &ConnectionKey, commands: &[String]) -> Vec<String> {
+    pub(crate) fn register(&self, key: &ConnectionKey, commands: Vec<String>) -> Vec<String> {
         let mut origins = self
             .origins
             .lock()
             .recover_poison("CommandOriginRegistry::register");
         let mut added = Vec::new();
         for command in commands {
-            if let Some(existing) = origins.get_mut(command) {
+            if let Some(existing) = origins.get_mut(&command) {
                 // Re-point routing to the current owner; don't re-advertise (and
                 // don't clone the key string — the entry already exists).
                 *existing = key.clone();
             } else {
+                // Clone only for the map key; move the name itself into `added`.
                 origins.insert(command.clone(), key.clone());
-                added.push(command.clone());
+                added.push(command);
             }
         }
         added
@@ -75,7 +76,10 @@ mod tests {
         let ruff_b = ConnectionKey::new("ruff", Some("/w/b".to_string()));
 
         assert_eq!(
-            reg.register(&ruff_a, &["ruff.fix".to_string(), "ruff.sort".to_string()]),
+            reg.register(
+                &ruff_a,
+                vec!["ruff.fix".to_string(), "ruff.sort".to_string()]
+            ),
             vec!["ruff.fix".to_string(), "ruff.sort".to_string()]
         );
         assert_eq!(reg.route("ruff.fix").as_ref(), Some(&ruff_a));
@@ -83,7 +87,10 @@ mod tests {
         // A respawn under a DIFFERENT root re-advertises nothing new (the name is
         // already registered with the editor) but RE-POINTS routing to the live
         // connection, so a palette command reaches the current process.
-        assert!(reg.register(&ruff_b, &["ruff.fix".to_string()]).is_empty());
+        assert!(
+            reg.register(&ruff_b, vec!["ruff.fix".to_string()])
+                .is_empty()
+        );
         assert_eq!(
             reg.route("ruff.fix").as_ref(),
             Some(&ruff_b),

--- a/src/lsp/bridge/pool/connection_key.rs
+++ b/src/lsp/bridge/pool/connection_key.rs
@@ -76,6 +76,11 @@ impl ConnectionKey {
         matches!(self.root, ConnectionRoot::Shared)
     }
 
+    /// Whether this key is the client-root fallback (no resolved marker root).
+    pub(crate) fn is_client_fallback(&self) -> bool {
+        matches!(self.root, ConnectionRoot::ClientFallback)
+    }
+
     /// Build a key with no resolved root (client-root fallback).
     ///
     /// Test-only convenience: production builds keys via [`new`](Self::new) with

--- a/src/lsp/bridge/workspace/execute_command.rs
+++ b/src/lsp/bridge/workspace/execute_command.rs
@@ -53,14 +53,14 @@ impl LanguageServerPool {
                 route.command.to_string(),
             ),
             None => {
-                // Not a bridge-minted command (a client-side or foreign command)
-                // — the bridge has no origin to route it to.
-                warn!(
-                    target: "kakehashi::bridge",
-                    "executeCommand: '{}' is not a bridged command; ignoring",
-                    params.command
-                );
-                return None;
+                // Not an action-encoded command. It may still be a PALETTE
+                // command — a name a downstream advertised via
+                // `executeCommandProvider` that the client fired without an
+                // action context (#628). Route it by the command→origin registry;
+                // otherwise it's foreign and ignored.
+                return self
+                    .dispatch_palette_command(params, settings, upstream_id)
+                    .await;
             }
         };
 
@@ -117,6 +117,53 @@ impl LanguageServerPool {
             work_done_progress_params: params.work_done_progress_params,
         };
         self.send_execute_command_on_handle(&handle, outgoing, upstream_id)
+            .await
+    }
+
+    /// Route a PALETTE-fired command (a raw downstream command name, no action
+    /// envelope) to the server that advertised it, recorded in the
+    /// [`command_origins`](Self::command_origins) registry at handshake (#628).
+    /// No host document context, so it connects at the client root
+    /// (`document_uri = None`) — a multi-root server picks one root. Forwards the
+    /// command + arguments verbatim; fails soft (foreign command, unspawnable /
+    /// unreachable origin) like every other branch.
+    async fn dispatch_palette_command(
+        &self,
+        params: ExecuteCommandParams,
+        settings: &WorkspaceSettings,
+        upstream_id: Option<UpstreamId>,
+    ) -> Option<Value> {
+        let Some(origin) = self.command_origins().origin(&params.command) else {
+            warn!(
+                target: "kakehashi::bridge",
+                "executeCommand: '{}' is neither a bridged nor a registered command; ignoring",
+                params.command
+            );
+            return None;
+        };
+        if !crate::config::is_server_spawnable(&settings.language_servers, &origin) {
+            return None;
+        }
+        let config = resolve_with_wildcard(
+            &settings.language_servers,
+            &origin,
+            merge_bridge_server_configs,
+        )?;
+        let handle = match self.get_or_create_connection(&origin, &config, None).await {
+            Ok(handle) => handle,
+            Err(e) => {
+                warn!(
+                    target: "kakehashi::bridge",
+                    "executeCommand: failed to connect to {origin} for palette command: {e}"
+                );
+                return None;
+            }
+        };
+        if !handle.has_capability(METHOD) {
+            return None;
+        }
+        // Forward the command name and arguments verbatim.
+        self.send_execute_command_on_handle(&handle, params, upstream_id)
             .await
     }
 

--- a/src/lsp/bridge/workspace/execute_command.rs
+++ b/src/lsp/bridge/workspace/execute_command.rs
@@ -124,11 +124,10 @@ impl LanguageServerPool {
     /// envelope) to the exact connection that advertised it — recorded in the
     /// [`command_origins`](Self::command_origins) registry at handshake — so it
     /// runs in the same `(server, root)` workspace context (#628). Reuses the
-    /// live advertising connection; only if it has since been shut down does it
-    /// fall back to a client-root reconnect (where a multi-root server may land
-    /// on a different root). Forwards the command + arguments verbatim; fails
-    /// soft (foreign command, unspawnable / unreachable origin) like every other
-    /// branch.
+    /// live advertising connection; only if it has since been shut down AND the
+    /// key is a plain client-root fallback does it reconnect. Forwards the command
+    /// name and arguments verbatim; fails soft (foreign command, unspawnable or
+    /// unreachable origin) like every other branch.
     async fn dispatch_palette_command(
         &self,
         params: ExecuteCommandParams,
@@ -148,14 +147,18 @@ impl LanguageServerPool {
             // The connection that advertised the command is still Ready — route
             // there, preserving its workspace root/context.
             Some(handle) => handle,
-            // Not Ready or gone. Reconnect when routing doesn't depend on a
-            // specific marker root — a client-root fallback or a shared instance
-            // (`preferSharedInstance`) both reconnect correctly with
-            // `document_uri = None`. For a MARKER-rooted server a client-root
-            // reconnect would run the command against the WRONG workspace, so fail
-            // soft (the user re-fires once the server is back); reconstructing the
-            // marker root here is a deferred follow-up.
-            None if key.is_client_fallback() || key.is_shared() => {
+            // Not Ready or gone. Reconnect ONLY for a plain client-root fallback:
+            // `get_or_create_connection(.., None)` resolves back to that exact
+            // ClientFallback key, so the command runs in the same context. A
+            // SHARED key (`preferSharedInstance`) does NOT round-trip through
+            // `None` — `resolve_acquire` returns the client-fallback key for a
+            // marker-less acquisition, so reconnecting with `None` would spawn a
+            // client-root process instead of the shared instance and run the
+            // command in the wrong workspace. A MARKER-rooted key has the same
+            // problem. Both fail soft here (the user re-fires once the origin is
+            // back); reconstructing a shared/marker root without a document is a
+            // deferred follow-up.
+            None if key.is_client_fallback() => {
                 if !crate::config::is_server_spawnable(&settings.language_servers, origin) {
                     return None;
                 }

--- a/src/lsp/bridge/workspace/execute_command.rs
+++ b/src/lsp/bridge/workspace/execute_command.rs
@@ -188,6 +188,16 @@ impl LanguageServerPool {
             }
         };
         if !handle.has_capability(METHOD) {
+            // The advertising connection was Ready (capabilities set) when it
+            // registered the command, but the RECONNECT path can hand back a
+            // still-`Initializing` handle whose capabilities aren't set yet, so
+            // this is reachable. Warn rather than drop silently (every other
+            // failure branch warns) so a fail-soft `null` is diagnosable.
+            warn!(
+                target: "kakehashi::bridge",
+                "executeCommand: origin {origin} for palette command '{}' does not (yet) advertise executeCommandProvider; ignoring",
+                params.command
+            );
             return None;
         }
         // Forward the command name and arguments verbatim.

--- a/src/lsp/bridge/workspace/execute_command.rs
+++ b/src/lsp/bridge/workspace/execute_command.rs
@@ -121,19 +121,21 @@ impl LanguageServerPool {
     }
 
     /// Route a PALETTE-fired command (a raw downstream command name, no action
-    /// envelope) to the server that advertised it, recorded in the
-    /// [`command_origins`](Self::command_origins) registry at handshake (#628).
-    /// No host document context, so it connects at the client root
-    /// (`document_uri = None`) — a multi-root server picks one root. Forwards the
-    /// command + arguments verbatim; fails soft (foreign command, unspawnable /
-    /// unreachable origin) like every other branch.
+    /// envelope) to the exact connection that advertised it — recorded in the
+    /// [`command_origins`](Self::command_origins) registry at handshake — so it
+    /// runs in the same `(server, root)` workspace context (#628). Reuses the
+    /// live advertising connection; only if it has since been shut down does it
+    /// fall back to a client-root reconnect (where a multi-root server may land
+    /// on a different root). Forwards the command + arguments verbatim; fails
+    /// soft (foreign command, unspawnable / unreachable origin) like every other
+    /// branch.
     async fn dispatch_palette_command(
         &self,
         params: ExecuteCommandParams,
         settings: &WorkspaceSettings,
         upstream_id: Option<UpstreamId>,
     ) -> Option<Value> {
-        let Some(origin) = self.command_origins().origin(&params.command) else {
+        let Some(key) = self.command_origins().route(&params.command) else {
             warn!(
                 target: "kakehashi::bridge",
                 "executeCommand: '{}' is neither a bridged nor a registered command; ignoring",
@@ -141,20 +143,41 @@ impl LanguageServerPool {
             );
             return None;
         };
-        if !crate::config::is_server_spawnable(&settings.language_servers, &origin) {
-            return None;
-        }
-        let config = resolve_with_wildcard(
-            &settings.language_servers,
-            &origin,
-            merge_bridge_server_configs,
-        )?;
-        let handle = match self.get_or_create_connection(&origin, &config, None).await {
-            Ok(handle) => handle,
-            Err(e) => {
+        let origin = key.server();
+        let handle = match self.ready_connection_by_key(&key).await {
+            // The connection that advertised the command is still Ready — route
+            // there, preserving its workspace root/context.
+            Some(handle) => handle,
+            // Not Ready or gone. A client-root reconnect would run the command
+            // against the WRONG workspace for a marker/shared-rooted server, so
+            // only fall back when the advertising key was ITSELF the client-root
+            // fallback; otherwise fail soft (the user re-fires once the server is
+            // back). Reconstructing the marker root here is a deferred follow-up.
+            None if key.is_client_fallback() => {
+                if !crate::config::is_server_spawnable(&settings.language_servers, origin) {
+                    return None;
+                }
+                let config = resolve_with_wildcard(
+                    &settings.language_servers,
+                    origin,
+                    merge_bridge_server_configs,
+                )?;
+                match self.get_or_create_connection(origin, &config, None).await {
+                    Ok(handle) => handle,
+                    Err(e) => {
+                        warn!(
+                            target: "kakehashi::bridge",
+                            "executeCommand: failed to reconnect to {origin} for palette command: {e}"
+                        );
+                        return None;
+                    }
+                }
+            }
+            None => {
                 warn!(
                     target: "kakehashi::bridge",
-                    "executeCommand: failed to connect to {origin} for palette command: {e}"
+                    "executeCommand: origin connection for palette command '{}' ({origin}) is not ready; ignoring",
+                    params.command
                 );
                 return None;
             }

--- a/src/lsp/bridge/workspace/execute_command.rs
+++ b/src/lsp/bridge/workspace/execute_command.rs
@@ -148,12 +148,14 @@ impl LanguageServerPool {
             // The connection that advertised the command is still Ready — route
             // there, preserving its workspace root/context.
             Some(handle) => handle,
-            // Not Ready or gone. A client-root reconnect would run the command
-            // against the WRONG workspace for a marker/shared-rooted server, so
-            // only fall back when the advertising key was ITSELF the client-root
-            // fallback; otherwise fail soft (the user re-fires once the server is
-            // back). Reconstructing the marker root here is a deferred follow-up.
-            None if key.is_client_fallback() => {
+            // Not Ready or gone. Reconnect when routing doesn't depend on a
+            // specific marker root — a client-root fallback or a shared instance
+            // (`preferSharedInstance`) both reconnect correctly with
+            // `document_uri = None`. For a MARKER-rooted server a client-root
+            // reconnect would run the command against the WRONG workspace, so fail
+            // soft (the user re-fires once the server is back); reconstructing the
+            // marker root here is a deferred follow-up.
+            None if key.is_client_fallback() || key.is_shared() => {
                 if !crate::config::is_server_spawnable(&settings.language_servers, origin) {
                     return None;
                 }

--- a/src/lsp/bridge/workspace/execute_command.rs
+++ b/src/lsp/bridge/workspace/execute_command.rs
@@ -167,7 +167,21 @@ impl LanguageServerPool {
                     origin,
                     merge_bridge_server_configs,
                 )?;
-                match self.get_or_create_connection(origin, &config, None).await {
+                // Wait through initialization (bounded by the standard init
+                // budget) rather than take a possibly-`Initializing` handle: the
+                // pool returns an existing not-yet-Ready connection here, whose
+                // `has_capability` check below would then spuriously fail-soft to
+                // `null` even though it would be Ready moments later. Fails soft on
+                // timeout/spawn error like every other branch.
+                match self
+                    .get_or_create_connection_wait_ready(
+                        origin,
+                        &config,
+                        None,
+                        std::time::Duration::from_secs(crate::lsp::bridge::pool::INIT_TIMEOUT_SECS),
+                    )
+                    .await
+                {
                     Ok(handle) => handle,
                     Err(e) => {
                         warn!(

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1070,11 +1070,23 @@ fn spawn_upstream_request(
                     method: "workspace/executeCommand".to_string(),
                     register_options: Some(serde_json::json!({ "commands": commands })),
                 };
-                if let Err(e) = client.register_capability(vec![registration]).await {
-                    log::warn!(
+                // Bound the await: a non-responsive editor must not leak a task
+                // pending forever on the registration request.
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(10),
+                    client.register_capability(vec![registration]),
+                )
+                .await
+                {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => log::warn!(
                         target: "kakehashi::bridge",
                         "Failed to register palette commands upstream: {e}"
-                    );
+                    ),
+                    Err(_) => log::warn!(
+                        target: "kakehashi::bridge",
+                        "Timed out registering palette commands upstream"
+                    ),
                 }
             }
             UpstreamRequest::ShowMessageRequest {

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1058,6 +1058,25 @@ fn spawn_upstream_request(
     let client = client.clone();
     tokio::spawn(async move {
         match request {
+            UpstreamRequest::RegisterCommands { commands } => {
+                use tower_lsp_server::ls_types::Registration;
+                // Fire-and-forget dynamic registration of palette command names.
+                // A unique registration id (we never unregister — a disconnected
+                // server's command simply routes fail-soft). Register-options
+                // carry the `commands` for `workspace/executeCommand`.
+                let id = format!("kakehashi/executeCommand/{}", client.next_request_id());
+                let registration = Registration {
+                    id,
+                    method: "workspace/executeCommand".to_string(),
+                    register_options: Some(serde_json::json!({ "commands": commands })),
+                };
+                if let Err(e) = client.register_capability(vec![registration]).await {
+                    log::warn!(
+                        target: "kakehashi::bridge",
+                        "Failed to register palette commands upstream: {e}"
+                    );
+                }
+            }
             UpstreamRequest::ShowMessageRequest {
                 typ,
                 message,

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -914,3 +914,43 @@ fn palette_fired_command_routes_to_its_origin_server() {
 
     shutdown(&mut client);
 }
+
+#[test]
+fn downstream_command_names_are_registered_upstream_for_the_palette() {
+    // #628: a downstream that advertises `executeCommandProvider.commands` has
+    // those names dynamically registered with the editor via
+    // `client/registerCapability`, so the palette lists them — gated on the
+    // client advertising `workspace.executeCommand.dynamicRegistration`.
+    let caps = json!({
+        "textDocument": { "codeAction": {
+            "codeActionLiteralSupport": { "codeActionKind": { "valueSet": [] } }
+        }},
+        "workspace": { "executeCommand": { "dynamicRegistration": true } }
+    });
+    let (mut client, init_response, _config_dir) = init_client(caps);
+    assert_advertised(&init_response);
+    // Opening the doc eager-spawns mock-codeaction (the lua fence's bridge
+    // server); its handshake advertises `executeCommandProvider.commands`.
+    open_markdown(&mut client);
+
+    let (reg_id, reg_params) = client
+        .wait_for_server_request("client/registerCapability", Duration::from_secs(5))
+        .expect("the bridge must register the downstream's palette commands upstream");
+    let registrations = reg_params["registrations"]
+        .as_array()
+        .expect("registrations array");
+    let exec = registrations
+        .iter()
+        .find(|r| r["method"] == "workspace/executeCommand")
+        .expect("a workspace/executeCommand registration");
+    let commands = exec["registerOptions"]["commands"]
+        .as_array()
+        .expect("registerOptions.commands");
+    assert!(
+        commands.iter().any(|c| c == "mock.run"),
+        "the mock's advertised command must be registered, got: {commands:?}"
+    );
+    client.send_response(reg_id, json!(null));
+
+    shutdown(&mut client);
+}

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -883,3 +883,34 @@ fn code_action_over_a_multi_fence_range_merges_actions_from_every_region() {
 
     shutdown(&mut client);
 }
+
+#[test]
+fn palette_fired_command_routes_to_its_origin_server() {
+    // #628: a command the client fires WITHOUT an action context — a raw name
+    // from the palette, keyed off the advertised executeCommandProvider.commands
+    // — routes to the server that advertised it (recorded at handshake), not just
+    // commands surfaced through a bridged code action.
+    let (mut client, init_response, _config_dir) = init_client(literal_support_caps(true));
+    assert_advertised(&init_response);
+    open_markdown(&mut client);
+    // Drive a codeAction so mock-codeaction handshakes and registers "mock.run".
+    let _ = code_action_with_retry(&mut client);
+
+    // Fire the RAW command name (palette style): no routing prefix, no action.
+    let exec_id = client.send_request_async(
+        "workspace/executeCommand",
+        json!({ "command": "mock.run", "arguments": [] }),
+    );
+    let (apply_id, _apply_params) = client
+        .wait_for_server_request("workspace/applyEdit", Duration::from_secs(5))
+        .expect("the palette command must reach the origin server (which issues applyEdit)");
+    client.send_response(apply_id, json!({ "applied": true }));
+
+    let response = client.receive_response_for_id_public(exec_id);
+    assert_eq!(
+        response["result"]["executed"], "mock.run",
+        "the palette command must reach its origin with the raw name, got: {response:?}"
+    );
+
+    shutdown(&mut client);
+}


### PR DESCRIPTION
Closes the last #628 item: **palette-fired `workspace/executeCommand`**.

A command surfaced in a bridged code action routes by its name-encoded envelope. But a command the client fires WITHOUT an action context — a raw name from the command palette, keyed off the advertised `executeCommandProvider.commands` — was dropped as "not a bridged command". Now it's bridged, via dynamic capability registration.

**How**
- New pool-level `CommandOriginRegistry` (command name → advertising `ConnectionKey`), populated at each downstream handshake (**after** the Ready flip) from its `executeCommandProvider.commands`, deduped by name across the session.
- **Upstream advertisement**: the newly-added names are dynamically registered with the editor via `client/registerCapability` (a new fire-and-forget `UpstreamRequest::RegisterCommands` handled in the forwarding loop), gated on the client's `workspace.executeCommand.dynamicRegistration` — so the palette lists them.
- **Routing**: `dispatch_execute_command`'s decode-miss branch looks the raw command up in the registry and routes it to the exact **live advertising connection** (`ready_connection_by_key`), preserving its `(server, root)` workspace context. If that connection is gone/not-Ready it fails soft — falling back to a client-root reconnect **only** when the key was itself the client-root fallback (a client-root reconnect for a marker/shared-rooted server would run the command against the wrong workspace).

**Tests:** unit (registry dedup/route) + two e2es — the client receives `client/registerCapability` for the mock's command, and firing a raw `mock.run` with no preceding action reaches the origin and relays its result.

**Known limitations (documented in code):**
- Bootstrapping: a command appears in the palette only after its server has handshaked (lazy spawn) — inherent, same as the existing static advertise.
- Two servers advertising the same command name collide to one origin (bridged-action commands, which embed the origin, don't).
- Registrations are never unregistered — a disconnected server's name routes fail-soft.
- If the advertising connection was shut down since registration, a marker/shared-rooted command fails soft rather than reconnecting at the wrong root (marker-root respawn deferred).

Reviewed locally + codex (which caught the connection-reuse/root-mismatch + the register-before-Ready race, both fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic upstream registration of downstream `workspace/executeCommand` command names when dynamic capability registration is enabled.
* **Bug Fixes**
  * Improved `workspace/executeCommand` handling by routing non-bridge-encoded requests to the correct originating server using the latest command registry.
  * Added readiness-aware routing to reduce failures when the advertising connection is not yet available.
* **Tests**
  * Added end-to-end coverage for palette-style command routing and for verifying upstream command-name registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->