### PR TITLE
fix(install): bound parser archive extraction

### DIFF
--- a/docs/architecture-decisions/http-archive-primary-source-acquisition.md
+++ b/docs/architecture-decisions/http-archive-primary-source-acquisition.md
@@ -25,7 +25,7 @@ GitHub serves repository archives at deterministic URLs (`/archive/{revision}.ta
 
 1. **Fastest for the common case**: All nvim-treesitter parsers are on GitHub, so archive download covers 100% of standard usage
 2. **Git becomes optional**: Users without git can still install parsers from GitHub
-3. **Graceful fallback**: Non-GitHub URLs or download failures transparently fall back to git clone
+3. **Graceful fallback**: Non-GitHub URLs or ordinary download/extraction failures transparently fall back to git clone
 4. **No regressions**: The git clone path is preserved and well-tested
 
 ### Implementation
@@ -34,8 +34,9 @@ The `fetch_source()` function implements the strategy:
 
 1. Construct archive URL: `https://github.com/{owner}/{repo}/archive/{revision}.tar.gz`
 2. Download and extract tarball, stripping the root directory prefix (`{repo}-{revision_no_v}/`)
-3. On any failure, clean up and fall back to `clone_repo()`
-4. For non-GitHub URLs, skip directly to git clone
+3. On ordinary archive download/extraction failures, clean up and fall back to `clone_repo()`
+4. On archive size-limit failures, clean up and fail without fallback to preserve the resource budget
+5. For non-GitHub URLs, skip directly to git clone
 
 ### Consequences
 
@@ -49,6 +50,7 @@ The `fetch_source()` function implements the strategy:
 
 * Two new dependencies: `flate2` and `tar` crates (well-established, ~10 transitive crates)
 * Archive root directory naming depends on GitHub's convention (`{repo}-{revision_no_v}/`)
+* Archive size-limit failures are terminal rather than falling back to git, because retrying through another acquisition path would bypass the resource budget
 
 **Neutral:**
 

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -4,6 +4,7 @@
 //! compiling them with tree-sitter-loader, and installing the resulting shared library.
 
 use std::fs;
+use std::io::{self, Read};
 use std::path::Component;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -18,6 +19,8 @@ use super::metadata::{FetchOptions, MetadataError, fetch_parser_metadata};
 
 /// HTTP timeout for archive downloads.
 const ARCHIVE_HTTP_TIMEOUT: Duration = Duration::from_secs(120);
+/// Maximum decompressed tar stream or extracted file bytes for parser archives.
+const MAX_ARCHIVE_DECOMPRESSED_BYTES: u64 = 100 * 1024 * 1024;
 
 /// Error types for parser installation.
 #[derive(Debug)]
@@ -465,15 +468,18 @@ fn download_and_extract_archive(
         e => ParserInstallError::ArchiveError(format!("Download failed: {}", e)),
     })?;
 
-    // into_reader() streams without a size limit; parser archives can exceed
-    // ureq's 10MB read_to_* default.
+    // into_reader() streams without ureq's 10MB read_to_* cap, so enforce our
+    // own limit on the decompressed tar stream.
     let decoder = GzDecoder::new(response.into_body().into_reader());
-    let mut archive = Archive::new(decoder);
+    let bounded_decoder =
+        LimitedReader::new(decoder, MAX_ARCHIVE_DECOMPRESSED_BYTES, "decompressed size");
+    let mut archive = Archive::new(bounded_decoder);
 
     // GitHub names the root directory `{repo}-{revision_without_v_prefix}`
     let expected_prefix = archive_root_dir_name(repo_name, revision);
 
     fs::create_dir_all(dest)?;
+    let mut extracted_bytes = 0u64;
 
     for entry_result in archive.entries().map_err(|e| {
         ParserInstallError::ArchiveError(format!("Failed to read archive entries: {}", e))
@@ -513,6 +519,26 @@ fn download_and_extract_archive(
         if entry.header().entry_type().is_dir() {
             fs::create_dir_all(&target)?;
         } else {
+            let entry_size = entry.header().size().map_err(|e| {
+                ParserInstallError::ArchiveError(format!(
+                    "Invalid size for {}: {}",
+                    relative.display(),
+                    e
+                ))
+            })?;
+            extracted_bytes = extracted_bytes.checked_add(entry_size).ok_or_else(|| {
+                ParserInstallError::ArchiveError(format!(
+                    "Archive decompressed size exceeds {} bytes",
+                    MAX_ARCHIVE_DECOMPRESSED_BYTES
+                ))
+            })?;
+            if extracted_bytes > MAX_ARCHIVE_DECOMPRESSED_BYTES {
+                return Err(ParserInstallError::ArchiveError(format!(
+                    "Archive decompressed size exceeds {} bytes while extracting {}",
+                    MAX_ARCHIVE_DECOMPRESSED_BYTES,
+                    relative.display()
+                )));
+            }
             if let Some(parent) = target.parent() {
                 fs::create_dir_all(parent)?;
             }
@@ -527,6 +553,50 @@ fn download_and_extract_archive(
     }
 
     Ok(())
+}
+
+struct LimitedReader<R> {
+    inner: R,
+    remaining: u64,
+    limit: u64,
+    label: &'static str,
+}
+
+impl<R> LimitedReader<R> {
+    fn new(inner: R, limit: u64, label: &'static str) -> Self {
+        Self {
+            inner,
+            remaining: limit,
+            limit,
+            label,
+        }
+    }
+}
+
+impl<R: Read> Read for LimitedReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        if self.remaining == 0 {
+            let mut probe = [0];
+            return match self.inner.read(&mut probe) {
+                Ok(0) => Ok(0),
+                Ok(_) => Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Archive {} exceeds {} bytes", self.label, self.limit),
+                )),
+                Err(e) => Err(e),
+            };
+        }
+
+        let max_read = usize::try_from(self.remaining)
+            .unwrap_or(usize::MAX)
+            .min(buf.len());
+        let read = self.inner.read(&mut buf[..max_read])?;
+        self.remaining -= read as u64;
+        Ok(read)
+    }
 }
 
 /// Derive the expected root directory name inside a GitHub archive tarball.
@@ -1504,6 +1574,96 @@ mod tests {
             dest.join("src").join("parser.c").exists(),
             "Extracted archive should contain src/parser.c"
         );
