### PR TITLE
fix(bridge): validate downstream applyEdit versions against tracked state

### DIFF
--- a/src/lsp/bridge/actor/reader.rs
+++ b/src/lsp/bridge/actor/reader.rs
@@ -30,7 +30,7 @@ use super::OutboundMessage;
 use super::ResponseRouter;
 use super::response_router::{LivenessExpiry, RouteResult};
 use crate::error::LockResultExt;
-use crate::lsp::bridge::pool::DynamicCapabilityRegistry;
+use crate::lsp::bridge::pool::{ConnectionKey, DynamicCapabilityRegistry};
 use crate::lsp::bridge::workspace::{self, WorkspaceFolderSet};
 
 /// Notification to forward from downstream server to upstream editor.
@@ -188,6 +188,12 @@ pub(crate) enum UpstreamRequest {
     /// `applied: false` locally (#568).
     ApplyEdit {
         params: tower_lsp_server::ls_types::ApplyWorkspaceEditParams,
+        /// The `(server, root)` connection the request arrived on. Versioned
+        /// `TextDocumentEdit`s in the edit are validated against the version
+        /// the bridge tracks for that virtual document ON THIS CONNECTION
+        /// (each connection's didOpen starts its own counter), so the
+        /// translation must know which connection's version space applies.
+        connection: ConnectionKey,
         reply: oneshot::Sender<tower_lsp_server::ls_types::ApplyWorkspaceEditResponse>,
         cancel: ForwardedRequestCancel,
     },
@@ -245,6 +251,11 @@ struct LivenessParams {
 /// `workspace.workspaceFolders` capability, so servers may query them).
 pub(crate) struct ServerRequestDeps {
     pub(crate) server_name: Option<String>,
+    /// The `(server, root)` key of this connection, carried on forwarded
+    /// `workspace/applyEdit` requests so the translation can validate
+    /// downstream-supplied `TextDocumentEdit.version`s against the version the
+    /// bridge tracks for the virtual document on THIS connection.
+    pub(crate) connection_key: ConnectionKey,
     pub(crate) response_tx: mpsc::Sender<OutboundMessage>,
     pub(crate) dynamic_capabilities: Arc<DynamicCapabilityRegistry>,
     /// Loss-intolerant notifications (`DiagnosticRefresh` and work-done
@@ -549,6 +560,7 @@ pub(crate) fn spawn_reader_task_with_liveness(
         ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
+            connection_key: ConnectionKey::for_server("test"),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -640,6 +652,7 @@ async fn reader_loop(
     let server_request_deps = ServerRequestDeps {
         settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
         server_name: None,
+        connection_key: ConnectionKey::for_server("test"),
         response_tx,
         dynamic_capabilities,
         upstream_tx,
@@ -1231,6 +1244,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: server_name.map(String::from),
+            connection_key: ConnectionKey::for_server("test"),
             response_tx: tx,
             dynamic_capabilities: caps,
             upstream_tx,
@@ -1329,6 +1343,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: Some("mock-ls".to_string()),
+            connection_key: ConnectionKey::for_server("test"),
             response_tx: tx,
             dynamic_capabilities: caps,
             upstream_tx,
@@ -1406,6 +1421,7 @@ mod tests {
             ServerRequestDeps {
                 settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
                 server_name: None,
+                connection_key: ConnectionKey::for_server("test"),
                 response_tx,
                 dynamic_capabilities: Arc::new(DynamicCapabilityRegistry::new()),
                 upstream_tx,
@@ -1860,6 +1876,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
+            connection_key: ConnectionKey::for_server("test"),
             response_tx,
             dynamic_capabilities: Arc::clone(&dynamic_capabilities),
             upstream_tx,
@@ -1922,6 +1939,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
+            connection_key: ConnectionKey::for_server("test"),
             response_tx,
             dynamic_capabilities: Arc::clone(&dynamic_capabilities),
             upstream_tx,
@@ -1984,6 +2002,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
+            connection_key: ConnectionKey::for_server("test"),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2073,6 +2092,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
+            connection_key: ConnectionKey::for_server("test"),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2133,6 +2153,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
+            connection_key: ConnectionKey::for_server("test"),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2191,6 +2212,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
+            connection_key: ConnectionKey::for_server("test"),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2250,6 +2272,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
+            connection_key: ConnectionKey::for_server("test"),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2318,6 +2341,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
+            connection_key: ConnectionKey::for_server("test"),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2404,6 +2428,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
+            connection_key: ConnectionKey::for_server("test"),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2461,6 +2486,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
+            connection_key: ConnectionKey::for_server("test"),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2546,6 +2572,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
+            connection_key: ConnectionKey::for_server("test"),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2586,6 +2613,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
+            connection_key: ConnectionKey::for_server("test"),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2643,6 +2671,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
+            connection_key: ConnectionKey::for_server("test"),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2688,6 +2717,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
+            connection_key: ConnectionKey::for_server("test"),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2733,6 +2763,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
+            connection_key: ConnectionKey::for_server("test"),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -2784,6 +2815,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: Some("luals".to_string()),
+            connection_key: ConnectionKey::for_server("test"),
             response_tx,
             dynamic_capabilities: Arc::new(DynamicCapabilityRegistry::new()),
             upstream_tx,
@@ -2843,6 +2875,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: Some("lua_ls".to_string()),
+            connection_key: ConnectionKey::for_server("test"),
             response_tx,
             dynamic_capabilities: Arc::new(DynamicCapabilityRegistry::new()),
             upstream_tx,
@@ -2895,6 +2928,7 @@ mod tests {
             let deps = ServerRequestDeps {
                 settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
                 server_name: Some("luals".to_string()),
+                connection_key: ConnectionKey::for_server("test"),
                 response_tx,
                 dynamic_capabilities: Arc::new(DynamicCapabilityRegistry::new()),
                 upstream_tx,
@@ -2977,6 +3011,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
+            connection_key: ConnectionKey::for_server("test"),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -3018,6 +3053,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
+            connection_key: ConnectionKey::for_server("test"),
             response_tx,
             dynamic_capabilities: Arc::clone(&dynamic_capabilities),
             upstream_tx,
@@ -3074,6 +3110,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
+            connection_key: ConnectionKey::for_server("test"),
             response_tx,
             dynamic_capabilities: Arc::clone(&dynamic_capabilities),
             upstream_tx,
@@ -3141,6 +3178,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
+            connection_key: ConnectionKey::for_server("test"),
             response_tx: response_tx.clone(),
             dynamic_capabilities,
             upstream_tx,
@@ -3203,6 +3241,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
+            connection_key: ConnectionKey::for_server("test"),
             response_tx,
             dynamic_capabilities,
             upstream_tx,
@@ -3593,6 +3632,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: Some("mock-ls".to_string()),
+            connection_key: ConnectionKey::for_server("test"),
             response_tx,
             dynamic_capabilities: Arc::new(DynamicCapabilityRegistry::new()),
             upstream_tx,
@@ -4044,6 +4084,7 @@ mod tests {
         let deps = ServerRequestDeps {
             settings: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
             server_name: None,
+            connection_key: ConnectionKey::for_server("test"),
             response_tx: tx,
             dynamic_capabilities: caps,
             upstream_tx,

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -218,12 +218,13 @@ impl BridgeCoordinator {
         self.pool.resolve_virtual_uri(virtual_uri).await
     }
 
-    /// The version currently tracked for a virtual document on one connection —
-    /// the revision of the content the bridge last announced there (didOpen = 1,
-    /// each content-changing didChange bumps it). `None` when the document is
-    /// not tracked for this connection. Used by the inbound
-    /// `workspace/applyEdit` translation to validate downstream-supplied
-    /// `TextDocumentEdit.version`s. Delegates to the pool.
+    /// The version currently tracked for a virtual document on one connection
+    /// (didOpen = 1, each content-changing didChange bumps it; the bridge's
+    /// own revision counter, not a delivery receipt — see
+    /// `DocumentTracker::document_version`). `None` when the document is not
+    /// tracked for this connection. Used by the inbound `workspace/applyEdit`
+    /// translation to validate downstream-supplied `TextDocumentEdit.version`s.
+    /// Delegates to the pool.
     pub(crate) async fn virtual_document_version(
         &self,
         virtual_uri: &str,

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -218,6 +218,22 @@ impl BridgeCoordinator {
         self.pool.resolve_virtual_uri(virtual_uri).await
     }
 
+    /// The version currently tracked for a virtual document on one connection —
+    /// the revision of the content the bridge last announced there (didOpen = 1,
+    /// each content-changing didChange bumps it). `None` when the document is
+    /// not tracked for this connection. Used by the inbound
+    /// `workspace/applyEdit` translation to validate downstream-supplied
+    /// `TextDocumentEdit.version`s. Delegates to the pool.
+    pub(crate) async fn virtual_document_version(
+        &self,
+        virtual_uri: &str,
+        connection_key: &crate::lsp::bridge::pool::ConnectionKey,
+    ) -> Option<i32> {
+        self.pool
+            .virtual_document_version(virtual_uri, connection_key)
+            .await
+    }
+
     /// Access the underlying node tracker.
     ///
     /// Used by handlers for `InjectionResolver::resolve_at_byte_offset()`.
@@ -305,6 +321,20 @@ impl BridgeCoordinator {
     ) {
         self.pool
             .register_opened_document(host_uri, virtual_uri, connection_key)
+            .await
+    }
+
+    /// Bump a virtual document's tracked version, as a content-changing
+    /// `didChange` forward would (test helper for the applyEdit version
+    /// validation).
+    #[cfg(test)]
+    pub(crate) async fn increment_document_version_for_test(
+        &self,
+        virtual_uri: &crate::lsp::bridge::protocol::VirtualDocumentUri,
+        connection_key: &crate::lsp::bridge::pool::ConnectionKey,
+    ) -> Option<i32> {
+        self.pool
+            .increment_document_version(virtual_uri, connection_key)
             .await
     }
 

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -882,6 +882,19 @@ impl LanguageServerPool {
         self.document_tracker.resolve_virtual_uri(virtual_uri).await
     }
 
+    /// The version currently tracked for a virtual document on one connection
+    /// (used by the inbound `workspace/applyEdit` version validation). See
+    /// [`DocumentTracker::document_version`].
+    pub(super) async fn virtual_document_version(
+        &self,
+        virtual_uri: &str,
+        connection_key: &ConnectionKey,
+    ) -> Option<i32> {
+        self.document_tracker
+            .document_version(virtual_uri, connection_key)
+            .await
+    }
+
     /// Find ALL connections (`(server, root)` keys) that have opened a given
     /// virtual document URI.
     ///
@@ -1776,6 +1789,9 @@ impl LanguageServerPool {
             Some(liveness_timeout.as_duration()),
             ServerRequestDeps {
                 server_name: Some(server_name.to_string()),
+                // The applyEdit version validation scopes downstream-supplied
+                // versions to this connection's version space (PR-L).
+                connection_key: connection_key.clone(),
                 response_tx: tx.clone(),
                 dynamic_capabilities: Arc::clone(&dynamic_capabilities),
                 upstream_tx: self.upstream_tx.clone(),

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -371,11 +371,13 @@ impl DocumentTracker {
         None
     }
 
-    /// The version currently tracked for a virtual document on one connection —
-    /// the version of the content the bridge last announced to that connection
+    /// The version currently tracked for a virtual document on one connection
     /// (didOpen = 1, each content-changing didChange bumps it). `None` when the
     /// document is not tracked for this connection (never opened here, or
-    /// purged on respawn).
+    /// purged on respawn). This is the bridge's own revision counter, not a
+    /// delivery receipt: the bump happens before the didChange enqueue, so a
+    /// dropped notification (queue full) can leave the downstream one revision
+    /// behind the tracked value until the next content change re-syncs.
     ///
     /// Used by the inbound `workspace/applyEdit` validation: a downstream that
     /// versions a `TextDocumentEdit` pins the edit to the content revision it

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -382,7 +382,7 @@ impl DocumentTracker {
     /// Used by the inbound `workspace/applyEdit` validation: a downstream that
     /// versions a `TextDocumentEdit` pins the edit to the content revision it
     /// computed against, and the bridge rejects the edit when that revision is
-    /// no longer the one it last synced.
+    /// no longer the tracked one.
     ///
     /// Gated on CONFIRMED opened state (the reverse index, promoted only after
     /// the didOpen is enqueued), not just the version map: `try_claim_for_open`

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -384,11 +384,14 @@ impl DocumentTracker {
     /// computed against, and the bridge rejects the edit when that revision is
     /// no longer the tracked one.
     ///
-    /// Gated on CONFIRMED opened state (the reverse index, promoted only after
-    /// the didOpen is enqueued), not just the version map: `try_claim_for_open`
-    /// seeds the version at claim time, BEFORE the didOpen reaches the FIFO,
-    /// so reading the bare map would let a versioned edit validate against a
-    /// revision the downstream was never actually given.
+    /// Gated on CONFIRMED opened state, not just the version map:
+    /// `try_claim_for_open` seeds the version at claim time, BEFORE the
+    /// didOpen reaches the FIFO, so reading the bare map would let a versioned
+    /// edit validate against a revision the downstream was never actually
+    /// given. The primary gate is the ABSENCE of a pending pre-send claim
+    /// (checked under the version lock — sound even against the close+reclaim
+    /// interleaving where the prior lifetime's reverse-index membership is
+    /// still visible); the reverse-index check on top is defense in depth.
     pub(super) async fn document_version(
         &self,
         virtual_uri: &str,
@@ -396,17 +399,28 @@ impl DocumentTracker {
     ) -> Option<i32> {
         let versions = self.document_versions.lock().await;
         let version = versions.get(connection_key)?.get(virtual_uri).copied()?;
-        // Membership is checked AFTER the version read, WHILE the version
-        // lock is still held, and that order is what makes the gate sound
-        // against a concurrent close+reclaim: every remove path (`untrack_
-        // document`, `purge_connection`) deletes the version entry under
-        // this lock BEFORE touching the reverse index, and `mark_open_sent`
-        // only ADDS membership (turning the claim-seeded version into the
-        // confirmed didOpen version). So membership observed here proves the
-        // version read above belongs to a confirmed-open lifetime — checking
-        // membership first (or outside the lock) would let a close+reclaim
-        // slip a fresh pre-send claim's version past an opened-state check
-        // made against the previous lifetime.
+        // A pending pre-send claim means the version just read was seeded by
+        // `try_claim_for_open` and its didOpen is NOT yet confirmed enqueued —
+        // fail closed. This gate (not the reverse index) is what defeats the
+        // close+reclaim interleaving: the remove paths (`untrack_document`,
+        // `purge_connection`) delete the version entry under this lock and
+        // clean the reverse index only AFTERWARDS, so a reclaim landing in
+        // that gap seeds a fresh version while the PRIOR lifetime's stale
+        // membership is still visible — but the reclaim's claim entry is
+        // visible too (inserted under this same lock, removed by
+        // `mark_open_sent` only once the didOpen is confirmed enqueued, at
+        // which point the seeded version IS the confirmed one), so the read
+        // still answers None.
+        if self
+            .open_claims
+            .contains_key(&(connection_key.clone(), virtual_uri.to_string()))
+        {
+            return None;
+        }
+        // Belt-and-suspenders on top of the claim gate: a version entry with
+        // neither a pending claim nor confirmed-open membership shouldn't
+        // exist, but if bookkeeping ever drifts, fail closed rather than
+        // vouch for it.
         if !self.is_virtual_doc_open_on_connection(virtual_uri, connection_key) {
             return None;
         }
@@ -1124,6 +1138,50 @@ mod tests {
             tracker.document_version(&uri_string, &conn).await,
             Some(1),
             "a confirmed open exposes the didOpen version"
+        );
+    }
+
+    /// The close+reclaim interleaving (CodeRabbit, PR #679): the remove paths
+    /// delete the version entry, then a reclaim seeds a fresh version + claim
+    /// BEFORE the prior lifetime's reverse-index membership is cleaned up.
+    /// Stale membership must not vouch for the unconfirmed reclaimed version —
+    /// the pending-claim gate answers None.
+    #[tokio::test]
+    async fn document_version_rejects_reclaim_behind_stale_membership() {
+        let tracker = DocumentTracker::new();
+        let host_uri = Url::parse("file:///test/doc.md").unwrap();
+        let virtual_uri = VirtualDocumentUri::new(&url_to_uri(&host_uri), "lua", TEST_ULID_LUA_0);
+        let conn = ConnectionKey::for_server("lua");
+        let uri_string = virtual_uri.to_uri_string();
+
+        // Confirmed open in the prior lifetime.
+        tracker
+            .register_opened_document(&host_uri, &virtual_uri, &conn)
+            .await;
+        // First half of untrack/purge: the version entry is removed under the
+        // lock; reverse-index cleanup has NOT happened yet.
+        tracker
+            .document_versions
+            .lock()
+            .await
+            .get_mut(&conn)
+            .expect("connection tracked")
+            .remove(&uri_string);
+        // A reclaim lands in the gap: fresh version 1 + pending claim, didOpen
+        // not yet confirmed enqueued.
+        assert!(
+            tracker.try_claim_for_open(&virtual_uri, &conn).await,
+            "reclaim must win the claim (version entry was removed)"
+        );
+        assert!(
+            tracker.is_virtual_doc_open_on_connection(&uri_string, &conn),
+            "precondition: the prior lifetime's stale membership is still visible"
+        );
+
+        assert_eq!(
+            tracker.document_version(&uri_string, &conn).await,
+            None,
+            "stale membership must not vouch for the unconfirmed reclaimed version"
         );
     }
 

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -395,10 +395,7 @@ impl DocumentTracker {
         connection_key: &ConnectionKey,
     ) -> Option<i32> {
         let versions = self.document_versions.lock().await;
-        let version = versions
-            .get(connection_key)?
-            .get(virtual_uri)
-            .copied()?;
+        let version = versions.get(connection_key)?.get(virtual_uri).copied()?;
         // Membership is checked AFTER the version read, WHILE the version
         // lock is still held, and that order is what makes the gate sound
         // against a concurrent close+reclaim: every remove path (`untrack_

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -381,11 +381,20 @@ impl DocumentTracker {
     /// versions a `TextDocumentEdit` pins the edit to the content revision it
     /// computed against, and the bridge rejects the edit when that revision is
     /// no longer the one it last synced.
+    ///
+    /// Gated on CONFIRMED opened state (the reverse index, promoted only after
+    /// the didOpen is enqueued), not just the version map: `try_claim_for_open`
+    /// seeds the version at claim time, BEFORE the didOpen reaches the FIFO,
+    /// so reading the bare map would let a versioned edit validate against a
+    /// revision the downstream was never actually given.
     pub(super) async fn document_version(
         &self,
         virtual_uri: &str,
         connection_key: &ConnectionKey,
     ) -> Option<i32> {
+        if !self.is_virtual_doc_open_on_connection(virtual_uri, connection_key) {
+            return None;
+        }
         self.document_versions
             .lock()
             .await
@@ -1075,6 +1084,36 @@ mod tests {
             version,
             Some(2),
             "Version should be available immediately after claim (1 → 2)"
+        );
+    }
+
+    /// `document_version` (the applyEdit validation read) must NOT see a
+    /// pre-send claim: the claim seeds the version map before the didOpen
+    /// reaches the FIFO, but the downstream was never given that revision, so
+    /// a versioned edit must not validate against it. Only a confirmed open
+    /// (reverse-index promotion) exposes the version.
+    #[tokio::test]
+    async fn document_version_hidden_until_open_confirmed() {
+        let tracker = DocumentTracker::new();
+        let host_uri = Url::parse("file:///test/doc.md").unwrap();
+        let virtual_uri = VirtualDocumentUri::new(&url_to_uri(&host_uri), "lua", TEST_ULID_LUA_0);
+        let conn = ConnectionKey::for_server("lua");
+        let uri_string = virtual_uri.to_uri_string();
+
+        assert!(tracker.try_claim_for_open(&virtual_uri, &conn).await);
+        assert_eq!(
+            tracker.document_version(&uri_string, &conn).await,
+            None,
+            "a pre-send claim must stay invisible to the applyEdit validation"
+        );
+
+        tracker
+            .register_opened_document(&host_uri, &virtual_uri, &conn)
+            .await;
+        assert_eq!(
+            tracker.document_version(&uri_string, &conn).await,
+            Some(1),
+            "a confirmed open exposes the didOpen version"
         );
     }
 

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -392,15 +392,26 @@ impl DocumentTracker {
         virtual_uri: &str,
         connection_key: &ConnectionKey,
     ) -> Option<i32> {
+        let versions = self.document_versions.lock().await;
+        let version = versions
+            .get(connection_key)?
+            .get(virtual_uri)
+            .copied()?;
+        // Membership is checked AFTER the version read, WHILE the version
+        // lock is still held, and that order is what makes the gate sound
+        // against a concurrent close+reclaim: every remove path (`untrack_
+        // document`, `purge_connection`) deletes the version entry under
+        // this lock BEFORE touching the reverse index, and `mark_open_sent`
+        // only ADDS membership (turning the claim-seeded version into the
+        // confirmed didOpen version). So membership observed here proves the
+        // version read above belongs to a confirmed-open lifetime — checking
+        // membership first (or outside the lock) would let a close+reclaim
+        // slip a fresh pre-send claim's version past an opened-state check
+        // made against the previous lifetime.
         if !self.is_virtual_doc_open_on_connection(virtual_uri, connection_key) {
             return None;
         }
-        self.document_versions
-            .lock()
-            .await
-            .get(connection_key)?
-            .get(virtual_uri)
-            .copied()
+        Some(version)
     }
 
     /// Like [`Self::increment_document_version`], but a no-op (`None`) when

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -371,6 +371,29 @@ impl DocumentTracker {
         None
     }
 
+    /// The version currently tracked for a virtual document on one connection —
+    /// the version of the content the bridge last announced to that connection
+    /// (didOpen = 1, each content-changing didChange bumps it). `None` when the
+    /// document is not tracked for this connection (never opened here, or
+    /// purged on respawn).
+    ///
+    /// Used by the inbound `workspace/applyEdit` validation: a downstream that
+    /// versions a `TextDocumentEdit` pins the edit to the content revision it
+    /// computed against, and the bridge rejects the edit when that revision is
+    /// no longer the one it last synced.
+    pub(super) async fn document_version(
+        &self,
+        virtual_uri: &str,
+        connection_key: &ConnectionKey,
+    ) -> Option<i32> {
+        self.document_versions
+            .lock()
+            .await
+            .get(connection_key)?
+            .get(virtual_uri)
+            .copied()
+    }
+
     /// Like [`Self::increment_document_version`], but a no-op (`None`) when
     /// `content` is unchanged since the last `didChange` sent to this connection
     /// for this virtual document — so a host edit that doesn't alter a region's

--- a/src/lsp/bridge/protocol/workspace_edit.rs
+++ b/src/lsp/bridge/protocol/workspace_edit.rs
@@ -213,15 +213,20 @@ fn transform_text_document_edit(
 /// request's own document. Call at every editor-ward relay boundary
 /// (applyEdit forward, host-layer rename/codeAction results).
 ///
-/// Deliberately erase-without-validate: the version was never a working
+/// Deliberately erase-without-validate HERE: the version was never a working
 /// cross-boundary protection (the spaces differ, so pre-strip it rejected
 /// EVERYTHING), and the majority shape (`changes` map) carries no version at
-/// all. What remains is COORDINATE validity on virtual paths (region
-/// freshness + region bounds) — not general content freshness, and nothing
-/// on host paths: an action whose edit aged in the editor's menu while the
-/// user kept typing applies unconditionally, versioned shape or not. Mapping
-/// downstream versions to editor versions (instead of erasing) is follow-up
-/// hardening.
+/// all. On the applyEdit path, versioned VIRTUAL-document edits are validated
+/// against the connection's tracked version BEFORE this strip runs (see
+/// `ApplyEditTranslator::validate_virtual_document_versions`), so the erase
+/// only ever launders a version the bridge has confirmed current. What
+/// remains unvalidated is real-file versions (see the applyEdit translation
+/// module docs for that decision) and the host-layer rename/codeAction relay
+/// paths, where the guards are COORDINATE validity (region freshness + region
+/// bounds), not content freshness: an action whose edit aged in the editor's
+/// menu while the user kept typing applies unconditionally, versioned shape
+/// or not. Mapping downstream versions to editor versions (instead of
+/// erasing) is follow-up hardening.
 pub(crate) fn strip_bridge_local_versions(edit: &mut WorkspaceEdit) {
     let Some(doc_changes) = &mut edit.document_changes else {
         return;

--- a/src/lsp/bridge/workspace/apply_edit.rs
+++ b/src/lsp/bridge/workspace/apply_edit.rs
@@ -116,6 +116,7 @@ pub(in crate::lsp::bridge) fn handle(
         .upstream_request_tx
         .send(UpstreamRequest::ApplyEdit {
             params,
+            connection: deps.connection_key.clone(),
             reply: reply_tx,
             cancel,
         })

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -295,9 +295,10 @@ pub(super) fn document_change_count(params: &ApplyWorkspaceEditParams) -> usize 
 /// `kakehashi://` URI could make the client fail the whole apply (or open a
 /// phantom document). Call AFTER version validation: a versioned no-op's
 /// precondition is honored before its carrier is dropped. Dropping a no-op
-/// can skew an editor `failedChange` index relative to what the downstream
-/// sent — the same accepted skew the transform's foreign-empty-entry drop
-/// already has (see the module docs).
+/// shifts the `documentChanges` indices the editor's `failedChange` refers
+/// to; the forwarding loop detects the count change and drops `failedChange`
+/// from the relayed response rather than relaying a misaligned index (see
+/// [`document_change_count`] and the module docs).
 fn remove_empty_virtual_entries(edit: &mut WorkspaceEdit) {
     if let Some(changes) = &mut edit.changes {
         changes.retain(|uri, edits| {

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -27,12 +27,22 @@
 //! coordinates cannot be trusted, so it is rejected with `applied: false`
 //! instead of silently un-versioning it. Versions on REAL-file edits are
 //! nulled without validation, as before: they are equally bridge-local (a
-//! host-layer didOpen starts its own counter), but the bridge tracks host
-//! documents in a separate per-connection tracker keyed by server name, not
-//! [`ConnectionKey`], and the editor-side freshness of a host edit is the
-//! editor's own version check to make — nulling ("apply without check") is
-//! the spec-sanctioned degradation there, while validating host versions is
-//! follow-up hardening.
+//! host-layer didOpen starts its own counter), but a real-file edit may
+//! target a file the bridge never synced at all (a downstream can edit any
+//! file it knows from disk), and the host-document sync state lives in a
+//! separate tracker (`LanguageServerPool::host_documents`) not exposed to
+//! this translator — nulling ("apply without a version check") is the
+//! spec-sanctioned degradation there, and the editor still applies host
+//! edits against its own live buffer. Validating host-document versions
+//! through that tracker is follow-up hardening.
+//!
+//! The validation is a point-in-time read, not a lock: a content-changing
+//! `didChange` can still race in between the check and the editor applying
+//! the edit (exactly as it always could for the unversioned majority shape).
+//! The check narrows the stale window to that race instead of accepting
+//! arbitrarily old revisions; CLOSING it needs a bridge→editor version
+//! mapping so the editor can do the atomic check itself — also follow-up
+//! hardening (see `strip_bridge_local_versions`).
 //!
 //! Unlike `window/showDocument` — which degrades by dropping the selection —
 //! an applyEdit whose coordinates can't be trusted must **not** be forwarded:

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -55,19 +55,21 @@
 //! `label` and `changeAnnotations` pass through untouched (the transform only
 //! rewrites URIs/ranges/versions).
 //!
-//! Known degenerate edge: the transform drops a foreign-virtual entry with an
-//! EMPTY edit vector (a no-op), so an editor `failedChange` index can be
-//! skewed by one relative to what the downstream sent. A real (non-empty)
-//! foreign entry rejects the whole edit instead, so indexes never skew for
-//! edits that actually apply anything.
+//! Known degenerate edge: no-op (empty) virtual entries are removed before
+//! the forward — [`remove_empty_virtual_entries`] on every path (a raw
+//! virtual URI must never reach the editor), and the transform's
+//! foreign-virtual drop on the translated path — so an editor `failedChange`
+//! index can be skewed by one relative to what the downstream sent. A real
+//! (non-empty) foreign entry rejects the whole edit instead, so indexes
+//! never skew for edits that actually apply anything.
 //!
 //! [`transform_workspace_edit_to_host`]: crate::lsp::bridge::transform_workspace_edit_to_host
 
 use std::sync::Arc;
 
 use tower_lsp_server::ls_types::{
-    ApplyWorkspaceEditParams, DocumentChangeOperation, DocumentChanges, Position, ResourceOp, Uri,
-    WorkspaceEdit,
+    ApplyWorkspaceEditParams, DocumentChangeOperation, DocumentChanges, Position, ResourceOp,
+    TextDocumentEdit, Uri, WorkspaceEdit,
 };
 
 use crate::document::DocumentStore;
@@ -129,6 +131,12 @@ impl ApplyEditTranslator {
         // Downstream document versions live in the bridge's version space,
         // never the editor's — null them on every forward (see the helper).
         strip_bridge_local_versions(&mut params.edit);
+        // No-op virtual entries skip the translation path below (they don't
+        // count as touching a virtual document), so they must be dropped here
+        // or a real-file-only forward would carry raw virtual URIs to the
+        // editor. Runs after validation: a versioned no-op's precondition has
+        // already been honored before its carrier is removed.
+        remove_empty_virtual_entries(&mut params.edit);
         let virtual_uris = collect_virtual_uris(&params.edit);
         let virtual_uri = match virtual_uris.as_slice() {
             // No virtual URIs: a host-layer connection's edit (real URIs
@@ -202,12 +210,33 @@ impl ApplyEditTranslator {
     /// empty entries, since a no-op needs no coordinate translation).
     /// Real-file versions are out of scope here (see the module docs) and are
     /// nulled by `strip_bridge_local_versions`.
+    ///
+    /// Entries are grouped per URI BEFORE any tracker read: two entries for
+    /// the same document claiming different versions are self-contradictory
+    /// (at most one can match) and are rejected up front — checking each
+    /// entry with its own awaited read would let a didChange bump the
+    /// tracked version between reads so that versions N and N+1 both pass.
+    /// One read per distinct URI then keeps the equal-version case coherent.
     async fn validate_virtual_document_versions(
         &self,
         edit: &WorkspaceEdit,
         connection: &ConnectionKey,
     ) -> Result<(), String> {
+        let mut versions_by_uri: Vec<(&str, i32)> = Vec::new();
         for (uri, version) in versioned_virtual_text_document_edits(edit) {
+            match versions_by_uri.iter().find(|(seen, _)| *seen == uri) {
+                Some((_, seen_version)) if *seen_version != version => {
+                    return Err(format!(
+                        "kakehashi: the edit claims two different versions ({seen_version} \
+                         and {version}) for the same virtual document; at most one can be \
+                         current, so the edit cannot be applied",
+                    ));
+                }
+                Some(_) => {}
+                None => versions_by_uri.push((uri, version)),
+            }
+        }
+        for (uri, version) in versions_by_uri {
             let Some(tracked) = self.bridge.virtual_document_version(uri, connection).await
             else {
                 return Err(format!(
@@ -233,6 +262,36 @@ impl ApplyEditTranslator {
             }
         }
         Ok(())
+    }
+}
+
+/// Remove no-op (empty) virtual-document entries so no raw virtual URI ever
+/// crosses the editor boundary. An empty entry skips the translation path
+/// ([`collect_virtual_uris`] ignores it), so on a real-file-only forward it
+/// would otherwise reach the editor verbatim — and LSP does not require
+/// clients to skip URI resolution for an empty `TextDocumentEdit`, so a
+/// `kakehashi://` URI could make the client fail the whole apply (or open a
+/// phantom document). Call AFTER version validation: a versioned no-op's
+/// precondition is honored before its carrier is dropped. Dropping a no-op
+/// can skew an editor `failedChange` index relative to what the downstream
+/// sent — the same accepted skew the transform's foreign-empty-entry drop
+/// already has (see the module docs).
+fn remove_empty_virtual_entries(edit: &mut WorkspaceEdit) {
+    if let Some(changes) = &mut edit.changes {
+        changes.retain(|uri, edits| {
+            !(edits.is_empty() && VirtualDocumentUri::is_virtual_uri(uri.as_str()))
+        });
+    }
+    let keep = |e: &TextDocumentEdit| {
+        !(e.edits.is_empty() && VirtualDocumentUri::is_virtual_uri(e.text_document.uri.as_str()))
+    };
+    match &mut edit.document_changes {
+        None => {}
+        Some(DocumentChanges::Edits(edits)) => edits.retain(keep),
+        Some(DocumentChanges::Operations(ops)) => ops.retain(|op| match op {
+            DocumentChangeOperation::Edit(e) => keep(e),
+            DocumentChangeOperation::Op(_) => true,
+        }),
     }
 }
 
@@ -534,8 +593,8 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_stale_virtual_document_version() {
-        // The downstream computed the edit against version 2, but the bridge
-        // has since synced version 3 (a content-changing didChange): the
+        // The downstream computed the edit against version 2, but the bridge's
+        // tracked version advanced to 3 (a content-changing didChange): the
         // edit's coordinates target replaced content and applying it could
         // misplace the edit. Reject with applied:false, never strip-and-apply.
         let connection = test_connection();
@@ -690,14 +749,16 @@ mod tests {
         // An UNVERSIONED empty virtual entry asserts nothing (no version, no
         // edits): the real-file-only edit around it must still pass through,
         // and the empty entry must not route it down the virtual path either
-        // (collect_virtual_uris ignores empty entries).
+        // (collect_virtual_uris ignores empty entries). The no-op carrier is
+        // REMOVED on the forward — LSP doesn't require clients to skip URI
+        // resolution for empty entries, so a raw kakehashi:// URI (in either
+        // shape) could fail the whole apply editor-side.
+        let vuri = virtual_uri("01ARZ3NDEKTSV4RRFFQ69G5FAV");
         let params = params_with_edit(json!({
+            "changes": { vuri.clone(): [] },
             "documentChanges": [
                 {
-                    "textDocument": {
-                        "uri": virtual_uri("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
-                        "version": null
-                    },
+                    "textDocument": { "uri": vuri, "version": null },
                     "edits": []
                 },
                 {
@@ -707,10 +768,56 @@ mod tests {
             ]
         }));
 
-        translator()
+        let out = translator()
             .translate(params, &test_connection())
             .await
             .expect("an unversioned no-op virtual entry must not trip anything");
+        assert!(
+            out.edit
+                .changes
+                .as_ref()
+                .is_some_and(std::collections::HashMap::is_empty),
+            "the empty virtual `changes` entry must not reach the editor"
+        );
+        match out.edit.document_changes.as_ref().unwrap() {
+            DocumentChanges::Edits(edits) => {
+                assert_eq!(edits.len(), 1, "only the real-file edit survives");
+                assert_eq!(edits[0].text_document.uri.as_str(), "file:///project/main.rs");
+            }
+            DocumentChanges::Operations(_) => panic!("Expected Edits variant"),
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_conflicting_versions_for_the_same_virtual_document() {
+        // Two entries for the same document claiming different versions are
+        // self-contradictory (at most one can be current). Rejected BEFORE any
+        // tracker read: per-entry reads could interleave with a didChange bump
+        // so that versions 2 and 3 both matched, once each.
+        let connection = test_connection();
+        let (bridge, typed_uri) =
+            bridge_with_open_document("01ARZ3NDEKTSV4RRFFQ69G5FAV", &connection).await;
+        let params = params_with_edit(json!({
+            "documentChanges": [
+                {
+                    "textDocument": { "uri": typed_uri.to_uri_string(), "version": 1 },
+                    "edits": [text_edit(0)]
+                },
+                {
+                    "textDocument": { "uri": typed_uri.to_uri_string(), "version": 2 },
+                    "edits": [text_edit(1)]
+                }
+            ]
+        }));
+
+        let reason = translator_with_bridge(bridge)
+            .translate(params, &connection)
+            .await
+            .expect_err("conflicting versions for one document must be rejected");
+        assert!(
+            reason.contains("two different versions"),
+            "reason should name the failure: {reason}"
+        );
     }
 
     #[test]

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -193,10 +193,15 @@ impl ApplyEditTranslator {
     /// Unversioned edits (`version: null`) and the `changes` map (which
     /// carries no versions) are not validated — the spec defines a missing
     /// version as "apply without a version check", and the region-freshness +
-    /// region-bounds guards downstream of this still apply. Entries with an
-    /// EMPTY edit vector are no-ops and skipped, mirroring
-    /// [`collect_virtual_uris`]. Real-file versions are out of scope here (see
-    /// the module docs) and are nulled by `strip_bridge_local_versions`.
+    /// region-bounds guards downstream of this still apply. A VERSIONED entry
+    /// is validated even with an EMPTY edit vector: per spec the version is a
+    /// per-document precondition on the whole apply, so a downstream may send
+    /// `edits: []` purely to assert "only apply the rest if this document is
+    /// still at version N" — stripping such an entry's version unvalidated
+    /// would erase that precondition (only [`collect_virtual_uris`] ignores
+    /// empty entries, since a no-op needs no coordinate translation).
+    /// Real-file versions are out of scope here (see the module docs) and are
+    /// nulled by `strip_bridge_local_versions`.
     async fn validate_virtual_document_versions(
         &self,
         edit: &WorkspaceEdit,
@@ -215,13 +220,13 @@ impl ApplyEditTranslator {
                 return Err(if version < tracked {
                     format!(
                         "kakehashi: the edit was computed against version {version} of \
-                         the virtual document, but the bridge has since synced version \
+                         the virtual document, but the bridge's tracked version is now \
                          {tracked}; applying it could misplace the edit"
                     )
                 } else {
                     format!(
                         "kakehashi: the edit claims version {version} of the virtual \
-                         document, but the bridge has only synced up to version \
+                         document, but the bridge has only tracked up to version \
                          {tracked}; the edit cannot be validated"
                     )
                 });
@@ -232,8 +237,9 @@ impl ApplyEditTranslator {
 }
 
 /// The `(virtual URI, version)` of every VERSIONED `TextDocumentEdit` that
-/// targets a virtual document and carries at least one edit (empty edit
-/// vectors are no-ops, mirroring [`collect_virtual_uris`]). Only
+/// targets a virtual document — INCLUDING entries with an empty edit vector,
+/// whose version is still a per-document precondition on the apply (see
+/// [`ApplyEditTranslator::validate_virtual_document_versions`]). Only
 /// `documentChanges` can carry versions; the `changes` map cannot.
 fn versioned_virtual_text_document_edits(edit: &WorkspaceEdit) -> Vec<(&str, i32)> {
     let mut versioned = Vec::new();
@@ -250,7 +256,7 @@ fn versioned_virtual_text_document_edits(edit: &WorkspaceEdit) -> Vec<(&str, i32
         };
     for e in doc_edits {
         let uri = e.text_document.uri.as_str();
-        if e.edits.is_empty() || !VirtualDocumentUri::is_virtual_uri(uri) {
+        if !VirtualDocumentUri::is_virtual_uri(uri) {
             continue;
         }
         if let Some(version) = e.text_document.version {
@@ -555,7 +561,7 @@ mod tests {
             .await
             .expect_err("a stale versioned edit must be rejected");
         assert!(
-            reason.contains("version 2") && reason.contains("since synced version 3"),
+            reason.contains("version 2") && reason.contains("tracked version is now 3"),
             "reason should name both versions: {reason}"
         );
     }
@@ -580,7 +586,7 @@ mod tests {
             .await
             .expect_err("a version ahead of the tracked one must be rejected");
         assert!(
-            reason.contains("version 5") && reason.contains("synced up to version 1"),
+            reason.contains("version 5") && reason.contains("tracked up to version 1"),
             "reason should name both versions: {reason}"
         );
     }
@@ -646,10 +652,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn versioned_empty_virtual_entry_does_not_trip_validation() {
+    async fn versioned_empty_virtual_entry_is_still_a_validated_precondition() {
         // A versioned virtual TextDocumentEdit with an EMPTY edit vector is a
-        // no-op (mirrors collect_virtual_uris): it must not reject an
-        // otherwise valid real-file-only edit, whatever version it claims.
+        // pure precondition per spec ("only apply the rest if this document is
+        // still at version N"): its version must be validated even though it
+        // carries no edits of its own — here the doc is untracked, so the
+        // whole edit (including the real-file part) fails closed.
+        let connection = test_connection();
         let params = params_with_edit(json!({
             "documentChanges": [
                 {
@@ -666,10 +675,42 @@ mod tests {
             ]
         }));
 
+        let reason = translator()
+            .translate(params, &connection)
+            .await
+            .expect_err("a versioned no-op entry is a precondition and must be validated");
+        assert!(
+            reason.contains("no longer open on this connection"),
+            "reason should name the failure: {reason}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unversioned_empty_virtual_entry_does_not_trip_validation() {
+        // An UNVERSIONED empty virtual entry asserts nothing (no version, no
+        // edits): the real-file-only edit around it must still pass through,
+        // and the empty entry must not route it down the virtual path either
+        // (collect_virtual_uris ignores empty entries).
+        let params = params_with_edit(json!({
+            "documentChanges": [
+                {
+                    "textDocument": {
+                        "uri": virtual_uri("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+                        "version": null
+                    },
+                    "edits": []
+                },
+                {
+                    "textDocument": { "uri": "file:///project/main.rs", "version": null },
+                    "edits": [text_edit(3)]
+                }
+            ]
+        }));
+
         translator()
             .translate(params, &test_connection())
             .await
-            .expect("a no-op versioned virtual entry must not trip validation");
+            .expect("an unversioned no-op virtual entry must not trip anything");
     }
 
     #[test]

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -17,6 +17,23 @@
 //! against that region's live offset (rebuilt exactly as goto/showDocument do,
 //! via [`resolve_region_offset`](super::region_offset::resolve_region_offset)).
 //!
+//! **Version validation** (before the nulling): a downstream that versions a
+//! `TextDocumentEdit` for a VIRTUAL document pins the edit to the content
+//! revision it computed against, in the bridge-local version space of the
+//! connection it arrived on. The translation compares that version against the
+//! version the bridge currently tracks for `(connection, virtual doc)`: a
+//! mismatch means the bridge has since replaced the content (stale) — or the
+//! downstream claims a revision the bridge never announced — and the edit's
+//! coordinates cannot be trusted, so it is rejected with `applied: false`
+//! instead of silently un-versioning it. Versions on REAL-file edits are
+//! nulled without validation, as before: they are equally bridge-local (a
+//! host-layer didOpen starts its own counter), but the bridge tracks host
+//! documents in a separate per-connection tracker keyed by server name, not
+//! [`ConnectionKey`], and the editor-side freshness of a host edit is the
+//! editor's own version check to make — nulling ("apply without check") is
+//! the spec-sanctioned degradation there, while validating host versions is
+//! follow-up hardening.
+//!
 //! Unlike `window/showDocument` — which degrades by dropping the selection —
 //! an applyEdit whose coordinates can't be trusted must **not** be forwarded:
 //! a mistranslated edit corrupts the user's buffer. Untranslatable edits
@@ -46,9 +63,9 @@ use tower_lsp_server::ls_types::{
 use crate::document::DocumentStore;
 use crate::language::LanguageCoordinator;
 use crate::lsp::bridge::{
-    BridgeCoordinator, RegionOffset, VirtualDocumentUri, strip_bridge_local_versions,
-    transform_workspace_edit_to_host, workspace_edit_preserves_line_prefixes,
-    workspace_edit_within_region,
+    BridgeCoordinator, ConnectionKey, RegionOffset, VirtualDocumentUri,
+    strip_bridge_local_versions, transform_workspace_edit_to_host,
+    workspace_edit_preserves_line_prefixes, workspace_edit_within_region,
 };
 
 use super::region_offset::resolve_region_offset;
@@ -80,13 +97,25 @@ impl ApplyEditTranslator {
 
     /// Translate a virtual-document applyEdit to host coordinates; when the
     /// edit touches no virtual URIs, forward `params` with only the
-    /// bridge-local `TextDocumentEdit.version`s nulled. `Err` carries the
-    /// `failureReason` for a local `applied: false` answer — the edit must
-    /// not reach the editor. See the module docs for the exact behavior.
+    /// bridge-local `TextDocumentEdit.version`s nulled. `connection` is the
+    /// `(server, root)` key of the downstream connection the request arrived
+    /// on — versioned virtual-document edits are validated against that
+    /// connection's tracked versions before the versions are nulled. `Err`
+    /// carries the `failureReason` for a local `applied: false` answer — the
+    /// edit must not reach the editor. See the module docs for the exact
+    /// behavior.
     pub(super) async fn translate(
         &self,
         mut params: ApplyWorkspaceEditParams,
+        connection: &ConnectionKey,
     ) -> Result<ApplyWorkspaceEditParams, String> {
+        // A versioned virtual-document edit pins the content revision the
+        // downstream computed against; validate it against the version this
+        // connection currently tracks BEFORE the versions are erased below —
+        // a stale edit's coordinates target content the bridge has since
+        // replaced and must not be applied.
+        self.validate_virtual_document_versions(&params.edit, connection)
+            .await?;
         // Downstream document versions live in the bridge's version space,
         // never the editor's — null them on every forward (see the helper).
         strip_bridge_local_versions(&mut params.edit);
@@ -137,6 +166,88 @@ impl ApplyEditTranslator {
         transform_params_to_host(&mut params, virtual_uri, &host_uri, &offset, region_end)?;
         Ok(params)
     }
+
+    /// Validate every versioned `TextDocumentEdit` targeting a VIRTUAL
+    /// document against the version the bridge tracks for that document on
+    /// `connection` (didOpen = 1, each content-changing didChange bumps it).
+    ///
+    /// `Err` (→ `applied: false`) when the supplied version is STALE (older
+    /// than tracked: the downstream computed the edit against content the
+    /// bridge has since replaced — its coordinates may be misplaced), AHEAD
+    /// (newer than tracked: a revision the bridge never announced on this
+    /// connection — bookkeeping is broken, fail closed), or the document is
+    /// not tracked on this connection at all (closed or purged since the
+    /// downstream saw it — its content basis is gone). Only a version equal
+    /// to the tracked one proceeds.
+    ///
+    /// Unversioned edits (`version: null`) and the `changes` map (which
+    /// carries no versions) are not validated — the spec defines a missing
+    /// version as "apply without a version check", and the region-freshness +
+    /// region-bounds guards downstream of this still apply. Entries with an
+    /// EMPTY edit vector are no-ops and skipped, mirroring
+    /// [`collect_virtual_uris`]. Real-file versions are out of scope here (see
+    /// the module docs) and are nulled by `strip_bridge_local_versions`.
+    async fn validate_virtual_document_versions(
+        &self,
+        edit: &WorkspaceEdit,
+        connection: &ConnectionKey,
+    ) -> Result<(), String> {
+        for (uri, version) in versioned_virtual_text_document_edits(edit) {
+            let Some(tracked) = self.bridge.virtual_document_version(uri, connection).await
+            else {
+                return Err(format!(
+                    "kakehashi: the edit is versioned against virtual document {uri}, \
+                     which is no longer open on this connection; the content it was \
+                     computed against is gone"
+                ));
+            };
+            if version != tracked {
+                return Err(if version < tracked {
+                    format!(
+                        "kakehashi: the edit was computed against version {version} of \
+                         the virtual document, but the bridge has since synced version \
+                         {tracked}; applying it could misplace the edit"
+                    )
+                } else {
+                    format!(
+                        "kakehashi: the edit claims version {version} of the virtual \
+                         document, but the bridge has only synced up to version \
+                         {tracked}; the edit cannot be validated"
+                    )
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The `(virtual URI, version)` of every VERSIONED `TextDocumentEdit` that
+/// targets a virtual document and carries at least one edit (empty edit
+/// vectors are no-ops, mirroring [`collect_virtual_uris`]). Only
+/// `documentChanges` can carry versions; the `changes` map cannot.
+fn versioned_virtual_text_document_edits(edit: &WorkspaceEdit) -> Vec<(&str, i32)> {
+    let mut versioned = Vec::new();
+    let doc_edits: Box<dyn Iterator<Item = &tower_lsp_server::ls_types::TextDocumentEdit>> =
+        match &edit.document_changes {
+            None => Box::new(std::iter::empty()),
+            Some(DocumentChanges::Edits(edits)) => Box::new(edits.iter()),
+            Some(DocumentChanges::Operations(ops)) => Box::new(ops.iter().filter_map(|op| {
+                match op {
+                    DocumentChangeOperation::Edit(e) => Some(e),
+                    DocumentChangeOperation::Op(_) => None,
+                }
+            })),
+        };
+    for e in doc_edits {
+        let uri = e.text_document.uri.as_str();
+        if e.edits.is_empty() || !VirtualDocumentUri::is_virtual_uri(uri) {
+            continue;
+        }
+        if let Some(version) = e.text_document.version {
+            versioned.push((uri, version));
+        }
+    }
+    versioned
 }
 
 /// Rewrite `params.edit` to host coordinates via the shared WorkspaceEdit
@@ -251,11 +362,19 @@ mod tests {
     use std::str::FromStr;
 
     fn translator() -> ApplyEditTranslator {
+        translator_with_bridge(Arc::new(BridgeCoordinator::new()))
+    }
+
+    fn translator_with_bridge(bridge: Arc<BridgeCoordinator>) -> ApplyEditTranslator {
         ApplyEditTranslator::new(
             Arc::new(DocumentStore::new()),
             Arc::new(LanguageCoordinator::new()),
-            Arc::new(BridgeCoordinator::new()),
+            bridge,
         )
+    }
+
+    fn test_connection() -> ConnectionKey {
+        ConnectionKey::for_server("lua_ls")
     }
 
     fn host_uri() -> Uri {
@@ -290,7 +409,7 @@ mod tests {
         }))
         .unwrap();
         let out = translator()
-            .translate(original.clone())
+            .translate(original.clone(), &test_connection())
             .await
             .expect("real-file edit must pass through");
         assert_eq!(out, original);
@@ -311,7 +430,7 @@ mod tests {
         }))
         .unwrap();
         let out = translator()
-            .translate(original)
+            .translate(original, &test_connection())
             .await
             .expect("real-file edit must pass through");
         match out.edit.document_changes.as_ref().unwrap() {
@@ -332,7 +451,7 @@ mod tests {
         let uri = virtual_uri("01ARZ3NDEKTSV4RRFFQ69G5FAV");
         let original = params_with_edit(json!({ "changes": { uri.clone(): [text_edit(0)] } }));
         let reason = translator()
-            .translate(original)
+            .translate(original, &test_connection())
             .await
             .expect_err("unknown virtual document must be rejected");
         assert!(
@@ -352,7 +471,7 @@ mod tests {
             }
         }));
         let reason = translator()
-            .translate(original)
+            .translate(original, &test_connection())
             .await
             .expect_err("multi-region edit must be rejected");
         assert!(
@@ -370,15 +489,177 @@ mod tests {
         let original = params_with_edit(json!({
             "changes": { uri.clone(): [text_edit(0)] },
             "documentChanges": [{
-                "textDocument": { "uri": uri, "version": 2 },
+                "textDocument": { "uri": uri, "version": null },
                 "edits": [text_edit(1)]
             }]
         }));
-        let reason = translator().translate(original).await.unwrap_err();
+        let reason = translator().translate(original, &test_connection()).await.unwrap_err();
         assert!(
             reason.contains("unknown virtual document"),
             "dedup must reach the single-region path, not the multi-region reject: {reason}"
         );
+    }
+
+    /// Bridge with the test virtual document registered on `connection`
+    /// (tracked version starts at 1, as after didOpen), returning the typed
+    /// virtual URI for version bumps.
+    async fn bridge_with_open_document(
+        region_id: &str,
+        connection: &ConnectionKey,
+    ) -> (Arc<BridgeCoordinator>, VirtualDocumentUri) {
+        let bridge = Arc::new(BridgeCoordinator::new());
+        let host_url = url::Url::parse("file:///project/doc.md").unwrap();
+        let typed_uri = VirtualDocumentUri::new(&host_uri(), "lua", region_id);
+        bridge
+            .register_opened_document_for_test(&host_url, &typed_uri, connection)
+            .await;
+        (bridge, typed_uri)
+    }
+
+    #[tokio::test]
+    async fn rejects_stale_virtual_document_version() {
+        // The downstream computed the edit against version 2, but the bridge
+        // has since synced version 3 (a content-changing didChange): the
+        // edit's coordinates target replaced content and applying it could
+        // misplace the edit. Reject with applied:false, never strip-and-apply.
+        let connection = test_connection();
+        let (bridge, typed_uri) =
+            bridge_with_open_document("01ARZ3NDEKTSV4RRFFQ69G5FAV", &connection).await;
+        for expected in [2, 3] {
+            assert_eq!(
+                bridge
+                    .increment_document_version_for_test(&typed_uri, &connection)
+                    .await,
+                Some(expected)
+            );
+        }
+        let params = params_with_edit(json!({
+            "documentChanges": [{
+                "textDocument": { "uri": typed_uri.to_uri_string(), "version": 2 },
+                "edits": [text_edit(0)]
+            }]
+        }));
+
+        let reason = translator_with_bridge(bridge)
+            .translate(params, &connection)
+            .await
+            .expect_err("a stale versioned edit must be rejected");
+        assert!(
+            reason.contains("version 2") && reason.contains("since synced version 3"),
+            "reason should name both versions: {reason}"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_virtual_document_version_ahead_of_tracked() {
+        // A version the bridge never announced on this connection (tracked is
+        // 1, the edit claims 5): bookkeeping is broken somewhere — fail closed
+        // rather than un-version and apply.
+        let connection = test_connection();
+        let (bridge, typed_uri) =
+            bridge_with_open_document("01ARZ3NDEKTSV4RRFFQ69G5FAV", &connection).await;
+        let params = params_with_edit(json!({
+            "documentChanges": [{
+                "textDocument": { "uri": typed_uri.to_uri_string(), "version": 5 },
+                "edits": [text_edit(0)]
+            }]
+        }));
+
+        let reason = translator_with_bridge(bridge)
+            .translate(params, &connection)
+            .await
+            .expect_err("a version ahead of the tracked one must be rejected");
+        assert!(
+            reason.contains("version 5") && reason.contains("synced up to version 1"),
+            "reason should name both versions: {reason}"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_versioned_edit_for_document_not_open_on_this_connection() {
+        // The document is open on ANOTHER connection only (this one was
+        // purged/closed since the downstream saw the doc): the content basis
+        // for the versioned edit is gone on the requesting connection — fail
+        // closed. Version spaces are per connection, so the sibling's tracked
+        // version must not vouch for this connection's edit.
+        let other = ConnectionKey::for_server("emmylua");
+        let (bridge, typed_uri) =
+            bridge_with_open_document("01ARZ3NDEKTSV4RRFFQ69G5FAV", &other).await;
+        let params = params_with_edit(json!({
+            "documentChanges": [{
+                "textDocument": { "uri": typed_uri.to_uri_string(), "version": 1 },
+                "edits": [text_edit(0)]
+            }]
+        }));
+
+        let reason = translator_with_bridge(bridge)
+            .translate(params, &test_connection())
+            .await
+            .expect_err("a versioned edit for a doc this connection no longer has must be rejected");
+        assert!(
+            reason.contains("no longer open on this connection"),
+            "reason should name the failure: {reason}"
+        );
+    }
+
+    #[tokio::test]
+    async fn current_version_passes_validation() {
+        // A version matching the tracked one proceeds as before: validation
+        // lets it through to the translation pipeline, whose next stage
+        // (region-offset resolution against an empty document store) fails
+        // with the REGION error — proof the version gate did not fire.
+        let connection = test_connection();
+        let (bridge, typed_uri) =
+            bridge_with_open_document("01ARZ3NDEKTSV4RRFFQ69G5FAV", &connection).await;
+        assert_eq!(
+            bridge
+                .increment_document_version_for_test(&typed_uri, &connection)
+                .await,
+            Some(2)
+        );
+        let params = params_with_edit(json!({
+            "documentChanges": [{
+                "textDocument": { "uri": typed_uri.to_uri_string(), "version": 2 },
+                "edits": [text_edit(0)]
+            }]
+        }));
+
+        let reason = translator_with_bridge(bridge)
+            .translate(params, &connection)
+            .await
+            .expect_err("empty document store cannot resolve the region");
+        assert!(
+            reason.contains("the injected region changed"),
+            "a matching version must pass the gate and fail only at region \
+             resolution: {reason}"
+        );
+    }
+
+    #[tokio::test]
+    async fn versioned_empty_virtual_entry_does_not_trip_validation() {
+        // A versioned virtual TextDocumentEdit with an EMPTY edit vector is a
+        // no-op (mirrors collect_virtual_uris): it must not reject an
+        // otherwise valid real-file-only edit, whatever version it claims.
+        let params = params_with_edit(json!({
+            "documentChanges": [
+                {
+                    "textDocument": {
+                        "uri": virtual_uri("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+                        "version": 99
+                    },
+                    "edits": []
+                },
+                {
+                    "textDocument": { "uri": "file:///project/main.rs", "version": null },
+                    "edits": [text_edit(3)]
+                }
+            ]
+        }));
+
+        translator()
+            .translate(params, &test_connection())
+            .await
+            .expect("a no-op versioned virtual entry must not trip validation");
     }
 
     #[test]

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -228,18 +228,23 @@ impl ApplyEditTranslator {
         edit: &WorkspaceEdit,
         connection: &ConnectionKey,
     ) -> Result<(), String> {
-        let mut versions_by_uri: Vec<(&str, i32)> = Vec::new();
+        let mut versions_by_uri: std::collections::HashMap<&str, i32> =
+            std::collections::HashMap::new();
         for (uri, version) in versioned_virtual_text_document_edits(edit) {
-            match versions_by_uri.iter().find(|(seen, _)| *seen == uri) {
-                Some((_, seen_version)) if *seen_version != version => {
-                    return Err(format!(
-                        "kakehashi: the edit claims two different versions ({seen_version} \
-                         and {version}) for the same virtual document; at most one can be \
-                         current, so the edit cannot be applied",
-                    ));
+            match versions_by_uri.entry(uri) {
+                std::collections::hash_map::Entry::Occupied(seen) => {
+                    let seen_version = *seen.get();
+                    if seen_version != version {
+                        return Err(format!(
+                            "kakehashi: the edit claims two different versions ({seen_version} \
+                             and {version}) for the same virtual document; at most one can be \
+                             current, so the edit cannot be applied",
+                        ));
+                    }
                 }
-                Some(_) => {}
-                None => versions_by_uri.push((uri, version)),
+                std::collections::hash_map::Entry::Vacant(slot) => {
+                    slot.insert(version);
+                }
             }
         }
         for (uri, version) in versions_by_uri {
@@ -303,6 +308,14 @@ fn remove_empty_virtual_entries(edit: &mut WorkspaceEdit) {
         changes.retain(|uri, edits| {
             !(edits.is_empty() && VirtualDocumentUri::is_virtual_uri(uri.as_str()))
         });
+        // Drop the map entirely rather than forwarding `Some({})`: a client
+        // without `documentChanges` support processes `changes` (LSP 3.13's
+        // preference rule only orders the two when both are meaningful), and
+        // an empty map there would read as "whole edit is a no-op", silently
+        // losing the real edits carried in documentChanges.
+        if changes.is_empty() {
+            edit.changes = None;
+        }
     }
     let keep = |e: &TextDocumentEdit| {
         !(e.edits.is_empty() && VirtualDocumentUri::is_virtual_uri(e.text_document.uri.as_str()))
@@ -324,7 +337,7 @@ fn remove_empty_virtual_entries(edit: &mut WorkspaceEdit) {
 /// `documentChanges` can carry versions; the `changes` map cannot.
 fn versioned_virtual_text_document_edits(edit: &WorkspaceEdit) -> Vec<(&str, i32)> {
     let mut versioned = Vec::new();
-    let doc_edits: Box<dyn Iterator<Item = &tower_lsp_server::ls_types::TextDocumentEdit>> =
+    let doc_edits: Box<dyn Iterator<Item = &tower_lsp_server::ls_types::TextDocumentEdit> + '_> =
         match &edit.document_changes {
             None => Box::new(std::iter::empty()),
             Some(DocumentChanges::Edits(edits)) => Box::new(edits.iter()),
@@ -800,12 +813,10 @@ mod tests {
             .translate(params, &test_connection())
             .await
             .expect("an unversioned no-op virtual entry must not trip anything");
-        assert!(
-            out.edit
-                .changes
-                .as_ref()
-                .is_some_and(std::collections::HashMap::is_empty),
-            "the empty virtual `changes` entry must not reach the editor"
+        assert_eq!(
+            out.edit.changes, None,
+            "the emptied `changes` map must be dropped, not forwarded as `Some({{}})` \
+             (a documentChanges-unaware client would read that as a no-op edit)"
         );
         match out.edit.document_changes.as_ref().unwrap() {
             DocumentChanges::Edits(edits) => {

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -243,8 +243,7 @@ impl ApplyEditTranslator {
             }
         }
         for (uri, version) in versions_by_uri {
-            let Some(tracked) = self.bridge.virtual_document_version(uri, connection).await
-            else {
+            let Some(tracked) = self.bridge.virtual_document_version(uri, connection).await else {
                 return Err(format!(
                     "kakehashi: the edit is versioned against virtual document {uri}, \
                      which is no longer open on this connection; the content it was \
@@ -329,12 +328,12 @@ fn versioned_virtual_text_document_edits(edit: &WorkspaceEdit) -> Vec<(&str, i32
         match &edit.document_changes {
             None => Box::new(std::iter::empty()),
             Some(DocumentChanges::Edits(edits)) => Box::new(edits.iter()),
-            Some(DocumentChanges::Operations(ops)) => Box::new(ops.iter().filter_map(|op| {
-                match op {
+            Some(DocumentChanges::Operations(ops)) => {
+                Box::new(ops.iter().filter_map(|op| match op {
                     DocumentChangeOperation::Edit(e) => Some(e),
                     DocumentChangeOperation::Op(_) => None,
-                }
-            })),
+                }))
+            }
         };
     for e in doc_edits {
         let uri = e.text_document.uri.as_str();
@@ -592,7 +591,10 @@ mod tests {
                 "edits": [text_edit(1)]
             }]
         }));
-        let reason = translator().translate(original, &test_connection()).await.unwrap_err();
+        let reason = translator()
+            .translate(original, &test_connection())
+            .await
+            .unwrap_err();
         assert!(
             reason.contains("unknown virtual document"),
             "dedup must reach the single-region path, not the multi-region reject: {reason}"
@@ -694,7 +696,9 @@ mod tests {
         let reason = translator_with_bridge(bridge)
             .translate(params, &test_connection())
             .await
-            .expect_err("a versioned edit for a doc this connection no longer has must be rejected");
+            .expect_err(
+                "a versioned edit for a doc this connection no longer has must be rejected",
+            );
         assert!(
             reason.contains("no longer open on this connection"),
             "reason should name the failure: {reason}"
@@ -806,7 +810,10 @@ mod tests {
         match out.edit.document_changes.as_ref().unwrap() {
             DocumentChanges::Edits(edits) => {
                 assert_eq!(edits.len(), 1, "only the real-file edit survives");
-                assert_eq!(edits[0].text_document.uri.as_str(), "file:///project/main.rs");
+                assert_eq!(
+                    edits[0].text_document.uri.as_str(),
+                    "file:///project/main.rs"
+                );
             }
             DocumentChanges::Operations(_) => panic!("Expected Edits variant"),
         }

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -11,8 +11,10 @@
 //! The host/virt distinction is made from the edit itself, not the connection:
 //! an edit that touches **no** virtual URIs (every edit from a host-layer
 //! connection, and real-file-only edits from virt connections) is forwarded
-//! as-is except that every `TextDocumentEdit.version` is nulled — downstream
-//! versions are bridge-local and would read as stale to the editor. An edit
+//! with every `TextDocumentEdit.version` nulled — downstream versions are
+//! bridge-local and would read as stale to the editor — and no-op (empty)
+//! virtual entries removed (a raw virtual URI must never reach the editor,
+//! see [`remove_empty_virtual_entries`]); it is otherwise unchanged. An edit
 //! that touches exactly one virtual document is translated
 //! against that region's live offset (rebuilt exactly as goto/showDocument do,
 //! via [`resolve_region_offset`](super::region_offset::resolve_region_offset)).
@@ -55,13 +57,16 @@
 //! `label` and `changeAnnotations` pass through untouched (the transform only
 //! rewrites URIs/ranges/versions).
 //!
-//! Known degenerate edge: no-op (empty) virtual entries are removed before
-//! the forward — [`remove_empty_virtual_entries`] on every path (a raw
-//! virtual URI must never reach the editor), and the transform's
-//! foreign-virtual drop on the translated path — so an editor `failedChange`
-//! index can be skewed by one relative to what the downstream sent. A real
-//! (non-empty) foreign entry rejects the whole edit instead, so indexes
-//! never skew for edits that actually apply anything.
+//! No-op (empty) virtual entries are removed before the forward —
+//! [`remove_empty_virtual_entries`] on every path (a raw virtual URI must
+//! never reach the editor), and the transform's foreign-virtual drop on the
+//! translated path — which shifts the `documentChanges` indices the editor's
+//! `failedChange` answer refers to. The forwarding loop compares the entry
+//! count before/after translation (via [`document_change_count`]) and drops
+//! `failedChange` from the relayed response when they differ, rather than
+//! relaying a misaligned index. A real (non-empty) foreign entry rejects the
+//! whole edit instead, so responses for edits that actually apply anything
+//! keep their index.
 //!
 //! [`transform_workspace_edit_to_host`]: crate::lsp::bridge::transform_workspace_edit_to_host
 
@@ -108,8 +113,9 @@ impl ApplyEditTranslator {
     }
 
     /// Translate a virtual-document applyEdit to host coordinates; when the
-    /// edit touches no virtual URIs, forward `params` with only the
-    /// bridge-local `TextDocumentEdit.version`s nulled. `connection` is the
+    /// edit touches no virtual URIs, forward `params` with the bridge-local
+    /// `TextDocumentEdit.version`s nulled and no-op virtual entries removed
+    /// (otherwise unchanged). `connection` is the
     /// `(server, root)` key of the downstream connection the request arrived
     /// on — versioned virtual-document edits are validated against that
     /// connection's tracked versions before the versions are nulled. `Err`
@@ -265,6 +271,22 @@ impl ApplyEditTranslator {
     }
 }
 
+/// The number of `documentChanges` entries in an applyEdit's edit — the index
+/// space of the editor's `failedChange` answer. The forwarding loop compares
+/// this count before and after translation: translation can REMOVE entries
+/// (no-op virtual entries via [`remove_empty_virtual_entries`], foreign
+/// no-op entries via the transform), which shifts the indices of everything
+/// after them, so a `failedChange` computed by the editor against the
+/// forwarded array would misindex the downstream's original array. It never
+/// reorders or inserts, so an unchanged count means the indices still align.
+pub(super) fn document_change_count(params: &ApplyWorkspaceEditParams) -> usize {
+    match &params.edit.document_changes {
+        None => 0,
+        Some(DocumentChanges::Edits(edits)) => edits.len(),
+        Some(DocumentChanges::Operations(ops)) => ops.len(),
+    }
+}
+
 /// Remove no-op (empty) virtual-document entries so no raw virtual URI ever
 /// crosses the editor boundary. An empty entry skips the translation path
 /// ([`collect_virtual_uris`] ignores it), so on a real-file-only forward it
@@ -376,9 +398,10 @@ fn transform_params_to_host(
 /// discovery and is only meaningful for the single-element case.
 ///
 /// A text-edit entry (`changes` value or a `TextDocumentEdit`) with an EMPTY
-/// edit vector is a no-op and does NOT count as touching its URI: an edit that
-/// is real-file-only but carries a stray empty virtual entry must forward
-/// as-is (modulo the version nulling every forward gets), not be routed down
+/// edit vector is a no-op and does NOT count as touching its URI: an edit
+/// that is real-file-only but carries a stray empty virtual entry must still
+/// forward (the caller removes the no-op carrier via
+/// [`remove_empty_virtual_entries`] before this runs), not be routed down
 /// the virtual-translation path (and then fail `applied: false`). File
 /// operations always count — a create/rename/delete is a real change even
 /// with no accompanying text edits.

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -328,6 +328,18 @@ fn remove_empty_virtual_entries(edit: &mut WorkspaceEdit) {
             DocumentChangeOperation::Op(_) => true,
         }),
     }
+    // Mirror the `changes` handling above: clients that prefer
+    // `documentChanges` when both fields are present would read a forwarded
+    // `Some([])` as "whole edit is a no-op" and drop the real edits still
+    // carried in `changes`.
+    let emptied = match &edit.document_changes {
+        None => false,
+        Some(DocumentChanges::Edits(edits)) => edits.is_empty(),
+        Some(DocumentChanges::Operations(ops)) => ops.is_empty(),
+    };
+    if emptied {
+        edit.document_changes = None;
+    }
 }
 
 /// The `(virtual URI, version)` of every VERSIONED `TextDocumentEdit` that
@@ -828,6 +840,39 @@ mod tests {
             }
             DocumentChanges::Operations(_) => panic!("Expected Edits variant"),
         }
+    }
+
+    #[tokio::test]
+    async fn emptied_document_changes_is_dropped_not_forwarded_as_some_empty() {
+        // When every documentChanges entry is a removed no-op virtual carrier
+        // but `changes` still holds a real edit, forwarding
+        // `documentChanges: []` would overshadow `changes` for clients that
+        // prefer documentChanges when both are present — the real edit would
+        // silently no-op. The emptied container must become None.
+        let vuri = virtual_uri("01ARZ3NDEKTSV4RRFFQ69G5FAV");
+        let params = params_with_edit(json!({
+            "changes": { "file:///project/main.rs": [text_edit(3)] },
+            "documentChanges": [
+                {
+                    "textDocument": { "uri": vuri, "version": null },
+                    "edits": []
+                }
+            ]
+        }));
+
+        let out = translator()
+            .translate(params, &test_connection())
+            .await
+            .expect("a removable no-op virtual entry must not fail the apply");
+        assert_eq!(
+            out.edit.document_changes, None,
+            "an emptied documentChanges must be dropped, not forwarded as `Some([])`"
+        );
+        let changes = out.edit.changes.expect("the real edit must survive");
+        assert!(
+            changes.contains_key(&"file:///project/main.rs".parse().unwrap()),
+            "the real-file edit in `changes` survives: {changes:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1255,6 +1255,7 @@ fn spawn_upstream_request(
             }
             UpstreamRequest::ApplyEdit {
                 params,
+                connection,
                 reply,
                 cancel,
             } => {
@@ -1284,11 +1285,15 @@ fn spawn_upstream_request(
                 // Translate virtual-document edits back to host coordinates
                 // before forwarding (#568). Unlike showDocument there is no
                 // safe degraded forward: an untranslatable edit (unknown/stale
-                // region, virtual-URI file ops, multi-region edit) is answered
-                // `applied: false` locally with a failureReason, never sent to
-                // the editor. See `ApplyEditTranslator::translate`.
+                // region, virtual-URI file ops, multi-region edit, or a
+                // versioned edit whose version no longer matches what the
+                // bridge tracks for `connection`) is answered `applied: false`
+                // locally with a failureReason, never sent to the editor. See
+                // `ApplyEditTranslator::translate`.
                 let params = match &translators {
-                    Some(translators) => translators.apply_edit.translate(params).await,
+                    Some(translators) => {
+                        translators.apply_edit.translate(params, &connection).await
+                    }
                     None => Ok(params),
                 };
                 let response = match params {
@@ -3079,6 +3084,7 @@ mod tests {
         let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
         request_tx
             .send(UpstreamRequest::ApplyEdit {
+                connection: crate::lsp::bridge::ConnectionKey::for_server("test"),
                 params: serde_json::from_value(serde_json::json!({
                     "edit": { "changes": { "file:///x.rs": [] } }
                 }))
@@ -3154,6 +3160,7 @@ mod tests {
         let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
         request_tx
             .send(UpstreamRequest::ApplyEdit {
+                connection: crate::lsp::bridge::ConnectionKey::for_server("test"),
                 // A NON-empty edit against a virtual URI that resolves to no open
                 // document: the translator can't map it, so the loop must reject
                 // it locally. (An empty edit array would be a no-op forwarded

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -3131,6 +3131,131 @@ mod tests {
         let _ = loop_handle.await;
     }
 
+    /// The editor's `failedChange` indexes the FORWARDED documentChanges
+    /// array. When translation removed an entry (here: a no-op virtual
+    /// entry), the index spaces diverge and the relayed response must DROP
+    /// the index instead of misindexing the downstream's original array;
+    /// with no removal the index must relay untouched.
+    #[tokio::test]
+    async fn forwarding_loop_drops_failed_change_only_when_translation_removed_entries() {
+        use crate::lsp::bridge::{BridgeCoordinator, UpstreamRequest, VirtualDocumentUri};
+        use futures::{SinkExt, StreamExt};
+        use std::str::FromStr;
+        use tower_lsp_server::jsonrpc::Response;
+
+        let (client, mut requests, mut responses) = init_client_and_socket().await;
+
+        let (_upstream_tx, upstream_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (_window_tx, window_rx) = tokio::sync::mpsc::channel(16);
+        let (request_tx, request_rx) = tokio::sync::mpsc::unbounded_channel();
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let translators = Some(Arc::new(UpstreamRequestTranslators {
+            show_document: ShowDocumentTranslator::new(
+                Arc::new(crate::document::DocumentStore::new()),
+                Arc::new(crate::language::LanguageCoordinator::new()),
+                Arc::new(BridgeCoordinator::new()),
+            ),
+            apply_edit: ApplyEditTranslator::new(
+                Arc::new(crate::document::DocumentStore::new()),
+                Arc::new(crate::language::LanguageCoordinator::new()),
+                Arc::new(BridgeCoordinator::new()),
+            ),
+        }));
+        let loop_handle = tokio::spawn(upstream_forwarding_loop(
+            upstream_rx,
+            window_rx,
+            request_rx,
+            translators,
+            crate::lsp::bridge::InboundRequestRegistry::default(),
+            client,
+            None,
+            cancel.clone(),
+        ));
+
+        let host = tower_lsp_server::ls_types::Uri::from_str("file:///project/doc.md").unwrap();
+        let virtual_uri =
+            VirtualDocumentUri::new(&host, "lua", "01ARZ3NDEKTSV4RRFFQ69G5FAV").to_uri_string();
+        let real_edit = serde_json::json!({
+            "textDocument": { "uri": "file:///x.rs", "version": null },
+            "edits": [{
+                "range": {
+                    "start": { "line": 0, "character": 0 },
+                    "end": { "line": 0, "character": 1 }
+                },
+                "newText": "x"
+            }]
+        });
+
+        // Round 1: [no-op virtual entry, real edit] — the no-op is removed
+        // before forwarding, so the editor's failedChange: 0 (the real edit,
+        // index 0 FORWARDED) would misindex the downstream's array (where
+        // index 0 is the virtual no-op). It must be dropped.
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        request_tx
+            .send(UpstreamRequest::ApplyEdit {
+                connection: crate::lsp::bridge::ConnectionKey::for_server("test"),
+                params: serde_json::from_value(serde_json::json!({
+                    "edit": { "documentChanges": [
+                        {
+                            "textDocument": { "uri": virtual_uri, "version": null },
+                            "edits": []
+                        },
+                        real_edit.clone()
+                    ] }
+                }))
+                .unwrap(),
+                reply: reply_tx,
+                cancel: test_forwarded_cancel(),
+            })
+            .unwrap();
+        let req = requests.next().await.expect("applyEdit emitted");
+        let id = req.id().expect("request has an id").clone();
+        let _ = responses
+            .send(Response::from_ok(
+                id,
+                serde_json::json!({ "applied": false, "failedChange": 0 }),
+            ))
+            .await;
+        let response = reply_rx.await.expect("reply delivered");
+        assert!(!response.applied);
+        assert_eq!(
+            response.failed_change, None,
+            "a failedChange computed against a shrunken array must be dropped"
+        );
+
+        // Round 2 (control): real-only edit, nothing removed — the index
+        // spaces align and failedChange must relay untouched.
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        request_tx
+            .send(UpstreamRequest::ApplyEdit {
+                connection: crate::lsp::bridge::ConnectionKey::for_server("test"),
+                params: serde_json::from_value(serde_json::json!({
+                    "edit": { "documentChanges": [real_edit] }
+                }))
+                .unwrap(),
+                reply: reply_tx,
+                cancel: test_forwarded_cancel(),
+            })
+            .unwrap();
+        let req = requests.next().await.expect("applyEdit emitted");
+        let id = req.id().expect("request has an id").clone();
+        let _ = responses
+            .send(Response::from_ok(
+                id,
+                serde_json::json!({ "applied": false, "failedChange": 0 }),
+            ))
+            .await;
+        let response = reply_rx.await.expect("reply delivered");
+        assert_eq!(
+            response.failed_change,
+            Some(0),
+            "with aligned index spaces the editor's failedChange must relay"
+        );
+
+        cancel.cancel();
+        let _ = loop_handle.await;
+    }
+
     /// An applyEdit whose edit can't be translated to host coordinates (here: a
     /// virtual URI no open document maps to) must be answered `applied: false`
     /// locally — the editor must never see the corrupted edit (#568).
@@ -3182,8 +3307,8 @@ mod tests {
                 connection: crate::lsp::bridge::ConnectionKey::for_server("test"),
                 // A NON-empty edit against a virtual URI that resolves to no open
                 // document: the translator can't map it, so the loop must reject
-                // it locally. (An empty edit array would be a no-op forwarded
-                // verbatim — see `collect_virtual_uris`.)
+                // it locally. (An empty edit array would be a no-op removed
+                // before forwarding — see `remove_empty_virtual_entries`.)
                 params: serde_json::from_value(serde_json::json!({
                     "edit": { "changes": { virtual_uri: [
                         { "range": {

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1290,6 +1290,15 @@ fn spawn_upstream_request(
                 // bridge tracks for `connection`) is answered `applied: false`
                 // locally with a failureReason, never sent to the editor. See
                 // `ApplyEditTranslator::translate`.
+                // The editor answers `failedChange` as an index into the
+                // FORWARDED documentChanges array; the downstream interprets
+                // it against the array it SENT. Translation can REMOVE no-op
+                // entries (never reorder or insert), so a changed entry count
+                // means the two index spaces diverged and the index must be
+                // dropped rather than relayed misaligned — `applied` and
+                // `failureReason` still relay.
+                let sent_change_count =
+                    super::apply_edit_translation::document_change_count(&params);
                 let params = match &translators {
                     Some(translators) => {
                         translators.apply_edit.translate(params, &connection).await
@@ -1316,43 +1325,53 @@ fn spawn_upstream_request(
                     // but forwarding `params: null` on the off chance it did
                     // would send the editor an invalid request; answer local
                     // applied:false with a serialization reason instead.
-                    Ok(params) => match serde_json::to_value(params) {
-                        Ok(value) => {
-                            let id = client.next_request_id();
-                            forward_with_cancel(
-                                &client,
-                                id,
-                                "workspace/applyEdit",
-                                value,
-                                &cancel.token,
-                            )
-                            .await
-                            .and_then(|v| {
-                                serde_json::from_value::<ApplyWorkspaceEditResponse>(v).ok()
-                            })
-                            // Editor error/cancel, or a response that didn't
-                            // parse as an ApplyWorkspaceEditResponse: the
-                            // protocol default — the edit was not applied.
-                            .unwrap_or(ApplyWorkspaceEditResponse {
+                    Ok(params) => {
+                        let forwarded_change_count =
+                            super::apply_edit_translation::document_change_count(&params);
+                        match serde_json::to_value(params) {
+                            Ok(value) => {
+                                let id = client.next_request_id();
+                                let mut response = forward_with_cancel(
+                                    &client,
+                                    id,
+                                    "workspace/applyEdit",
+                                    value,
+                                    &cancel.token,
+                                )
+                                .await
+                                .and_then(|v| {
+                                    serde_json::from_value::<ApplyWorkspaceEditResponse>(v).ok()
+                                })
+                                // Editor error/cancel, or a response that didn't
+                                // parse as an ApplyWorkspaceEditResponse: the
+                                // protocol default — the edit was not applied.
+                                .unwrap_or(ApplyWorkspaceEditResponse {
+                                    applied: false,
+                                    // Covers editor error, cancellation, AND an
+                                    // unparseable response — neutral wording (like
+                                    // the reader drop-path) so a cancel/transport
+                                    // failure isn't misattributed to the editor.
+                                    failure_reason: Some(
+                                        "kakehashi: no valid workspace/applyEdit response"
+                                            .to_string(),
+                                    ),
+                                    failed_change: None,
+                                });
+                                if forwarded_change_count != sent_change_count {
+                                    // Index spaces diverged; see above.
+                                    response.failed_change = None;
+                                }
+                                response
+                            }
+                            Err(e) => ApplyWorkspaceEditResponse {
                                 applied: false,
-                                // Covers editor error, cancellation, AND an
-                                // unparseable response — neutral wording (like
-                                // the reader drop-path) so a cancel/transport
-                                // failure isn't misattributed to the editor.
-                                failure_reason: Some(
-                                    "kakehashi: no valid workspace/applyEdit response".to_string(),
-                                ),
+                                failure_reason: Some(format!(
+                                    "kakehashi: could not serialize the workspace/applyEdit request: {e}"
+                                )),
                                 failed_change: None,
-                            })
+                            },
                         }
-                        Err(e) => ApplyWorkspaceEditResponse {
-                            applied: false,
-                            failure_reason: Some(format!(
-                                "kakehashi: could not serialize the workspace/applyEdit request: {e}"
-                            )),
-                            failed_change: None,
-                        },
-                    },
+                    }
                 };
                 inbound_request_registry.unregister(
                     cancel.connection_id,

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -3029,6 +3029,7 @@ mod tests {
                     "edit": { "changes": { "file:///x.rs": [] } }
                 }))
                 .unwrap(),
+                connection: crate::lsp::bridge::ConnectionKey::for_server("test"),
                 reply: reply_tx,
                 cancel: forwarded_cancel,
             })
@@ -3172,6 +3173,7 @@ mod tests {
             client,
             None,
             cancel.clone(),
+            true,
         ));
 
         let host = tower_lsp_server::ls_types::Uri::from_str("file:///project/doc.md").unwrap();

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -1345,18 +1345,20 @@ fn spawn_upstream_request(
                                 // Editor error/cancel, or a response that didn't
                                 // parse as an ApplyWorkspaceEditResponse: the
                                 // protocol default — the edit was not applied.
-                                .unwrap_or(ApplyWorkspaceEditResponse {
-                                    applied: false,
-                                    // Covers editor error, cancellation, AND an
-                                    // unparseable response — neutral wording (like
-                                    // the reader drop-path) so a cancel/transport
-                                    // failure isn't misattributed to the editor.
-                                    failure_reason: Some(
-                                        "kakehashi: no valid workspace/applyEdit response"
-                                            .to_string(),
-                                    ),
-                                    failed_change: None,
-                                });
+                                .unwrap_or(
+                                    ApplyWorkspaceEditResponse {
+                                        applied: false,
+                                        // Covers editor error, cancellation, AND an
+                                        // unparseable response — neutral wording (like
+                                        // the reader drop-path) so a cancel/transport
+                                        // failure isn't misattributed to the editor.
+                                        failure_reason: Some(
+                                            "kakehashi: no valid workspace/applyEdit response"
+                                                .to_string(),
+                                        ),
+                                        failed_change: None,
+                                    },
+                                );
                                 if forwarded_change_count != sent_change_count {
                                     // Index spaces diverged; see above.
                                     response.failed_change = None;


### PR DESCRIPTION
## The stale-version scenario

A bridged downstream that versions a `TextDocumentEdit` in a `workspace/applyEdit` pins the edit to the content revision it computed against — in the bridge-local version space of the connection it arrived on (each connection's `didOpen` starts its own counter at 1; each content-changing `didChange` bumps it). The editor-ward relay used to null every version unconditionally, which also laundered STALE edits: a downstream that computed an edit against content the bridge had since replaced had its version erased and its possibly-misplaced coordinates forwarded, guarded only by region bounds and prefix safety.

## What this PR does

- **Validate instead of blindly stripping**: versioned virtual-document edits are compared against the version the `DocumentTracker` holds for `(connection, virtual doc)`. Stale, ahead, or untracked versions answer `applied: false` with a `failureReason` naming both versions; only a matching version proceeds (version still nulled editor-ward, since the editor doesn't know the bridge-local space). The connection identity rides `UpstreamRequest::ApplyEdit` from a new `ServerRequestDeps.connection_key` — version spaces are per `(server, root)` connection, so a sibling connection's counter must not vouch for another's edit.
- **Precondition semantics**: a versioned entry with `edits: []` is still validated — per spec the version is a per-document precondition on the whole apply.
- **Self-contradictory shapes rejected up front**: two entries claiming different versions for the same document are rejected before any tracker read (per-entry awaited reads could otherwise interleave with a `didChange` bump so both matched).
- **Atomic tracker read**: the version lookup checks confirmed-opened membership while holding the version mutex, so a pre-`didOpen` claim (seeded at claim time) or a close+reclaim interleaving can never satisfy the gate.
- **No raw virtual URIs editor-ward**: no-op (empty) virtual entries are removed before forwarding on every path (previously forwarded verbatim on the real-file-only path; LSP doesn't require clients to skip URI resolution for empty entries).
- **`failedChange` integrity**: translation can remove entries, shifting the editor's `failedChange` index space; the forwarding loop compares the entry count before/after translation and drops the index (never relays it misaligned) when they differ.

## Decision on real-file versions

Real-file versioned edits keep the null-without-validate behavior. Their versions are equally bridge-local, but a real-file edit may target a file the bridge never synced at all (a downstream can edit any file it knows from disk), and host-document sync state lives in a separate tracker (`LanguageServerPool::host_documents`) not exposed to this translator. Nulling ("apply without a version check") is the spec-sanctioned degradation; the editor still applies host edits against its own live buffer. Validating host-document versions through that tracker is named follow-up hardening in the module docs.

Residual, documented: the validation is a point-in-time read — a `didChange` can still race between the check and the editor applying the edit, exactly as it always could for the unversioned majority shape (`changes` map). Closing that window needs a bridge→editor version mapping so the editor performs the atomic check itself (follow-up).

## Review rounds

- Self-review of the full diff.
- codex MCP session 1: 2 rounds — fixed the pre-`didOpen` claim window (opened-state gate) and its close+reclaim atomicity hole; corrected a factually wrong doc rationale; converged at "no comments to provide".
- codex MCP session 2 (fresh): 4 rounds — fixed empty-versioned-entry bypass, "synced" vs "tracked" wording, duplicate-URI version conflicts, virtual-URI leak of no-op entries, `failedChange` misindexing, regression tests; refuted percent-encoded URI aliasing as out of scope (classified as a real file, which grants nothing beyond the supported real-file edit path); converged at "no comments to provide".
- Quality gate before every commit: full lib test suite (2762 passed) + `clippy --lib --tests -D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `workspace/applyEdit` reliability with connection-scoped validation of virtual-document `TextDocumentEdit` versions.
  * Correctly rejects stale, ahead-of-current, conflicting, or unconfirmed/unopened virtual document versions.
  * Removes empty/no-op virtual edit carriers before forwarding to the editor to prevent invalid virtual URIs.
  * Fixed `failedChange` relaying to stay consistent when translation changes `documentChanges` indexing.
* **Tests**
  * Added/updated coverage for connection-scoped version gating, empty-carrier cleanup behavior, and `failedChange` index handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->