### PR TITLE
fix(bridge): gate workspace.applyEdit on the editor's own capability

### DIFF
--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -901,7 +901,8 @@ async fn handle_message(
 }
 
 /// Handle an inbound downstream `$/cancelRequest`: if it targets a forwarded
-/// request still in flight (`window/showMessageRequest` / `window/showDocument`),
+/// request still in flight (`window/showMessageRequest`, `window/showDocument`,
+/// or a supported `workspace/applyEdit`),
 /// cancel the editor-bound request so its dialog is dismissed (#404). The id is
 /// parsed as a [`jsonrpc::Id`] exactly as the original request's id was, so the
 /// registry key matches. Ids that aren't tracked (e.g. the bridge's own outbound

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -183,7 +183,8 @@ pub(crate) enum UpstreamRequest {
     /// `failureReason`, `failedChange`) is relayed back — the downstream acts
     /// on the outcome. The forwarding loop translates virtual-document edits
     /// back to host coordinates before the editor sees them, and answers
-    /// untranslatable edits `applied: false` locally (#568).
+    /// untranslatable edits — and all edits when the editor never declared
+    /// `workspace.applyEdit` — `applied: false` locally (#568).
     ApplyEdit {
         params: tower_lsp_server::ls_types::ApplyWorkspaceEditParams,
         reply: oneshot::Sender<tower_lsp_server::ls_types::ApplyWorkspaceEditResponse>,

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -254,8 +254,9 @@ pub(crate) struct ServerRequestDeps {
     pub(crate) window_tx: mpsc::Sender<UpstreamNotification>,
     /// Downstream-initiated requests forwarded to the editor with a response
     /// relayed back (`window/showMessageRequest`, `window/showDocument`,
-    /// `workspace/applyEdit`). Unbounded: a dropped request would hang the
-    /// downstream. See [`UpstreamRequest`].
+    /// `workspace/applyEdit` — answered locally when the editor lacks the
+    /// capability). Unbounded: a dropped request would hang the downstream.
+    /// See [`UpstreamRequest`].
     pub(crate) upstream_request_tx: mpsc::UnboundedSender<UpstreamRequest>,
     /// Tracks in-flight forwarded requests so a downstream `$/cancelRequest`
     /// (or connection death) can cancel the editor-bound request (#404).

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -183,8 +183,9 @@ pub(crate) enum UpstreamRequest {
     /// `failureReason`, `failedChange`) is relayed back — the downstream acts
     /// on the outcome. The forwarding loop translates virtual-document edits
     /// back to host coordinates before the editor sees them, and answers
-    /// untranslatable edits — and all edits when the editor never declared
-    /// `workspace.applyEdit` — `applied: false` locally (#568).
+    /// untranslatable edits — and every `workspace/applyEdit` request when
+    /// the editor never declared the `workspace.applyEdit` capability —
+    /// `applied: false` locally (#568).
     ApplyEdit {
         params: tower_lsp_server::ls_types::ApplyWorkspaceEditParams,
         reply: oneshot::Sender<tower_lsp_server::ls_types::ApplyWorkspaceEditResponse>,

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -260,6 +260,8 @@ pub(crate) struct ServerRequestDeps {
     pub(crate) upstream_request_tx: mpsc::UnboundedSender<UpstreamRequest>,
     /// Tracks in-flight forwarded requests so a downstream `$/cancelRequest`
     /// (or connection death) can cancel the editor-bound request (#404).
+    /// (Capability-gated applyEdits are registered too, though answered
+    /// locally.)
     pub(crate) inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry,
     /// The folders this connection currently serves, used to answer downstream
     /// `workspace/workspaceFolders` pulls. Mutable: a `preferSharedInstance`
@@ -959,10 +961,12 @@ async fn handle_server_request(
         .unwrap_or_default();
     let method = message.get("method").and_then(|v| v.as_str()).unwrap_or("");
 
-    // Deferred request handlers forward to the editor and relay its response
-    // back asynchronously (the editor may pend on user interaction), so they own
-    // their entire response lifecycle on a spawned task rather than returning a
-    // synchronous `body` to frame-and-send below.
+    // Deferred request handlers forward to the editor (or, for a
+    // workspace/applyEdit the editor never declared support for, answer
+    // locally) and relay the response back asynchronously (the editor may
+    // pend on user interaction), so they own their entire response lifecycle
+    // on a spawned task rather than returning a synchronous `body` to
+    // frame-and-send below.
     match method {
         "window/showMessageRequest" => {
             window::show_message_request::handle(&message, id, server_prefix, deps);
@@ -1018,7 +1022,8 @@ async fn handle_server_request(
 ///
 /// Used both by the synchronous dispatch in [`handle_server_request`] and by the
 /// deferred request handlers ([`window::show_message_request`],
-/// [`window::show_document`]) that relay an editor response back asynchronously.
+/// [`window::show_document`], [`workspace::apply_edit`]) that relay a
+/// response back asynchronously.
 ///
 /// We use [`OutboundMessage::Untracked`] because a server-initiated response has
 /// no [`ResponseRouter`] entry to clean up on failure (unlike `Tracked`

--- a/src/lsp/bridge/inbound_request_registry.rs
+++ b/src/lsp/bridge/inbound_request_registry.rs
@@ -8,7 +8,9 @@
 //! cancel so a `showMessageRequest` dialog is dismissed. tower-lsp's `Client`
 //! exposes no cancel API for an outgoing request, so the forwarding loop instead
 //! sends the request with an id it minted (see `send_editor_request`) and, on
-//! cancel, sends a correlated `$/cancelRequest` to the editor.
+//! cancel, sends a correlated `$/cancelRequest` to the editor. (A locally
+//! answered request — the capability-gated applyEdit — is unregistered before
+//! its token is ever awaited, so cancellation has nothing to do there.)
 //!
 //! This registry connects the two halves: the per-connection reader (which sees
 //! the downstream `$/cancelRequest` and the connection lifecycle) registers each

--- a/src/lsp/bridge/inbound_request_registry.rs
+++ b/src/lsp/bridge/inbound_request_registry.rs
@@ -1,6 +1,7 @@
 //! Cancellation registry for downstream-initiated requests forwarded to the
 //! editor (`window/showMessageRequest`, `window/showDocument`,
-//! `workspace/applyEdit`).
+//! `workspace/applyEdit` — which is registered but answered locally, never
+//! editor-bound, when the editor lacks the capability).
 //!
 //! When a downstream server sends `$/cancelRequest` for such a request — or its
 //! connection dies while one is in flight — the bridge must tell the editor to

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -340,7 +340,8 @@ pub struct LanguageServerPool {
     client_progress_registry: Arc<super::ClientProgressRegistry>,
     /// Tracks downstream-initiated requests forwarded to the editor so a
     /// downstream `$/cancelRequest` (or connection death) can cancel the
-    /// editor-bound request (#404). Shared with every reader task (to register /
+    /// editor-bound request (#404) — capability-gated applyEdits are
+    /// registered too, though answered locally. Shared with every reader task (to register /
     /// fire) and the forwarding loop (to await / drop). Distinct from
     /// `upstream_request_registry`, which is the *outbound* (editor → downstream)
     /// cancel direction.

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -318,7 +318,9 @@ pub struct LanguageServerPool {
     /// Receiver for window notifications, taken once by the forwarding task.
     window_rx: std::sync::Mutex<Option<tokio::sync::mpsc::Receiver<UpstreamNotification>>>,
     /// Sender for downstream-initiated requests forwarded to the editor with a
-    /// response relayed back (`window/showMessageRequest`, `window/showDocument`).
+    /// response relayed back (`window/showMessageRequest`, `window/showDocument`,
+    /// `workspace/applyEdit` — answered locally when the editor lacks the
+    /// capability).
     ///
     /// Cloned into each reader task. Unbounded: a dropped request would hang the
     /// downstream waiting for a response (loss-intolerant, like `upstream_tx`).

--- a/src/lsp/bridge/protocol/client_capabilities.rs
+++ b/src/lsp/bridge/protocol/client_capabilities.rs
@@ -126,11 +126,13 @@ fn build_baseline_capabilities(
         workspace: Some(WorkspaceClientCapabilities {
             // The bridge handles inbound `workspace/applyEdit` (#568 PR 5),
             // translating virtual-document edits to the host document and
-            // relaying the editor's response. Advertise it so a spec-compliant
-            // downstream server actually issues applyEdit (e.g. rust-analyzer's
-            // "extract into function") instead of assuming the client can't
-            // apply edits.
-            apply_edit: Some(true),
+            // relaying the editor's response — but the relay terminates at the
+            // EDITOR, so the capability is only honest when the editor itself
+            // declared `workspace.applyEdit`. Gated in
+            // `merge_upstream_capabilities` (like `window.workDoneProgress`):
+            // withheld here, advertised downstream only when the editor
+            // genuinely supports it.
+            apply_edit: None,
             // The bridge executes a surfaced command via `workspace/executeCommand`
             // (#568 PR 6), so advertise the client capability — a spec-compliant
             // server may withhold command-carrying actions otherwise. No dynamic
@@ -178,7 +180,9 @@ fn build_baseline_capabilities(
 /// `signatureHelp.signatureInformation`, `window.workDoneProgress`,
 /// `window.showDocument`, `window.showMessage`,
 /// `workspace.workspaceEdit` (mirrored minus `changeAnnotationSupport` — see
-/// the merge site for why annotations are withheld).
+/// the merge site for why annotations are withheld), and `workspace.applyEdit`
+/// (gated on the editor genuinely declaring it — the relay terminates at the
+/// editor).
 ///
 /// `window.workDoneProgress` and `window.showDocument` are gated on the real
 /// upstream editor so the bridge only invites a downstream server-initiated
@@ -319,6 +323,23 @@ fn merge_upstream_capabilities(
         base.workspace
             .get_or_insert_with(Default::default)
             .workspace_edit = Some(mirrored);
+    }
+
+    // --- workspace.applyEdit (gated on real upstream support) ---
+    // The bridge can only relay a downstream `workspace/applyEdit` to an
+    // editor that declared the capability itself; advertising it regardless
+    // would invite requests the bridge can only answer `applied: false`.
+    // Same gating rationale as `window.workDoneProgress` below. An explicit
+    // `false` or an absent value stays unadvertised.
+    if upstream
+        .workspace
+        .as_ref()
+        .and_then(|w| w.apply_edit)
+        .unwrap_or(false)
+    {
+        base.workspace
+            .get_or_insert_with(Default::default)
+            .apply_edit = Some(true);
     }
 
     // --- window.workDoneProgress (gated on real upstream support) ---
@@ -471,6 +492,41 @@ mod tests {
                 .is_none(),
             "an editor that omits workspaceEdit implies documentChanges:false — do not overclaim"
         );
+    }
+
+    #[test]
+    fn apply_edit_gated_on_upstream_declaration() {
+        use tower_lsp_server::ls_types::WorkspaceClientCapabilities;
+
+        // Editor declares workspace.applyEdit → advertised downstream.
+        let upstream = ClientCapabilities {
+            workspace: Some(WorkspaceClientCapabilities {
+                apply_edit: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let merged = build_bridge_client_capabilities(Some(&upstream), true, false);
+        assert_eq!(
+            merged.workspace.as_ref().and_then(|w| w.apply_edit),
+            Some(true)
+        );
+
+        // Editor silent (or explicit false) → withheld: the bridge could only
+        // ever answer applied:false, so inviting applyEdits would overclaim.
+        let merged =
+            build_bridge_client_capabilities(Some(&ClientCapabilities::default()), true, false);
+        assert_eq!(merged.workspace.as_ref().and_then(|w| w.apply_edit), None);
+
+        let upstream_false = ClientCapabilities {
+            workspace: Some(WorkspaceClientCapabilities {
+                apply_edit: Some(false),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let merged = build_bridge_client_capabilities(Some(&upstream_false), true, false);
+        assert_eq!(merged.workspace.as_ref().and_then(|w| w.apply_edit), None);
     }
 
     #[test]
@@ -910,6 +966,8 @@ mod tests {
                     ]),
                     ..Default::default()
                 }),
+                // Neovim's default capabilities declare applyEdit.
+                apply_edit: Some(true),
                 ..Default::default()
             }),
             text_document: Some(TextDocumentClientCapabilities {

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@default.snap
@@ -4,7 +4,6 @@ expression: capabilities
 ---
 {
   "workspace": {
-    "applyEdit": true,
     "executeCommand": {
       "dynamicRegistration": false
     },

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__client_capabilities__tests__bridge_client_capabilities_snapshot@experimental.snap
@@ -4,7 +4,6 @@ expression: capabilities
 ---
 {
   "workspace": {
-    "applyEdit": true,
     "executeCommand": {
       "dynamicRegistration": false
     },

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@default.snap
@@ -11,7 +11,6 @@ expression: request
     "rootUri": null,
     "capabilities": {
       "workspace": {
-        "applyEdit": true,
         "executeCommand": {
           "dynamicRegistration": false
         },

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_has_correct_structure@experimental.snap
@@ -11,7 +11,6 @@ expression: request
     "rootUri": null,
     "capabilities": {
       "workspace": {
-        "applyEdit": true,
         "executeCommand": {
           "dynamicRegistration": false
         },

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@default.snap
@@ -22,7 +22,6 @@ expression: request
     },
     "capabilities": {
       "workspace": {
-        "applyEdit": true,
         "executeCommand": {
           "dynamicRegistration": false
         },

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_initialization_options@experimental.snap
@@ -22,7 +22,6 @@ expression: request
     },
     "capabilities": {
       "workspace": {
-        "applyEdit": true,
         "executeCommand": {
           "dynamicRegistration": false
         },

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@default.snap
@@ -11,7 +11,6 @@ expression: request
     "rootUri": null,
     "capabilities": {
       "workspace": {
-        "applyEdit": true,
         "executeCommand": {
           "dynamicRegistration": false
         },

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_includes_workspace_folders_when_provided@experimental.snap
@@ -11,7 +11,6 @@ expression: request
     "rootUri": null,
     "capabilities": {
       "workspace": {
-        "applyEdit": true,
         "executeCommand": {
           "dynamicRegistration": false
         },

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@default.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@default.snap
@@ -11,7 +11,6 @@ expression: request
     "rootUri": null,
     "capabilities": {
       "workspace": {
-        "applyEdit": true,
         "executeCommand": {
           "dynamicRegistration": false
         },

--- a/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@experimental.snap
+++ b/src/lsp/bridge/protocol/snapshots/kakehashi__lsp__bridge__protocol__lifecycle__tests__initialize_request_with_upstream_capabilities@experimental.snap
@@ -11,7 +11,6 @@ expression: request
     "rootUri": null,
     "capabilities": {
       "workspace": {
-        "applyEdit": true,
         "executeCommand": {
           "dynamicRegistration": false
         },

--- a/src/lsp/bridge/workspace/apply_edit.rs
+++ b/src/lsp/bridge/workspace/apply_edit.rs
@@ -9,9 +9,9 @@
 //! **Edit translation happens downstream of this handler:** the forwarding
 //! loop rewrites virtual-document URIs + ranges back to the host document
 //! (see `ApplyEditTranslator` in `lsp_impl::apply_edit_translation`) before
-//! sending the edit to the editor, and answers untranslatable edits —
-//! and, when the editor never declared `workspace.applyEdit`, ALL edits —
-//! `applied: false` locally. This handler stays transport-only, exactly like
+//! sending the edit to the editor, and answers untranslatable edits
+//! `applied: false` locally — as it does EVERY `workspace/applyEdit` request
+//! when the editor never declared the `workspace.applyEdit` capability. This handler stays transport-only, exactly like
 //! [`show_document`](crate::lsp::bridge::window::show_document).
 //!
 //! Like the other deferred handlers this **defers** its response on a spawned

--- a/src/lsp/bridge/workspace/apply_edit.rs
+++ b/src/lsp/bridge/workspace/apply_edit.rs
@@ -35,7 +35,9 @@ use crate::lsp::bridge::actor::{
 const METHOD: &str = "workspace/applyEdit";
 
 /// Handle a `workspace/applyEdit` request, relaying the editor's
-/// `ApplyWorkspaceEditResponse` back to the downstream asynchronously.
+/// `ApplyWorkspaceEditResponse` back to the downstream asynchronously (the
+/// forwarding loop answers `applied: false` locally — no editor round-trip —
+/// when the editor never declared `workspace.applyEdit`).
 pub(in crate::lsp::bridge) fn handle(
     message: &serde_json::Value,
     id: jsonrpc::Id,

--- a/src/lsp/bridge/workspace/apply_edit.rs
+++ b/src/lsp/bridge/workspace/apply_edit.rs
@@ -9,7 +9,8 @@
 //! **Edit translation happens downstream of this handler:** the forwarding
 //! loop rewrites virtual-document URIs + ranges back to the host document
 //! (see `ApplyEditTranslator` in `lsp_impl::apply_edit_translation`) before
-//! sending the edit to the editor, and answers untranslatable edits
+//! sending the edit to the editor, and answers untranslatable edits —
+//! and, when the editor never declared `workspace.applyEdit`, ALL edits —
 //! `applied: false` locally. This handler stays transport-only, exactly like
 //! [`show_document`](crate::lsp::bridge::window::show_document).
 //!

--- a/src/lsp/bridge/workspace/apply_edit.rs
+++ b/src/lsp/bridge/workspace/apply_edit.rs
@@ -10,8 +10,10 @@
 //! loop rewrites virtual-document URIs + ranges back to the host document
 //! (see `ApplyEditTranslator` in `lsp_impl::apply_edit_translation`) before
 //! sending the edit to the editor, and answers untranslatable edits
-//! `applied: false` locally — as it does EVERY `workspace/applyEdit` request
-//! when the editor never declared the `workspace.applyEdit` capability. This handler stays transport-only, exactly like
+//! `applied: false` locally. When the editor never declared the
+//! `workspace.applyEdit` capability, the loop answers every
+//! `workspace/applyEdit` request `applied: false` the same way. This handler
+//! stays transport-only, exactly like
 //! [`show_document`](crate::lsp::bridge::window::show_document).
 //!
 //! Like the other deferred handlers this **defers** its response on a spawned

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -454,7 +454,10 @@ impl Kakehashi {
         //   window/showMessage, and telemetry/event.
         // - unbounded `upstream_request_rx` (loss-intolerant): downstream
         //   requests forwarded with a response relayed back
-        //   (window/showMessageRequest, window/showDocument, workspace/applyEdit).
+        //   (window/showMessageRequest, window/showDocument, and — only when
+        //   the editor declared the capability — workspace/applyEdit; without
+        //   it the reader answers applied:false locally and nothing reaches
+        //   this channel).
         if let Some(upstream_rx) = self.bridge.take_upstream_rx()
             && let Some(window_rx) = self.bridge.take_window_rx()
             && let Some(upstream_request_rx) = self.bridge.take_upstream_request_rx()
@@ -3002,9 +3005,11 @@ mod tests {
             .expect("reply delivered");
         // And nothing was emitted toward the editor: the request stream must
         // be empty (a regression that both forwards and answers locally would
-        // otherwise pass).
+        // otherwise pass). Yield first so a wrongly-spawned forward gets a
+        // fair chance to run before the bounded negative-observation window.
+        tokio::task::yield_now().await;
         let no_request = tokio::time::timeout(
-            std::time::Duration::from_millis(100),
+            std::time::Duration::from_millis(250),
             futures::StreamExt::next(&mut requests),
         )
         .await;

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -454,10 +454,10 @@ impl Kakehashi {
         //   window/showMessage, and telemetry/event.
         // - unbounded `upstream_request_rx` (loss-intolerant): downstream
         //   requests forwarded with a response relayed back
-        //   (window/showMessageRequest, window/showDocument, and — only when
-        //   the editor declared the capability — workspace/applyEdit; without
-        //   it the reader answers applied:false locally and nothing reaches
-        //   this channel).
+        //   (window/showMessageRequest, window/showDocument,
+        //   workspace/applyEdit — though when the editor never declared the
+        //   applyEdit capability, the forwarding loop answers applied:false
+        //   itself instead of forwarding to the editor).
         if let Some(upstream_rx) = self.bridge.take_upstream_rx()
             && let Some(window_rx) = self.bridge.take_window_rx()
             && let Some(upstream_request_rx) = self.bridge.take_upstream_request_rx()

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -688,7 +688,9 @@ async fn forward_upstream_request(
 ///   Every region slot is retained and barriers remain FIFO, so
 ///   `publish`↔`evict` order and create-before-progress hold.
 /// - `upstream_request_rx` (unbounded): downstream-initiated *requests*
-///   (`window/showMessageRequest`, `window/showDocument`) forwarded with the
+///   (`window/showMessageRequest`, `window/showDocument`,
+///   `workspace/applyEdit` — the latter answered `applied: false` locally
+///   when the editor never declared the capability) forwarded with the
 ///   editor's response relayed back; loss-intolerant (a dropped request hangs
 ///   the downstream). Serviced via [`spawn_upstream_request`] so a slow/human
 ///   editor never stalls the loop.
@@ -2943,7 +2945,7 @@ mod tests {
     async fn apply_edit_answers_applied_false_when_editor_lacks_capability() {
         use crate::lsp::bridge::UpstreamRequest;
 
-        let (client, _requests, _responses) = init_client_and_socket().await;
+        let (client, mut requests, _responses) = init_client_and_socket().await;
 
         let (_upstream_tx, upstream_rx) = tokio::sync::mpsc::unbounded_channel();
         let (_window_tx, window_rx) = tokio::sync::mpsc::channel(16);
@@ -2990,6 +2992,18 @@ mod tests {
         // The reply arrives WITHOUT any editor round-trip (no response is ever
         // fed to `_responses`), proving the request was answered locally.
         let response = reply_rx.await.expect("reply delivered");
+        // And nothing was emitted toward the editor: the request stream must
+        // be empty (a regression that both forwards and answers locally would
+        // otherwise pass).
+        let no_request = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            futures::StreamExt::next(&mut requests),
+        )
+        .await;
+        assert!(
+            no_request.is_err(),
+            "no editor-bound request may be emitted, got: {no_request:?}"
+        );
         assert!(!response.applied);
         assert!(
             response

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -482,6 +482,16 @@ impl Kakehashi {
             let diagnostic_publisher = Some(Arc::new(
                 crate::lsp::lsp_impl::coordinator::DiagnosticPublisher::new(self),
             ));
+            // LSP conditions workspace/applyEdit on the client capability;
+            // resolved once here — client capabilities are fixed after
+            // initialize.
+            let editor_supports_apply_edit = self
+                .settings_manager
+                .client_capabilities_lock()
+                .get()
+                .and_then(|caps| caps.workspace.as_ref())
+                .and_then(|w| w.apply_edit)
+                .unwrap_or(false);
             tokio::spawn(upstream_forwarding_loop(
                 upstream_rx,
                 window_rx,
@@ -491,6 +501,7 @@ impl Kakehashi {
                 client,
                 diagnostic_publisher,
                 token,
+                editor_supports_apply_edit,
             ));
         }
     }
@@ -713,6 +724,7 @@ async fn upstream_forwarding_loop(
     client: Client,
     diagnostic_publisher: Option<Arc<crate::lsp::lsp_impl::coordinator::DiagnosticPublisher>>,
     cancel_token: tokio_util::sync::CancellationToken,
+    editor_supports_apply_edit: bool,
 ) {
     // Tokens the editor successfully created. `$/progress` is forwarded only for
     // these: if a create timed out or was rejected, the editor never created the
@@ -789,6 +801,7 @@ async fn upstream_forwarding_loop(
                             translators.clone(),
                             &client,
                             request,
+                            editor_supports_apply_edit,
                         )
                     }
                     None => break, // Channel closed
@@ -1119,6 +1132,7 @@ fn spawn_upstream_request(
     translators: Option<Arc<UpstreamRequestTranslators>>,
     client: &Client,
     request: crate::lsp::bridge::UpstreamRequest,
+    editor_supports_apply_edit: bool,
 ) {
     use crate::lsp::bridge::UpstreamRequest;
     use tower_lsp_server::ls_types::{
@@ -1225,6 +1239,27 @@ fn spawn_upstream_request(
                 cancel,
             } => {
                 use tower_lsp_server::ls_types::ApplyWorkspaceEditResponse;
+                // LSP makes workspace/applyEdit conditional on the CLIENT
+                // capability: an editor that did not declare
+                // `workspace.applyEdit` must not receive the request (the
+                // bridge also stops advertising it downstream in that case,
+                // so this is the fail-soft for servers that send one anyway).
+                if !editor_supports_apply_edit {
+                    inbound_request_registry.unregister(
+                        cancel.connection_id,
+                        &cancel.request_id,
+                        cancel.generation,
+                    );
+                    let _ = reply.send(ApplyWorkspaceEditResponse {
+                        applied: false,
+                        failure_reason: Some(
+                            "kakehashi: the editor does not support workspace/applyEdit"
+                                .to_string(),
+                        ),
+                        failed_change: None,
+                    });
+                    return;
+                }
                 // Translate virtual-document edits back to host coordinates
                 // before forwarding (#568). Unlike showDocument there is no
                 // safe degraded forward: an untranslatable edit (unknown/stale
@@ -1802,6 +1837,7 @@ mod tests {
             client,
             None,
             cancel.clone(),
+            true,
         ));
 
         let token = NumberOrString::String("kakehashi/bridge/progress/0".to_string());
@@ -1922,6 +1958,7 @@ mod tests {
             client,
             None,
             cancel.clone(),
+            true,
         ));
 
         // The loop delivers the first create (a request that awaits the editor).
@@ -2013,6 +2050,7 @@ mod tests {
             client,
             None,
             cancel.clone(),
+            true,
         ));
 
         let token = NumberOrString::String("kakehashi/bridge/progress/0".to_string());
@@ -2130,6 +2168,7 @@ mod tests {
             client,
             None,
             cancel.clone(),
+            true,
         ));
 
         let token = NumberOrString::String("kakehashi/bridge/progress/0".to_string());
@@ -2248,6 +2287,7 @@ mod tests {
             client,
             None,
             cancel.clone(),
+            true,
         ));
 
         let token = NumberOrString::String("kakehashi/bridge/progress/0".to_string());
@@ -2368,6 +2408,7 @@ mod tests {
             client,
             None,
             cancel.clone(),
+            true,
         ));
 
         let token = NumberOrString::String("kakehashi/bridge/progress/0".to_string());
@@ -2491,6 +2532,7 @@ mod tests {
             client,
             None,
             cancel.clone(),
+            true,
         ));
 
         let stale = NumberOrString::String("kakehashi/bridge/progress/0".to_string());
@@ -2659,6 +2701,7 @@ mod tests {
             client,
             None,
             cancel.clone(),
+            true,
         ));
 
         // No create was ever sent for this token, yet ClientProgress must be
@@ -2810,6 +2853,7 @@ mod tests {
             client,
             None,
             cancel.clone(),
+            true,
         ));
 
         let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
@@ -2866,6 +2910,7 @@ mod tests {
             client,
             None,
             cancel.clone(),
+            true,
         ));
 
         let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
@@ -2895,6 +2940,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn apply_edit_answers_applied_false_when_editor_lacks_capability() {
+        use crate::lsp::bridge::UpstreamRequest;
+
+        let (client, _requests, _responses) = init_client_and_socket().await;
+
+        let (_upstream_tx, upstream_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (_window_tx, window_rx) = tokio::sync::mpsc::channel(16);
+        let (request_tx, request_rx) = tokio::sync::mpsc::unbounded_channel();
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let loop_handle = tokio::spawn(upstream_forwarding_loop(
+            upstream_rx,
+            window_rx,
+            request_rx,
+            None,
+            crate::lsp::bridge::InboundRequestRegistry::default(),
+            client,
+            None,
+            cancel.clone(),
+            // The editor did NOT declare workspace.applyEdit: the request
+            // must be answered applied:false locally, never forwarded.
+            false,
+        ));
+
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        request_tx
+            .send(UpstreamRequest::ApplyEdit {
+                params: serde_json::from_value(serde_json::json!({
+                    "edit": { "changes": { "file:///x.rs": [] } }
+                }))
+                .unwrap(),
+                reply: reply_tx,
+                cancel: test_forwarded_cancel(),
+            })
+            .unwrap();
+
+        // The reply arrives WITHOUT any editor round-trip (no response is ever
+        // fed to `_responses`), proving the request was answered locally.
+        let response = reply_rx.await.expect("reply delivered");
+        assert!(!response.applied);
+        assert!(
+            response
+                .failure_reason
+                .as_deref()
+                .is_some_and(|r| r.contains("does not support workspace/applyEdit")),
+            "failureReason should name the missing capability: {:?}",
+            response.failure_reason
+        );
+
+        cancel.cancel();
+        let _ = loop_handle.await;
+    }
+
+    #[tokio::test]
     async fn forwarding_loop_relays_apply_edit_response() {
         use crate::lsp::bridge::UpstreamRequest;
         use futures::{SinkExt, StreamExt};
@@ -2917,6 +3015,7 @@ mod tests {
             client,
             None,
             cancel.clone(),
+            true,
         ));
 
         let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
@@ -2988,6 +3087,7 @@ mod tests {
             client,
             None,
             cancel.clone(),
+            true,
         ));
 
         let host = tower_lsp_server::ls_types::Uri::from_str("file:///project/doc.md").unwrap();
@@ -3060,6 +3160,7 @@ mod tests {
             client,
             None,
             loop_cancel.clone(),
+            true,
         ));
 
         // The per-request cancel token the reader would have registered.
@@ -3137,6 +3238,7 @@ mod tests {
             client,
             None,
             cancel.clone(),
+            true,
         ));
 
         // An object payload passes through unchanged.

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -993,7 +993,9 @@ fn coalesce_upstream_batch(
 
 /// Service a downstream-initiated request by forwarding it to the editor on a
 /// detached task and relaying the editor's answer through the request's `reply`
-/// oneshot.
+/// oneshot. (Exception: a `workspace/applyEdit` the editor never declared
+/// support for is answered `applied: false` locally, without an editor
+/// round-trip.)
 ///
 /// Spawned (not awaited) so the shared forwarding loop keeps draining
 /// notifications while the editor — possibly a human — takes its time. On editor
@@ -1018,7 +1020,8 @@ fn coalesce_upstream_batch(
 /// `client.*` call returns `Err` promptly and the task ends.
 ///
 /// Why not bound this as flood protection? A request flood from an
-/// adversarial/buggy downstream propagates to the editor either way — exactly as
+/// adversarial/buggy downstream propagates to the editor either way (modulo
+/// the capability-gated applyEdit local answer) — exactly as
 /// it would if the editor spoke to that server directly, with no bridge. The
 /// bridge cannot shield the client from such floods, and rate-limiting
 /// client-facing requests is the *client's* responsibility; the bridge's job is
@@ -2991,7 +2994,10 @@ mod tests {
 
         // The reply arrives WITHOUT any editor round-trip (no response is ever
         // fed to `_responses`), proving the request was answered locally.
-        let response = reply_rx.await.expect("reply delivered");
+        let response = tokio::time::timeout(std::time::Duration::from_secs(5), reply_rx)
+            .await
+            .expect("a local answer must arrive without any editor round-trip")
+            .expect("reply delivered");
         // And nothing was emitted toward the editor: the request stream must
         // be empty (a regression that both forwards and answers locally would
         // otherwise pass).

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -2949,12 +2949,13 @@ mod tests {
         let (_window_tx, window_rx) = tokio::sync::mpsc::channel(16);
         let (request_tx, request_rx) = tokio::sync::mpsc::unbounded_channel();
         let cancel = tokio_util::sync::CancellationToken::new();
+        let registry = crate::lsp::bridge::InboundRequestRegistry::default();
         let loop_handle = tokio::spawn(upstream_forwarding_loop(
             upstream_rx,
             window_rx,
             request_rx,
             None,
-            crate::lsp::bridge::InboundRequestRegistry::default(),
+            registry.clone(),
             client,
             None,
             cancel.clone(),
@@ -2963,6 +2964,17 @@ mod tests {
             false,
         ));
 
+        // Register the request the way the reader does, so the test verifies
+        // the local-answer path unregisters it.
+        let connection_id = crate::lsp::bridge::ProgressConnectionId::for_test(0);
+        let request_id = tower_lsp_server::jsonrpc::Id::Number(1);
+        let (token, generation) = registry.register(connection_id, request_id.clone());
+        let forwarded_cancel = crate::lsp::bridge::ForwardedRequestCancel {
+            connection_id,
+            request_id: request_id.clone(),
+            token: token.clone(),
+            generation,
+        };
         let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
         request_tx
             .send(UpstreamRequest::ApplyEdit {
@@ -2971,7 +2983,7 @@ mod tests {
                 }))
                 .unwrap(),
                 reply: reply_tx,
-                cancel: test_forwarded_cancel(),
+                cancel: forwarded_cancel,
             })
             .unwrap();
 
@@ -2986,6 +2998,14 @@ mod tests {
                 .is_some_and(|r| r.contains("does not support workspace/applyEdit")),
             "failureReason should name the missing capability: {:?}",
             response.failure_reason
+        );
+
+        // The registry entry must be gone: a $/cancelRequest after the local
+        // answer must find nothing to cancel.
+        registry.cancel(connection_id, &request_id);
+        assert!(
+            !token.is_cancelled(),
+            "the entry must have been unregistered by the local-answer path"
         );
 
         cancel.cancel();

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1263,7 +1263,8 @@ fn spawn_upstream_request(
                     let _ = reply.send(ApplyWorkspaceEditResponse {
                         applied: false,
                         failure_reason: Some(
-                            "kakehashi: the editor does not support workspace/applyEdit"
+                            "kakehashi: the editor did not declare the workspace.applyEdit \
+                             capability"
                                 .to_string(),
                         ),
                         failed_change: None,
@@ -3022,7 +3023,7 @@ mod tests {
             response
                 .failure_reason
                 .as_deref()
-                .is_some_and(|r| r.contains("does not support workspace/applyEdit")),
+                .is_some_and(|r| r.contains("workspace.applyEdit")),
             "failureReason should name the missing capability: {:?}",
             response.failure_reason
         );

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -444,8 +444,10 @@ impl Kakehashi {
     pub(crate) async fn initialized_impl(&self, _: InitializedParams) {
         self.notifier().log_info("server is ready").await;
 
-        // Forward downstream-initiated messages to the upstream editor. The
-        // reader tasks feed three channels:
+        // Forward downstream-initiated messages to the upstream editor
+        // (workspace/applyEdit is answered locally instead when the editor
+        // never declared the capability). The reader tasks feed three
+        // channels:
         // - unbounded `upstream_rx` (loss-intolerant): DiagnosticRefresh and
         //   work-done progress (create/$progress/forget).
         // - bounded `window_rx` (best-effort, drop-on-full): window/logMessage,

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -121,7 +121,16 @@ fn literal_support_caps(disabled_support: bool) -> Value {
 /// the applyEdit-relay e2e tests opt in, so every other test keeps the
 /// minimal capability surface.
 fn with_apply_edit(mut caps: Value) -> Value {
-    caps["workspace"] = json!({ "applyEdit": true });
+    // Merge instead of replacing `workspace`, so a caller that already
+    // declares other workspace.* capabilities keeps them.
+    match caps.get_mut("workspace") {
+        Some(Value::Object(workspace)) => {
+            workspace.insert("applyEdit".to_string(), json!(true));
+        }
+        _ => {
+            caps["workspace"] = json!({ "applyEdit": true });
+        }
+    }
     caps
 }
 

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -113,10 +113,16 @@ fn literal_support_caps(disabled_support: bool) -> Value {
     }
     json!({
         "textDocument": { "codeAction": code_action },
-        // The bridge relays downstream workspace/applyEdit only to editors
-        // that declare the capability; the applyEdit e2e depends on it.
-        "workspace": { "applyEdit": true }
     })
+}
+
+/// Add `workspace.applyEdit` to a capability set. The bridge relays
+/// downstream `workspace/applyEdit` only to editors that declare it; only
+/// the applyEdit-relay e2e tests opt in, so every other test keeps the
+/// minimal capability surface.
+fn with_apply_edit(mut caps: Value) -> Value {
+    caps["workspace"] = json!({ "applyEdit": true });
+    caps
 }
 
 /// Literal support PLUS dataSupport + resolveSupport — the client can hold a
@@ -440,7 +446,8 @@ fn executing_a_bridged_command_routes_back_and_relays_the_server_applyedit() {
     // server with the ORIGINAL name; the server answers by asking the client to
     // apply an edit (host-translated by the bridge) and returns a result the
     // bridge relays verbatim.
-    let (mut client, init_response, _config_dir) = init_client(literal_support_caps(true));
+    let (mut client, init_response, _config_dir) =
+        init_client(with_apply_edit(literal_support_caps(true)));
     assert_advertised(&init_response);
     open_markdown(&mut client);
 
@@ -895,7 +902,8 @@ fn palette_fired_command_routes_to_its_origin_server() {
     // from the palette, keyed off the advertised executeCommandProvider.commands
     // — routes to the server that advertised it (recorded at handshake), not just
     // commands surfaced through a bridged code action.
-    let (mut client, init_response, _config_dir) = init_client(literal_support_caps(true));
+    let (mut client, init_response, _config_dir) =
+        init_client(with_apply_edit(literal_support_caps(true)));
     assert_advertised(&init_response);
     open_markdown(&mut client);
     // Drive a codeAction so mock-codeaction handshakes and registers "mock.run".

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -111,7 +111,12 @@ fn literal_support_caps(disabled_support: bool) -> Value {
     if disabled_support {
         code_action["disabledSupport"] = json!(true);
     }
-    json!({ "textDocument": { "codeAction": code_action } })
+    json!({
+        "textDocument": { "codeAction": code_action },
+        // The bridge relays downstream workspace/applyEdit only to editors
+        // that declare the capability; the applyEdit e2e depends on it.
+        "workspace": { "applyEdit": true }
+    })
 }
 
 /// Literal support PLUS dataSupport + resolveSupport — the client can hold a

--- a/tests/e2e_code_action.rs
+++ b/tests/e2e_code_action.rs
@@ -121,6 +121,13 @@ fn literal_support_caps(disabled_support: bool) -> Value {
 /// the applyEdit-relay e2e tests opt in, so every other test keeps the
 /// minimal capability surface.
 fn with_apply_edit(mut caps: Value) -> Value {
+    // A capability set is always a JSON object; fail with a clear message
+    // instead of the opaque panic Value's index-assign raises on, say, an
+    // array.
+    assert!(
+        caps.is_object(),
+        "with_apply_edit expects a capability object, got: {caps:?}"
+    );
     // Merge instead of replacing `workspace`, so a caller that already
     // declares other workspace.* capabilities keeps them.
     match caps.get_mut("workspace") {


### PR DESCRIPTION
## Problem

The bridge advertised `workspace.applyEdit` to every downstream server unconditionally, and the forwarding loop sent `workspace/applyEdit` to the editor without checking its capability. If the editor never declared `workspace.applyEdit`, the bridge (a) invited downstream applyEdits it could only fail, and (b) sent the editor a server→client request outside its advertised capabilities — a spec violation, and inconsistent with the same file's careful gating of `window.workDoneProgress`/`window.showDocument`.

## Fix

- **Advertisement**: withheld from the baseline; `merge_upstream_capabilities` mirrors it only when the editor genuinely declares `workspace.applyEdit == true` (explicit `false` and absent stay unadvertised) — the same gating pattern as `workDoneProgress`.
- **Forwarding**: the flag is resolved once at `initialized` (client capabilities are fixed after initialize) and threaded into the forwarding loop, whose ApplyEdit arm answers a stray downstream request `applied: false` locally with a capability-naming `failureReason` — registered/unregistered in the inbound cancel registry, never contacting the editor.
- Snapshots: baseline + initialize-request fixtures lose the unconditional `applyEdit`; the typical-Neovim merge fixture gains the declaration (Neovim's defaults do declare it). e2e capability fixtures now declare it where the tests depend on the relay.
- Docs: every applyEdit-specific contract (variant, handler, registry, cancel handler, channel notes) carries the local-answer exception.

## Review provenance

Flagged as MAJOR by the LSP-spec reviewer in the codeAction-family audit. 5 codex rounds fixed: e2e fixtures that would have timed out under the gate, a registry-cleanup assertion, a bounded test wait, and doc drift; one generic-contract doc request was declined with rationale (no correctness consequence — codex concurred). Converged: fresh codex session returned "no comments to provide" on first response.

## Testing

Capability-merge unit tests (declared/absent/explicit-false), a forwarding-loop test pinning the local `applied:false` answer (asserts NO editor-bound request is emitted and the registry entry is gone), full e2e_code_action suite (43 tests, --features e2e), full lib suite + clippy \-D warnings green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The bridge now advertises `workspace/applyEdit` only when the editor explicitly declares support.
  * If `workspace/applyEdit` isn’t supported, edit requests are handled locally with `applied: false` and a `failureReason`, without involving the editor.
  * Local `applyEdit` handling is decoupled from editor-bound request cancellation behavior.
* **Tests**
  * Added unit coverage for capability-gated `applyEdit` and updated related snapshots.
  * Updated end-to-end test initialization to declare `workspace.applyEdit: true`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->