### PR TITLE
fix(install): require HTTPS downloads

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -229,15 +229,38 @@ impl InstallResult {
 
 /// Install a language synchronously (both parser and queries).
 ///
-/// `queries_base_url` is injected so tests can serve query files from a
-/// local HTTP server; production callers pass
-/// [`queries::NVIM_TREESITTER_QUERIES_URL`].
+/// Production callers pass [`queries::NVIM_TREESITTER_QUERIES_URL`]. Tests
+/// can inject other HTTPS endpoints; local HTTP fixtures use a test-only
+/// wrapper below so production downloads stay HTTPS-only.
 fn install_language_blocking(
     language: &str,
     data_dir: &std::path::Path,
     force: bool,
     queries_base_url: &str,
     compile: parser::ParserCompile,
+) -> InstallResult {
+    install_language_blocking_with_query_installer(
+        language,
+        data_dir,
+        force,
+        queries_base_url,
+        compile,
+        queries::install_queries_with_dependencies_from,
+    )
+}
+
+fn install_language_blocking_with_query_installer(
+    language: &str,
+    data_dir: &std::path::Path,
+    force: bool,
+    queries_base_url: &str,
+    compile: parser::ParserCompile,
+    install_queries: fn(
+        &str,
+        &str,
+        &std::path::Path,
+        bool,
+    ) -> Result<queries::QueryInstallResult, queries::QueryInstallError>,
 ) -> InstallResult {
     let mut result = InstallResult {
         parser_path: None,
@@ -287,12 +310,7 @@ fn install_language_blocking(
 
     // Install queries, following `; inherits:` so languages like html
     // (which keeps its @comment capture in html_tags) highlight correctly.
-    match queries::install_queries_with_dependencies_from(
-        queries_base_url,
-        language,
-        data_dir,
-        force,
-    ) {
+    match install_queries(queries_base_url, language, data_dir, force) {
         Ok(query_result) => {
             result.queries_path = Some(query_result.install_path);
         }
@@ -334,6 +352,24 @@ pub(crate) async fn install_language_async(
         parser_error: Some(format!("Task panicked: {}", e)),
         queries_error: None,
     })
+}
+
+#[cfg(test)]
+fn install_language_blocking_allowing_http_queries_for_tests(
+    language: &str,
+    data_dir: &std::path::Path,
+    force: bool,
+    queries_base_url: &str,
+    compile: parser::ParserCompile,
+) -> InstallResult {
+    install_language_blocking_with_query_installer(
+        language,
+        data_dir,
+        force,
+        queries_base_url,
+        compile,
+        queries::install_queries_with_dependencies_from_allowing_http_for_tests,
+    )
 }
 
 #[cfg(test)]
@@ -465,7 +501,7 @@ mod tests {
             ("/parent_lang/highlights.scm", "(comment) @comment\n"),
         ]);
 
-        let result = install_language_blocking(
+        let result = install_language_blocking_allowing_http_queries_for_tests(
             "child_lang",
             data_dir,
             false,

--- a/src/install/http.rs
+++ b/src/install/http.rs
@@ -11,15 +11,19 @@ use ureq::tls::{RootCerts, TlsConfig};
 /// private root CAs trusted by the OS keep working, where ureq's default
 /// WebPKI roots would reject them.
 pub(crate) fn agent_with_timeout(timeout: Duration) -> Agent {
-    let mut config = Agent::config_builder().timeout_global(Some(timeout));
-    // Unit tests use loopback HTTP fixture servers; production install
-    // downloads stay HTTPS-only.
-    if !cfg!(test) {
-        config = config.https_only(true);
-    }
+    agent_with_timeout_with_https_policy(timeout, true)
+}
 
+#[cfg(test)]
+pub(crate) fn agent_with_timeout_allowing_http(timeout: Duration) -> Agent {
+    agent_with_timeout_with_https_policy(timeout, false)
+}
+
+fn agent_with_timeout_with_https_policy(timeout: Duration, https_only: bool) -> Agent {
     Agent::new_with_config(
-        config
+        Agent::config_builder()
+            .timeout_global(Some(timeout))
+            .https_only(https_only)
             .tls_config(
                 TlsConfig::builder()
                     .root_certs(RootCerts::PlatformVerifier)
@@ -27,4 +31,22 @@ pub(crate) fn agent_with_timeout(timeout: Duration) -> Agent {
             )
             .build(),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_agent_rejects_plain_http() {
+        let err = agent_with_timeout(Duration::from_secs(1))
+            .get("http://127.0.0.1:1/")
+            .call()
+            .expect_err("install downloads must be HTTPS-only");
+
+        assert!(
+            matches!(err, ureq::Error::RequireHttpsOnly(_)),
+            "expected HTTPS-only rejection before transport, got {err:?}"
+        );
+    }
 }

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -183,11 +183,6 @@ fn install_queries_with_dependencies_from_with_http_policy(
     force: bool,
     http_policy: QueryHttpPolicy,
 ) -> Result<QueryInstallResult, QueryInstallError> {
-    if !is_safe_language_name(language) {
-        return Err(QueryInstallError::LanguageNotSupported(
-            language.escape_default().to_string(),
-        ));
-    }
     let mut installed = std::collections::HashSet::new();
     install_queries_recursive(
         base_url,
@@ -199,14 +194,14 @@ fn install_queries_with_dependencies_from_with_http_policy(
     )
 }
 
-fn validate_base_url_http_policy(
-    base_url: &str,
+fn validate_url_http_policy(
+    url: &str,
     http_policy: QueryHttpPolicy,
 ) -> Result<(), QueryInstallError> {
     match http_policy {
-        QueryHttpPolicy::HttpsOnly if base_url.starts_with("http://") => {
+        QueryHttpPolicy::HttpsOnly if url.starts_with("http://") => {
             Err(QueryInstallError::HttpsOnly {
-                url: base_url.to_string(),
+                url: url.to_string(),
             })
         }
         _ => Ok(()),
@@ -359,7 +354,7 @@ fn install_queries_recursive(
 
 /// Download a file from a URL.
 fn download_file(url: &str, http_policy: QueryHttpPolicy) -> Result<String, QueryInstallError> {
-    validate_base_url_http_policy(url, http_policy)?;
+    validate_url_http_policy(url, http_policy)?;
     let agent = match http_policy {
         QueryHttpPolicy::HttpsOnly => agent_with_timeout(QUERY_HTTP_TIMEOUT),
         #[cfg(test)]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -6,6 +6,8 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use super::http::agent_with_timeout;
+#[cfg(test)]
+use super::http::agent_with_timeout_allowing_http;
 
 /// Base URL for nvim-treesitter query files on GitHub (main branch).
 /// Note: In the main branch, queries are under runtime/queries instead of queries.
@@ -118,19 +120,72 @@ pub fn install_queries_with_dependencies(
     data_dir: &Path,
     force: bool,
 ) -> Result<QueryInstallResult, QueryInstallError> {
-    install_queries_with_dependencies_from(NVIM_TREESITTER_QUERIES_URL, language, data_dir, force)
+    install_queries_with_dependencies_from_with_http_policy(
+        NVIM_TREESITTER_QUERIES_URL,
+        language,
+        data_dir,
+        force,
+        QueryHttpPolicy::HttpsOnly,
+    )
 }
 
-/// Like [`install_queries_with_dependencies`] but downloading from `base_url`,
-/// so tests can serve query files from a local HTTP server.
+/// Like [`install_queries_with_dependencies`] but downloading from `base_url`.
 pub(crate) fn install_queries_with_dependencies_from(
     base_url: &str,
     language: &str,
     data_dir: &Path,
     force: bool,
 ) -> Result<QueryInstallResult, QueryInstallError> {
+    install_queries_with_dependencies_from_with_http_policy(
+        base_url,
+        language,
+        data_dir,
+        force,
+        QueryHttpPolicy::HttpsOnly,
+    )
+}
+
+/// Like [`install_queries_with_dependencies_from`] but allows tests to serve
+/// fixture query files from a loopback HTTP server.
+#[cfg(test)]
+pub(crate) fn install_queries_with_dependencies_from_allowing_http_for_tests(
+    base_url: &str,
+    language: &str,
+    data_dir: &Path,
+    force: bool,
+) -> Result<QueryInstallResult, QueryInstallError> {
+    install_queries_with_dependencies_from_with_http_policy(
+        base_url,
+        language,
+        data_dir,
+        force,
+        QueryHttpPolicy::AllowHttpForTests,
+    )
+}
+
+#[derive(Clone, Copy)]
+enum QueryHttpPolicy {
+    HttpsOnly,
+    #[cfg(test)]
+    AllowHttpForTests,
+}
+
+fn install_queries_with_dependencies_from_with_http_policy(
+    base_url: &str,
+    language: &str,
+    data_dir: &Path,
+    force: bool,
+    http_policy: QueryHttpPolicy,
+) -> Result<QueryInstallResult, QueryInstallError> {
     let mut installed = std::collections::HashSet::new();
-    install_queries_recursive(base_url, language, data_dir, force, &mut installed)
+    install_queries_recursive(
+        base_url,
+        language,
+        data_dir,
+        force,
+        &mut installed,
+        http_policy,
+    )
 }
 
 /// Internal recursive helper for installing queries with dependencies.
@@ -140,6 +195,7 @@ fn install_queries_recursive(
     data_dir: &Path,
     force: bool,
     installed: &mut std::collections::HashSet<String>,
+    http_policy: QueryHttpPolicy,
 ) -> Result<QueryInstallResult, QueryInstallError> {
     // The name becomes a path and URL segment below; reject anything that
     // could escape the data dir (e.g. a caller-provided `../../x`).
@@ -178,7 +234,14 @@ fn install_queries_recursive(
             let parents = parse_inherits_directive(&content);
             for parent in parents {
                 // Install parent dependencies (don't force, just ensure they exist)
-                match install_queries_recursive(base_url, &parent, data_dir, false, installed) {
+                match install_queries_recursive(
+                    base_url,
+                    &parent,
+                    data_dir,
+                    false,
+                    installed,
+                    http_policy,
+                ) {
                     Ok(_) | Err(QueryInstallError::AlreadyExists(_)) => {}
                     Err(e) => {
                         eprintln!(
@@ -203,7 +266,7 @@ fn install_queries_recursive(
     for query_file in QUERY_FILES {
         let url = format!("{}/{}/{}", base_url, language, query_file);
 
-        match download_file(&url) {
+        match download_file(&url, http_policy) {
             Ok(content) => {
                 // Check for inherits directive in highlights.scm
                 if *query_file == "highlights.scm" {
@@ -247,7 +310,8 @@ fn install_queries_recursive(
     for parent in parents_to_install {
         eprintln!("Installing inherited queries: {}", parent);
         // Don't fail if parent already exists
-        match install_queries_recursive(base_url, &parent, data_dir, false, installed) {
+        match install_queries_recursive(base_url, &parent, data_dir, false, installed, http_policy)
+        {
             Ok(_) | Err(QueryInstallError::AlreadyExists(_)) => {}
             Err(e) => {
                 eprintln!(
@@ -266,16 +330,19 @@ fn install_queries_recursive(
 }
 
 /// Download a file from a URL.
-fn download_file(url: &str) -> Result<String, QueryInstallError> {
-    let mut response = agent_with_timeout(QUERY_HTTP_TIMEOUT)
-        .get(url)
-        .call()
-        .map_err(|e| match e {
-            ureq::Error::StatusCode(code) => {
-                QueryInstallError::HttpError(format!("HTTP {} for {}", code, url))
-            }
-            e => QueryInstallError::HttpError(e.to_string()),
-        })?;
+fn download_file(url: &str, http_policy: QueryHttpPolicy) -> Result<String, QueryInstallError> {
+    let agent = match http_policy {
+        QueryHttpPolicy::HttpsOnly => agent_with_timeout(QUERY_HTTP_TIMEOUT),
+        #[cfg(test)]
+        QueryHttpPolicy::AllowHttpForTests => agent_with_timeout_allowing_http(QUERY_HTTP_TIMEOUT),
+    };
+
+    let mut response = agent.get(url).call().map_err(|e| match e {
+        ureq::Error::StatusCode(code) => {
+            QueryInstallError::HttpError(format!("HTTP {} for {}", code, url))
+        }
+        e => QueryInstallError::HttpError(e.to_string()),
+    })?;
 
     response
         .body_mut()

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -28,6 +28,10 @@ pub enum QueryInstallError {
     LanguageNotSupported(String),
     /// HTTP request failed.
     HttpError(String),
+    /// HTTP response returned a structured non-success status code.
+    HttpStatus { code: u16, url: String },
+    /// Plain HTTP was rejected by the production HTTPS-only policy.
+    HttpsOnly { url: String },
     /// File system operation failed.
     IoError(std::io::Error),
     /// Queries already exist and --force not specified.
@@ -45,6 +49,8 @@ impl std::fmt::Display for QueryInstallError {
                 )
             }
             Self::HttpError(msg) => write!(f, "HTTP error: {}", msg),
+            Self::HttpStatus { code, url } => write!(f, "HTTP {} for {}", code, url),
+            Self::HttpsOnly { url } => write!(f, "HTTPS-only policy rejected {}", url),
             Self::IoError(e) => write!(f, "IO error: {}", e),
             Self::AlreadyExists(path) => {
                 write!(
@@ -145,8 +151,8 @@ pub(crate) fn install_queries_with_dependencies_from(
     )
 }
 
-/// Like [`install_queries_with_dependencies_from`] but allows tests to serve
-/// fixture query files from a loopback HTTP server.
+/// Like [`install_queries_with_dependencies_from`] but disables the HTTPS-only
+/// policy for tests that serve fixture query files over local plain HTTP.
 #[cfg(test)]
 pub(crate) fn install_queries_with_dependencies_from_allowing_http_for_tests(
     base_url: &str,
@@ -177,6 +183,12 @@ fn install_queries_with_dependencies_from_with_http_policy(
     force: bool,
     http_policy: QueryHttpPolicy,
 ) -> Result<QueryInstallResult, QueryInstallError> {
+    if !is_safe_language_name(language) {
+        return Err(QueryInstallError::LanguageNotSupported(
+            language.escape_default().to_string(),
+        ));
+    }
+    validate_base_url_http_policy(base_url, http_policy)?;
     let mut installed = std::collections::HashSet::new();
     install_queries_recursive(
         base_url,
@@ -186,6 +198,20 @@ fn install_queries_with_dependencies_from_with_http_policy(
         &mut installed,
         http_policy,
     )
+}
+
+fn validate_base_url_http_policy(
+    base_url: &str,
+    http_policy: QueryHttpPolicy,
+) -> Result<(), QueryInstallError> {
+    match http_policy {
+        QueryHttpPolicy::HttpsOnly if base_url.starts_with("http://") => {
+            Err(QueryInstallError::HttpsOnly {
+                url: base_url.to_string(),
+            })
+        }
+        _ => Ok(()),
+    }
 }
 
 /// Internal recursive helper for installing queries with dependencies.
@@ -284,9 +310,12 @@ fn install_queries_recursive(
                 if *query_file == "highlights.scm" {
                     // Clean up the directory we created
                     let _ = fs::remove_dir_all(&queries_dir);
-                    return Err(QueryInstallError::LanguageNotSupported(
-                        language.to_string(),
-                    ));
+                    return match e {
+                        QueryInstallError::HttpStatus { code: 404, .. } => Err(
+                            QueryInstallError::LanguageNotSupported(language.to_string()),
+                        ),
+                        other => Err(other),
+                    };
                 }
                 // Log but continue for optional files
                 eprintln!(
@@ -338,9 +367,13 @@ fn download_file(url: &str, http_policy: QueryHttpPolicy) -> Result<String, Quer
     };
 
     let mut response = agent.get(url).call().map_err(|e| match e {
-        ureq::Error::StatusCode(code) => {
-            QueryInstallError::HttpError(format!("HTTP {} for {}", code, url))
-        }
+        ureq::Error::StatusCode(code) => QueryInstallError::HttpStatus {
+            code,
+            url: url.to_string(),
+        },
+        ureq::Error::RequireHttpsOnly(_) => QueryInstallError::HttpsOnly {
+            url: url.to_string(),
+        },
         e => QueryInstallError::HttpError(e.to_string()),
     })?;
 
@@ -354,6 +387,33 @@ fn download_file(url: &str, http_policy: QueryHttpPolicy) -> Result<String, Quer
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    fn spawn_404_server() -> String {
+        use std::io::{BufRead, BufReader, Write};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local server");
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                let mut reader = BufReader::new(&mut stream);
+                let mut line = String::new();
+                let _ = reader.read_line(&mut line);
+                loop {
+                    line.clear();
+                    match reader.read_line(&mut line) {
+                        Ok(0) | Err(_) => break,
+                        Ok(_) if line == "\r\n" || line == "\n" => break,
+                        Ok(_) => {}
+                    }
+                }
+                let response =
+                    "HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n";
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+        base_url
+    }
 
     /// The rejected name flows into the error's `Display` (printed raw by
     /// the CLI), so control characters in an untrusted name must be escaped
@@ -377,6 +437,50 @@ mod tests {
             }
             other => panic!("expected LanguageNotSupported, got {:?}", other.err()),
         }
+    }
+
+    #[test]
+    fn production_query_install_rejects_plain_http_base_url() {
+        let temp = TempDir::new().unwrap();
+        let result =
+            install_queries_with_dependencies_from("http://127.0.0.1:1", "lua", temp.path(), false);
+
+        assert!(
+            matches!(result, Err(QueryInstallError::HttpsOnly { url }) if url == "http://127.0.0.1:1"),
+            "plain HTTP base URLs should fail before being reported as missing queries"
+        );
+    }
+
+    #[test]
+    fn missing_required_highlights_remains_language_not_supported() {
+        let temp = TempDir::new().unwrap();
+        let base_url = spawn_404_server();
+
+        let result = install_queries_with_dependencies_from_allowing_http_for_tests(
+            &base_url,
+            "missing_lang",
+            temp.path(),
+            false,
+        );
+
+        assert!(
+            matches!(result, Err(QueryInstallError::LanguageNotSupported(lang)) if lang == "missing_lang"),
+            "404 for required highlights.scm still means the language has no query support"
+        );
+    }
+
+    #[test]
+    fn download_file_preserves_http_status_code() {
+        let base_url = spawn_404_server();
+        let result = download_file(
+            &format!("{base_url}/missing_lang/highlights.scm"),
+            QueryHttpPolicy::AllowHttpForTests,
+        );
+
+        assert!(
+            matches!(result, Err(QueryInstallError::HttpStatus { code: 404, .. })),
+            "download errors should preserve structured status codes"
+        );
     }
 
     /// Inherited language names become path segments (`queries/<name>/`) and

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -389,23 +389,23 @@ mod tests {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local server");
         let base_url = format!("http://{}", listener.local_addr().unwrap());
         std::thread::spawn(move || {
-            for stream in listener.incoming() {
-                let Ok(mut stream) = stream else { continue };
-                let mut reader = BufReader::new(&mut stream);
-                let mut line = String::new();
-                let _ = reader.read_line(&mut line);
-                loop {
-                    line.clear();
-                    match reader.read_line(&mut line) {
-                        Ok(0) | Err(_) => break,
-                        Ok(_) if line == "\r\n" || line == "\n" => break,
-                        Ok(_) => {}
-                    }
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            let mut reader = BufReader::new(&mut stream);
+            let mut line = String::new();
+            let _ = reader.read_line(&mut line);
+            loop {
+                line.clear();
+                match reader.read_line(&mut line) {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) if line == "\r\n" || line == "\n" => break,
+                    Ok(_) => {}
                 }
-                let response =
-                    "HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n";
-                let _ = stream.write_all(response.as_bytes());
             }
+            let response =
+                "HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n";
+            let _ = stream.write_all(response.as_bytes());
         });
         base_url
     }

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -188,7 +188,6 @@ fn install_queries_with_dependencies_from_with_http_policy(
             language.escape_default().to_string(),
         ));
     }
-    validate_base_url_http_policy(base_url, http_policy)?;
     let mut installed = std::collections::HashSet::new();
     install_queries_recursive(
         base_url,
@@ -360,6 +359,7 @@ fn install_queries_recursive(
 
 /// Download a file from a URL.
 fn download_file(url: &str, http_policy: QueryHttpPolicy) -> Result<String, QueryInstallError> {
+    validate_base_url_http_policy(url, http_policy)?;
     let agent = match http_policy {
         QueryHttpPolicy::HttpsOnly => agent_with_timeout(QUERY_HTTP_TIMEOUT),
         #[cfg(test)]
@@ -446,8 +446,24 @@ mod tests {
             install_queries_with_dependencies_from("http://127.0.0.1:1", "lua", temp.path(), false);
 
         assert!(
-            matches!(result, Err(QueryInstallError::HttpsOnly { url }) if url == "http://127.0.0.1:1"),
-            "plain HTTP base URLs should fail before being reported as missing queries"
+            matches!(result, Err(QueryInstallError::HttpsOnly { url }) if url == "http://127.0.0.1:1/lua/highlights.scm"),
+            "plain HTTP downloads should fail before being reported as missing queries"
+        );
+    }
+
+    #[test]
+    fn installed_queries_skip_plain_http_sentinel_base_url() {
+        let temp = TempDir::new().unwrap();
+        let queries_dir = temp.path().join("queries").join("lua");
+        fs::create_dir_all(&queries_dir).unwrap();
+        fs::write(queries_dir.join("highlights.scm"), "(comment) @comment\n").unwrap();
+
+        let result =
+            install_queries_with_dependencies_from("http://127.0.0.1:1", "lua", temp.path(), false);
+
+        assert!(
+            matches!(result, Err(QueryInstallError::AlreadyExists(path)) if path == queries_dir),
+            "already-installed queries must not validate an unused HTTP sentinel URL"
         );
     }
 


### PR DESCRIPTION
## Summary
- require the shared install HTTP agent to use HTTPS-only requests
- keep loopback HTTP query fixtures behind explicit test-only installers
- avoid DNS or external transport in the HTTPS-only regression test

## Tests
- cargo test install_agent_rejects_plain_http --lib -- --nocapture
- cargo test auto_install_installs_inherited_query_dependencies --lib -- --nocapture
- cargo test unsafe_language_name_error_escapes_control_characters --lib -- --nocapture
- cargo test install_rejects_unsafe_top_level_language_name --lib -- --nocapture
- make check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved installation of inherited query dependencies so parent and child `highlights.scm` queries download reliably.

* **Bug Fixes**
  * Strengthened network handling for query downloads: plain HTTP base URLs are rejected by default.
  * Refined error reporting for query installs, including structured HTTP status details and correct mapping of missing required `highlights.scm` resources.

* **Tests**
  * Updated regression and unit coverage to use test-only HTTP fixtures while keeping production HTTPS behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->