### PR TITLE
fix(bridge): codeAction-family concurrency polish

### DIFF
--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -1054,16 +1054,40 @@ impl LanguageServerPool {
         let request = JsonRpcRequest::new(request_id.as_i64(), "codeAction/resolve", &action);
         let mut router_guard = RouterCleanupGuard::new(Arc::clone(handle.router()), request_id);
 
-        if let Err(e) = handle.send_request(request, request_id) {
-            // DEBUG: see the register-failure note above.
-            log::debug!(
-                target: "kakehashi::bridge",
-                "codeAction/resolve: failed to send request on {connection_key:?}: {e}"
-            );
-            if let Some(ref id) = upstream_id {
-                self.unregister_upstream_request(id, connection_key);
+        // Verify `handle` is still the pool's LIVE connection for its key
+        // before sending, under the `connections` lock (the same guard the
+        // executeCommand and generic execute paths use): a respawn between
+        // fetching the handle — earliest on the eager-resolve pass — and this
+        // send would queue the resolve and its cancel bookkeeping on a dead
+        // handle, losing cancel forwarding and waiting out the full timeout.
+        {
+            let connections = self.connections().await;
+            if !connections
+                .get(connection_key)
+                .is_some_and(|current| Arc::ptr_eq(current, handle))
+            {
+                drop(connections);
+                warn!(
+                    target: "kakehashi::bridge",
+                    "codeAction/resolve: connection {connection_key} was replaced before send"
+                );
+                if let Some(ref id) = upstream_id {
+                    self.unregister_upstream_request(id, connection_key);
+                }
+                return None;
             }
-            return None;
+            if let Err(e) = handle.send_request(request, request_id) {
+                drop(connections);
+                // DEBUG: see the register-failure note above.
+                log::debug!(
+                    target: "kakehashi::bridge",
+                    "codeAction/resolve: failed to send request on {connection_key:?}: {e}"
+                );
+                if let Some(ref id) = upstream_id {
+                    self.unregister_upstream_request(id, connection_key);
+                }
+                return None;
+            }
         }
 
         let response = handle.wait_for_response(request_id, response_rx).await;

--- a/src/lsp/bridge/workspace/execute_command.rs
+++ b/src/lsp/bridge/workspace/execute_command.rs
@@ -99,8 +99,17 @@ impl LanguageServerPool {
             );
             return None;
         };
+        // Wait through initialization like the palette path: after a respawn
+        // the fail-fast variant hands back an Initializing handle whose
+        // capability probe is still false, spuriously dropping the command
+        // with a misleading "does not advertise executeCommandProvider".
         let handle = match self
-            .get_or_create_connection(&origin, &config, Some(&host_url))
+            .get_or_create_connection_wait_ready(
+                &origin,
+                &config,
+                Some(&host_url),
+                std::time::Duration::from_secs(crate::lsp::bridge::pool::INIT_TIMEOUT_SECS),
+            )
             .await
         {
             Ok(handle) => handle,

--- a/src/lsp/bridge/workspace/execute_command.rs
+++ b/src/lsp/bridge/workspace/execute_command.rs
@@ -122,9 +122,11 @@ impl LanguageServerPool {
             }
         };
         if !handle.has_capability(METHOD) {
-            // Should be unreachable — the bridge only mints commands from servers
-            // it bridged — but if it happens, a log entry beats a silent drop
-            // (every other failure branch here warns).
+            // Nearly unreachable: the bridge only mints commands from servers it
+            // bridged, and the wait-ready acquisition above rules out the
+            // still-Initializing false negative. Reaching it means the server
+            // genuinely dropped the capability across a respawn — a log entry
+            // beats a silent drop (every other failure branch here warns).
             warn!(
                 target: "kakehashi::bridge",
                 "executeCommand: {origin:?} does not advertise executeCommandProvider; ignoring {command:?}"

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -211,10 +211,27 @@ impl Kakehashi {
         let settings = self.settings_manager.load_settings();
         let upstream_caps = self.upstream_code_action_caps();
         let upstream_id = crate::lsp::current_upstream_id();
+        // Propagate a client $/cancelRequest as RequestCancelled instead of
+        // masking it as an unresolved-action success (the cancel is forwarded
+        // downstream; the -32800 answer would otherwise be collapsed by the
+        // fail-soft parsing) — mirrors the multi-region codeAction walk.
+        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(upstream_id.as_ref());
         let pool = self.bridge.pool_arc();
-        Ok(pool
-            .dispatch_code_action_resolve(action, &settings, upstream_caps, upstream_id, region_end)
-            .await)
+        let dispatch = pool.dispatch_code_action_resolve(
+            action,
+            &settings,
+            upstream_caps,
+            upstream_id,
+            region_end,
+        );
+        match cancel_rx {
+            Some(rx) => tokio::select! {
+                biased;
+                _ = rx => Err(tower_lsp_server::jsonrpc::Error::request_cancelled()),
+                resolved = dispatch => Ok(resolved),
+            },
+            None => Ok(dispatch.await),
+        }
     }
 
     /// The region's current content-precise host-document END position if the

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -216,6 +216,7 @@ impl Kakehashi {
         // downstream; the -32800 answer would otherwise be collapsed by the
         // fail-soft parsing) — mirrors the multi-region codeAction walk.
         let (cancel_rx, _cancel_guard) = self.subscribe_cancel(upstream_id.as_ref());
+        let sweep_id = upstream_id.clone();
         let pool = self.bridge.pool_arc();
         let dispatch = pool.dispatch_code_action_resolve(
             action,
@@ -235,7 +236,9 @@ impl Kakehashi {
         // The cancel arm DROPS the in-flight dispatch, which then never
         // reaches its own refcounted unregister — sweep the id (idempotent
         // after normal completion, where the dispatch cleaned up itself).
-        pool.unregister_all_for_upstream_id(crate::lsp::current_upstream_id().as_ref());
+        // The CAPTURED id, not a re-read of the task-local: the sweep must
+        // target exactly the id the dispatch registered under.
+        pool.unregister_all_for_upstream_id(sweep_id.as_ref());
         result
     }
 

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -224,14 +224,19 @@ impl Kakehashi {
             upstream_id,
             region_end,
         );
-        match cancel_rx {
+        let result = match cancel_rx {
             Some(rx) => tokio::select! {
                 biased;
                 _ = rx => Err(tower_lsp_server::jsonrpc::Error::request_cancelled()),
                 resolved = dispatch => Ok(resolved),
             },
             None => Ok(dispatch.await),
-        }
+        };
+        // The cancel arm DROPS the in-flight dispatch, which then never
+        // reaches its own refcounted unregister — sweep the id (idempotent
+        // after normal completion, where the dispatch cleaned up itself).
+        pool.unregister_all_for_upstream_id(crate::lsp::current_upstream_id().as_ref());
+        result
     }
 
     /// The region's current content-precise host-document END position if the

--- a/src/lsp/lsp_impl/workspace/execute_command.rs
+++ b/src/lsp/lsp_impl/workspace/execute_command.rs
@@ -31,6 +31,13 @@ impl Kakehashi {
         // and may queue nothing). Fail-soft: any gap (foreign command, unparseable
         // host URI, undetectable host language, no matching injection) just skips
         // the sync and dispatches as before.
+        // Subscribe for the client's $/cancelRequest BEFORE the first await:
+        // the forwarder does not buffer cancels that arrive pre-subscribe, so
+        // subscribing after the (up to SYNC_TIMEOUT) pre-sync would silently
+        // drop a cancel fired while it runs. Subscribed here, such a cancel is
+        // latched in the receiver and the select below sees it immediately.
+        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(upstream_id.as_ref());
+
         self.sync_origin_documents_before_execute(&params, &settings)
             .await;
 
@@ -39,14 +46,13 @@ impl Kakehashi {
         // the registry, the downstream answers -32800, and fail-soft parsing
         // would otherwise collapse that to `Ok(None)` (the same masking the
         // multi-region codeAction walk already fixed).
-        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(upstream_id.as_ref());
         let pool = self.bridge.pool_arc();
         let dispatch = pool.dispatch_execute_command(params, &settings, upstream_id);
         let result = match cancel_rx {
             Some(rx) => tokio::select! {
                 biased;
                 _ = rx => Err(tower_lsp_server::jsonrpc::Error::request_cancelled()),
-                result = dispatch => Ok(result),
+                outcome = dispatch => Ok(outcome),
             },
             None => Ok(dispatch.await),
         };

--- a/src/lsp/lsp_impl/workspace/execute_command.rs
+++ b/src/lsp/lsp_impl/workspace/execute_command.rs
@@ -37,6 +37,7 @@ impl Kakehashi {
         // drop a cancel fired while it runs. Subscribed here, such a cancel is
         // latched in the receiver and the select below sees it immediately.
         let (cancel_rx, _cancel_guard) = self.subscribe_cancel(upstream_id.as_ref());
+        let sweep_id = upstream_id.clone();
 
         self.sync_origin_documents_before_execute(&params, &settings)
             .await;
@@ -59,7 +60,9 @@ impl Kakehashi {
         // The cancel arm DROPS the in-flight dispatch, which then never
         // reaches its own refcounted unregister — sweep the id (idempotent
         // after normal completion, where the dispatch cleaned up itself).
-        pool.unregister_all_for_upstream_id(crate::lsp::current_upstream_id().as_ref());
+        // The CAPTURED id, not a re-read of the task-local: the sweep must
+        // target exactly the id the dispatch registered under.
+        pool.unregister_all_for_upstream_id(sweep_id.as_ref());
         result
     }
 
@@ -120,7 +123,11 @@ impl Kakehashi {
                 )
                 .await;
         });
-        match tokio::time::timeout(SYNC_TIMEOUT, open_task).await {
+        // Bound only the WAIT: on timeout the task keeps running detached (see
+        // above), but a watcher still awaits the handle so a background panic
+        // surfaces instead of vanishing with the dropped JoinHandle.
+        let mut open_task = open_task;
+        match tokio::time::timeout(SYNC_TIMEOUT, &mut open_task).await {
             Ok(Ok(())) => return,
             // The spawned open PANICKED (or was aborted): surface it — a
             // swallowed JoinError would hide a real bug behind "the heal
@@ -144,6 +151,15 @@ impl Kakehashi {
                 "executeCommand: pre-sync of origin '{}' documents timed out after {SYNC_TIMEOUT:?}; dispatching anyway",
                 route.origin
             );
+            let origin = route.origin.to_string();
+            tokio::spawn(async move {
+                if let Err(join_error) = open_task.await {
+                    log::warn!(
+                        target: "kakehashi::bridge",
+                        "executeCommand: background pre-sync of origin {origin:?} documents failed: {join_error}"
+                    );
+                }
+            });
         }
     }
 }

--- a/src/lsp/lsp_impl/workspace/execute_command.rs
+++ b/src/lsp/lsp_impl/workspace/execute_command.rs
@@ -101,12 +101,12 @@ impl Kakehashi {
         // initialization with its own INIT_TIMEOUT bound.)
         const SYNC_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
         // Run the open as a SPAWNED task and bound only the wait: a plain
-        // `timeout(fut)` DROPS the future on expiry, and `ensure_document_opened`
-        // has await points between claiming a document for open and registering
-        // it — a drop in that window leaves the doc claimed-but-never-opened
-        // (every later open attempt short-circuits on the claim). Spawning lets
-        // the open run to completion in the background while the command
-        // dispatches.
+        // `timeout(fut)` DROPS the future on expiry, throwing away the
+        // best-effort didOpen mid-flight (the open path itself is
+        // cancellation-safe — `OpenClaimGuard` rolls back an orphaned claim on
+        // drop). Spawning lets the open run to completion in the background
+        // while the command dispatches, so a slow-but-healthy downstream still
+        // ends up with the document open.
         let bridge = std::sync::Arc::clone(&self.bridge);
         let settings = std::sync::Arc::clone(settings);
         let host_language_owned = host_language.clone();

--- a/src/lsp/lsp_impl/workspace/execute_command.rs
+++ b/src/lsp/lsp_impl/workspace/execute_command.rs
@@ -42,14 +42,19 @@ impl Kakehashi {
         let (cancel_rx, _cancel_guard) = self.subscribe_cancel(upstream_id.as_ref());
         let pool = self.bridge.pool_arc();
         let dispatch = pool.dispatch_execute_command(params, &settings, upstream_id);
-        match cancel_rx {
+        let result = match cancel_rx {
             Some(rx) => tokio::select! {
                 biased;
                 _ = rx => Err(tower_lsp_server::jsonrpc::Error::request_cancelled()),
                 result = dispatch => Ok(result),
             },
             None => Ok(dispatch.await),
-        }
+        };
+        // The cancel arm DROPS the in-flight dispatch, which then never
+        // reaches its own refcounted unregister — sweep the id (idempotent
+        // after normal completion, where the dispatch cleaned up itself).
+        pool.unregister_all_for_upstream_id(crate::lsp::current_upstream_id().as_ref());
+        result
     }
 
     /// Best-effort re-open of the routed command's origin-server documents (see
@@ -82,9 +87,9 @@ impl Kakehashi {
         // Bound the best-effort pre-sync: `eager_open_virtual_documents` can wait
         // up to the init timeout for a cold/stuck downstream to reach Ready, and
         // this sits on the user-facing executeCommand path. If it doesn't finish
-        // quickly, skip it and dispatch anyway — the happy path (doc already
-        // open) returns immediately, and dispatch uses the fail-fast connection
-        // variant, so a slow downstream can't block command execution here.
+        // quickly, stop waiting and dispatch anyway — the happy path (doc
+        // already open) returns immediately. (Dispatch itself waits through
+        // initialization with its own INIT_TIMEOUT bound.)
         const SYNC_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
         // Run the open as a SPAWNED task and bound only the wait: a plain
         // `timeout(fut)` DROPS the future on expiry, and `ensure_document_opened`
@@ -109,10 +114,25 @@ impl Kakehashi {
                 )
                 .await;
         });
-        if tokio::time::timeout(SYNC_TIMEOUT, open_task).await.is_err() {
-            // Timed out waiting for the downstream to open its documents; dispatch
-            // anyway (fail-fast connection variant). Logged so an intermittent
-            // "downstream never saw didOpen before the command" is diagnosable.
+        match tokio::time::timeout(SYNC_TIMEOUT, open_task).await {
+            Ok(Ok(())) => return,
+            // The spawned open PANICKED (or was aborted): surface it — a
+            // swallowed JoinError would hide a real bug behind "the heal
+            // just didn't help".
+            Ok(Err(join_error)) => {
+                log::warn!(
+                    target: "kakehashi::bridge",
+                    "executeCommand: pre-sync of origin '{}' documents failed: {join_error}",
+                    route.origin
+                );
+                return;
+            }
+            Err(_) => {}
+        }
+        {
+            // Timed out waiting for the downstream to open its documents;
+            // dispatch anyway. Logged so an intermittent "downstream never saw
+            // didOpen before the command" is diagnosable.
             log::debug!(
                 target: "kakehashi::bridge",
                 "executeCommand: pre-sync of origin '{}' documents timed out after {SYNC_TIMEOUT:?}; dispatching anyway",

--- a/src/lsp/lsp_impl/workspace/execute_command.rs
+++ b/src/lsp/lsp_impl/workspace/execute_command.rs
@@ -34,10 +34,22 @@ impl Kakehashi {
         self.sync_origin_documents_before_execute(&params, &settings)
             .await;
 
+        // Propagate a client $/cancelRequest as RequestCancelled instead of
+        // masking it as a null success: the cancel IS forwarded downstream via
+        // the registry, the downstream answers -32800, and fail-soft parsing
+        // would otherwise collapse that to `Ok(None)` (the same masking the
+        // multi-region codeAction walk already fixed).
+        let (cancel_rx, _cancel_guard) = self.subscribe_cancel(upstream_id.as_ref());
         let pool = self.bridge.pool_arc();
-        Ok(pool
-            .dispatch_execute_command(params, &settings, upstream_id)
-            .await)
+        let dispatch = pool.dispatch_execute_command(params, &settings, upstream_id);
+        match cancel_rx {
+            Some(rx) => tokio::select! {
+                biased;
+                _ = rx => Err(tower_lsp_server::jsonrpc::Error::request_cancelled()),
+                result = dispatch => Ok(result),
+            },
+            None => Ok(dispatch.await),
+        }
     }
 
     /// Best-effort re-open of the routed command's origin-server documents (see
@@ -54,6 +66,11 @@ impl Kakehashi {
         let Ok(host_url) = url::Url::parse(route.host_uri) else {
             return;
         };
+        // didChange clears the tree and reparses off-ingress: an executeCommand
+        // landing right after an edit would otherwise find no injections and
+        // silently skip the heal (the request paths await the fresh tree the
+        // same way).
+        self.ensure_document_parsed(&host_url).await;
         let Some((host_language, injections)) =
             self.injection_coordinator().bridge_injections(&host_url)
         else {
@@ -69,19 +86,30 @@ impl Kakehashi {
         // open) returns immediately, and dispatch uses the fail-fast connection
         // variant, so a slow downstream can't block command execution here.
         const SYNC_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
-        if tokio::time::timeout(
-            SYNC_TIMEOUT,
-            self.bridge.ensure_server_documents_open(
-                settings,
-                &host_language,
-                &host_url,
-                injections,
-                route.origin,
-            ),
-        )
-        .await
-        .is_err()
-        {
+        // Run the open as a SPAWNED task and bound only the wait: a plain
+        // `timeout(fut)` DROPS the future on expiry, and `ensure_document_opened`
+        // has await points between claiming a document for open and registering
+        // it — a drop in that window leaves the doc claimed-but-never-opened
+        // (every later open attempt short-circuits on the claim). Spawning lets
+        // the open run to completion in the background while the command
+        // dispatches.
+        let bridge = std::sync::Arc::clone(&self.bridge);
+        let settings = std::sync::Arc::clone(settings);
+        let host_language_owned = host_language.clone();
+        let host_url_owned = host_url.clone();
+        let origin = route.origin.to_string();
+        let open_task = tokio::spawn(async move {
+            bridge
+                .ensure_server_documents_open(
+                    &settings,
+                    &host_language_owned,
+                    &host_url_owned,
+                    injections,
+                    &origin,
+                )
+                .await;
+        });
+        if tokio::time::timeout(SYNC_TIMEOUT, open_task).await.is_err() {
             // Timed out waiting for the downstream to open its documents; dispatch
             // anyway (fail-fast connection variant). Logged so an intermittent
             // "downstream never saw didOpen before the command" is diagnosable.


### PR DESCRIPTION
## Problem

Five reachable races/hazards in the codeAction family, all fail-soft in outcome but degrading behavior (from the completeness audit's concurrency review):

1. A client `$/cancelRequest` for `codeAction/resolve` or `workspace/executeCommand` was forwarded downstream, the downstream answered `-32800`, and fail-soft parsing collapsed that into an unresolved-action / `null` **success** — the same masking commit 8e852bed6 fixed for the multi-region walk.
2. `send_code_action_resolve_on_handle` sent without the connections-lock `ptr_eq` stale-handle guard its executeCommand/generic siblings use — a respawn between fetching the handle (earliest on the eager-resolve pass) and the send queued the resolve and its cancel bookkeeping on a dead handle.
3. The executeCommand pre-sync bounded `ensure_server_documents_open` with a plain `timeout`, which **drops** the future on expiry; `ensure_document_opened` has await points between claiming a document for open and registering it, so the drop could wedge the document claimed-but-never-opened (every later open short-circuits on the claim).
4. The pre-sync read `bridge_injections` without `ensure_document_parsed`: right after an edit (tree cleared, reparse off-ingress) it found no injections and silently skipped the heal it exists for.
5. The bridged executeCommand path used the fail-fast connection variant; after a respawn it received an `Initializing` handle whose capability probe spuriously dropped the command (with a misleading "does not advertise executeCommandProvider" warn). The palette path already used `wait_ready`.

## Fix

(1) both handlers subscribe to the cancel forwarder and surface `RequestCancelled` via a biased select; (2) the resolve send adopts the shared check-and-enqueue-under-lock guard; (3) the open runs as a spawned task — the timeout bounds only the wait, the open completes in the background; (4) `ensure_document_parsed` precedes the injections read; (5) the bridged path waits through initialization with the same INIT_TIMEOUT bound as the palette path.

## Review provenance

Concurrency-perspective findings from the codeAction completeness audit (items 2,4,5,6,7 of that review). **Caveat: the codex stage for this PR is pending (usage limit reset); all changes verified by the full gate.**

## Testing

Full lib suite + clippy \-D warnings + e2e_code_action (43 tests, --features e2e) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented code action resolution from being sent with stale connection handles by validating connection liveness before dispatch.
  * Improved execute command handling by acquiring initialization-capable, capability-ready connections before capability checks.
  * Added robust client cancellation for code action resolve and execute command flows by racing work against `$/cancelRequest` and returning a request-cancelled error when canceled.
  * Ensured cleanup of upstream registrations after both completion and cancellation.
  * Enhanced origin-document pre-sync/open behavior, including best-effort parsing recovery and safer timeout handling during document opening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->