### PR TITLE
fix(bridge): fail closed on prefix-breaking WorkspaceEdits in prefixed regions

### DIFF
--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -71,6 +71,7 @@ pub(crate) use protocol::strip_bridge_local_versions;
 pub(crate) use protocol::transform_workspace_edit_to_host;
 pub(crate) use protocol::translate_virtual_range_to_host;
 pub(crate) use protocol::workspace_edit_has_effect;
+pub(crate) use protocol::workspace_edit_preserves_line_prefixes;
 pub(crate) use protocol::workspace_edit_within_region;
 pub(crate) use text_document::host::{HostDocument, HostTextReader, normalize_host_goto_result};
 pub(crate) use text_document::{

--- a/src/lsp/bridge/protocol.rs
+++ b/src/lsp/bridge/protocol.rs
@@ -39,6 +39,7 @@ pub(crate) use response::*;
 pub(crate) use translation::*;
 pub(crate) use virtual_uri::VirtualDocumentUri;
 pub(crate) use workspace_edit::{
-    strip_bridge_local_versions, transform_workspace_edit_to_host, workspace_edit_has_effect,
-    workspace_edit_preserves_line_prefixes, workspace_edit_within_region,
+    region_host_end, strip_bridge_local_versions, transform_workspace_edit_to_host,
+    workspace_edit_has_effect, workspace_edit_preserves_line_prefixes,
+    workspace_edit_within_region,
 };

--- a/src/lsp/bridge/protocol.rs
+++ b/src/lsp/bridge/protocol.rs
@@ -40,5 +40,5 @@ pub(crate) use translation::*;
 pub(crate) use virtual_uri::VirtualDocumentUri;
 pub(crate) use workspace_edit::{
     strip_bridge_local_versions, transform_workspace_edit_to_host, workspace_edit_has_effect,
-    workspace_edit_within_region,
+    workspace_edit_preserves_line_prefixes, workspace_edit_within_region,
 };

--- a/src/lsp/bridge/protocol/translation.rs
+++ b/src/lsp/bridge/protocol/translation.rs
@@ -15,7 +15,11 @@ use tower_lsp_server::ls_types::{Position, Range};
 /// virtual line 0 gets `start_column`, line 1+ gets `0` (via fallback).
 ///
 /// For blockquoted injections, `columns` has one entry per virtual line,
-/// each representing the width of the blockquote prefix (e.g., `> ` = 2).
+/// each representing the width of the blockquote prefix (e.g., `> ` = 2) —
+/// plus, when the content ends with a newline, a trailing `0` entry for the
+/// row where the included ranges end (the closing-fence line). That row's
+/// real prefix is unrecorded; `workspace_edit_preserves_line_prefixes`
+/// derives its boundary semantics from the region end instead.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RegionOffset {
     /// The starting line of the injection region in the host document.

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -350,6 +350,12 @@ pub(crate) fn workspace_edit_preserves_line_prefixes(
     // closed-fence row, so the guard stays fail-closed there — rejecting a
     // boundary-touching edit in a transient malformed construct is acceptable,
     // corrupting a well-formed one is not.
+    // Fast path: a region with no prefixes anywhere (plain fenced blocks —
+    // the common case) can't have anything stripped; skip the per-edit line
+    // scans entirely.
+    if columns.iter().all(|&column| column == 0) {
+        return true;
+    }
     let content_prefixed = columns.len() > 1 && columns.iter().any(|&column| column > 0);
     let boundary_at = |host_line: u32| {
         content_prefixed && region_end.character == 0 && host_line >= region_end.line
@@ -369,8 +375,18 @@ pub(crate) fn workspace_edit_preserves_line_prefixes(
         // end.line at character 0 still counts as spanned — deliberately
         // conservative (REJECT, never clamp): deleting up to (end, 0) removes
         // the previous line's newline and merges the prefixed line upward.
-        let spans_prefixed_line =
-            end.line > start.line && (start.line.saturating_add(1)..=end.line).any(prefix_at);
+        //
+        // The scan is CLAMPED to the explicit per-line array: every line past
+        // it classifies via `boundary_at`, which is monotone in the line
+        // number, so the range's largest line (`end.line`) decides for all of
+        // them — the scan is O(columns.len()), never O(end.line), even for a
+        // malformed edit claiming a huge range.
+        let last_explicit = offset
+            .line()
+            .saturating_add((columns.len() as u32).saturating_sub(1));
+        let spans_prefixed_line = end.line > start.line
+            && ((start.line.saturating_add(1)..=end.line.min(last_explicit)).any(prefix_at)
+                || boundary_at(end.line));
         // Single-element MULTI-LINE regions are exempt from the newline check:
         // later lines are designed unprefixed and line 0's region content runs
         // to end-of-line, so an inserted newline splits nothing. For a

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -773,6 +773,91 @@ mod tests {
     }
 
     #[test]
+    fn preserves_line_prefixes_rejects_insertion_when_only_the_next_line_is_prefixed() {
+        let host_uri = make_host_uri();
+        // Start line unprefixed, the FOLLOWING line prefixed (lazy-continuation
+        // first line): an inserted newline puts the new unprefixed line into a
+        // prefixed neighborhood. Pins the second disjunct of the insertion
+        // check — prefix_at(start.line) alone would let this through.
+        let offset = RegionOffset::with_per_line_offsets(3, vec![0, 2]);
+        let edit = parse_workspace_edit(json!({
+            "changes": { host_uri.as_str(): [
+                { "range": {"start": {"line": 3, "character": 1}, "end": {"line": 3, "character": 1}},
+                  "newText": "a\nb" }
+            ] }
+        }));
+
+        assert!(!workspace_edit_preserves_line_prefixes(
+            &edit, &host_uri, &offset
+        ));
+    }
+
+    #[test]
+    fn preserves_line_prefixes_rejects_span_when_only_the_end_line_is_prefixed() {
+        let host_uri = make_host_uri();
+        // Interior line unprefixed, END line prefixed: the range's tail eats
+        // the end line's prefix. Pins the `..=end.line` inclusivity — an
+        // exclusive range would miss it. Deletion-only (empty newText) shows
+        // the span check is independent of the replacement text.
+        let offset = RegionOffset::with_per_line_offsets(3, vec![0, 0, 2]);
+        let edit = parse_workspace_edit(json!({
+            "changes": { host_uri.as_str(): [
+                { "range": {"start": {"line": 3, "character": 0}, "end": {"line": 5, "character": 1}},
+                  "newText": "" }
+            ] }
+        }));
+
+        assert!(!workspace_edit_preserves_line_prefixes(
+            &edit, &host_uri, &offset
+        ));
+    }
+
+    #[test]
+    fn preserves_line_prefixes_checks_annotated_document_changes_operations() {
+        use tower_lsp_server::ls_types::{
+            AnnotatedTextEdit, OptionalVersionedTextDocumentIdentifier, Range, TextDocumentEdit,
+        };
+
+        let host_uri = make_host_uri();
+        let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2]);
+        // Typed construction: serde's untagged OneOf never parses Right from
+        // JSON (annotationId is silently dropped), so exercise the annotated
+        // arm and the Operations arm of the shared walk in code. A newline-
+        // bearing annotated edit in a prefixed region must be rejected.
+        let edit = WorkspaceEdit {
+            document_changes: Some(DocumentChanges::Operations(vec![
+                DocumentChangeOperation::Edit(TextDocumentEdit {
+                    text_document: OptionalVersionedTextDocumentIdentifier {
+                        uri: host_uri.clone(),
+                        version: None,
+                    },
+                    edits: vec![OneOf::Right(AnnotatedTextEdit {
+                        text_edit: TextEdit {
+                            range: Range {
+                                start: Position {
+                                    line: 3,
+                                    character: 2,
+                                },
+                                end: Position {
+                                    line: 3,
+                                    character: 2,
+                                },
+                            },
+                            new_text: "a\nb".to_string(),
+                        },
+                        annotation_id: "refactor".to_string(),
+                    })],
+                }),
+            ])),
+            ..Default::default()
+        };
+
+        assert!(!workspace_edit_preserves_line_prefixes(
+            &edit, &host_uri, &offset
+        ));
+    }
+
+    #[test]
     fn within_region_bounds_the_host_uri_edits_only() {
         let host_uri = make_host_uri();
         // A 2-line BLOCKQUOTE region: starts at host line 3, and every line has a

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -316,6 +316,7 @@ pub(crate) fn workspace_edit_preserves_line_prefixes(
     edit: &WorkspaceEdit,
     host_uri: &Uri,
     offset: &RegionOffset,
+    region_end: Position,
 ) -> bool {
     let columns = offset.columns();
     // Per-line arrays (the blockquote shape from `compute_line_column_offsets`)
@@ -327,6 +328,12 @@ pub(crate) fn workspace_edit_preserves_line_prefixes(
     // as the prefixed BOUNDARY. Single-element arrays are the non-blockquote
     // fallback whose later lines are designed unprefixed (see `RegionOffset`),
     // so they get no boundary semantics.
+    //
+    // A trailing zero can also be the EOF row of an UNCLOSED blockquote fence
+    // (no closing line exists); `columns` alone cannot distinguish that from
+    // the closed-fence row, so the guard stays fail-closed there — rejecting a
+    // boundary-touching edit in a transient malformed construct is acceptable,
+    // corrupting a well-formed one is not.
     let content_prefixed = columns.len() > 1 && columns.iter().any(|&column| column > 0);
     let boundary_at = |host_line: u32| {
         content_prefixed
@@ -352,7 +359,15 @@ pub(crate) fn workspace_edit_preserves_line_prefixes(
         // the previous line's newline and merges the prefixed line upward.
         let spans_prefixed_line =
             end.line > start.line && (start.line.saturating_add(1)..=end.line).any(prefix_at);
-        let inserts_unprefixed_line = e.new_text.contains(['\n', '\r'])
+        // Single-element MULTI-LINE regions are exempt from the newline check:
+        // later lines are designed unprefixed and line 0's region content runs
+        // to end-of-line, so an inserted newline splits nothing. For a
+        // SINGLE-LINE region (region end on the start line — e.g. inline code)
+        // the host line continues past the region and a newline would split
+        // it, so line 0's offset still rejects there.
+        let newline_splits_nothing = columns.len() == 1 && region_end.line > offset.line();
+        let inserts_unprefixed_line = !newline_splits_nothing
+            && e.new_text.contains(['\n', '\r'])
             && (prefix_at(start.line) || prefix_at(start.line.saturating_add(1)));
         !touches_boundary && !spans_prefixed_line && !inserts_unprefixed_line
     })
@@ -665,7 +680,13 @@ mod tests {
         }));
 
         assert!(!workspace_edit_preserves_line_prefixes(
-            &edit, &host_uri, &offset
+            &edit,
+            &host_uri,
+            &offset,
+            Position {
+                line: 5,
+                character: 8,
+            },
         ));
     }
 
@@ -683,8 +704,15 @@ mod tests {
             ] }
         }));
 
