### PR TITLE
feat(bridge): mirror workspace.workspaceEdit downstream + null bridge-local edit versions

### DIFF
--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -67,6 +67,7 @@ pub(crate) use protocol::RequestId;
 pub(crate) use protocol::VirtualDocumentUri;
 pub(crate) use protocol::decode_command;
 pub(crate) use protocol::location_link_to_location;
+pub(crate) use protocol::strip_bridge_local_versions;
 pub(crate) use protocol::transform_workspace_edit_to_host;
 pub(crate) use protocol::translate_virtual_range_to_host;
 pub(crate) use protocol::workspace_edit_has_effect;

--- a/src/lsp/bridge/protocol.rs
+++ b/src/lsp/bridge/protocol.rs
@@ -39,5 +39,6 @@ pub(crate) use response::*;
 pub(crate) use translation::*;
 pub(crate) use virtual_uri::VirtualDocumentUri;
 pub(crate) use workspace_edit::{
-    transform_workspace_edit_to_host, workspace_edit_has_effect, workspace_edit_within_region,
+    strip_bridge_local_versions, transform_workspace_edit_to_host, workspace_edit_has_effect,
+    workspace_edit_within_region,
 };

--- a/src/lsp/bridge/protocol/client_capabilities.rs
+++ b/src/lsp/bridge/protocol/client_capabilities.rs
@@ -304,7 +304,11 @@ fn merge_upstream_capabilities(
     // `failureHandling`/`normalizesLineEndings`) is the honest semantics.
     // `changeAnnotationSupport` is deliberately withheld: ls-types' untagged
     // `OneOf` drops `annotationId` when deserializing downstream responses, so
-    // inviting annotated edits would silently lose `needsConfirmation`.
+    // inviting annotated edits would silently lose `needsConfirmation`. The
+    // proposed 3.18 `metadataSupport`/`snippetEditSupport` fields are also
+    // effectively withheld — ls-types' WorkspaceEditClientCapabilities has no
+    // such fields, so the typed InitializeParams parse drops them before this
+    // clone ever sees them.
     if let Some(upstream_workspace_edit) = upstream
         .workspace
         .as_ref()

--- a/src/lsp/bridge/protocol/client_capabilities.rs
+++ b/src/lsp/bridge/protocol/client_capabilities.rs
@@ -176,7 +176,9 @@ fn build_baseline_capabilities(
 /// tagSupport, commitCharactersSupport, resolveSupport, insertTextModeSupport,
 /// labelDetailsSupport, preselectSupport}`, `hover.contentFormat`,
 /// `signatureHelp.signatureInformation`, `window.workDoneProgress`,
-/// `window.showDocument`, `window.showMessage`.
+/// `window.showDocument`, `window.showMessage`,
+/// `workspace.workspaceEdit` (mirrored minus `changeAnnotationSupport` — see
+/// the merge site for why annotations are withheld).
 ///
 /// `window.workDoneProgress` and `window.showDocument` are gated on the real
 /// upstream editor so the bridge only invites a downstream server-initiated
@@ -288,6 +290,29 @@ fn merge_upstream_capabilities(
         }
     }
 
+    // --- workspace.workspaceEdit (mirror, minus changeAnnotationSupport) ---
+    // A client that omits `workspace.workspaceEdit` implies
+    // `documentChanges: false` and no `resourceOperations`, so a spec-compliant
+    // downstream withholds documentChanges-shaped edits and every
+    // create/rename/delete-carrying refactor ("extract into file") — even
+    // though the bridge transform handles both (real-file ops pass through;
+    // virtual-URI ops reject the whole edit). Mirror the editor's declaration
+    // so downstream servers offer exactly what the editor can apply.
+    // `changeAnnotationSupport` is deliberately withheld: ls-types' untagged
+    // `OneOf` drops `annotationId` when deserializing downstream responses, so
+    // inviting annotated edits would silently lose `needsConfirmation`.
+    if let Some(upstream_workspace_edit) = upstream
+        .workspace
+        .as_ref()
+        .and_then(|w| w.workspace_edit.as_ref())
+    {
+        let mut mirrored = upstream_workspace_edit.clone();
+        mirrored.change_annotation_support = None;
+        base.workspace
+            .get_or_insert_with(Default::default)
+            .workspace_edit = Some(mirrored);
+    }
+
     // --- window.workDoneProgress (gated on real upstream support) ---
     // Advertise server-initiated progress downstream ONLY when the editor
     // genuinely supports it (`Some(true)`), so the bridge never invites progress
@@ -370,6 +395,74 @@ mod tests {
                 insta::assert_json_snapshot!(capabilities);
             });
         }
