### PR TITLE
perf(transport): measure stdout head-of-line blocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2111,6 +2111,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ tar = "0.4.46"
 tempfile = "3"
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "io-util", "time", "process", "fs", "signal"] }
-tokio-util = "0.7"
+tokio-util = { version = "0.7", features = ["rt"] }
 toml = "1"
 tower = { version = "0.5", default-features = false }
 tower-lsp-server = "0.23"
@@ -136,4 +136,3 @@ rstest = "0.26"
 [[bench]]
 name = "semantic_tokens"
 harness = false
-

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 # Variables
 CARGO = cargo
+PYTHON = python3
 TARGET_DIR = target
 RELEASE_DIR = $(TARGET_DIR)/release
 BINARY_NAME = kakehashi
@@ -62,6 +63,7 @@ check:
 	$(CARGO) check
 	$(CARGO) clippy -- -D warnings
 	$(CARGO) fmt --check
+	$(PYTHON) -m unittest benches/profile/test_drive.py
 
 # Format code
 .PHONY: fmt

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -27,11 +27,14 @@ python3 benches/profile/drive.py \
   --bin ./target/release/kakehashi \
   --file path/to/input.md --requests 20 --edits 1
 
-# Queue a captures delta first, then semantic tokens, to reproduce shared-pool and
-# response-output contention from an already-busy highlighter client.
-python3 benches/profile/drive.py \
-  --bin ./target/release/kakehashi \
-  --file path/to/input.md --requests 20 --edits 1 --concurrent-captures
+# Measure the four stdout head-of-line scenarios from issue #665. The captures
+# modes verify that the response is a real delta or the intended full fallback.
+for scenario in semantic-only captures-delta captures-full diagnostics-burst; do
+  python3 benches/profile/drive.py \
+    --bin ./target/release/kakehashi \
+    --file path/to/input.md --requests 20 --edits 1 \
+    --stdout-metrics --scenario "$scenario"
+done
 
 # Send superseding requests in bursts to measure cancellation pressure.
 python3 benches/profile/drive.py \
@@ -45,6 +48,16 @@ successful semantic response in each cycle, exact JSON response-body bytes,
 and server notifications/requests grouped separately. This keeps completed
 semantic compute latency separate from cheap supersession responses and from
 large captures or diagnostic output that may dominate a cycle.
+
+`--stdout-metrics` also reports exact framed bytes and p50/p90
+response-ready→last-byte-accepted and response-ready→flush-complete latency.
+For semantic responses delayed behind a frame of at least 64 KiB, it separates
+cases where semantic work was ready before that frame started (a bounded writer
+scheduler could help) from cases where the frame was already being written (it
+cannot be safely interrupted). Change the classification threshold with
+`--large-frame-kib`. The driver's dedicated reader thread continuously drains
+stdout in every mode, so waiting for one request ID does not create artificial
+pipe backpressure or hide out-of-order responses.
 
 With full Xcode installed, Instruments' Time Profiler can also be used from the
 CLI:
@@ -62,7 +75,8 @@ suite (or `make deps/tree-sitter`) once populates it.
 
 ## Why it's shaped this way
 
-- **Drive synchronously, don't pipe a static session.** The default isolates one
+- **Drain continuously, drive synchronously by default.** A dedicated reader
+  always drains and dispatches stdout while the default workload isolates one
   request at a time; without `--edits`, requests after warmup intentionally
   measure unchanged-snapshot cache hits. Add `--edits 1` to measure the
   edit→reparse→recompute path, or `--burst`/`--burst-edits` to measure

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -53,7 +53,8 @@ large captures or diagnostic output that may dominate a cycle.
 
 `--stdout-metrics` also reports exact framed bytes and p50/p90
 response-ready→last-byte-accepted and response-ready→flush-complete latency.
-For semantic responses delayed behind a frame of at least 64 KiB, it separates
+For semantic responses delayed behind an attributed response frame of at least
+64 KiB, it separates
 cases where semantic work was ready before that frame started (a bounded writer
 scheduler could help) from cases where the frame was already being written (it
 cannot be safely interrupted). Change the classification threshold with
@@ -63,6 +64,8 @@ pipe backpressure or hide out-of-order responses.
 Metrics mode fails rather than reporting a zero opportunity count if attributed
 responses are missing, counts do not match, metadata is unattributed, or any
 frame is partial/censored.
+Notifications and server requests are not labeled schedulable because overtaking
+their stateful effects requires a separate protocol-safety decision.
 
 With full Xcode installed, Instruments' Time Profiler can also be used from the
 CLI:

--- a/benches/profile/README.md
+++ b/benches/profile/README.md
@@ -29,11 +29,13 @@ python3 benches/profile/drive.py \
 
 # Measure the four stdout head-of-line scenarios from issue #665. The captures
 # modes verify that the response is a real delta or the intended full fallback.
-for scenario in semantic-only captures-delta captures-full diagnostics-burst; do
-  python3 benches/profile/drive.py \
-    --bin ./target/release/kakehashi \
-    --file path/to/input.md --requests 20 --edits 1 \
-    --stdout-metrics --scenario "$scenario"
+for repeat in 1 2 3; do
+  for scenario in semantic-only captures-delta captures-full diagnostics-burst; do
+    python3 benches/profile/drive.py \
+      --bin ./target/release/kakehashi \
+      --file path/to/input.md --requests 20 --edits 1 \
+      --stdout-metrics --scenario "$scenario"
+  done
 done
 
 # Send superseding requests in bursts to measure cancellation pressure.
@@ -58,6 +60,9 @@ cannot be safely interrupted). Change the classification threshold with
 `--large-frame-kib`. The driver's dedicated reader thread continuously drains
 stdout in every mode, so waiting for one request ID does not create artificial
 pipe backpressure or hide out-of-order responses.