+        // Single-LINE region: the region end sits on the start line.
         assert!(!workspace_edit_preserves_line_prefixes(
-            &edit, &host_uri, &offset
+            &edit,
+            &host_uri,
+            &offset,
+            Position {
+                line: 3,
+                character: 6,
+            },
         ));
     }
 
@@ -717,7 +745,13 @@ mod tests {
         }));
 
         assert!(!workspace_edit_preserves_line_prefixes(
-            &edit, &host_uri, &offset
+            &edit,
+            &host_uri,
+            &offset,
+            Position {
+                line: fence_line,
+                character: 0,
+            },
         ));
     }
 
@@ -738,7 +772,38 @@ mod tests {
         }));
 
         assert!(!workspace_edit_preserves_line_prefixes(
-            &edit, &host_uri, &offset
+            &edit,
+            &host_uri,
+            &offset,
+            Position {
+                line: 5,
+                character: 0,
+            },
+        ));
+    }
+
+    #[test]
+    fn preserves_line_prefixes_allows_newline_insertion_in_multi_line_single_element_region() {
+        let host_uri = make_host_uri();
+        // Production single-element shape over a MULTI-LINE region: later
+        // lines are designed unprefixed, and line 0's region content runs to
+        // end-of-line (the region continues on the next host line), so a
+        // newline-bearing replacement starting on line 0 splits nothing and
+        // its continuation lines correctly land at column 0.
+        let offset = RegionOffset::new(3, 4);
+        let region_end = Position {
+            line: 5,
+            character: 2,
+        };
+        let edit = parse_workspace_edit(json!({
+            "changes": { host_uri.as_str(): [
+                { "range": {"start": {"line": 3, "character": 4}, "end": {"line": 3, "character": 6}},
+                  "newText": "x\ny" }
+            ] }
+        }));
+
+        assert!(workspace_edit_preserves_line_prefixes(
+            &edit, &host_uri, &offset, region_end
         ));
     }
 
@@ -755,8 +820,15 @@ mod tests {
             ] }
         }));
 
+        // Single-LINE region, like the \n sibling above.
         assert!(!workspace_edit_preserves_line_prefixes(
-            &edit, &host_uri, &offset
+            &edit,
+            &host_uri,
+            &offset,
+            Position {
+                line: 3,
+                character: 6,
+            },
         ));
     }
 
@@ -775,7 +847,13 @@ mod tests {
         }));
 
         assert!(workspace_edit_preserves_line_prefixes(
-            &edit, &host_uri, &offset
+            &edit,
+            &host_uri,
+            &offset,
+            Position {
+                line: 6,
+                character: 0,
+            },
         ));
     }
 
@@ -793,7 +871,13 @@ mod tests {
         }));
 
         assert!(workspace_edit_preserves_line_prefixes(
-            &edit, &host_uri, &offset
+            &edit,
+            &host_uri,
+            &offset,
+            Position {
+                line: 4,
+                character: 9,
+            },
         ));
     }
 
@@ -815,7 +899,13 @@ mod tests {
         }));
 
         assert!(workspace_edit_preserves_line_prefixes(
-            &edit, &host_uri, &offset
+            &edit,
+            &host_uri,
+            &offset,
+            Position {
+                line: 5,
+                character: 2,
+            },
         ));
     }
 
@@ -835,7 +925,13 @@ mod tests {
         }));
 
         assert!(!workspace_edit_preserves_line_prefixes(
-            &edit, &host_uri, &offset
+            &edit,
+            &host_uri,
+            &offset,
+            Position {
+                line: 4,
+                character: 9,
+            },
         ));
     }
 
@@ -855,7 +951,13 @@ mod tests {
         }));
 
         assert!(!workspace_edit_preserves_line_prefixes(
-            &edit, &host_uri, &offset
+            &edit,
+            &host_uri,
+            &offset,
+            Position {
+                line: 5,
+                character: 9,
+            },
         ));
     }
 
@@ -900,7 +1002,13 @@ mod tests {
         };
 
         assert!(!workspace_edit_preserves_line_prefixes(
-            &edit, &host_uri, &offset
+            &edit,
+            &host_uri,
+            &offset,
+            Position {
+                line: 4,
+                character: 9,
+            },
         ));
     }
 

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -6,9 +6,8 @@
 //! map) or `documentChanges`; both are handled.
 //!
 //! The guards below ([`workspace_edit_within_region`],
-//! [`workspace_edit_preserves_line_prefixes`]) are enforced by codeAction and
-//! applyEdit; rename still calls the bare transform and adopts both guards in
-//! a follow-up PR.
+//! [`workspace_edit_preserves_line_prefixes`]) are enforced by codeAction,
+//! rename, and applyEdit.
 
 use std::collections::HashMap;
 
@@ -365,7 +364,7 @@ pub(crate) fn workspace_edit_preserves_line_prefixes(
         // it, so line 0's offset still rejects there.
         let newline_splits_nothing = columns.len() == 1 && region_end.line > offset.line();
         let inserts_unprefixed_line = !newline_splits_nothing
-            && e.new_text.contains(['\n', '\r'])
+            && (e.new_text.contains('\n') || e.new_text.contains('\r'))
             && (prefix_at(start.line) || prefix_at(start.line.saturating_add(1)));
         !touches_boundary && !spans_prefixed_line && !inserts_unprefixed_line
     })

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -8,8 +8,8 @@
 use std::collections::HashMap;
 
 use tower_lsp_server::ls_types::{
-    AnnotatedTextEdit, DocumentChangeOperation, DocumentChanges, OneOf, Position, Range,
-    ResourceOp, TextDocumentEdit, TextEdit, Uri, WorkspaceEdit,
+    AnnotatedTextEdit, DocumentChangeOperation, DocumentChanges, OneOf, Position, ResourceOp,
+    TextDocumentEdit, TextEdit, Uri, WorkspaceEdit,
 };
 
 use super::translation::{RegionOffset, translate_virtual_range_to_host};
