### PR TITLE
fix(bridge): extend region-safety guards to every verbatim-newText relay path

### DIFF
--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -186,12 +186,22 @@ fn main() {
 
 But line 0 of the virtual document maps to the injection start line in the host—**inside the code fence**, not at the file top where imports belong.
 
-**Solutions**:
-1. **Filter out**: Remove additionalTextEdits outside injection range (loses auto-import)
-2. **Warn user**: Apply main edit, show message about skipped import
-3. **Smart placement**: Detect import patterns and place at injection start (complex)
+**Implemented policy** (fail-closed, atomic):
 
-Recommended: Option 1 or 2 for initial implementation.
+- The primary `textEdit`/`InsertReplaceEdit` (or the insertText/label
+  fallback, and snippet variables whose client-side expansion is unknowable)
+  is validated against the injection region — containment, per-line prefix
+  preservation, and the fence-boundary rule. An unsafe primary drops the
+  whole item.
+- `additionalTextEdits` are validated as one atomic set: any unsafe member
+  drops the entire array (never a subset — the array can carry paired halves
+  of one operation). The item is kept; its primary insertion stays
+  mechanically applicable, though possibly semantically incomplete without
+  its auto-import (availability over fidelity, with a warn log).
+- The same guards apply to inlay-hint `textEdits` (the hint is kept, its
+  accept-edit set drops whole) and color presentations (an unsafe explicit or
+  implicit label-replacement edit drops the presentation; unsafe
+  additionalTextEdits drop as an array).
 
 #### textDocument/rename
 
@@ -223,7 +233,10 @@ Rename can affect multiple files. For injections, only same-document renames are
 | Position mapping | All edit ranges |
 | Multi-server | full formatting: `preferred` by default, `concatenated` opts into a sequential pipeline over `priorities` (also the membership allowlist — unlisted servers do not run). `textDocument/rangeFormatting`: `preferred` only |
 
-Single-server formatting is simple—all edits are within the virtual document.
+Formatting responses are validated per edit (virtual-EOF bounds, region
+containment, prefix preservation, fence-boundary rule) and dropped **whole**
+when any edit is unsafe — a formatter answer is one atomic diff, so applying
+only its safe edits could duplicate or lose content.
 For multiple servers, the `concatenated`
 behavior does **not** concatenate edit lists (that would overlap); it runs a
 sequential formatter pipeline over `priorities`, which is both the

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -337,7 +337,12 @@ stands for the unlisted rest, and absence of the list means `["*"]`.
 
 ## Implementation Status
 
-The following table shows the current implementation status of bridged LSP methods:
+The following table shows the implementation status of the bridged LSP
+methods this ADR's strategies cover (many more pass-through/position-mapped
+methods — declaration, typeDefinition, implementation, documentLink,
+documentSymbol, prepareRename, documentColor, moniker, codeLens/resolve,
+foldingRange, linkedEditingRange, … — are implemented and documented in
+`docs/language-features.md`):
 
 | Feature | Status | Notes |
 |---------|--------|-------|
@@ -345,7 +350,7 @@ The following table shows the current implementation status of bridged LSP metho
 | hover | ✅ Implemented | Pass-through with position translation |
 | signatureHelp | ✅ Implemented | Pass-through |
 | completion | ✅ Implemented | Fail-closed edit guards; atomic additionalTextEdits drop |
-| completionItem/resolve | ✅ Implemented | Envelope-routed; unsafe resolved responses serve the unresolved item |
+| completionItem/resolve | ✅ Implemented | Envelope-routed; an unsafe resolved PRIMARY edit serves the unresolved item, unsafe additionalTextEdits drop as an atomic set |
 | references | ✅ Implemented | With cross-file filtering |
 | rename | ✅ Implemented | With workspace edit validation |
 | codeAction | ✅ Implemented | With edit filtering (incl. resolve + executeCommand routing) |

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -344,14 +344,19 @@ The following table shows the current implementation status of bridged LSP metho
 | definition | ✅ Implemented | Full delegation with response filtering |
 | hover | ✅ Implemented | Pass-through with position translation |
 | signatureHelp | ✅ Implemented | Pass-through |
-| completion | ✅ Implemented | With additionalTextEdits filtering |
+| completion | ✅ Implemented | Fail-closed edit guards; atomic additionalTextEdits drop |
+| completionItem/resolve | ✅ Implemented | Envelope-routed; unsafe resolved responses serve the unresolved item |
 | references | ✅ Implemented | With cross-file filtering |
 | rename | ✅ Implemented | With workspace edit validation |
-| codeAction | ✅ Implemented | With edit filtering |
-| formatting | ✅ Implemented | With position mapping |
-| documentHighlight | ❌ Not implemented | |
-| diagnostics | ❌ Not implemented | Requires async push model |
-| semanticTokens | ❌ Not implemented | Would enable parallel fetch strategy |
+| codeAction | ✅ Implemented | With edit filtering (incl. resolve + executeCommand routing) |
+| formatting | ✅ Implemented | Whole-response atomic drop on unsafe edits |
+| rangeFormatting | ✅ Implemented | Shares the formatting guards |
+| onTypeFormatting | ✅ Implemented | Shares the formatting guards |
+| inlayHint | ✅ Implemented | Unsafe accept-edit sets dropped whole; hint kept |
+| colorPresentation | ✅ Implemented | Experimental opt-in; unsafe presentations dropped |
+| documentHighlight | ✅ Implemented | |
+| diagnostics | ✅ Implemented | Push + pull with host translation |
+| semanticTokens | ✅ Implemented | Cross-layer merge (see semantic-token merge ADR) |
 
 ### Original Implementation Priority
 

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -85,7 +85,9 @@ A single bridge strategy doesn't fit all methods. We need per-method strategies 
 
 ### Strategy 2: Full Delegation with Response Filtering
 
-**Applies to**: `textDocument/definition`, `textDocument/references`, `textDocument/hover`, `textDocument/signatureHelp`
+**Applies to**: `textDocument/definition`, `textDocument/declaration`,
+`textDocument/typeDefinition`, `textDocument/implementation`,
+`textDocument/references`, `textDocument/hover`, `textDocument/signatureHelp`
 
 ```
 Request (cursor in injection) ──▶ Forward to language server
@@ -93,8 +95,8 @@ Request (cursor in injection) ──▶ Forward to language server
                                          ▼
                                   Filter response
                                   (translate same-region virtual URIs,
-                                   keep real-file URIs, drop other
-                                   virtual-region URIs)
+                                   keep real-file URIs untranslated, drop
+                                   other virtual-region URIs)
                                          │
                                          ▼
                                   Translate positions
@@ -103,7 +105,7 @@ Request (cursor in injection) ──▶ Forward to language server
 
 **Per-Method Details**:
 
-#### textDocument/definition (PoC implemented)
+#### textDocument/definition (and declaration / typeDefinition / implementation, via the shared goto transformer)
 
 | Aspect | Handling |
 |--------|----------|

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -150,7 +150,10 @@ No position information in response—pass through directly.
 
 ### Strategy 3: Delegation with Edit Filtering
 
-**Applies to**: `textDocument/completion`, `textDocument/rename`, `textDocument/codeAction`, `textDocument/formatting`
+**Applies to**: `textDocument/completion`, `completionItem/resolve`,
+`textDocument/rename`, `textDocument/codeAction`, `textDocument/formatting`,
+`textDocument/rangeFormatting`, `textDocument/onTypeFormatting`,
+`textDocument/inlayHint` (its `textEdits`), `textDocument/colorPresentation`
 
 These methods return edits that must be carefully validated.
 
@@ -223,7 +226,7 @@ Rename can affect multiple files. For injections, only same-document renames are
 | Cross-file | Filter out actions with cross-file edits |
 | Position mapping | All ranges in remaining actions |
 
-#### textDocument/formatting / textDocument/rangeFormatting
+#### textDocument/formatting / rangeFormatting / onTypeFormatting
 
 | Aspect | Handling |
 |--------|----------|

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -5,12 +5,6 @@
 > ls-bridge-message-ordering and
 > ls-bridge-server-pool-coordination.
 
-## Decision–Implementation Gap
-
-8 of the 11 per-method strategies described below are implemented (definition,
-hover, signatureHelp, completion, references, rename, codeAction, formatting).
-The remaining three are not yet implemented.
-
 ## Context
 
 When bridging LSP requests for injection regions (see language-server-bridge), different LSP methods have different characteristics:

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -21,7 +21,10 @@ A single bridge strategy doesn't fit all methods. We need per-method strategies 
 
 ### Injection Isolation Constraint
 
-**Critical insight**: Injection regions are isolated code fragments. They exist within a single host document and have no relationship to other files. This affects how we handle features that can return cross-file results.
+**Critical insight**: Injection regions are isolated code fragments with no
+relationship to OTHER VIRTUAL REGIONS — each is analyzed on its own. Real
+files on disk (library sources, workspace files) remain valid targets. This
+affects how we handle features that can return cross-file results.
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -289,8 +292,8 @@ concatenated-formatting-pipeline.
 
 | Response Type | Fields to Map |
 |---------------|---------------|
-| Location | uri (rewrite to host), range |
-| Location[] | Each location |
+| Location | same-region virtual targets: uri rewritten to host + range translated; real-file targets: untouched |
+| Location[] | Each location, same rule |
 | Hover | range (if present) |
 | CompletionItem | textEdit.range, additionalTextEdits[].range |
 | TextEdit | range |
@@ -329,7 +332,7 @@ stands for the unlisted rest, and absence of the list means `["*"]`.
 ### Negative
 
 - **Implementation complexity**: Four different strategies to implement and maintain
-- **Feature limitations**: Some features degraded (no auto-import in completion)
+- **Feature limitations**: Some features degraded (auto-imports may be dropped when unsafe for the region)
 - **Inconsistent latency**: Some features instant (semantic tokens), others have server latency
 - **Refresh mechanism dependency**: Progressive refinement requires editor support for token refresh
 

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -100,7 +100,9 @@ Request (cursor in injection) ──▶ Forward to language server
                                          │
                                          ▼
                                   Translate positions
-                                  (virtual → host)
+                                  (virtual → host — same-region
+                                   targets only; real-file locations
+                                   keep URI and range unchanged)
 ```
 
 **Per-Method Details**:
@@ -112,7 +114,7 @@ Request (cursor in injection) ──▶ Forward to language server
 | Input | Position (host → virtual translation) |
 | Output | Location or Location[] |
 | Cross-file | Keep real-file locations; translate same-region virtual URIs; drop other virtual regions |
-| Position mapping | Range start/end: virtual → host |
+| Position mapping | Range start/end virtual → host for same-region targets; real-file ranges untouched |
 
 #### textDocument/references
 
@@ -121,7 +123,7 @@ Request (cursor in injection) ──▶ Forward to language server
 | Input | Position + includeDeclaration flag |
 | Output | Location[] |
 | Cross-file | Keep real-file locations; translate same-region virtual URIs; drop other virtual regions |
-| Position mapping | Each location's range: virtual → host |
+| Position mapping | Each same-region location's range virtual → host; real-file ranges untouched |
 
 **Important**: Real-file locations (e.g. library sources on disk) are kept —
 they are valid navigation targets. Only locations in OTHER virtual regions are
@@ -338,16 +340,16 @@ stands for the unlisted rest, and absence of the list means `["*"]`.
 
 ## Implementation Status
 
-The following table shows the implementation status of the bridged LSP
-methods this ADR's strategies cover (many more pass-through/position-mapped
-methods — declaration, typeDefinition, implementation, documentLink,
+The following table is a SELECTED-FEATURE summary of the bridged LSP methods
+this ADR discusses in detail (the goto family rows stand for
+definition/declaration/typeDefinition/implementation, which share one
+transformer). The full, user-facing feature list — documentLink,
 documentSymbol, prepareRename, documentColor, moniker, codeLens/resolve,
-foldingRange, linkedEditingRange, … — are implemented and documented in
-`docs/language-features.md`):
+foldingRange, linkedEditingRange, … — lives in `docs/language-features.md`.
 
 | Feature | Status | Notes |
 |---------|--------|-------|
-| definition | ✅ Implemented | Full delegation; real-file URIs kept, cross-region virtual URIs dropped |
+| definition (+ declaration / typeDefinition / implementation) | ✅ Implemented | Shared goto transformer; real-file URIs kept, cross-region virtual URIs dropped |
 | hover | ✅ Implemented | Pass-through with position translation |
 | signatureHelp | ✅ Implemented | Pass-through |
 | completion | ✅ Implemented | Fail-closed edit guards; atomic additionalTextEdits drop |
@@ -360,7 +362,7 @@ foldingRange, linkedEditingRange, … — are implemented and documented in
 | onTypeFormatting | ✅ Implemented | Shares the formatting guards |
 | inlayHint | ✅ Implemented | Unsafe accept-edit sets dropped whole; hint kept |
 | colorPresentation | ✅ Implemented | Experimental opt-in; unsafe presentations dropped |
-| documentHighlight | ✅ Implemented | |
+| documentHighlight | ✅ Implemented | Strategy-2 shape (single-document, position-mapped) |
 | diagnostics | ✅ Implemented | Push + pull with host translation |
 | semanticTokens | ✅ Implemented | Cross-layer merge (see semantic-token merge ADR) |
 

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -220,7 +220,7 @@ But line 0 of the virtual document maps to the injection start line in the hostâ
 |--------|----------|
 | Input | Position + newName |
 | Output | WorkspaceEdit (changes across files) |
-| Cross-file | Real-file edits pass through; same-region virtual edits translate; foreign virtual-region or structurally unsafe edits reject |
+| Cross-file | Real-file edits pass through; same-region virtual edits translate; foreign virtual-region entries filtered (siblings survive); structurally unsafe edits or virtual-URI file operations reject the result |
 | Position mapping | Same-region TextEdit ranges (real-file ranges untouched) |
 
 Rename can affect multiple files. Real-file edits (a project-aware server's

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -220,10 +220,13 @@ But line 0 of the virtual document maps to the injection start line in the host�
 |--------|----------|
 | Input | Position + newName |
 | Output | WorkspaceEdit (changes across files) |
-| Cross-file | **Reject entirely** if any edit outside virtual document |
-| Position mapping | All TextEdit ranges |
+| Cross-file | Real-file edits pass through; same-region virtual edits translate; foreign virtual-region or structurally unsafe edits reject |
+| Position mapping | Same-region TextEdit ranges (real-file ranges untouched) |
 
-Rename can affect multiple files. For injections, only same-document renames are valid.
+Rename can affect multiple files. Real-file edits (a project-aware server's
+cross-file rename) are preserved verbatim; only edits addressed to other
+regions' virtual URIs — meaningless to the editor — or edits that fail the
+region-safety guards are rejected.
 
 #### textDocument/codeAction
 
@@ -231,8 +234,8 @@ Rename can affect multiple files. For injections, only same-document renames are
 |--------|----------|
 | Input | Range + context (diagnostics) |
 | Output | CodeAction[] (each may contain WorkspaceEdit) |
-| Cross-file | Filter out actions with cross-file edits |
-| Position mapping | All ranges in remaining actions |
+| Cross-file | Real-file edits/resource ops pass through; actions with foreign virtual-region or unsafe edits are disabled/dropped |
+| Position mapping | Same-region ranges in remaining actions |
 
 #### textDocument/formatting / rangeFormatting / onTypeFormatting
 

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -224,9 +224,11 @@ But line 0 of the virtual document maps to the injection start line in the host�
 | Position mapping | Same-region TextEdit ranges (real-file ranges untouched) |
 
 Rename can affect multiple files. Real-file edits (a project-aware server's
-cross-file rename) are preserved verbatim; only edits addressed to other
-regions' virtual URIs — meaningless to the editor — or edits that fail the
-region-safety guards are rejected.
+cross-file rename) are preserved — content and ranges untouched, though
+bridge-local `TextDocumentEdit.version` values are cleared before relaying —
+while entries addressed to other regions' virtual URIs (meaningless to the
+editor) are FILTERED out with usable siblings surviving. Only edits that fail
+the region-safety guards reject the result.
 
 #### textDocument/codeAction
 
@@ -300,9 +302,9 @@ concatenated-formatting-pipeline.
 | Hover | range (if present) |
 | CompletionItem | textEdit.range, additionalTextEdits[].range |
 | TextEdit | range |
-| WorkspaceEdit | All documentChanges/changes entries |
+| WorkspaceEdit | Same-region virtual entries translated; real-file ranges untouched; foreign virtual entries filtered (or the action rejected) |
 | Diagnostic | range, relatedInformation[].location |
-| CodeAction | All contained edits |
+| CodeAction | Contained edits, same conditional rule |
 
 ### Multi-Server Merging Rules
 
@@ -329,7 +331,7 @@ stands for the unlisted rest, and absence of the list means `["*"]`.
 - **Optimized UX per feature**: Each method gets the strategy that best fits its characteristics
 - **Fast visual feedback**: Semantic tokens appear instantly via parallel fetch
 - **Accurate navigation**: Go-to-definition uses authoritative language server
-- **Safe editing**: Cross-file edits are filtered to prevent corruption
+- **Safe editing**: real-file edits/resource operations are retained; foreign virtual-region or structurally unsafe edits are filtered/rejected to prevent corruption
 - **Comprehensive diagnostics**: Aggregated from multiple sources
 
 ### Negative

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -40,7 +40,8 @@ A single bridge strategy doesn't fit all methods. We need per-method strategies 
 │         │  on "Serialize"              │                        │
 │         └──────────────────────────────┘                        │
 │                                                                 │
-│  Result: Location in serde crate → FILTER OUT (not in injection)│
+│  Result: Location in serde crate → KEPT (real file on disk);   │
+│  only OTHER VIRTUAL-REGION locations are filtered out           │
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -91,7 +92,9 @@ Request (cursor in injection) ──▶ Forward to language server
                                          │
                                          ▼
                                   Filter response
-                                  (remove cross-file locations)
+                                  (translate same-region virtual URIs,
+                                   keep real-file URIs, drop other
+                                   virtual-region URIs)
                                          │
                                          ▼
                                   Translate positions
@@ -106,7 +109,7 @@ Request (cursor in injection) ──▶ Forward to language server
 |--------|----------|
 | Input | Position (host → virtual translation) |
 | Output | Location or Location[] |
-| Cross-file | Filter out locations outside virtual document |
+| Cross-file | Keep real-file locations; translate same-region virtual URIs; drop other virtual regions |
 | Position mapping | Range start/end: virtual → host |
 
 #### textDocument/references
@@ -115,10 +118,12 @@ Request (cursor in injection) ──▶ Forward to language server
 |--------|----------|
 | Input | Position + includeDeclaration flag |
 | Output | Location[] |
-| Cross-file | **Filter out** locations outside virtual document |
+| Cross-file | Keep real-file locations; translate same-region virtual URIs; drop other virtual regions |
 | Position mapping | Each location's range: virtual → host |
 
-**Important**: References may return many locations from external files. Only references within the same injection region are meaningful.
+**Important**: Real-file locations (e.g. library sources on disk) are kept —
+they are valid navigation targets. Only locations in OTHER virtual regions are
+dropped, since their URIs are meaningless to the editor.
 
 #### textDocument/hover
 
@@ -340,12 +345,12 @@ foldingRange, linkedEditingRange, … — are implemented and documented in
 
 | Feature | Status | Notes |
 |---------|--------|-------|
-| definition | ✅ Implemented | Full delegation with response filtering |
+| definition | ✅ Implemented | Full delegation; real-file URIs kept, cross-region virtual URIs dropped |
 | hover | ✅ Implemented | Pass-through with position translation |
 | signatureHelp | ✅ Implemented | Pass-through |
 | completion | ✅ Implemented | Fail-closed edit guards; atomic additionalTextEdits drop |
 | completionItem/resolve | ✅ Implemented | Envelope-routed; an unsafe resolved PRIMARY edit serves the unresolved item, unsafe additionalTextEdits drop as an atomic set |
-| references | ✅ Implemented | With cross-file filtering |
+| references | ✅ Implemented | Real-file URIs kept, cross-region virtual URIs dropped |
 | rename | ✅ Implemented | With workspace edit validation |
 | codeAction | ✅ Implemented | With edit filtering (incl. resolve + executeCommand routing) |
 | formatting | ✅ Implemented | Whole-response atomic drop on unsafe edits |

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -195,7 +195,9 @@ But line 0 of the virtual document maps to the injection start line in the host�
   fallback, and snippet variables whose client-side expansion is unknowable)
   is validated against the injection region — containment, per-line prefix
   preservation, and the fence-boundary rule. An unsafe primary drops the
-  whole item.
+  whole item at completion time; at `completionItem/resolve` time the unsafe
+  resolved response is discarded and the original (already-validated)
+  unresolved item is served instead.
 - `additionalTextEdits` are validated as one atomic set: any unsafe member
   drops the entire array (never a subset — the array can carry paired halves
   of one operation). The item is kept; its primary insertion stays

--- a/docs/architecture-decisions/language-server-bridge-request-strategies.md
+++ b/docs/architecture-decisions/language-server-bridge-request-strategies.md
@@ -227,8 +227,9 @@ Rename can affect multiple files. Real-file edits (a project-aware server's
 cross-file rename) are preserved — content and ranges untouched, though
 bridge-local `TextDocumentEdit.version` values are cleared before relaying —
 while entries addressed to other regions' virtual URIs (meaningless to the
-editor) are FILTERED out with usable siblings surviving. Only edits that fail
-the region-safety guards reject the result.
+editor) are FILTERED out with usable siblings surviving. The whole result is
+rejected only when an edit fails the region-safety guards or the edit carries
+a file operation (create/rename/delete) targeting a virtual URI.
 
 #### textDocument/codeAction
 

--- a/docs/language-features.md
+++ b/docs/language-features.md
@@ -116,7 +116,11 @@ Additional details for a highlighted item (documentation, extra edits) are resol
 on demand from the server that produced it. Because the language server only sees
 the isolated snippet, any edits it returns — including auto-import edits — are
 placed relative to the embedded block, so file-level imports may not land where they
-would in a standalone file. Default combine strategy: `preferred`.
+would in a standalone file. Edits that would corrupt the host document around the
+embedded block (escape the region, break blockquote `> ` prefixes, or merge content
+into the closing fence) are dropped fail-closed: an unsafe primary edit drops the
+completion item, an unsafe auto-import set is dropped whole while the completion
+itself still applies. Default combine strategy: `preferred`.
 
 ### Signature help
 

--- a/docs/language-features.md
+++ b/docs/language-features.md
@@ -118,10 +118,10 @@ the isolated snippet, any edits it returns — including auto-import edits — a
 placed relative to the embedded block, so file-level imports may not land where they
 would in a standalone file. Edits that would corrupt the host document around the
 embedded block (escape the region, break blockquote `> ` prefixes, or merge content
-into the closing fence) are dropped fail-closed: at completion time an unsafe
-primary edit drops the item and an unsafe auto-import set is dropped whole while
-the completion itself still applies; at resolve time an unsafe resolved response
-is discarded and the unresolved item is served instead. Default combine strategy: `preferred`.
+into the closing fence) are dropped fail-closed: an unsafe primary edit drops
+the item (at resolve time, the unsafe resolved response is discarded and the
+unresolved item is served instead), while an unsafe auto-import set — at either
+stage — is dropped whole and the completion itself still applies. Default combine strategy: `preferred`.
 
 ### Signature help
 
@@ -238,8 +238,10 @@ differently.
 and [`textDocument/colorPresentation`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_colorPresentation)
 
 Shows color swatches and color picker presentations for embedded blocks.
-Presentations whose edits (explicit, or the implicit label replacement) would
-corrupt the host document around the embedded block are dropped fail-closed.
+Presentations whose primary edit (explicit, or the implicit label replacement)
+would corrupt the host document around the embedded block are dropped
+fail-closed; unsafe additional edits are dropped as one atomic set while the
+presentation itself survives.
 **Only available with the `KAKEHASHI_EXPERIMENTAL=true` environment variable** —
 without the opt-in the server does not advertise color support.
 

--- a/docs/language-features.md
+++ b/docs/language-features.md
@@ -190,6 +190,12 @@ seeing the previous formatter's output (e.g. `black` then `isort`). The
 pipeline requires explicitly named servers — `"*"` is ignored there, since a
 reproducible pipeline needs a deterministic order.
 
+A response whose edits would corrupt the host document around the embedded
+block (escape the region, break blockquote `> ` prefixes, or merge content
+into the closing fence) is dropped **whole** — a formatter answer is one
+atomic diff, so applying only its safe edits could duplicate or lose content.
+The same rule covers range and on-type formatting.
+
 ### Range formatting
 
 [`textDocument/rangeFormatting`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_rangeFormatting)
@@ -202,7 +208,9 @@ formatting, scoped to the selection.
 [`textDocument/inlayHint`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_inlayHint)
 
 Shows inline hints (types, parameter names) for the embedded block overlapping the
-requested range. Default combine strategy: `preferred`.
+requested range. A hint whose accept-time text edits would corrupt the host
+document around the embedded block is served without them (the edits drop as
+one atomic set). Default combine strategy: `preferred`.
 
 ### Moniker
 
@@ -229,6 +237,8 @@ differently.
 and [`textDocument/colorPresentation`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_colorPresentation)
 
 Shows color swatches and color picker presentations for embedded blocks.
+Presentations whose edits (explicit, or the implicit label replacement) would
+corrupt the host document around the embedded block are dropped fail-closed.
 **Only available with the `KAKEHASHI_EXPERIMENTAL=true` environment variable** —
 without the opt-in the server does not advertise color support.
 

--- a/docs/language-features.md
+++ b/docs/language-features.md
@@ -118,9 +118,10 @@ the isolated snippet, any edits it returns — including auto-import edits — a
 placed relative to the embedded block, so file-level imports may not land where they
 would in a standalone file. Edits that would corrupt the host document around the
 embedded block (escape the region, break blockquote `> ` prefixes, or merge content
-into the closing fence) are dropped fail-closed: an unsafe primary edit drops the
-completion item, an unsafe auto-import set is dropped whole while the completion
-itself still applies. Default combine strategy: `preferred`.
+into the closing fence) are dropped fail-closed: at completion time an unsafe
+primary edit drops the item and an unsafe auto-import set is dropped whole while
+the completion itself still applies; at resolve time an unsafe resolved response
+is discarded and the unresolved item is served instead. Default combine strategy: `preferred`.
 
 ### Signature help
 

--- a/src/lsp/bridge/protocol.rs
+++ b/src/lsp/bridge/protocol.rs
@@ -39,7 +39,7 @@ pub(crate) use response::*;
 pub(crate) use translation::*;
 pub(crate) use virtual_uri::VirtualDocumentUri;
 pub(crate) use workspace_edit::{
-    region_host_end, strip_bridge_local_versions, transform_workspace_edit_to_host,
-    workspace_edit_has_effect, workspace_edit_preserves_line_prefixes,
-    workspace_edit_within_region,
+    region_host_end, strip_bridge_local_versions, text_edit_preserves_line_prefixes,
+    transform_workspace_edit_to_host, workspace_edit_has_effect,
+    workspace_edit_preserves_line_prefixes, workspace_edit_within_region,
 };