+    }
+
+    #[test]
+    fn download_and_extract_archive_rejects_oversized_decompressed_archive() {
+        let temp = tempdir().expect("Failed to create temp dir");
+        let dest = temp.path().join("source");
+        let archive = oversized_archive("parser-1.0.0", 101 * 1024 * 1024);
+        let archive_url = serve_once(archive);
+
+        let result = download_and_extract_archive(&archive_url, "parser", "v1.0.0", &dest);
+
+        match result {
+            Err(ParserInstallError::ArchiveError(message)) => {
+                assert!(
+                    message.contains("Archive decompressed size exceeds"),
+                    "expected archive size limit error, got: {message}"
+                );
+            }
+            other => panic!("expected archive size limit error, got {other:?}"),
+        }
+        assert!(
+            !dest.join("payload.bin").exists(),
+            "oversized archive payload must not be fully extracted"
+        );
+    }
+
+    #[test]
+    fn limited_reader_rejects_reads_past_limit() {
+        use std::io::Read;
+
+        let mut reader = LimitedReader::new(&b"abcdef"[..], 3, "test size");
+        let mut buffer = Vec::new();
+        let error = reader
+            .read_to_end(&mut buffer)
+            .expect_err("reader should reject data past the limit");
+
+        assert_eq!(buffer, b"abc");
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(
+            error
+                .to_string()
+                .contains("Archive test size exceeds 3 bytes"),
+            "unexpected error: {error}"
+        );
+    }
+
+    fn oversized_archive(root: &str, payload_size: u64) -> Vec<u8> {
+        use flate2::Compression;
+        use flate2::write::GzEncoder;
+        use std::io::Read;
+        use tar::{Builder, Header};
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::best());
+        {
+            let mut builder = Builder::new(&mut encoder);
+            let mut header = Header::new_gnu();
+            header.set_size(payload_size);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder
+                .append_data(
+                    &mut header,
+                    format!("{root}/payload.bin"),
+                    std::io::repeat(0).take(payload_size),
+                )
+                .expect("append oversized payload");
+            builder.finish().expect("finish tar");
+        }
+
+        encoder.finish().expect("finish gzip")
+    }
+
+    fn serve_once(body: Vec<u8>) -> String {
+        use std::io::{Read, Write};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local server");
+        let addr = listener.local_addr().expect("local addr");
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut request = [0; 1024];
+            let _ = stream.read(&mut request);
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/gzip\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            )
+            .expect("write response headers");
+            stream.write_all(&body).expect("write response body");
+        });
+        format!("http://{addr}/archive.tar.gz")
     }
 
     /// Test that fetch_source succeeds for a GitHub URL (uses archive download).

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -648,7 +648,17 @@ fn extract_archive_with_limits<R: Read>(
             if let Some(parent) = target.parent() {
                 fs::create_dir_all(parent)?;
             }
-            unpack_entry_atomically(&mut entry, &target, &relative)?;
+            if entry.header().entry_type().is_file() {
+                unpack_entry_atomically(&mut entry, &target, &relative)?;
+            } else {
+                // Atomic publication pre-creates a regular tempfile, which is
+                // incompatible with link and other non-file tar entries. Keep
+                // the pre-existing unpack behavior for those entry types;
+                // archive confinement is handled separately by #600.
+                entry.unpack(&target).map_err(|error| {
+                    archive_io_error(&format!("Failed to extract {}", relative.display()), error)
+                })?;
+            }
         }
     }
 

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -1753,8 +1753,11 @@ mod tests {
     fn download_and_extract_archive_rejects_oversized_extracted_payload() {
         let temp = tempdir().expect("Failed to create temp dir");
         let dest = temp.path().join("source");
-        let archive =
-            compressed_tar_archive_with_payload("parser-1.0.0", MAX_ARCHIVE_EXTRACTED_BYTES + 1);
+        let archive = gzip_archive(tar_archive_with_declared_payload(
+            "parser-1.0.0",
+            MAX_ARCHIVE_EXTRACTED_BYTES + 1,
+            0,
+        ));
         let result = extract_archive(GzDecoder::new(&archive[..]), "parser", "v1.0.0", &dest);
 
         match result {
@@ -2079,6 +2082,23 @@ mod tests {
         archive
     }
 
+    fn tar_archive_with_declared_payload(
+        root: &str,
+        declared_size: u64,
+        data_len: usize,
+    ) -> Vec<u8> {
+        let mut archive = Vec::new();
+        append_tar_entry(
+            &mut archive,
+            &format!("{root}/payload.bin"),
+            tar::EntryType::file(),
+            &vec![0; data_len],
+            declared_size,
+        );
+        archive.extend_from_slice(&[0; 1024]);
+        archive
+    }
+
     fn pax_size_override_archive_with_data_len(
         path: &str,
         raw_size: u64,
@@ -2164,32 +2184,6 @@ mod tests {
         gzip.extend_from_slice(&[1, 0, 0, 0xff, 0xff]);
         gzip.extend_from_slice(&[0; 8]);
         gzip
-    }
-
-    fn compressed_tar_archive_with_payload(root: &str, payload_size: u64) -> Vec<u8> {
-        use flate2::Compression;
-        use flate2::write::GzEncoder;
-        use std::io::Read;
-        use tar::{Builder, Header};
-
-        let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
-        {
-            let mut builder = Builder::new(&mut encoder);
-            let mut header = Header::new_gnu();
-            header.set_size(payload_size);
-            header.set_mode(0o644);
-            header.set_cksum();
-            builder
-                .append_data(
-                    &mut header,
-                    format!("{root}/payload.bin"),
-                    std::io::repeat(0).take(payload_size),
-                )
-                .expect("append payload");
-            builder.finish().expect("finish tar");
-        }
-
-        encoder.finish().expect("finish gzip")
     }
 
     /// Test that fetch_source succeeds for a GitHub URL (uses archive download).

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -29,6 +29,9 @@ const ARCHIVE_TAR_METADATA_MARGIN_BYTES: u64 = 10 * 1024 * 1024;
 /// Maximum decompressed tar stream bytes for parser archives.
 const MAX_ARCHIVE_TAR_STREAM_BYTES: u64 =
     MAX_ARCHIVE_EXTRACTED_BYTES + ARCHIVE_TAR_METADATA_MARGIN_BYTES;
+/// Maximum compressed bytes downloaded for a parser archive.
+const MAX_ARCHIVE_DOWNLOAD_BYTES: u64 =
+    MAX_ARCHIVE_TAR_STREAM_BYTES + ARCHIVE_TAR_METADATA_MARGIN_BYTES;
 
 /// Error types for parser installation.
 #[derive(Debug)]
@@ -497,9 +500,30 @@ fn download_and_extract_archive(
         e => ParserInstallError::ArchiveError(format!("Download failed: {}", e)),
     })?;
 
-    // into_reader() streams without ureq's 10MB read_to_* cap, so enforce our
-    // own limit on the decompressed tar stream.
-    let decoder = GzDecoder::new(response.into_body().into_reader());
+    // into_reader() streams without ureq's 10MB read_to_* cap, so bound the
+    // compressed response here; extract_archive separately bounds output.
+    extract_downloaded_archive(
+        response.into_body().into_reader(),
+        repo_name,
+        revision,
+        dest,
+        MAX_ARCHIVE_DOWNLOAD_BYTES,
+    )
+}
+
+fn extract_downloaded_archive<R: Read>(
+    compressed_reader: R,
+    repo_name: &str,
+    revision: &str,
+    dest: &Path,
+    compressed_limit: u64,
+) -> Result<(), ParserInstallError> {
+    let bounded_compressed = LimitedReader::with_resource(
+        compressed_reader,
+        compressed_limit,
+        "compressed archive download",
+    );
+    let decoder = GzDecoder::new(bounded_compressed);
     extract_archive(decoder, repo_name, revision, dest)
 }
 
@@ -645,15 +669,21 @@ struct LimitedReader<R> {
     inner: R,
     remaining: u64,
     limit: u64,
+    resource: &'static str,
     limit_exceeded: bool,
 }
 
 impl<R> LimitedReader<R> {
     fn new(inner: R, limit: u64) -> Self {
+        Self::with_resource(inner, limit, "decompressed tar stream")
+    }
+
+    fn with_resource(inner: R, limit: u64, resource: &'static str) -> Self {
         Self {
             inner,
             remaining: limit,
             limit,
+            resource,
             limit_exceeded: false,
         }
     }
@@ -668,7 +698,10 @@ impl<R: Read> Read for LimitedReader<R> {
             if self.limit_exceeded {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
-                    ArchiveLimitError { limit: self.limit },
+                    ArchiveLimitError {
+                        resource: self.resource,
+                        limit: self.limit,
+                    },
                 ));
             }
             let mut probe = [0];
@@ -678,7 +711,10 @@ impl<R: Read> Read for LimitedReader<R> {
                     self.limit_exceeded = true;
                     Err(io::Error::new(
                         io::ErrorKind::InvalidData,
-                        ArchiveLimitError { limit: self.limit },
+                        ArchiveLimitError {
+                            resource: self.resource,
+                            limit: self.limit,
+                        },
                     ))
                 }
                 Err(e) => Err(e),
@@ -696,12 +732,13 @@ impl<R: Read> Read for LimitedReader<R> {
 
 #[derive(Debug)]
 struct ArchiveLimitError {
+    resource: &'static str,
     limit: u64,
 }
 
 impl std::fmt::Display for ArchiveLimitError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "decompressed tar stream exceeds {} bytes", self.limit)
+        write!(f, "{} exceeds {} bytes", self.resource, self.limit)
     }
 }
 
@@ -1735,6 +1772,25 @@ mod tests {
     }
 
     #[test]
