### PR TITLE
fix(queries): match nvim predicate semantics

### DIFF
--- a/src/analysis/offset_calculator.rs
+++ b/src/analysis/offset_calculator.rs
@@ -44,8 +44,8 @@ pub fn calculate_effective_range(
     // Calculate raw effective positions
     let (raw_start, raw_end) = if offset.start_row == 0 && offset.end_row == 0 {
         // Column offsets only - apply directly
-        let start = (byte_range.start as i32 + offset.start_column).max(0) as usize;
-        let end = (byte_range.end as i32 + offset.end_column).max(0) as usize;
+        let start = apply_column_offset(byte_range.start, offset.start_column);
+        let end = apply_column_offset(byte_range.end, offset.end_column);
         (start, end)
     } else {
         // Row offsets require text scanning
@@ -89,7 +89,7 @@ fn apply_offset_to_position(
 ) -> usize {
     if row_offset == 0 {
         // No row offset, just apply column offset
-        return (byte_pos as i32 + col_offset).max(0) as usize;
+        return apply_column_offset(byte_pos, col_offset);
     }
 
     // Start of the line containing byte_pos, found by scanning backward from
@@ -125,8 +125,20 @@ fn apply_offset_to_position(
         pos
     };
 
-    // Apply column offset from the start of the target line
-    (target_line_start as i32 + col_offset).max(0) as usize
+    let original_column = byte_pos.saturating_sub(current_line_start);
+    apply_column_offset(
+        target_line_start.saturating_add(original_column),
+        col_offset,
+    )
+}
+
+fn apply_column_offset(base: usize, offset: i32) -> usize {
+    let result = base as i128 + offset as i128;
+    if result <= 0 {
+        0
+    } else {
+        usize::try_from(result).unwrap_or(usize::MAX)
+    }
 }
 
 #[cfg(test)]
@@ -286,7 +298,7 @@ mod tests {
         // line's start, not the document end — pins the exact overshoot
         // value against the whole-scan behavior this function replaced.
         let text = "line 1\nline 2";
-        assert_eq!(apply_offset_to_position(text, 6, 5, 0), 7);
+        assert_eq!(apply_offset_to_position(text, 0, 5, 0), 7);
     }
 
     #[test]
@@ -298,6 +310,26 @@ mod tests {
         // Byte 8 is the second byte of "あ" (starts at byte 7, 3 bytes).
         let _ = apply_offset_to_position(text, 8, 1, 0);
         let _ = apply_offset_to_position(text, 8, -1, 0);
+    }
+
+    #[test]
+    fn test_apply_offset_to_position_row_offset_preserves_original_column() {
+        let text = "aaXX\nbbYY\n";
+
+        assert_eq!(
+            apply_offset_to_position(text, 2, 1, 1),
+            8,
+            "row offsets should apply column deltas relative to the original column"
+        );
+    }
+
+    #[test]
+    fn test_apply_column_offset_does_not_narrow_large_positions() {
+        let base = i32::MAX as usize + 10;
+
+        assert_eq!(apply_column_offset(base, 5), base + 5);
+        assert_eq!(apply_column_offset(3, -10), 0);
+        assert_eq!(apply_offset_to_position("", base, 0, 5), base + 5);
     }
 
     #[test]

--- a/src/analysis/offset_calculator.rs
+++ b/src/analysis/offset_calculator.rs
@@ -98,14 +98,16 @@ fn apply_offset_to_position(
     // slicing at a raw byte_pos panics if it lands mid-codepoint (e.g. a
     // stale tree-sitter offset) — the caller's later clamp/snap only applies
     // to the *returned* value, not this internal slice.
-    let current_line_start = text[..floor_char_boundary(text, byte_pos)]
+    let snapped_byte_pos = floor_char_boundary(text, byte_pos);
+    let current_line_start = text[..snapped_byte_pos]
         .rfind('\n')
         .map(|i| i + 1)
         .unwrap_or(0);
 
     let target_line_start = if row_offset > 0 {
-        // Overshooting the last line stops at that line's start (matching the
-        // original whole-scan behavior), not the document end.
+        // Overshooting the last line stops row movement at that line's start
+        // (matching the original whole-scan behavior) before the original
+        // column and column offset are reapplied.
         let mut pos = current_line_start;
         for _ in 0..row_offset {
             match text[pos..].find('\n') {
@@ -125,7 +127,7 @@ fn apply_offset_to_position(
         pos
     };
 
-    let original_column = byte_pos.saturating_sub(current_line_start);
+    let original_column = snapped_byte_pos.saturating_sub(current_line_start);
     apply_column_offset(
         target_line_start.saturating_add(original_column),
         col_offset,
@@ -320,6 +322,17 @@ mod tests {
             apply_offset_to_position(text, 2, 1, 1),
             8,
             "row offsets should apply column deltas relative to the original column"
+        );
+    }
+
+    #[test]
+    fn test_apply_offset_to_position_out_of_bounds_uses_clamped_column() {
+        let text = "a\nb";
+
+        assert_eq!(
+            apply_offset_to_position(text, usize::MAX, 1, 0),
+            text.len(),
+            "stale out-of-bounds byte positions should not produce huge columns"
         );
     }
 

--- a/src/language/query_loader.rs
+++ b/src/language/query_loader.rs
@@ -168,7 +168,7 @@ impl QueryLoader {
         let first_line = content.lines().next().unwrap_or("");
         if let Some(rest) = first_line.strip_prefix(INHERITS_DIRECTIVE_PREFIX) {
             rest.split(',')
-                .map(|s| s.trim().to_string())
+                .map(|s| normalize_inherited_language_name(s.trim()))
                 .filter(|s| !s.is_empty())
                 .collect()
         } else {
@@ -410,6 +410,14 @@ impl QueryLoader {
     }
 }
 
+fn normalize_inherited_language_name(name: &str) -> String {
+    name.strip_prefix('(')
+        .and_then(|name| name.strip_suffix(')'))
+        .unwrap_or(name)
+        .trim()
+        .to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -543,6 +551,13 @@ mod tests {
         let result = QueryLoader::load_content_from_paths(&paths).unwrap();
         assert!(result.contains("(identifier) @variable"));
         assert!(result.contains("(string) @string"));
+    }
+
+    #[test]
+    fn parse_inherits_directive_strips_parenthesized_language_names() {
+        let parents = QueryLoader::parse_inherits_directive("; inherits: c, (cpp), (cuda)\n");
+
+        assert_eq!(parents, vec!["c", "cpp", "cuda"]);
     }
 
     /// Create a directory with non-UTF-8 bytes in its name under the given temp dir.

--- a/src/language/query_predicates.rs
+++ b/src/language/query_predicates.rs
@@ -115,7 +115,8 @@ pub(crate) fn check_predicate(
 /// rejects the whole match.
 ///
 /// Aggregation per operator mirrors Neovim's handlers:
-/// - `lua-match?` / `contains?`: ALL nodes of the capture must satisfy;
+/// - `lua-match?`: ALL nodes of the capture must satisfy;
+/// - `contains?`: ANY node of the capture must satisfy;
 /// - `has-parent?` / `has-ancestor?`: ANY node suffices;
 /// - a capture with no nodes is vacuously true;
 /// - unknown operators (including the unimplemented `any-*` family) are
@@ -155,8 +156,9 @@ pub(crate) fn check_match_predicates(query: &Query, match_: &QueryMatch, text: &
         let aggregate = match operator {
             "lua-match?" => nodes()
                 .all(|n| node_text(n).is_none_or(|t| check_lua_match(predicate.args.get(1), t))),
-            "contains?" => nodes()
-                .all(|n| node_text(n).is_none_or(|t| check_contains(&predicate.args[1..], t))),
+            "contains?" => any_or_vacuously_true(nodes(), |n| {
+                node_text(n).is_none_or(|t| check_contains(&predicate.args[1..], t))
+            }),
             // Neovim: vacuously true with no nodes, otherwise ANY node hit.
             "has-parent?" => {
                 any_or_vacuously_true(nodes(), |n| check_has_parent(&predicate.args[1..], n))
@@ -277,17 +279,19 @@ fn compile_lua_regex(pattern_str: &str) -> Option<Regex> {
     }
 }
 
-/// Check contains? predicate - returns true if ALL string args are substrings of node_text.
+/// Check contains? predicate - returns true if ANY string arg is a substring of node_text.
 ///
 /// Non-string args (captures) are skipped permissively — they don't affect the result.
-/// Zero string args yields true (vacuous truth via `Iterator::all`).
+/// Zero string args yields true, matching the previous permissive behavior for malformed queries.
 fn check_contains(args: &[tree_sitter::QueryPredicateArg], node_text: &str) -> bool {
-    args.iter().all(|arg| {
-        let tree_sitter::QueryPredicateArg::String(s) = arg else {
-            return true; // Skip non-string args (permissive)
-        };
-        node_text.contains(s.as_ref())
-    })
+    let mut string_args = args.iter().filter_map(|arg| match arg {
+        tree_sitter::QueryPredicateArg::String(s) => Some(s.as_ref()),
+        _ => None,
+    });
+    match string_args.next() {
+        None => true,
+        Some(first) => node_text.contains(first) || string_args.any(|s| node_text.contains(s)),
+    }
 }
 
 /// Check has-parent? predicate - returns true if direct parent's kind matches ANY string arg
@@ -504,8 +508,42 @@ mod tests {
         let results = collect_filtered_captures(source_code, query_str);
 
         assert!(results.contains(&"foobar".to_string()));
-        assert!(!results.contains(&"foo".to_string()));
-        assert!(!results.contains(&"bar".to_string()));
+        assert!(results.contains(&"foo".to_string()));
+        assert!(results.contains(&"bar".to_string()));
+    }
+
+    #[test]
+    fn contains_match_predicate_accepts_any_quantified_capture_node() {
+        let source_code = "fn target(foo: i32, baz: i32) {}";
+        let mut parser = Parser::new();
+        let language = tree_sitter_rust::LANGUAGE.into();
+        parser.set_language(&language).unwrap();
+        let tree = parser.parse(source_code, None).unwrap();
+        let root_node = tree.root_node();
+
+        let query = Query::new(
+            &language,
+            r#"
+            ((function_item
+                parameters: (parameters
+                  (parameter pattern: (identifier) @param)+))
+             (#contains? @param "foo"))
+            "#,
+        )
+        .unwrap();
+        let mut cursor = QueryCursor::new();
+        let mut matches = cursor.matches(&query, root_node, source_code.as_bytes());
+        let mut accepted = 0;
+        while let Some(match_) = matches.next() {
+            if check_match_predicates(&query, match_, source_code) {
+                accepted += 1;
+            }
+        }
+
+        assert_eq!(
+            accepted, 1,
+            "#contains? should accept when any node of a quantified capture contains an argument"
+        );
     }
 
     #[test]

--- a/src/language/query_predicates.rs
+++ b/src/language/query_predicates.rs
@@ -149,15 +149,16 @@ pub(crate) fn check_match_predicates(query: &Query, match_: &QueryMatch, text: &
                 .filter(|c| Some(c.index) == capture_id)
                 .map(|c| c.node)
         };
-        // A node whose span doesn't slice as UTF-8 passes its check
-        // permissively, matching check_predicate's unreadable-text skip.
+        // A node whose span doesn't slice as UTF-8 cannot satisfy positive
+        // ANY predicates like #contains?: otherwise one stale capture would
+        // make the whole match pass.
         let node_text = |node: tree_sitter::Node| text.get(node.start_byte()..node.end_byte());
 
         let aggregate = match operator {
             "lua-match?" => nodes()
                 .all(|n| node_text(n).is_none_or(|t| check_lua_match(predicate.args.get(1), t))),
             "contains?" => any_or_vacuously_true(nodes(), |n| {
-                node_text(n).is_none_or(|t| check_contains(&predicate.args[1..], t))
+                node_text(n).is_some_and(|t| check_contains(&predicate.args[1..], t))
             }),
             // Neovim: vacuously true with no nodes, otherwise ANY node hit.
             "has-parent?" => {
@@ -543,6 +544,34 @@ mod tests {
         assert_eq!(
             accepted, 1,
             "#contains? should accept when any node of a quantified capture contains an argument"
+        );
+    }
+
+    #[test]
+    fn contains_match_predicate_rejects_unreadable_capture_node() {
+        let source_code = "fn target(foo: i32) {}";
+        let mut parser = Parser::new();
+        let language = tree_sitter_rust::LANGUAGE.into();
+        parser.set_language(&language).unwrap();
+        let tree = parser.parse(source_code, None).unwrap();
+        let root_node = tree.root_node();
+
+        let query = Query::new(
+            &language,
+            r#"
+            ((function_item
+                name: (identifier) @name)
+             (#contains? @name "target"))
+            "#,
+        )
+        .unwrap();
+        let mut cursor = QueryCursor::new();
+        let mut matches = cursor.matches(&query, root_node, source_code.as_bytes());
+        let match_ = matches.next().expect("query should match the parsed tree");
+
+        assert!(
+            !check_match_predicates(&query, match_, "x"),
+            "a stale capture whose byte span is unreadable must not satisfy #contains?"
         );
     }
 

--- a/src/language/query_predicates.rs
+++ b/src/language/query_predicates.rs
@@ -153,19 +153,20 @@ pub(crate) fn check_match_predicates(query: &Query, match_: &QueryMatch, text: &
         // ANY predicates like #contains?: otherwise one stale capture would
         // make the whole match pass.
         let node_text = |node: tree_sitter::Node| text.get(node.start_byte()..node.end_byte());
+        let predicate_tail = predicate.args.get(1..).unwrap_or(&[]);
 
         let aggregate = match operator {
             "lua-match?" => nodes()
                 .all(|n| node_text(n).is_none_or(|t| check_lua_match(predicate.args.get(1), t))),
             "contains?" => any_or_vacuously_true(nodes(), |n| {
-                node_text(n).is_some_and(|t| check_contains(&predicate.args[1..], t))
+                node_text(n).is_some_and(|t| check_contains(predicate_tail, t))
             }),
             // Neovim: vacuously true with no nodes, otherwise ANY node hit.
             "has-parent?" => {
-                any_or_vacuously_true(nodes(), |n| check_has_parent(&predicate.args[1..], n))
+                any_or_vacuously_true(nodes(), |n| check_has_parent(predicate_tail, n))
             }
             "has-ancestor?" => {
-                any_or_vacuously_true(nodes(), |n| check_has_ancestor(&predicate.args[1..], n))
+                any_or_vacuously_true(nodes(), |n| check_has_ancestor(predicate_tail, n))
             }
             unknown => {
                 log::debug!(
@@ -573,6 +574,15 @@ mod tests {
             !check_match_predicates(&query, match_, "x"),
             "a stale capture whose byte span is unreadable must not satisfy #contains?"
         );
+    }
+
+    #[test]
+    fn contains_match_predicate_zero_args_does_not_panic() {
+        let source_code = "fn target() {}";
+        let results =
+            collect_filtered_captures(source_code, r#"((identifier) @name (#contains?))"#);
+
+        assert!(results.contains(&"target".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- align `#contains?` with nvim-treesitter OR/ANY semantics
- strip parenthesized `; inherits:` language names such as `(cpp)`
- apply `#offset!` row movement column deltas relative to the original column

Fixes #599

## Verification
- cargo test contains --lib -- --nocapture
- cargo test parse_inherits_directive_strips_parenthesized_language_names --lib -- --nocapture
- cargo test test_apply_offset_to_position_row_offset_preserves_original_column --lib -- --nocapture
- make check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved position/offset calculations to prevent overflow, preserve column behavior across row+column moves, and clamp out-of-range/negative results consistently.
  * Updated `#contains?` matching so it succeeds when **any** node in a capture satisfies the substring rule (including quantified captures).
  * Revised multiple-argument `#contains?` so success occurs if the text contains **any** provided string.
* **Language Support**
  * Improved `inherits` handling: inherited language names wrapped in parentheses (e.g., `(cpp)`) are now normalized correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->