### PR TITLE
fix(lsp): ignore empty rename workspace edits

### DIFF
--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -69,6 +69,7 @@ pub(crate) use protocol::decode_command;
 pub(crate) use protocol::location_link_to_location;
 pub(crate) use protocol::transform_workspace_edit_to_host;
 pub(crate) use protocol::translate_virtual_range_to_host;
+pub(crate) use protocol::workspace_edit_has_effect;
 pub(crate) use protocol::workspace_edit_within_region;
 pub(crate) use text_document::host::{HostDocument, HostTextReader, normalize_host_goto_result};
 pub(crate) use text_document::{

--- a/src/lsp/bridge/protocol.rs
+++ b/src/lsp/bridge/protocol.rs
@@ -38,4 +38,6 @@ pub(crate) use request_id::RequestId;
 pub(crate) use response::*;
 pub(crate) use translation::*;
 pub(crate) use virtual_uri::VirtualDocumentUri;
-pub(crate) use workspace_edit::{transform_workspace_edit_to_host, workspace_edit_within_region};
+pub(crate) use workspace_edit::{
+    transform_workspace_edit_to_host, workspace_edit_has_effect, workspace_edit_within_region,
+};

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -67,9 +67,9 @@ pub(crate) fn workspace_edit_has_effect(edit: &WorkspaceEdit) -> bool {
         .is_some_and(|changes| changes.values().any(|edits| !edits.is_empty()));
     let doc_changes_has_edit = match &edit.document_changes {
         None => false,
-        Some(DocumentChanges::Edits(edits)) => edits.iter().any(|edit| !edit.edits.is_empty()),
+        Some(DocumentChanges::Edits(edits)) => edits.iter().any(|e| !e.edits.is_empty()),
         Some(DocumentChanges::Operations(ops)) => ops.iter().any(|op| match op {
-            DocumentChangeOperation::Edit(edit) => !edit.edits.is_empty(),
+            DocumentChangeOperation::Edit(e) => !e.edits.is_empty(),
             DocumentChangeOperation::Op(_) => true,
         }),
     };

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -55,6 +55,27 @@ pub(crate) fn transform_workspace_edit_to_host(
     true
 }
 
+/// Whether a `WorkspaceEdit` contains at least one actual change.
+///
+/// Empty `changes` maps, empty edit vectors, and empty `documentChanges` are
+/// no-ops and must not win preferred fan-in over another server or layer that
+/// can return real edits. Resource operations count as changes.
+pub(crate) fn workspace_edit_has_effect(edit: &WorkspaceEdit) -> bool {
+    let changes_has_edit = edit
+        .changes
+        .as_ref()
+        .is_some_and(|changes| changes.values().any(|edits| !edits.is_empty()));
+    let doc_changes_has_edit = match &edit.document_changes {
+        None => false,
+        Some(DocumentChanges::Edits(edits)) => edits.iter().any(|edit| !edit.edits.is_empty()),
+        Some(DocumentChanges::Operations(ops)) => ops.iter().any(|op| match op {
+            DocumentChangeOperation::Edit(edit) => !edit.edits.is_empty(),
+            DocumentChangeOperation::Op(_) => true,
+        }),
+    };
+    changes_has_edit || doc_changes_has_edit
+}
+
 /// Transform the `changes` map in a WorkspaceEdit.
 ///
 /// Re-keys virtual URIs to host URI and transforms TextEdit ranges.

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -37,7 +37,8 @@ use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, encode_command,
     host_position_within_region, response_has_jsonrpc_error, transform_workspace_edit_to_host,
     translate_host_range_to_virtual, translate_virtual_position_to_host,
-    translate_virtual_range_to_host, virtual_uri_to_lsp_uri, workspace_edit_within_region,
+    translate_virtual_range_to_host, virtual_uri_to_lsp_uri, workspace_edit_has_effect,
+    workspace_edit_within_region,
 };
 use super::completion::EnvelopeOffset;
 
@@ -311,19 +312,7 @@ fn finalize_host_resolved_action(
 /// is an empty `TextEdit[]`, or `documentChanges` whose every entry has empty
 /// `edits`, is still a no-op. A file operation counts as a real change.
 fn workspace_edit_is_empty(edit: &WorkspaceEdit) -> bool {
-    let changes_has_edit = edit
-        .changes
-        .as_ref()
-        .is_some_and(|c| c.values().any(|edits| !edits.is_empty()));
-    let doc_changes_has_edit = match &edit.document_changes {
-        None => false,
-        Some(DocumentChanges::Edits(edits)) => edits.iter().any(|e| !e.edits.is_empty()),
-        Some(DocumentChanges::Operations(ops)) => ops.iter().any(|op| match op {
-            DocumentChangeOperation::Edit(e) => !e.edits.is_empty(),
-            DocumentChangeOperation::Op(_) => true, // a create/rename/delete is a real change
-        }),
-    };
-    !changes_has_edit && !doc_changes_has_edit
+    !workspace_edit_has_effect(edit)
 }
 
 /// Translate an action's edit host-ward with resolve-grade validation, in

--- a/src/lsp/bridge/text_document/rename.rs
+++ b/src/lsp/bridge/text_document/rename.rs
@@ -22,7 +22,7 @@ use tower_lsp_server::ls_types::RenameParams;
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri,
     build_text_document_position_params, response_has_jsonrpc_error,
-    transform_workspace_edit_to_host,
+    transform_workspace_edit_to_host, workspace_edit_has_effect,
 };
 
 impl LanguageServerPool {
@@ -136,7 +136,7 @@ fn transform_workspace_edit_response_to_host(
         return None;
     }
 
-    Some(edit)
+    workspace_edit_has_effect(&edit).then_some(edit)
 }
 
 #[cfg(test)]
@@ -697,7 +697,7 @@ mod tests {
     }
 
     #[test]
-    fn workspace_edit_empty_changes_returns_empty() {
+    fn workspace_edit_empty_changes_returns_none() {
         let virtual_uri = make_virtual_uri_string();
         let host_uri = make_host_uri();
 
@@ -714,9 +714,47 @@ mod tests {
             &virtual_uri,
             &host_uri,
             &RegionOffset::new(5, 0),
-        )
-        .unwrap();
+        );
 
-        assert!(edit.changes.unwrap().is_empty());
+        assert!(
+            edit.is_none(),
+            "empty WorkspaceEdit must fall through to lower-priority rename contributors"
+        );
+    }
+
+    #[test]
+    fn workspace_edit_cross_region_only_changes_returns_none() {
+        let virtual_uri = make_virtual_uri_string();
+        let host_uri = make_host_uri();
+        let cross_region_uri =
+            VirtualDocumentUri::new(&host_uri, "lua", "region-1").to_uri_string();
+
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 42,
+            "result": {
+                "changes": {
+                    cross_region_uri: [{
+                        "range": {
+                            "start": { "line": 0, "character": 0 },
+                            "end": { "line": 0, "character": 5 }
+                        },
+                        "newText": "filtered"
+                    }]
+                }
+            }
+        });
+
+        let edit = transform_workspace_edit_response_to_host(
+            response,
+            &virtual_uri,
+            &host_uri,
+            &RegionOffset::new(5, 0),
+        );
+
+        assert!(
+            edit.is_none(),
+            "filtered-to-empty WorkspaceEdit must not mask another rename result"
+        );
     }
 }

