### PR TITLE
fix(lsp): stop per-layer registry wipes from breaking sibling cancel forwarding

### DIFF
--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -48,20 +48,12 @@ fn capability_prefilter_applies(method: &str) -> bool {
     )
 }
 
-/// All resolved context needed to send bridge requests to multiple servers.
-///
-/// Produced by `Kakehashi::resolve_bridge_contexts`. Returns ALL matching server
-/// configs for the injection language, enabling fan-out to multiple downstream
-/// servers via [`fan_out()`](crate::lsp::aggregation::server::fan_out::fan_out).
-///
-/// This is the document-level context (no position). Position-based handlers
-/// use [`PositionRequestContext`] which wraps this struct.
 /// RAII sweep of the upstream-request registry for one request id: on drop,
 /// removes every entry a dropped/aborted layer future did not get to
 /// unregister itself. Idempotent with the arms' own refcounted unregisters.
-/// Hold it across a layer race so the sweep runs on every exit — normal
-/// completion, `?`, cancellation, and even the whole request future being
-/// dropped.
+/// Hold it across a layer race (or a standalone dispatch with no outer
+/// sweep) so the sweep runs on every exit — normal completion, `?`,
+/// cancellation, and even the whole request future being dropped.
 pub(crate) struct UpstreamRegistrySweepGuard {
     pub(crate) pool: std::sync::Arc<crate::lsp::bridge::LanguageServerPool>,
     pub(crate) id: Option<UpstreamId>,
@@ -73,6 +65,14 @@ impl Drop for UpstreamRegistrySweepGuard {
     }
 }
 
