### PR TITLE
fix(cli): surface directory walk errors

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -637,11 +637,12 @@ Line and column are 1-based; a diagnostic with no severity is treated as an
 error (so it can never silently slip past the gate). Exit codes: `0` no failing
 diagnostic; `1` a failing diagnostic — any error always, plus warnings with
 `--fail-on-warning` (info/hint never fail); `2` an operational error (a file
-could not be read, a path could not be opened, or a configured downstream
-server failed — including one that answered the `textDocument/diagnostic` pull
-with an error response or a present-but-malformed payload, matching
-`kakehashi format`'s strictness) — independent of the diagnostics, so it
-surfaces a broken run rather than looking clean to CI.
+could not be read, a path could not be opened or fully enumerated, or a
+configured downstream server failed — including one that answered the
+`textDocument/diagnostic` pull with an error response or a
+present-but-malformed payload, matching `kakehashi format`'s strictness) —
+independent of the diagnostics, so it surfaces a broken run rather than
+looking clean to CI.
 
 > Under the non-default `preferred` aggregation strategy, the winning server's
 > result is authoritative, so a *non-winning* server's request-time failure is

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -94,7 +94,8 @@ enum Commands {
     /// Exit codes: 0 = no failing diagnostics; 1 = a failing diagnostic (any
     /// error, plus warnings with --fail-on-warning; info/hint never fail —
     /// append `|| true` to never fail); 2 = an operational error (unreadable
-    /// file, downstream server failure), independent of the diagnostics.
+    /// file, path open/enumeration failure, downstream server failure),
+    /// independent of the diagnostics.
     Diagnose {
         /// Files or directories to diagnose ("-" for stdin with --stdin-filename)
         paths: Vec<PathBuf>,

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -226,17 +226,21 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &DiagnoseOptions) ->
         return EXIT_ERROR;
     }
 
-    let files = match collect_files(cwd, &options.paths, &options.excludes, &|path| {
+    let collected = match collect_files(cwd, &options.paths, &options.excludes, &|path| {
         server.cli_can_handle_path(path)
     }) {
-        Ok(files) => files,
+        Ok(collected) => collected,
         Err(e) => {
             elnln!("error: {e}");
             return EXIT_ERROR;
         }
     };
+    let files = collected.files;
 
-    let mut report = Report::default();
+    let mut report = Report {
+        operational_error: collected.walk_errors > 0,
+        ..Default::default()
+    };
     // Stream per file: a single reused buffer holds one file's rendered
     // diagnostics, so peak memory is bounded by the noisiest file rather than
     // the whole run. `write_chunk` locks stdout per call, so the lock is never

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -22,9 +22,9 @@
 //!   `--fail-on-warning`. Info/hint never fail. To never fail on diagnostics,
 //!   append `|| true`.
 //! - `2`: an operational error (a file could not be read, a path could not be
-//!   opened, or a configured downstream server failed). Independent of the
-//!   diagnostics — a tool that could not even read a file must not look "clean"
-//!   to CI, so it surfaces as `2` regardless.
+//!   opened or fully enumerated, or a configured downstream server failed).
+//!   Independent of the diagnostics — a tool that could not even read a file
+//!   must not look "clean" to CI, so it surfaces as `2` regardless.
 //!
 //! Diagnostics stream to stdout per file. Every file is always scanned so the
 //! exit code reflects the whole set; if stdout is closed early (e.g. `kakehashi

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -160,8 +160,8 @@ struct Report {
     /// Whether any printed diagnostic should fail the run (an error, or a
     /// warning under `--fail-on-warning`).
     failure: bool,
-    /// Whether any operational error occurred (unreadable file, server
-    /// failure, un-openable path).
+    /// Whether any operational error occurred (unreadable file, path
+    /// open/enumeration failure, server failure).
     operational_error: bool,
 }
 

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -98,8 +98,8 @@ pub struct DiagnoseOptions {
 pub const EXIT_OK: u8 = 0;
 /// A failing diagnostic (an error, or a warning under `--fail-on-warning`).
 pub const EXIT_DIAGNOSTICS: u8 = 1;
-/// An operational error (unreadable file, un-openable path, downstream server
-/// failure). Independent of the diagnostics.
+/// An operational error (unreadable file, path open/enumeration failure,
+/// downstream server failure). Independent of the diagnostics.
 pub const EXIT_ERROR: u8 = 2;
 
 /// Per-server bound for waiting on cold downstream language servers, matching

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -162,11 +162,14 @@ fn walk_directory(
             }
             Err(e) => {
                 // Discard the write result rather than `eprintln!`: `diagnose`
-                // and `format` ignore SIGPIPE, so writing this warning to a
+                // and `format` ignore SIGPIPE, so writing this error to a
                 // closed stderr (`… 2>&1 | head`) would panic (exit 101).
-                // There is nowhere to report a failed warning, so drop it.
+                // There is nowhere to report a failed error message, so drop it.
                 use std::io::Write as _;
-                let _ = writeln!(std::io::stderr(), "warning: skipping unreadable entry: {e}");
+                let _ = writeln!(
+                    std::io::stderr(),
+                    "error: skipping unreadable entry (will exit 2): {e}"
+                );
                 errors += 1;
             }
         }

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -16,6 +16,13 @@
 
 use std::path::{Path, PathBuf};
 
+/// Files collected from CLI paths plus any non-fatal directory walk errors
+/// encountered while discovering them.
+pub(crate) struct CollectedFiles {
+    pub(crate) files: Vec<PathBuf>,
+    pub(crate) walk_errors: usize,
+}
+
 /// Build the `--excludes` matcher: gitignore-style patterns rooted at `base`
 /// (the current directory). [`ignore::overrides::Override`] is
 /// whitelist-oriented, so each user pattern is added negated (`!pattern`) to
@@ -42,17 +49,18 @@ fn build_exclude_matcher(
 ///   are kept.
 /// - A path that does not exist is an error.
 ///
-/// The result is sorted and deduplicated for deterministic processing order.
+/// The files are sorted and deduplicated for deterministic processing order.
 pub(crate) fn collect_files(
     base: &Path,
     paths: &[PathBuf],
     excludes: &[String],
     is_supported: &dyn Fn(&Path) -> bool,
-) -> Result<Vec<PathBuf>, String> {
+) -> Result<CollectedFiles, String> {
     let exclude_matcher = build_exclude_matcher(base, excludes)
         .map_err(|e| format!("invalid --excludes pattern: {e}"))?;
 
     let mut files = Vec::new();
+    let mut walk_errors = 0usize;
     for path in paths {
         // Normalize before stat: a relative path must resolve against
         // `base`, not against whatever the process cwd happens to be.
@@ -63,7 +71,7 @@ pub(crate) fn collect_files(
             if is_excluded(&exclude_matcher, base, &path, true) {
                 continue;
             }
-            walk_directory(&path, &exclude_matcher, is_supported, &mut files);
+            walk_errors += walk_directory(&path, &exclude_matcher, is_supported, &mut files);
         } else {
             if is_excluded(&exclude_matcher, base, &path, false) {
                 continue;
@@ -73,7 +81,7 @@ pub(crate) fn collect_files(
     }
     files.sort();
     files.dedup();
-    Ok(files)
+    Ok(CollectedFiles { files, walk_errors })
 }
 
 /// Absolutize `path` against `base` and clean `.`/`..` components, so the
@@ -128,14 +136,15 @@ fn is_excluded(
 }
 
 /// Walk `dir` respecting `.gitignore` and `--excludes`, appending every
-/// supported file to `out`. Unreadable entries are warned about and skipped
-/// rather than failing the whole run.
+/// supported file to `out`. Unreadable entries are warned about and counted
+/// so callers can surface an operational-error exit code after processing the
+/// files that were still discoverable.
 fn walk_directory(
     dir: &Path,
     exclude_matcher: &ignore::overrides::Override,
     is_supported: &dyn Fn(&Path) -> bool,
     out: &mut Vec<PathBuf>,
-) {
+) -> usize {
     let walker = ignore::WalkBuilder::new(dir)
         .overrides(exclude_matcher.clone())
         // Respect .gitignore files even outside a git repository: the
@@ -143,6 +152,7 @@ fn walk_directory(
         // only when git initialized the directory".
         .require_git(false)
         .build();
+    let mut errors = 0usize;
     for entry in walker {
         match entry {
             Ok(entry) => {
@@ -157,9 +167,11 @@ fn walk_directory(
                 // There is nowhere to report a failed warning, so drop it.
                 use std::io::Write as _;
                 let _ = writeln!(std::io::stderr(), "warning: skipping unreadable entry: {e}");
+                errors += 1;
             }
         }
     }
+    errors
 }
 
 #[cfg(test)]
@@ -177,6 +189,17 @@ mod tests {
         path.extension().is_some_and(|e| e == "md")
     }
 
+    fn collect_paths(
+        base: &Path,
+        paths: &[PathBuf],
+        excludes: &[String],
+        is_supported: &dyn Fn(&Path) -> bool,
+    ) -> Vec<PathBuf> {
+        collect_files(base, paths, excludes, is_supported)
+            .unwrap()
+            .files
+    }
+
     #[test]
     fn directory_walk_respects_gitignore_without_git_repo() {
         let tmp = tempfile::tempdir().unwrap();
@@ -184,8 +207,7 @@ mod tests {
         write(&tmp.path().join("ignored.md"), "x");
         write(&tmp.path().join(".gitignore"), "ignored.md\n");
 
-        let files =
-            collect_files(tmp.path(), &[tmp.path().to_path_buf()], &[], &markdown_only).unwrap();
+        let files = collect_paths(tmp.path(), &[tmp.path().to_path_buf()], &[], &markdown_only);
 
         assert_eq!(files, vec![tmp.path().join("kept.md")]);
     }
@@ -196,13 +218,12 @@ mod tests {
         write(&tmp.path().join("ignored.md"), "x");
         write(&tmp.path().join(".gitignore"), "ignored.md\n");
 
-        let files = collect_files(
+        let files = collect_paths(
             tmp.path(),
             &[tmp.path().join("ignored.md")],
             &[],
             &markdown_only,
-        )
-        .unwrap();
+        );
 
         assert_eq!(files, vec![tmp.path().join("ignored.md")]);
     }
@@ -213,13 +234,12 @@ mod tests {
         write(&tmp.path().join("kept.md"), "x");
         write(&tmp.path().join("dropped.md"), "x");
 
-        let files = collect_files(
+        let files = collect_paths(
             tmp.path(),
             &[tmp.path().to_path_buf()],
             &["dropped.md".to_string()],
             &markdown_only,
-        )
-        .unwrap();
+        );
 
         assert_eq!(files, vec![tmp.path().join("kept.md")]);
     }
@@ -229,13 +249,12 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         write(&tmp.path().join("dropped.md"), "x");
 
-        let files = collect_files(
+        let files = collect_paths(
             tmp.path(),
             &[tmp.path().join("dropped.md")],
             &["dropped.md".to_string()],
             &markdown_only,
-        )
-        .unwrap();
+        );
 
         assert!(files.is_empty());
     }
@@ -247,13 +266,12 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         write(&tmp.path().join("vendor/dep.md"), "x");
 
-        let files = collect_files(
+        let files = collect_paths(
             tmp.path(),
             &[tmp.path().join("vendor/dep.md")],
             &["vendor/".to_string()],
             &markdown_only,
-        )
-        .unwrap();
+        );
 
         assert!(files.is_empty());
     }
@@ -268,13 +286,12 @@ mod tests {
         std::fs::create_dir_all(&base).unwrap();
         write(&tmp.path().join("outside/doc.md"), "x");
 
-        let files = collect_files(
+        let files = collect_paths(
             &base,
             &[tmp.path().join("outside/doc.md")],
             &["outside/".to_string()],
             &markdown_only,
-        )
-        .unwrap();
+        );
 
         assert_eq!(files, vec![tmp.path().join("outside/doc.md")]);
     }
@@ -288,13 +305,12 @@ mod tests {
         let base = tmp.path().join("vendor");
         write(&base.join("kept.md"), "x");
 
-        let files = collect_files(
+        let files = collect_paths(
             &base,
             &[base.join("kept.md")],
             &["vendor/".to_string()],
             &markdown_only,
-        )
-        .unwrap();
+        );
 
         assert_eq!(files, vec![base.join("kept.md")]);
     }
@@ -305,13 +321,12 @@ mod tests {
         write(&tmp.path().join("vendor/dep.md"), "x");
         write(&tmp.path().join("kept.md"), "x");
 
-        let files = collect_files(
+        let files = collect_paths(
             tmp.path(),
             &[tmp.path().to_path_buf()],
             &["vendor/".to_string()],
             &markdown_only,
-        )
-        .unwrap();
+        );
 
         assert_eq!(files, vec![tmp.path().join("kept.md")]);
     }
@@ -322,10 +337,29 @@ mod tests {
         write(&tmp.path().join("doc.md"), "x");
         write(&tmp.path().join("notes.txt"), "x");
 
-        let files =
-            collect_files(tmp.path(), &[tmp.path().to_path_buf()], &[], &markdown_only).unwrap();
+        let files = collect_paths(tmp.path(), &[tmp.path().to_path_buf()], &[], &markdown_only);
 
         assert_eq!(files, vec![tmp.path().join("doc.md")]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn directory_walk_counts_unreadable_entries() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let tmp = tempfile::tempdir().unwrap();
+        write(&tmp.path().join("kept.md"), "x");
+        let unreadable = tmp.path().join("unreadable");
+        write(&unreadable.join("hidden.md"), "x");
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let result =
+            collect_files(tmp.path(), &[tmp.path().to_path_buf()], &[], &markdown_only).unwrap();
+
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        assert_eq!(result.files, vec![tmp.path().join("kept.md")]);
+        assert!(result.walk_errors > 0);
     }
 
     #[test]
@@ -335,13 +369,12 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         write(&tmp.path().join("script"), "#!/usr/bin/env lua");
 
-        let files = collect_files(
+        let files = collect_paths(
             tmp.path(),
             &[tmp.path().join("script")],
             &[],
             &markdown_only,
-        )
-        .unwrap();
+        );
 
         assert_eq!(files, vec![tmp.path().join("script")]);
     }
@@ -363,13 +396,12 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         write(&tmp.path().join("doc.md"), "x");
 
-        let files = collect_files(
+        let files = collect_paths(
             tmp.path(),
             &[tmp.path().join("doc.md"), tmp.path().to_path_buf()],
             &[],
             &markdown_only,
-        )
-        .unwrap();
+        );
 
         assert_eq!(files, vec![tmp.path().join("doc.md")]);
     }
@@ -382,7 +414,7 @@ mod tests {
         write(&tmp.path().join("doc.md"), "x");
         std::fs::create_dir_all(tmp.path().join("sub")).unwrap();
 
-        let files = collect_files(
+        let files = collect_paths(
             tmp.path(),
             &[
                 tmp.path().join("doc.md"),
@@ -390,8 +422,7 @@ mod tests {
             ],
             &[],
             &markdown_only,
-        )
-        .unwrap();
+        );
 
         assert_eq!(files, vec![tmp.path().join("doc.md")]);
     }
@@ -404,13 +435,12 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         write(&tmp.path().join(".hidden/doc.md"), "x");
 
-        let files = collect_files(
+        let files = collect_paths(
             tmp.path(),
             &[tmp.path().join(".hidden")],
             &[],
             &markdown_only,
-        )
-        .unwrap();
+        );
 
         assert_eq!(files, vec![tmp.path().join(".hidden/doc.md")]);
     }
@@ -424,8 +454,7 @@ mod tests {
         write(&tmp.path().join(".gitignore"), "build/\n");
         write(&tmp.path().join("build/out.md"), "x");
 
-        let files =
-            collect_files(tmp.path(), &[tmp.path().join("build")], &[], &markdown_only).unwrap();
+        let files = collect_paths(tmp.path(), &[tmp.path().join("build")], &[], &markdown_only);
 
         assert_eq!(files, vec![tmp.path().join("build/out.md")]);
     }

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -136,8 +136,8 @@ fn is_excluded(
 }
 
 /// Walk `dir` respecting `.gitignore` and `--excludes`, appending every
-/// supported file to `out`. Unreadable entries are warned about and counted
-/// so callers can surface an operational-error exit code after processing the
+/// supported file to `out`. Unreadable entries are reported and counted so
+/// callers can surface an operational-error exit code after processing the
 /// files that were still discoverable.
 fn walk_directory(
     dir: &Path,

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -347,16 +347,34 @@ mod tests {
     fn directory_walk_counts_unreadable_entries() {
         use std::os::unix::fs::PermissionsExt as _;
 
+        struct RestorePermissions<'a> {
+            path: &'a Path,
+            mode: u32,
+        }
+
+        impl Drop for RestorePermissions<'_> {
+            fn drop(&mut self) {
+                let _ =
+                    std::fs::set_permissions(self.path, std::fs::Permissions::from_mode(self.mode));
+            }
+        }
+
         let tmp = tempfile::tempdir().unwrap();
         write(&tmp.path().join("kept.md"), "x");
         let unreadable = tmp.path().join("unreadable");
         write(&unreadable.join("hidden.md"), "x");
         std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let _restore = RestorePermissions {
+            path: &unreadable,
+            mode: 0o700,
+        };
+
+        if std::fs::read_dir(&unreadable).is_ok() {
+            return;
+        }
 
         let result =
             collect_files(tmp.path(), &[tmp.path().to_path_buf()], &[], &markdown_only).unwrap();
-
-        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o700)).unwrap();
 
         assert_eq!(result.files, vec![tmp.path().join("kept.md")]);
         assert!(result.walk_errors > 0);

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -211,15 +211,17 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
         return EXIT_ERROR;
     }
 
-    let files = match collect_files(cwd, &options.paths, &options.excludes, &|path| {
+    let collected = match collect_files(cwd, &options.paths, &options.excludes, &|path| {
         server.cli_can_handle_path(path)
     }) {
-        Ok(files) => files,
+        Ok(collected) => collected,
         Err(e) => {
             eprintln!("error: {e}");
             return EXIT_ERROR;
         }
     };
+    let files = collected.files;
+    let walk_errors = collected.walk_errors;
 
     let mut changed = 0usize;
     let mut unchanged = 0usize;
@@ -279,7 +281,7 @@ async fn run_paths(server: &Kakehashi, cwd: &Path, options: &FormatOptions) -> u
         }
     }
 
-    let errors = read_errors + write_errors + server_errors;
+    let errors = walk_errors + read_errors + write_errors + server_errors;
     let error_suffix = if errors > 0 {
         format!(", {errors} error(s)")
     } else {


### PR DESCRIPTION
## Summary
- return directory walk enumeration error counts from the shared CLI file collector
- make both format and diagnose exit 2 when a tree is only partially enumerable
- add a Unix regression for unreadable directory entries with cleanup/privileged-runner guards
- align diagnose exit-code docs, README text, and CLI help

## Tests
- cargo test cli::files --lib
- make check

Fixes #490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `kakehashi diagnose` now reports “operational error” and exit code behavior correctly when file/directory walking fails (e.g., unreadable entries), even if diagnostics are produced.
  * Path formatting now includes directory-walking/globbing walk errors in the final error count and exit status.
* **Documentation**
  * Updated `kakehashi diagnose` help/README and inline documentation to clarify exit code 2 semantics, including path open/enumeration failure wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->