--- a/src/lsp/bridge/text_document/rename.rs
+++ b/src/lsp/bridge/text_document/rename.rs
@@ -757,4 +757,70 @@ mod tests {
             "filtered-to-empty WorkspaceEdit must not mask another rename result"
         );
     }
+
+    #[test]
+    fn workspace_edit_cross_region_only_document_changes_returns_none() {
+        let virtual_uri = make_virtual_uri_string();
+        let host_uri = make_host_uri();
+        let cross_region_uri =
+            VirtualDocumentUri::new(&host_uri, "lua", "region-1").to_uri_string();
+
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 42,
+            "result": {
+                "documentChanges": [{
+                    "textDocument": { "uri": cross_region_uri, "version": 1 },
+                    "edits": [{
+                        "range": {
+                            "start": { "line": 0, "character": 0 },
+                            "end": { "line": 0, "character": 5 }
+                        },
+                        "newText": "filtered"
+                    }]
+                }]
+            }
+        });
+
+        let edit = transform_workspace_edit_response_to_host(
+            response,
+            &virtual_uri,
+            &host_uri,
+            &RegionOffset::new(5, 0),
+        );
+
+        assert!(
+            edit.is_none(),
+            "documentChanges filtered to empty must not mask another rename result"
+        );
+    }
+
+    #[test]
+    fn workspace_edit_empty_document_changes_returns_none() {
+        let virtual_uri = make_virtual_uri_string();
+        let host_uri = make_host_uri();
+
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 42,
+            "result": {
+                "documentChanges": [{
+                    "textDocument": { "uri": virtual_uri, "version": 1 },
+                    "edits": []
+                }]
+            }
+        });
+
+        let edit = transform_workspace_edit_response_to_host(
+            response,
+            &virtual_uri,
+            &host_uri,
+            &RegionOffset::new(5, 0),
+        );
+
+        assert!(
+            edit.is_none(),
+            "documentChanges with no edits must fall through to other rename contributors"
+        );
+    }
 }

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -215,7 +215,10 @@ pub(crate) fn is_empty_layer_value(value: &serde_json::Value) -> bool {
                 return list.is_empty();
             }
         }