+/// All resolved context needed to send bridge requests to multiple servers.
+///
+/// Produced by `Kakehashi::resolve_bridge_contexts`. Returns ALL matching server
+/// configs for the injection language, enabling fan-out to multiple downstream
+/// servers via [`fan_out()`](crate::lsp::aggregation::server::fan_out::fan_out).
+///
+/// This is the document-level context (no position). Position-based handlers
+/// use [`PositionRequestContext`] which wraps this struct.
 pub(crate) struct DocumentRequestContext {
     /// The parsed document URL (url::Url).
     pub(crate) uri: Url,

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -1158,7 +1158,8 @@ impl Kakehashi {
         &self,
         race: impl Future<Output = tower_lsp_server::jsonrpc::Result<Option<R>>>,
     ) -> tower_lsp_server::jsonrpc::Result<Option<R>> {
-        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(current_upstream_id().as_ref());
+        let upstream_id = current_upstream_id();
+        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(upstream_id.as_ref());
         // RAII: sweep upstream-registry entries a dropped (losing or
         // cancelled) layer future did not get to unregister itself.
         // Idempotent; a completed arm already cleaned up its own. A guard
@@ -1166,7 +1167,7 @@ impl Kakehashi {
         // request future is ever dropped mid-race.
         let _sweep = UpstreamRegistrySweepGuard {
             pool: self.bridge.pool_arc(),
-            id: current_upstream_id(),
+            id: upstream_id,
         };
         match cancel_rx {
             Some(mut cancel_rx) => {

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -1337,9 +1337,10 @@ impl Kakehashi {
             injection_query.as_ref(),
         );
 
-        // One upstream request ID for the whole scan: every overlapping region's
-        // context shares it, and the virt codeAction path unregisters it ONCE
-        // (`unregister_all_for_upstream_id`) after fanning out to all regions.
+        // One upstream request ID for the whole scan: every overlapping
+        // region's context shares it — with the OTHER layers too, so nothing
+        // in the virt walk may wipe the registry for it; `run_layer_race`'s
+        // request-wide sweep guard owns the cleanup after all layers finish.
         // Hoisted out of the loop so that shared-ID invariant is explicit and
         // can't drift if this scan is reused under a different request-id scope.
         let upstream_request_id = current_upstream_id();

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -56,6 +56,23 @@ fn capability_prefilter_applies(method: &str) -> bool {
 ///
 /// This is the document-level context (no position). Position-based handlers
 /// use [`PositionRequestContext`] which wraps this struct.
+/// RAII sweep of the upstream-request registry for one request id: on drop,
+/// removes every entry a dropped/aborted layer future did not get to
+/// unregister itself. Idempotent with the arms' own refcounted unregisters.
+/// Hold it across a layer race so the sweep runs on every exit — normal
+/// completion, `?`, cancellation, and even the whole request future being
+/// dropped.
+pub(crate) struct UpstreamRegistrySweepGuard {
+    pub(crate) pool: std::sync::Arc<crate::lsp::bridge::LanguageServerPool>,
+    pub(crate) id: Option<UpstreamId>,
+}
+
+impl Drop for UpstreamRegistrySweepGuard {
+    fn drop(&mut self) {
+        self.pool.unregister_all_for_upstream_id(self.id.as_ref());
+    }
+}
+
 pub(crate) struct DocumentRequestContext {
     /// The parsed document URL (url::Url).
     pub(crate) uri: Url,
@@ -980,7 +997,12 @@ impl Kakehashi {
             cancel_rx,
         )
         .await;
-        pool.unregister_all_for_upstream_id(ctx.upstream_request_id.as_ref());
+        // No `unregister_all` here: as a walk arm this future runs
+        // concurrently with the virt/native layers under the SAME upstream id
+        // (`run_layer_race` sweeps after the whole race), and wiping the
+        // registry on this arm's completion would drop a live sibling's
+        // cancel registrations. The one non-walk caller
+        // (`will_save_wait_until`) sweeps for itself.
         // Quieter than `FanInResult::handle`: an all-empty host layer is the
         // normal outcome whenever virt answers, and the virt arm already
         // emits the client-visible "no response" LOG — only real host
@@ -1137,7 +1159,16 @@ impl Kakehashi {
         race: impl Future<Output = tower_lsp_server::jsonrpc::Result<Option<R>>>,
     ) -> tower_lsp_server::jsonrpc::Result<Option<R>> {
         let (cancel_rx, _cancel_guard) = self.subscribe_cancel(current_upstream_id().as_ref());
-        let result = match cancel_rx {
+        // RAII: sweep upstream-registry entries a dropped (losing or
+        // cancelled) layer future did not get to unregister itself.
+        // Idempotent; a completed arm already cleaned up its own. A guard
+        // (not a trailing statement) so the sweep also runs if this whole
+        // request future is ever dropped mid-race.
+        let _sweep = UpstreamRegistrySweepGuard {
+            pool: self.bridge.pool_arc(),
+            id: current_upstream_id(),
+        };
+        match cancel_rx {
             Some(mut cancel_rx) => {
                 tokio::select! {
                     biased;
@@ -1146,14 +1177,7 @@ impl Kakehashi {
                 }
             }
             None => race.await,
-        };
-        // Sweep upstream-registry entries a dropped (losing or cancelled) layer
-        // future did not get to unregister itself. Idempotent; a completed arm
-        // already cleaned up its own.
-        self.bridge
-            .pool_arc()
-            .unregister_all_for_upstream_id(current_upstream_id().as_ref());
-        result
+        }
     }
 
     /// Cross-layer walk that picks `preferred` (first-wins) vs `concatenated`

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -55,8 +55,17 @@ fn capability_prefilter_applies(method: &str) -> bool {
 /// sweep) so the sweep runs on every exit — normal completion, `?`,
 /// cancellation, and even the whole request future being dropped.
 pub(crate) struct UpstreamRegistrySweepGuard {
-    pub(crate) pool: std::sync::Arc<crate::lsp::bridge::LanguageServerPool>,
-    pub(crate) id: Option<UpstreamId>,
+    pool: std::sync::Arc<crate::lsp::bridge::LanguageServerPool>,
+    id: Option<UpstreamId>,
+}
+
+impl UpstreamRegistrySweepGuard {
+    pub(crate) fn new(
+        pool: std::sync::Arc<crate::lsp::bridge::LanguageServerPool>,
+        id: Option<UpstreamId>,
+    ) -> Self {
+        Self { pool, id }
+    }
 }
 
 impl Drop for UpstreamRegistrySweepGuard {
@@ -1165,10 +1174,7 @@ impl Kakehashi {
         // Idempotent; a completed arm already cleaned up its own. A guard
         // (not a trailing statement) so the sweep also runs if this whole
         // request future is ever dropped mid-race.
-        let _sweep = UpstreamRegistrySweepGuard {
-            pool: self.bridge.pool_arc(),
-            id: upstream_id,
-        };
+        let _sweep = UpstreamRegistrySweepGuard::new(self.bridge.pool_arc(), upstream_id);
         match cancel_rx {
             Some(mut cancel_rx) => {
                 tokio::select! {

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -1050,9 +1050,11 @@ impl Kakehashi {
     /// - Native has no contributor for bridged methods.
     ///
     /// A losing in-flight future is dropped; its RAII guards clean up the
-    /// response router and cancel subscription, and the trailing
-    /// `unregister_all_for_upstream_id` sweeps any upstream-registry entries
-    /// the dropped future did not get to remove itself.
+    /// response router and cancel subscription, and the request-scoped
+    /// [`UpstreamRegistrySweepGuard`] in [`run_layer_race`](Self::run_layer_race)
+    /// sweeps any upstream-registry entries the dropped future did not get to
+    /// remove itself — on drop, so the sweep also runs when this whole request
+    /// is cancelled.
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn walk_layers<R>(
         &self,

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -337,14 +337,17 @@ impl Kakehashi {
             return Ok(None);
         }
 
-        // All overlapping regions share THIS request's upstream id. Hold the
-        // pool registration cleanup ONCE for the whole walk (single
-        // `unregister_all` after the loop) rather than per region. The cancel
-        // subscription here is usually a redundant duplicate — the caller
-        // (`walk_layers_by_strategy` → `run_layer_race`) already subscribes the
-        // same id across the whole virt future, so this returns `None` and the
-        // outer race's `select!` cancels the loop. Keeping it makes the walk
-        // self-cancelling even if ever driven outside that race.
+        // All overlapping regions share THIS request's upstream id. Pool
+        // registration cleanup is NOT done here: the host layer runs
+        // concurrently under the same upstream id (`race_layers_concatenated`
+        // is codeAction's default), so a walk-level `unregister_all` would
+        // wipe the sibling layer's live cancel registrations the moment this
+        // layer finishes. Completed dispatches unregister themselves
+        // (refcounted), and the caller (`walk_layers_by_strategy` →
+        // `run_layer_race`) sweeps whatever a dropped arm left behind after
+        // the WHOLE race. The cancel subscription here is usually a redundant
+        // duplicate of that caller's — kept so the walk stays self-cancelling
+        // even if ever driven outside the race.
         let upstream_id = contexts[0].document.upstream_request_id.clone();
         let (cancel_rx, _cancel_guard) = self.subscribe_cancel(upstream_id.as_ref());
 
@@ -368,17 +371,13 @@ impl Kakehashi {
         // surfaces `RequestCancelled` (-32800), matching how the outer
         // `run_layer_race` reports cancellation — so a client `$/cancelRequest`
         // is never masked as an empty result.
-        let result = match cancel_rx {
+        match cancel_rx {
             Some(rx) => tokio::select! {
                 r = walk => r,
                 _ = rx => Err(tower_lsp_server::jsonrpc::Error::request_cancelled()),
             },
             None => walk.await,
-        };
-        self.bridge
-            .pool_arc()
-            .unregister_all_for_upstream_id(upstream_id.as_ref());
-        result
+        }
     }
 
     /// Fan out `textDocument/codeAction` across the servers bridging ONE
@@ -529,7 +528,12 @@ impl Kakehashi {
                 )))
             }
         };
-        let result = match ctx.strategy {
+        // No layer-level `unregister_all` here: the virt layer runs
+        // concurrently under the SAME upstream id, so wiping the registry on
+        // this layer's completion would drop the sibling's live cancel
+        // registrations. Completed dispatches unregister themselves
+        // (refcounted); `run_layer_race` sweeps after the whole race.
+        match ctx.strategy {
             AggregationStrategy::Preferred => {
                 let fan_in = dispatch_host_preferred(
                     &ctx,
@@ -546,9 +550,7 @@ impl Kakehashi {
                     dispatch_host_concatenated(&ctx, pool.clone(), f, cancel_rx, None, None).await;
                 self.host_code_action_result(fan_in, concat_merge).await
             }
-        };
-        pool.unregister_all_for_upstream_id(ctx.upstream_request_id.as_ref());
-        result
+        }
     }
 
     /// Fold a host-layer fan-in result into the handler's return, with the

--- a/src/lsp/lsp_impl/text_document/color_presentation.rs
+++ b/src/lsp/lsp_impl/text_document/color_presentation.rs
@@ -33,6 +33,13 @@ impl Kakehashi {
 
         // Fan-out color presentation requests to all matching servers
         let pool = self.bridge.pool_arc();
+        // RAII sweep: virt-only handler with no layer race or outer sweep —
+        // clean stale registry entries on every exit, including a dropped
+        // request future (dispatch_preferred aborts losers without joining).
+        let _sweep = crate::lsp::lsp_impl::bridge_context::UpstreamRegistrySweepGuard {
+            pool: pool.clone(),
+            id: ctx.document.upstream_request_id.clone(),
+        };
         let range = ctx.range;
         let result = dispatch_preferred(
             &ctx.document,
@@ -57,7 +64,6 @@ impl Kakehashi {
             cancel_rx,
         )
         .await;
-        pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
 
         result
             .handle(&self.client, "color presentation", Vec::new(), Ok)

--- a/src/lsp/lsp_impl/text_document/color_presentation.rs
+++ b/src/lsp/lsp_impl/text_document/color_presentation.rs
@@ -36,10 +36,10 @@ impl Kakehashi {
         // RAII sweep: virt-only handler with no layer race or outer sweep —
         // clean stale registry entries on every exit, including a dropped
         // request future (dispatch_preferred aborts losers without joining).
-        let _sweep = crate::lsp::lsp_impl::bridge_context::UpstreamRegistrySweepGuard {
-            pool: pool.clone(),
-            id: ctx.document.upstream_request_id.clone(),
-        };
+        let _sweep = crate::lsp::lsp_impl::bridge_context::UpstreamRegistrySweepGuard::new(
+            pool.clone(),
+            ctx.document.upstream_request_id.clone(),
+        );
         let range = ctx.range;
         let result = dispatch_preferred(
             &ctx.document,

--- a/src/lsp/lsp_impl/text_document/completion.rs
+++ b/src/lsp/lsp_impl/text_document/completion.rs
@@ -82,7 +82,6 @@ impl Kakehashi {
             cancel_rx,
         )
         .await;
-        pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
 
         result
             .handle(&self.client, "completion", None, |v| {

--- a/src/lsp/lsp_impl/text_document/declaration.rs
+++ b/src/lsp/lsp_impl/text_document/declaration.rs
@@ -88,7 +88,6 @@ impl Kakehashi {
             cancel_rx,
         )
         .await;
-        pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
         result.handle(&self.client, "declaration", None, Ok).await
     }
 

--- a/src/lsp/lsp_impl/text_document/definition.rs
+++ b/src/lsp/lsp_impl/text_document/definition.rs
@@ -92,7 +92,6 @@ impl Kakehashi {
             cancel_rx,
         )
         .await;
-        pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
         result.handle(&self.client, "definition", None, Ok).await
     }
 

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -312,14 +312,23 @@ impl Kakehashi {
         };
 
         // Both layers fan out concurrently; the layer strategy decides the
-        // combine. Cancel drops both in-flight layer futures.
+        // combine. Cancel drops both in-flight layer futures. The RAII sweep
+        // cleans stale upstream-registry entries on every exit (completion,
+        // cancel, or the request future being dropped) — it fires only after
+        // both layer futures are dropped/settled, so no live sharer of the
+        // id can be wiped. Sweeping while dropped futures unwind is safe:
+        // cancel forwarding captures its targets before notifying, and the
+        // pool tolerates entries unregistered out of order.
+        let _sweep = crate::lsp::lsp_impl::bridge_context::UpstreamRegistrySweepGuard {
+            pool: pool.clone(),
+            id: upstream_request_id.clone(),
+        };
         let combined = async { tokio::join!(virt_fut, host_fut) };
         let (mut virt_items, mut host_items) = match cancel_rx {
             Some(mut cancel_rx) => {
                 tokio::select! {
                     biased;
                     _ = &mut cancel_rx => {
-                        pool.unregister_all_for_upstream_id(upstream_request_id.as_ref());
                         return Err(tower_lsp_server::jsonrpc::Error::request_cancelled());
                     }
                     result = combined => result,
@@ -327,14 +336,6 @@ impl Kakehashi {
             }
             None => combined.await,
         };
-
-        // Clean up stale upstream registry entries once all layer tasks have
-        // completed. On the cancel path above the sweep runs BEFORE the
-        // dropped futures unwind — safe because cancel forwarding
-        // captures its targets before notifying, and the pool tolerates
-        // entries unregistered out of order (see forward_cancel_by
-        // _upstream_id_with_notify).
-        pool.unregister_all_for_upstream_id(upstream_request_id.as_ref());
 
         // pushFallback (Path B, #425): the live pulls above cover only
         // pull-driven servers (capability-gated). Fold in push-driven servers'

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -319,10 +319,10 @@ impl Kakehashi {
         // id can be wiped. Sweeping while dropped futures unwind is safe:
         // cancel forwarding captures its targets before notifying, and the
         // pool tolerates entries unregistered out of order.
-        let _sweep = crate::lsp::lsp_impl::bridge_context::UpstreamRegistrySweepGuard {
-            pool: pool.clone(),
-            id: upstream_request_id.clone(),
-        };
+        let _sweep = crate::lsp::lsp_impl::bridge_context::UpstreamRegistrySweepGuard::new(
+            pool.clone(),
+            upstream_request_id.clone(),
+        );
         let combined = async { tokio::join!(virt_fut, host_fut) };
         let (mut virt_items, mut host_items) = match cancel_rx {
             Some(mut cancel_rx) => {

--- a/src/lsp/lsp_impl/text_document/document_color.rs
+++ b/src/lsp/lsp_impl/text_document/document_color.rs
@@ -177,19 +177,21 @@ impl Kakehashi {
             });
         }
 
+        // RAII sweep of stale upstream registry entries: fires after the
+        // collection settles or the whole request future is dropped — after
+        // the JoinSet is drained/dropped, so cancel forwarding remains intact
+        // for all in-flight downstream requests. Nothing else shares the id
+        // (virt-only handler, no layer race, no outer sweep).
+        let _sweep = crate::lsp::lsp_impl::bridge_context::UpstreamRegistrySweepGuard {
+            pool: pool.clone(),
+            id: upstream_request_id.clone(),
+        };
         // Collect results, aborting early if $/cancelRequest arrives.
-        let result = crate::lsp::aggregation::region::collect_region_results_with_cancel(
+        crate::lsp::aggregation::region::collect_region_results_with_cancel(
             outer_join_set,
             cancel_rx,
             |acc, items: Vec<ColorInformation>| acc.extend(items),
         )
-        .await;
-
-        // Clean up stale upstream registry entries once all region tasks have completed
-        // (or been aborted via JoinSet drop). Must happen after the JoinSet is drained
-        // so cancel forwarding remains intact for all in-flight downstream requests.
-        pool.unregister_all_for_upstream_id(upstream_request_id.as_ref());
-
-        result
+        .await
     }
 }

--- a/src/lsp/lsp_impl/text_document/document_color.rs
+++ b/src/lsp/lsp_impl/text_document/document_color.rs
@@ -182,10 +182,10 @@ impl Kakehashi {
         // the JoinSet is drained/dropped, so cancel forwarding remains intact
         // for all in-flight downstream requests. Nothing else shares the id
         // (virt-only handler, no layer race, no outer sweep).
-        let _sweep = crate::lsp::lsp_impl::bridge_context::UpstreamRegistrySweepGuard {
-            pool: pool.clone(),
-            id: upstream_request_id.clone(),
-        };
+        let _sweep = crate::lsp::lsp_impl::bridge_context::UpstreamRegistrySweepGuard::new(
+            pool.clone(),
+            upstream_request_id.clone(),
+        );
         // Collect results, aborting early if $/cancelRequest arrives.
         crate::lsp::aggregation::region::collect_region_results_with_cancel(
             outer_join_set,

--- a/src/lsp/lsp_impl/text_document/document_highlight.rs
+++ b/src/lsp/lsp_impl/text_document/document_highlight.rs
@@ -82,7 +82,6 @@ impl Kakehashi {
             cancel_rx,
         )
         .await;
-        pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
 
         result
             .handle(&self.client, "document highlight", None, Ok)

--- a/src/lsp/lsp_impl/text_document/document_symbol.rs
+++ b/src/lsp/lsp_impl/text_document/document_symbol.rs
@@ -250,10 +250,6 @@ impl Kakehashi {
         )
         .await;
 
-        // Clean up stale upstream registry entries once all region tasks have completed
-        // (or been aborted via JoinSet drop). Must happen after the JoinSet is drained
-        // so cancel forwarding remains intact for all in-flight downstream requests.
-
         let all_symbols = result?;
 
         Ok(format_document_symbol_response(

--- a/src/lsp/lsp_impl/text_document/document_symbol.rs
+++ b/src/lsp/lsp_impl/text_document/document_symbol.rs
@@ -253,7 +253,6 @@ impl Kakehashi {
         // Clean up stale upstream registry entries once all region tasks have completed
         // (or been aborted via JoinSet drop). Must happen after the JoinSet is drained
         // so cancel forwarding remains intact for all in-flight downstream requests.
-        pool.unregister_all_for_upstream_id(upstream_request_id.as_ref());
 
         let all_symbols = result?;
 

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -136,10 +136,10 @@ impl Kakehashi {
         // aborted region task may not reach its refcounted unregister. RAII so
         // the sweep also runs on the `?` early returns; it fires only after
         // BOTH layers settled, so no live sibling can be wiped.
-        let _sweep = crate::lsp::lsp_impl::bridge_context::UpstreamRegistrySweepGuard {
-            pool: self.bridge.pool_arc(),
-            id: upstream_request_id.clone(),
-        };
+        let _sweep = crate::lsp::lsp_impl::bridge_context::UpstreamRegistrySweepGuard::new(
+            self.bridge.pool_arc(),
+            upstream_request_id.clone(),
+        );
         let mut cancel_state = self.setup_formatting_cancel_token(upstream_request_id.as_ref());
         cancel_state.request_error_sink = request_error_sink;
         let original = snapshot.text_arc();

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -131,6 +131,15 @@ impl Kakehashi {
         let layer_cfg = self.resolve_layer_config(&language_name, "textDocument/formatting");
 
         let upstream_request_id = crate::lsp::current_upstream_id();
+        // Formatting drives its own layer race (not `run_layer_race`), so it
+        // holds its own registry sweep: a dropped losing arm (Preferred) or an
+        // aborted region task may not reach its refcounted unregister. RAII so
+        // the sweep also runs on the `?` early returns; it fires only after
+        // BOTH layers settled, so no live sibling can be wiped.
+        let _sweep = crate::lsp::lsp_impl::bridge_context::UpstreamRegistrySweepGuard {
+            pool: self.bridge.pool_arc(),
+            id: upstream_request_id.clone(),
+        };
         let mut cancel_state = self.setup_formatting_cancel_token(upstream_request_id.as_ref());
         cancel_state.request_error_sink = request_error_sink;
         let original = snapshot.text_arc();
@@ -452,9 +461,12 @@ impl Kakehashi {
             ClientProgressDeregisterGuard::new(registry, cp_minted, aggregator, pool.upstream_tx())
         });
 
-        let response = finalize_formatting_edits(outer_join_set, cancel_state.token.clone()).await;
-        pool.unregister_all_for_upstream_id(upstream_request_id.as_ref());
-        response
+        // No `unregister_all` here: under the Preferred cross-layer strategy
+        // this future races the host layer under the SAME upstream id, and
+        // wiping the registry on this arm's completion would drop the
+        // sibling's live cancel registrations. `formatting_impl_with_error_sink`
+        // sweeps once after the whole strategy dispatch.
+        finalize_formatting_edits(outer_join_set, cancel_state.token.clone()).await
     }
 
     /// Format the host document itself (the **host** layer,
@@ -520,7 +532,9 @@ impl Kakehashi {
             cancel_rx,
         )
         .await;
-        pool.unregister_all_for_upstream_id(ctx.upstream_request_id.as_ref());
+        // No `unregister_all` here — same reason as the virt arm: under
+        // Preferred this races the virt layer on one shared upstream id;
+        // the caller sweeps once after the whole strategy dispatch.
         // Count failures only when no host server won (#503): `NoResult` drains
         // every task, so its `errors` is the exhaustive, deterministic count.
         count_no_winner_errors(&result, &cancel_state.request_error_sink);

--- a/src/lsp/lsp_impl/text_document/hover.rs
+++ b/src/lsp/lsp_impl/text_document/hover.rs
@@ -70,7 +70,6 @@ impl Kakehashi {
             cancel_rx,
         )
         .await;
-        pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
         result.handle(&self.client, "hover", None, Ok).await
     }
 }

--- a/src/lsp/lsp_impl/text_document/implementation.rs
+++ b/src/lsp/lsp_impl/text_document/implementation.rs
@@ -88,7 +88,6 @@ impl Kakehashi {
             cancel_rx,
         )
         .await;
-        pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
         result
             .handle(&self.client, "implementation", None, Ok)
             .await

--- a/src/lsp/lsp_impl/text_document/inlay_hint.rs
+++ b/src/lsp/lsp_impl/text_document/inlay_hint.rs
@@ -83,7 +83,6 @@ impl Kakehashi {
             cancel_rx,
         )
         .await;
-        pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
 
         result.handle(&self.client, "inlay hint", None, Ok).await
     }

--- a/src/lsp/lsp_impl/text_document/linked_editing_range.rs
+++ b/src/lsp/lsp_impl/text_document/linked_editing_range.rs
@@ -78,7 +78,6 @@ impl Kakehashi {
             cancel_rx,
         )
         .await;
-        pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
         result
             .handle(&self.client, "linkedEditingRange", None, Ok)
             .await

--- a/src/lsp/lsp_impl/text_document/moniker.rs
+++ b/src/lsp/lsp_impl/text_document/moniker.rs
@@ -75,7 +75,6 @@ impl Kakehashi {
             cancel_rx,
         )
         .await;
-        pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
 
         result.handle(&self.client, "moniker", None, Ok).await
     }

--- a/src/lsp/lsp_impl/text_document/on_type_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/on_type_formatting.rs
@@ -91,7 +91,6 @@ impl Kakehashi {
             cancel_rx,
         )
         .await;
-        pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
         result
             .handle(&self.client, "onTypeFormatting", None, Ok)
             .await

--- a/src/lsp/lsp_impl/text_document/prepare_rename.rs
+++ b/src/lsp/lsp_impl/text_document/prepare_rename.rs
@@ -84,7 +84,6 @@ impl Kakehashi {
             cancel_rx,
         )
         .await;
-        pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
         result.handle(&self.client, "prepareRename", None, Ok).await
     }
 }

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -356,9 +356,7 @@ impl Kakehashi {
                 )
             });
 
-            let response =
-                finalize_formatting_edits(outer_join_set, cancel_state.token.clone()).await;
-            response
+            finalize_formatting_edits(outer_join_set, cancel_state.token.clone()).await
         };
 
         // layer_method keys off "textDocument/formatting" ON PURPOSE: range

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -358,7 +358,6 @@ impl Kakehashi {
 
             let response =
                 finalize_formatting_edits(outer_join_set, cancel_state.token.clone()).await;
-            pool.unregister_all_for_upstream_id(upstream_request_id.as_ref());
             response
         };
 

--- a/src/lsp/lsp_impl/text_document/references.rs
+++ b/src/lsp/lsp_impl/text_document/references.rs
@@ -92,7 +92,6 @@ impl Kakehashi {
             cancel_rx,
         )
         .await;
-        pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
 
         result.handle(&self.client, "references", None, Ok).await
     }

--- a/src/lsp/lsp_impl/text_document/rename.rs
+++ b/src/lsp/lsp_impl/text_document/rename.rs
@@ -99,7 +99,6 @@ impl Kakehashi {
             cancel_rx,
         )
         .await;
-        pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
         result.handle(&self.client, "rename", None, Ok).await
     }
 }

--- a/src/lsp/lsp_impl/text_document/signature_help.rs
+++ b/src/lsp/lsp_impl/text_document/signature_help.rs
@@ -82,7 +82,6 @@ impl Kakehashi {
             cancel_rx,
         )
         .await;
-        pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
         result
             .handle(&self.client, "signature help", None, Ok)
             .await

--- a/src/lsp/lsp_impl/text_document/type_definition.rs
+++ b/src/lsp/lsp_impl/text_document/type_definition.rs
@@ -88,7 +88,6 @@ impl Kakehashi {
             cancel_rx,
         )
         .await;
-        pool.unregister_all_for_upstream_id(ctx.document.upstream_request_id.as_ref());
         result
             .handle(&self.client, "type definition", None, Ok)
             .await

--- a/src/lsp/lsp_impl/text_document/will_save_wait_until.rs
+++ b/src/lsp/lsp_impl/text_document/will_save_wait_until.rs
@@ -58,10 +58,10 @@ impl Kakehashi {
         // upstream-registry unregister. The RAII sweep cleans the id on every
         // exit — success, timeout, and a dropped request future alike.
         // Nothing else shares the id here.
-        let _sweep = crate::lsp::lsp_impl::bridge_context::UpstreamRegistrySweepGuard {
-            pool: self.bridge.pool_arc(),
-            id: ctx.upstream_request_id.clone(),
-        };
+        let _sweep = crate::lsp::lsp_impl::bridge_context::UpstreamRegistrySweepGuard::new(
+            self.bridge.pool_arc(),
+            ctx.upstream_request_id.clone(),
+        );
         let fut =
             self.host_layer_value_with_ctx(&ctx, "textDocument/willSaveWaitUntil", raw_params);
         let value = match tokio::time::timeout(WILL_SAVE_WAIT_UNTIL_BUDGET, fut).await {

--- a/src/lsp/lsp_impl/text_document/will_save_wait_until.rs
+++ b/src/lsp/lsp_impl/text_document/will_save_wait_until.rs
@@ -55,7 +55,17 @@ impl Kakehashi {
         let fut =
             self.host_layer_value_with_ctx(&ctx, "textDocument/willSaveWaitUntil", raw_params);
         let value = match tokio::time::timeout(WILL_SAVE_WAIT_UNTIL_BUDGET, fut).await {
-            Ok(result) => result?,
+            Ok(result) => {
+                // Standalone host dispatch (no layer race, so no
+                // `run_layer_race` sweep): `dispatch_host_preferred` aborts
+                // losing per-server tasks without joining them, and an
+                // aborted task may not reach its own unregister — sweep the
+                // id ourselves. Nothing else shares it here.
+                self.bridge
+                    .pool_arc()
+                    .unregister_all_for_upstream_id(ctx.upstream_request_id.as_ref());
+                result?
+            }
             Err(_) => {
                 // Bounded save latency (#357 Q3): abandon the in-flight host
                 // request and let the editor save without save-time edits.

--- a/src/lsp/lsp_impl/text_document/will_save_wait_until.rs
+++ b/src/lsp/lsp_impl/text_document/will_save_wait_until.rs
@@ -52,36 +52,31 @@ impl Kakehashi {
             }
         };
 
+        // Standalone host dispatch (no layer race, so no `run_layer_race`
+        // sweep): `dispatch_host_preferred` aborts losing per-server tasks
+        // without joining them, and an aborted task may not reach its own
+        // upstream-registry unregister. The RAII sweep cleans the id on every
+        // exit — success, timeout, and a dropped request future alike.
+        // Nothing else shares the id here.
+        let _sweep = crate::lsp::lsp_impl::bridge_context::UpstreamRegistrySweepGuard {
+            pool: self.bridge.pool_arc(),
+            id: ctx.upstream_request_id.clone(),
+        };
         let fut =
             self.host_layer_value_with_ctx(&ctx, "textDocument/willSaveWaitUntil", raw_params);
         let value = match tokio::time::timeout(WILL_SAVE_WAIT_UNTIL_BUDGET, fut).await {
-            Ok(result) => {
-                // Standalone host dispatch (no layer race, so no
-                // `run_layer_race` sweep): `dispatch_host_preferred` aborts
-                // losing per-server tasks without joining them, and an
-                // aborted task may not reach its own unregister — sweep the
-                // id ourselves. Nothing else shares it here.
-                self.bridge
-                    .pool_arc()
-                    .unregister_all_for_upstream_id(ctx.upstream_request_id.as_ref());
-                result?
-            }
+            Ok(result) => result?,
             Err(_) => {
                 // Bounded save latency (#357 Q3): abandon the in-flight host
                 // request and let the editor save without save-time edits.
-                // The per-server requests run as spawned tasks; dropping `fut`
-                // aborts them, and an aborted task may not reach its own
-                // upstream-registry unregister, so sweep the id here to avoid
-                // leaking the cancel mapping. (The abort does not send a
-                // downstream $/cancelRequest — the host server keeps computing,
-                // which the 5s budget accepts in exchange for a fast save.)
+                // Dropping `fut` aborts the spawned per-server tasks. (The
+                // abort does not send a downstream $/cancelRequest — the host
+                // server keeps computing, which the 5s budget accepts in
+                // exchange for a fast save.)
                 log::warn!(
                     "willSaveWaitUntil timed out after {WILL_SAVE_WAIT_UNTIL_BUDGET:?}; \
                      saving without host save-time edits"
                 );
-                self.bridge
-                    .pool_arc()
-                    .unregister_all_for_upstream_id(ctx.upstream_request_id.as_ref());
                 return Ok(None);
             }
         };

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -255,7 +255,6 @@ impl Kakehashi {
             // Clean up stale upstream registry entries once all region tasks have completed
             // (or been aborted via JoinSet drop). Must happen after the JoinSet is drained
             // so cancel forwarding remains intact for all in-flight downstream requests.
-            pool.unregister_all_for_upstream_id(upstream_request_id.as_ref());
 
             let all_items = all_items?;
             Ok(if all_items.is_empty() {

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -252,10 +252,6 @@ impl Kakehashi {
             )
             .await;
 
-            // Clean up stale upstream registry entries once all region tasks have completed
-            // (or been aborted via JoinSet drop). Must happen after the JoinSet is drained
-            // so cancel forwarding remains intact for all in-flight downstream requests.
-
             let all_items = all_items?;
             Ok(if all_items.is_empty() {
                 None


### PR DESCRIPTION
## Problem

Every LSP request's virt/host/native layers race concurrently under ONE shared upstream request id, but nearly every layered method's arms called `pool.unregister_all_for_upstream_id` on their own completion — a call that bypasses the per-(id,key) refcounts and deletes the whole registry entry. Whichever arm finished first wiped its still-running sibling's cancel registrations: a `$/cancelRequest` arriving after that was never forwarded downstream, leaving the sibling's requests to run to completion (up to the 30s timeout). Best-effort-cancel degradation only — no result corruption. Affected: codeAction (where it was found), plus hover, definition/declaration/typeDefinition/implementation, references, rename/prepareRename, completion, signatureHelp, documentHighlight, linkedEditingRange, inlayHint, moniker, documentSymbol, onTypeFormatting, foldingRange, rangeFormatting, the generic host arm, and formatting's two arms.

## Fix

Per-layer wipes removed everywhere, per a full classification pass over all 28 call sites:

- **Deleted (19 sites + generic host arm)**: completed dispatches already unregister themselves refcount-correctly, and `run_layer_race`'s request-wide sweep covers dropped/losing arms — every deleted site is only ever driven under that race.
- **New RAII guard** (`UpstreamRegistrySweepGuard`): `run_layer_race`'s trailing sweep became a guard held across the race (drop-safe); formatting — which races layers outside `run_layer_race` — holds its own; the standalone handlers with no outer sweep (will_save_wait_until, pull diagnostics, document_color, color_presentation) each hold one instead of their manual sweeps, all placed to fire only after their layer futures/JoinSets are dropped, so no live sharer can be wiped.
- Ownership comments updated at every touched site.

## Review provenance

Concurrency-perspective review confirmed the refcount-bypass class (distinct from the previously-refuted refcounted `unregister_upstream_request` concerns); codex rounds drove the repo-wide sibling sweep, the classification of keep-vs-delete sites, drop-safety, and comment accuracy. Converged: fresh codex session returned "no comments to provide" on first response.

## Testing

Full lib suite + clippy \-D warnings green. Not separately unit-tested: exercising the wipe needs a full two-layer concurrent walk against a live pool registry; the cancel-forwarding e2e gap is tracked with the other codeAction test-coverage follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved request cleanup consistency by introducing request-scoped automatic upstream registry sweeping, ensuring stale entries are removed on normal completion, cancellation, timeouts, and when in-flight work is dropped mid-race.
  - Fixed concurrent host/virtual layer races by removing per-layer unregister behavior that could wipe sibling cancel/registration state; cleanup is now handled once per request.
  - Kept `/cancelRequest` behavior consistent across diagnostics, formatting, completion, hover, rename/navigation-related requests, and multi-region flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->