--- a/src/lsp/bridge/protocol.rs
+++ b/src/lsp/bridge/protocol.rs
@@ -39,7 +39,7 @@ pub(crate) use response::*;
 pub(crate) use translation::*;
 pub(crate) use virtual_uri::VirtualDocumentUri;
 pub(crate) use workspace_edit::{
-    region_host_end, strip_bridge_local_versions, text_edit_preserves_line_prefixes,
+    region_host_end, strip_bridge_local_versions, text_edit_safe_in_region,
     transform_workspace_edit_to_host, workspace_edit_has_effect,
     workspace_edit_preserves_line_prefixes, workspace_edit_within_region,
 };

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -421,7 +421,7 @@ pub(crate) fn text_edit_preserves_line_prefixes(
     // lines removed; the preceding newline survives). Reject everything
     // else. The canonical insertFinalNewline ("\n" at the boundary) passes.
     if region_end.character == 0 && e.range.end == region_end {
-        let ends_with_newline = e.new_text.ends_with('\n');
+        let ends_with_newline = e.new_text.ends_with('\n') || e.new_text.ends_with('\r');
         let whole_line_deletion = e.new_text.is_empty() && e.range.start.character == 0;
         if !ends_with_newline && !whole_line_deletion {
             return false;

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -1387,4 +1387,26 @@ mod tests {
             region_end
         ));
     }
+
+    #[test]
+    fn boundary_deletion_accepts_a_lone_cr_terminator() {
+        // LSP recognizes lone '\r' as an EOL; a replacement ending with it
+        // still separates content from the closing fence.
+        let offset = RegionOffset::with_per_line_offsets(3, vec![0, 0, 0]);
+        let region_end = Position {
+            line: 5,
+            character: 0,
+        };
+        let e = TextEdit {
+            range: tower_lsp_server::ls_types::Range {
+                start: Position {
+                    line: 3,
+                    character: 0,
+                },
+                end: region_end,
+            },
+            new_text: "replaced\r".to_string(),
+        };
+        assert!(text_edit_safe_in_region(&e, &offset, region_end));
+    }
 }

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -400,6 +400,24 @@ pub(crate) fn text_edit_preserves_line_prefixes(
     offset: &RegionOffset,
     region_end: Position,
 ) -> bool {
+    // Fence-boundary EOL preservation — checked BEFORE the all-zero fast
+    // path because it protects plain fenced regions too. When the region's
+    // content end is the START of the closing-fence row (character 0 —
+    // content ends with a newline), an edit reaching that boundary erases or
+    // omits the newline separating content from fence: inserting "y" there
+    // yields "y```" on the fence line. After the edit, the text before the
+    // fence still ends with a newline iff the newText ends with one, or —
+    // for a pure deletion — the range starts at a line start (whole trailing
+    // lines removed; the preceding newline survives). Reject everything
+    // else. The canonical insertFinalNewline ("\n" at the boundary) passes.
+    if region_end.character == 0 && e.range.end == region_end {
+        let ends_with_newline = e.new_text.ends_with('\n');
+        let whole_line_deletion = e.new_text.is_empty() && e.range.start.character == 0;
+        if !ends_with_newline && !whole_line_deletion {
+            return false;
+        }
+    }
+
     let columns = offset.columns();
     if columns.iter().all(|&column| column == 0) {
         return true;
@@ -1260,5 +1278,41 @@ mod tests {
             }]
         }));
         assert!(!check(&doc_changes_into_prefix));