-        if object.contains_key("changes") || object.contains_key("documentChanges") {
+        if object.contains_key("changes")
+            || object.contains_key("documentChanges")
+            || object.contains_key("changeAnnotations")
+        {
             return serde_json::from_value::<WorkspaceEdit>(value.clone())
                 .map(|edit| !workspace_edit_has_effect(&edit))
                 .unwrap_or(false);
@@ -226,9 +229,10 @@ pub(crate) fn is_empty_layer_value(value: &serde_json::Value) -> bool {
 
 fn is_empty_host_layer_value(request_method: &str, value: &serde_json::Value) -> bool {
     if request_method == "textDocument/rename" {
-        // Rename must reject malformed WorkspaceEdits before host-server
-        // preferred fan-in decides a winner; otherwise a bad higher-priority
-        // response would parse to None later and mask lower-priority edits.
+        // This is intentionally stricter than is_empty_layer_value: rename
+        // must reject malformed WorkspaceEdits before host-server preferred
+        // fan-in decides a winner; otherwise a bad higher-priority response
+        // would parse to None later and mask lower-priority edits.
         return serde_json::from_value::<WorkspaceEdit>(value.clone())
             .map(|edit| !workspace_edit_has_effect(&edit))
             .unwrap_or(true);
@@ -1675,6 +1679,11 @@ mod tests {
         })));
         assert!(is_empty_layer_value(&serde_json::json!({
             "documentChanges": []
+        })));
+        assert!(is_empty_layer_value(&serde_json::json!({
+            "changeAnnotations": {
+                "rename": { "label": "rename symbol" }
+            }
         })));
     }
 

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -5,7 +5,7 @@
 //! of resolving injection context before sending requests. This module extracts
 //! that shared preamble into a reusable method: `resolve_bridge_contexts`.
 
-use tower_lsp_server::ls_types::{Position, Range, Uri};
+use tower_lsp_server::ls_types::{Position, Range, Uri, WorkspaceEdit};
 use url::Url;
 
 use crate::config::WorkspaceSettings;
@@ -14,7 +14,7 @@ use crate::config::settings::{
     ResolvedLayerConfig,
 };
 use crate::language::injection::ResolvedInjection;
-use crate::lsp::bridge::{ResolvedServerConfig, UpstreamId};
+use crate::lsp::bridge::{ResolvedServerConfig, UpstreamId, workspace_edit_has_effect};
 use crate::lsp::request_id::{CancelReceiver, CancelSubscriptionGuard, current_upstream_id};
 use crate::text::PositionMapper;
 
@@ -213,6 +213,11 @@ pub(crate) fn is_empty_layer_value(value: &serde_json::Value) -> bool {
                 }
                 return list.is_empty();
             }
