### PR TITLE
Deprecate flat didChange configuration settings

### DIFF
--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -20,7 +20,7 @@ pub(crate) const ROOT_MARKERS_DEPRECATION_NOTICE: &str = "kakehashi: the `rootMa
 /// User-facing text for runtime client-pushed configuration that still uses the
 /// old unwrapped/flat `workspace/didChangeConfiguration` shape.
 pub(crate) const UNWRAPPED_DIDCHANGE_CONFIGURATION_NOTICE: &str = "kakehashi: unwrapped `workspace/didChangeConfiguration` settings are deprecated; \
-     send runtime settings as `settings.kakehashi` or top-level `kakehashi`. \
+     send runtime settings in the notification's `settings.kakehashi` object. \
      Flat didChange settings still work for now but may be removed in a future release.";
 
 /// True if any `[languageServers.*]` entry declares the deprecated `rootMarkers`

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -17,6 +17,12 @@ pub(crate) const ROOT_MARKERS_DEPRECATION_NOTICE: &str = "kakehashi: the `rootMa
      `workspaceMarkers`. `rootMarkers` still works for now but may be removed \
      in a future release.";
 
+/// User-facing text for runtime client-pushed configuration that still uses the
+/// old unwrapped/flat `workspace/didChangeConfiguration` shape.
+pub(crate) const UNWRAPPED_DIDCHANGE_CONFIGURATION_NOTICE: &str = "kakehashi: unwrapped `workspace/didChangeConfiguration` settings are deprecated; \
+     send runtime settings as `settings.kakehashi` or top-level `kakehashi`. \
+     Flat didChange settings still work for now but may be removed in a future release.";
+
 /// True if any `[languageServers.*]` entry declares the deprecated `rootMarkers`
 /// key (superseded by `workspaceMarkers`), scanning raw TOML text.
 ///

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -431,6 +431,11 @@ impl Kakehashi {
                         ..Default::default()
                     },
                 )),
