### PR TITLE
fix(config): validate didChangeConfiguration payloads

### DIFF
--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -609,7 +609,7 @@ pub(crate) fn infer_query_kind(path: &str) -> Option<QueryKind> {
     }
 }
 
-#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq, JsonSchema)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RawWorkspaceSettings {
     /// Directories to search for Tree-sitter parser libraries and query files.
@@ -629,12 +629,6 @@ pub struct RawWorkspaceSettings {
     /// Language servers for bridging LSP requests to injection regions.
     /// Map of server name to server configuration.
     pub language_servers: Option<HashMap<String, BridgeServerConfig>>,
-}
-
-impl RawWorkspaceSettings {
-    pub fn is_effectively_empty(&self) -> bool {
-        self == &Self::default()
-    }
 }
 
 /// Generate JSON Schema for the workspace configuration.

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -68,14 +68,19 @@ fn settings_payload(settings: Value) -> (Value, Vec<String>) {
             .filter(|key| is_workspace_setting_key_or_typo(key))
             .collect::<Vec<_>>();
         unknown_keys.extend(unknown_workspace_setting_keys(&kakehashi));
-        unknown_keys.sort();
+        sort_and_dedup_unknown_keys(&mut unknown_keys);
         return (kakehashi, unknown_keys);
     }
 
     let settings = kakehashi_targeted_payload(object);
     let mut unknown_keys = unknown_workspace_setting_keys(&settings);
-    unknown_keys.sort();
+    sort_and_dedup_unknown_keys(&mut unknown_keys);
     (settings, unknown_keys)
