### PR TITLE
test(bridge): pin the codeAction family's untested contracts

### DIFF
--- a/src/language/injection/content.rs
+++ b/src/language/injection/content.rs
@@ -397,6 +397,45 @@ mod tests {
         );
     }
 
+    #[test]
+    fn compute_line_column_offsets_converts_non_ascii_prefix_to_utf16() {
+        // The offsets contract is UTF-16 code units. A fullwidth prefix
+        // "\u{ff1e} " is 4 UTF-8 bytes but 2 UTF-16 units — a byte-derived
+        // width would mint 4 here and shift every translated column. Ranges
+        // carry raw BYTE columns (tree_sitter::Point), so this pins the
+        // byte→UTF-16 conversion at the mint site.
+        //
+        // Text: "\u{ff1e} let x = 1;\n\u{ff1e} let y = 2;\n"
+        //   line 0: bytes  0..15 (prefix 0..4,  code 4..14,  \n at 14)
+        //   line 1: bytes 15..30 (prefix 15..19, code 19..29, \n at 29)
+        let text = "\u{ff1e} let x = 1;\n\u{ff1e} let y = 2;\n";
+        assert_eq!(&text[15..19], "\u{ff1e} ");
+        let included_ranges = vec![
+            tree_sitter::Range {
+                start_byte: 4,
+                end_byte: 15,
+                start_point: tree_sitter::Point { row: 0, column: 4 },
+                end_point: tree_sitter::Point { row: 0, column: 15 },
+            },
+            tree_sitter::Range {
+                start_byte: 19,
+                end_byte: 30,
+                start_point: tree_sitter::Point { row: 1, column: 4 },
+                end_point: tree_sitter::Point { row: 1, column: 15 },
+            },
+        ];
+
+        // start_column mirrors production (already UTF-16, content.rs mints it
+        // via encode_utf16 from the line-0 prefix).
+        let offsets = compute_line_column_offsets(text, 0..30, 2, Some(&included_ranges));
+
+        assert_eq!(
+            offsets,
+            vec![2, 2],
+            "line 1 must mint the UTF-16 width (2), not the 4-byte width"
+        );
+    }
+
     /// Tree-sitter assigns column positions from Range.start_point, not byte offset.
     ///
     /// When `set_included_ranges` is called with ranges whose `start_point.column = 2`,

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -1115,27 +1115,9 @@ mod tests {
     ///
     /// Returns the deps along with the receivers (stored in a tuple) to keep them alive.
     fn dummy_server_request_deps() -> (ServerRequestDeps, impl std::any::Any) {
-        let (tx, rx) = mpsc::channel(16);
-        let caps = Arc::new(DynamicCapabilityRegistry::new());
-        let (upstream_tx, upstream_rx) = mpsc::unbounded_channel();
-        let (window_tx, window_rx) = mpsc::channel(16);
-        let progress_registry = Arc::new(crate::lsp::bridge::ProgressRegistry::new());
-        let progress_connection_id = progress_registry.new_connection_id();
-        let deps = ServerRequestDeps {
-            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
-            server_name: None,
-            response_tx: tx,
-            dynamic_capabilities: caps,
-            upstream_tx,
-            workspace_folders: WorkspaceFolderSet::new(None),
-            window_tx,
-            upstream_request_tx: mpsc::unbounded_channel().0,
-            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
-            progress_registry,
-            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
-            progress_connection_id,
-        };
-        (deps, (rx, upstream_rx, window_rx))
+        // Same construction as the typed builder; callers here only need the
+        // receivers kept alive, not read.
+        dummy_server_request_deps_with_rx()
     }
 
     #[tokio::test]
@@ -3591,7 +3573,8 @@ mod tests {
 
     #[tokio::test]
     async fn apply_edit_rejects_unparseable_params_with_invalid_params() {
-        let (deps, mut keep) = dummy_server_request_deps_with_rx();
+        let (deps, (mut response_rx, _upstream_rx, _window_rx)) =
+            dummy_server_request_deps_with_rx();
         let message = json!({
             "jsonrpc": "2.0", "id": 9, "method": "workspace/applyEdit",
             "params": { "edit": "not-an-object" }
@@ -3604,7 +3587,7 @@ mod tests {
             &deps,
         );
 
-        let sent = tokio::time::timeout(std::time::Duration::from_secs(5), keep.0.recv())
+        let sent = tokio::time::timeout(std::time::Duration::from_secs(5), response_rx.recv())
             .await
             .expect("a response must be produced")
             .expect("channel open");
@@ -3622,7 +3605,8 @@ mod tests {
         // The forwarding loop dying mid-flight (or losing the editor response)
         // drops the reply sender; the downstream must still get a response —
         // applied:false with the neutral reason — never a hang.
-        let (mut deps, mut keep) = dummy_server_request_deps_with_rx();
+        let (mut deps, (mut response_rx, _upstream_rx, _window_rx)) =
+            dummy_server_request_deps_with_rx();
         let (request_tx, mut request_rx) = mpsc::unbounded_channel();
         deps.upstream_request_tx = request_tx;
         let message = json!({
@@ -3646,7 +3630,7 @@ mod tests {
         };
         drop(reply);
 
-        let sent = tokio::time::timeout(std::time::Duration::from_secs(5), keep.0.recv())
+        let sent = tokio::time::timeout(std::time::Duration::from_secs(5), response_rx.recv())
             .await
             .expect("a response must be produced")
             .expect("channel open");
@@ -3669,7 +3653,8 @@ mod tests {
         // answers applied:false via the dropped reply channel — the
         // downstream never hangs and the registry entry doesn't leak into
         // the #404 cancel path.
-        let (deps, mut keep) = dummy_server_request_deps_with_rx();
+        let (deps, (mut response_rx, _upstream_rx, _window_rx)) =
+            dummy_server_request_deps_with_rx();
         // dummy deps' upstream_request_tx receiver is already dropped.
         let message = json!({
             "jsonrpc": "2.0", "id": 11, "method": "workspace/applyEdit",
@@ -3683,7 +3668,7 @@ mod tests {
             &deps,
         );
 
-        let sent = tokio::time::timeout(std::time::Duration::from_secs(5), keep.0.recv())
+        let sent = tokio::time::timeout(std::time::Duration::from_secs(5), response_rx.recv())
             .await
             .expect("a response must be produced")
             .expect("channel open");
@@ -3691,6 +3676,14 @@ mod tests {
             panic!("expected an untracked server-request response");
         };
         assert_eq!(value["result"]["applied"], false, "got: {value}");
+        // The failed-enqueue path must also unregister its just-made registry
+        // entry, or it would leak into the #404 cancel path.
+        assert!(
+            !deps
+                .inbound_request_registry
+                .is_registered(deps.progress_connection_id, &jsonrpc::Id::Number(11)),
+            "the registry entry must not leak after a failed enqueue"
+        );
     }
 
     /// Like `dummy_server_request_deps` but hands back the typed receiver

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -3586,4 +3586,144 @@ mod tests {
         // No request should have been forwarded to the editor.
         assert!(request_rx.try_recv().is_err());
     }
+
+    // ---- workspace/applyEdit reader handler ---------------------------------
+
+    #[tokio::test]
+    async fn apply_edit_rejects_unparseable_params_with_invalid_params() {
+        let (deps, mut keep) = dummy_server_request_deps_with_rx();
+        let message = json!({
+            "jsonrpc": "2.0", "id": 9, "method": "workspace/applyEdit",
+            "params": { "edit": "not-an-object" }
+        });
+
+        crate::lsp::bridge::workspace::apply_edit::handle(
+            &message,
+            jsonrpc::Id::Number(9),
+            "[test] ",
+            &deps,
+        );
+
+        let sent = tokio::time::timeout(std::time::Duration::from_secs(5), keep.0.recv())
+            .await
+            .expect("a response must be produced")
+            .expect("channel open");
+        let OutboundMessage::Untracked(value) = sent else {
+            panic!("expected an untracked server-request response");
+        };
+        assert_eq!(
+            value["error"]["code"], -32602,
+            "unparseable params must answer InvalidParams: {value}"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_edit_answers_applied_false_when_the_reply_channel_drops() {
+        // The forwarding loop dying mid-flight (or losing the editor response)
+        // drops the reply sender; the downstream must still get a response —
+        // applied:false with the neutral reason — never a hang.
+        let (mut deps, mut keep) = dummy_server_request_deps_with_rx();
+        let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+        deps.upstream_request_tx = request_tx;
+        let message = json!({
+            "jsonrpc": "2.0", "id": 10, "method": "workspace/applyEdit",
+            "params": { "edit": { "changes": { "file:///x.rs": [] } } }
+        });
+
+        crate::lsp::bridge::workspace::apply_edit::handle(
+            &message,
+            jsonrpc::Id::Number(10),
+            "[test] ",
+            &deps,
+        );
+
+        let forwarded = tokio::time::timeout(std::time::Duration::from_secs(5), request_rx.recv())
+            .await
+            .expect("the request must be enqueued")
+            .expect("channel open");
+        let UpstreamRequest::ApplyEdit { reply, .. } = forwarded else {
+            panic!("expected an ApplyEdit upstream request");
+        };
+        drop(reply);
+
+        let sent = tokio::time::timeout(std::time::Duration::from_secs(5), keep.0.recv())
+            .await
+            .expect("a response must be produced")
+            .expect("channel open");
+        let OutboundMessage::Untracked(value) = sent else {
+            panic!("expected an untracked server-request response");
+        };
+        assert_eq!(value["result"]["applied"], false, "got: {value}");
+        assert!(
+            value["result"]["failureReason"]
+                .as_str()
+                .is_some_and(|r| r.contains("no workspace/applyEdit response")),
+            "the drop path's neutral reason must be relayed: {value}"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_edit_still_answers_when_the_forwarding_loop_is_gone() {
+        // Enqueue failure (receiver dropped — shutdown): the handler
+        // unregisters its just-made registry entry and the responder still
+        // answers applied:false via the dropped reply channel — the
+        // downstream never hangs and the registry entry doesn't leak into
+        // the #404 cancel path.
+        let (deps, mut keep) = dummy_server_request_deps_with_rx();
+        // dummy deps' upstream_request_tx receiver is already dropped.
+        let message = json!({
+            "jsonrpc": "2.0", "id": 11, "method": "workspace/applyEdit",
+            "params": { "edit": { "changes": {} } }
+        });
+
+        crate::lsp::bridge::workspace::apply_edit::handle(
+            &message,
+            jsonrpc::Id::Number(11),
+            "[test] ",
+            &deps,
+        );
+
+        let sent = tokio::time::timeout(std::time::Duration::from_secs(5), keep.0.recv())
+            .await
+            .expect("a response must be produced")
+            .expect("channel open");
+        let OutboundMessage::Untracked(value) = sent else {
+            panic!("expected an untracked server-request response");
+        };
+        assert_eq!(value["result"]["applied"], false, "got: {value}");
+    }
+
+    /// Like `dummy_server_request_deps` but hands back the typed receiver
+    /// tuple so tests can read the produced responses.
+    #[allow(clippy::type_complexity)]
+    fn dummy_server_request_deps_with_rx() -> (
+        ServerRequestDeps,
+        (
+            mpsc::Receiver<OutboundMessage>,
+            mpsc::UnboundedReceiver<UpstreamNotification>,
+            mpsc::Receiver<UpstreamNotification>,
+        ),
+    ) {
+        let (tx, rx) = mpsc::channel(16);
+        let caps = Arc::new(DynamicCapabilityRegistry::new());
+        let (upstream_tx, upstream_rx) = mpsc::unbounded_channel();
+        let (window_tx, window_rx) = mpsc::channel(16);
+        let progress_registry = Arc::new(crate::lsp::bridge::ProgressRegistry::new());
+        let progress_connection_id = progress_registry.new_connection_id();
+        let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
+            server_name: None,
+            response_tx: tx,
+            dynamic_capabilities: caps,
+            upstream_tx,
+            workspace_folders: WorkspaceFolderSet::new(None),
+            window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
+            progress_registry,
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
+            progress_connection_id,
+        };
+        (deps, (rx, upstream_rx, window_rx))
+    }
 }

--- a/src/lsp/bridge/inbound_request_registry.rs
+++ b/src/lsp/bridge/inbound_request_registry.rs
@@ -141,6 +141,21 @@ impl InboundRequestRegistry {
             }
         }
     }
+
+    /// Test-only probe: whether an entry is currently registered. Production
+    /// code must not branch on this (register/unregister own the lifecycle).
+    #[cfg(test)]
+    pub(crate) fn is_registered(
+        &self,
+        connection_id: ProgressConnectionId,
+        request_id: &jsonrpc::Id,
+    ) -> bool {
+        self.inner
+            .lock()
+            .recover_poison("InboundRequestRegistry::is_registered")
+            .get(&connection_id)
+            .is_some_and(|requests| requests.contains_key(request_id))
+    }
 }
 
 #[cfg(test)]

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -1069,6 +1069,67 @@ mod tests {
     }
 
     #[test]
+    fn within_region_accepts_exact_boundary_positions() {
+        let host_uri = make_host_uri();
+        // Region: blockquote, host lines 3-4 behind a `> ` floor of 2,
+        // region end at (4, 11). Both boundaries are INCLUSIVE: an edit
+        // ending exactly at region_end (whole-region replacement — the
+        // organize-imports shape) and one starting exactly at the column
+        // floor must be accepted; `position_after` is strict and rejecting
+        // equality would silently disable every full-region action.
+        let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2]);
+        let region_end = Position {
+            line: 4,
+            character: 11,
+        };
+        let check = |edit: &WorkspaceEdit| {
+            workspace_edit_within_region(edit, &host_uri, &offset, region_end)
+        };
+
+        let ends_at_region_end = parse_workspace_edit(json!({
+            "changes": { host_uri.as_str(): [
+                { "range": {"start": {"line": 3, "character": 2}, "end": {"line": 4, "character": 11}}, "newText": "x" }
+            ] }
+        }));
+        assert!(check(&ends_at_region_end), "end == region_end must pass");
+
+        let starts_at_floor = parse_workspace_edit(json!({
+            "changes": { host_uri.as_str(): [
+                { "range": {"start": {"line": 4, "character": 2}, "end": {"line": 4, "character": 5}}, "newText": "x" }
+            ] }
+        }));
+        assert!(check(&starts_at_floor), "start == column floor must pass");
+    }
+
+    #[test]
+    fn transform_translates_utf16_prefix_widths() {
+        // Per-line offsets are UTF-16 code units. A blockquote prefix built
+        // from a non-ASCII marker (e.g. "＞ " — U+FF1E is ONE UTF-16 unit but
+        // three UTF-8 bytes) must translate by its UTF-16 width; a byte-width
+        // confusion in the offsets would shift every translated column. The
+        // fixture pins the transform against a width that differs between the
+        // two encodings ("＞ " = 2 UTF-16 units, 4 bytes).
+        let virtual_uri = make_virtual_uri_string();
+        let host_uri = make_host_uri();
+        let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2]);
+        let mut edit = parse_workspace_edit(json!({
+            "changes": { virtual_uri.clone(): [
+                { "range": {"start": {"line": 1, "character": 4}, "end": {"line": 1, "character": 7}}, "newText": "x" }
+            ] }
+        }));
+
+        transform_workspace_edit_to_host(&mut edit, &virtual_uri, &host_uri, &offset);
+
+        let edits = edit.changes.unwrap().remove(&host_uri).unwrap();
+        assert_eq!(edits[0].range.start.line, 4);
+        assert_eq!(
+            edits[0].range.start.character, 6,
+            "virtual col 4 + UTF-16 prefix width 2 (NOT the 4-byte width)"
+        );
+        assert_eq!(edits[0].range.end.character, 9);
+    }
+
+    #[test]
     fn within_region_bounds_the_host_uri_edits_only() {
         let host_uri = make_host_uri();
         // A 2-line BLOCKQUOTE region: starts at host line 3, and every line has a

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -1103,12 +1103,13 @@ mod tests {
 
     #[test]
     fn transform_translates_utf16_prefix_widths() {
-        // Per-line offsets are UTF-16 code units. A blockquote prefix built
-        // from a non-ASCII marker (e.g. "＞ " — U+FF1E is ONE UTF-16 unit but
-        // three UTF-8 bytes) must translate by its UTF-16 width; a byte-width
-        // confusion in the offsets would shift every translated column. The
-        // fixture pins the transform against a width that differs between the
-        // two encodings ("＞ " = 2 UTF-16 units, 4 bytes).
+        // Per-line offsets are UTF-16 code units by contract: the transform
+        // adds the STORED width verbatim, so this test pins only that
+        // addition (offset 2 → +2 columns). The byte-vs-UTF-16 distinction is
+        // enforced where offsets are MINTED — see
+        // compute_line_column_offsets_converts_non_ascii_prefix_to_utf16 in
+        // language/injection/content.rs, whose fullwidth prefix would mint 4
+        // if the width were byte-derived.
         let virtual_uri = make_virtual_uri_string();
         let host_uri = make_host_uri();
         let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2]);

--- a/src/lsp/bridge/workspace/execute_command.rs
+++ b/src/lsp/bridge/workspace/execute_command.rs
@@ -322,3 +322,40 @@ fn parse_execute_command_response(mut response: Value) -> Option<Value> {
     }
     Some(result)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_relays_a_real_result_verbatim() {
+        let response = json!({
+            "jsonrpc": "2.0", "id": 7,
+            "result": { "applied": true, "custom": [1, 2, 3] }
+        });
+        assert_eq!(
+            parse_execute_command_response(response),
+            Some(json!({ "applied": true, "custom": [1, 2, 3] }))
+        );
+    }
+
+    #[test]
+    fn parse_collapses_a_jsonrpc_error_to_none() {
+        // Fail-soft contract: a downstream error becomes a null result
+        // upstream (warn-logged elsewhere), never an upstream error.
+        let response = json!({
+            "jsonrpc": "2.0", "id": 7,
+            "error": { "code": -32603, "message": "boom" }
+        });
+        assert_eq!(parse_execute_command_response(response), None);
+    }
+
+    #[test]
+    fn parse_collapses_a_null_result_to_none() {
+        // Many servers legitimately answer null (they applied their effect
+        // via applyEdit); None keeps the upstream response null.
+        let response = json!({ "jsonrpc": "2.0", "id": 7, "result": null });
+        assert_eq!(parse_execute_command_response(response), None);
+    }
+}


### PR DESCRIPTION
## What

Test-only PR closing the coverage gaps the completeness review flagged as "a regression here ships green":

- `parse_execute_command_response` (previously zero tests): verbatim relay, JSON-RPC-error→None (the fail-soft contract three module docs state), null→None.
- `workspace/applyEdit` reader handler (previously zero tests): InvalidParams on unparseable params; applied:false with the neutral reason when the reply channel drops; a response (not a hang) when the forwarding loop is gone at enqueue time.
- `workspace_edit_within_region` boundary equality: end == region_end and start == per-line column floor both accepted (an off-by-one would disable every whole-region action).
- UTF-16 prefix-width fixture for the WorkspaceEdit transform (all previous fixtures were ASCII, where UTF-16 units and bytes coincide).

Tracked but out of scope (need mock-downstream infra): respawn pre-sync e2e, applied:false relay e2e.

**Caveat: codex stage pending (usage limit); test-only diff verified by the full gate.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `workspace/applyEdit` handling to return JSON-RPC *Invalid params* for malformed `params.edit` and to fail safely with `applied: false` when upstream replies are missing.
  * Fixed `workspaceEdit` region checks to treat the end boundary as inclusive and correctly handle column “floor” equality cases.
  * Corrected workspace edit range translation to use UTF-16 code-unit column semantics.
  * Improved fail-soft parsing of `executeCommand` responses to ignore `error` and `result: null`.
* **Tests**
  * Added reliability and unit tests covering `workspace/applyEdit`, region boundary logic, UTF-16 translation offsets, and `executeCommand` parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->