### PR TITLE
fix(bridge): log the codeAction family's silent fail-softs

### DIFF
--- a/src/lsp/bridge/protocol/command_routing.rs
+++ b/src/lsp/bridge/protocol/command_routing.rs
@@ -63,6 +63,16 @@ pub(crate) struct CommandRoute<'a> {
 /// remainder).
 pub(crate) fn encode_command(origin: &str, host_uri: &str, command: &str) -> Option<String> {
     if origin.contains(SEP) || host_uri.contains(SEP) {
+        // Not a transient: the origin is a TOML config key, so an affected
+        // config drops this server's commands on EVERY request. One warn here
+        // covers all four call sites (initial bare/embedded command, virt and
+        // host resolve), which fail closed on the `None`.
+        log::warn!(
+            target: "kakehashi::bridge",
+            "cannot mint a routing name for command '{command}': the server name \
+             ('{origin}') or host URI contains the reserved separator; the command \
+             is dropped — rename the server in languageServers to fix this"
+        );
         return None;
     }
     Some(format!(

--- a/src/lsp/bridge/protocol/command_routing.rs
+++ b/src/lsp/bridge/protocol/command_routing.rs
@@ -68,12 +68,14 @@ pub(crate) fn encode_command(origin: &str, host_uri: &str, command: &str) -> Opt
         // covers all four call sites (initial bare/embedded command, virt and
         // host resolve), which fail closed on the `None` — deduplicated per
         // distinct origin so per-action shaping loops don't spam the log.
-        static WARNED_ORIGINS: std::sync::Mutex<Option<std::collections::HashSet<String>>> =
-            std::sync::Mutex::new(None);
+        // (Not `Mutex::new(HashSet::new())` in a plain static: `HashSet::new`
+        // is not const — it builds a RandomState. LazyLock defers it.)
+        static WARNED_ORIGINS: std::sync::LazyLock<
+            std::sync::Mutex<std::collections::HashSet<String>>,
+        > = std::sync::LazyLock::new(Default::default);
         let first_for_origin = WARNED_ORIGINS
             .lock()
             .map(|mut set| {
-                let set = set.get_or_insert_with(Default::default);
                 // Check before allocating: after the first warn, the hot
                 // per-action path pays only a lookup.
                 !set.contains(origin) && set.insert(origin.to_string())
@@ -83,9 +85,10 @@ pub(crate) fn encode_command(origin: &str, host_uri: &str, command: &str) -> Opt
             log::warn!(
                 target: "kakehashi::bridge",
                 "cannot mint routing names for server '{origin}' (first affected \
-                 command: '{command}'): the server name or host URI contains the \
-                 reserved separator; its commands are dropped — rename the server \
-                 in languageServers to fix this"
+                 command: '{command}'): the server name or the host URI contains \
+                 the reserved 0x1f separator, so its routed commands are dropped. \
+                 If the server name is the culprit, rename it in languageServers; \
+                 a separator in a document URI has no config fix"
             );
         }
         return None;

--- a/src/lsp/bridge/protocol/command_routing.rs
+++ b/src/lsp/bridge/protocol/command_routing.rs
@@ -73,19 +73,23 @@ pub(crate) fn encode_command(origin: &str, host_uri: &str, command: &str) -> Opt
         static WARNED_ORIGINS: std::sync::LazyLock<
             std::sync::Mutex<std::collections::HashSet<String>>,
         > = std::sync::LazyLock::new(Default::default);
-        let first_for_origin = WARNED_ORIGINS
+        // Recover a poisoned mutex (the set is always in a valid state) so
+        // the dedup invariant survives a panic elsewhere — falling back to
+        // "first" would re-open the warn spam this exists to prevent.
+        let mut warned = WARNED_ORIGINS
             .lock()
-            .map(|mut set| {
-                // Check before allocating: after the first warn, the hot
-                // per-action path pays only a lookup.
-                !set.contains(origin) && set.insert(origin.to_string())
-            })
-            .unwrap_or(true);
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // Check before allocating: after the first warn, the hot per-action
+        // path pays only a lookup.
+        let first_for_origin = !warned.contains(origin) && warned.insert(origin.to_string());
+        drop(warned);
         if first_for_origin {
+            // {:?} escapes the very control character that triggered this
+            // branch, keeping the log line consumable.
             log::warn!(
                 target: "kakehashi::bridge",
-                "cannot mint routing names for server '{origin}' (first affected \
-                 command: '{command}'): the server name or the host URI contains \
+                "cannot mint routing names for server {origin:?} (first affected \
+                 command: {command:?}): the server name or the host URI contains \
                  the reserved 0x1f separator, so its routed commands are dropped. \
                  If the server name is the culprit, rename it in languageServers; \
                  a separator in a document URI has no config fix"

--- a/src/lsp/bridge/protocol/command_routing.rs
+++ b/src/lsp/bridge/protocol/command_routing.rs
@@ -73,8 +73,10 @@ pub(crate) fn encode_command(origin: &str, host_uri: &str, command: &str) -> Opt
         let first_for_origin = WARNED_ORIGINS
             .lock()
             .map(|mut set| {
-                set.get_or_insert_with(Default::default)
-                    .insert(origin.to_string())
+                let set = set.get_or_insert_with(Default::default);
+                // Check before allocating: after the first warn, the hot
+                // per-action path pays only a lookup.
+                !set.contains(origin) && set.insert(origin.to_string())
             })
             .unwrap_or(true);
         if first_for_origin {

--- a/src/lsp/bridge/protocol/command_routing.rs
+++ b/src/lsp/bridge/protocol/command_routing.rs
@@ -81,7 +81,11 @@ pub(crate) fn encode_command(origin: &str, host_uri: &str, command: &str) -> Opt
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         // Check before allocating: after the first warn, the hot per-action
         // path pays only a lookup.
-        let first_for_origin = !warned.contains(origin) && warned.insert(origin.to_string());
+        let first_for_origin = if warned.contains(origin) {
+            false
+        } else {
+            warned.insert(origin.to_string())
+        };
         drop(warned);
         if first_for_origin {
             // {:?} escapes the very control character that triggered this

--- a/src/lsp/bridge/protocol/command_routing.rs
+++ b/src/lsp/bridge/protocol/command_routing.rs
@@ -66,13 +66,26 @@ pub(crate) fn encode_command(origin: &str, host_uri: &str, command: &str) -> Opt
         // Not a transient: the origin is a TOML config key, so an affected
         // config drops this server's commands on EVERY request. One warn here
         // covers all four call sites (initial bare/embedded command, virt and
-        // host resolve), which fail closed on the `None`.
-        log::warn!(
-            target: "kakehashi::bridge",
-            "cannot mint a routing name for command '{command}': the server name \
-             ('{origin}') or host URI contains the reserved separator; the command \
-             is dropped — rename the server in languageServers to fix this"
-        );
+        // host resolve), which fail closed on the `None` — deduplicated per
+        // distinct origin so per-action shaping loops don't spam the log.
+        static WARNED_ORIGINS: std::sync::Mutex<Option<std::collections::HashSet<String>>> =
+            std::sync::Mutex::new(None);
+        let first_for_origin = WARNED_ORIGINS
+            .lock()
+            .map(|mut set| {
+                set.get_or_insert_with(Default::default)
+                    .insert(origin.to_string())
+            })
+            .unwrap_or(true);
+        if first_for_origin {
+            log::warn!(
+                target: "kakehashi::bridge",
+                "cannot mint routing names for server '{origin}' (first affected \
+                 command: '{command}'): the server name or host URI contains the \
+                 reserved separator; its commands are dropped — rename the server \
+                 in languageServers to fix this"
+            );
+        }
         return None;
     }
     Some(format!(

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -1026,9 +1026,13 @@ fn parse_code_action_resolve_response(mut response: serde_json::Value) -> Option
         // is undebuggable in the field (the action just stays unresolved).
         // Mirrors parse_code_actions_leniently's per-item warn.
         Err(e) => {
+            // Truncate: serde errors can embed downstream payload snippets,
+            // and the eager-resolve fan-out can hit this once per lazy action.
+            let mut detail = e.to_string();
+            detail.truncate(200);
             warn!(
                 target: "kakehashi::bridge",
-                "codeAction/resolve: malformed resolve result: {e}"
+                "codeAction/resolve: malformed resolve result: {detail}"
             );
             None
         }

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -814,6 +814,12 @@ impl LanguageServerPool {
             .send_code_action_resolve_on_handle(&handle, outgoing, upstream_id)
             .await
         else {
+            // Per-selection warn (bounded: one per user-selected action) — the
+            // helper's transport failures log at debug and defer to callers.
+            warn!(
+                target: "kakehashi::bridge",
+                "codeAction/resolve: no usable response from {server_name}; returning unresolved"
+            );
             re_envelope_action(&mut action, &envelope);
             return action;
         };

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -583,8 +583,10 @@ impl LanguageServerPool {
         if failed > 0 {
             warn!(
                 target: "kakehashi::bridge",
-                "codeAction: {failed} of {total} eager resolves failed (transport \
-                 error or malformed result; see debug logs); those actions stay lazy"
+                "codeAction: {failed} of {total} eager resolves failed on {:?} \
+                 (transport error or malformed result; see debug logs); those \
+                 actions stay lazy",
+                handle.key()
             );
         }
     }
@@ -971,7 +973,10 @@ impl LanguageServerPool {
             match handle.register_request_with_upstream(upstream_id.clone()) {
                 Ok(pair) => pair,
                 Err(e) => {
-                    warn!(
+                    // DEBUG: this helper runs once per action on the eager
+                    // fan-out (unbounded by a hostile lazy-action list); the
+                    // callers own the bounded warn (aggregate / per-selection).
+                    log::debug!(
                         target: "kakehashi::bridge",
                         "codeAction/resolve: failed to register request on {connection_key:?}: {e}"
                     );
@@ -986,7 +991,8 @@ impl LanguageServerPool {
         let mut router_guard = RouterCleanupGuard::new(Arc::clone(handle.router()), request_id);
 
         if let Err(e) = handle.send_request(request, request_id) {
-            warn!(
+            // DEBUG: see the register-failure note above.
+            log::debug!(
                 target: "kakehashi::bridge",
                 "codeAction/resolve: failed to send request on {connection_key:?}: {e}"
             );
@@ -1002,13 +1008,13 @@ impl LanguageServerPool {
             self.unregister_upstream_request(id, connection_key);
         }
 
-        // Fail soft, but not silently: surface timeouts / channel-closed like the
-        // sibling codeLens/completion resolve paths so resolve-time issues are
-        // debuggable (qodo review finding).
+        // Fail soft, but not silently. DEBUG here: this helper runs once per
+        // action on the eager fan-out (unbounded by a hostile lazy-action
+        // list); the callers own the bounded warn (aggregate / per-selection).
         let response = match response {
             Ok(r) => r,
             Err(e) => {
-                warn!(
+                log::debug!(
                     target: "kakehashi::bridge",
                     "codeAction/resolve failed for {connection_key:?}: {e}"
                 );

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -614,7 +614,7 @@ impl LanguageServerPool {
         if !crate::config::is_server_spawnable(&settings.language_servers, &envelope.origin) {
             warn!(
                 target: "kakehashi::bridge",
-                "codeAction/resolve: origin '{}' is not spawnable (removed or \
+                "codeAction/resolve: origin {:?} is not spawnable (removed or \
                  misconfigured since the action was produced); returning unresolved",
                 envelope.origin
             );
@@ -628,7 +628,7 @@ impl LanguageServerPool {
         ) else {
             warn!(
                 target: "kakehashi::bridge",
-                "codeAction/resolve: origin '{}' has no resolvable config; returning unresolved",
+                "codeAction/resolve: origin {:?} has no resolvable config; returning unresolved",
                 envelope.origin
             );
             re_envelope_action(&mut action, &envelope);
@@ -714,7 +714,7 @@ impl LanguageServerPool {
             // capabilities (or the handle is still initializing).
             warn!(
                 target: "kakehashi::bridge",
-                "codeAction/resolve: {} no longer advertises resolveProvider; returning unresolved",
+                "codeAction/resolve: {:?} no longer advertises resolveProvider; returning unresolved",
                 envelope.origin
             );
             re_envelope_action(&mut action, &envelope);
@@ -736,7 +736,7 @@ impl LanguageServerPool {
             // carry the detail); the action goes back unresolved.
             warn!(
                 target: "kakehashi::bridge",
-                "codeAction/resolve: no usable response from {server_name}; returning unresolved"
+                "codeAction/resolve: no usable response from {server_name:?}; returning unresolved"
             );
             re_envelope_action(&mut action, &envelope);
             return action;
@@ -792,7 +792,7 @@ impl LanguageServerPool {
             // capabilities (or the handle is still initializing).
             warn!(
                 target: "kakehashi::bridge",
-                "codeAction/resolve: {} no longer advertises resolveProvider; returning unresolved",
+                "codeAction/resolve: {:?} no longer advertises resolveProvider; returning unresolved",
                 envelope.origin
             );
             re_envelope_action(&mut action, &envelope);
@@ -818,7 +818,7 @@ impl LanguageServerPool {
             // helper's transport failures log at debug and defer to callers.
             warn!(
                 target: "kakehashi::bridge",
-                "codeAction/resolve: no usable response from {server_name}; returning unresolved"
+                "codeAction/resolve: no usable response from {server_name:?}; returning unresolved"
             );
             re_envelope_action(&mut action, &envelope);
             return action;

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -1026,13 +1026,16 @@ fn parse_code_action_resolve_response(mut response: serde_json::Value) -> Option
         // is undebuggable in the field (the action just stays unresolved).
         // Mirrors parse_code_actions_leniently's per-item warn.
         Err(e) => {
-            // Truncate: serde errors can embed downstream payload snippets,
-            // and the eager-resolve fan-out can hit this once per lazy action.
-            let mut detail = e.to_string();
-            detail.truncate(200);
+            // Log the error CLASS and position, not `{e}`: serde's Display
+            // embeds downstream payload snippets (arbitrary, possibly
+            // non-ASCII values), which neither belongs in the log nor
+            // truncates safely.
             warn!(
                 target: "kakehashi::bridge",
-                "codeAction/resolve: malformed resolve result: {detail}"
+                "codeAction/resolve: malformed resolve result: {:?} at line {} column {}",
+                e.classify(),
+                e.line(),
+                e.column()
             );
             None
         }

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -566,12 +566,26 @@ impl LanguageServerPool {
             .buffer_unordered(MAX_CONCURRENT_EAGER_RESOLVES)
             .collect()
             .await;
+        let mut failed = 0usize;
+        let total = resolved.len();
         for (idx, outcome) in resolved {
-            if let Some(materialized) = outcome
-                && let CodeActionOrCommand::CodeAction(slot) = &mut actions[idx]
-            {
-                *slot = materialized;
+            match outcome {
+                Some(materialized) => {
+                    if let CodeActionOrCommand::CodeAction(slot) = &mut actions[idx] {
+                        *slot = materialized;
+                    }
+                }
+                None => failed += 1,
             }
+        }
+        // ONE aggregated warn per request, however many lazy actions the
+        // server returned (per-result warns would be unbounded).
+        if failed > 0 {
+            warn!(
+                target: "kakehashi::bridge",
+                "codeAction: {failed} of {total} eager resolves failed (transport \
+                 error or malformed result; see debug logs); those actions stay lazy"
+            );
         }
     }
 
@@ -715,6 +729,13 @@ impl LanguageServerPool {
             .send_code_action_resolve_on_handle(&handle, outgoing, upstream_id)
             .await
         else {
+            // Client-driven (one per user selection, so bounded): the resolve
+            // failed in transport or returned a malformed result (debug logs
+            // carry the detail); the action goes back unresolved.
+            warn!(
+                target: "kakehashi::bridge",
+                "codeAction/resolve: no usable response from {server_name}; returning unresolved"
+            );
             re_envelope_action(&mut action, &envelope);
             return action;
         };
@@ -1026,16 +1047,16 @@ fn parse_code_action_resolve_response(mut response: serde_json::Value) -> Option
         // is undebuggable in the field (the action just stays unresolved).
         // Mirrors parse_code_actions_leniently's per-item warn.
         Err(e) => {
-            // Log the error CLASS and position, not `{e}`: serde's Display
-            // embeds downstream payload snippets (arbitrary, possibly
-            // non-ASCII values), which neither belongs in the log nor
-            // truncates safely.
-            warn!(
+            // DEBUG and payload-free: serde's Display embeds downstream
+            // payload snippets, and `from_value` reports a meaningless
+            // line 0 column 0 — only the error class is trustworthy. The
+            // call sites aggregate the user-facing warn (a hostile server
+            // could return arbitrarily many lazy actions, so a per-result
+            // warn here would be unbounded per request).
+            log::debug!(
                 target: "kakehashi::bridge",
-                "codeAction/resolve: malformed resolve result: {:?} at line {} column {}",
-                e.classify(),
-                e.line(),
-                e.column()
+                "codeAction/resolve: malformed resolve result: {:?}",
+                e.classify()
             );
             None
         }
@@ -1492,18 +1513,17 @@ fn disable_action(
     if !upstream_caps.disabled_support {
         // Without disabledSupport the action vanishes from the menu — the
         // only trace of a server bug (e.g. an out-of-region edit) is this log.
+        // No title in the log: titles are downstream-controlled free text.
         log::debug!(
             target: "kakehashi::bridge",
-            "codeAction '{}' from {server_name} dropped ({reason}); the client \
-             lacks disabledSupport to show it disabled",
-            action.title
+            "codeAction from {server_name} dropped ({reason}); the client \
+             lacks disabledSupport to show it disabled"
         );
         return None;
     }
     log::debug!(
         target: "kakehashi::bridge",
-        "codeAction '{}' from {server_name} disabled: {reason}",
-        action.title
+        "codeAction from {server_name} disabled: {reason}"
     );
     action.title = suffix_title(action.title, server_name);
     action.edit = None;

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -592,7 +592,16 @@ impl LanguageServerPool {
             return action;
         };
 
+        // resolve is USER-initiated (they selected the action): fail soft,
+        // but never silently — a server removed/renamed since the action was
+        // minted lands here.
         if !crate::config::is_server_spawnable(&settings.language_servers, &envelope.origin) {
+            warn!(
+                target: "kakehashi::bridge",
+                "codeAction/resolve: origin '{}' is not spawnable (removed or \
+                 misconfigured since the action was produced); returning unresolved",
+                envelope.origin
+            );
             re_envelope_action(&mut action, &envelope);
             return action;
         }
@@ -601,6 +610,11 @@ impl LanguageServerPool {
             &envelope.origin,
             merge_bridge_server_configs,
         ) else {
+            warn!(
+                target: "kakehashi::bridge",
+                "codeAction/resolve: origin '{}' has no resolvable config; returning unresolved",
+                envelope.origin
+            );
             re_envelope_action(&mut action, &envelope);
             return action;
         };
@@ -679,6 +693,14 @@ impl LanguageServerPool {
             }
         };
         if !handle.has_capability("codeAction/resolve") {
+            // Anomalous: the envelope was only minted because the origin
+            // advertised resolve, so reaching here means a respawn changed
+            // capabilities (or the handle is still initializing).
+            warn!(
+                target: "kakehashi::bridge",
+                "codeAction/resolve: {} no longer advertises resolveProvider; returning unresolved",
+                envelope.origin
+            );
             re_envelope_action(&mut action, &envelope);
             return action;
         }
@@ -742,6 +764,14 @@ impl LanguageServerPool {
             }
         };
         if !handle.has_capability("codeAction/resolve") {
+            // Anomalous: the envelope was only minted because the origin
+            // advertised resolve, so reaching here means a respawn changed
+            // capabilities (or the handle is still initializing).
+            warn!(
+                target: "kakehashi::bridge",
+                "codeAction/resolve: {} no longer advertises resolveProvider; returning unresolved",
+                envelope.origin
+            );
             re_envelope_action(&mut action, &envelope);
             return action;
         }
@@ -922,7 +952,7 @@ impl LanguageServerPool {
                 Err(e) => {
                     warn!(
                         target: "kakehashi::bridge",
-                        "codeAction/resolve: failed to register request: {e}"
+                        "codeAction/resolve: failed to register request on {connection_key:?}: {e}"
                     );
                     if let Some(ref id) = upstream_id {
                         self.unregister_upstream_request(id, connection_key);
@@ -937,7 +967,7 @@ impl LanguageServerPool {
         if let Err(e) = handle.send_request(request, request_id) {
             warn!(
                 target: "kakehashi::bridge",
-                "codeAction/resolve: failed to send request: {e}"
+                "codeAction/resolve: failed to send request on {connection_key:?}: {e}"
             );
             if let Some(ref id) = upstream_id {
                 self.unregister_upstream_request(id, connection_key);
@@ -990,7 +1020,19 @@ fn parse_code_action_resolve_response(mut response: serde_json::Value) -> Option
     if result.is_null() {
         return None;
     }
-    serde_json::from_value(result).ok()
+    match serde_json::from_value(result) {
+        Ok(resolved) => Some(resolved),
+        // A present, non-null result that doesn't parse: without a log this
+        // is undebuggable in the field (the action just stays unresolved).
+        // Mirrors parse_code_actions_leniently's per-item warn.
+        Err(e) => {
+            warn!(
+                target: "kakehashi::bridge",
+                "codeAction/resolve: malformed resolve result: {e}"
+            );
+            None
+        }
+    }
 }
 
 /// Build a JSON-RPC code action request for a downstream language server.
@@ -1441,8 +1483,21 @@ fn disable_action(
     upstream_caps: UpstreamCodeActionCaps,
 ) -> Option<CodeActionOrCommand> {
     if !upstream_caps.disabled_support {
+        // Without disabledSupport the action vanishes from the menu — the
+        // only trace of a server bug (e.g. an out-of-region edit) is this log.
+        log::debug!(
+            target: "kakehashi::bridge",
+            "codeAction '{}' from {server_name} dropped ({reason}); the client \
+             lacks disabledSupport to show it disabled",
+            action.title
+        );
         return None;
     }
+    log::debug!(
+        target: "kakehashi::bridge",
+        "codeAction '{}' from {server_name} disabled: {reason}",
+        action.title
+    );
     action.title = suffix_title(action.title, server_name);
     action.edit = None;
     action.command = None;

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -1528,14 +1528,14 @@ fn disable_action(
         // No title in the log: titles are downstream-controlled free text.
         log::debug!(
             target: "kakehashi::bridge",
-            "codeAction from {server_name} dropped ({reason}); the client \
+            "codeAction from {server_name:?} dropped ({reason}); the client \
              lacks disabledSupport to show it disabled"
         );
         return None;
     }
     log::debug!(
         target: "kakehashi::bridge",
-        "codeAction from {server_name} disabled: {reason}"
+        "codeAction from {server_name:?} disabled: {reason}"
     );
     action.title = suffix_title(action.title, server_name);
     action.edit = None;

--- a/src/lsp/bridge/workspace/execute_command.rs
+++ b/src/lsp/bridge/workspace/execute_command.rs
@@ -174,14 +174,31 @@ impl LanguageServerPool {
             // back); reconstructing a shared/marker root without a document is a
             // deferred follow-up.
             None if key.is_client_fallback() => {
+                // The palette registry is session-persistent, so an origin
+                // removed/disabled from config after registration lands here —
+                // warn like the encoded-command path (user-invoked).
                 if !crate::config::is_server_spawnable(&settings.language_servers, origin) {
+                    warn!(
+                        target: "kakehashi::bridge",
+                        "executeCommand: palette origin '{origin}' is no longer spawnable; \
+                         dropping '{}'",
+                        params.command
+                    );
                     return None;
                 }
-                let config = resolve_with_wildcard(
+                let Some(config) = resolve_with_wildcard(
                     &settings.language_servers,
                     origin,
                     merge_bridge_server_configs,
-                )?;
+                ) else {
+                    warn!(
+                        target: "kakehashi::bridge",
+                        "executeCommand: palette origin '{origin}' has no resolvable config; \
+                         dropping '{}'",
+                        params.command
+                    );
+                    return None;
+                };
                 // Wait through initialization (bounded by the standard init
                 // budget) rather than take a possibly-`Initializing` handle: the
                 // pool returns an existing not-yet-Ready connection here, whose

--- a/src/lsp/bridge/workspace/execute_command.rs
+++ b/src/lsp/bridge/workspace/execute_command.rs
@@ -71,8 +71,8 @@ impl LanguageServerPool {
         if !crate::config::is_server_spawnable(&settings.language_servers, &origin) {
             warn!(
                 target: "kakehashi::bridge",
-                "executeCommand: origin '{origin}' is not spawnable (removed or \
-                 misconfigured since the action was produced); dropping '{command}'"
+                "executeCommand: origin {origin:?} is not spawnable (removed or \
+                 misconfigured since the action was produced); dropping {command:?}"
             );
             return None;
         }
@@ -83,7 +83,7 @@ impl LanguageServerPool {
         ) else {
             warn!(
                 target: "kakehashi::bridge",
-                "executeCommand: origin '{origin}' has no resolvable config; dropping '{command}'"
+                "executeCommand: origin {origin:?} has no resolvable config; dropping {command:?}"
             );
             return None;
         };
@@ -118,7 +118,7 @@ impl LanguageServerPool {
             // (every other failure branch here warns).
             warn!(
                 target: "kakehashi::bridge",
-                "executeCommand: {origin} does not advertise executeCommandProvider; ignoring '{command}'"
+                "executeCommand: {origin:?} does not advertise executeCommandProvider; ignoring {command:?}"
             );
             return None;
         }
@@ -152,7 +152,7 @@ impl LanguageServerPool {
         let Some(key) = self.command_origins().route(&params.command) else {
             warn!(
                 target: "kakehashi::bridge",
-                "executeCommand: '{}' is neither a bridged nor a registered command; ignoring",
+                "executeCommand: {:?} is neither a bridged nor a registered command; ignoring",
                 params.command
             );
             return None;
@@ -180,8 +180,8 @@ impl LanguageServerPool {
                 if !crate::config::is_server_spawnable(&settings.language_servers, origin) {
                     warn!(
                         target: "kakehashi::bridge",
-                        "executeCommand: palette origin '{origin}' is no longer spawnable; \
-                         dropping '{}'",
+                        "executeCommand: palette origin {origin:?} is no longer spawnable; \
+                         dropping {:?}",
                         params.command
                     );
                     return None;
@@ -193,8 +193,8 @@ impl LanguageServerPool {
                 ) else {
                     warn!(
                         target: "kakehashi::bridge",
-                        "executeCommand: palette origin '{origin}' has no resolvable config; \
-                         dropping '{}'",
+                        "executeCommand: palette origin {origin:?} has no resolvable config; \
+                         dropping {:?}",
                         params.command
                     );
                     return None;
@@ -227,7 +227,7 @@ impl LanguageServerPool {
             None => {
                 warn!(
                     target: "kakehashi::bridge",
-                    "executeCommand: origin connection for palette command '{}' ({origin}) is not ready; ignoring",
+                    "executeCommand: origin connection for palette command {:?} ({origin:?}) is not ready; ignoring",
                     params.command
                 );
                 return None;
@@ -241,7 +241,7 @@ impl LanguageServerPool {
             // failure branch warns) so a fail-soft `null` is diagnosable.
             warn!(
                 target: "kakehashi::bridge",
-                "executeCommand: origin {origin} for palette command '{}' does not (yet) advertise executeCommandProvider; ignoring",
+                "executeCommand: origin {origin:?} for palette command {:?} does not (yet) advertise executeCommandProvider; ignoring",
                 params.command
             );
             return None;
@@ -271,7 +271,7 @@ impl LanguageServerPool {
                     warn!(
                         target: "kakehashi::bridge",
                         "executeCommand: failed to register request on {connection_key:?} \
-                         for '{}': {e}",
+                         for {:?}: {e}",
                         params.command
                     );
                     if let Some(ref id) = upstream_id {
@@ -312,7 +312,7 @@ impl LanguageServerPool {
                 drop(connections);
                 warn!(
                     target: "kakehashi::bridge",
-                    "executeCommand: failed to send '{}' on {connection_key:?}: {e}",
+                    "executeCommand: failed to send {:?} on {connection_key:?}: {e}",
                     params.command
                 );
                 if let Some(ref id) = upstream_id {

--- a/src/lsp/bridge/workspace/execute_command.rs
+++ b/src/lsp/bridge/workspace/execute_command.rs
@@ -64,14 +64,29 @@ impl LanguageServerPool {
             }
         };
 
+        // executeCommand is USER-invoked (they picked the action/palette
+        // entry): failing soft is right, failing silently is not. The encoded
+        // command outlives config edits, so a server removed/renamed since the
+        // action was minted lands here.
         if !crate::config::is_server_spawnable(&settings.language_servers, &origin) {
+            warn!(
+                target: "kakehashi::bridge",
+                "executeCommand: origin '{origin}' is not spawnable (removed or \
+                 misconfigured since the action was produced); dropping '{command}'"
+            );
             return None;
         }
-        let config = resolve_with_wildcard(
+        let Some(config) = resolve_with_wildcard(
             &settings.language_servers,
             &origin,
             merge_bridge_server_configs,
-        )?;
+        ) else {
+            warn!(
+                target: "kakehashi::bridge",
+                "executeCommand: origin '{origin}' has no resolvable config; dropping '{command}'"
+            );
+            return None;
+        };
 
         // A malformed host_uri must REJECT, not fall through to a client-root
         // fallback connection (which could execute the command against the
@@ -238,7 +253,9 @@ impl LanguageServerPool {
                 Err(e) => {
                     warn!(
                         target: "kakehashi::bridge",
-                        "executeCommand: failed to register request: {e}"
+                        "executeCommand: failed to register request on {connection_key:?} \
+                         for '{}': {e}",
+                        params.command
                     );
                     if let Some(ref id) = upstream_id {
                         self.unregister_upstream_request(id, connection_key);
@@ -278,7 +295,8 @@ impl LanguageServerPool {
                 drop(connections);
                 warn!(
                     target: "kakehashi::bridge",
-                    "executeCommand: failed to send request: {e}"
+                    "executeCommand: failed to send '{}' on {connection_key:?}: {e}",
+                    params.command
                 );
                 if let Some(ref id) = upstream_id {
                     self.unregister_upstream_request(id, connection_key);

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1236,11 +1236,21 @@ fn spawn_upstream_request(
                     None => Ok(params),
                 };
                 let response = match params {
-                    Err(failure_reason) => ApplyWorkspaceEditResponse {
-                        applied: false,
-                        failure_reason: Some(failure_reason),
-                        failed_change: None,
-                    },
+                    Err(failure_reason) => {
+                        // The reason is otherwise write-only: it goes to the
+                        // DOWNSTREAM (which typically ignores failureReason),
+                        // so without this log a rejected server-driven edit is
+                        // invisible on the kakehashi side.
+                        log::warn!(
+                            target: "kakehashi::bridge",
+                            "workspace/applyEdit rejected locally: {failure_reason}"
+                        );
+                        ApplyWorkspaceEditResponse {
+                            applied: false,
+                            failure_reason: Some(failure_reason),
+                            failed_change: None,
+                        }
+                    }
                     // Serializing the (typed) translated params ~never fails,
                     // but forwarding `params: null` on the off chance it did
                     // would send the editor an invalid request; answer local

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1243,7 +1243,7 @@ fn spawn_upstream_request(
                         // invisible on the kakehashi side.
                         log::warn!(
                             target: "kakehashi::bridge",
-                            "workspace/applyEdit rejected locally: {failure_reason}"
+                            "workspace/applyEdit rejected locally: {failure_reason:?}"
                         );
                         ApplyWorkspaceEditResponse {
                             applied: false,

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -42,6 +42,14 @@ use crate::text::PositionMapper;
 
 const METHOD: &str = "textDocument/codeAction";
 
+/// Why [`Kakehashi::code_action_region_end_if_fresh`] produced no region end,
+/// so the caller logs staleness once and skips it for already-warned
+/// malformed envelopes.
+enum RegionEndUnavailable {
+    MalformedEnvelope,
+    Stale,
+}
+
 /// Flatten the per-server results of a `concatenated` dispatch into one response
 /// in priority order (`dispatch_concatenated` yields them ordered). Each server
 /// contributes `Option<CodeActionResponse>`; drop the `None`s, concatenate the
@@ -181,12 +189,16 @@ impl Kakehashi {
             Position::default()
         } else {
             match self.code_action_region_end_if_fresh(&envelope) {
-                Some(region_end) => region_end,
-                None => {
+                Ok(region_end) => region_end,
+                Err(RegionEndUnavailable::MalformedEnvelope) => {
+                    // Already warned with the malformed field; no stale-debug.
+                    return Ok(action);
+                }
+                Err(RegionEndUnavailable::Stale) => {
                     log::debug!(
                         target: "kakehashi::bridge",
-                        "codeAction/resolve: region {} of {} (origin {}) is stale or \
-                         unresolvable; returning action unresolved",
+                        "codeAction/resolve: region {} of {} (origin {}) is stale; \
+                         returning action unresolved",
                         envelope.region_id,
                         envelope.host_uri,
                         envelope.origin
@@ -226,17 +238,21 @@ impl Kakehashi {
     /// never matches and resolve always fails soft for those regions. That errs
     /// in the safe direction (the action stays unresolved) and frontmatter code
     /// actions have no known real-world producer; revisit if one appears.
-    fn code_action_region_end_if_fresh(&self, envelope: &CodeActionEnvelope) -> Option<Position> {
+    fn code_action_region_end_if_fresh(
+        &self,
+        envelope: &CodeActionEnvelope,
+    ) -> std::result::Result<Position, RegionEndUnavailable> {
         // A malformed envelope is NOT staleness — the bridge only mints valid
         // URLs/ULIDs, so warn (mirroring the bridge-side host_uri warn) rather
-        // than letting it hide under the "stale region" debug line.
+        // than letting it hide under the "stale region" debug line; the
+        // caller skips its stale-debug for this classification.
         let Ok(host_url) = Url::parse(&envelope.host_uri) else {
             log::warn!(
                 target: "kakehashi::bridge",
                 "codeAction/resolve: envelope host_uri '{}' is not a valid URL",
                 envelope.host_uri
             );
-            return None;
+            return Err(RegionEndUnavailable::MalformedEnvelope);
         };
         let Ok(ulid) = envelope.region_id.parse::<Ulid>() else {
             log::warn!(
@@ -244,20 +260,33 @@ impl Kakehashi {
                 "codeAction/resolve: envelope region_id '{}' is not a valid ULID",
                 envelope.region_id
             );
-            return None;
+            return Err(RegionEndUnavailable::MalformedEnvelope);
         };
+        self.code_action_region_end_live(envelope, &host_url, ulid)
+            .ok_or(RegionEndUnavailable::Stale)
+    }
+
+    /// The live-lookup half of [`Self::code_action_region_end_if_fresh`]:
+    /// every `None` here is the STALE class (region moved, invalidated, or
+    /// diverged), never a malformed envelope.
+    fn code_action_region_end_live(
+        &self,
+        envelope: &CodeActionEnvelope,
+        host_url: &Url,
+        ulid: Ulid,
+    ) -> Option<Position> {
         // Re-resolve the region from the LIVE parse (same construction as the
         // goto/showDocument offset path), yielding the current per-line offset
         // AND the content-precise host byte range.
         let (start_byte, _end, _kind, _layer) =
-            self.bridge.node_tracker().lookup_node(&host_url, &ulid)?;
-        let snapshot = self.documents.get(&host_url)?.snapshot()?;
-        let language_name = detect_document_language(&self.language, &self.documents, &host_url)?;
+            self.bridge.node_tracker().lookup_node(host_url, &ulid)?;
+        let snapshot = self.documents.get(host_url)?.snapshot()?;
+        let language_name = detect_document_language(&self.language, &self.documents, host_url)?;
         let injection_query = self.language.injection_query(&language_name)?;
         let resolved = InjectionResolver::resolve_at_byte_offset(
             &self.language,
             self.bridge.node_tracker(),
-            &host_url,
+            host_url,
             snapshot.tree(),
             snapshot.text(),
             injection_query.as_ref(),

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -249,7 +249,7 @@ impl Kakehashi {
         let Ok(host_url) = Url::parse(&envelope.host_uri) else {
             log::warn!(
                 target: "kakehashi::bridge",
-                "codeAction/resolve: envelope host_uri '{}' is not a valid URL",
+                "codeAction/resolve: envelope host_uri {:?} is not a valid URL",
                 envelope.host_uri
             );
             return Err(RegionEndUnavailable::MalformedEnvelope);
@@ -257,7 +257,7 @@ impl Kakehashi {
         let Ok(ulid) = envelope.region_id.parse::<Ulid>() else {
             log::warn!(
                 target: "kakehashi::bridge",
-                "codeAction/resolve: envelope region_id '{}' is not a valid ULID",
+                "codeAction/resolve: envelope region_id {:?} is not a valid ULID",
                 envelope.region_id
             );
             return Err(RegionEndUnavailable::MalformedEnvelope);

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -197,7 +197,7 @@ impl Kakehashi {
                 Err(RegionEndUnavailable::Stale) => {
                     log::debug!(
                         target: "kakehashi::bridge",
-                        "codeAction/resolve: region {} of {} (origin {}) is stale; \
+                        "codeAction/resolve: region {} of {} (origin {:?}) is stale; \
                          returning action unresolved",
                         envelope.region_id,
                         envelope.host_uri,

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -185,8 +185,11 @@ impl Kakehashi {
                 None => {
                     log::debug!(
                         target: "kakehashi::bridge",
-                        "codeAction/resolve: region {} is stale; returning action unresolved",
-                        envelope.region_id
+                        "codeAction/resolve: region {} of {} (origin {}) is stale or \
+                         unresolvable; returning action unresolved",
+                        envelope.region_id,
+                        envelope.host_uri,
+                        envelope.origin
                     );
                     return Ok(action);
                 }
@@ -224,8 +227,25 @@ impl Kakehashi {
     /// in the safe direction (the action stays unresolved) and frontmatter code
     /// actions have no known real-world producer; revisit if one appears.
     fn code_action_region_end_if_fresh(&self, envelope: &CodeActionEnvelope) -> Option<Position> {
-        let host_url = Url::parse(&envelope.host_uri).ok()?;
-        let ulid = envelope.region_id.parse::<Ulid>().ok()?;
+        // A malformed envelope is NOT staleness — the bridge only mints valid
+        // URLs/ULIDs, so warn (mirroring the bridge-side host_uri warn) rather
+        // than letting it hide under the "stale region" debug line.
+        let Ok(host_url) = Url::parse(&envelope.host_uri) else {
+            log::warn!(
+                target: "kakehashi::bridge",
+                "codeAction/resolve: envelope host_uri '{}' is not a valid URL",
+                envelope.host_uri
+            );
+            return None;
+        };
+        let Ok(ulid) = envelope.region_id.parse::<Ulid>() else {
+            log::warn!(
+                target: "kakehashi::bridge",
+                "codeAction/resolve: envelope region_id '{}' is not a valid ULID",
+                envelope.region_id
+            );
+            return None;
+        };
         // Re-resolve the region from the LIVE parse (same construction as the
         // goto/showDocument offset path), yielding the current per-line offset
         // AND the content-precise host byte range.


### PR DESCRIPTION
## Problem

The codeAction family fails soft by design, but many branches failed **silently** — worst for the user-invoked operations: an `executeCommand` whose origin was removed from config since the action was minted did nothing with zero trace; `codeAction/resolve` dropped malformed results and capability regressions invisibly; `encode_command`'s fail-closed drop (a `0x1f` separator in a server name — a persistent config problem) silently removed commands from every menu; applyEdit's carefully-worded local `failureReason`s went only to the downstream (which typically ignores them); actions disabled/dropped by the bridge policy left no trace for clients without `disabledSupport`.

## Fix (logging only — every fail-soft stays fail-soft)

- `executeCommand` (encoded + palette): unspawnable origin / unresolvable config warn with the command name; register/send warns carry command + connection key.
- `codeAction/resolve`: unspawnable/unresolvable origin, respawn-lost `resolveProvider`, and no-usable-response warn (client-driven = bounded per user selection); the freshness gate classifies malformed envelopes (warn) vs stale regions (debug, with host_uri + origin) via a typed result — no double logging.
- `encode_command` warns once **per distinct origin** (checked before allocating) inside the encoder, covering all four fail-closed call sites.
- Eager-resolve failures aggregate into ONE warn per request (failed/total) — a hostile server can return arbitrarily many lazy actions, so per-result warns would be unbounded; the per-result detail is debug and payload-free (serde error class only; `from_value`'s line/column are meaningless, and Display embeds downstream payload).
- applyEdit local rejections log their failureReason on the kakehashi side.
- `disable_action` debug-logs every disable and every capability-gated drop — no downstream-controlled titles in the logs.

## Review provenance

Error-handling/observability perspective of the codeAction completeness audit; 3 codex rounds fixed: palette-path parity, per-origin dedup, warn-flood bounds, a genuine `String::truncate` UTF-8 boundary panic on the (new) log path, payload sanitization, and log-classification. **Caveat: codex's confirmation pass on the round-3 fixes is pending (usage limit); the fixes are mechanical logging changes verified by the full gate.**

## Testing

Full lib suite + clippy \-D warnings green (logging-only paths; behavior pinned by the existing fail-soft tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fail-soft behavior for `workspace/executeCommand` and palette-origin commands when an origin becomes non-spawnable or unroutable.
  * Strengthened `codeAction/resolve` staleness gating by separating malformed envelopes from stale regions.
  * Improved `workspace/applyEdit` handling by warning with the rejection reason on local translation failures.
* **Diagnostics**
  * Added clearer, more observable logging for `codeAction/resolve`, including aggregated lazy-resolve failures and better handling of missing/invalid resolve responses.
  * Deduplicated reserved routing-separator warnings to “warn once per distinct origin.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->