### PR TITLE
fix(install): idempotent uninstall on externally-removed dirs

### DIFF
--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -529,10 +529,11 @@ pub fn remove_query_install_and_backups(
         removed_backups: false,
     };
 
-    if queries_dir.exists() {
-        remove_dir_all_tolerating_vanished(&queries_dir)?;
-        removal.removed_queries = true;
-    }
+    // No exists() pre-check: Path::exists() reads false on metadata errors
+    // (e.g. PermissionDenied), which would skip removal and report "not
+    // installed" over a still-present unreadable dir. The tolerant removal
+    // reports whether anything was actually removed.
+    removal.removed_queries = remove_dir_all_tolerating_vanished(&queries_dir)?;
 
     // Propagate per-entry read_dir errors: uninstall must not report success
     // while backups it could not even enumerate stay behind.
@@ -542,22 +543,28 @@ pub fn remove_query_install_and_backups(
         let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
             continue;
         };
-        if path.is_dir()
+        // file_type() over path.is_dir(): is_dir() swallows metadata errors
+        // as "not a directory", which could leave an unreadable backup behind
+        // while uninstall reports success.
+        if entry.file_type()?.is_dir()
             && generated_backup_matches_language(name, language)
             && backup_is_owned(&path)
         {
             let ownership = backup_ownership_sidecar(&path);
             // Same NotFound tolerance as the canonical dir above: a backup
             // deleted externally after enumeration is already the end state.
-            remove_dir_all_tolerating_vanished(&path)?;
+            if remove_dir_all_tolerating_vanished(&path)? {
+                removal.removed_backups = true;
+            }
             let _ = fs::remove_file(ownership);
-            removal.removed_backups = true;
         }
     }
     Ok(removal)
 }
 
-/// `fs::remove_dir_all` that treats a CONFIRMED-vanished directory as removed.
+/// `fs::remove_dir_all` that treats a CONFIRMED-vanished directory as the
+/// desired end state. Returns whether this call actually removed anything
+/// (`false` = the dir was already gone).
 ///
 /// NotFound = the dir disappeared between the caller's observation and the
 /// removal (external cleanup — the replace lock only serializes kakehashi's