+        }
+        if object.contains_key("changes") || object.contains_key("documentChanges") {
+            return serde_json::from_value::<WorkspaceEdit>(value.clone())
+                .map(|edit| !workspace_edit_has_effect(&edit))
+                .unwrap_or(false);
         }
     }
     false
@@ -1644,6 +1649,41 @@ mod tests {
         assert!(is_empty_layer_value(&serde_json::json!({ "ranges": [] })));
         assert!(!is_empty_layer_value(&serde_json::json!({
             "isIncomplete": false, "items": [{ "label": "x" }]
+        })));
+    }
+
+    #[test]
+    fn empty_layer_value_recognizes_empty_workspace_edits() {
+        assert!(is_empty_layer_value(&serde_json::json!({ "changes": {} })));
+        assert!(is_empty_layer_value(&serde_json::json!({
+            "changes": {
+                "file:///test.md": []
+            }
+        })));
+        assert!(is_empty_layer_value(&serde_json::json!({
+            "documentChanges": []
+        })));
+    }
+
+    #[test]
+    fn empty_layer_value_treats_workspace_edits_with_effect_as_results() {
+        assert!(!is_empty_layer_value(&serde_json::json!({
+            "changes": {
+                "file:///test.md": [{
+                    "range": {
+                        "start": { "line": 0, "character": 0 },
+                        "end": { "line": 0, "character": 1 }
+                    },
+                    "newText": "x"
+                }]
+            }
+        })));
+        assert!(!is_empty_layer_value(&serde_json::json!({
+            "documentChanges": [{
+                "kind": "rename",
+                "oldUri": "file:///old.md",
+                "newUri": "file:///new.md"
+            }]
         })));
     }
 

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -188,11 +188,12 @@ pub(crate) fn resolve_layer_config_from_settings(
 /// fan-in: `null` and `[]` are "no result", as are the object-shaped
 /// "empty but valid" responses whose single canonical list field is empty:
 /// `CompletionList.items` when `isIncomplete` is not true,
-/// `SignatureHelp.signatures`, and `LinkedEditingRanges.ranges`. Keep the
-/// completion-list rule in sync with `completion_list_has_result` in the
-/// completion handler. Without the object shapes, a
-/// higher-priority host server's empty list would prematurely win the
-/// fan-in over a lower-priority server with actual results.
+/// `SignatureHelp.signatures`, `LinkedEditingRanges.ranges`, and
+/// `WorkspaceEdit` `changes`/`documentChanges` with no effective edits. Keep
+/// the completion-list rule in sync with `completion_list_has_result` in the
+/// completion handler. Without the object shapes, a higher-priority host
+/// server's empty list or edit would prematurely win the fan-in over a
+/// lower-priority server with actual results.
 pub(crate) fn is_empty_layer_value(value: &serde_json::Value) -> bool {
     if value.is_null() {
         return true;

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -225,7 +225,7 @@ pub(crate) fn is_empty_layer_value(value: &serde_json::Value) -> bool {
 }
 
 fn is_empty_host_layer_value(request_method: &str, value: &serde_json::Value) -> bool {
-    if request_method == "textDocument/rename" && value.is_object() {
+    if request_method == "textDocument/rename" {
         return serde_json::from_value::<WorkspaceEdit>(value.clone())
             .map(|edit| !workspace_edit_has_effect(&edit))
             .unwrap_or(true);
@@ -1741,10 +1741,18 @@ mod tests {
 
     #[test]
     fn host_layer_rename_treats_malformed_workspace_edit_as_empty() {
-        assert!(is_empty_host_layer_value(
-            "textDocument/rename",
-            &serde_json::json!({ "changes": "bad" })
-        ));
+        for value in [
+            serde_json::json!({ "changes": "bad" }),
+            serde_json::json!("bad"),
+            serde_json::json!(42),
+            serde_json::json!(true),
+            serde_json::json!([{ "not": "a WorkspaceEdit" }]),
+        ] {
+            assert!(
+                is_empty_host_layer_value("textDocument/rename", &value),
+                "{value:?} must not win host rename fan-in"
+            );
+        }
     }
 
     #[test]

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -224,6 +224,15 @@ pub(crate) fn is_empty_layer_value(value: &serde_json::Value) -> bool {
     false
 }
 
+fn is_empty_host_layer_value(request_method: &str, value: &serde_json::Value) -> bool {
+    if request_method == "textDocument/rename" && value.is_object() {
+        return serde_json::from_value::<WorkspaceEdit>(value.clone())
+            .map(|edit| !workspace_edit_has_effect(&edit))
+            .unwrap_or(false);
+    }
+    is_empty_layer_value(value)
+}
+
 /// Race the virt, host, and native layer futures **concurrently** and decide
 /// by the resolved layer `priorities` (cross-layer-aggregation, `preferred`
 /// semantics) — the layer-level analogue of the stage-1 `preferred` fan-in:
@@ -937,7 +946,7 @@ impl Kakehashi {
                         .await
                 }
             },
-            |opt| matches!(opt, Some(v) if !is_empty_layer_value(v)),
+            |opt| matches!(opt, Some(v) if !is_empty_host_layer_value(request_method, v)),
             cancel_rx,
         )
         .await;
@@ -1686,6 +1695,48 @@ mod tests {
                 "newUri": "file:///new.md"
             }]
         })));