+}
+
+fn sort_and_dedup_unknown_keys(unknown_keys: &mut Vec<String>) {
+    unknown_keys.sort();
+    unknown_keys.dedup();
 }
 
 fn uses_deprecated_unwrapped_didchange_shape(settings: &Value) -> bool {
@@ -474,6 +479,18 @@ mod tests {
         assert_eq!(payload, serde_json::Value::Null);
         assert!(unknown_keys.is_empty());
         assert!(serde_json::from_value::<RawWorkspaceSettings>(payload).is_err());
+    }
+
+    #[test]
+    fn settings_payload_deduplicates_unknown_keys() {
+        let (_payload, unknown_keys) = settings_payload(serde_json::json!({
+            "kakehashi": {
+                "autoInstal": true
+            },
+            "autoInstal": false
+        }));
+
+        assert_eq!(unknown_keys, ["autoInstal"]);
     }
 
     #[test]

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -1,24 +1,341 @@
 //! didChangeConfiguration notification handler for Kakehashi.
 
-use std::collections::HashSet;
-use std::sync::OnceLock;
-
+use serde_json::Value;
 use tower_lsp_server::ls_types::DidChangeConfigurationParams;
 
 use crate::config::{RawWorkspaceSettings, WorkspaceSettings, merge_workspace_settings};
 
 use super::super::Kakehashi;
 
+const KNOWN_WORKSPACE_SETTING_KEYS: &[&str] = &[
+    "searchPaths",
+    "languages",
+    "captureMappings",
+    "autoInstall",
+    "diagnosticsDebounceMs",
+    "languageServers",
+];
+
+const KNOWN_AGGREGATION_SETTING_KEYS: &[&str] = &[
+    "maxFanOut",
+    "priorities",
+    "pullFallback",
+    "pushFallback",
+    "strategy",
+];
+
+const KNOWN_BRIDGE_LANGUAGE_SETTING_KEYS: &[&str] = &["aggregation", "enabled"];
+
+const KNOWN_BRIDGE_SERVER_SETTING_KEYS: &[&str] = &[
+    "cmd",
+    "enabled",
+    "initializationOptions",
+    "languages",
+    "onTypeFormattingTriggers",
+    "preferSharedInstance",
+    "rootMarkers",
+    "settings",
+    "workspaceMarkers",
+];
+
+const KNOWN_CAPTURE_MAPPINGS_SETTING_KEYS: &[&str] = &["folds", "highlights"];
+
+const KNOWN_LANGUAGE_SETTING_KEYS: &[&str] =
+    &["aliases", "base", "bridge", "layers", "parser", "queries"];
+
+const KNOWN_LAYER_AGGREGATION_SETTING_KEYS: &[&str] = &["priorities", "strategy"];
+
+const KNOWN_LAYERS_SETTING_KEYS: &[&str] = &["aggregation"];
+
+const KNOWN_QUERY_ITEM_SETTING_KEYS: &[&str] = &["kind", "path"];
+
+fn settings_payload(settings: Value) -> (Value, Vec<String>) {
+    let Value::Object(mut object) = settings else {
+        return (settings, Vec::new());
+    };
+
+    if object.contains_key("kakehashi") {
+        let kakehashi = object
+            .remove("kakehashi")
+            .expect("kakehashi key should exist after object lookup");
+        if !kakehashi.is_object() {
+            return (kakehashi, Vec::new());
+        }
+
+        let mut unknown_keys = object
+            .into_iter()
+            .map(|(key, _)| key)
+            .filter(|key| is_workspace_setting_key_or_typo(key))
+            .collect::<Vec<_>>();
+        unknown_keys.extend(unknown_workspace_setting_keys(&kakehashi));
+        unknown_keys.sort();
+        return (kakehashi, unknown_keys);
+    }
+
+    let settings = kakehashi_targeted_payload(object);
+    let mut unknown_keys = unknown_workspace_setting_keys(&settings);
+    unknown_keys.sort();
+    (settings, unknown_keys)
+}
+
+fn uses_deprecated_unwrapped_didchange_shape(settings: &Value) -> bool {
+    let Some(object) = settings.as_object() else {
+        return false;
+    };
+    if object.contains_key("kakehashi") {
+        return false;
+    }
+
+    kakehashi_targeted_payload(object.clone())
+        .as_object()
+        .is_some_and(|object| !object.is_empty())
+}
+
+fn kakehashi_targeted_payload(object: serde_json::Map<String, Value>) -> serde_json::Value {
+    let object = object
+        .into_iter()
+        .filter(|(key, _)| is_workspace_setting_key_or_typo(key))
+        .collect();
+    Value::Object(object)
+}
+
+fn format_rejected_keys(keys: &[String]) -> String {
+    keys.iter()
+        .map(|key| format!("`{key}`"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn unknown_object_keys(path: &str, value: &Value, known_keys: &[&str]) -> Vec<String> {
+    let Some(object) = value.as_object() else {
+        return Vec::new();
+    };
+
+    object
+        .keys()
+        .filter(|key| !known_keys.contains(&key.as_str()))
+        .map(|key| format!("{path}.{key}"))
+        .collect()
+}
+
+fn is_workspace_setting_key_or_typo(key: &str) -> bool {
+    KNOWN_WORKSPACE_SETTING_KEYS.contains(&key)
+        || KNOWN_WORKSPACE_SETTING_KEYS
+            .iter()
+            .any(|known_key| is_one_edit_apart(key, known_key))
+}
+
+fn is_one_edit_apart(candidate: &str, known: &str) -> bool {
+    let candidate = candidate.as_bytes();
+    let known = known.as_bytes();
+    let len_diff = candidate.len().abs_diff(known.len());
+    if len_diff > 1 {
+        return false;
+    }
+
+    if len_diff == 0 {
+        return candidate
+            .iter()
+            .zip(known.iter())
+            .filter(|(candidate, known)| candidate != known)
+            .count()
+            == 1;
+    }
+
+    let (shorter, longer) = if candidate.len() < known.len() {
+        (candidate, known)
+    } else {
+        (known, candidate)
+    };
+    let mut short_index = 0;
+    let mut long_index = 0;
+    let mut edits = 0;
+    while short_index < shorter.len() && long_index < longer.len() {
+        if shorter[short_index] == longer[long_index] {
+            short_index += 1;
+        } else {
+            edits += 1;
+            if edits > 1 {
+                return false;
+            }
+        }
+        long_index += 1;
+    }
+
+    true
+}
+
+fn unknown_workspace_setting_keys(settings: &Value) -> Vec<String> {
+    let Some(object) = settings.as_object() else {
+        return Vec::new();
+    };
+
+    let mut unknown_keys = object
+        .keys()
+        .filter(|key| !KNOWN_WORKSPACE_SETTING_KEYS.contains(&key.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    append_unknown_bridge_server_setting_keys(object, &mut unknown_keys);
+    append_unknown_capture_mappings_setting_keys(object, &mut unknown_keys);
+    append_unknown_language_setting_keys(object, &mut unknown_keys);
+
+    unknown_keys
+}
+
+fn append_unknown_bridge_server_setting_keys(
+    object: &serde_json::Map<String, Value>,
+    unknown_keys: &mut Vec<String>,
+) {
+    let Some(servers) = object.get("languageServers").and_then(Value::as_object) else {
+        return;
+    };
+
+    for (server_name, server) in servers {
+        unknown_keys.extend(unknown_object_keys(
+            &format!("languageServers.{server_name}"),
+            server,
+            KNOWN_BRIDGE_SERVER_SETTING_KEYS,
+        ));
+    }
+}
+
+fn append_unknown_capture_mappings_setting_keys(
+    object: &serde_json::Map<String, Value>,
+    unknown_keys: &mut Vec<String>,
+) {
+    let Some(capture_mappings) = object.get("captureMappings").and_then(Value::as_object) else {
+        return;
+    };
+
+    for (scope, query_type_mappings) in capture_mappings {
+        unknown_keys.extend(unknown_object_keys(
+            &format!("captureMappings.{scope}"),
+            query_type_mappings,
+            KNOWN_CAPTURE_MAPPINGS_SETTING_KEYS,
+        ));
+    }
+}
+
+fn append_unknown_language_setting_keys(
+    object: &serde_json::Map<String, Value>,
+    unknown_keys: &mut Vec<String>,
+) {
+    let Some(languages) = object.get("languages").and_then(Value::as_object) else {
+        return;
+    };
+
+    for (language_name, language) in languages {
+        let language_path = format!("languages.{language_name}");
+        unknown_keys.extend(unknown_object_keys(
+            &language_path,
+            language,
+            KNOWN_LANGUAGE_SETTING_KEYS,
+        ));
+
+        let Some(language) = language.as_object() else {
+            continue;
+        };
+
+        append_unknown_query_item_keys(&language_path, language, unknown_keys);
+        append_unknown_bridge_language_keys(&language_path, language, unknown_keys);
+        append_unknown_layers_keys(&language_path, language, unknown_keys);
+    }
+}
+
+fn append_unknown_query_item_keys(
+    language_path: &str,
+    language: &serde_json::Map<String, Value>,
+    unknown_keys: &mut Vec<String>,
+) {
+    let Some(queries) = language.get("queries").and_then(Value::as_array) else {
+        return;
+    };
+
+    for (query_index, query) in queries.iter().enumerate() {
+        unknown_keys.extend(unknown_object_keys(
+            &format!("{language_path}.queries.{query_index}"),
+            query,
+            KNOWN_QUERY_ITEM_SETTING_KEYS,
+        ));
+    }
+}
+
+fn append_unknown_bridge_language_keys(
+    language_path: &str,
+    language: &serde_json::Map<String, Value>,
+    unknown_keys: &mut Vec<String>,
+) {
+    let Some(bridge) = language.get("bridge").and_then(Value::as_object) else {
+        return;
+    };
+
+    for (bridge_name, bridge) in bridge {
+        let bridge_path = format!("{language_path}.bridge.{bridge_name}");
+        unknown_keys.extend(unknown_object_keys(
+            &bridge_path,
+            bridge,
+            KNOWN_BRIDGE_LANGUAGE_SETTING_KEYS,
+        ));
+
+        let Some(bridge) = bridge.as_object() else {
+            continue;
+        };
+        let Some(aggregation) = bridge.get("aggregation").and_then(Value::as_object) else {
+            continue;
+        };
+
+        for (method, config) in aggregation {
+            unknown_keys.extend(unknown_object_keys(
+                &format!("{bridge_path}.aggregation.{method}"),
+                config,
+                KNOWN_AGGREGATION_SETTING_KEYS,
+            ));
+        }
+    }
+}
+
+fn append_unknown_layers_keys(
+    language_path: &str,
+    language: &serde_json::Map<String, Value>,
+    unknown_keys: &mut Vec<String>,
+) {
+    let Some(layers) = language.get("layers") else {
+        return;
+    };
+
+    let layers_path = format!("{language_path}.layers");
+    unknown_keys.extend(unknown_object_keys(
+        &layers_path,
+        layers,
+        KNOWN_LAYERS_SETTING_KEYS,
+    ));
+
+    let Some(aggregation) = layers.get("aggregation").and_then(Value::as_object) else {
+        return;
+    };
+
+    for (method, config) in aggregation {
+        unknown_keys.extend(unknown_object_keys(
+            &format!("{layers_path}.aggregation.{method}"),
+            config,
+            KNOWN_LAYER_AGGREGATION_SETTING_KEYS,
+        ));
+    }
+}
+
 impl Kakehashi {
     /// Handle workspace/didChangeConfiguration notification.
     pub(crate) async fn did_change_configuration_impl(&self, params: DidChangeConfigurationParams) {
-        let normalized = normalize_kakehashi_settings(params.settings);
+        let uses_deprecated_unwrapped_shape =
+            uses_deprecated_unwrapped_didchange_shape(&params.settings);
+        let (settings_value, unknown_keys) = settings_payload(params.settings);
 
         // Nudge users off the deprecated `rootMarkers` key if this push carries
         // it. Detect from the raw value before serde's alias erases which key
         // was used; the claim guard shares the once-per-session slot with the
         // initialize path.
-        if crate::config::deprecation::json_uses_deprecated_root_markers(&normalized.raw_value)
+        if crate::config::deprecation::json_uses_deprecated_root_markers(&settings_value)
             && self
                 .settings_manager
                 .claim_root_markers_deprecation_warning()
@@ -28,7 +345,7 @@ impl Kakehashi {
                 .await;
         }
 
-        if normalized.uses_deprecated_unwrapped_shape
+        if uses_deprecated_unwrapped_shape
             && self
                 .settings_manager
                 .claim_unwrapped_didchange_deprecation_warning()
@@ -38,8 +355,26 @@ impl Kakehashi {
                 .await;
         }
 
-        let parsed = match parse_normalized_client_configuration(normalized) {
-            Ok(update) => update,
+        if !unknown_keys.is_empty() {
+            self.notifier()
+                .log_warning(format!(
+                    "workspace/didChangeConfiguration rejected configuration update containing unknown or mixed-format key(s): {}",
+                    format_rejected_keys(&unknown_keys)
+                ))
+                .await;
+            return;
+        }
+
+        if settings_value
+            .as_object()
+            .is_some_and(serde_json::Map::is_empty)
+        {
+            return;
+        }
+
+        // Parse the incoming settings.
+        let parsed = match serde_json::from_value::<RawWorkspaceSettings>(settings_value) {
+            Ok(settings) => settings,
             Err(err) => {
                 self.notifier()
                     .log_warning(format!("Failed to parse client configuration: {}", err))
@@ -48,23 +383,13 @@ impl Kakehashi {
             }
         };
 
-        let ClientConfigurationUpdate { settings, warnings } = parsed;
-
-        for warning in warnings {
-            self.notifier().log_warning(warning).await;
-        }
-
-        if raw_workspace_settings_is_empty(&settings) {
-            return;
-        }
-
         // Merge onto current effective settings (not from scratch).
         // The current settings already reflect defaults < user < project < initializationOptions,
         // so merging preserves languages and other fields set during initialize.
         let current_ts = self.settings_manager.load_raw_settings();
         // SAFETY: merge_workspace_settings(Some, Some) always returns Some, so unwrap_or_return is
         // defensive only — the None branch is unreachable under the current implementation.
-        let Some(merged_ts) = merge_workspace_settings(Some((*current_ts).clone()), Some(settings))
+        let Some(merged_ts) = merge_workspace_settings(Some((*current_ts).clone()), Some(parsed))
         else {
             log::warn!(
                 "merge_workspace_settings returned None despite two Some inputs; skipping configuration update"
@@ -93,629 +418,113 @@ impl Kakehashi {
     }
 }
 
-struct ClientConfigurationUpdate {
-    settings: RawWorkspaceSettings,
-    warnings: Vec<String>,
-}
-
-struct NormalizedClientConfiguration {
-    raw_value: serde_json::Value,
-    warnings: Vec<String>,
-    uses_deprecated_unwrapped_shape: bool,
-}
-
-#[cfg(test)]
-fn parse_client_configuration(
-    value: serde_json::Value,
-) -> Result<ClientConfigurationUpdate, serde_json::Error> {
-    parse_normalized_client_configuration(normalize_kakehashi_settings(value))
-}
-
-fn parse_normalized_client_configuration(
-    normalized: NormalizedClientConfiguration,
-) -> Result<ClientConfigurationUpdate, serde_json::Error> {
-    let settings = serde_json::from_value::<RawWorkspaceSettings>(normalized.raw_value)?;
-
-    Ok(ClientConfigurationUpdate {
-        settings,
-        warnings: normalized.warnings,
-    })
-}
-
-fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientConfiguration {
-    let Some(inner) = value.get("kakehashi").filter(|value| value.is_object()) else {
-        let top_level_flat = flat_configuration_without_wrappers(&value);
-        let top_level_flat_has_signal = has_configuration_signal(&top_level_flat);
-        let (raw_value, has_signal) = if top_level_flat_has_signal {
-            (top_level_flat, true)
-        } else {
-            (serde_json::Value::Object(serde_json::Map::new()), false)
-        };
-        let warnings = if has_signal {
-            ignored_key_warnings_from_keys(ignored_keys(&raw_value))
-        } else {
-            Vec::new()
-        };
-        return NormalizedClientConfiguration {
-            raw_value,
-            warnings,
-            uses_deprecated_unwrapped_shape: has_signal,
-        };
-    };
-
-    let mut warnings = Vec::new();
-    let mut raw_value = inner.clone();
-    let mut uses_deprecated_unwrapped_shape = false;
-
-    if let Some(raw_object) = raw_value.as_object_mut()
-        && let Some(root_object) = value.as_object()
-    {
-        uses_deprecated_unwrapped_shape |=
-            merge_flat_sibling_settings(raw_object, &mut warnings, root_object);
-    }
-
-    warnings.extend(ignored_keys(&raw_value));
-    warnings.sort();
-    warnings.dedup();
-
-    if warnings.is_empty() {
-        NormalizedClientConfiguration {
-            raw_value,
-            warnings: Vec::new(),
-            uses_deprecated_unwrapped_shape,
-        }
-    } else {
-        NormalizedClientConfiguration {
-            raw_value,
-            warnings: vec![format!(
-                "Ignored unknown client configuration key(s): {}",
-                warnings.join(", ")
-            )],
-            uses_deprecated_unwrapped_shape,
-        }
-    }
-}
-
-fn ignored_key_warnings_from_keys(mut ignored: Vec<String>) -> Vec<String> {
-    ignored.sort();
-    ignored.dedup();
-    if ignored.is_empty() {
-        Vec::new()
-    } else {
-        vec![format!(
-            "Ignored unknown client configuration key(s): {}",
-            ignored.join(", ")
-        )]
-    }
-}
-
-fn ignored_keys(value: &serde_json::Value) -> Vec<String> {
-    let Some(object) = value.as_object() else {
-        return Vec::new();
-    };
-
-    let mut ignored: Vec<_> = object
-        .iter()
-        .filter(|(key, value)| should_warn_unknown_key(key, value))
-        .map(|(key, _)| key.clone())
-        .collect();
-    ignored.sort();
-    ignored
-}
-
-fn flat_configuration_without_wrappers(value: &serde_json::Value) -> serde_json::Value {
-    let Some(object) = value.as_object() else {
-        return serde_json::Value::Object(serde_json::Map::new());
-    };
-
-    serde_json::Value::Object(
-        object
-            .iter()
-            .filter(|(key, _)| key.as_str() != "settings" && key.as_str() != "kakehashi")
-            .map(|(key, value)| (key.clone(), value.clone()))
-            .collect(),
-    )
-}
-
-fn merge_flat_sibling_settings(
-    raw_object: &mut serde_json::Map<String, serde_json::Value>,
-    warnings: &mut Vec<String>,
-    siblings: &serde_json::Map<String, serde_json::Value>,
-) -> bool {
-    let mut has_flat_configuration_signal = false;
-
-    for (key, candidate) in siblings {
-        if key == "settings" || key == "kakehashi" {
-            continue;
-        }
-
-        if is_known_configuration_key(key) {
-            has_flat_configuration_signal = true;
-            raw_object
-                .entry(key.clone())
-                .or_insert_with(|| candidate.clone());
-        } else if should_warn_unknown_key(key, candidate) {
-            has_flat_configuration_signal = true;
-            warnings.push(key.clone());
-        }
-    }
-
-    has_flat_configuration_signal
-}
-
-fn has_configuration_signal(value: &serde_json::Value) -> bool {
-    has_known_configuration_key(value) || has_probable_unknown_configuration_key(value)
-}
-
-fn has_known_configuration_key(value: &serde_json::Value) -> bool {
-    value.as_object().is_some_and(|object| {
-        object
-            .keys()
-            .any(|key| is_known_configuration_key(key.as_str()))
-    })
-}
-
-fn has_probable_unknown_configuration_key(value: &serde_json::Value) -> bool {
-    value.as_object().is_some_and(|object| {
-        object
-            .iter()
-            .any(|(key, value)| should_warn_unknown_key(key, value))
-    })
-}
-
-fn should_warn_unknown_key(key: &str, value: &serde_json::Value) -> bool {
-    !is_known_configuration_key(key)
-        && key != "settings"
-        && key != "kakehashi"
-        && !key.contains('.')
-        && if value.is_object() {
-            is_one_edit_from_known_configuration_key(key)
-        } else {
-            key.chars().any(|ch| ch.is_ascii_uppercase())
-                || is_one_edit_from_known_configuration_key(key)
-        }
-}
-
-fn is_known_configuration_key(key: &str) -> bool {
-    known_configuration_keys().contains(key)
-}
-
-fn is_one_edit_from_known_configuration_key(key: &str) -> bool {
-    known_configuration_keys()
-        .iter()
-        .any(|known| is_one_edit_apart(key, known))
-}
-
-fn is_one_edit_apart(left: &str, right: &str) -> bool {
-    let left = left.as_bytes();
-    let right = right.as_bytes();
-    let len_diff = left.len().abs_diff(right.len());
-    if len_diff > 1 {
-        return false;
-    }
-
-    if len_diff == 0 {
-        return left
-            .iter()
-            .zip(right.iter())
-            .filter(|(left, right)| left != right)
-            .count()
-            == 1;
-    }
-
-    let (shorter, longer) = if left.len() < right.len() {
-        (left, right)
-    } else {
-        (right, left)
-    };
-    let mut short_index = 0;
-    let mut long_index = 0;
-    let mut edits = 0;
-    while short_index < shorter.len() && long_index < longer.len() {
-        if shorter[short_index] == longer[long_index] {
-            short_index += 1;
-        } else {
-            edits += 1;
-            if edits > 1 {
-                return false;
-            }
-        }
-        long_index += 1;
-    }
-
-    true
-}
-
-fn known_configuration_keys() -> &'static HashSet<String> {
-    static KEYS: OnceLock<HashSet<String>> = OnceLock::new();
-
-    KEYS.get_or_init(|| {
-        let schema = serde_json::to_value(crate::config::json_schema()).unwrap_or_else(|err| {
-            log::warn!("failed to serialize RawWorkspaceSettings schema: {err}");
-            serde_json::Value::Null
-        });
-
-        schema
-            .get("properties")
-            .and_then(|properties| properties.as_object())
-            .map(|properties| properties.keys().cloned().collect())
-            .unwrap_or_default()
-    })
-}
-
-fn raw_workspace_settings_is_empty(settings: &RawWorkspaceSettings) -> bool {
-    settings.is_effectively_empty()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::settings::{
+        AggregationConfig, BridgeLanguageConfig, BridgeServerConfig, LanguageSettings,
+        LayerAggregationConfig, LayersConfig, QueryItem, QueryTypeMappings,
+    };
+    use std::collections::BTreeSet;
 
-    #[test]
-    fn parses_wire_wrapped_kakehashi_settings() {
-        let params = serde_json::from_value::<DidChangeConfigurationParams>(serde_json::json!({
-            "settings": {
-                "kakehashi": {
-                    "autoInstall": false
-                }
-            }
-        }))
-        .expect("wire didChangeConfiguration params should deserialize");
-        let update = parse_client_configuration(params.settings)
-            .expect("wire settings.kakehashi payload should parse");
+    fn assert_known_keys_match_schema<T: schemars::JsonSchema>(
+        known_keys: &[&str],
+        aliases: &[&str],
+    ) {
+        let schema = schemars::schema_for!(T);
+        let value = serde_json::to_value(schema).expect("schema should serialize");
+        let properties = value["properties"]
+            .as_object()
+            .expect("schema should have properties");
 
-        assert_eq!(update.settings.auto_install, Some(false));
-        assert!(update.warnings.is_empty());
+        let mut schema_keys = properties.keys().cloned().collect::<BTreeSet<_>>();
+        schema_keys.extend(aliases.iter().map(|alias| (*alias).to_string()));
+        let known_keys = known_keys
+            .iter()
+            .map(|key| (*key).to_string())
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(known_keys, schema_keys);
     }
 
     #[test]
-    fn merges_known_flat_siblings_with_wrapped_settings() {
-        let payload = serde_json::json!({
-            "kakehashi": {
-                "autoInstall": false
-            },
-            "autoInstall": true,
-            "diagnosticsDebounceMs": 250,
-            "editorSetting": true
-        });
-        let update = parse_client_configuration(payload.clone())
-            .expect("mixed wrapped and flat settings should parse");
-
-        assert_eq!(update.settings.auto_install, Some(false));
-        assert_eq!(update.settings.diagnostics_debounce_ms, Some(250));
-        assert_eq!(
-            update.warnings,
-            vec!["Ignored unknown client configuration key(s): editorSetting"]
-        );
-        assert!(
-            normalize_kakehashi_settings(payload).uses_deprecated_unwrapped_shape,
-            "accepted flat siblings beside wrapped settings should still warn as deprecated"
-        );
-
-        let normalized = normalize_kakehashi_settings(serde_json::json!({
-            "kakehashi": {
-                "autoInstall": false
-            }
-        }));
-        assert!(
-            !normalized.uses_deprecated_unwrapped_shape,
-            "canonical wire settings.kakehashi payloads must not warn as deprecated"
-        );
+    fn known_workspace_setting_keys_match_schema_properties() {
+        assert_known_keys_match_schema::<RawWorkspaceSettings>(KNOWN_WORKSPACE_SETTING_KEYS, &[]);
     }
 
     #[test]
-    fn ignores_nested_settings_flat_siblings_with_wrapped_settings() {
-        let payload = serde_json::json!({
-            "kakehashi": {
-                "autoInstall": false
-            },
-            "settings": {
-                "diagnosticsDebounceMs": 250,
-                "editorSetting": true
-            }
-        });
-        let update = parse_client_configuration(payload.clone())
-            .expect("unsupported nested settings beside wrapped settings should parse");
+    fn section_sibling_filter_matches_workspace_keys_and_typos_only() {
+        assert!(is_workspace_setting_key_or_typo("autoInstall"));
+        assert!(is_workspace_setting_key_or_typo("autoInstal"));
+        assert!(is_workspace_setting_key_or_typo("languageServers"));
+        assert!(!is_workspace_setting_key_or_typo("autXInstal"));
 
-        assert_eq!(update.settings.auto_install, Some(false));
-        assert_eq!(update.settings.diagnostics_debounce_ms, None);
-        assert!(update.warnings.is_empty());
-        assert!(
-            !normalize_kakehashi_settings(payload).uses_deprecated_unwrapped_shape,
-            "unsupported nested settings are ignored rather than treated as accepted flat siblings"
-        );
+        assert!(!is_workspace_setting_key_or_typo("editor"));
+        assert!(!is_workspace_setting_key_or_typo("files"));
+        assert!(!is_workspace_setting_key_or_typo("workbench"));
     }
 
     #[test]
-    fn flat_siblings_do_not_override_wrapped_settings() {
-        let payload = serde_json::json!({
-            "kakehashi": {
-                "autoInstall": false
-            },
-            "autoInstall": true
-        });
-        let update = parse_client_configuration(payload.clone())
-            .expect("conflicting mixed settings should parse");
-
-        assert_eq!(update.settings.auto_install, Some(false));
-        assert!(update.warnings.is_empty());
-        assert!(
-            normalize_kakehashi_settings(payload).uses_deprecated_unwrapped_shape,
-            "accepted conflicting flat siblings beside wrapped settings should warn as deprecated"
-        );
-    }
-
-    #[test]
-    fn ignores_double_wrapped_kakehashi_settings() {
-        let update = parse_client_configuration(serde_json::json!({
-            "settings": {
-                "kakehashi": {
-                    "autoInstall": false
-                },
-                "diagnosticsDebounceMs": 250
-            }
-        }))
-        .expect("unsupported double-wrapped settings should parse as an empty update");
-
-        assert!(raw_workspace_settings_is_empty(&update.settings));
-        assert!(update.warnings.is_empty());
-    }
-
-    #[test]
-    fn warns_about_unknown_wrapped_keys() {
-        let update = parse_client_configuration(serde_json::json!({
-            "kakehashi": {
-                "autoInstal": false,
-                "autoInstall": true
-            }
-        }))
-        .expect("settings with unknown keys should still parse");
-
-        assert_eq!(update.settings.auto_install, Some(true));
-        assert_eq!(
-            update.warnings,
-            vec!["Ignored unknown client configuration key(s): autoInstal"]
-        );
-    }
-
-    #[test]
-    fn recognizes_empty_client_configuration() {
-        let update = parse_client_configuration(serde_json::json!({
-            "autoInstal": false
-        }))
-        .expect("unknown-only settings should still parse");
-
-        assert!(raw_workspace_settings_is_empty(&update.settings));
-        assert_eq!(
-            update.warnings,
-            vec!["Ignored unknown client configuration key(s): autoInstal"]
-        );
-
-        let normalized = normalize_kakehashi_settings(serde_json::json!({
-            "autoInstal": false
-        }));
-        assert!(
-            normalized.uses_deprecated_unwrapped_shape,
-            "typo-like flat didChange payloads should still surface the flat-shape deprecation"
-        );
-    }
-
-    #[test]
-    fn parses_flat_known_keys() {
-        let payload = serde_json::json!({
+    fn non_object_kakehashi_wrapper_reaches_parse_error_path() {
+        let (payload, unknown_keys) = settings_payload(serde_json::json!({
+            "kakehashi": null,
             "autoInstall": false
-        });
-        let update =
-            parse_client_configuration(payload.clone()).expect("flat payload should parse");
-
-        assert_eq!(update.settings.auto_install, Some(false));
-        assert!(update.warnings.is_empty());
-
-        let normalized = normalize_kakehashi_settings(payload);
-        assert!(
-            normalized.uses_deprecated_unwrapped_shape,
-            "flat didChange payloads should be accepted but deprecated"
-        );
-    }
-
-    #[test]
-    fn warns_about_unknown_flat_keys() {
-        let update = parse_client_configuration(serde_json::json!({
-            "autoInstall": false,
-            "autoInstal": true
-        }))
-        .expect("flat payload with typo should parse");
-
-        assert_eq!(update.settings.auto_install, Some(false));
-        assert_eq!(
-            update.warnings,
-            vec!["Ignored unknown client configuration key(s): autoInstal"]
-        );
-    }
-
-    #[test]
-    fn parses_multiple_flat_known_keys() {
-        let update = parse_client_configuration(serde_json::json!({
-            "autoInstall": false,
-            "diagnosticsDebounceMs": 250
-        }))
-        .expect("flat payload with multiple known keys should parse");
-
-        assert_eq!(update.settings.auto_install, Some(false));
-        assert_eq!(update.settings.diagnostics_debounce_ms, Some(250));
-        assert!(update.warnings.is_empty());
-    }
-
-    #[test]
-    fn parses_top_level_known_keys_when_settings_contains_other_servers() {
-        let update = parse_client_configuration(serde_json::json!({
-            "settings": {
-                "gopls": {
-                    "usePlaceholders": true
-                }
-            },
-            "autoInstall": false
-        }))
-        .expect("top-level known settings should parse beside other server settings");
-
-        assert_eq!(update.settings.auto_install, Some(false));
-        assert!(update.warnings.is_empty());
-    }
-
-    #[test]
-    fn unrelated_settings_do_not_trigger_flat_shape_deprecation() {
-        let normalized = normalize_kakehashi_settings(serde_json::json!({
-            "settings": {
-                "gopls": {
-                    "usePlaceholders": true
-                }
-            }
         }));
 
-        assert!(
-            !normalized.uses_deprecated_unwrapped_shape,
-            "unrelated editor/server settings must not claim the flat-shape deprecation slot"
-        );
-        assert!(raw_workspace_settings_is_empty(
-            &parse_normalized_client_configuration(normalized)
-                .expect("unrelated settings should parse as an empty update")
-                .settings
-        ));
+        assert_eq!(payload, serde_json::Value::Null);
+        assert!(unknown_keys.is_empty());
+        assert!(serde_json::from_value::<RawWorkspaceSettings>(payload).is_err());
     }
 
     #[test]
-    fn ignores_other_servers_settings_without_warning() {
-        let update = parse_client_configuration(serde_json::json!({
-            "settings": {
-                "gopls": {
-                    "usePlaceholders": true
-                }
-            }
-        }))
-        .expect("other servers' settings should parse as an empty update");
-
-        assert!(raw_workspace_settings_is_empty(&update.settings));
-        assert!(update.warnings.is_empty());
-    }
-
-    #[test]
-    fn ignores_dotted_editor_settings_without_warning() {
-        let update = parse_client_configuration(serde_json::json!({
-            "editor.fontSize": 14,
-            "gopls": {
-                "usePlaceholders": true
-            }
-        }))
-        .expect("editor settings should parse as an empty update");
-
-        assert!(raw_workspace_settings_is_empty(&update.settings));
-        assert!(update.warnings.is_empty());
-    }
-
-    #[test]
-    fn warns_about_object_valued_camel_case_typos() {
-        let update = parse_client_configuration(serde_json::json!({
-            "languageServerss": {},
-            "autoInstall": true
-        }))
-        .expect("object-valued config typo should still parse");
-
-        assert_eq!(update.settings.auto_install, Some(true));
-        assert_eq!(
-            update.warnings,
-            vec!["Ignored unknown client configuration key(s): languageServerss"]
+    fn known_bridge_server_setting_keys_match_schema_properties_and_aliases() {
+        assert_known_keys_match_schema::<BridgeServerConfig>(
+            KNOWN_BRIDGE_SERVER_SETTING_KEYS,
+            &["rootMarkers"],
         );
     }
 
     #[test]
-    fn ignores_unrelated_object_sections_beside_wrapped_settings() {
-        let normalized = normalize_kakehashi_settings(serde_json::json!({
-            "kakehashi": {
-                "autoInstall": false
-            },
-            "someServer": {
-                "usePlaceholders": true
-            }
-        }));
-
-        assert!(
-            !normalized.uses_deprecated_unwrapped_shape,
-            "unrelated object sections must not claim the flat-shape deprecation slot"
-        );
-        let update = parse_normalized_client_configuration(normalized)
-            .expect("wrapped settings with unrelated object section should parse");
-        assert_eq!(update.settings.auto_install, Some(false));
-        assert!(update.warnings.is_empty());
-    }
-
-    #[test]
-    fn warns_about_lowercase_object_typos_near_known_keys() {
-        let update = parse_client_configuration(serde_json::json!({
-            "languagess": {}
-        }))
-        .expect("lowercase object-valued config typo should still parse");
-
-        assert!(raw_workspace_settings_is_empty(&update.settings));
-        assert_eq!(
-            update.warnings,
-            vec!["Ignored unknown client configuration key(s): languagess"]
+    fn known_capture_mappings_setting_keys_match_schema_properties() {
+        assert_known_keys_match_schema::<QueryTypeMappings>(
+            KNOWN_CAPTURE_MAPPINGS_SETTING_KEYS,
+            &[],
         );
     }
 
     #[test]
-    fn non_object_kakehashi_settings_are_empty() {
-        let update = parse_client_configuration(serde_json::json!({
-            "settings": {
-                "kakehashi": null
-            }
-        }))
-        .expect("non-object wrapped settings should parse as an empty update");
-
-        assert!(raw_workspace_settings_is_empty(&update.settings));
-        assert!(update.warnings.is_empty());
+    fn known_language_setting_keys_match_schema_properties() {
+        assert_known_keys_match_schema::<LanguageSettings>(KNOWN_LANGUAGE_SETTING_KEYS, &[]);
     }
 
     #[test]
-    fn known_configuration_keys_come_from_schema_properties() {
-        let schema = serde_json::to_value(crate::config::json_schema())
-            .expect("RawWorkspaceSettings schema should serialize");
-        let expected: HashSet<_> = schema
-            .get("properties")
-            .and_then(|properties| properties.as_object())
-            .expect("schema should define top-level properties")
-            .keys()
-            .cloned()
-            .collect();
-
-        assert_eq!(known_configuration_keys(), &expected);
-        assert!(is_known_configuration_key("autoInstall"));
-        assert!(!is_known_configuration_key("autoInstal"));
+    fn known_query_item_setting_keys_match_schema_properties() {
+        assert_known_keys_match_schema::<QueryItem>(KNOWN_QUERY_ITEM_SETTING_KEYS, &[]);
     }
 
     #[test]
-    fn language_servers_empty_map_is_effective_configuration() {
-        let update = parse_client_configuration(serde_json::json!({
-            "languageServers": {}
-        }))
-        .expect("empty languageServers should parse");
-
-        assert!(!raw_workspace_settings_is_empty(&update.settings));
-    }
-
-    #[test]
-    fn normalization_preserves_deprecated_root_markers_before_parse_error() {
-        let normalized = normalize_kakehashi_settings(serde_json::json!({
-            "languageServers": {
-                "rust-analyzer": {
-                    "rootMarkers": [".git"],
-                    "cmd": "rust-analyzer"
-                }
-            }
-        }));
-
-        assert!(
-            crate::config::deprecation::json_uses_deprecated_root_markers(&normalized.raw_value)
+    fn known_bridge_language_setting_keys_match_schema_properties() {
+        assert_known_keys_match_schema::<BridgeLanguageConfig>(
+            KNOWN_BRIDGE_LANGUAGE_SETTING_KEYS,
+            &[],
         );
-        assert!(parse_normalized_client_configuration(normalized).is_err());
+    }
+
+    #[test]
+    fn known_aggregation_setting_keys_match_schema_properties() {
+        assert_known_keys_match_schema::<AggregationConfig>(KNOWN_AGGREGATION_SETTING_KEYS, &[]);
+    }
+
+    #[test]
+    fn known_layers_setting_keys_match_schema_properties() {
+        assert_known_keys_match_schema::<LayersConfig>(KNOWN_LAYERS_SETTING_KEYS, &[]);
+    }
+
+    #[test]
+    fn known_layer_aggregation_setting_keys_match_schema_properties() {
+        assert_known_keys_match_schema::<LayerAggregationConfig>(
+            KNOWN_LAYER_AGGREGATION_SETTING_KEYS,
+            &[],
+        );
     }
 }

--- a/tests/e2e_config_file.rs
+++ b/tests/e2e_config_file.rs
@@ -10,7 +10,7 @@
 mod helpers;
 
 use helpers::lsp_client::LspClient;
-use serde_json::json;
+use serde_json::{Value, json};
 use std::time::Duration;
 use tempfile::TempDir;
 
@@ -78,6 +78,25 @@ fn poll_effective_settings(
     let settings = query_effective_settings(client);
     assert!(predicate(&settings), "{}", msg);
     settings
+}
+
+fn is_config_updated(params: &Value) -> bool {
+    params["message"]
+        .as_str()
+        .is_some_and(|m| m.contains("Configuration updated"))
+}
+
+fn contains_unknown_config_key_warning(params: &Value, key: &str) -> bool {
+    params["message"].as_str().is_some_and(|m| {
+        params["type"].as_i64() == Some(2)
+            && m.contains("unknown")
+            && m.contains(key)
+            && m.contains("workspace/didChangeConfiguration")
+    })
+}
+
+fn is_unknown_config_key_warning(params: &Value) -> bool {
+    contains_unknown_config_key_warning(params, "autoInstal")
 }
 
 /// --config-file with a single valid file overrides default config locations.
@@ -374,6 +393,445 @@ fn test_did_change_configuration_updates_auto_install() {
         "didChangeConfiguration should update autoInstall to true",
     );
     assert_eq!(settings["autoInstall"], json!(true));
+}
+
+/// didChangeConfiguration accepts section-wrapped kakehashi settings.
+#[test]
+fn test_did_change_configuration_accepts_kakehashi_section() {
+    let dir = TempDir::new().unwrap();
+    let config = dir.path().join("base.toml");
+    std::fs::write(&config, "autoInstall = false\n").unwrap();
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config.to_str().unwrap())
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let settings = get_effective_settings(&mut client);
+    assert_eq!(settings["autoInstall"], json!(false), "precondition");
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({ "settings": { "kakehashi": { "autoInstall": true } } }),
+    );
+
+    let settings = poll_effective_settings(
+        &mut client,
+        |s| s["autoInstall"] == json!(true),
+        "didChangeConfiguration should accept kakehashi section-wrapped settings",
+    );
+    assert_eq!(settings["autoInstall"], json!(true));
+}
+
+/// didChangeConfiguration warns on unknown keys instead of reporting success.
+#[test]
+fn test_did_change_configuration_warns_on_unknown_keys() {
+    let dir = TempDir::new().unwrap();
+    let config = dir.path().join("base.toml");
+    std::fs::write(&config, "autoInstall = false\n").unwrap();
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config.to_str().unwrap())
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let settings = get_effective_settings(&mut client);
+    assert_eq!(settings["autoInstall"], json!(false), "precondition");
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({ "settings": { "autoInstal": true } }),
+    );
+
+    let (method, params) = client
+        .wait_for_notification_where(&["window/logMessage"], Duration::from_secs(5), |params| {
+            is_unknown_config_key_warning(params) || is_config_updated(params)
+        })
+        .expect("didChangeConfiguration should log a warning or success");
+    assert_eq!(method, "window/logMessage");
+    assert!(
+        is_unknown_config_key_warning(&params),
+        "unknown key should warn instead of reporting success; got: {params:?}"
+    );
+    let unexpected_success = client.wait_for_notification_where(
+        &["window/logMessage"],
+        Duration::from_millis(250),
+        is_config_updated,
+    );
+    assert!(
+        unexpected_success.is_none(),
+        "unknown-key-only update must not also log success; got: {unexpected_success:?}"
+    );
+
+    let settings = query_effective_settings(&mut client);
+    assert_eq!(
+        settings["autoInstall"],
+        json!(false),
+        "unknown-key-only update should leave settings unchanged"
+    );
+}
+
+/// didChangeConfiguration warns and does not apply mixed section/root payloads.
+#[test]
+fn test_did_change_configuration_warns_on_section_sibling_keys() {
+    let dir = TempDir::new().unwrap();
+    let config = dir.path().join("base.toml");
+    std::fs::write(&config, "autoInstall = false\n").unwrap();
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config.to_str().unwrap())
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let settings = get_effective_settings(&mut client);
+    assert_eq!(settings["autoInstall"], json!(false), "precondition");
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": {
+                "kakehashi": {
+                    "autoInstall": true
+                },
+                "autoInstal": false
+            }
+        }),
+    );
+
+    let (method, params) = client
+        .wait_for_notification_where(&["window/logMessage"], Duration::from_secs(5), |params| {
+            is_unknown_config_key_warning(params) || is_config_updated(params)
+        })
+        .expect("didChangeConfiguration should log a section-sibling warning or success");
+    assert_eq!(method, "window/logMessage");
+    assert!(
+        is_unknown_config_key_warning(&params),
+        "section sibling key should warn instead of reporting success; got: {params:?}"
+    );
+    let unexpected_success = client.wait_for_notification_where(
+        &["window/logMessage"],
+        Duration::from_millis(250),
+        is_config_updated,
+    );
+    assert!(
+        unexpected_success.is_none(),
+        "section-sibling update must not also log success; got: {unexpected_success:?}"
+    );
+
+    let settings = query_effective_settings(&mut client);
+    assert_eq!(
+        settings["autoInstall"],
+        json!(false),
+        "section-sibling update should leave settings unchanged"
+    );
+}
+
+/// didChangeConfiguration reports valid kakehashi sibling keys as mixed format.
+#[test]
+fn test_did_change_configuration_warns_on_valid_section_sibling_keys() {
+    let dir = TempDir::new().unwrap();
+    let config = dir.path().join("base.toml");
+    std::fs::write(&config, "autoInstall = false\n").unwrap();
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config.to_str().unwrap())
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let settings = get_effective_settings(&mut client);
+    assert_eq!(settings["autoInstall"], json!(false), "precondition");
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": {
+                "kakehashi": {
+                    "autoInstall": true
+                },
+                "autoInstall": false
+            }
+        }),
+    );
+
+    let (method, params) = client
+        .wait_for_notification_where(&["window/logMessage"], Duration::from_secs(5), |params| {
+            contains_unknown_config_key_warning(params, "autoInstall") || is_config_updated(params)
+        })
+        .expect("didChangeConfiguration should log a mixed-format warning or success");
+    assert_eq!(method, "window/logMessage");
+    assert!(
+        contains_unknown_config_key_warning(&params, "autoInstall"),
+        "mixed-format sibling key should warn instead of reporting success; got: {params:?}"
+    );
+    assert!(
+        params["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("mixed-format")),
+        "known sibling key should be described as mixed-format; got: {params:?}"
+    );
+    let unexpected_success = client.wait_for_notification_where(
+        &["window/logMessage"],
+        Duration::from_millis(250),
+        is_config_updated,
+    );
+    assert!(
+        unexpected_success.is_none(),
+        "mixed-format update must not also log success; got: {unexpected_success:?}"
+    );
+
+    let settings = query_effective_settings(&mut client);
+    assert_eq!(
+        settings["autoInstall"],
+        json!(false),
+        "mixed-format update should leave settings unchanged"
+    );
+}
+
+/// didChangeConfiguration ignores unrelated editor settings beside kakehashi.
+#[test]
+fn test_did_change_configuration_ignores_unrelated_section_siblings() {
+    let dir = TempDir::new().unwrap();
+    let config = dir.path().join("base.toml");
+    std::fs::write(&config, "autoInstall = false\n").unwrap();
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config.to_str().unwrap())
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let settings = get_effective_settings(&mut client);
+    assert_eq!(settings["autoInstall"], json!(false), "precondition");
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": {
+                "kakehashi": {
+                    "autoInstall": true
+                },
+                "editor": {
+                    "tabSize": 2
+                },
+                "files": {
+                    "trimTrailingWhitespace": true
+                }
+            }
+        }),
+    );
+
+    let settings = poll_effective_settings(
+        &mut client,
+        |s| s["autoInstall"] == json!(true),
+        "unrelated section siblings should not block kakehashi section updates",
+    );
+    assert_eq!(settings["autoInstall"], json!(true));
+}
+
+/// didChangeConfiguration does not report success for empty kakehashi sections.
+#[test]
+fn test_did_change_configuration_skips_empty_kakehashi_section() {
+    let dir = TempDir::new().unwrap();
+    let config = dir.path().join("base.toml");
+    std::fs::write(&config, "autoInstall = false\n").unwrap();
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config.to_str().unwrap())
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let settings = get_effective_settings(&mut client);
+    assert_eq!(settings["autoInstall"], json!(false), "precondition");
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": {
+                "kakehashi": {},
+                "editor": {
+                    "tabSize": 2
+                }
+            }
+        }),
+    );
+
+    let unexpected_success = client.wait_for_notification_where(
+        &["window/logMessage"],
+        Duration::from_millis(250),
+        is_config_updated,
+    );
+    assert!(
+        unexpected_success.is_none(),
+        "empty kakehashi section must not log success; got: {unexpected_success:?}"
+    );
+
+    let settings = query_effective_settings(&mut client);
+    assert_eq!(
+        settings["autoInstall"],
+        json!(false),
+        "empty kakehashi section should leave settings unchanged"
+    );
+}
+
+/// didChangeConfiguration warns and does not apply nested languageServers typos.
+#[test]
+fn test_did_change_configuration_warns_on_nested_unknown_keys() {
+    let mut client = LspClient::builder()
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let settings = get_effective_settings(&mut client);
+    assert!(settings["languageServers"].get("pyright").is_none());
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": {
+                "languageServers": {
+                    "pyright": {
+                        "cmd": ["pyright-langserver", "--stdio"],
+                        "languages": ["python"],
+                        "rootMarker": [".git"]
+                    }
+                }
+            }
+        }),
+    );
+
+    let (method, params) = client
+        .wait_for_notification_where(&["window/logMessage"], Duration::from_secs(5), |params| {
+            contains_unknown_config_key_warning(params, "languageServers.pyright.rootMarker")
+                || is_config_updated(params)
+        })
+        .expect("didChangeConfiguration should log a nested-key warning or success");
+    assert_eq!(method, "window/logMessage");
+    assert!(
+        contains_unknown_config_key_warning(&params, "languageServers.pyright.rootMarker"),
+        "nested unknown key should warn instead of reporting success; got: {params:?}"
+    );
+    let unexpected_success = client.wait_for_notification_where(
+        &["window/logMessage"],
+        Duration::from_millis(250),
+        is_config_updated,
+    );
+    assert!(
+        unexpected_success.is_none(),
+        "nested unknown-key update must not also log success; got: {unexpected_success:?}"
+    );
+
+    let settings = query_effective_settings(&mut client);
+    assert!(
+        settings["languageServers"].get("pyright").is_none(),
+        "nested unknown-key update should leave languageServers unchanged"
+    );
+}
+
+/// didChangeConfiguration warns and does not apply nested languages typos.
+#[test]
+fn test_did_change_configuration_warns_on_nested_language_unknown_keys() {
+    let mut client = LspClient::builder()
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let settings = get_effective_settings(&mut client);
+    assert!(settings["languages"].get("python").is_none());
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": {
+                "languages": {
+                    "python": {
+                        "parseer": "/tmp/parser.so"
+                    }
+                }
+            }
+        }),
+    );
+
+    let (method, params) = client
+        .wait_for_notification_where(&["window/logMessage"], Duration::from_secs(5), |params| {
+            contains_unknown_config_key_warning(params, "languages.python.parseer")
+                || is_config_updated(params)
+        })
+        .expect("didChangeConfiguration should log a nested language-key warning or success");
+    assert_eq!(method, "window/logMessage");
+    assert!(
+        contains_unknown_config_key_warning(&params, "languages.python.parseer"),
+        "nested language unknown key should warn instead of reporting success; got: {params:?}"
+    );
+    let unexpected_success = client.wait_for_notification_where(
+        &["window/logMessage"],
+        Duration::from_millis(250),
+        is_config_updated,
+    );
+    assert!(
+        unexpected_success.is_none(),
+        "nested language unknown-key update must not also log success; got: {unexpected_success:?}"
+    );
+
+    let settings = query_effective_settings(&mut client);
+    assert!(
+        settings["languages"].get("python").is_none(),
+        "nested language unknown-key update should leave languages unchanged"
+    );
+}
+
+/// didChangeConfiguration warns and does not apply nested captureMappings typos.
+#[test]
+fn test_did_change_configuration_warns_on_nested_capture_mapping_unknown_keys() {
+    let mut client = LspClient::builder()
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let initial_capture_mappings = get_effective_settings(&mut client)["captureMappings"].clone();
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": {
+                "captureMappings": {
+                    "_": {
+                        "highlight": {
+                            "variable.builtin": "keyword"
+                        }
+                    }
+                }
+            }
+        }),
+    );
+
+    let (method, params) = client
+        .wait_for_notification_where(&["window/logMessage"], Duration::from_secs(5), |params| {
+            contains_unknown_config_key_warning(params, "captureMappings._.highlight")
+                || is_config_updated(params)
+        })
+        .expect("didChangeConfiguration should log a nested capture mapping warning or success");
+    assert_eq!(method, "window/logMessage");
+    assert!(
+        contains_unknown_config_key_warning(&params, "captureMappings._.highlight"),
+        "nested capture mapping unknown key should warn instead of reporting success; got: {params:?}"
+    );
+    let unexpected_success = client.wait_for_notification_where(
+        &["window/logMessage"],
+        Duration::from_millis(250),
+        is_config_updated,
+    );
+    assert!(
+        unexpected_success.is_none(),
+        "nested capture mapping unknown-key update must not also log success; got: {unexpected_success:?}"
+    );
+
+    let updated_capture_mappings = query_effective_settings(&mut client)["captureMappings"].clone();
+    assert_eq!(
+        updated_capture_mappings, initial_capture_mappings,
+        "nested capture mapping unknown-key update should leave captureMappings unchanged",
+    );
 }
 
 /// didChangeConfiguration preserves config-file settings not mentioned in the update.

