### PR TITLE
fix(install): stage query downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,6 +957,7 @@ dependencies = [
  "env_logger",
  "filetime",
  "flate2",
+ "fs4",
  "futures",
  "ignore",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ serde_json = "1"
 shellexpand = "3"
 similar = "3"
 flate2 = "1"
+fs4 = "0.12"
 # Gitignore-respecting file walker for `kakehashi format <paths...>`; also
 # provides the gitignore-style Override matcher backing --excludes.
 ignore = "0.4"
@@ -136,4 +137,3 @@ rstest = "0.26"
 [[bench]]
 name = "semantic_tokens"
 harness = false
-

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, Subcommand};
 use kakehashi::install::{default_data_dir, metadata, parser, queries};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 /// A Language Server Protocol (LSP) server using Tree-sitter for parsing
@@ -397,6 +397,9 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
 
     let parser_dir = data_dir.join("parser");
     let queries_dir = data_dir.join("queries");
+    if let Err(e) = queries::recover_interrupted_query_installs(&queries_dir) {
+        eprintln!("Warning: failed to recover interrupted query installs: {e}");
+    }
 
     // Collect all installed languages from both parser and queries directories
     let mut languages = BTreeSet::new();
@@ -418,11 +421,8 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
     // Also check queries directory for languages that might only have queries
     if let Ok(entries) = fs::read_dir(&queries_dir) {
         for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_dir()
-                && let Some(name) = path.file_name()
-            {
-                languages.insert(name.to_string_lossy().to_string());
+            if let Some(name) = installed_query_language_name(&entry.path()) {
+                languages.insert(name);
             }
         }
     }