@@ -279,6 +279,47 @@ pub(crate) fn workspace_edit_within_region(
     };
     host_uri_text_edits_all(edit, host_uri, |e| {
         in_region(e.range.start) && in_region(e.range.end)
+    })
+}
+
+/// Whether every text edit targeting `host_uri` keeps the region's per-line
+/// host prefixes (e.g. a blockquote's `> ` on every line) intact.
+///
+/// The virtual→host transform translates RANGES but emits `newText` verbatim
+/// — nothing re-inserts host line prefixes into replacement text. Two edit
+/// shapes would therefore strip or omit prefixes and structurally corrupt the
+/// host document (a broken blockquote un-fences the injected block):
+/// - a MULTI-LINE range: the host range legitimately contains the interior/end
+///   lines' prefixes, so replacing it deletes them. Unsafe iff any line after
+///   the start line carries a non-zero prefix.
+/// - a `newText` containing a NEWLINE: the inserted lines carry no prefix.
+///   Unsafe iff the insertion point's neighborhood is prefixed (the start line
+///   or the one after it has a non-zero prefix — a single-line inline/
+///   blockquote region has no line after, so the start line's own offset is
+///   the only signal there).
+///
+/// Plain fenced blocks (all-zero column offsets) are unaffected: every edit is
+/// prefix-safe there, which keeps the common case (whole-block refactors like
+/// organize-imports) working. Callers must REJECT unsafe edits, never clamp —
+/// same contract as [`workspace_edit_within_region`]. Positions outside the
+/// region are this predicate's don't-care (the region bound rejects them).
+pub(crate) fn workspace_edit_preserves_line_prefixes(
+    edit: &WorkspaceEdit,
+    host_uri: &Uri,
+    offset: &RegionOffset,
+) -> bool {
+    let prefix_at = |host_line: u32| {
+        host_line
+            .checked_sub(offset.line())
+            .is_some_and(|virtual_line| offset.column_for_line(virtual_line) > 0)
+    };
+    host_uri_text_edits_all(edit, host_uri, |e| {
+        let (start, end) = (e.range.start, e.range.end);
+        let spans_prefixed_line =
+            end.line > start.line && (start.line.saturating_add(1)..=end.line).any(&prefix_at);
+        let inserts_unprefixed_line = e.new_text.contains('\n')
+            && (prefix_at(start.line) || prefix_at(start.line.saturating_add(1)));
+        !spans_prefixed_line && !inserts_unprefixed_line
     })
 }
 
@@ -569,6 +610,104 @@ mod tests {
             }
             DocumentChanges::Operations(_) => panic!("Expected Edits variant"),
         }
+    }
+
+    #[test]
+    fn preserves_line_prefixes_rejects_multi_line_edit_spanning_prefixed_lines() {
+        let host_uri = make_host_uri();
+        // A 3-line BLOCKQUOTE region starting at host line 3: every line's
+        // injected content sits behind a `> ` prefix (width 2).
+        let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2, 2]);
+        // A downstream multi-line replacement (host lines 3-5). The host range
+        // legitimately contains lines 4 and 5's `> ` prefixes, but the verbatim
+        // newText carries no prefixes — applying it would strip them and break
+        // the blockquote.
+        let edit = parse_workspace_edit(json!({
+            "changes": { host_uri.as_str(): [
+                { "range": {"start": {"line": 3, "character": 2}, "end": {"line": 5, "character": 6}},
+                  "newText": "import a\nimport b" }
+            ] }
+        }));
+
+        assert!(!workspace_edit_preserves_line_prefixes(
+            &edit, &host_uri, &offset
+        ));
+    }
+
+    #[test]
+    fn preserves_line_prefixes_rejects_newline_insertion_in_prefixed_region() {
+        let host_uri = make_host_uri();
+        // Single-line blockquote region: `> code` at host line 3, prefix width 2.
+        let offset = RegionOffset::with_per_line_offsets(3, vec![2]);
+        // Inserting a newline splits the host line; the continuation line has
+        // no `> ` prefix, so the blockquote breaks.
+        let edit = parse_workspace_edit(json!({
+            "changes": { host_uri.as_str(): [
+                { "range": {"start": {"line": 3, "character": 4}, "end": {"line": 3, "character": 4}},
+                  "newText": "a\nb" }
+            ] }
+        }));
+
+        assert!(!workspace_edit_preserves_line_prefixes(
+            &edit, &host_uri, &offset
+        ));
+    }
+
+    #[test]
+    fn preserves_line_prefixes_allows_edits_in_unprefixed_fence() {
+        let host_uri = make_host_uri();
+        // Plain fenced block: content starts at column 0 on every line.
+        let offset = RegionOffset::new(3, 0);
+        // Whole-block multi-line replacement with newlines — the
+        // organize-imports shape. Nothing to corrupt; must stay allowed.
+        let edit = parse_workspace_edit(json!({
+            "changes": { host_uri.as_str(): [
+                { "range": {"start": {"line": 3, "character": 0}, "end": {"line": 6, "character": 0}},
+                  "newText": "import a\nimport b\n" }
+            ] }
+        }));
+
+        assert!(workspace_edit_preserves_line_prefixes(
+            &edit, &host_uri, &offset
+        ));
+    }
+
+    #[test]
+    fn preserves_line_prefixes_allows_single_line_edit_in_prefixed_region() {
+        let host_uri = make_host_uri();
+        let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2]);
+        // A rename-shaped single-line replacement behind the prefix: the
+        // prefix is outside the range and no line structure changes.
+        let edit = parse_workspace_edit(json!({
+            "changes": { host_uri.as_str(): [
+                { "range": {"start": {"line": 4, "character": 2}, "end": {"line": 4, "character": 7}},
+                  "newText": "renamed" }
+            ] }
+        }));
+
+        assert!(workspace_edit_preserves_line_prefixes(
+            &edit, &host_uri, &offset
+        ));
+    }
+
+    #[test]
+    fn preserves_line_prefixes_allows_multi_line_edit_over_unprefixed_tail() {
+        let host_uri = make_host_uri();
+        // Only virtual line 0 has a column offset (inline-start region whose
+        // continuation lines begin at column 0): a multi-line edit STARTING
+        // there never deletes a prefix — line 0's offset sits before the range
+        // start, and the spanned lines carry none.
+        let offset = RegionOffset::new(3, 4);
+        let edit = parse_workspace_edit(json!({
+            "changes": { host_uri.as_str(): [
+                { "range": {"start": {"line": 3, "character": 4}, "end": {"line": 5, "character": 2}},
+                  "newText": "x" }
+            ] }
+        }));
+
+        assert!(workspace_edit_preserves_line_prefixes(
+            &edit, &host_uri, &offset
+        ));
     }
 
     #[test]

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -334,7 +334,7 @@ pub(crate) fn workspace_edit_preserves_line_prefixes(
         // the previous line's newline and merges the prefixed line upward.
         let spans_prefixed_line =
             end.line > start.line && (start.line.saturating_add(1)..=end.line).any(prefix_at);
-        let inserts_unprefixed_line = e.new_text.contains('\n')
+        let inserts_unprefixed_line = e.new_text.contains(['\n', '\r'])
             && (prefix_at(start.line) || prefix_at(start.line.saturating_add(1)));
         !spans_prefixed_line && !inserts_unprefixed_line
     })