@@ -567,14 +574,14 @@ pub fn remove_query_install_and_backups(
 /// deleted, and (b) `Path::exists()` returns false on ANY metadata error
 /// (e.g. PermissionDenied), which must propagate the original error instead
 /// of being mistaken for absence.
-fn remove_dir_all_tolerating_vanished(dir: &Path) -> Result<(), QueryInstallError> {
+fn remove_dir_all_tolerating_vanished(dir: &Path) -> Result<bool, QueryInstallError> {
     match fs::remove_dir_all(dir) {
-        Ok(()) => Ok(()),
+        Ok(()) => Ok(true),
         Err(e)
             if e.kind() == std::io::ErrorKind::NotFound
                 && matches!(dir.try_exists(), Ok(false)) =>
         {
-            Ok(())
+            Ok(false)
         }
         Err(e) => Err(QueryInstallError::IoError(e)),
     }
@@ -976,19 +983,22 @@ mod tests {
         let gone = temp.path().join("never-created");
 
         assert!(
-            remove_dir_all_tolerating_vanished(&gone).is_ok(),
-            "a confirmed-absent dir is the desired end state"
+            matches!(remove_dir_all_tolerating_vanished(&gone), Ok(false)),
+            "a confirmed-absent dir is the desired end state (nothing removed)"
         );
     }
 
     #[test]
-    fn remove_dir_all_still_removes_and_propagates_content() {
+    fn remove_dir_all_removes_a_dir_with_contents() {
         let temp = TempDir::new().unwrap();
         let dir = temp.path().join("queries-lang");
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("highlights.scm"), "(x) @y").unwrap();
 
-        remove_dir_all_tolerating_vanished(&dir).expect("normal removal succeeds");
+        assert!(
+            remove_dir_all_tolerating_vanished(&dir).expect("normal removal succeeds"),
+            "an actual removal reports true"
+        );
         assert!(!dir.exists(), "the dir and its contents are removed");
     }
 

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -530,8 +530,17 @@ pub fn remove_query_install_and_backups(
     };
 
     if queries_dir.exists() {
-        fs::remove_dir_all(&queries_dir)?;
-        removal.removed_queries = true;
+        // NotFound = the dir vanished between the exists() check and the
+        // removal (external cleanup — the lock only serializes kakehashi's
+        // own installers): already gone is the desired end state, so treat
+        // it as removed rather than failing the uninstall.
+        match fs::remove_dir_all(&queries_dir) {
+            Ok(()) => removal.removed_queries = true,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                removal.removed_queries = true;
+            }
+            Err(e) => return Err(QueryInstallError::IoError(e)),
+        }
     }
 
     // Propagate per-entry read_dir errors: uninstall must not report success
@@ -547,7 +556,13 @@ pub fn remove_query_install_and_backups(
             && backup_is_owned(&path)
         {
             let ownership = backup_ownership_sidecar(&path);
-            fs::remove_dir_all(path)?;
+            // Same NotFound tolerance as the canonical dir above: a backup
+            // deleted externally after enumeration is already the end state.
+            match fs::remove_dir_all(path) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(QueryInstallError::IoError(e)),
+            }
             let _ = fs::remove_file(ownership);
             removal.removed_backups = true;
         }

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -535,12 +535,11 @@ pub fn remove_query_install_and_backups(
         // own installers): already gone is the desired end state, so treat
         // it as removed rather than failing the uninstall.
         match fs::remove_dir_all(&queries_dir) {
-            Ok(()) => removal.removed_queries = true,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                removal.removed_queries = true;
-            }
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
             Err(e) => return Err(QueryInstallError::IoError(e)),
         }
+        removal.removed_queries = true;
     }
 
     // Propagate per-entry read_dir errors: uninstall must not report success

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -553,10 +553,13 @@ pub fn remove_query_install_and_backups(
             let ownership = backup_ownership_sidecar(&path);
             // Same NotFound tolerance as the canonical dir above: a backup
             // deleted externally after enumeration is already the end state.
-            if remove_dir_all_tolerating_vanished(&path)? {
+            let removed_dir = remove_dir_all_tolerating_vanished(&path)?;
+            // The sidecar is a kakehashi-owned artifact too: deleting it
+            // counts as removal even when the dir itself vanished first.
+            let removed_sidecar = fs::remove_file(ownership).is_ok();
+            if removed_dir || removed_sidecar {
                 removal.removed_backups = true;
             }
-            let _ = fs::remove_file(ownership);
         }
     }
     Ok(removal)

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -530,18 +530,7 @@ pub fn remove_query_install_and_backups(
     };
 
     if queries_dir.exists() {
-        // NotFound = the dir vanished between the exists() check and the
-        // removal (external cleanup — the lock only serializes kakehashi's
-        // own installers): already gone is the desired end state, so treat
-        // it as removed rather than failing the uninstall. Re-checked against
-        // the filesystem because remove_dir_all can also surface NotFound for
-        // a child that vanished mid-recursion while the dir itself survives
-        // partially deleted.
-        match fs::remove_dir_all(&queries_dir) {
-            Ok(()) => {}
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound && !queries_dir.exists() => {}
-            Err(e) => return Err(QueryInstallError::IoError(e)),
-        }
+        remove_dir_all_tolerating_vanished(&queries_dir)?;
         removal.removed_queries = true;
     }
 
@@ -558,19 +547,37 @@ pub fn remove_query_install_and_backups(
             && backup_is_owned(&path)
         {
             let ownership = backup_ownership_sidecar(&path);
-            // Same NotFound tolerance as the canonical dir above (including
-            // the gone-for-real re-check): a backup deleted externally after
-            // enumeration is already the end state.
-            match fs::remove_dir_all(&path) {
-                Ok(()) => {}
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound && !path.exists() => {}
-                Err(e) => return Err(QueryInstallError::IoError(e)),
-            }
+            // Same NotFound tolerance as the canonical dir above: a backup
+            // deleted externally after enumeration is already the end state.
+            remove_dir_all_tolerating_vanished(&path)?;
             let _ = fs::remove_file(ownership);
             removal.removed_backups = true;
         }
     }
     Ok(removal)
+}
+
+/// `fs::remove_dir_all` that treats a CONFIRMED-vanished directory as removed.
+///
+/// NotFound = the dir disappeared between the caller's observation and the
+/// removal (external cleanup — the replace lock only serializes kakehashi's
+/// own installers): already gone is the desired end state. Confirmed via
+/// `try_exists` because (a) remove_dir_all can also surface NotFound for a
+/// child that vanished mid-recursion while the dir survives partially
+/// deleted, and (b) `Path::exists()` returns false on ANY metadata error
+/// (e.g. PermissionDenied), which must propagate the original error instead
+/// of being mistaken for absence.
+fn remove_dir_all_tolerating_vanished(dir: &Path) -> Result<(), QueryInstallError> {
+    match fs::remove_dir_all(dir) {
+        Ok(()) => Ok(()),
+        Err(e)
+            if e.kind() == std::io::ErrorKind::NotFound
+                && matches!(dir.try_exists(), Ok(false)) =>
+        {
+            Ok(())
+        }
+        Err(e) => Err(QueryInstallError::IoError(e)),
+    }
 }
 
 fn backup_language_name(path: &Path) -> Option<String> {
@@ -959,6 +966,31 @@ fn download_file(url: &str, http_policy: QueryHttpPolicy) -> Result<String, Quer
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn remove_dir_all_tolerates_a_confirmed_vanished_dir() {
+        // The dir disappearing between the caller's observation and the
+        // removal (external cleanup) must read as already-removed, not fail
+        // the uninstall.
+        let temp = TempDir::new().unwrap();
+        let gone = temp.path().join("never-created");
+
+        assert!(
+            remove_dir_all_tolerating_vanished(&gone).is_ok(),
+            "a confirmed-absent dir is the desired end state"
+        );
+    }
+
+    #[test]
+    fn remove_dir_all_still_removes_and_propagates_content() {
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path().join("queries-lang");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("highlights.scm"), "(x) @y").unwrap();
+
+        remove_dir_all_tolerating_vanished(&dir).expect("normal removal succeeds");
+        assert!(!dir.exists(), "the dir and its contents are removed");
+    }
 
     /// Serve canned query files over HTTP from an OS-assigned local port.
     fn spawn_query_file_server(routes: Vec<(&str, &str)>) -> String {

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -555,8 +555,15 @@ pub fn remove_query_install_and_backups(
             // deleted externally after enumeration is already the end state.
             let removed_dir = remove_dir_all_tolerating_vanished(&path)?;
             // The sidecar is a kakehashi-owned artifact too: deleting it
-            // counts as removal even when the dir itself vanished first.
-            let removed_sidecar = fs::remove_file(ownership).is_ok();
+            // counts as removal even when the dir itself vanished first —
+            // and, like every other I/O in this loop, only NotFound is
+            // tolerated (an unremovable marker must fail the uninstall, not
+            // linger behind a success report).
+            let removed_sidecar = match fs::remove_file(ownership) {
+                Ok(()) => true,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
+                Err(e) => return Err(QueryInstallError::IoError(e)),
+            };
             if removed_dir || removed_sidecar {
                 removal.removed_backups = true;
             }

--- a/src/install/queries.rs
+++ b/src/install/queries.rs
@@ -533,10 +533,13 @@ pub fn remove_query_install_and_backups(
         // NotFound = the dir vanished between the exists() check and the
         // removal (external cleanup — the lock only serializes kakehashi's
         // own installers): already gone is the desired end state, so treat
-        // it as removed rather than failing the uninstall.
+        // it as removed rather than failing the uninstall. Re-checked against
+        // the filesystem because remove_dir_all can also surface NotFound for
+        // a child that vanished mid-recursion while the dir itself survives
+        // partially deleted.
         match fs::remove_dir_all(&queries_dir) {
             Ok(()) => {}
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound && !queries_dir.exists() => {}
             Err(e) => return Err(QueryInstallError::IoError(e)),
         }
         removal.removed_queries = true;
@@ -555,11 +558,12 @@ pub fn remove_query_install_and_backups(
             && backup_is_owned(&path)
         {
             let ownership = backup_ownership_sidecar(&path);
-            // Same NotFound tolerance as the canonical dir above: a backup
-            // deleted externally after enumeration is already the end state.
-            match fs::remove_dir_all(path) {
+            // Same NotFound tolerance as the canonical dir above (including
+            // the gone-for-real re-check): a backup deleted externally after
+            // enumeration is already the end state.
+            match fs::remove_dir_all(&path) {
                 Ok(()) => {}
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound && !path.exists() => {}
                 Err(e) => return Err(QueryInstallError::IoError(e)),
             }
             let _ = fs::remove_file(ownership);


### PR DESCRIPTION
Follow-up to #661 (Copilot finding that landed after the merge): `remove_query_install_and_backups` treated `remove_dir_all` NotFound as fatal, so external cleanup racing an uninstall (the replace lock only serializes kakehashi's own installers) produced a spurious failure even though the queries were already gone. Treat NotFound as the desired end state for both the canonical dir and owned backup dirs, matching the install-side rename tolerance added in #661.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of installation cleanup when query or backup directories are removed concurrently.
  * Made directory removal idempotent by treating missing per-language query folders and generated backup folders as already cleaned up.
  * Continues to surface genuine I/O errors while consistently tracking cleanup results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->