### PR TITLE
fix(install): validate parser metadata before fetch

### DIFF
--- a/src/install/http.rs
+++ b/src/install/http.rs
@@ -11,10 +11,15 @@ use ureq::tls::{RootCerts, TlsConfig};
 /// private root CAs trusted by the OS keep working, where ureq's default
 /// WebPKI roots would reject them.
 pub(crate) fn agent_with_timeout(timeout: Duration) -> Agent {
+    let mut config = Agent::config_builder().timeout_global(Some(timeout));
+    // Unit tests use loopback HTTP fixture servers; production install
+    // downloads stay HTTPS-only.
+    if !cfg!(test) {
+        config = config.https_only(true);
+    }
+
     Agent::new_with_config(
-        Agent::config_builder()
-            .timeout_global(Some(timeout))
-            .https_only(true)
+        config
             .tls_config(
                 TlsConfig::builder()
                     .root_certs(RootCerts::PlatformVerifier)

--- a/src/install/http.rs
+++ b/src/install/http.rs
@@ -14,6 +14,7 @@ pub(crate) fn agent_with_timeout(timeout: Duration) -> Agent {
     Agent::new_with_config(
         Agent::config_builder()
             .timeout_global(Some(timeout))
+            .https_only(true)
             .tls_config(
                 TlsConfig::builder()
                     .root_certs(RootCerts::PlatformVerifier)

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -820,7 +820,7 @@ fn parser_source_dir(
     location: Option<&str>,
 ) -> Result<PathBuf, ParserInstallError> {
     let Some(location) = location else {
-        return Ok(clone_dir.to_path_buf());
+        return Ok(clone_dir.canonicalize()?);
     };
     if location.is_empty()
         || Path::new(location)
@@ -833,7 +833,16 @@ fn parser_source_dir(
         )));
     }
 
-    Ok(clone_dir.join(location))
+    let clone_dir = clone_dir.canonicalize()?;
+    let source_dir = clone_dir.join(location).canonicalize()?;
+    if !source_dir.starts_with(&clone_dir) {
+        return Err(invalid_metadata(format!(
+            "unsafe parser location '{}'",
+            location.escape_default()
+        )));
+    }
+
+    Ok(source_dir)
 }
 
 fn invalid_metadata(message: String) -> ParserInstallError {
@@ -928,14 +937,38 @@ mod tests {
     #[test]
     fn parser_source_dir_accepts_safe_relative_location() {
         let temp = tempdir().expect("temp dir");
+        fs::create_dir_all(temp.path().join("typescript/common")).expect("create location");
         assert_eq!(
             parser_source_dir(temp.path(), Some("typescript/common")).expect("safe location"),
-            temp.path().join("typescript/common")
+            temp.path()
+                .join("typescript/common")
+                .canonicalize()
+                .unwrap()
         );
         assert_eq!(
             parser_source_dir(temp.path(), None).expect("missing location uses clone dir"),
-            temp.path()
+            temp.path().canonicalize().unwrap()
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parser_source_dir_rejects_symlink_location_escape() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().expect("temp dir");
+        let clone_dir = temp.path().join("clone");
+        let outside = temp.path().join("outside");
+        fs::create_dir_all(&clone_dir).expect("create clone dir");
+        fs::create_dir_all(&outside).expect("create outside dir");
+        symlink(&outside, clone_dir.join("grammar")).expect("create symlink");
+
+        match parser_source_dir(&clone_dir, Some("grammar")) {
+            Err(ParserInstallError::IoError(e)) => {
+                assert_eq!(e.kind(), std::io::ErrorKind::InvalidInput);
+            }
+            other => panic!("expected an InvalidInput IoError, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -742,8 +742,10 @@ fn kill_process_group(child: &mut std::process::Child) {
 
 /// Clone a git repository at a specific revision.
 fn clone_repo(url: &str, revision: &str, dest: &Path) -> Result<(), ParserInstallError> {
+    validate_git_clone_input(url, revision)?;
+
     // First, clone with depth 1 (we'll fetch the specific revision)
-    let mut clone = git_command(&["clone", "--depth", "1", url], None);
+    let mut clone = git_command(&["clone", "--depth", "1", "--", url], None);
     clone.arg(dest);
     let status = run_with_timeout(clone, GIT_COMMAND_TIMEOUT, "git clone")?;
 
@@ -756,7 +758,10 @@ fn clone_repo(url: &str, revision: &str, dest: &Path) -> Result<(), ParserInstal
 
     // Fetch the specific revision
     let status = run_with_timeout(
-        git_command(&["fetch", "--depth", "1", "origin", revision], Some(dest)),
+        git_command(
+            &["fetch", "--depth", "1", "origin", "--", revision],
+            Some(dest),
+        ),
         GIT_COMMAND_TIMEOUT,
         "git fetch",
     )?;
@@ -790,6 +795,36 @@ fn clone_repo(url: &str, revision: &str, dest: &Path) -> Result<(), ParserInstal
     Ok(())
 }
 
+fn validate_git_clone_input(url: &str, revision: &str) -> Result<(), ParserInstallError> {
+    if url.starts_with('-') {
+        return Err(invalid_metadata(format!(
+            "unsafe parser repository URL '{}'",
+            url.escape_default()
+        )));
+    }
+    if !url.starts_with("https://") {
+        return Err(invalid_metadata(format!(
+            "parser repository URL must use https://: '{}'",
+            url.escape_default()
+        )));
+    }
+    if revision.starts_with('-') {
+        return Err(invalid_metadata(format!(
+            "unsafe parser revision '{}'",
+            revision.escape_default()
+        )));
+    }
+
+    Ok(())
+}
+
+fn invalid_metadata(message: String) -> ParserInstallError {
+    ParserInstallError::IoError(std::io::Error::new(
+        std::io::ErrorKind::InvalidInput,
+        message,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -811,6 +846,19 @@ mod tests {
         // A traversal-capable name must be rejected before any filesystem or
         // network work — `install_parser` is a public entry point.
         match install_parser("../../evil", &options) {
+            Err(ParserInstallError::IoError(e)) => {
+                assert_eq!(e.kind(), std::io::ErrorKind::InvalidInput);
+            }
+            other => panic!("expected an InvalidInput IoError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn clone_repo_rejects_option_like_url() {
+        let temp = tempdir().expect("temp dir");
+        let dest = temp.path().join("parser");
+
+        match clone_repo("--upload-pack=sh", "main", &dest) {
             Err(ParserInstallError::IoError(e)) => {
                 assert_eq!(e.kind(), std::io::ErrorKind::InvalidInput);
             }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -4,6 +4,7 @@
 //! compiling them with tree-sitter-loader, and installing the resulting shared library.
 
 use std::fs;
+use std::path::Component;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
@@ -311,11 +312,7 @@ pub fn install_parser(
     fetch_source(&metadata.url, &metadata.revision, &clone_dir)?;
 
     // Determine the source directory (handle monorepos)
-    let source_dir = if let Some(ref location) = metadata.location {
-        clone_dir.join(location)
-    } else {
-        clone_dir.clone()
-    };
+    let source_dir = parser_source_dir(&clone_dir, metadata.location.as_deref())?;
 
     if options.verbose {
         eprintln!("Building parser in: {}", source_dir.display());
@@ -818,6 +815,27 @@ fn validate_git_clone_input(url: &str, revision: &str) -> Result<(), ParserInsta
     Ok(())
 }
 
+fn parser_source_dir(
+    clone_dir: &Path,
+    location: Option<&str>,
+) -> Result<PathBuf, ParserInstallError> {
+    let Some(location) = location else {
+        return Ok(clone_dir.to_path_buf());
+    };
+    if location.is_empty()
+        || Path::new(location)
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(invalid_metadata(format!(
+            "unsafe parser location '{}'",
+            location.escape_default()
+        )));
+    }
+
+    Ok(clone_dir.join(location))
+}
+
 fn invalid_metadata(message: String) -> ParserInstallError {
     ParserInstallError::IoError(std::io::Error::new(
         std::io::ErrorKind::InvalidInput,
@@ -864,6 +882,60 @@ mod tests {
             }
             other => panic!("expected an InvalidInput IoError, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn clone_repo_rejects_non_https_url() {
+        let temp = tempdir().expect("temp dir");
+        let dest = temp.path().join("parser");
+
+        match clone_repo("file:///tmp/parser", "main", &dest) {
+            Err(ParserInstallError::IoError(e)) => {
+                assert_eq!(e.kind(), std::io::ErrorKind::InvalidInput);
+            }
+            other => panic!("expected an InvalidInput IoError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn clone_repo_rejects_option_like_revision() {
+        let temp = tempdir().expect("temp dir");
+        let dest = temp.path().join("parser");
+
+        match clone_repo("https://example.invalid/parser", "--upload-pack=sh", &dest) {
+            Err(ParserInstallError::IoError(e)) => {
+                assert_eq!(e.kind(), std::io::ErrorKind::InvalidInput);
+            }
+            other => panic!("expected an InvalidInput IoError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parser_source_dir_rejects_unsafe_location() {
+        let temp = tempdir().expect("temp dir");
+        for location in ["", "/tmp/parser", "../parser", "parser/../other"] {
+            match parser_source_dir(temp.path(), Some(location)) {
+                Err(ParserInstallError::IoError(e)) => {
+                    assert_eq!(e.kind(), std::io::ErrorKind::InvalidInput);
+                }
+                other => {
+                    panic!("expected InvalidInput for location {location:?}, got {other:?}")
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn parser_source_dir_accepts_safe_relative_location() {
+        let temp = tempdir().expect("temp dir");
+        assert_eq!(
+            parser_source_dir(temp.path(), Some("typescript/common")).expect("safe location"),
+            temp.path().join("typescript/common")
+        );
+        assert_eq!(
+            parser_source_dir(temp.path(), None).expect("missing location uses clone dir"),
+            temp.path()
+        );
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -555,11 +555,18 @@ const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(120);
 /// diagnostics go to stderr, which stays inherited for the logs.
 fn git_command(args: &[&str], current_dir: Option<&Path>) -> Command {
     let mut cmd = Command::new("git");
-    cmd.args(["-c", "http.followRedirects=false"])
-        .args(args)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .env("GIT_TERMINAL_PROMPT", "0");
+    cmd.args([
+        "-c",
+        "http.followRedirects=false",
+        "-c",
+        "protocol.allow=never",
+        "-c",
+        "protocol.https.allow=always",
+    ])
+    .args(args)
+    .stdin(std::process::Stdio::null())
+    .stdout(std::process::Stdio::null())
+    .env("GIT_TERMINAL_PROMPT", "0");
     // `true` as an askpass helper answers any credential prompt with an empty
     // string immediately. POSIX guarantees the binary; Windows does not ship
     // one (git would fail trying to run it), so gate to unix — Windows relies
@@ -901,14 +908,25 @@ mod tests {
     }
 
     #[test]
-    fn git_command_disables_http_redirects() {
+    fn git_command_pins_https_transport() {
         let cmd = git_command(&["clone", "https://example.invalid/parser"], None);
         let args = cmd
             .get_args()
             .map(|arg| arg.to_string_lossy().into_owned())
             .collect::<Vec<_>>();
 
-        assert_eq!(&args[..3], ["-c", "http.followRedirects=false", "clone"]);
+        assert_eq!(
+            &args[..7],
+            [
+                "-c",
+                "http.followRedirects=false",
+                "-c",
+                "protocol.allow=never",
+                "-c",
+                "protocol.https.allow=always",
+                "clone",
+            ]
+        );
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -814,7 +814,19 @@ fn validate_git_clone_input(url: &str, revision: &str) -> Result<(), ParserInsta
             url.escape_default()
         )));
     }
+    if url.chars().any(char::is_control) {
+        return Err(invalid_metadata(format!(
+            "unsafe parser repository URL '{}'",
+            url.escape_default()
+        )));
+    }
     if revision.starts_with('-') {
+        return Err(invalid_metadata(format!(
+            "unsafe parser revision '{}'",
+            revision.escape_default()
+        )));
+    }
+    if revision.chars().any(char::is_control) {
         return Err(invalid_metadata(format!(
             "unsafe parser revision '{}'",
             revision.escape_default()
@@ -857,6 +869,9 @@ fn parser_source_dir(
 fn reject_symlinks_under(path: &Path) -> Result<(), ParserInstallError> {
     for entry in fs::read_dir(path)? {
         let entry = entry?;
+        if entry.file_name() == ".git" {
+            continue;
+        }
         let file_type = entry.file_type()?;
         if file_type.is_symlink() {
             return Err(invalid_metadata(format!(
@@ -969,6 +984,26 @@ mod tests {
     }
 
     #[test]
+    fn clone_repo_rejects_control_characters() {
+        let temp = tempdir().expect("temp dir");
+        let dest = temp.path().join("parser");
+
+        for (url, revision) in [
+            ("https://example.invalid/parser\nnext", "main"),
+            ("https://example.invalid/parser", "main\u{1b}[31m"),
+        ] {
+            match clone_repo(url, revision, &dest) {
+                Err(ParserInstallError::IoError(e)) => {
+                    assert_eq!(e.kind(), std::io::ErrorKind::InvalidInput);
+                }
+                other => panic!(
+                    "expected an InvalidInput IoError for {url:?} {revision:?}, got {other:?}"
+                ),
+            }
+        }
+    }
+
+    #[test]
     fn parser_source_dir_rejects_unsafe_location() {
         let temp = tempdir().expect("temp dir");
         for location in ["", "/tmp/parser", "../parser", "parser/../other"] {
@@ -1038,6 +1073,21 @@ mod tests {
             }
             other => panic!("expected an InvalidInput IoError, got {other:?}"),
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reject_symlinks_under_ignores_git_directory() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().expect("temp dir");
+        let source_dir = temp.path().join("grammar");
+        let outside = temp.path().join("outside");
+        fs::create_dir_all(source_dir.join(".git/objects")).expect("create git dir");
+        fs::write(&outside, "outside").expect("write outside file");
+        symlink(&outside, source_dir.join(".git/objects/link")).expect("create git symlink");
+
+        reject_symlinks_under(&source_dir).expect(".git contents are not parser source");
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -812,7 +812,7 @@ fn validate_parser_source_metadata(url: &str, revision: &str) -> Result<(), Pars
     }
     if !url.starts_with("https://") {
         return Err(invalid_metadata(format!(
-            "parser repository URL must use https://: '{}'",
+            "parser repository URL must use the https:// scheme: '{}'",
             url.escape_default()
         )));
     }
@@ -857,10 +857,22 @@ fn parser_source_dir(
     }
 
     let clone_dir = clone_dir.canonicalize()?;
-    let source_dir = clone_dir.join(location).canonicalize()?;
+    let source_dir = clone_dir.join(location).canonicalize().map_err(|err| {
+        invalid_metadata(format!(
+            "unsafe parser location '{}': {}",
+            location.escape_default(),
+            err
+        ))
+    })?;
     if !source_dir.starts_with(&clone_dir) {
         return Err(invalid_metadata(format!(
             "unsafe parser location '{}'",
+            location.escape_default()
+        )));
+    }
+    if !source_dir.is_dir() {
+        return Err(invalid_metadata(format!(
+            "unsafe parser location '{}' is not a directory",
             location.escape_default()
         )));
     }
@@ -1064,6 +1076,23 @@ mod tests {
             parser_source_dir(temp.path(), None).expect("missing location uses clone dir"),
             temp.path().canonicalize().unwrap()
         );
+    }
+
+    #[test]
+    fn parser_source_dir_rejects_missing_or_file_location() {
+        let temp = tempdir().expect("temp dir");
+        fs::write(temp.path().join("parser.c"), "void parser(void) {}").expect("write file");
+
+        for location in ["missing", "parser.c"] {
+            match parser_source_dir(temp.path(), Some(location)) {
+                Err(ParserInstallError::IoError(e)) => {
+                    assert_eq!(e.kind(), std::io::ErrorKind::InvalidInput);
+                }
+                other => {
+                    panic!("expected InvalidInput for location {location:?}, got {other:?}")
+                }
+            }
+        }
     }
 
     #[cfg(unix)]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -555,7 +555,8 @@ const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(120);
 /// diagnostics go to stderr, which stays inherited for the logs.
 fn git_command(args: &[&str], current_dir: Option<&Path>) -> Command {
     let mut cmd = Command::new("git");
-    cmd.args(args)
+    cmd.args(["-c", "http.followRedirects=false"])
+        .args(args)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .env("GIT_TERMINAL_PROMPT", "0");
@@ -897,6 +898,17 @@ mod tests {
             }
             other => panic!("expected an InvalidInput IoError, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn git_command_disables_http_redirects() {
+        let cmd = git_command(&["clone", "https://example.invalid/parser"], None);
+        let args = cmd
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(&args[..3], ["-c", "http.followRedirects=false", "clone"]);
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -411,6 +411,8 @@ fn clean_url(url: &str) -> &str {
 /// 1. If the URL is a GitHub HTTPS URL, try downloading the archive tarball.
 /// 2. If archive download fails (or URL is not GitHub), fall back to git clone.
 fn fetch_source(url: &str, revision: &str, dest: &Path) -> Result<(), ParserInstallError> {
+    validate_parser_source_metadata(url, revision)?;
+
     // Try archive download for GitHub URLs
     if let Some(archive_url) = github_archive_url(url, revision)
         && let Some(repo_name) = repo_name_from_url(url)
@@ -748,7 +750,7 @@ fn kill_process_group(child: &mut std::process::Child) {
 
 /// Clone a git repository at a specific revision.
 fn clone_repo(url: &str, revision: &str, dest: &Path) -> Result<(), ParserInstallError> {
-    validate_git_clone_input(url, revision)?;
+    validate_parser_source_metadata(url, revision)?;
 
     // First, clone with depth 1 (we'll fetch the specific revision)
     let mut clone = git_command(&["clone", "--depth", "1", "--", url], None);
@@ -801,7 +803,7 @@ fn clone_repo(url: &str, revision: &str, dest: &Path) -> Result<(), ParserInstal
     Ok(())
 }
 
-fn validate_git_clone_input(url: &str, revision: &str) -> Result<(), ParserInstallError> {
+fn validate_parser_source_metadata(url: &str, revision: &str) -> Result<(), ParserInstallError> {
     if url.starts_with('-') {
         return Err(invalid_metadata(format!(
             "unsafe parser repository URL '{}'",
@@ -814,7 +816,7 @@ fn validate_git_clone_input(url: &str, revision: &str) -> Result<(), ParserInsta
             url.escape_default()
         )));
     }
-    if url.chars().any(char::is_control) {
+    if url.chars().any(char::is_control) || url.contains("..") {
         return Err(invalid_metadata(format!(
             "unsafe parser repository URL '{}'",
             url.escape_default()
@@ -826,7 +828,7 @@ fn validate_git_clone_input(url: &str, revision: &str) -> Result<(), ParserInsta
             revision.escape_default()
         )));
     }
-    if revision.chars().any(char::is_control) {
+    if revision.chars().any(char::is_control) || revision.contains("..") {
         return Err(invalid_metadata(format!(
             "unsafe parser revision '{}'",
             revision.escape_default()
@@ -997,6 +999,31 @@ mod tests {
             ("https://example.invalid/parser", "main\u{1b}[31m"),
         ] {
             match clone_repo(url, revision, &dest) {
+                Err(ParserInstallError::IoError(e)) => {
+                    assert_eq!(e.kind(), std::io::ErrorKind::InvalidInput);
+                }
+                other => panic!(
+                    "expected an InvalidInput IoError for {url:?} {revision:?}, got {other:?}"
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn fetch_source_rejects_unsafe_archive_metadata() {
+        let temp = tempdir().expect("temp dir");
+        for (url, revision) in [
+            (
+                "https://github.com/tree-sitter/tree-sitter-json",
+                "main\nnext",
+            ),
+            (
+                "https://github.com/tree-sitter/tree-sitter-json",
+                "../../other/archive/main",
+            ),
+            ("https://github.com/tree-sitter/../other", "main"),
+        ] {
+            match fetch_source(url, revision, &temp.path().join("parser")) {
                 Err(ParserInstallError::IoError(e)) => {
                     assert_eq!(e.kind(), std::io::ErrorKind::InvalidInput);
                 }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -313,6 +313,7 @@ pub fn install_parser(
 
     // Determine the source directory (handle monorepos)
     let source_dir = parser_source_dir(&clone_dir, metadata.location.as_deref())?;
+    reject_symlinks_under(&source_dir)?;
 
     if options.verbose {
         eprintln!("Building parser in: {}", source_dir.display());
@@ -845,6 +846,24 @@ fn parser_source_dir(
     Ok(source_dir)
 }
 
+fn reject_symlinks_under(path: &Path) -> Result<(), ParserInstallError> {
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        let metadata = fs::symlink_metadata(entry.path())?;
+        if metadata.file_type().is_symlink() {
+            return Err(invalid_metadata(format!(
+                "unsafe symlink in parser source '{}'",
+                entry.path().display()
+            )));
+        }
+        if metadata.is_dir() {
+            reject_symlinks_under(&entry.path())?;
+        }
+    }
+
+    Ok(())
+}
+
 fn invalid_metadata(message: String) -> ParserInstallError {
     ParserInstallError::IoError(std::io::Error::new(
         std::io::ErrorKind::InvalidInput,
@@ -964,6 +983,26 @@ mod tests {
         symlink(&outside, clone_dir.join("grammar")).expect("create symlink");
 
         match parser_source_dir(&clone_dir, Some("grammar")) {
+            Err(ParserInstallError::IoError(e)) => {
+                assert_eq!(e.kind(), std::io::ErrorKind::InvalidInput);
+            }
+            other => panic!("expected an InvalidInput IoError, got {other:?}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reject_symlinks_under_rejects_nested_source_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().expect("temp dir");
+        let source_dir = temp.path().join("grammar");
+        let outside = temp.path().join("outside.c");
+        fs::create_dir_all(source_dir.join("src")).expect("create source src dir");
+        fs::write(&outside, "void tree_sitter_evil(void) {}").expect("write outside file");
+        symlink(&outside, source_dir.join("src/parser.c")).expect("create nested symlink");
+
+        match reject_symlinks_under(&source_dir) {
             Err(ParserInstallError::IoError(e)) => {
                 assert_eq!(e.kind(), std::io::ErrorKind::InvalidInput);
             }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -313,7 +313,7 @@ pub fn install_parser(
 
     // Determine the source directory (handle monorepos)
     let source_dir = parser_source_dir(&clone_dir, metadata.location.as_deref())?;
-    reject_symlinks_under(&source_dir)?;
+    reject_parser_source_symlinks(&source_dir)?;
 
     if options.verbose {
         eprintln!("Building parser in: {}", source_dir.display());
@@ -881,15 +881,27 @@ fn parser_source_dir(
     Ok(source_dir)
 }
 
-fn reject_symlinks_under(path: &Path) -> Result<(), ParserInstallError> {
-    let root = path.to_path_buf();
+fn reject_parser_source_symlinks(path: &Path) -> Result<(), ParserInstallError> {
+    let root = path.join("src");
+    let metadata = match fs::symlink_metadata(&root) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(ParserInstallError::IoError(err)),
+    };
+    if metadata.file_type().is_symlink() {
+        return Err(invalid_metadata(format!(
+            "unsafe symlink in parser source '{}'",
+            root.display().to_string().escape_default()
+        )));
+    }
+    if !metadata.is_dir() {
+        return Ok(());
+    }
+
     let mut pending = vec![root.clone()];
     while let Some(dir) = pending.pop() {
         for entry in fs::read_dir(&dir)? {
             let entry = entry?;
-            if dir == root && entry.file_name() == ".git" {
-                continue;
-            }
             let file_type = entry.file_type()?;
             if file_type.is_symlink() {
                 return Err(invalid_metadata(format!(
@@ -1145,7 +1157,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn reject_symlinks_under_rejects_nested_source_symlink() {
+    fn reject_parser_source_symlinks_rejects_nested_source_symlink() {
         use std::os::unix::fs::symlink;
 
         let temp = tempdir().expect("temp dir");
@@ -1155,7 +1167,7 @@ mod tests {
         fs::write(&outside, "void tree_sitter_evil(void) {}").expect("write outside file");
         symlink(&outside, source_dir.join("src/parser\n.c")).expect("create nested symlink");
 
-        match reject_symlinks_under(&source_dir) {
+        match reject_parser_source_symlinks(&source_dir) {
             Err(ParserInstallError::IoError(e)) => {
                 assert_eq!(e.kind(), std::io::ErrorKind::InvalidInput);
                 assert!(
@@ -1169,22 +1181,29 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn reject_symlinks_under_ignores_git_directory() {
+    fn reject_parser_source_symlinks_allows_symlinks_outside_compile_source() {
         use std::os::unix::fs::symlink;
 
         let temp = tempdir().expect("temp dir");
         let source_dir = temp.path().join("grammar");
         let outside = temp.path().join("outside");
-        fs::create_dir_all(source_dir.join(".git/objects")).expect("create git dir");
+        fs::create_dir_all(source_dir.join("bindings/go")).expect("create binding dir");
+        fs::create_dir_all(source_dir.join("scripts/dummy_plugin/queries"))
+            .expect("create script dir");
+        fs::create_dir_all(source_dir.join("src")).expect("create parser src dir");
         fs::write(&outside, "outside").expect("write outside file");
-        symlink(&outside, source_dir.join(".git/objects/link")).expect("create git symlink");
+        symlink(&outside, source_dir.join("bindings/go/scanner.c"))
+            .expect("create binding symlink");
+        symlink(&outside, source_dir.join("scripts/dummy_plugin/queries/bp"))
+            .expect("create script symlink");
 
-        reject_symlinks_under(&source_dir).expect(".git contents are not parser source");
+        reject_parser_source_symlinks(&source_dir)
+            .expect("non-compiled support files are not parser source");
     }
 
     #[cfg(unix)]
     #[test]
-    fn reject_symlinks_under_rejects_nested_dot_git_symlink() {
+    fn reject_parser_source_symlinks_rejects_nested_dot_git_symlink() {
         use std::os::unix::fs::symlink;
 
         let temp = tempdir().expect("temp dir");
@@ -1194,7 +1213,7 @@ mod tests {
         fs::create_dir_all(&outside).expect("create outside dir");
         symlink(&outside, source_dir.join("src/.git")).expect("create nested .git symlink");
 
-        match reject_symlinks_under(&source_dir) {
+        match reject_parser_source_symlinks(&source_dir) {
             Err(ParserInstallError::IoError(e)) => {
                 assert_eq!(e.kind(), std::io::ErrorKind::InvalidInput);
             }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -867,20 +867,23 @@ fn parser_source_dir(
 }
 
 fn reject_symlinks_under(path: &Path) -> Result<(), ParserInstallError> {
-    for entry in fs::read_dir(path)? {
-        let entry = entry?;
-        if entry.file_name() == ".git" {
-            continue;
-        }
-        let file_type = entry.file_type()?;
-        if file_type.is_symlink() {
-            return Err(invalid_metadata(format!(
-                "unsafe symlink in parser source '{}'",
-                entry.path().display()
-            )));
-        }
-        if file_type.is_dir() {
-            reject_symlinks_under(&entry.path())?;
+    let mut pending = vec![path.to_path_buf()];
+    while let Some(dir) = pending.pop() {
+        for entry in fs::read_dir(&dir)? {
+            let entry = entry?;
+            if entry.file_name() == ".git" {
+                continue;
+            }
+            let file_type = entry.file_type()?;
+            if file_type.is_symlink() {
+                return Err(invalid_metadata(format!(
+                    "unsafe symlink in parser source '{}'",
+                    entry.path().display().to_string().escape_default()
+                )));
+            }
+            if file_type.is_dir() {
+                pending.push(entry.path());
+            }
         }
     }
 
@@ -1065,11 +1068,15 @@ mod tests {
         let outside = temp.path().join("outside.c");
         fs::create_dir_all(source_dir.join("src")).expect("create source src dir");
         fs::write(&outside, "void tree_sitter_evil(void) {}").expect("write outside file");
-        symlink(&outside, source_dir.join("src/parser.c")).expect("create nested symlink");
+        symlink(&outside, source_dir.join("src/parser\n.c")).expect("create nested symlink");
 
         match reject_symlinks_under(&source_dir) {
             Err(ParserInstallError::IoError(e)) => {
                 assert_eq!(e.kind(), std::io::ErrorKind::InvalidInput);
+                assert!(
+                    e.to_string().contains("\\n"),
+                    "symlink path should escape control characters: {e}"
+                );
             }
             other => panic!("expected an InvalidInput IoError, got {other:?}"),
         }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -766,10 +766,7 @@ fn clone_repo(url: &str, revision: &str, dest: &Path) -> Result<(), ParserInstal
 
     // Fetch the specific revision
     let status = run_with_timeout(
-        git_command(
-            &["fetch", "--depth", "1", "origin", "--", revision],
-            Some(dest),
-        ),
+        git_fetch_revision_command(revision, dest),
         GIT_COMMAND_TIMEOUT,
         "git fetch",
     )?;
@@ -801,6 +798,10 @@ fn clone_repo(url: &str, revision: &str, dest: &Path) -> Result<(), ParserInstal
     }
 
     Ok(())
+}
+
+fn git_fetch_revision_command(revision: &str, dest: &Path) -> Command {
+    git_command(&["fetch", "--depth", "1", "origin", revision], Some(dest))
 }
 
 fn validate_parser_source_metadata(url: &str, revision: &str) -> Result<(), ParserInstallError> {
@@ -958,6 +959,33 @@ mod tests {
                 "-c",
                 "protocol.https.allow=always",
                 "clone",
+            ]
+        );
+    }
+
+    #[test]
+    fn git_fetch_revision_command_uses_revision_as_refspec() {
+        let temp = tempdir().expect("temp dir");
+        let cmd = git_fetch_revision_command("v0.24.8", temp.path());
+        let args = cmd
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            args,
+            [
+                "-c",
+                "http.followRedirects=false",
+                "-c",
+                "protocol.allow=never",
+                "-c",
+                "protocol.https.allow=always",
+                "fetch",
+                "--depth",
+                "1",
+                "origin",
+                "v0.24.8",
             ]
         );
     }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -857,14 +857,14 @@ fn parser_source_dir(
 fn reject_symlinks_under(path: &Path) -> Result<(), ParserInstallError> {
     for entry in fs::read_dir(path)? {
         let entry = entry?;
-        let metadata = fs::symlink_metadata(entry.path())?;
-        if metadata.file_type().is_symlink() {
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
             return Err(invalid_metadata(format!(
                 "unsafe symlink in parser source '{}'",
                 entry.path().display()
             )));
         }
-        if metadata.is_dir() {
+        if file_type.is_dir() {
             reject_symlinks_under(&entry.path())?;
         }
     }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -867,11 +867,12 @@ fn parser_source_dir(
 }
 
 fn reject_symlinks_under(path: &Path) -> Result<(), ParserInstallError> {
-    let mut pending = vec![path.to_path_buf()];
+    let root = path.to_path_buf();
+    let mut pending = vec![root.clone()];
     while let Some(dir) = pending.pop() {
         for entry in fs::read_dir(&dir)? {
             let entry = entry?;
-            if entry.file_name() == ".git" {
+            if dir == root && entry.file_name() == ".git" {
                 continue;
             }
             let file_type = entry.file_type()?;
@@ -1095,6 +1096,26 @@ mod tests {
         symlink(&outside, source_dir.join(".git/objects/link")).expect("create git symlink");
 
         reject_symlinks_under(&source_dir).expect(".git contents are not parser source");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reject_symlinks_under_rejects_nested_dot_git_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().expect("temp dir");
+        let source_dir = temp.path().join("grammar");
+        let outside = temp.path().join("outside");
+        fs::create_dir_all(source_dir.join("src")).expect("create source src dir");
+        fs::create_dir_all(&outside).expect("create outside dir");
+        symlink(&outside, source_dir.join("src/.git")).expect("create nested .git symlink");
+
+        match reject_symlinks_under(&source_dir) {
+            Err(ParserInstallError::IoError(e)) => {
+                assert_eq!(e.kind(), std::io::ErrorKind::InvalidInput);
+            }
+            other => panic!("expected an InvalidInput IoError, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -801,7 +801,10 @@ fn clone_repo(url: &str, revision: &str, dest: &Path) -> Result<(), ParserInstal
 }
 
 fn git_fetch_revision_command(revision: &str, dest: &Path) -> Command {
-    git_command(&["fetch", "--depth", "1", "origin", revision], Some(dest))
+    git_command(
+        &["fetch", "--depth", "1", "origin", "--", revision],
+        Some(dest),
+    )
 }
 
 fn validate_parser_source_metadata(url: &str, revision: &str) -> Result<(), ParserInstallError> {
@@ -821,6 +824,12 @@ fn validate_parser_source_metadata(url: &str, revision: &str) -> Result<(), Pars
         return Err(invalid_metadata(format!(
             "unsafe parser repository URL '{}'",
             url.escape_default()
+        )));
+    }
+    if revision.is_empty() || revision.chars().any(char::is_whitespace) {
+        return Err(invalid_metadata(format!(
+            "unsafe parser revision '{}'",
+            revision.escape_default()
         )));
     }
     if revision.starts_with('-') {
@@ -909,7 +918,7 @@ fn reject_parser_source_symlinks(path: &Path) -> Result<(), ParserInstallError> 
                     entry.path().display().to_string().escape_default()
                 )));
             }
-            if file_type.is_dir() {
+            if file_type.is_dir() && entry.file_name() != ".git" {
                 pending.push(entry.path());
             }
         }
@@ -997,6 +1006,7 @@ mod tests {
                 "--depth",
                 "1",
                 "origin",
+                "--",
                 "v0.24.8",
             ]
         );
@@ -1038,6 +1048,23 @@ mod tests {
                 assert_eq!(e.kind(), std::io::ErrorKind::InvalidInput);
             }
             other => panic!("expected an InvalidInput IoError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn clone_repo_rejects_empty_or_whitespace_revision() {
+        let temp = tempdir().expect("temp dir");
+        let dest = temp.path().join("parser");
+
+        for revision in ["", " ", "main branch"] {
+            match clone_repo("https://example.invalid/parser", revision, &dest) {
+                Err(ParserInstallError::IoError(e)) => {
+                    assert_eq!(e.kind(), std::io::ErrorKind::InvalidInput);
+                }
+                other => panic!(
+                    "expected an InvalidInput IoError for revision {revision:?}, got {other:?}"
+                ),
+            }
         }
     }
 
@@ -1219,6 +1246,23 @@ mod tests {
             }
             other => panic!("expected an InvalidInput IoError, got {other:?}"),
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reject_parser_source_symlinks_skips_real_dot_git_directories() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().expect("temp dir");
+        let source_dir = temp.path().join("grammar");
+        let outside = temp.path().join("outside");
+        fs::create_dir_all(source_dir.join("src/.git/objects")).expect("create nested .git dir");
+        fs::create_dir_all(&outside).expect("create outside dir");
+        symlink(&outside, source_dir.join("src/.git/objects/link"))
+            .expect("create ignored git metadata symlink");
+
+        reject_parser_source_symlinks(&source_dir)
+            .expect("real .git directories are ignored after their own type check");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Reject unsafe parser git metadata before spawning git: non-HTTPS URLs, option-looking URLs/revisions, redirects, and protocol rewrites.
- Validate parser location metadata as a safe relative path, canonicalize containment after fetch, and reject symlinks under the compiled `src` tree before compilation.
- Allow parser repository support-file symlinks outside the compile source tree, fixing installs for languages such as `bp` and `foam`.
- Enforce HTTPS-only install HTTP requests.

Closes #602.

## Verification
- cargo test clone_repo_rejects --lib
- cargo test git_command --lib
- cargo test parser_source_dir --lib
- cargo test symlink --lib
- cargo fmt --check
- cargo test --lib -q reject_parser_source_symlinks
- cargo run -- language install --force bp
- cargo run -- language install --force foam
- cargo run -- language list | xargs -I{} bash -c 'cargo run -- language install --force {} || exit 255'
  - Confirmed `bp` and `foam` now install successfully.
  - Stopped later at `latex` because the upstream parser revision lacks generated `src/parser.c`, which is separate from the symlink validation change.
- make check
- Codex MCP review: clean after follow-up fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Security**
  * Strengthened parser installation to prevent path traversal and symlink-based escapes, ensuring downloaded sources stay within the intended directory.
  * Hardened Git-based parser retrieval by validating inputs, preventing option-like URL/revision values from being misinterpreted, and safely constructing clone/fetch operations.
  * Enforced HTTPS-only behavior for installer network requests, preventing non-HTTPS handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->