@@ -686,6 +686,24 @@ mod tests {
             "changes": { host_uri.as_str(): [
                 { "range": {"start": {"line": 5, "character": 2}, "end": {"line": 6, "character": 0}},
                   "newText": "" }
+            ] }
+        }));
+
+        assert!(!workspace_edit_preserves_line_prefixes(
+            &edit, &host_uri, &offset
+        ));
+    }
+
+    #[test]
+    fn preserves_line_prefixes_rejects_lone_cr_newline_insertion() {
+        let host_uri = make_host_uri();
+        let offset = RegionOffset::with_per_line_offsets(3, vec![2]);
+        // LSP admits bare `\r` as an EOL: it inserts an unprefixed line just
+        // like `\n` and must be caught by the same guard.
+        let edit = parse_workspace_edit(json!({
+            "changes": { host_uri.as_str(): [
+                { "range": {"start": {"line": 3, "character": 4}, "end": {"line": 3, "character": 4}},
+                  "newText": "a\rb" }
             ] }
         }));
 

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -300,23 +300,40 @@ pub(crate) fn workspace_edit_within_region(
 ///
 /// Plain fenced blocks (all-zero column offsets) are unaffected: every edit is
 /// prefix-safe there, which keeps the common case (whole-block refactors like
-/// organize-imports) working. Callers must REJECT unsafe edits, never clamp —
-/// same contract as [`workspace_edit_within_region`]. Positions outside the
-/// region are this predicate's don't-care (the region bound rejects them).
+/// organize-imports) working. In a prefixed region, lines PAST the per-line
+/// array (the closing-fence boundary the region end still admits at column 0)
+/// count as prefixed — conservative, since that next host line does carry the
+/// prefix. Callers must REJECT unsafe edits, never clamp — same contract as
+/// [`workspace_edit_within_region`]. Positions ABOVE the region are this
+/// predicate's don't-care (the region bound rejects them).
 pub(crate) fn workspace_edit_preserves_line_prefixes(
     edit: &WorkspaceEdit,
     host_uri: &Uri,
     offset: &RegionOffset,
 ) -> bool {
+    // Lines past the columns array are NOT known-unprefixed: for a blockquote
+    // the array covers only the CONTENT lines, and the next host line is the
+    // prefixed closing fence (`> ```` ), which the region end (content end,
+    // column 0 of that line) lets an edit reach. Merging or inserting there
+    // must reject too, so in a prefixed region the out-of-array fallback is
+    // "prefixed" — conservative, never corrupting. All-zero regions (plain
+    // fences) keep the permissive fallback.
+    let region_prefixed = offset.columns().iter().any(|&column| column > 0);
     let prefix_at = |host_line: u32| {
-        host_line
-            .checked_sub(offset.line())
-            .is_some_and(|virtual_line| offset.column_for_line(virtual_line) > 0)
+        host_line.checked_sub(offset.line()).is_some_and(|v| {
+            match offset.columns().get(v as usize) {
+                Some(&column) => column > 0,
+                None => region_prefixed,
+            }
+        })
     };
     host_uri_text_edits_all(edit, host_uri, |e| {
         let (start, end) = (e.range.start, e.range.end);
+        // end.line at character 0 still counts as spanned — deliberately
+        // conservative (REJECT, never clamp): deleting up to (end, 0) removes
+        // the previous line's newline and merges the prefixed line upward.
         let spans_prefixed_line =
-            end.line > start.line && (start.line.saturating_add(1)..=end.line).any(&prefix_at);
+            end.line > start.line && (start.line.saturating_add(1)..=end.line).any(prefix_at);
         let inserts_unprefixed_line = e.new_text.contains('\n')
             && (prefix_at(start.line) || prefix_at(start.line.saturating_add(1)));
         !spans_prefixed_line && !inserts_unprefixed_line
@@ -654,6 +671,30 @@ mod tests {
     }
 
     #[test]
+    fn preserves_line_prefixes_rejects_edit_reaching_the_boundary_of_prefixed_region() {
+        let host_uri = make_host_uri();
+        // Blockquote region, content on host lines 3-5 (`columns` has one entry
+        // per CONTENT line). The line just past the array — host line 6 — is
+        // the closing `> ```` fence line. Content ends with a newline, so the
+        // region end is (6, 0) and edits may legally reach it.
+        let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2, 2]);
+        // "Delete the last line": host (5,2)-(6,0). Applying removes line 5's
+        // newline and merges the PREFIXED fence line up into `> `, yielding
+        // `> > ```` — structural corruption past the columns array. Must be
+        // rejected even though every touched line inside the array is handled.
+        let edit = parse_workspace_edit(json!({
+            "changes": { host_uri.as_str(): [
+                { "range": {"start": {"line": 5, "character": 2}, "end": {"line": 6, "character": 0}},
+                  "newText": "" }
+            ] }
+        }));
+
+        assert!(!workspace_edit_preserves_line_prefixes(
+            &edit, &host_uri, &offset
+        ));
+    }
+
+    #[test]
     fn preserves_line_prefixes_allows_edits_in_unprefixed_fence() {
         let host_uri = make_host_uri();
         // Plain fenced block: content starts at column 0 on every line.
@@ -693,11 +734,14 @@ mod tests {
     #[test]
     fn preserves_line_prefixes_allows_multi_line_edit_over_unprefixed_tail() {
         let host_uri = make_host_uri();
-        // Only virtual line 0 has a column offset (inline-start region whose
-        // continuation lines begin at column 0): a multi-line edit STARTING
-        // there never deletes a prefix — line 0's offset sits before the range
-        // start, and the spanned lines carry none.
-        let offset = RegionOffset::new(3, 4);
+        // Only virtual line 0 has a column offset; lines 1-2 are KNOWN
+        // unprefixed (explicit zero entries). A multi-line edit starting on
+        // line 0 never deletes a prefix — line 0's offset sits before the
+        // range start, and the spanned lines carry none. (A single-entry
+        // `columns` would leave the tail out-of-array, which in a prefixed
+        // region falls back to "prefixed" and rejects — see the boundary
+        // test.)
+        let offset = RegionOffset::with_per_line_offsets(3, vec![4, 0, 0]);
         let edit = parse_workspace_edit(json!({
             "changes": { host_uri.as_str(): [
                 { "range": {"start": {"line": 3, "character": 4}, "end": {"line": 5, "character": 2}},

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -319,28 +319,26 @@ pub(crate) fn workspace_edit_preserves_line_prefixes(
     region_end: Position,
 ) -> bool {
     let columns = offset.columns();
-    // Per-line arrays (the blockquote shape from `compute_line_column_offsets`)
-    // carry one entry per content line PLUS a trailing row where the included
-    // ranges end — column 0 of the closing-fence line. That row's recorded
-    // offset is 0 even though the host line carries the `> ` prefix, and the
-    // region end (content end) admits edits reaching it. So in a prefixed
-    // per-line region, a trailing zero entry and anything past the array count
-    // as the prefixed BOUNDARY. Single-element arrays are the non-blockquote
-    // fallback whose later lines are designed unprefixed (see `RegionOffset`),
-    // so they get no boundary semantics.
+    // In the per-line (blockquote) shape, content ending with a newline puts
+    // the region end at column 0 of the NEXT host row — the closing fence,
+    // whose recorded offset is 0 (`compute_line_column_offsets` leaves a
+    // trailing zero for the row where the included ranges end) even though the
+    // host line carries the `> ` prefix. That row is the prefixed BOUNDARY:
+    // derived from the region end, not the array shape, because a trailing
+    // zero entry can equally be a REAL unprefixed content row when an included
+    // gap ends mid-row (region end at a non-zero character — no boundary row
+    // is reachable then). Single-element arrays are the non-blockquote
+    // fallback whose closing fence carries no prefix, so no boundary
+    // semantics.
     //
-    // A trailing zero can also be the EOF row of an UNCLOSED blockquote fence
-    // (no closing line exists); `columns` alone cannot distinguish that from
-    // the closed-fence row, so the guard stays fail-closed there — rejecting a
+    // The boundary row can also be the EOF row of an UNCLOSED blockquote fence
+    // (no closing line exists); the offsets cannot distinguish that from the
+    // closed-fence row, so the guard stays fail-closed there — rejecting a
     // boundary-touching edit in a transient malformed construct is acceptable,
     // corrupting a well-formed one is not.
     let content_prefixed = columns.len() > 1 && columns.iter().any(|&column| column > 0);
     let boundary_at = |host_line: u32| {
-        content_prefixed
-            && host_line.checked_sub(offset.line()).is_some_and(|v| {
-                let v = v as usize;
-                v >= columns.len() - 1 && columns.get(v).copied().unwrap_or(0) == 0
-            })
+        content_prefixed && region_end.character == 0 && host_line >= region_end.line
     };
     let prefix_at = |host_line: u32| {
         boundary_at(host_line)
@@ -799,6 +797,32 @@ mod tests {
             "changes": { host_uri.as_str(): [
                 { "range": {"start": {"line": 3, "character": 4}, "end": {"line": 3, "character": 6}},
                   "newText": "x\ny" }
+            ] }
+        }));
+
+        assert!(workspace_edit_preserves_line_prefixes(
+            &edit, &host_uri, &offset, region_end
+        ));
+    }
+
+    #[test]
+    fn preserves_line_prefixes_allows_edit_on_trailing_zero_content_row() {
+        let host_uri = make_host_uri();
+        // A trailing zero entry is NOT always the closing-fence boundary:
+        // custom injection queries can produce an included gap that spans into
+        // a real second row and ends MID-row, yielding [start_column, 0] where
+        // row 1 is genuine unprefixed content. The region end then sits at a
+        // non-zero character on that row — no boundary row is reachable, and
+        // edits touching it must stay allowed.
+        let offset = RegionOffset::with_per_line_offsets(3, vec![4, 0]);
+        let region_end = Position {
+            line: 4,
+            character: 3,
+        };
+        let edit = parse_workspace_edit(json!({
+            "changes": { host_uri.as_str(): [
+                { "range": {"start": {"line": 4, "character": 0}, "end": {"line": 4, "character": 2}},
+                  "newText": "x" }
             ] }
         }));
 

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -305,35 +305,48 @@ pub(crate) fn workspace_edit_within_region(
 ///
 /// Plain fenced blocks (all-zero column offsets) are unaffected: every edit is
 /// prefix-safe there, which keeps the common case (whole-block refactors like
-/// organize-imports) working. In a prefixed region, lines PAST the per-line
-/// array (the closing-fence boundary the region end still admits at column 0)
-/// count as prefixed — conservative, since that next host line does carry the
-/// prefix. Callers must REJECT unsafe edits, never clamp — same contract as
-/// [`workspace_edit_within_region`]. Positions ABOVE the region are this
-/// predicate's don't-care (the region bound rejects them).
+/// organize-imports) working. In a prefixed per-line region, the closing-fence
+/// BOUNDARY row (recorded as a trailing zero entry, or falling past the array)
+/// counts as prefixed, and edits touching it are rejected outright — the row's
+/// real prefix is unrecorded, so even a no-newline insertion at its column 0
+/// would land before the `> `. Callers must REJECT unsafe edits, never clamp —
+/// same contract as [`workspace_edit_within_region`]. Positions ABOVE the
+/// region are this predicate's don't-care (the region bound rejects them).
 pub(crate) fn workspace_edit_preserves_line_prefixes(
     edit: &WorkspaceEdit,
     host_uri: &Uri,
     offset: &RegionOffset,
 ) -> bool {
-    // Lines past the columns array are NOT known-unprefixed: for a blockquote
-    // the array covers only the CONTENT lines, and the next host line is the
-    // prefixed closing fence (`> ```` ), which the region end (content end,
-    // column 0 of that line) lets an edit reach. Merging or inserting there
-    // must reject too, so in a prefixed region the out-of-array fallback is
-    // "prefixed" — conservative, never corrupting. All-zero regions (plain
-    // fences) keep the permissive fallback.
-    let region_prefixed = offset.columns().iter().any(|&column| column > 0);
+    let columns = offset.columns();
+    // Per-line arrays (the blockquote shape from `compute_line_column_offsets`)
+    // carry one entry per content line PLUS a trailing row where the included
+    // ranges end — column 0 of the closing-fence line. That row's recorded
+    // offset is 0 even though the host line carries the `> ` prefix, and the
+    // region end (content end) admits edits reaching it. So in a prefixed
+    // per-line region, a trailing zero entry and anything past the array count
+    // as the prefixed BOUNDARY. Single-element arrays are the non-blockquote
+    // fallback whose later lines are designed unprefixed (see `RegionOffset`),
+    // so they get no boundary semantics.
+    let content_prefixed = columns.len() > 1 && columns.iter().any(|&column| column > 0);
+    let boundary_at = |host_line: u32| {
+        content_prefixed
+            && host_line.checked_sub(offset.line()).is_some_and(|v| {
+                let v = v as usize;
+                v >= columns.len() - 1 && columns.get(v).copied().unwrap_or(0) == 0
+            })
+    };
     let prefix_at = |host_line: u32| {
-        host_line.checked_sub(offset.line()).is_some_and(|v| {
-            match offset.columns().get(v as usize) {
-                Some(&column) => column > 0,
-                None => region_prefixed,
-            }
-        })
+        boundary_at(host_line)
+            || host_line
+                .checked_sub(offset.line())
+                .is_some_and(|v| offset.column_for_line(v) > 0)
     };
     host_uri_text_edits_all(edit, host_uri, |e| {
         let (start, end) = (e.range.start, e.range.end);
+        // The boundary row's real prefix is unrecorded (0), so the per-line
+        // floor can't protect it: even a same-line, no-newline insertion at
+        // (fence, 0) lands before the `> `. Reject anything touching it.
+        let touches_boundary = boundary_at(start.line) || boundary_at(end.line);
         // end.line at character 0 still counts as spanned — deliberately
         // conservative (REJECT, never clamp): deleting up to (end, 0) removes
         // the previous line's newline and merges the prefixed line upward.
@@ -341,7 +354,7 @@ pub(crate) fn workspace_edit_preserves_line_prefixes(
             end.line > start.line && (start.line.saturating_add(1)..=end.line).any(prefix_at);
         let inserts_unprefixed_line = e.new_text.contains(['\n', '\r'])
             && (prefix_at(start.line) || prefix_at(start.line.saturating_add(1)));
-        !spans_prefixed_line && !inserts_unprefixed_line
+        !touches_boundary && !spans_prefixed_line && !inserts_unprefixed_line
     })
 }
 
@@ -675,22 +688,52 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn preserves_line_prefixes_rejects_edit_reaching_the_boundary_of_prefixed_region() {
+    #[rstest::rstest]
+    // The PRODUCTION blockquote shape: included ranges end at column 0 of the
+    // closing-fence line, so `compute_line_column_offsets` leaves a trailing
+    // EXPLICIT zero entry for that row — content on host lines 3-4, fence on
+    // host line 5 recorded as offset 0 despite its real `> ` prefix.
+    #[case::trailing_zero_entry(vec![2, 2, 0], 4, 5)]
+    // Defensive shape: no trailing artifact (content ends mid-line); the
+    // fence line falls PAST the array and must count as prefixed too.
+    #[case::past_the_array(vec![2, 2, 2], 5, 6)]
+    fn preserves_line_prefixes_rejects_edit_reaching_the_boundary_of_prefixed_region(
+        #[case] columns: Vec<u32>,
+        #[case] last_content_line: u32,
+        #[case] fence_line: u32,
+    ) {
         let host_uri = make_host_uri();
-        // Blockquote region, content on host lines 3-5 (`columns` has one entry
-        // per CONTENT line). The line just past the array — host line 6 — is
-        // the closing `> ```` fence line. Content ends with a newline, so the
-        // region end is (6, 0) and edits may legally reach it.
-        let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2, 2]);
-        // "Delete the last line": host (5,2)-(6,0). Applying removes line 5's
-        // newline and merges the PREFIXED fence line up into `> `, yielding
-        // `> > ```` — structural corruption past the columns array. Must be
-        // rejected even though every touched line inside the array is handled.
+        let offset = RegionOffset::with_per_line_offsets(3, columns);
+        // "Delete the last line": ends at (fence_line, 0), which the region
+        // end admits. Applying removes the previous line's newline and merges
+        // the PREFIXED fence line up into `> `, yielding `> > ```` —
+        // structural corruption at the boundary row.
         let edit = parse_workspace_edit(json!({
             "changes": { host_uri.as_str(): [
-                { "range": {"start": {"line": 5, "character": 2}, "end": {"line": 6, "character": 0}},
+                { "range": {"start": {"line": last_content_line, "character": 2},
+                            "end": {"line": fence_line, "character": 0}},
                   "newText": "" }
+            ] }
+        }));
+
+        assert!(!workspace_edit_preserves_line_prefixes(
+            &edit, &host_uri, &offset
+        ));
+    }
+
+    #[test]
+    fn preserves_line_prefixes_rejects_plain_insertion_on_the_boundary_row() {
+        let host_uri = make_host_uri();
+        // Production blockquote shape: trailing zero entry = the closing-fence
+        // row. A same-line, no-newline insertion at (5, 0) — which the region
+        // end admits and the per-line floor (recorded 0) lets through — would
+        // land BEFORE the fence line's `> `, producing `x> ````. No span, no
+        // newline: only boundary awareness catches it.
+        let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2, 0]);
+        let edit = parse_workspace_edit(json!({
+            "changes": { host_uri.as_str(): [
+                { "range": {"start": {"line": 5, "character": 0}, "end": {"line": 5, "character": 0}},
+                  "newText": "x" }
             ] }
         }));
 
@@ -757,14 +800,13 @@ mod tests {
     #[test]
     fn preserves_line_prefixes_allows_multi_line_edit_over_unprefixed_tail() {
         let host_uri = make_host_uri();
-        // Only virtual line 0 has a column offset; lines 1-2 are KNOWN
-        // unprefixed (explicit zero entries). A multi-line edit starting on
-        // line 0 never deletes a prefix — line 0's offset sits before the
-        // range start, and the spanned lines carry none. (A single-entry
-        // `columns` would leave the tail out-of-array, which in a prefixed
-        // region falls back to "prefixed" and rejects — see the boundary
-        // test.)
-        let offset = RegionOffset::with_per_line_offsets(3, vec![4, 0, 0]);
+        // The PRODUCTION non-blockquote shape (`vec![start_column]`): per the
+        // RegionOffset contract, lines past the first are DESIGNED unprefixed
+        // — a single-element array never means "blockquote", which always
+        // carries one entry per content line plus the trailing boundary row.
+        // A multi-line edit starting on line 0 never deletes a prefix: line
+        // 0's offset sits before the range start, and the tail carries none.
+        let offset = RegionOffset::new(3, 4);
         let edit = parse_workspace_edit(json!({
             "changes": { host_uri.as_str(): [
                 { "range": {"start": {"line": 3, "character": 4}, "end": {"line": 5, "character": 2}},

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -1,9 +1,14 @@
 //! WorkspaceEdit coordinate transformation from virtual to host documents.
 //!
-//! Shared by response paths that carry a `WorkspaceEdit` produced against a
-//! virtual document — rename today; codeAction and workspace/applyEdit will
-//! reuse it (#568). Per LSP spec a WorkspaceEdit may carry edits via `changes`
-//! (URI→TextEdit map) or `documentChanges`; both are handled.
+//! Shared by the response paths that carry a `WorkspaceEdit` produced against
+//! a virtual document: rename, codeAction, and workspace/applyEdit (#568).
+//! Per LSP spec a WorkspaceEdit may carry edits via `changes` (URI→TextEdit
+//! map) or `documentChanges`; both are handled.
+//!
+//! The guards below ([`workspace_edit_within_region`],
+//! [`workspace_edit_preserves_line_prefixes`]) are enforced by codeAction and
+//! applyEdit; rename still calls the bare transform and adopts both guards in
+//! a follow-up PR.
 
 use std::collections::HashMap;
 

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -356,7 +356,9 @@ pub(crate) fn workspace_edit_preserves_line_prefixes(
     if columns.iter().all(|&column| column == 0) {
         return true;
     }
-    let content_prefixed = columns.len() > 1 && columns.iter().any(|&column| column > 0);
+    // The all-zero fast path above guarantees SOME column is non-zero here,
+    // so only the shape distinction remains.
+    let content_prefixed = columns.len() > 1;
     let boundary_at = |host_line: u32| {
         content_prefixed && region_end.character == 0 && host_line >= region_end.line
     };

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -239,6 +239,21 @@ pub(crate) fn strip_bridge_local_versions(edit: &mut WorkspaceEdit) {
     }
 }
 
+/// The exclusive host-document end of an injection region: the position just
+/// past its `virtual_content`, mapped back to host coordinates — the
+/// position-precise (line AND column) upper bound for
+/// [`workspace_edit_within_region`].
+pub(crate) fn region_host_end(virtual_content: &str, offset: &RegionOffset) -> Position {
+    let mut end = crate::text::PositionMapper::new(virtual_content)
+        .byte_to_position(virtual_content.len())
+        .unwrap_or(Position {
+            line: 0,
+            character: 0,
+        });
+    super::translation::translate_virtual_position_to_host(&mut end, offset);
+    end
+}
+
 /// Whether every text edit targeting `host_uri` in a HOST-coordinate
 /// `WorkspaceEdit` is CONTAINED in the injection region — bounded above by
 /// `region_end` and below, PER LINE, by the region's line offset (`offset`).

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -277,27 +277,39 @@ pub(crate) fn workspace_edit_within_region(
             p.character >= offset.column_for_line(virtual_line) && !position_after(p, region_end)
         }
     };
-    let within = |range: Range| in_region(range.start) && in_region(range.end);
+    host_uri_text_edits_all(edit, host_uri, |e| {
+        in_region(e.range.start) && in_region(e.range.end)
+    })
+}
+
+/// Whether every text edit targeting `host_uri` (across both the `changes` map
+/// and `documentChanges`, unwrapping annotated edits) satisfies `pred`.
+/// Edits to other URIs are ignored; file operations carry no text edit.
+fn host_uri_text_edits_all(
+    edit: &WorkspaceEdit,
+    host_uri: &Uri,
+    pred: impl Fn(&TextEdit) -> bool,
+) -> bool {
     if let Some(changes) = &edit.changes
         && let Some(edits) = changes.get(host_uri)
-        && !edits.iter().all(|e| within(e.range))
+        && !edits.iter().all(&pred)
     {
         return false;
     }
-    let doc_edits_within = |edits: &[OneOf<TextEdit, AnnotatedTextEdit>]| {
+    let doc_edits_all = |edits: &[OneOf<TextEdit, AnnotatedTextEdit>]| {
         edits.iter().all(|one_of| {
-            let range = match one_of {
-                OneOf::Left(text_edit) => text_edit.range,
-                OneOf::Right(annotated) => annotated.text_edit.range,
+            let text_edit = match one_of {
+                OneOf::Left(text_edit) => text_edit,
+                OneOf::Right(annotated) => &annotated.text_edit,
             };
-            within(range)
+            pred(text_edit)
         })
     };
     match &edit.document_changes {
         None => {}
         Some(DocumentChanges::Edits(edits)) => {
             for e in edits {
-                if e.text_document.uri == *host_uri && !doc_edits_within(&e.edits) {
+                if e.text_document.uri == *host_uri && !doc_edits_all(&e.edits) {
                     return false;
                 }
             }
@@ -306,7 +318,7 @@ pub(crate) fn workspace_edit_within_region(
             for op in ops {
                 if let DocumentChangeOperation::Edit(e) = op
                     && e.text_document.uri == *host_uri
-                    && !doc_edits_within(&e.edits)
+                    && !doc_edits_all(&e.edits)
                 {
                     return false;
                 }

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -323,7 +323,7 @@ fn workspace_edit_is_empty(edit: &WorkspaceEdit) -> bool {
 /// Translate an action's edit host-ward with resolve-grade validation, in
 /// place. Returns `Err(reason)` (leaving the edit partially mutated — the caller
 /// must discard the action and disable it with `reason`) when the edit can't be
-/// faithfully represented in the host document. The reason distinguishes two
+/// faithfully represented in the host document. The reason distinguishes three
 /// permanent failures the client shows to the user:
 /// - [`REASON_CROSS_REGION`] — the edit touches another injection region (the
 ///   shared transform would silently filter those and partially apply the rest),
@@ -334,6 +334,9 @@ fn workspace_edit_is_empty(edit: &WorkspaceEdit) -> bool {
 /// - [`REASON_RESOLVE`] — the edit ended up empty: the server produced nothing
 ///   applicable, which reads as "could not be resolved to an applicable edit",
 ///   not "cannot be represented in the host document".
+/// - [`REASON_PREFIXED_REGION`] — the translated edit spans or inserts lines in
+///   a line-prefixed (e.g. blockquote) region; the verbatim newText would strip
+///   the prefixes and corrupt the host document.
 ///
 /// Used by BOTH the initial-response policy and the codeAction/resolve path so
 /// these are rejected uniformly, never partially applied.
@@ -1190,8 +1193,8 @@ pub(crate) fn bridge_code_actions(
 
 const REASON_RESOLVE: &str = "this action could not be resolved to an applicable edit";
 const REASON_CROSS_REGION: &str = "the edit cannot be represented in the host document";
-const REASON_PREFIXED_REGION: &str =
-    "the edit would break the host document's line prefixes around the injected region";
+const REASON_PREFIXED_REGION: &str = "the edit would break the host document's line prefixes \
+     (e.g. a blockquote) around the injected region";
 
 fn bridge_code_action(
     item: CodeActionOrCommand,

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -23,7 +23,6 @@ use serde_json::Value;
 use crate::config::settings::{BridgeServerConfig, WorkspaceSettings};
 use crate::config::{merge_bridge_server_configs, resolve_with_wildcard};
 use crate::lsp::bridge::actor::RouterCleanupGuard;
-use crate::text::PositionMapper;
 use tower_lsp_server::ls_types::{
     CodeAction, CodeActionContext, CodeActionDisabled, CodeActionOrCommand, CodeActionParams,
     CodeActionResponse, DocumentChangeOperation, DocumentChanges, NumberOrString,
@@ -35,11 +34,10 @@ use url::Url;
 use super::super::pool::{ConnectionHandle, LanguageServerPool, UpstreamId};
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, encode_command,
-    host_position_within_region, response_has_jsonrpc_error, strip_bridge_local_versions,
-    transform_workspace_edit_to_host, translate_host_range_to_virtual,
-    translate_virtual_position_to_host, translate_virtual_range_to_host, virtual_uri_to_lsp_uri,
-    workspace_edit_has_effect, workspace_edit_preserves_line_prefixes,
-    workspace_edit_within_region,
+    host_position_within_region, region_host_end, response_has_jsonrpc_error,
+    strip_bridge_local_versions, transform_workspace_edit_to_host, translate_host_range_to_virtual,
+    translate_virtual_range_to_host, virtual_uri_to_lsp_uri, workspace_edit_has_effect,
+    workspace_edit_preserves_line_prefixes, workspace_edit_within_region,
 };
 use super::completion::EnvelopeOffset;
 
@@ -403,21 +401,6 @@ fn workspace_edit_touches_foreign_region(edit: &WorkspaceEdit, request_virtual_u
             DocumentChangeOperation::Op(_) => false,
         }),
     }
-}
-
-/// The exclusive host-document end of an injection region: the position just
-/// past its `virtual_content`, mapped back to host coordinates. Bounds the
-/// in-region diagnostic filter position-precisely (line AND column), so a
-/// diagnostic after an inline same-line injection is dropped, not leaked.
-fn region_host_end(virtual_content: &str, offset: &RegionOffset) -> Position {
-    let mut end = PositionMapper::new(virtual_content)
-        .byte_to_position(virtual_content.len())
-        .unwrap_or(Position {
-            line: 0,
-            character: 0,
-        });
-    translate_virtual_position_to_host(&mut end, offset);
-    end
 }
 
 impl LanguageServerPool {

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -38,7 +38,8 @@ use super::super::protocol::{
     host_position_within_region, response_has_jsonrpc_error, strip_bridge_local_versions,
     transform_workspace_edit_to_host, translate_host_range_to_virtual,
     translate_virtual_position_to_host, translate_virtual_range_to_host, virtual_uri_to_lsp_uri,
-    workspace_edit_has_effect, workspace_edit_within_region,
+    workspace_edit_has_effect, workspace_edit_preserves_line_prefixes,
+    workspace_edit_within_region,
 };
 use super::completion::EnvelopeOffset;
 
@@ -358,6 +359,9 @@ fn translate_edit_host_ward_strict(
     }
     if !workspace_edit_within_region(edit, host_uri, offset, region_end) {
         return Err(REASON_CROSS_REGION);
+    }
+    if !workspace_edit_preserves_line_prefixes(edit, host_uri, offset) {
+        return Err(REASON_PREFIXED_REGION);
     }
     Ok(())
 }
@@ -1186,6 +1190,8 @@ pub(crate) fn bridge_code_actions(
 
 const REASON_RESOLVE: &str = "this action could not be resolved to an applicable edit";
 const REASON_CROSS_REGION: &str = "the edit cannot be represented in the host document";
+const REASON_PREFIXED_REGION: &str =
+    "the edit would break the host document's line prefixes around the injected region";
 
 fn bridge_code_action(
     item: CodeActionOrCommand,
@@ -1742,9 +1748,22 @@ mod tests {
         upstream_caps: UpstreamCodeActionCaps,
         server_resolves: bool,
     ) -> Option<CodeActionResponse> {
+        transform_impl_with_offset(
+            result,
+            upstream_caps,
+            server_resolves,
+            RegionOffset::new(10, 0),
+        )
+    }
+
+    fn transform_impl_with_offset(
+        result: serde_json::Value,
+        upstream_caps: UpstreamCodeActionCaps,
+        server_resolves: bool,
+        offset: RegionOffset,
+    ) -> Option<CodeActionResponse> {
         let host_uri = make_host_uri();
         let virtual_uri = make_virtual_uri_string();
-        let offset = RegionOffset::new(10, 0);
         let actions = parse_code_action_response_raw(json!({
             "jsonrpc": "2.0", "id": 42, "result": result
         }))?;
@@ -2080,6 +2099,40 @@ mod tests {
             "empty edit must disable as unresolvable, not cross-region"
         );
         assert!(action.edit.is_none(), "unusable edit must not leak");
+    }
+
+    #[test]
+    fn prefix_breaking_edit_disables_the_action() {
+        // A blockquote region (`> ` prefix, width 2, on every line): a
+        // multi-line replacement's host range contains the interior lines'
+        // prefixes, but its verbatim newText carries none — applying it would
+        // strip the prefixes and break the blockquote. The action must be
+        // disabled with the prefix-specific reason, not applied.
+        let action = json!({
+            "title": "Organize imports",
+            "edit": { "changes": { make_virtual_uri_string(): [{
+                "range": {
+                    "start": { "line": 0, "character": 0 },
+                    "end": { "line": 1, "character": 3 }
+                },
+                "newText": "import a\nimport b"
+            }] } }
+        });
+        let actions = transform_impl_with_offset(
+            json!([action]),
+            caps(true),
+            false,
+            RegionOffset::with_per_line_offsets(10, vec![2, 2]),
+        )
+        .unwrap();
+        let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
+            panic!("Expected CodeAction");
+        };
+        assert_eq!(
+            action.disabled.as_ref().unwrap().reason,
+            REASON_PREFIXED_REGION
+        );
+        assert!(action.edit.is_none(), "prefix-breaking edit must not leak");
     }
 
     #[test]

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -363,7 +363,7 @@ fn translate_edit_host_ward_strict(
     if !workspace_edit_within_region(edit, host_uri, offset, region_end) {
         return Err(REASON_CROSS_REGION);
     }
-    if !workspace_edit_preserves_line_prefixes(edit, host_uri, offset) {
+    if !workspace_edit_preserves_line_prefixes(edit, host_uri, offset, region_end) {
         return Err(REASON_PREFIXED_REGION);
     }
     Ok(())

--- a/src/lsp/bridge/text_document/rename.rs
+++ b/src/lsp/bridge/text_document/rename.rs
@@ -11,7 +11,6 @@
 use std::io;
 
 use crate::config::settings::BridgeServerConfig;
-use crate::text::PositionMapper;
 use tower_lsp_server::ls_types::{
     NumberOrString, Position, Uri, WorkDoneProgressParams, WorkspaceEdit,
 };
@@ -22,10 +21,9 @@ use tower_lsp_server::ls_types::RenameParams;
 
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri,
-    build_text_document_position_params, response_has_jsonrpc_error, strip_bridge_local_versions,
-    transform_workspace_edit_to_host, translate_virtual_position_to_host,
-    workspace_edit_has_effect, workspace_edit_preserves_line_prefixes,
-    workspace_edit_within_region,
+    build_text_document_position_params, region_host_end, response_has_jsonrpc_error,
+    strip_bridge_local_versions, transform_workspace_edit_to_host, workspace_edit_has_effect,
+    workspace_edit_preserves_line_prefixes, workspace_edit_within_region,
 };
 
 impl LanguageServerPool {
@@ -88,17 +86,6 @@ impl LanguageServerPool {
         )
         .await
     }
-}
-
-fn region_host_end(virtual_content: &str, offset: &RegionOffset) -> Position {
-    let mut end = PositionMapper::new(virtual_content)
-        .byte_to_position(virtual_content.len())
-        .unwrap_or(Position {
-            line: 0,
-            character: 0,
-        });
-    translate_virtual_position_to_host(&mut end, offset);
-    end
 }
 
 /// Build a JSON-RPC rename request for a downstream language server.

--- a/src/lsp/bridge/text_document/rename.rs
+++ b/src/lsp/bridge/text_document/rename.rs
@@ -11,6 +11,7 @@
 use std::io;
 
 use crate::config::settings::BridgeServerConfig;
+use crate::text::PositionMapper;
 use tower_lsp_server::ls_types::{
     NumberOrString, Position, Uri, WorkDoneProgressParams, WorkspaceEdit,
 };
@@ -22,7 +23,9 @@ use tower_lsp_server::ls_types::RenameParams;
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri,
     build_text_document_position_params, response_has_jsonrpc_error, strip_bridge_local_versions,
-    transform_workspace_edit_to_host, workspace_edit_has_effect,
+    transform_workspace_edit_to_host, translate_virtual_position_to_host,
+    workspace_edit_has_effect, workspace_edit_preserves_line_prefixes,
+    workspace_edit_within_region,
 };
 
 impl LanguageServerPool {
@@ -52,6 +55,7 @@ impl LanguageServerPool {
         if !handle.has_capability("textDocument/rename") {
             return Ok(None);
         }
+        let region_end = region_host_end(virtual_content, &offset);
         self.execute_position_bridge_request_with_handle(
             handle,
             host_uri,
@@ -73,16 +77,28 @@ impl LanguageServerPool {
                 )
             },
             |response, ctx| {
-                transform_workspace_edit_response_to_host(
+                transform_workspace_edit_response_to_host_bounded(
                     response,
                     &ctx.virtual_uri_string,
                     ctx.host_uri_lsp,
                     ctx.offset,
+                    region_end,
                 )
             },
         )
         .await
     }
+}
+
+fn region_host_end(virtual_content: &str, offset: &RegionOffset) -> Position {
+    let mut end = PositionMapper::new(virtual_content)
+        .byte_to_position(virtual_content.len())
+        .unwrap_or(Position {
+            line: 0,
+            character: 0,
+        });
+    translate_virtual_position_to_host(&mut end, offset);
+    end
 }
 
 /// Build a JSON-RPC rename request for a downstream language server.
@@ -112,13 +128,30 @@ fn build_rename_request(
 
 /// Transform a WorkspaceEdit response from virtual to host document coordinates.
 ///
-/// Unwraps the JSON-RPC response, then delegates the coordinate transformation
-/// to [`transform_workspace_edit_to_host`].
+/// Test helper for legacy unit cases whose edits are intentionally unbounded.
+#[cfg(test)]
 fn transform_workspace_edit_response_to_host(
+    response: serde_json::Value,
+    request_virtual_uri: &str,
+    host_uri: &Uri,
+    offset: &RegionOffset,
+) -> Option<WorkspaceEdit> {
+    transform_workspace_edit_response_to_host_bounded(
+        response,
+        request_virtual_uri,
+        host_uri,
+        offset,
+        Position::new(u32::MAX, u32::MAX),
+    )
+}
+
+/// Transform a WorkspaceEdit response and reject edits that escape the region.
+fn transform_workspace_edit_response_to_host_bounded(
     mut response: serde_json::Value,
     request_virtual_uri: &str,
     host_uri: &Uri,
     offset: &RegionOffset,
+    region_end: Position,
 ) -> Option<WorkspaceEdit> {
     if response_has_jsonrpc_error(&response, "textDocument/rename") {
         return None;
@@ -139,6 +172,14 @@ fn transform_workspace_edit_response_to_host(
     // those versions are bridge-local (the downstream's own counters) and
     // would read as stale to version-checking editors.
     strip_bridge_local_versions(&mut edit);
+
+    if !workspace_edit_within_region(&edit, host_uri, offset, region_end) {
+        return None;
+    }
+
+    if !workspace_edit_preserves_line_prefixes(&edit, host_uri, offset, region_end) {
+        return None;
+    }
 
     workspace_edit_has_effect(&edit).then_some(edit)
 }
@@ -869,6 +910,74 @@ mod tests {
         assert!(
             edit.is_none(),
             "documentChanges with no edits must fall through to other rename contributors"
+        );
+    }
+
+    #[test]
+    fn workspace_edit_multiline_edit_in_prefixed_region_returns_none() {
+        let virtual_uri = make_virtual_uri_string();
+        let host_uri = make_host_uri();
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 42,
+            "result": {
+                "changes": {
+                    virtual_uri.clone(): [{
+                        "range": {
+                            "start": { "line": 0, "character": 0 },
+                            "end": { "line": 1, "character": 1 }
+                        },
+                        "newText": "renamed"
+                    }]
+                }
+            }
+        });
+
+        let edit = transform_workspace_edit_response_to_host_bounded(
+            response,
+            &virtual_uri,
+            &host_uri,
+            &RegionOffset::with_per_line_offsets(3, vec![2, 2, 2]),
+            Position::new(5, 0),
+        );
+
+        assert!(
+            edit.is_none(),
+            "rename must not strip host line prefixes in blockquoted regions"
+        );
+    }
+
+    #[test]
+    fn workspace_edit_newline_insert_in_prefixed_region_returns_none() {
+        let virtual_uri = make_virtual_uri_string();
+        let host_uri = make_host_uri();
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 42,
+            "result": {
+                "changes": {
+                    virtual_uri.clone(): [{
+                        "range": {
+                            "start": { "line": 0, "character": 1 },
+                            "end": { "line": 0, "character": 1 }
+                        },
+                        "newText": "new\nname"
+                    }]
+                }
+            }
+        });
+
+        let edit = transform_workspace_edit_response_to_host_bounded(
+            response,
+            &virtual_uri,
+            &host_uri,
+            &RegionOffset::with_per_line_offsets(3, vec![2, 2]),
+            Position::new(5, 0),
+        );
+
+        assert!(
+            edit.is_none(),
+            "rename must not insert unprefixed lines into blockquoted regions"
         );
     }
 }

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -47,7 +47,8 @@ use crate::document::DocumentStore;
 use crate::language::LanguageCoordinator;
 use crate::lsp::bridge::{
     BridgeCoordinator, RegionOffset, VirtualDocumentUri, strip_bridge_local_versions,
-    transform_workspace_edit_to_host, workspace_edit_within_region,
+    transform_workspace_edit_to_host, workspace_edit_preserves_line_prefixes,
+    workspace_edit_within_region,
 };
 
 use super::region_offset::resolve_region_offset;
@@ -164,6 +165,17 @@ fn transform_params_to_host(
         return Err(
             "kakehashi: the edit extends outside the injected region; it cannot be applied to the \
              host document without corrupting surrounding text"
+                .to_string(),
+        );
+    }
+    // The transform translates ranges but emits newText verbatim: an edit that
+    // spans or inserts lines in a line-prefixed (e.g. blockquote) region would
+    // strip the prefixes it overlaps and leave the inserted lines unprefixed.
+    if !workspace_edit_preserves_line_prefixes(&params.edit, host_uri, offset) {
+        return Err(
+            "kakehashi: the edit would break the host document's line prefixes around the \
+             injected region (e.g. a blockquote); it cannot be applied without corrupting the \
+             host document"
                 .to_string(),
         );
     }
@@ -490,6 +502,38 @@ mod tests {
         .expect_err("a host edit before the region start must reject the whole edit");
         assert!(
             reason.contains("outside the injected region"),
+            "reason should name the failure: {reason}"
+        );
+    }
+
+    #[test]
+    fn transform_params_to_host_rejects_prefix_breaking_edit() {
+        // A blockquote region (per-line `> ` prefixes, width 2): a downstream
+        // multi-line replacement translates to a host range containing the
+        // interior lines' prefixes, but its newText carries none — applying it
+        // would strip the prefixes and break the blockquote. Reject with
+        // applied:false, never corrupt.
+        let uri = virtual_uri("01ARZ3NDEKTSV4RRFFQ69G5FAV");
+        let mut params = params_with_edit(json!({
+            "changes": { uri.clone(): [{
+                "range": {
+                    "start": { "line": 0, "character": 0 },
+                    "end": { "line": 1, "character": 4 }
+                },
+                "newText": "import a\nimport b"
+            }] }
+        }));
+
+        let reason = transform_params_to_host(
+            &mut params,
+            &uri,
+            &host_uri(),
+            &RegionOffset::with_per_line_offsets(10, vec![2, 2]),
+            Position::new(11, 6),
+        )
+        .expect_err("a prefix-breaking edit must reject the whole edit");
+        assert!(
+            reason.contains("line prefixes"),
             "reason should name the failure: {reason}"
         );
     }

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -171,7 +171,7 @@ fn transform_params_to_host(
     // The transform translates ranges but emits newText verbatim: an edit that
     // spans or inserts lines in a line-prefixed (e.g. blockquote) region would
     // strip the prefixes it overlaps and leave the inserted lines unprefixed.
-    if !workspace_edit_preserves_line_prefixes(&params.edit, host_uri, offset) {
+    if !workspace_edit_preserves_line_prefixes(&params.edit, host_uri, offset, region_end) {
         return Err(
             "kakehashi: the edit would break the host document's line prefixes around the \
              injected region (e.g. a blockquote); it cannot be applied without corrupting the \


### PR DESCRIPTION
## Problem

The virtual→host WorkspaceEdit transform translates **ranges** but emits `newText` **verbatim** — nothing re-inserts per-line host prefixes (e.g. a blockquote's `> `). A downstream multi-line replacement (organize-imports) or newline insertion inside a blockquote-fenced injection therefore stripped the prefixes it overlapped and left inserted lines bare: the blockquote silently split and the closing `> \`\`\`` no longer closed the block — structural corruption of the host document, on the codeAction, codeAction/resolve, and workspace/applyEdit paths.

## Fix (fail closed, never corrupt)

New shared predicate `workspace_edit_preserves_line_prefixes` (workspace_edit.rs), enforced by both consumers:

- **codeAction / resolve** — the action is disabled with a prefix-specific reason (new `REASON_PREFIXED_REGION`), or dropped without `disabledSupport`.
- **workspace/applyEdit** — answered `applied: false` with a `failureReason`.

Rejected shapes, in a prefixed region: a range spanning a prefixed line (its prefix would be deleted), a newline-bearing `newText` in a prefixed neighborhood (inserted lines carry no prefix), and anything touching the closing-fence **boundary row** — derived from `region_end` (content ending with a newline puts it at column 0 of the fence row), whose real prefix is unrecorded in the offsets.

**Unaffected:** plain fenced blocks (all-zero offsets) — whole-block refactors like organize-imports keep working; single-line edits (the rename/quickfix shape) in blockquotes; multi-line single-element regions' newline insertions (later lines are designed unprefixed).

Fail-closed was chosen over prefix re-insertion: re-applying prefixes to `newText` needs the live host line text (`RegionOffset` only carries widths) and is riskier than rejecting; re-insertion can follow up if demand appears.

**Scope update:** rename adopted both guards IN THIS PR (commit "fix(bridge): guard rename prefix edits" — the module doc now says "enforced by codeAction, rename, and applyEdit"). Remaining deliberate cut: the EOF row of an *unclosed* blockquote fence is indistinguishable from the closed-fence row in the offsets and stays fail-closed (transient malformed construct).

## Review provenance

Local multi-perspective review + 4 codex rounds; substantive rounds fixed: the production trailing-zero offset shape (`[2,2,0]`), no-newline insertion at the boundary row, single-element false rejections (newline + multi-line tail), boundary derivation from `region_end` instead of array shape, bare-CR newlines. Converged: fresh codex session returned "no comments to provide".

## Testing

12 predicate unit tests (production offset shapes, boundary geometry, mutation-killing branch pins, annotated/Operations arms), call-site tests at all three enforcement points. Full lib suite (2612) + clippy \-D warnings green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented bridged code actions, `workspace/applyEdit`, and rename edits from being applied when translated `WorkspaceEdit`s could break host per-line text prefixes (for example, blockquote markers).
  * Strengthened validation for multi-line `WorkspaceEdit`s, including stricter boundary-row handling and rejection of newline/CR insertions that would create unprefixed/prefix-breaking lines.
  * Ensured invalid edits are not forwarded to the editor and are returned as unapplied/absent.
* **Tests**
  * Expanded unit test coverage for prefix preservation, multi-line and annotated `documentChanges` cases, and rename-bounded transformation rejection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