--- a/tests/e2e_config_file.rs
+++ b/tests/e2e_config_file.rs
@@ -90,7 +90,7 @@ fn contains_unknown_config_key_warning(params: &Value, key: &str) -> bool {
     params["message"].as_str().is_some_and(|m| {
         params["type"].as_i64() == Some(2)
             && m.contains("unknown")
-            && m.contains(key)
+            && m.contains(&format!("`{key}`"))
             && m.contains("workspace/didChangeConfiguration")
     })
 }
@@ -630,6 +630,93 @@ fn test_did_change_configuration_ignores_unrelated_section_siblings() {
         "unrelated section siblings should not block kakehashi section updates",
     );
     assert_eq!(settings["autoInstall"], json!(true));
+}
+
+/// didChangeConfiguration ignores unrelated flat settings while applying kakehashi keys.
+#[test]
+fn test_did_change_configuration_filters_unrelated_flat_settings() {
+    let dir = TempDir::new().unwrap();
+    let config = dir.path().join("base.toml");
+    std::fs::write(&config, "autoInstall = false\n").unwrap();
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config.to_str().unwrap())
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let settings = get_effective_settings(&mut client);
+    assert_eq!(settings["autoInstall"], json!(false), "precondition");
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": {
+                "autoInstall": true,
+                "gopls": {
+                    "staticcheck": true
+                },
+                "editor": {
+                    "tabSize": 2
+                }
+            }
+        }),
+    );
+
+    let settings = poll_effective_settings(
+        &mut client,
+        |s| s["autoInstall"] == json!(true),
+        "unrelated flat settings should not block kakehashi updates",
+    );
+    assert_eq!(settings["autoInstall"], json!(true));
+}
+
+/// didChangeConfiguration ignores unrelated flat settings without reporting success.
+#[test]
+fn test_did_change_configuration_skips_unrelated_flat_settings() {
+    let dir = TempDir::new().unwrap();
+    let config = dir.path().join("base.toml");
+    std::fs::write(&config, "autoInstall = false\n").unwrap();
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config.to_str().unwrap())
+        .env_remove("KAKEHASHI_DATA_DIR")
+        .build();
+
+    let settings = get_effective_settings(&mut client);
+    assert_eq!(settings["autoInstall"], json!(false), "precondition");
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": {
+                "gopls": {
+                    "staticcheck": true
+                },
+                "editor": {
+                    "tabSize": 2
+                }
+            }
+        }),
+    );
+
+    let unexpected_success = client.wait_for_notification_where(
+        &["window/logMessage"],
+        Duration::from_millis(250),
+        is_config_updated,
+    );
+    assert!(
+        unexpected_success.is_none(),
+        "unrelated flat settings must not log success; got: {unexpected_success:?}"
+    );
+
+    let settings = query_effective_settings(&mut client);
+    assert_eq!(
+        settings["autoInstall"],
+        json!(false),
+        "unrelated flat settings should leave kakehashi settings unchanged"
+    );
 }
 
 /// didChangeConfiguration does not report success for empty kakehashi sections.