+    }
+
+    #[test]
+    fn merge_mirrors_workspace_edit_capability_without_annotations() {
+        use tower_lsp_server::ls_types::{
+            ChangeAnnotationWorkspaceEditClientCapabilities, FailureHandlingKind,
+            ResourceOperationKind, WorkspaceClientCapabilities, WorkspaceEditClientCapabilities,
+        };
+
+        let upstream = ClientCapabilities {
+            workspace: Some(WorkspaceClientCapabilities {
+                workspace_edit: Some(WorkspaceEditClientCapabilities {
+                    document_changes: Some(true),
+                    resource_operations: Some(vec![
+                        ResourceOperationKind::Create,
+                        ResourceOperationKind::Rename,
+                        ResourceOperationKind::Delete,
+                    ]),
+                    failure_handling: Some(FailureHandlingKind::Abort),
+                    normalizes_line_endings: Some(true),
+                    change_annotation_support: Some(
+                        ChangeAnnotationWorkspaceEditClientCapabilities {
+                            groups_on_label: Some(true),
+                        },
+                    ),
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let merged = build_bridge_client_capabilities(Some(&upstream), true, false);
+        let workspace_edit = merged
+            .workspace
+            .as_ref()
+            .and_then(|w| w.workspace_edit.as_ref())
+            .expect("the editor's workspaceEdit capability must be mirrored downstream");
+        assert_eq!(workspace_edit.document_changes, Some(true));
+        assert_eq!(
+            workspace_edit
+                .resource_operations
+                .as_ref()
+                .map(|ops| ops.len()),
+            Some(3)
+        );
+        assert_eq!(
+            workspace_edit.failure_handling,
+            Some(FailureHandlingKind::Abort)
+        );
+        assert_eq!(workspace_edit.normalizes_line_endings, Some(true));
+        assert_eq!(
+            workspace_edit.change_annotation_support, None,
+            "annotation support must be withheld: ls-types drops annotationId on parse"
+        );
+    }
+
+    #[test]
+    fn merge_without_upstream_workspace_edit_advertises_none() {
+        let merged =
+            build_bridge_client_capabilities(Some(&ClientCapabilities::default()), true, false);
+        assert!(
+            merged
+                .workspace
+                .as_ref()
+                .and_then(|w| w.workspace_edit.as_ref())
+                .is_none(),
+            "an editor that omits workspaceEdit implies documentChanges:false — do not overclaim"
+        );
     }
 
     #[test]
@@ -793,8 +886,23 @@ mod tests {
             TextDocumentClientCapabilities,
         };
 
+        use tower_lsp_server::ls_types::{
+            ResourceOperationKind, WorkspaceClientCapabilities, WorkspaceEditClientCapabilities,
+        };
+
         // Simulate typical Neovim capabilities
         let upstream = ClientCapabilities {
+            workspace: Some(WorkspaceClientCapabilities {
+                workspace_edit: Some(WorkspaceEditClientCapabilities {
+                    resource_operations: Some(vec![
+                        ResourceOperationKind::Rename,
+                        ResourceOperationKind::Create,
+                        ResourceOperationKind::Delete,
+                    ]),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
             text_document: Some(TextDocumentClientCapabilities {
                 completion: Some(CompletionClientCapabilities {
                     completion_item: Some(CompletionItemCapability {

--- a/src/lsp/bridge/protocol/client_capabilities.rs
+++ b/src/lsp/bridge/protocol/client_capabilities.rs
@@ -297,7 +297,11 @@ fn merge_upstream_capabilities(
     // create/rename/delete-carrying refactor ("extract into file") — even
     // though the bridge transform handles both (real-file ops pass through;
     // virtual-URI ops reject the whole edit). Mirror the editor's declaration
-    // so downstream servers offer exactly what the editor can apply.
+    // so downstream servers offer exactly what the editor can apply. Unlike
+    // the `window.*` fields below — gated because they invite server-initiated
+    // REQUESTS the bridge must relay — this declares a response SHAPE the
+    // editor ultimately applies, so full-fidelity mirroring (including
+    // `failureHandling`/`normalizesLineEndings`) is the honest semantics.
     // `changeAnnotationSupport` is deliberately withheld: ls-types' untagged
     // `OneOf` drops `annotationId` when deserializing downstream responses, so
     // inviting annotated edits would silently lose `needsConfirmation`.
@@ -882,17 +886,18 @@ mod tests {
             CompletionClientCapabilities, CompletionItemCapability,
             CompletionItemCapabilityResolveSupport, CompletionItemTag, HoverClientCapabilities,
             InsertTextMode, InsertTextModeSupport, MarkupKind, ParameterInformationSettings,
-            SignatureHelpClientCapabilities, SignatureInformationSettings, TagSupport,
-            TextDocumentClientCapabilities,
-        };
-
-        use tower_lsp_server::ls_types::{
-            ResourceOperationKind, WorkspaceClientCapabilities, WorkspaceEditClientCapabilities,
+            ResourceOperationKind, SignatureHelpClientCapabilities, SignatureInformationSettings,
+            TagSupport, TextDocumentClientCapabilities, WorkspaceClientCapabilities,
+            WorkspaceEditClientCapabilities,
         };
 
         // Simulate typical Neovim capabilities
         let upstream = ClientCapabilities {
             workspace: Some(WorkspaceClientCapabilities {
+                // Neovim's default make_client_capabilities() really does omit
+                // `documentChanges` — it advertises only resourceOperations
+                // (in this exact order) even though apply_workspace_edit
+                // handles documentChanges. Mirrored faithfully.
                 workspace_edit: Some(WorkspaceEditClientCapabilities {
                     resource_operations: Some(vec![
                         ResourceOperationKind::Rename,

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@default.snap
@@ -5,6 +5,13 @@ expression: merged
 {
   "workspace": {
     "applyEdit": true,
+    "workspaceEdit": {
+      "resourceOperations": [
+        "rename",
+        "create",
+        "delete"
+      ]
+    },
     "executeCommand": {
       "dynamicRegistration": false
     },

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_merged_with_typical_upstream@experimental.snap
@@ -5,6 +5,13 @@ expression: merged
 {
   "workspace": {
     "applyEdit": true,
+    "workspaceEdit": {
+      "resourceOperations": [
+        "rename",
+        "create",
+        "delete"
+      ]
+    },
     "executeCommand": {
       "dynamicRegistration": false
     },

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -211,10 +211,12 @@ fn transform_text_document_edit(
 ///
 /// Deliberately erase-without-validate: the version was never a working
 /// cross-boundary protection (the spaces differ, so pre-strip it rejected
-/// EVERYTHING), the majority shape (`changes` map) carries no version at all,
-/// and staleness is guarded by the region-freshness resolution and region
-/// bounds that apply to both shapes alike. Validating the versioned minority
-/// against the originating connection's tracked version first is follow-up
+/// EVERYTHING), and the majority shape (`changes` map) carries no version at
+/// all. What remains is COORDINATE validity on virtual paths (region
+/// freshness + region bounds) — not general content freshness, and nothing
+/// on host paths: an action whose edit aged in the editor's menu while the
+/// user kept typing applies unconditionally, versioned shape or not. Mapping
+/// downstream versions to editor versions (instead of erasing) is follow-up
 /// hardening.
 pub(crate) fn strip_bridge_local_versions(edit: &mut WorkspaceEdit) {
     let Some(doc_changes) = &mut edit.document_changes else {

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -198,6 +198,33 @@ fn transform_text_document_edit(
     false
 }
 
+/// Null every `TextDocumentEdit.version` in an editor-ward `WorkspaceEdit`.
+///
+/// A bridged downstream's document versions live in the BRIDGE's version
+/// space (each connection's didOpen starts its own counter at 1), not the
+/// editor's. Relaying a versioned `documentChanges` edit verbatim makes
+/// version-checking editors (e.g. Neovim's `apply_text_document_edit`) skip
+/// the edit as stale. `version: null` means "apply without a version check"
+/// per spec — the same treatment the virtual→host transform gives the
+/// request's own document. Call at every editor-ward relay boundary
+/// (applyEdit forward, host-layer rename/codeAction results).
+pub(crate) fn strip_bridge_local_versions(edit: &mut WorkspaceEdit) {
+    let Some(doc_changes) = &mut edit.document_changes else {
+        return;
+    };
+    let strip = |e: &mut TextDocumentEdit| e.text_document.version = None;
+    match doc_changes {
+        DocumentChanges::Edits(edits) => edits.iter_mut().for_each(strip),
+        DocumentChanges::Operations(ops) => ops
+            .iter_mut()
+            .filter_map(|op| match op {
+                DocumentChangeOperation::Edit(e) => Some(e),
+                DocumentChangeOperation::Op(_) => None,
+            })
+            .for_each(strip),
+    }
+}
+
 /// Whether every text edit targeting `host_uri` in a HOST-coordinate
 /// `WorkspaceEdit` is CONTAINED in the injection region — bounded above by
 /// `region_end` and below, PER LINE, by the region's line offset (`offset`).

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -208,6 +208,14 @@ fn transform_text_document_edit(
 /// per spec — the same treatment the virtual→host transform gives the
 /// request's own document. Call at every editor-ward relay boundary
 /// (applyEdit forward, host-layer rename/codeAction results).
+///
+/// Deliberately erase-without-validate: the version was never a working
+/// cross-boundary protection (the spaces differ, so pre-strip it rejected
+/// EVERYTHING), the majority shape (`changes` map) carries no version at all,
+/// and staleness is guarded by the region-freshness resolution and region
+/// bounds that apply to both shapes alike. Validating the versioned minority
+/// against the originating connection's tracked version first is follow-up
+/// hardening.
 pub(crate) fn strip_bridge_local_versions(edit: &mut WorkspaceEdit) {
     let Some(doc_changes) = &mut edit.document_changes else {
         return;

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -36,10 +36,9 @@ use super::super::pool::{ConnectionHandle, LanguageServerPool, UpstreamId};
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, encode_command,
     host_position_within_region, response_has_jsonrpc_error, strip_bridge_local_versions,
-    transform_workspace_edit_to_host,
-    translate_host_range_to_virtual, translate_virtual_position_to_host,
-    translate_virtual_range_to_host, virtual_uri_to_lsp_uri, workspace_edit_has_effect,
-    workspace_edit_within_region,
+    transform_workspace_edit_to_host, translate_host_range_to_virtual,
+    translate_virtual_position_to_host, translate_virtual_range_to_host, virtual_uri_to_lsp_uri,
+    workspace_edit_has_effect, workspace_edit_within_region,
 };
 use super::completion::EnvelopeOffset;
 

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -35,7 +35,8 @@ use url::Url;
 use super::super::pool::{ConnectionHandle, LanguageServerPool, UpstreamId};
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, encode_command,
-    host_position_within_region, response_has_jsonrpc_error, transform_workspace_edit_to_host,
+    host_position_within_region, response_has_jsonrpc_error, strip_bridge_local_versions,
+    transform_workspace_edit_to_host,
     translate_host_range_to_virtual, translate_virtual_position_to_host,
     translate_virtual_range_to_host, virtual_uri_to_lsp_uri, workspace_edit_has_effect,
     workspace_edit_within_region,
@@ -287,7 +288,11 @@ fn finalize_host_resolved_action(
     }
 
     // The resolved edit is already in host coordinates — kept verbatim (no
-    // cross-region / translation concern the virt path guards against).
+    // cross-region / translation concern the virt path guards against),
+    // except versions, which are bridge-local and must not reach the editor.
+    if let Some(edit) = &mut resolved.edit {
+        strip_bridge_local_versions(edit);
+    }
     let server_title = std::mem::take(&mut resolved.title);
     resolved.title = resuffix_resolved_title(server_title.clone(), suffixed_title, &server_name);
 
@@ -1262,6 +1267,10 @@ fn bridge_code_action(
 
     match &mut action.edit {
         Some(edit) => {
+            // Versions in a downstream's edit are bridge-local (its own didOpen
+            // counter) and would read as stale to version-checking editors —
+            // null them on every layer before the edit can reach the client.
+            strip_bridge_local_versions(edit);
             // Virt layer: translate host-ward with resolve-grade validation
             // (the same check the client-driven resolve path uses), so an
             // edit touching another region — including an eager-resolved lazy
@@ -2556,6 +2565,104 @@ mod tests {
     }
 
     // -- host resolve finalization -------------------------------------------
+
+    #[test]
+    fn host_layer_edit_versions_are_stripped() {
+        // Host-layer edits are verbatim EXCEPT versions: the downstream's
+        // document versions live in the bridge's version space (its own
+        // didOpen counter), so relaying them verbatim makes version-checking
+        // editors (Neovim) skip the edit as stale.
+        let actions: Vec<CodeActionOrCommand> = serde_json::from_value(json!([
+            {
+                "title": "Sort imports",
+                "edit": {
+                    "documentChanges": [{
+                        "textDocument": { "uri": "file:///test.md", "version": 2 },
+                        "edits": [{
+                            "range": {
+                                "start": { "line": 50, "character": 0 },
+                                "end": { "line": 50, "character": 5 }
+                            },
+                            "newText": "sorted"
+                        }]
+                    }]
+                }
+            }
+        ]))
+        .unwrap();
+
+        let bridged = bridge_code_actions(
+            actions,
+            "marksman",
+            "file:///test.md",
+            caps(true),
+            false,
+            None,
+        );
+        let CodeActionOrCommand::CodeAction(action) = &bridged[0] else {
+            panic!("Expected CodeAction");
+        };
+        match action.edit.as_ref().unwrap().document_changes.as_ref() {
+            Some(DocumentChanges::Edits(edits)) => {
+                assert_eq!(
+                    edits[0].text_document.version, None,
+                    "bridge-local version must not reach the editor"
+                );
+            }
+            other => panic!("Expected Edits variant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn host_resolve_strips_bridge_local_edit_versions() {
+        let resolved: CodeAction = serde_json::from_value(json!({
+            "title": "Sort imports",
+            "edit": { "documentChanges": [{
+                "textDocument": { "uri": "file:///test.md", "version": 3 },
+                "edits": [{
+                    "range": {
+                        "start": { "line": 1, "character": 0 },
+                        "end": { "line": 1, "character": 5 }
+                    },
+                    "newText": "sorted"
+                }]
+            }] }
+        }))
+        .unwrap();
+        let action: CodeAction = serde_json::from_value(json!({
+            "title": "Sort imports — srv", "data": { "id": 1 }
+        }))
+        .unwrap();
+        let envelope: CodeActionEnvelope = serde_json::from_value(json!({
+            "origin": "srv",
+            "host_uri": "file:///test.md",
+            "region_id": "",
+            "injection_language": "",
+            "offset": { "line": 0, "column": 0 },
+            "original_title": "Sort imports",
+            "inner": null,
+            "host_layer": true
+        }))
+        .unwrap();
+
+        let out = finalize_host_resolved_action(
+            resolved,
+            action,
+            envelope,
+            "Sort imports — srv".to_string(),
+            caps_resolve(),
+        );
+
+        match out.edit.as_ref().unwrap().document_changes.as_ref() {
+            Some(DocumentChanges::Edits(edits)) => {
+                assert_eq!(
+                    edits[0].text_document.version, None,
+                    "bridge-local version must not reach the editor"
+                );
+            }
+            other => panic!("Expected Edits variant, got {other:?}"),
+        }
+    }
 
     #[test]
     fn host_resolve_disables_command_only_action_when_routing_name_unencodable() {

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -349,6 +349,10 @@ fn translate_edit_host_ward_strict(
     if !transform_workspace_edit_to_host(edit, request_virtual_uri, host_uri, offset) {
         return Err(REASON_CROSS_REGION);
     }
+    // Reached directly by the client-driven resolve path (which bypasses
+    // bridge_code_action's own strip): versions on OTHER real files are
+    // bridge-local too and must not reach the editor.
+    strip_bridge_local_versions(edit);
     if workspace_edit_is_empty(edit) {
         return Err(REASON_RESOLVE);
     }
@@ -2609,6 +2613,63 @@ mod tests {
                 );
             }
             other => panic!("Expected Edits variant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn strict_translate_strips_bridge_local_versions_on_real_files() {
+        // The client-driven virt resolve path reaches the shared strict
+        // translate directly (not via bridge_code_action), so the strip must
+        // live inside it too: a resolved multi-file edit's OTHER real files
+        // carry bridge-local versions that would read as stale to the editor.
+        let virtual_uri = make_virtual_uri_string();
+        let host_uri = make_host_uri();
+        let mut edit: WorkspaceEdit = serde_json::from_value(json!({
+            "documentChanges": [
+                {
+                    "textDocument": { "uri": virtual_uri, "version": 3 },
+                    "edits": [{
+                        "range": {
+                            "start": { "line": 0, "character": 0 },
+                            "end": { "line": 0, "character": 5 }
+                        },
+                        "newText": "x"
+                    }]
+                },
+                {
+                    "textDocument": { "uri": "file:///other.lua", "version": 7 },
+                    "edits": [{
+                        "range": {
+                            "start": { "line": 1, "character": 0 },
+                            "end": { "line": 1, "character": 5 }
+                        },
+                        "newText": "x"
+                    }]
+                }
+            ]
+        }))
+        .unwrap();
+
+        translate_edit_host_ward_strict(
+            &mut edit,
+            &virtual_uri,
+            &host_uri,
+            &RegionOffset::new(10, 0),
+            Position {
+                line: u32::MAX,
+                character: u32::MAX,
+            },
+        )
+        .expect("edit must translate");
+
+        match edit.document_changes.unwrap() {
+            DocumentChanges::Edits(edits) => {
+                assert!(
+                    edits.iter().all(|e| e.text_document.version.is_none()),
+                    "no bridge-local version may reach the editor"
+                );
+            }
+            DocumentChanges::Operations(_) => panic!("Expected Edits variant"),
         }
     }
 

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -2107,9 +2107,10 @@ mod tests {
     }
 
     #[test]
-    fn host_layer_policy_keeps_edit_verbatim() {
+    fn host_layer_policy_keeps_edit_uris_and_ranges_untranslated() {
         // Host layer (virt = None): real URIs/coordinates, no translation —
-        // but the suffix and command policy still apply.
+        // but the suffix and command policy still apply (and versions are
+        // nulled, pinned separately by host_layer_edit_versions_are_stripped).
         let actions: Vec<CodeActionOrCommand> = serde_json::from_value(json!([
             {
                 "title": "Sort imports",

--- a/src/lsp/bridge/text_document/rename.rs
+++ b/src/lsp/bridge/text_document/rename.rs
@@ -135,6 +135,10 @@ fn transform_workspace_edit_response_to_host(
     if !transform_workspace_edit_to_host(&mut edit, request_virtual_uri, host_uri, offset) {
         return None;
     }
+    // A multi-file rename's OTHER real files can carry versioned entries;
+    // those versions are bridge-local (the downstream's own counters) and
+    // would read as stale to version-checking editors.
+    crate::lsp::bridge::strip_bridge_local_versions(&mut edit);
 
     workspace_edit_has_effect(&edit).then_some(edit)
 }
@@ -248,6 +252,50 @@ mod tests {
             &RegionOffset::new(5, 0),
         );
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn workspace_edit_strips_bridge_local_versions_on_real_files() {
+        // A multi-file rename can carry versioned documentChanges entries for
+        // OTHER real files; those versions are bridge-local (the downstream's
+        // own counters) and would read as stale to version-checking editors,
+        // silently skipping part of the rename.
+        let virtual_uri = make_virtual_uri_string();
+        let host_uri = make_host_uri();
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 42,
+            "result": {
+                "documentChanges": [{
+                    "textDocument": { "uri": "file:///other.lua", "version": 7 },
+                    "edits": [{
+                        "range": {
+                            "start": { "line": 1, "character": 0 },
+                            "end": { "line": 1, "character": 5 }
+                        },
+                        "newText": "newName"
+                    }]
+                }]
+            }
+        });
+
+        let edit = transform_workspace_edit_response_to_host(
+            response,
+            &virtual_uri,
+            &host_uri,
+            &RegionOffset::new(10, 0),
+        )
+        .unwrap();
+
+        match edit.document_changes.unwrap() {
+            DocumentChanges::Edits(edits) => {
+                assert_eq!(
+                    edits[0].text_document.version, None,
+                    "bridge-local version must not reach the editor"
+                );
+            }
+            DocumentChanges::Operations(_) => panic!("Expected Edits variant"),
+        }
     }
 
     #[test]

--- a/src/lsp/bridge/text_document/rename.rs
+++ b/src/lsp/bridge/text_document/rename.rs
@@ -21,7 +21,7 @@ use tower_lsp_server::ls_types::RenameParams;
 
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri,
-    build_text_document_position_params, response_has_jsonrpc_error,
+    build_text_document_position_params, response_has_jsonrpc_error, strip_bridge_local_versions,
     transform_workspace_edit_to_host, workspace_edit_has_effect,
 };
 
@@ -138,7 +138,7 @@ fn transform_workspace_edit_response_to_host(
     // A multi-file rename's OTHER real files can carry versioned entries;
     // those versions are bridge-local (the downstream's own counters) and
     // would read as stale to version-checking editors.
-    crate::lsp::bridge::strip_bridge_local_versions(&mut edit);
+    strip_bridge_local_versions(&mut edit);
 
     workspace_edit_has_effect(&edit).then_some(edit)
 }

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -178,9 +178,10 @@ fn transform_params_to_host(
 /// A text-edit entry (`changes` value or a `TextDocumentEdit`) with an EMPTY
 /// edit vector is a no-op and does NOT count as touching its URI: an edit that
 /// is real-file-only but carries a stray empty virtual entry must forward
-/// verbatim, not be routed down the virtual-translation path (and then fail
-/// `applied: false`). File operations always count — a create/rename/delete is
-/// a real change even with no accompanying text edits.
+/// as-is (modulo the version nulling every forward gets), not be routed down
+/// the virtual-translation path (and then fail `applied: false`). File
+/// operations always count — a create/rename/delete is a real change even
+/// with no accompanying text edits.
 fn collect_virtual_uris(edit: &WorkspaceEdit) -> Vec<String> {
     let mut uris: Vec<String> = Vec::new();
     let mut push = |uri: &str| {

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -26,6 +26,12 @@
 //! `label` and `changeAnnotations` pass through untouched (the transform only
 //! rewrites URIs/ranges/versions).
 //!
+//! Known degenerate edge: the transform drops a foreign-virtual entry with an
+//! EMPTY edit vector (a no-op), so an editor `failedChange` index can be
+//! skewed by one relative to what the downstream sent. A real (non-empty)
+//! foreign entry rejects the whole edit instead, so indexes never skew for
+//! edits that actually apply anything.
+//!
 //! [`transform_workspace_edit_to_host`]: crate::lsp::bridge::transform_workspace_edit_to_host
 
 use std::sync::Arc;

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -38,8 +38,8 @@ use tower_lsp_server::ls_types::{
 use crate::document::DocumentStore;
 use crate::language::LanguageCoordinator;
 use crate::lsp::bridge::{
-    BridgeCoordinator, RegionOffset, VirtualDocumentUri, transform_workspace_edit_to_host,
-    workspace_edit_within_region,
+    BridgeCoordinator, RegionOffset, VirtualDocumentUri, strip_bridge_local_versions,
+    transform_workspace_edit_to_host, workspace_edit_within_region,
 };
 
 use super::region_offset::resolve_region_offset;
@@ -77,6 +77,9 @@ impl ApplyEditTranslator {
         &self,
         mut params: ApplyWorkspaceEditParams,
     ) -> Result<ApplyWorkspaceEditParams, String> {
+        // Downstream document versions live in the bridge's version space,
+        // never the editor's — null them on every forward (see the helper).
+        strip_bridge_local_versions(&mut params.edit);
         let virtual_uris = collect_virtual_uris(&params.edit);
         let virtual_uri = match virtual_uris.as_slice() {
             // No virtual URIs: a host-layer connection's edit (real URIs
@@ -267,6 +270,35 @@ mod tests {
             .await
             .expect("real-file edit must pass through");
         assert_eq!(out, original);
+    }
+
+    #[tokio::test]
+    async fn strips_bridge_local_versions_from_forwarded_real_file_edits() {
+        // A host-layer downstream's document versions live in the BRIDGE's
+        // version space (didOpen starts its own counter at 1), not the
+        // editor's. Relaying a versioned documentChanges edit verbatim makes
+        // version-checking editors (Neovim) skip it as stale — the version
+        // must be nulled ("apply without check") on the editor-ward relay.
+        let original: ApplyWorkspaceEditParams = serde_json::from_value(json!({
+            "edit": { "documentChanges": [{
+                "textDocument": { "uri": "file:///project/doc.md", "version": 2 },
+                "edits": [text_edit(3)]
+            }] }
+        }))
+        .unwrap();
+        let out = translator()
+            .translate(original)
+            .await
+            .expect("real-file edit must pass through");
+        match out.edit.document_changes.as_ref().unwrap() {
+            DocumentChanges::Edits(edits) => {
+                assert_eq!(
+                    edits[0].text_document.version, None,
+                    "bridge-local version must not reach the editor"
+                );
+            }
+            DocumentChanges::Operations(_) => panic!("Expected Edits variant"),
+        }
     }
 
     #[tokio::test]

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -11,7 +11,9 @@
 //! The host/virt distinction is made from the edit itself, not the connection:
 //! an edit that touches **no** virtual URIs (every edit from a host-layer
 //! connection, and real-file-only edits from virt connections) is forwarded
-//! verbatim. An edit that touches exactly one virtual document is translated
+//! as-is except that every `TextDocumentEdit.version` is nulled — downstream
+//! versions are bridge-local and would read as stale to the editor. An edit
+//! that touches exactly one virtual document is translated
 //! against that region's live offset (rebuilt exactly as goto/showDocument do,
 //! via [`resolve_region_offset`](super::region_offset::resolve_region_offset)).
 //!
@@ -75,9 +77,10 @@ impl ApplyEditTranslator {
         }
     }
 
-    /// Translate a virtual-document applyEdit to host coordinates; forward
-    /// `params` unchanged when the edit touches no virtual URIs. `Err` carries
-    /// the `failureReason` for a local `applied: false` answer — the edit must
+    /// Translate a virtual-document applyEdit to host coordinates; when the
+    /// edit touches no virtual URIs, forward `params` with only the
+    /// bridge-local `TextDocumentEdit.version`s nulled. `Err` carries the
+    /// `failureReason` for a local `applied: false` answer — the edit must
     /// not reach the editor. See the module docs for the exact behavior.
     pub(super) async fn translate(
         &self,

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -396,8 +396,9 @@ impl Kakehashi {
 
     /// Host layer: forward the params verbatim to the host language's own
     /// servers, then apply the bridge action policy (suffix, command
-    /// disabling) per winning server. Edits stay verbatim — real URIs and
-    /// coordinates need no translation.
+    /// disabling) per winning server. Edit URIs and coordinates stay
+    /// untranslated (already real); only bridge-local
+    /// `TextDocumentEdit.version`s are nulled.
     async fn code_action_host_layer(
         &self,
         lsp_uri: &Uri,

--- a/src/lsp/lsp_impl/text_document/rename.rs
+++ b/src/lsp/lsp_impl/text_document/rename.rs
@@ -35,7 +35,14 @@ impl Kakehashi {
             raw_params,
             virt,
             native,
-            parse_host_verbatim::<WorkspaceEdit>,
+            // Host-layer edits are verbatim except versions: a downstream's
+            // document versions are bridge-local and would read as stale to
+            // version-checking editors.
+            |value| {
+                let mut edit = parse_host_verbatim::<WorkspaceEdit>(value)?;
+                crate::lsp::bridge::strip_bridge_local_versions(&mut edit);
+                Some(edit)
+            },
             rename_workspace_edit_has_result,
         )
         .await

--- a/src/lsp/lsp_impl/text_document/rename.rs
+++ b/src/lsp/lsp_impl/text_document/rename.rs
@@ -12,6 +12,7 @@ use tower_lsp_server::ls_types::{NumberOrString, Position, RenameParams, Uri, Wo
 
 use super::super::Kakehashi;
 use crate::lsp::aggregation::server::dispatch_preferred;
+use crate::lsp::bridge::strip_bridge_local_versions;
 use crate::lsp::bridge::workspace_edit_has_effect;
 use crate::lsp::lsp_impl::bridge_context::parse_host_verbatim;
 
@@ -41,7 +42,7 @@ impl Kakehashi {
             // version-checking editors.
             |value| {
                 let mut edit = parse_host_verbatim::<WorkspaceEdit>(value)?;
-                crate::lsp::bridge::strip_bridge_local_versions(&mut edit);
+                strip_bridge_local_versions(&mut edit);
                 Some(edit)
             },
             rename_workspace_edit_has_result,

--- a/src/lsp/lsp_impl/text_document/rename.rs
+++ b/src/lsp/lsp_impl/text_document/rename.rs
@@ -3,8 +3,9 @@
 //! Walks the resolved layer order (cross-layer-aggregation): the virt layer
 //! bridges the injection region under the cursor, the host layer
 //! (host-document-bridge) bridges the host document itself with the real URI
-//! and the response verbatim. The first layer producing a non-empty result
-//! wins (`preferred`).
+//! and the response as-is except that bridge-local
+//! `TextDocumentEdit.version`s are nulled. The first layer producing a
+//! non-empty result wins (`preferred`).
 
 use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::{NumberOrString, Position, RenameParams, Uri, WorkspaceEdit};


### PR DESCRIPTION
## Problem

The bridge never advertised `workspace.workspaceEdit` to downstream servers — neither in the baseline nor via the upstream merge. Per LSP, omitting it implies `documentChanges: false` and no `resourceOperations`, so spec-compliant downstreams (rust-analyzer, typescript-language-server) withheld documentChanges-shaped edits and every create/rename/delete-carrying refactor ("extract into file") from bridged codeAction — even though the bridge's WorkspaceEdit transform explicitly supports both shapes.

## Fix

**1. Mirror the editor's declaration** (`merge_upstream_capabilities`): clone `workspace.workspaceEdit` minus `changeAnnotationSupport`, which stays withheld because ls-types' untagged `OneOf` drops `annotationId` on response deserialization — inviting annotated edits would silently lose `needsConfirmation`. (The proposed 3.18 `metadataSupport`/`snippetEditSupport` are also effectively withheld: ls-types has no such fields.) Absent upstream declaration stays absent — no overclaim.

**2. Null bridge-local versions at every editor-ward relay boundary** (new shared `strip_bridge_local_versions`): mirroring `documentChanges` invites versioned `TextDocumentEdit`s, but downstream versions live in the BRIDGE's version space (each connection's didOpen counter starts at 1) — relayed verbatim, version-checking editors (Neovim) skip them as stale, i.e. the mirror's headline benefit silently no-ops. Stripped at: applyEdit forward, rename (both layers), codeAction policy + resolve (both layers), the shared strict translate. `version: null` = "apply without version check" per spec.

**Deliberate deferrals** (doc'd in the helper): mapping downstream versions to editor versions (instead of erasing) is follow-up hardening — the version was never a working cross-boundary protection (pre-strip it rejected everything), and the majority `changes`-map shape carries no version; region freshness/bounds guard coordinate validity on virtual paths, not content freshness.

## Review provenance

Local multi-perspective review (spec/correctness + bot-anticipation) + 3 codex sessions. Substantive rounds: the version-space mismatch itself (spec reviewer), virt rename/resolve leak paths (codex), doc-drift sweeps. Converged: fresh codex session returned "no comments to provide" on first response.

## Testing

Capability mirror pinned (positive with annotation strip + negative no-overclaim), snapshot fixtures updated with the faithful typical-Neovim shape (Neovim's defaults really do omit `documentChanges`), version-strip regression tests at all relay boundaries incl. multi-file documentChanges. Full lib suite + clippy \-D warnings green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale bridge-local `textDocument.version` values from reaching the editor in code actions, renames, bridged workspace edits, and `workspace/applyEdit`.
  * Ensured consistent version-stripping for multi-file edits across host and virtual translation paths.
  * Updated capability merging to mirror upstream `workspaceEdit` while withholding `changeAnnotationSupport`.
  * Clarified handling of empty virtual edit entries to avoid incorrect routing and failure indexing.
* **Tests**
  * Added and updated unit/snapshot coverage for the new version-stripping and merge behaviors.
* **Documentation**
  * Refreshed comments to reflect the narrowed “verbatim except version stripping” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->