+                experimental: Some(serde_json::json!({
+                    "kakehashi": {
+                        "wrappedDidChangeConfigurationSettings": true,
+                    },
+                })),
                 ..ServerCapabilities::default()
             },
         })

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -352,26 +352,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parses_section_wrapped_kakehashi_settings() {
-        let update = parse_client_configuration(serde_json::json!({
-            "kakehashi": {
-                "autoInstall": false
+    fn parses_wire_wrapped_kakehashi_settings() {
+        let params = serde_json::from_value::<DidChangeConfigurationParams>(serde_json::json!({
+            "settings": {
+                "kakehashi": {
+                    "autoInstall": false
+                }
             }
         }))
-        .expect("wire settings.kakehashi payload should parse");
-
-        assert_eq!(update.settings.auto_install, Some(false));
-        assert!(update.warnings.is_empty());
-    }
-
-    #[test]
-    fn parses_top_level_wrapped_kakehashi_settings() {
-        let update = parse_client_configuration(serde_json::json!({
-            "kakehashi": {
-                "autoInstall": false
-            }
-        }))
-        .expect("top-level wrapped settings should parse");
+        .expect("wire didChangeConfiguration params should deserialize");
+        let update = parse_client_configuration(params.settings)
+            .expect("wire settings.kakehashi payload should parse");
 
         assert_eq!(update.settings.auto_install, Some(false));
         assert!(update.warnings.is_empty());

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -147,11 +147,11 @@ fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientCon
     let mut raw_value = inner.clone();
     let mut uses_deprecated_unwrapped_shape = false;
 
-    if let Some(raw_object) = raw_value.as_object_mut() {
-        if let Some(root_object) = value.as_object() {
-            uses_deprecated_unwrapped_shape |=
-                merge_flat_sibling_settings(raw_object, &mut warnings, root_object);
-        }
+    if let Some(raw_object) = raw_value.as_object_mut()
+        && let Some(root_object) = value.as_object()
+    {
+        uses_deprecated_unwrapped_shape |=
+            merge_flat_sibling_settings(raw_object, &mut warnings, root_object);
     }
 
     warnings.extend(ignored_keys(&raw_value));

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -28,6 +28,16 @@ impl Kakehashi {
                 .await;
         }
 
+        if normalized.uses_deprecated_unwrapped_shape
+            && self
+                .settings_manager
+                .claim_unwrapped_didchange_deprecation_warning()
+        {
+            self.notifier()
+                .show_warning(crate::config::deprecation::UNWRAPPED_DIDCHANGE_CONFIGURATION_NOTICE)
+                .await;
+        }
+
         let parsed = match parse_normalized_client_configuration(normalized) {
             Ok(update) => update,
             Err(err) => {
@@ -91,6 +101,7 @@ struct ClientConfigurationUpdate {
 struct NormalizedClientConfiguration {
     raw_value: serde_json::Value,
     warnings: Vec<String>,
+    uses_deprecated_unwrapped_shape: bool,
 }
 
 #[cfg(test)]
@@ -134,6 +145,7 @@ fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientCon
             return NormalizedClientConfiguration {
                 raw_value,
                 warnings,
+                uses_deprecated_unwrapped_shape: true,
             };
         }
 
@@ -150,6 +162,7 @@ fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientCon
         return NormalizedClientConfiguration {
             raw_value,
             warnings,
+            uses_deprecated_unwrapped_shape: has_signal,
         };
     };
 
@@ -174,6 +187,7 @@ fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientCon
         NormalizedClientConfiguration {
             raw_value,
             warnings: Vec::new(),
+            uses_deprecated_unwrapped_shape: false,
         }
     } else {
         NormalizedClientConfiguration {
@@ -182,6 +196,7 @@ fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientCon
                 "Ignored unknown client configuration key(s): {}",
                 warnings.join(", ")
             )],
+            uses_deprecated_unwrapped_shape: false,
         }
     }
 }
@@ -400,6 +415,18 @@ mod tests {
             update.warnings,
             vec!["Ignored unknown client configuration key(s): editorSetting"]
         );
+
+        let normalized = normalize_kakehashi_settings(serde_json::json!({
+            "settings": {
+                "kakehashi": {
+                    "autoInstall": false
+                }
+            }
+        }));
+        assert!(
+            !normalized.uses_deprecated_unwrapped_shape,
+            "canonical settings.kakehashi payloads must not warn as deprecated"
+        );
     }
 
     #[test]
@@ -485,19 +512,34 @@ mod tests {
             update.warnings,
             vec!["Ignored unknown client configuration key(s): autoInstal"]
         );
+
+        let normalized = normalize_kakehashi_settings(serde_json::json!({
+            "autoInstal": false
+        }));
+        assert!(
+            normalized.uses_deprecated_unwrapped_shape,
+            "typo-like flat didChange payloads should still surface the flat-shape deprecation"
+        );
     }
 
     #[test]
     fn parses_settings_root_known_keys() {
-        let update = parse_client_configuration(serde_json::json!({
+        let payload = serde_json::json!({
             "settings": {
                 "autoInstall": false
             }
-        }))
-        .expect("settings-root payload should parse");
+        });
+        let update = parse_client_configuration(payload.clone())
+            .expect("settings-root payload should parse");
 
         assert_eq!(update.settings.auto_install, Some(false));
         assert!(update.warnings.is_empty());
+
+        let normalized = normalize_kakehashi_settings(payload);
+        assert!(
+            normalized.uses_deprecated_unwrapped_shape,
+            "settings-root flat didChange payloads should be accepted but deprecated"
+        );
     }
 
     #[test]
@@ -547,6 +589,27 @@ mod tests {
 
         assert_eq!(update.settings.auto_install, Some(false));
         assert!(update.warnings.is_empty());
+    }
+
+    #[test]
+    fn unrelated_settings_do_not_trigger_flat_shape_deprecation() {
+        let normalized = normalize_kakehashi_settings(serde_json::json!({
+            "settings": {
+                "gopls": {
+                    "usePlaceholders": true
+                }
+            }
+        }));
+
+        assert!(
+            !normalized.uses_deprecated_unwrapped_shape,
+            "unrelated editor/server settings must not claim the flat-shape deprecation slot"
+        );
+        assert!(raw_workspace_settings_is_empty(
+            &parse_normalized_client_configuration(normalized)
+                .expect("unrelated settings should parse as an empty update")
+                .settings
+        ));
     }
 
     #[test]

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -123,36 +123,13 @@ fn parse_normalized_client_configuration(
 }
 
 fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientConfiguration {
-    let settings_root = value.get("settings").unwrap_or(&value);
-    let Some(inner) = settings_root
-        .get("kakehashi")
-        .filter(|value| value.is_object())
-        .or_else(|| value.get("kakehashi"))
-        .filter(|value| value.is_object())
-    else {
+    let Some(inner) = value.get("kakehashi").filter(|value| value.is_object()) else {
         let top_level_flat = flat_configuration_without_wrappers(&value);
-        let settings_root_has_signal = has_configuration_signal(settings_root);
         let top_level_flat_has_signal = has_configuration_signal(&top_level_flat);
-        if settings_root_has_signal {
-            let mut ignored = ignored_keys(settings_root);
-            let mut raw_value = settings_root.clone();
-            if let Some(raw_object) = raw_value.as_object_mut()
-                && let Some(top_level_object) = top_level_flat.as_object()
-            {
-                merge_flat_sibling_settings(raw_object, &mut ignored, top_level_object);
-            }
-            let warnings = ignored_key_warnings_from_keys(ignored);
-            return NormalizedClientConfiguration {
-                raw_value,
-                warnings,
-                uses_deprecated_unwrapped_shape: true,
-            };
-        }
-
         let (raw_value, has_signal) = if top_level_flat_has_signal {
             (top_level_flat, true)
         } else {
-            (settings_root.clone(), false)
+            (serde_json::Value::Object(serde_json::Map::new()), false)
         };
         let warnings = if has_signal {
             ignored_key_warnings_from_keys(ignored_keys(&raw_value))
@@ -171,11 +148,6 @@ fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientCon
     let mut uses_deprecated_unwrapped_shape = false;
 
     if let Some(raw_object) = raw_value.as_object_mut() {
-        if let Some(settings_object) = value["settings"].as_object() {
-            uses_deprecated_unwrapped_shape |=
-                merge_flat_sibling_settings(raw_object, &mut warnings, settings_object);
-        }
-
         if let Some(root_object) = value.as_object() {
             uses_deprecated_unwrapped_shape |=
                 merge_flat_sibling_settings(raw_object, &mut warnings, root_object);
@@ -379,13 +351,11 @@ mod tests {
     #[test]
     fn parses_section_wrapped_kakehashi_settings() {
         let update = parse_client_configuration(serde_json::json!({
-            "settings": {
-                "kakehashi": {
-                    "autoInstall": false
-                }
+            "kakehashi": {
+                "autoInstall": false
             }
         }))
-        .expect("section-wrapped settings should parse");
+        .expect("wire settings.kakehashi payload should parse");
 
         assert_eq!(update.settings.auto_install, Some(false));
         assert!(update.warnings.is_empty());
@@ -407,10 +377,8 @@ mod tests {
     #[test]
     fn merges_known_flat_siblings_with_wrapped_settings() {
         let payload = serde_json::json!({
-            "settings": {
-                "kakehashi": {
-                    "autoInstall": false
-                }
+            "kakehashi": {
+                "autoInstall": false
             },
             "autoInstall": true,
             "diagnosticsDebounceMs": 250,
@@ -431,49 +399,43 @@ mod tests {
         );
 
         let normalized = normalize_kakehashi_settings(serde_json::json!({
-            "settings": {
-                "kakehashi": {
-                    "autoInstall": false
-                }
+            "kakehashi": {
+                "autoInstall": false
             }
         }));
         assert!(
             !normalized.uses_deprecated_unwrapped_shape,
-            "canonical settings.kakehashi payloads must not warn as deprecated"
+            "canonical wire settings.kakehashi payloads must not warn as deprecated"
         );
     }
 
     #[test]
-    fn merges_settings_root_flat_siblings_with_wrapped_settings() {
+    fn ignores_nested_settings_flat_siblings_with_wrapped_settings() {
         let payload = serde_json::json!({
+            "kakehashi": {
+                "autoInstall": false
+            },
             "settings": {
-                "kakehashi": {
-                    "autoInstall": false
-                },
                 "diagnosticsDebounceMs": 250,
                 "editorSetting": true
             }
         });
         let update = parse_client_configuration(payload.clone())
-            .expect("settings-root mixed wrapped and flat settings should parse");
+            .expect("unsupported nested settings beside wrapped settings should parse");
 
         assert_eq!(update.settings.auto_install, Some(false));
-        assert_eq!(update.settings.diagnostics_debounce_ms, Some(250));
-        assert_eq!(
-            update.warnings,
-            vec!["Ignored unknown client configuration key(s): editorSetting"]
-        );
+        assert_eq!(update.settings.diagnostics_debounce_ms, None);
+        assert!(update.warnings.is_empty());
         assert!(
-            normalize_kakehashi_settings(payload).uses_deprecated_unwrapped_shape,
-            "accepted settings-root flat siblings beside wrapped settings should warn as deprecated"
+            !normalize_kakehashi_settings(payload).uses_deprecated_unwrapped_shape,
+            "unsupported nested settings are ignored rather than treated as accepted flat siblings"
         );
     }
 
     #[test]
-    fn settings_root_flat_siblings_precede_top_level_siblings() {
+    fn flat_siblings_do_not_override_wrapped_settings() {
         let payload = serde_json::json!({
-            "settings": {
-                "kakehashi": {},
+            "kakehashi": {
                 "autoInstall": false
             },
             "autoInstall": true
@@ -493,12 +455,10 @@ mod tests {
     fn ignores_double_wrapped_kakehashi_settings() {
         let update = parse_client_configuration(serde_json::json!({
             "settings": {
-                "settings": {
-                    "kakehashi": {
-                        "autoInstall": false
-                    },
-                    "diagnosticsDebounceMs": 250
-                }
+                "kakehashi": {
+                    "autoInstall": false
+                },
+                "diagnosticsDebounceMs": 250
             }
         }))
         .expect("unsupported double-wrapped settings should parse as an empty update");
@@ -547,14 +507,12 @@ mod tests {
     }
 
     #[test]
-    fn parses_settings_root_known_keys() {
+    fn parses_flat_known_keys() {
         let payload = serde_json::json!({
-            "settings": {
-                "autoInstall": false
-            }
+            "autoInstall": false
         });
-        let update = parse_client_configuration(payload.clone())
-            .expect("settings-root payload should parse");
+        let update =
+            parse_client_configuration(payload.clone()).expect("flat payload should parse");
 
         assert_eq!(update.settings.auto_install, Some(false));
         assert!(update.warnings.is_empty());
@@ -562,19 +520,17 @@ mod tests {
         let normalized = normalize_kakehashi_settings(payload);
         assert!(
             normalized.uses_deprecated_unwrapped_shape,
-            "settings-root flat didChange payloads should be accepted but deprecated"
+            "flat didChange payloads should be accepted but deprecated"
         );
     }
 
     #[test]
-    fn warns_about_unknown_top_level_keys_dropped_for_settings_root() {
+    fn warns_about_unknown_flat_keys() {
         let update = parse_client_configuration(serde_json::json!({
-            "settings": {
-                "autoInstall": false
-            },
+            "autoInstall": false,
             "autoInstal": true
         }))
-        .expect("settings-root payload with top-level typo should parse");
+        .expect("flat payload with typo should parse");
 
         assert_eq!(update.settings.auto_install, Some(false));
         assert_eq!(
@@ -584,15 +540,12 @@ mod tests {
     }
 
     #[test]
-    fn merges_known_top_level_keys_with_settings_root() {
+    fn parses_multiple_flat_known_keys() {
         let update = parse_client_configuration(serde_json::json!({
-            "settings": {
-                "autoInstall": false
-            },
-            "autoInstall": true,
+            "autoInstall": false,
             "diagnosticsDebounceMs": 250
         }))
-        .expect("settings-root payload with top-level known keys should parse");
+        .expect("flat payload with multiple known keys should parse");
 
         assert_eq!(update.settings.auto_install, Some(false));
         assert_eq!(update.settings.diagnostics_debounce_ms, Some(250));

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -168,14 +168,17 @@ fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientCon
 
     let mut warnings = Vec::new();
     let mut raw_value = inner.clone();
+    let mut uses_deprecated_unwrapped_shape = false;
 
     if let Some(raw_object) = raw_value.as_object_mut() {
         if let Some(settings_object) = value["settings"].as_object() {
-            merge_flat_sibling_settings(raw_object, &mut warnings, settings_object);
+            uses_deprecated_unwrapped_shape |=
+                merge_flat_sibling_settings(raw_object, &mut warnings, settings_object);
         }
 
         if let Some(root_object) = value.as_object() {
-            merge_flat_sibling_settings(raw_object, &mut warnings, root_object);
+            uses_deprecated_unwrapped_shape |=
+                merge_flat_sibling_settings(raw_object, &mut warnings, root_object);
         }
     }
 
@@ -187,7 +190,7 @@ fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientCon
         NormalizedClientConfiguration {
             raw_value,
             warnings: Vec::new(),
-            uses_deprecated_unwrapped_shape: false,
+            uses_deprecated_unwrapped_shape,
         }
     } else {
         NormalizedClientConfiguration {
@@ -196,7 +199,7 @@ fn normalize_kakehashi_settings(value: serde_json::Value) -> NormalizedClientCon
                 "Ignored unknown client configuration key(s): {}",
                 warnings.join(", ")
             )],
-            uses_deprecated_unwrapped_shape: false,
+            uses_deprecated_unwrapped_shape,
         }
     }
 }
@@ -246,20 +249,26 @@ fn merge_flat_sibling_settings(
     raw_object: &mut serde_json::Map<String, serde_json::Value>,
     warnings: &mut Vec<String>,
     siblings: &serde_json::Map<String, serde_json::Value>,
-) {
+) -> bool {
+    let mut has_flat_configuration_signal = false;
+
     for (key, candidate) in siblings {
         if key == "settings" || key == "kakehashi" {
             continue;
         }
 
         if is_known_configuration_key(key) {
+            has_flat_configuration_signal = true;
             raw_object
                 .entry(key.clone())
                 .or_insert_with(|| candidate.clone());
         } else if should_warn_unknown_key(key, candidate) {
+            has_flat_configuration_signal = true;
             warnings.push(key.clone());
         }
     }
+
+    has_flat_configuration_signal
 }
 
 fn has_configuration_signal(value: &serde_json::Value) -> bool {
@@ -397,7 +406,7 @@ mod tests {
 
     #[test]
     fn merges_known_flat_siblings_with_wrapped_settings() {
-        let update = parse_client_configuration(serde_json::json!({
+        let payload = serde_json::json!({
             "settings": {
                 "kakehashi": {
                     "autoInstall": false
@@ -406,14 +415,19 @@ mod tests {
             "autoInstall": true,
             "diagnosticsDebounceMs": 250,
             "editorSetting": true
-        }))
-        .expect("mixed wrapped and flat settings should parse");
+        });
+        let update = parse_client_configuration(payload.clone())
+            .expect("mixed wrapped and flat settings should parse");
 
         assert_eq!(update.settings.auto_install, Some(false));
         assert_eq!(update.settings.diagnostics_debounce_ms, Some(250));
         assert_eq!(
             update.warnings,
             vec!["Ignored unknown client configuration key(s): editorSetting"]
+        );
+        assert!(
+            normalize_kakehashi_settings(payload).uses_deprecated_unwrapped_shape,
+            "accepted flat siblings beside wrapped settings should still warn as deprecated"
         );
 
         let normalized = normalize_kakehashi_settings(serde_json::json!({
@@ -431,7 +445,7 @@ mod tests {
 
     #[test]
     fn merges_settings_root_flat_siblings_with_wrapped_settings() {
-        let update = parse_client_configuration(serde_json::json!({
+        let payload = serde_json::json!({
             "settings": {
                 "kakehashi": {
                     "autoInstall": false
@@ -439,8 +453,9 @@ mod tests {
                 "diagnosticsDebounceMs": 250,
                 "editorSetting": true
             }
-        }))
-        .expect("settings-root mixed wrapped and flat settings should parse");
+        });
+        let update = parse_client_configuration(payload.clone())
+            .expect("settings-root mixed wrapped and flat settings should parse");
 
         assert_eq!(update.settings.auto_install, Some(false));
         assert_eq!(update.settings.diagnostics_debounce_ms, Some(250));
@@ -448,21 +463,30 @@ mod tests {
             update.warnings,
             vec!["Ignored unknown client configuration key(s): editorSetting"]
         );
+        assert!(
+            normalize_kakehashi_settings(payload).uses_deprecated_unwrapped_shape,
+            "accepted settings-root flat siblings beside wrapped settings should warn as deprecated"
+        );
     }
 
     #[test]
     fn settings_root_flat_siblings_precede_top_level_siblings() {
-        let update = parse_client_configuration(serde_json::json!({
+        let payload = serde_json::json!({
             "settings": {
                 "kakehashi": {},
                 "autoInstall": false
             },
             "autoInstall": true
-        }))
-        .expect("conflicting mixed settings should parse");
+        });
+        let update = parse_client_configuration(payload.clone())
+            .expect("conflicting mixed settings should parse");
 
         assert_eq!(update.settings.auto_install, Some(false));
         assert!(update.warnings.is_empty());
+        assert!(
+            normalize_kakehashi_settings(payload).uses_deprecated_unwrapped_shape,
+            "accepted conflicting flat siblings beside wrapped settings should warn as deprecated"
+        );
     }
 
     #[test]

--- a/src/lsp/lsp_impl/workspace/did_change_configuration.rs
+++ b/src/lsp/lsp_impl/workspace/did_change_configuration.rs
@@ -268,9 +268,12 @@ fn should_warn_unknown_key(key: &str, value: &serde_json::Value) -> bool {
         && key != "settings"
         && key != "kakehashi"
         && !key.contains('.')
-        && (!value.is_object()
-            || key.chars().any(|ch| ch.is_ascii_uppercase())
-            || is_one_edit_from_known_configuration_key(key))
+        && if value.is_object() {
+            is_one_edit_from_known_configuration_key(key)
+        } else {
+            key.chars().any(|ch| ch.is_ascii_uppercase())
+                || is_one_edit_from_known_configuration_key(key)
+        }
 }
 
 fn is_known_configuration_key(key: &str) -> bool {
@@ -631,6 +634,27 @@ mod tests {
             update.warnings,
             vec!["Ignored unknown client configuration key(s): languageServerss"]
         );
+    }
+
+    #[test]
+    fn ignores_unrelated_object_sections_beside_wrapped_settings() {
+        let normalized = normalize_kakehashi_settings(serde_json::json!({
+            "kakehashi": {
+                "autoInstall": false
+            },
+            "someServer": {
+                "usePlaceholders": true
+            }
+        }));
+
+        assert!(
+            !normalized.uses_deprecated_unwrapped_shape,
+            "unrelated object sections must not claim the flat-shape deprecation slot"
+        );
+        let update = parse_normalized_client_configuration(normalized)
+            .expect("wrapped settings with unrelated object section should parse");
+        assert_eq!(update.settings.auto_install, Some(false));
+        assert!(update.warnings.is_empty());
     }
 
     #[test]

--- a/src/lsp/settings_manager.rs
+++ b/src/lsp/settings_manager.rs
@@ -33,6 +33,10 @@ pub(crate) struct SettingsManager {
     /// about, so the notice is shown at most once per session regardless of
     /// which path (initialize or didChangeConfiguration) first sees it.
     root_markers_deprecation_warned: AtomicBool,
+    /// Latches once an unwrapped runtime `workspace/didChangeConfiguration`
+    /// payload has been warned about. Unlike `rootMarkers`, this applies only to
+    /// client-pushed runtime settings, not initializationOptions or TOML files.
+    unwrapped_didchange_deprecation_warned: AtomicBool,
 }
 
 impl std::fmt::Debug for SettingsManager {
@@ -77,6 +81,7 @@ impl SettingsManager {
             })),
             client_capabilities: OnceLock::new(),
             root_markers_deprecation_warned: AtomicBool::new(false),
+            unwrapped_didchange_deprecation_warned: AtomicBool::new(false),
         }
     }
 
@@ -88,6 +93,14 @@ impl SettingsManager {
     pub(crate) fn claim_root_markers_deprecation_warning(&self) -> bool {
         !self
             .root_markers_deprecation_warned
+            .swap(true, Ordering::Relaxed)
+    }
+
+    /// Claim the one-per-session slot for unwrapped/flat
+    /// `workspace/didChangeConfiguration` payloads.
+    pub(crate) fn claim_unwrapped_didchange_deprecation_warning(&self) -> bool {
+        !self
+            .unwrapped_didchange_deprecation_warned
             .swap(true, Ordering::Relaxed)
     }
 
@@ -655,6 +668,20 @@ mod tests {
             "subsequent claims must not re-warn"
         );
         assert!(!manager.claim_root_markers_deprecation_warning());
+    }
+
+    #[test]
+    fn claim_unwrapped_didchange_deprecation_warning_is_true_exactly_once() {
+        let manager = SettingsManager::new();
+        assert!(
+            manager.claim_unwrapped_didchange_deprecation_warning(),
+            "first flat didChange claim should win the once-per-session slot"
+        );
+        assert!(
+            !manager.claim_unwrapped_didchange_deprecation_warning(),
+            "subsequent flat didChange claims must not re-warn"
+        );
+        assert!(!manager.claim_unwrapped_didchange_deprecation_warning());
     }
 
     /// Parameterized tests for supports_*_link() capability checking.

--- a/tests/e2e_deprecation_warning.rs
+++ b/tests/e2e_deprecation_warning.rs
@@ -60,6 +60,16 @@ fn wrapped_didchange_config(auto_install: bool) -> Value {
     json!({ "settings": { "kakehashi": { "autoInstall": auto_install } } })
 }
 
+fn query_effective_settings(client: &mut LspClient) -> Value {
+    client
+        .send_request("kakehashi/internal/effectiveConfiguration", json!({}))
+        .get("result")
+        .expect("should have result")
+        .get("settings")
+        .expect("should have settings")
+        .clone()
+}
+
 #[test]
 fn e2e_root_markers_deprecation_warns_once_across_didchange() {
     let config_dir = tempfile::TempDir::new().expect("temp config dir");
@@ -169,6 +179,11 @@ fn e2e_unwrapped_didchange_deprecation_warns_once_and_ignores_unrelated_settings
     assert_eq!(
         method, "window/logMessage",
         "wrapped didChange config must not trigger the flat-shape deprecation popup; got: {params:?}"
+    );
+    assert_eq!(
+        query_effective_settings(&mut client)["autoInstall"],
+        json!(false),
+        "wrapped didChange config should update the effective runtime settings"
     );
 
     // The first actual flat kakehashi runtime setting still gets the warning,

--- a/tests/e2e_deprecation_warning.rs
+++ b/tests/e2e_deprecation_warning.rs
@@ -191,7 +191,7 @@ fn e2e_unwrapped_didchange_deprecation_warns_once_and_ignores_unrelated_settings
     // guard and the wrapped payload above did not warn.
     client.send_notification(
         "workspace/didChangeConfiguration",
-        flat_didchange_config(false),
+        flat_didchange_config(true),
     );
     let (method, params) = client
         .wait_for_notification_where(
@@ -209,12 +209,17 @@ fn e2e_unwrapped_didchange_deprecation_warns_once_and_ignores_unrelated_settings
     client
         .wait_for_notification_where(&["window/logMessage"], TIMEOUT, is_config_updated)
         .expect("first flat reconfig should log a config-updated message");
+    assert_eq!(
+        query_effective_settings(&mut client)["autoInstall"],
+        json!(true),
+        "flat didChange config should still update the effective runtime settings"
+    );
 
     // A second flat payload is still accepted, but the deprecation popup does
     // not repeat before the successful update log.
     client.send_notification(
         "workspace/didChangeConfiguration",
-        flat_didchange_config(true),
+        flat_didchange_config(false),
     );
     let (method, params) = client
         .wait_for_notification_where(&["window/showMessage", "window/logMessage"], TIMEOUT, |p| {
@@ -224,6 +229,11 @@ fn e2e_unwrapped_didchange_deprecation_warns_once_and_ignores_unrelated_settings
     assert_eq!(
         method, "window/logMessage",
         "no second flat-shape deprecation popup should fire; got: {params:?}"
+    );
+    assert_eq!(
+        query_effective_settings(&mut client)["autoInstall"],
+        json!(false),
+        "second flat didChange config should still update the effective runtime settings"
     );
 
     let _ = client.send_request("shutdown", json!(null));

--- a/tests/e2e_deprecation_warning.rs
+++ b/tests/e2e_deprecation_warning.rs
@@ -1,12 +1,10 @@
 //! E2E tests for one-per-session deprecation notices.
 //!
-//! The notice is surfaced by `initialize` and `workspace/didChangeConfiguration`
-//! sharing a single session-scoped claim guard, so it fires at most once even
-//! when config keeps carrying the deprecated key. This drives it through
-//! didChangeConfiguration (whose notifications, unlike a warning emitted during
-//! the `initialize` request, are observable by the test client) to prove the
-//! warn-path works and the guard suppresses the repeat. The guard and detectors
-//! are also covered in isolation by unit tests.
+//! `rootMarkers` shares a session-scoped guard between `initialize` and
+//! `workspace/didChangeConfiguration`; this drives the observable didChange path
+//! to prove the guard suppresses repeats. The unwrapped didChangeConfiguration
+//! notice is didChange-only, and is covered separately below. The guard and
+//! detectors are also covered in isolation by unit tests.
 
 #![cfg(feature = "e2e")]
 

--- a/tests/e2e_deprecation_warning.rs
+++ b/tests/e2e_deprecation_warning.rs
@@ -26,6 +26,12 @@ fn is_deprecation_notice(params: &Value) -> bool {
         .is_some_and(|m| m.contains("rootMarkers") && m.contains("deprecated"))
 }
 
+fn is_unwrapped_didchange_deprecation_notice(params: &Value) -> bool {
+    params["message"].as_str().is_some_and(|m| {
+        m.contains("unwrapped") && m.contains("didChangeConfiguration") && m.contains("deprecated")
+    })
+}
+
 /// The `didChangeConfiguration` success log ("Configuration updated!"). The
 /// handler emits the claim-gated popup *before* this log, so seeing this log
 /// with no preceding popup is a positive proof that no popup fired — no flaky
@@ -44,6 +50,10 @@ fn config_with_root_markers() -> Value {
             }
         }
     })
+}
+
+fn flat_didchange_config(auto_install: bool) -> Value {
+    json!({ "settings": { "autoInstall": auto_install } })
 }
 
 #[test]
@@ -105,6 +115,80 @@ fn e2e_root_markers_deprecation_warns_once_across_didchange() {
     assert_eq!(
         method, "window/logMessage",
         "no second deprecation popup should fire; got: {params:?}"
+    );
+
+    let _ = client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
+fn e2e_unwrapped_didchange_deprecation_warns_once_and_ignores_unrelated_settings() {
+    let config_dir = tempfile::TempDir::new().expect("temp config dir");
+    let config_path = config_dir.path().join("kakehashi.toml");
+    std::fs::write(&config_path, "").expect("write empty config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("utf-8 temp path"))
+        .build();
+
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": null,
+            "initializationOptions": {}
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    // Unrelated editor/server settings are ignored as an empty update and must
+    // not claim the flat-shape deprecation slot.
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        json!({ "settings": { "gopls": { "usePlaceholders": true } } }),
+    );
+
+    // The first actual flat kakehashi runtime setting still gets the warning,
+    // proving the unrelated payload above did not consume the once-per-session
+    // guard.
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        flat_didchange_config(false),
+    );
+    let (method, params) = client
+        .wait_for_notification_where(
+            &["window/showMessage"],
+            TIMEOUT,
+            is_unwrapped_didchange_deprecation_notice,
+        )
+        .expect("first flat didChange config should surface the deprecation popup");
+    assert_eq!(method, "window/showMessage");
+    assert_eq!(
+        params["type"].as_i64(),
+        Some(2),
+        "deprecation notice should be MessageType::WARNING"
+    );
+    client
+        .wait_for_notification_where(&["window/logMessage"], TIMEOUT, is_config_updated)
+        .expect("first flat reconfig should log a config-updated message");
+
+    // A second flat payload is still accepted, but the deprecation popup does
+    // not repeat before the successful update log.
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        flat_didchange_config(true),
+    );
+    let (method, params) = client
+        .wait_for_notification_where(&["window/showMessage", "window/logMessage"], TIMEOUT, |p| {
+            is_unwrapped_didchange_deprecation_notice(p) || is_config_updated(p)
+        })
+        .expect("second flat reconfig should log a config-updated message");
+    assert_eq!(
+        method, "window/logMessage",
+        "no second flat-shape deprecation popup should fire; got: {params:?}"
     );
 
     let _ = client.send_request("shutdown", json!(null));

--- a/tests/e2e_deprecation_warning.rs
+++ b/tests/e2e_deprecation_warning.rs
@@ -1,4 +1,4 @@
-//! E2E test for the one-per-session `rootMarkers` deprecation notice.
+//! E2E tests for one-per-session deprecation notices.
 //!
 //! The notice is surfaced by `initialize` and `workspace/didChangeConfiguration`
 //! sharing a single session-scoped claim guard, so it fires at most once even
@@ -54,6 +54,10 @@ fn config_with_root_markers() -> Value {
 
 fn flat_didchange_config(auto_install: bool) -> Value {
     json!({ "settings": { "autoInstall": auto_install } })
+}
+
+fn wrapped_didchange_config(auto_install: bool) -> Value {
+    json!({ "settings": { "kakehashi": { "autoInstall": auto_install } } })
 }
 
 #[test]
@@ -151,9 +155,25 @@ fn e2e_unwrapped_didchange_deprecation_warns_once_and_ignores_unrelated_settings
         json!({ "settings": { "gopls": { "usePlaceholders": true } } }),
     );
 
+    // Canonical wrapped settings are applied without the flat-shape
+    // deprecation popup.
+    client.send_notification(
+        "workspace/didChangeConfiguration",
+        wrapped_didchange_config(false),
+    );
+    let (method, params) = client
+        .wait_for_notification_where(&["window/showMessage", "window/logMessage"], TIMEOUT, |p| {
+            is_unwrapped_didchange_deprecation_notice(p) || is_config_updated(p)
+        })
+        .expect("wrapped reconfig should log a config-updated message");
+    assert_eq!(
+        method, "window/logMessage",
+        "wrapped didChange config must not trigger the flat-shape deprecation popup; got: {params:?}"
+    );
+
     // The first actual flat kakehashi runtime setting still gets the warning,
     // proving the unrelated payload above did not consume the once-per-session
-    // guard.
+    // guard and the wrapped payload above did not warn.
     client.send_notification(
         "workspace/didChangeConfiguration",
         flat_didchange_config(false),

--- a/tests/e2e_lsp_protocol.rs
+++ b/tests/e2e_lsp_protocol.rs
@@ -47,6 +47,35 @@ fn test_initialize_returns_capabilities() {
 }
 
 #[test]
+fn test_initialize_exposes_kakehashi_version_and_wrapped_didchange_capability() {
+    let mut client = LspClient::new();
+
+    let response = client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {}
+        }),
+    );
+
+    let result = response
+        .get("result")
+        .expect("initialize should return a result");
+    assert_eq!(result["serverInfo"]["name"], json!("kakehashi"));
+    assert_eq!(
+        result["serverInfo"]["version"],
+        json!(env!("CARGO_PKG_VERSION")),
+        "clients use serverInfo.version to distinguish old flat-only servers"
+    );
+    assert_eq!(
+        result["capabilities"]["experimental"]["kakehashi"]["wrappedDidChangeConfigurationSettings"],
+        json!(true),
+        "clients should be able to choose wrapped didChangeConfiguration payloads without parsing versions"
+    );
+}
+
+#[test]
 fn test_advertises_work_done_progress_independent_of_window_capability() {
     // Client-initiated progress has NO client capability — the provider's
     // `workDoneProgress` advertisement alone prompts the token. So we advertise it

--- a/tests/snapshots/e2e_lsp_protocol__initialize_capabilities.snap
+++ b/tests/snapshots/e2e_lsp_protocol__initialize_capabilities.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/e2e_lsp_protocol.rs
+assertion_line: 46
 expression: capabilities
 ---
 {
@@ -111,5 +112,10 @@ expression: capabilities
   "diagnosticProvider": {
     "interFileDependencies": false,
     "workspaceDiagnostics": false
+  },
+  "experimental": {
+    "kakehashi": {
+      "wrappedDidChangeConfigurationSettings": true
+    }
   }
 }


### PR DESCRIPTION
## Summary
- advertise kakehashi version and wrapped didChange support in initialize
- accept wrapped runtime didChange settings as the canonical wire shape (`settings.kakehashi`)
- keep flat and mixed flat runtime didChange settings compatible, but warn once per session
- ignore unrelated editor/server settings and intentionally ignore double-wrapped `settings.settings.kakehashi`

Fixes #639

## Verification
- cargo fmt --check
- cargo test lsp::lsp_impl::workspace::did_change_configuration
- cargo test --test e2e_deprecation_warning --features e2e
- cargo test --test e2e_lsp_protocol test_initialize --features e2e
- cargo test --test e2e_config_file did_change --features e2e
- git diff --check origin/main...HEAD

## Review pipeline
- local multi-perspective review converged
- codex MCP review converged, including a clean fresh session


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a once-per-session deprecation notice for clients sending the older unwrapped/flat `workspace/didChangeConfiguration` payload shape.
  * The server now advertises support for wrapped `didChangeConfiguration` settings during initialization.
* **Bug Fixes**
  * Improved detection and warning heuristics to more accurately identify the deprecated unwrapped/flat shape and avoid triggering on unrelated settings.
* **Tests**
  * Expanded end-to-end coverage for initialization capabilities and verified the deprecation notice is shown only once per session while unrelated updates are ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->