@@ -437,7 +437,7 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
 
     for lang in &languages {
         let parser_path = find_parser_file(&parser_dir, lang);
-        let queries_path = queries_dir.join(lang).join("highlights.scm");
+        let queries_path = queries_dir.join(lang);
 
         let parser_status = if parser_path.is_some() {
             "✓ parser"
@@ -445,7 +445,7 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
             "✗ parser"
         };
 
-        let queries_status = if queries_path.exists() {
+        let queries_status = if queries::query_install_is_complete(&queries_path) {
             "✓ queries"
         } else {
             "✗ queries (missing)"
@@ -457,16 +457,24 @@ fn run_language_status(verbose: bool) -> Result<(), ExitCode> {
             if let Some(ref p) = parser_path {
                 println!("               parser: {}", p.display());
             }
-            if queries_path.exists() {
-                println!(
-                    "               queries: {}",
-                    queries_path.parent().unwrap().display()
-                );
+            if queries::query_install_is_complete(&queries_path) {
+                println!("               queries: {}", queries_path.display());
             }
         }
     }
 
     Ok(())
+}
+
+fn installed_query_language_name(path: &Path) -> Option<String> {
+    if !path.is_dir() {
+        return None;
+    }
+    let name = path.file_name()?.to_string_lossy();
+    if name.starts_with('.') {
+        return None;
+    }
+    Some(name.to_string())
 }
 
 /// Run the language uninstall command
@@ -486,6 +494,9 @@ fn run_language_uninstall(
 
     let parser_dir = data_dir.join("parser");
     let queries_dir = data_dir.join("queries");
+    if let Err(e) = queries::recover_interrupted_query_installs(&queries_dir) {
+        eprintln!("Warning: failed to recover interrupted query installs: {e}");
+    }
 
     // Determine which languages to uninstall
     let languages_to_uninstall: Vec<String> = if all {
@@ -507,11 +518,8 @@ fn run_language_uninstall(
 
         if let Ok(entries) = fs::read_dir(&queries_dir) {
             for entry in entries.flatten() {
-                let path = entry.path();
-                if path.is_dir()
-                    && let Some(name) = path.file_name()
-                {
-                    languages.insert(name.to_string_lossy().to_string());
+                if let Some(name) = installed_query_language_name(&entry.path()) {
+                    languages.insert(name);
                 }
             }
         }
@@ -547,6 +555,7 @@ fn run_language_uninstall(
 
     // Uninstall each language
     let mut any_removed = false;
+    let mut any_failed = false;
     for lang in &languages_to_uninstall {
         let mut removed_something = false;
 
@@ -559,25 +568,27 @@ fn run_language_uninstall(
                 }
                 Err(e) => {
                     eprintln!("✗ Failed to remove parser {}: {}", parser_path.display(), e);
+                    any_failed = true;
                 }
             }
         }
 
-        // Remove queries directory
-        let queries_path = queries_dir.join(lang);
-        if queries_path.exists() {
-            match fs::remove_dir_all(&queries_path) {
-                Ok(()) => {
-                    eprintln!("✓ Removed queries: {}", queries_path.display());
-                    removed_something = true;
+        // Remove queries directory and any kakehashi-created backups under the
+        // same lock used by install replacement, so uninstall cannot race a
+        // concurrent install into resurrecting queries after reporting success.
+        match queries::remove_query_install_and_backups(&queries_dir, lang) {
+            Ok(removal) => {
+                if removal.removed_queries {
+                    eprintln!("✓ Removed queries: {}", queries_dir.join(lang).display());
                 }
-                Err(e) => {
-                    eprintln!(
-                        "✗ Failed to remove queries {}: {}",
-                        queries_path.display(),
-                        e
-                    );
+                if removal.removed_backups {
+                    eprintln!("✓ Removed query backups for '{}'", lang);
                 }
+                removed_something |= removal.removed_anything();
+            }
+            Err(e) => {
+                eprintln!("✗ Failed to remove queries for '{}': {}", lang, e);
+                any_failed = true;
             }
         }
 
@@ -586,6 +597,10 @@ fn run_language_uninstall(
         } else if !all {
             eprintln!("Language '{}' is not installed.", lang);
         }
+    }
+
+    if any_failed {
+        return Err(ExitCode::FAILURE);
     }
 
     if any_removed {
@@ -683,6 +698,11 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
     let mut parser_success = true;
     let mut queries_success = true;
 
+    if let Err(e) = queries::clear_uninstall_tombstone_for_install(&data_dir, language) {
+        eprintln!("✗ Failed to prepare query installation: {}", e);
+        return Err(ExitCode::FAILURE);
+    }
+
     // Install parser
     eprintln!("Installing parser for '{}' to {:?}...", language, data_dir);
 
@@ -712,7 +732,9 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
     // Install queries (with inherited dependencies)
     eprintln!("Installing queries for '{}' to {:?}...", language, data_dir);
 
-    match queries::install_queries_with_dependencies(language, &data_dir, force) {
+    match queries::install_queries_with_dependencies_after_install_started(
+        language, &data_dir, force,
+    ) {
         Ok(result) => {
             eprintln!("✓ Queries installed: {}", result.install_path.display());
             if verbose {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -474,6 +474,9 @@ fn installed_query_language_name(path: &Path) -> Option<String> {
     if name.starts_with('.') {
         return None;
     }
+    if !queries::is_safe_language_name(&name) {
+        return None;
+    }
     Some(name.to_string())
 }
 
@@ -1060,4 +1063,27 @@ async fn run_lsp_server() {
         .concurrency_level(INGRESS_CONCURRENCY)
         .serve(service)
         .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn installed_query_language_name_filters_unsafe_dirs() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let safe = temp.path().join("lua");
+        let unsafe_name = temp.path().join("foo.bar");
+        let hidden = temp.path().join(".lua");
+        std::fs::create_dir_all(&safe).unwrap();
+        std::fs::create_dir_all(&unsafe_name).unwrap();
+        std::fs::create_dir_all(&hidden).unwrap();
+
+        assert_eq!(
+            installed_query_language_name(&safe),
+            Some("lua".to_string())
+        );
+        assert_eq!(installed_query_language_name(&unsafe_name), None);
+        assert_eq!(installed_query_language_name(&hidden), None);
+    }
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -703,7 +703,7 @@ fn run_install(language: &str, force: bool, verbose: bool, no_cache: bool) -> Re
 
     if let Err(e) = queries::clear_uninstall_tombstone_for_install(&data_dir, language) {
         eprintln!("✗ Failed to prepare query installation: {}", e);
-        return Err(ExitCode::FAILURE);
+        queries_success = false;
     }
 
     // Install parser

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -560,6 +560,16 @@ fn run_language_uninstall(
     let mut any_removed = false;
     let mut any_failed = false;
     for lang in &languages_to_uninstall {
+        // Reject unsafe names before building any path from them: `lang` is
+        // user input and feeds fs::remove_file via find_parser_file, so a
+        // separator-carrying name must not escape the data dir.
+        if !queries::is_safe_language_name(lang) {
+            // Debug-format: untrusted input could smuggle ANSI escapes.
+            eprintln!("✗ Invalid language name {:?}", lang);
+            any_failed = true;
+            continue;
+        }
+
         let mut removed_something = false;
 
         // Remove parser file

--- a/src/install.rs
+++ b/src/install.rs
@@ -567,7 +567,7 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Err(queries::QueryInstallError::LanguageNotSupported(_))
+                Err(queries::QueryInstallError::InvalidLanguageName(_))
             ),
             "unsafe top-level language name must be rejected"
         );

--- a/src/install.rs
+++ b/src/install.rs
@@ -279,6 +279,13 @@ fn install_language_blocking_with_query_installer(
         return result;
     }
 
+    if let Err(e) = queries::clear_uninstall_tombstone_for_install(data_dir, language) {
+        let reason = e.to_string();
+        result.parser_error = Some(reason.clone());
+        result.queries_error = Some(reason);
+        return result;
+    }
+
     // Install parser
     // For async/auto-install, always use cache (background operation)
     let parser_options = parser::InstallOptions {
@@ -632,6 +639,7 @@ mod tests {
         let queries_dir = data_dir.join("queries").join("exists_lang");
         std::fs::create_dir_all(&queries_dir).unwrap();
         std::fs::write(queries_dir.join("highlights.scm"), "(comment) @comment\n").unwrap();
+        queries::write_install_marker_for_tests(&queries_dir).unwrap();
 
         // Everything exists, so no download may happen — point the base URL
         // at a closed port to fail loudly if one is attempted anyway.

--- a/src/install.rs
+++ b/src/install.rs
@@ -282,7 +282,6 @@ fn install_language_blocking_with_query_installer(
     if let Err(e) = queries::clear_uninstall_tombstone_for_install(data_dir, language) {
         let reason = e.to_string();
         result.queries_error = Some(reason);
-        return result;
     }
 
     // Install parser
@@ -698,7 +697,11 @@ mod tests {
 
         assert!(
             result.parser_error.is_none(),
-            "parser install was never attempted, so tombstone cleanup must not be reported as a parser error"
+            "tombstone cleanup must not be reported as a parser error"
+        );
+        assert!(
+            result.parser_path.is_some(),
+            "query tombstone cleanup failures must not prevent parser installation"
         );
         assert!(result.queries_error.is_some());
     }

--- a/src/install.rs
+++ b/src/install.rs
@@ -281,7 +281,6 @@ fn install_language_blocking_with_query_installer(
 
     if let Err(e) = queries::clear_uninstall_tombstone_for_install(data_dir, language) {
         let reason = e.to_string();
-        result.parser_error = Some(reason.clone());
         result.queries_error = Some(reason);
         return result;
     }
@@ -681,5 +680,26 @@ mod tests {
             queries_error: Some("Queries failed".to_string()),
         };
         assert!(!failure.is_success());
+    }
+
+    #[test]
+    fn install_language_reports_tombstone_cleanup_as_query_error_only() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let data_dir = temp.path();
+        std::fs::write(data_dir.join("queries"), "not a directory").unwrap();
+
+        let result = install_language_blocking(
+            "lua",
+            data_dir,
+            false,
+            "http://127.0.0.1:1",
+            parser::ParserCompile::InProcess,
+        );
+
+        assert!(
+            result.parser_error.is_none(),
+            "parser install was never attempted, so tombstone cleanup must not be reported as a parser error"
+        );
+        assert!(result.queries_error.is_some());
     }
 }

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -472,13 +472,20 @@ pub fn recover_interrupted_query_installs(queries_parent: &Path) -> Result<(), Q
         Err(e) => return Err(QueryInstallError::IoError(e)),
     };
 
+    // Recover at most once per language: a single recovery pass already
+    // considers every backup for that language (newest_complete_backup_dir
+    // rescans the parent), so running it per backup directory would redo the
+    // same scan and lock acquisition for each stranded backup.
+    let mut recovered_languages = std::collections::HashSet::new();
     for entry in entries.flatten() {
         let path = entry.path();
         if !path.is_dir() {
             continue;
         }
         if let Some(language) = backup_language_name(&path) {
-            recover_interrupted_query_install(queries_parent, &language)?;
+            if recovered_languages.insert(language.clone()) {
+                recover_interrupted_query_install(queries_parent, &language)?;
+            }
         } else if let Some((language, _)) = temp_language_name_and_pid(&path) {
             remove_interrupted_temp_query_install(queries_parent, &language, &path)?;
         }

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -34,6 +34,9 @@ static QUERY_TMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
 pub enum QueryInstallError {
     /// The language is not supported (queries don't exist in nvim-treesitter).
     LanguageNotSupported(String),
+    /// The language name is not a valid path/URL segment (see
+    /// [`is_safe_language_name`]) — invalid input, not a missing upstream.
+    InvalidLanguageName(String),
     /// HTTP request failed.
     HttpError(String),
     /// HTTP response returned a structured non-success status code.
@@ -53,6 +56,13 @@ impl std::fmt::Display for QueryInstallError {
                 write!(
                     f,
                     "Language '{}' is not supported or queries not found in nvim-treesitter",
+                    lang
+                )
+            }
+            Self::InvalidLanguageName(lang) => {
+                write!(
+                    f,
+                    "Invalid language name '{}' (allowed: lowercase ASCII letters, digits, underscore)",
                     lang
                 )
             }
@@ -106,7 +116,7 @@ fn validate_safe_language_name(language: &str) -> Result<(), QueryInstallError> 
     if is_safe_language_name(language) {
         Ok(())
     } else {
-        Err(QueryInstallError::LanguageNotSupported(
+        Err(QueryInstallError::InvalidLanguageName(
             language.escape_default().to_string(),
         ))
     }
@@ -524,8 +534,10 @@ pub fn remove_query_install_and_backups(
         removal.removed_queries = true;
     }
 
-    let entries = fs::read_dir(queries_parent)?;
-    for entry in entries.flatten() {
+    // Propagate per-entry read_dir errors: uninstall must not report success
+    // while backups it could not even enumerate stay behind.
+    for entry in fs::read_dir(queries_parent)? {
+        let entry = entry?;
         let path = entry.path();
         let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
             continue;
@@ -1002,14 +1014,14 @@ mod tests {
             false,
         );
         match result {
-            Err(QueryInstallError::LanguageNotSupported(name)) => {
+            Err(QueryInstallError::InvalidLanguageName(name)) => {
                 assert!(
                     !name.contains('\u{1b}'),
                     "stored name must not carry raw escape bytes: {:?}",
                     name
                 );
             }
-            other => panic!("expected LanguageNotSupported, got {:?}", other.err()),
+            other => panic!("expected InvalidLanguageName, got {:?}", other.err()),
         }
     }
 
@@ -1035,7 +1047,7 @@ mod tests {
         let result = clear_uninstall_tombstone_for_install(data_dir, "a/../../victim");
 
         assert!(
-            matches!(result, Err(QueryInstallError::LanguageNotSupported(_))),
+            matches!(result, Err(QueryInstallError::InvalidLanguageName(_))),
             "unsafe language must be rejected before tombstone path construction"
         );
         assert_eq!(
@@ -1101,7 +1113,7 @@ mod tests {
         let result = remove_query_install_and_backups(&queries_parent, "a/../../victim");
 
         assert!(
-            matches!(result, Err(QueryInstallError::LanguageNotSupported(_))),
+            matches!(result, Err(QueryInstallError::InvalidLanguageName(_))),
             "unsafe language must be rejected before cleanup paths are derived"
         );
         assert!(

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -311,6 +311,9 @@ fn install_queries_recursive(
     }
 
     let tmp_queries_dir = create_unique_temp_query_dir(&queries_parent, language)?;
+    let _tmp_guard = TempQueryDirGuard {
+        path: tmp_queries_dir.clone(),
+    };
 
     let mut files_downloaded = Vec::new();
     let mut any_success = false;
@@ -328,17 +331,13 @@ fn install_queries_recursive(
                 }
 
                 let file_path = tmp_queries_dir.join(query_file);
-                if let Err(e) = write_query_file(&file_path, &content) {
-                    let _ = fs::remove_dir_all(&tmp_queries_dir);
-                    return Err(e);
-                }
+                write_query_file(&file_path, &content)?;
                 files_downloaded.push(query_file.to_string());
                 any_success = true;
             }
             Err(e) => {
                 // highlights.scm is required, others are optional
                 if *query_file == "highlights.scm" {
-                    let _ = fs::remove_dir_all(&tmp_queries_dir);
                     return match e {
                         QueryInstallError::HttpStatus { code: 404, .. } => Err(
                             QueryInstallError::LanguageNotSupported(language.to_string()),
@@ -356,32 +355,25 @@ fn install_queries_recursive(
     }
 
     if !any_success {
-        let _ = fs::remove_dir_all(&tmp_queries_dir);
         return Err(QueryInstallError::LanguageNotSupported(
             language.to_string(),
         ));
     }
 
-    if let Err(e) = write_install_marker(&tmp_queries_dir) {
-        let _ = fs::remove_dir_all(&tmp_queries_dir);
-        return Err(e);
-    }
+    write_install_marker(&tmp_queries_dir)?;
 
     match replace_query_dir(&tmp_queries_dir, &queries_dir, language, force) {
         Ok(ReplaceQueryDirResult::Replaced) => {}
         Ok(ReplaceQueryDirResult::AlreadyComplete) => {
-            let _ = fs::remove_dir_all(&tmp_queries_dir);
             return Err(QueryInstallError::AlreadyExists(queries_dir));
         }
         Ok(ReplaceQueryDirResult::Uninstalled) => {
-            let _ = fs::remove_dir_all(&tmp_queries_dir);
             return Err(QueryInstallError::IoError(std::io::Error::new(
                 std::io::ErrorKind::Interrupted,
                 format!("Query install for {language} was superseded by uninstall"),
             )));
         }
         Err(e) => {
-            let _ = fs::remove_dir_all(&tmp_queries_dir);
             return Err(e);
         }
     }
@@ -423,6 +415,20 @@ pub fn query_install_is_complete(queries_dir: &Path) -> bool {
     // valid user-managed or pre-marker query directories.
     metadata.is_file()
         && (queries_dir.join(QUERY_INSTALL_COMPLETE_MARKER).is_file() || metadata.len() > 0)
+}
+
+/// RAII cleanup for a staging directory: removes it on drop so every error
+/// path (including `?` propagation added later) leaves nothing stranded. On
+/// the success path `replace_query_dir` renames the directory away, making
+/// the drop-time removal a harmless no-op.
+struct TempQueryDirGuard {
+    path: PathBuf,
+}
+
+impl Drop for TempQueryDirGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
 }
 
 fn create_unique_temp_query_dir(
@@ -942,6 +948,7 @@ mod tests {
         base_url
     }
 
+    #[cfg(unix)]
     fn dead_test_pid() -> u32 {
         let mut pid = std::process::id().saturating_add(100_000);
         while process_is_running(&pid.to_string()) {
@@ -1072,6 +1079,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn recover_interrupted_query_installs_removes_stranded_tmp_dirs() {
         let temp = TempDir::new().unwrap();
         let queries_parent = temp.path().join("queries");
@@ -1106,6 +1114,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn remove_interrupted_temp_query_install_treats_missing_tmp_as_clean() {
         let temp = TempDir::new().unwrap();
         let queries_parent = temp.path().join("queries");

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -656,10 +656,6 @@ fn recover_interrupted_query_install(
         return Ok(());
     }
 
-    let Some(backup_dir) = newest_complete_backup_dir(queries_parent, language)? else {
-        return Ok(());
-    };
-
     let _replace_lock = QueryReplaceLockGuard::acquire(queries_parent, language)?;
     if uninstall_tombstone_path(queries_parent, language).is_file() {
         return Ok(());
@@ -668,8 +664,21 @@ fn recover_interrupted_query_install(
         return Ok(());
     }
 
+    // Select the backup UNDER the lock: chosen before it, a concurrent
+    // uninstall/cleanup could delete the directory between selection and the
+    // rename, turning a clean "nothing to restore" into a NotFound error.
+    let Some(backup_dir) = newest_complete_backup_dir(queries_parent, language)? else {
+        return Ok(());
+    };
+
     let ownership = backup_ownership_sidecar(&backup_dir);
-    fs::rename(&backup_dir, queries_dir)?;
+    match fs::rename(&backup_dir, queries_dir) {
+        Ok(()) => {}
+        // The backup vanished after selection (external cleanup — the lock
+        // only serializes kakehashi's own installers): nothing to restore.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(QueryInstallError::IoError(e)),
+    }
     let _ = fs::remove_file(ownership);
     Ok(())
 }

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -942,7 +942,10 @@ mod tests {
         let base_url = format!("http://{}", listener.local_addr().unwrap());
 
         std::thread::spawn(move || {
-            for stream in listener.incoming() {
+            // Bounded so the thread (and its socket) terminates instead of
+            // living until process exit: no test downloads anywhere near this
+            // many files (2 query files per language, short inherits chains).
+            for stream in listener.incoming().take(64) {
                 let Ok(mut stream) = stream else { continue };
                 let mut reader = BufReader::new(&mut stream);
                 let mut request_line = String::new();

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -682,8 +682,13 @@ fn recover_interrupted_query_install(
     match fs::rename(&backup_dir, queries_dir) {
         Ok(()) => {}
         // The backup vanished after selection (external cleanup — the lock
-        // only serializes kakehashi's own installers): nothing to restore.
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        // only serializes kakehashi's own installers): nothing to restore,
+        // but drop the now-orphaned ownership sidecar so markers don't
+        // accumulate under queries/ (idempotent if it is already gone).
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            let _ = fs::remove_file(ownership);
+            return Ok(());
+        }
         Err(e) => return Err(QueryInstallError::IoError(e)),
     }
     let _ = fs::remove_file(ownership);
@@ -845,6 +850,14 @@ fn replace_query_dir(
     write_backup_ownership_marker(&backup_dir)?;
     if let Err(e) = fs::rename(queries_dir, &backup_dir) {
         let _ = fs::remove_file(backup_ownership_sidecar(&backup_dir));
+        // The target vanished between the exists() check above and this
+        // rename (external cleanup — the lock only serializes kakehashi's own
+        // installers): nothing to back up, so publish the staged dir instead
+        // of aborting the install.
+        if e.kind() == std::io::ErrorKind::NotFound {
+            fs::rename(tmp_queries_dir, queries_dir)?;
+            return Ok(ReplaceQueryDirResult::Replaced);
+        }
         return Err(QueryInstallError::IoError(e));
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -3,7 +3,10 @@
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
+
+use fs4::fs_std::FileExt;
 
 use super::http::agent_with_timeout;
 #[cfg(test)]
@@ -20,6 +23,11 @@ const QUERY_FILES: &[&str] = &["highlights.scm", "injections.scm"];
 /// HTTP timeout for query file downloads; keeps installs bounded when a
 /// response stalls (query files are small text files, so 60s is generous).
 const QUERY_HTTP_TIMEOUT: Duration = Duration::from_secs(60);
+const QUERY_INSTALL_COMPLETE_MARKER: &str = ".kakehashi-install-complete";
+const QUERY_BACKUP_OWNERSHIP_MARKER: &str = ".kakehashi-backup";
+const QUERY_UNINSTALL_TOMBSTONE_SUFFIX: &str = ".uninstalled";
+
+static QUERY_TMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 /// Error types for query installation.
 #[derive(Debug)]
@@ -94,6 +102,16 @@ pub(crate) fn is_safe_language_name(name: &str) -> bool {
             .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'_')
 }
 
+fn validate_safe_language_name(language: &str) -> Result<(), QueryInstallError> {
+    if is_safe_language_name(language) {
+        Ok(())
+    } else {
+        Err(QueryInstallError::LanguageNotSupported(
+            language.escape_default().to_string(),
+        ))
+    }
+}
+
 /// Parse the `; inherits: lang1,lang2` directive from query content.
 /// Returns the list of parent languages, dropping unsafe names
 /// (see [`is_safe_language_name`]).
@@ -122,6 +140,21 @@ fn parse_inherits_directive(content: &str) -> Vec<String> {
 ///
 /// This recursively downloads parent queries (e.g., ecma, jsx for TypeScript).
 pub fn install_queries_with_dependencies(
+    language: &str,
+    data_dir: &Path,
+    force: bool,
+) -> Result<QueryInstallResult, QueryInstallError> {
+    clear_uninstall_tombstone_for_install(data_dir, language)?;
+    install_queries_with_dependencies_from_with_http_policy(
+        NVIM_TREESITTER_QUERIES_URL,
+        language,
+        data_dir,
+        force,
+        QueryHttpPolicy::HttpsOnly,
+    )
+}
+
+pub fn install_queries_with_dependencies_after_install_started(
     language: &str,
     data_dir: &Path,
     force: bool,
@@ -221,11 +254,7 @@ fn install_queries_recursive(
     // could escape the data dir (e.g. a caller-provided `../../x`).
     // Escape the untrusted name: the error's Display is printed raw by
     // the CLI, so control characters must not reach the terminal.
-    if !is_safe_language_name(language) {
-        return Err(QueryInstallError::LanguageNotSupported(
-            language.escape_default().to_string(),
-        ));
-    }
+    validate_safe_language_name(language)?;
 
     // Skip if already installed in this session
     if installed.contains(language) {
@@ -237,9 +266,14 @@ fn install_queries_recursive(
     }
 
     let queries_dir = data_dir.join("queries").join(language);
+    let queries_parent = data_dir.join("queries");
+    fs::create_dir_all(&queries_parent)?;
+    recover_interrupted_query_install(&queries_parent, language)?;
 
-    // Check if queries already exist
-    if queries_dir.exists() && !force {
+    // Check if queries already exist. A previous interrupted install may
+    // leave a directory without the required highlights.scm; that is treated
+    // as incomplete so a later install can repair it without --force.
+    if query_install_is_complete(&queries_dir) && !force {
         // Mark as installed BEFORE recursing into parents: an inheritance
         // cycle among on-disk query files (self-inherit typo, A↔B) would
         // otherwise recurse forever and overflow the stack. The download
@@ -254,6 +288,7 @@ fn install_queries_recursive(
             let parents = parse_inherits_directive(&content);
             for parent in parents {
                 // Install parent dependencies (don't force, just ensure they exist)
+                clear_uninstall_tombstone(&queries_parent, &parent)?;
                 match install_queries_recursive(
                     base_url,
                     &parent,
@@ -275,8 +310,7 @@ fn install_queries_recursive(
         return Err(QueryInstallError::AlreadyExists(queries_dir));
     }
 
-    // Create the queries directory
-    fs::create_dir_all(&queries_dir)?;
+    let tmp_queries_dir = create_unique_temp_query_dir(&queries_parent, language)?;
 
     let mut files_downloaded = Vec::new();
     let mut any_success = false;
@@ -293,17 +327,18 @@ fn install_queries_recursive(
                     parents_to_install = parse_inherits_directive(&content);
                 }
 
-                let file_path = queries_dir.join(query_file);
-                let mut file = fs::File::create(&file_path)?;
-                file.write_all(content.as_bytes())?;
+                let file_path = tmp_queries_dir.join(query_file);
+                if let Err(e) = write_query_file(&file_path, &content) {
+                    let _ = fs::remove_dir_all(&tmp_queries_dir);
+                    return Err(e);
+                }
                 files_downloaded.push(query_file.to_string());
                 any_success = true;
             }
             Err(e) => {
                 // highlights.scm is required, others are optional
                 if *query_file == "highlights.scm" {
-                    // Clean up the directory we created
-                    let _ = fs::remove_dir_all(&queries_dir);
+                    let _ = fs::remove_dir_all(&tmp_queries_dir);
                     return match e {
                         QueryInstallError::HttpStatus { code: 404, .. } => Err(
                             QueryInstallError::LanguageNotSupported(language.to_string()),
@@ -321,10 +356,34 @@ fn install_queries_recursive(
     }
 
     if !any_success {
-        let _ = fs::remove_dir_all(&queries_dir);
+        let _ = fs::remove_dir_all(&tmp_queries_dir);
         return Err(QueryInstallError::LanguageNotSupported(
             language.to_string(),
         ));
+    }
+
+    if let Err(e) = write_install_marker(&tmp_queries_dir) {
+        let _ = fs::remove_dir_all(&tmp_queries_dir);
+        return Err(e);
+    }
+
+    match replace_query_dir(&tmp_queries_dir, &queries_dir, language, force) {
+        Ok(ReplaceQueryDirResult::Replaced) => {}
+        Ok(ReplaceQueryDirResult::AlreadyComplete) => {
+            let _ = fs::remove_dir_all(&tmp_queries_dir);
+            return Err(QueryInstallError::AlreadyExists(queries_dir));
+        }
+        Ok(ReplaceQueryDirResult::Uninstalled) => {
+            let _ = fs::remove_dir_all(&tmp_queries_dir);
+            return Err(QueryInstallError::IoError(std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                format!("Query install for {language} was superseded by uninstall"),
+            )));
+        }
+        Err(e) => {
+            let _ = fs::remove_dir_all(&tmp_queries_dir);
+            return Err(e);
+        }
     }
 
     installed.insert(language.to_string());
@@ -333,6 +392,7 @@ fn install_queries_recursive(
     for parent in parents_to_install {
         eprintln!("Installing inherited queries: {}", parent);
         // Don't fail if parent already exists
+        clear_uninstall_tombstone(&queries_parent, &parent)?;
         match install_queries_recursive(base_url, &parent, data_dir, false, installed, http_policy)
         {
             Ok(_) | Err(QueryInstallError::AlreadyExists(_)) => {}
@@ -350,6 +410,377 @@ fn install_queries_recursive(
         install_path: queries_dir,
         files_downloaded,
     })
+}
+
+pub fn query_install_is_complete(queries_dir: &Path) -> bool {
+    let highlights_path = queries_dir.join("highlights.scm");
+    let Ok(metadata) = fs::metadata(&highlights_path) else {
+        return false;
+    };
+    // The marker is written only after a staged install has written all
+    // required files. Legacy direct-write directories did not have it, so a
+    // non-empty highlights.scm still counts as installed to avoid clobbering
+    // valid user-managed or pre-marker query directories.
+    metadata.is_file()
+        && (queries_dir.join(QUERY_INSTALL_COMPLETE_MARKER).is_file() || metadata.len() > 0)
+}
+
+fn create_unique_temp_query_dir(
+    queries_parent: &Path,
+    language: &str,
+) -> Result<PathBuf, QueryInstallError> {
+    loop {
+        let candidate = queries_parent.join(format!(
+            ".{}.{}.{}.tmp",
+            language,
+            std::process::id(),
+            QUERY_TMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        match fs::create_dir(&candidate) {
+            Ok(()) => return Ok(candidate),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(QueryInstallError::IoError(e)),
+        }
+    }
+}
+
+fn unique_backup_query_dir(queries_dir: &Path, language: &str) -> PathBuf {
+    loop {
+        let candidate = queries_dir.with_file_name(format!(
+            ".{}.{}.{}.backup",
+            language,
+            std::process::id(),
+            QUERY_TMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+}
+
+/// Recover query directories stranded by a process exit during replacement.
+pub fn recover_interrupted_query_installs(queries_parent: &Path) -> Result<(), QueryInstallError> {
+    let entries = match fs::read_dir(queries_parent) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(QueryInstallError::IoError(e)),
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(language) = backup_language_name(&path) else {
+            continue;
+        };
+        recover_interrupted_query_install(queries_parent, &language)?;
+    }
+
+    Ok(())
+}
+
+pub struct QueryRemoval {
+    pub removed_queries: bool,
+    pub removed_backups: bool,
+}
+
+impl QueryRemoval {
+    pub fn removed_anything(&self) -> bool {
+        self.removed_queries || self.removed_backups
+    }
+}
+
+pub fn remove_query_install_and_backups(
+    queries_parent: &Path,
+    language: &str,
+) -> Result<QueryRemoval, QueryInstallError> {
+    validate_safe_language_name(language)?;
+    fs::create_dir_all(queries_parent)?;
+    let _replace_lock = QueryReplaceLockGuard::acquire(queries_parent, language)?;
+    write_uninstall_tombstone(queries_parent, language)?;
+    let queries_dir = queries_parent.join(language);
+    let mut removal = QueryRemoval {
+        removed_queries: false,
+        removed_backups: false,
+    };
+
+    if queries_dir.exists() {
+        fs::remove_dir_all(&queries_dir)?;
+        removal.removed_queries = true;
+    }
+
+    let entries = fs::read_dir(queries_parent)?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if path.is_dir()
+            && generated_backup_matches_language(name, language)
+            && backup_is_owned(&path)
+        {
+            let ownership = backup_ownership_sidecar(&path);
+            fs::remove_dir_all(path)?;
+            let _ = fs::remove_file(ownership);
+            removal.removed_backups = true;
+        }
+    }
+    Ok(removal)
+}
+
+fn backup_language_name(path: &Path) -> Option<String> {
+    let name = path.file_name()?.to_str()?;
+    let (language, _, _) = generated_backup_parts(name)?;
+    if is_safe_language_name(language) {
+        Some(language.to_string())
+    } else {
+        None
+    }
+}
+
+fn generated_backup_matches_language(name: &str, language: &str) -> bool {
+    matches!(
+        generated_backup_parts(name),
+        Some((backup_language, _, _)) if backup_language == language
+    )
+}
+
+fn generated_backup_parts(name: &str) -> Option<(&str, &str, &str)> {
+    let rest = name.strip_prefix('.')?.strip_suffix(".backup")?;
+    let mut parts = rest.split('.');
+    let language = parts.next()?;
+    let pid = parts.next()?;
+    let counter = parts.next()?;
+    if parts.next().is_none()
+        && pid.bytes().all(|b| b.is_ascii_digit())
+        && counter.bytes().all(|b| b.is_ascii_digit())
+    {
+        Some((language, pid, counter))
+    } else {
+        None
+    }
+}
+
+fn recover_interrupted_query_install(
+    queries_parent: &Path,
+    language: &str,
+) -> Result<(), QueryInstallError> {
+    validate_safe_language_name(language)?;
+    if uninstall_tombstone_path(queries_parent, language).is_file() {
+        return Ok(());
+    }
+    let queries_dir = queries_parent.join(language);
+    if queries_dir.exists() {
+        return Ok(());
+    }
+
+    let Some(backup_dir) = newest_complete_backup_dir(queries_parent, language)? else {
+        return Ok(());
+    };
+
+    let _replace_lock = QueryReplaceLockGuard::acquire(queries_parent, language)?;
+    if uninstall_tombstone_path(queries_parent, language).is_file() {
+        return Ok(());
+    }
+    if queries_dir.exists() {
+        return Ok(());
+    }
+
+    let ownership = backup_ownership_sidecar(&backup_dir);
+    fs::rename(&backup_dir, queries_dir)?;
+    let _ = fs::remove_file(ownership);
+    Ok(())
+}
+
+fn uninstall_tombstone_path(queries_parent: &Path, language: &str) -> PathBuf {
+    queries_parent.join(format!(".{language}{QUERY_UNINSTALL_TOMBSTONE_SUFFIX}"))
+}
+
+fn write_uninstall_tombstone(
+    queries_parent: &Path,
+    language: &str,
+) -> Result<(), QueryInstallError> {
+    validate_safe_language_name(language)?;
+    let mut file = fs::File::create(uninstall_tombstone_path(queries_parent, language))?;
+    file.write_all(b"ok\n")?;
+    Ok(())
+}
+
+fn clear_uninstall_tombstone(
+    queries_parent: &Path,
+    language: &str,
+) -> Result<(), QueryInstallError> {
+    validate_safe_language_name(language)?;
+    match fs::remove_file(uninstall_tombstone_path(queries_parent, language)) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(QueryInstallError::IoError(e)),
+    }
+}
+
+pub fn clear_uninstall_tombstone_for_install(
+    data_dir: &Path,
+    language: &str,
+) -> Result<(), QueryInstallError> {
+    clear_uninstall_tombstone(&data_dir.join("queries"), language)
+}
+
+fn backup_is_owned(path: &Path) -> bool {
+    backup_ownership_sidecar(path).is_file()
+}
+
+fn newest_complete_backup_dir(
+    queries_parent: &Path,
+    language: &str,
+) -> Result<Option<PathBuf>, QueryInstallError> {
+    let entries = match fs::read_dir(queries_parent) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(QueryInstallError::IoError(e)),
+    };
+    let mut newest: Option<(std::time::SystemTime, PathBuf)> = None;
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if !generated_backup_matches_language(name, language) {
+            continue;
+        }
+        if !backup_is_owned(&path) || !query_install_is_complete(&path) {
+            continue;
+        }
+        let modified = entry
+            .metadata()
+            .and_then(|metadata| metadata.modified())
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        if newest
+            .as_ref()
+            .is_none_or(|(current, _)| modified > *current)
+        {
+            newest = Some((modified, path));
+        }
+    }
+
+    Ok(newest.map(|(_, path)| path))
+}
+
+fn write_query_file(file_path: &Path, content: &str) -> Result<(), QueryInstallError> {
+    let mut file = fs::File::create(file_path)?;
+    file.write_all(content.as_bytes())?;
+    Ok(())
+}
+
+fn write_install_marker(queries_dir: &Path) -> Result<(), QueryInstallError> {
+    let mut file = fs::File::create(queries_dir.join(QUERY_INSTALL_COMPLETE_MARKER))?;
+    file.write_all(b"ok\n")?;
+    Ok(())
+}
+
+fn backup_ownership_sidecar(backup_dir: &Path) -> PathBuf {
+    backup_dir.with_file_name(format!(
+        "{}{}",
+        backup_dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or(".query.backup"),
+        QUERY_BACKUP_OWNERSHIP_MARKER
+    ))
+}
+
+fn write_backup_ownership_marker(backup_dir: &Path) -> Result<(), QueryInstallError> {
+    let mut file = fs::File::create(backup_ownership_sidecar(backup_dir))?;
+    file.write_all(b"ok\n")?;
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn write_install_marker_for_tests(queries_dir: &Path) -> Result<(), QueryInstallError> {
+    write_install_marker(queries_dir)
+}
+
+enum ReplaceQueryDirResult {
+    Replaced,
+    AlreadyComplete,
+    Uninstalled,
+}
+
+fn replace_query_dir(
+    tmp_queries_dir: &Path,
+    queries_dir: &Path,
+    language: &str,
+    force: bool,
+) -> Result<ReplaceQueryDirResult, QueryInstallError> {
+    let _replace_lock = QueryReplaceLockGuard::acquire(
+        queries_dir
+            .parent()
+            .ok_or_else(|| QueryInstallError::IoError(std::io::Error::other("missing parent")))?,
+        language,
+    )?;
+
+    if !force && query_install_is_complete(queries_dir) {
+        return Ok(ReplaceQueryDirResult::AlreadyComplete);
+    }
+    if uninstall_tombstone_path(
+        queries_dir
+            .parent()
+            .ok_or_else(|| QueryInstallError::IoError(std::io::Error::other("missing parent")))?,
+        language,
+    )
+    .is_file()
+    {
+        return Ok(ReplaceQueryDirResult::Uninstalled);
+    }
+
+    if !queries_dir.exists() {
+        fs::rename(tmp_queries_dir, queries_dir)?;
+        return Ok(ReplaceQueryDirResult::Replaced);
+    }
+
+    let backup_dir = unique_backup_query_dir(queries_dir, language);
+    write_backup_ownership_marker(&backup_dir)?;
+    if let Err(e) = fs::rename(queries_dir, &backup_dir) {
+        let _ = fs::remove_file(backup_ownership_sidecar(&backup_dir));
+        return Err(QueryInstallError::IoError(e));
+    }
+
+    if let Err(e) = fs::rename(tmp_queries_dir, queries_dir) {
+        match fs::rename(&backup_dir, queries_dir) {
+            Ok(()) => {
+                let _ = fs::remove_file(backup_ownership_sidecar(&backup_dir));
+            }
+            Err(rollback_error) => {
+                return Err(QueryInstallError::IoError(std::io::Error::other(format!(
+                    "failed to publish staged queries: {e}; failed to restore backup: {rollback_error}"
+                ))));
+            }
+        }
+        return Err(QueryInstallError::IoError(e));
+    }
+
+    let _ = fs::remove_dir_all(&backup_dir);
+    let _ = fs::remove_file(backup_ownership_sidecar(&backup_dir));
+    Ok(ReplaceQueryDirResult::Replaced)
+}
+
+struct QueryReplaceLockGuard {
+    _file: fs::File,
+}
+
+impl QueryReplaceLockGuard {
+    fn acquire(queries_parent: &Path, language: &str) -> Result<Self, QueryInstallError> {
+        validate_safe_language_name(language)?;
+        let path = queries_parent.join(format!(".{}.replace.lock", language));
+        let file = fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(path)?;
+        file.lock_exclusive()?;
+        Ok(Self { _file: file })
+    }
 }
 
 /// Download a file from a URL.
@@ -383,30 +814,50 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    fn spawn_404_server() -> String {
+    /// Serve canned query files over HTTP from an OS-assigned local port.
+    fn spawn_query_file_server(routes: Vec<(&str, &str)>) -> String {
         use std::io::{BufRead, BufReader, Write};
 
+        let routes: Vec<(String, String)> = routes
+            .into_iter()
+            .map(|(p, b)| (p.to_string(), b.to_string()))
+            .collect();
         let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local server");
         let base_url = format!("http://{}", listener.local_addr().unwrap());
+
         std::thread::spawn(move || {
-            let Ok((mut stream, _)) = listener.accept() else {
-                return;
-            };
-            let mut reader = BufReader::new(&mut stream);
-            let mut line = String::new();
-            let _ = reader.read_line(&mut line);
-            loop {
-                line.clear();
-                match reader.read_line(&mut line) {
-                    Ok(0) | Err(_) => break,
-                    Ok(_) if line == "\r\n" || line == "\n" => break,
-                    Ok(_) => {}
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                let mut reader = BufReader::new(&mut stream);
+                let mut request_line = String::new();
+                if reader.read_line(&mut request_line).is_err() {
+                    continue;
                 }
+                let mut header = String::new();
+                loop {
+                    header.clear();
+                    match reader.read_line(&mut header) {
+                        Ok(0) | Err(_) => break,
+                        Ok(_) if header == "\r\n" || header == "\n" => break,
+                        Ok(_) => {}
+                    }
+                }
+                let path = request_line.split_whitespace().nth(1).unwrap_or("");
+                let response = match routes.iter().find(|(p, _)| p == path) {
+                    Some((_, body)) => format!(
+                        "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    ),
+                    None => {
+                        "HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
+                            .to_string()
+                    }
+                };
+                let _ = stream.write_all(response.as_bytes());
             }
-            let response =
-                "HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n";
-            let _ = stream.write_all(response.as_bytes());
         });
+
         base_url
     }
 
@@ -447,6 +898,26 @@ mod tests {
     }
 
     #[test]
+    fn clear_uninstall_tombstone_rejects_unsafe_language_before_path_use() {
+        let temp = TempDir::new().unwrap();
+        let data_dir = temp.path();
+        fs::create_dir_all(data_dir.join("queries/.a")).unwrap();
+        fs::write(data_dir.join("victim.uninstalled"), "keep").unwrap();
+
+        let result = clear_uninstall_tombstone_for_install(data_dir, "a/../../victim");
+
+        assert!(
+            matches!(result, Err(QueryInstallError::LanguageNotSupported(_))),
+            "unsafe language must be rejected before tombstone path construction"
+        );
+        assert_eq!(
+            fs::read_to_string(data_dir.join("victim.uninstalled")).unwrap(),
+            "keep",
+            "unsafe tombstone cleanup must not escape queries/"
+        );
+    }
+
+    #[test]
     fn installed_queries_skip_plain_http_sentinel_base_url() {
         let temp = TempDir::new().unwrap();
         let queries_dir = temp.path().join("queries").join("lua");
@@ -465,7 +936,7 @@ mod tests {
     #[test]
     fn missing_required_highlights_remains_language_not_supported() {
         let temp = TempDir::new().unwrap();
-        let base_url = spawn_404_server();
+        let base_url = spawn_query_file_server(vec![]);
 
         let result = install_queries_with_dependencies_from_allowing_http_for_tests(
             &base_url,
@@ -482,7 +953,7 @@ mod tests {
 
     #[test]
     fn download_file_preserves_http_status_code() {
-        let base_url = spawn_404_server();
+        let base_url = spawn_query_file_server(vec![]);
         let result = download_file(
             &format!("{base_url}/missing_lang/highlights.scm"),
             QueryHttpPolicy::AllowHttpForTests,
@@ -491,6 +962,23 @@ mod tests {
         assert!(
             matches!(result, Err(QueryInstallError::HttpStatus { code: 404, .. })),
             "download errors should preserve structured status codes"
+        );
+    }
+
+    #[test]
+    fn remove_query_install_rejects_unsafe_language_before_creating_queries_parent() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+
+        let result = remove_query_install_and_backups(&queries_parent, "a/../../victim");
+
+        assert!(
+            matches!(result, Err(QueryInstallError::LanguageNotSupported(_))),
+            "unsafe language must be rejected before cleanup paths are derived"
+        );
+        assert!(
+            !queries_parent.exists(),
+            "unsafe cleanup must not even create the queries directory"
         );
     }
 
@@ -541,6 +1029,7 @@ mod tests {
         let a_dir = data_dir.join("queries").join("cyclic_a");
         fs::create_dir_all(&a_dir).unwrap();
         std::fs::write(a_dir.join("highlights.scm"), "; inherits: cyclic_a\n").unwrap();
+        write_install_marker_for_tests(&a_dir).unwrap();
 
         let result = install_queries_with_dependencies("cyclic_a", &data_dir, false);
         assert!(
@@ -555,6 +1044,8 @@ mod tests {
         fs::create_dir_all(&c_dir).unwrap();
         std::fs::write(b_dir.join("highlights.scm"), "; inherits: cyclic_c\n").unwrap();
         std::fs::write(c_dir.join("highlights.scm"), "; inherits: cyclic_b\n").unwrap();
+        write_install_marker_for_tests(&b_dir).unwrap();
+        write_install_marker_for_tests(&c_dir).unwrap();
 
         let result = install_queries_with_dependencies("cyclic_b", &data_dir, false);
         assert!(
@@ -586,6 +1077,7 @@ mod tests {
         // Create existing directory
         fs::create_dir_all(&queries_dir).unwrap();
         fs::write(queries_dir.join("highlights.scm"), "existing content").unwrap();
+        write_install_marker_for_tests(&queries_dir).unwrap();
 
         // Without force, should error
         let result = install_queries_with_dependencies("lua", &data_dir, false);
@@ -593,5 +1085,165 @@ mod tests {
 
         // With force, should succeed (requires network)
         // Skip actual download test to avoid flaky CI
+    }
+
+    #[test]
+    fn install_repairs_partial_query_dir_without_force() {
+        let temp_dir = TempDir::new().unwrap();
+        let data_dir = temp_dir.path().to_path_buf();
+        let queries_dir = data_dir.join("queries").join("partial_lang");
+        fs::create_dir_all(&queries_dir).unwrap();
+        fs::write(queries_dir.join("highlights.scm"), "").unwrap();
+        fs::write(queries_dir.join("injections.scm"), "stale optional query").unwrap();
+
+        let base_url = spawn_query_file_server(vec![(
+            "/partial_lang/highlights.scm",
+            "(identifier) @variable\n",
+        )]);
+
+        let result = install_queries_with_dependencies_from_allowing_http_for_tests(
+            &base_url,
+            "partial_lang",
+            &data_dir,
+            false,
+        )
+        .expect("partial install should be repaired");
+
+        assert_eq!(result.install_path, queries_dir);
+        assert_eq!(result.files_downloaded, vec!["highlights.scm"]);
+        assert_eq!(
+            fs::read_to_string(queries_dir.join("highlights.scm")).unwrap(),
+            "(identifier) @variable\n"
+        );
+        assert!(
+            !queries_dir.join("injections.scm").exists(),
+            "repair should replace stale partial contents with the successful download"
+        );
+    }
+
+    #[test]
+    fn install_preserves_legacy_non_marker_query_dir_without_force() {
+        let temp_dir = TempDir::new().unwrap();
+        let data_dir = temp_dir.path().to_path_buf();
+        let queries_dir = data_dir.join("queries").join("legacy_lang");
+        fs::create_dir_all(&queries_dir).unwrap();
+        fs::write(queries_dir.join("highlights.scm"), "legacy highlights").unwrap();
+        fs::write(queries_dir.join("bindings.scm"), "user managed query").unwrap();
+
+        let base_url = spawn_query_file_server(vec![(
+            "/legacy_lang/highlights.scm",
+            "replacement highlights\n",
+        )]);
+
+        let result =
+            install_queries_with_dependencies_from(&base_url, "legacy_lang", &data_dir, false);
+
+        assert!(
+            matches!(result, Err(QueryInstallError::AlreadyExists(path)) if path == queries_dir),
+            "legacy query dir should be treated as already installed"
+        );
+        assert_eq!(
+            fs::read_to_string(queries_dir.join("highlights.scm")).unwrap(),
+            "legacy highlights",
+            "non-force install must not overwrite legacy highlights"
+        );
+        assert_eq!(
+            fs::read_to_string(queries_dir.join("bindings.scm")).unwrap(),
+            "user managed query",
+            "non-force install must preserve user-managed query files"
+        );
+    }
+
+    #[test]
+    fn install_treats_marker_with_empty_highlights_as_complete() {
+        let temp_dir = TempDir::new().unwrap();
+        let data_dir = temp_dir.path().to_path_buf();
+        let base_url = spawn_query_file_server(vec![("/empty_lang/highlights.scm", "")]);
+
+        let result = install_queries_with_dependencies_from_allowing_http_for_tests(
+            &base_url,
+            "empty_lang",
+            &data_dir,
+            false,
+        )
+        .expect("empty staged highlights should install");
+        assert_eq!(result.files_downloaded, vec!["highlights.scm"]);
+
+        let result = install_queries_with_dependencies_from_allowing_http_for_tests(
+            &base_url,
+            "empty_lang",
+            &data_dir,
+            false,
+        );
+        assert!(
+            matches!(result, Err(QueryInstallError::AlreadyExists(_))),
+            "marker should make an empty staged highlights.scm count as complete"
+        );
+    }
+
+    #[test]
+    fn replace_query_dir_aborts_when_uninstall_tombstone_exists() {
+        let temp_dir = TempDir::new().unwrap();
+        let queries_parent = temp_dir.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let tmp_queries_dir = create_unique_temp_query_dir(&queries_parent, "raced_lang").unwrap();
+        fs::write(
+            tmp_queries_dir.join("highlights.scm"),
+            "(comment) @comment\n",
+        )
+        .unwrap();
+        write_install_marker_for_tests(&tmp_queries_dir).unwrap();
+        write_uninstall_tombstone(&queries_parent, "raced_lang").unwrap();
+
+        let result = replace_query_dir(
+            &tmp_queries_dir,
+            &queries_parent.join("raced_lang"),
+            "raced_lang",
+            false,
+        );
+
+        assert!(
+            matches!(result, Ok(ReplaceQueryDirResult::Uninstalled)),
+            "replacement should observe uninstall tombstone under the lock"
+        );
+        assert!(
+            !queries_parent.join("raced_lang").exists(),
+            "uninstall tombstone must prevent restoring canonical queries"
+        );
+    }
+
+    #[test]
+    fn force_reinstall_preserves_existing_queries_on_required_download_failure() {
+        let temp_dir = TempDir::new().unwrap();
+        let data_dir = temp_dir.path().to_path_buf();
+        let queries_dir = data_dir.join("queries").join("stable_lang");
+        fs::create_dir_all(&queries_dir).unwrap();
+        fs::write(queries_dir.join("highlights.scm"), "working highlights").unwrap();
+        fs::write(queries_dir.join("injections.scm"), "working injections").unwrap();
+        write_install_marker_for_tests(&queries_dir).unwrap();
+
+        let base_url = spawn_query_file_server(vec![]);
+
+        let result = install_queries_with_dependencies_from_allowing_http_for_tests(
+            &base_url,
+            "stable_lang",
+            &data_dir,
+            true,
+        );
+
+        assert!(
+            matches!(result, Err(QueryInstallError::LanguageNotSupported(lang)) if lang == "stable_lang"),
+            "required highlights download failure should be reported"
+        );
+        assert_eq!(
+            fs::read_to_string(queries_dir.join("highlights.scm")).unwrap(),
+            "working highlights",
+            "force reinstall must not destroy previously working highlights"
+        );
+        assert_eq!(
+            fs::read_to_string(queries_dir.join("injections.scm")).unwrap(),
+            "working injections",
+            "force reinstall must not destroy previously working optional queries"
+        );
     }
 }

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -630,8 +630,9 @@ fn process_is_running(pid: &str) -> bool {
 }
 
 #[cfg(not(unix))]
-fn process_is_running(_pid: &str) -> bool {
-    false
+fn process_is_running(pid: &str) -> bool {
+    pid.parse::<u32>()
+        .is_ok_and(|pid| pid == std::process::id())
 }
 
 fn recover_interrupted_query_install(

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -631,6 +631,9 @@ fn process_is_running(pid: &str) -> bool {
 
 #[cfg(not(unix))]
 fn process_is_running(pid: &str) -> bool {
+    // No portable std API can test another process's liveness. Be
+    // conservative: generated temp names contain numeric PIDs, so treat them
+    // as possibly live and leave cleanup to a future platform-specific pass.
     pid.parse::<u32>().is_ok()
 }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -473,7 +473,7 @@ pub fn recover_interrupted_query_installs(queries_parent: &Path) -> Result<(), Q
         }
         if let Some(language) = backup_language_name(&path) {
             recover_interrupted_query_install(queries_parent, &language)?;
-        } else if let Some(language) = temp_language_name(&path) {
+        } else if let Some((language, _)) = temp_language_name_and_pid(&path) {
             remove_interrupted_temp_query_install(queries_parent, &language, &path)?;
         }
     }
@@ -540,11 +540,11 @@ fn backup_language_name(path: &Path) -> Option<String> {
     }
 }
 
-fn temp_language_name(path: &Path) -> Option<String> {
+fn temp_language_name_and_pid(path: &Path) -> Option<(String, u32)> {
     let name = path.file_name()?.to_str()?;
-    let (language, _, _) = generated_temp_parts(name)?;
+    let (language, pid, _) = generated_temp_parts(name)?;
     if is_safe_language_name(language) {
-        Some(language.to_string())
+        Some((language.to_string(), pid.parse().ok()?))
     } else {
         None
     }
@@ -554,13 +554,6 @@ fn generated_backup_matches_language(name: &str, language: &str) -> bool {
     matches!(
         generated_backup_parts(name),
         Some((backup_language, _, _)) if backup_language == language
-    )
-}
-
-fn generated_temp_matches_language(name: &str, language: &str) -> bool {
-    matches!(
-        generated_temp_parts(name),
-        Some((tmp_language, _, _)) if tmp_language == language
     )
 }
 
@@ -602,13 +595,43 @@ fn remove_interrupted_temp_query_install(
     tmp_dir: &Path,
 ) -> Result<(), QueryInstallError> {
     validate_safe_language_name(language)?;
+    let Some(name) = tmp_dir.file_name().and_then(|name| name.to_str()) else {
+        return Ok(());
+    };
+    let Some((tmp_language, pid, _)) = generated_temp_parts(name) else {
+        return Ok(());
+    };
+    if tmp_language != language || process_is_running(pid) {
+        return Ok(());
+    }
+
     let _replace_lock = QueryReplaceLockGuard::acquire(queries_parent, language)?;
-    if let Some(name) = tmp_dir.file_name().and_then(|name| name.to_str())
-        && generated_temp_matches_language(name, language)
-    {
-        fs::remove_dir_all(tmp_dir)?;
+    match fs::remove_dir_all(tmp_dir) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(QueryInstallError::IoError(e)),
     }
     Ok(())
+}
+
+#[cfg(unix)]
+fn process_is_running(pid: &str) -> bool {
+    let Ok(pid) = pid.parse::<i32>() else {
+        return false;
+    };
+    if pid <= 0 {
+        return false;
+    }
+    match nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None) {
+        Ok(()) | Err(nix::errno::Errno::EPERM) => true,
+        Err(nix::errno::Errno::ESRCH) => false,
+        Err(_) => true,
+    }
+}
+
+#[cfg(not(unix))]
+fn process_is_running(_pid: &str) -> bool {
+    false
 }
 
 fn recover_interrupted_query_install(
@@ -916,6 +939,14 @@ mod tests {
         base_url
     }
 
+    fn dead_test_pid() -> u32 {
+        let mut pid = std::process::id().saturating_add(100_000);
+        while process_is_running(&pid.to_string()) {
+            pid = pid.saturating_add(1);
+        }
+        pid
+    }
+
     /// The rejected name flows into the error's `Display` (printed raw by
     /// the CLI), so control characters in an untrusted name must be escaped
     /// before they reach terminal output.
@@ -1042,7 +1073,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let queries_parent = temp.path().join("queries");
         fs::create_dir_all(&queries_parent).unwrap();
-        let tmp = queries_parent.join(".lua.123.0.tmp");
+        let tmp = queries_parent.join(format!(".lua.{}.0.tmp", dead_test_pid()));
         fs::create_dir_all(&tmp).unwrap();
         fs::write(tmp.join("highlights.scm"), "(comment) @comment\n").unwrap();
 
@@ -1052,6 +1083,33 @@ mod tests {
             !tmp.exists(),
             "generated staging dirs from crashed installs should be collected"
         );
+    }
+
+    #[test]
+    fn recover_interrupted_query_installs_preserves_live_tmp_dirs() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let tmp = queries_parent.join(format!(".lua.{}.0.tmp", std::process::id()));
+        fs::create_dir_all(&tmp).unwrap();
+        fs::write(tmp.join("highlights.scm"), "(comment) @comment\n").unwrap();
+
+        recover_interrupted_query_installs(&queries_parent).unwrap();
+
+        assert!(
+            tmp.exists(),
+            "generated staging dirs from live installers must not be collected"
+        );
+    }
+
+    #[test]
+    fn remove_interrupted_temp_query_install_treats_missing_tmp_as_clean() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let tmp = queries_parent.join(format!(".lua.{}.0.tmp", dead_test_pid()));
+
+        remove_interrupted_temp_query_install(&queries_parent, "lua", &tmp).unwrap();
     }
 
     #[test]

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -95,7 +95,7 @@ pub struct QueryInstallResult {
 /// segments, so anything outside nvim-treesitter's `[a-z0-9_]+` naming is
 /// rejected: a name like `../../x` (from a caller or a `; inherits:` line in
 /// a compromised or custom query source) must not escape the data dir.
-pub(crate) fn is_safe_language_name(name: &str) -> bool {
+pub fn is_safe_language_name(name: &str) -> bool {
     !name.is_empty()
         && name
             .bytes()
@@ -471,10 +471,11 @@ pub fn recover_interrupted_query_installs(queries_parent: &Path) -> Result<(), Q
         if !path.is_dir() {
             continue;
         }
-        let Some(language) = backup_language_name(&path) else {
-            continue;
-        };
-        recover_interrupted_query_install(queries_parent, &language)?;
+        if let Some(language) = backup_language_name(&path) {
+            recover_interrupted_query_install(queries_parent, &language)?;
+        } else if let Some(language) = temp_language_name(&path) {
+            remove_interrupted_temp_query_install(queries_parent, &language, &path)?;
+        }
     }
 
     Ok(())
@@ -539,10 +540,27 @@ fn backup_language_name(path: &Path) -> Option<String> {
     }
 }
 
+fn temp_language_name(path: &Path) -> Option<String> {
+    let name = path.file_name()?.to_str()?;
+    let (language, _, _) = generated_temp_parts(name)?;
+    if is_safe_language_name(language) {
+        Some(language.to_string())
+    } else {
+        None
+    }
+}
+
 fn generated_backup_matches_language(name: &str, language: &str) -> bool {
     matches!(
         generated_backup_parts(name),
         Some((backup_language, _, _)) if backup_language == language
+    )
+}
+
+fn generated_temp_matches_language(name: &str, language: &str) -> bool {
+    matches!(
+        generated_temp_parts(name),
+        Some((tmp_language, _, _)) if tmp_language == language
     )
 }
 
@@ -560,6 +578,37 @@ fn generated_backup_parts(name: &str) -> Option<(&str, &str, &str)> {
     } else {
         None
     }
+}
+
+fn generated_temp_parts(name: &str) -> Option<(&str, &str, &str)> {
+    let rest = name.strip_prefix('.')?.strip_suffix(".tmp")?;
+    let mut parts = rest.split('.');
+    let language = parts.next()?;
+    let pid = parts.next()?;
+    let counter = parts.next()?;
+    if parts.next().is_none()
+        && pid.bytes().all(|b| b.is_ascii_digit())
+        && counter.bytes().all(|b| b.is_ascii_digit())
+    {
+        Some((language, pid, counter))
+    } else {
+        None
+    }
+}
+
+fn remove_interrupted_temp_query_install(
+    queries_parent: &Path,
+    language: &str,
+    tmp_dir: &Path,
+) -> Result<(), QueryInstallError> {
+    validate_safe_language_name(language)?;
+    let _replace_lock = QueryReplaceLockGuard::acquire(queries_parent, language)?;
+    if let Some(name) = tmp_dir.file_name().and_then(|name| name.to_str())
+        && generated_temp_matches_language(name, language)
+    {
+        fs::remove_dir_all(tmp_dir)?;
+    }
+    Ok(())
 }
 
 fn recover_interrupted_query_install(
@@ -612,6 +661,11 @@ fn clear_uninstall_tombstone(
     language: &str,
 ) -> Result<(), QueryInstallError> {
     validate_safe_language_name(language)?;
+    let _replace_lock = if queries_parent.exists() {
+        Some(QueryReplaceLockGuard::acquire(queries_parent, language)?)
+    } else {
+        None
+    };
     match fs::remove_file(uninstall_tombstone_path(queries_parent, language)) {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
@@ -760,8 +814,9 @@ fn replace_query_dir(
         return Err(QueryInstallError::IoError(e));
     }
 
-    let _ = fs::remove_dir_all(&backup_dir);
-    let _ = fs::remove_file(backup_ownership_sidecar(&backup_dir));
+    if fs::remove_dir_all(&backup_dir).is_ok() {
+        let _ = fs::remove_file(backup_ownership_sidecar(&backup_dir));
+    }
     Ok(ReplaceQueryDirResult::Replaced)
 }
 
@@ -979,6 +1034,39 @@ mod tests {
         assert!(
             !queries_parent.exists(),
             "unsafe cleanup must not even create the queries directory"
+        );
+    }
+
+    #[test]
+    fn recover_interrupted_query_installs_removes_stranded_tmp_dirs() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let tmp = queries_parent.join(".lua.123.0.tmp");
+        fs::create_dir_all(&tmp).unwrap();
+        fs::write(tmp.join("highlights.scm"), "(comment) @comment\n").unwrap();
+
+        recover_interrupted_query_installs(&queries_parent).unwrap();
+
+        assert!(
+            !tmp.exists(),
+            "generated staging dirs from crashed installs should be collected"
+        );
+    }
+
+    #[test]
+    fn recover_interrupted_query_installs_ignores_unsafe_tmp_language_names() {
+        let temp = TempDir::new().unwrap();
+        let queries_parent = temp.path().join("queries");
+        fs::create_dir_all(&queries_parent).unwrap();
+        let tmp = queries_parent.join(".bad-name.123.0.tmp");
+        fs::create_dir_all(&tmp).unwrap();
+
+        recover_interrupted_query_installs(&queries_parent).unwrap();
+
+        assert!(
+            tmp.exists(),
+            "tmp cleanup must only derive paths from safe generated language names"
         );
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -631,8 +631,7 @@ fn process_is_running(pid: &str) -> bool {
 
 #[cfg(not(unix))]
 fn process_is_running(pid: &str) -> bool {
-    pid.parse::<u32>()
-        .is_ok_and(|pid| pid == std::process::id())
+    pid.parse::<u32>().is_ok()
 }
 
 fn recover_interrupted_query_install(

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -768,6 +768,288 @@ fn test_language_status_missing_queries() {
     );
 }
 
+/// Test that language status treats zero-byte unmarked queries as incomplete
+#[test]
+fn test_language_status_zero_byte_unmarked_queries_missing() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+
+    fs::create_dir_all(test_dir.path().join("parser")).expect("Failed to create parser dir");
+    fs::create_dir_all(test_dir.path().join("queries/partial"))
+        .expect("Failed to create queries dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    fs::write(
+        test_dir.path().join(format!("parser/partial.{ext}")),
+        "fake",
+    )
+    .expect("Failed to write parser");
+    fs::write(test_dir.path().join("queries/partial/highlights.scm"), "")
+        .expect("Failed to write empty query");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "status",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        combined.contains("partial") && combined.contains("missing"),
+        "Status should match installer completeness for zero-byte unmarked queries. Got: {combined}"
+    );
+}
+
+/// Test that language status ignores internal query staging directories
+#[test]
+fn test_language_status_ignores_internal_query_dirs() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    fs::create_dir_all(test_dir.path().join("queries/.testlang.123.tmp"))
+        .expect("Failed to create internal query dir");
+    fs::write(
+        test_dir
+            .path()
+            .join("queries/.testlang.123.tmp/highlights.scm"),
+        "(comment) @comment",
+    )
+    .expect("Failed to write internal query");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "status",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{}{}", stdout, stderr);
+
+    assert!(
+        !combined.contains(".testlang.123.tmp"),
+        "Status must not report internal query dirs as languages. Got: {combined}"
+    );
+    assert!(
+        combined.contains("No languages installed"),
+        "Only internal query dirs should not count as installed languages. Got: {combined}"
+    );
+}
+
+/// Test that language status recovers a query dir stranded as a hidden backup
+#[test]
+fn test_language_status_recovers_internal_query_backup() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    fs::create_dir_all(test_dir.path().join("parser")).expect("Failed to create parser dir");
+    fs::create_dir_all(test_dir.path().join("queries/.recover_lang.123.0.backup"))
+        .expect("Failed to create backup query dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    fs::write(
+        test_dir.path().join(format!("parser/recover_lang.{ext}")),
+        "fake",
+    )
+    .expect("Failed to write parser");
+    fs::write(
+        test_dir
+            .path()
+            .join("queries/.recover_lang.123.0.backup/highlights.scm"),
+        "(comment) @comment",
+    )
+    .expect("Failed to write backup query");
+    fs::write(
+        test_dir
+            .path()
+            .join("queries/.recover_lang.123.0.backup/.kakehashi-install-complete"),
+        "ok\n",
+    )
+    .expect("Failed to write backup marker");
+    fs::write(
+        test_dir
+            .path()
+            .join("queries/.recover_lang.123.0.backup.kakehashi-backup"),
+        "ok\n",
+    )
+    .expect("Failed to write backup ownership marker");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "status",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{}{}", stdout, stderr);
+
+    assert!(
+        output.status.success(),
+        "Status should exit with success. stderr: {stderr}"
+    );
+    assert!(
+        combined.contains("recover_lang") && combined.contains("✓ queries"),
+        "Status should report recovered queries. Got: {combined}"
+    );
+    assert!(
+        test_dir.path().join("queries/recover_lang").exists(),
+        "Backup query dir should be restored to the canonical path"
+    );
+    assert!(
+        !test_dir
+            .path()
+            .join("queries/.recover_lang.123.0.backup")
+            .exists(),
+        "Recovered backup dir should not remain stranded"
+    );
+}
+
+/// Test that status recovery does not delete an incomplete canonical query dir
+#[test]
+fn test_language_status_preserves_incomplete_query_dir_when_backup_exists() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    fs::create_dir_all(test_dir.path().join("parser")).expect("Failed to create parser dir");
+    fs::create_dir_all(test_dir.path().join("queries/recover_lang"))
+        .expect("Failed to create canonical query dir");
+    fs::create_dir_all(test_dir.path().join("queries/.recover_lang.123.0.backup"))
+        .expect("Failed to create backup query dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    fs::write(
+        test_dir.path().join(format!("parser/recover_lang.{ext}")),
+        "fake",
+    )
+    .expect("Failed to write parser");
+    fs::write(
+        test_dir.path().join("queries/recover_lang/bindings.scm"),
+        "user managed query",
+    )
+    .expect("Failed to write canonical query");
+    fs::write(
+        test_dir
+            .path()
+            .join("queries/.recover_lang.123.0.backup/highlights.scm"),
+        "(comment) @comment",
+    )
+    .expect("Failed to write backup query");
+    fs::write(
+        test_dir
+            .path()
+            .join("queries/.recover_lang.123.0.backup/.kakehashi-install-complete"),
+        "ok\n",
+    )
+    .expect("Failed to write backup marker");
+    fs::write(
+        test_dir
+            .path()
+            .join("queries/.recover_lang.123.0.backup.kakehashi-backup"),
+        "ok\n",
+    )
+    .expect("Failed to write backup ownership marker");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "status",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(
+        output.status.success(),
+        "Status should exit with success. stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(test_dir.path().join("queries/recover_lang/bindings.scm")).unwrap(),
+        "user managed query",
+        "Status recovery must not delete incomplete canonical query dirs"
+    );
+    assert!(
+        test_dir
+            .path()
+            .join("queries/.recover_lang.123.0.backup")
+            .exists(),
+        "Backup should remain when canonical query dir already exists"
+    );
+}
+
+/// Test that status does not recover user-created hidden backup directories
+#[test]
+fn test_language_status_ignores_manual_query_backup() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    fs::create_dir_all(test_dir.path().join("parser")).expect("Failed to create parser dir");
+    fs::create_dir_all(test_dir.path().join("queries/.recover_lang.manual.backup"))
+        .expect("Failed to create manual backup query dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    fs::write(
+        test_dir.path().join(format!("parser/recover_lang.{ext}")),
+        "fake",
+    )
+    .expect("Failed to write parser");
+    fs::write(
+        test_dir
+            .path()
+            .join("queries/.recover_lang.manual.backup/highlights.scm"),
+        "(comment) @comment",
+    )
+    .expect("Failed to write manual backup query");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "status",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        combined.contains("recover_lang") && combined.contains("missing"),
+        "Manual backup should not be restored as installed queries. Got: {combined}"
+    );
+    assert!(
+        !test_dir.path().join("queries/recover_lang").exists(),
+        "Manual backup must not be moved to the canonical query path"
+    );
+    assert!(
+        test_dir
+            .path()
+            .join("queries/.recover_lang.manual.backup")
+            .exists(),
+        "Manual backup should be left untouched"
+    );
+}
+
 /// Test that language uninstall --help shows expected options
 #[test]
 fn test_language_uninstall_help() {
@@ -909,11 +1191,164 @@ fn test_language_uninstall_all() {
         .unwrap_or_default();
     assert!(parsers.is_empty(), "All parsers should be removed");
 
-    // All queries should be removed
+    // All installed query directories should be removed; internal tombstone/lock
+    // files may remain hidden under queries/.
     let queries: Vec<_> = fs::read_dir(test_dir.path().join("queries"))
-        .map(|entries| entries.filter_map(|e| e.ok()).collect())
+        .map(|entries| {
+            entries
+                .filter_map(|e| e.ok())
+                .filter(|entry| {
+                    entry
+                        .file_name()
+                        .to_str()
+                        .is_none_or(|name| !name.starts_with('.'))
+                })
+                .collect()
+        })
         .unwrap_or_default();
     assert!(queries.is_empty(), "All queries should be removed");
+}
+
+/// Test that language uninstall --all ignores internal query staging directories
+#[test]
+fn test_language_uninstall_all_ignores_internal_query_dirs() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+
+    fs::create_dir_all(test_dir.path().join("parser")).expect("Failed to create parser dir");
+    fs::create_dir_all(test_dir.path().join("queries/lang1")).expect("Failed to create query dir");
+    fs::create_dir_all(test_dir.path().join("queries/.lang1.123.tmp"))
+        .expect("Failed to create internal query dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    fs::write(test_dir.path().join(format!("parser/lang1.{ext}")), "fake")
+        .expect("Failed to write parser");
+    fs::write(
+        test_dir.path().join("queries/lang1/highlights.scm"),
+        "(comment) @comment",
+    )
+    .expect("Failed to write query");
+    fs::write(
+        test_dir
+            .path()
+            .join("queries/.lang1.123.tmp/highlights.scm"),
+        "(comment) @comment",
+    )
+    .expect("Failed to write internal query");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "--all",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+            "--force",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(
+        output.status.success(),
+        "Uninstall --all should exit with success. stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !test_dir.path().join(format!("parser/lang1.{ext}")).exists(),
+        "Installed parser should be removed"
+    );
+    assert!(
+        !test_dir.path().join("queries/lang1").exists(),
+        "Installed query dir should be removed"
+    );
+    assert!(
+        test_dir.path().join("queries/.lang1.123.tmp").exists(),
+        "Internal query dir should not be treated as an installed language"
+    );
+}
+
+/// Test that uninstall removes backups so later status cannot recover them
+#[test]
+fn test_language_uninstall_removes_query_backups() {
+    use std::fs;
+
+    let test_dir = tempfile::tempdir().expect("Failed to create temp dir");
+
+    fs::create_dir_all(test_dir.path().join("parser")).expect("Failed to create parser dir");
+    fs::create_dir_all(test_dir.path().join("queries/lang1")).expect("Failed to create query dir");
+    fs::create_dir_all(test_dir.path().join("queries/.lang1.123.0.backup"))
+        .expect("Failed to create backup query dir");
+    let ext = std::env::consts::DLL_EXTENSION;
+    fs::write(test_dir.path().join(format!("parser/lang1.{ext}")), "fake")
+        .expect("Failed to write parser");
+    fs::write(
+        test_dir.path().join("queries/lang1/highlights.scm"),
+        "(comment) @comment",
+    )
+    .expect("Failed to write query");
+    fs::write(
+        test_dir
+            .path()
+            .join("queries/.lang1.123.0.backup/highlights.scm"),
+        "(comment) @comment",
+    )
+    .expect("Failed to write backup query");
+    fs::write(
+        test_dir
+            .path()
+            .join("queries/.lang1.123.0.backup/.kakehashi-install-complete"),
+        "ok\n",
+    )
+    .expect("Failed to write backup marker");
+    fs::write(
+        test_dir
+            .path()
+            .join("queries/.lang1.123.0.backup.kakehashi-backup"),
+        "ok\n",
+    )
+    .expect("Failed to write backup ownership marker");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "uninstall",
+            "lang1",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+            "--force",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(
+        output.status.success(),
+        "Uninstall should exit with success. stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !test_dir.path().join("queries/.lang1.123.0.backup").exists(),
+        "Uninstall must remove query backups so they cannot be recovered later"
+    );
+
+    let status = Command::new(env!("CARGO_BIN_EXE_kakehashi"))
+        .args([
+            "language",
+            "status",
+            "--data-dir",
+            test_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&status.stdout),
+        String::from_utf8_lossy(&status.stderr)
+    );
+
+    assert!(
+        !combined.contains("lang1"),
+        "Status must not recover an uninstalled language from backup. Got: {combined}"
+    );
 }
 
 /// Test that language uninstall rejects a language together with --all


### PR DESCRIPTION
## Summary
- stage query downloads in a temp dir and publish only after the required query file succeeds
- preserve valid legacy query dirs, repair zero-byte/partial installs, and keep failed --force reinstalls from deleting working queries
- recover kakehashi-owned interrupted query backups, keep status/uninstall scans from treating internal dirs as languages, and remove backups under the install lock during uninstall

## Tests
- cargo test install_repairs_partial_query_dir_without_force --lib -- --nocapture
- cargo test install_treats_marker_with_empty_highlights_as_complete --lib -- --nocapture
- cargo test --test test_cli test_language_uninstall_removes_query_backups -- --nocapture
- cargo test --test test_cli test_language_status_zero_byte_unmarked_queries_missing -- --nocapture
- make check

Fixes part of #588.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Safer query installation via staging, completion markers, interruption-safe recovery, and atomic replacement.
  * Automatic recovery of interrupted query installs by restoring stranded generated backups when appropriate.
  * CLI install/uninstall flow now clears stale uninstall markers before installing queries.
* **Bug Fixes**
  * `language status` ignores dot-prefixed internal query folders and treats zero-byte/incomplete queries as not installed.
  * `language uninstall` now fails when query/parser removal fails and handles hidden internal backups correctly.
* **Tests**
  * Expanded CLI integration coverage for recovery, completeness detection, dot-prefixed directories, and uninstall edge cases.
* **Chores**
  * Added a new direct filesystem helper dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->