+Metrics mode fails rather than reporting a zero opportunity count if attributed
+responses are missing, counts do not match, metadata is unattributed, or any
+frame is partial/censored.
 
 With full Xcode installed, Instruments' Time Profiler can also be used from the
 CLI:

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -10,8 +10,9 @@ the sampled process actually spends its time in the semantic-tokens hot path.
 Usage:
     drive.py --bin ./target/profiling/kakehashi --lang rust --size 150 --requests 300
 """
+
 import argparse
-from collections import Counter, defaultdict
+from collections import Counter, defaultdict, deque
 from dataclasses import dataclass
 import json
 import math
@@ -46,13 +47,117 @@ class RequestSummary:
     wire_bytes: int
 
 
+@dataclass(frozen=True)
+class TransportFrame:
+    method: str | None
+    request_id: int | str | None
+    frame_bytes: int
+    ready_us: int | None
+    write_start_us: int
+    last_byte_us: int
+    flush_complete_us: int | None
+
+
+@dataclass(frozen=True)
+class TransportSummary:
+    count: int
+    censored_flushes: int
+    p50_ready_to_write_complete_ms: float
+    p90_ready_to_write_complete_ms: float
+    p50_ready_to_flush_complete_ms: float | None
+    p90_ready_to_flush_complete_ms: float | None
+    max_frame_bytes: int
+
+
+def parse_stdout_metric_line(line: str) -> TransportFrame | None:
+    try:
+        metric = json.loads(line)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(metric, dict) or metric.get("event") != "stdout_frame":
+        return None
+    frame = metric.get("frame")
+    if not isinstance(frame, dict):
+        return None
+    return TransportFrame(
+        method=frame.get("method"),
+        request_id=frame.get("id"),
+        frame_bytes=frame["frame_bytes"],
+        ready_us=frame.get("ready_us"),
+        write_start_us=frame["write_start_us"],
+        last_byte_us=frame["last_byte_us"],
+        flush_complete_us=frame.get("flush_complete_us"),
+    )
+
+
+def percentile(values: list[float], q: float) -> float:
+    if not values:
+        raise ValueError("cannot calculate percentile of empty values")
+    ordered = sorted(values)
+    return ordered[max(0, math.ceil(q * len(ordered)) - 1)]
+
+
+def summarize_transport_frames(frames: list[TransportFrame]) -> TransportSummary:
+    if not frames:
+        raise ValueError("cannot summarize empty transport frames")
+    if any(frame.ready_us is None for frame in frames):
+        raise ValueError("transport response frames must have ready timestamps")
+    write_complete = [(frame.last_byte_us - frame.ready_us) / 1000 for frame in frames]
+    flush_complete = [
+        (frame.flush_complete_us - frame.ready_us) / 1000
+        for frame in frames
+        if frame.flush_complete_us is not None
+    ]
+    return TransportSummary(
+        count=len(frames),
+        censored_flushes=len(frames) - len(flush_complete),
+        p50_ready_to_write_complete_ms=percentile(write_complete, 0.5),
+        p90_ready_to_write_complete_ms=percentile(write_complete, 0.9),
+        p50_ready_to_flush_complete_ms=(
+            percentile(flush_complete, 0.5) if flush_complete else None
+        ),
+        p90_ready_to_flush_complete_ms=(
+            percentile(flush_complete, 0.9) if flush_complete else None
+        ),
+        max_frame_bytes=max(frame.frame_bytes for frame in frames),
+    )
+
+
+def classify_semantic_blocking(
+    frames: list[TransportFrame], large_frame_bytes: int
+) -> tuple[int, int]:
+    """Return (schedulable-before-start, already-writing) semantic blockers."""
+    schedulable = 0
+    already_writing = 0
+    semantics = [
+        frame
+        for frame in frames
+        if frame.ready_us is not None
+        and (frame.method or "").startswith("textDocument/semanticTokens/")
+    ]
+    for semantic in semantics:
+        blockers = [
+            frame
+            for frame in frames
+            if frame is not semantic
+            and frame.frame_bytes >= large_frame_bytes
+            and frame.write_start_us < semantic.write_start_us
+            and frame.last_byte_us >= semantic.ready_us
+        ]
+        if not blockers:
+            continue
+        blocker = max(blockers, key=lambda frame: frame.last_byte_us)
+        if semantic.ready_us <= blocker.write_start_us:
+            schedulable += 1
+        else:
+            already_writing += 1
+    return schedulable, already_writing
+
+
 def summarize_samples(samples: list[RequestSample]) -> RequestSummary:
     if not samples:
         raise ValueError("cannot summarize an empty request sample")
     latencies = sorted(sample.seconds * 1000 for sample in samples)
-
-    def percentile(q: float) -> float:
-        return latencies[max(0, math.ceil(q * len(latencies)) - 1)]
 
     statuses = Counter(sample.status for sample in samples)
     return RequestSummary(
@@ -61,8 +166,8 @@ def summarize_samples(samples: list[RequestSample]) -> RequestSummary:
         canceled=statuses["canceled"],
         null=statuses["null"],
         errors=statuses["error"],
-        p50_ms=percentile(0.5),
-        p90_ms=percentile(0.9),
+        p50_ms=percentile(latencies, 0.5),
+        p90_ms=percentile(latencies, 0.9),
         max_ms=latencies[-1],
         wire_bytes=sum(sample.wire_bytes for sample in samples),
     )
@@ -126,9 +231,7 @@ def count_semantic_outcomes(
     return ok, canceled, superseded, tokens
 
 
-def next_toggle_change(
-    first_line_len: int, line_has_extra: bool
-) -> tuple[dict, bool]:
+def next_toggle_change(first_line_len: int, line_has_extra: bool) -> tuple[dict, bool]:
     grow = not line_has_extra
     if grow:
         change = {
@@ -152,51 +255,105 @@ def next_toggle_change(
 def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--bin", required=True)
-    ap.add_argument("--server-arg", action="append", default=[],
-                    help="extra argument passed to the server (repeatable), e.g. "
-                         "--server-arg=--config-file --server-arg=/path/lsp.toml "
-                         "to reproduce a real user configuration")
+    ap.add_argument(
+        "--server-arg",
+        action="append",
+        default=[],
+        help="extra argument passed to the server (repeatable), e.g. "
+        "--server-arg=--config-file --server-arg=/path/lsp.toml "
+        "to reproduce a real user configuration",
+    )
     ap.add_argument("--lang", choices=["rust", "markdown"], default="rust")
     ap.add_argument("--size", type=int, default=150)
     ap.add_argument("--requests", type=int, default=300)
     ap.add_argument(
-        "--burst", type=int, default=1,
+        "--burst",
+        type=int,
+        default=1,
         help="send this many semantic-token requests back-to-back per cycle; "
-             "reproduces supersession/cancellation pressure")
+        "reproduces supersession/cancellation pressure",
+    )
     ap.add_argument(
-        "--burst-edits", action="store_true",
+        "--burst-edits",
+        action="store_true",
         help="toggle a real edit between requests in each burst so every request "
-             "targets a newer snapshot")
+        "targets a newer snapshot",
+    )
     ap.add_argument(
-        "--burst-delay-ms", type=float, default=1.0,
-        help="typing interval between a burst request and the next edit")
-    ap.add_argument("--file", help="drive with this file's content instead of a "
-                                   "generated document (language inferred from the "
-                                   "extension, falling back to --lang)")
+        "--burst-delay-ms",
+        type=float,
+        default=1.0,
+        help="typing interval between a burst request and the next edit",
+    )
     ap.add_argument(
-        "--captures", action="store_true",
+        "--file",
+        help="drive with this file's content instead of a "
+        "generated document (language inferred from the "
+        "extension, falling back to --lang)",
+    )
+    ap.add_argument(
+        "--captures",
+        action="store_true",
         help="warm kakehashi/captures/full once, then send a real injection-mode "
-             "captures delta per cycle")
+        "captures delta per cycle",
+    )
     ap.add_argument(
-        "--concurrent-captures", action="store_true",
+        "--concurrent-captures",
+        action="store_true",
         help="send semantic tokens and the captures delta as one concurrent "
-             "batch; implies --captures and exposes shared-pool/output contention")
+        "batch; implies --captures and exposes shared-pool/output contention",
+    )
     ap.add_argument(
-        "--settle", type=float, default=0.3,
+        "--scenario",
+        choices=(
+            "semantic-only",
+            "captures-delta",
+            "captures-full",
+            "diagnostics-burst",
+        ),
+        help="run one of issue #665's stdout head-of-line scenarios",
+    )
+    ap.add_argument(
+        "--diagnostics-burst-size",
+        type=int,
+        default=4,
+        help="diagnostic requests queued before semantic tokens in the diagnostics-burst scenario",
+    )
+    ap.add_argument(
+        "--settle",
+        type=float,
+        default=0.3,
         help="seconds to wait after didOpen before the first request "
-             "(0 reproduces a client that requests immediately)")
+        "(0 reproduces a client that requests immediately)",
+    )
     ap.add_argument(
-        "--edits", type=int, default=0,
+        "--edits",
+        type=int,
+        default=0,
         help="simulate typing: before each request, send this many incremental "
-             "didChange edits (appending/removing a char at the end of the first "
-             "line), then request tokens. Exercises the edit->reparse->recompute "
-             "cycle instead of the unchanged-document cache hit; the request "
-             "parks until the matching parse snapshot is current.")
+        "didChange edits (appending/removing a char at the end of the first "
+        "line), then request tokens. Exercises the edit->reparse->recompute "
+        "cycle instead of the unchanged-document cache hit; the request "
+        "parks until the matching parse snapshot is current.",
+    )
     ap.add_argument(
-        "--data-dir", default=os.path.join(os.getcwd(), "deps/test/kakehashi"),
+        "--data-dir",
+        default=os.path.join(os.getcwd(), "deps/test/kakehashi"),
         help="parser/query data dir; must already contain installed parsers "
-             "(populated by `cargo test --features e2e` or `make deps/tree-sitter`), "
-             "else the server auto-installs on first request")
+        "(populated by `cargo test --features e2e` or `make deps/tree-sitter`), "
+        "else the server auto-installs on first request",
+    )
+    ap.add_argument(
+        "--stdout-metrics",
+        action="store_true",
+        help="enable and summarize response-ready to stdout-write transport metrics",
+    )
+    ap.add_argument(
+        "--large-frame-kib",
+        type=float,
+        default=64,
+        help="minimum competing frame size for scheduler-opportunity classification",
+    )
     args = ap.parse_args()
     if args.requests <= 0:
         ap.error("--requests must be positive")  # avoids divide-by-zero in the summary
@@ -206,6 +363,17 @@ def main() -> None:
         ap.error("--burst-edits requires --burst greater than 1")
     if args.burst_delay_ms < 0:
         ap.error("--burst-delay-ms must be non-negative")
+    if args.diagnostics_burst_size <= 0:
+        ap.error("--diagnostics-burst-size must be positive")
+    if args.large_frame_kib <= 0:
+        ap.error("--large-frame-kib must be positive")
+    if args.scenario and (args.captures or args.concurrent_captures):
+        ap.error("--scenario cannot be combined with legacy captures flags")
+    captures_full_fallback = args.scenario == "captures-full"
+    diagnostics_burst = args.scenario == "diagnostics-burst"
+    if args.scenario in ("captures-delta", "captures-full"):
+        args.captures = True
+        args.concurrent_captures = True
     if args.burst > 1 and (args.captures or args.concurrent_captures):
         ap.error("--burst cannot be combined with captures modes")
     if args.concurrent_captures:
@@ -224,13 +392,22 @@ def main() -> None:
     elif args.lang == "rust":
         uri, lang, text = "file:///profile/large.rs", "rust", gen_rust(args.size)
     else:
-        uri, lang, text = "file:///profile/inj.md", "markdown", gen_markdown_injections(args.size)
+        uri, lang, text = (
+            "file:///profile/inj.md",
+            "markdown",
+            gen_markdown_injections(args.size),
+        )
 
     env = dict(os.environ, KAKEHASHI_DATA_DIR=args.data_dir)
-    # Let the server's stderr through (it's silent unless RUST_LOG is set) so a
-    # crash or panic is visible instead of being swallowed during profiling.
-    srv = subprocess.Popen([args.bin, *args.server_arg], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                           env=env)
+    if args.stdout_metrics:
+        env["KAKEHASHI_STDOUT_METRICS"] = "1"
+    srv = subprocess.Popen(
+        [args.bin, *args.server_arg],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
     rid = 0
     request_samples = defaultdict(list)
     notification_counts = Counter()
@@ -238,6 +415,11 @@ def main() -> None:
     server_request_counts = Counter()
     server_request_bytes = Counter()
     send_lock = threading.Lock()
+    response_condition = threading.Condition()
+    received_responses = defaultdict(deque)
+    reader_errors = []
+    reader_done = False
+    transport_frames = []
 
     def send(obj):
         body = json.dumps(obj).encode()
@@ -263,7 +445,7 @@ def main() -> None:
         while True:
             line = srv.stdout.readline()
             if not line:
-                raise RuntimeError("server closed stdout")
+                raise EOFError("server closed stdout")
             line = line.strip()
             if not line:
                 break
@@ -287,58 +469,96 @@ def main() -> None:
         if "id" in message:
             server_request_counts[method] += 1
             server_request_bytes[method] += wire_bytes
-            send({
-                "jsonrpc": "2.0",
-                "id": message["id"],
-                "result": server_request_result(message),
-            })
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": message["id"],
+                    "result": server_request_result(message),
+                }
+            )
         else:
             record_notification(message, wire_bytes)
         return True
 
+    def collect_stdout():
+        nonlocal reader_done
+        try:
+            while True:
+                message, wire_bytes = read_message()
+                if handle_server_method(message, wire_bytes):
+                    continue
+                with response_condition:
+                    received_responses[message.get("id")].append(
+                        (message, wire_bytes, time.perf_counter())
+                    )
+                    response_condition.notify_all()
+        except EOFError:
+            pass
+        except BaseException as error:
+            reader_errors.append(error)
+        finally:
+            with response_condition:
+                reader_done = True
+                response_condition.notify_all()
+
+    def collect_stderr():
+        for raw_line in srv.stderr:
+            line = raw_line.decode(errors="replace").rstrip("\n")
+            frame = parse_stdout_metric_line(line)
+            if frame is not None:
+                transport_frames.append(frame)
+            else:
+                sys.stderr.write(line + "\n")
+
+    def wait_response(want_id):
+        with response_condition:
+            while not received_responses[want_id]:
+                if reader_errors:
+                    raise reader_errors[0]
+                if reader_done:
+                    raise RuntimeError(
+                        f"server closed stdout before response id={want_id}"
+                    )
+                response_condition.wait()
+            return received_responses[want_id].popleft()
+
     def read_until(want_id):
-        while True:
-            m, wire_bytes = read_message()
-            if handle_server_method(m, wire_bytes):
-                continue
-            if m.get("id") == want_id:
-                return m, wire_bytes
+        message, wire_bytes, _ = wait_response(want_id)
+        return message, wire_bytes
 
     def measured_request(method, params):
         started = time.perf_counter()
-        response, wire_bytes = request(method, params)
-        completed_at = time.perf_counter()
-        request_samples[method].append(RequestSample(
-            seconds=completed_at - started,
-            wire_bytes=wire_bytes,
-            status=response_status(response),
-            completed_at=completed_at,
-        ))
+        request_id = send_request(method, params)
+        response, wire_bytes, completed_at = wait_response(request_id)
+        request_samples[method].append(
+            RequestSample(
+                seconds=completed_at - started,
+                wire_bytes=wire_bytes,
+                status=response_status(response),
+                completed_at=completed_at,
+            )
+        )
         return response
 
     def measured_batch(requests):
         pending = {}
         for method, params in requests:
+            started = time.perf_counter()
             request_id = send_request(method, params)
-            pending[request_id] = (method, time.perf_counter())
+            pending[request_id] = (method, started)
 
-        responses = {}
-        while pending:
-            message, wire_bytes = read_message()
-            if handle_server_method(message, wire_bytes):
-                continue
-            request_id = message.get("id")
-            if request_id not in pending:
-                continue
-            method, started = pending.pop(request_id)
-            completed_at = time.perf_counter()
-            request_samples[method].append(RequestSample(
-                seconds=completed_at - started,
-                wire_bytes=wire_bytes,
-                status=response_status(message),
-                completed_at=completed_at,
-            ))
-            responses[method] = message
+        responses = []
+        for request_id, (method, started) in pending.items():
+            message, wire_bytes, completed_at = wait_response(request_id)
+            request_samples[method].append(
+                RequestSample(
+                    seconds=completed_at - started,
+                    wire_bytes=wire_bytes,
+                    status=response_status(message),
+                    completed_at=completed_at,
+                )
+            )
+            responses.append(message)
         return responses
 
     def measured_repeated(method, params, count, before_next=None, delay_seconds=0):
@@ -346,63 +566,72 @@ def main() -> None:
         request_ids = list(range(rid + 1, rid + count + 1))
         rid += count
         pending = {}
-        pending_lock = threading.Lock()
         responses = {}
-        reader_errors = []
-
-        def collect_responses():
-            try:
-                while len(responses) < count:
-                    message, wire_bytes = read_message()
-                    if handle_server_method(message, wire_bytes):
-                        continue
-                    request_id = message.get("id")
-                    with pending_lock:
-                        if request_id not in pending:
-                            continue
-                        started = pending.pop(request_id)
-                    completed_at = time.perf_counter()
-                    request_samples[method].append(RequestSample(
-                        seconds=completed_at - started,
-                        wire_bytes=wire_bytes,
-                        status=response_status(message),
-                        completed_at=completed_at,
-                    ))
-                    responses[request_id] = message
-            except BaseException as error:
-                reader_errors.append(error)
-
-        reader_thread = threading.Thread(target=collect_responses, daemon=True)
-        reader_thread.start()
         for index, request_id in enumerate(request_ids):
-            with pending_lock:
-                pending[request_id] = time.perf_counter()
-            send({
-                "jsonrpc": "2.0",
-                "id": request_id,
-                "method": method,
-                "params": params,
-            })
+            pending[request_id] = time.perf_counter()
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "method": method,
+                    "params": params,
+                }
+            )
             if index + 1 < count and before_next is not None:
                 if delay_seconds > 0:
                     time.sleep(delay_seconds)
                 before_next()
-        reader_thread.join()
-        if reader_errors:
-            raise reader_errors[0]
+        for request_id in request_ids:
+            message, wire_bytes, completed_at = wait_response(request_id)
+            request_samples[method].append(
+                RequestSample(
+                    seconds=completed_at - pending[request_id],
+                    wire_bytes=wire_bytes,
+                    status=response_status(message),
+                    completed_at=completed_at,
+                )
+            )
+            responses[request_id] = message
         return [responses[request_id] for request_id in request_ids]
+
+    stdout_reader = threading.Thread(target=collect_stdout, daemon=True)
+    stderr_reader = threading.Thread(target=collect_stderr, daemon=True)
+    stdout_reader.start()
+    stderr_reader.start()
 
     # Drive inside try/finally so any error (e.g. a server error raised in the
     # loop, or a shutdown timeout) still reaps the server instead of leaving a
     # stray process behind.
     try:
-        request("initialize", {"processId": None, "rootUri": None, "capabilities": {
-            "textDocument": {"semanticTokens": {"requests": {"full": {"delta": True}},
-                                                "tokenTypes": [], "tokenModifiers": [],
-                                                "formats": ["relative"]}}}})
+        request(
+            "initialize",
+            {
+                "processId": None,
+                "rootUri": None,
+                "capabilities": {
+                    "textDocument": {
+                        "semanticTokens": {
+                            "requests": {"full": {"delta": True}},
+                            "tokenTypes": [],
+                            "tokenModifiers": [],
+                            "formats": ["relative"],
+                        }
+                    }
+                },
+            },
+        )
         notify("initialized", {})
-        notify("textDocument/didOpen", {"textDocument": {
-            "uri": uri, "languageId": lang, "version": 1, "text": text}})
+        notify(
+            "textDocument/didOpen",
+            {
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": lang,
+                    "version": 1,
+                    "text": text,
+                }
+            },
+        )
         if args.settle > 0:
             time.sleep(args.settle)  # let the initial parse settle
 
@@ -435,14 +664,15 @@ def main() -> None:
 
         def send_toggle_edit():
             nonlocal version, line_has_extra
-            change, line_has_extra = next_toggle_change(
-                first_line_len, line_has_extra
-            )
+            change, line_has_extra = next_toggle_change(first_line_len, line_has_extra)
             version += 1
-            notify("textDocument/didChange", {
-                "textDocument": {"uri": uri, "version": version},
-                "contentChanges": [change],
-            })
+            notify(
+                "textDocument/didChange",
+                {
+                    "textDocument": {"uri": uri, "version": version},
+                    "contentChanges": [change],
+                },
+            )
 
         for i in range(args.requests):
             for j in range(args.edits):
@@ -459,20 +689,53 @@ def main() -> None:
                 {"textDocument": {"uri": uri}},
             )
             captures_requests = [
-                ("kakehashi/captures/full/delta",
-                 {"textDocument": {"uri": uri}, "kind": "highlights",
-                  "previousResultId": captures_result_id}),
+                (
+                    "kakehashi/captures/full/delta",
+                    {
+                        "textDocument": {"uri": uri},
+                        "kind": "highlights",
+                        "previousResultId": (
+                            "stale-profile-lineage"
+                            if captures_full_fallback
+                            else captures_result_id
+                        ),
+                    },
+                ),
             ]
             captures_responses = {}
             if args.concurrent_captures:
                 # Queue captures first to model an editor whose highlighting work
                 # is already in flight when semantic tokens arrive.
                 responses = measured_batch([*captures_requests, semantic_request])
-                semantic_responses = [responses[semantic_request[0]]]
+                semantic_responses = [responses[-1]]
                 captures_responses = {
-                    method: responses[method]
-                    for method, _ in captures_requests
+                    method: response
+                    for (method, _), response in zip(
+                        captures_requests, responses[:-1], strict=True
+                    )
                 }
+                captures_result = (
+                    captures_responses["kakehashi/captures/full/delta"].get("result")
+                    or {}
+                )
+                expected_field = "matches" if captures_full_fallback else "edits"
+                if expected_field not in captures_result:
+                    raise RuntimeError(
+                        f"captures scenario expected {expected_field}, got "
+                        f"{captures_result.keys()}"
+                    )
+            elif diagnostics_burst:
+                diagnostic_request = (
+                    "textDocument/diagnostic",
+                    {"textDocument": {"uri": uri}},
+                )
+                responses = measured_batch(
+                    [
+                        *([diagnostic_request] * args.diagnostics_burst_size),
+                        semantic_request,
+                    ]
+                )
+                semantic_responses = [responses[-1]]
             elif args.burst > 1:
                 if args.burst_edits:
                     send_toggle_edit()
@@ -490,9 +753,7 @@ def main() -> None:
                             *captures_request
                         )
             for method, _ in reversed(captures_requests):
-                next_result_id = response_result_id(
-                    captures_responses.get(method, {})
-                )
+                next_result_id = response_result_id(captures_responses.get(method, {}))
                 if next_result_id is not None:
                     captures_result_id = next_result_id
                     break
@@ -507,8 +768,8 @@ def main() -> None:
             ]
             if successes:
                 cycle_success_times.append(max(successes))
-            cycle_ok, cycle_canceled, cycle_superseded, tokens = count_semantic_outcomes(
-                semantic_responses, tokens
+            cycle_ok, cycle_canceled, cycle_superseded, tokens = (
+                count_semantic_outcomes(semantic_responses, tokens)
             )
             ok += cycle_ok
             canceled += cycle_canceled
@@ -518,34 +779,44 @@ def main() -> None:
         request("shutdown", None)
         notify("exit", {})
         srv.wait(timeout=5)
+        stdout_reader.join(timeout=5)
+        stderr_reader.join(timeout=5)
     except subprocess.TimeoutExpired:
         pass  # graceful shutdown didn't land in time; the finally kills it
     finally:
         if srv.poll() is None:
             srv.kill()
             srv.wait()
+        stdout_reader.join(timeout=5)
+        stderr_reader.join(timeout=5)
 
     n_bytes = len(text.encode("utf-8"))
     n_lines = len(text.splitlines())
-    source = (f"file={args.file} ({n_bytes}B/{n_lines}L)"
-              if args.file else f"size={args.size}")
-    firsts = " ".join(f"{t*1000:.0f}" for t in req_times[:5])
+    source = (
+        f"file={args.file} ({n_bytes}B/{n_lines}L)"
+        if args.file
+        else f"size={args.size}"
+    )
+    firsts = " ".join(f"{t * 1000:.0f}" for t in req_times[:5])
     measured_responses = sum(len(samples) for samples in request_samples.values())
     sys.stderr.write(f"[drive] first-cycle ms: {firsts}\n")
     sys.stderr.write(
-        f"[drive] lang={lang} {source} cycles={args.requests} burst={args.burst} "
+        f"[drive] scenario={args.scenario or 'custom'} lang={lang} {source} "
+        f"cycles={args.requests} burst={args.burst} "
         f"responses={measured_responses} "
         f"ok={ok} canceled={canceled} superseded={superseded} tokens/req={tokens} "
-        f"wall={elapsed*1000:.0f}ms "
-        f"({elapsed/args.requests*1000:.2f}ms/cycle, "
-        f"{elapsed/measured_responses*1000:.2f}ms/measured-response)\n")
+        f"wall={elapsed * 1000:.0f}ms "
+        f"({elapsed / args.requests * 1000:.2f}ms/cycle, "
+        f"{elapsed / measured_responses * 1000:.2f}ms/measured-response)\n"
+    )
     for method, samples in request_samples.items():
         summary = summarize_samples(samples)
         sys.stderr.write(
             f"[drive] method={method} count={summary.count} ok={summary.ok} "
             f"canceled={summary.canceled} null={summary.null} errors={summary.errors} "
             f"p50={summary.p50_ms:.1f}ms p90={summary.p90_ms:.1f}ms "
-            f"max={summary.max_ms:.1f}ms wire={summary.wire_bytes / 1024:.1f}KiB\n")
+            f"max={summary.max_ms:.1f}ms wire={summary.wire_bytes / 1024:.1f}KiB\n"
+        )
         for status, status_summary in summarize_samples_by_status(samples).items():
             sys.stderr.write(
                 f"[drive] method={method} status={status} "
@@ -573,13 +844,44 @@ def main() -> None:
         )
         sys.stderr.write(
             f"[drive] notifications count={total_count} wire={total_bytes / 1024:.1f}KiB "
-            f"top=[{top}]\n")
+            f"top=[{top}]\n"
+        )
     if server_request_counts:
         total_count = sum(server_request_counts.values())
         total_bytes = sum(server_request_bytes.values())
         sys.stderr.write(
             f"[drive] server-requests count={total_count} "
             f"wire={total_bytes / 1024:.1f}KiB methods={dict(server_request_counts)}\n"
+        )
+    transport_by_method = defaultdict(list)
+    for frame in transport_frames:
+        if frame.ready_us is not None and frame.method is not None:
+            transport_by_method[frame.method].append(frame)
+    for method, frames in transport_by_method.items():
+        summary = summarize_transport_frames(frames)
+        flush_p90 = (
+            f"{summary.p90_ready_to_flush_complete_ms:.1f}ms"
+            if summary.p90_ready_to_flush_complete_ms is not None
+            else "n/a"
+        )
+        sys.stderr.write(
+            f"[stdout] method={method} count={summary.count} "
+            f"ready-to-write-complete-p50="
+            f"{summary.p50_ready_to_write_complete_ms:.1f}ms "
+            f"p90={summary.p90_ready_to_write_complete_ms:.1f}ms "
+            f"ready-to-flush-p90={flush_p90} "
+            f"censored={summary.censored_flushes} "
+            f"max-frame={summary.max_frame_bytes / 1024:.1f}KiB\n"
+        )
+    if args.stdout_metrics:
+        schedulable, already_writing = classify_semantic_blocking(
+            transport_frames, int(args.large_frame_kib * 1024)
+        )
+        sys.stderr.write(
+            f"[stdout] semantic-large-frame-overlap "
+            f"threshold={args.large_frame_kib:g}KiB "
+            f"schedulable-before-write={schedulable} "
+            f"already-writing={already_writing}\n"
         )
 
 

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -132,20 +132,20 @@ def classify_semantic_blocking(
     schedulable = 0
     already_writing = 0
     semantics = [
-        frame
-        for frame in frames
+        (index, frame)
+        for index, frame in enumerate(frames)
         if frame.ready_us is not None
         and (frame.method or "").startswith("textDocument/semanticTokens/")
     ]
-    for semantic in semantics:
+    for semantic_index, semantic in semantics:
         blockers = [
             frame
-            for frame in frames
-            if frame is not semantic
+            for blocker_index, frame in enumerate(frames)
+            if blocker_index < semantic_index
             and frame.request_id is not None
             and frame.ready_us is not None
             and frame.frame_bytes >= large_frame_bytes
-            and frame.write_start_us < semantic.write_start_us
+            and frame.write_start_us <= semantic.write_start_us
             and (
                 frame.flush_complete_us
                 if frame.flush_complete_us is not None

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -159,7 +159,7 @@ def classify_semantic_blocking(
         ]
         if not blockers:
             continue
-        blocker = max(blockers, key=lambda frame: frame.last_byte_us)
+        blocker = max(blockers, key=lambda frame: frame.write_sequence)
         if semantic.ready_sequence < blocker.write_sequence:
             schedulable += 1
         else:

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -58,7 +58,8 @@ class TransportFrame:
     flush_complete_us: int | None
     id_unattributed: bool = False
     ready_sequence: int | None = None
-    write_sequence: int = 0
+    write_sequence: int | None = None
+    flush_sequence: int | None = None
 
 
 @dataclass(frozen=True)
@@ -92,7 +93,8 @@ def parse_stdout_metric_line(line: str) -> TransportFrame | None:
         flush_complete_us=frame.get("flush_complete_us"),
         id_unattributed=frame.get("id_unattributed", False),
         ready_sequence=frame.get("ready_sequence"),
-        write_sequence=frame.get("write_sequence", 0),
+        write_sequence=frame.get("write_sequence"),
+        flush_sequence=frame.get("flush_sequence"),
     )
 
 
@@ -149,14 +151,11 @@ def classify_semantic_blocking(
             if blocker_index < semantic_index
             and frame.request_id is not None
             and frame.ready_us is not None
+            and frame.write_sequence is not None
+            and frame.flush_sequence is not None
             and frame.frame_bytes >= large_frame_bytes
             and frame.write_start_us <= semantic.write_start_us
-            and (
-                frame.flush_complete_us
-                if frame.flush_complete_us is not None
-                else frame.last_byte_us
-            )
-            >= semantic.ready_us
+            and frame.flush_sequence > semantic.ready_sequence
         ]
         if not blockers:
             continue
@@ -188,6 +187,20 @@ def validate_transport_metrics(
     censored = [frame for frame in frames if frame.flush_complete_us is None]
     if censored:
         raise RuntimeError(f"stdout metrics contain {len(censored)} censored flushes")
+    incomplete_sequences = [
+        frame
+        for frame in frames
+        if frame.ready_us is not None
+        and (
+            frame.ready_sequence is None
+            or frame.write_sequence is None
+            or frame.flush_sequence is None
+        )
+    ]
+    if incomplete_sequences:
+        raise RuntimeError(
+            f"stdout metrics contain {len(incomplete_sequences)} incomplete event sequences"
+        )
     for method, expected in expected_counts.items():
         actual = sum(
             frame.ready_us is not None and frame.method == method for frame in frames

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -128,7 +128,7 @@ def summarize_transport_frames(frames: list[TransportFrame]) -> TransportSummary
 def classify_semantic_blocking(
     frames: list[TransportFrame], large_frame_bytes: int
 ) -> tuple[int, int]:
-    """Return (schedulable-before-start, already-writing) semantic blockers."""
+    """Classify semantic blocking behind attributed, reorderable responses."""
     schedulable = 0
     already_writing = 0
     semantics = [
@@ -142,9 +142,16 @@ def classify_semantic_blocking(
             frame
             for frame in frames
             if frame is not semantic
+            and frame.request_id is not None
+            and frame.ready_us is not None
             and frame.frame_bytes >= large_frame_bytes
             and frame.write_start_us < semantic.write_start_us
-            and (frame.flush_complete_us or frame.last_byte_us) >= semantic.ready_us
+            and (
+                frame.flush_complete_us
+                if frame.flush_complete_us is not None
+                else frame.last_byte_us
+            )
+            >= semantic.ready_us
         ]
         if not blockers:
             continue
@@ -184,6 +191,16 @@ def validate_transport_metrics(
             raise RuntimeError(
                 f"stdout metric count mismatch for {method}: expected {expected}, got {actual}"
             )
+
+
+def validate_diagnostic_report(response: dict) -> None:
+    result = response.get("result")
+    if response_status(response) != "ok" or not isinstance(result, dict):
+        raise RuntimeError(
+            f"diagnostics scenario expected a full report, got {response}"
+        )
+    if result.get("kind") != "full" or not isinstance(result.get("items"), list):
+        raise RuntimeError(f"diagnostics scenario expected full items, got {result}")
 
 
 def summarize_samples(samples: list[RequestSample]) -> RequestSummary:
@@ -784,17 +801,7 @@ def main() -> None:
                     ]
                 )
                 for response in responses[:-1]:
-                    result = response.get("result")
-                    if response_status(response) != "ok" or not isinstance(
-                        result, dict
-                    ):
-                        raise RuntimeError(
-                            f"diagnostics scenario expected a report, got {response}"
-                        )
-                    if result.get("kind") not in ("full", "unchanged"):
-                        raise RuntimeError(
-                            f"diagnostics scenario returned invalid report kind: {result}"
-                        )
+                    validate_diagnostic_report(response)
                 semantic_responses = [responses[-1]]
             elif args.burst > 1:
                 if args.burst_edits:
@@ -949,7 +956,7 @@ def main() -> None:
             transport_frames, int(args.large_frame_kib * 1024)
         )
         sys.stderr.write(
-            f"[stdout] semantic-large-frame-overlap "
+            f"[stdout] semantic-large-response-overlap "
             f"threshold={args.large_frame_kib:g}KiB "
             f"schedulable-before-write={schedulable} "
             f"already-writing={already_writing}\n"

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -57,6 +57,8 @@ class TransportFrame:
     last_byte_us: int
     flush_complete_us: int | None
     id_unattributed: bool = False
+    ready_sequence: int | None = None
+    write_sequence: int = 0
 
 
 @dataclass(frozen=True)
@@ -89,6 +91,8 @@ def parse_stdout_metric_line(line: str) -> TransportFrame | None:
         last_byte_us=frame["last_byte_us"],
         flush_complete_us=frame.get("flush_complete_us"),
         id_unattributed=frame.get("id_unattributed", False),
+        ready_sequence=frame.get("ready_sequence"),
+        write_sequence=frame.get("write_sequence", 0),
     )
 
 
@@ -135,6 +139,7 @@ def classify_semantic_blocking(
         (index, frame)
         for index, frame in enumerate(frames)
         if frame.ready_us is not None
+        and frame.ready_sequence is not None
         and (frame.method or "").startswith("textDocument/semanticTokens/")
     ]
     for semantic_index, semantic in semantics:
@@ -156,7 +161,7 @@ def classify_semantic_blocking(
         if not blockers:
             continue
         blocker = max(blockers, key=lambda frame: frame.last_byte_us)
-        if semantic.ready_us <= blocker.write_start_us:
+        if semantic.ready_sequence < blocker.write_sequence:
             schedulable += 1
         else:
             already_writing += 1

--- a/benches/profile/drive.py
+++ b/benches/profile/drive.py
@@ -56,6 +56,7 @@ class TransportFrame:
     write_start_us: int
     last_byte_us: int
     flush_complete_us: int | None
+    id_unattributed: bool = False
 
 
 @dataclass(frozen=True)
@@ -87,6 +88,7 @@ def parse_stdout_metric_line(line: str) -> TransportFrame | None:
         write_start_us=frame["write_start_us"],
         last_byte_us=frame["last_byte_us"],
         flush_complete_us=frame.get("flush_complete_us"),
+        id_unattributed=frame.get("id_unattributed", False),
     )
 
 
@@ -142,7 +144,7 @@ def classify_semantic_blocking(
             if frame is not semantic
             and frame.frame_bytes >= large_frame_bytes
             and frame.write_start_us < semantic.write_start_us
-            and frame.last_byte_us >= semantic.ready_us
+            and (frame.flush_complete_us or frame.last_byte_us) >= semantic.ready_us
         ]
         if not blockers:
             continue
@@ -152,6 +154,36 @@ def classify_semantic_blocking(
         else:
             already_writing += 1
     return schedulable, already_writing
+
+
+def validate_transport_metrics(
+    frames: list[TransportFrame],
+    expected_counts: dict[str, int],
+    partial_frame_count: int,
+    collector_errors: list[BaseException],
+) -> None:
+    if collector_errors:
+        raise RuntimeError(f"stdout metric collector failed: {collector_errors[0]}")
+    if partial_frame_count:
+        raise RuntimeError(
+            f"stdout metrics contain {partial_frame_count} partial frames"
+        )
+    unattributed = [frame for frame in frames if frame.id_unattributed]
+    if unattributed:
+        raise RuntimeError(
+            f"stdout metrics contain {len(unattributed)} unattributed frames"
+        )
+    censored = [frame for frame in frames if frame.flush_complete_us is None]
+    if censored:
+        raise RuntimeError(f"stdout metrics contain {len(censored)} censored flushes")
+    for method, expected in expected_counts.items():
+        actual = sum(
+            frame.ready_us is not None and frame.method == method for frame in frames
+        )
+        if actual != expected:
+            raise RuntimeError(
+                f"stdout metric count mismatch for {method}: expected {expected}, got {actual}"
+            )
 
 
 def summarize_samples(samples: list[RequestSample]) -> RequestSummary:
@@ -420,6 +452,8 @@ def main() -> None:
     reader_errors = []
     reader_done = False
     transport_frames = []
+    stderr_reader_errors = []
+    partial_frame_count = 0
 
     def send(obj):
         body = json.dumps(obj).encode()
@@ -502,13 +536,27 @@ def main() -> None:
                 response_condition.notify_all()
 
     def collect_stderr():
+        nonlocal partial_frame_count
         for raw_line in srv.stderr:
-            line = raw_line.decode(errors="replace").rstrip("\n")
-            frame = parse_stdout_metric_line(line)
-            if frame is not None:
-                transport_frames.append(frame)
-            else:
-                sys.stderr.write(line + "\n")
+            try:
+                line = raw_line.decode(errors="replace").rstrip("\n")
+                frame = parse_stdout_metric_line(line)
+                if frame is not None:
+                    transport_frames.append(frame)
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    event = None
+                if (
+                    isinstance(event, dict)
+                    and event.get("event") == "stdout_partial_frame"
+                ):
+                    partial_frame_count += 1
+                else:
+                    sys.stderr.write(line + "\n")
+            except BaseException as error:
+                stderr_reader_errors.append(error)
 
     def wait_response(want_id):
         with response_condition:
@@ -735,6 +783,18 @@ def main() -> None:
                         semantic_request,
                     ]
                 )
+                for response in responses[:-1]:
+                    result = response.get("result")
+                    if response_status(response) != "ok" or not isinstance(
+                        result, dict
+                    ):
+                        raise RuntimeError(
+                            f"diagnostics scenario expected a report, got {response}"
+                        )
+                    if result.get("kind") not in ("full", "unchanged"):
+                        raise RuntimeError(
+                            f"diagnostics scenario returned invalid report kind: {result}"
+                        )
                 semantic_responses = [responses[-1]]
             elif args.burst > 1:
                 if args.burst_edits:
@@ -789,6 +849,17 @@ def main() -> None:
             srv.wait()
         stdout_reader.join(timeout=5)
         stderr_reader.join(timeout=5)
+
+    if args.stdout_metrics:
+        expected_transport_counts = {
+            method: len(samples) for method, samples in request_samples.items()
+        }
+        validate_transport_metrics(
+            transport_frames,
+            expected_transport_counts,
+            partial_frame_count,
+            stderr_reader_errors,
+        )
 
     n_bytes = len(text.encode("utf-8"))
     n_lines = len(text.splitlines())

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -208,6 +208,16 @@ class RequestSummaryTest(unittest.TestCase):
             classify_semantic_blocking([notification, semantic], 64 * 1024),
             (0, 0),
         )
+        tied_batch_blocker = dataclasses.replace(
+            large,
+            write_start_us=semantic.write_start_us,
+            last_byte_us=semantic.write_start_us,
+            flush_complete_us=semantic.flush_complete_us,
+        )
+        self.assertEqual(
+            classify_semantic_blocking([tied_batch_blocker, semantic], 64 * 1024),
+            (1, 0),
+        )
 
     def test_transport_validation_rejects_missing_or_censored_metrics(self):
         frame = TransportFrame(

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -107,6 +107,7 @@ class RequestSummaryTest(unittest.TestCase):
                 "frame": {
                     "ready_sequence": 3,
                     "write_sequence": 4,
+                    "flush_sequence": 5,
                     "method": "textDocument/semanticTokens/full",
                     "id": 9,
                     "body_bytes": 100,
@@ -133,6 +134,7 @@ class RequestSummaryTest(unittest.TestCase):
                 flush_complete_us=3000,
                 ready_sequence=3,
                 write_sequence=4,
+                flush_sequence=5,
             ),
         )
         summary = summarize_transport_frames([frame])
@@ -177,6 +179,7 @@ class RequestSummaryTest(unittest.TestCase):
             flush_complete_us=520,
             ready_sequence=1,
             write_sequence=4,
+            flush_sequence=6,
         )
         large = TransportFrame(
             method="kakehashi/captures/full/delta",
@@ -188,6 +191,7 @@ class RequestSummaryTest(unittest.TestCase):
             flush_complete_us=460,
             ready_sequence=0,
             write_sequence=2,
+            flush_sequence=4,
         )
 
         self.assertEqual(
@@ -239,6 +243,9 @@ class RequestSummaryTest(unittest.TestCase):
             write_start_us=110,
             last_byte_us=120,
             flush_complete_us=130,
+            ready_sequence=1,
+            write_sequence=2,
+            flush_sequence=3,
         )
         validate_transport_metrics(
             [frame], {"textDocument/semanticTokens/full": 1}, 0, []
@@ -257,6 +264,13 @@ class RequestSummaryTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             validate_transport_metrics(
                 [frame], {"textDocument/semanticTokens/full": 1}, 1, []
+            )
+        with self.assertRaises(RuntimeError):
+            validate_transport_metrics(
+                [dataclasses.replace(frame, flush_sequence=None)],
+                {"textDocument/semanticTokens/full": 1},
+                0,
+                [],
             )
 
     def test_diagnostic_scenario_requires_a_full_items_report(self):

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -18,6 +18,7 @@ from drive import (
     summarize_samples,
     summarize_samples_by_status,
     summarize_transport_frames,
+    validate_transport_metrics,
 )
 
 
@@ -190,6 +191,41 @@ class RequestSummaryTest(unittest.TestCase):
             classify_semantic_blocking([large, semantic_after_start], 64 * 1024),
             (0, 1),
         )
+
+        semantic_during_flush = dataclasses.replace(semantic, ready_us=455)
+        self.assertEqual(
+            classify_semantic_blocking([large, semantic_during_flush], 64 * 1024),
+            (0, 1),
+        )
+
+    def test_transport_validation_rejects_missing_or_censored_metrics(self):
+        frame = TransportFrame(
+            method="textDocument/semanticTokens/full",
+            request_id=2,
+            frame_bytes=100,
+            ready_us=100,
+            write_start_us=110,
+            last_byte_us=120,
+            flush_complete_us=130,
+        )
+        validate_transport_metrics(
+            [frame], {"textDocument/semanticTokens/full": 1}, 0, []
+        )
+        with self.assertRaises(RuntimeError):
+            validate_transport_metrics(
+                [], {"textDocument/semanticTokens/full": 1}, 0, []
+            )
+        with self.assertRaises(RuntimeError):
+            validate_transport_metrics(
+                [dataclasses.replace(frame, flush_complete_us=None)],
+                {"textDocument/semanticTokens/full": 1},
+                0,
+                [],
+            )
+        with self.assertRaises(RuntimeError):
+            validate_transport_metrics(
+                [frame], {"textDocument/semanticTokens/full": 1}, 1, []
+            )
 
 
 if __name__ == "__main__":

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -233,6 +233,25 @@ class RequestSummaryTest(unittest.TestCase):
             classify_semantic_blocking([tied_batch_blocker, semantic], 64 * 1024),
             (1, 0),
         )
+        earlier_blocker = dataclasses.replace(
+            large,
+            write_sequence=0,
+            flush_sequence=6,
+            last_byte_us=500,
+        )
+        later_blocker = dataclasses.replace(
+            large,
+            write_sequence=2,
+            flush_sequence=6,
+            last_byte_us=500,
+        )
+        semantic_between = dataclasses.replace(semantic, ready_sequence=1)
+        self.assertEqual(
+            classify_semantic_blocking(
+                [earlier_blocker, later_blocker, semantic_between], 64 * 1024
+            ),
+            (1, 0),
+        )
 
     def test_transport_validation_rejects_missing_or_censored_metrics(self):
         frame = TransportFrame(

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -106,6 +106,7 @@ class RequestSummaryTest(unittest.TestCase):
                 "event": "stdout_frame",
                 "frame": {
                     "ready_sequence": 3,
+                    "write_sequence": 4,
                     "method": "textDocument/semanticTokens/full",
                     "id": 9,
                     "body_bytes": 100,
@@ -130,6 +131,8 @@ class RequestSummaryTest(unittest.TestCase):
                 write_start_us=1500,
                 last_byte_us=2500,
                 flush_complete_us=3000,
+                ready_sequence=3,
+                write_sequence=4,
             ),
         )
         summary = summarize_transport_frames([frame])
@@ -172,6 +175,8 @@ class RequestSummaryTest(unittest.TestCase):
             write_start_us=500,
             last_byte_us=510,
             flush_complete_us=520,
+            ready_sequence=1,
+            write_sequence=4,
         )
         large = TransportFrame(
             method="kakehashi/captures/full/delta",
@@ -181,19 +186,25 @@ class RequestSummaryTest(unittest.TestCase):
             write_start_us=200,
             last_byte_us=450,
             flush_complete_us=460,
+            ready_sequence=0,
+            write_sequence=2,
         )
 
         self.assertEqual(
             classify_semantic_blocking([large, semantic], 64 * 1024),
             (1, 0),
         )
-        semantic_after_start = dataclasses.replace(semantic, ready_us=300)
+        semantic_after_start = dataclasses.replace(
+            semantic, ready_us=300, ready_sequence=3
+        )
         self.assertEqual(
             classify_semantic_blocking([large, semantic_after_start], 64 * 1024),
             (0, 1),
         )
 
-        semantic_during_flush = dataclasses.replace(semantic, ready_us=455)
+        semantic_during_flush = dataclasses.replace(
+            semantic, ready_us=455, ready_sequence=3
+        )
         self.assertEqual(
             classify_semantic_blocking([large, semantic_during_flush], 64 * 1024),
             (0, 1),

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -1,3 +1,5 @@
+import dataclasses
+import json
 import pathlib
 import sys
 import unittest
@@ -6,12 +8,16 @@ sys.path.insert(0, str(pathlib.Path(__file__).parent))
 
 from drive import (
     RequestSample,
+    TransportFrame,
+    classify_semantic_blocking,
     count_semantic_outcomes,
     next_toggle_change,
+    parse_stdout_metric_line,
     response_result_id,
     server_request_result,
     summarize_samples,
     summarize_samples_by_status,
+    summarize_transport_frames,
 )
 
 
@@ -68,10 +74,12 @@ class RequestSummaryTest(unittest.TestCase):
 
     def test_server_request_results_match_expected_shapes(self):
         self.assertEqual(
-            server_request_result({
-                "method": "workspace/configuration",
-                "params": {"items": [{}, {}]},
-            }),
+            server_request_result(
+                {
+                    "method": "workspace/configuration",
+                    "params": {"items": [{}, {}]},
+                }
+            ),
             [None, None],
         )
         self.assertEqual(
@@ -89,6 +97,99 @@ class RequestSummaryTest(unittest.TestCase):
         )
         self.assertIsNone(response_result_id({"result": None}))
         self.assertIsNone(response_result_id({"error": {"code": -32800}}))
+
+    def test_parses_and_summarizes_stdout_transport_metrics(self):
+        line = json.dumps(
+            {
+                "event": "stdout_frame",
+                "frame": {
+                    "ready_sequence": 3,
+                    "method": "textDocument/semanticTokens/full",
+                    "id": 9,
+                    "body_bytes": 100,
+                    "frame_bytes": 123,
+                    "ready_us": 1000,
+                    "write_start_us": 1500,
+                    "last_byte_us": 2500,
+                    "flush_complete_us": 3000,
+                },
+            }
+        )
+
+        frame = parse_stdout_metric_line(line)
+
+        self.assertEqual(
+            frame,
+            TransportFrame(
+                method="textDocument/semanticTokens/full",
+                request_id=9,
+                frame_bytes=123,
+                ready_us=1000,
+                write_start_us=1500,
+                last_byte_us=2500,
+                flush_complete_us=3000,
+            ),
+        )
+        summary = summarize_transport_frames([frame])
+        self.assertEqual(summary.count, 1)
+        self.assertEqual(summary.p90_ready_to_write_complete_ms, 1.5)
+        self.assertEqual(summary.p90_ready_to_flush_complete_ms, 2.0)
+        self.assertEqual(summary.max_frame_bytes, 123)
+
+    def test_rejects_non_metric_stderr_lines_and_unattributed_notifications(self):
+        self.assertIsNone(parse_stdout_metric_line("ordinary server log"))
+        self.assertIsNone(parse_stdout_metric_line(json.dumps({"event": "other"})))
+        frame = parse_stdout_metric_line(
+            json.dumps(
+                {
+                    "event": "stdout_frame",
+                    "frame": {
+                        "ready_sequence": None,
+                        "method": "window/logMessage",
+                        "id": None,
+                        "body_bytes": 10,
+                        "frame_bytes": 32,
+                        "ready_us": None,
+                        "write_start_us": 10,
+                        "last_byte_us": 10,
+                        "flush_complete_us": None,
+                    },
+                }
+            )
+        )
+        self.assertEqual(frame.method, "window/logMessage")
+        with self.assertRaises(ValueError):
+            summarize_transport_frames([frame])
+
+    def test_classifies_scheduler_opportunity_before_large_write_starts(self):
+        semantic = TransportFrame(
+            method="textDocument/semanticTokens/full",
+            request_id=2,
+            frame_bytes=100,
+            ready_us=100,
+            write_start_us=500,
+            last_byte_us=510,
+            flush_complete_us=520,
+        )
+        large = TransportFrame(
+            method="kakehashi/captures/full/delta",
+            request_id=1,
+            frame_bytes=1_000_000,
+            ready_us=90,
+            write_start_us=200,
+            last_byte_us=450,
+            flush_complete_us=460,
+        )
+
+        self.assertEqual(
+            classify_semantic_blocking([large, semantic], 64 * 1024),
+            (1, 0),
+        )
+        semantic_after_start = dataclasses.replace(semantic, ready_us=300)
+        self.assertEqual(
+            classify_semantic_blocking([large, semantic_after_start], 64 * 1024),
+            (0, 1),
+        )
 
 
 if __name__ == "__main__":

--- a/benches/profile/test_drive.py
+++ b/benches/profile/test_drive.py
@@ -19,6 +19,7 @@ from drive import (
     summarize_samples_by_status,
     summarize_transport_frames,
     validate_transport_metrics,
+    validate_diagnostic_report,
 )
 
 
@@ -197,6 +198,16 @@ class RequestSummaryTest(unittest.TestCase):
             classify_semantic_blocking([large, semantic_during_flush], 64 * 1024),
             (0, 1),
         )
+        notification = dataclasses.replace(
+            large,
+            method="textDocument/publishDiagnostics",
+            request_id=None,
+            ready_us=None,
+        )
+        self.assertEqual(
+            classify_semantic_blocking([notification, semantic], 64 * 1024),
+            (0, 0),
+        )
 
     def test_transport_validation_rejects_missing_or_censored_metrics(self):
         frame = TransportFrame(
@@ -226,6 +237,17 @@ class RequestSummaryTest(unittest.TestCase):
             validate_transport_metrics(
                 [frame], {"textDocument/semanticTokens/full": 1}, 1, []
             )
+
+    def test_diagnostic_scenario_requires_a_full_items_report(self):
+        validate_diagnostic_report({"result": {"kind": "full", "items": []}})
+        for response in (
+            {"result": {"kind": "unchanged", "resultId": "1"}},
+            {"result": {"kind": "full"}},
+            {"result": None},
+            {"error": {"code": -32603}},
+        ):
+            with self.assertRaises(RuntimeError):
+                validate_diagnostic_report(response)
 
 
 if __name__ == "__main__":

--- a/docs/architecture-decisions/upstream-stdout-frame-ordering.md
+++ b/docs/architecture-decisions/upstream-stdout-frame-ordering.md
@@ -26,13 +26,14 @@ that would introduce the very head-of-line cost being measured.
 The release workload used `__ignored/example.md`, a 5,088-line, 37,940-byte
 Markdown document matching the captured editor session's scale. Its SHA-256 is
 `bad443ab7b8d4328e1b255f90db65ee9c83353394e1db9f84f57b371972777f6`.
-Each scenario ran 20 edit/recompute cycles, repeated three times in interleaved
-A/A runs. The profile driver continuously drained stdout so the client did not
-manufacture pipe backpressure.
+Each scenario ran 20 edit/recompute cycles and was repeated three times. The
+captures-full observer check additionally interleaved three instrumented and
+three uninstrumented runs. The profile driver continuously drained stdout so
+the client did not manufacture pipe backpressure.
 
 Measurement provenance:
 
-- source: `420acaf5`;
+- source: `ea372f821`;
 - build: `cargo build --release --bin kakehashi`, rustc 1.95.0;
 - host: arm64 macOS 26.5.1 (Darwin 25.5.0, T8132); and
 - configuration: repository default discovery, `deps/test/kakehashi` data dir,
@@ -53,13 +54,14 @@ done
 
 | Scenario | Semantic request p90, three runs | Semantic ready → last byte p90 | Semantic ready → flush p90 |
 | --- | --- | --- | --- |
-| semantic only | 7.7 / 7.4 / 7.4 ms | 0.3 ms | 0.4 ms |
-| valid captures delta | 7.5 / 7.5 / 7.5 ms | 0.3 ms | 0.4 ms |
-| captures full fallback | 7.6 / 7.4 / 7.7 ms | 0.3 ms | 0.4 ms |
-| diagnostics burst | 9.3 / 9.4 / 9.3 ms | 0.3 ms | 0.4 ms |
+| semantic only | 7.9 / 11.7 / 8.5 ms | 0.3 / 0.6 / 0.3 ms | 0.4 / 0.7 / 0.4 ms |
+| valid captures delta | 7.6 / 15.1 / 10.0 ms | 0.3 / 0.6 / 0.4 ms | 0.4 / 0.7 / 0.5 ms |
+| captures full fallback | 9.1 / 9.6 / 9.0 ms | 0.4 / 0.4 / 0.4 ms | 0.4 / 0.5 / 0.5 ms |
+| diagnostics burst | 11.1 / 9.6 / 11.6 ms | 0.4 / 0.3 / 0.4 ms | 0.4 / 0.4 / 0.5 ms |
 
 The full captures fallback produced a 4,408.4 KiB frame. Its own
-ready-to-last-byte and ready-to-flush p90 were both 11.8–11.9 ms,
+ready-to-last-byte p90 was 14.2 / 15.8 / 14.3 ms and ready-to-flush
+p90 was 14.3 / 15.9 / 14.4 ms,
 but semantic responses were ready before that frame started in 0 of 60 cycles.
 They completed first, so a pre-write scheduler had no opportunity to improve
 semantic latency. The diagnostic responses in this configuration were valid
@@ -70,9 +72,10 @@ path; it is not a claim that every large-diagnostics configuration has the same
 opportunity rate.
 
 To check observer effect, the captures-full matrix was also run three times
-without `--stdout-metrics`. Instrumented captures p90 was 93.9 / 93.2 / 96.4 ms
-versus 90.1 / 94.6 / 93.7 ms uninstrumented; semantic p90 was
-7.6 / 7.4 / 7.7 ms versus 7.2 / 7.6 / 8.5 ms. The differences stayed within
+without `--stdout-metrics`. Instrumented captures p90 was
+110.3 / 125.3 / 110.3 ms versus 129.4 / 119.2 / 116.1 ms uninstrumented;
+semantic p90 was 9.1 / 9.6 / 9.0 ms versus 10.2 / 9.0 / 9.4 ms. The
+differences stayed within
 run-to-run variation after replacing per-byte tail maintenance with bounded
 slice copies.
 
@@ -105,7 +108,7 @@ must not hold service futures or consume ingress concurrency slots while queued.
 
 ### Keep FIFO and retain opt-in measurement
 
-Chosen. The measured semantic transport p90 is 0.3 ms and no schedulable
+Chosen. The measured semantic transport p90 is 0.3–0.6 ms and no schedulable
 large-frame overlap occurred, giving a very low current improvement ceiling.
 
 ### Add a bounded pre-write priority scheduler

--- a/docs/architecture-decisions/upstream-stdout-frame-ordering.md
+++ b/docs/architecture-decisions/upstream-stdout-frame-ordering.md
@@ -26,7 +26,7 @@ manufacture pipe backpressure.
 
 Measurement provenance:
 
-- source: `df555b55`;
+- source: `420acaf5`;
 - build: `cargo build --release --bin kakehashi`, rustc 1.95.0;
 - host: arm64 macOS 26.5.1 (Darwin 25.5.0, T8132); and
 - configuration: repository default discovery, `deps/test/kakehashi` data dir,
@@ -47,13 +47,13 @@ done
 
 | Scenario | Semantic request p90, three runs | Semantic ready → last byte p90 | Semantic ready → flush p90 |
 | --- | --- | --- | --- |
-| semantic only | 7.1 / 7.3 / 7.4 ms | 0.3 ms | 0.3–0.4 ms |
-| valid captures delta | 7.4 / 7.3 / 7.6 ms | 0.3 ms | 0.4 ms |
-| captures full fallback | 7.4 / 7.5 / 7.6 ms | 0.3 ms | 0.4 ms |
-| diagnostics burst | 9.2 / 9.1 / 9.1 ms | 0.3 ms | 0.3–0.4 ms |
+| semantic only | 7.7 / 7.4 / 7.4 ms | 0.3 ms | 0.4 ms |
+| valid captures delta | 7.5 / 7.5 / 7.5 ms | 0.3 ms | 0.4 ms |
+| captures full fallback | 7.6 / 7.4 / 7.7 ms | 0.3 ms | 0.4 ms |
+| diagnostics burst | 9.3 / 9.4 / 9.3 ms | 0.3 ms | 0.4 ms |
 
 The full captures fallback produced a 4,408.4 KiB frame. Its own
-ready-to-last-byte p90 was 11.4–12.5 ms and ready-to-flush p90 was 11.5–12.6 ms,
+ready-to-last-byte and ready-to-flush p90 were both 11.8–11.9 ms,
 but semantic responses were ready before that frame started in 0 of 60 cycles.
 They completed first, so a pre-write scheduler had no opportunity to improve
 semantic latency. The diagnostic responses in this configuration were valid
@@ -64,9 +64,9 @@ path; it is not a claim that every large-diagnostics configuration has the same
 opportunity rate.
 
 To check observer effect, the captures-full matrix was also run three times
-without `--stdout-metrics`. Instrumented captures p90 was 94.5 / 97.5 / 95.3 ms
+without `--stdout-metrics`. Instrumented captures p90 was 93.9 / 93.2 / 96.4 ms
 versus 90.1 / 94.6 / 93.7 ms uninstrumented; semantic p90 was
-7.4 / 7.5 / 7.6 ms versus 7.2 / 7.6 / 8.5 ms. The differences stayed within
+7.6 / 7.4 / 7.7 ms versus 7.2 / 7.6 / 8.5 ms. The differences stayed within
 run-to-run variation after replacing per-byte tail maintenance with bounded
 slice copies.
 

--- a/docs/architecture-decisions/upstream-stdout-frame-ordering.md
+++ b/docs/architecture-decisions/upstream-stdout-frame-ordering.md
@@ -1,0 +1,117 @@
+# Preserve FIFO Ordering for Upstream Stdout Frames
+
+**Related Decisions**: [ls-bridge-message-ordering](ls-bridge-message-ordering.md)
+
+## Context
+
+LSP uses one framed JSON-RPC byte stream on stdout. A response cannot be
+interleaved with another frame, but a bounded scheduler could choose among
+complete frames before any bytes of the selected frame are written. Issue #665
+asked whether large captures or diagnostic responses create enough head-of-line
+blocking to justify such a scheduler for semantic-token responses.
+
+The transport observer records, on a shared monotonic clock:
+
+- handler response-ready time and originating method;
+- first and last byte accepted by stdout, plus successful flush completion;
+- response ID and exact header + body byte count; and
+- censored frames whose final flush is not observed.
+
+The release workload used a 5,088-line, 37,940-byte Markdown document matching
+the captured editor session's scale. Each scenario ran 20 edit/recompute cycles,
+repeated three times in interleaved A/A runs. The profile driver continuously
+drained stdout so the client did not manufacture pipe backpressure.
+
+| Scenario | Semantic request p90, three runs | Semantic ready → last byte p90 | Semantic ready → flush p90 |
+| --- | --- | --- | --- |
+| semantic only | 7.5 / 7.3 / 7.3 ms | 0.3 ms | 0.5–0.6 ms |
+| valid captures delta | 7.1 / 7.3 / 7.2 ms | 0.3 ms | 0.5–0.6 ms |
+| captures full fallback | 7.1 / 7.2 / 7.5 ms | 0.3 ms | 0.6 ms |
+| diagnostics burst | 18.2 / 18.1 / 18.2 ms | 0.3 ms | 0.5–0.6 ms |
+
+The full captures fallback produced a 4,408.4 KiB frame. Its own
+ready-to-last-byte p90 was 22.3–23.2 ms and ready-to-flush p90 was 23.2–24.1 ms,
+but semantic responses were ready before that frame started in 0 of 60 cycles.
+They completed first, so a pre-write scheduler had no opportunity to improve
+semantic latency. The diagnostic responses in this configuration were small;
+the transport instrumentation remains available for configurations with large
+downstream diagnostic payloads.
+
+## Decision Drivers
+
+- JSON-RPC frames must never interleave.
+- The common path should not pay instrumentation or scheduling overhead.
+- Scheduling complexity requires measured opportunity, not only a large payload.
+- An optimization must exceed A/A variation and materially improve semantic p90.
+- Measurements must preserve response contents and continuously drain stdout.
+
+## Decision
+
+Keep the existing single physical FIFO stdout writer and do not add a frame
+scheduler now. Retain opt-in instrumentation and the repeatable four-scenario
+driver so future reports can be evaluated with the same metrics.
+
+Reconsider scheduling only if a representative trace shows both:
+
+1. semantic responses repeatedly become ready before a competing large frame
+   starts writing; and
+2. ready-to-last-byte semantic p90 has at least 1 ms of avoidable delay beyond
+   A/A variation.
+
+Any future scheduler must remain bounded, select only complete frames before
+their first byte is written, and keep one non-interleaving physical writer. It
+must not hold service futures or consume ingress concurrency slots while queued.
+
+## Considered Options
+
+### Keep FIFO and retain opt-in measurement
+
+Chosen. The measured semantic transport p90 is 0.3 ms and no schedulable
+large-frame overlap occurred, giving a very low current improvement ceiling.
+
+### Add a bounded pre-write priority scheduler
+
+Deferred. It could help only when semantic work is ready before another frame's
+first byte. The measured workload produced no such cases, while the scheduler
+would add queueing state, starvation policy, cancellation behavior, and a local
+replacement or upstream change for tower-lsp-server's private transport loop.
+
+### Interrupt or interleave a large frame already being written
+
+Rejected. Byte-level interleaving corrupts the JSON-RPC stream, and pausing a
+partially written frame does not create a valid boundary for another response.
+
+### Reduce or paginate large payloads
+
+Not selected as a transport change. A valid captures delta already reduces the
+repeat payload from 4,408.4 KiB to about 0.3 KiB. Full fallback remains a protocol
+compatibility path; pagination would change the protocol result and clients.
+
+## Consequences
+
+### Positive
+
+- Protocol ordering and the one-writer invariant remain simple and explicit.
+- Normal sessions pay no observer or scheduler overhead.
+- Future regressions can be separated into handler compute, queued transport,
+  active write, flush, payload-size, and scheduling-opportunity components.
+
+### Negative
+
+- A semantic response that becomes ready just before a future large write will
+  still follow FIFO order until measurements justify scheduling.
+- Opt-in runs retain frame metrics in memory until server shutdown.
+
+### Neutral
+
+- A frame already in progress remains uninterruptible under every valid option.
+- This decision does not change semantic-token, captures, or diagnostic payloads.
+
+## Confirmation
+
+Run the release driver three or more times for each scenario documented in
+`benches/profile/README.md`. Confirm exact response shapes, zero censored samples,
+per-method payload sizes, semantic ready-to-write/flush percentiles, and the
+`semantic-large-frame-overlap` classification. Open a new transport optimization
+only when the reconsideration thresholds above are met on a representative
+configuration.

--- a/docs/architecture-decisions/upstream-stdout-frame-ordering.md
+++ b/docs/architecture-decisions/upstream-stdout-frame-ordering.md
@@ -86,8 +86,8 @@ driver so future reports can be evaluated with the same metrics.
 
 Reconsider scheduling only if a representative trace shows both:
 
-1. semantic responses repeatedly become ready before a competing large frame
-   starts writing; and
+1. semantic responses repeatedly become ready before a competing large response
+   frame starts writing; and
 2. ready-to-last-byte semantic p90 has at least 1 ms of avoidable delay beyond
    A/A variation.
 
@@ -145,7 +145,7 @@ compatibility path; pagination would change the protocol result and clients.
 Run the release driver three or more times for each scenario documented in
 `benches/profile/README.md`. Confirm exact response shapes, zero censored samples,
 per-method payload sizes, semantic ready-to-write/flush percentiles, and the
-`semantic-large-frame-overlap` classification. Open a new transport optimization
+`semantic-large-response-overlap` classification. Open a new transport optimization
 only when the reconsideration thresholds above are met on a representative
 configuration.
 Do not generalize this decision to large diagnostic frames until a downstream

--- a/docs/architecture-decisions/upstream-stdout-frame-ordering.md
+++ b/docs/architecture-decisions/upstream-stdout-frame-ordering.md
@@ -17,6 +17,12 @@ The transport observer records, on a shared monotonic clock:
 - response ID and exact header + body byte count; and
 - censored frames whose final flush is not observed.
 
+The writer observer is scoped to tower-lsp-server 0.23's tokio-util
+`FramedWrite`: while a write is pending, its encoded buffer is immutable, and
+only a successfully accepted prefix is advanced. The observer deliberately does
+not hash the complete outstanding multi-megabyte range on every retry, because
+that would introduce the very head-of-line cost being measured.
+
 The release workload used `__ignored/example.md`, a 5,088-line, 37,940-byte
 Markdown document matching the captured editor session's scale. Its SHA-256 is
 `bad443ab7b8d4328e1b255f90db65ee9c83353394e1db9f84f57b371972777f6`.

--- a/docs/architecture-decisions/upstream-stdout-frame-ordering.md
+++ b/docs/architecture-decisions/upstream-stdout-frame-ordering.md
@@ -61,10 +61,11 @@ done
 
 The full captures fallback produced a 4,408.4 KiB frame. Its own
 ready-to-last-byte p90 was 14.2 / 15.8 / 14.3 ms and ready-to-flush
-p90 was 14.3 / 15.9 / 14.4 ms,
-but semantic responses were ready before that frame started in 0 of 60 cycles.
-They completed first, so a pre-write scheduler had no opportunity to improve
-semantic latency. The diagnostic responses in this configuration were valid
+p90 was 14.3 / 15.9 / 14.4 ms, but 0 of 60 semantic responses were queued
+behind an attributed large frame whose first write had not started. The
+semantic responses instead completed first, so a pre-write scheduler had no
+opportunity to improve semantic latency. The diagnostic responses in this
+configuration were valid
 full reports but only about 0.1 KiB. They exercise burst ordering and metric
 attribution, not the large diagnostic payload from the captured editor log. The
 scheduling defer is therefore supported by the representative captures-full
@@ -95,8 +96,8 @@ driver so future reports can be evaluated with the same metrics.
 
 Reconsider scheduling only if a representative trace shows both:
 
-1. semantic responses repeatedly become ready before a competing large response
-   frame starts writing; and
+1. semantic responses repeatedly become ready while an earlier competing large
+   response is queued but has not started writing; and
 2. ready-to-last-byte semantic p90 has at least 1 ms of avoidable delay beyond
    A/A variation.
 
@@ -113,10 +114,11 @@ large-frame overlap occurred, giving a very low current improvement ceiling.
 
 ### Add a bounded pre-write priority scheduler
 
-Deferred. It could help only when semantic work is ready before another frame's
-first byte. The measured workload produced no such cases, while the scheduler
-would add queueing state, starvation policy, cancellation behavior, and a local
-replacement or upstream change for tower-lsp-server's private transport loop.
+Deferred. It could help only when semantic work is ready while an earlier large
+frame is queued but has not written its first byte. The measured workload
+produced no such cases, while the scheduler would add queueing state, starvation
+policy, cancellation behavior, and a local replacement or upstream change for
+tower-lsp-server's private transport loop.
 
 ### Interrupt or interleave a large frame already being written
 

--- a/docs/architecture-decisions/upstream-stdout-frame-ordering.md
+++ b/docs/architecture-decisions/upstream-stdout-frame-ordering.md
@@ -26,7 +26,7 @@ manufacture pipe backpressure.
 
 Measurement provenance:
 
-- source: `feb35ab2`;
+- source: `df555b55`;
 - build: `cargo build --release --bin kakehashi`, rustc 1.95.0;
 - host: arm64 macOS 26.5.1 (Darwin 25.5.0, T8132); and
 - configuration: repository default discovery, `deps/test/kakehashi` data dir,
@@ -47,13 +47,13 @@ done
 
 | Scenario | Semantic request p90, three runs | Semantic ready → last byte p90 | Semantic ready → flush p90 |
 | --- | --- | --- | --- |
-| semantic only | 7.4 / 7.4 / 7.1 ms | 0.3 ms | 0.3–0.4 ms |
-| valid captures delta | 7.4 / 7.4 / 7.3 ms | 0.3 ms | 0.4 ms |
-| captures full fallback | 7.3 / 7.4 / 7.5 ms | 0.3 ms | 0.4 ms |
-| diagnostics burst | 18.4 / 17.9 / 17.8 ms | 0.3 ms | 0.3–0.4 ms |
+| semantic only | 7.1 / 7.3 / 7.4 ms | 0.3 ms | 0.3–0.4 ms |
+| valid captures delta | 7.4 / 7.3 / 7.6 ms | 0.3 ms | 0.4 ms |
+| captures full fallback | 7.4 / 7.5 / 7.6 ms | 0.3 ms | 0.4 ms |
+| diagnostics burst | 9.2 / 9.1 / 9.1 ms | 0.3 ms | 0.3–0.4 ms |
 
 The full captures fallback produced a 4,408.4 KiB frame. Its own
-ready-to-last-byte p90 was 11.0–12.0 ms and ready-to-flush p90 was 11.0–12.1 ms,
+ready-to-last-byte p90 was 11.4–12.5 ms and ready-to-flush p90 was 11.5–12.6 ms,
 but semantic responses were ready before that frame started in 0 of 60 cycles.
 They completed first, so a pre-write scheduler had no opportunity to improve
 semantic latency. The diagnostic responses in this configuration were valid
@@ -64,9 +64,9 @@ path; it is not a claim that every large-diagnostics configuration has the same
 opportunity rate.
 
 To check observer effect, the captures-full matrix was also run three times
-without `--stdout-metrics`. Instrumented captures p90 was 93.6 / 89.8 / 90.7 ms
+without `--stdout-metrics`. Instrumented captures p90 was 94.5 / 97.5 / 95.3 ms
 versus 90.1 / 94.6 / 93.7 ms uninstrumented; semantic p90 was
-7.3 / 7.4 / 7.5 ms versus 7.2 / 7.6 / 8.5 ms. The differences stayed within
+7.4 / 7.5 / 7.6 ms versus 7.2 / 7.6 / 8.5 ms. The differences stayed within
 run-to-run variation after replacing per-byte tail maintenance with bounded
 slice copies.
 

--- a/docs/architecture-decisions/upstream-stdout-frame-ordering.md
+++ b/docs/architecture-decisions/upstream-stdout-frame-ordering.md
@@ -13,29 +13,62 @@ blocking to justify such a scheduler for semantic-token responses.
 The transport observer records, on a shared monotonic clock:
 
 - handler response-ready time and originating method;
-- first and last byte accepted by stdout, plus successful flush completion;
+- first write attempt, last byte accepted by stdout, and successful flush completion;
 - response ID and exact header + body byte count; and
 - censored frames whose final flush is not observed.
 
-The release workload used a 5,088-line, 37,940-byte Markdown document matching
-the captured editor session's scale. Each scenario ran 20 edit/recompute cycles,
-repeated three times in interleaved A/A runs. The profile driver continuously
-drained stdout so the client did not manufacture pipe backpressure.
+The release workload used `__ignored/example.md`, a 5,088-line, 37,940-byte
+Markdown document matching the captured editor session's scale. Its SHA-256 is
+`bad443ab7b8d4328e1b255f90db65ee9c83353394e1db9f84f57b371972777f6`.
+Each scenario ran 20 edit/recompute cycles, repeated three times in interleaved
+A/A runs. The profile driver continuously drained stdout so the client did not
+manufacture pipe backpressure.
+
+Measurement provenance:
+
+- source: `feb35ab2`;
+- build: `cargo build --release --bin kakehashi`, rustc 1.95.0;
+- host: arm64 macOS 26.5.1 (Darwin 25.5.0, T8132); and
+- configuration: repository default discovery, `deps/test/kakehashi` data dir,
+  no extra server arguments.
+
+The exact interleaved matrix was:
+
+```sh
+for repeat in 1 2 3; do
+  for scenario in semantic-only captures-delta captures-full diagnostics-burst; do
+    benches/profile/drive.py \
+      --bin ./target/release/kakehashi \
+      --file __ignored/example.md --requests 20 --edits 1 --settle 0.3 \
+      --stdout-metrics --scenario "$scenario"
+  done
+done
+```
 
 | Scenario | Semantic request p90, three runs | Semantic ready → last byte p90 | Semantic ready → flush p90 |
 | --- | --- | --- | --- |
-| semantic only | 7.5 / 7.3 / 7.3 ms | 0.3 ms | 0.5–0.6 ms |
-| valid captures delta | 7.1 / 7.3 / 7.2 ms | 0.3 ms | 0.5–0.6 ms |
-| captures full fallback | 7.1 / 7.2 / 7.5 ms | 0.3 ms | 0.6 ms |
-| diagnostics burst | 18.2 / 18.1 / 18.2 ms | 0.3 ms | 0.5–0.6 ms |
+| semantic only | 7.4 / 7.4 / 7.1 ms | 0.3 ms | 0.3–0.4 ms |
+| valid captures delta | 7.4 / 7.4 / 7.3 ms | 0.3 ms | 0.4 ms |
+| captures full fallback | 7.3 / 7.4 / 7.5 ms | 0.3 ms | 0.4 ms |
+| diagnostics burst | 18.4 / 17.9 / 17.8 ms | 0.3 ms | 0.3–0.4 ms |
 
 The full captures fallback produced a 4,408.4 KiB frame. Its own
-ready-to-last-byte p90 was 22.3–23.2 ms and ready-to-flush p90 was 23.2–24.1 ms,
+ready-to-last-byte p90 was 11.0–12.0 ms and ready-to-flush p90 was 11.0–12.1 ms,
 but semantic responses were ready before that frame started in 0 of 60 cycles.
 They completed first, so a pre-write scheduler had no opportunity to improve
-semantic latency. The diagnostic responses in this configuration were small;
-the transport instrumentation remains available for configurations with large
-downstream diagnostic payloads.
+semantic latency. The diagnostic responses in this configuration were valid
+full reports but only about 0.1 KiB. They exercise burst ordering and metric
+attribution, not the large diagnostic payload from the captured editor log. The
+scheduling defer is therefore supported by the representative captures-full
+path; it is not a claim that every large-diagnostics configuration has the same
+opportunity rate.
+
+To check observer effect, the captures-full matrix was also run three times
+without `--stdout-metrics`. Instrumented captures p90 was 93.6 / 89.8 / 90.7 ms
+versus 90.1 / 94.6 / 93.7 ms uninstrumented; semantic p90 was
+7.3 / 7.4 / 7.5 ms versus 7.2 / 7.6 / 8.5 ms. The differences stayed within
+run-to-run variation after replacing per-byte tail maintenance with bounded
+slice copies.
 
 ## Decision Drivers
 
@@ -115,3 +148,5 @@ per-method payload sizes, semantic ready-to-write/flush percentiles, and the
 `semantic-large-frame-overlap` classification. Open a new transport optimization
 only when the reconsideration thresholds above are met on a representative
 configuration.
+Do not generalize this decision to large diagnostic frames until a downstream
+fixture or real configuration produces a representative diagnostic payload.

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -799,9 +799,12 @@ fn run_diagnose(options: kakehashi::cli::diagnose::DiagnoseOptions) -> Result<()
 async fn run_lsp_server() {
     use env_logger::Builder;
     use kakehashi::lsp::{
-        CancelForwarder, IngressOrderGate, Kakehashi, LanguageServerPool, RequestIdCapture,
+        CancelForwarder, IngressOrderGate, Kakehashi, LanguageServerPool, MeasuredStdout,
+        RequestIdCapture, ResponseReadyService, StdoutMetrics,
     };
+    use std::io;
     use std::sync::Arc;
+    use std::time::Instant;
     use tokio::io::{stdin, stdout};
     use tower_lsp_server::{LspService, Server};
 
@@ -1034,8 +1037,23 @@ async fn run_lsp_server() {
     // burst (≈10 concurrent reader parks per document) across several
     // documents, with headroom.
     const INGRESS_CONCURRENCY: usize = 64;
-    Server::new(stdin, stdout, socket)
+    if std::env::var_os("KAKEHASHI_STDOUT_METRICS").is_some() {
+        let metrics = Arc::new(StdoutMetrics::new(Instant::now()));
+        Server::new(
+            stdin,
+            MeasuredStdout::new(stdout, Arc::clone(&metrics)),
+            socket,
+        )
         .concurrency_level(INGRESS_CONCURRENCY)
-        .serve(service)
+        .serve(ResponseReadyService::new(service, Arc::clone(&metrics)))
         .await;
+        if let Err(error) = metrics.write_jsonl(io::stderr().lock()) {
+            eprintln!("failed to write stdout metrics: {error}");
+        }
+    } else {
+        Server::new(stdin, stdout, socket)
+            .concurrency_level(INGRESS_CONCURRENCY)
+            .serve(service)
+            .await;
+    }
 }

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -6,6 +6,7 @@ mod debounced_diagnostics;
 mod diagnostic_cache;
 pub(crate) mod in_progress_set;
 mod settings_manager;
+mod stdout_metrics;
 mod synthetic_diagnostics;
 mod text_sync;
 
@@ -24,3 +25,5 @@ pub use lsp_impl::Kakehashi;
 pub(crate) use request_id::current_upstream_id;
 pub use request_id::{CancelForwarder, RequestIdCapture};
 pub(crate) use settings::{SettingsEvent, SettingsEventKind, SettingsSource, load_settings};
+#[doc(hidden)]
+pub use stdout_metrics::{MeasuredStdout, ResponseReadyService, StdoutMetrics};

--- a/src/lsp/stdout_metrics.rs
+++ b/src/lsp/stdout_metrics.rs
@@ -1,0 +1,597 @@
+use std::collections::{HashMap, VecDeque};
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWrite;
+use tower::Service;
+use tower_lsp_server::jsonrpc::{Id, Request, Response};
+
+use crate::error::LockResultExt;
+
+const HEADER_LIMIT: usize = 8 * 1024;
+const BODY_PREFIX_LIMIT: usize = 512;
+const BODY_TAIL_LIMIT: usize = 256;
+
+#[derive(Clone, Debug)]
+struct ReadyEvent {
+    sequence: u64,
+    method: String,
+    at: Instant,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+struct FrameMetric {
+    ready_sequence: Option<u64>,
+    method: Option<String>,
+    id: Option<Id>,
+    body_bytes: usize,
+    frame_bytes: usize,
+    ready_us: Option<u64>,
+    write_start_us: u64,
+    last_byte_us: u64,
+    flush_complete_us: Option<u64>,
+}
+
+#[derive(Default)]
+struct MetricsState {
+    next_sequence: u64,
+    response_ready: HashMap<Id, VecDeque<ReadyEvent>>,
+    frames: Vec<FrameMetric>,
+}
+
+#[doc(hidden)]
+pub struct StdoutMetrics {
+    origin: Instant,
+    state: Mutex<MetricsState>,
+}
+
+impl StdoutMetrics {
+    pub fn new(origin: Instant) -> Self {
+        Self {
+            origin,
+            state: Mutex::new(MetricsState::default()),
+        }
+    }
+
+    fn record_response_ready(&self, id: Id, method: String, at: Instant) {
+        let mut state = self
+            .state
+            .lock()
+            .recover_poison("StdoutMetrics::record_response_ready");
+        let sequence = state.next_sequence;
+        state.next_sequence = state.next_sequence.wrapping_add(1);
+        state
+            .response_ready
+            .entry(id)
+            .or_default()
+            .push_back(ReadyEvent {
+                sequence,
+                method,
+                at,
+            });
+    }
+
+    #[cfg(test)]
+    fn frames(&self) -> Vec<FrameMetric> {
+        self.state
+            .lock()
+            .expect("stdout metrics lock poisoned")
+            .frames
+            .clone()
+    }
+
+    fn finish_frame(&self, mut frame: FrameMetric, id: Option<Id>) {
+        let mut state = self
+            .state
+            .lock()
+            .recover_poison("StdoutMetrics::finish_frame");
+        if frame.method.is_none()
+            && let Some(id) = id.as_ref()
+            && let Some(queue) = state.response_ready.get_mut(id)
+            && let Some(ready) = queue.pop_front()
+        {
+            frame.ready_sequence = Some(ready.sequence);
+            frame.method = Some(ready.method);
+            frame.ready_us = Some(self.timestamp_us(ready.at));
+            if queue.is_empty() {
+                state.response_ready.remove(id);
+            }
+        }
+        state.frames.push(frame);
+    }
+
+    fn timestamp_us(&self, at: Instant) -> u64 {
+        at.saturating_duration_since(self.origin).as_micros() as u64
+    }
+
+    pub fn write_jsonl(&self, mut writer: impl io::Write) -> io::Result<()> {
+        let state = self
+            .state
+            .lock()
+            .recover_poison("StdoutMetrics::write_jsonl");
+        for frame in &state.frames {
+            serde_json::to_writer(
+                &mut writer,
+                &serde_json::json!({"event": "stdout_frame", "frame": frame}),
+            )?;
+            writer.write_all(b"\n")?;
+        }
+        Ok(())
+    }
+}
+
+struct FrameObserver {
+    metrics: Arc<StdoutMetrics>,
+    decode: DecodeState,
+    awaiting_flush: Vec<(FrameMetric, Option<Id>)>,
+}
+
+#[doc(hidden)]
+pub struct MeasuredStdout<W> {
+    inner: W,
+    observer: FrameObserver,
+}
+
+#[doc(hidden)]
+pub struct ResponseReadyService<S> {
+    inner: S,
+    metrics: Arc<StdoutMetrics>,
+}
+
+impl<S> ResponseReadyService<S> {
+    pub fn new(inner: S, metrics: Arc<StdoutMetrics>) -> Self {
+        Self { inner, metrics }
+    }
+}
+
+impl<S> Service<Request> for ResponseReadyService<S>
+where
+    S: Service<Request, Response = Option<Response>>,
+    S::Future: Send + 'static,
+    S::Error: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        let method = request.method().to_string();
+        let future = self.inner.call(request);
+        let metrics = Arc::clone(&self.metrics);
+        Box::pin(async move {
+            let response = future.await?;
+            if let Some(response) = response.as_ref() {
+                metrics.record_response_ready(response.id().clone(), method, Instant::now());
+            }
+            Ok(response)
+        })
+    }
+}
+
+impl<W> MeasuredStdout<W> {
+    pub fn new(inner: W, metrics: Arc<StdoutMetrics>) -> Self {
+        Self {
+            inner,
+            observer: FrameObserver::new(metrics),
+        }
+    }
+}
+
+impl<W: AsyncWrite + Unpin> AsyncWrite for MeasuredStdout<W> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bytes: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let result = Pin::new(&mut self.inner).poll_write(cx, bytes);
+        if let Poll::Ready(Ok(accepted)) = result
+            && accepted > 0
+        {
+            self.observer.accepted(&bytes[..accepted], Instant::now());
+        }
+        result
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let result = Pin::new(&mut self.inner).poll_flush(cx);
+        if matches!(result, Poll::Ready(Ok(()))) {
+            self.observer.flushed(Instant::now());
+        }
+        result
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let result = Pin::new(&mut self.inner).poll_shutdown(cx);
+        if matches!(result, Poll::Ready(Ok(()))) {
+            self.observer.flushed(Instant::now());
+        }
+        result
+    }
+}
+
+enum DecodeState {
+    Header {
+        bytes: Vec<u8>,
+        write_start: Option<Instant>,
+    },
+    Body {
+        header_bytes: usize,
+        content_length: usize,
+        seen: usize,
+        prefix: Vec<u8>,
+        tail: VecDeque<u8>,
+        write_start: Instant,
+    },
+    Disabled,
+}
+
+impl FrameObserver {
+    fn new(metrics: Arc<StdoutMetrics>) -> Self {
+        Self {
+            metrics,
+            decode: DecodeState::Header {
+                bytes: Vec::new(),
+                write_start: None,
+            },
+            awaiting_flush: Vec::new(),
+        }
+    }
+
+    fn accepted(&mut self, mut bytes: &[u8], at: Instant) {
+        while !bytes.is_empty() {
+            match &mut self.decode {
+                DecodeState::Header {
+                    bytes: header,
+                    write_start,
+                } => {
+                    write_start.get_or_insert(at);
+                    let byte = bytes[0];
+                    bytes = &bytes[1..];
+                    header.push(byte);
+                    if header.len() > HEADER_LIMIT {
+                        self.decode = DecodeState::Disabled;
+                        return;
+                    }
+                    if header.ends_with(b"\r\n\r\n") {
+                        let Some(content_length) = content_length(header) else {
+                            self.decode = DecodeState::Disabled;
+                            return;
+                        };
+                        self.decode = DecodeState::Body {
+                            header_bytes: header.len(),
+                            content_length,
+                            seen: 0,
+                            prefix: Vec::with_capacity(content_length.min(BODY_PREFIX_LIMIT)),
+                            tail: VecDeque::with_capacity(content_length.min(BODY_TAIL_LIMIT)),
+                            write_start: write_start.expect("header start is set before bytes"),
+                        };
+                    }
+                }
+                DecodeState::Body {
+                    header_bytes,
+                    content_length,
+                    seen,
+                    prefix,
+                    tail,
+                    write_start,
+                } => {
+                    let take = (*content_length - *seen).min(bytes.len());
+                    let accepted = &bytes[..take];
+                    bytes = &bytes[take..];
+                    if prefix.len() < BODY_PREFIX_LIMIT {
+                        let prefix_take = (BODY_PREFIX_LIMIT - prefix.len()).min(accepted.len());
+                        prefix.extend_from_slice(&accepted[..prefix_take]);
+                    }
+                    for byte in accepted {
+                        if tail.len() == BODY_TAIL_LIMIT {
+                            tail.pop_front();
+                        }
+                        tail.push_back(*byte);
+                    }
+                    *seen += take;
+                    if *seen == *content_length {
+                        let tail: Vec<u8> = tail.iter().copied().collect();
+                        let id = response_id(&tail);
+                        let method = method_name(prefix);
+                        self.awaiting_flush.push((
+                            FrameMetric {
+                                ready_sequence: None,
+                                method,
+                                id: id.clone(),
+                                body_bytes: *content_length,
+                                frame_bytes: *header_bytes + *content_length,
+                                ready_us: None,
+                                write_start_us: self.metrics.timestamp_us(*write_start),
+                                last_byte_us: self.metrics.timestamp_us(at),
+                                flush_complete_us: None,
+                            },
+                            id,
+                        ));
+                        self.decode = DecodeState::Header {
+                            bytes: Vec::new(),
+                            write_start: None,
+                        };
+                    }
+                }
+                DecodeState::Disabled => return,
+            }
+        }
+    }
+
+    fn flushed(&mut self, at: Instant) {
+        let flush_complete_us = self.metrics.timestamp_us(at);
+        for (mut frame, id) in self.awaiting_flush.drain(..) {
+            frame.flush_complete_us = Some(flush_complete_us);
+            self.metrics.finish_frame(frame, id);
+        }
+    }
+}
+
+impl Drop for FrameObserver {
+    fn drop(&mut self) {
+        for (frame, id) in self.awaiting_flush.drain(..) {
+            self.metrics.finish_frame(frame, id);
+        }
+    }
+}
+
+fn content_length(header: &[u8]) -> Option<usize> {
+    std::str::from_utf8(header).ok()?.lines().find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        name.eq_ignore_ascii_case("content-length")
+            .then(|| value.trim().parse().ok())
+            .flatten()
+    })
+}
+
+fn response_id(tail: &[u8]) -> Option<Id> {
+    let marker = b",\"id\":";
+    let start = tail
+        .windows(marker.len())
+        .rposition(|window| window == marker)?
+        + marker.len();
+    let mut deserializer = serde_json::Deserializer::from_slice(&tail[start..]);
+    Id::deserialize(&mut deserializer).ok()
+}
+
+fn method_name(prefix: &[u8]) -> Option<String> {
+    let start = top_level_value_start(prefix, b"method")?;
+    let mut deserializer = serde_json::Deserializer::from_slice(&prefix[start..]);
+    String::deserialize(&mut deserializer).ok()
+}
+
+fn top_level_value_start(json: &[u8], wanted_key: &[u8]) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut string_start = None;
+    let mut escaped = false;
+
+    for (index, byte) in json.iter().copied().enumerate() {
+        if let Some(start) = string_start {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                string_start = None;
+                if depth == 1 && json.get(start..index) == Some(wanted_key) {
+                    let colon = json[index + 1..]
+                        .iter()
+                        .position(|byte| !byte.is_ascii_whitespace())?
+                        + index
+                        + 1;
+                    if json.get(colon) == Some(&b':') {
+                        return Some(colon + 1);
+                    }
+                }
+            }
+            continue;
+        }
+
+        match byte {
+            b'"' => string_start = Some(index + 1),
+            b'{' | b'[' => depth = depth.saturating_add(1),
+            b'}' | b']' => depth = depth.saturating_sub(1),
+            _ => {}
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::convert::Infallible;
+    use std::future::ready;
+    use std::time::Duration;
+    use tower_lsp_server::jsonrpc::{Request, Response};
+
+    #[derive(Clone)]
+    struct EchoService;
+
+    impl tower::Service<Request> for EchoService {
+        type Response = Option<Response>;
+        type Error = Infallible;
+        type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, request: Request) -> Self::Future {
+            ready(Ok(request
+                .id()
+                .cloned()
+                .map(|id| Response::from_ok(id, serde_json::Value::Null))))
+        }
+    }
+
+    #[tokio::test]
+    async fn service_records_a_completed_response_with_its_request_method() {
+        let origin = Instant::now();
+        let metrics = Arc::new(StdoutMetrics::new(origin));
+        let mut service = ResponseReadyService::new(EchoService, Arc::clone(&metrics));
+        let request = Request::build("textDocument/semanticTokens/full")
+            .id(7i64)
+            .finish();
+
+        let response = tower::Service::call(&mut service, request)
+            .await
+            .unwrap()
+            .unwrap();
+        metrics.finish_frame(
+            FrameMetric {
+                ready_sequence: None,
+                method: None,
+                id: Some(response.id().clone()),
+                body_bytes: 0,
+                frame_bytes: 0,
+                ready_us: None,
+                write_start_us: 0,
+                last_byte_us: 0,
+                flush_complete_us: None,
+            },
+            Some(response.id().clone()),
+        );
+
+        let frame = &metrics.frames()[0];
+        assert_eq!(frame.ready_sequence, Some(0));
+        assert_eq!(
+            frame.method.as_deref(),
+            Some("textDocument/semanticTokens/full")
+        );
+        assert!(frame.ready_us.is_some());
+    }
+
+    #[test]
+    fn split_response_is_reported_only_after_flush() {
+        let origin = Instant::now();
+        let metrics = Arc::new(StdoutMetrics::new(origin));
+        metrics.record_response_ready(
+            Id::Number(7),
+            "textDocument/semanticTokens/full".to_string(),
+            origin + Duration::from_micros(10),
+        );
+        let mut observer = FrameObserver::new(Arc::clone(&metrics));
+        let body = br#"{"jsonrpc":"2.0","id":7,"result":null}"#;
+        let frame = [
+            format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes(),
+            body.to_vec(),
+        ]
+        .concat();
+
+        observer.accepted(&frame[..9], origin + Duration::from_micros(20));
+        observer.accepted(&frame[9..], origin + Duration::from_micros(30));
+        assert!(
+            metrics.frames().is_empty(),
+            "accepted bytes are not flushed"
+        );
+
+        observer.flushed(origin + Duration::from_micros(40));
+
+        assert_eq!(
+            metrics.frames(),
+            vec![FrameMetric {
+                ready_sequence: Some(0),
+                method: Some("textDocument/semanticTokens/full".to_string()),
+                id: Some(Id::Number(7)),
+                body_bytes: body.len(),
+                frame_bytes: frame.len(),
+                ready_us: Some(10),
+                write_start_us: 20,
+                last_byte_us: 30,
+                flush_complete_us: Some(40),
+            }]
+        );
+    }
+
+    #[test]
+    fn nested_method_field_does_not_hide_response_attribution() {
+        let origin = Instant::now();
+        let metrics = Arc::new(StdoutMetrics::new(origin));
+        metrics.record_response_ready(
+            Id::Number(7),
+            "textDocument/semanticTokens/full".to_string(),
+            origin + Duration::from_micros(10),
+        );
+        let mut observer = FrameObserver::new(Arc::clone(&metrics));
+        let body = br#"{"jsonrpc":"2.0","result":{"method":"nested"},"id":7}"#;
+        let frame = [
+            format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes(),
+            body.to_vec(),
+        ]
+        .concat();
+
+        observer.accepted(&frame, origin + Duration::from_micros(20));
+        observer.flushed(origin + Duration::from_micros(30));
+
+        assert_eq!(
+            metrics.frames()[0].method.as_deref(),
+            Some("textDocument/semanticTokens/full")
+        );
+    }
+
+    #[tokio::test]
+    async fn async_writer_reports_the_bytes_accepted_by_its_inner_writer() {
+        use tokio::io::AsyncWriteExt;
+
+        let origin = Instant::now();
+        let metrics = Arc::new(StdoutMetrics::new(origin));
+        metrics.record_response_ready(
+            Id::String("semantic-7".to_string()),
+            "textDocument/semanticTokens/full".to_string(),
+            origin,
+        );
+        let body = br#"{"jsonrpc":"2.0","result":null,"id":"semantic-7"}"#;
+        let frame = [
+            format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes(),
+            body.to_vec(),
+        ]
+        .concat();
+        let mock = tokio_test::io::Builder::new().write(&frame).build();
+        let mut stdout = MeasuredStdout::new(mock, Arc::clone(&metrics));
+
+        stdout.write_all(&frame).await.unwrap();
+        assert!(
+            metrics.frames().is_empty(),
+            "write acceptance is not a flush"
+        );
+        stdout.flush().await.unwrap();
+
+        let frames = metrics.frames();
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].id, Some(Id::String("semantic-7".to_string())));
+        assert_eq!(frames[0].body_bytes, body.len());
+        assert_eq!(frames[0].frame_bytes, frame.len());
+        assert!(frames[0].flush_complete_us.unwrap() >= frames[0].last_byte_us);
+    }
+
+    #[test]
+    fn completed_frame_without_flush_is_reported_as_censored_on_drop() {
+        let origin = Instant::now();
+        let metrics = Arc::new(StdoutMetrics::new(origin));
+        let body = br#"{"jsonrpc":"2.0","method":"window/logMessage"}"#;
+        let frame = [
+            format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes(),
+            body.to_vec(),
+        ]
+        .concat();
+
+        {
+            let mut observer = FrameObserver::new(Arc::clone(&metrics));
+            observer.accepted(&frame, origin + Duration::from_micros(10));
+        }
+
+        let frames = metrics.frames();
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].flush_complete_us, None);
+    }
+}

--- a/src/lsp/stdout_metrics.rs
+++ b/src/lsp/stdout_metrics.rs
@@ -195,6 +195,8 @@ struct FrameObserver {
     decode: DecodeState,
     awaiting_flush: Vec<(FrameMetric, Option<Id>)>,
     offered: VecDeque<OfferedSegment>,
+    offered_ptr: Option<usize>,
+    offered_prefix: Vec<u8>,
 }
 
 struct OfferedSegment {
@@ -285,7 +287,7 @@ impl<W: AsyncWrite + Unpin> AsyncWrite for MeasuredStdout<W> {
         bytes: &[u8],
     ) -> Poll<io::Result<usize>> {
         if !bytes.is_empty() {
-            self.observer.offered(bytes.len(), Instant::now());
+            self.observer.offered(bytes, Instant::now());
         }
         let result = Pin::new(&mut self.inner).poll_write(cx, bytes);
         if let Poll::Ready(Ok(accepted)) = result
@@ -299,6 +301,7 @@ impl<W: AsyncWrite + Unpin> AsyncWrite for MeasuredStdout<W> {
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         let result = Pin::new(&mut self.inner).poll_flush(cx);
         if matches!(result, Poll::Ready(Ok(()))) {
+            self.observer.abandon_unaccepted_offer();
             self.observer.flushed(Instant::now());
         }
         result
@@ -307,6 +310,7 @@ impl<W: AsyncWrite + Unpin> AsyncWrite for MeasuredStdout<W> {
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         let result = Pin::new(&mut self.inner).poll_shutdown(cx);
         if matches!(result, Poll::Ready(Ok(()))) {
+            self.observer.abandon_unaccepted_offer();
             self.observer.flushed(Instant::now());
         }
         result
@@ -342,12 +346,28 @@ impl FrameObserver {
             },
             awaiting_flush: Vec::new(),
             offered: VecDeque::new(),
+            offered_ptr: None,
+            offered_prefix: Vec::new(),
         }
     }
 
-    fn offered(&mut self, bytes: usize, at: Instant) {
+    fn offered(&mut self, bytes: &[u8], at: Instant) {
         let covered: usize = self.offered.iter().map(|segment| segment.remaining).sum();
-        if bytes <= covered {
+        let pointer = bytes.as_ptr() as usize;
+        let same_offer = self.offered_ptr == Some(pointer)
+            && covered <= bytes.len()
+            && (self.offered_prefix.is_empty() || bytes.starts_with(&self.offered_prefix));
+        let covered = if same_offer {
+            covered
+        } else {
+            self.abandon_unaccepted_offer();
+            0
+        };
+        self.offered_ptr = Some(pointer);
+        self.offered_prefix.clear();
+        self.offered_prefix
+            .extend_from_slice(&bytes[..bytes.len().min(64)]);
+        if bytes.len() <= covered {
             return;
         }
         let attempt = WriteAttempt {
@@ -355,7 +375,7 @@ impl FrameObserver {
             sequence: self.metrics.next_event_sequence(),
         };
         self.offered.push_back(OfferedSegment {
-            remaining: bytes - covered,
+            remaining: bytes.len() - covered,
             attempt,
         });
         if covered == 0
@@ -367,11 +387,12 @@ impl FrameObserver {
 
     fn accepted(&mut self, mut bytes: &[u8], at: Instant) {
         if self.offered.is_empty() {
-            self.offered(bytes.len(), at);
+            self.offered(bytes, at);
         }
+        let accepted_len = bytes.len();
         while !bytes.is_empty() {
             let Some(mut segment) = self.offered.pop_front() else {
-                self.offered(bytes.len(), at);
+                self.offered(bytes, at);
                 continue;
             };
             let take = segment.remaining.min(bytes.len());
@@ -381,6 +402,33 @@ impl FrameObserver {
             if segment.remaining > 0 {
                 self.offered.push_front(segment);
             }
+        }
+        if self.offered.is_empty() {
+            self.offered_ptr = None;
+            self.offered_prefix.clear();
+        } else if let Some(pointer) = self.offered_ptr.as_mut() {
+            *pointer = pointer.saturating_add(accepted_len);
+            if accepted_len < self.offered_prefix.len() {
+                self.offered_prefix.drain(..accepted_len);
+            } else {
+                self.offered_prefix.clear();
+            }
+        }
+    }
+
+    fn abandon_unaccepted_offer(&mut self) {
+        self.offered.clear();
+        self.offered_ptr = None;
+        self.offered_prefix.clear();
+        if let DecodeState::Header {
+            bytes,
+            write_start,
+            last_byte,
+        } = &mut self.decode
+            && bytes.is_empty()
+        {
+            *write_start = None;
+            *last_byte = None;
         }
     }
 
@@ -786,7 +834,7 @@ mod tests {
         let batch = [frame.clone(), frame].concat();
         let mut observer = FrameObserver::new(Arc::clone(&metrics));
 
-        observer.offered(batch.len(), origin + Duration::from_micros(10));
+        observer.offered(&batch, origin + Duration::from_micros(10));
         observer.accepted(&batch, origin + Duration::from_micros(20));
         observer.flushed(origin + Duration::from_micros(30));
 
@@ -821,9 +869,9 @@ mod tests {
         let batch = [frame.clone(), frame.clone()].concat();
         let mut observer = FrameObserver::new(Arc::clone(&metrics));
 
-        observer.offered(batch.len(), origin + Duration::from_micros(10));
+        observer.offered(&batch, origin + Duration::from_micros(10));
         observer.accepted(&batch[..frame.len()], origin + Duration::from_micros(20));
-        observer.offered(frame.len(), origin + Duration::from_micros(30));
+        observer.offered(&batch[frame.len()..], origin + Duration::from_micros(30));
         observer.accepted(&batch[frame.len()..], origin + Duration::from_micros(40));
         observer.flushed(origin + Duration::from_micros(50));
 
@@ -835,6 +883,28 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![(0, 10), (0, 10)]
         );
+    }
+
+    #[test]
+    fn abandoned_pending_buffer_does_not_lend_its_attempt_to_new_bytes() {
+        let origin = Instant::now();
+        let metrics = Arc::new(StdoutMetrics::new(origin));
+        let body = br#"{"jsonrpc":"2.0","method":"window/logMessage"}"#;
+        let frame = [
+            format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes(),
+            body.to_vec(),
+        ]
+        .concat();
+        let abandoned = vec![b'x'; frame.len()];
+        let mut observer = FrameObserver::new(Arc::clone(&metrics));
+
+        observer.offered(&abandoned, origin + Duration::from_micros(10));
+        observer.offered(&frame, origin + Duration::from_micros(20));
+        observer.accepted(&frame, origin + Duration::from_micros(30));
+        observer.flushed(origin + Duration::from_micros(40));
+
+        assert_eq!(metrics.frames()[0].write_start_us, 20);
+        assert_eq!(metrics.frames()[0].write_sequence, 1);
     }
 
     #[tokio::test]
@@ -939,7 +1009,8 @@ mod tests {
 
         {
             let mut observer = FrameObserver::new(Arc::clone(&metrics));
-            observer.offered(header.len() + 5, origin + Duration::from_micros(5));
+            let offered = [header.as_bytes(), &body[..5]].concat();
+            observer.offered(&offered, origin + Duration::from_micros(5));
             observer.accepted(header.as_bytes(), origin + Duration::from_micros(10));
             observer.accepted(&body[..5], origin + Duration::from_micros(15));
         }
@@ -962,7 +1033,7 @@ mod tests {
         let metrics = Arc::new(StdoutMetrics::new(origin));
         {
             let mut observer = FrameObserver::new(Arc::clone(&metrics));
-            observer.offered(10, origin + Duration::from_micros(5));
+            observer.offered(&[0; 10], origin + Duration::from_micros(5));
         }
 
         assert_eq!(

--- a/src/lsp/stdout_metrics.rs
+++ b/src/lsp/stdout_metrics.rs
@@ -37,6 +37,7 @@ struct FrameMetric {
     write_start_us: u64,
     last_byte_us: u64,
     flush_complete_us: Option<u64>,
+    flush_sequence: Option<u64>,
     id_unattributed: bool,
 }
 
@@ -433,6 +434,7 @@ impl FrameObserver {
                                 write_start_us: self.metrics.timestamp_us(write_start.at),
                                 last_byte_us: self.metrics.timestamp_us(at),
                                 flush_complete_us: None,
+                                flush_sequence: None,
                                 id_unattributed,
                             },
                             id,
@@ -451,8 +453,10 @@ impl FrameObserver {
 
     fn flushed(&mut self, at: Instant) {
         let flush_complete_us = self.metrics.timestamp_us(at);
+        let flush_sequence = self.metrics.next_event_sequence();
         for (mut frame, id) in self.awaiting_flush.drain(..) {
             frame.flush_complete_us = Some(flush_complete_us);
+            frame.flush_sequence = Some(flush_sequence);
             self.metrics.finish_frame(frame, id);
         }
     }
@@ -631,6 +635,7 @@ mod tests {
                 write_start_us: 0,
                 last_byte_us: 0,
                 flush_complete_us: None,
+                flush_sequence: None,
                 id_unattributed: false,
             },
             Some(response.id().clone()),
@@ -705,6 +710,7 @@ mod tests {
                 write_start_us: 20,
                 last_byte_us: 30,
                 flush_complete_us: Some(40),
+                flush_sequence: Some(3),
                 id_unattributed: false,
             }]
         );

--- a/src/lsp/stdout_metrics.rs
+++ b/src/lsp/stdout_metrics.rs
@@ -194,7 +194,12 @@ struct FrameObserver {
     metrics: Arc<StdoutMetrics>,
     decode: DecodeState,
     awaiting_flush: Vec<(FrameMetric, Option<Id>)>,
-    poll_write_attempt: Option<WriteAttempt>,
+    offered: VecDeque<OfferedSegment>,
+}
+
+struct OfferedSegment {
+    remaining: usize,
+    attempt: WriteAttempt,
 }
 
 #[doc(hidden)]
@@ -280,7 +285,7 @@ impl<W: AsyncWrite + Unpin> AsyncWrite for MeasuredStdout<W> {
         bytes: &[u8],
     ) -> Poll<io::Result<usize>> {
         if !bytes.is_empty() {
-            self.observer.write_attempt(Instant::now());
+            self.observer.offered(bytes.len(), Instant::now());
         }
         let result = Pin::new(&mut self.inner).poll_write(cx, bytes);
         if let Poll::Ready(Ok(accepted)) = result
@@ -336,29 +341,55 @@ impl FrameObserver {
                 last_byte: None,
             },
             awaiting_flush: Vec::new(),
-            poll_write_attempt: None,
+            offered: VecDeque::new(),
         }
     }
 
-    fn write_attempt(&mut self, at: Instant) {
+    fn offered(&mut self, bytes: usize, at: Instant) {
+        let covered: usize = self.offered.iter().map(|segment| segment.remaining).sum();
+        if bytes <= covered {
+            return;
+        }
         let attempt = WriteAttempt {
             at,
             sequence: self.metrics.next_event_sequence(),
         };
-        self.poll_write_attempt = Some(attempt);
-        if let DecodeState::Header { write_start, .. } = &mut self.decode {
+        self.offered.push_back(OfferedSegment {
+            remaining: bytes - covered,
+            attempt,
+        });
+        if covered == 0
+            && let DecodeState::Header { write_start, .. } = &mut self.decode
+        {
             write_start.get_or_insert(attempt);
         }
     }
 
     fn accepted(&mut self, mut bytes: &[u8], at: Instant) {
-        let poll_write_attempt = self
-            .poll_write_attempt
-            .take()
-            .unwrap_or_else(|| WriteAttempt {
-                at,
-                sequence: self.metrics.next_event_sequence(),
-            });
+        if self.offered.is_empty() {
+            self.offered(bytes.len(), at);
+        }
+        while !bytes.is_empty() {
+            let Some(mut segment) = self.offered.pop_front() else {
+                self.offered(bytes.len(), at);
+                continue;
+            };
+            let take = segment.remaining.min(bytes.len());
+            self.accepted_segment(&bytes[..take], at, segment.attempt);
+            bytes = &bytes[take..];
+            segment.remaining -= take;
+            if segment.remaining > 0 {
+                self.offered.push_front(segment);
+            }
+        }
+    }
+
+    fn accepted_segment(
+        &mut self,
+        mut bytes: &[u8],
+        at: Instant,
+        poll_write_attempt: WriteAttempt,
+    ) {
         while !bytes.is_empty() {
             match &mut self.decode {
                 DecodeState::Header {
@@ -755,7 +786,7 @@ mod tests {
         let batch = [frame.clone(), frame].concat();
         let mut observer = FrameObserver::new(Arc::clone(&metrics));
 
-        observer.write_attempt(origin + Duration::from_micros(10));
+        observer.offered(batch.len(), origin + Duration::from_micros(10));
         observer.accepted(&batch, origin + Duration::from_micros(20));
         observer.flushed(origin + Duration::from_micros(30));
 
@@ -774,6 +805,35 @@ mod tests {
                 .map(|frame| frame.write_sequence)
                 .collect::<Vec<_>>(),
             vec![0, 0]
+        );
+    }
+
+    #[test]
+    fn partial_write_preserves_the_attempt_for_the_unaccepted_frame() {
+        let origin = Instant::now();
+        let metrics = Arc::new(StdoutMetrics::new(origin));
+        let body = br#"{"jsonrpc":"2.0","method":"window/logMessage"}"#;
+        let frame = [
+            format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes(),
+            body.to_vec(),
+        ]
+        .concat();
+        let batch = [frame.clone(), frame.clone()].concat();
+        let mut observer = FrameObserver::new(Arc::clone(&metrics));
+
+        observer.offered(batch.len(), origin + Duration::from_micros(10));
+        observer.accepted(&batch[..frame.len()], origin + Duration::from_micros(20));
+        observer.offered(frame.len(), origin + Duration::from_micros(30));
+        observer.accepted(&batch[frame.len()..], origin + Duration::from_micros(40));
+        observer.flushed(origin + Duration::from_micros(50));
+
+        assert_eq!(
+            metrics
+                .frames()
+                .iter()
+                .map(|frame| (frame.write_sequence, frame.write_start_us))
+                .collect::<Vec<_>>(),
+            vec![(0, 10), (0, 10)]
         );
     }
 
@@ -879,7 +939,7 @@ mod tests {
 
         {
             let mut observer = FrameObserver::new(Arc::clone(&metrics));
-            observer.write_attempt(origin + Duration::from_micros(5));
+            observer.offered(header.len() + 5, origin + Duration::from_micros(5));
             observer.accepted(header.as_bytes(), origin + Duration::from_micros(10));
             observer.accepted(&body[..5], origin + Duration::from_micros(15));
         }
@@ -902,7 +962,7 @@ mod tests {
         let metrics = Arc::new(StdoutMetrics::new(origin));
         {
             let mut observer = FrameObserver::new(Arc::clone(&metrics));
-            observer.write_attempt(origin + Duration::from_micros(5));
+            observer.offered(10, origin + Duration::from_micros(5));
         }
 
         assert_eq!(

--- a/src/lsp/stdout_metrics.rs
+++ b/src/lsp/stdout_metrics.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, VecDeque};
+use std::fmt;
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
@@ -105,6 +106,17 @@ impl StdoutMetrics {
             .clone()
     }
 
+    #[cfg(test)]
+    fn ready_count(&self) -> usize {
+        self.state
+            .lock()
+            .expect("stdout metrics lock poisoned")
+            .response_ready
+            .values()
+            .map(VecDeque::len)
+            .sum()
+    }
+
     fn finish_frame(&self, mut frame: FrameMetric, id: Option<Id>) {
         let mut state = self
             .state
@@ -164,6 +176,7 @@ struct FrameObserver {
     metrics: Arc<StdoutMetrics>,
     decode: DecodeState,
     awaiting_flush: Vec<(FrameMetric, Option<Id>)>,
+    poll_write_attempt: Option<Instant>,
 }
 
 #[doc(hidden)]
@@ -178,6 +191,24 @@ pub struct ResponseReadyService<S> {
     metrics: Arc<StdoutMetrics>,
 }
 
+#[doc(hidden)]
+#[derive(Debug)]
+pub enum ResponseReadyError<E> {
+    Inner(E),
+    Task(tokio::task::JoinError),
+}
+
+impl<E: fmt::Display> fmt::Display for ResponseReadyError<E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Inner(error) => error.fmt(formatter),
+            Self::Task(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl<E: std::error::Error + 'static> std::error::Error for ResponseReadyError<E> {}
+
 impl<S> ResponseReadyService<S> {
     pub fn new(inner: S, metrics: Arc<StdoutMetrics>) -> Self {
         Self { inner, metrics }
@@ -188,27 +219,28 @@ impl<S> Service<Request> for ResponseReadyService<S>
 where
     S: Service<Request, Response = Option<Response>>,
     S::Future: Send + 'static,
-    S::Error: Send + 'static,
+    S::Error: std::error::Error + Send + Sync + 'static,
 {
     type Response = S::Response;
-    type Error = S::Error;
+    type Error = ResponseReadyError<S::Error>;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
+        self.inner.poll_ready(cx).map_err(ResponseReadyError::Inner)
     }
 
     fn call(&mut self, request: Request) -> Self::Future {
         let method = request.method().to_string();
         let future = self.inner.call(request);
         let metrics = Arc::clone(&self.metrics);
-        Box::pin(async move {
-            let response = future.await?;
+        let task = tokio_util::task::AbortOnDropHandle::new(tokio::spawn(async move {
+            let response = future.await.map_err(ResponseReadyError::Inner)?;
             if let Some(response) = response.as_ref() {
                 metrics.record_response_ready(response.id().clone(), method, Instant::now());
             }
             Ok(response)
-        })
+        }));
+        Box::pin(async move { task.await.map_err(ResponseReadyError::Task)? })
     }
 }
 
@@ -284,16 +316,19 @@ impl FrameObserver {
                 last_byte: None,
             },
             awaiting_flush: Vec::new(),
+            poll_write_attempt: None,
         }
     }
 
     fn write_attempt(&mut self, at: Instant) {
+        self.poll_write_attempt = Some(at);
         if let DecodeState::Header { write_start, .. } = &mut self.decode {
             write_start.get_or_insert(at);
         }
     }
 
     fn accepted(&mut self, mut bytes: &[u8], at: Instant) {
+        let poll_write_attempt = self.poll_write_attempt.take().unwrap_or(at);
         while !bytes.is_empty() {
             match &mut self.decode {
                 DecodeState::Header {
@@ -374,7 +409,7 @@ impl FrameObserver {
                         ));
                         self.decode = DecodeState::Header {
                             bytes: Vec::new(),
-                            write_start: None,
+                            write_start: (!bytes.is_empty()).then_some(poll_write_attempt),
                             last_byte: None,
                         };
                     }
@@ -577,6 +612,23 @@ mod tests {
         assert!(frame.ready_us.is_some());
     }
 
+    #[tokio::test]
+    async fn service_records_completion_before_its_response_is_consumed() {
+        let metrics = Arc::new(StdoutMetrics::new(Instant::now()));
+        let mut service = ResponseReadyService::new(EchoService, Arc::clone(&metrics));
+        let response_future = tower::Service::call(
+            &mut service,
+            Request::build("textDocument/semanticTokens/full")
+                .id(7i64)
+                .finish(),
+        );
+
+        tokio::task::yield_now().await;
+
+        assert_eq!(metrics.ready_count(), 1);
+        assert!(response_future.await.unwrap().is_some());
+    }
+
     #[test]
     fn split_response_is_reported_only_after_flush() {
         let origin = Instant::now();
@@ -643,6 +695,33 @@ mod tests {
         assert_eq!(
             metrics.frames()[0].method.as_deref(),
             Some("textDocument/semanticTokens/full")
+        );
+    }
+
+    #[test]
+    fn batched_frames_share_the_poll_write_attempt_timestamp() {
+        let origin = Instant::now();
+        let metrics = Arc::new(StdoutMetrics::new(origin));
+        let body = br#"{"jsonrpc":"2.0","method":"window/logMessage"}"#;
+        let frame = [
+            format!("Content-Length: {}\r\n\r\n", body.len()).into_bytes(),
+            body.to_vec(),
+        ]
+        .concat();
+        let batch = [frame.clone(), frame].concat();
+        let mut observer = FrameObserver::new(Arc::clone(&metrics));
+
+        observer.write_attempt(origin + Duration::from_micros(10));
+        observer.accepted(&batch, origin + Duration::from_micros(20));
+        observer.flushed(origin + Duration::from_micros(30));
+
+        assert_eq!(
+            metrics
+                .frames()
+                .iter()
+                .map(|frame| frame.write_start_us)
+                .collect::<Vec<_>>(),
+            vec![10, 10]
         );
     }
 

--- a/src/lsp/stdout_metrics.rs
+++ b/src/lsp/stdout_metrics.rs
@@ -205,6 +205,14 @@ struct OfferedSegment {
 }
 
 #[doc(hidden)]
+/// Opt-in observer for the writer passed to tower-lsp-server's `Server`.
+///
+/// This is intentionally not a general-purpose `AsyncWrite` wrapper. Its
+/// offered-byte correlation relies on tokio-util `FramedWrite` retaining an
+/// immutable buffer while `poll_write` is pending and advancing only the
+/// accepted prefix (`FramedImpl::poll_flush` via `poll_write_buf`). Hashing a
+/// complete multi-megabyte pending range on every retry would itself create
+/// the head-of-line delay this observer measures.
 pub struct MeasuredStdout<W> {
     inner: W,
     observer: FrameObserver,
@@ -354,6 +362,9 @@ impl FrameObserver {
     fn offered(&mut self, bytes: &[u8], at: Instant) {
         let covered: usize = self.offered.iter().map(|segment| segment.remaining).sum();
         let pointer = bytes.as_ptr() as usize;
+        // FramedWrite preserves this range across Pending; the bounded prefix
+        // also detects unexpected replacement for the supported caller without
+        // rescanning a multi-megabyte frame on every retry.
         let same_offer = self.offered_ptr == Some(pointer)
             && covered <= bytes.len()
             && (self.offered_prefix.is_empty() || bytes.starts_with(&self.offered_prefix));

--- a/src/lsp/stdout_metrics.rs
+++ b/src/lsp/stdout_metrics.rs
@@ -28,6 +28,7 @@ struct ReadyEvent {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 struct FrameMetric {
     ready_sequence: Option<u64>,
+    write_sequence: u64,
     method: Option<String>,
     id: Option<Id>,
     body_bytes: usize,
@@ -46,6 +47,12 @@ struct PartialFrameMetric {
     accepted_frame_bytes: usize,
     write_start_us: u64,
     last_byte_us: u64,
+}
+
+#[derive(Clone, Copy)]
+struct WriteAttempt {
+    at: Instant,
+    sequence: u64,
 }
 
 #[derive(Default)]
@@ -141,6 +148,16 @@ impl StdoutMetrics {
         at.saturating_duration_since(self.origin).as_micros() as u64
     }
 
+    fn next_event_sequence(&self) -> u64 {
+        let mut state = self
+            .state
+            .lock()
+            .recover_poison("StdoutMetrics::next_event_sequence");
+        let sequence = state.next_sequence;
+        state.next_sequence = state.next_sequence.wrapping_add(1);
+        sequence
+    }
+
     fn record_partial_frame(&self, frame: PartialFrameMetric) {
         self.state
             .lock()
@@ -176,7 +193,7 @@ struct FrameObserver {
     metrics: Arc<StdoutMetrics>,
     decode: DecodeState,
     awaiting_flush: Vec<(FrameMetric, Option<Id>)>,
-    poll_write_attempt: Option<Instant>,
+    poll_write_attempt: Option<WriteAttempt>,
 }
 
 #[doc(hidden)]
@@ -293,7 +310,7 @@ impl<W: AsyncWrite + Unpin> AsyncWrite for MeasuredStdout<W> {
 enum DecodeState {
     Header {
         bytes: Vec<u8>,
-        write_start: Option<Instant>,
+        write_start: Option<WriteAttempt>,
         last_byte: Option<Instant>,
     },
     Body {
@@ -302,7 +319,7 @@ enum DecodeState {
         seen: usize,
         prefix: Vec<u8>,
         tail: Vec<u8>,
-        write_start: Instant,
+        write_start: WriteAttempt,
         last_byte: Instant,
     },
     Disabled,
@@ -323,14 +340,24 @@ impl FrameObserver {
     }
 
     fn write_attempt(&mut self, at: Instant) {
-        self.poll_write_attempt = Some(at);
+        let attempt = WriteAttempt {
+            at,
+            sequence: self.metrics.next_event_sequence(),
+        };
+        self.poll_write_attempt = Some(attempt);
         if let DecodeState::Header { write_start, .. } = &mut self.decode {
-            write_start.get_or_insert(at);
+            write_start.get_or_insert(attempt);
         }
     }
 
     fn accepted(&mut self, mut bytes: &[u8], at: Instant) {
-        let poll_write_attempt = self.poll_write_attempt.take().unwrap_or(at);
+        let poll_write_attempt = self
+            .poll_write_attempt
+            .take()
+            .unwrap_or_else(|| WriteAttempt {
+                at,
+                sequence: self.metrics.next_event_sequence(),
+            });
         while !bytes.is_empty() {
             match &mut self.decode {
                 DecodeState::Header {
@@ -338,7 +365,7 @@ impl FrameObserver {
                     write_start,
                     last_byte,
                 } => {
-                    write_start.get_or_insert(at);
+                    write_start.get_or_insert(poll_write_attempt);
                     *last_byte = Some(at);
                     let byte = bytes[0];
                     bytes = &bytes[1..];
@@ -397,12 +424,13 @@ impl FrameObserver {
                         self.awaiting_flush.push((
                             FrameMetric {
                                 ready_sequence: None,
+                                write_sequence: write_start.sequence,
                                 method,
                                 id: id.clone(),
                                 body_bytes: *content_length,
                                 frame_bytes: *header_bytes + *content_length,
                                 ready_us: None,
-                                write_start_us: self.metrics.timestamp_us(*write_start),
+                                write_start_us: self.metrics.timestamp_us(write_start.at),
                                 last_byte_us: self.metrics.timestamp_us(at),
                                 flush_complete_us: None,
                                 id_unattributed,
@@ -444,8 +472,10 @@ impl Drop for FrameObserver {
                 phase: "header",
                 expected_frame_bytes: None,
                 accepted_frame_bytes: bytes.len(),
-                write_start_us: self.metrics.timestamp_us(*write_start),
-                last_byte_us: self.metrics.timestamp_us(last_byte.unwrap_or(*write_start)),
+                write_start_us: self.metrics.timestamp_us(write_start.at),
+                last_byte_us: self
+                    .metrics
+                    .timestamp_us(last_byte.unwrap_or(write_start.at)),
             }),
             DecodeState::Body {
                 header_bytes,
@@ -458,7 +488,7 @@ impl Drop for FrameObserver {
                 phase: "body",
                 expected_frame_bytes: Some(*header_bytes + *content_length),
                 accepted_frame_bytes: *header_bytes + *seen,
-                write_start_us: self.metrics.timestamp_us(*write_start),
+                write_start_us: self.metrics.timestamp_us(write_start.at),
                 last_byte_us: self.metrics.timestamp_us(*last_byte),
             }),
             _ => None,
@@ -592,6 +622,7 @@ mod tests {
         metrics.finish_frame(
             FrameMetric {
                 ready_sequence: None,
+                write_sequence: 0,
                 method: None,
                 id: Some(response.id().clone()),
                 body_bytes: 0,
@@ -665,6 +696,7 @@ mod tests {
             metrics.frames(),
             vec![FrameMetric {
                 ready_sequence: Some(0),
+                write_sequence: 1,
                 method: Some("textDocument/semanticTokens/full".to_string()),
                 id: Some(Id::Number(7)),
                 body_bytes: body.len(),
@@ -728,6 +760,14 @@ mod tests {
                 .map(|frame| frame.write_start_us)
                 .collect::<Vec<_>>(),
             vec![10, 10]
+        );
+        assert_eq!(
+            metrics
+                .frames()
+                .iter()
+                .map(|frame| frame.write_sequence)
+                .collect::<Vec<_>>(),
+            vec![0, 0]
         );
     }
 

--- a/src/lsp/stdout_metrics.rs
+++ b/src/lsp/stdout_metrics.rs
@@ -233,14 +233,16 @@ where
         let method = request.method().to_string();
         let future = self.inner.call(request);
         let metrics = Arc::clone(&self.metrics);
-        let task = tokio_util::task::AbortOnDropHandle::new(tokio::spawn(async move {
-            let response = future.await.map_err(ResponseReadyError::Inner)?;
-            if let Some(response) = response.as_ref() {
-                metrics.record_response_ready(response.id().clone(), method, Instant::now());
-            }
-            Ok(response)
-        }));
-        Box::pin(async move { task.await.map_err(ResponseReadyError::Task)? })
+        Box::pin(async move {
+            let task = tokio_util::task::AbortOnDropHandle::new(tokio::spawn(async move {
+                let response = future.await.map_err(ResponseReadyError::Inner)?;
+                if let Some(response) = response.as_ref() {
+                    metrics.record_response_ready(response.id().clone(), method, Instant::now());
+                }
+                Ok(response)
+            }));
+            task.await.map_err(ResponseReadyError::Task)?
+        })
     }
 }
 
@@ -616,13 +618,17 @@ mod tests {
     async fn service_records_completion_before_its_response_is_consumed() {
         let metrics = Arc::new(StdoutMetrics::new(Instant::now()));
         let mut service = ResponseReadyService::new(EchoService, Arc::clone(&metrics));
-        let response_future = tower::Service::call(
+        let mut response_future = tower::Service::call(
             &mut service,
             Request::build("textDocument/semanticTokens/full")
                 .id(7i64)
                 .finish(),
         );
 
+        tokio::task::yield_now().await;
+        assert_eq!(metrics.ready_count(), 0, "call alone does not admit work");
+
+        assert!(futures::poll!(response_future.as_mut()).is_pending());
         tokio::task::yield_now().await;
 
         assert_eq!(metrics.ready_count(), 1);

--- a/src/lsp/stdout_metrics.rs
+++ b/src/lsp/stdout_metrics.rs
@@ -15,7 +15,7 @@ use crate::error::LockResultExt;
 
 const HEADER_LIMIT: usize = 8 * 1024;
 const BODY_PREFIX_LIMIT: usize = 512;
-const BODY_TAIL_LIMIT: usize = 256;
+const BODY_TAIL_LIMIT: usize = 1024;
 
 #[derive(Clone, Debug)]
 struct ReadyEvent {
@@ -35,6 +35,16 @@ struct FrameMetric {
     write_start_us: u64,
     last_byte_us: u64,
     flush_complete_us: Option<u64>,
+    id_unattributed: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+struct PartialFrameMetric {
+    phase: &'static str,
+    expected_frame_bytes: Option<usize>,
+    accepted_frame_bytes: usize,
+    write_start_us: u64,
+    last_byte_us: u64,
 }
 
 #[derive(Default)]
@@ -42,6 +52,7 @@ struct MetricsState {
     next_sequence: u64,
     response_ready: HashMap<Id, VecDeque<ReadyEvent>>,
     frames: Vec<FrameMetric>,
+    partial_frames: Vec<PartialFrameMetric>,
 }
 
 #[doc(hidden)]
@@ -85,6 +96,15 @@ impl StdoutMetrics {
             .clone()
     }
 
+    #[cfg(test)]
+    fn partial_frames(&self) -> Vec<PartialFrameMetric> {
+        self.state
+            .lock()
+            .expect("stdout metrics lock poisoned")
+            .partial_frames
+            .clone()
+    }
+
     fn finish_frame(&self, mut frame: FrameMetric, id: Option<Id>) {
         let mut state = self
             .state
@@ -109,6 +129,14 @@ impl StdoutMetrics {
         at.saturating_duration_since(self.origin).as_micros() as u64
     }
 
+    fn record_partial_frame(&self, frame: PartialFrameMetric) {
+        self.state
+            .lock()
+            .recover_poison("StdoutMetrics::record_partial_frame")
+            .partial_frames
+            .push(frame);
+    }
+
     pub fn write_jsonl(&self, mut writer: impl io::Write) -> io::Result<()> {
         let state = self
             .state
@@ -118,6 +146,13 @@ impl StdoutMetrics {
             serde_json::to_writer(
                 &mut writer,
                 &serde_json::json!({"event": "stdout_frame", "frame": frame}),
+            )?;
+            writer.write_all(b"\n")?;
+        }
+        for frame in &state.partial_frames {
+            serde_json::to_writer(
+                &mut writer,
+                &serde_json::json!({"event": "stdout_partial_frame", "frame": frame}),
             )?;
             writer.write_all(b"\n")?;
         }
@@ -192,6 +227,9 @@ impl<W: AsyncWrite + Unpin> AsyncWrite for MeasuredStdout<W> {
         cx: &mut Context<'_>,
         bytes: &[u8],
     ) -> Poll<io::Result<usize>> {
+        if !bytes.is_empty() {
+            self.observer.write_attempt(Instant::now());
+        }
         let result = Pin::new(&mut self.inner).poll_write(cx, bytes);
         if let Poll::Ready(Ok(accepted)) = result
             && accepted > 0
@@ -222,14 +260,16 @@ enum DecodeState {
     Header {
         bytes: Vec<u8>,
         write_start: Option<Instant>,
+        last_byte: Option<Instant>,
     },
     Body {
         header_bytes: usize,
         content_length: usize,
         seen: usize,
         prefix: Vec<u8>,
-        tail: VecDeque<u8>,
+        tail: Vec<u8>,
         write_start: Instant,
+        last_byte: Instant,
     },
     Disabled,
 }
@@ -241,8 +281,15 @@ impl FrameObserver {
             decode: DecodeState::Header {
                 bytes: Vec::new(),
                 write_start: None,
+                last_byte: None,
             },
             awaiting_flush: Vec::new(),
+        }
+    }
+
+    fn write_attempt(&mut self, at: Instant) {
+        if let DecodeState::Header { write_start, .. } = &mut self.decode {
+            write_start.get_or_insert(at);
         }
     }
 
@@ -252,8 +299,10 @@ impl FrameObserver {
                 DecodeState::Header {
                     bytes: header,
                     write_start,
+                    last_byte,
                 } => {
                     write_start.get_or_insert(at);
+                    *last_byte = Some(at);
                     let byte = bytes[0];
                     bytes = &bytes[1..];
                     header.push(byte);
@@ -266,13 +315,22 @@ impl FrameObserver {
                             self.decode = DecodeState::Disabled;
                             return;
                         };
+                        let Some(write_start) = *write_start else {
+                            self.decode = DecodeState::Disabled;
+                            return;
+                        };
+                        if content_length == 0 {
+                            self.decode = DecodeState::Disabled;
+                            return;
+                        }
                         self.decode = DecodeState::Body {
                             header_bytes: header.len(),
                             content_length,
                             seen: 0,
                             prefix: Vec::with_capacity(content_length.min(BODY_PREFIX_LIMIT)),
-                            tail: VecDeque::with_capacity(content_length.min(BODY_TAIL_LIMIT)),
-                            write_start: write_start.expect("header start is set before bytes"),
+                            tail: Vec::with_capacity(content_length.min(BODY_TAIL_LIMIT)),
+                            write_start,
+                            last_byte: at,
                         };
                     }
                 }
@@ -283,6 +341,7 @@ impl FrameObserver {
                     prefix,
                     tail,
                     write_start,
+                    last_byte,
                 } => {
                     let take = (*content_length - *seen).min(bytes.len());
                     let accepted = &bytes[..take];
@@ -291,17 +350,13 @@ impl FrameObserver {
                         let prefix_take = (BODY_PREFIX_LIMIT - prefix.len()).min(accepted.len());
                         prefix.extend_from_slice(&accepted[..prefix_take]);
                     }
-                    for byte in accepted {
-                        if tail.len() == BODY_TAIL_LIMIT {
-                            tail.pop_front();
-                        }
-                        tail.push_back(*byte);
-                    }
+                    retain_tail(tail, accepted);
                     *seen += take;
+                    *last_byte = at;
                     if *seen == *content_length {
-                        let tail: Vec<u8> = tail.iter().copied().collect();
-                        let id = response_id(&tail);
+                        let id = response_id(tail);
                         let method = method_name(prefix);
+                        let id_unattributed = method.is_none() && id.is_none();
                         self.awaiting_flush.push((
                             FrameMetric {
                                 ready_sequence: None,
@@ -313,12 +368,14 @@ impl FrameObserver {
                                 write_start_us: self.metrics.timestamp_us(*write_start),
                                 last_byte_us: self.metrics.timestamp_us(at),
                                 flush_complete_us: None,
+                                id_unattributed,
                             },
                             id,
                         ));
                         self.decode = DecodeState::Header {
                             bytes: Vec::new(),
                             write_start: None,
+                            last_byte: None,
                         };
                     }
                 }
@@ -341,7 +398,55 @@ impl Drop for FrameObserver {
         for (frame, id) in self.awaiting_flush.drain(..) {
             self.metrics.finish_frame(frame, id);
         }
+        let partial = match &self.decode {
+            DecodeState::Header {
+                bytes,
+                write_start: Some(write_start),
+                last_byte,
+            } => Some(PartialFrameMetric {
+                phase: "header",
+                expected_frame_bytes: None,
+                accepted_frame_bytes: bytes.len(),
+                write_start_us: self.metrics.timestamp_us(*write_start),
+                last_byte_us: self.metrics.timestamp_us(last_byte.unwrap_or(*write_start)),
+            }),
+            DecodeState::Body {
+                header_bytes,
+                content_length,
+                seen,
+                write_start,
+                last_byte,
+                ..
+            } => Some(PartialFrameMetric {
+                phase: "body",
+                expected_frame_bytes: Some(*header_bytes + *content_length),
+                accepted_frame_bytes: *header_bytes + *seen,
+                write_start_us: self.metrics.timestamp_us(*write_start),
+                last_byte_us: self.metrics.timestamp_us(*last_byte),
+            }),
+            _ => None,
+        };
+        if let Some(partial) = partial {
+            self.metrics.record_partial_frame(partial);
+        }
     }
+}
+
+fn retain_tail(tail: &mut Vec<u8>, accepted: &[u8]) {
+    if accepted.len() >= BODY_TAIL_LIMIT {
+        tail.clear();
+        tail.extend_from_slice(&accepted[accepted.len() - BODY_TAIL_LIMIT..]);
+        return;
+    }
+    let overflow = tail
+        .len()
+        .saturating_add(accepted.len())
+        .saturating_sub(BODY_TAIL_LIMIT);
+    if overflow > 0 {
+        tail.copy_within(overflow.., 0);
+        tail.truncate(tail.len() - overflow);
+    }
+    tail.extend_from_slice(accepted);
 }
 
 fn content_length(header: &[u8]) -> Option<usize> {
@@ -458,6 +563,7 @@ mod tests {
                 write_start_us: 0,
                 last_byte_us: 0,
                 flush_complete_us: None,
+                id_unattributed: false,
             },
             Some(response.id().clone()),
         );
@@ -509,6 +615,7 @@ mod tests {
                 write_start_us: 20,
                 last_byte_us: 30,
                 flush_complete_us: Some(40),
+                id_unattributed: false,
             }]
         );
     }
@@ -593,5 +700,89 @@ mod tests {
         let frames = metrics.frames();
         assert_eq!(frames.len(), 1);
         assert_eq!(frames[0].flush_complete_us, None);
+    }
+
+    #[test]
+    fn long_string_response_id_is_attributed_without_scanning_the_full_body() {
+        let origin = Instant::now();
+        let metrics = Arc::new(StdoutMetrics::new(origin));
+        let id = "x".repeat(300);
+        metrics.record_response_ready(
+            Id::String(id.clone()),
+            "textDocument/semanticTokens/full".to_string(),
+            origin,
+        );
+        let body = format!(r#"{{"jsonrpc":"2.0","result":null,"id":"{id}"}}"#);
+        let frame = format!("Content-Length: {}\r\n\r\n{body}", body.len());
+        let mut observer = FrameObserver::new(Arc::clone(&metrics));
+
+        observer.accepted(frame.as_bytes(), origin + Duration::from_micros(10));
+        observer.flushed(origin + Duration::from_micros(20));
+
+        assert_eq!(metrics.frames()[0].id, Some(Id::String(id)));
+        assert!(!metrics.frames()[0].id_unattributed);
+    }
+
+    #[test]
+    fn oversized_string_response_id_is_explicitly_unattributed() {
+        let origin = Instant::now();
+        let metrics = Arc::new(StdoutMetrics::new(origin));
+        let id = "x".repeat(BODY_TAIL_LIMIT + 100);
+        let body = format!(r#"{{"jsonrpc":"2.0","result":null,"id":"{id}"}}"#);
+        let frame = format!("Content-Length: {}\r\n\r\n{body}", body.len());
+        let mut observer = FrameObserver::new(Arc::clone(&metrics));
+
+        observer.accepted(frame.as_bytes(), origin + Duration::from_micros(10));
+        observer.flushed(origin + Duration::from_micros(20));
+
+        assert_eq!(metrics.frames()[0].id, None);
+        assert!(metrics.frames()[0].id_unattributed);
+    }
+
+    #[test]
+    fn partial_body_is_reported_as_a_censored_frame_on_drop() {
+        let origin = Instant::now();
+        let metrics = Arc::new(StdoutMetrics::new(origin));
+        let body = br#"{"jsonrpc":"2.0","result":null,"id":7}"#;
+        let header = format!("Content-Length: {}\r\n\r\n", body.len());
+
+        {
+            let mut observer = FrameObserver::new(Arc::clone(&metrics));
+            observer.write_attempt(origin + Duration::from_micros(5));
+            observer.accepted(header.as_bytes(), origin + Duration::from_micros(10));
+            observer.accepted(&body[..5], origin + Duration::from_micros(15));
+        }
+
+        assert_eq!(
+            metrics.partial_frames(),
+            vec![PartialFrameMetric {
+                phase: "body",
+                expected_frame_bytes: Some(header.len() + body.len()),
+                accepted_frame_bytes: header.len() + 5,
+                write_start_us: 5,
+                last_byte_us: 15,
+            }]
+        );
+    }
+
+    #[test]
+    fn pending_first_write_attempt_is_reported_as_a_censored_header() {
+        let origin = Instant::now();
+        let metrics = Arc::new(StdoutMetrics::new(origin));
+        {
+            let mut observer = FrameObserver::new(Arc::clone(&metrics));
+            observer.write_attempt(origin + Duration::from_micros(5));
+        }
+
+        assert_eq!(
+            metrics.partial_frames(),
+            vec![PartialFrameMetric {
+                phase: "header",
+                expected_frame_bytes: None,
+                accepted_frame_bytes: 0,
+                write_start_us: 5,
+                last_byte_us: 5,
+            }]
+        );
     }
 }


### PR DESCRIPTION
## Summary

- add opt-in response-ready, stdout write, flush, frame-size, and censorship metrics behind `KAKEHASHI_STDOUT_METRICS`
- extend the profiling driver with semantic-only, valid captures delta, captures full fallback, and diagnostics burst scenarios plus strict protocol-shape validation
- preserve the single FIFO writer and document why a priority scheduler is deferred under the measured workload

## Measured result

Release measurements used the 5,088-line, 37,940-byte captured-scale Markdown fixture, 20 edit/recompute cycles, and three repetitions per scenario.

- semantic ready to last byte p90: **0.3-0.6 ms** across all scenarios
- semantic ready to flush p90: **0.4-0.7 ms**
- 4,408.4 KiB captures-full frame ready to last byte p90: **14.2 / 15.8 / 14.3 ms**
- semantic responses queued behind an earlier not-yet-started large frame: **0 / 60**
- valid captures delta payload: about **0.3 KiB**, versus **4,408.4 KiB** for full fallback

The interleaved observer A/A check showed no systematic regression: semantic p90 was **9.1 / 9.6 / 9.0 ms** with metrics and **10.2 / 9.0 / 9.4 ms** without metrics. Therefore this PR does not add a scheduler: the observed avoidable FIFO contribution is below the 1 ms decision threshold and there were no reorderable overlaps.

## Validation

- `cargo test --lib`: 2728 passed, 2 ignored
- `make check`: passed, including 10 profiling-driver tests
- release four-scenario matrix and captures-full observer A/A: passed with zero censored or unattributed samples
- `make test_e2e`: 56/57 binaries passed after retry; the remaining `e2e_code_action::concatenated_default_merges_actions_from_both_servers` test added on current `main` independently drops either mock server result and also failed 5/5 focused retries. This branch does not change code-action paths, and metrics-disabled server construction retains the original path.

Fixes #665.