+    fn extract_downloaded_archive_rejects_oversized_compressed_stream() {
+        let temp = tempdir().expect("Failed to create temp dir");
+        let dest = temp.path().join("source");
+        let archive = gzip_with_empty_deflate_blocks(4);
+
+        let result = extract_downloaded_archive(&archive[..], "parser", "v1.0.0", &dest, 15);
+
+        match result {
+            Err(ParserInstallError::ArchiveSizeLimitExceeded(message)) => {
+                assert!(
+                    message.contains("compressed archive download exceeds 15 bytes"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected compressed archive size limit error, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn archive_io_error_maps_limited_reader_archive_failures() {
         let tar = tar_archive_with_payload("parser-1.0.0", 1);
         let mut archive = Archive::new(LimitedReader::new(&tar[..], 1));
@@ -1984,6 +2040,16 @@ mod tests {
         let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
         std::io::copy(&mut &archive[..], &mut encoder).expect("compress tar");
         encoder.finish().expect("finish gzip")
+    }
+
+    fn gzip_with_empty_deflate_blocks(block_count: usize) -> Vec<u8> {
+        let mut gzip = vec![0x1f, 0x8b, 0x08, 0, 0, 0, 0, 0, 0, 0xff];
+        for _ in 0..block_count {
+            gzip.extend_from_slice(&[0, 0, 0, 0xff, 0xff]);
+        }
+        gzip.extend_from_slice(&[1, 0, 0, 0xff, 0xff]);
+        gzip.extend_from_slice(&[0; 8]);
+        gzip
     }
 
     fn compressed_tar_archive_with_payload(root: &str, payload_size: u64) -> Vec<u8> {

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -1847,6 +1847,40 @@ mod tests {
     }
 
     #[test]
+    fn extract_archive_rejects_oversized_decompressed_stream() {
+        const STREAM_LIMIT_BYTES: u64 = 520;
+
+        let temp = tempdir().expect("Failed to create temp dir");
+        let dest = temp.path().join("source");
+        let archive = tar_archive_with_payload("parser-1.0.0", 16);
+
+        let result = extract_archive_with_limits(
+            &archive[..],
+            "parser",
+            "v1.0.0",
+            &dest,
+            STREAM_LIMIT_BYTES,
+            MAX_ARCHIVE_ENTRIES,
+        );
+
+        match result {
+            Err(ParserInstallError::ArchiveSizeLimitExceeded(message)) => {
+                assert!(
+                    message.contains(&format!(
+                        "decompressed tar stream exceeds {STREAM_LIMIT_BYTES} bytes"
+                    )),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected decompressed archive size limit error, got {other:?}"),
+        }
+        assert!(
+            !dest.join("payload.bin").exists(),
+            "stream-limit failure must not leave a completed target"
+        );
+    }
+
+    #[test]
     fn archive_io_error_maps_limited_reader_archive_failures() {
         let tar = tar_archive_with_payload("parser-1.0.0", 1);
         let mut archive = Archive::new(LimitedReader::new(&tar[..], 1));

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -636,6 +636,7 @@ struct LimitedReader<R> {
     inner: R,
     remaining: u64,
     limit: u64,
+    limit_exceeded: bool,
 }
 
 impl<R> LimitedReader<R> {
@@ -644,6 +645,7 @@ impl<R> LimitedReader<R> {
             inner,
             remaining: limit,
             limit,
+            limit_exceeded: false,
         }
     }
 }
@@ -654,13 +656,22 @@ impl<R: Read> Read for LimitedReader<R> {
             return Ok(0);
         }
         if self.remaining == 0 {
+            if self.limit_exceeded {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    ArchiveLimitError { limit: self.limit },
+                ));
+            }
             let mut probe = [0];
             return match self.inner.read(&mut probe) {
                 Ok(0) => Ok(0),
-                Ok(_) => Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    ArchiveLimitError { limit: self.limit },
-                )),
+                Ok(_) => {
+                    self.limit_exceeded = true;
+                    Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        ArchiveLimitError { limit: self.limit },
+                    ))
+                }
                 Err(e) => Err(e),
             };
         }
@@ -1745,11 +1756,13 @@ mod tests {
 
     #[test]
     fn unpack_entry_atomically_removes_partial_file_on_stream_limit() {
+        const STREAM_LIMIT_BYTES: u64 = 520;
+
         let temp = tempdir().expect("Failed to create temp dir");
         let relative = Path::new("payload.bin");
         let target = temp.path().join(relative);
         let tar = tar_archive_with_payload("parser-1.0.0", 16);
-        let mut archive = Archive::new(LimitedReader::new(&tar[..], 520));
+        let mut archive = Archive::new(LimitedReader::new(&tar[..], STREAM_LIMIT_BYTES));
         let mut entry = archive
             .entries()
             .expect("entry iterator should be created")
@@ -1762,7 +1775,9 @@ mod tests {
         match result {
             Err(ParserInstallError::ArchiveSizeLimitExceeded(message)) => {
                 assert!(
-                    message.contains("decompressed tar stream exceeds 520 bytes"),
+                    message.contains(&format!(
+                        "decompressed tar stream exceeds {STREAM_LIMIT_BYTES} bytes"
+                    )),
                     "unexpected message: {message}"
                 );
             }
@@ -1838,6 +1853,33 @@ mod tests {
         );
     }
 
+    #[test]
+    fn limited_reader_does_not_consume_more_after_limit_error() {
+        use std::io::Read;
+
+        let inner = std::io::Cursor::new(b"abcdef".to_vec());
+        let mut reader = LimitedReader::new(inner, 3);
+        let mut buffer = [0; 3];
+
+        assert_eq!(reader.read(&mut buffer).unwrap(), 3);
+        assert_eq!(buffer, *b"abc");
+        assert_eq!(
+            reader.read(&mut [0]).unwrap_err().kind(),
+            std::io::ErrorKind::InvalidData
+        );
+        let position_after_first_error = reader.inner.position();
+
+        assert_eq!(
+            reader.read(&mut [0]).unwrap_err().kind(),
+            std::io::ErrorKind::InvalidData
+        );
+        assert_eq!(
+            reader.inner.position(),
+            position_after_first_error,
+            "retries after the first limit error must not advance the inner reader"
+        );
+    }
+
     fn tar_archive_with_payload(root: &str, payload_size: u64) -> Vec<u8> {
         use std::io::Read;
         use tar::{Builder, Header};
@@ -1908,18 +1950,20 @@ mod tests {
         path: &str,
         entry_type: tar::EntryType,
         data: &[u8],
-        header_size: u64,
+        declared_size: u64,
     ) {
         use tar::Header;
 
         let mut header = Header::new_ustar();
         header.set_path(path).expect("set tar path");
         header.set_entry_type(entry_type);
-        header.set_size(header_size);
+        header.set_size(declared_size);
         header.set_mode(0o644);
         header.set_cksum();
         archive.extend_from_slice(header.as_bytes());
         archive.extend_from_slice(data);
+        // Fixtures may declare more bytes than they write so size-limit tests
+        // stay small. Padding follows the bytes actually written.
         pad_tar_entry(archive, data.len() as u64);
     }
 

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -479,7 +479,14 @@ fn fail_terminal_archive_error(
     error: ParserInstallError,
     dest: &Path,
 ) -> Result<(), ParserInstallError> {
-    let _ = fs::remove_dir_all(dest);
+    if let Err(cleanup_error) = fs::remove_dir_all(dest) {
+        return Err(ParserInstallError::ArchiveError(format!(
+            "{}; failed to remove partial destination {}: {}",
+            error,
+            dest.display(),
+            cleanup_error
+        )));
+    }
     Err(error)
 }
 
@@ -1970,6 +1977,27 @@ mod tests {
             Err(ParserInstallError::ArchiveSizeLimitExceeded(_))
         ));
         assert!(!dest.exists(), "terminal archive errors should clean dest");
+    }
+
+    #[test]
+    fn terminal_archive_errors_report_cleanup_failure() {
+        let temp = tempdir().expect("Failed to create temp dir");
+        let dest = temp.path().join("source");
+        fs::write(&dest, "not a directory").expect("create non-directory destination");
+
+        let result = fail_terminal_archive_error(
+            ParserInstallError::ArchiveSizeLimitExceeded("too large".to_string()),
+            &dest,
+        );
+
+        match result {
+            Err(ParserInstallError::ArchiveError(message)) => {
+                assert!(message.contains("Archive size limit exceeded: too large"));
+                assert!(message.contains("failed to remove partial destination"));
+                assert!(message.contains(&dest.display().to_string()));
+            }
+            other => panic!("expected combined archive cleanup error, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -19,8 +19,16 @@ use super::metadata::{FetchOptions, MetadataError, fetch_parser_metadata};
 
 /// HTTP timeout for archive downloads.
 const ARCHIVE_HTTP_TIMEOUT: Duration = Duration::from_secs(120);
-/// Maximum decompressed tar stream or extracted file bytes for parser archives.
-const MAX_ARCHIVE_DECOMPRESSED_BYTES: u64 = 100 * 1024 * 1024;
+/// Maximum total file bytes extracted from parser archives.
+///
+/// Parser grammars are source archives, not vendored corpora; 100 MiB keeps
+/// normal tree-sitter parsers below the budget while bounding gzip bombs.
+const MAX_ARCHIVE_EXTRACTED_BYTES: u64 = 100 * 1024 * 1024;
+/// Extra tar header/padding budget above extracted payload bytes.
+const ARCHIVE_TAR_METADATA_MARGIN_BYTES: u64 = 10 * 1024 * 1024;
+/// Maximum decompressed tar stream bytes for parser archives.
+const MAX_ARCHIVE_TAR_STREAM_BYTES: u64 =
+    MAX_ARCHIVE_EXTRACTED_BYTES + ARCHIVE_TAR_METADATA_MARGIN_BYTES;
 
 /// Error types for parser installation.
 #[derive(Debug)]
@@ -31,6 +39,8 @@ pub enum ParserInstallError {
     GitError(String),
     /// Archive download or extraction failed.
     ArchiveError(String),
+    /// Archive exceeded the configured extraction size budget.
+    ArchiveSizeLimitExceeded(String),
     /// Compilation failed.
     CompileError(String),
     /// File system operation failed.
@@ -45,6 +55,9 @@ impl std::fmt::Display for ParserInstallError {
             Self::MetadataError(e) => write!(f, "{}", e),
             Self::GitError(msg) => write!(f, "Git error: {}", msg),
             Self::ArchiveError(msg) => write!(f, "Archive error: {}", msg),
+            Self::ArchiveSizeLimitExceeded(msg) => {
+                write!(f, "Archive size limit exceeded: {}", msg)
+            }
             Self::CompileError(msg) => write!(f, "Compilation error: {}", msg),
             Self::IoError(e) => write!(f, "IO error: {}", e),
             Self::AlreadyExists(path) => {
@@ -427,6 +440,7 @@ fn fetch_source(url: &str, revision: &str, dest: &Path) -> Result<(), ParserInst
         );
         match download_and_extract_archive(&archive_url, &repo_name, revision, dest) {
             Ok(()) => return Ok(()),
+            Err(e) if !archive_error_allows_git_fallback(&e) => return Err(e),
             Err(e) => {
                 log::warn!(
                     target: "kakehashi::install",
@@ -447,6 +461,10 @@ fn fetch_source(url: &str, revision: &str, dest: &Path) -> Result<(), ParserInst
         revision
     );
     clone_repo(url, revision, dest)
+}
+
+fn archive_error_allows_git_fallback(error: &ParserInstallError) -> bool {
+    !matches!(error, ParserInstallError::ArchiveSizeLimitExceeded(_))
 }
 
 /// Download a GitHub archive tarball and extract it to the destination directory.
@@ -471,8 +489,7 @@ fn download_and_extract_archive(
     // into_reader() streams without ureq's 10MB read_to_* cap, so enforce our
     // own limit on the decompressed tar stream.
     let decoder = GzDecoder::new(response.into_body().into_reader());
-    let bounded_decoder =
-        LimitedReader::new(decoder, MAX_ARCHIVE_DECOMPRESSED_BYTES, "decompressed size");
+    let bounded_decoder = LimitedReader::new(decoder, MAX_ARCHIVE_TAR_STREAM_BYTES);
     let mut archive = Archive::new(bounded_decoder);
 
     // GitHub names the root directory `{repo}-{revision_without_v_prefix}`
@@ -481,12 +498,11 @@ fn download_and_extract_archive(
     fs::create_dir_all(dest)?;
     let mut extracted_bytes = 0u64;
 
-    for entry_result in archive.entries().map_err(|e| {
-        ParserInstallError::ArchiveError(format!("Failed to read archive entries: {}", e))
-    })? {
-        let mut entry = entry_result.map_err(|e| {
-            ParserInstallError::ArchiveError(format!("Failed to read entry: {}", e))
-        })?;
+    for entry_result in archive
+        .entries()
+        .map_err(|e| archive_io_error("Failed to read archive entries", e))?
+    {
+        let mut entry = entry_result.map_err(|e| archive_io_error("Failed to read entry", e))?;
 
         let path = entry.path().map_err(|e| {
             ParserInstallError::ArchiveError(format!("Invalid path in archive: {}", e))
@@ -527,48 +543,103 @@ fn download_and_extract_archive(
                 ))
             })?;
             extracted_bytes = extracted_bytes.checked_add(entry_size).ok_or_else(|| {
-                ParserInstallError::ArchiveError(format!(
-                    "Archive decompressed size exceeds {} bytes",
-                    MAX_ARCHIVE_DECOMPRESSED_BYTES
+                ParserInstallError::ArchiveSizeLimitExceeded(format!(
+                    "extracted file bytes exceed {} bytes",
+                    MAX_ARCHIVE_EXTRACTED_BYTES
                 ))
             })?;
-            if extracted_bytes > MAX_ARCHIVE_DECOMPRESSED_BYTES {
-                return Err(ParserInstallError::ArchiveError(format!(
-                    "Archive decompressed size exceeds {} bytes while extracting {}",
-                    MAX_ARCHIVE_DECOMPRESSED_BYTES,
+            if extracted_bytes > MAX_ARCHIVE_EXTRACTED_BYTES {
+                return Err(ParserInstallError::ArchiveSizeLimitExceeded(format!(
+                    "extracted file bytes exceed {} bytes while extracting {}",
+                    MAX_ARCHIVE_EXTRACTED_BYTES,
                     relative.display()
                 )));
             }
             if let Some(parent) = target.parent() {
                 fs::create_dir_all(parent)?;
             }
-            entry.unpack(&target).map_err(|e| {
-                ParserInstallError::ArchiveError(format!(
-                    "Failed to extract {}: {}",
-                    relative.display(),
-                    e
-                ))
-            })?;
+            unpack_entry_atomically(&mut entry, &target, &relative)?;
         }
     }
 
     Ok(())
 }
 
+fn unpack_entry_atomically<R: Read>(
+    entry: &mut tar::Entry<'_, R>,
+    target: &Path,
+    relative: &Path,
+) -> Result<(), ParserInstallError> {
+    let parent = target.parent().ok_or_else(|| {
+        ParserInstallError::ArchiveError(format!(
+            "Invalid extraction target for {}",
+            relative.display()
+        ))
+    })?;
+    let temp_file = tempfile::Builder::new()
+        .prefix(".kakehashi-extract-")
+        .tempfile_in(parent)?;
+    let temp_path = temp_file.path().to_path_buf();
+
+    if let Err(error) = entry.unpack(&temp_path) {
+        let _ = fs::remove_file(&temp_path);
+        return Err(archive_io_error(
+            &format!("Failed to extract {}", relative.display()),
+            error,
+        ));
+    }
+
+    temp_file.persist(target).map_err(|error| {
+        ParserInstallError::ArchiveError(format!(
+            "Failed to move extracted {} into place: {}",
+            relative.display(),
+            error.error
+        ))
+    })?;
+
+    Ok(())
+}
+
+fn archive_io_error(context: &str, error: io::Error) -> ParserInstallError {
+    if let Some(limit_error) = archive_limit_error_source(&error) {
+        return ParserInstallError::ArchiveSizeLimitExceeded(limit_error.to_string());
+    }
+
+    ParserInstallError::ArchiveError(format!("{}: {}", context, error))
+}
+
+fn archive_limit_error_source<'a>(
+    error: &'a (dyn std::error::Error + 'static),
+) -> Option<&'a ArchiveLimitError> {
+    let mut source = Some(error);
+    while let Some(error) = source {
+        if let Some(limit_error) = error.downcast_ref::<ArchiveLimitError>() {
+            return Some(limit_error);
+        }
+        if let Some(io_error) = error.downcast_ref::<io::Error>()
+            && let Some(inner) = io_error.get_ref()
+            && let Some(limit_error) = archive_limit_error_source(inner)
+        {
+            return Some(limit_error);
+        }
+        source = error.source();
+    }
+
+    None
+}
+
 struct LimitedReader<R> {
     inner: R,
     remaining: u64,
     limit: u64,
-    label: &'static str,
 }
 
 impl<R> LimitedReader<R> {
-    fn new(inner: R, limit: u64, label: &'static str) -> Self {
+    fn new(inner: R, limit: u64) -> Self {
         Self {
             inner,
             remaining: limit,
             limit,
-            label,
         }
     }
 }
@@ -584,7 +655,7 @@ impl<R: Read> Read for LimitedReader<R> {
                 Ok(0) => Ok(0),
                 Ok(_) => Err(io::Error::new(
                     io::ErrorKind::InvalidData,
-                    format!("Archive {} exceeds {} bytes", self.label, self.limit),
+                    ArchiveLimitError { limit: self.limit },
                 )),
                 Err(e) => Err(e),
             };
@@ -598,6 +669,19 @@ impl<R: Read> Read for LimitedReader<R> {
         Ok(read)
     }
 }
+
+#[derive(Debug)]
+struct ArchiveLimitError {
+    limit: u64,
+}
+
+impl std::fmt::Display for ArchiveLimitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "decompressed tar stream exceeds {} bytes", self.limit)
+    }
+}
+
+impl std::error::Error for ArchiveLimitError {}
 
 /// Derive the expected root directory name inside a GitHub archive tarball.
 ///
@@ -1577,18 +1661,19 @@ mod tests {
     }
 
     #[test]
-    fn download_and_extract_archive_rejects_oversized_decompressed_archive() {
+    fn download_and_extract_archive_rejects_oversized_extracted_payload() {
         let temp = tempdir().expect("Failed to create temp dir");
         let dest = temp.path().join("source");
-        let archive = oversized_archive("parser-1.0.0", 101 * 1024 * 1024);
+        let archive =
+            compressed_tar_archive_with_payload("parser-1.0.0", MAX_ARCHIVE_EXTRACTED_BYTES + 1);
         let archive_url = serve_once(archive);
 
         let result = download_and_extract_archive(&archive_url, "parser", "v1.0.0", &dest);
 
         match result {
-            Err(ParserInstallError::ArchiveError(message)) => {
+            Err(ParserInstallError::ArchiveSizeLimitExceeded(message)) => {
                 assert!(
-                    message.contains("Archive decompressed size exceeds"),
+                    message.contains("extracted file bytes exceed"),
                     "expected archive size limit error, got: {message}"
                 );
             }
@@ -1601,10 +1686,76 @@ mod tests {
     }
 
     #[test]
+    fn archive_io_error_maps_limited_reader_archive_failures() {
+        let tar = tar_archive_with_payload("parser-1.0.0", 1);
+        let mut archive = Archive::new(LimitedReader::new(&tar[..], 1));
+        let entry_result = archive
+            .entries()
+            .expect("entry iterator should be created")
+            .next()
+            .expect("archive should have one entry");
+        let error = match entry_result {
+            Ok(_) => panic!("tar stream should exceed the reader limit"),
+            Err(error) => error,
+        };
+
+        match archive_io_error("read entry", error) {
+            ParserInstallError::ArchiveSizeLimitExceeded(message) => {
+                assert!(
+                    message.contains("decompressed tar stream exceeds 1 bytes"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected archive size limit error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unpack_entry_atomically_removes_partial_file_on_stream_limit() {
+        let temp = tempdir().expect("Failed to create temp dir");
+        let relative = Path::new("payload.bin");
+        let target = temp.path().join(relative);
+        let tar = tar_archive_with_payload("parser-1.0.0", 16);
+        let mut archive = Archive::new(LimitedReader::new(&tar[..], 520));
+        let mut entry = archive
+            .entries()
+            .expect("entry iterator should be created")
+            .next()
+            .expect("archive should have one entry")
+            .expect("entry header should fit within the reader limit");
+
+        let result = unpack_entry_atomically(&mut entry, &target, relative);
+
+        match result {
+            Err(ParserInstallError::ArchiveSizeLimitExceeded(message)) => {
+                assert!(
+                    message.contains("decompressed tar stream exceeds 520 bytes"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected archive size limit error, got {other:?}"),
+        }
+        assert!(
+            !target.exists(),
+            "partial extraction target should be removed"
+        );
+    }
+
+    #[test]
+    fn archive_size_limit_errors_do_not_allow_git_fallback() {
+        assert!(!archive_error_allows_git_fallback(
+            &ParserInstallError::ArchiveSizeLimitExceeded("too large".to_string())
+        ));
+        assert!(archive_error_allows_git_fallback(
+            &ParserInstallError::ArchiveError("network failed".to_string())
+        ));
+    }
+
+    #[test]
     fn limited_reader_rejects_reads_past_limit() {
         use std::io::Read;
 
-        let mut reader = LimitedReader::new(&b"abcdef"[..], 3, "test size");
+        let mut reader = LimitedReader::new(&b"abcdef"[..], 3);
         let mut buffer = Vec::new();
         let error = reader
             .read_to_end(&mut buffer)
@@ -1615,18 +1766,42 @@ mod tests {
         assert!(
             error
                 .to_string()
-                .contains("Archive test size exceeds 3 bytes"),
+                .contains("decompressed tar stream exceeds 3 bytes"),
             "unexpected error: {error}"
         );
     }
 
-    fn oversized_archive(root: &str, payload_size: u64) -> Vec<u8> {
+    fn tar_archive_with_payload(root: &str, payload_size: u64) -> Vec<u8> {
+        use std::io::Read;
+        use tar::{Builder, Header};
+
+        let mut archive = Vec::new();
+        {
+            let mut builder = Builder::new(&mut archive);
+            let mut header = Header::new_gnu();
+            header.set_size(payload_size);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder
+                .append_data(
+                    &mut header,
+                    format!("{root}/payload.bin"),
+                    std::io::repeat(0).take(payload_size),
+                )
+                .expect("append payload");
+            builder.finish().expect("finish tar");
+        }
+
+        archive
+    }
+
+    fn compressed_tar_archive_with_payload(root: &str, payload_size: u64) -> Vec<u8> {
         use flate2::Compression;
         use flate2::write::GzEncoder;
         use std::io::Read;
         use tar::{Builder, Header};
 
-        let mut encoder = GzEncoder::new(Vec::new(), Compression::best());
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
         {
             let mut builder = Builder::new(&mut encoder);
             let mut header = Header::new_gnu();
@@ -1639,7 +1814,7 @@ mod tests {
                     format!("{root}/payload.bin"),
                     std::io::repeat(0).take(payload_size),
                 )
-                .expect("append oversized payload");
+                .expect("append payload");
             builder.finish().expect("finish tar");
         }
 

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -492,13 +492,17 @@ fn fail_terminal_archive_error(
     error: ParserInstallError,
     dest: &Path,
 ) -> Result<(), ParserInstallError> {
-    if let Err(cleanup_error) = fs::remove_dir_all(dest) {
-        return Err(ParserInstallError::ArchiveError(format!(
-            "{}; failed to remove partial destination {}: {}",
-            error,
-            dest.display(),
-            cleanup_error
-        )));
+    match fs::remove_dir_all(dest) {
+        Ok(()) => {}
+        Err(cleanup_error) if cleanup_error.kind() == io::ErrorKind::NotFound => {}
+        Err(cleanup_error) => {
+            return Err(ParserInstallError::ArchiveError(format!(
+                "{}; failed to remove partial destination {}: {}",
+                error,
+                dest.display(),
+                cleanup_error
+            )));
+        }
     }
     Err(error)
 }

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -458,8 +458,10 @@ fn fetch_source(url: &str, revision: &str, dest: &Path) -> Result<(), ParserInst
                     "Archive download failed, falling back to git clone: {}",
                     e
                 );
-                // Clean up partial extraction before fallback
-                let _ = fs::remove_dir_all(dest);
+                // Never let git consume a partially extracted archive tree.
+                // Cleanup failure is a local I/O error, not a recoverable
+                // archive-content failure.
+                remove_partial_archive_destination(dest)?;
             }
         }
     }
@@ -472,6 +474,14 @@ fn fetch_source(url: &str, revision: &str, dest: &Path) -> Result<(), ParserInst
         revision
     );
     clone_repo(url, revision, dest)
+}
+
+fn remove_partial_archive_destination(dest: &Path) -> Result<(), ParserInstallError> {
+    match fs::remove_dir_all(dest) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(ParserInstallError::IoError(error)),
+    }
 }
 
 fn archive_error_allows_git_fallback(error: &ParserInstallError) -> bool {

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -1968,6 +1968,17 @@ mod tests {
             !target.exists(),
             "partial extraction target should be removed"
         );
+        let leaked_temps = fs::read_dir(temp.path())
+            .expect("read extraction directory")
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with(".kakehashi-extract-")
+            })
+            .count();
+        assert_eq!(leaked_temps, 0, "partial extraction temp should be removed");
     }
 
     #[test]

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -29,7 +29,10 @@ const ARCHIVE_TAR_METADATA_MARGIN_BYTES: u64 = 10 * 1024 * 1024;
 /// Maximum decompressed tar stream bytes for parser archives.
 const MAX_ARCHIVE_TAR_STREAM_BYTES: u64 =
     MAX_ARCHIVE_EXTRACTED_BYTES + ARCHIVE_TAR_METADATA_MARGIN_BYTES;
-/// Maximum compressed bytes downloaded for a parser archive.
+/// Maximum accepted compressed payload bytes for a parser archive.
+///
+/// Oversize detection may consume one additional probe byte to distinguish a
+/// payload at the exact limit from one with more data.
 const MAX_ARCHIVE_DOWNLOAD_BYTES: u64 =
     MAX_ARCHIVE_TAR_STREAM_BYTES + ARCHIVE_TAR_METADATA_MARGIN_BYTES;
 /// Maximum number of filesystem entries accepted from a parser archive.
@@ -739,6 +742,9 @@ impl<R: Read> Read for LimitedReader<R> {
                     },
                 ));
             }
+            // A reader cannot distinguish exact-limit EOF without probing.
+            // Consume at most one detection byte, then make every retry fail
+            // without advancing the inner reader.
             let mut probe = [0];
             return match self.inner.read(&mut probe) {
                 Ok(0) => Ok(0),

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -426,6 +426,7 @@ fn clean_url(url: &str) -> &str {
 /// Strategy:
 /// 1. If the URL is a GitHub HTTPS URL, try downloading the archive tarball.
 /// 2. If archive download fails (or URL is not GitHub), fall back to git clone.
+/// 3. If archive extraction exceeds size limits, clean up and fail without fallback.
 fn fetch_source(url: &str, revision: &str, dest: &Path) -> Result<(), ParserInstallError> {
     validate_parser_source_metadata(url, revision)?;
 
@@ -440,7 +441,9 @@ fn fetch_source(url: &str, revision: &str, dest: &Path) -> Result<(), ParserInst
         );
         match download_and_extract_archive(&archive_url, &repo_name, revision, dest) {
             Ok(()) => return Ok(()),
-            Err(e) if !archive_error_allows_git_fallback(&e) => return Err(e),
+            Err(e) if !archive_error_allows_git_fallback(&e) => {
+                return fail_terminal_archive_error(e, dest);
+            }
             Err(e) => {
                 log::warn!(
                     target: "kakehashi::install",
@@ -465,6 +468,14 @@ fn fetch_source(url: &str, revision: &str, dest: &Path) -> Result<(), ParserInst
 
 fn archive_error_allows_git_fallback(error: &ParserInstallError) -> bool {
     !matches!(error, ParserInstallError::ArchiveSizeLimitExceeded(_))
+}
+
+fn fail_terminal_archive_error(
+    error: ParserInstallError,
+    dest: &Path,
+) -> Result<(), ParserInstallError> {
+    let _ = fs::remove_dir_all(dest);
+    Err(error)
 }
 
 /// Download a GitHub archive tarball and extract it to the destination directory.
@@ -535,13 +546,7 @@ fn download_and_extract_archive(
         if entry.header().entry_type().is_dir() {
             fs::create_dir_all(&target)?;
         } else {
-            let entry_size = entry.header().size().map_err(|e| {
-                ParserInstallError::ArchiveError(format!(
-                    "Invalid size for {}: {}",
-                    relative.display(),
-                    e
-                ))
-            })?;
+            let entry_size = entry.size();
             extracted_bytes = extracted_bytes.checked_add(entry_size).ok_or_else(|| {
                 ParserInstallError::ArchiveSizeLimitExceeded(format!(
                     "extracted file bytes exceed {} bytes",
@@ -1686,6 +1691,35 @@ mod tests {
     }
 
     #[test]
+    fn download_and_extract_archive_rejects_oversized_pax_effective_size() {
+        let temp = tempdir().expect("Failed to create temp dir");
+        let dest = temp.path().join("source");
+        let archive = gzip_archive(pax_size_override_archive_with_data_len(
+            "parser-1.0.0/payload.bin",
+            1,
+            MAX_ARCHIVE_EXTRACTED_BYTES + 1,
+            0,
+        ));
+        let archive_url = serve_once(archive);
+
+        let result = download_and_extract_archive(&archive_url, "parser", "v1.0.0", &dest);
+
+        match result {
+            Err(ParserInstallError::ArchiveSizeLimitExceeded(message)) => {
+                assert!(
+                    message.contains("extracted file bytes exceed"),
+                    "expected archive size limit error, got: {message}"
+                );
+            }
+            other => panic!("expected archive size limit error, got {other:?}"),
+        }
+        assert!(
+            !dest.join("payload.bin").exists(),
+            "oversized PAX effective payload must not be extracted"
+        );
+    }
+
+    #[test]
     fn archive_io_error_maps_limited_reader_archive_failures() {
         let tar = tar_archive_with_payload("parser-1.0.0", 1);
         let mut archive = Archive::new(LimitedReader::new(&tar[..], 1));
@@ -1752,6 +1786,40 @@ mod tests {
     }
 
     #[test]
+    fn terminal_archive_errors_remove_partial_destination() {
+        let temp = tempdir().expect("Failed to create temp dir");
+        let dest = temp.path().join("source");
+        fs::create_dir_all(&dest).expect("create dest");
+        fs::write(dest.join("already-extracted.c"), "partial").expect("write partial file");
+
+        let result = fail_terminal_archive_error(
+            ParserInstallError::ArchiveSizeLimitExceeded("too large".to_string()),
+            &dest,
+        );
+
+        assert!(matches!(
+            result,
+            Err(ParserInstallError::ArchiveSizeLimitExceeded(_))
+        ));
+        assert!(!dest.exists(), "terminal archive errors should clean dest");
+    }
+
+    #[test]
+    fn extracted_quota_uses_effective_entry_size() {
+        let tar = pax_size_override_archive_with_data_len("parser-1.0.0/payload.bin", 1, 16, 16);
+        let mut archive = Archive::new(&tar[..]);
+        let entry = archive
+            .entries()
+            .expect("entry iterator should be created")
+            .next()
+            .expect("archive should have one entry")
+            .expect("entry should be readable");
+
+        assert_eq!(entry.header().size().expect("raw header size"), 1);
+        assert_eq!(entry.size(), 16);
+    }
+
+    #[test]
     fn limited_reader_rejects_reads_past_limit() {
         use std::io::Read;
 
@@ -1793,6 +1861,81 @@ mod tests {
         }
 
         archive
+    }
+
+    fn pax_size_override_archive_with_data_len(
+        path: &str,
+        raw_size: u64,
+        effective_size: u64,
+        data_len: usize,
+    ) -> Vec<u8> {
+        use tar::EntryType;
+
+        let pax_record = pax_record("size", &effective_size.to_string());
+        let mut archive = Vec::new();
+        append_tar_entry(
+            &mut archive,
+            "pax-size",
+            EntryType::XHeader,
+            pax_record.as_bytes(),
+            pax_record.len() as u64,
+        );
+        append_tar_entry(
+            &mut archive,
+            path,
+            EntryType::file(),
+            &vec![0; data_len],
+            raw_size,
+        );
+        archive.extend_from_slice(&[0; 1024]);
+        archive
+    }
+
+    fn pax_record(key: &str, value: &str) -> String {
+        let body = format!("{key}={value}\n");
+        let mut length = body.len() + 2;
+        loop {
+            let record = format!("{length} {body}");
+            let actual = record.len();
+            if actual == length {
+                return record;
+            }
+            length = actual;
+        }
+    }
+
+    fn append_tar_entry(
+        archive: &mut Vec<u8>,
+        path: &str,
+        entry_type: tar::EntryType,
+        data: &[u8],
+        header_size: u64,
+    ) {
+        use tar::Header;
+
+        let mut header = Header::new_ustar();
+        header.set_path(path).expect("set tar path");
+        header.set_entry_type(entry_type);
+        header.set_size(header_size);
+        header.set_mode(0o644);
+        header.set_cksum();
+        archive.extend_from_slice(header.as_bytes());
+        archive.extend_from_slice(data);
+        pad_tar_entry(archive, data.len() as u64);
+    }
+
+    fn pad_tar_entry(archive: &mut Vec<u8>, size: u64) {
+        let padding = (512 - (size as usize % 512)) % 512;
+        archive.extend(std::iter::repeat_n(0, padding));
+    }
+
+    fn gzip_archive(archive: Vec<u8>) -> Vec<u8> {
+        use flate2::Compression;
+        use flate2::write::GzEncoder;
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
+        std::io::copy(&mut &archive[..], &mut encoder).expect("compress tar");
+        encoder.finish().expect("finish gzip")
     }
 
     fn compressed_tar_archive_with_payload(root: &str, payload_size: u64) -> Vec<u8> {

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -32,6 +32,8 @@ const MAX_ARCHIVE_TAR_STREAM_BYTES: u64 =
 /// Maximum compressed bytes downloaded for a parser archive.
 const MAX_ARCHIVE_DOWNLOAD_BYTES: u64 =
     MAX_ARCHIVE_TAR_STREAM_BYTES + ARCHIVE_TAR_METADATA_MARGIN_BYTES;
+/// Maximum number of filesystem entries accepted from a parser archive.
+const MAX_ARCHIVE_ENTRIES: u64 = 10_000;
 
 /// Error types for parser installation.
 #[derive(Debug)]
@@ -533,7 +535,25 @@ fn extract_archive<R: Read>(
     revision: &str,
     dest: &Path,
 ) -> Result<(), ParserInstallError> {
-    let bounded_decoder = LimitedReader::new(decoder, MAX_ARCHIVE_TAR_STREAM_BYTES);
+    extract_archive_with_limits(
+        decoder,
+        repo_name,
+        revision,
+        dest,
+        MAX_ARCHIVE_TAR_STREAM_BYTES,
+        MAX_ARCHIVE_ENTRIES,
+    )
+}
+
+fn extract_archive_with_limits<R: Read>(
+    decoder: R,
+    repo_name: &str,
+    revision: &str,
+    dest: &Path,
+    tar_stream_limit: u64,
+    entry_limit: u64,
+) -> Result<(), ParserInstallError> {
+    let bounded_decoder = LimitedReader::new(decoder, tar_stream_limit);
     let mut archive = Archive::new(bounded_decoder);
 
     // GitHub names the root directory `{repo}-{revision_without_v_prefix}`
@@ -541,12 +561,20 @@ fn extract_archive<R: Read>(
 
     fs::create_dir_all(dest)?;
     let mut extracted_bytes = 0u64;
+    let mut entry_count = 0u64;
 
     for entry_result in archive
         .entries()
         .map_err(|e| archive_io_error("Failed to read archive entries", e))?
     {
         let mut entry = entry_result.map_err(|e| archive_io_error("Failed to read entry", e))?;
+        entry_count += 1;
+        if entry_count > entry_limit {
+            return Err(ParserInstallError::ArchiveSizeLimitExceeded(format!(
+                "archive contains more than {} entries",
+                entry_limit
+            )));
+        }
 
         let path = entry.path().map_err(|e| {
             ParserInstallError::ArchiveError(format!("Invalid path in archive: {}", e))
@@ -1791,6 +1819,34 @@ mod tests {
     }
 
     #[test]
+    fn extract_archive_rejects_too_many_entries() {
+        let temp = tempdir().expect("Failed to create temp dir");
+        let dest = temp.path().join("source");
+        let archive = tar_archive_with_empty_files("parser-1.0.0", 2);
+
+        let result = extract_archive_with_limits(
+            &archive[..],
+            "parser",
+            "v1.0.0",
+            &dest,
+            archive.len() as u64,
+            1,
+        );
+
+        match result {
+            Err(ParserInstallError::ArchiveSizeLimitExceeded(message)) => {
+                assert!(
+                    message.contains("archive contains more than 1 entries"),
+                    "unexpected message: {message}"
+                );
+            }
+            other => panic!("expected archive entry count limit error, got {other:?}"),
+        }
+        assert!(dest.join("file-0").exists());
+        assert!(!dest.join("file-1").exists());
+    }
+
+    #[test]
     fn archive_io_error_maps_limited_reader_archive_failures() {
         let tar = tar_archive_with_payload("parser-1.0.0", 1);
         let mut archive = Archive::new(LimitedReader::new(&tar[..], 1));
@@ -1962,6 +2018,30 @@ mod tests {
             builder.finish().expect("finish tar");
         }
 
+        archive
+    }
+
+    fn tar_archive_with_empty_files(root: &str, count: usize) -> Vec<u8> {
+        use tar::{Builder, Header};
+
+        let mut archive = Vec::new();
+        {
+            let mut builder = Builder::new(&mut archive);
+            for index in 0..count {
+                let mut header = Header::new_gnu();
+                header.set_size(0);
+                header.set_mode(0o644);
+                header.set_cksum();
+                builder
+                    .append_data(
+                        &mut header,
+                        format!("{root}/file-{index}"),
+                        std::io::empty(),
+                    )
+                    .expect("append empty file");
+            }
+            builder.finish().expect("finish tar");
+        }
         archive
     }
 

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -581,20 +581,19 @@ fn unpack_entry_atomically<R: Read>(
             relative.display()
         ))
     })?;
-    let temp_file = tempfile::Builder::new()
+    let temp_path = tempfile::Builder::new()
         .prefix(".kakehashi-extract-")
-        .tempfile_in(parent)?;
-    let temp_path = temp_file.path().to_path_buf();
+        .tempfile_in(parent)?
+        .into_temp_path();
 
     if let Err(error) = entry.unpack(&temp_path) {
-        let _ = fs::remove_file(&temp_path);
         return Err(archive_io_error(
             &format!("Failed to extract {}", relative.display()),
             error,
         ));
     }
 
-    temp_file.persist(target).map_err(|error| {
+    temp_path.persist(target).map_err(|error| {
         ParserInstallError::ArchiveError(format!(
             "Failed to move extracted {} into place: {}",
             relative.display(),

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -500,6 +500,15 @@ fn download_and_extract_archive(
     // into_reader() streams without ureq's 10MB read_to_* cap, so enforce our
     // own limit on the decompressed tar stream.
     let decoder = GzDecoder::new(response.into_body().into_reader());
+    extract_archive(decoder, repo_name, revision, dest)
+}
+
+fn extract_archive<R: Read>(
+    decoder: R,
+    repo_name: &str,
+    revision: &str,
+    dest: &Path,
+) -> Result<(), ParserInstallError> {
     let bounded_decoder = LimitedReader::new(decoder, MAX_ARCHIVE_TAR_STREAM_BYTES);
     let mut archive = Archive::new(bounded_decoder);
 
@@ -1681,9 +1690,7 @@ mod tests {
         let dest = temp.path().join("source");
         let archive =
             compressed_tar_archive_with_payload("parser-1.0.0", MAX_ARCHIVE_EXTRACTED_BYTES + 1);
-        let archive_url = serve_once(archive);
-
-        let result = download_and_extract_archive(&archive_url, "parser", "v1.0.0", &dest);
+        let result = extract_archive(GzDecoder::new(&archive[..]), "parser", "v1.0.0", &dest);
 
         match result {
             Err(ParserInstallError::ArchiveSizeLimitExceeded(message)) => {
@@ -1710,9 +1717,7 @@ mod tests {
             MAX_ARCHIVE_EXTRACTED_BYTES + 1,
             0,
         ));
-        let archive_url = serve_once(archive);
-
-        let result = download_and_extract_archive(&archive_url, "parser", "v1.0.0", &dest);
+        let result = extract_archive(GzDecoder::new(&archive[..]), "parser", "v1.0.0", &dest);
 
         match result {
             Err(ParserInstallError::ArchiveSizeLimitExceeded(message)) => {
@@ -2005,26 +2010,6 @@ mod tests {
         }
 
         encoder.finish().expect("finish gzip")
-    }
-
-    fn serve_once(body: Vec<u8>) -> String {
-        use std::io::{Read, Write};
-
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local server");
-        let addr = listener.local_addr().expect("local addr");
-        std::thread::spawn(move || {
-            let (mut stream, _) = listener.accept().expect("accept request");
-            let mut request = [0; 1024];
-            let _ = stream.read(&mut request);
-            write!(
-                stream,
-                "HTTP/1.1 200 OK\r\nContent-Type: application/gzip\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-                body.len()
-            )
-            .expect("write response headers");
-            stream.write_all(&body).expect("write response body");
-        });
-        format!("http://{addr}/archive.tar.gz")
     }
 
     /// Test that fetch_source succeeds for a GitHub URL (uses archive download).

--- a/src/install/parser.rs
+++ b/src/install/parser.rs
@@ -24,6 +24,8 @@ const ARCHIVE_HTTP_TIMEOUT: Duration = Duration::from_secs(120);
 /// Parser grammars are source archives, not vendored corpora; 100 MiB keeps
 /// normal tree-sitter parsers below the budget while bounding gzip bombs.
 const MAX_ARCHIVE_EXTRACTED_BYTES: u64 = 100 * 1024 * 1024;
+/// Maximum bytes accepted for one regular archive entry.
+const MAX_ARCHIVE_ENTRY_BYTES: u64 = MAX_ARCHIVE_EXTRACTED_BYTES;
 /// Extra tar header/padding budget above extracted payload bytes.
 const ARCHIVE_TAR_METADATA_MARGIN_BYTES: u64 = 10 * 1024 * 1024;
 /// Maximum decompressed tar stream bytes for parser archives.
@@ -632,23 +634,30 @@ fn extract_archive_with_limits<R: Read>(
             fs::create_dir_all(&target)?;
         } else {
             let entry_size = entry.size();
-            extracted_bytes = extracted_bytes.checked_add(entry_size).ok_or_else(|| {
-                ParserInstallError::ArchiveSizeLimitExceeded(format!(
-                    "extracted file bytes exceed {} bytes",
-                    MAX_ARCHIVE_EXTRACTED_BYTES
-                ))
-            })?;
-            if extracted_bytes > MAX_ARCHIVE_EXTRACTED_BYTES {
-                return Err(ParserInstallError::ArchiveSizeLimitExceeded(format!(
-                    "extracted file bytes exceed {} bytes while extracting {}",
-                    MAX_ARCHIVE_EXTRACTED_BYTES,
-                    relative.display()
-                )));
-            }
             if let Some(parent) = target.parent() {
                 fs::create_dir_all(parent)?;
             }
             if entry.header().entry_type().is_file() {
+                if entry_size > MAX_ARCHIVE_ENTRY_BYTES {
+                    return Err(ParserInstallError::ArchiveSizeLimitExceeded(format!(
+                        "archive entry exceeds {} bytes while extracting {}",
+                        MAX_ARCHIVE_ENTRY_BYTES,
+                        relative.display()
+                    )));
+                }
+                extracted_bytes = extracted_bytes.checked_add(entry_size).ok_or_else(|| {
+                    ParserInstallError::ArchiveSizeLimitExceeded(format!(
+                        "extracted file bytes exceed {} bytes",
+                        MAX_ARCHIVE_EXTRACTED_BYTES
+                    ))
+                })?;
+                if extracted_bytes > MAX_ARCHIVE_EXTRACTED_BYTES {
+                    return Err(ParserInstallError::ArchiveSizeLimitExceeded(format!(
+                        "extracted file bytes exceed {} bytes while extracting {}",
+                        MAX_ARCHIVE_EXTRACTED_BYTES,
+                        relative.display()
+                    )));
+                }
                 unpack_entry_atomically(&mut entry, &target, &relative)?;
             } else {
                 // Atomic publication pre-creates a regular tempfile, which is
@@ -686,6 +695,10 @@ fn unpack_entry_atomically<R: Read>(
             &format!("Failed to extract {}", relative.display()),
             error,
         ));
+    }
+
+    if target.is_file() || target.is_symlink() {
+        fs::remove_file(target)?;
     }
 
     temp_path.persist(target).map_err(|error| {
@@ -1800,7 +1813,7 @@ mod tests {
         match result {
             Err(ParserInstallError::ArchiveSizeLimitExceeded(message)) => {
                 assert!(
-                    message.contains("extracted file bytes exceed"),
+                    message.contains("archive entry exceeds"),
                     "expected archive size limit error, got: {message}"
                 );
             }
@@ -1827,7 +1840,7 @@ mod tests {
         match result {
             Err(ParserInstallError::ArchiveSizeLimitExceeded(message)) => {
                 assert!(
-                    message.contains("extracted file bytes exceed"),
+                    message.contains("archive entry exceeds"),
                     "expected archive size limit error, got: {message}"
                 );
             }
@@ -1992,6 +2005,18 @@ mod tests {
     }
 
     #[test]
+    fn archive_duplicate_regular_file_uses_last_entry() {
+        let temp = tempdir().expect("Failed to create temp dir");
+        let dest = temp.path().join("source");
+        let archive = gzip_archive(tar_archive_with_duplicate_payloads("parser-1.0.0"));
+
+        extract_archive(GzDecoder::new(&archive[..]), "parser", "v1.0.0", &dest)
+            .expect("duplicate regular paths retain tar overwrite semantics");
+
+        assert_eq!(fs::read(dest.join("payload.bin")).unwrap(), b"second");
+    }
+
+    #[test]
     fn archive_size_limit_errors_do_not_allow_git_fallback() {
         assert!(!archive_error_allows_git_fallback(
             &ParserInstallError::ArchiveSizeLimitExceeded("too large".to_string())
@@ -2124,6 +2149,26 @@ mod tests {
             builder.finish().expect("finish tar");
         }
 
+        archive
+    }
+
+    fn tar_archive_with_duplicate_payloads(root: &str) -> Vec<u8> {
+        use tar::{Builder, Header};
+
+        let mut archive = Vec::new();
+        {
+            let mut builder = Builder::new(&mut archive);
+            for payload in [b"first".as_slice(), b"second".as_slice()] {
+                let mut header = Header::new_gnu();
+                header.set_size(payload.len() as u64);
+                header.set_mode(0o644);
+                header.set_cksum();
+                builder
+                    .append_data(&mut header, format!("{root}/payload.bin"), payload)
+                    .expect("append duplicate payload");
+            }
+            builder.finish().expect("finish tar");
+        }
         archive
     }
 


### PR DESCRIPTION
## Summary
- cap compressed archive downloads, decompressed tar streams, extracted payload bytes, and archive entry counts
- keep resource-limit failures terminal and clean partial destinations instead of bypassing quotas through git fallback
- publish extracted files atomically and cover raw-size, PAX-size, compressed-input, decompressed-stream, entry-count, and cleanup contracts
- document terminal archive quota behavior in the HTTP archive ADR

## Verification
- `cargo test --lib archive`
- `cargo test --lib limited_reader`
- `cargo test --lib unpack_entry_atomically`
- `cargo test --lib extracted_quota_uses_effective_entry_size`
- `make check`

Archive path/link validation remains scoped to #600.

Closes #601.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source installation so Git-based retrieval is used only for ordinary archive failures.
  * Added stronger archive size/complexity safeguards (download/decompression/extracted-byte limits and max entry count) to prevent resource exhaustion.
  * When an archive exceeds the size budget, installation now cleans up partial output and fails without Git fallback.
  * Reduced partial-install risk by ensuring extracted files are only committed after successful unpack.
* **Documentation**
  * Updated the HTTP Archive vs Git acquisition guidance, including non-GitHub behavior and terminal handling for size-limit failures.
* **Tests**
  * Expanded oversize and limit-failure scenarios and verified cleanup and no leftover outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->