### PR TITLE
fix(lsp): warn on malformed goto responses

### DIFF
--- a/src/lsp/bridge/protocol/response.rs
+++ b/src/lsp/bridge/protocol/response.rs
@@ -202,6 +202,7 @@ mod tests {
         messages: Mutex::new(Vec::new()),
     };
     static INIT_LOGGER: Once = Once::new();
+    static CAPTURE_LOCK: Mutex<()> = Mutex::new(());
 
     struct CapturingLogger {
         messages: Mutex<Vec<String>>,
@@ -231,6 +232,7 @@ mod tests {
             log::set_logger(&LOGGER).expect("test logger should install once");
             log::set_max_level(LevelFilter::Warn);
         });
+        let _capture = CAPTURE_LOCK.lock().unwrap();
         LOGGER.messages.lock().unwrap().clear();
         f();
         LOGGER.messages.lock().unwrap().clone()

--- a/src/lsp/bridge/protocol/response.rs
+++ b/src/lsp/bridge/protocol/response.rs
@@ -220,7 +220,9 @@ mod tests {
 
     impl Log for CapturingLogger {
         fn enabled(&self, metadata: &Metadata<'_>) -> bool {
-            metadata.level() <= Level::Warn
+            CAPTURING.load(Ordering::Relaxed)
+                && metadata.level() <= Level::Warn
+                && metadata.target() == "kakehashi::bridge"
         }
 
         fn log(&self, record: &Record<'_>) {
@@ -228,11 +230,7 @@ mod tests {
                 return;
             }
             let message = format!("{}:{}:{}", record.level(), record.target(), record.args());
-            if CAPTURING.load(Ordering::Relaxed) && record.target() == "kakehashi::bridge" {
-                self.messages.lock().unwrap().push(message);
-            } else {
-                eprintln!("{message}");
-            }
+            self.messages.lock().unwrap().push(message);
         }
 
         fn flush(&self) {}

--- a/src/lsp/bridge/protocol/response.rs
+++ b/src/lsp/bridge/protocol/response.rs
@@ -35,7 +35,7 @@ pub(crate) fn transform_goto_response_to_host(
     let Some(result) = response.get_mut("result").map(serde_json::Value::take) else {
         log::warn!(
             target: "kakehashi::bridge",
-            "goto response is missing result and has no non-null error"
+            "goto response is missing result without a JSON-RPC error (protocol violation)"
         );
         return None;
     };
@@ -220,7 +220,7 @@ mod tests {
 
     impl Log for CapturingLogger {
         fn enabled(&self, metadata: &Metadata<'_>) -> bool {
-            metadata.level() <= Level::Warn && metadata.target() == "kakehashi::bridge"
+            metadata.level() <= Level::Warn
         }
 
         fn log(&self, record: &Record<'_>) {
@@ -228,7 +228,7 @@ mod tests {
                 return;
             }
             let message = format!("{}:{}:{}", record.level(), record.target(), record.args());
-            if CAPTURING.load(Ordering::Relaxed) {
+            if CAPTURING.load(Ordering::Relaxed) && record.target() == "kakehashi::bridge" {
                 self.messages.lock().unwrap().push(message);
             } else {
                 eprintln!("{message}");
@@ -305,7 +305,9 @@ mod tests {
         assert!(
             warnings.iter().any(|message| {
                 message.contains("kakehashi::bridge")
-                    && message.contains("goto response is missing result and has no non-null error")
+                    && message.contains(
+                        "goto response is missing result without a JSON-RPC error (protocol violation)",
+                    )
             }),
             "expected missing-result goto response warning, got {warnings:?}"
         );

--- a/src/lsp/bridge/protocol/response.rs
+++ b/src/lsp/bridge/protocol/response.rs
@@ -35,7 +35,7 @@ pub(crate) fn transform_goto_response_to_host(
     let Some(result) = response.get_mut("result").map(serde_json::Value::take) else {
         log::warn!(
             target: "kakehashi::bridge",
-            "goto response carries neither result nor error"
+            "goto response is missing result and has no non-null error"
         );
         return None;
     };
@@ -224,13 +224,14 @@ mod tests {
         }
 
         fn log(&self, record: &Record<'_>) {
-            if CAPTURING.load(Ordering::Relaxed) && self.enabled(record.metadata()) {
-                self.messages.lock().unwrap().push(format!(
-                    "{}:{}:{}",
-                    record.level(),
-                    record.target(),
-                    record.args()
-                ));
+            if !self.enabled(record.metadata()) {
+                return;
+            }
+            let message = format!("{}:{}:{}", record.level(), record.target(), record.args());
+            if CAPTURING.load(Ordering::Relaxed) {
+                self.messages.lock().unwrap().push(message);
+            } else {
+                eprintln!("{message}");
             }
         }
 
@@ -240,13 +241,14 @@ mod tests {
     fn captured_warnings_for<F: FnOnce()>(f: F) -> Vec<String> {
         INIT_LOGGER.call_once(|| {
             log::set_logger(&LOGGER).expect("test logger should install once");
-            log::set_max_level(LevelFilter::Trace);
+            log::set_max_level(LevelFilter::Warn);
         });
         let _capture = CAPTURE_LOCK.lock().unwrap();
         LOGGER.messages.lock().unwrap().clear();
         CAPTURING.store(true, Ordering::Relaxed);
-        let _guard = CaptureGuard;
+        let guard = CaptureGuard;
         f();
+        drop(guard);
         let captured = LOGGER.messages.lock().unwrap().clone();
         LOGGER.messages.lock().unwrap().clear();
         captured
@@ -303,7 +305,7 @@ mod tests {
         assert!(
             warnings.iter().any(|message| {
                 message.contains("kakehashi::bridge")
-                    && message.contains("goto response carries neither result nor error")
+                    && message.contains("goto response is missing result and has no non-null error")
             }),
             "expected missing-result goto response warning, got {warnings:?}"
         );

--- a/src/lsp/bridge/protocol/response.rs
+++ b/src/lsp/bridge/protocol/response.rs
@@ -191,6 +191,7 @@ fn transform_location_link_for_goto(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Mutex, Once};
 
     use log::{Level, LevelFilter, Log, Metadata, Record};
@@ -203,18 +204,27 @@ mod tests {
     };
     static INIT_LOGGER: Once = Once::new();
     static CAPTURE_LOCK: Mutex<()> = Mutex::new(());
+    static CAPTURING: AtomicBool = AtomicBool::new(false);
 
     struct CapturingLogger {
         messages: Mutex<Vec<String>>,
     }
 
+    struct CaptureGuard;
+
+    impl Drop for CaptureGuard {
+        fn drop(&mut self) {
+            CAPTURING.store(false, Ordering::Relaxed);
+        }
+    }
+
     impl Log for CapturingLogger {
         fn enabled(&self, metadata: &Metadata<'_>) -> bool {
-            metadata.level() <= Level::Warn
+            metadata.level() <= Level::Warn && metadata.target() == "kakehashi::bridge"
         }
 
         fn log(&self, record: &Record<'_>) {
-            if self.enabled(record.metadata()) {
+            if CAPTURING.load(Ordering::Relaxed) && self.enabled(record.metadata()) {
                 self.messages.lock().unwrap().push(format!(
                     "{}:{}:{}",
                     record.level(),
@@ -230,12 +240,16 @@ mod tests {
     fn captured_warnings_for<F: FnOnce()>(f: F) -> Vec<String> {
         INIT_LOGGER.call_once(|| {
             log::set_logger(&LOGGER).expect("test logger should install once");
-            log::set_max_level(LevelFilter::Warn);
+            log::set_max_level(LevelFilter::Trace);
         });
         let _capture = CAPTURE_LOCK.lock().unwrap();
         LOGGER.messages.lock().unwrap().clear();
+        CAPTURING.store(true, Ordering::Relaxed);
+        let _guard = CaptureGuard;
         f();
-        LOGGER.messages.lock().unwrap().clone()
+        let captured = LOGGER.messages.lock().unwrap().clone();
+        LOGGER.messages.lock().unwrap().clear();
+        captured
     }
 
     #[test]

--- a/src/lsp/bridge/protocol/response.rs
+++ b/src/lsp/bridge/protocol/response.rs
@@ -90,7 +90,10 @@ pub(crate) fn transform_goto_response_to_host(
         }
     }
 
-    // Failed to deserialize as any known variant
+    log::warn!(
+        target: "kakehashi::bridge",
+        "goto response did not match Location | Location[] | LocationLink[]"
+    );
     None
 }
 
@@ -178,4 +181,82 @@ fn transform_location_link_for_goto(
 
     // Case 3: Different virtual URI (cross-region) → filter out
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Mutex, Once};
+
+    use log::{Level, LevelFilter, Log, Metadata, Record};
+    use serde_json::json;
+
+    use super::*;
+
+    static LOGGER: CapturingLogger = CapturingLogger {
+        messages: Mutex::new(Vec::new()),
+    };
+    static INIT_LOGGER: Once = Once::new();
+
+    struct CapturingLogger {
+        messages: Mutex<Vec<String>>,
+    }
+
+    impl Log for CapturingLogger {
+        fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+            metadata.level() <= Level::Warn
+        }
+
+        fn log(&self, record: &Record<'_>) {
+            if self.enabled(record.metadata()) {
+                self.messages.lock().unwrap().push(format!(
+                    "{}:{}:{}",
+                    record.level(),
+                    record.target(),
+                    record.args()
+                ));
+            }
+        }
+
+        fn flush(&self) {}
+    }
+
+    fn captured_warnings_for<F: FnOnce()>(f: F) -> Vec<String> {
+        INIT_LOGGER.call_once(|| {
+            log::set_logger(&LOGGER).expect("test logger should install once");
+            log::set_max_level(LevelFilter::Warn);
+        });
+        LOGGER.messages.lock().unwrap().clear();
+        f();
+        LOGGER.messages.lock().unwrap().clone()
+    }
+
+    #[test]
+    fn goto_response_warns_on_malformed_success_result() {
+        let warnings = captured_warnings_for(|| {
+            let response = json!({
+                "jsonrpc": "2.0",
+                "id": 42,
+                "result": "not a goto result"
+            });
+
+            let transformed = transform_goto_response_to_host(
+                response,
+                "file:///project/kakehashi-virtual-uri-region-0.lua",
+                &"file:///project/host.lua".parse().unwrap(),
+                &RegionOffset::new(5, 0),
+            );
+
+            assert!(transformed.is_none());
+        });
+
+        assert!(
+            warnings.iter().any(|message| {
+                message.contains("kakehashi::bridge")
+                    && message.contains(
+                        "goto response did not match Location | Location[] | LocationLink[]",
+                    )
+            }),
+            "expected malformed goto response warning, got {warnings:?}"
+        );
+    }
 }

--- a/src/lsp/bridge/protocol/response.rs
+++ b/src/lsp/bridge/protocol/response.rs
@@ -32,7 +32,13 @@ pub(crate) fn transform_goto_response_to_host(
     if response_has_jsonrpc_error(&response, "goto request") {
         return None;
     }
-    let result = response.get_mut("result").map(serde_json::Value::take)?;
+    let Some(result) = response.get_mut("result").map(serde_json::Value::take) else {
+        log::warn!(
+            target: "kakehashi::bridge",
+            "goto response carries neither result nor error"
+        );
+        return None;
+    };
     if result.is_null() {
         return None;
     }
@@ -257,6 +263,33 @@ mod tests {
                     )
             }),
             "expected malformed goto response warning, got {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn goto_response_warns_on_missing_result_success() {
+        let warnings = captured_warnings_for(|| {
+            let response = json!({
+                "jsonrpc": "2.0",
+                "id": 42
+            });
+
+            let transformed = transform_goto_response_to_host(
+                response,
+                "file:///project/kakehashi-virtual-uri-region-0.lua",
+                &"file:///project/host.lua".parse().unwrap(),
+                &RegionOffset::new(5, 0),
+            );
+
+            assert!(transformed.is_none());
+        });
+
+        assert!(
+            warnings.iter().any(|message| {
+                message.contains("kakehashi::bridge")
+                    && message.contains("goto response carries neither result nor error")
+            }),
+            "expected missing-result goto response warning, got {warnings:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary
- warn when goto-family bridge responses are successful JSON-RPC messages with no `result` and no `error`
- warn when non-null goto-family `result` does not match `Location | Location[] | LocationLink[]`
- add warning-capture regression tests for both malformed success paths

This addresses the goto-family portion of #582 (`definition`, `typeDefinition`, `implementation`, `declaration`). The other transformer families in #582 remain for follow-up PRs.

## Verification
- `cargo test goto_response_warns --lib -- --test-threads=2`
- `cargo test definition_response --lib`
- `make check`

## Review
- Codex MCP found the initial log-capture race; fixed in `2c5faf53`
- Follow-up Codex MCP review: no comments
- Fresh Codex MCP review: no comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed navigation responses by treating a missing `result` field (in a successful reply) as a protocol violation and ignoring the response.
  * Added clearer warnings when a successful `result` value is present but doesn’t match supported location formats.

* **Tests**
  * Added deterministic log-capture tests to confirm warnings are emitted for successful responses with an incompatible `result` shape and for responses that omit the `result` field entirely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->