+    }
+
+    #[test]
+    fn boundary_edits_must_preserve_the_fence_separating_newline() {
+        // PLAIN fenced region (all-zero offsets): content host lines 3-4,
+        // closing fence at line 5, region end (5, 0) — the boundary is the
+        // fence row's start. Containment is inclusive there and the all-zero
+        // fast path skips the prefix rules, so the EOL-preservation rule is
+        // the only thing keeping "y" from landing as "y```".
+        let offset = RegionOffset::with_per_line_offsets(3, vec![0, 0, 0]);
+        let region_end = Position {
+            line: 5,
+            character: 0,
+        };
+        let edit = |start: Position, end: Position, new_text: &str| TextEdit {
+            range: tower_lsp_server::ls_types::Range { start, end },
+            new_text: new_text.to_string(),
+        };
+        let p = |line: u32, character: u32| Position { line, character };
+        let check = |e: &TextEdit| text_edit_safe_in_region(e, &offset, region_end);
+
+        // Insert without a trailing newline at the boundary → "y```". Reject.
+        assert!(!check(&edit(p(5, 0), p(5, 0), "y")));
+        // Canonical insertFinalNewline. Accept.
+        assert!(check(&edit(p(5, 0), p(5, 0), "\n")));
+        // Whole-block replacement ending at the boundary with a trailing
+        // newline (organize-imports shape). Accept.
+        assert!(check(&edit(p(3, 0), p(5, 0), "import a\nimport b\n")));
+        // Same replacement WITHOUT the trailing newline → fence merges into
+        // the last content line. Reject.
+        assert!(!check(&edit(p(3, 0), p(5, 0), "import a\nimport b")));
+        // Whole trailing-line deletion: preceding newline survives. Accept.
+        assert!(check(&edit(p(4, 0), p(5, 0), "")));
+        // Mid-line deletion ending at the boundary eats the separating
+        // newline → "x```". Reject.
+        assert!(!check(&edit(p(4, 2), p(5, 0), "")));
     }
 }

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -356,8 +356,26 @@ pub(crate) fn workspace_edit_preserves_line_prefixes(
     if columns.iter().all(|&column| column == 0) {
         return true;
     }
-    // The all-zero fast path above guarantees SOME column is non-zero here,
-    // so only the shape distinction remains.
+    host_uri_text_edits_all(edit, host_uri, |e| {
+        text_edit_preserves_line_prefixes(e, offset, region_end)
+    })
+}
+
+/// Per-edit form of [`workspace_edit_preserves_line_prefixes`], for response
+/// shapes that carry bare `TextEdit`s rather than a `WorkspaceEdit`
+/// (formatting-family responses, completion/inlayHint/colorPresentation item
+/// edits). Same contract: `false` means applying the edit verbatim would
+/// strip or omit the region's per-line host prefixes — callers must reject
+/// or drop, never clamp.
+pub(crate) fn text_edit_preserves_line_prefixes(
+    e: &TextEdit,
+    offset: &RegionOffset,
+    region_end: Position,
+) -> bool {
+    let columns = offset.columns();
+    if columns.iter().all(|&column| column == 0) {
+        return true;
+    }
     let content_prefixed = columns.len() > 1;
     let boundary_at = |host_line: u32| {
         content_prefixed && region_end.character == 0 && host_line >= region_end.line
@@ -368,7 +386,7 @@ pub(crate) fn workspace_edit_preserves_line_prefixes(
                 .checked_sub(offset.line())
                 .is_some_and(|v| offset.column_for_line(v) > 0)
     };
-    host_uri_text_edits_all(edit, host_uri, |e| {
+    {
         let (start, end) = (e.range.start, e.range.end);
         // The boundary row's real prefix is unrecorded (0), so the per-line
         // floor can't protect it: even a same-line, no-newline insertion at
@@ -400,7 +418,7 @@ pub(crate) fn workspace_edit_preserves_line_prefixes(
             && (e.new_text.contains('\n') || e.new_text.contains('\r'))
             && (prefix_at(start.line) || prefix_at(start.line.saturating_add(1)));
         !touches_boundary && !spans_prefixed_line && !inserts_unprefixed_line
-    })
+    }
 }
 
 /// Whether every text edit targeting `host_uri` (across both the `changes` map

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -363,7 +363,9 @@ pub(crate) fn text_edit_safe_in_region(
 /// capture a column-0 same-line range with a host suffix after it; the
 /// offsets cannot represent that shape (it is indistinguishable from a
 /// one-line fenced block, where rejecting newlines would break
-/// insertFinalNewline), and the built-in queries never produce it. In a prefixed per-line region, the closing-fence
+/// insertFinalNewline), and the built-in queries never produce it.
+///
+/// In a prefixed per-line region, the closing-fence
 /// BOUNDARY row (recorded as a trailing zero entry, or falling past the array)
 /// counts as prefixed, and edits touching it are rejected outright — the row's
 /// real prefix is unrecorded, so even a no-newline insertion at its column 0

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -303,6 +303,13 @@ pub(crate) fn text_edit_within_region(
     offset: &RegionOffset,
     region_end: Position,
 ) -> bool {
+    // A REVERSED range (start after end) is malformed; some clients would
+    // normalize it by swapping, turning it into an edit the checks below (and
+    // the prefix/boundary rules, which assume start <= end) never inspected —
+    // reject it outright.
+    if position_after(e.range.start, e.range.end) {
+        return false;
+    }
     // A host position is in-region iff it's at/after the region's start line, at
     // /after that line's column floor, and at/before the region end.
     let in_region = |p: Position| {
@@ -330,7 +337,9 @@ pub(crate) fn text_edit_safe_in_region(
 }
 
 /// Whether every text edit targeting `host_uri` keeps the region's per-line
-/// host prefixes (e.g. a blockquote's `> ` on every line) intact.
+/// host prefixes (e.g. a blockquote's `> ` on every line) intact, and — in
+/// every region shape — preserves the newline separating content from the
+/// closing fence (the fence-boundary EOL rule).
 ///
 /// The virtual→host transform translates RANGES but emits `newText` verbatim
 /// — nothing re-inserts host line prefixes into replacement text. Two edit
@@ -345,9 +354,11 @@ pub(crate) fn text_edit_safe_in_region(
 ///   blockquote region has no line after, so the start line's own offset is
 ///   the only signal there).
 ///
-/// Plain fenced blocks (all-zero column offsets) are unaffected: every edit is
-/// prefix-safe there, which keeps the common case (whole-block refactors like
-/// organize-imports) working. In a prefixed per-line region, the closing-fence
+/// Plain fenced blocks (all-zero column offsets) are exempt from the prefix
+/// rules — every edit is prefix-safe there, which keeps the common case
+/// (whole-block refactors like organize-imports) working — but the
+/// fence-boundary EOL rule still applies to edits reaching a character-0
+/// region end. In a prefixed per-line region, the closing-fence
 /// BOUNDARY row (recorded as a trailing zero entry, or falling past the array)
 /// counts as prefixed, and edits touching it are rejected outright — the row's
 /// real prefix is unrecorded, so even a no-newline insertion at its column 0
@@ -390,7 +401,8 @@ pub(crate) fn workspace_edit_preserves_line_prefixes(
 /// shapes that carry bare `TextEdit`s rather than a `WorkspaceEdit`
 /// (formatting-family responses, completion/inlayHint/colorPresentation item
 /// edits). Same contract: `false` means applying the edit verbatim would
-/// strip or omit the region's per-line host prefixes — callers must reject
+/// strip or omit the region's per-line host prefixes, or merge content into
+/// the closing fence (the fence-boundary EOL rule) — callers must reject
 /// or drop, never clamp.
 pub(crate) fn text_edit_preserves_line_prefixes(
     e: &TextEdit,
@@ -1338,5 +1350,40 @@ mod tests {
 
         assert!(!check("y"), "non-newline boundary insert must reject");
         assert!(check("\n"), "insertFinalNewline must pass");
+    }
+
+    #[test]
+    fn reversed_ranges_are_rejected_in_every_region_shape() {
+        // A reversed range (start after end) is malformed, and a client that
+        // normalizes it by swapping would apply an edit none of the rules
+        // inspected (the boundary rule keys on range.end; the multi-line scan
+        // assumes start <= end). Containment must reject it outright.
+        let p = |line: u32, character: u32| Position { line, character };
+        let edit = |start: Position, end: Position, new_text: &str| TextEdit {
+            range: tower_lsp_server::ls_types::Range { start, end },
+            new_text: new_text.to_string(),
+        };
+        let region_end = Position {
+            line: 5,
+            character: 0,
+        };
+
+        // Plain fence: reversed {start: region_end, end: earlier} would
+        // normalize to a replacement ending at the fence without a newline.
+        let plain = RegionOffset::with_per_line_offsets(3, vec![0, 0, 0]);
+        assert!(!text_edit_safe_in_region(
+            &edit(p(5, 0), p(4, 0), "x"),
+            &plain,
+            region_end
+        ));
+
+        // Prefixed region: reversed multi-line span would normalize to a
+        // prefix-stripping replacement.
+        let prefixed = RegionOffset::with_per_line_offsets(3, vec![2, 2, 0]);
+        assert!(!text_edit_safe_in_region(
+            &edit(p(4, 4), p(3, 2), "x"),
+            &prefixed,
+            region_end
+        ));
     }
 }

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -288,6 +288,21 @@ pub(crate) fn workspace_edit_within_region(
     offset: &RegionOffset,
     region_end: Position,
 ) -> bool {
+    host_uri_text_edits_all(edit, host_uri, |e| {
+        text_edit_within_region(e, offset, region_end)
+    })
+}
+
+/// Whether a single already-host-translated text edit stays inside the region
+/// (see [`workspace_edit_within_region`]). Response transforms use this to
+/// reject a downstream range that — via a stale/malformed virtual range —
+/// lands past the region's content end (the closing fence, or the rest of an
+/// inline region's host line), which range translation alone cannot prevent.
+pub(crate) fn text_edit_within_region(
+    e: &TextEdit,
+    offset: &RegionOffset,
+    region_end: Position,
+) -> bool {
     // A host position is in-region iff it's at/after the region's start line, at
     // /after that line's column floor, and at/before the region end.
     let in_region = |p: Position| {
@@ -296,9 +311,22 @@ pub(crate) fn workspace_edit_within_region(
             p.character >= offset.column_for_line(virtual_line) && !position_after(p, region_end)
         }
     };
-    host_uri_text_edits_all(edit, host_uri, |e| {
-        in_region(e.range.start) && in_region(e.range.end)
-    })
+    in_region(e.range.start) && in_region(e.range.end)
+}
+
+/// Combined per-edit safety check for response transforms: an
+/// already-host-translated edit is safe iff it stays inside the region AND
+/// keeps the region's per-line prefixes. Range translation guarantees the
+/// start bound, but not the end: a stale/oversized downstream range still
+/// translates to a host range that overruns the closing fence (or the rest of
+/// an inline region's host line), so containment must be checked explicitly.
+pub(crate) fn text_edit_safe_in_region(
+    e: &TextEdit,
+    offset: &RegionOffset,
+    region_end: Position,
+) -> bool {
+    text_edit_within_region(e, offset, region_end)
+        && text_edit_preserves_line_prefixes(e, offset, region_end)
 }
 
 /// Whether every text edit targeting `host_uri` keeps the region's per-line

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -323,7 +323,8 @@ pub(crate) fn text_edit_within_region(
 
 /// Combined per-edit safety check for response transforms: an
 /// already-host-translated edit is safe iff it stays inside the region AND
-/// keeps the region's per-line prefixes. Range translation guarantees the
+/// preserves its structure (per-line prefixes and the newline separating
+/// content from the closing fence). Range translation guarantees the
 /// start bound, but not the end: a stale/oversized downstream range still
 /// translates to a host range that overruns the closing fence (or the rest of
 /// an inline region's host line), so containment must be checked explicitly.

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -359,7 +359,11 @@ pub(crate) fn text_edit_safe_in_region(
 /// rules — every edit is prefix-safe there, which keeps the common case
 /// (whole-block refactors like organize-imports) working — but the
 /// fence-boundary EOL rule still applies to edits reaching a character-0
-/// region end. In a prefixed per-line region, the closing-fence
+/// region end. Known limitation: a CUSTOM injection query (`#offset!`) could
+/// capture a column-0 same-line range with a host suffix after it; the
+/// offsets cannot represent that shape (it is indistinguishable from a
+/// one-line fenced block, where rejecting newlines would break
+/// insertFinalNewline), and the built-in queries never produce it. In a prefixed per-line region, the closing-fence
 /// BOUNDARY row (recorded as a trailing zero entry, or falling past the array)
 /// counts as prefixed, and edits touching it are rejected outright — the row's
 /// real prefix is unrecorded, so even a no-newline insertion at its column 0

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -360,7 +360,6 @@ pub(crate) fn workspace_edit_preserves_line_prefixes(
     offset: &RegionOffset,
     region_end: Position,
 ) -> bool {
-    let columns = offset.columns();
     // In the per-line (blockquote) shape, content ending with a newline puts
     // the region end at column 0 of the NEXT host row — the closing fence,
     // whose recorded offset is 0 (`compute_line_column_offsets` leaves a
@@ -378,12 +377,10 @@ pub(crate) fn workspace_edit_preserves_line_prefixes(
     // closed-fence row, so the guard stays fail-closed there — rejecting a
     // boundary-touching edit in a transient malformed construct is acceptable,
     // corrupting a well-formed one is not.
-    // Fast path: a region with no prefixes anywhere (plain fenced blocks —
-    // the common case) can't have anything stripped; skip the per-edit line
-    // scans entirely.
-    if columns.iter().all(|&column| column == 0) {
-        return true;
-    }
+    // No outer all-zero fast path: the per-edit predicate keeps its own for
+    // the prefix rules, but its fence-boundary EOL rule must run even in
+    // plain fenced regions (a boundary edit there can merge content into the
+    // closing fence — "y```").
     host_uri_text_edits_all(edit, host_uri, |e| {
         text_edit_preserves_line_prefixes(e, offset, region_end)
     })
@@ -1314,5 +1311,32 @@ mod tests {
         // Mid-line deletion ending at the boundary eats the separating
         // newline → "x```". Reject.
         assert!(!check(&edit(p(4, 2), p(5, 0), "")));
+    }
+
+    #[test]
+    fn workspace_edit_boundary_rule_applies_to_plain_fenced_regions() {
+        // Regression: the wrapper used to fast-path all-zero regions before
+        // the per-edit predicate ran, so codeAction/rename/applyEdit edits
+        // could still merge content into the closing fence ("y```"). The
+        // fence-boundary EOL rule must fire through the WorkspaceEdit form.
+        let host_uri = make_host_uri();
+        let offset = RegionOffset::with_per_line_offsets(3, vec![0, 0, 0]);
+        let region_end = Position {
+            line: 5,
+            character: 0,
+        };
+        let check = |new_text: &str| {
+            let edit = parse_workspace_edit(json!({
+                "changes": { host_uri.as_str(): [
+                    { "range": {"start": {"line": 5, "character": 0},
+                                "end": {"line": 5, "character": 0}},
+                      "newText": new_text }
+                ] }
+            }));
+            workspace_edit_preserves_line_prefixes(&edit, &host_uri, &offset, region_end)
+        };
+
+        assert!(!check("y"), "non-newline boundary insert must reject");
+        assert!(check("\n"), "insertFinalNewline must pass");
     }
 }

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -332,9 +332,10 @@ fn workspace_edit_is_empty(edit: &WorkspaceEdit) -> bool {
 /// - [`REASON_RESOLVE`] — the edit ended up empty: the server produced nothing
 ///   applicable, which reads as "could not be resolved to an applicable edit",
 ///   not "cannot be represented in the host document".
-/// - [`REASON_PREFIXED_REGION`] — the translated edit spans or inserts lines in
-///   a line-prefixed (e.g. blockquote) region; the verbatim newText would strip
-///   the prefixes and corrupt the host document.
+/// - [`REASON_PREFIXED_REGION`] — the translated edit would corrupt the host
+///   structure around the region: it spans/inserts lines in a line-prefixed
+///   (e.g. blockquote) region whose prefixes the verbatim newText would strip,
+///   or it merges content into the closing fence.
 ///
 /// Used by BOTH the initial-response policy and the codeAction/resolve path so
 /// these are rejected uniformly, never partially applied.

--- a/src/lsp/bridge/text_document/code_action.rs
+++ b/src/lsp/bridge/text_document/code_action.rs
@@ -1176,8 +1176,9 @@ pub(crate) fn bridge_code_actions(
 
 const REASON_RESOLVE: &str = "this action could not be resolved to an applicable edit";
 const REASON_CROSS_REGION: &str = "the edit cannot be represented in the host document";
-const REASON_PREFIXED_REGION: &str = "the edit would break the host document's line prefixes \
-     (e.g. a blockquote) around the injected region";
+const REASON_PREFIXED_REGION: &str = "the edit would break the host document's structure \
+     around the injected region (its line prefixes, e.g. a blockquote's, or the \
+     closing fence)";
 
 fn bridge_code_action(
     item: CodeActionOrCommand,

--- a/src/lsp/bridge/text_document/color_presentation.rs
+++ b/src/lsp/bridge/text_document/color_presentation.rs
@@ -131,8 +131,9 @@ fn transform_color_presentation_response_to_host(
     };
 
     // Transform textEdit and additionalTextEdits ranges to host coordinates,
-    // then drop any presentation whose edits would break region line prefixes
-    // (e.g. blockquote `> `) if applied verbatim. Unlike completion, the
+    // then drop any presentation whose edits are unsafe for the injection
+    // region (escape it, break line prefixes, or merge content into the
+    // closing fence) if applied verbatim. Unlike completion, the
     // primary textEdit is not separable from the presentation (without it the
     // editor falls back to inserting the label, still at the unguarded
     // range), so an unsafe textEdit drops the whole presentation; unsafe
@@ -171,7 +172,7 @@ fn transform_color_presentation_response_to_host(
             if stripped > 0 {
                 log::warn!(
                     target: "kakehashi::bridge",
-                    "colorPresentation: stripped {stripped} additionalTextEdit(s) unsafe for the injection region (escape it or break line prefixes)"
+                    "colorPresentation: stripped {stripped} additionalTextEdit(s) unsafe for the injection region (escape it, break line prefixes, or merge content into the closing fence)"
                 );
             }
         }

--- a/src/lsp/bridge/text_document/color_presentation.rs
+++ b/src/lsp/bridge/text_document/color_presentation.rs
@@ -171,7 +171,7 @@ fn transform_color_presentation_response_to_host(
             if stripped > 0 {
                 log::warn!(
                     target: "kakehashi::bridge",
-                    "colorPresentation: stripped {stripped} additionalTextEdit(s) that would break region line prefixes"
+                    "colorPresentation: stripped {stripped} additionalTextEdit(s) unsafe for the injection region (escape it or break line prefixes)"
                 );
             }
         }
@@ -181,7 +181,7 @@ fn transform_color_presentation_response_to_host(
     if dropped > 0 {
         log::warn!(
             target: "kakehashi::bridge",
-            "colorPresentation: dropped {dropped} presentation(s) whose textEdit would break region line prefixes"
+            "colorPresentation: dropped {dropped} presentation(s) whose (implicit or explicit) textEdit is unsafe for the injection region"
         );
     }
 

--- a/src/lsp/bridge/text_document/color_presentation.rs
+++ b/src/lsp/bridge/text_document/color_presentation.rs
@@ -2,6 +2,8 @@
 //! host↔virtual coordinate transformation. Like inlay hints, the request carries a
 //! range (where the color was found) and the response may include textEdits and
 //! additionalTextEdits whose ranges must be translated back to host coordinates.
+//! Presentations whose textEdit would break per-line region prefixes
+//! (blockquote `> `) are dropped; unsafe additionalTextEdits are stripped.
 
 use std::io;
 
@@ -171,16 +173,10 @@ fn transform_color_presentation_response_to_host(
 
 #[cfg(test)]
 mod tests {
+    use super::super::test_helpers::TEST_REGION_END;
     use super::*;
     use rstest::rstest;
     use serde_json::json;
-
-    /// A region end far past any test edit: keeps the prefix-safety guard out
-    /// of the way for tests that exercise coordinate translation only.
-    const TEST_REGION_END: Position = Position {
-        line: u32::MAX,
-        character: u32::MAX,
-    };
 
     // ==========================================================================
     // Color presentation request tests

--- a/src/lsp/bridge/text_document/color_presentation.rs
+++ b/src/lsp/bridge/text_document/color_presentation.rs
@@ -65,7 +65,9 @@ impl LanguageServerPool {
             },
             |response, ctx| {
                 let region_end = region_host_end(virtual_content, ctx.offset);
-                transform_color_presentation_response_to_host(response, ctx.offset, region_end)
+                transform_color_presentation_response_to_host(
+                    response, ctx.offset, region_end, host_range,
+                )
             },
         )
         .await
@@ -109,6 +111,7 @@ fn transform_color_presentation_response_to_host(
     mut response: serde_json::Value,
     offset: &RegionOffset,
     region_end: Position,
+    host_request_range: Range,
 ) -> Vec<ColorPresentation> {
     if response_has_jsonrpc_error(&response, "textDocument/colorPresentation") {
         return vec![];
@@ -134,18 +137,21 @@ fn transform_color_presentation_response_to_host(
     // editor falls back to inserting the label, still at the unguarded
     // range), so an unsafe textEdit drops the whole presentation; unsafe
     // additionalTextEdits are merely stripped.
-    let region_prefixed = offset.columns().iter().any(|column| *column != 0);
     let before = presentations.len();
     presentations.retain_mut(|presentation| {
-        // No textEdit: the client inserts the LABEL at the request range. A
-        // multi-line label in a prefixed region is the same hazard as a
-        // multi-line textEdit (no range to check here — the newline is the
-        // signal). Labels are single-line in practice, so this never bites.
-        if presentation.text_edit.is_none()
-            && region_prefixed
-            && (presentation.label.contains('\n') || presentation.label.contains('\r'))
-        {
-            return false;
+        // No textEdit: the client replaces the REQUEST range with the label
+        // (LSP 3.18). Guard that implicit edit exactly like an explicit one —
+        // a synthetic TextEdit over the (host) request range with the label
+        // as newText. Labels are single-line and request ranges in-region in
+        // practice, so this rarely bites.
+        if presentation.text_edit.is_none() {
+            let implicit = tower_lsp_server::ls_types::TextEdit {
+                range: host_request_range,
+                new_text: presentation.label.clone(),
+            };
+            if !text_edit_safe_in_region(&implicit, offset, region_end) {
+                return false;
+            }
         }
         if let Some(text_edit) = &mut presentation.text_edit {
             translate_virtual_range_to_host(&mut text_edit.range, offset);
@@ -188,6 +194,21 @@ mod tests {
     use super::*;
     use rstest::rstest;
     use serde_json::json;
+
+    /// In-region host request range used by tests that don't exercise the
+    /// implicit label-replacement guard (single position on the region line).
+    fn test_host_request_range(region_start_line: u32) -> Range {
+        Range {
+            start: Position {
+                line: region_start_line,
+                character: 0,
+            },
+            end: Position {
+                line: region_start_line,
+                character: 4,
+            },
+        }
+    }
 
     // ==========================================================================
     // Color presentation request tests
@@ -492,6 +513,7 @@ mod tests {
             response,
             &RegionOffset::new(region_start_line, 0),
             TEST_REGION_END,
+            test_host_request_range(region_start_line),
         );
 
         assert_eq!(presentations.len(), 1);
@@ -540,6 +562,7 @@ mod tests {
             response,
             &RegionOffset::new(region_start_line, 0),
             TEST_REGION_END,
+            test_host_request_range(region_start_line),
         );
 
         assert_eq!(presentations.len(), 1);
@@ -572,6 +595,7 @@ mod tests {
             response,
             &RegionOffset::new(region_start_line, 0),
             TEST_REGION_END,
+            test_host_request_range(region_start_line),
         );
 
         assert_eq!(presentations.len(), 3);
@@ -591,6 +615,7 @@ mod tests {
             response,
             &RegionOffset::new(5, 0),
             TEST_REGION_END,
+            test_host_request_range(5),
         );
         assert!(presentations.is_empty());
     }
@@ -603,6 +628,7 @@ mod tests {
             response,
             &RegionOffset::new(5, 0),
             TEST_REGION_END,
+            test_host_request_range(5),
         );
         assert!(presentations.is_empty());
     }
@@ -637,8 +663,12 @@ mod tests {
             ]
         });
 
-        let presentations =
-            transform_color_presentation_response_to_host(response, &offset, region_end);
+        let presentations = transform_color_presentation_response_to_host(
+            response,
+            &offset,
+            region_end,
+            test_host_request_range(3),
+        );
 
         assert_eq!(presentations.len(), 1, "unsafe presentation is dropped");
         assert_eq!(presentations[0].label, "safe");
@@ -676,10 +706,53 @@ mod tests {
             ]
         });
 
-        let presentations =
-            transform_color_presentation_response_to_host(response, &offset, region_end);
+        let presentations = transform_color_presentation_response_to_host(
+            response,
+            &offset,
+            region_end,
+            test_host_request_range(3),
+        );
 
         assert_eq!(presentations.len(), 1, "region-escaping presentation drops");
         assert_eq!(presentations[0].label, "contained");
+    }
+
+    #[test]
+    fn color_presentation_drops_label_fallback_over_a_prefixed_multiline_range() {
+        // No textEdit: the client replaces the REQUEST range with the label.
+        // A request range spanning prefixed lines makes even a single-line
+        // label strip the second line's `> ` prefix — the synthetic implicit
+        // edit must be rejected like an explicit one.
+        let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2, 0]);
+        let region_end = Position {
+            line: 5,
+            character: 0,
+        };
+        let multiline_request_range = Range {
+            start: Position {
+                line: 3,
+                character: 2,
+            },
+            end: Position {
+                line: 4,
+                character: 4,
+            },
+        };
+        let response = json!({
+            "jsonrpc": "2.0", "id": 42,
+            "result": [ { "label": "#ff0000" } ]
+        });
+
+        let presentations = transform_color_presentation_response_to_host(
+            response,
+            &offset,
+            region_end,
+            multiline_request_range,
+        );
+
+        assert!(
+            presentations.is_empty(),
+            "label fallback over a prefixed multi-line range must drop: {presentations:?}"
+        );
     }
 }

--- a/src/lsp/bridge/text_document/color_presentation.rs
+++ b/src/lsp/bridge/text_document/color_presentation.rs
@@ -16,7 +16,7 @@ use url::Url;
 use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, region_host_end,
-    response_has_jsonrpc_error, text_edit_preserves_line_prefixes, translate_host_range_to_virtual,
+    response_has_jsonrpc_error, text_edit_safe_in_region, translate_host_range_to_virtual,
     translate_virtual_range_to_host, virtual_uri_to_lsp_uri,
 };
 
@@ -134,11 +134,22 @@ fn transform_color_presentation_response_to_host(
     // editor falls back to inserting the label, still at the unguarded
     // range), so an unsafe textEdit drops the whole presentation; unsafe
     // additionalTextEdits are merely stripped.
+    let region_prefixed = offset.columns().iter().any(|column| *column != 0);
     let before = presentations.len();
     presentations.retain_mut(|presentation| {
+        // No textEdit: the client inserts the LABEL at the request range. A
+        // multi-line label in a prefixed region is the same hazard as a
+        // multi-line textEdit (no range to check here — the newline is the
+        // signal). Labels are single-line in practice, so this never bites.
+        if presentation.text_edit.is_none()
+            && region_prefixed
+            && (presentation.label.contains('\n') || presentation.label.contains('\r'))
+        {
+            return false;
+        }
         if let Some(text_edit) = &mut presentation.text_edit {
             translate_virtual_range_to_host(&mut text_edit.range, offset);
-            if !text_edit_preserves_line_prefixes(text_edit, offset, region_end) {
+            if !text_edit_safe_in_region(text_edit, offset, region_end) {
                 return false;
             }
         }
@@ -149,7 +160,7 @@ fn transform_color_presentation_response_to_host(
                 translate_virtual_range_to_host(&mut edit.range, offset);
             }
             additional_edits
-                .retain(|edit| text_edit_preserves_line_prefixes(edit, offset, region_end));
+                .retain(|edit| text_edit_safe_in_region(edit, offset, region_end));
             let stripped = before - additional_edits.len();
             if stripped > 0 {
                 log::warn!(
@@ -639,5 +650,36 @@ mod tests {
             Some(0),
             "prefix-breaking additionalTextEdit is stripped"
         );
+    }
+
+    #[test]
+    fn color_presentation_drops_presentations_whose_edit_escapes_the_region() {
+        // Plain fenced region (all-zero offsets), region end (5, 0): a
+        // textEdit range translating past the closing fence must drop the
+        // presentation even though the prefix rules fast-path.
+        let offset = RegionOffset::with_per_line_offsets(3, vec![0, 0, 0]);
+        let region_end = Position {
+            line: 5,
+            character: 0,
+        };
+        let response = json!({
+            "jsonrpc": "2.0", "id": 42,
+            "result": [
+                { "label": "escapes",
+                  "textEdit": { "range": { "start": { "line": 0, "character": 0 },
+                                           "end": { "line": 9, "character": 0 } },
+                                "newText": "#fff" } },
+                { "label": "contained",
+                  "textEdit": { "range": { "start": { "line": 0, "character": 0 },
+                                           "end": { "line": 0, "character": 4 } },
+                                "newText": "#fff" } }
+            ]
+        });
+
+        let presentations =
+            transform_color_presentation_response_to_host(response, &offset, region_end);
+
+        assert_eq!(presentations.len(), 1, "region-escaping presentation drops");
+        assert_eq!(presentations[0].label, "contained");
     }
 }

--- a/src/lsp/bridge/text_document/color_presentation.rs
+++ b/src/lsp/bridge/text_document/color_presentation.rs
@@ -7,14 +7,15 @@ use std::io;
 
 use crate::config::settings::BridgeServerConfig;
 use tower_lsp_server::ls_types::{
-    Color, ColorPresentation, ColorPresentationParams, Range, TextDocumentIdentifier,
+    Color, ColorPresentation, ColorPresentationParams, Position, Range, TextDocumentIdentifier,
 };
 use url::Url;
 
 use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::{
-    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, response_has_jsonrpc_error,
-    translate_host_range_to_virtual, translate_virtual_range_to_host, virtual_uri_to_lsp_uri,
+    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, region_host_end,
+    response_has_jsonrpc_error, text_edit_preserves_line_prefixes, translate_host_range_to_virtual,
+    translate_virtual_range_to_host, virtual_uri_to_lsp_uri,
 };
 
 impl LanguageServerPool {
@@ -60,7 +61,10 @@ impl LanguageServerPool {
                     request_id,
                 )
             },
-            |response, ctx| transform_color_presentation_response_to_host(response, ctx.offset),
+            |response, ctx| {
+                let region_end = region_host_end(virtual_content, ctx.offset);
+                transform_color_presentation_response_to_host(response, ctx.offset, region_end)
+            },
         )
         .await
     }
@@ -102,6 +106,7 @@ fn build_color_presentation_request(
 fn transform_color_presentation_response_to_host(
     mut response: serde_json::Value,
     offset: &RegionOffset,
+    region_end: Position,
 ) -> Vec<ColorPresentation> {
     if response_has_jsonrpc_error(&response, "textDocument/colorPresentation") {
         return vec![];
@@ -120,17 +125,45 @@ fn transform_color_presentation_response_to_host(
         Err(_) => return vec![],
     };
 
-    // Transform textEdit and additionalTextEdits ranges to host coordinates
-    for presentation in &mut presentations {
+    // Transform textEdit and additionalTextEdits ranges to host coordinates,
+    // then drop any presentation whose edits would break region line prefixes
+    // (e.g. blockquote `> `) if applied verbatim. Unlike completion, the
+    // primary textEdit is not separable from the presentation (without it the
+    // editor falls back to inserting the label, still at the unguarded
+    // range), so an unsafe textEdit drops the whole presentation; unsafe
+    // additionalTextEdits are merely stripped.
+    let before = presentations.len();
+    presentations.retain_mut(|presentation| {
         if let Some(text_edit) = &mut presentation.text_edit {
             translate_virtual_range_to_host(&mut text_edit.range, offset);
+            if !text_edit_preserves_line_prefixes(text_edit, offset, region_end) {
+                return false;
+            }
         }
 
         if let Some(additional_edits) = &mut presentation.additional_text_edits {
+            let before = additional_edits.len();
             for edit in additional_edits.iter_mut() {
                 translate_virtual_range_to_host(&mut edit.range, offset);
             }
+            additional_edits
+                .retain(|edit| text_edit_preserves_line_prefixes(edit, offset, region_end));
+            let stripped = before - additional_edits.len();
+            if stripped > 0 {
+                log::warn!(
+                    target: "kakehashi::bridge",
+                    "colorPresentation: stripped {stripped} additionalTextEdit(s) that would break region line prefixes"
+                );
+            }
         }
+        true
+    });
+    let dropped = before - presentations.len();
+    if dropped > 0 {
+        log::warn!(
+            target: "kakehashi::bridge",
+            "colorPresentation: dropped {dropped} presentation(s) whose textEdit would break region line prefixes"
+        );
     }
 
     presentations
@@ -141,6 +174,13 @@ mod tests {
     use super::*;
     use rstest::rstest;
     use serde_json::json;
+
+    /// A region end far past any test edit: keeps the prefix-safety guard out
+    /// of the way for tests that exercise coordinate translation only.
+    const TEST_REGION_END: Position = Position {
+        line: u32::MAX,
+        character: u32::MAX,
+    };
 
     // ==========================================================================
     // Color presentation request tests
@@ -444,6 +484,7 @@ mod tests {
         let presentations = transform_color_presentation_response_to_host(
             response,
             &RegionOffset::new(region_start_line, 0),
+            TEST_REGION_END,
         );
 
         assert_eq!(presentations.len(), 1);
@@ -491,6 +532,7 @@ mod tests {
         let presentations = transform_color_presentation_response_to_host(
             response,
             &RegionOffset::new(region_start_line, 0),
+            TEST_REGION_END,
         );
 
         assert_eq!(presentations.len(), 1);
@@ -522,6 +564,7 @@ mod tests {
         let presentations = transform_color_presentation_response_to_host(
             response,
             &RegionOffset::new(region_start_line, 0),
+            TEST_REGION_END,
         );
 
         assert_eq!(presentations.len(), 3);
@@ -537,8 +580,11 @@ mod tests {
     fn color_presentation_response_returns_empty_for_invalid_response(
         #[case] response: serde_json::Value,
     ) {
-        let presentations =
-            transform_color_presentation_response_to_host(response, &RegionOffset::new(5, 0));
+        let presentations = transform_color_presentation_response_to_host(
+            response,
+            &RegionOffset::new(5, 0),
+            TEST_REGION_END,
+        );
         assert!(presentations.is_empty());
     }
 
@@ -546,8 +592,56 @@ mod tests {
     fn color_presentation_response_with_empty_array_returns_empty() {
         let response = json!({ "jsonrpc": "2.0", "id": 42, "result": [] });
 
-        let presentations =
-            transform_color_presentation_response_to_host(response, &RegionOffset::new(5, 0));
+        let presentations = transform_color_presentation_response_to_host(
+            response,
+            &RegionOffset::new(5, 0),
+            TEST_REGION_END,
+        );
         assert!(presentations.is_empty());
+    }
+
+    #[test]
+    fn color_presentation_drops_prefix_breaking_presentations() {
+        // Blockquote region, content host lines 3-4, region end (5, 0). A
+        // presentation whose textEdit spans prefixed lines is dropped whole
+        // (the label fallback would insert at the same unsafe range); an
+        // unsafe additionalTextEdit is stripped from a kept presentation.
+        let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2, 0]);
+        let region_end = Position {
+            line: 5,
+            character: 0,
+        };
+        let response = json!({
+            "jsonrpc": "2.0", "id": 42,
+            "result": [
+                { "label": "unsafe",
+                  "textEdit": { "range": { "start": { "line": 0, "character": 0 },
+                                           "end": { "line": 1, "character": 2 } },
+                                "newText": "#fff" } },
+                { "label": "safe",
+                  "textEdit": { "range": { "start": { "line": 0, "character": 0 },
+                                           "end": { "line": 0, "character": 4 } },
+                                "newText": "#fff" },
+                  "additionalTextEdits": [
+                      { "range": { "start": { "line": 1, "character": 0 },
+                                   "end": { "line": 1, "character": 0 } },
+                        "newText": "x\n" }
+                  ] }
+            ]
+        });
+
+        let presentations =
+            transform_color_presentation_response_to_host(response, &offset, region_end);
+
+        assert_eq!(presentations.len(), 1, "unsafe presentation is dropped");
+        assert_eq!(presentations[0].label, "safe");
+        assert_eq!(
+            presentations[0]
+                .additional_text_edits
+                .as_ref()
+                .map(Vec::len),
+            Some(0),
+            "prefix-breaking additionalTextEdit is stripped"
+        );
     }
 }

--- a/src/lsp/bridge/text_document/color_presentation.rs
+++ b/src/lsp/bridge/text_document/color_presentation.rs
@@ -663,6 +663,9 @@ mod tests {
                                            "end": { "line": 0, "character": 4 } },
                                 "newText": "#fff" },
                   "additionalTextEdits": [
+                      { "range": { "start": { "line": 0, "character": 0 },
+                                   "end": { "line": 0, "character": 2 } },
+                        "newText": "safe-sibling" },
                       { "range": { "start": { "line": 1, "character": 0 },
                                    "end": { "line": 1, "character": 0 } },
                         "newText": "x\n" }

--- a/src/lsp/bridge/text_document/color_presentation.rs
+++ b/src/lsp/bridge/text_document/color_presentation.rs
@@ -163,19 +163,23 @@ fn transform_color_presentation_response_to_host(
             }
         }
 
+        // ALL-OR-NOTHING (same reasoning as completion): the array can carry
+        // paired halves of one operation, so any unsafe member drops the
+        // whole array rather than half-applying it.
         if let Some(additional_edits) = &mut presentation.additional_text_edits {
-            let before = additional_edits.len();
             for edit in additional_edits.iter_mut() {
                 translate_virtual_range_to_host(&mut edit.range, offset);
             }
-            additional_edits
-                .retain(|edit| text_edit_safe_in_region(edit, offset, region_end));
-            let stripped = before - additional_edits.len();
-            if stripped > 0 {
+            if !additional_edits
+                .iter()
+                .all(|edit| text_edit_safe_in_region(edit, offset, region_end))
+            {
                 log::warn!(
                     target: "kakehashi::bridge",
-                    "colorPresentation: stripped {stripped} additionalTextEdit(s) unsafe for the injection region (escape it, break line prefixes, or merge content into the closing fence)"
+                    "colorPresentation: dropped a presentation's additionalTextEdits ({}): a member is unsafe for the injection region",
+                    additional_edits.len()
                 );
+                presentation.additional_text_edits = None;
             }
         }
         true
@@ -675,13 +679,9 @@ mod tests {
 
         assert_eq!(presentations.len(), 1, "unsafe presentation is dropped");
         assert_eq!(presentations[0].label, "safe");
-        assert_eq!(
-            presentations[0]
-                .additional_text_edits
-                .as_ref()
-                .map(Vec::len),
-            Some(0),
-            "prefix-breaking additionalTextEdit is stripped"
+        assert!(
+            presentations[0].additional_text_edits.is_none(),
+            "an unsafe member drops the whole additionalTextEdits array"
         );
     }
 

--- a/src/lsp/bridge/text_document/color_presentation.rs
+++ b/src/lsp/bridge/text_document/color_presentation.rs
@@ -165,7 +165,9 @@ fn transform_color_presentation_response_to_host(
 
         // ALL-OR-NOTHING (same reasoning as completion): the array can carry
         // paired halves of one operation, so any unsafe member drops the
-        // whole array rather than half-applying it.
+        // whole array rather than half-applying it. The presentation is kept:
+        // its textEdit still applies, though possibly semantically incomplete
+        // — availability over fidelity, never corruption.
         if let Some(additional_edits) = &mut presentation.additional_text_edits {
             for edit in additional_edits.iter_mut() {
                 translate_virtual_range_to_host(&mut edit.range, offset);
@@ -663,8 +665,8 @@ mod tests {
                                            "end": { "line": 0, "character": 4 } },
                                 "newText": "#fff" },
                   "additionalTextEdits": [
-                      { "range": { "start": { "line": 0, "character": 0 },
-                                   "end": { "line": 0, "character": 2 } },
+                      { "range": { "start": { "line": 1, "character": 3 },
+                                   "end": { "line": 1, "character": 5 } },
                         "newText": "safe-sibling" },
                       { "range": { "start": { "line": 1, "character": 0 },
                                    "end": { "line": 1, "character": 0 } },

--- a/src/lsp/bridge/text_document/color_presentation.rs
+++ b/src/lsp/bridge/text_document/color_presentation.rs
@@ -2,8 +2,10 @@
 //! host↔virtual coordinate transformation. Like inlay hints, the request carries a
 //! range (where the color was found) and the response may include textEdits and
 //! additionalTextEdits whose ranges must be translated back to host coordinates.
-//! Presentations whose textEdit would break per-line region prefixes
-//! (blockquote `> `) are dropped; unsafe additionalTextEdits are stripped.
+//! Presentations whose (implicit or explicit) textEdit is unsafe for the
+//! injection region — escapes it, breaks per-line `> ` prefixes, or merges
+//! content into the closing fence — are dropped; unsafe additionalTextEdits
+//! are stripped.
 
 use std::io;
 

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -158,7 +158,7 @@ fn transform_completion_response_to_host(
     if dropped > 0 {
         log::warn!(
             target: "kakehashi::bridge",
-            "completion: dropped {dropped} item(s) whose text edit is unsafe for the injection region (escapes it, breaks line prefixes, or merges content into the closing fence)"
+            "completion: dropped {dropped} item(s) whose primary insertion/edit is unsafe for the injection region (escapes it, breaks line prefixes, splits the host line, or merges content into the closing fence)"
         );
     }
 
@@ -170,7 +170,8 @@ fn transform_completion_response_to_host(
 /// Handles both TextEdit format and InsertReplaceEdit format. Also transforms
 /// additionalTextEdits if present.
 ///
-/// Returns `false` when the item's primary text edit is unsafe for the
+/// Returns `false` when the item's primary insertion — its text edit, or the
+/// insertText/label fallback applied at the request position — is unsafe for the
 /// injection region — escapes it, corrupts per-line `> ` prefixes, or merges
 /// content into the closing fence — if applied verbatim; the caller must
 /// drop the whole item (same fail-closed rule as WorkspaceEdit bridging).
@@ -191,8 +192,8 @@ pub(super) fn transform_completion_item(
     // region-wide any-prefix: fail-closed.
     let prefixed_at_insertion = |host_line: Option<u32>| match host_line {
         Some(line) => {
-            insertion_point_prefixed(offset, line)
-                || insertion_point_prefixed(offset, line.saturating_add(1))
+            insertion_point_prefixed(offset, region_end, line)
+                || insertion_point_prefixed(offset, region_end, line.saturating_add(1))
         }
         None => offset.columns().iter().any(|&column| column != 0),
     };
@@ -232,12 +233,13 @@ pub(super) fn transform_completion_item(
                 probe.range = edit.replace;
                 let replace_ok = text_edit_safe_in_region(&probe, offset, region_end);
                 edit.new_text = probe.new_text;
+                // Check BOTH client-selectable ranges: with unequal starts,
+                // the minimum line could be unprefixed while the other range
+                // starts on a prefixed line.
                 if !insert_ok
                     || !replace_ok
-                    || snippet_unsafe(
-                        &edit.new_text,
-                        Some(edit.insert.start.line.min(edit.replace.start.line)),
-                    )
+                    || snippet_unsafe(&edit.new_text, Some(edit.insert.start.line))
+                    || snippet_unsafe(&edit.new_text, Some(edit.replace.start.line))
                 {
                     return false;
                 }
@@ -283,18 +285,24 @@ pub(super) fn transform_completion_item(
     true
 }
 
-/// Whether the host line carries a region prefix an unprefixed insertion
-/// would break. Lines before the region are fail-closed `true`. Lines past
+/// Whether the host line carries region-adjacent host content an unprefixed
+/// insertion would break. Lines before the region are fail-closed `true`.
+/// Lines past
 /// the recorded per-line array are the BOUNDARY in per-line (blockquote)
 /// regions — fail-closed `true` (their real prefix is unrecorded) — but in
 /// the single-element fallback shape (`[start_column]`: only line 0 starts
 /// mid-host-line) later lines are whole and unprefixed: `false`.
-fn insertion_point_prefixed(offset: &RegionOffset, host_line: u32) -> bool {
+fn insertion_point_prefixed(offset: &RegionOffset, region_end: Position, host_line: u32) -> bool {
     let columns = offset.columns();
     match host_line.checked_sub(offset.line()) {
         None => true,
         Some(virtual_line) => match columns.get(virtual_line as usize) {
-            Some(&column) => column != 0,
+            // Single-element shape on line 0: the captured content runs to
+            // end-of-line in a MULTI-LINE region, so an inserted newline
+            // splits only injected content — mirror the shared guard's
+            // `newline_splits_nothing`. Only a same-line inline region (the
+            // host line continues past the region) counts as prefixed.
+            Some(&column) => column != 0 && (columns.len() > 1 || region_end.line == offset.line()),
             None => columns.len() > 1,
         },
     }
@@ -1373,13 +1381,32 @@ mod tests {
         .unwrap();
         assert_eq!(list.items.len(), 1, "later-line insertion is safe");
 
-        // Requested on host line 3 (virtual line 0, mid-host-line): dropped.
+        // Requested on host line 3 (virtual line 0): in a MULTI-LINE region
+        // line 0's captured content runs to end-of-line, so the inserted
+        // newline splits only injected content — kept.
+        let list = transform_completion_response_to_host(
+            response.clone(),
+            &offset,
+            region_end,
+            Some(3),
+            None,
+        )
+        .unwrap();
+        assert_eq!(list.items.len(), 1, "multi-line region line 0 is safe");
+
+        // Same shape but a SAME-LINE inline region (region end on the start
+        // line): the host line continues past the region, so a newline
+        // splits it — dropped.
+        let inline_end = Position {
+            line: 3,
+            character: 20,
+        };
         let list =
-            transform_completion_response_to_host(response, &offset, region_end, Some(3), None)
+            transform_completion_response_to_host(response, &offset, inline_end, Some(3), None)
                 .unwrap();
         assert!(
             list.items.is_empty(),
-            "line-0 insertion would split the host line"
+            "inline-region line-0 insertion would split the host line"
         );
     }
 }

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -1184,7 +1184,8 @@ mod tests {
         // An import-style additionalTextEdit that inserts a raw newline at a
         // prefixed line would break the `> ` prefix — the array drops WHOLE
         // (it can carry paired halves of one operation); the item's primary
-        // insertion still works.
+        // insertion stays mechanically applicable, though possibly
+        // semantically incomplete without its auxiliaries.
         let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2, 0]);
         let region_end = Position {
             line: 5,

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -274,8 +274,8 @@ pub(crate) struct KakehashiEnvelope {
     /// Region offset snapshot for coordinate transformation of the resolved response.
     pub offset: EnvelopeOffset,
     /// Region end (host `(line, character)`) snapshot for the resolve-path
-    /// prefix-safety guard — the resolve has no region-content access, so it
-    /// can't recompute this. `None` (via `serde(default)`) for envelopes
+    /// safety guard (containment, prefixes, fence boundary) — the resolve has
+    /// no region-content access, so it can't recompute this. `None` (via `serde(default)`) for envelopes
     /// minted before this field existed → the resolve path falls back to a
     /// fully fail-closed guard in prefixed regions.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -324,7 +324,7 @@ pub(crate) struct EnvelopeContext<'a> {
     /// `completionItem/resolve` can route back to the originating connection.
     pub host_uri: &'a str,
     pub offset: &'a RegionOffset,
-    /// Region end (host coords) snapshot for the resolve-path prefix guard;
+    /// Region end (host coords) snapshot for the resolve-path safety guard;
     /// `None` only when re-enveloping a legacy envelope that never carried it.
     pub region_end: Option<Position>,
 }

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -154,7 +154,7 @@ fn transform_completion_response_to_host(
     if dropped > 0 {
         log::warn!(
             target: "kakehashi::bridge",
-            "completion: dropped {dropped} item(s) whose text edit is unsafe for the injection region (escapes it or breaks line prefixes)"
+            "completion: dropped {dropped} item(s) whose text edit is unsafe for the injection region (escapes it, breaks line prefixes, or merges content into the closing fence)"
         );
     }
 
@@ -220,8 +220,8 @@ pub(super) fn transform_completion_item(
         }
     }
 
-    // Transform additional_text_edits if present, stripping any that would
-    // break region line prefixes.
+    // Transform additional_text_edits if present, stripping any unsafe for
+    // the injection region.
     if let Some(ref mut additional_edits) = item.additional_text_edits {
         let before = additional_edits.len();
         for edit in additional_edits.iter_mut() {
@@ -232,7 +232,7 @@ pub(super) fn transform_completion_item(
         if dropped > 0 {
             log::warn!(
                 target: "kakehashi::bridge",
-                "completion: stripped {dropped} additionalTextEdit(s) unsafe for the injection region (escape it or break line prefixes)"
+                "completion: stripped {dropped} additionalTextEdit(s) unsafe for the injection region (escape it, break line prefixes, or merge content into the closing fence)"
             );
         }
     }

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -176,8 +176,9 @@ fn transform_completion_response_to_host(
 /// injection region — escapes it, corrupts per-line `> ` prefixes, or merges
 /// content into the closing fence — if applied verbatim; the caller must
 /// drop the whole item (same fail-closed rule as WorkspaceEdit bridging).
-/// Unsafe `additionalTextEdits` are merely stripped: the primary insertion
-/// still works without them, so the item stays useful.
+/// An unsafe `additionalTextEdits` member drops the whole array instead:
+/// the primary insertion still applies, though possibly semantically
+/// incomplete (e.g. without its auto-import) — availability over fidelity.
 pub(super) fn transform_completion_item(
     item: &mut CompletionItem,
     offset: &RegionOffset,
@@ -1473,9 +1474,9 @@ mod tests {
     #[test]
     fn mixed_offset_boundary_rows_reject_multiline_fallbacks() {
         // Mixed per-line offsets [2,0,0] (a blockquote with a lazy
-        // continuation line): the trailing recorded zeros are BOUNDARY rows
-        // whose real prefix is unrecorded: host 4 is the lazy-continuation
-        // CONTENT row (recorded 0), host 5 the boundary. A multi-line
+        // continuation line): host 4 is the lazy-continuation CONTENT row
+        // (recorded 0); host 5 is the BOUNDARY row, whose real prefix is
+        // unrecorded. A multi-line
         // fallback insertion on host 4 must reject — its following row is
         // the boundary; the same shape in an all-zero region has no boundary
         // semantics and passes.

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -179,12 +179,24 @@ pub(super) fn transform_completion_item(
     offset: &RegionOffset,
     region_end: Position,
 ) -> bool {
+    let region_prefixed = offset.columns().iter().any(|&column| column != 0);
+    // The literal newline scans below can't see what a SNIPPET expands to at
+    // the client: runtime variables (`${CLIPBOARD}`, `$TM_SELECTED_TEXT`) may
+    // be multiline. In a prefixed region, fail closed on any snippet variable
+    // in the primary insert text (tabstops/placeholders expand from literal
+    // text the scans already cover; additionalTextEdits are never snippets).
+    let snippet =
+        item.insert_text_format == Some(tower_lsp_server::ls_types::InsertTextFormat::SNIPPET);
+    let snippet_unsafe = |text: &str| region_prefixed && snippet && snippet_contains_variable(text);
+
     // Transform text_edit if present
     if let Some(ref mut text_edit) = item.text_edit {
         match text_edit {
             tower_lsp_server::ls_types::CompletionTextEdit::Edit(edit) => {
                 translate_virtual_range_to_host(&mut edit.range, offset);
-                if !text_edit_safe_in_region(edit, offset, region_end) {
+                if !text_edit_safe_in_region(edit, offset, region_end)
+                    || snippet_unsafe(&edit.new_text)
+                {
                     return false;
                 }
             }
@@ -201,7 +213,7 @@ pub(super) fn transform_completion_item(
                 probe.range = edit.replace;
                 let replace_ok = text_edit_safe_in_region(&probe, offset, region_end);
                 edit.new_text = probe.new_text;
-                if !insert_ok || !replace_ok {
+                if !insert_ok || !replace_ok || snippet_unsafe(&edit.new_text) {
                     return false;
                 }
             }
@@ -216,9 +228,11 @@ pub(super) fn transform_completion_item(
     // reject signal. All-zero (plain fenced) regions take multi-line
     // insertions safely and stay exempt.
     if item.text_edit.is_none() {
-        let region_prefixed = offset.columns().iter().any(|&column| column != 0);
         let effective = item.insert_text.as_deref().unwrap_or(&item.label);
         if region_prefixed && (effective.contains('\n') || effective.contains('\r')) {
+            return false;
+        }
+        if snippet_unsafe(effective) {
             return false;
         }
     }
@@ -240,6 +254,40 @@ pub(super) fn transform_completion_item(
         }
     }
     true
+}
+
+/// Whether snippet-syntax text references a snippet VARIABLE — `$name` or
+/// `${name...}` with a leading letter/underscore — whose expansion the client
+/// resolves at insert time and may be multiline (`${CLIPBOARD}`,
+/// `$TM_SELECTED_TEXT`). Numeric tabstops/placeholders (`$1`, `${1:text}`)
+/// expand from literal text the caller's newline scans already cover, so they
+/// don't count. An escaped `\\$` is literal per the snippet grammar; a
+/// preceding backslash therefore skips the candidate (an over-escape here
+/// would only reject, never admit).
+fn snippet_contains_variable(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    let mut escaped = false;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' if !escaped => escaped = true,
+            b'$' if !escaped => {
+                let next = bytes.get(i + 1).copied();
+                let starts_name = |c: u8| c.is_ascii_alphabetic() || c == b'_';
+                match next {
+                    Some(b'{') if bytes.get(i + 2).copied().is_some_and(starts_name) => {
+                        return true;
+                    }
+                    Some(c) if starts_name(c) => return true,
+                    _ => {}
+                }
+                escaped = false;
+            }
+            _ => escaped = false,
+        }
+        i += 1;
+    }
+    false
 }
 
 // =============================================================================
@@ -1172,5 +1220,64 @@ mod tests {
         let list =
             transform_completion_response_to_host(response, &plain, region_end, None).unwrap();
         assert_eq!(list.items.len(), 2, "plain regions take multiline inserts");
+    }
+
+    #[test]
+    fn transform_drops_snippet_variables_in_prefixed_regions() {
+        // A snippet VARIABLE (`${CLIPBOARD}`) expands client-side and may be
+        // multiline — the literal newline scan can't see it, so a prefixed
+        // region must fail closed. Numeric tabstops/placeholders expand from
+        // literal text and stay allowed; plain regions are exempt.
+        let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2, 0]);
+        let region_end = Position {
+            line: 5,
+            character: 0,
+        };
+        let response = json!({
+            "jsonrpc": "2.0", "id": 1,
+            "result": [
+                { "label": "clipboard", "insertTextFormat": 2,
+                  "textEdit": { "range": { "start": { "line": 0, "character": 0 },
+                                           "end": { "line": 0, "character": 3 } },
+                                "newText": "${CLIPBOARD}" } },
+                { "label": "tabstop", "insertTextFormat": 2,
+                  "textEdit": { "range": { "start": { "line": 0, "character": 0 },
+                                           "end": { "line": 0, "character": 3 } },
+                                "newText": "print(${1:msg})" } },
+                { "label": "fallback-variable", "insertTextFormat": 2,
+                  "insertText": "$TM_SELECTED_TEXT" }
+            ]
+        });
+
+        let list =
+            transform_completion_response_to_host(response.clone(), &offset, region_end, None)
+                .unwrap();
+        let labels: Vec<_> = list.items.iter().map(|i| i.label.as_str()).collect();
+        assert_eq!(
+            labels,
+            vec!["tabstop"],
+            "snippet variables must drop in prefixed regions (both textEdit and fallback)"
+        );
+
+        // Plain (all-zero) region: everything survives.
+        let plain = RegionOffset::with_per_line_offsets(3, vec![0, 0, 0]);
+        let list =
+            transform_completion_response_to_host(response, &plain, region_end, None).unwrap();
+        assert_eq!(list.items.len(), 3, "plain regions are exempt");
+    }
+
+    #[test]
+    fn snippet_variable_detection_handles_escapes_and_tabstops() {
+        assert!(snippet_contains_variable("${CLIPBOARD}"));
+        assert!(snippet_contains_variable("$TM_SELECTED_TEXT"));
+        assert!(snippet_contains_variable("x${_private}y"));
+        assert!(!snippet_contains_variable("$1"));
+        assert!(!snippet_contains_variable("${1:placeholder}"));
+        assert!(!snippet_contains_variable("plain text"));
+        assert!(!snippet_contains_variable("price: \\$100"));
+        assert!(
+            !snippet_contains_variable("\\$CLIPBOARD"),
+            "escaped dollar is literal per the snippet grammar"
+        );
     }
 }

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -72,6 +72,7 @@ impl LanguageServerPool {
                     response,
                     ctx.offset,
                     region_end,
+                    Some(host_position.line),
                     Some(EnvelopeContext {
                         server_name,
                         host_uri: host_uri.as_str(),
@@ -111,6 +112,7 @@ fn transform_completion_response_to_host(
     mut response: serde_json::Value,
     offset: &RegionOffset,
     region_end: Position,
+    request_host_line: Option<u32>,
     envelope_ctx: Option<EnvelopeContext<'_>>,
 ) -> Option<CompletionList> {
     if response_has_jsonrpc_error(&response, "textDocument/completion") {
@@ -144,7 +146,7 @@ fn transform_completion_response_to_host(
     // routing
     let before = list.items.len();
     list.items.retain_mut(|item| {
-        if !transform_completion_item(item, offset, region_end) {
+        if !transform_completion_item(item, offset, region_end, request_host_line) {
             return false;
         }
         if let Some(ref ctx) = envelope_ctx {
@@ -178,16 +180,33 @@ pub(super) fn transform_completion_item(
     item: &mut CompletionItem,
     offset: &RegionOffset,
     region_end: Position,
+    request_host_line: Option<u32>,
 ) -> bool {
-    let region_prefixed = offset.columns().iter().any(|&column| column != 0);
+    // A multi-line insertion is unsafe only where its INSERTION POINT's
+    // neighborhood is prefixed — a mixed region (single-element `[n]` offsets:
+    // line 0 starts mid-host-line, later lines are whole and unprefixed)
+    // safely takes it on a later line. Checking the following line too covers
+    // the inserted-lines-land-below shape, mirroring the shared predicate.
+    // `None` (the resolve path, which has no position snapshot) falls back to
+    // region-wide any-prefix: fail-closed.
+    let prefixed_at_insertion = |host_line: Option<u32>| match host_line {
+        Some(line) => {
+            insertion_point_prefixed(offset, line)
+                || insertion_point_prefixed(offset, line.saturating_add(1))
+        }
+        None => offset.columns().iter().any(|&column| column != 0),
+    };
     // The literal newline scans below can't see what a SNIPPET expands to at
     // the client: runtime variables (`${CLIPBOARD}`, `$TM_SELECTED_TEXT`) may
-    // be multiline. In a prefixed region, fail closed on any snippet variable
-    // in the primary insert text (tabstops/placeholders expand from literal
-    // text the scans already cover; additionalTextEdits are never snippets).
+    // be multiline. At a prefixed insertion point, fail closed on any snippet
+    // variable in the primary insert text (tabstops/placeholders expand from
+    // literal text the scans already cover; additionalTextEdits are never
+    // snippets).
     let snippet =
         item.insert_text_format == Some(tower_lsp_server::ls_types::InsertTextFormat::SNIPPET);
-    let snippet_unsafe = |text: &str| region_prefixed && snippet && snippet_contains_variable(text);
+    let snippet_unsafe = |text: &str, host_line: Option<u32>| {
+        snippet && prefixed_at_insertion(host_line) && snippet_contains_variable(text)
+    };
 
     // Transform text_edit if present
     if let Some(ref mut text_edit) = item.text_edit {
@@ -195,7 +214,7 @@ pub(super) fn transform_completion_item(
             tower_lsp_server::ls_types::CompletionTextEdit::Edit(edit) => {
                 translate_virtual_range_to_host(&mut edit.range, offset);
                 if !text_edit_safe_in_region(edit, offset, region_end)
-                    || snippet_unsafe(&edit.new_text)
+                    || snippet_unsafe(&edit.new_text, Some(edit.range.start.line))
                 {
                     return false;
                 }
@@ -213,7 +232,13 @@ pub(super) fn transform_completion_item(
                 probe.range = edit.replace;
                 let replace_ok = text_edit_safe_in_region(&probe, offset, region_end);
                 edit.new_text = probe.new_text;
-                if !insert_ok || !replace_ok || snippet_unsafe(&edit.new_text) {
+                if !insert_ok
+                    || !replace_ok
+                    || snippet_unsafe(
+                        &edit.new_text,
+                        Some(edit.insert.start.line.min(edit.replace.start.line)),
+                    )
+                {
                     return false;
                 }
             }
@@ -229,10 +254,12 @@ pub(super) fn transform_completion_item(
     // insertions safely and stay exempt.
     if item.text_edit.is_none() {
         let effective = item.insert_text.as_deref().unwrap_or(&item.label);
-        if region_prefixed && (effective.contains('\n') || effective.contains('\r')) {
+        if (effective.contains('\n') || effective.contains('\r'))
+            && prefixed_at_insertion(request_host_line)
+        {
             return false;
         }
-        if snippet_unsafe(effective) {
+        if snippet_unsafe(effective, request_host_line) {
             return false;
         }
     }
@@ -254,6 +281,23 @@ pub(super) fn transform_completion_item(
         }
     }
     true
+}
+
+/// Whether the host line carries a region prefix an unprefixed insertion
+/// would break. Lines before the region are fail-closed `true`. Lines past
+/// the recorded per-line array are the BOUNDARY in per-line (blockquote)
+/// regions — fail-closed `true` (their real prefix is unrecorded) — but in
+/// the single-element fallback shape (`[start_column]`: only line 0 starts
+/// mid-host-line) later lines are whole and unprefixed: `false`.
+fn insertion_point_prefixed(offset: &RegionOffset, host_line: u32) -> bool {
+    let columns = offset.columns();
+    match host_line.checked_sub(offset.line()) {
+        None => true,
+        Some(virtual_line) => match columns.get(virtual_line as usize) {
+            Some(&column) => column != 0,
+            None => columns.len() > 1,
+        },
+    }
 }
 
 /// Whether snippet-syntax text references a snippet VARIABLE — `$name` or
@@ -484,6 +528,7 @@ mod tests {
             &RegionOffset::new(region_start_line, 0),
             TEST_REGION_END,
             None,
+            None,
         );
 
         assert!(transformed.is_some());
@@ -517,6 +562,7 @@ mod tests {
             &RegionOffset::new(3, 0),
             TEST_REGION_END,
             None,
+            None,
         );
         assert!(transformed.is_none());
     }
@@ -543,6 +589,7 @@ mod tests {
             response,
             &RegionOffset::new(region_start_line, 0),
             TEST_REGION_END,
+            None,
             None,
         );
 
@@ -593,6 +640,7 @@ mod tests {
             &RegionOffset::new(region_start_line, 0),
             TEST_REGION_END,
             None,
+            None,
         );
 
         assert!(transformed.is_some());
@@ -639,6 +687,7 @@ mod tests {
             &RegionOffset::new(region_start_line, 0),
             TEST_REGION_END,
             None,
+            None,
         );
 
         assert!(transformed.is_some());
@@ -681,6 +730,7 @@ mod tests {
             &RegionOffset::new(10, 4),
             TEST_REGION_END,
             None,
+            None,
         );
 
         let list = transformed.unwrap();
@@ -721,6 +771,7 @@ mod tests {
             response,
             &RegionOffset::new(10, 4),
             TEST_REGION_END,
+            None,
             None,
         );
 
@@ -766,6 +817,7 @@ mod tests {
             response,
             &RegionOffset::new(5, 7),
             TEST_REGION_END,
+            None,
             None,
         );
 
@@ -813,6 +865,7 @@ mod tests {
             response,
             &RegionOffset::new(5, 3),
             TEST_REGION_END,
+            None,
             None,
         );
 
@@ -887,6 +940,7 @@ mod tests {
             response,
             &RegionOffset::new(region_start_line, 0),
             TEST_REGION_END,
+            None,
             None,
         );
 
@@ -1086,8 +1140,8 @@ mod tests {
             ]
         });
 
-        let list =
-            transform_completion_response_to_host(response, &offset, region_end, None).unwrap();
+        let list = transform_completion_response_to_host(response, &offset, region_end, None, None)
+            .unwrap();
 
         assert_eq!(list.items.len(), 1, "prefix-breaking item must be dropped");
         assert_eq!(list.items[0].label, "safe");
@@ -1121,8 +1175,8 @@ mod tests {
             ]
         });
 
-        let list =
-            transform_completion_response_to_host(response, &offset, region_end, None).unwrap();
+        let list = transform_completion_response_to_host(response, &offset, region_end, None, None)
+            .unwrap();
 
         assert_eq!(list.items.len(), 1, "item with safe primary edit is kept");
         let additional = list.items[0].additional_text_edits.as_ref().unwrap();
@@ -1150,8 +1204,8 @@ mod tests {
             ]
         });
 
-        let list =
-            transform_completion_response_to_host(response, &offset, region_end, None).unwrap();
+        let list = transform_completion_response_to_host(response, &offset, region_end, None, None)
+            .unwrap();
 
         assert!(
             list.items.is_empty(),
@@ -1183,8 +1237,8 @@ mod tests {
             ]
         });
 
-        let list =
-            transform_completion_response_to_host(response, &offset, region_end, None).unwrap();
+        let list = transform_completion_response_to_host(response, &offset, region_end, None, None)
+            .unwrap();
 
         assert_eq!(list.items.len(), 1, "region-escaping item must drop");
         assert_eq!(list.items[0].label, "contained");
@@ -1209,16 +1263,21 @@ mod tests {
             ]
         });
 
-        let list =
-            transform_completion_response_to_host(response.clone(), &offset, region_end, None)
-                .unwrap();
+        let list = transform_completion_response_to_host(
+            response.clone(),
+            &offset,
+            region_end,
+            None,
+            None,
+        )
+        .unwrap();
         assert_eq!(list.items.len(), 1, "multiline fallback must drop");
         assert_eq!(list.items[0].label, "single");
 
         // Same response in a plain fenced region: both survive.
         let plain = RegionOffset::with_per_line_offsets(3, vec![0, 0, 0]);
-        let list =
-            transform_completion_response_to_host(response, &plain, region_end, None).unwrap();
+        let list = transform_completion_response_to_host(response, &plain, region_end, None, None)
+            .unwrap();
         assert_eq!(list.items.len(), 2, "plain regions take multiline inserts");
     }
 
@@ -1249,9 +1308,14 @@ mod tests {
             ]
         });
 
-        let list =
-            transform_completion_response_to_host(response.clone(), &offset, region_end, None)
-                .unwrap();
+        let list = transform_completion_response_to_host(
+            response.clone(),
+            &offset,
+            region_end,
+            None,
+            None,
+        )
+        .unwrap();
         let labels: Vec<_> = list.items.iter().map(|i| i.label.as_str()).collect();
         assert_eq!(
             labels,
@@ -1261,8 +1325,8 @@ mod tests {
 
         // Plain (all-zero) region: everything survives.
         let plain = RegionOffset::with_per_line_offsets(3, vec![0, 0, 0]);
-        let list =
-            transform_completion_response_to_host(response, &plain, region_end, None).unwrap();
+        let list = transform_completion_response_to_host(response, &plain, region_end, None, None)
+            .unwrap();
         assert_eq!(list.items.len(), 3, "plain regions are exempt");
     }
 
@@ -1278,6 +1342,44 @@ mod tests {
         assert!(
             !snippet_contains_variable("\\$CLIPBOARD"),
             "escaped dollar is literal per the snippet grammar"
+        );
+    }
+
+    #[test]
+    fn mixed_region_allows_multiline_fallback_on_unprefixed_later_lines() {
+        // Single-element offsets `[7]`: only line 0 starts mid-host-line;
+        // later lines are whole and unprefixed. A multi-line no-textEdit
+        // insertion is unsafe at line 0 (it would split the host line) but
+        // safe on a later line — the region-wide any-prefix shortcut used to
+        // drop both.
+        let offset = RegionOffset::new(3, 7);
+        let region_end = Position {
+            line: 9,
+            character: 0,
+        };
+        let response = json!({
+            "jsonrpc": "2.0", "id": 1,
+            "result": [ { "label": "multiline", "insertText": "a\nb" } ]
+        });
+
+        // Requested on host line 5 (virtual line 2, unprefixed): kept.
+        let list = transform_completion_response_to_host(
+            response.clone(),
+            &offset,
+            region_end,
+            Some(5),
+            None,
+        )
+        .unwrap();
+        assert_eq!(list.items.len(), 1, "later-line insertion is safe");
+
+        // Requested on host line 3 (virtual line 0, mid-host-line): dropped.
+        let list =
+            transform_completion_response_to_host(response, &offset, region_end, Some(3), None)
+                .unwrap();
+        assert!(
+            list.items.is_empty(),
+            "line-0 insertion would split the host line"
         );
     }
 }

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -267,20 +267,25 @@ pub(super) fn transform_completion_item(
         }
     }
 
-    // Transform additional_text_edits if present, stripping any unsafe for
-    // the injection region.
+    // Transform additional_text_edits if present. ALL-OR-NOTHING: the array
+    // can carry paired halves of one operation (a deletion plus a
+    // reinsertion), so stripping only the unsafe member could apply half and
+    // lose content — if any member is unsafe, drop the whole array. The
+    // primary insertion still works without it.
     if let Some(ref mut additional_edits) = item.additional_text_edits {
-        let before = additional_edits.len();
         for edit in additional_edits.iter_mut() {
             translate_virtual_range_to_host(&mut edit.range, offset);
         }
-        additional_edits.retain(|edit| text_edit_safe_in_region(edit, offset, region_end));
-        let dropped = before - additional_edits.len();
-        if dropped > 0 {
+        if !additional_edits
+            .iter()
+            .all(|edit| text_edit_safe_in_region(edit, offset, region_end))
+        {
             log::warn!(
                 target: "kakehashi::bridge",
-                "completion: stripped {dropped} additionalTextEdit(s) unsafe for the injection region (escape it, break line prefixes, or merge content into the closing fence)"
+                "completion: dropped an item's additionalTextEdits ({}): a member is unsafe for the injection region (escapes it, breaks line prefixes, or merges content into the closing fence)",
+                additional_edits.len()
             );
+            item.additional_text_edits = None;
         }
     }
     true
@@ -313,6 +318,11 @@ fn insertion_point_prefixed(offset: &RegionOffset, region_end: Position, host_li
             // continues past the region, so a non-zero start column (inline
             // content always sits behind its delimiter) is prefixed. A
             // column-0 same-line region is a one-line fenced block — safe.
+            // Known limitation: a CUSTOM injection query (`#offset!`) could
+            // capture a column-0 same-line range with a host suffix after it;
+            // the offsets can't represent that, and treating column 0 as
+            // unsafe breaks insertFinalNewline for one-line fences — the
+            // built-in queries never produce the shape.
             Some(&column) => column != 0 && (columns.len() > 1 || region_end.line == offset.line()),
             None => per_line_prefixed,
         },
@@ -1167,10 +1177,11 @@ mod tests {
     }
 
     #[test]
-    fn transform_strips_prefix_breaking_additional_edits_but_keeps_item() {
+    fn transform_drops_whole_additional_edit_array_but_keeps_item() {
         // An import-style additionalTextEdit that inserts a raw newline at a
-        // prefixed line would break the `> ` prefix — strip just that edit;
-        // the item's primary insertion still works.
+        // prefixed line would break the `> ` prefix — the array drops WHOLE
+        // (it can carry paired halves of one operation); the item's primary
+        // insertion still works.
         let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2, 0]);
         let region_end = Position {
             line: 5,
@@ -1198,9 +1209,11 @@ mod tests {
             .unwrap();
 
         assert_eq!(list.items.len(), 1, "item with safe primary edit is kept");
-        let additional = list.items[0].additional_text_edits.as_ref().unwrap();
-        assert_eq!(additional.len(), 1, "newline-inserting edit is stripped");
-        assert_eq!(additional[0].new_text, "ok");
+        assert!(
+            list.items[0].additional_text_edits.is_none(),
+            "an unsafe member drops the whole additionalTextEdits array \
+             (halves of one operation must not apply separately)"
+        );
     }
 
     #[test]
@@ -1424,22 +1437,25 @@ mod tests {
 
     #[test]
     fn insert_replace_snippet_checks_both_start_lines() {
-        // Malformed InsertReplaceEdit with unequal starts: insert anchors on
-        // the (unprefixed) later line, replace on the prefixed line 0-adjacent
-        // row of a blockquote. The snippet-variable gate must check BOTH.
-        let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2, 0]);
+        // Malformed InsertReplaceEdit with unequal starts in a MIXED-offset
+        // region ([0,0,2,0]): the insert range anchors on virtual line 0
+        // (host 3 — unprefixed, and host 4 is unprefixed too), the replace
+        // range on virtual line 2 (host 5 — prefixed). A minimum-start
+        // implementation anchors at the unprefixed line and would ADMIT the
+        // snippet variable; checking both starts rejects it.
+        let offset = RegionOffset::with_per_line_offsets(3, vec![0, 0, 2, 0]);
         let region_end = Position {
-            line: 5,
+            line: 7,
             character: 0,
         };
         let response = json!({
             "jsonrpc": "2.0", "id": 1,
             "result": [
                 { "label": "unequal", "insertTextFormat": 2,
-                  "textEdit": { "insert": { "start": { "line": 1, "character": 0 },
-                                            "end": { "line": 1, "character": 3 } },
-                                "replace": { "start": { "line": 0, "character": 0 },
-                                             "end": { "line": 0, "character": 3 } },
+                  "textEdit": { "insert": { "start": { "line": 0, "character": 0 },
+                                            "end": { "line": 0, "character": 3 } },
+                                "replace": { "start": { "line": 2, "character": 2 },
+                                             "end": { "line": 2, "character": 5 } },
                                 "newText": "${CLIPBOARD}" } }
             ]
         });

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -17,7 +17,7 @@ use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::translate_virtual_range_to_host;
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, build_position_based_request,
-    response_has_jsonrpc_error,
+    region_host_end, response_has_jsonrpc_error, text_edit_preserves_line_prefixes,
 };
 use tower_lsp_server::ls_types::TextDocumentPositionParams;
 
@@ -64,9 +64,11 @@ impl LanguageServerPool {
                 build_completion_request(virtual_uri, host_position, &offset, request_id)
             },
             |response, ctx| {
+                let region_end = region_host_end(virtual_content, ctx.offset);
                 transform_completion_response_to_host(
                     response,
                     ctx.offset,
+                    region_end,
                     Some(EnvelopeContext {
                         server_name,
                         host_uri: host_uri.as_str(),
@@ -104,6 +106,7 @@ fn build_completion_request(
 fn transform_completion_response_to_host(
     mut response: serde_json::Value,
     offset: &RegionOffset,
+    region_end: Position,
     envelope_ctx: Option<EnvelopeContext<'_>>,
 ) -> Option<CompletionList> {
     if response_has_jsonrpc_error(&response, "textDocument/completion") {
@@ -132,12 +135,24 @@ fn transform_completion_response_to_host(
         list
     };
 
-    // Transform all items in the list, then optionally envelope for resolve routing
-    for item in &mut list.items {
-        transform_completion_item(item, offset);
+    // Transform all items in the list (dropping any whose primary edit would
+    // corrupt region line prefixes), then optionally envelope for resolve routing
+    let before = list.items.len();
+    list.items.retain_mut(|item| {
+        if !transform_completion_item(item, offset, region_end) {
+            return false;
+        }
         if let Some(ref ctx) = envelope_ctx {
             envelope_item_data(item, ctx);
         }
+        true
+    });
+    let dropped = before - list.items.len();
+    if dropped > 0 {
+        log::warn!(
+            target: "kakehashi::bridge",
+            "completion: dropped {dropped} item(s) whose text edit would break region line prefixes"
+        );
     }
 
     Some(list)
@@ -147,26 +162,63 @@ fn transform_completion_response_to_host(
 ///
 /// Handles both TextEdit format and InsertReplaceEdit format. Also transforms
 /// additionalTextEdits if present.
-pub(super) fn transform_completion_item(item: &mut CompletionItem, offset: &RegionOffset) {
+///
+/// Returns `false` when the item's primary text edit would corrupt per-line
+/// region prefixes (e.g. blockquote `> `) if applied verbatim — the caller
+/// must drop the whole item (same fail-closed rule as WorkspaceEdit
+/// bridging). Unsafe `additionalTextEdits` are merely stripped: the primary
+/// insertion still works without them, so the item stays useful.
+pub(super) fn transform_completion_item(
+    item: &mut CompletionItem,
+    offset: &RegionOffset,
+    region_end: Position,
+) -> bool {
     // Transform text_edit if present
     if let Some(ref mut text_edit) = item.text_edit {
         match text_edit {
             tower_lsp_server::ls_types::CompletionTextEdit::Edit(edit) => {
                 translate_virtual_range_to_host(&mut edit.range, offset);
+                if !text_edit_preserves_line_prefixes(edit, offset, region_end) {
+                    return false;
+                }
             }
             tower_lsp_server::ls_types::CompletionTextEdit::InsertAndReplace(edit) => {
                 translate_virtual_range_to_host(&mut edit.insert, offset);
                 translate_virtual_range_to_host(&mut edit.replace, offset);
+                // Check both ranges through one probe edit, moving new_text in
+                // and out instead of cloning it per range.
+                let mut probe = tower_lsp_server::ls_types::TextEdit {
+                    range: edit.insert,
+                    new_text: std::mem::take(&mut edit.new_text),
+                };
+                let insert_ok = text_edit_preserves_line_prefixes(&probe, offset, region_end);
+                probe.range = edit.replace;
+                let replace_ok = text_edit_preserves_line_prefixes(&probe, offset, region_end);
+                edit.new_text = probe.new_text;
+                if !insert_ok || !replace_ok {
+                    return false;
+                }
             }
         }
     }
 
-    // Transform additional_text_edits if present
+    // Transform additional_text_edits if present, stripping any that would
+    // break region line prefixes.
     if let Some(ref mut additional_edits) = item.additional_text_edits {
-        for edit in additional_edits {
+        let before = additional_edits.len();
+        for edit in additional_edits.iter_mut() {
             translate_virtual_range_to_host(&mut edit.range, offset);
         }
+        additional_edits.retain(|edit| text_edit_preserves_line_prefixes(edit, offset, region_end));
+        let dropped = before - additional_edits.len();
+        if dropped > 0 {
+            log::warn!(
+                target: "kakehashi::bridge",
+                "completion: stripped {dropped} additionalTextEdit(s) that would break region line prefixes"
+            );
+        }
     }
+    true
 }
 
 // =============================================================================
@@ -287,6 +339,13 @@ mod tests {
     use rstest::rstest;
     use serde_json::json;
 
+    /// A region end far past any test edit: keeps the prefix-safety guard out
+    /// of the way for tests that exercise coordinate translation only.
+    const TEST_REGION_END: Position = Position {
+        line: u32::MAX,
+        character: u32::MAX,
+    };
+
     // ==========================================================================
     // Completion request tests
     // ==========================================================================
@@ -350,6 +409,7 @@ mod tests {
         let transformed = transform_completion_response_to_host(
             response,
             &RegionOffset::new(region_start_line, 0),
+            TEST_REGION_END,
             None,
         );
 
@@ -379,8 +439,12 @@ mod tests {
     #[case::malformed_result(json!({"jsonrpc": "2.0", "id": 42, "result": "not_a_completion_response"}))]
     #[case::error_response(json!({"jsonrpc": "2.0", "id": 42, "error": {"code": -32600, "message": "Invalid Request"}}))]
     fn completion_response_returns_none_for_invalid_response(#[case] response: serde_json::Value) {
-        let transformed =
-            transform_completion_response_to_host(response, &RegionOffset::new(3, 0), None);
+        let transformed = transform_completion_response_to_host(
+            response,
+            &RegionOffset::new(3, 0),
+            TEST_REGION_END,
+            None,
+        );
         assert!(transformed.is_none());
     }
 
@@ -405,6 +469,7 @@ mod tests {
         let transformed = transform_completion_response_to_host(
             response,
             &RegionOffset::new(region_start_line, 0),
+            TEST_REGION_END,
             None,
         );
 
@@ -453,6 +518,7 @@ mod tests {
         let transformed = transform_completion_response_to_host(
             response,
             &RegionOffset::new(region_start_line, 0),
+            TEST_REGION_END,
             None,
         );
 
@@ -498,6 +564,7 @@ mod tests {
         let transformed = transform_completion_response_to_host(
             response,
             &RegionOffset::new(region_start_line, 0),
+            TEST_REGION_END,
             None,
         );
 
@@ -536,8 +603,12 @@ mod tests {
             }
         });
 
-        let transformed =
-            transform_completion_response_to_host(response, &RegionOffset::new(10, 4), None);
+        let transformed = transform_completion_response_to_host(
+            response,
+            &RegionOffset::new(10, 4),
+            TEST_REGION_END,
+            None,
+        );
 
         let list = transformed.unwrap();
         if let Some(tower_lsp_server::ls_types::CompletionTextEdit::Edit(ref edit)) =
@@ -573,8 +644,12 @@ mod tests {
             }
         });
 
-        let transformed =
-            transform_completion_response_to_host(response, &RegionOffset::new(10, 4), None);
+        let transformed = transform_completion_response_to_host(
+            response,
+            &RegionOffset::new(10, 4),
+            TEST_REGION_END,
+            None,
+        );
 
         let list = transformed.unwrap();
         if let Some(tower_lsp_server::ls_types::CompletionTextEdit::Edit(ref edit)) =
@@ -614,8 +689,12 @@ mod tests {
             }
         });
 
-        let transformed =
-            transform_completion_response_to_host(response, &RegionOffset::new(5, 7), None);
+        let transformed = transform_completion_response_to_host(
+            response,
+            &RegionOffset::new(5, 7),
+            TEST_REGION_END,
+            None,
+        );
 
         let list = transformed.unwrap();
         if let Some(tower_lsp_server::ls_types::CompletionTextEdit::InsertAndReplace(ref edit)) =
@@ -657,8 +736,12 @@ mod tests {
             }
         });
 
-        let transformed =
-            transform_completion_response_to_host(response, &RegionOffset::new(5, 3), None);
+        let transformed = transform_completion_response_to_host(
+            response,
+            &RegionOffset::new(5, 3),
+            TEST_REGION_END,
+            None,
+        );
 
         let list = transformed.unwrap();
         let edits = list.items[0].additional_text_edits.as_ref().unwrap();
@@ -730,6 +813,7 @@ mod tests {
         let transformed = transform_completion_response_to_host(
             response,
             &RegionOffset::new(region_start_line, 0),
+            TEST_REGION_END,
             None,
         );
 
@@ -899,5 +983,104 @@ mod tests {
         };
         let json = serde_json::to_value(&offset).expect("should serialize");
         assert!(json.get("line_column_offsets").is_none());
+    }
+
+    #[test]
+    fn transform_drops_prefix_breaking_items_in_blockquote_regions() {
+        // Blockquote region (per-line `> ` widths plus the trailing
+        // boundary-row zero), content host lines 3-4, region end (5, 0).
+        // An item whose primary textEdit inserts a newline behind the prefix
+        // would produce an unprefixed continuation line — the whole item must
+        // be dropped. A same-line item survives.
+        let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2, 0]);
+        let region_end = Position {
+            line: 5,
+            character: 0,
+        };
+        let response = json!({
+            "jsonrpc": "2.0", "id": 1,
+            "result": [
+                { "label": "unsafe",
+                  "textEdit": { "range": { "start": { "line": 0, "character": 0 },
+                                           "end": { "line": 0, "character": 3 } },
+                                "newText": "multi\nline" } },
+                { "label": "safe",
+                  "textEdit": { "range": { "start": { "line": 0, "character": 0 },
+                                           "end": { "line": 0, "character": 3 } },
+                                "newText": "single" } }
+            ]
+        });
+
+        let list =
+            transform_completion_response_to_host(response, &offset, region_end, None).unwrap();
+
+        assert_eq!(list.items.len(), 1, "prefix-breaking item must be dropped");
+        assert_eq!(list.items[0].label, "safe");
+    }
+
+    #[test]
+    fn transform_strips_prefix_breaking_additional_edits_but_keeps_item() {
+        // An import-style additionalTextEdit that inserts a raw newline at a
+        // prefixed line would break the `> ` prefix — strip just that edit;
+        // the item's primary insertion still works.
+        let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2, 0]);
+        let region_end = Position {
+            line: 5,
+            character: 0,
+        };
+        let response = json!({
+            "jsonrpc": "2.0", "id": 1,
+            "result": [
+                { "label": "item",
+                  "textEdit": { "range": { "start": { "line": 1, "character": 0 },
+                                           "end": { "line": 1, "character": 3 } },
+                                "newText": "single" },
+                  "additionalTextEdits": [
+                      { "range": { "start": { "line": 0, "character": 0 },
+                                   "end": { "line": 0, "character": 0 } },
+                        "newText": "import x\n" },
+                      { "range": { "start": { "line": 0, "character": 0 },
+                                   "end": { "line": 0, "character": 2 } },
+                        "newText": "ok" }
+                  ] }
+            ]
+        });
+
+        let list =
+            transform_completion_response_to_host(response, &offset, region_end, None).unwrap();
+
+        assert_eq!(list.items.len(), 1, "item with safe primary edit is kept");
+        let additional = list.items[0].additional_text_edits.as_ref().unwrap();
+        assert_eq!(additional.len(), 1, "newline-inserting edit is stripped");
+        assert_eq!(additional[0].new_text, "ok");
+    }
+
+    #[test]
+    fn transform_drops_prefix_breaking_insert_replace_items() {
+        // InsertReplaceEdit variant: reject when EITHER range is unsafe.
+        let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2, 0]);
+        let region_end = Position {
+            line: 5,
+            character: 0,
+        };
+        let response = json!({
+            "jsonrpc": "2.0", "id": 1,
+            "result": [
+                { "label": "unsafe",
+                  "textEdit": { "insert": { "start": { "line": 0, "character": 0 },
+                                            "end": { "line": 0, "character": 3 } },
+                                "replace": { "start": { "line": 0, "character": 0 },
+                                             "end": { "line": 1, "character": 3 } },
+                                "newText": "x" } }
+            ]
+        });
+
+        let list =
+            transform_completion_response_to_host(response, &offset, region_end, None).unwrap();
+
+        assert!(
+            list.items.is_empty(),
+            "item whose replace range spans a prefixed line must be dropped"
+        );
     }
 }

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -1467,4 +1467,42 @@ mod tests {
             "either prefixed start line must reject the snippet variable"
         );
     }
+
+    #[test]
+    fn mixed_offset_boundary_rows_reject_multiline_fallbacks() {
+        // Mixed per-line offsets [2,0,0] (a blockquote with a lazy
+        // continuation line): the trailing recorded zeros are BOUNDARY rows
+        // whose real prefix is unrecorded. A multi-line fallback insertion on
+        // the last content row (host 4 — its following row is the boundary)
+        // must reject; the same shape in an all-zero region has no boundary
+        // semantics and passes.
+        let region_end = Position {
+            line: 5,
+            character: 0,
+        };
+        let response = json!({
+            "jsonrpc": "2.0", "id": 1,
+            "result": [ { "label": "multiline", "insertText": "a\nb" } ]
+        });
+
+        let mixed = RegionOffset::with_per_line_offsets(3, vec![2, 0, 0]);
+        let list = transform_completion_response_to_host(
+            response.clone(),
+            &mixed,
+            region_end,
+            Some(4),
+            None,
+        )
+        .unwrap();
+        assert!(
+            list.items.is_empty(),
+            "boundary-adjacent insertion in a prefixed region must drop"
+        );
+
+        let plain = RegionOffset::with_per_line_offsets(3, vec![0, 0, 0]);
+        let list =
+            transform_completion_response_to_host(response, &plain, region_end, Some(4), None)
+                .unwrap();
+        assert_eq!(list.items.len(), 1, "all-zero regions keep no boundary");
+    }
 }

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -1,8 +1,9 @@
 //! Completion request handling for bridge connections.
 //!
 //! Handles the coordinate transformation between host and virtual documents,
-//! and drops items whose text edits would break per-line region prefixes
-//! (blockquote `> `) if applied verbatim (see `transform_completion_item`).
+//! and drops items whose text edits are unsafe for the injection region —
+//! escape it, break per-line `> ` prefixes, or merge content into the closing
+//! fence — if applied verbatim (see `transform_completion_item`).
 //! Messages are queued via the channel-based writer task (ls-bridge-message-ordering) for FIFO
 //! ordering with other messages.
 
@@ -138,8 +139,9 @@ fn transform_completion_response_to_host(
         list
     };
 
-    // Transform all items in the list (dropping any whose primary edit would
-    // corrupt region line prefixes), then optionally envelope for resolve routing
+    // Transform all items in the list (dropping any whose primary edit is
+    // unsafe for the injection region), then optionally envelope for resolve
+    // routing
     let before = list.items.len();
     list.items.retain_mut(|item| {
         if !transform_completion_item(item, offset, region_end) {
@@ -166,11 +168,12 @@ fn transform_completion_response_to_host(
 /// Handles both TextEdit format and InsertReplaceEdit format. Also transforms
 /// additionalTextEdits if present.
 ///
-/// Returns `false` when the item's primary text edit would corrupt per-line
-/// region prefixes (e.g. blockquote `> `) if applied verbatim — the caller
-/// must drop the whole item (same fail-closed rule as WorkspaceEdit
-/// bridging). Unsafe `additionalTextEdits` are merely stripped: the primary
-/// insertion still works without them, so the item stays useful.
+/// Returns `false` when the item's primary text edit is unsafe for the
+/// injection region — escapes it, corrupts per-line `> ` prefixes, or merges
+/// content into the closing fence — if applied verbatim; the caller must
+/// drop the whole item (same fail-closed rule as WorkspaceEdit bridging).
+/// Unsafe `additionalTextEdits` are merely stripped: the primary insertion
+/// still works without them, so the item stays useful.
 pub(super) fn transform_completion_item(
     item: &mut CompletionItem,
     offset: &RegionOffset,

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -1,6 +1,8 @@
 //! Completion request handling for bridge connections.
 //!
-//! Handles the coordinate transformation between host and virtual documents.
+//! Handles the coordinate transformation between host and virtual documents,
+//! and drops items whose text edits would break per-line region prefixes
+//! (blockquote `> `) if applied verbatim (see `transform_completion_item`).
 //! Messages are queued via the channel-based writer task (ls-bridge-message-ordering) for FIFO
 //! ordering with other messages.
 
@@ -73,6 +75,7 @@ impl LanguageServerPool {
                         server_name,
                         host_uri: host_uri.as_str(),
                         offset: ctx.offset,
+                        region_end: Some(region_end),
                     }),
                 )
             },
@@ -252,6 +255,13 @@ pub(crate) struct KakehashiEnvelope {
     pub inner: Option<Value>,
     /// Region offset snapshot for coordinate transformation of the resolved response.
     pub offset: EnvelopeOffset,
+    /// Region end (host `(line, character)`) snapshot for the resolve-path
+    /// prefix-safety guard — the resolve has no region-content access, so it
+    /// can't recompute this. `None` (via `serde(default)`) for envelopes
+    /// minted before this field existed → the resolve path falls back to a
+    /// fully fail-closed guard in prefixed regions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub region_end: Option<(u32, u32)>,
 }
 
 /// Offset snapshot stored in the envelope for coordinate back-translation.
@@ -296,6 +306,9 @@ pub(crate) struct EnvelopeContext<'a> {
     /// `completionItem/resolve` can route back to the originating connection.
     pub host_uri: &'a str,
     pub offset: &'a RegionOffset,
+    /// Region end (host coords) snapshot for the resolve-path prefix guard;
+    /// `None` only when re-enveloping a legacy envelope that never carried it.
+    pub region_end: Option<Position>,
 }
 
 /// Wrap `item.data` in a Kakehashi envelope for origin tracking.
@@ -309,6 +322,7 @@ pub(crate) fn envelope_item_data(item: &mut CompletionItem, ctx: &EnvelopeContex
         host_uri: ctx.host_uri.to_string(),
         inner,
         offset: EnvelopeOffset::from(ctx.offset),
+        region_end: ctx.region_end.map(|end| (end.line, end.character)),
     };
     item.data = Some(serde_json::json!({ ENVELOPE_KEY: envelope }));
 }
@@ -338,13 +352,6 @@ mod tests {
     use super::*;
     use rstest::rstest;
     use serde_json::json;
-
-    /// A region end far past any test edit: keeps the prefix-safety guard out
-    /// of the way for tests that exercise coordinate translation only.
-    const TEST_REGION_END: Position = Position {
-        line: u32::MAX,
-        character: u32::MAX,
-    };
 
     // ==========================================================================
     // Completion request tests
@@ -848,6 +855,7 @@ mod tests {
             server_name: "lua-ls",
             host_uri: "file:///test/doc.md",
             offset: &offset,
+            region_end: Some(TEST_REGION_END),
         };
         envelope_item_data(&mut item, &ctx);
 
@@ -905,6 +913,7 @@ mod tests {
             server_name: "lua-ls",
             host_uri: "file:///test/doc.md",
             offset: &offset,
+            region_end: Some(TEST_REGION_END),
         };
         envelope_item_data(&mut item, &ctx);
 

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -1,7 +1,8 @@
 //! Completion request handling for bridge connections.
 //!
 //! Handles the coordinate transformation between host and virtual documents,
-//! and drops items whose text edits are unsafe for the injection region —
+//! and drops items whose primary insertion (text edit, or the insertText/
+//! label fallback at the request position) is unsafe for the injection region —
 //! escape it, break per-line `> ` prefixes, or merge content into the closing
 //! fence — if applied verbatim (see `transform_completion_item`).
 //! Messages are queued via the channel-based writer task (ls-bridge-message-ordering) for FIFO
@@ -294,16 +295,26 @@ pub(super) fn transform_completion_item(
 /// mid-host-line) later lines are whole and unprefixed: `false`.
 fn insertion_point_prefixed(offset: &RegionOffset, region_end: Position, host_line: u32) -> bool {
     let columns = offset.columns();
+    // Boundary rows of a per-line-prefixed region — the recorded trailing
+    // zeros and everything past the array — carry an unrecorded real prefix
+    // (the closing fence's `> `): fail-closed, mirroring the shared guard's
+    // boundary rule. All-zero multi-line regions have no boundary semantics.
+    let per_line_prefixed = columns.len() > 1 && columns.iter().any(|&column| column != 0);
+    if per_line_prefixed && region_end.character == 0 && host_line >= region_end.line {
+        return true;
+    }
     match host_line.checked_sub(offset.line()) {
         None => true,
         Some(virtual_line) => match columns.get(virtual_line as usize) {
-            // Single-element shape on line 0: the captured content runs to
-            // end-of-line in a MULTI-LINE region, so an inserted newline
-            // splits only injected content — mirror the shared guard's
-            // `newline_splits_nothing`. Only a same-line inline region (the
-            // host line continues past the region) counts as prefixed.
+            // Single-element shape on line 0: in a MULTI-LINE region the
+            // captured content runs to end-of-line, so an inserted newline
+            // splits only injected content (mirror the shared guard's
+            // `newline_splits_nothing`); in a SAME-LINE region the host line
+            // continues past the region, so a non-zero start column (inline
+            // content always sits behind its delimiter) is prefixed. A
+            // column-0 same-line region is a one-line fenced block — safe.
             Some(&column) => column != 0 && (columns.len() > 1 || region_end.line == offset.line()),
-            None => columns.len() > 1,
+            None => per_line_prefixed,
         },
     }
 }
@@ -1355,11 +1366,12 @@ mod tests {
 
     #[test]
     fn mixed_region_allows_multiline_fallback_on_unprefixed_later_lines() {
-        // Single-element offsets `[7]`: only line 0 starts mid-host-line;
-        // later lines are whole and unprefixed. A multi-line no-textEdit
-        // insertion is unsafe at line 0 (it would split the host line) but
-        // safe on a later line — the region-wide any-prefix shortcut used to
-        // drop both.
+        // Single-element offsets `[7]`: line 0 starts mid-host-line but its
+        // captured content runs to end-of-line in a MULTI-LINE region, and
+        // later lines are whole and unprefixed — multi-line no-textEdit
+        // insertions are safe on every content line; only a SAME-LINE inline
+        // region rejects them. The region-wide any-prefix shortcut used to
+        // drop all of these.
         let offset = RegionOffset::new(3, 7);
         let region_end = Position {
             line: 9,
@@ -1407,6 +1419,36 @@ mod tests {
         assert!(
             list.items.is_empty(),
             "inline-region line-0 insertion would split the host line"
+        );
+    }
+
+    #[test]
+    fn insert_replace_snippet_checks_both_start_lines() {
+        // Malformed InsertReplaceEdit with unequal starts: insert anchors on
+        // the (unprefixed) later line, replace on the prefixed line 0-adjacent
+        // row of a blockquote. The snippet-variable gate must check BOTH.
+        let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2, 0]);
+        let region_end = Position {
+            line: 5,
+            character: 0,
+        };
+        let response = json!({
+            "jsonrpc": "2.0", "id": 1,
+            "result": [
+                { "label": "unequal", "insertTextFormat": 2,
+                  "textEdit": { "insert": { "start": { "line": 1, "character": 0 },
+                                            "end": { "line": 1, "character": 3 } },
+                                "replace": { "start": { "line": 0, "character": 0 },
+                                             "end": { "line": 0, "character": 3 } },
+                                "newText": "${CLIPBOARD}" } }
+            ]
+        });
+
+        let list = transform_completion_response_to_host(response, &offset, region_end, None, None)
+            .unwrap();
+        assert!(
+            list.items.is_empty(),
+            "either prefixed start line must reject the snippet variable"
         );
     }
 }

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -342,26 +342,25 @@ fn insertion_point_prefixed(offset: &RegionOffset, region_end: Position, host_li
 /// would only reject, never admit).
 fn snippet_contains_variable(text: &str) -> bool {
     let bytes = text.as_bytes();
-    let mut escaped = false;
+    let starts_name = |c: u8| c.is_ascii_alphabetic() || c == b'_';
     let mut i = 0;
     while i < bytes.len() {
         match bytes[i] {
-            b'\\' if !escaped => escaped = true,
-            b'$' if !escaped => {
-                let next = bytes.get(i + 1).copied();
-                let starts_name = |c: u8| c.is_ascii_alphabetic() || c == b'_';
-                match next {
+            // A backslash escapes the next character (literal per the snippet
+            // grammar) — skip both.
+            b'\\' => i += 2,
+            b'$' => {
+                match bytes.get(i + 1).copied() {
                     Some(b'{') if bytes.get(i + 2).copied().is_some_and(starts_name) => {
                         return true;
                     }
                     Some(c) if starts_name(c) => return true,
                     _ => {}
                 }
-                escaped = false;
+                i += 1;
             }
-            _ => escaped = false,
+            _ => i += 1,
         }
-        i += 1;
     }
     false
 }

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -270,8 +270,10 @@ pub(super) fn transform_completion_item(
     // Transform additional_text_edits if present. ALL-OR-NOTHING: the array
     // can carry paired halves of one operation (a deletion plus a
     // reinsertion), so stripping only the unsafe member could apply half and
-    // lose content — if any member is unsafe, drop the whole array. The
-    // primary insertion still works without it.
+    // lose content — if any member is unsafe, drop the whole array. The item
+    // is kept: its primary insertion still applies, though possibly
+    // semantically incomplete (e.g. without its auto-import) — availability
+    // over fidelity, never corruption.
     if let Some(ref mut additional_edits) = item.additional_text_edits {
         for edit in additional_edits.iter_mut() {
             translate_virtual_range_to_host(&mut edit.range, offset);
@@ -1472,9 +1474,10 @@ mod tests {
     fn mixed_offset_boundary_rows_reject_multiline_fallbacks() {
         // Mixed per-line offsets [2,0,0] (a blockquote with a lazy
         // continuation line): the trailing recorded zeros are BOUNDARY rows
-        // whose real prefix is unrecorded. A multi-line fallback insertion on
-        // the last content row (host 4 — its following row is the boundary)
-        // must reject; the same shape in an all-zero region has no boundary
+        // whose real prefix is unrecorded: host 4 is the lazy-continuation
+        // CONTENT row (recorded 0), host 5 the boundary. A multi-line
+        // fallback insertion on host 4 must reject — its following row is
+        // the boundary; the same shape in an all-zero region has no boundary
         // semantics and passes.
         let region_end = Position {
             line: 5,

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -154,7 +154,7 @@ fn transform_completion_response_to_host(
     if dropped > 0 {
         log::warn!(
             target: "kakehashi::bridge",
-            "completion: dropped {dropped} item(s) whose text edit would break region line prefixes"
+            "completion: dropped {dropped} item(s) whose text edit is unsafe for the injection region (escapes it or breaks line prefixes)"
         );
     }
 
@@ -232,7 +232,7 @@ pub(super) fn transform_completion_item(
         if dropped > 0 {
             log::warn!(
                 target: "kakehashi::bridge",
-                "completion: stripped {dropped} additionalTextEdit(s) that would break region line prefixes"
+                "completion: stripped {dropped} additionalTextEdit(s) unsafe for the injection region (escape it or break line prefixes)"
             );
         }
     }

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -19,7 +19,7 @@ use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::translate_virtual_range_to_host;
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, build_position_based_request,
-    region_host_end, response_has_jsonrpc_error, text_edit_preserves_line_prefixes,
+    region_host_end, response_has_jsonrpc_error, text_edit_safe_in_region,
 };
 use tower_lsp_server::ls_types::TextDocumentPositionParams;
 
@@ -181,7 +181,7 @@ pub(super) fn transform_completion_item(
         match text_edit {
             tower_lsp_server::ls_types::CompletionTextEdit::Edit(edit) => {
                 translate_virtual_range_to_host(&mut edit.range, offset);
-                if !text_edit_preserves_line_prefixes(edit, offset, region_end) {
+                if !text_edit_safe_in_region(edit, offset, region_end) {
                     return false;
                 }
             }
@@ -194,14 +194,29 @@ pub(super) fn transform_completion_item(
                     range: edit.insert,
                     new_text: std::mem::take(&mut edit.new_text),
                 };
-                let insert_ok = text_edit_preserves_line_prefixes(&probe, offset, region_end);
+                let insert_ok = text_edit_safe_in_region(&probe, offset, region_end);
                 probe.range = edit.replace;
-                let replace_ok = text_edit_preserves_line_prefixes(&probe, offset, region_end);
+                let replace_ok = text_edit_safe_in_region(&probe, offset, region_end);
                 edit.new_text = probe.new_text;
                 if !insert_ok || !replace_ok {
                     return false;
                 }
             }
+        }
+    }
+
+    // No textEdit: the client inserts insertText (or the label) at the
+    // completion position instead. In a prefixed region (per-line `> ` or an
+    // inline region's host-line tail) a multi-line insertion creates
+    // unprefixed/splitting lines — the same class the textEdit guard rejects —
+    // and the transform has no range to check, so the newline itself is the
+    // reject signal. All-zero (plain fenced) regions take multi-line
+    // insertions safely and stay exempt.
+    if item.text_edit.is_none() {
+        let region_prefixed = offset.columns().iter().any(|&column| column != 0);
+        let effective = item.insert_text.as_deref().unwrap_or(&item.label);
+        if region_prefixed && (effective.contains('\n') || effective.contains('\r')) {
+            return false;
         }
     }
 
@@ -212,7 +227,7 @@ pub(super) fn transform_completion_item(
         for edit in additional_edits.iter_mut() {
             translate_virtual_range_to_host(&mut edit.range, offset);
         }
-        additional_edits.retain(|edit| text_edit_preserves_line_prefixes(edit, offset, region_end));
+        additional_edits.retain(|edit| text_edit_safe_in_region(edit, offset, region_end));
         let dropped = before - additional_edits.len();
         if dropped > 0 {
             log::warn!(
@@ -1091,5 +1106,68 @@ mod tests {
             list.items.is_empty(),
             "item whose replace range spans a prefixed line must be dropped"
         );
+    }
+
+    #[test]
+    fn transform_drops_items_whose_edit_escapes_the_region() {
+        // Plain fenced region (all-zero offsets — the prefix rules fast-path),
+        // content host lines 3-4, region end (5, 0). A stale/oversized range
+        // translates past the closing fence; containment must drop the item.
+        let offset = RegionOffset::with_per_line_offsets(3, vec![0, 0, 0]);
+        let region_end = Position {
+            line: 5,
+            character: 0,
+        };
+        let response = json!({
+            "jsonrpc": "2.0", "id": 1,
+            "result": [
+                { "label": "escapes",
+                  "textEdit": { "range": { "start": { "line": 0, "character": 0 },
+                                           "end": { "line": 9, "character": 0 } },
+                                "newText": "x" } },
+                { "label": "contained",
+                  "textEdit": { "range": { "start": { "line": 0, "character": 0 },
+                                           "end": { "line": 0, "character": 3 } },
+                                "newText": "y" } }
+            ]
+        });
+
+        let list =
+            transform_completion_response_to_host(response, &offset, region_end, None).unwrap();
+
+        assert_eq!(list.items.len(), 1, "region-escaping item must drop");
+        assert_eq!(list.items[0].label, "contained");
+    }
+
+    #[test]
+    fn transform_drops_multiline_insert_text_fallback_in_prefixed_regions() {
+        // No textEdit: the client inserts insertText (or the label) at the
+        // completion position. Multi-line fallback text in a prefixed region
+        // creates unprefixed lines — drop the item. Single-line fallbacks and
+        // multi-line fallbacks in plain (all-zero) regions are kept.
+        let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2, 0]);
+        let region_end = Position {
+            line: 5,
+            character: 0,
+        };
+        let response = json!({
+            "jsonrpc": "2.0", "id": 1,
+            "result": [
+                { "label": "multiline", "insertText": "for x in y:\n    pass" },
+                { "label": "single", "insertText": "print" }
+            ]
+        });
+
+        let list =
+            transform_completion_response_to_host(response.clone(), &offset, region_end, None)
+                .unwrap();
+        assert_eq!(list.items.len(), 1, "multiline fallback must drop");
+        assert_eq!(list.items[0].label, "single");
+
+        // Same response in a plain fenced region: both survive.
+        let plain = RegionOffset::with_per_line_offsets(3, vec![0, 0, 0]);
+        let list =
+            transform_completion_response_to_host(response, &plain, region_end, None).unwrap();
+        assert_eq!(list.items.len(), 2, "plain regions take multiline inserts");
     }
 }

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -1201,8 +1201,8 @@ mod tests {
                       { "range": { "start": { "line": 0, "character": 0 },
                                    "end": { "line": 0, "character": 0 } },
                         "newText": "import x\n" },
-                      { "range": { "start": { "line": 0, "character": 0 },
-                                   "end": { "line": 0, "character": 2 } },
+                      { "range": { "start": { "line": 0, "character": 3 },
+                                   "end": { "line": 0, "character": 5 } },
                         "newText": "ok" }
                   ] }
             ]

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -11,7 +11,7 @@
 use std::sync::Arc;
 
 use log::warn;
-use tower_lsp_server::ls_types::CompletionItem;
+use tower_lsp_server::ls_types::{CompletionItem, Position};
 use url::Url;
 
 use super::super::pool::{LanguageServerPool, UpstreamId};
@@ -182,9 +182,30 @@ impl LanguageServerPool {
         match parse_completion_resolve_response(response) {
             Some(mut resolved) => {
                 let offset = RegionOffset::from(&envelope.offset);
-                transform_completion_item(&mut resolved, &offset);
-                re_envelope_item(&mut resolved, &envelope);
-                resolved
+                // The envelope has no region-content snapshot, so the real
+                // region end is unknown here. Assume a single-line region —
+                // the strictest setting for the prefix-safety guard (it can
+                // only over-strip in PREFIXED regions; unprefixed regions
+                // pass the guard's fast path untouched).
+                let region_end = Position {
+                    line: offset.line(),
+                    character: u32::MAX,
+                };
+                if transform_completion_item(&mut resolved, &offset, region_end) {
+                    re_envelope_item(&mut resolved, &envelope);
+                    resolved
+                } else {
+                    // The resolved primary edit would corrupt region line
+                    // prefixes — serve the original (already host-translated,
+                    // guard-passed) item instead of a corrupting one.
+                    warn!(
+                        target: "kakehashi::bridge",
+                        "completionItem/resolve: resolved item from {} would break region line prefixes; serving unresolved item",
+                        server_name
+                    );
+                    re_envelope_item(&mut item, &envelope);
+                    item
+                }
             }
             None => {
                 re_envelope_item(&mut item, &envelope);

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -7,8 +7,9 @@
 //! completion that produced this item. If the downstream server has since
 //! restarted (or the connection was recreated), the resolve fails and we
 //! return the unresolved item with envelope intact: graceful degradation.
-//! The same degradation serves a resolved item whose primary edit would break
-//! per-line region prefixes (see `resolve_guard_region_end`).
+//! The same degradation serves a resolved item whose primary edit is unsafe
+//! for the injection region — escapes it, breaks per-line prefixes, or merges
+//! content into the closing fence (see `resolve_guard_region_end`).
 
 use std::sync::Arc;
 
@@ -189,8 +190,8 @@ impl LanguageServerPool {
                     re_envelope_item(&mut resolved, &envelope);
                     resolved
                 } else {
-                    // The resolved primary edit would corrupt region line
-                    // prefixes — serve the original (already host-translated,
+                    // The resolved primary edit is unsafe for the injection
+                    // region — serve the original (already host-translated,
                     // guard-passed) item instead of a corrupting one.
                     warn!(
                         target: "kakehashi::bridge",

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -250,7 +250,14 @@ fn re_envelope_item(item: &mut CompletionItem, envelope: &KakehashiEnvelope) {
     envelope_item_data(item, &ctx);
 }
 
-/// The `region_end` the resolve-path prefix guard runs with. Normally the
+/// The `region_end` the resolve-path prefix guard runs with.
+///
+/// Known limitation (pre-existing class, shared with the envelope's `offset`
+/// itself, which has translated resolve responses since #382): both are
+/// completion-time snapshots round-tripped through the client, so an edit
+/// arriving after the region moved translates against stale geometry. A live
+/// re-resolution needs a region identity the envelope doesn't carry — the
+/// codeAction path's freshness gate is the model if this ever bites. Normally the
 /// envelope carries the completion-time snapshot verbatim. A LEGACY envelope
 /// (minted before the field existed) has none, and the resolve path cannot
 /// recompute it — fall back to `(region start line, character 0)`, which is

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -18,7 +18,10 @@ use tower_lsp_server::ls_types::{CompletionItem, Position};
 use url::Url;
 
 use super::super::pool::{LanguageServerPool, UpstreamId};
-use super::super::protocol::{JsonRpcRequest, RegionOffset, RequestId, response_has_jsonrpc_error};
+use super::super::protocol::{
+    JsonRpcRequest, RegionOffset, RequestId, response_has_jsonrpc_error,
+    translate_host_range_to_virtual,
+};
 use super::completion::{
     EnvelopeContext, KakehashiEnvelope, envelope_item_data, strip_envelope,
     transform_completion_item,
@@ -144,7 +147,15 @@ impl LanguageServerPool {
                 }
             };
 
-        let request = build_completion_resolve_request(&item, request_id);
+        // Forward with the item's edit ranges restored to VIRTUAL coordinates
+        // (the served item is host-translated; a downstream that echoes the
+        // ranges verbatim would otherwise get them re-translated on the way
+        // back — a double shift the safety guard can't always catch). The
+        // original host-coordinate `item` is kept untouched for the
+        // fail-soft returns below. Mirrors the codeAction resolve path.
+        let mut outgoing = item.clone();
+        translate_item_ranges_host_to_virtual(&mut outgoing, &RegionOffset::from(&envelope.offset));
+        let request = build_completion_resolve_request(&outgoing, request_id);
 
         let mut router_guard = RouterCleanupGuard::new(Arc::clone(handle.router()), request_id);
 
@@ -233,6 +244,28 @@ fn parse_completion_resolve_response(mut response: serde_json::Value) -> Option<
         return None;
     }
     serde_json::from_value(result).ok()
+}
+
+/// Translate a served (host-coordinate) item's edit ranges back to virtual
+/// coordinates before forwarding it in a `completionItem/resolve` request —
+/// the inverse of `transform_completion_item`'s range translation.
+fn translate_item_ranges_host_to_virtual(item: &mut CompletionItem, offset: &RegionOffset) {
+    if let Some(text_edit) = &mut item.text_edit {
+        match text_edit {
+            tower_lsp_server::ls_types::CompletionTextEdit::Edit(edit) => {
+                translate_host_range_to_virtual(&mut edit.range, offset);
+            }
+            tower_lsp_server::ls_types::CompletionTextEdit::InsertAndReplace(edit) => {
+                translate_host_range_to_virtual(&mut edit.insert, offset);
+                translate_host_range_to_virtual(&mut edit.replace, offset);
+            }
+        }
+    }
+    if let Some(additional_edits) = &mut item.additional_text_edits {
+        for edit in additional_edits.iter_mut() {
+            translate_host_range_to_virtual(&mut edit.range, offset);
+        }
+    }
 }
 
 /// Restore the envelope into a resolved item's `data` field.
@@ -636,5 +669,42 @@ mod tests {
                 line_column_offsets: Some(vec![0])
             }
         );
+    }
+
+    #[test]
+    fn resolve_forwards_edit_ranges_in_virtual_coordinates() {
+        // The served item is host-translated (region at host line 5); the
+        // outgoing resolve must restore virtual coordinates or a downstream
+        // echoing the ranges verbatim gets them double-shifted on return.
+        let mut item = CompletionItem {
+            label: "print".to_string(),
+            text_edit: Some(tower_lsp_server::ls_types::CompletionTextEdit::Edit(
+                tower_lsp_server::ls_types::TextEdit {
+                    range: tower_lsp_server::ls_types::Range {
+                        start: Position {
+                            line: 5,
+                            character: 2,
+                        },
+                        end: Position {
+                            line: 5,
+                            character: 7,
+                        },
+                    },
+                    new_text: "print".to_string(),
+                },
+            )),
+            ..Default::default()
+        };
+        let envelope = test_envelope();
+        let offset = RegionOffset::from(&envelope.offset);
+
+        translate_item_ranges_host_to_virtual(&mut item, &offset);
+
+        let Some(tower_lsp_server::ls_types::CompletionTextEdit::Edit(edit)) = &item.text_edit
+        else {
+            panic!("edit variant preserved");
+        };
+        assert_eq!(edit.range.start.line, 0, "host line 5 → virtual line 0");
+        assert_eq!(edit.range.end.line, 0);
     }
 }

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -263,8 +263,9 @@ fn re_envelope_item(item: &mut CompletionItem, envelope: &KakehashiEnvelope) {
 /// recompute it — fall back to `(region start line, character 0)`, which is
 /// fully fail-closed: with `character == 0` the guard's boundary rule rejects
 /// every edit at or past the region start in per-line-prefixed regions (the
-/// unresolved item is served instead), while unprefixed regions still pass
-/// via the all-zero fast path. A permissive sentinel here would disable the
+/// unresolved item is served instead); unprefixed regions skip the prefix
+/// rules but stay subject to containment and the fence-boundary EOL rule,
+/// both fail-closed under this anchor. A permissive sentinel would disable the
 /// boundary rule entirely and let fence-row edits through — never trade that
 /// for fewer over-strips on envelopes that disappear after one session.
 fn resolve_guard_region_end(envelope: &KakehashiEnvelope, offset: &RegionOffset) -> Position {

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -676,7 +676,7 @@ mod tests {
         // The served item is host-translated (region at host line 5); the
         // outgoing resolve must restore virtual coordinates or a downstream
         // echoing the ranges verbatim gets them double-shifted on return.
-        let mut item = CompletionItem {
+        let item = CompletionItem {
             label: "print".to_string(),
             text_edit: Some(tower_lsp_server::ls_types::CompletionTextEdit::Edit(
                 tower_lsp_server::ls_types::TextEdit {
@@ -698,13 +698,25 @@ mod tests {
         let envelope = test_envelope();
         let offset = RegionOffset::from(&envelope.offset);
 
-        translate_item_ranges_host_to_virtual(&mut item, &offset);
+        // Reproduce the production wiring: clone, untranslate, build the
+        // outgoing request — and assert on the SERIALIZED request, so
+        // removing the untranslation step in send_completion_resolve_request
+        // has a matching failure here.
+        let mut outgoing = item.clone();
+        translate_item_ranges_host_to_virtual(&mut outgoing, &offset);
+        let request = build_completion_resolve_request(&outgoing, RequestId::new(7));
+        let wire = serde_json::to_value(&request).unwrap();
 
+        assert_eq!(
+            wire["params"]["textEdit"]["range"]["start"]["line"], 0,
+            "the resolve request must carry VIRTUAL coordinates (host 5 → virtual 0): {wire}"
+        );
+        assert_eq!(wire["params"]["textEdit"]["range"]["end"]["line"], 0);
+        // The served item stays host-translated for the fail-soft returns.
         let Some(tower_lsp_server::ls_types::CompletionTextEdit::Edit(edit)) = &item.text_edit
         else {
             panic!("edit variant preserved");
         };
-        assert_eq!(edit.range.start.line, 0, "host line 5 → virtual line 0");
-        assert_eq!(edit.range.end.line, 0);
+        assert_eq!(edit.range.start.line, 5);
     }
 }

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -7,6 +7,8 @@
 //! completion that produced this item. If the downstream server has since
 //! restarted (or the connection was recreated), the resolve fails and we
 //! return the unresolved item with envelope intact: graceful degradation.
+//! The same degradation serves a resolved item whose primary edit would break
+//! per-line region prefixes (see `resolve_guard_region_end`).
 
 use std::sync::Arc;
 
@@ -182,15 +184,7 @@ impl LanguageServerPool {
         match parse_completion_resolve_response(response) {
             Some(mut resolved) => {
                 let offset = RegionOffset::from(&envelope.offset);
-                // The envelope has no region-content snapshot, so the real
-                // region end is unknown here. Assume a single-line region —
-                // the strictest setting for the prefix-safety guard (it can
-                // only over-strip in PREFIXED regions; unprefixed regions
-                // pass the guard's fast path untouched).
-                let region_end = Position {
-                    line: offset.line(),
-                    character: u32::MAX,
-                };
+                let region_end = resolve_guard_region_end(&envelope, &offset);
                 if transform_completion_item(&mut resolved, &offset, region_end) {
                     re_envelope_item(&mut resolved, &envelope);
                     resolved
@@ -249,8 +243,31 @@ fn re_envelope_item(item: &mut CompletionItem, envelope: &KakehashiEnvelope) {
         server_name: &envelope.origin,
         host_uri: &envelope.host_uri,
         offset: &RegionOffset::from(&envelope.offset),
+        region_end: envelope
+            .region_end
+            .map(|(line, character)| Position { line, character }),
     };
     envelope_item_data(item, &ctx);
+}
+
+/// The `region_end` the resolve-path prefix guard runs with. Normally the
+/// envelope carries the completion-time snapshot verbatim. A LEGACY envelope
+/// (minted before the field existed) has none, and the resolve path cannot
+/// recompute it — fall back to `(region start line, character 0)`, which is
+/// fully fail-closed: with `character == 0` the guard's boundary rule rejects
+/// every edit at or past the region start in per-line-prefixed regions (the
+/// unresolved item is served instead), while unprefixed regions still pass
+/// via the all-zero fast path. A permissive sentinel here would disable the
+/// boundary rule entirely and let fence-row edits through — never trade that
+/// for fewer over-strips on envelopes that disappear after one session.
+fn resolve_guard_region_end(envelope: &KakehashiEnvelope, offset: &RegionOffset) -> Position {
+    envelope
+        .region_end
+        .map(|(line, character)| Position { line, character })
+        .unwrap_or(Position {
+            line: offset.line(),
+            character: 0,
+        })
 }
 
 #[cfg(test)]
@@ -271,7 +288,72 @@ mod tests {
                 column: 0,
                 line_column_offsets: None,
             },
+            region_end: Some((9, 0)),
         }
+    }
+
+    // ==========================================================================
+    // resolve_guard_region_end tests
+    // ==========================================================================
+
+    #[test]
+    fn guard_region_end_uses_the_envelope_snapshot_when_carried() {
+        let envelope = test_envelope();
+        let offset = RegionOffset::from(&envelope.offset);
+        assert_eq!(
+            resolve_guard_region_end(&envelope, &offset),
+            Position {
+                line: 9,
+                character: 0
+            },
+        );
+    }
+
+    #[test]
+    fn guard_region_end_falls_back_fail_closed_for_legacy_envelopes() {
+        let mut envelope = test_envelope();
+        envelope.region_end = None;
+        envelope.offset.line = 3;
+        envelope.offset.line_column_offsets = Some(vec![2, 2, 0]);
+        let offset = RegionOffset::from(&envelope.offset);
+
+        let region_end = resolve_guard_region_end(&envelope, &offset);
+        assert_eq!(
+            region_end,
+            Position {
+                line: 3,
+                character: 0
+            },
+            "legacy fallback anchors the boundary at the region start"
+        );
+
+        // Fail-closed: with character 0 the guard's boundary rule rejects even
+        // a same-line, newline-free edit in this per-line-prefixed region —
+        // the resolve serves the unresolved item rather than guessing where
+        // the region really ends.
+        let mut resolved = CompletionItem {
+            label: "x".into(),
+            text_edit: Some(tower_lsp_server::ls_types::CompletionTextEdit::Edit(
+                tower_lsp_server::ls_types::TextEdit {
+                    range: tower_lsp_server::ls_types::Range {
+                        start: Position {
+                            line: 0,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 0,
+                            character: 3,
+                        },
+                    },
+                    new_text: "single".into(),
+                },
+            )),
+            ..Default::default()
+        };
+        assert!(
+            !transform_completion_item(&mut resolved, &offset, region_end),
+            "prefixed-region edits must be rejected under the legacy fallback"
+        );
     }
 
     // ==========================================================================
@@ -394,6 +476,7 @@ mod tests {
                 column: 0,
                 line_column_offsets: None,
             },
+            region_end: Some((9, 0)),
         };
         let mut item = CompletionItem {
             label: "print".to_string(),

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -194,7 +194,7 @@ impl LanguageServerPool {
                     // guard-passed) item instead of a corrupting one.
                     warn!(
                         target: "kakehashi::bridge",
-                        "completionItem/resolve: resolved item from {} would break region line prefixes; serving unresolved item",
+                        "completionItem/resolve: resolved item from {} carries an edit unsafe for the injection region; serving unresolved item",
                         server_name
                     );
                     re_envelope_item(&mut item, &envelope);

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -147,15 +147,9 @@ impl LanguageServerPool {
                 }
             };
 
-        // Forward with the item's edit ranges restored to VIRTUAL coordinates
-        // (the served item is host-translated; a downstream that echoes the
-        // ranges verbatim would otherwise get them re-translated on the way
-        // back — a double shift the safety guard can't always catch). The
-        // original host-coordinate `item` is kept untouched for the
-        // fail-soft returns below. Mirrors the codeAction resolve path.
-        let mut outgoing = item.clone();
-        translate_item_ranges_host_to_virtual(&mut outgoing, &RegionOffset::from(&envelope.offset));
-        let request = build_completion_resolve_request(&outgoing, request_id);
+        // The original host-coordinate `item` is kept untouched for the
+        // fail-soft returns below.
+        let request = prepare_completion_resolve_request(&item, &envelope, request_id);
 
         let mut router_guard = RouterCleanupGuard::new(Arc::clone(handle.router()), request_id);
 
@@ -226,9 +220,9 @@ impl LanguageServerPool {
 /// The `completionItem/resolve` method is unique: its params is the
 /// `CompletionItem` itself (not a wrapper struct), per the LSP spec.
 fn build_completion_resolve_request(
-    item: &CompletionItem,
+    item: CompletionItem,
     request_id: RequestId,
-) -> JsonRpcRequest<&CompletionItem> {
+) -> JsonRpcRequest<CompletionItem> {
     JsonRpcRequest::new(request_id.as_i64(), "completionItem/resolve", item)
 }
 
@@ -244,6 +238,21 @@ fn parse_completion_resolve_response(mut response: serde_json::Value) -> Option<
         return None;
     }
     serde_json::from_value(result).ok()
+}
+
+/// Build the outgoing `completionItem/resolve` request from a SERVED item:
+/// a clone with its edit ranges restored to VIRTUAL coordinates (the served
+/// item is host-translated; a downstream that echoes the ranges verbatim
+/// would otherwise get them re-translated on the way back — a double shift
+/// the safety guard can't always catch). Mirrors the codeAction resolve path.
+fn prepare_completion_resolve_request(
+    item: &CompletionItem,
+    envelope: &KakehashiEnvelope,
+    request_id: RequestId,
+) -> JsonRpcRequest<CompletionItem> {
+    let mut outgoing = item.clone();
+    translate_item_ranges_host_to_virtual(&mut outgoing, &RegionOffset::from(&envelope.offset));
+    build_completion_resolve_request(outgoing, request_id)
 }
 
 /// Translate a served (host-coordinate) item's edit ranges back to virtual
@@ -409,7 +418,7 @@ mod tests {
             data: Some(json!({"resolve_id": 99})),
             ..Default::default()
         };
-        let request = build_completion_resolve_request(&item, RequestId::new(7));
+        let request = build_completion_resolve_request(item, RequestId::new(7));
 
         let json = serde_json::to_value(&request).unwrap();
         assert_eq!(json["jsonrpc"], "2.0");
@@ -696,15 +705,10 @@ mod tests {
             ..Default::default()
         };
         let envelope = test_envelope();
-        let offset = RegionOffset::from(&envelope.offset);
 
-        // Reproduce the production wiring: clone, untranslate, build the
-        // outgoing request — and assert on the SERIALIZED request, so
-        // removing the untranslation step in send_completion_resolve_request
-        // has a matching failure here.
-        let mut outgoing = item.clone();
-        translate_item_ranges_host_to_virtual(&mut outgoing, &offset);
-        let request = build_completion_resolve_request(&outgoing, RequestId::new(7));
+        // Go through the SAME request-preparation helper production uses, and
+        // assert on the serialized request.
+        let request = prepare_completion_resolve_request(&item, &envelope, RequestId::new(7));
         let wire = serde_json::to_value(&request).unwrap();
 
         assert_eq!(

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -186,7 +186,7 @@ impl LanguageServerPool {
             Some(mut resolved) => {
                 let offset = RegionOffset::from(&envelope.offset);
                 let region_end = resolve_guard_region_end(&envelope, &offset);
-                if transform_completion_item(&mut resolved, &offset, region_end) {
+                if transform_completion_item(&mut resolved, &offset, region_end, None) {
                     re_envelope_item(&mut resolved, &envelope);
                     resolved
                 } else {
@@ -360,7 +360,7 @@ mod tests {
             ..Default::default()
         };
         assert!(
-            !transform_completion_item(&mut resolved, &offset, region_end),
+            !transform_completion_item(&mut resolved, &offset, region_end, None),
             "prefixed-region edits must be rejected under the legacy fallback"
         );
     }

--- a/src/lsp/bridge/text_document/formatting.rs
+++ b/src/lsp/bridge/text_document/formatting.rs
@@ -6,16 +6,21 @@
 //! so [`super::range_formatting`], which shares the same virtual→host hazards,
 //! can reuse them.
 //!
-//! # Known limitation: multi-line edits drop host indentation
+//! # Known limitation: multi-line edits in prefixed regions are DROPPED
 //!
 //! [`RegionOffset::column_for_line`] translates positions correctly for both
 //! `new()` (single-column) and `with_per_line_offsets()` (blockquote `> `) shapes.
 //! But `new_text` of a multi-line edit starts at column 0 of the embedded language,
-//! so replacement lines insert at host column 0 instead of re-applying the indent
-//! or `> ` prefix. Single-line edits and zero-width inserts (the common
-//! `trimTrailingWhitespace` / `insertFinalNewline` cases) are unaffected. Fixing
-//! this means rewriting `new_text` per embedded newline; deferred because it
-//! interacts with `trim_final_newlines` semantics.
+//! so replacement lines would insert at host column 0 instead of re-applying the
+//! `> ` prefix. Such edits are now dropped by the shared prefix guard
+//! (`text_edit_preserves_line_prefixes`) rather than corrupting the host
+//! document. Single-line edits and zero-width inserts (the common
+//! `trimTrailingWhitespace` cases) pass through, and unprefixed regions are
+//! unaffected. Re-applying prefixes to `new_text` (which would let these
+//! edits APPLY instead of dropping) means rewriting it per embedded newline;
+//! deferred because it interacts with `trim_final_newlines` semantics —
+//! the lsp_impl concatenated pipeline's `reapply_host_line_prefixes` is the
+//! model if demand appears.
 
 use std::io;
 
@@ -23,15 +28,16 @@ use log::warn;
 
 use crate::config::settings::BridgeServerConfig;
 use tower_lsp_server::ls_types::{
-    DocumentFormattingParams, FormattingOptions, NumberOrString, TextDocumentIdentifier, TextEdit,
-    WorkDoneProgressParams,
+    DocumentFormattingParams, FormattingOptions, NumberOrString, Position, TextDocumentIdentifier,
+    TextEdit, WorkDoneProgressParams,
 };
 use url::Url;
 
 use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::translate_virtual_range_to_host;
 use super::super::protocol::{
-    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, response_has_jsonrpc_error,
+    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, region_host_end,
+    response_has_jsonrpc_error, text_edit_preserves_line_prefixes,
 };
 
 impl LanguageServerPool {
@@ -70,6 +76,7 @@ impl LanguageServerPool {
             return Ok(None);
         }
         let virtual_line_count = count_lines(virtual_content);
+        let region_end = region_host_end(virtual_content, &offset);
         self.execute_bridge_request_observed(
             handle,
             host_uri,
@@ -85,8 +92,13 @@ impl LanguageServerPool {
             // malformed payloads to `Err` (request failure) — only the
             // no-capability early return above yields `Ok(None)`.
             |response, ctx| {
-                transform_formatting_response_to_host(response, ctx.offset, virtual_line_count)
-                    .map(Some)
+                transform_formatting_response_to_host(
+                    response,
+                    ctx.offset,
+                    virtual_line_count,
+                    region_end,
+                )
+                .map(Some)
             },
             downstream_id_probe,
         )
@@ -176,6 +188,7 @@ pub(super) fn transform_formatting_response_to_host(
     mut response: serde_json::Value,
     offset: &RegionOffset,
     virtual_line_count: u32,
+    region_end: Position,
 ) -> io::Result<Vec<TextEdit>> {
     if response_has_jsonrpc_error(&response, "formatting-style request") {
         return Err(io::Error::other(
@@ -252,6 +265,23 @@ pub(super) fn transform_formatting_response_to_host(
         translate_virtual_range_to_host(&mut edit.range, offset);
     }
 
+    // Prefix safety (same guard codeAction/rename/applyEdit apply via the
+    // WorkspaceEdit form): the transform translates RANGES but emits newText
+    // verbatim, so a multi-line replacement or newline insertion in a
+    // prefixed (blockquote) region would strip the `> ` prefixes it overlaps.
+    // Drop the unsafe edits — mirroring the past-EOF drop above — rather than
+    // corrupt the host document. All-zero regions (plain fences) fast-path.
+    let before_prefix = edits.len();
+    edits.retain(|edit| text_edit_preserves_line_prefixes(edit, offset, region_end));
+    let dropped_prefix = before_prefix.saturating_sub(edits.len());
+    if dropped_prefix > 0 {
+        warn!(
+            target: "kakehashi::bridge",
+            "Dropped {dropped_prefix} formatting edit(s) that would strip the region's \
+             per-line host prefixes (e.g. a blockquote's `> `)"
+        );
+    }
+
     Ok(edits)
 }
 
@@ -261,6 +291,48 @@ mod tests {
     use super::*;
     use rstest::rstest;
     use serde_json::json;
+
+    /// Generous host region end for fixtures that don't exercise the prefix
+    /// guard (their prefixless offsets fast-path it).
+    const TEST_REGION_END: Position = Position {
+        line: u32::MAX,
+        character: u32::MAX,
+    };
+
+    #[test]
+    fn transform_drops_prefix_breaking_edits_in_blockquote_regions() {
+        // Blockquote region (production offsets: per-line `> ` widths plus the
+        // trailing boundary-row zero), content host lines 3-4, fence line 5,
+        // region end (5, 0). A whole-block multi-line replacement — the
+        // classic formatter shape — would strip the interior prefixes; it
+        // must be dropped. A single-line edit behind the prefix survives.
+        let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2, 0]);
+        let region_end = Position {
+            line: 5,
+            character: 0,
+        };
+        let response = json!({
+            "jsonrpc": "2.0", "id": 1,
+            "result": [
+                { "range": { "start": { "line": 0, "character": 0 },
+                             "end": { "line": 1, "character": 4 } },
+                  "newText": "formatted\nlines" },
+                { "range": { "start": { "line": 1, "character": 0 },
+                             "end": { "line": 1, "character": 4 } },
+                  "newText": "safe" }
+            ]
+        });
+
+        let edits =
+            transform_formatting_response_to_host(response, &offset, 2, region_end).unwrap();
+
+        assert_eq!(
+            edits.len(),
+            1,
+            "the multi-line prefix-breaking edit must be dropped: {edits:?}"
+        );
+        assert_eq!(edits[0].new_text, "safe");
+    }
 
     fn default_options() -> FormattingOptions {
         FormattingOptions {
@@ -377,9 +449,13 @@ mod tests {
             ]
         });
 
-        let edits =
-            transform_formatting_response_to_host(response, &RegionOffset::new(10, 0), UNBOUNDED)
-                .unwrap();
+        let edits = transform_formatting_response_to_host(
+            response,
+            &RegionOffset::new(10, 0),
+            UNBOUNDED,
+            TEST_REGION_END,
+        )
+        .unwrap();
 
         assert_eq!(edits.len(), 2);
         assert_eq!(edits[0].range.start.line, 10);
@@ -414,9 +490,13 @@ mod tests {
             ]
         });
 
-        let edits =
-            transform_formatting_response_to_host(response, &RegionOffset::new(5, 4), UNBOUNDED)
-                .unwrap();
+        let edits = transform_formatting_response_to_host(
+            response,
+            &RegionOffset::new(5, 4),
+            UNBOUNDED,
+            TEST_REGION_END,
+        )
+        .unwrap();
 
         // Line 0 in virtual → line 5 in host, character shifted by column offset 4
         assert_eq!(edits[0].range.start.line, 5);
@@ -439,8 +519,12 @@ mod tests {
         // Error / missing / malformed must be `Err` (request failure) — not
         // the no-capability `None` — so the fan-in counts it and CLI mode
         // can exit non-zero for a broken formatter.
-        let transformed =
-            transform_formatting_response_to_host(response, &RegionOffset::new(5, 0), UNBOUNDED);
+        let transformed = transform_formatting_response_to_host(
+            response,
+            &RegionOffset::new(5, 0),
+            UNBOUNDED,
+            TEST_REGION_END,
+        );
         assert!(transformed.is_err());
     }
 
@@ -455,9 +539,13 @@ mod tests {
         // concatenated-formatting-pipeline Decision point 3.2).
         let response = json!({"jsonrpc": "2.0", "id": 42, "result": null});
 
-        let transformed =
-            transform_formatting_response_to_host(response, &RegionOffset::new(5, 0), UNBOUNDED)
-                .expect("null result is a handled response, not a failure");
+        let transformed = transform_formatting_response_to_host(
+            response,
+            &RegionOffset::new(5, 0),
+            UNBOUNDED,
+            TEST_REGION_END,
+        )
+        .expect("null result is a handled response, not a failure");
 
         assert_eq!(
             transformed,
@@ -470,9 +558,13 @@ mod tests {
     fn formatting_response_with_empty_array_returns_empty_vec() {
         let response = json!({ "jsonrpc": "2.0", "id": 42, "result": [] });
 
-        let edits =
-            transform_formatting_response_to_host(response, &RegionOffset::new(5, 0), UNBOUNDED)
-                .unwrap();
+        let edits = transform_formatting_response_to_host(
+            response,
+            &RegionOffset::new(5, 0),
+            UNBOUNDED,
+            TEST_REGION_END,
+        )
+        .unwrap();
         assert!(edits.is_empty());
     }
 
@@ -493,9 +585,13 @@ mod tests {
             }]
         });
 
-        let edits =
-            transform_formatting_response_to_host(response, &RegionOffset::new(u32::MAX - 1, 0), 2)
-                .unwrap();
+        let edits = transform_formatting_response_to_host(
+            response,
+            &RegionOffset::new(u32::MAX - 1, 0),
+            2,
+            TEST_REGION_END,
+        )
+        .unwrap();
 
         assert_eq!(edits.len(), 1);
         assert_eq!(
@@ -536,8 +632,13 @@ mod tests {
             ]
         });
 
-        let edits =
-            transform_formatting_response_to_host(response, &RegionOffset::new(10, 0), 3).unwrap();
+        let edits = transform_formatting_response_to_host(
+            response,
+            &RegionOffset::new(10, 0),
+            3,
+            TEST_REGION_END,
+        )
+        .unwrap();
 
         assert_eq!(edits.len(), 1, "synthetic-EOF-anchored edit is kept");
         assert_eq!(edits[0].new_text, "\n");
@@ -567,8 +668,13 @@ mod tests {
             ]
         });
 
-        let edits =
-            transform_formatting_response_to_host(response, &RegionOffset::new(10, 0), 3).unwrap();
+        let edits = transform_formatting_response_to_host(
+            response,
+            &RegionOffset::new(10, 0),
+            3,
+            TEST_REGION_END,
+        )
+        .unwrap();
 
         assert_eq!(edits.len(), 1, "in-bounds zero-width EOF insert is kept");
         assert_eq!(edits[0].new_text, "\n");
@@ -599,8 +705,13 @@ mod tests {
             ]
         });
 
-        let edits =
-            transform_formatting_response_to_host(response, &RegionOffset::new(10, 0), 2).unwrap();
+        let edits = transform_formatting_response_to_host(
+            response,
+            &RegionOffset::new(10, 0),
+            2,
+            TEST_REGION_END,
+        )
+        .unwrap();
 
         assert_eq!(edits.len(), 1, "only the in-bounds edit survives");
         assert_eq!(edits[0].new_text, "    ");
@@ -649,8 +760,13 @@ mod tests {
             ]
         });
 
-        let edits =
-            transform_formatting_response_to_host(response, &RegionOffset::new(10, 0), 1).unwrap();
+        let edits = transform_formatting_response_to_host(
+            response,
+            &RegionOffset::new(10, 0),
+            1,
+            TEST_REGION_END,
+        )
+        .unwrap();
 
         assert_eq!(edits.len(), 1, "canonical insertFinalNewline shape kept");
         assert_eq!(edits[0].new_text, "\n");
@@ -686,8 +802,13 @@ mod tests {
             ]
         });
 
-        let edits =
-            transform_formatting_response_to_host(response, &RegionOffset::new(0, 0), 2).unwrap();
+        let edits = transform_formatting_response_to_host(
+            response,
+            &RegionOffset::new(0, 0),
+            2,
+            TEST_REGION_END,
+        )
+        .unwrap();
 
         assert_eq!(edits.len(), 1, "boundary-crossing replacement kept");
         assert_eq!(edits[0].range.start.line, 1);
@@ -718,8 +839,13 @@ mod tests {
             ]
         });
 
-        let edits =
-            transform_formatting_response_to_host(response, &RegionOffset::new(0, 0), 2).unwrap();
+        let edits = transform_formatting_response_to_host(
+            response,
+            &RegionOffset::new(0, 0),
+            2,
+            TEST_REGION_END,
+        )
+        .unwrap();
 
         assert!(
             edits.is_empty(),
@@ -747,8 +873,13 @@ mod tests {
             ]
         });
 
-        let edits =
-            transform_formatting_response_to_host(response, &RegionOffset::new(0, 0), 2).unwrap();
+        let edits = transform_formatting_response_to_host(
+            response,
+            &RegionOffset::new(0, 0),
+            2,
+            TEST_REGION_END,
+        )
+        .unwrap();
 
         assert!(
             edits.is_empty(),

--- a/src/lsp/bridge/text_document/formatting.rs
+++ b/src/lsp/bridge/text_document/formatting.rs
@@ -6,17 +6,18 @@
 //! so [`super::range_formatting`], which shares the same virtual→host hazards,
 //! can reuse them.
 //!
-//! # Known limitation: multi-line edits in prefixed regions are DROPPED
+//! # Known limitation: formatting in prefixed regions can drop WHOLE responses
 //!
 //! [`RegionOffset::column_for_line`] translates positions correctly for both
 //! `new()` (single-column) and `with_per_line_offsets()` (blockquote `> `) shapes.
 //! But `new_text` of a multi-line edit starts at column 0 of the embedded language,
 //! so replacement lines would insert at host column 0 instead of re-applying the
-//! `> ` prefix. Such edits are now dropped by the shared prefix guard
-//! (`text_edit_preserves_line_prefixes`) rather than corrupting the host
-//! document. Single-line edits and zero-width inserts (the common
-//! `trimTrailingWhitespace` cases) pass through, and unprefixed regions are
-//! unaffected. Re-applying prefixes to `new_text` (which would let these
+//! `> ` prefix. A response containing any such edit is dropped WHOLE by the
+//! shared prefix guard (`text_edit_preserves_line_prefixes`) — a formatter
+//! answer is one atomic diff, so applying only its safe edits could
+//! duplicate or lose content. All-safe responses (single-line edits and
+//! zero-width inserts — the common `trimTrailingWhitespace` cases) pass
+//! through, and unprefixed regions are unaffected. Re-applying prefixes to `new_text` (which would let these
 //! edits APPLY instead of dropping) means rewriting it per embedded newline;
 //! deferred because it interacts with `trim_final_newlines` semantics —
 //! the lsp_impl concatenated pipeline's `reapply_host_line_prefixes` is the

--- a/src/lsp/bridge/text_document/formatting.rs
+++ b/src/lsp/bridge/text_document/formatting.rs
@@ -121,9 +121,10 @@ pub(super) fn count_lines(text: &str) -> u32 {
 
 /// If `pos` is the "synthetic next-line anchor" (column 0 of the line
 /// immediately after `last_real_line`), rewrite it to (last_real_line,
-/// u32::MAX) so the editor's standard end-of-line clamping snaps it to the
-/// real last column. Used to accept the canonical insertFinalNewline shape
-/// without dropping it as past-EOF.
+/// u32::MAX) — a sentinel the transform later snaps to the region's
+/// content-precise host end (see `transform_formatting_response_to_host`).
+/// Used to accept the canonical insertFinalNewline shape without dropping it
+/// as past-EOF.
 ///
 /// `virtual_line_count` is the synthetic-line index — i.e., the value that
 /// would be `last_real_line + 1` for non-empty docs. Passed in to avoid
@@ -262,6 +263,28 @@ pub(super) fn transform_formatting_response_to_host(
 
     for edit in &mut edits {
         translate_virtual_range_to_host(&mut edit.range, offset);
+    }
+
+    // Clamp synthetic-EOF sentinels into the region: the (last line, u32::MAX)
+    // sentinel from `clamp_synthetic_eof_anchor` saturates through translation
+    // and would otherwise fail the exact containment check below, dropping
+    // every canonical insertFinalNewline response. Clamping to `region_end`
+    // (the content-precise host end) is exact — the sentinel means "end of
+    // the region's last content line", which IS the region end. Restricted to
+    // the last content line: a stray u32::MAX character anywhere else stays
+    // put and fails containment (fail-closed).
+    let last_real_host_line = offset
+        .line()
+        .saturating_add(virtual_line_count.saturating_sub(1));
+    for edit in &mut edits {
+        for pos in [&mut edit.range.start, &mut edit.range.end] {
+            if pos.character == u32::MAX
+                && pos.line == last_real_host_line
+                && (pos.line, pos.character) > (region_end.line, region_end.character)
+            {
+                *pos = region_end;
+            }
+        }
     }
 
     // Prefix safety (same guard codeAction/rename/applyEdit apply via the
@@ -743,6 +766,36 @@ mod tests {
             edits.is_empty(),
             "any out-of-bounds edit must drop the whole response: {edits:?}"
         );
+    }
+
+    #[test]
+    fn insert_final_newline_survives_a_realistic_region_end() {
+        // Content "local x = 1" (no trailing newline) at host line 3 in a
+        // plain fence: region end is the exact content end (3, 11), NOT a
+        // permissive sentinel. The canonical insertFinalNewline shape — a
+        // zero-width insert at the synthetic next-line anchor — must snap to
+        // the region end and survive containment.
+        let offset = RegionOffset::new(3, 0);
+        let region_end = Position {
+            line: 3,
+            character: 11,
+        };
+        let response = json!({
+            "jsonrpc": "2.0", "id": 42,
+            "result": [
+                { "range": { "start": { "line": 1, "character": 0 },
+                             "end": { "line": 1, "character": 0 } },
+                  "newText": "\n" }
+            ]
+        });
+
+        let edits =
+            transform_formatting_response_to_host(response, &offset, 1, region_end).unwrap();
+
+        assert_eq!(edits.len(), 1, "insertFinalNewline must survive: {edits:?}");
+        assert_eq!(edits[0].range.start, region_end);
+        assert_eq!(edits[0].range.end, region_end);
+        assert_eq!(edits[0].new_text, "\n");
     }
 
     #[rstest]

--- a/src/lsp/bridge/text_document/formatting.rs
+++ b/src/lsp/bridge/text_document/formatting.rs
@@ -17,8 +17,9 @@
 //! answer is one atomic diff, so applying only its safe edits could
 //! duplicate or lose content. All-safe responses (single-line edits and
 //! zero-width inserts — the common `trimTrailingWhitespace` cases) pass
-//! through (a newline-bearing `new_text` in a prefixed region still rejects),
-//! and unprefixed regions are unaffected. Re-applying prefixes to `new_text` (which would let these
+//! through (a newline-bearing `new_text` in a prefixed region still rejects).
+//! Unprefixed regions are exempt from the prefix rules but still subject to
+//! region containment and the fence-boundary EOL rule. Re-applying prefixes to `new_text` (which would let these
 //! edits APPLY instead of dropping) means rewriting it per embedded newline;
 //! deferred because it interacts with `trim_final_newlines` semantics —
 //! the lsp_impl concatenated pipeline's `reapply_host_line_prefixes` is the
@@ -297,7 +298,8 @@ pub(super) fn transform_formatting_response_to_host(
     // text, so dropping only the unsafe half would duplicate or lose content.
     // If any edit is unsafe, drop the whole response (an empty edit list —
     // the document is left untouched, like the null "already formatted"
-    // answer). All-zero regions (plain fences) fast-path the predicate.
+    // answer). All-zero regions (plain fences) skip the prefix rules but are
+    // still containment- and fence-boundary-checked.
     if !edits
         .iter()
         .all(|edit| text_edit_safe_in_region(edit, offset, region_end))

--- a/src/lsp/bridge/text_document/formatting.rs
+++ b/src/lsp/bridge/text_document/formatting.rs
@@ -306,8 +306,9 @@ pub(super) fn transform_formatting_response_to_host(
     {
         warn!(
             target: "kakehashi::bridge",
-            "Dropped a formatting response ({} edit(s)): it would strip the region's \
-             per-line host prefixes (e.g. a blockquote's `> `)",
+            "Dropped a formatting response ({} edit(s)): an edit is unsafe for the \
+             injection region (escapes it, breaks per-line `> ` prefixes, or merges \
+             content into the closing fence)",
             edits.len()
         );
         return Ok(Vec::new());

--- a/src/lsp/bridge/text_document/formatting.rs
+++ b/src/lsp/bridge/text_document/formatting.rs
@@ -269,17 +269,23 @@ pub(super) fn transform_formatting_response_to_host(
     // WorkspaceEdit form): the transform translates RANGES but emits newText
     // verbatim, so a multi-line replacement or newline insertion in a
     // prefixed (blockquote) region would strip the `> ` prefixes it overlaps.
-    // Drop the unsafe edits — mirroring the past-EOF drop above — rather than
-    // corrupt the host document. All-zero regions (plain fences) fast-path.
-    let before_prefix = edits.len();
-    edits.retain(|edit| text_edit_preserves_line_prefixes(edit, offset, region_end));
-    let dropped_prefix = before_prefix.saturating_sub(edits.len());
-    if dropped_prefix > 0 {
+    // ALL-OR-NOTHING: a formatting response is one atomic diff — formatters
+    // routinely pair a line-deletion with a same-line insertion of the merged
+    // text, so dropping only the unsafe half would duplicate or lose content.
+    // If any edit is unsafe, drop the whole response (an empty edit list —
+    // the document is left untouched, like the null "already formatted"
+    // answer). All-zero regions (plain fences) fast-path the predicate.
+    if !edits
+        .iter()
+        .all(|edit| text_edit_preserves_line_prefixes(edit, offset, region_end))
+    {
         warn!(
             target: "kakehashi::bridge",
-            "Dropped {dropped_prefix} formatting edit(s) that would strip the region's \
-             per-line host prefixes (e.g. a blockquote's `> `)"
+            "Dropped a formatting response ({} edit(s)): it would strip the region's \
+             per-line host prefixes (e.g. a blockquote's `> `)",
+            edits.len()
         );
+        return Ok(Vec::new());
     }
 
     Ok(edits)
@@ -292,20 +298,14 @@ mod tests {
     use rstest::rstest;
     use serde_json::json;
 
-    /// Generous host region end for fixtures that don't exercise the prefix
-    /// guard (their prefixless offsets fast-path it).
-    const TEST_REGION_END: Position = Position {
-        line: u32::MAX,
-        character: u32::MAX,
-    };
-
     #[test]
-    fn transform_drops_prefix_breaking_edits_in_blockquote_regions() {
+    fn transform_drops_the_whole_response_when_any_edit_breaks_prefixes() {
         // Blockquote region (production offsets: per-line `> ` widths plus the
         // trailing boundary-row zero), content host lines 3-4, fence line 5,
-        // region end (5, 0). A whole-block multi-line replacement — the
-        // classic formatter shape — would strip the interior prefixes; it
-        // must be dropped. A single-line edit behind the prefix survives.
+        // region end (5, 0). The response pairs a multi-line prefix-breaking
+        // replacement with a safe single-line edit — the diff halves of one
+        // atomic formatter answer. Applying only the safe half would
+        // duplicate/lose content, so the WHOLE response must drop.
         let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2, 0]);
         let region_end = Position {
             line: 5,
@@ -326,12 +326,37 @@ mod tests {
         let edits =
             transform_formatting_response_to_host(response, &offset, 2, region_end).unwrap();
 
-        assert_eq!(
-            edits.len(),
-            1,
-            "the multi-line prefix-breaking edit must be dropped: {edits:?}"
+        assert!(
+            edits.is_empty(),
+            "a response with any prefix-breaking edit must drop whole: {edits:?}"
         );
+    }
+
+    #[test]
+    fn transform_keeps_an_all_safe_response_in_blockquote_regions() {
+        // Same region: single-line, newline-free edits behind the prefix are
+        // safe and must pass through (translated), not be caught by the
+        // all-or-nothing drop.
+        let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2, 0]);
+        let region_end = Position {
+            line: 5,
+            character: 0,
+        };
+        let response = json!({
+            "jsonrpc": "2.0", "id": 1,
+            "result": [
+                { "range": { "start": { "line": 1, "character": 0 },
+                             "end": { "line": 1, "character": 4 } },
+                  "newText": "safe" }
+            ]
+        });
+
+        let edits =
+            transform_formatting_response_to_host(response, &offset, 2, region_end).unwrap();
+
+        assert_eq!(edits.len(), 1, "all-safe response passes: {edits:?}");
         assert_eq!(edits[0].new_text, "safe");
+        assert_eq!(edits[0].range.start.line, 4, "translated to host line");
     }
 
     fn default_options() -> FormattingOptions {

--- a/src/lsp/bridge/text_document/formatting.rs
+++ b/src/lsp/bridge/text_document/formatting.rs
@@ -17,7 +17,8 @@
 //! answer is one atomic diff, so applying only its safe edits could
 //! duplicate or lose content. All-safe responses (single-line edits and
 //! zero-width inserts — the common `trimTrailingWhitespace` cases) pass
-//! through, and unprefixed regions are unaffected. Re-applying prefixes to `new_text` (which would let these
+//! through (a newline-bearing `new_text` in a prefixed region still rejects),
+//! and unprefixed regions are unaffected. Re-applying prefixes to `new_text` (which would let these
 //! edits APPLY instead of dropping) means rewriting it per embedded newline;
 //! deferred because it interacts with `trim_final_newlines` semantics —
 //! the lsp_impl concatenated pipeline's `reapply_host_line_prefixes` is the

--- a/src/lsp/bridge/text_document/formatting.rs
+++ b/src/lsp/bridge/text_document/formatting.rs
@@ -343,8 +343,8 @@ mod tests {
                 { "range": { "start": { "line": 0, "character": 0 },
                              "end": { "line": 1, "character": 4 } },
                   "newText": "formatted\nlines" },
-                { "range": { "start": { "line": 1, "character": 0 },
-                             "end": { "line": 1, "character": 4 } },
+                { "range": { "start": { "line": 1, "character": 6 },
+                             "end": { "line": 1, "character": 8 } },
                   "newText": "safe" }
             ]
         });

--- a/src/lsp/bridge/text_document/formatting.rs
+++ b/src/lsp/bridge/text_document/formatting.rs
@@ -13,7 +13,7 @@
 //! But `new_text` of a multi-line edit starts at column 0 of the embedded language,
 //! so replacement lines would insert at host column 0 instead of re-applying the
 //! `> ` prefix. A response containing any such edit is dropped WHOLE by the
-//! shared prefix guard (`text_edit_preserves_line_prefixes`) — a formatter
+//! shared prefix guard (`text_edit_safe_in_region`) — a formatter
 //! answer is one atomic diff, so applying only its safe edits could
 //! duplicate or lose content. All-safe responses (single-line edits and
 //! zero-width inserts — the common `trimTrailingWhitespace` cases) pass
@@ -38,7 +38,7 @@ use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::translate_virtual_range_to_host;
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, region_host_end,
-    response_has_jsonrpc_error, text_edit_preserves_line_prefixes,
+    response_has_jsonrpc_error, text_edit_safe_in_region,
 };
 
 impl LanguageServerPool {
@@ -245,21 +245,19 @@ pub(super) fn transform_formatting_response_to_host(
     // function-level docs). Checking both endpoints handles both the common
     // "formatter overshoots EOF" case and the malformed `start > virtual_eof`
     // shape that would otherwise sneak through with an in-bounds `end`.
-    let before = edits.len();
-    edits.retain(|edit| {
+    // ALL-OR-NOTHING (like the prefix gate below): a formatter answer is one
+    // atomic diff, so applying only its in-bounds edits could pair-break a
+    // deletion/insertion and duplicate or lose content.
+    if !edits.iter().all(|edit| {
         edit.range.start.line < virtual_line_count && edit.range.end.line < virtual_line_count
-    });
-    // `retain` never grows the vec so this can't underflow today, but
-    // saturating_sub keeps the count valid if the surrounding logic ever
-    // changes (e.g., a new clamping step that re-inserts edits).
-    let dropped = before.saturating_sub(edits.len());
-    if dropped > 0 {
+    }) {
         warn!(
             target: "kakehashi::bridge",
-            "Dropped {} formatting edit(s) extending past virtual EOF (line {}); would corrupt host content beyond injection region",
-            dropped,
+            "Dropped a formatting response ({} edit(s)): an edit extends past virtual EOF (line {}) and would corrupt host content beyond the injection region",
+            edits.len(),
             virtual_line_count
         );
+        return Ok(Vec::new());
     }
 
     for edit in &mut edits {
@@ -278,7 +276,7 @@ pub(super) fn transform_formatting_response_to_host(
     // answer). All-zero regions (plain fences) fast-path the predicate.
     if !edits
         .iter()
-        .all(|edit| text_edit_preserves_line_prefixes(edit, offset, region_end))
+        .all(|edit| text_edit_safe_in_region(edit, offset, region_end))
     {
         warn!(
             target: "kakehashi::bridge",
@@ -707,9 +705,11 @@ mod tests {
     }
 
     #[test]
-    fn formatting_response_keeps_in_bounds_drops_out_of_bounds() {
+    fn formatting_response_with_an_out_of_bounds_edit_drops_whole() {
         // Mixed batch: a valid edit on line 0 and a malformed edit whose end
-        // extends past EOF. Only the valid one survives.
+        // extends past EOF. A formatter answer is one atomic diff, so the
+        // WHOLE response drops — applying only the valid half could
+        // duplicate or lose content.
         let response = json!({
             "jsonrpc": "2.0",
             "id": 42,
@@ -739,8 +739,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(edits.len(), 1, "only the in-bounds edit survives");
-        assert_eq!(edits[0].new_text, "    ");
+        assert!(
+            edits.is_empty(),
+            "any out-of-bounds edit must drop the whole response: {edits:?}"
+        );
     }
 
     #[rstest]

--- a/src/lsp/bridge/text_document/inlay_hint.rs
+++ b/src/lsp/bridge/text_document/inlay_hint.rs
@@ -797,7 +797,7 @@ mod tests {
             "jsonrpc": "2.0", "id": 42,
             "result": [
                 {
-                    "position": { "line": 0, "character": 5 },
+                    "position": { "line": 1, "character": 4 },
                     "label": ": number",
                     "textEdits": [
                         { "range": { "start": { "line": 0, "character": 0 },
@@ -842,7 +842,7 @@ mod tests {
             "jsonrpc": "2.0", "id": 42,
             "result": [
                 {
-                    "position": { "line": 0, "character": 5 },
+                    "position": { "line": 1, "character": 4 },
                     "label": ": number",
                     "textEdits": [
                         { "range": { "start": { "line": 0, "character": 0 },

--- a/src/lsp/bridge/text_document/inlay_hint.rs
+++ b/src/lsp/bridge/text_document/inlay_hint.rs
@@ -5,9 +5,10 @@
 //!
 //! Unlike position-based requests, inlay hints use a range parameter in the request
 //! that specifies the visible document range. Both request range (host->virtual) and
-//! response positions/textEdits (virtual->host) need transformation. A hint whose
-//! textEdits would break per-line region prefixes (blockquote `> `) is served
-//! without them (see the prefix-safety guard in the response transform).
+//! response positions/textEdits (virtual->host) need transformation. A hint
+//! whose textEdits are unsafe for the injection region (escape it, break
+//! per-line `> ` prefixes, or merge content into the closing fence) is served
+//! without them (see the safety guard in the response transform).
 //!
 //! # Single-Writer Loop (ls-bridge-message-ordering)
 //!

--- a/src/lsp/bridge/text_document/inlay_hint.rs
+++ b/src/lsp/bridge/text_document/inlay_hint.rs
@@ -148,9 +148,9 @@ fn transform_inlay_hint_response_to_host(
         // Transform position to host coordinates
         translate_virtual_position_to_host(&mut hint.position, offset);
 
-        // Transform textEdits ranges. If ANY edit would break region line
-        // prefixes (e.g. blockquote `> `) when applied verbatim, strip them
-        // ALL: the client applies the whole array on accept (LSP 3.18), so a
+        // Transform textEdits ranges. If ANY edit is unsafe for the injection
+        // region (escapes it, breaks `> ` prefixes, or merges content into
+        // the closing fence) when applied verbatim, strip them ALL: the client applies the whole array on accept (LSP 3.18), so a
         // partial set could apply half of an interdependent pair. The hint
         // itself stays useful without its accept edits (textEdits optional).
         if let Some(text_edits) = &mut hint.text_edits {
@@ -163,7 +163,7 @@ fn transform_inlay_hint_response_to_host(
             {
                 log::warn!(
                     target: "kakehashi::bridge",
-                    "inlayHint: dropped a hint's textEdits ({}): an edit is unsafe for the injection region (escapes it or breaks line prefixes)",
+                    "inlayHint: dropped a hint's textEdits ({}): an edit is unsafe for the injection region (escapes it, breaks line prefixes, or merges content into the closing fence)",
                     text_edits.len()
                 );
                 hint.text_edits = None;

--- a/src/lsp/bridge/text_document/inlay_hint.rs
+++ b/src/lsp/bridge/text_document/inlay_hint.rs
@@ -151,9 +151,10 @@ fn transform_inlay_hint_response_to_host(
 
         // Transform textEdits ranges. If ANY edit is unsafe for the injection
         // region (escapes it, breaks `> ` prefixes, or merges content into
-        // the closing fence) when applied verbatim, strip them ALL: the client applies the whole array on accept (LSP 3.18), so a
-        // partial set could apply half of an interdependent pair. The hint
-        // itself stays useful without its accept edits (textEdits optional).
+        // the closing fence) when applied verbatim, strip them ALL: the
+        // client applies the whole array on accept (LSP 3.18), so a partial
+        // set could apply half of an interdependent pair. The hint itself
+        // stays useful without its accept edits (textEdits optional).
         if let Some(text_edits) = &mut hint.text_edits {
             for edit in text_edits.iter_mut() {
                 translate_virtual_range_to_host(&mut edit.range, offset);

--- a/src/lsp/bridge/text_document/inlay_hint.rs
+++ b/src/lsp/bridge/text_document/inlay_hint.rs
@@ -5,7 +5,9 @@
 //!
 //! Unlike position-based requests, inlay hints use a range parameter in the request
 //! that specifies the visible document range. Both request range (host->virtual) and
-//! response positions/textEdits (virtual->host) need transformation.
+//! response positions/textEdits (virtual->host) need transformation. A hint whose
+//! textEdits would break per-line region prefixes (blockquote `> `) is served
+//! without them (see the prefix-safety guard in the response transform).
 //!
 //! # Single-Writer Loop (ls-bridge-message-ordering)
 //!
@@ -146,21 +148,25 @@ fn transform_inlay_hint_response_to_host(
         // Transform position to host coordinates
         translate_virtual_position_to_host(&mut hint.position, offset);
 
-        // Transform textEdits ranges, stripping any edit that would break
-        // region line prefixes (e.g. blockquote `> `) if applied verbatim.
-        // The hint itself stays useful without its double-click edit.
+        // Transform textEdits ranges. If ANY edit would break region line
+        // prefixes (e.g. blockquote `> `) when applied verbatim, strip them
+        // ALL: the client applies the whole array on accept (LSP 3.18), so a
+        // partial set could apply half of an interdependent pair. The hint
+        // itself stays useful without its accept edits (textEdits optional).
         if let Some(text_edits) = &mut hint.text_edits {
-            let before = text_edits.len();
             for edit in text_edits.iter_mut() {
                 translate_virtual_range_to_host(&mut edit.range, offset);
             }
-            text_edits.retain(|edit| text_edit_preserves_line_prefixes(edit, offset, region_end));
-            let dropped = before - text_edits.len();
-            if dropped > 0 {
+            if !text_edits
+                .iter()
+                .all(|edit| text_edit_preserves_line_prefixes(edit, offset, region_end))
+            {
                 log::warn!(
                     target: "kakehashi::bridge",
-                    "inlayHint: stripped {dropped} textEdit(s) that would break region line prefixes"
+                    "inlayHint: dropped a hint's textEdits ({}): they would break region line prefixes",
+                    text_edits.len()
                 );
+                hint.text_edits = None;
             }
         }
 
@@ -200,13 +206,6 @@ mod tests {
     use super::*;
     use rstest::rstest;
     use serde_json::json;
-
-    /// A region end far past any test edit: keeps the prefix-safety guard out
-    /// of the way for tests that exercise coordinate translation only.
-    const TEST_REGION_END: Position = Position {
-        line: u32::MAX,
-        character: u32::MAX,
-    };
 
     // ==========================================================================
     // Inlay hint request builder tests
@@ -783,10 +782,11 @@ mod tests {
     }
 
     #[test]
-    fn inlay_hint_strips_prefix_breaking_text_edits() {
+    fn inlay_hint_drops_all_text_edits_when_any_breaks_prefixes() {
         // Blockquote region, content host lines 3-4, region end (5, 0). A
         // hint textEdit spanning prefixed lines would strip the `> ` prefix
-        // when double-click-applied — strip it; the hint itself is kept.
+        // when accept-applied; the accept set applies atomically, so ALL
+        // textEdits drop while the (display-only) hint itself is kept.
         let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2, 0]);
         let region_end = Position {
             line: 5,
@@ -820,8 +820,10 @@ mod tests {
         .unwrap();
 
         assert_eq!(hints.len(), 1, "the hint itself is kept");
-        let edits = hints[0].text_edits.as_ref().unwrap();
-        assert_eq!(edits.len(), 1, "prefix-breaking textEdit is stripped");
-        assert_eq!(edits[0].new_text, ": number");
+        assert!(
+            hints[0].text_edits.is_none(),
+            "one unsafe edit drops the WHOLE accept-edit set (it applies atomically): {:?}",
+            hints[0].text_edits
+        );
     }
 }

--- a/src/lsp/bridge/text_document/inlay_hint.rs
+++ b/src/lsp/bridge/text_document/inlay_hint.rs
@@ -803,8 +803,8 @@ mod tests {
                         { "range": { "start": { "line": 0, "character": 0 },
                                      "end": { "line": 1, "character": 2 } },
                           "newText": "a\nb" },
-                        { "range": { "start": { "line": 0, "character": 5 },
-                                     "end": { "line": 0, "character": 5 } },
+                        { "range": { "start": { "line": 1, "character": 5 },
+                                     "end": { "line": 1, "character": 5 } },
                           "newText": ": number" }
                     ]
                 }

--- a/src/lsp/bridge/text_document/inlay_hint.rs
+++ b/src/lsp/bridge/text_document/inlay_hint.rs
@@ -163,7 +163,7 @@ fn transform_inlay_hint_response_to_host(
             {
                 log::warn!(
                     target: "kakehashi::bridge",
-                    "inlayHint: dropped a hint's textEdits ({}): they would break region line prefixes",
+                    "inlayHint: dropped a hint's textEdits ({}): an edit is unsafe for the injection region (escapes it or breaks line prefixes)",
                     text_edits.len()
                 );
                 hint.text_edits = None;

--- a/src/lsp/bridge/text_document/inlay_hint.rs
+++ b/src/lsp/bridge/text_document/inlay_hint.rs
@@ -15,7 +15,7 @@
 use std::io;
 
 use crate::config::settings::BridgeServerConfig;
-use tower_lsp_server::ls_types::{InlayHint, InlayHintLabel, Range, Uri};
+use tower_lsp_server::ls_types::{InlayHint, InlayHintLabel, Position, Range, Uri};
 use url::Url;
 
 use super::super::pool::{LanguageServerPool, UpstreamId};
@@ -24,9 +24,9 @@ use tower_lsp_server::ls_types::{
 };
 
 use super::super::protocol::{
-    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, response_has_jsonrpc_error,
-    translate_host_range_to_virtual, translate_virtual_position_to_host,
-    translate_virtual_range_to_host, virtual_uri_to_lsp_uri,
+    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, region_host_end,
+    response_has_jsonrpc_error, text_edit_preserves_line_prefixes, translate_host_range_to_virtual,
+    translate_virtual_position_to_host, translate_virtual_range_to_host, virtual_uri_to_lsp_uri,
 };
 
 impl LanguageServerPool {
@@ -73,11 +73,13 @@ impl LanguageServerPool {
                 )
             },
             |response, ctx| {
+                let region_end = region_host_end(virtual_content, ctx.offset);
                 transform_inlay_hint_response_to_host(
                     response,
                     &ctx.virtual_uri_string,
                     ctx.host_uri_lsp,
                     ctx.offset,
+                    region_end,
                 )
             },
         )
@@ -126,6 +128,7 @@ fn transform_inlay_hint_response_to_host(
     request_virtual_uri: &str,
     host_uri: &Uri,
     offset: &RegionOffset,
+    region_end: Position,
 ) -> Option<Vec<InlayHint>> {
     if response_has_jsonrpc_error(&response, "textDocument/inlayHint") {
         return None;
@@ -143,10 +146,21 @@ fn transform_inlay_hint_response_to_host(
         // Transform position to host coordinates
         translate_virtual_position_to_host(&mut hint.position, offset);
 
-        // Transform textEdits ranges
+        // Transform textEdits ranges, stripping any edit that would break
+        // region line prefixes (e.g. blockquote `> `) if applied verbatim.
+        // The hint itself stays useful without its double-click edit.
         if let Some(text_edits) = &mut hint.text_edits {
+            let before = text_edits.len();
             for edit in text_edits.iter_mut() {
                 translate_virtual_range_to_host(&mut edit.range, offset);
+            }
+            text_edits.retain(|edit| text_edit_preserves_line_prefixes(edit, offset, region_end));
+            let dropped = before - text_edits.len();
+            if dropped > 0 {
+                log::warn!(
+                    target: "kakehashi::bridge",
+                    "inlayHint: stripped {dropped} textEdit(s) that would break region line prefixes"
+                );
             }
         }
 
@@ -186,6 +200,13 @@ mod tests {
     use super::*;
     use rstest::rstest;
     use serde_json::json;
+
+    /// A region end far past any test edit: keeps the prefix-safety guard out
+    /// of the way for tests that exercise coordinate translation only.
+    const TEST_REGION_END: Position = Position {
+        line: u32::MAX,
+        character: u32::MAX,
+    };
 
     // ==========================================================================
     // Inlay hint request builder tests
@@ -424,6 +445,7 @@ mod tests {
             &make_virtual_uri_string(),
             &make_host_uri(),
             &RegionOffset::new(5, 0),
+            TEST_REGION_END,
         );
 
         let hints = hints.unwrap();
@@ -445,6 +467,7 @@ mod tests {
             &make_virtual_uri_string(),
             &make_host_uri(),
             &RegionOffset::new(5, 0),
+            TEST_REGION_END,
         );
         assert!(result.is_none());
     }
@@ -458,6 +481,7 @@ mod tests {
             &make_virtual_uri_string(),
             &make_host_uri(),
             &RegionOffset::new(5, 0),
+            TEST_REGION_END,
         );
 
         assert!(hints.is_some());
@@ -496,6 +520,7 @@ mod tests {
             &make_virtual_uri_string(),
             &make_host_uri(),
             &RegionOffset::new(5, 0),
+            TEST_REGION_END,
         )
         .unwrap();
 
@@ -541,6 +566,7 @@ mod tests {
             &virtual_uri,
             &host_uri,
             &RegionOffset::new(10, 0),
+            TEST_REGION_END,
         )
         .unwrap();
 
@@ -590,6 +616,7 @@ mod tests {
             &virtual_uri,
             &host_uri,
             &RegionOffset::new(10, 0),
+            TEST_REGION_END,
         )
         .unwrap();
 
@@ -648,6 +675,7 @@ mod tests {
             &virtual_uri,
             &host_uri,
             &RegionOffset::new(10, 0),
+            TEST_REGION_END,
         )
         .unwrap();
 
@@ -687,6 +715,7 @@ mod tests {
             &make_virtual_uri_string(),
             &make_host_uri(),
             &RegionOffset::new(region_start_line, 0),
+            TEST_REGION_END,
         );
 
         assert!(hints.is_some());
@@ -738,6 +767,7 @@ mod tests {
             &virtual_uri,
             &host_uri,
             &RegionOffset::new(10, 0),
+            TEST_REGION_END,
         )
         .unwrap();
 
@@ -750,5 +780,48 @@ mod tests {
         } else {
             panic!("Expected LabelParts variant");
         }
+    }
+
+    #[test]
+    fn inlay_hint_strips_prefix_breaking_text_edits() {
+        // Blockquote region, content host lines 3-4, region end (5, 0). A
+        // hint textEdit spanning prefixed lines would strip the `> ` prefix
+        // when double-click-applied — strip it; the hint itself is kept.
+        let offset = RegionOffset::with_per_line_offsets(3, vec![2, 2, 0]);
+        let region_end = Position {
+            line: 5,
+            character: 0,
+        };
+        let response = json!({
+            "jsonrpc": "2.0", "id": 42,
+            "result": [
+                {
+                    "position": { "line": 0, "character": 5 },
+                    "label": ": number",
+                    "textEdits": [
+                        { "range": { "start": { "line": 0, "character": 0 },
+                                     "end": { "line": 1, "character": 2 } },
+                          "newText": "a\nb" },
+                        { "range": { "start": { "line": 0, "character": 5 },
+                                     "end": { "line": 0, "character": 5 } },
+                          "newText": ": number" }
+                    ]
+                }
+            ]
+        });
+
+        let hints = transform_inlay_hint_response_to_host(
+            response,
+            &make_virtual_uri_string(),
+            &make_host_uri(),
+            &offset,
+            region_end,
+        )
+        .unwrap();
+
+        assert_eq!(hints.len(), 1, "the hint itself is kept");
+        let edits = hints[0].text_edits.as_ref().unwrap();
+        assert_eq!(edits.len(), 1, "prefix-breaking textEdit is stripped");
+        assert_eq!(edits[0].new_text, ": number");
     }
 }

--- a/src/lsp/bridge/text_document/inlay_hint.rs
+++ b/src/lsp/bridge/text_document/inlay_hint.rs
@@ -27,7 +27,7 @@ use tower_lsp_server::ls_types::{
 
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, region_host_end,
-    response_has_jsonrpc_error, text_edit_preserves_line_prefixes, translate_host_range_to_virtual,
+    response_has_jsonrpc_error, text_edit_safe_in_region, translate_host_range_to_virtual,
     translate_virtual_position_to_host, translate_virtual_range_to_host, virtual_uri_to_lsp_uri,
 };
 
@@ -159,7 +159,7 @@ fn transform_inlay_hint_response_to_host(
             }
             if !text_edits
                 .iter()
-                .all(|edit| text_edit_preserves_line_prefixes(edit, offset, region_end))
+                .all(|edit| text_edit_safe_in_region(edit, offset, region_end))
             {
                 log::warn!(
                     target: "kakehashi::bridge",
@@ -823,6 +823,48 @@ mod tests {
         assert!(
             hints[0].text_edits.is_none(),
             "one unsafe edit drops the WHOLE accept-edit set (it applies atomically): {:?}",
+            hints[0].text_edits
+        );
+    }
+
+    #[test]
+    fn inlay_hint_drops_text_edits_that_escape_the_region() {
+        // Plain fenced region (all-zero offsets), region end (5, 0): a
+        // textEdit whose stale range translates past the closing fence must
+        // drop the accept-edit set even though the prefix rules fast-path.
+        let offset = RegionOffset::with_per_line_offsets(3, vec![0, 0, 0]);
+        let region_end = Position {
+            line: 5,
+            character: 0,
+        };
+        let response = json!({
+            "jsonrpc": "2.0", "id": 42,
+            "result": [
+                {
+                    "position": { "line": 0, "character": 5 },
+                    "label": ": number",
+                    "textEdits": [
+                        { "range": { "start": { "line": 0, "character": 0 },
+                                     "end": { "line": 9, "character": 0 } },
+                          "newText": "x" }
+                    ]
+                }
+            ]
+        });
+
+        let hints = transform_inlay_hint_response_to_host(
+            response,
+            &make_virtual_uri_string(),
+            &make_host_uri(),
+            &offset,
+            region_end,
+        )
+        .unwrap();
+
+        assert_eq!(hints.len(), 1);
+        assert!(
+            hints[0].text_edits.is_none(),
+            "region-escaping accept edits must drop: {:?}",
             hints[0].text_edits
         );
     }

--- a/src/lsp/bridge/text_document/on_type_formatting.rs
+++ b/src/lsp/bridge/text_document/on_type_formatting.rs
@@ -25,7 +25,7 @@ use url::Url;
 use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::{
     JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri,
-    build_text_document_position_params,
+    build_text_document_position_params, region_host_end,
 };
 use super::formatting::{count_lines, transform_formatting_response_to_host};
 
@@ -81,6 +81,7 @@ impl LanguageServerPool {
             return Ok(None);
         }
         let virtual_line_count = count_lines(virtual_content);
+        let region_end = region_host_end(virtual_content, &offset);
         self.execute_position_bridge_request_with_handle(
             handle,
             host_uri,
@@ -105,8 +106,13 @@ impl LanguageServerPool {
             // malformed payloads to `Err` (request failure) — only the
             // capability/trigger early returns above yield `Ok(None)`.
             |response, ctx| {
-                transform_formatting_response_to_host(response, ctx.offset, virtual_line_count)
-                    .map(Some)
+                transform_formatting_response_to_host(
+                    response,
+                    ctx.offset,
+                    virtual_line_count,
+                    region_end,
+                )
+                .map(Some)
             },
         )
         .await?

--- a/src/lsp/bridge/text_document/range_formatting.rs
+++ b/src/lsp/bridge/text_document/range_formatting.rs
@@ -13,9 +13,10 @@
 //! # Multi-line edit limitation
 //!
 //! Same caveat as full formatting: a multi-line edit's `new_text` inside a
-//! prefixed injection is not re-prefixed, so the shared guard now DROPS such
-//! edits instead of corrupting the host document. Single-line edits — which
-//! dominate the "format the selected range" use case — are unaffected.
+//! prefixed injection is not re-prefixed, so the shared guard DROPS the WHOLE
+//! response (one atomic formatter diff) when any edit is unsafe, instead of
+//! corrupting the host document. All-safe responses — the common case for
+//! "format the selected range" — are unaffected.
 
 use std::io;
 

--- a/src/lsp/bridge/text_document/range_formatting.rs
+++ b/src/lsp/bridge/text_document/range_formatting.rs
@@ -12,11 +12,10 @@
 //!
 //! # Multi-line edit limitation
 //!
-//! Same caveat as full formatting: positions translate correctly via
-//! [`RegionOffset::column_for_line`], but the `new_text` payload of a
-//! multi-line edit inside a prefixed injection (indented or blockquoted code
-//! block) is not re-indented. Single-line edits — which dominate the
-//! "format the selected range" use case — are unaffected.
+//! Same caveat as full formatting: a multi-line edit's `new_text` inside a
+//! prefixed injection is not re-prefixed, so the shared guard now DROPS such
+//! edits instead of corrupting the host document. Single-line edits — which
+//! dominate the "format the selected range" use case — are unaffected.
 
 use std::io;
 
@@ -29,7 +28,8 @@ use url::Url;
 
 use super::super::pool::{LanguageServerPool, UpstreamId};
 use super::super::protocol::{
-    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, translate_host_range_to_virtual,
+    JsonRpcRequest, RegionOffset, RequestId, VirtualDocumentUri, region_host_end,
+    translate_host_range_to_virtual,
 };
 use super::formatting::{count_lines, transform_formatting_response_to_host};
 
@@ -70,6 +70,7 @@ impl LanguageServerPool {
             return Ok(None);
         }
         let virtual_line_count = count_lines(virtual_content);
+        let region_end = region_host_end(virtual_content, &offset);
         let offset_for_request = offset.clone();
         self.execute_bridge_request_observed(
             handle,
@@ -93,8 +94,13 @@ impl LanguageServerPool {
             // malformed payloads to `Err` (request failure) — only the
             // no-capability early return above yields `Ok(None)`.
             |response, ctx| {
-                transform_formatting_response_to_host(response, ctx.offset, virtual_line_count)
-                    .map(Some)
+                transform_formatting_response_to_host(
+                    response,
+                    ctx.offset,
+                    virtual_line_count,
+                    region_end,
+                )
+                .map(Some)
             },
             downstream_id_probe,
         )

--- a/src/lsp/bridge/text_document/test_helpers.rs
+++ b/src/lsp/bridge/text_document/test_helpers.rs
@@ -18,6 +18,13 @@ pub(in crate::lsp::bridge) fn test_host_uri() -> tower_lsp_server::ls_types::Uri
     crate::lsp::lsp_impl::url_to_uri(&url).expect("test URL should convert to URI")
 }
 
+/// A region end far past any test edit: keeps the prefix-safety guard out
+/// of the way for tests that exercise coordinate translation only.
+pub(super) const TEST_REGION_END: Position = Position {
+    line: u32::MAX,
+    character: u32::MAX,
+};
+
 /// Standard test position (line 5, character 10).
 pub(super) fn test_position() -> Position {
     Position {

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -173,9 +173,9 @@ fn transform_params_to_host(
     // strip the prefixes it overlaps and leave the inserted lines unprefixed.
     if !workspace_edit_preserves_line_prefixes(&params.edit, host_uri, offset, region_end) {
         return Err(
-            "kakehashi: the edit would break the host document's line prefixes around the \
-             injected region (e.g. a blockquote); it cannot be applied without corrupting the \
-             host document"
+            "kakehashi: the edit would break the host document's structure around the \
+             injected region (its line prefixes, e.g. a blockquote's, or the closing \
+             fence); it cannot be applied without corrupting the host document"
                 .to_string(),
         );
     }

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -170,7 +170,9 @@ fn transform_params_to_host(
     }
     // The transform translates ranges but emits newText verbatim: an edit that
     // spans or inserts lines in a line-prefixed (e.g. blockquote) region would
-    // strip the prefixes it overlaps and leave the inserted lines unprefixed.
+    // strip the prefixes it overlaps and leave the inserted lines unprefixed;
+    // an edit reaching a character-0 region end without a trailing newline
+    // would merge content into the closing fence.
     if !workspace_edit_preserves_line_prefixes(&params.edit, host_uri, offset, region_end) {
         return Err(
             "kakehashi: the edit would break the host document's structure around the \


### PR DESCRIPTION
Follow-up to #663 (prefix-safety for WorkspaceEdits). The formatting family and item-edit family relay downstream `newText` verbatim after range translation, so the same corruption classes #663 fixed for WorkspaceEdits — region escape, per-line `> ` prefix loss, closing-fence merges — remained open on those paths.

## What this does

**Shared predicates** (`protocol/workspace_edit.rs`)
- Extracts per-edit `text_edit_within_region` and adds a combined `text_edit_safe_in_region` (containment + prefix preservation).
- New fence-boundary EOL rule (runs before the all-zero fast path, so plain fenced regions and the WorkspaceEdit callers get it too): an edit ending at a character-0 region end must end its newText with a newline or be a whole-line deletion — otherwise content merges into the closing fence (`y```` ``).
- Reversed ranges (start after end) are rejected centrally.

**Formatting family** (`formatting.rs`, `on_type_formatting.rs`, `range_formatting.rs`)
- Whole-response ATOMIC drops: a formatter answer is one diff, so any unsafe edit (past-EOF, region escape, prefix break, fence merge) drops the entire response rather than half-applying paired edits.
- The synthetic-EOF sentinel (insertFinalNewline) is clamped to the content-precise region end so it survives exact containment.

**Item-edit family**
- completion: unsafe primary textEdit/InsertReplaceEdit (both starts checked) drops the item; multi-line insertText/label fallbacks and snippet VARIABLES (`${CLIPBOARD}` — client-side expansion is unknowable) reject at prefixed insertion points (insertion-point-aware: mixed-offset regions keep safe lines usable); unsafe `additionalTextEdits` drop as one atomic array while the item survives.
- completionItem/resolve: the envelope now carries a region_end snapshot (serde-default compatible); legacy envelopes fall back to a fully fail-closed guard; an unsafe resolved primary serves the unresolved item. The outgoing resolve also restores VIRTUAL coordinates (a range-echoing downstream previously got double-shifted ranges).
- inlayHint: unsafe accept-edit sets drop whole (they apply atomically); the hint itself is kept.
- colorPresentation: the implicit label-replacement edit is guarded like an explicit one (synthetic TextEdit over the request range); unsafe presentations drop; additional edits drop as an array.

Docs (module docs, the request-strategies ADR incl. its stale status table, language-features) aligned with the shipped behavior.

## Review
Local multi-perspective review + codex MCP to full convergence (2 threaded rounds + 4 fresh sessions; the last fresh session was clean on first response). Known limitations documented in-code and scoped out with codex's agreement: stale resolve geometry (#674, pre-existing class) and the custom-query `#offset!` column-0 same-line shape.

## Testing
- `cargo test --lib` (2713 tests) + `cargo clippy --lib --tests -- -D warnings` green at every commit.
- New tests: per-family drop/strip/keep fixtures (all discriminating — verified they fail if the guard runs pre-translation or is removed), predicate-level boundary/reversed-range/CR shapes, wire-level resolve coordinate assertion, snippet-variable detector unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety for embedded-region language-server edits across completion, formatting (range/on-type), inlay hints, and experimental color presentations.
  * Unsafe, prefix-breaking, or closing-fence/region-escaping edits are now handled fail-closed and atomically (entire items/whole edit sets dropped), while valid real-file edits are preserved.
  * Completion resolves no longer risk returning unsafe resolved results; unsafe resolved primary edits fall back safely.
* **Documentation**
  * Updated language-feature guidance and architecture notes to clarify the new fail-closed, atomic, region-safety semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->