### PR TITLE
fix(lsp): fail malformed references

### DIFF
--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -35,6 +35,8 @@ mod progress_registry;
 mod protocol;
 mod root_markers;
 mod telemetry;
+#[cfg(test)]
+pub(crate) mod test_logging;
 mod text_document;
 mod window;
 mod workspace;

--- a/src/lsp/bridge/protocol/response.rs
+++ b/src/lsp/bridge/protocol/response.rs
@@ -191,66 +191,11 @@ fn transform_location_link_for_goto(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::{Mutex, Once};
-
-    use log::{Level, LevelFilter, Log, Metadata, Record};
     use serde_json::json;
 
+    use crate::lsp::bridge::test_logging::captured_warnings_for;
+
     use super::*;
-
-    static LOGGER: CapturingLogger = CapturingLogger {
-        messages: Mutex::new(Vec::new()),
-    };
-    static INIT_LOGGER: Once = Once::new();
-    static CAPTURE_LOCK: Mutex<()> = Mutex::new(());
-    static CAPTURING: AtomicBool = AtomicBool::new(false);
-
-    struct CapturingLogger {
-        messages: Mutex<Vec<String>>,
-    }
-
-    struct CaptureGuard;
-
-    impl Drop for CaptureGuard {
-        fn drop(&mut self) {
-            CAPTURING.store(false, Ordering::Relaxed);
-        }
-    }
-
-    impl Log for CapturingLogger {
-        fn enabled(&self, metadata: &Metadata<'_>) -> bool {
-            CAPTURING.load(Ordering::Relaxed)
-                && metadata.level() <= Level::Warn
-                && metadata.target() == "kakehashi::bridge"
-        }
-
-        fn log(&self, record: &Record<'_>) {
-            if !self.enabled(record.metadata()) {
-                return;
-            }
-            let message = format!("{}:{}:{}", record.level(), record.target(), record.args());
-            self.messages.lock().unwrap().push(message);
-        }
-
-        fn flush(&self) {}
-    }
-
-    fn captured_warnings_for<F: FnOnce()>(f: F) -> Vec<String> {
-        INIT_LOGGER.call_once(|| {
-            log::set_logger(&LOGGER).expect("test logger should install once");
-            log::set_max_level(LevelFilter::Warn);
-        });
-        let _capture = CAPTURE_LOCK.lock().unwrap();
-        LOGGER.messages.lock().unwrap().clear();
-        CAPTURING.store(true, Ordering::Relaxed);
-        let guard = CaptureGuard;
-        f();
-        drop(guard);
-        let captured = LOGGER.messages.lock().unwrap().clone();
-        LOGGER.messages.lock().unwrap().clear();
-        captured
-    }
 
     #[test]
     fn goto_response_warns_on_malformed_success_result() {

--- a/src/lsp/bridge/test_logging.rs
+++ b/src/lsp/bridge/test_logging.rs
@@ -27,13 +27,13 @@ struct CaptureGuard;
 
 impl Drop for CaptureGuard {
     fn drop(&mut self) {
-        CAPTURING.store(false, Ordering::Relaxed);
+        CAPTURING.store(false, Ordering::Release);
     }
 }
 
 impl Log for CapturingLogger {
     fn enabled(&self, metadata: &Metadata<'_>) -> bool {
-        CAPTURING.load(Ordering::Relaxed)
+        CAPTURING.load(Ordering::Acquire)
             && metadata.level() <= Level::Warn
             && metadata.target() == "kakehashi::bridge"
     }
@@ -66,7 +66,7 @@ pub(crate) fn captured_warnings_for<F: FnOnce()>(f: F) -> Vec<String> {
         .lock()
         .unwrap_or_else(|p| p.into_inner())
         .clear();
-    CAPTURING.store(true, Ordering::Relaxed);
+    CAPTURING.store(true, Ordering::Release);
     let guard = CaptureGuard;
     f();
     drop(guard);

--- a/src/lsp/bridge/test_logging.rs
+++ b/src/lsp/bridge/test_logging.rs
@@ -1,0 +1,84 @@
+//! Shared test-only log capture for `kakehashi::bridge` warnings.
+//!
+//! `log::set_logger` is process-global and may only succeed ONCE — a second
+//! test module installing its own capturing logger panics (or silently
+//! captures nothing, depending on run order). Every bridge test that asserts
+//! on emitted warnings must therefore share this single logger via
+//! [`captured_warnings_for`]. Captures are serialized by an internal lock, so
+//! concurrent capture tests never observe each other's messages.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, Once};
+
+use log::{Level, LevelFilter, Log, Metadata, Record};
+
+static LOGGER: CapturingLogger = CapturingLogger {
+    messages: Mutex::new(Vec::new()),
+};
+static INIT_LOGGER: Once = Once::new();
+static CAPTURE_LOCK: Mutex<()> = Mutex::new(());
+static CAPTURING: AtomicBool = AtomicBool::new(false);
+
+struct CapturingLogger {
+    messages: Mutex<Vec<String>>,
+}
+
+struct CaptureGuard;
+
+impl Drop for CaptureGuard {
+    fn drop(&mut self) {
+        CAPTURING.store(false, Ordering::Relaxed);
+    }
+}
+
+impl Log for CapturingLogger {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        CAPTURING.load(Ordering::Relaxed)
+            && metadata.level() <= Level::Warn
+            && metadata.target() == "kakehashi::bridge"
+    }
+
+    fn log(&self, record: &Record<'_>) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+        let message = format!("{}:{}:{}", record.level(), record.target(), record.args());
+        self.messages
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push(message);
+    }
+
+    fn flush(&self) {}
+}
+
+/// Run `f` and return every `kakehashi::bridge` warning (or error) it logged,
+/// formatted `LEVEL:target:message`. Serialized across the process: parallel
+/// callers block on an internal lock rather than interleave captures.
+pub(crate) fn captured_warnings_for<F: FnOnce()>(f: F) -> Vec<String> {
+    INIT_LOGGER.call_once(|| {
+        log::set_logger(&LOGGER).expect("the shared test logger installs once per process");
+        log::set_max_level(LevelFilter::Warn);
+    });
+    let _capture = CAPTURE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    LOGGER
+        .messages
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .clear();
+    CAPTURING.store(true, Ordering::Relaxed);
+    let guard = CaptureGuard;
+    f();
+    drop(guard);
+    let captured = LOGGER
+        .messages
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .clone();
+    LOGGER
+        .messages
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .clear();
+    captured
+}

--- a/src/lsp/bridge/text_document/references.rs
+++ b/src/lsp/bridge/text_document/references.rs
@@ -95,7 +95,9 @@ impl LanguageServerPool {
 /// applying the same URI filter as goto: keep real-file URIs, translate matches
 /// on the request's virtual URI, drop other virtual URIs (cross-region offsets
 /// are unsafe). An empty filtered vec is preserved (not `None`) so callers can
-/// tell "no results" from "search failed".
+/// tell "no results" from a downstream error response (`None`). Malformed
+/// success responses are protocol violations and return `Err` so callers can
+/// surface a warning.
 fn transform_references_response_to_host(
     mut response: serde_json::Value,
     request_virtual_uri: &str,
@@ -196,7 +198,9 @@ mod tests {
 
     impl Log for CapturingLogger {
         fn enabled(&self, metadata: &Metadata<'_>) -> bool {
-            metadata.level() == Level::Warn && metadata.target() == "kakehashi::bridge"
+            CAPTURING.load(Ordering::Relaxed)
+                && metadata.level() == Level::Warn
+                && metadata.target() == "kakehashi::bridge"
         }
 
         fn log(&self, record: &Record<'_>) {
@@ -219,7 +223,7 @@ mod tests {
     fn captured_warnings_for<F: FnOnce()>(f: F) -> Vec<String> {
         INIT_LOGGER.call_once(|| {
             log::set_logger(&LOGGER).expect("test logger should install once");
-            log::set_max_level(LevelFilter::Trace);
+            log::set_max_level(LevelFilter::Warn);
         });
         let _capture = CAPTURE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         LOGGER
@@ -228,8 +232,9 @@ mod tests {
             .unwrap_or_else(|p| p.into_inner())
             .clear();
         CAPTURING.store(true, Ordering::Relaxed);
-        let _guard = CaptureGuard;
+        let guard = CaptureGuard;
         f();
+        drop(guard);
         let captured = LOGGER
             .messages
             .lock()

--- a/src/lsp/bridge/text_document/references.rs
+++ b/src/lsp/bridge/text_document/references.rs
@@ -91,13 +91,13 @@ impl LanguageServerPool {
     }
 }
 
-/// Normalize a `references` response (`Location[] | null`) into `Vec<Location>`,
-/// applying the same URI filter as goto: keep real-file URIs, translate matches
-/// on the request's virtual URI, drop other virtual URIs (cross-region offsets
-/// are unsafe). An empty filtered vec is preserved (not `None`) so callers can
-/// tell "no results" from a downstream error response (`None`). Malformed
-/// success responses are protocol violations and return `Err` so callers can
-/// surface a warning.
+/// Normalize a `references` response (`Location[] | null`) into
+/// `io::Result<Option<Vec<Location>>>`, applying the same URI filter as goto:
+/// keep real-file URIs, translate matches on the request's virtual URI, drop
+/// other virtual URIs (cross-region offsets are unsafe). `Ok(Some(vec))` may
+/// be empty — preserved so callers can tell "no results" from a downstream
+/// error response (`Ok(None)`). A malformed success response is a protocol
+/// violation and returns `Err`, letting callers surface a warning.
 fn transform_references_response_to_host(
     mut response: serde_json::Value,
     request_virtual_uri: &str,
@@ -168,85 +168,11 @@ fn transform_references_response_to_host(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::{Mutex, Once};
-
-    use log::{Level, LevelFilter, Log, Metadata, Record};
 
     use super::super::test_helpers::test_host_uri;
     use super::RegionOffset;
     use super::transform_references_response_to_host;
-
-    static LOGGER: CapturingLogger = CapturingLogger {
-        messages: Mutex::new(Vec::new()),
-    };
-    static INIT_LOGGER: Once = Once::new();
-    static CAPTURE_LOCK: Mutex<()> = Mutex::new(());
-    static CAPTURING: AtomicBool = AtomicBool::new(false);
-
-    struct CapturingLogger {
-        messages: Mutex<Vec<String>>,
-    }
-
-    struct CaptureGuard;
-
-    impl Drop for CaptureGuard {
-        fn drop(&mut self) {
-            CAPTURING.store(false, Ordering::Relaxed);
-        }
-    }
-
-    impl Log for CapturingLogger {
-        fn enabled(&self, metadata: &Metadata<'_>) -> bool {
-            CAPTURING.load(Ordering::Relaxed)
-                && metadata.level() == Level::Warn
-                && metadata.target() == "kakehashi::bridge"
-        }
-
-        fn log(&self, record: &Record<'_>) {
-            if CAPTURING.load(Ordering::Relaxed) && self.enabled(record.metadata()) {
-                self.messages
-                    .lock()
-                    .unwrap_or_else(|p| p.into_inner())
-                    .push(format!(
-                        "{}:{}:{}",
-                        record.level(),
-                        record.target(),
-                        record.args()
-                    ));
-            }
-        }
-
-        fn flush(&self) {}
-    }
-
-    fn captured_warnings_for<F: FnOnce()>(f: F) -> Vec<String> {
-        INIT_LOGGER.call_once(|| {
-            log::set_logger(&LOGGER).expect("test logger should install once");
-            log::set_max_level(LevelFilter::Warn);
-        });
-        let _capture = CAPTURE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-        LOGGER
-            .messages
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .clear();
-        CAPTURING.store(true, Ordering::Relaxed);
-        let guard = CaptureGuard;
-        f();
-        drop(guard);
-        let captured = LOGGER
-            .messages
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .clone();
-        LOGGER
-            .messages
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .clear();
-        captured
-    }
+    use crate::lsp::bridge::test_logging::captured_warnings_for;
 
     // ==========================================================================
     // References response transformation tests

--- a/src/lsp/bridge/text_document/references.rs
+++ b/src/lsp/bridge/text_document/references.rs
@@ -87,7 +87,7 @@ impl LanguageServerPool {
                 )
             },
         )
-        .await
+        .await?
     }
 }
 
@@ -101,29 +101,33 @@ fn transform_references_response_to_host(
     request_virtual_uri: &str,
     host_uri: &Uri,
     offset: &RegionOffset,
-) -> Option<Vec<Location>> {
+) -> io::Result<Option<Vec<Location>>> {
     if response_has_jsonrpc_error(&response, "textDocument/references") {
-        return None;
+        return Ok(None);
     }
     let Some(result) = response.get_mut("result").map(serde_json::Value::take) else {
         log::warn!(
             target: "kakehashi::bridge",
             "textDocument/references response carries neither result nor error (protocol violation)"
         );
-        return None;
+        return Err(io::Error::other(
+            "textDocument/references response carries neither result nor error (protocol violation)",
+        ));
     };
     if result.is_null() {
-        return None;
+        return Ok(None);
     }
 
     // The LSP spec defines ReferenceResponse as: Location[] | null
     // References only returns arrays of Location (simpler than goto endpoints)
 
     if result.is_array() {
-        let arr = result.as_array()?;
+        let arr = result
+            .as_array()
+            .expect("result.is_array() was checked above");
         if arr.is_empty() {
             // Preserve empty arrays (semantic: "searched, found nothing")
-            return Some(vec![]);
+            return Ok(Some(vec![]));
         }
 
         // Location[] → transform each location
@@ -137,14 +141,16 @@ fn transform_references_response_to_host(
                     .collect();
 
                 // Preserve empty array after filtering
-                return Some(transformed);
+                return Ok(Some(transformed));
             }
             Err(err) => {
                 log::warn!(
                     target: "kakehashi::bridge",
                     "references response did not match Location[]: {err}"
                 );
-                return None;
+                return Err(io::Error::other(format!(
+                    "malformed textDocument/references result from downstream server: {err}"
+                )));
             }
         }
     }
@@ -153,7 +159,9 @@ fn transform_references_response_to_host(
         target: "kakehashi::bridge",
         "references response did not match Location[]"
     );
-    None
+    Err(io::Error::other(
+        "malformed textDocument/references result from downstream server",
+    ))
 }
 
 #[cfg(test)]
@@ -254,7 +262,7 @@ mod tests {
             &RegionOffset::new(5, 0),
         );
 
-        assert!(transformed.is_none());
+        assert!(transformed.unwrap().is_none());
     }
 
     #[test]
@@ -272,7 +280,7 @@ mod tests {
                 &RegionOffset::new(5, 0),
             );
 
-            assert!(transformed.is_none());
+            assert!(transformed.is_err());
         });
 
         assert!(
@@ -302,7 +310,7 @@ mod tests {
                 &RegionOffset::new(5, 0),
             );
 
-            assert!(transformed.is_none());
+            assert!(transformed.is_err());
         });
 
         assert!(
@@ -334,7 +342,7 @@ mod tests {
                 &RegionOffset::new(5, 0),
             );
 
-            assert!(transformed.is_none());
+            assert!(transformed.is_err());
         });
 
         assert!(
@@ -362,8 +370,7 @@ mod tests {
             &RegionOffset::new(5, 0),
         );
 
-        assert!(transformed.is_some());
-        let locations = transformed.unwrap();
+        let locations = transformed.unwrap().unwrap();
         assert!(
             locations.is_empty(),
             "Should preserve empty array from server"
@@ -396,8 +403,7 @@ mod tests {
             &RegionOffset::new(region_start_line, 0),
         );
 
-        assert!(transformed.is_some());
-        let locations = transformed.unwrap();
+        let locations = transformed.unwrap().unwrap();
         assert_eq!(locations.len(), 1);
         assert_eq!(locations[0].uri, host_uri);
         assert_eq!(locations[0].range.start.line, 12); // 2 + 10
@@ -433,8 +439,7 @@ mod tests {
             &RegionOffset::new(region_start_line, 0),
         );
 
-        assert!(transformed.is_some());
-        let locations = transformed.unwrap();
+        let locations = transformed.unwrap().unwrap();
         assert_eq!(locations.len(), 1);
         assert_eq!(locations[0].uri.as_str(), real_file_uri);
         assert_eq!(locations[0].range.start.line, 10); // Unchanged
@@ -468,8 +473,7 @@ mod tests {
         );
 
         // Should filter out cross-region virtual URI, resulting in empty array
-        assert!(transformed.is_some());
-        let locations = transformed.unwrap();
+        let locations = transformed.unwrap().unwrap();
         assert!(
             locations.is_empty(),
             "Should have empty array after filtering"
@@ -518,8 +522,7 @@ mod tests {
             &RegionOffset::new(region_start_line, 0),
         );
 
-        assert!(transformed.is_some());
-        let locations = transformed.unwrap();
+        let locations = transformed.unwrap().unwrap();
         assert_eq!(locations.len(), 2); // Cross-region filtered out
         assert_eq!(locations[0].uri, host_uri);
         assert_eq!(locations[0].range.start.line, 3); // Transformed: 0 + 3

--- a/src/lsp/bridge/text_document/references.rs
+++ b/src/lsp/bridge/text_document/references.rs
@@ -95,9 +95,11 @@ impl LanguageServerPool {
 /// `io::Result<Option<Vec<Location>>>`, applying the same URI filter as goto:
 /// keep real-file URIs, translate matches on the request's virtual URI, drop
 /// other virtual URIs (cross-region offsets are unsafe). `Ok(Some(vec))` may
-/// be empty — preserved so callers can tell "no results" from a downstream
-/// error response (`Ok(None)`). A malformed success response is a protocol
-/// violation and returns `Err`, letting callers surface a warning.
+/// be empty — an empty array from the server is preserved as-is, while
+/// `Ok(None)` covers everything the server did not answer with an array: a
+/// JSON-RPC error response, a `null` result, or a missing `result` field. A
+/// malformed success response is a protocol violation and returns `Err`,
+/// letting callers surface a warning.
 fn transform_references_response_to_host(
     mut response: serde_json::Value,
     request_virtual_uri: &str,

--- a/src/lsp/bridge/text_document/references.rs
+++ b/src/lsp/bridge/text_document/references.rs
@@ -275,6 +275,38 @@ mod tests {
     }
 
     #[test]
+    fn references_response_warns_on_malformed_location_array() {
+        let warnings = captured_warnings_for(|| {
+            let response = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 42,
+                "result": [
+                    {
+                        "uri": "file:///project/referenced.lua"
+                    }
+                ]
+            });
+
+            let transformed = transform_references_response_to_host(
+                response,
+                "file:///project/kakehashi-virtual-uri-region-0.lua",
+                &test_host_uri(),
+                &RegionOffset::new(5, 0),
+            );
+
+            assert!(transformed.is_none());
+        });
+
+        assert!(
+            warnings.iter().any(|message| {
+                message.contains("kakehashi::bridge")
+                    && message.contains("references response did not match Location[]")
+            }),
+            "expected malformed references array warning, got {warnings:?}"
+        );
+    }
+
+    #[test]
     fn references_response_with_empty_array_preserves_empty() {
         // Server explicitly returns [] - preserve to distinguish from null
         let response = serde_json::json!({

--- a/src/lsp/bridge/text_document/references.rs
+++ b/src/lsp/bridge/text_document/references.rs
@@ -149,6 +149,7 @@ fn transform_references_response_to_host(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Mutex, Once};
 
     use log::{Level, LevelFilter, Log, Metadata, Record};
@@ -162,18 +163,27 @@ mod tests {
     };
     static INIT_LOGGER: Once = Once::new();
     static CAPTURE_LOCK: Mutex<()> = Mutex::new(());
+    static CAPTURING: AtomicBool = AtomicBool::new(false);
 
     struct CapturingLogger {
         messages: Mutex<Vec<String>>,
     }
 
+    struct CaptureGuard;
+
+    impl Drop for CaptureGuard {
+        fn drop(&mut self) {
+            CAPTURING.store(false, Ordering::Relaxed);
+        }
+    }
+
     impl Log for CapturingLogger {
         fn enabled(&self, metadata: &Metadata<'_>) -> bool {
-            metadata.level() <= Level::Warn
+            metadata.level() <= Level::Warn && metadata.target() == "kakehashi::bridge"
         }
 
         fn log(&self, record: &Record<'_>) {
-            if self.enabled(record.metadata()) {
+            if CAPTURING.load(Ordering::Relaxed) && self.enabled(record.metadata()) {
                 self.messages.lock().unwrap().push(format!(
                     "{}:{}:{}",
                     record.level(),
@@ -189,12 +199,16 @@ mod tests {
     fn captured_warnings_for<F: FnOnce()>(f: F) -> Vec<String> {
         INIT_LOGGER.call_once(|| {
             log::set_logger(&LOGGER).expect("test logger should install once");
-            log::set_max_level(LevelFilter::Warn);
+            log::set_max_level(LevelFilter::Trace);
         });
         let _capture = CAPTURE_LOCK.lock().unwrap();
         LOGGER.messages.lock().unwrap().clear();
+        CAPTURING.store(true, Ordering::Relaxed);
+        let _guard = CaptureGuard;
         f();
-        LOGGER.messages.lock().unwrap().clone()
+        let captured = LOGGER.messages.lock().unwrap().clone();
+        LOGGER.messages.lock().unwrap().clear();
+        captured
     }
 
     // ==========================================================================

--- a/src/lsp/bridge/text_document/references.rs
+++ b/src/lsp/bridge/text_document/references.rs
@@ -105,7 +105,13 @@ fn transform_references_response_to_host(
     if response_has_jsonrpc_error(&response, "textDocument/references") {
         return None;
     }
-    let result = response.get_mut("result").map(serde_json::Value::take)?;
+    let Some(result) = response.get_mut("result").map(serde_json::Value::take) else {
+        log::warn!(
+            target: "kakehashi::bridge",
+            "references response carries neither result nor error"
+        );
+        return None;
+    };
     if result.is_null() {
         return None;
     }
@@ -134,15 +140,62 @@ fn transform_references_response_to_host(
         }
     }
 
-    // Failed to deserialize as Location[]
+    log::warn!(
+        target: "kakehashi::bridge",
+        "references response did not match Location[]"
+    );
     None
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Mutex, Once};
+
+    use log::{Level, LevelFilter, Log, Metadata, Record};
+
     use super::super::test_helpers::test_host_uri;
     use super::RegionOffset;
     use super::transform_references_response_to_host;
+
+    static LOGGER: CapturingLogger = CapturingLogger {
+        messages: Mutex::new(Vec::new()),
+    };
+    static INIT_LOGGER: Once = Once::new();
+    static CAPTURE_LOCK: Mutex<()> = Mutex::new(());
+
+    struct CapturingLogger {
+        messages: Mutex<Vec<String>>,
+    }
+
+    impl Log for CapturingLogger {
+        fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+            metadata.level() <= Level::Warn
+        }
+
+        fn log(&self, record: &Record<'_>) {
+            if self.enabled(record.metadata()) {
+                self.messages.lock().unwrap().push(format!(
+                    "{}:{}:{}",
+                    record.level(),
+                    record.target(),
+                    record.args()
+                ));
+            }
+        }
+
+        fn flush(&self) {}
+    }
+
+    fn captured_warnings_for<F: FnOnce()>(f: F) -> Vec<String> {
+        INIT_LOGGER.call_once(|| {
+            log::set_logger(&LOGGER).expect("test logger should install once");
+            log::set_max_level(LevelFilter::Warn);
+        });
+        let _capture = CAPTURE_LOCK.lock().unwrap();
+        LOGGER.messages.lock().unwrap().clear();
+        f();
+        LOGGER.messages.lock().unwrap().clone()
+    }
 
     // ==========================================================================
     // References response transformation tests
@@ -164,6 +217,61 @@ mod tests {
         );
 
         assert!(transformed.is_none());
+    }
+
+    #[test]
+    fn references_response_warns_on_missing_result_success() {
+        let warnings = captured_warnings_for(|| {
+            let response = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 42
+            });
+
+            let transformed = transform_references_response_to_host(
+                response,
+                "file:///project/kakehashi-virtual-uri-region-0.lua",
+                &test_host_uri(),
+                &RegionOffset::new(5, 0),
+            );
+
+            assert!(transformed.is_none());
+        });
+
+        assert!(
+            warnings.iter().any(|message| {
+                message.contains("kakehashi::bridge")
+                    && message.contains("references response carries neither result nor error")
+            }),
+            "expected missing-result references warning, got {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn references_response_warns_on_malformed_success_result() {
+        let warnings = captured_warnings_for(|| {
+            let response = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 42,
+                "result": "not references"
+            });
+
+            let transformed = transform_references_response_to_host(
+                response,
+                "file:///project/kakehashi-virtual-uri-region-0.lua",
+                &test_host_uri(),
+                &RegionOffset::new(5, 0),
+            );
+
+            assert!(transformed.is_none());
+        });
+
+        assert!(
+            warnings.iter().any(|message| {
+                message.contains("kakehashi::bridge")
+                    && message.contains("references response did not match Location[]")
+            }),
+            "expected malformed references warning, got {warnings:?}"
+        );
     }
 
     #[test]

--- a/src/lsp/bridge/text_document/references.rs
+++ b/src/lsp/bridge/text_document/references.rs
@@ -199,6 +199,26 @@ mod tests {
     }
 
     #[test]
+    fn references_response_with_jsonrpc_error_returns_ok_none() {
+        // A downstream error response is a protocol-legal "no answer": it must
+        // stay Ok(None), not become Err (which is reserved for violations).
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 42,
+            "error": { "code": -32603, "message": "internal error" }
+        });
+
+        let transformed = transform_references_response_to_host(
+            response,
+            "file:///virtual.lua",
+            &test_host_uri(),
+            &RegionOffset::new(5, 0),
+        );
+
+        assert!(transformed.unwrap().is_none());
+    }
+
+    #[test]
     fn references_response_warns_on_missing_result_success() {
         let warnings = captured_warnings_for(|| {
             let response = serde_json::json!({

--- a/src/lsp/bridge/text_document/references.rs
+++ b/src/lsp/bridge/text_document/references.rs
@@ -96,10 +96,10 @@ impl LanguageServerPool {
 /// keep real-file URIs, translate matches on the request's virtual URI, drop
 /// other virtual URIs (cross-region offsets are unsafe). `Ok(Some(vec))` may
 /// be empty — an empty array from the server is preserved as-is, while
-/// `Ok(None)` covers everything the server did not answer with an array: a
-/// JSON-RPC error response, a `null` result, or a missing `result` field. A
-/// malformed success response is a protocol violation and returns `Err`,
-/// letting callers surface a warning.
+/// `Ok(None)` covers the answers the protocol allows that carry no array: a
+/// JSON-RPC error response or a `null` result. Protocol violations — a
+/// response with neither `result` nor `error`, or a result that is not
+/// `Location[] | null` — return `Err`, letting callers surface a warning.
 fn transform_references_response_to_host(
     mut response: serde_json::Value,
     request_virtual_uri: &str,

--- a/src/lsp/bridge/text_document/references.rs
+++ b/src/lsp/bridge/text_document/references.rs
@@ -108,7 +108,7 @@ fn transform_references_response_to_host(
     let Some(result) = response.get_mut("result").map(serde_json::Value::take) else {
         log::warn!(
             target: "kakehashi::bridge",
-            "references response carries neither result nor error"
+            "textDocument/references response carries neither result nor error (protocol violation)"
         );
         return None;
     };
@@ -127,16 +127,25 @@ fn transform_references_response_to_host(
         }
 
         // Location[] → transform each location
-        if let Ok(locations) = serde_json::from_value::<Vec<Location>>(result) {
-            let transformed: Vec<Location> = locations
-                .into_iter()
-                .filter_map(|location| {
-                    transform_location_for_goto(location, request_virtual_uri, host_uri, offset)
-                })
-                .collect();
+        match serde_json::from_value::<Vec<Location>>(result) {
+            Ok(locations) => {
+                let transformed: Vec<Location> = locations
+                    .into_iter()
+                    .filter_map(|location| {
+                        transform_location_for_goto(location, request_virtual_uri, host_uri, offset)
+                    })
+                    .collect();
 
-            // Preserve empty array after filtering
-            return Some(transformed);
+                // Preserve empty array after filtering
+                return Some(transformed);
+            }
+            Err(err) => {
+                log::warn!(
+                    target: "kakehashi::bridge",
+                    "references response did not match Location[]: {err}"
+                );
+                return None;
+            }
         }
     }
 
@@ -179,17 +188,20 @@ mod tests {
 
     impl Log for CapturingLogger {
         fn enabled(&self, metadata: &Metadata<'_>) -> bool {
-            metadata.level() <= Level::Warn && metadata.target() == "kakehashi::bridge"
+            metadata.level() == Level::Warn && metadata.target() == "kakehashi::bridge"
         }
 
         fn log(&self, record: &Record<'_>) {
             if CAPTURING.load(Ordering::Relaxed) && self.enabled(record.metadata()) {
-                self.messages.lock().unwrap().push(format!(
-                    "{}:{}:{}",
-                    record.level(),
-                    record.target(),
-                    record.args()
-                ));
+                self.messages
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .push(format!(
+                        "{}:{}:{}",
+                        record.level(),
+                        record.target(),
+                        record.args()
+                    ));
             }
         }
 
@@ -201,13 +213,25 @@ mod tests {
             log::set_logger(&LOGGER).expect("test logger should install once");
             log::set_max_level(LevelFilter::Trace);
         });
-        let _capture = CAPTURE_LOCK.lock().unwrap();
-        LOGGER.messages.lock().unwrap().clear();
+        let _capture = CAPTURE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        LOGGER
+            .messages
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clear();
         CAPTURING.store(true, Ordering::Relaxed);
         let _guard = CaptureGuard;
         f();
-        let captured = LOGGER.messages.lock().unwrap().clone();
-        LOGGER.messages.lock().unwrap().clear();
+        let captured = LOGGER
+            .messages
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone();
+        LOGGER
+            .messages
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clear();
         captured
     }
 
@@ -254,7 +278,9 @@ mod tests {
         assert!(
             warnings.iter().any(|message| {
                 message.contains("kakehashi::bridge")
-                    && message.contains("references response carries neither result nor error")
+                    && message.contains(
+                        "textDocument/references response carries neither result nor error (protocol violation)",
+                    )
             }),
             "expected missing-result references warning, got {warnings:?}"
         );


### PR DESCRIPTION
## Summary
- return `io::Error` for malformed successful `textDocument/references` responses
- preserve `Ok(None)` for JSON-RPC errors and legitimate `null` results
- keep valid, empty, and filtered `Location[]` results covered

This addresses the references portion of #582. Other transformer families in #582 remain for follow-up PRs.

## Verification
- `cargo test references_response --lib`
- `cargo test references_response_warns --lib -- --test-threads=2`
- `make check`

## Review
- Codex MCP found missing malformed-array coverage; fixed in `37eacaa0`
- Qodo/Greptile/Copilot found test logger and observability issues; fixed through `0f839bba`
- Qodo found malformed successes still collapsed to `None`; fixed in `187384f5`
- Latest Codex MCP reviews after the stronger error contract: no comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reference lookup handling by distinguishing “no data” (`null`) from valid empty results.
  * Added stricter validation for malformed successful responses, returning errors instead of treating them as valid.
  * Transformed navigation targets and filtered out unsafe cross-region virtual entries.
  * Warning logs are now emitted when reference data can’t be processed.

* **Tests**
  * Updated and expanded unit tests to cover all response variants and verify emitted warning messages using shared warning-capture helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->