+    }
+
+    #[test]
+    fn host_layer_rename_treats_bare_empty_workspace_edit_as_empty() {
+        assert!(is_empty_host_layer_value(
+            "textDocument/rename",
+            &serde_json::json!({})
+        ));
+        assert!(is_empty_host_layer_value(
+            "textDocument/rename",
+            &serde_json::json!({
+                "changeAnnotations": {
+                    "rename": { "label": "rename symbol" }
+                }
+            })
+        ));
+    }
+
+    #[test]
+    fn host_layer_non_rename_keeps_bare_object_as_result() {
+        assert!(!is_empty_host_layer_value(
+            "textDocument/hover",
+            &serde_json::json!({})
+        ));
+    }
+
+    #[test]
+    fn host_layer_rename_treats_workspace_edit_with_effect_as_result() {
+        assert!(!is_empty_host_layer_value(
+            "textDocument/rename",
+            &serde_json::json!({
+                "changes": {
+                    "file:///test.md": [{
+                        "range": {
+                            "start": { "line": 0, "character": 0 },
+                            "end": { "line": 0, "character": 1 }
+                        },
+                        "newText": "x"
+                    }]
+                }
+            })
+        ));
     }
 
     #[test]

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -226,6 +226,9 @@ pub(crate) fn is_empty_layer_value(value: &serde_json::Value) -> bool {
 
 fn is_empty_host_layer_value(request_method: &str, value: &serde_json::Value) -> bool {
     if request_method == "textDocument/rename" {
+        // Rename must reject malformed WorkspaceEdits before host-server
+        // preferred fan-in decides a winner; otherwise a bad higher-priority
+        // response would parse to None later and mask lower-priority edits.
         return serde_json::from_value::<WorkspaceEdit>(value.clone())
             .map(|edit| !workspace_edit_has_effect(&edit))
             .unwrap_or(true);

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -228,7 +228,7 @@ fn is_empty_host_layer_value(request_method: &str, value: &serde_json::Value) ->
     if request_method == "textDocument/rename" && value.is_object() {
         return serde_json::from_value::<WorkspaceEdit>(value.clone())
             .map(|edit| !workspace_edit_has_effect(&edit))
-            .unwrap_or(false);
+            .unwrap_or(true);
     }
     is_empty_layer_value(value)
 }
@@ -1736,6 +1736,14 @@ mod tests {
                     }]
                 }
             })
+        ));
+    }
+
+    #[test]
+    fn host_layer_rename_treats_malformed_workspace_edit_as_empty() {
+        assert!(is_empty_host_layer_value(
+            "textDocument/rename",
+            &serde_json::json!({ "changes": "bad" })
         ));
     }
 

