### PR TITLE
fix(lsp): stabilize pull response ordering

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -446,8 +446,11 @@ Example with per-method priorities, strategy, and maxFanOut:
 A request to kakehashi can be answered by up to three *result layers*:
 `virt` (the injection bridges above), `host` (a host-document language
 server — opt-in via `bridge._self` above), and `native` (kakehashi's
-own features). `layers.aggregation` orders them per LSP method, mirroring
-the `bridge.<lang>.aggregation` nesting:
+own features). `layers.aggregation` prioritizes which layer contributions are
+selected and staged per LSP method, mirroring the
+`bridge.<lang>.aggregation` nesting. Methods with a deterministic wire-order
+contract, such as diagnostics, normalize those staged contributions before
+returning the response:
 
 ```json
 {

--- a/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
+++ b/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
@@ -658,7 +658,9 @@ because the #380 benefit now outweighs it:
   there is no stale-overwrite guard and a brief wrong-content window after edits
   (lazy re-anchor still keeps *positions* current via the retained pull trigger).
 - Per-source strategy fan-in (`preferred` sticky / `concatenated` visible-walk);
-  the staged merge concatenates, with HashMap-nondeterministic cross-source order.
+  the staged merge currently concatenates every eligible source. The shared
+  diagnostic sorter makes the final wire order deterministic, but does not
+  implement per-source selection or precedence.
   This also subsumes the **interim `pullFallback` dedup limitation**: because
   `PullLayer` is one host-wide blob with no per-server identity,
   `filter_pull_driven_push_slots` triggers on "any `PullLayer` present" rather

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -4,6 +4,7 @@ mod cache;
 mod client;
 mod debounced_diagnostics;
 mod diagnostic_cache;
+mod diagnostic_order;
 pub(crate) mod in_progress_set;
 mod settings_manager;
 mod synthetic_diagnostics;

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -162,57 +162,8 @@ pub(crate) fn merge_cached_diagnostics(
     // multi-source/multi-server host. This is the `concatenated` strategy (every
     // server's diagnostics are kept); the `preferred` election is deferred (it needs a
     // per-source version baseline, which #422 left unbuilt).
-    sort_diagnostics(&mut merged);
+    crate::lsp::diagnostic_order::sort_diagnostics_deterministically(&mut merged);
     merged
-}
-
-/// Order diagnostics deterministically: by host position (top-to-bottom —
-/// "order cross-region merge by region start position"), then by the cheap
-/// distinguishing fields (message, source, severity).
-///
-/// The final tiebreak is each diagnostic's full serialized form — a **total**
-/// order over every field (code, tags, data, relatedInformation, …), so two
-/// genuinely distinct diagnostics at the same span can never fall back to
-/// input (e.g. `HashMap`-walk or fan-in completion) order. It is evaluated
-/// **lazily** (`then_with`), only when every cheap field above already ties,
-/// so the serialization is off the hot path. Fully-identical diagnostics
-/// serialize equally and keep their (immaterial) relative order.
-///
-/// Shared by the proactive publish merge ([`merge_cached_diagnostics`], #423)
-/// and the client-pull response (`diagnostic_impl`): the pull's `resultId` is
-/// a content hash of the serialized items, so the same logical set must
-/// serialize identically across pulls regardless of fan-in completion order.
-///
-/// The tiebreak's `unwrap_or_default` cannot fire in practice: `ls_types`
-/// values serialize infallibly (string-keyed maps only, no non-UTF-8, no
-/// custom `Serialize`), and the idiom predates this sort's extraction. Were
-/// serialization ever to fail, the cheap keys above still order by
-/// position/message/source/severity — only fully-tied distinct diagnostics
-/// could then keep input order, and the `resultId`'s length suffix plus the
-/// per-item hash of everything that DID serialize bound the unchanged-report
-/// consequence to the same accepted 2^-64 collision class documented at
-/// `diagnostic_result_id`.
-pub(crate) fn sort_diagnostics(diagnostics: &mut [Diagnostic]) {
-    diagnostics.sort_by(|a, b| {
-        let key = |d: &Diagnostic| {
-            (
-                d.range.start.line,
-                d.range.start.character,
-                d.range.end.line,
-                d.range.end.character,
-            )
-        };
-        key(a)
-            .cmp(&key(b))
-            .then_with(|| a.message.cmp(&b.message))
-            .then_with(|| a.source.cmp(&b.source))
-            .then_with(|| a.severity.cmp(&b.severity))
-            .then_with(|| {
-                serde_json::to_string(a)
-                    .unwrap_or_default()
-                    .cmp(&serde_json::to_string(b).unwrap_or_default())
-            })
-    });
 }
 
 /// Whether `slots` holds any **non-empty** `Region` push slot — the shared

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1011,7 +1011,8 @@ impl DiagnosticAggregator {
         // present (the common path), cloning the `host` key only on first insert.
         if let Some(prev) = last.get_mut(host) {
             // Fast path: `merge_cached_diagnostics` output is deterministically
-            // sorted (#423 / `sort_diagnostics`, a total order), so equal sets
+            // sorted (#423 / `sort_diagnostics_deterministically`, a total order),
+            // so equal sets
             // arrive slice-equal — the O(n²) multiset walk below is only the
             // fallback for order variation a future unsorted caller could
             // introduce.

--- a/src/lsp/diagnostic_order.rs
+++ b/src/lsp/diagnostic_order.rs
@@ -1,0 +1,103 @@
+use tower_lsp_server::ls_types::Diagnostic;
+
+pub(crate) fn sort_diagnostics_deterministically(diagnostics: &mut [Diagnostic]) {
+    diagnostics.sort_by(|a, b| {
+        diagnostic_position_key(a)
+            .cmp(&diagnostic_position_key(b))
+            .then_with(|| a.message.cmp(&b.message))
+            .then_with(|| a.source.cmp(&b.source))
+            .then_with(|| a.severity.cmp(&b.severity))
+            .then_with(|| canonical_json_string(a).cmp(&canonical_json_string(b)))
+    });
+}
+
+fn diagnostic_position_key(diagnostic: &Diagnostic) -> (u32, u32, u32, u32) {
+    (
+        diagnostic.range.start.line,
+        diagnostic.range.start.character,
+        diagnostic.range.end.line,
+        diagnostic.range.end.character,
+    )
+}
+
+fn canonical_json_string<T: serde::Serialize>(value: &T) -> String {
+    let value = serde_json::to_value(value).unwrap_or(serde_json::Value::Null);
+    serde_json::to_string(&canonicalize_json(value)).unwrap_or_default()
+}
+
+fn canonicalize_json(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Array(values) => {
+            serde_json::Value::Array(values.into_iter().map(canonicalize_json).collect())
+        }
+        serde_json::Value::Object(map) => {
+            let mut entries: Vec<_> = map.into_iter().collect();
+            entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+            let mut sorted = serde_json::Map::new();
+            for (key, value) in entries {
+                sorted.insert(key, canonicalize_json(value));
+            }
+            serde_json::Value::Object(sorted)
+        }
+        value => value,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower_lsp_server::ls_types::{Position, Range};
+
+    fn diag(message: &str) -> Diagnostic {
+        Diagnostic {
+            range: Range::new(Position::new(0, 0), Position::new(0, 1)),
+            message: message.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn orders_by_position_before_message() {
+        let mut first = diag("first");
+        first.range = Range::new(Position::new(1, 0), Position::new(1, 1));
+
+        let mut second = diag("second");
+        second.range = Range::new(Position::new(0, 0), Position::new(0, 1));
+
+        let mut diagnostics = vec![first, second];
+        sort_diagnostics_deterministically(&mut diagnostics);
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.message.as_str())
+                .collect::<Vec<_>>(),
+            vec!["second", "first"]
+        );
+    }
+
+    #[test]
+    fn canonical_json_key_order_breaks_deep_ties() {
+        let mut first = diag("same");
+        first.data = Some(serde_json::json!({
+            "outer": {
+                "z": 1,
+                "a": 1
+            }
+        }));
+
+        let mut second = diag("same");
+        second.data = Some(serde_json::json!({
+            "outer": {
+                "a": 0,
+                "z": 9
+            }
+        }));
+
+        let mut diagnostics = vec![first, second];
+        sort_diagnostics_deterministically(&mut diagnostics);
+
+        assert_eq!(diagnostics[0].data.as_ref().unwrap()["outer"]["a"], 0);
+    }
+}

--- a/src/lsp/diagnostic_order.rs
+++ b/src/lsp/diagnostic_order.rs
@@ -44,28 +44,41 @@ pub(crate) fn canonical_json_string<T: serde::Serialize + std::fmt::Debug>(value
     // serialization failure instead of a shared sentinel: distinct
     // diagnostics must not collapse to one cached sort key, or the final
     // order would silently degrade to input order for them.
-    let Ok(json) = serde_json::to_value(value) else {
+    let Ok(json) = canonical_json_value(value) else {
         return format!("{value:?}");
     };
-    serde_json::to_string(&canonicalize_json(json)).unwrap_or_else(|_| format!("{value:?}"))
+    serde_json::to_string(&json).unwrap_or_else(|_| format!("{value:?}"))
 }
 
-fn canonicalize_json(value: serde_json::Value) -> serde_json::Value {
+/// Write one diagnostic in the same canonical form used by the total-order
+/// tiebreaker, without allocating an intermediate serialized `String`.
+pub(crate) fn write_diagnostic_canonical_json<W: std::io::Write>(
+    writer: W,
+    diagnostic: &Diagnostic,
+) -> serde_json::Result<()> {
+    serde_json::to_writer(writer, &canonical_json_value(diagnostic)?)
+}
+
+fn canonical_json_value<T: serde::Serialize>(value: &T) -> serde_json::Result<serde_json::Value> {
+    let mut json = serde_json::to_value(value)?;
+    canonicalize_json_in_place(&mut json);
+    Ok(json)
+}
+
+fn canonicalize_json_in_place(value: &mut serde_json::Value) {
     match value {
         serde_json::Value::Array(values) => {
-            serde_json::Value::Array(values.into_iter().map(canonicalize_json).collect())
+            for value in values {
+                canonicalize_json_in_place(value);
+            }
         }
         serde_json::Value::Object(map) => {
-            let mut entries: Vec<_> = map.into_iter().collect();
-            entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
-
-            let mut sorted = serde_json::Map::new();
-            for (key, value) in entries {
-                sorted.insert(key, canonicalize_json(value));
+            for value in map.values_mut() {
+                canonicalize_json_in_place(value);
             }
-            serde_json::Value::Object(sorted)
+            map.sort_keys();
         }
-        value => value,
+        _ => {}
     }
 }
 
@@ -128,6 +141,20 @@ mod tests {
         assert_eq!(
             canonical_json_string(&first),
             canonical_json_string(&second)
+        );
+    }
+
+    #[test]
+    fn canonical_diagnostic_writer_matches_canonical_string() {
+        let mut diagnostic = diag("same");
+        diagnostic.data = Some(serde_json::json!({"z": 1, "nested": {"z": 2, "a": 1}}));
+
+        let mut written = Vec::new();
+        write_diagnostic_canonical_json(&mut written, &diagnostic).unwrap();
+
+        assert_eq!(
+            String::from_utf8(written).unwrap(),
+            canonical_json_string(&diagnostic)
         );
     }
 }

--- a/src/lsp/diagnostic_order.rs
+++ b/src/lsp/diagnostic_order.rs
@@ -28,9 +28,15 @@ fn diagnostic_position_key(diagnostic: &Diagnostic) -> (u32, u32, u32, u32) {
     )
 }
 
-fn canonical_json_string<T: serde::Serialize>(value: &T) -> String {
-    let value = serde_json::to_value(value).unwrap_or(serde_json::Value::Null);
-    serde_json::to_string(&canonicalize_json(value)).unwrap_or_default()
+fn canonical_json_string<T: serde::Serialize + std::fmt::Debug>(value: &T) -> String {
+    // Fall back to the (deterministic, derive-generated) Debug rendering on a
+    // serialization failure instead of a shared sentinel: distinct
+    // diagnostics must not collapse to one cached sort key, or the final
+    // order would silently degrade to input order for them.
+    let Ok(json) = serde_json::to_value(value) else {
+        return format!("{value:?}");
+    };
+    serde_json::to_string(&canonicalize_json(json)).unwrap_or_else(|_| format!("{value:?}"))
 }
 
 fn canonicalize_json(value: serde_json::Value) -> serde_json::Value {

--- a/src/lsp/diagnostic_order.rs
+++ b/src/lsp/diagnostic_order.rs
@@ -5,7 +5,7 @@ pub(crate) fn sort_diagnostics_deterministically(diagnostics: &mut [Diagnostic])
     // every cheap field need the full-value tiebreaker; caching that key within
     // each tie group avoids both serializing unrelated diagnostics and
     // repeating serialization per comparison for tie-heavy inputs.
-    diagnostics.sort_by(diagnostic_cheap_cmp);
+    diagnostics.sort_unstable_by(diagnostic_cheap_cmp);
 
     let mut start = 0;
     while start < diagnostics.len() {

--- a/src/lsp/diagnostic_order.rs
+++ b/src/lsp/diagnostic_order.rs
@@ -39,7 +39,7 @@ fn diagnostic_position_key(diagnostic: &Diagnostic) -> (u32, u32, u32, u32) {
     )
 }
 
-fn canonical_json_string<T: serde::Serialize + std::fmt::Debug>(value: &T) -> String {
+pub(crate) fn canonical_json_string<T: serde::Serialize + std::fmt::Debug>(value: &T) -> String {
     // Fall back to the (deterministic, derive-generated) Debug rendering on a
     // serialization failure instead of a shared sentinel: distinct
     // diagnostics must not collapse to one cached sort key, or the final

--- a/src/lsp/diagnostic_order.rs
+++ b/src/lsp/diagnostic_order.rs
@@ -1,13 +1,19 @@
 use tower_lsp_server::ls_types::Diagnostic;
 
 pub(crate) fn sort_diagnostics_deterministically(diagnostics: &mut [Diagnostic]) {
-    diagnostics.sort_by(|a, b| {
-        diagnostic_position_key(a)
-            .cmp(&diagnostic_position_key(b))
-            .then_with(|| a.message.cmp(&b.message))
-            .then_with(|| a.source.cmp(&b.source))
-            .then_with(|| a.severity.cmp(&b.severity))
-            .then_with(|| canonical_json_string(a).cmp(&canonical_json_string(b)))
+    // Cached key: the canonical-JSON tiebreaker serializes the whole
+    // diagnostic, so computing it per COMPARISON (O(n log n) times, twice
+    // each) would dominate the sort — compute every component once per
+    // element instead. Key order preserves the previous comparator's
+    // tie-break semantics exactly.
+    diagnostics.sort_by_cached_key(|d| {
+        (
+            diagnostic_position_key(d),
+            d.message.clone(),
+            d.source.clone(),
+            d.severity,
+            canonical_json_string(d),
+        )
     });
 }
 

--- a/src/lsp/diagnostic_order.rs
+++ b/src/lsp/diagnostic_order.rs
@@ -1,4 +1,4 @@
-use tower_lsp_server::ls_types::Diagnostic;
+use tower_lsp_server::ls_types::{Diagnostic, NumberOrString};
 
 pub(crate) fn sort_diagnostics_deterministically(diagnostics: &mut [Diagnostic]) {
     // Establish the common-case order without allocating. Only true ties on
@@ -27,7 +27,25 @@ fn diagnostic_cheap_cmp(left: &Diagnostic, right: &Diagnostic) -> std::cmp::Orde
         .cmp(&diagnostic_position_key(right))
         .then_with(|| left.message.cmp(&right.message))
         .then_with(|| left.source.cmp(&right.source))
+        .then_with(|| diagnostic_code_cmp(left.code.as_ref(), right.code.as_ref()))
         .then_with(|| left.severity.cmp(&right.severity))
+}
+
+fn diagnostic_code_cmp(
+    left: Option<&NumberOrString>,
+    right: Option<&NumberOrString>,
+) -> std::cmp::Ordering {
+    use NumberOrString::{Number, String};
+
+    match (left, right) {
+        (Some(Number(left)), Some(Number(right))) => left.cmp(right),
+        (Some(String(left)), Some(String(right))) => left.cmp(right),
+        (Some(Number(_)), Some(String(_))) => std::cmp::Ordering::Less,
+        (Some(String(_)), Some(Number(_))) => std::cmp::Ordering::Greater,
+        (None, None) => std::cmp::Ordering::Equal,
+        (None, Some(_)) => std::cmp::Ordering::Less,
+        (Some(_), None) => std::cmp::Ordering::Greater,
+    }
 }
 
 fn diagnostic_position_key(diagnostic: &Diagnostic) -> (u32, u32, u32, u32) {
@@ -99,6 +117,29 @@ mod tests {
                 .map(|diagnostic| diagnostic.message.as_str())
                 .collect::<Vec<_>>(),
             vec!["second", "first"]
+        );
+    }
+
+    #[test]
+    fn orders_tied_diagnostics_by_code_without_canonical_json() {
+        let mut later = diag("same");
+        later.code = Some(NumberOrString::String("B".to_string()));
+
+        let mut earlier = diag("same");
+        earlier.code = Some(NumberOrString::String("A".to_string()));
+
+        let mut diagnostics = vec![later, earlier];
+        sort_diagnostics_deterministically(&mut diagnostics);
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .filter_map(|diagnostic| diagnostic.code.clone())
+                .collect::<Vec<_>>(),
+            vec![
+                NumberOrString::String("A".to_string()),
+                NumberOrString::String("B".to_string()),
+            ]
         );
     }
 

--- a/src/lsp/diagnostic_order.rs
+++ b/src/lsp/diagnostic_order.rs
@@ -2,7 +2,10 @@ use tower_lsp_server::ls_types::Diagnostic;
 
 // Cache enough canonical keys to cover thousands of ordinary diagnostics,
 // while staying well below the roughly 1 MiB full reports observed in the
-// pull hot path. Oversized tie groups fall back to transient pairwise keys.
+// pull hot path. `Diagnostic.data` is unbounded, so caching every key could
+// duplicate an arbitrarily large result. Oversized mixed tie groups therefore
+// trade repeated serialization for bounded retained memory; oversized
+// canonical-duplicate groups exit through the linear prepass below.
 const MAX_CACHED_TIE_KEY_CAPACITY_BYTES: usize = 256 * 1024;
 
 pub(crate) fn sort_diagnostics_deterministically(diagnostics: &mut [Diagnostic]) {

--- a/src/lsp/diagnostic_order.rs
+++ b/src/lsp/diagnostic_order.rs
@@ -1,4 +1,4 @@
-use tower_lsp_server::ls_types::{Diagnostic, NumberOrString};
+use tower_lsp_server::ls_types::Diagnostic;
 
 pub(crate) fn sort_diagnostics_deterministically(diagnostics: &mut [Diagnostic]) {
     // Establish the common-case order without allocating. Only true ties on
@@ -28,24 +28,6 @@ fn diagnostic_cheap_cmp(left: &Diagnostic, right: &Diagnostic) -> std::cmp::Orde
         .then_with(|| left.message.cmp(&right.message))
         .then_with(|| left.source.cmp(&right.source))
         .then_with(|| left.severity.cmp(&right.severity))
-        .then_with(|| diagnostic_code_cmp(left.code.as_ref(), right.code.as_ref()))
-}
-
-fn diagnostic_code_cmp(
-    left: Option<&NumberOrString>,
-    right: Option<&NumberOrString>,
-) -> std::cmp::Ordering {
-    use NumberOrString::{Number, String};
-
-    match (left, right) {
-        (Some(Number(left)), Some(Number(right))) => left.cmp(right),
-        (Some(String(left)), Some(String(right))) => left.cmp(right),
-        (Some(Number(_)), Some(String(_))) => std::cmp::Ordering::Less,
-        (Some(String(_)), Some(Number(_))) => std::cmp::Ordering::Greater,
-        (None, None) => std::cmp::Ordering::Equal,
-        (None, Some(_)) => std::cmp::Ordering::Less,
-        (Some(_), None) => std::cmp::Ordering::Greater,
-    }
 }
 
 fn diagnostic_position_key(diagnostic: &Diagnostic) -> (u32, u32, u32, u32) {
@@ -90,7 +72,7 @@ fn canonicalize_json(value: serde_json::Value) -> serde_json::Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tower_lsp_server::ls_types::{DiagnosticSeverity, Position, Range};
+    use tower_lsp_server::ls_types::{Position, Range};
 
     fn diag(message: &str) -> Diagnostic {
         Diagnostic {
@@ -117,54 +99,6 @@ mod tests {
                 .map(|diagnostic| diagnostic.message.as_str())
                 .collect::<Vec<_>>(),
             vec!["second", "first"]
-        );
-    }
-
-    #[test]
-    fn orders_tied_diagnostics_by_code_without_canonical_json() {
-        let mut later = diag("same");
-        later.code = Some(NumberOrString::String("B".to_string()));
-
-        let mut earlier = diag("same");
-        earlier.code = Some(NumberOrString::String("A".to_string()));
-
-        let mut diagnostics = vec![later, earlier];
-        sort_diagnostics_deterministically(&mut diagnostics);
-
-        assert_eq!(
-            diagnostics
-                .iter()
-                .filter_map(|diagnostic| diagnostic.code.clone())
-                .collect::<Vec<_>>(),
-            vec![
-                NumberOrString::String("A".to_string()),
-                NumberOrString::String("B".to_string()),
-            ]
-        );
-    }
-
-    #[test]
-    fn preserves_severity_precedence_before_code() {
-        let mut later_severity = diag("same");
-        later_severity.severity = Some(DiagnosticSeverity::WARNING);
-        later_severity.code = Some(NumberOrString::String("A".to_string()));
-
-        let mut earlier_severity = diag("same");
-        earlier_severity.severity = Some(DiagnosticSeverity::ERROR);
-        earlier_severity.code = Some(NumberOrString::String("B".to_string()));
-
-        let mut diagnostics = vec![later_severity, earlier_severity];
-        sort_diagnostics_deterministically(&mut diagnostics);
-
-        assert_eq!(
-            diagnostics
-                .iter()
-                .map(|diagnostic| diagnostic.severity)
-                .collect::<Vec<_>>(),
-            vec![
-                Some(DiagnosticSeverity::ERROR),
-                Some(DiagnosticSeverity::WARNING),
-            ]
         );
     }
 

--- a/src/lsp/diagnostic_order.rs
+++ b/src/lsp/diagnostic_order.rs
@@ -27,8 +27,8 @@ fn diagnostic_cheap_cmp(left: &Diagnostic, right: &Diagnostic) -> std::cmp::Orde
         .cmp(&diagnostic_position_key(right))
         .then_with(|| left.message.cmp(&right.message))
         .then_with(|| left.source.cmp(&right.source))
-        .then_with(|| diagnostic_code_cmp(left.code.as_ref(), right.code.as_ref()))
         .then_with(|| left.severity.cmp(&right.severity))
+        .then_with(|| diagnostic_code_cmp(left.code.as_ref(), right.code.as_ref()))
 }
 
 fn diagnostic_code_cmp(
@@ -90,7 +90,7 @@ fn canonicalize_json(value: serde_json::Value) -> serde_json::Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tower_lsp_server::ls_types::{Position, Range};
+    use tower_lsp_server::ls_types::{DiagnosticSeverity, Position, Range};
 
     fn diag(message: &str) -> Diagnostic {
         Diagnostic {
@@ -139,6 +139,31 @@ mod tests {
             vec![
                 NumberOrString::String("A".to_string()),
                 NumberOrString::String("B".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn preserves_severity_precedence_before_code() {
+        let mut later_severity = diag("same");
+        later_severity.severity = Some(DiagnosticSeverity::WARNING);
+        later_severity.code = Some(NumberOrString::String("A".to_string()));
+
+        let mut earlier_severity = diag("same");
+        earlier_severity.severity = Some(DiagnosticSeverity::ERROR);
+        earlier_severity.code = Some(NumberOrString::String("B".to_string()));
+
+        let mut diagnostics = vec![later_severity, earlier_severity];
+        sort_diagnostics_deterministically(&mut diagnostics);
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.severity)
+                .collect::<Vec<_>>(),
+            vec![
+                Some(DiagnosticSeverity::ERROR),
+                Some(DiagnosticSeverity::WARNING),
             ]
         );
     }

--- a/src/lsp/diagnostic_order.rs
+++ b/src/lsp/diagnostic_order.rs
@@ -1,10 +1,15 @@
 use tower_lsp_server::ls_types::Diagnostic;
 
+// Cache enough canonical keys to cover thousands of ordinary diagnostics,
+// while staying well below the roughly 1 MiB full reports observed in the
+// pull hot path. Oversized tie groups fall back to transient pairwise keys.
+const MAX_CACHED_TIE_KEY_CAPACITY_BYTES: usize = 256 * 1024;
+
 pub(crate) fn sort_diagnostics_deterministically(diagnostics: &mut [Diagnostic]) {
     // Establish the common-case order without allocating. Only true ties on
-    // every cheap field need the full-value tiebreaker; caching that key within
-    // each tie group avoids both serializing unrelated diagnostics and
-    // repeating serialization per comparison for tie-heavy inputs.
+    // every cheap field need the full-value tiebreaker; each tie group caches
+    // canonical keys up to a fixed byte budget, then uses transient pairwise
+    // keys so neither repeated work nor retained memory grows unchecked.
     diagnostics.sort_unstable_by(diagnostic_cheap_cmp);
 
     let mut start = 0;
@@ -16,9 +21,56 @@ pub(crate) fn sort_diagnostics_deterministically(diagnostics: &mut [Diagnostic])
             end += 1;
         }
         if end - start > 1 {
-            diagnostics[start..end].sort_by_cached_key(canonical_json_string);
+            sort_diagnostic_tie_group(&mut diagnostics[start..end]);
         }
         start = end;
+    }
+}
+
+fn sort_diagnostic_tie_group(diagnostics: &mut [Diagnostic]) {
+    // Structural equality is only a cheap candidate filter: serde_json treats
+    // 0.0 and -0.0 as equal even though their canonical bytes differ. Confirm
+    // canonical equality once per item before skipping an all-duplicate group.
+    if diagnostics[1..]
+        .iter()
+        .all(|diagnostic| diagnostic == &diagnostics[0])
+    {
+        let first_key = canonical_json_string(&diagnostics[0]);
+        if diagnostics[1..]
+            .iter()
+            .all(|diagnostic| canonical_json_string(diagnostic) == first_key)
+        {
+            return;
+        }
+    }
+
+    let mut cached_capacity = 0usize;
+    let mut keyed: Vec<_> = diagnostics
+        .iter_mut()
+        .map(|diagnostic| {
+            let key = canonical_json_string(diagnostic);
+            let key_capacity = key.capacity();
+            let key = if cached_capacity.saturating_add(key_capacity)
+                <= MAX_CACHED_TIE_KEY_CAPACITY_BYTES
+            {
+                cached_capacity += key_capacity;
+                Some(key)
+            } else {
+                None
+            };
+            (key, std::mem::take(diagnostic))
+        })
+        .collect();
+
+    keyed.sort_unstable_by(|left, right| match (&left.0, &right.0) {
+        (Some(left), Some(right)) => left.cmp(right),
+        (Some(left), None) => left.cmp(&canonical_json_string(&right.1)),
+        (None, Some(right)) => canonical_json_string(&left.1).cmp(right),
+        (None, None) => canonical_json_string(&left.1).cmp(&canonical_json_string(&right.1)),
+    });
+
+    for (slot, (_, diagnostic)) in diagnostics.iter_mut().zip(keyed) {
+        *slot = diagnostic;
     }
 }
 
@@ -155,6 +207,56 @@ mod tests {
         assert_eq!(
             String::from_utf8(written).unwrap(),
             canonical_json_string(&diagnostic)
+        );
+    }
+
+    #[test]
+    fn tie_sort_preserves_canonical_order_after_key_budget() {
+        let padding = "x".repeat(MAX_CACHED_TIE_KEY_CAPACITY_BYTES + 1);
+        let with_value = |value| {
+            let mut diagnostic = diag("same");
+            diagnostic.data = Some(serde_json::json!({
+                "padding": padding,
+                "value": value,
+            }));
+            diagnostic
+        };
+        let first = with_value(1);
+        let second = with_value(2);
+        let mut diagnostics = vec![second, first.clone()];
+
+        sort_diagnostics_deterministically(&mut diagnostics);
+
+        assert_eq!(diagnostics[0], first);
+    }
+
+    #[test]
+    fn tie_sort_distinguishes_signed_zero_serialization() {
+        let with_data = |value| {
+            let mut diagnostic = diag("same");
+            diagnostic.data = Some(value);
+            diagnostic
+        };
+        let positive = with_data(serde_json::json!(0.0));
+        let negative = with_data(serde_json::json!(-0.0));
+        assert_eq!(
+            positive, negative,
+            "JSON number equality ignores zero's sign"
+        );
+        assert_ne!(
+            canonical_json_string(&positive),
+            canonical_json_string(&negative),
+            "canonical JSON preserves zero's sign"
+        );
+        let mut first = vec![positive.clone(), negative.clone()];
+        let mut second = vec![negative, positive];
+
+        sort_diagnostics_deterministically(&mut first);
+        sort_diagnostics_deterministically(&mut second);
+
+        assert_eq!(
+            first.iter().map(canonical_json_string).collect::<Vec<_>>(),
+            second.iter().map(canonical_json_string).collect::<Vec<_>>()
         );
     }
 }

--- a/src/lsp/diagnostic_order.rs
+++ b/src/lsp/diagnostic_order.rs
@@ -1,22 +1,33 @@
 use tower_lsp_server::ls_types::Diagnostic;
 
 pub(crate) fn sort_diagnostics_deterministically(diagnostics: &mut [Diagnostic]) {
-    // Cached key: the canonical-JSON tiebreaker serializes the whole
-    // diagnostic, so computing it per COMPARISON (O(n log n) times, twice
-    // each) would dominate the sort — compute every component once per
-    // element instead. The key components compare in the same order as the
-    // previous comparator; the final tiebreaker is canonical JSON (sorted
-    // object keys), stronger than the old serde_json::to_string whose key
-    // order could differ between equal-content diagnostics.
-    diagnostics.sort_by_cached_key(|d| {
-        (
-            diagnostic_position_key(d),
-            d.message.clone(),
-            d.source.clone(),
-            d.severity,
-            canonical_json_string(d),
-        )
-    });
+    // Establish the common-case order without allocating. Only true ties on
+    // every cheap field need the full-value tiebreaker; caching that key within
+    // each tie group avoids both serializing unrelated diagnostics and
+    // repeating serialization per comparison for tie-heavy inputs.
+    diagnostics.sort_by(diagnostic_cheap_cmp);
+
+    let mut start = 0;
+    while start < diagnostics.len() {
+        let mut end = start + 1;
+        while end < diagnostics.len()
+            && diagnostic_cheap_cmp(&diagnostics[start], &diagnostics[end]).is_eq()
+        {
+            end += 1;
+        }
+        if end - start > 1 {
+            diagnostics[start..end].sort_by_cached_key(canonical_json_string);
+        }
+        start = end;
+    }
+}
+
+fn diagnostic_cheap_cmp(left: &Diagnostic, right: &Diagnostic) -> std::cmp::Ordering {
+    diagnostic_position_key(left)
+        .cmp(&diagnostic_position_key(right))
+        .then_with(|| left.message.cmp(&right.message))
+        .then_with(|| left.source.cmp(&right.source))
+        .then_with(|| left.severity.cmp(&right.severity))
 }
 
 fn diagnostic_position_key(diagnostic: &Diagnostic) -> (u32, u32, u32, u32) {

--- a/src/lsp/diagnostic_order.rs
+++ b/src/lsp/diagnostic_order.rs
@@ -75,7 +75,7 @@ fn canonicalize_json(value: serde_json::Value) -> serde_json::Value {
         }
         serde_json::Value::Object(map) => {
             let mut entries: Vec<_> = map.into_iter().collect();
-            entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+            entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
 
             let mut sorted = serde_json::Map::new();
             for (key, value) in entries {

--- a/src/lsp/diagnostic_order.rs
+++ b/src/lsp/diagnostic_order.rs
@@ -4,8 +4,10 @@ pub(crate) fn sort_diagnostics_deterministically(diagnostics: &mut [Diagnostic])
     // Cached key: the canonical-JSON tiebreaker serializes the whole
     // diagnostic, so computing it per COMPARISON (O(n log n) times, twice
     // each) would dominate the sort — compute every component once per
-    // element instead. Key order preserves the previous comparator's
-    // tie-break semantics exactly.
+    // element instead. The key components compare in the same order as the
+    // previous comparator; the final tiebreaker is canonical JSON (sorted
+    // object keys), stronger than the old serde_json::to_string whose key
+    // order could differ between equal-content diagnostics.
     diagnostics.sort_by_cached_key(|d| {
         (
             diagnostic_position_key(d),

--- a/src/lsp/diagnostic_order.rs
+++ b/src/lsp/diagnostic_order.rs
@@ -78,26 +78,31 @@ mod tests {
     }
 
     #[test]
-    fn canonical_json_key_order_breaks_deep_ties() {
-        let mut first = diag("same");
-        first.data = Some(serde_json::json!({
-            "outer": {
-                "z": 1,
-                "a": 1
+    fn canonical_json_string_ignores_recursive_object_insertion_order() {
+        let nested_data = |keys: [&str; 2]| {
+            let mut outer = serde_json::Map::new();
+            for key in keys {
+                outer.insert(key.to_string(), serde_json::json!(1));
             }
-        }));
+
+            let mut root = serde_json::Map::new();
+            root.insert("outer".to_string(), serde_json::Value::Object(outer));
+            serde_json::Value::Object(root)
+        };
+
+        let mut first = diag("same");
+        first.data = Some(nested_data(["z", "a"]));
 
         let mut second = diag("same");
-        second.data = Some(serde_json::json!({
-            "outer": {
-                "a": 0,
-                "z": 9
-            }
-        }));
+        second.data = Some(nested_data(["a", "z"]));
 
-        let mut diagnostics = vec![first, second];
-        sort_diagnostics_deterministically(&mut diagnostics);
-
-        assert_eq!(diagnostics[0].data.as_ref().unwrap()["outer"]["a"], 0);
+        assert_ne!(
+            serde_json::to_string(&first).unwrap(),
+            serde_json::to_string(&second).unwrap()
+        );
+        assert_eq!(
+            canonical_json_string(&first),
+            canonical_json_string(&second)
+        );
     }
 }

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -788,23 +788,6 @@ fn finalize_pull_items(mut items: Vec<Diagnostic>) -> (Vec<Diagnostic>, String) 
     (items, id)
 }
 
-/// FNV-1a 64-bit writer used to hash canonical JSON incrementally without
-/// materializing the full diagnostic array.
-struct FnvWriter(u64);
-
-impl std::io::Write for FnvWriter {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        const FNV_PRIME: u64 = 0x100000001b3;
-        for &byte in buf {
-            self.0 = (self.0 ^ u64::from(byte)).wrapping_mul(FNV_PRIME);
-        }
-        Ok(buf.len())
-    }
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
-
 /// Content-address a **sorted** pull result: the deterministic sort
 /// ([`sort_diagnostics_deterministically`], applied by [`finalize_pull_items`]) makes the
 /// serialization canonical, so the same logical set always hashes to the same
@@ -816,8 +799,7 @@ impl std::io::Write for FnvWriter {
 ///
 /// [`sort_diagnostics_deterministically`]: crate::lsp::diagnostic_order::sort_diagnostics_deterministically
 fn diagnostic_result_id(items: &[Diagnostic]) -> String {
-    const FNV_OFFSET: u64 = 0xcbf29ce484222325;
-    let mut writer = FnvWriter(FNV_OFFSET);
+    let mut writer = crate::text::Fnv1aWriter::new();
     std::io::Write::write_all(&mut writer, b"[").expect("FNV writer is infallible");
     for (index, item) in items.iter().enumerate() {
         if index > 0 {
@@ -834,7 +816,7 @@ fn diagnostic_result_id(items: &[Diagnostic]) -> String {
         }
     }
     std::io::Write::write_all(&mut writer, b"]").expect("FNV writer is infallible");
-    format!("{:016x}-{}", writer.0, items.len())
+    format!("{:016x}-{}", writer.finish(), items.len())
 }
 
 /// Create a full diagnostic report from aggregated diagnostics. `result_id`

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -788,10 +788,8 @@ fn finalize_pull_items(mut items: Vec<Diagnostic>) -> (Vec<Diagnostic>, String) 
     (items, id)
 }
 
-/// FNV-1a 64-bit over a serde serialization stream: hashes without
-/// materializing the serialized form (a full pull set is ~1 MB — see
-/// [`diagnostic_result_id`]). Byte-identical to `fnv1a_hash(to_string(..))`
-/// because `to_writer` produces the same bytes as `to_string`.
+/// FNV-1a 64-bit writer used to hash canonical JSON incrementally without
+/// materializing the full diagnostic array.
 struct FnvWriter(u64);
 
 impl std::io::Write for FnvWriter {
@@ -820,16 +818,16 @@ impl std::io::Write for FnvWriter {
 fn diagnostic_result_id(items: &[Diagnostic]) -> String {
     const FNV_OFFSET: u64 = 0xcbf29ce484222325;
     let mut writer = FnvWriter(FNV_OFFSET);
-    // Serialization of ls_types values cannot realistically fail (no non-string
-    // map keys, and JSON numbers cannot be non-finite) and `FnvWriter` never
-    // errors; if it ever fails anyway, FAIL OPEN with an id that can never
-    // match a previous one — two differing sets could share a partial-stream
-    // prefix hash, and a false "unchanged" must stay impossible.
-    if serde_json::to_writer(&mut writer, items).is_err() {
-        static UNHASHABLE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-        let nonce = UNHASHABLE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        return format!("unhashable-{nonce}-{}", items.len());
+    std::io::Write::write_all(&mut writer, b"[").expect("FNV writer is infallible");
+    for (index, item) in items.iter().enumerate() {
+        if index > 0 {
+            std::io::Write::write_all(&mut writer, b",").expect("FNV writer is infallible");
+        }
+        let canonical = crate::lsp::diagnostic_order::canonical_json_string(item);
+        std::io::Write::write_all(&mut writer, canonical.as_bytes())
+            .expect("FNV writer is infallible");
     }
+    std::io::Write::write_all(&mut writer, b"]").expect("FNV writer is infallible");
     format!("{:016x}-{}", writer.0, items.len())
 }
 
@@ -971,18 +969,42 @@ mod tests {
 
     #[test]
     fn result_id_streaming_hash_matches_the_materialized_form() {
-        // `diagnostic_result_id` hashes through a serde writer to avoid a ~1 MB
-        // transient; the id must stay byte-identical to hashing the
-        // materialized serialization (the stateless contract: clients hold ids
-        // across server restarts, so the id algorithm is wire-format).
+        // `diagnostic_result_id` hashes one canonical item at a time to avoid a
+        // ~1 MB array transient; it must stay byte-identical to hashing the
+        // equivalent materialized canonical array.
         let items = vec![diag("x"), diag("y")];
-        let materialized = serde_json::to_string(&items).expect("serializes");
+        let materialized = format!(
+            "[{},{}]",
+            crate::lsp::diagnostic_order::canonical_json_string(&items[0]),
+            crate::lsp::diagnostic_order::canonical_json_string(&items[1])
+        );
         let expected = format!(
             "{:016x}-{}",
             crate::text::fnv1a_hash(&materialized),
             items.len()
         );
         assert_eq!(diagnostic_result_id(&items), expected);
+    }
+
+    #[test]
+    fn result_id_ignores_json_object_insertion_order() {
+        let with_data = |keys: [&str; 2]| {
+            let mut diagnostic = diag("same");
+            let mut data = serde_json::Map::new();
+            for key in keys {
+                data.insert(key.to_string(), serde_json::json!(1));
+            }
+            diagnostic.data = Some(serde_json::Value::Object(data));
+            diagnostic
+        };
+
+        let first = vec![with_data(["z", "a"])];
+        let second = vec![with_data(["a", "z"])];
+        assert_ne!(
+            serde_json::to_string(&first).unwrap(),
+            serde_json::to_string(&second).unwrap()
+        );
+        assert_eq!(diagnostic_result_id(&first), diagnostic_result_id(&second));
     }
 
     #[test]

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -823,9 +823,15 @@ fn diagnostic_result_id(items: &[Diagnostic]) -> String {
         if index > 0 {
             std::io::Write::write_all(&mut writer, b",").expect("FNV writer is infallible");
         }
-        let canonical = crate::lsp::diagnostic_order::canonical_json_string(item);
-        std::io::Write::write_all(&mut writer, canonical.as_bytes())
-            .expect("FNV writer is infallible");
+        // Keep peak canonicalization memory bounded to one diagnostic and
+        // stream its JSON directly into the hash. If serialization ever fails,
+        // fail open: a fresh id is safer than falsely reporting `unchanged`.
+        if crate::lsp::diagnostic_order::write_diagnostic_canonical_json(&mut writer, item).is_err()
+        {
+            static UNHASHABLE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+            let nonce = UNHASHABLE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            return format!("unhashable-{nonce}-{}", items.len());
+        }
     }
     std::io::Write::write_all(&mut writer, b"]").expect("FNV writer is infallible");
     format!("{:016x}-{}", writer.0, items.len())
@@ -964,6 +970,25 @@ mod tests {
         let (sorted_a, id_a) = finalize_pull_items(a);
         let (sorted_b, id_b) = finalize_pull_items(b);
         assert_eq!(sorted_a, sorted_b, "the sort canonicalizes permutations");
+        assert_eq!(id_a, id_b);
+    }
+
+    #[test]
+    fn result_id_is_stable_across_deep_tie_order() {
+        let with_data = |value| {
+            let mut diagnostic = diag("same");
+            diagnostic.data = Some(serde_json::json!({"nested": {"value": value}}));
+            diagnostic
+        };
+        let first = with_data(1);
+        let second = with_data(2);
+
+        // These diagnostics tie on every cheap sort field and differ only in
+        // nested data, so reversing them exercises the canonical tiebreaker.
+        let (sorted_a, id_a) = finalize_pull_items(vec![first.clone(), second.clone()]);
+        let (sorted_b, id_b) = finalize_pull_items(vec![second, first]);
+
+        assert_eq!(sorted_a, sorted_b);
         assert_eq!(id_a, id_b);
     }
 

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -783,7 +783,7 @@ async fn dispatch_preferred_diagnostics(
 /// handler cannot hash unsorted items — an order-unstable id would make
 /// `unchanged` reports silently never fire on multi-server hosts.
 fn finalize_pull_items(mut items: Vec<Diagnostic>) -> (Vec<Diagnostic>, String) {
-    crate::lsp::diagnostic_cache::sort_diagnostics(&mut items);
+    crate::lsp::diagnostic_order::sort_diagnostics_deterministically(&mut items);
     let id = diagnostic_result_id(&items);
     (items, id)
 }
@@ -808,7 +808,7 @@ impl std::io::Write for FnvWriter {
 }
 
 /// Content-address a **sorted** pull result: the deterministic sort
-/// ([`sort_diagnostics`], applied by [`finalize_pull_items`]) makes the
+/// ([`sort_diagnostics_deterministically`], applied by [`finalize_pull_items`]) makes the
 /// serialization canonical, so the same logical set always hashes to the same
 /// id and any field change produces a different one. The length suffix is
 /// cheap insurance against a 64-bit collision making a changed set read as
@@ -816,7 +816,7 @@ impl std::io::Write for FnvWriter {
 /// content fingerprint). Stateless: the client echoes the id back as
 /// `previousResultId` and the handler just recomputes — nothing to invalidate.
 ///
-/// [`sort_diagnostics`]: crate::lsp::diagnostic_cache::sort_diagnostics
+/// [`sort_diagnostics_deterministically`]: crate::lsp::diagnostic_order::sort_diagnostics_deterministically
 fn diagnostic_result_id(items: &[Diagnostic]) -> String {
     const FNV_OFFSET: u64 = 0xcbf29ce484222325;
     let mut writer = FnvWriter(FNV_OFFSET);

--- a/src/lsp/lsp_impl/text_document/document_color.rs
+++ b/src/lsp/lsp_impl/text_document/document_color.rs
@@ -106,7 +106,7 @@ impl Kakehashi {
         let pool = self.bridge.pool_arc();
 
         // Outer JoinSet: one task per injection region, all in parallel
-        let mut outer_join_set: JoinSet<Vec<ColorInformation>> = JoinSet::new();
+        let mut outer_join_set: JoinSet<(usize, Option<Vec<ColorInformation>>)> = JoinSet::new();
 
         // Drop servers already known (a live, `Ready` connection) NOT to support
         // this method before the per-region fan-out spawns their tasks
@@ -119,7 +119,7 @@ impl Kakehashi {
             )
             .await;
 
-        for resolved in all_regions.iter() {
+        for (region_index, resolved) in all_regions.iter().enumerate() {
             // Get ALL bridge server configs for this injection language
             let mut configs = self.bridge_configs_for_injection_language(
                 &language_name,
@@ -171,10 +171,11 @@ impl Kakehashi {
                     None,
                 )
                 .await;
-                match result {
-                    FanInResult::Done(colors) => colors,
-                    FanInResult::NoResult { .. } | FanInResult::Cancelled => Vec::new(),
-                }
+                let colors = match result {
+                    FanInResult::Done(colors) => Some(colors),
+                    FanInResult::NoResult { .. } | FanInResult::Cancelled => None,
+                };
+                (region_index, colors)
             });
         }
 
@@ -188,11 +189,17 @@ impl Kakehashi {
             upstream_request_id.clone(),
         );
         // Collect results, aborting early if $/cancelRequest arrives.
-        crate::lsp::aggregation::region::collect_region_results_with_cancel(
-            outer_join_set,
-            cancel_rx,
-            |acc, items: Vec<ColorInformation>| acc.extend(items),
+        let completion_order_items =
+            crate::lsp::aggregation::region::collect_region_results_with_cancel(
+                outer_join_set,
+                cancel_rx,
+                |acc, region_items: (usize, Option<Vec<ColorInformation>>)| acc.push(region_items),
+            )
+            .await?;
+        Ok(
+            crate::lsp::lsp_impl::whole_document::flatten_ordered_region_items(
+                completion_order_items,
+            ),
         )
-        .await
     }
 }

--- a/src/lsp/lsp_impl/text_document/document_symbol.rs
+++ b/src/lsp/lsp_impl/text_document/document_symbol.rs
@@ -129,7 +129,7 @@ impl Kakehashi {
         let pool = self.bridge.pool_arc();
 
         // Outer JoinSet: one task per injection region, all in parallel
-        let mut outer_join_set: JoinSet<Vec<DocumentSymbol>> = JoinSet::new();
+        let mut outer_join_set: JoinSet<(usize, Option<Vec<DocumentSymbol>>)> = JoinSet::new();
 
         // Shared client progress: a whole-document request fans out over several
         // injection regions (one `dispatch_preferred` each), so they share ONE
@@ -155,7 +155,7 @@ impl Kakehashi {
             )
             .await;
 
-        for resolved in all_regions.iter() {
+        for (region_index, resolved) in all_regions.iter().enumerate() {
             // Get ALL bridge server configs for this injection language
             let mut configs = self.bridge_configs_for_injection_language(
                 &language_name,
@@ -229,10 +229,11 @@ impl Kakehashi {
                         dispatch_preferred(&region_ctx, pool.clone(), send, is_nonempty, None).await
                     }
                 };
-                match result {
-                    FanInResult::Done(symbols) => symbols.unwrap_or_default(),
-                    FanInResult::NoResult { .. } | FanInResult::Cancelled => Vec::new(),
-                }
+                let symbols = match result {
+                    FanInResult::Done(symbols) => symbols,
+                    FanInResult::NoResult { .. } | FanInResult::Cancelled => None,
+                };
+                (region_index, symbols)
             });
         }
 
@@ -247,11 +248,12 @@ impl Kakehashi {
         let result = crate::lsp::aggregation::region::collect_region_results_with_cancel(
             outer_join_set,
             cancel_rx,
-            |acc, items: Vec<DocumentSymbol>| acc.extend(items),
+            |acc, region_items: (usize, Option<Vec<DocumentSymbol>>)| acc.push(region_items),
         )
         .await;
 
-        let all_symbols = result?;
+        let all_symbols =
+            crate::lsp::lsp_impl::whole_document::flatten_ordered_region_items(result?);
 
         Ok(format_document_symbol_response(
             all_symbols,

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -306,6 +306,11 @@ pub(super) fn flatten_ordered_region_items<T>(
     mut region_items: Vec<(usize, Option<Vec<T>>)>,
 ) -> Vec<T> {
     region_items.sort_unstable_by_key(|(region_index, _)| *region_index);
+    let total_len = region_items
+        .iter()
+        .filter_map(|(_, items)| items.as_ref())
+        .map(Vec::len)
+        .sum::<usize>();
     let mut ordered_items = region_items
         .into_iter()
         .filter_map(|(_, items)| items)
@@ -313,6 +318,7 @@ pub(super) fn flatten_ordered_region_items<T>(
     let Some(mut flattened) = ordered_items.next() else {
         return Vec::new();
     };
+    flattened.reserve(total_len - flattened.len());
     for mut items in ordered_items {
         flattened.append(&mut items);
     }

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -297,6 +297,18 @@ fn nonempty_whole_document_items<T>(items: Vec<T>) -> Option<Vec<T>> {
     if items.is_empty() { None } else { Some(items) }
 }
 
+/// Flatten per-region result vectors back into ONE list in region source
+/// order (the region index recorded at fan-out time), regardless of task
+/// completion order.
+fn flatten_ordered_region_items<T>(mut region_items: Vec<(usize, Option<Vec<T>>)>) -> Vec<T> {
+    region_items.sort_by_key(|(region_index, _)| *region_index);
+    region_items
+        .into_iter()
+        .filter_map(|(_, items)| items)
+        .flatten()
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -381,15 +393,6 @@ mod tests {
 
         assert_eq!(result, Some(vec!["virt", "host"]));
     }
-}
-
-fn flatten_ordered_region_items<T>(mut region_items: Vec<(usize, Option<Vec<T>>)>) -> Vec<T> {
-    region_items.sort_by_key(|(region_index, _)| *region_index);
-    region_items
-        .into_iter()
-        .filter_map(|(_, items)| items)
-        .flatten()
-        .collect()
 }
 
 #[cfg(test)]

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -306,16 +306,15 @@ pub(super) fn flatten_ordered_region_items<T>(
     mut region_items: Vec<(usize, Option<Vec<T>>)>,
 ) -> Vec<T> {
     region_items.sort_unstable_by_key(|(region_index, _)| *region_index);
-    let item_count = region_items
-        .iter()
-        .filter_map(|(_, items)| items.as_ref())
-        .map(Vec::len)
-        .sum();
-    let mut flattened = Vec::with_capacity(item_count);
-    for (_, items) in region_items {
-        if let Some(items) = items {
-            flattened.extend(items);
-        }
+    let mut ordered_items = region_items
+        .into_iter()
+        .filter_map(|(_, items)| items)
+        .filter(|items| !items.is_empty());
+    let Some(mut flattened) = ordered_items.next() else {
+        return Vec::new();
+    };
+    for mut items in ordered_items {
+        flattened.append(&mut items);
     }
     flattened
 }

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -246,7 +246,9 @@ impl Kakehashi {
             });
 
             // Collect results, aborting early if $/cancelRequest arrives.
-            let ordered_region_items =
+            // Completion order, NOT source order — each entry carries its
+            // region index and the flatten below sorts by it.
+            let completion_order_items =
                 crate::lsp::aggregation::region::collect_region_results_with_cancel(
                     outer_join_set,
                     cancel_rx,
@@ -257,7 +259,7 @@ impl Kakehashi {
                 .await;
 
             Ok(nonempty_whole_document_items(flatten_ordered_region_items(
-                ordered_region_items?,
+                completion_order_items?,
             )))
         };
 

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -302,7 +302,9 @@ fn nonempty_whole_document_items<T>(items: Vec<T>) -> Option<Vec<T>> {
 /// Flatten per-region result vectors back into ONE list in region source
 /// order (the region index recorded at fan-out time), regardless of task
 /// completion order.
-fn flatten_ordered_region_items<T>(mut region_items: Vec<(usize, Option<Vec<T>>)>) -> Vec<T> {
+pub(super) fn flatten_ordered_region_items<T>(
+    mut region_items: Vec<(usize, Option<Vec<T>>)>,
+) -> Vec<T> {
     region_items.sort_by_key(|(region_index, _)| *region_index);
     region_items
         .into_iter()

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -137,7 +137,7 @@ impl Kakehashi {
             let pool = self.bridge.pool_arc();
 
             // Outer JoinSet: one task per injection region, all in parallel
-            let mut outer_join_set: JoinSet<Option<Vec<T>>> = JoinSet::new();
+            let mut outer_join_set: JoinSet<(usize, Option<Vec<T>>)> = JoinSet::new();
 
             // Shared client progress across all regions: one aggregator + one
             // teardown guard for the whole request. The winner rule shows the first
@@ -165,7 +165,7 @@ impl Kakehashi {
                 )
                 .await;
 
-            for resolved in all_regions.iter() {
+            for (region_index, resolved) in all_regions.iter().enumerate() {
                 // Get ALL bridge server configs for this injection language
                 let mut configs = self.bridge_configs_for_injection_language(
                     &language_name,
@@ -225,10 +225,11 @@ impl Kakehashi {
                                 .await
                         }
                     };
-                    match result {
+                    let items = match result {
                         FanInResult::Done(items) => items,
                         FanInResult::NoResult { .. } | FanInResult::Cancelled => None,
-                    }
+                    };
+                    (region_index, items)
                 });
             }
 
@@ -245,18 +246,19 @@ impl Kakehashi {
             });
 
             // Collect results, aborting early if $/cancelRequest arrives.
-            let all_items = crate::lsp::aggregation::region::collect_region_results_with_cancel(
-                outer_join_set,
-                cancel_rx,
-                |acc, opt: Option<Vec<T>>| {
-                    if let Some(items) = opt {
-                        acc.extend(items);
-                    }
-                },
-            )
-            .await;
+            let ordered_region_items =
+                crate::lsp::aggregation::region::collect_region_results_with_cancel(
+                    outer_join_set,
+                    cancel_rx,
+                    |acc, region_items: (usize, Option<Vec<T>>)| {
+                        acc.push(region_items);
+                    },
+                )
+                .await;
 
-            Ok(nonempty_whole_document_items(all_items?))
+            Ok(nonempty_whole_document_items(flatten_ordered_region_items(
+                ordered_region_items?,
+            )))
         };
 
         let host = async {
@@ -378,5 +380,31 @@ mod tests {
             .expect("layer walk should succeed");
 
         assert_eq!(result, Some(vec!["virt", "host"]));
+    }
+}
+
+fn flatten_ordered_region_items<T>(mut region_items: Vec<(usize, Option<Vec<T>>)>) -> Vec<T> {
+    region_items.sort_by_key(|(region_index, _)| *region_index);
+    region_items
+        .into_iter()
+        .filter_map(|(_, items)| items)
+        .flatten()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flattens_region_results_by_source_order() {
+        let flattened = flatten_ordered_region_items(vec![
+            (2, Some(vec!["late"])),
+            (0, Some(vec!["early"])),
+            (1, None),
+            (3, Some(vec!["last"])),
+        ]);
+
+        assert_eq!(flattened, vec!["early", "late", "last"]);
     }
 }

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -305,7 +305,7 @@ fn nonempty_whole_document_items<T>(items: Vec<T>) -> Option<Vec<T>> {
 pub(super) fn flatten_ordered_region_items<T>(
     mut region_items: Vec<(usize, Option<Vec<T>>)>,
 ) -> Vec<T> {
-    region_items.sort_by_key(|(region_index, _)| *region_index);
+    region_items.sort_unstable_by_key(|(region_index, _)| *region_index);
     region_items
         .into_iter()
         .filter_map(|(_, items)| items)

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -393,7 +393,7 @@ fn flatten_ordered_region_items<T>(mut region_items: Vec<(usize, Option<Vec<T>>)
 }
 
 #[cfg(test)]
-mod tests {
+mod ordered_region_tests {
     use super::*;
 
     #[test]

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -306,11 +306,18 @@ pub(super) fn flatten_ordered_region_items<T>(
     mut region_items: Vec<(usize, Option<Vec<T>>)>,
 ) -> Vec<T> {
     region_items.sort_unstable_by_key(|(region_index, _)| *region_index);
-    region_items
-        .into_iter()
-        .filter_map(|(_, items)| items)
-        .flatten()
-        .collect()
+    let item_count = region_items
+        .iter()
+        .filter_map(|(_, items)| items.as_ref())
+        .map(Vec::len)
+        .sum();
+    let mut flattened = Vec::with_capacity(item_count);
+    for (_, items) in region_items {
+        if let Some(items) = items {
+            flattened.extend(items);
+        }
+    }
+    flattened
 }
 
 #[cfg(test)]

--- a/src/text.rs
+++ b/src/text.rs
@@ -10,5 +10,5 @@ mod hash;
 pub(crate) mod position;
 
 pub(crate) use char_boundary::{ceil_char_boundary, clamped_slice, floor_char_boundary};
-pub(crate) use hash::fnv1a_hash;
+pub(crate) use hash::{Fnv1aWriter, fnv1a_hash};
 pub(crate) use position::PositionMapper;

--- a/src/text/hash.rs
+++ b/src/text/hash.rs
@@ -1,24 +1,61 @@
 //! Non-cryptographic hashes for content-based cache keys.
 
+const FNV_OFFSET: u64 = 0xcbf29ce484222325;
+const FNV_PRIME: u64 = 0x100000001b3;
+
+/// Incremental FNV-1a writer for callers that already serialize into an
+/// `io::Write` sink and should not materialize the complete byte stream.
+pub(crate) struct Fnv1aWriter(u64);
+
+impl Fnv1aWriter {
+    pub(crate) fn new() -> Self {
+        Self(FNV_OFFSET)
+    }
+
+    pub(crate) fn finish(&self) -> u64 {
+        self.0
+    }
+}
+
+impl std::io::Write for Fnv1aWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        for &byte in buf {
+            self.0 = (self.0 ^ u64::from(byte)).wrapping_mul(FNV_PRIME);
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
 /// FNV-1a 64-bit hash. Fast and well-distributed enough for cache keys, change
 /// detection, and dedup; do **not** use for adversarial collision resistance
 /// (use SipHash) or cryptographic purposes (use SHA-256).
 #[inline]
 pub fn fnv1a_hash(text: &str) -> u64 {
-    const FNV_OFFSET: u64 = 0xcbf29ce484222325;
-    const FNV_PRIME: u64 = 0x100000001b3;
-
-    let mut hash = FNV_OFFSET;
+    let mut hash = Fnv1aWriter::new();
     for byte in text.bytes() {
-        hash ^= byte as u64;
-        hash = hash.wrapping_mul(FNV_PRIME);
+        hash.0 ^= u64::from(byte);
+        hash.0 = hash.0.wrapping_mul(FNV_PRIME);
     }
-    hash
+    hash.finish()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn streaming_writer_matches_one_shot_hash() {
+        let mut writer = Fnv1aWriter::new();
+        writer.write_all(b"hello ").unwrap();
+        writer.write_all(b"world").unwrap();
+
+        assert_eq!(writer.finish(), fnv1a_hash("hello world"));
+    }
 
     #[test]
     fn test_fnv1a_hash_deterministic() {


### PR DESCRIPTION
## Summary
- sort pull diagnostic reports deterministically with one shared canonical ordering for cached and fresh diagnostics
- preserve source region order for whole-document fan-in responses instead of JoinSet completion order
- stream canonical diagnostic JSON into result IDs so object insertion order does not cause spurious full reports
- bound retained canonical tie-key memory while keeping ordinary comparisons allocation-free
- document the diagnostic wire-order contract and the bounded-memory trade-off

Fixes #593.

## Verification
- `cargo test --lib diagnostic_order`
- `cargo test --lib result_id_`
- `cargo test flattens_region_results_by_source_order --lib`
- `cargo test merge_breaks_ties_by_serialized_form_for_data_only_differences --lib`
- `make check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made LSP diagnostic ordering consistently deterministic across diagnostic reports and merged cached/whole-document diagnostics.
  * Ensured whole-document diagnostics keep the original source-region order, even when some regions produce no diagnostics.
* **Tests**
  * Added unit coverage to verify deterministic diagnostic ordering (including canonicalized structured data) and correct whole-document region flattening order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
