### PR TITLE
fix(lsp): sweep upstream registry via RAII on cancel-select paths

### DIFF
--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -225,21 +225,25 @@ impl Kakehashi {
             upstream_id,
             region_end,
         );
-        let result = match cancel_rx {
+        // The cancel arm DROPS the in-flight dispatch, which then never
+        // reaches its own refcounted unregister — an RAII sweep (dropped at
+        // function exit) covers that, and unlike a trailing statement it also
+        // runs when this whole handler future is dropped (client disconnect /
+        // shutdown). Idempotent after normal completion, where the dispatch
+        // cleaned up itself. The CAPTURED id, not a re-read of the task-local:
+        // the sweep must target exactly the id the dispatch registered under.
+        let _sweep = crate::lsp::lsp_impl::bridge_context::UpstreamRegistrySweepGuard::new(
+            std::sync::Arc::clone(&pool),
+            sweep_id,
+        );
+        match cancel_rx {
             Some(rx) => tokio::select! {
                 biased;
                 _ = rx => Err(tower_lsp_server::jsonrpc::Error::request_cancelled()),
                 resolved = dispatch => Ok(resolved),
             },
             None => Ok(dispatch.await),
-        };
-        // The cancel arm DROPS the in-flight dispatch, which then never
-        // reaches its own refcounted unregister — sweep the id (idempotent
-        // after normal completion, where the dispatch cleaned up itself).
-        // The CAPTURED id, not a re-read of the task-local: the sweep must
-        // target exactly the id the dispatch registered under.
-        pool.unregister_all_for_upstream_id(sweep_id.as_ref());
-        result
+        }
     }
 
     /// The region's current content-precise host-document END position if the

--- a/src/lsp/lsp_impl/workspace/execute_command.rs
+++ b/src/lsp/lsp_impl/workspace/execute_command.rs
@@ -49,21 +49,25 @@ impl Kakehashi {
         // multi-region codeAction walk already fixed).
         let pool = self.bridge.pool_arc();
         let dispatch = pool.dispatch_execute_command(params, &settings, upstream_id);
-        let result = match cancel_rx {
+        // The cancel arm DROPS the in-flight dispatch, which then never
+        // reaches its own refcounted unregister — an RAII sweep (dropped at
+        // function exit) covers that, and unlike a trailing statement it also
+        // runs when this whole handler future is dropped (client disconnect /
+        // shutdown). Idempotent after normal completion, where the dispatch
+        // cleaned up itself. The CAPTURED id, not a re-read of the task-local:
+        // the sweep must target exactly the id the dispatch registered under.
+        let _sweep = crate::lsp::lsp_impl::bridge_context::UpstreamRegistrySweepGuard::new(
+            std::sync::Arc::clone(&pool),
+            sweep_id,
+        );
+        match cancel_rx {
             Some(rx) => tokio::select! {
                 biased;
                 _ = rx => Err(tower_lsp_server::jsonrpc::Error::request_cancelled()),
                 outcome = dispatch => Ok(outcome),
             },
             None => Ok(dispatch.await),
-        };
-        // The cancel arm DROPS the in-flight dispatch, which then never
-        // reaches its own refcounted unregister — sweep the id (idempotent
-        // after normal completion, where the dispatch cleaned up itself).
-        // The CAPTURED id, not a re-read of the task-local: the sweep must
-        // target exactly the id the dispatch registered under.
-        pool.unregister_all_for_upstream_id(sweep_id.as_ref());
-        result
+        }
     }
 
     /// Best-effort re-open of the routed command's origin-server documents (see


### PR DESCRIPTION
Follow-up to #672 (Copilot findings that landed after the merge): the trailing `unregister_all_for_upstream_id` after the cancel `select!` in `execute_command_impl` and the codeAction/resolve handler never runs when the whole handler future is dropped (client disconnect / server shutdown), leaking the entries registered by `dispatch_execute_command` / `dispatch_code_action_resolve`. Hold an `UpstreamRegistrySweepGuard` across the select instead — the same RAII pattern `run_layer_race` uses — so the sweep runs on every exit: normal completion, cancel arm, and drop.

The one lib-test failure locally (`process_injection_sync_returns_incomplete_on_mid_region_cancel`) is pre-existing on origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup for in-flight code action and execute command requests when a client cancels them.
  * Ensures temporary request registrations are reliably cleared not only after successful completion, but also on cancellation and early termination (for example, client disconnects or shutdown).
  * Kept cancellation and command execution outcomes consistent with prior behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->