### PR TITLE
fix(lsp): translate goto link origin ranges

### DIFF
--- a/src/lsp/bridge/protocol/response.rs
+++ b/src/lsp/bridge/protocol/response.rs
@@ -150,17 +150,18 @@ pub(crate) fn transform_location_for_goto(
 /// `originSelectionRange` belongs to the requesting virtual document, so it is
 /// always translated to host coordinates. Target ranges are translated only when
 /// the target points back to the same virtual document; real-file targets are
-/// preserved as-is.
+/// preserved as-is. Targets pointing at a different virtual URI are filtered
+/// out because cross-region offsets are unsafe.
 fn transform_location_link_for_goto(
     mut link: LocationLink,
     request_virtual_uri: &str,
     host_uri: &Uri,
     offset: &RegionOffset,
 ) -> Option<LocationLink> {
-    let uri_str = link.target_uri.as_str();
     if let Some(ref mut origin_range) = link.origin_selection_range {
         translate_virtual_range_to_host(origin_range, offset);
     }
+    let uri_str = link.target_uri.as_str();
 
     // Case 1: NOT a virtual URI (real file reference) → preserve as-is
     if !VirtualDocumentUri::is_virtual_uri(uri_str) {

--- a/src/lsp/bridge/protocol/response.rs
+++ b/src/lsp/bridge/protocol/response.rs
@@ -145,9 +145,12 @@ pub(crate) fn transform_location_for_goto(
     None
 }
 
-/// Transform a single LocationLink to host coordinates for goto endpoints, applying
-/// the region offset to all of its ranges (targetRange, targetSelectionRange,
-/// originSelectionRange) and returning `None` to filter out a cross-region virtual URI.
+/// Transform a single LocationLink to host coordinates for goto endpoints.
+///
+/// `originSelectionRange` belongs to the requesting virtual document, so it is
+/// always translated to host coordinates. Target ranges are translated only when
+/// the target points back to the same virtual document; real-file targets are
+/// preserved as-is.
 fn transform_location_link_for_goto(
     mut link: LocationLink,
     request_virtual_uri: &str,
@@ -155,6 +158,9 @@ fn transform_location_link_for_goto(
     offset: &RegionOffset,
 ) -> Option<LocationLink> {
     let uri_str = link.target_uri.as_str();
+    if let Some(ref mut origin_range) = link.origin_selection_range {
+        translate_virtual_range_to_host(origin_range, offset);
+    }
 
     // Case 1: NOT a virtual URI (real file reference) → preserve as-is
     if !VirtualDocumentUri::is_virtual_uri(uri_str) {
@@ -166,9 +172,6 @@ fn transform_location_link_for_goto(
         link.target_uri = host_uri.clone();
         translate_virtual_range_to_host(&mut link.target_range, offset);
         translate_virtual_range_to_host(&mut link.target_selection_range, offset);
-        if let Some(ref mut origin_range) = link.origin_selection_range {
-            translate_virtual_range_to_host(origin_range, offset);
-        }
         return Some(link);
     }
 

--- a/src/lsp/bridge/text_document/definition.rs
+++ b/src/lsp/bridge/text_document/definition.rs
@@ -101,6 +101,7 @@ mod tests {
     use super::super::super::protocol::transform_goto_response_to_host;
     use super::super::test_helpers::*;
     use super::*;
+    use tower_lsp_server::ls_types::Uri;
 
     // ==========================================================================
     // Definition request tests
@@ -509,7 +510,7 @@ mod tests {
         // target_selection_range: line 5 + 10 = 15
         assert_eq!(links[0].target_selection_range.start.line, 15);
         assert_eq!(links[0].target_selection_range.end.line, 15);
-        // origin_selection_range: line 2 + 10 = 12 (the bug: currently NOT transformed)
+        // origin_selection_range: line 2 + 10 = 12
         let origin = links[0]
             .origin_selection_range
             .expect("origin_selection_range should be present");
@@ -521,6 +522,54 @@ mod tests {
             origin.end.line, 12,
             "origin_selection_range end line should be translated from virtual (2) to host (12)"
         );
+        assert_eq!(origin.start.character, 4);
+        assert_eq!(origin.end.character, 9);
+    }
+
+    #[test]
+    fn definition_response_transforms_origin_selection_range_for_real_file_location_link() {
+        let virtual_uri = "file:///project/kakehashi-virtual-uri-region-0.lua";
+        let target_uri: Uri = "file:///project/lib.rs".parse().unwrap();
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 42,
+            "result": [
+                {
+                    "originSelectionRange": {
+                        "start": { "line": 2, "character": 4 },
+                        "end": { "line": 2, "character": 9 }
+                    },
+                    "targetUri": target_uri,
+                    "targetRange": {
+                        "start": { "line": 20, "character": 0 },
+                        "end": { "line": 22, "character": 1 }
+                    },
+                    "targetSelectionRange": {
+                        "start": { "line": 21, "character": 4 },
+                        "end": { "line": 21, "character": 9 }
+                    }
+                }
+            ]
+        });
+        let host_uri = test_host_uri();
+
+        let transformed = transform_goto_response_to_host(
+            response,
+            virtual_uri,
+            &host_uri,
+            &RegionOffset::new(10, 0),
+        )
+        .expect("real file LocationLink should be preserved");
+
+        assert_eq!(transformed.len(), 1);
+        assert_eq!(transformed[0].target_uri, target_uri);
+        assert_eq!(transformed[0].target_range.start.line, 20);
+        assert_eq!(transformed[0].target_selection_range.start.line, 21);
+        let origin = transformed[0]
+            .origin_selection_range
+            .expect("origin_selection_range should be present");
+        assert_eq!(origin.start.line, 12);
+        assert_eq!(origin.end.line, 12);
         assert_eq!(origin.start.character, 4);
         assert_eq!(origin.end.character, 9);
     }

--- a/src/lsp/bridge/text_document/definition.rs
+++ b/src/lsp/bridge/text_document/definition.rs
@@ -539,7 +539,7 @@ mod tests {
                         "start": { "line": 2, "character": 4 },
                         "end": { "line": 2, "character": 9 }
                     },
-                    "targetUri": target_uri,
+                    "targetUri": target_uri.as_str(),
                     "targetRange": {
                         "start": { "line": 20, "character": 0 },
                         "end": { "line": 22, "character": 1 }


### PR DESCRIPTION
## Summary
- translate `LocationLink.originSelectionRange` from virtual to host coordinates before target URI filtering
- preserve real-file target ranges unchanged for external goto targets
- add a regression test for real-file `LocationLink` responses

Closes #583.

## Verification
- `cargo test definition_response --lib`
- `cargo test origin_selection_range --lib`
- `make check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location link handling in definition results so `originSelectionRange` is consistently mapped to host/editor coordinates.
  * Corrected behavior for `LocationLink` responses, including scenarios where links target real (non-virtual) file URIs.
* **Tests**
  * Expanded the definition bridge test suite to verify `originSelectionRange` coordinate translation for both virtual and real targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->