### PR TITLE
perf: eliminate the bridge's outbound flood delaying semantic-token responses

### DIFF
--- a/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
+++ b/docs/architecture-decisions/ls-bridge-progress-disconnect-cleanup.md
@@ -7,8 +7,9 @@
 Under ls-bridge-work-done-progress, the bridge forwards a downstream's
 server-declared progress to the editor: a downstream requests a token with
 `window/workDoneProgress/create`, the bridge mints a unique upstream token,
-forwards the create, and then relays each `$/progress` (begin → report → end)
-against that token until a terminating `End` clears the mapping.
+and — on the token's first renderable `begin` (lazy announcement) — forwards
+the create followed by each `$/progress` (begin → report → end) against that
+token until a terminating `End` clears the mapping.
 
 A downstream can exit *between* `Begin` and `End` — it crashes, is shut down, or
 is respawned while work is in flight. Before #413 was implemented the bridge
@@ -34,10 +35,12 @@ existing mapping purge and admission cleanup.
 
 - The bridge ends only tokens that are **begun but not yet ended** — those whose
   `Begin` was already forwarded to the editor with no matching `End`. A token
-  whose `window/workDoneProgress/create` the editor accepted but whose `Begin`
-  was never forwarded (the downstream died between create and begin) has no
-  visible progress to terminate, so it gets no synthetic `End` — its mapping is
-  simply purged. This keeps every emitted `End` paired with a real `Begin`; a
+  the editor never saw a `Begin` for — never announced at all under lazy
+  announcement (pending/swallowed), or announced but with the create rejected —
+  has no visible progress to terminate, so it gets no synthetic `End` — its
+  mapping is simply purged. (With lazy announcement the create is enqueued
+  immediately before the begin, so the old create-accepted-but-begin-lost
+  window is nearly gone.) This keeps every emitted `End` paired with a real `Begin`; a
   `window/workDoneProgress/create` request the editor rejected likewise never
   receives a terminal.
 - Tracking the begun-not-ended set is cheap: the forwarding loop already relays

--- a/docs/architecture-decisions/ls-bridge-work-done-progress.md
+++ b/docs/architecture-decisions/ls-bridge-work-done-progress.md
@@ -26,25 +26,48 @@ so client–kakehashi–downstream stays consistent and collision-free:
 
 - **create** (downstream → bridge request): the reader mints a unique upstream
   token `kakehashi/bridge/progress/{N}`, records the mapping keyed by a