--- a/tests/e2e_deprecation_warning.rs
+++ b/tests/e2e_deprecation_warning.rs
@@ -1,10 +1,12 @@
-//! E2E tests for one-per-session deprecation notices.
+//! E2E test for the one-per-session `rootMarkers` deprecation notice.
 //!
-//! `rootMarkers` shares a session-scoped guard between `initialize` and
-//! `workspace/didChangeConfiguration`; this drives the observable didChange path
-//! to prove the guard suppresses repeats. The unwrapped didChangeConfiguration
-//! notice is didChange-only, and is covered separately below. The guard and
-//! detectors are also covered in isolation by unit tests.
+//! The notice is surfaced by `initialize` and `workspace/didChangeConfiguration`
+//! sharing a single session-scoped claim guard, so it fires at most once even
+//! when config keeps carrying the deprecated key. This drives it through
+//! didChangeConfiguration (whose notifications, unlike a warning emitted during
+//! the `initialize` request, are observable by the test client) to prove the
+//! warn-path works and the guard suppresses the repeat. The guard and detectors
+//! are also covered in isolation by unit tests.
 
 #![cfg(feature = "e2e")]
 
@@ -45,6 +47,18 @@ fn config_with_root_markers() -> Value {
         "settings": {
             "languageServers": {
                 "x": { "cmd": ["true"], "languages": ["lua"], "rootMarkers": [".git"] }
+            }
+        }
+    })
+}
+
+fn section_wrapped_config_with_root_markers() -> Value {
+    json!({
+        "settings": {
+            "kakehashi": {
+                "languageServers": {
+                    "x": { "cmd": ["true"], "languages": ["lua"], "rootMarkers": [".git"] }
+                }
             }
         }
     })
@@ -134,6 +148,51 @@ fn e2e_root_markers_deprecation_warns_once_across_didchange() {
 }
 
 #[test]
+fn e2e_root_markers_deprecation_warns_for_section_wrapped_didchange() {
+    let config_dir = tempfile::TempDir::new().expect("temp config dir");
+    let config_path = config_dir.path().join("kakehashi.toml");
+    std::fs::write(&config_path, "").expect("write empty config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("utf-8 temp path"))
+        .build();
+
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": {}
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        section_wrapped_config_with_root_markers(),
+    );
+
+    let (method, params) = client
+        .wait_for_notification_where(&["window/showMessage"], TIMEOUT, is_deprecation_notice)
+        .expect("section-wrapped rootMarkers config should surface the deprecation popup");
+    assert_eq!(method, "window/showMessage");
+    assert_eq!(
+        params["type"].as_i64(),
+        Some(2),
+        "deprecation notice should be MessageType::WARNING"
+    );
+    client
+        .wait_for_notification_where(&["window/logMessage"], TIMEOUT, is_config_updated)
+        .expect("section-wrapped rootMarkers config should still be applied successfully");
+
+    let _ = client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
 fn e2e_unwrapped_didchange_deprecation_warns_once_and_ignores_unrelated_settings() {
     let config_dir = tempfile::TempDir::new().expect("temp config dir");
     let config_path = config_dir.path().join("kakehashi.toml");
@@ -156,15 +215,11 @@ fn e2e_unwrapped_didchange_deprecation_warns_once_and_ignores_unrelated_settings
     );
     client.send_notification("initialized", json!({}));
 
-    // Unrelated editor/server settings are ignored as an empty update and must
-    // not claim the flat-shape deprecation slot.
     client.send_notification(
         "workspace/didChangeConfiguration",
         json!({ "settings": { "gopls": { "usePlaceholders": true } } }),
     );
 
-    // Canonical wrapped settings are applied without the flat-shape
-    // deprecation popup.
     client.send_notification(
         "workspace/didChangeConfiguration",
         wrapped_didchange_config(false),
@@ -184,9 +239,6 @@ fn e2e_unwrapped_didchange_deprecation_warns_once_and_ignores_unrelated_settings
         "wrapped didChange config should update the effective runtime settings"
     );
 
-    // The first actual flat kakehashi runtime setting still gets the warning,
-    // proving the unrelated payload above did not consume the once-per-session
-    // guard and the wrapped payload above did not warn.
     client.send_notification(
         "workspace/didChangeConfiguration",
         flat_didchange_config(true),
@@ -213,8 +265,6 @@ fn e2e_unwrapped_didchange_deprecation_warns_once_and_ignores_unrelated_settings
         "flat didChange config should still update the effective runtime settings"
     );
 
-    // A second flat payload is still accepted, but the deprecation popup does
-    // not repeat before the successful update log.
     client.send_notification(
         "workspace/didChangeConfiguration",
         flat_didchange_config(false),

--- a/tests/e2e_deprecation_warning.rs
+++ b/tests/e2e_deprecation_warning.rs
@@ -1,4 +1,4 @@
-//! E2E test for the one-per-session `rootMarkers` deprecation notice.
+//! E2E tests for the one-per-session `rootMarkers` deprecation notice.
 //!
 //! The notice is surfaced by `initialize` and `workspace/didChangeConfiguration`
 //! sharing a single session-scoped claim guard, so it fires at most once even


### PR DESCRIPTION
## Summary
- Accept section-wrapped workspace/didChangeConfiguration payloads under settings.kakehashi.
- Warn and reject unknown/typo keys before deserialization, including nested schema-owned objects under languageServers, languages, and captureMappings.
- Preserve rootMarkers deprecation warnings for section-wrapped changes and reject mixed section/root payloads that would otherwise apply partially.

Closes #595.

## Verification
- cargo test --features e2e --test e2e_config_file test_did_change_configuration
- cargo test --features e2e --test e2e_deprecation_warning
- cargo test known_ --lib
- make check
- Codex MCP review: initial thread clean after fixes, fresh final pass clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened `workspace/didChangeConfiguration` to fully reject updates with any unknown configuration keys, preventing partial application (including mixed-format payloads and empty `kakehashi` sections).
  * Improved `rootMarkers` deprecation warnings for section-wrapped configurations.
* **New Features**
  * Added more robust settings payload validation, including recursive unknown-field detection and “one-edit-apart” typo tolerance.
* **Tests**
  * Expanded end-to-end and unit test coverage for accepted updates, rejection/warning behavior, typo cases, and nested unknown keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->