--- a/src/lsp/lsp_impl/text_document/rename.rs
+++ b/src/lsp/lsp_impl/text_document/rename.rs
@@ -11,6 +11,7 @@ use tower_lsp_server::ls_types::{NumberOrString, Position, RenameParams, Uri, Wo
 
 use super::super::Kakehashi;
 use crate::lsp::aggregation::server::dispatch_preferred;
+use crate::lsp::bridge::workspace_edit_has_effect;
 use crate::lsp::lsp_impl::bridge_context::parse_host_verbatim;
 
 const METHOD: &str = "textDocument/rename";
@@ -35,7 +36,7 @@ impl Kakehashi {
             virt,
             native,
             parse_host_verbatim::<WorkspaceEdit>,
-            |_| true,
+            workspace_edit_has_effect,
         )
         .await
     }
@@ -85,7 +86,7 @@ impl Kakehashi {
                         .await
                 }
             },
-            |opt| opt.is_some(),
+            |opt| opt.as_ref().is_some_and(workspace_edit_has_effect),
             cancel_rx,
         )
         .await;

--- a/src/lsp/lsp_impl/text_document/rename.rs
+++ b/src/lsp/lsp_impl/text_document/rename.rs
@@ -36,7 +36,7 @@ impl Kakehashi {
             virt,
             native,
             parse_host_verbatim::<WorkspaceEdit>,
-            workspace_edit_has_effect,
+            rename_workspace_edit_has_result,
         )
         .await
     }
@@ -86,11 +86,56 @@ impl Kakehashi {
                         .await
                 }
             },
-            |opt| opt.as_ref().is_some_and(workspace_edit_has_effect),
+            rename_option_has_result,
             cancel_rx,
         )
         .await;
         pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
         result.handle(&self.client, "rename", None, Ok).await
+    }
+}
+
+fn rename_workspace_edit_has_result(edit: &WorkspaceEdit) -> bool {
+    workspace_edit_has_effect(edit)
+}
+
+fn rename_option_has_result(edit: &Option<WorkspaceEdit>) -> bool {
+    edit.as_ref().is_some_and(rename_workspace_edit_has_result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn workspace_edit(value: serde_json::Value) -> WorkspaceEdit {
+        serde_json::from_value(value).expect("valid WorkspaceEdit")
+    }
+
+    #[test]
+    fn rename_predicates_reject_empty_workspace_edits() {
+        let empty = workspace_edit(json!({ "changes": {} }));
+
+        assert!(!rename_workspace_edit_has_result(&empty));
+        assert!(!rename_option_has_result(&Some(empty)));
+        assert!(!rename_option_has_result(&None));
+    }
+
+    #[test]
+    fn rename_predicates_accept_workspace_edits_with_effect() {
+        let edit = workspace_edit(json!({
+            "changes": {
+                "file:///test.md": [{
+                    "range": {
+                        "start": { "line": 0, "character": 0 },
+                        "end": { "line": 0, "character": 1 }
+                    },
+                    "newText": "x"
+                }]
+            }
+        }));
+
+        assert!(rename_workspace_edit_has_result(&edit));
+        assert!(rename_option_has_result(&Some(edit)));
     }
 }


### PR DESCRIPTION
## Summary
- Treat empty and filtered-to-empty rename `WorkspaceEdit`s as no-result so lower-priority servers/layers can still answer
- Share WorkspaceEdit effect detection with code actions and apply it to rename bridge, server fan-in, cross-layer fan-in, and host raw-result fan-in
- Make host rename fan-in skip bare, annotation-only, and malformed WorkspaceEdit-shaped results before typed parsing can discard them

Fixes #589

## Verification
- cargo test rename --lib
- cargo test empty_layer_value --lib
- cargo test host_layer_rename --lib
- make check
- git diff --check origin/main...HEAD

## Review
- Local multi-perspective review: fixed missing documentChanges/predicate coverage and comment drift
- Codex MCP review: fixed bare/malformed host rename raw-result fan-in findings; final fresh review returned `no comments to provide`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved LSP rename handling by ignoring `WorkspaceEdit` results that contain no effective edits after normalization (including empty or malformed-looking payloads).
  - Updated code action/edit translation to better detect and treat resolved `WorkspaceEdit` instances with no real text changes as no-ops.
  - Tightened result selection so rename prefers workspace edits only when they will actually apply changes.
- **Tests**
  - Expanded unit coverage for detecting “has effect” workspace edits and rename-specific empty handling across empty and malformed inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->