-  per-connection id, acks the downstream immediately, and forwards a
-  `CreateWorkDoneProgress` for the editor. The downstream is acked optimistically
-  (not by relaying the editor's real response) to decouple it from editor
-  latency. The bridge advertises `window.workDoneProgress` to downstreams **only
-  when the real editor advertises it** (the capability merge gates it), so a
-  downstream only sends `create` when the editor can accept it — making the
-  optimistic ack sound.
-- **`$/progress`** (downstream → bridge notification): the reader rewrites the
-  token to the mapped upstream token and forwards it; a terminating `End` clears
-  the mapping.
+  per-connection id (phase `Pending`), and acks the downstream immediately.
+  The editor-facing `CreateWorkDoneProgress` is **deferred to the token's
+  first renderable `begin`** (lazy announcement, below). The downstream is
+  acked optimistically (not by relaying the editor's real response) to
+  decouple it from editor latency. The bridge advertises
+  `window.workDoneProgress` to downstreams **only when the real editor
+  advertises it** (the capability merge gates it), so a downstream only sends
+  `create` when the editor can accept it — making the optimistic ack sound.
+- **`$/progress`** (downstream → bridge notification): the first `begin`
+  decides the token's fate (lazy announcement). A `begin` carrying anything
+  renderable — a non-empty title, message, or a percentage — **announces**:
+  the bridge enqueues the editor-facing create immediately followed by the
+  begin on the same FIFO channel, then rewrites and forwards subsequent
+  progress. A fully blank `begin` (`{"kind":"begin","title":""}`) **swallows**
+  the lifecycle: nothing reaches the editor (a later renderable `begin`
+  reusing the token upgrades it to announced). A `report`/`end` before any
+  `begin` is dropped — the editor has no progress UI to update. A terminating
+  `End` always clears the mapping, forwarded or swallowed.
+
+  Rationale: some downstreams (e.g. basedpyright) declare a fresh token per
+  analysis pass — thousands of `create` → `begin("")` → `end` triples per
+  minute of typing. Each forwarded create is a full editor round-trip that
+  queues ahead of real responses on the shared stdout sink, measurably
+  delaying semantic-token replies. Blank begins give the editor nothing to
+  render, so eliding those lifecycles is pure win; renderable progress
+  (e.g. "Loading workspace") still shows immediately, with no timers or
+  reordering risk. The blank-only gate was verified against a production
+  capture: all 8,134 storm begins in a one-minute basedpyright session were
+  fully blank (empty title, no message, no percentage), while every
+  legitimate begin carried a title.
 - **cancel** (editor → bridge notification): `RequestIdCapture` intercepts
   `window/workDoneProgress/cancel` (as it already does for `$/cancelRequest`),
   resolves the upstream token to the owning downstream and its original token,
   and forwards the cancel there.
 
 Ordering (the editor must see `create` before that token's `$/progress`) is
-preserved because both flow through the single FIFO upstream channel and the
-forwarding loop awaits `create_work_done_progress` inline before draining the
-next item — mirroring the existing `workspace/diagnostic/refresh` forwarding.
+preserved because the announce path enqueues create-then-begin back-to-back on
+the single FIFO upstream channel and the forwarding loop awaits
+`create_work_done_progress` inline before draining the next item — mirroring
+the existing `workspace/diagnostic/refresh` forwarding. A re-`create` of a
+still-live downstream token only tells the forwarding loop to forget the
+evicted upstream token when that token was actually announced.
 
 Mappings are purged when a connection's reader task exits (crash, shutdown,
 respawn), so dead entries never leak and a later cancel cannot route to a dead
@@ -67,9 +90,16 @@ writer.
 - Concurrent downstreams report progress without collisions.
 - Server-declared progress reaches the editor at all (previously dropped).
 - Cancel is routed to the correct downstream with its own token.
+- Per-request blank-progress storms never reach the editor: no create
+  round-trips, no `$/progress` floods competing with responses for the
+  outbound sink.
 
 ### Negative
 
+- Progress whose every `begin` is fully blank is invisible to the editor by
+  design. The editor also cannot cancel a never-announced operation (it never
+  learns the token) — acceptable, since it has nothing to render a cancel
+  affordance on.
 - One registry entry per in-flight server-declared progress. Entries are cleared
   on a terminating `End` or on connection teardown. A misbehaving downstream that
   `create`s tokens (or gets cancelled) but never sends `End`, on a long-lived

--- a/docs/architecture-decisions/ls-bridge-work-done-progress.md
+++ b/docs/architecture-decisions/ls-bridge-work-done-progress.md
@@ -36,7 +36,8 @@ so client–kakehashi–downstream stays consistent and collision-free:
   `create` when the editor can accept it — making the optimistic ack sound.
 - **`$/progress`** (downstream → bridge notification): the first `begin`
   decides the token's fate (lazy announcement). A `begin` carrying anything
-  renderable — a non-empty title, message, or a percentage — **announces**:
+  renderable — a non-empty title or message, a percentage, or
+  `cancellable: true` (a cancel button is renderable too) — **announces**:
   the bridge enqueues the editor-facing create immediately followed by the
   begin on the same FIFO channel, then rewrites and forwards subsequent
   progress. A fully blank `begin` (`{"kind":"begin","title":""}`) **swallows**

--- a/docs/architecture-decisions/ls-bridge-work-done-progress.md
+++ b/docs/architecture-decisions/ls-bridge-work-done-progress.md
@@ -56,7 +56,11 @@ so client–kakehashi–downstream stays consistent and collision-free:
   reordering risk. The blank-only gate was verified against a production
   capture: all 8,134 storm begins in a one-minute basedpyright session were
   fully blank (empty title, no message, no percentage), while every
-  legitimate begin carried a title.
+  legitimate begin carried a title. The same capture also settles why only
+  the **begin** classifies and a renderable `report` does not upgrade a
+  swallowed lifecycle: 8,288 of the storm's 8,351 reports carried a
+  message ("analyzing 1 file", once per pass), so report-based upgrading
+  would re-admit essentially the entire flood.
 - **cancel** (editor → bridge notification): `RequestIdCapture` intercepts
   `window/workDoneProgress/cancel` (as it already does for `$/cancelRequest`),
   resolves the upstream token to the owning downstream and its original token,

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1102,7 +1102,8 @@ impl LanguageCoordinator {
     /// token (`"py"`, `"js"`), path token via `extract_token_from_path`, then
     /// first-line content (shebang, mode line, Emacs markers).
     /// Host call: `detect_language(path, content, None, language_id)`;
-    /// injection call: `detect_language(token, content, Some(token), Some(token))`.
+    /// injection call: `detect_language_hot(token, content, Some(token),
+    /// Some(token))` — the per-region hot path logs at TRACE.
     pub(crate) fn detect_language(
         &self,
         path: &str,

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1110,13 +1110,42 @@ impl LanguageCoordinator {
         token: Option<&str>,
         language_id: Option<&str>,
     ) -> Option<String> {
+        self.detect_language_logged(path, content, token, language_id, log::Level::Debug)
+    }
+
+    /// Hot-path variant of [`Self::detect_language`] that logs at TRACE.
+    ///
+    /// Per-injection-region resolution runs this once per region per walk —
+    /// thousands of calls per second during a typing storm — and per-call
+    /// DEBUG formatting/writes flood stderr (measured ~16k lines/sec, dwarfing
+    /// the detection chain itself). The chain is identical; only the log level
+    /// differs, matching `resolve_injection_language`'s TRACE convention.
+    pub(crate) fn detect_language_hot(
+        &self,
+        path: &str,
+        content: &str,
+        token: Option<&str>,
+        language_id: Option<&str>,
+    ) -> Option<String> {
+        self.detect_language_logged(path, content, token, language_id, log::Level::Trace)
+    }
+
+    fn detect_language_logged(
+        &self,
+        path: &str,
+        content: &str,
+        token: Option<&str>,
+        language_id: Option<&str>,
+        level: log::Level,
+    ) -> Option<String> {
         let (result, method, candidate) =
             self.detect_language_with_method(path, content, token, language_id);
 
         match result {
             Some(ref lang) => {
-                log::debug!(
+                log::log!(
                     target: "kakehashi::language_detection",
+                    level,
                     "Detected '{}' via {} for path='{}'",
                     lang,
                     method,
@@ -1125,15 +1154,17 @@ impl LanguageCoordinator {
             }
             None => {
                 if let Some(detected) = candidate {
-                    log::debug!(
+                    log::log!(
                         target: "kakehashi::language_detection",
+                        level,
                         "Detected '{}' but no parser available for path='{}'",
                         detected,
                         path
                     );
                 } else {
-                    log::debug!(
+                    log::log!(
                         target: "kakehashi::language_detection",
+                        level,
                         "No language detected for path='{}'",
                         path
                     );

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -525,7 +525,7 @@ impl InjectionResolver {
         content: &str,
     ) -> String {
         coordinator
-            .detect_language(
+            .detect_language_hot(
                 raw_identifier, // Use identifier as path for token extraction
                 content,
                 Some(raw_identifier), // Explicit token

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -99,8 +99,10 @@ pub(crate) enum UpstreamNotification {
     /// telemetry has no client capability and is always passed through.
     TelemetryEvent { data: serde_json::Value },
     /// Ask the editor to create a work-done progress for `token`.
-    /// Sent when a downstream issues `window/workDoneProgress/create`; `token`
-    /// is the bridge-minted *upstream* token, not the downstream's own.
+    /// Sent lazily on the token's first renderable `begin` — not when the
+    /// downstream issues `window/workDoneProgress/create` (lazy announcement,
+    /// see `ProgressRegistry`); `token` is the bridge-minted *upstream*
+    /// token, not the downstream's own.
     CreateWorkDoneProgress {
         token: tower_lsp_server::ls_types::NumberOrString,
     },
@@ -2043,10 +2045,11 @@ mod tests {
         assert_eq!(params.token, upstream_token);
     }
 
-    /// A downstream progress lifecycle whose `begin` has an empty title is
-    /// swallowed entirely: no create, no begin, no end reach the editor, and
-    /// the `End` still clears the mapping. This is the storm case — some
-    /// downstreams declare a token per analysis pass with nothing renderable.
+    /// A downstream progress lifecycle whose `begin` is fully blank (empty
+    /// title, no message, no percentage) is swallowed: no create, no begin,
+    /// no end reach the editor, and the `End` still clears the mapping. This
+    /// is the storm case — some downstreams declare a token per analysis pass
+    /// with nothing renderable.
     #[tokio::test]
     async fn handle_message_untitled_progress_lifecycle_is_swallowed() {
         use tower_lsp_server::ls_types::NumberOrString;
@@ -2102,6 +2105,132 @@ mod tests {
             progress_registry.translate(progress_connection_id, &downstream_token),
             None,
             "End clears the swallowed mapping"
+        );
+    }
+
+    /// A `begin` whose title is empty but which carries a renderable `message`
+    /// (or percentage) is NOT swallowed: an empty title alone is legal and
+    /// clients render message/percentage without one — only the fully blank
+    /// storm shape is elided.
+    #[tokio::test]
+    async fn handle_message_blank_title_with_message_still_announces() {
+        let router = ResponseRouter::new();
+        let (response_tx, _response_rx) = mpsc::channel(16);
+        let dynamic_capabilities = Arc::new(DynamicCapabilityRegistry::new());
+        let (upstream_tx, mut upstream_rx) = mpsc::unbounded_channel();
+        let (window_tx, _window_rx) = mpsc::channel(16);
+        let progress_registry = Arc::new(crate::lsp::bridge::ProgressRegistry::new());
+        let progress_connection_id = progress_registry.new_connection_id();
+        let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
+            server_name: None,
+            response_tx,
+            dynamic_capabilities,
+            upstream_tx,
+            workspace_folders: WorkspaceFolderSet::new(None),
+            window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
+            progress_registry: Arc::clone(&progress_registry),
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
+            progress_connection_id,
+        };
+
+        let create = json!({
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "window/workDoneProgress/create",
+            "params": { "token": "msg-only" }
+        });
+        handle_message(create, &router, "", &deps).await;
+        let begin = json!({
+            "jsonrpc": "2.0",
+            "method": "$/progress",
+            "params": {
+                "token": "msg-only",
+                "value": { "kind": "begin", "title": "", "message": "Indexing 42%" }
+            }
+        });
+        handle_message(begin, &router, "", &deps).await;
+
+        let UpstreamNotification::CreateWorkDoneProgress { .. } = upstream_rx
+            .try_recv()
+            .expect("message-bearing begin must announce")
+        else {
+            panic!("expected CreateWorkDoneProgress");
+        };
+        assert!(
+            matches!(
+                upstream_rx.try_recv(),
+                Ok(UpstreamNotification::Progress { .. })
+            ),
+            "the begin itself must forward after the create"
+        );
+    }
+
+    /// A swallowed token that a downstream reuses with a renderable `begin`
+    /// (no intervening `end`) upgrades to announced instead of staying dark.
+    #[tokio::test]
+    async fn handle_message_swallowed_token_upgrades_on_renderable_begin() {
+        let router = ResponseRouter::new();
+        let (response_tx, _response_rx) = mpsc::channel(16);
+        let dynamic_capabilities = Arc::new(DynamicCapabilityRegistry::new());
+        let (upstream_tx, mut upstream_rx) = mpsc::unbounded_channel();
+        let (window_tx, _window_rx) = mpsc::channel(16);
+        let progress_registry = Arc::new(crate::lsp::bridge::ProgressRegistry::new());
+        let progress_connection_id = progress_registry.new_connection_id();
+        let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
+            server_name: None,
+            response_tx,
+            dynamic_capabilities,
+            upstream_tx,
+            workspace_folders: WorkspaceFolderSet::new(None),
+            window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
+            progress_registry: Arc::clone(&progress_registry),
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
+            progress_connection_id,
+        };
+
+        let create = json!({
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "window/workDoneProgress/create",
+            "params": { "token": "reused" }
+        });
+        handle_message(create, &router, "", &deps).await;
+        let blank = json!({
+            "jsonrpc": "2.0",
+            "method": "$/progress",
+            "params": { "token": "reused", "value": { "kind": "begin", "title": "" } }
+        });
+        handle_message(blank, &router, "", &deps).await;
+        assert!(
+            upstream_rx.try_recv().is_err(),
+            "blank begin is swallowed first"
+        );
+
+        let renderable = json!({
+            "jsonrpc": "2.0",
+            "method": "$/progress",
+            "params": { "token": "reused", "value": { "kind": "begin", "title": "Indexing" } }
+        });
+        handle_message(renderable, &router, "", &deps).await;
+        assert!(
+            matches!(
+                upstream_rx.try_recv(),
+                Ok(UpstreamNotification::CreateWorkDoneProgress { .. })
+            ),
+            "renderable reuse must upgrade to announced"
+        );
+        assert!(
+            matches!(
+                upstream_rx.try_recv(),
+                Ok(UpstreamNotification::Progress { .. })
+            ),
+            "the upgrading begin must forward"
         );
     }
 
@@ -2176,7 +2305,21 @@ mod tests {
         else {
             panic!("expected ForgetWorkDoneProgress");
         };
-        assert_eq!(forgotten, vec![announced]);
+        assert_eq!(forgotten, vec![announced.clone()]);
+
+        // The replacement lifecycle announces under a FRESH upstream token.
+        let begin2 = json!({
+            "jsonrpc": "2.0",
+            "method": "$/progress",
+            "params": { "token": "dup", "value": { "kind": "begin", "title": "Indexing" } }
+        });
+        handle_message(begin2, &router, "", &deps).await;
+        let UpstreamNotification::CreateWorkDoneProgress { token: reannounced } =
+            upstream_rx.try_recv().expect("re-announce create")
+        else {
+            panic!("expected CreateWorkDoneProgress");
+        };
+        assert_ne!(reannounced, announced, "re-create must mint a fresh token");
     }
 
     /// A `window/workDoneProgress/create` without a token is rejected with
@@ -2285,6 +2428,26 @@ mod tests {
             panic!("Expected Progress");
         };
         assert_eq!(params.token, upstream_token);
+
+        // A mid-lifecycle "report" forwards with the translated token and
+        // must NOT clear the mapping — only End does.
+        let report = json!({
+            "jsonrpc": "2.0",
+            "method": "$/progress",
+            "params": { "token": 1, "value": { "kind": "report", "message": "50%" } }
+        });
+        handle_message(report, &router, "", &deps).await;
+        let UpstreamNotification::Progress { params } =
+            upstream_rx.try_recv().expect("report should forward")
+        else {
+            panic!("Expected Progress");
+        };
+        assert_eq!(params.token, upstream_token);
+        assert_eq!(
+            progress_registry.translate(progress_connection_id, &downstream_token),
+            Some(upstream_token.clone()),
+            "mapping must survive a report"
+        );
 
         // An "end" is forwarded too, then the mapping is cleared.
         let end = json!({

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -1955,9 +1955,10 @@ mod tests {
     }
 
     /// A downstream `window/workDoneProgress/create` is acknowledged to the
-    /// downstream AND bridged upstream: a unique upstream token is minted,
-    /// registered (so `$/progress` can be translated), and a
-    /// `CreateWorkDoneProgress` notification is emitted for the editor.
+    /// downstream and registered (so `$/progress` can be translated), but the
+    /// editor-facing `CreateWorkDoneProgress` is deferred until the token's
+    /// first titled `begin` (lazy announcement: per-request downstream
+    /// progress storms must not reach the editor).
     #[tokio::test]
     async fn handle_message_work_done_progress_create_bridges_upstream() {
         use tower_lsp_server::ls_types::NumberOrString;
@@ -2001,26 +2002,113 @@ mod tests {
         assert_eq!(val["id"], 5);
         assert!(val["result"].is_null());
 
-        // The editor is asked to create a *different* (unique) token.
+        // Nothing reaches the editor yet: announcement waits for a titled begin.
+        assert!(
+            upstream_rx.try_recv().is_err(),
+            "create must not be bridged before a titled begin"
+        );
+
+        // The mapping is registered so downstream `$/progress` can be translated.
+        let downstream_token = NumberOrString::String("some-token".to_string());
+        let upstream_token = progress_registry
+            .translate(progress_connection_id, &downstream_token)
+            .expect("mapping registered");
+        assert_ne!(
+            upstream_token, downstream_token,
+            "upstream token must be remapped"
+        );
+
+        // The first titled begin announces: create, then the begin itself.
+        let begin = json!({
+            "jsonrpc": "2.0",
+            "method": "$/progress",
+            "params": {
+                "token": "some-token",
+                "value": { "kind": "begin", "title": "Indexing" }
+            }
+        });
+        handle_message(begin, &router, "", &deps).await;
         let UpstreamNotification::CreateWorkDoneProgress { token } = upstream_rx
             .try_recv()
-            .expect("should forward CreateWorkDoneProgress")
+            .expect("titled begin should announce the token")
         else {
             panic!("Expected CreateWorkDoneProgress");
         };
-        let downstream_token = NumberOrString::String("some-token".to_string());
-        assert_ne!(token, downstream_token, "upstream token must be remapped");
+        assert_eq!(token, upstream_token);
+        let UpstreamNotification::Progress { params } =
+            upstream_rx.try_recv().expect("begin should forward")
+        else {
+            panic!("Expected Progress");
+        };
+        assert_eq!(params.token, upstream_token);
+    }
 
-        // The mapping is registered so downstream `$/progress` can be translated.
+    /// A downstream progress lifecycle whose `begin` has an empty title is
+    /// swallowed entirely: no create, no begin, no end reach the editor, and
+    /// the `End` still clears the mapping. This is the storm case — some
+    /// downstreams declare a token per analysis pass with nothing renderable.
+    #[tokio::test]
+    async fn handle_message_untitled_progress_lifecycle_is_swallowed() {
+        use tower_lsp_server::ls_types::NumberOrString;
+
+        let router = ResponseRouter::new();
+        let (response_tx, _response_rx) = mpsc::channel(16);
+        let dynamic_capabilities = Arc::new(DynamicCapabilityRegistry::new());
+        let (upstream_tx, mut upstream_rx) = mpsc::unbounded_channel();
+        let (window_tx, _window_rx) = mpsc::channel(16);
+        let progress_registry = Arc::new(crate::lsp::bridge::ProgressRegistry::new());
+        let progress_connection_id = progress_registry.new_connection_id();
+        let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
+            server_name: None,
+            response_tx,
+            dynamic_capabilities,
+            upstream_tx,
+            workspace_folders: WorkspaceFolderSet::new(None),
+            window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
+            progress_registry: Arc::clone(&progress_registry),
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
+            progress_connection_id,
+        };
+
+        let create = json!({
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "window/workDoneProgress/create",
+            "params": { "token": "storm" }
+        });
+        handle_message(create, &router, "", &deps).await;
+        let begin = json!({
+            "jsonrpc": "2.0",
+            "method": "$/progress",
+            "params": { "token": "storm", "value": { "kind": "begin", "title": "" } }
+        });
+        handle_message(begin, &router, "", &deps).await;
+        let end = json!({
+            "jsonrpc": "2.0",
+            "method": "$/progress",
+            "params": { "token": "storm", "value": { "kind": "end" } }
+        });
+        handle_message(end, &router, "", &deps).await;
+
+        assert!(
+            upstream_rx.try_recv().is_err(),
+            "untitled lifecycle must not reach the editor"
+        );
+        let downstream_token = NumberOrString::String("storm".to_string());
         assert_eq!(
             progress_registry.translate(progress_connection_id, &downstream_token),
-            Some(token)
+            None,
+            "End clears the swallowed mapping"
         );
     }
 
     /// Re-`create`ing the same downstream token mints a fresh upstream token and
-    /// emits a `ForgetWorkDoneProgress` for the evicted one, so the forwarding
-    /// loop's admission set can't leak the stale token.
+    /// emits a `ForgetWorkDoneProgress` for the evicted one — but only if it was
+    /// announced (the editor saw a create); unannounced tokens have no admission
+    /// to forget, so no message is wasted on them.
     #[tokio::test]
     async fn handle_message_recreate_same_token_forgets_stale() {
         let router = ResponseRouter::new();
@@ -2055,28 +2143,40 @@ mod tests {
         };
 
         handle_message(make(), &router, "", &deps).await;
-        let UpstreamNotification::CreateWorkDoneProgress { token: first } =
-            upstream_rx.try_recv().expect("first create")
+
+        // Re-create before any begin: the first token was never announced, so
+        // nothing is forgotten (and nothing was created).
+        handle_message(make(), &router, "", &deps).await;
+        assert!(
+            upstream_rx.try_recv().is_err(),
+            "unannounced stale token needs no Forget"
+        );
+
+        // Announce the second token via a titled begin...
+        let begin = json!({
+            "jsonrpc": "2.0",
+            "method": "$/progress",
+            "params": { "token": "dup", "value": { "kind": "begin", "title": "Indexing" } }
+        });
+        handle_message(begin, &router, "", &deps).await;
+        let UpstreamNotification::CreateWorkDoneProgress { token: announced } =
+            upstream_rx.try_recv().expect("announce create")
         else {
             panic!("expected CreateWorkDoneProgress");
         };
+        let UpstreamNotification::Progress { .. } = upstream_rx.try_recv().expect("begin forwards")
+        else {
+            panic!("expected Progress");
+        };
 
-        // Second create for the SAME downstream token.
+        // ...then a third create for the SAME downstream token forgets it.
         handle_message(make(), &router, "", &deps).await;
-        // It first forgets the stale upstream token...
         let UpstreamNotification::ForgetWorkDoneProgress(forgotten) =
             upstream_rx.try_recv().expect("forget stale")
         else {
             panic!("expected ForgetWorkDoneProgress");
         };
-        assert_eq!(forgotten, vec![first.clone()]);
-        // ...then creates a fresh, distinct upstream token.
-        let UpstreamNotification::CreateWorkDoneProgress { token: second } =
-            upstream_rx.try_recv().expect("second create")
-        else {
-            panic!("expected CreateWorkDoneProgress");
-        };
-        assert_ne!(first, second);
+        assert_eq!(forgotten, vec![announced]);
     }
 
     /// A `window/workDoneProgress/create` without a token is rejected with
@@ -2162,7 +2262,8 @@ mod tests {
             progress_connection_id,
         };
 
-        // A "begin" progress is forwarded with the translated token.
+        // A titled "begin" announces the token (create first) and is forwarded
+        // with the translated token.
         let begin = json!({
             "jsonrpc": "2.0",
             "method": "$/progress",
@@ -2172,6 +2273,12 @@ mod tests {
             }
         });
         handle_message(begin, &router, "", &deps).await;
+        let UpstreamNotification::CreateWorkDoneProgress { token } =
+            upstream_rx.try_recv().expect("begin should announce")
+        else {
+            panic!("Expected CreateWorkDoneProgress");
+        };
+        assert_eq!(token, upstream_token);
         let UpstreamNotification::Progress { params } =
             upstream_rx.try_recv().expect("begin should forward")
         else {

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -1959,7 +1959,7 @@ mod tests {
     /// A downstream `window/workDoneProgress/create` is acknowledged to the
     /// downstream and registered (so `$/progress` can be translated), but the
     /// editor-facing `CreateWorkDoneProgress` is deferred until the token's
-    /// first titled `begin` (lazy announcement: per-request downstream
+    /// first renderable `begin` (lazy announcement: per-request downstream
     /// progress storms must not reach the editor).
     #[tokio::test]
     async fn handle_message_work_done_progress_create_bridges_upstream() {

--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -2004,10 +2004,10 @@ mod tests {
         assert_eq!(val["id"], 5);
         assert!(val["result"].is_null());
 
-        // Nothing reaches the editor yet: announcement waits for a titled begin.
+        // Nothing reaches the editor yet: announcement waits for a renderable begin.
         assert!(
             upstream_rx.try_recv().is_err(),
-            "create must not be bridged before a titled begin"
+            "create must not be bridged before a renderable begin"
         );
 
         // The mapping is registered so downstream `$/progress` can be translated.
@@ -2020,7 +2020,7 @@ mod tests {
             "upstream token must be remapped"
         );
 
-        // The first titled begin announces: create, then the begin itself.
+        // The first renderable begin announces: create, then the begin itself.
         let begin = json!({
             "jsonrpc": "2.0",
             "method": "$/progress",
@@ -2032,7 +2032,7 @@ mod tests {
         handle_message(begin, &router, "", &deps).await;
         let UpstreamNotification::CreateWorkDoneProgress { token } = upstream_rx
             .try_recv()
-            .expect("titled begin should announce the token")
+            .expect("renderable begin should announce the token")
         else {
             panic!("Expected CreateWorkDoneProgress");
         };
@@ -2051,7 +2051,7 @@ mod tests {
     /// is the storm case — some downstreams declare a token per analysis pass
     /// with nothing renderable.
     #[tokio::test]
-    async fn handle_message_untitled_progress_lifecycle_is_swallowed() {
+    async fn handle_message_blank_progress_lifecycle_is_swallowed() {
         use tower_lsp_server::ls_types::NumberOrString;
 
         let router = ResponseRouter::new();
@@ -2098,7 +2098,7 @@ mod tests {
 
         assert!(
             upstream_rx.try_recv().is_err(),
-            "untitled lifecycle must not reach the editor"
+            "blank lifecycle must not reach the editor"
         );
         let downstream_token = NumberOrString::String("storm".to_string());
         assert_eq!(
@@ -2159,6 +2159,65 @@ mod tests {
         else {
             panic!("expected CreateWorkDoneProgress");
         };
+        assert!(
+            matches!(
+                upstream_rx.try_recv(),
+                Ok(UpstreamNotification::Progress { .. })
+            ),
+            "the begin itself must forward after the create"
+        );
+    }
+
+    /// A begin that is blank except for `cancellable: true` still announces:
+    /// a cancel button is renderable.
+    #[tokio::test]
+    async fn handle_message_cancellable_only_begin_still_announces() {
+        let router = ResponseRouter::new();
+        let (response_tx, _response_rx) = mpsc::channel(16);
+        let dynamic_capabilities = Arc::new(DynamicCapabilityRegistry::new());
+        let (upstream_tx, mut upstream_rx) = mpsc::unbounded_channel();
+        let (window_tx, _window_rx) = mpsc::channel(16);
+        let progress_registry = Arc::new(crate::lsp::bridge::ProgressRegistry::new());
+        let progress_connection_id = progress_registry.new_connection_id();
+        let deps = ServerRequestDeps {
+            settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
+            server_name: None,
+            response_tx,
+            dynamic_capabilities,
+            upstream_tx,
+            workspace_folders: WorkspaceFolderSet::new(None),
+            window_tx,
+            upstream_request_tx: mpsc::unbounded_channel().0,
+            inbound_request_registry: crate::lsp::bridge::InboundRequestRegistry::default(),
+            progress_registry: Arc::clone(&progress_registry),
+            client_progress_registry: Arc::new(crate::lsp::bridge::ClientProgressRegistry::new()),
+            progress_connection_id,
+        };
+
+        let create = json!({
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "window/workDoneProgress/create",
+            "params": { "token": "cancellable-only" }
+        });
+        handle_message(create, &router, "", &deps).await;
+        let begin = json!({
+            "jsonrpc": "2.0",
+            "method": "$/progress",
+            "params": {
+                "token": "cancellable-only",
+                "value": { "kind": "begin", "title": "", "cancellable": true }
+            }
+        });
+        handle_message(begin, &router, "", &deps).await;
+
+        assert!(
+            matches!(
+                upstream_rx.try_recv(),
+                Ok(UpstreamNotification::CreateWorkDoneProgress { .. })
+            ),
+            "cancellable begin must announce"
+        );
         assert!(
             matches!(
                 upstream_rx.try_recv(),
@@ -2281,7 +2340,7 @@ mod tests {
             "unannounced stale token needs no Forget"
         );
 
-        // Announce the second token via a titled begin...
+        // Announce the second token via a renderable begin...
         let begin = json!({
             "jsonrpc": "2.0",
             "method": "$/progress",
@@ -2405,7 +2464,7 @@ mod tests {
             progress_connection_id,
         };
 
-        // A titled "begin" announces the token (create first) and is forwarded
+        // A renderable "begin" announces the token (create first) and is forwarded
         // with the translated token.
         let begin = json!({
             "jsonrpc": "2.0",

--- a/src/lsp/bridge/progress_registry.rs
+++ b/src/lsp/bridge/progress_registry.rs
@@ -26,6 +26,19 @@
 //! Forward translation is keyed by [`ProgressConnectionId`] because the same
 //! downstream token value may be used by different connections; the connection
 //! id disambiguates them.
+//!
+//! # Lazy announcement (storm suppression)
+//!
+//! Registering a token does **not** immediately ask the editor to create it.
+//! Some downstreams (e.g. basedpyright) declare a fresh progress token for
+//! every analysis pass — thousands of `create` → `begin("")` → `end` triples
+//! per minute of typing — and each forwarded `create` is a full editor
+//! round-trip that queues ahead of real responses on the shared stdout sink.
+//! Instead the registry tracks a per-token phase and [`ProgressRegistry::admit`]
+//! decides, on the first `$/progress`, whether the token is worth announcing:
+//! a `begin` with a non-empty title announces (create + begin forwarded, in
+//! order, on the same FIFO channel); a `begin` with an empty title has nothing
+//! the editor could render, so the whole lifecycle is swallowed.
 
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -60,16 +73,65 @@ struct CancelTarget {
     downstream_token: NumberOrString,
 }
 
+/// Lifecycle phase of a registered token (lazy announcement, see module docs).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Phase {
+    /// Registered via `create`, no `$/progress` seen yet; nothing sent upstream.
+    Pending,
+    /// A titled `begin` arrived; the editor has been asked to create the token
+    /// and subsequent progress is forwarded.
+    Announced,
+    /// An untitled `begin` arrived; the whole lifecycle is dropped.
+    Swallowed,
+}
+
+struct TokenEntry {
+    upstream: NumberOrString,
+    phase: Phase,
+}
+
+/// What the first `$/progress` for a token reveals about it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProgressSignal {
+    /// `begin` with a non-empty title — renderable, worth announcing.
+    TitledBegin,
+    /// `begin` with an empty title — nothing the editor could render.
+    UntitledBegin,
+    /// `report`/`end` (or anything else).
+    Other,
+}
+
+/// Routing decision for one `$/progress` notification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ProgressAdmission {
+    /// First titled `begin`: send `window/workDoneProgress/create` for the
+    /// token, then forward this notification with it.
+    Announce(NumberOrString),
+    /// Already announced: forward with the token.
+    Forward(NumberOrString),
+    /// Swallowed or meaningless without a `begin`: drop the notification.
+    Drop,
+}
+
+/// A previously registered upstream token evicted by a re-`create`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EvictedToken {
+    pub(crate) token: NumberOrString,
+    /// Whether the editor was ever asked to create it — only then does the
+    /// forwarding loop hold an admission that needs forgetting.
+    pub(crate) announced: bool,
+}
+
 #[derive(Default)]
 struct Inner {
     /// upstream token → cancel routing target.
     up_to_down: HashMap<NumberOrString, CancelTarget>,
-    /// connection → (downstream token → upstream token). Nesting by connection
+    /// connection → (downstream token → upstream entry). Nesting by connection
     /// keeps forward translation scoped (the same downstream token value may be
     /// used by different connections) and makes per-connection purge a single
     /// map removal. `NumberOrString` derives `Hash`/`Eq`, so the numeric token
     /// `1` and the string token `"1"` never collide as keys.
-    down_to_up: HashMap<ProgressConnectionId, HashMap<NumberOrString, NumberOrString>>,
+    down_to_up: HashMap<ProgressConnectionId, HashMap<NumberOrString, TokenEntry>>,
 }
 
 /// Bidirectional registry mapping downstream-declared progress tokens to
@@ -98,10 +160,14 @@ impl ProgressRegistry {
     }
 
     /// Register a downstream-declared token and return `(upstream_token, stale)`:
-    /// the unique upstream token the editor should see, plus the prior upstream
-    /// token if this `(connection, downstream_token)` was already registered.
+    /// the unique upstream token the editor should see, plus the prior entry if
+    /// this `(connection, downstream_token)` was already registered.
     /// `writer` is the owning connection's writer channel, used later to route a
     /// cancel back to that downstream.
+    ///
+    /// The token starts [`Phase::Pending`]: nothing is sent to the editor until
+    /// [`ProgressRegistry::admit`] sees a titled `begin` (lazy announcement, see
+    /// module docs).
     ///
     /// Re-registering the same `(connection, downstream_token)` (a downstream that
     /// re-creates a token it already declared) replaces the prior mapping and
@@ -113,7 +179,7 @@ impl ProgressRegistry {
         connection_id: ProgressConnectionId,
         downstream_token: NumberOrString,
         writer: tokio::sync::mpsc::Sender<OutboundMessage>,
-    ) -> (NumberOrString, Option<NumberOrString>) {
+    ) -> (NumberOrString, Option<EvictedToken>) {
         let suffix = self.token_counter.fetch_add(1, Ordering::Relaxed);
         let upstream_token = NumberOrString::String(format!("kakehashi/bridge/progress/{suffix}"));
 
@@ -126,9 +192,19 @@ impl ProgressRegistry {
             .down_to_up
             .entry(connection_id)
             .or_default()
-            .insert(downstream_token.clone(), upstream_token.clone());
+            .insert(
+                downstream_token.clone(),
+                TokenEntry {
+                    upstream: upstream_token.clone(),
+                    phase: Phase::Pending,
+                },
+            )
+            .map(|entry| EvictedToken {
+                announced: entry.phase == Phase::Announced,
+                token: entry.upstream,
+            });
         if let Some(ref stale_upstream) = stale {
-            inner.up_to_down.remove(stale_upstream);
+            inner.up_to_down.remove(&stale_upstream.token);
         }
         inner.up_to_down.insert(
             upstream_token.clone(),
@@ -140,9 +216,46 @@ impl ProgressRegistry {
         (upstream_token, stale)
     }
 
-    /// Translate a downstream token to its upstream token for `$/progress`
-    /// forwarding. Returns `None` for tokens this registry never minted (e.g.
-    /// client-provided `workDoneToken`s — out of scope, see module docs).
+    /// Decide how to route one `$/progress` for a registered token, advancing
+    /// its phase (lazy announcement, see module docs). Returns `None` for
+    /// tokens this registry never minted.
+    ///
+    /// - `Pending` + titled `begin` → `Announce` (create + forward).
+    /// - `Pending` + untitled `begin` → swallow the whole lifecycle.
+    /// - `Pending` + `report`/`end` (no `begin` seen) → drop: without a `begin`
+    ///   the editor has no progress UI to update.
+    /// - `Swallowed` + titled `begin` (token reuse without an `end`) → upgrade
+    ///   to `Announce` rather than lose renderable progress.
+    pub(crate) fn admit(
+        &self,
+        connection_id: ProgressConnectionId,
+        downstream_token: &NumberOrString,
+        signal: ProgressSignal,
+    ) -> Option<ProgressAdmission> {
+        let mut guard = self.inner.lock().recover_poison("ProgressRegistry::admit");
+        let entry = guard
+            .down_to_up
+            .get_mut(&connection_id)
+            .and_then(|tokens| tokens.get_mut(downstream_token))?;
+        Some(match (entry.phase, signal) {
+            (Phase::Announced, _) => ProgressAdmission::Forward(entry.upstream.clone()),
+            (Phase::Pending | Phase::Swallowed, ProgressSignal::TitledBegin) => {
+                entry.phase = Phase::Announced;
+                ProgressAdmission::Announce(entry.upstream.clone())
+            }
+            (Phase::Pending, ProgressSignal::UntitledBegin) => {
+                entry.phase = Phase::Swallowed;
+                ProgressAdmission::Drop
+            }
+            (Phase::Pending | Phase::Swallowed, _) => ProgressAdmission::Drop,
+        })
+    }
+
+    /// Translate a downstream token to its upstream token. Returns `None` for
+    /// tokens this registry never minted. Production forwarding goes through
+    /// [`ProgressRegistry::admit`] (which also advances the phase); this
+    /// phase-blind lookup remains for test assertions on the mapping itself.
+    #[cfg(test)]
     pub(crate) fn translate(
         &self,
         connection_id: ProgressConnectionId,
@@ -155,7 +268,8 @@ impl ProgressRegistry {
         inner
             .down_to_up
             .get(&connection_id)
-            .and_then(|tokens| tokens.get(downstream_token).cloned())
+            .and_then(|tokens| tokens.get(downstream_token))
+            .map(|entry| entry.upstream.clone())
     }
 
     /// Drop the mapping for a finished progress operation (a `$/progress` with
@@ -174,8 +288,8 @@ impl ProgressRegistry {
             .down_to_up
             .get_mut(&connection_id)
             .and_then(|tokens| tokens.remove(downstream_token));
-        if let Some(upstream_token) = removed {
-            inner.up_to_down.remove(&upstream_token);
+        if let Some(entry) = removed {
+            inner.up_to_down.remove(&entry.upstream);
         }
     }
 
@@ -196,7 +310,8 @@ impl ProgressRegistry {
         let Some(tokens) = inner.down_to_up.remove(&connection_id) else {
             return Vec::new();
         };
-        let upstream_tokens: Vec<NumberOrString> = tokens.into_values().collect();
+        let upstream_tokens: Vec<NumberOrString> =
+            tokens.into_values().map(|entry| entry.upstream).collect();
         for upstream_token in &upstream_tokens {
             inner.up_to_down.remove(upstream_token);
         }
@@ -352,11 +467,119 @@ mod tests {
         assert_ne!(up_first, up_second);
         // First registration evicts nothing; the second evicts and returns the first.
         assert_eq!(stale_first, None);
-        assert_eq!(stale_second, Some(up_first.clone()));
+        assert_eq!(
+            stale_second,
+            Some(EvictedToken {
+                token: up_first.clone(),
+                announced: false,
+            })
+        );
         // Stale upstream token no longer routable.
         assert!(reg.resolve_cancel(&up_first).is_none());
         // New one is.
         assert!(reg.resolve_cancel(&up_second).is_some());
         assert_eq!(reg.translate(conn, &downstream), Some(up_second));
+    }
+
+    #[test]
+    fn re_register_reports_whether_evicted_token_was_announced() {
+        let reg = ProgressRegistry::new();
+        let conn = reg.new_connection_id();
+        let downstream = NumberOrString::Number(1);
+
+        let (up_first, _) = reg.register(conn, downstream.clone(), dummy_writer());
+        assert_eq!(
+            reg.admit(conn, &downstream, ProgressSignal::TitledBegin),
+            Some(ProgressAdmission::Announce(up_first.clone()))
+        );
+
+        let (_, stale) = reg.register(conn, downstream.clone(), dummy_writer());
+        assert_eq!(
+            stale,
+            Some(EvictedToken {
+                token: up_first,
+                announced: true,
+            })
+        );
+    }
+
+    #[test]
+    fn admit_titled_begin_announces_then_forwards() {
+        let reg = ProgressRegistry::new();
+        let conn = reg.new_connection_id();
+        let downstream = NumberOrString::Number(1);
+        let (upstream, _) = reg.register(conn, downstream.clone(), dummy_writer());
+
+        assert_eq!(
+            reg.admit(conn, &downstream, ProgressSignal::TitledBegin),
+            Some(ProgressAdmission::Announce(upstream.clone()))
+        );
+        // Subsequent report/end forward without re-announcing.
+        assert_eq!(
+            reg.admit(conn, &downstream, ProgressSignal::Other),
+            Some(ProgressAdmission::Forward(upstream))
+        );
+    }
+
+    #[test]
+    fn admit_untitled_begin_swallows_whole_lifecycle() {
+        let reg = ProgressRegistry::new();
+        let conn = reg.new_connection_id();
+        let downstream = NumberOrString::Number(1);
+        let (_upstream, _) = reg.register(conn, downstream.clone(), dummy_writer());
+
+        assert_eq!(
+            reg.admit(conn, &downstream, ProgressSignal::UntitledBegin),
+            Some(ProgressAdmission::Drop)
+        );
+        // report/end for the swallowed token stay dropped.
+        assert_eq!(
+            reg.admit(conn, &downstream, ProgressSignal::Other),
+            Some(ProgressAdmission::Drop)
+        );
+    }
+
+    #[test]
+    fn admit_report_or_end_without_begin_is_dropped() {
+        let reg = ProgressRegistry::new();
+        let conn = reg.new_connection_id();
+        let downstream = NumberOrString::Number(1);
+        let (_upstream, _) = reg.register(conn, downstream.clone(), dummy_writer());
+
+        assert_eq!(
+            reg.admit(conn, &downstream, ProgressSignal::Other),
+            Some(ProgressAdmission::Drop)
+        );
+    }
+
+    #[test]
+    fn admit_titled_begin_after_swallow_upgrades_to_announce() {
+        let reg = ProgressRegistry::new();
+        let conn = reg.new_connection_id();
+        let downstream = NumberOrString::Number(1);
+        let (upstream, _) = reg.register(conn, downstream.clone(), dummy_writer());
+
+        assert_eq!(
+            reg.admit(conn, &downstream, ProgressSignal::UntitledBegin),
+            Some(ProgressAdmission::Drop)
+        );
+        assert_eq!(
+            reg.admit(conn, &downstream, ProgressSignal::TitledBegin),
+            Some(ProgressAdmission::Announce(upstream))
+        );
+    }
+
+    #[test]
+    fn admit_unknown_token_returns_none() {
+        let reg = ProgressRegistry::new();
+        let conn = reg.new_connection_id();
+        assert_eq!(
+            reg.admit(
+                conn,
+                &NumberOrString::Number(9),
+                ProgressSignal::TitledBegin
+            ),
+            None
+        );
     }
 }

--- a/src/lsp/bridge/progress_registry.rs
+++ b/src/lsp/bridge/progress_registry.rs
@@ -36,9 +36,10 @@
 //! round-trip that queues ahead of real responses on the shared stdout sink.
 //! Instead the registry tracks a per-token phase and [`ProgressRegistry::admit`]
 //! decides, on the first `$/progress`, whether the token is worth announcing:
-//! a `begin` with a non-empty title announces (create + begin forwarded, in
-//! order, on the same FIFO channel); a `begin` with an empty title has nothing
-//! the editor could render, so the whole lifecycle is swallowed.
+//! a `begin` with anything renderable (title, message, or percentage)
+//! announces — create + begin forwarded, in order, on the same FIFO channel —
+//! while a fully blank `begin` swallows the lifecycle's progress (a later
+//! renderable `begin` reusing the token still upgrades it to announced).
 
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -78,10 +79,12 @@ struct CancelTarget {
 enum Phase {
     /// Registered via `create`, no `$/progress` seen yet; nothing sent upstream.
     Pending,
-    /// A titled `begin` arrived; the editor has been asked to create the token
-    /// and subsequent progress is forwarded.
+    /// A renderable `begin` arrived; the editor has been asked to create the
+    /// token and subsequent progress is forwarded.
     Announced,
-    /// An untitled `begin` arrived; the whole lifecycle is dropped.
+    /// A blank `begin` arrived; the lifecycle's progress is dropped (unless a
+    /// later renderable `begin` reuses the token and upgrades it). Cleared by
+    /// `End`, a re-`create`, or connection purge.
     Swallowed,
 }
 
@@ -93,19 +96,21 @@ struct TokenEntry {
 /// What the first `$/progress` for a token reveals about it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ProgressSignal {
-    /// `begin` with a non-empty title — renderable, worth announcing.
-    TitledBegin,
-    /// `begin` with an empty title — nothing the editor could render.
-    UntitledBegin,
-    /// `report`/`end` (or anything else).
+    /// `begin` carrying something the editor can render (a non-empty
+    /// title, message, or a percentage) — worth announcing.
+    RenderableBegin,
+    /// `begin` with nothing renderable at all — the per-request storm shape.
+    BlankBegin,
+    /// `report`/`end` (or anything else). `admit` never distinguishes an
+    /// `end` — the caller handles End's mapping cleanup via `complete`.
     Other,
 }
 
 /// Routing decision for one `$/progress` notification.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ProgressAdmission {
-    /// First titled `begin`: send `window/workDoneProgress/create` for the
-    /// token, then forward this notification with it.
+    /// First renderable `begin`: send `window/workDoneProgress/create` for
+    /// the token, then forward this notification with it.
     Announce(NumberOrString),
     /// Already announced: forward with the token.
     Forward(NumberOrString),
@@ -166,8 +171,8 @@ impl ProgressRegistry {
     /// cancel back to that downstream.
     ///
     /// The token starts [`Phase::Pending`]: nothing is sent to the editor until
-    /// [`ProgressRegistry::admit`] sees a titled `begin` (lazy announcement, see
-    /// module docs).
+    /// [`ProgressRegistry::admit`] sees a renderable `begin` (lazy announcement,
+    /// see module docs).
     ///
     /// Re-registering the same `(connection, downstream_token)` (a downstream that
     /// re-creates a token it already declared) replaces the prior mapping and
@@ -206,6 +211,10 @@ impl ProgressRegistry {
         if let Some(ref stale_upstream) = stale {
             inner.up_to_down.remove(&stale_upstream.token);
         }
+        // Cancel routing is registered eagerly (before announcement): the
+        // editor can only learn announced tokens, but keeping the entry from
+        // birth means the pending→announced transition needs no second write
+        // and a cancel can never race a half-registered token.
         inner.up_to_down.insert(
             upstream_token.clone(),
             CancelTarget {
@@ -220,12 +229,12 @@ impl ProgressRegistry {
     /// its phase (lazy announcement, see module docs). Returns `None` for
     /// tokens this registry never minted.
     ///
-    /// - `Pending` + titled `begin` → `Announce` (create + forward).
-    /// - `Pending` + untitled `begin` → swallow the whole lifecycle.
+    /// - `Pending` + renderable `begin` → `Announce` (create + forward).
+    /// - `Pending` + blank `begin` → swallow the lifecycle.
     /// - `Pending` + `report`/`end` (no `begin` seen) → drop: without a `begin`
     ///   the editor has no progress UI to update.
-    /// - `Swallowed` + titled `begin` (token reuse without an `end`) → upgrade
-    ///   to `Announce` rather than lose renderable progress.
+    /// - `Swallowed` + renderable `begin` (token reuse without an `end`) →
+    ///   upgrade to `Announce` rather than lose renderable progress.
     pub(crate) fn admit(
         &self,
         connection_id: ProgressConnectionId,
@@ -239,11 +248,11 @@ impl ProgressRegistry {
             .and_then(|tokens| tokens.get_mut(downstream_token))?;
         Some(match (entry.phase, signal) {
             (Phase::Announced, _) => ProgressAdmission::Forward(entry.upstream.clone()),
-            (Phase::Pending | Phase::Swallowed, ProgressSignal::TitledBegin) => {
+            (Phase::Pending | Phase::Swallowed, ProgressSignal::RenderableBegin) => {
                 entry.phase = Phase::Announced;
                 ProgressAdmission::Announce(entry.upstream.clone())
             }
-            (Phase::Pending, ProgressSignal::UntitledBegin) => {
+            (Phase::Pending, ProgressSignal::BlankBegin) => {
                 entry.phase = Phase::Swallowed;
                 ProgressAdmission::Drop
             }
@@ -482,6 +491,74 @@ mod tests {
     }
 
     #[test]
+    fn re_register_of_swallowed_token_reports_unannounced() {
+        let reg = ProgressRegistry::new();
+        let conn = reg.new_connection_id();
+        let downstream = NumberOrString::Number(1);
+
+        let (up_first, _) = reg.register(conn, downstream.clone(), dummy_writer());
+        assert_eq!(
+            reg.admit(conn, &downstream, ProgressSignal::BlankBegin),
+            Some(ProgressAdmission::Drop)
+        );
+
+        let (_, stale) = reg.register(conn, downstream.clone(), dummy_writer());
+        assert_eq!(
+            stale,
+            Some(EvictedToken {
+                token: up_first,
+                announced: false,
+            })
+        );
+    }
+
+    #[test]
+    fn admit_is_connection_scoped() {
+        let reg = ProgressRegistry::new();
+        let conn_a = reg.new_connection_id();
+        let conn_b = reg.new_connection_id();
+        let downstream = NumberOrString::Number(1);
+        let (_up, _) = reg.register(conn_a, downstream.clone(), dummy_writer());
+
+        assert_eq!(
+            reg.admit(conn_b, &downstream, ProgressSignal::RenderableBegin),
+            None,
+            "a foreign connection's token must not admit"
+        );
+    }
+
+    /// Purge is deliberately phase-blind: it returns every phase's upstream
+    /// token. The Forget the purge guard sends for never-announced tokens is
+    /// a no-op in the forwarding loop (they were never admitted), so
+    /// filtering here would buy nothing on the rare crash path.
+    #[test]
+    fn purge_connection_returns_tokens_of_every_phase() {
+        let reg = ProgressRegistry::new();
+        let conn = reg.new_connection_id();
+        let pending = NumberOrString::Number(1);
+        let announced = NumberOrString::Number(2);
+        let swallowed = NumberOrString::Number(3);
+        let (up_pending, _) = reg.register(conn, pending.clone(), dummy_writer());
+        let (up_announced, _) = reg.register(conn, announced.clone(), dummy_writer());
+        let (up_swallowed, _) = reg.register(conn, swallowed.clone(), dummy_writer());
+        reg.admit(conn, &announced, ProgressSignal::RenderableBegin);
+        reg.admit(conn, &swallowed, ProgressSignal::BlankBegin);
+
+        let mut purged = reg.purge_connection(conn);
+        purged.sort_by_key(|t| format!("{t:?}"));
+        let mut expected = vec![
+            up_pending.clone(),
+            up_announced.clone(),
+            up_swallowed.clone(),
+        ];
+        expected.sort_by_key(|t| format!("{t:?}"));
+        assert_eq!(purged, expected);
+        for up in [up_pending, up_announced, up_swallowed] {
+            assert!(reg.resolve_cancel(&up).is_none(), "purged token routable");
+        }
+    }
+
+    #[test]
     fn re_register_reports_whether_evicted_token_was_announced() {
         let reg = ProgressRegistry::new();
         let conn = reg.new_connection_id();
@@ -489,7 +566,7 @@ mod tests {
 
         let (up_first, _) = reg.register(conn, downstream.clone(), dummy_writer());
         assert_eq!(
-            reg.admit(conn, &downstream, ProgressSignal::TitledBegin),
+            reg.admit(conn, &downstream, ProgressSignal::RenderableBegin),
             Some(ProgressAdmission::Announce(up_first.clone()))
         );
 
@@ -511,7 +588,7 @@ mod tests {
         let (upstream, _) = reg.register(conn, downstream.clone(), dummy_writer());
 
         assert_eq!(
-            reg.admit(conn, &downstream, ProgressSignal::TitledBegin),
+            reg.admit(conn, &downstream, ProgressSignal::RenderableBegin),
             Some(ProgressAdmission::Announce(upstream.clone()))
         );
         // Subsequent report/end forward without re-announcing.
@@ -529,7 +606,7 @@ mod tests {
         let (_upstream, _) = reg.register(conn, downstream.clone(), dummy_writer());
 
         assert_eq!(
-            reg.admit(conn, &downstream, ProgressSignal::UntitledBegin),
+            reg.admit(conn, &downstream, ProgressSignal::BlankBegin),
             Some(ProgressAdmission::Drop)
         );
         // report/end for the swallowed token stay dropped.
@@ -560,11 +637,11 @@ mod tests {
         let (upstream, _) = reg.register(conn, downstream.clone(), dummy_writer());
 
         assert_eq!(
-            reg.admit(conn, &downstream, ProgressSignal::UntitledBegin),
+            reg.admit(conn, &downstream, ProgressSignal::BlankBegin),
             Some(ProgressAdmission::Drop)
         );
         assert_eq!(
-            reg.admit(conn, &downstream, ProgressSignal::TitledBegin),
+            reg.admit(conn, &downstream, ProgressSignal::RenderableBegin),
             Some(ProgressAdmission::Announce(upstream))
         );
     }
@@ -577,7 +654,7 @@ mod tests {
             reg.admit(
                 conn,
                 &NumberOrString::Number(9),
-                ProgressSignal::TitledBegin
+                ProgressSignal::RenderableBegin
             ),
             None
         );

--- a/src/lsp/bridge/progress_registry.rs
+++ b/src/lsp/bridge/progress_registry.rs
@@ -36,8 +36,8 @@
 //! round-trip that queues ahead of real responses on the shared stdout sink.
 //! Instead the registry tracks a per-token phase and [`ProgressRegistry::admit`]
 //! decides, on the first `$/progress`, whether the token is worth announcing:
-//! a `begin` with anything renderable (title, message, or percentage)
-//! announces — create + begin forwarded, in order, on the same FIFO channel —
+//! a `begin` with anything renderable (title, message, percentage, or a
+//! cancel button) announces — create + begin forwarded, in order, on the same FIFO channel —
 //! while a fully blank `begin` swallows the lifecycle's progress (a later
 //! renderable `begin` reusing the token still upgrades it to announced).
 
@@ -96,8 +96,8 @@ struct TokenEntry {
 /// What the first `$/progress` for a token reveals about it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ProgressSignal {
-    /// `begin` carrying something the editor can render (a non-empty
-    /// title, message, or a percentage) — worth announcing.
+    /// `begin` carrying something the editor can render (a non-empty title
+    /// or message, a percentage, or `cancellable: true`) — worth announcing.
     RenderableBegin,
     /// `begin` with nothing renderable at all — the per-request storm shape.
     BlankBegin,
@@ -581,7 +581,7 @@ mod tests {
     }
 
     #[test]
-    fn admit_titled_begin_announces_then_forwards() {
+    fn admit_renderable_begin_announces_then_forwards() {
         let reg = ProgressRegistry::new();
         let conn = reg.new_connection_id();
         let downstream = NumberOrString::Number(1);
@@ -599,7 +599,7 @@ mod tests {
     }
 
     #[test]
-    fn admit_untitled_begin_swallows_whole_lifecycle() {
+    fn admit_blank_begin_swallows_lifecycle() {
         let reg = ProgressRegistry::new();
         let conn = reg.new_connection_id();
         let downstream = NumberOrString::Number(1);
@@ -630,7 +630,7 @@ mod tests {
     }
 
     #[test]
-    fn admit_titled_begin_after_swallow_upgrades_to_announce() {
+    fn admit_renderable_begin_after_swallow_upgrades_to_announce() {
         let reg = ProgressRegistry::new();
         let conn = reg.new_connection_id();
         let downstream = NumberOrString::Number(1);

--- a/src/lsp/bridge/progress_registry.rs
+++ b/src/lsp/bridge/progress_registry.rs
@@ -8,8 +8,9 @@
 //! upstream token for every downstream-declared token and remembers the mapping
 //! so the bridge can translate in both directions:
 //!
-//! - **downstream → upstream** ([`ProgressRegistry::translate`]): rewrite the
-//!   token on `$/progress` notifications before forwarding to the editor.
+//! - **downstream → upstream** ([`ProgressRegistry::admit`]): decide, per
+//!   `$/progress`, whether to announce/forward/drop, handing back the
+//!   upstream token to rewrite onto forwarded notifications.
 //! - **upstream → downstream** ([`ProgressRegistry::resolve_cancel`]): when the
 //!   editor sends `window/workDoneProgress/cancel` for an upstream token, find
 //!   the owning downstream connection and its original token.

--- a/src/lsp/bridge/text_document/diagnostic.rs
+++ b/src/lsp/bridge/text_document/diagnostic.rs
@@ -21,7 +21,7 @@ use tower_lsp_server::ls_types::{Diagnostic, DocumentDiagnosticReport};
 use url::Url;
 
 use super::super::pool::{INIT_TIMEOUT_SECS, LanguageServerPool, UpstreamId};
-use tower_lsp_server::ls_types::{DocumentDiagnosticParams, TextDocumentIdentifier};
+use tower_lsp_server::ls_types::TextDocumentIdentifier;
 
 use super::super::protocol::translate_virtual_range_to_host;
 use super::super::protocol::{
@@ -107,23 +107,35 @@ impl LanguageServerPool {
     }
 }
 
+/// `DocumentDiagnosticParams` for the wire, omitting absent optionals.
+///
+/// `ls_types::DocumentDiagnosticParams` serializes `identifier: None` and
+/// `previous_result_id: None` as explicit JSON `null`s (no
+/// `skip_serializing_if`), and strictly-decoding downstreams (typescript-go's
+/// Go unmarshaler) reject those nulls with InvalidParams on every pull. The
+/// spec marks both fields optional, so absent is the interoperable encoding.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DiagnosticRequestParams {
+    text_document: TextDocumentIdentifier,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    previous_result_id: Option<String>,
+}
+
 /// Build a JSON-RPC diagnostic request for a downstream language server.
 ///
-/// Like DocumentSymbolParams, DocumentDiagnosticParams operates on the entire
+/// Like DocumentSymbolParams, diagnostic params operate on the entire
 /// document; an optional `previous_result_id` enables incremental updates.
 fn build_diagnostic_request(
     virtual_uri: &VirtualDocumentUri,
     request_id: RequestId,
     previous_result_id: Option<&str>,
-) -> JsonRpcRequest<DocumentDiagnosticParams> {
-    let params = DocumentDiagnosticParams {
+) -> JsonRpcRequest<DiagnosticRequestParams> {
+    let params = DiagnosticRequestParams {
         text_document: TextDocumentIdentifier {
             uri: virtual_uri_to_lsp_uri(virtual_uri),
         },
-        identifier: None,
         previous_result_id: previous_result_id.map(|s| s.to_string()),
-        work_done_progress_params: Default::default(),
-        partial_result_params: Default::default(),
     };
     JsonRpcRequest::new(request_id.as_i64(), "textDocument/diagnostic", params)
 }
@@ -641,10 +653,15 @@ mod tests {
             json["params"].get("position").is_none(),
             "Diagnostic request should not have position parameter"
         );
-        // Without previous_result_id, the field should be null (typed params serialize None as null)
+        // Without previous_result_id, the field must be ABSENT, not null:
+        // strict downstream decoders (typescript-go) reject explicit nulls.
         assert!(
-            json["params"]["previousResultId"].is_null(),
-            "Diagnostic request without previous_result_id should have null previousResultId"
+            json["params"].get("previousResultId").is_none(),
+            "Diagnostic request without previous_result_id must omit previousResultId"
+        );
+        assert!(
+            json["params"].get("identifier").is_none(),
+            "Diagnostic request must omit the unused identifier field"
         );
     }
 

--- a/src/lsp/bridge/text_document/diagnostic.rs
+++ b/src/lsp/bridge/text_document/diagnostic.rs
@@ -124,7 +124,7 @@ struct DiagnosticRequestParams {
 
 /// Build a JSON-RPC diagnostic request for a downstream language server.
 ///
-/// Like DocumentSymbolParams, diagnostic params operate on the entire
+/// Like `textDocument/documentSymbol`, this request operates on the entire
 /// document; an optional `previous_result_id` enables incremental updates.
 fn build_diagnostic_request(
     virtual_uri: &VirtualDocumentUri,

--- a/src/lsp/bridge/window/progress.rs
+++ b/src/lsp/bridge/window/progress.rs
@@ -136,6 +136,14 @@ pub(in crate::lsp::bridge) fn forward(
         ProgressAdmission::Drop => {
             // Swallowed lifecycle (blank begin) or report/end without a begin:
             // nothing reaches the editor. An End still clears the mapping.
+            //
+            // Deliberately, a renderable REPORT does not upgrade a swallowed
+            // lifecycle: only the begin classifies. In the production storm
+            // this gate exists for, 8,288 of 8,351 reports carried a message
+            // ("analyzing 1 file" per pass) under blank begins — upgrading on
+            // renderable reports would re-admit essentially the whole flood.
+            // A downstream that wants its progress rendered must say so at
+            // begin time (title/message/percentage/cancellable).
             if is_end {
                 deps.progress_registry
                     .complete(deps.progress_connection_id, &params.token);

--- a/src/lsp/bridge/window/progress.rs
+++ b/src/lsp/bridge/window/progress.rs
@@ -69,18 +69,19 @@ pub(in crate::lsp::bridge) fn forward(
 
     let signal = match &params.value {
         ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(begin)) => {
-            // A begin is renderable when ANY of title/message/percentage gives
-            // the editor something to show — an empty title alone is legal
-            // (title is a required field, "" a legal value) and clients render
-            // message/percentage without one. Only a fully blank begin (the
-            // per-analysis-pass storm shape, `{"kind":"begin","title":""}`)
-            // is swallowed.
+            // A begin is renderable when ANY of title/message/percentage/
+            // cancellable gives the editor something to show — an empty title
+            // alone is legal (title is a required field, "" a legal value)
+            // and clients render message/percentage/a cancel button without
+            // one. Only a fully blank begin (the per-analysis-pass storm
+            // shape, `{"kind":"begin","title":""}`) is swallowed.
             let renderable = !begin.title.is_empty()
                 || begin
                     .message
                     .as_deref()
                     .is_some_and(|message| !message.is_empty())
-                || begin.percentage.is_some();
+                || begin.percentage.is_some()
+                || begin.cancellable == Some(true);
             if renderable {
                 ProgressSignal::RenderableBegin
             } else {

--- a/src/lsp/bridge/window/progress.rs
+++ b/src/lsp/bridge/window/progress.rs
@@ -24,10 +24,11 @@ use crate::lsp::bridge::progress_registry::{ProgressAdmission, ProgressSignal};
 /// and forwarding it verbatim risks duplicates under request fan-out.
 ///
 /// Announcement is lazy: the editor-facing `window/workDoneProgress/create` is
-/// enqueued here, immediately before the first titled `begin` (same FIFO
-/// channel, so create-before-progress ordering holds), and untitled progress
-/// lifecycles are swallowed entirely — see [`ProgressRegistry`] module docs
-/// for why (per-request downstream progress storms).
+/// enqueued here, immediately before the first renderable `begin` (same FIFO
+/// channel, so create-before-progress ordering holds), while blank progress
+/// lifecycles are swallowed (a later renderable `begin` reusing the token
+/// still upgrades it) — see [`ProgressRegistry`] module docs for why
+/// (per-request downstream progress storms).
 ///
 /// A terminating `WorkDoneProgress::End` clears the mapping after forwarding.
 ///
@@ -68,10 +69,22 @@ pub(in crate::lsp::bridge) fn forward(
 
     let signal = match &params.value {
         ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(begin)) => {
-            if begin.title.is_empty() {
-                ProgressSignal::UntitledBegin
+            // A begin is renderable when ANY of title/message/percentage gives
+            // the editor something to show — an empty title alone is legal
+            // (title is a required field, "" a legal value) and clients render
+            // message/percentage without one. Only a fully blank begin (the
+            // per-analysis-pass storm shape, `{"kind":"begin","title":""}`)
+            // is swallowed.
+            let renderable = !begin.title.is_empty()
+                || begin
+                    .message
+                    .as_deref()
+                    .is_some_and(|message| !message.is_empty())
+                || begin.percentage.is_some();
+            if renderable {
+                ProgressSignal::RenderableBegin
             } else {
-                ProgressSignal::TitledBegin
+                ProgressSignal::BlankBegin
             }
         }
         _ => ProgressSignal::Other,
@@ -96,7 +109,7 @@ pub(in crate::lsp::bridge) fn forward(
 
     match admission {
         ProgressAdmission::Announce(upstream_token) => {
-            // First titled begin: ask the editor to create the token, then
+            // First renderable begin: ask the editor to create the token, then
             // forward the begin. Same FIFO channel, and the forwarding loop
             // awaits the create inline, so ordering holds.
             let _ = deps
@@ -120,7 +133,7 @@ pub(in crate::lsp::bridge) fn forward(
             }
         }
         ProgressAdmission::Drop => {
-            // Swallowed lifecycle (untitled) or report/end without a begin:
+            // Swallowed lifecycle (blank begin) or report/end without a begin:
             // nothing reaches the editor. An End still clears the mapping.
             if is_end {
                 deps.progress_registry

--- a/src/lsp/bridge/window/progress.rs
+++ b/src/lsp/bridge/window/progress.rs
@@ -12,6 +12,7 @@ use serde::Deserialize;
 use tower_lsp_server::ls_types::{ProgressParams, ProgressParamsValue, WorkDoneProgress};
 
 use crate::lsp::bridge::actor::{ServerRequestDeps, UpstreamNotification};
+use crate::lsp::bridge::progress_registry::{ProgressAdmission, ProgressSignal};
 
 /// Translate and forward a downstream `$/progress` notification to the editor.
 ///
@@ -21,6 +22,12 @@ use crate::lsp::bridge::actor::{ServerRequestDeps, UpstreamNotification};
 /// any other token (e.g. a client-provided `workDoneToken`) is **dropped** — it
 /// is out of scope for token remapping (see [`ProgressRegistry`] module docs),
 /// and forwarding it verbatim risks duplicates under request fan-out.
+///
+/// Announcement is lazy: the editor-facing `window/workDoneProgress/create` is
+/// enqueued here, immediately before the first titled `begin` (same FIFO
+/// channel, so create-before-progress ordering holds), and untitled progress
+/// lifecycles are swallowed entirely — see [`ProgressRegistry`] module docs
+/// for why (per-request downstream progress storms).
 ///
 /// A terminating `WorkDoneProgress::End` clears the mapping after forwarding.
 ///
@@ -59,10 +66,25 @@ pub(in crate::lsp::bridge) fn forward(
         return;
     }
 
-    let Some(upstream_token) = deps
-        .progress_registry
-        .translate(deps.progress_connection_id, &params.token)
-    else {
+    let signal = match &params.value {
+        ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(begin)) => {
+            if begin.title.is_empty() {
+                ProgressSignal::UntitledBegin
+            } else {
+                ProgressSignal::TitledBegin
+            }
+        }
+        _ => ProgressSignal::Other,
+    };
+    let is_end = matches!(
+        &params.value,
+        ProgressParamsValue::WorkDone(WorkDoneProgress::End(_))
+    );
+
+    let admission =
+        deps.progress_registry
+            .admit(deps.progress_connection_id, &params.token, signal);
+    let Some(admission) = admission else {
         // Unknown token: not a downstream-declared progress we remapped.
         debug!(
             target: "kakehashi::bridge::reader",
@@ -72,18 +94,38 @@ pub(in crate::lsp::bridge) fn forward(
         return;
     };
 
-    let is_end = matches!(
-        &params.value,
-        ProgressParamsValue::WorkDone(WorkDoneProgress::End(_))
-    );
-
-    let downstream_token = std::mem::replace(&mut params.token, upstream_token);
-    let _ = deps
-        .upstream_tx
-        .send(UpstreamNotification::Progress { params });
-
-    if is_end {
-        deps.progress_registry
-            .complete(deps.progress_connection_id, &downstream_token);
+    match admission {
+        ProgressAdmission::Announce(upstream_token) => {
+            // First titled begin: ask the editor to create the token, then
+            // forward the begin. Same FIFO channel, and the forwarding loop
+            // awaits the create inline, so ordering holds.
+            let _ = deps
+                .upstream_tx
+                .send(UpstreamNotification::CreateWorkDoneProgress {
+                    token: upstream_token.clone(),
+                });
+            params.token = upstream_token;
+            let _ = deps
+                .upstream_tx
+                .send(UpstreamNotification::Progress { params });
+        }
+        ProgressAdmission::Forward(upstream_token) => {
+            let downstream_token = std::mem::replace(&mut params.token, upstream_token);
+            let _ = deps
+                .upstream_tx
+                .send(UpstreamNotification::Progress { params });
+            if is_end {
+                deps.progress_registry
+                    .complete(deps.progress_connection_id, &downstream_token);
+            }
+        }
+        ProgressAdmission::Drop => {
+            // Swallowed lifecycle (untitled) or report/end without a begin:
+            // nothing reaches the editor. An End still clears the mapping.
+            if is_end {
+                deps.progress_registry
+                    .complete(deps.progress_connection_id, &params.token);
+            }
+        }
     }
 }

--- a/src/lsp/bridge/window/work_done_progress_create.rs
+++ b/src/lsp/bridge/window/work_done_progress_create.rs
@@ -1,10 +1,11 @@
 //! `window/workDoneProgress/create` server-request handler.
 //!
 //! Inbound (downstream → bridge → editor). A downstream declares a progress
-//! token; the bridge mints a unique *upstream* token, records the mapping in the
-//! shared [`ProgressRegistry`], and asks the editor to create the progress. The
-//! data half of the feature — translating the downstream's `$/progress` to the
-//! upstream token — lives in [`progress`](super::progress).
+//! token; the bridge mints a unique *upstream* token and records the mapping
+//! in the shared [`ProgressRegistry`]. The editor is NOT asked to create the
+//! progress here: announcement is deferred to the token's first renderable
+//! `begin`, emitted by [`progress`](super::progress) (lazy announcement, see
+//! the registry's module docs).
 //!
 //! [`ProgressRegistry`]: crate::lsp::bridge::ProgressRegistry
 

--- a/src/lsp/bridge/window/work_done_progress_create.rs
+++ b/src/lsp/bridge/window/work_done_progress_create.rs
@@ -29,8 +29,9 @@ pub(in crate::lsp::bridge) fn handle(
     //
     // We ack the downstream immediately with Ok(null): this decouples the
     // downstream from editor latency. The editor is NOT asked to create the
-    // token here — announcement is deferred until the token's first titled
-    // `begin` (see `ProgressRegistry` lazy-announcement docs), because some
+    // token here — announcement is deferred until the token's first
+    // renderable `begin` (see `ProgressRegistry` lazy-announcement docs;
+    // renderable = title, message, percentage, or cancellable), because some
     // downstreams declare a token per analysis pass and the resulting
     // create-request storm queues ahead of real responses on the shared
     // stdout sink. The `$/progress` forwarder emits the create (an editor

--- a/src/lsp/bridge/window/work_done_progress_create.rs
+++ b/src/lsp/bridge/window/work_done_progress_create.rs
@@ -27,15 +27,15 @@ pub(in crate::lsp::bridge) fn handle(
     // token and remember the mapping so `$/progress` and cancel can be
     // translated in both directions (window-work-done-progress bridging).
     //
-    // We ack the downstream immediately with Ok(null) rather than relaying
-    // the editor's real create response: this decouples the downstream from
-    // editor latency and lets progress buffer on the FIFO upstream channel.
-    // The bridge only advertises `window.workDoneProgress` downstream when
-    // the real editor supports it (see client_capabilities merge), so the
-    // editor almost always accepts the create. If it nonetheless rejects
-    // or times out, the forwarding loop drops that token's `$/progress`
-    // (it admits a token only on a successful create), so the optimistic
-    // ack never leaks progress for a token the editor didn't create.
+    // We ack the downstream immediately with Ok(null): this decouples the
+    // downstream from editor latency. The editor is NOT asked to create the
+    // token here — announcement is deferred until the token's first titled
+    // `begin` (see `ProgressRegistry` lazy-announcement docs), because some
+    // downstreams declare a token per analysis pass and the resulting
+    // create-request storm queues ahead of real responses on the shared
+    // stdout sink. The `$/progress` forwarder emits the create (an editor
+    // round-trip awaited by the forwarding loop) immediately before the
+    // begin when a token proves renderable.
     // Deserialize the token from the borrowed value (indexing yields
     // `Null` for a missing key, which fails to parse) — no clone.
     match NumberOrString::deserialize(&message["params"]["token"]) {
@@ -44,7 +44,8 @@ pub(in crate::lsp::bridge) fn handle(
             // (without an intervening End) gets a fresh upstream token;
             // `register` evicts the prior one and returns it as `stale` so
             // we can tell the forwarding loop to forget its admission too —
-            // otherwise it would leak in `created_tokens`.
+            // otherwise it would leak in `created_tokens`. Tokens that were
+            // never announced have no admission to forget.
             let (upstream_token, stale_upstream_token) = deps.progress_registry.register(
                 deps.progress_connection_id,
                 downstream_token,
@@ -55,16 +56,15 @@ pub(in crate::lsp::bridge) fn handle(
                 "{}Bridging window/workDoneProgress/create as upstream token {:?}",
                 server_prefix, upstream_token
             );
-            if let Some(stale) = stale_upstream_token {
+            if let Some(stale) = stale_upstream_token
+                && stale.announced
+            {
                 let _ = deps
                     .upstream_tx
-                    .send(UpstreamNotification::ForgetWorkDoneProgress(vec![stale]));
+                    .send(UpstreamNotification::ForgetWorkDoneProgress(vec![
+                        stale.token,
+                    ]));
             }
-            let _ = deps
-                .upstream_tx
-                .send(UpstreamNotification::CreateWorkDoneProgress {
-                    token: upstream_token,
-                });
             Ok(serde_json::Value::Null)
         }
         Err(_) => {


### PR DESCRIPTION
## Problem

A production capture (nvim, 37KB markdown with 308 python + 231 lua + 77 ts fences) showed `textDocument/semanticTokens/full/delta` at p90 ≈ 509 ms despite compute phases of ~5 ms. Responses were queuing behind an outbound flood on the shared stdout sink:

- **8,342 `window/workDoneProgress/create` round-trips + 24,625 `$/progress`** in one minute — basedpyright declares a fresh progress token per analysis pass, and the bridge forwarded every `create` → `begin("")` → `report` → `end` verbatim. 8,134 of 8,137 begins were fully blank.
- **2,150 `textDocument/diagnostic` InvalidParams rejections** — `ls_types::DocumentDiagnosticParams` serializes `identifier`/`previousResultId` as explicit JSON `null`, which typescript-go's strict Go decoder rejects; every bridged pull to it failed.
- **~110k `kakehashi::language_detection` DEBUG lines (27 MB stderr/min)** — the detection chain re-logs once per injection region per walk.

## Fixes

1. **Lazy progress announcement** (`ProgressRegistry` phase machine): registering a downstream token no longer sends the editor a create. The token's first *renderable* `begin` (non-empty title or message, a percentage, or `cancellable: true`) announces — create enqueued immediately before the begin on the same FIFO channel, so create-before-progress ordering holds — while fully blank lifecycles are swallowed. `Forget` is emitted only for previously-announced evicted tokens. Deliberately, a renderable *report* does not upgrade a swallowed lifecycle: in the capture, 8,288 of the storm's 8,351 reports carried a per-pass message, so report-based upgrading would re-admit the flood (evidence recorded at the Drop arm and in the ADR).
2. **Pull-diagnostic params omit absent optionals** via a local `DiagnosticRequestParams` (spec marks both fields optional; absence is the interoperable encoding). Sibling sweep confirmed this was the only params builder emitting nulls.
3. **`detect_language_hot`** — the per-injection-region resolution path logs at TRACE (identical chain; host-document callers keep DEBUG).

ADRs updated: `ls-bridge-work-done-progress.md` (lazy announcement + renderability gate + capture evidence), `ls-bridge-progress-disconnect-cleanup.md` (context wording).

## Verification

Storm harness against real basedpyright + tsgo (30 didChange @60 ms + per-edit pulls), main vs branch:

| metric | main | branch |
|---|---|---|
| `workDoneProgress/create` round-trips | 9,221 | **0** |
| `$/progress` notifications | 13,860 | **0** |
| tsgo InvalidParams errors | 2,541 | **0** |
| `textDocument/diagnostic` p50 | 984 ms | **145 ms** |

Renderable progress (titled begins, message-bearing begins, cancellable-only begins) still announces — pinned by unit + handle_message tests. No-bridge A/B (drive.py, 40-cycle interleaved) shows parity, as expected. Full lib suite (2,721) green; clippy `-D warnings` clean.

Review: multi-perspective local review (protocol conformance, concurrency, lifecycle interplay, wire compat, logging, tests, bot-anticipation) + codex convergence (final fresh session: no comments on first response).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Work-done progress is now announced to the editor only when meaningful progress begins, reducing unnecessary progress notifications.
  - Blank progress lifecycles are suppressed while later meaningful updates can still appear.
  - Progress cancellation, recreation, cleanup, and token handling now follow more consistent lifecycle behavior.

- **Bug Fixes**
  - Diagnostic requests no longer include unused fields or `null` previous-result identifiers, improving compatibility with language servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->