### PR TITLE
fix(semantic): uniform host gap-fill on blockquote prose lines

### DIFF
--- a/docs/architecture-decisions/semantic-token-overlap-resolution.md
+++ b/docs/architecture-decisions/semantic-token-overlap-resolution.md
@@ -100,11 +100,11 @@ Host tokens (depth=0) overlapping **active** injection regions are handled with 
 | **Fully inside** | Token bounds ⊂ region bounds (strict) | Remove | Code block content line inside blockquote injection |
 | **Exact match** | Token bounds = region bounds | Keep for sweep line | Fish `(comment) @comment` + `(comment) @injection.content` |
 | **Partial overlap, single-line region** | Token extends beyond a single-line region | Keep entire token for sweep line | Heading `## foo **bar**` overlapping `(inline)` injection |
-| **Partial overlap, multiline region** | Token extends beyond a multiline region | Split, keep outside fragments only | Blockquote `> ` prefix survives, content removed |
+| **Partial overlap, multiline region** | Token extends beyond a multiline region | Split, keep outside fragments only | In a blockquoted code fence, `> ` prefix survives, code content removed |
 
 The single-line/multiline distinction for partial overlaps identifies the injection's nature:
-- **Single-line regions** arise from direct child injections (e.g., `markdown_inline` within a heading). The host token should fill gaps where the injection produces no tokens (e.g., plain text in headings).
-- **Multiline regions** arise from container injections (e.g., blockquote content). The host token should not leak into the container's content.
+- **Single-line regions** arise from direct child injections (e.g., `markdown_inline` within a heading). The host token should fill gaps where the injection produces no tokens (e.g., plain text in headings). Blockquote *prose* gaps are trimmed of their trailing newline at the exclusion-range push site (`rebuild_context`) precisely so they classify here and gap-fill uniformly on every paragraph line.
+- **Multiline regions** arise from container injections (e.g., blockquoted code fence content). The host token should not leak into the container's content.
 
 Key concepts:
 

--- a/docs/architecture-decisions/semantic-token-overlap-resolution.md
+++ b/docs/architecture-decisions/semantic-token-overlap-resolution.md
@@ -100,7 +100,7 @@ Host tokens (depth=0) overlapping **active** injection regions are handled with 
 | **Fully inside** | Token bounds ⊂ region bounds (strict) | Remove | Code block content line inside blockquote injection |
 | **Exact match** | Token bounds = region bounds | Keep for sweep line | Fish `(comment) @comment` + `(comment) @injection.content` |
 | **Partial overlap, single-line region** | Token extends beyond a single-line region | Keep entire token for sweep line | Heading `## foo **bar**` overlapping `(inline)` injection |
-| **Partial overlap, multiline region** | Token extends beyond a multiline region | Split, keep outside fragments only | In a blockquoted code fence, `> ` prefix survives, code content removed |
+| **Partial overlap, multiline region** | Token extends beyond a multiline region | Split, keep outside fragments only | In a blockquoted code fence, the `>` prefix and its following space survive; code content is removed |
 
 The single-line/multiline distinction for partial overlaps identifies the injection's nature:
 - **Single-line regions** arise from direct child injections (e.g., `markdown_inline` within a heading). The host token should fill gaps where the injection produces no tokens (e.g., plain text in headings). Blockquote *prose* gaps are trimmed of their trailing newline at the exclusion-range push site (`rebuild_context`) precisely so they classify here and gap-fill uniformly on every paragraph line.

--- a/src/analysis/semantic/finalize.rs
+++ b/src/analysis/semantic/finalize.rs
@@ -574,9 +574,11 @@ fn apply_none_preprocessing(
 /// - Fully-contained tokens are removed (prevents code block host token leaks).
 /// - Single-line partial overlaps are kept whole so the sweep line can use the
 ///   host token as a gap filler (e.g., a heading token covering plain text that
-///   markdown_inline doesn't capture).
+///   markdown_inline doesn't capture; blockquote prose gaps are trimmed to this
+///   shape at the push site — see `rebuild_context`).
 /// - Multiline partial overlaps are split; only fragments outside the region
-///   are kept (e.g., blockquote `> ` prefix survives, content is removed).
+///   are kept (e.g., in a blockquoted code fence the `> ` prefix survives,
+///   the code content is removed).
 fn filter_by_injection_regions(
     tokens: Vec<RawToken>,
     regions: &[ActiveInjectionBounds],
@@ -626,9 +628,10 @@ fn filter_by_injection_regions(
         }
         // Partial overlap: check if any overlapping region is single-line.
         // Single-line regions indicate a direct child injection (e.g.,
-        // markdown_inline within a heading) where the host token should
-        // fill gaps. Multiline regions indicate container injections
-        // (e.g., blockquote content) where the host should not leak.
+        // markdown_inline within a heading, or a newline-trimmed blockquote
+        // prose gap) where the host token should fill gaps. Multiline
+        // regions indicate container injections (e.g., blockquoted code
+        // fence content) where the host should not leak.
         //
         // Note: a token overlapping both single-line and multiline regions
         // simultaneously is not a practical concern — the hierarchical

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -861,9 +861,13 @@ fn rebuild_context<'a>(
         // the single display line it covers. Containers keep their newlines:
         // their host tokens must not leak into code content. Known edge: a
         // container left unterminated at EOF in a file without a trailing
-        // newline ends flush and classifies prose until the fence closes — a
-        // transient, self-healing mis-render accepted over a per-language
-        // node-kind discriminator.
+        // newline ends flush and classifies prose until the fence closes.
+        // At EOF the two shapes are indistinguishable from the ranges alone,
+        // so one of them must misclassify; resolving toward container instead
+        // (e.g. by requiring a newline byte after the flush end) would
+        // reinstate the per-line highlight asymmetry for a paragraph ending
+        // the file without a trailing newline — the worse artifact, since the
+        // fence case renders uniformly and self-heals on close.
         // `get` instead of indexing: like the content re-slice above, a
         // corrupt reuse-path entry must degrade (here: to the untrimmed
         // container classification), not panic.

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -851,14 +851,19 @@ fn rebuild_context<'a>(
     // start (inj_start_byte).
     if let Some(ref ranges) = region.included_ranges {
         // Prose-style content (e.g. markdown_inline) ends flush with its last
-        // character, while container content (e.g. code_fence_content) is
-        // newline-terminated. Interior prose gaps still carry their line's
-        // newline, spanning (L, col)..(L+1, 0) — which finalize's region
-        // classifier reads as a multiline CONTAINER, stripping host gap-fill
-        // tokens (e.g. markup.quote) from every paragraph line except the
-        // last, so identical lines render differently. Trim the newline from
-        // prose gaps so each classifies as the single display line it covers.
-        // Containers keep their newlines: their host tokens must not leak.
+        // character, while container content (e.g. code_fence_content) is in
+        // practice newline-terminated. Interior prose gaps still carry their
+        // line's newline, spanning (L, col)..(L+1, 0) — which
+        // filter_by_injection_regions (finalize.rs) reads as a multiline
+        // CONTAINER, stripping host gap-fill tokens (e.g. markup.quote) from
+        // every paragraph line except the last, so identical lines rendered
+        // differently. Trim the newline from prose gaps so each classifies as
+        // the single display line it covers. Containers keep their newlines:
+        // their host tokens must not leak into code content. Known edge: a
+        // container left unterminated at EOF in a file without a trailing
+        // newline ends flush and classifies prose until the fence closes — a
+        // transient, self-healing mis-render accepted over a per-language
+        // node-kind discriminator.
         // `get` instead of indexing: like the content re-slice above, a
         // corrupt reuse-path entry must degrade (here: to the untrimmed
         // container classification), not panic.
@@ -1160,6 +1165,9 @@ fn build_combined_context<'a>(
     };
 
     // Suppress this layer's parent tokens within every combined block.
+    // No prose newline-trim here (cf. rebuild_context): every shipped
+    // injection.combined capture (html_block etc.) is container content whose
+    // ranges are newline-terminated, so the trim would never apply.
     for r in &included_ranges {
         exclusion_ranges.push((group_start + r.start_byte, group_start + r.end_byte));
     }

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -850,8 +850,30 @@ fn rebuild_context<'a>(
     // single full content range. Byte ranges are relative to the effective window
     // start (inj_start_byte).
     if let Some(ref ranges) = region.included_ranges {
+        // Prose-style content (e.g. markdown_inline) ends flush with its last
+        // character, while container content (e.g. code_fence_content) is
+        // newline-terminated. Interior prose gaps still carry their line's
+        // newline, spanning (L, col)..(L+1, 0) — which finalize's region
+        // classifier reads as a multiline CONTAINER, stripping host gap-fill
+        // tokens (e.g. markup.quote) from every paragraph line except the
+        // last, so identical lines render differently. Trim the newline from
+        // prose gaps so each classifies as the single display line it covers.
+        // Containers keep their newlines: their host tokens must not leak.
+        let prose = ranges
+            .last()
+            .is_some_and(|r| !text[..inj_start_byte + r.end_byte].ends_with('\n'));
         for r in ranges {
-            exclusion_ranges.push((inj_start_byte + r.start_byte, inj_start_byte + r.end_byte));
+            let start = inj_start_byte + r.start_byte;
+            let mut end = inj_start_byte + r.end_byte;
+            if prose && text[..end].ends_with('\n') {
+                end -= 1;
+                if text[..end].ends_with('\r') {
+                    end -= 1;
+                }
+            }
+            if start < end {
+                exclusion_ranges.push((start, end));
+            }
         }
     } else {
         exclusion_ranges.push((inj_start_byte, inj_end_byte));

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -872,13 +872,22 @@ fn rebuild_context<'a>(
         // corrupt reuse-path entry must degrade (here: to the untrimmed
         // container classification), not panic.
         let ends_with_newline = |end: usize| text.get(..end).is_some_and(|s| s.ends_with('\n'));
+        // checked_add everywhere: reuse-path bytes are untrusted, and a
+        // corrupt offset must degrade (skip / untrimmed) — release-mode wrap
+        // would misclassify, debug-mode overflow would panic.
         let prose = ranges.last().is_some_and(|r| {
-            text.get(..inj_start_byte + r.end_byte)
+            inj_start_byte
+                .checked_add(r.end_byte)
+                .and_then(|end| text.get(..end))
                 .is_some_and(|s| !s.ends_with('\n'))
         });
         for r in ranges {
-            let start = inj_start_byte + r.start_byte;
-            let mut end = inj_start_byte + r.end_byte;
+            let (Some(start), Some(mut end)) = (
+                inj_start_byte.checked_add(r.start_byte),
+                inj_start_byte.checked_add(r.end_byte),
+            ) else {
+                continue;
+            };
             if prose && ends_with_newline(end) {
                 end -= 1;
                 if text.get(..end).is_some_and(|s| s.ends_with('\r')) {

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -1925,6 +1925,111 @@ mod tests {
         std::env::var("TREE_SITTER_GRAMMARS").unwrap_or_else(|_| "deps/tree-sitter".to_string())
     }
 
+    /// Collect the exclusion-range text slices `collect_injection_contexts_sync`
+    /// pushes for a markdown document, or `None` when a required parser is
+    /// unavailable (test skips, matching the file's convention).
+    fn markdown_exclusion_slices(text: &str, extra_langs: &[&str]) -> Option<Vec<String>> {
+        use crate::config::WorkspaceSettings;
+
+        let coordinator = LanguageCoordinator::new();
+        let settings = WorkspaceSettings {
+            search_paths: vec![test_search_path()],
+            ..Default::default()
+        };
+        let _summary = coordinator.load_settings(&settings);
+
+        for lang in ["markdown", "markdown_inline"].iter().chain(extra_langs) {
+            if !coordinator.ensure_language_loaded(lang).success {
+                eprintln!("Skipping: {lang} parser not available");
+                return None;
+            }
+        }
+
+        let mut parser_pool = coordinator.create_document_parser_pool();
+        let mut parser = parser_pool.acquire("markdown")?;
+        let tree = parser.parse(text, None)?;
+        parser_pool.release("markdown".to_string(), parser);
+
+        let (_contexts, exclusion_ranges, _complete) = collect_injection_contexts_sync(
+            text,
+            &tree,
+            Some("markdown"),
+            &coordinator,
+            0,
+            None,
+            None,
+            None,
+        );
+
+        Some(
+            exclusion_ranges
+                .iter()
+                .map(|&(start, end)| text[start..end].to_string())
+                .collect(),
+        )
+    }
+
+    /// Prose gaps (markdown_inline in a blockquote paragraph) are trimmed of
+    /// their trailing newline so every gap classifies as the single display
+    /// line it covers — including interior lines, which previously kept the
+    /// newline and classified as multiline container spans.
+    #[test]
+    fn test_exclusion_ranges_blockquote_prose_gaps_trimmed() {
+        let Some(slices) = markdown_exclusion_slices("> foo\n> bar baz\n> qux\n", &[]) else {
+            return;
+        };
+        assert_eq!(
+            slices,
+            ["foo", "bar baz", "qux"],
+            "each prose gap should cover exactly its line's content"
+        );
+    }
+
+    /// CRLF documents trim the full `\r\n` pair, not just the `\n`.
+    #[test]
+    fn test_exclusion_ranges_blockquote_prose_gaps_trimmed_crlf() {
+        let Some(slices) = markdown_exclusion_slices("> foo\r\n> bar\r\n", &[]) else {
+            return;
+        };
+        assert_eq!(
+            slices,
+            ["foo", "bar"],
+            "CRLF prose gaps should lose both the \\r and the \\n"
+        );
+    }
+
+    /// Container content (a closed code fence in a blockquote) keeps its
+    /// newline-terminated gaps: host tokens must not gap-fill code content.
+    #[test]
+    fn test_exclusion_ranges_blockquote_code_fence_untrimmed() {
+        let Some(slices) = markdown_exclusion_slices("> ```lua\n> local x = 1\n> ```\n", &["lua"])
+        else {
+            return;
+        };
+        assert!(
+            slices
+                .iter()
+                .any(|s| s.contains("local x = 1") && s.ends_with('\n')),
+            "closed-fence code gaps should keep their trailing newline; got {slices:?}"
+        );
+    }
+
+    /// Documented edge (accepted, see rebuild_context): a fence left
+    /// unterminated at EOF in a file without a trailing newline ends flush,
+    /// so its gaps classify prose and are trimmed until the fence closes.
+    #[test]
+    fn test_exclusion_ranges_unterminated_fence_at_eof_classifies_prose() {
+        let Some(slices) =
+            markdown_exclusion_slices("> ```lua\n> local x = 1\n> local y = 2", &["lua"])
+        else {
+            return;
+        };
+        assert!(
+            slices.iter().any(|s| s == "local x = 1"),
+            "flush-at-EOF fence gaps are trimmed (prose classification); got {slices:?}"
+        );
+    }
+
     // Tests for parallel token collection
 
     #[test]

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -859,18 +859,24 @@ fn rebuild_context<'a>(
         // last, so identical lines render differently. Trim the newline from
         // prose gaps so each classifies as the single display line it covers.
         // Containers keep their newlines: their host tokens must not leak.
-        let prose = ranges
-            .last()
-            .is_some_and(|r| !text[..inj_start_byte + r.end_byte].ends_with('\n'));
+        // `get` instead of indexing: like the content re-slice above, a
+        // corrupt reuse-path entry must degrade (here: to the untrimmed
+        // container classification), not panic.
+        let ends_with_newline = |end: usize| text.get(..end).is_some_and(|s| s.ends_with('\n'));
+        let prose = ranges.last().is_some_and(|r| {
+            text.get(..inj_start_byte + r.end_byte)
+                .is_some_and(|s| !s.ends_with('\n'))
+        });
         for r in ranges {
             let start = inj_start_byte + r.start_byte;
             let mut end = inj_start_byte + r.end_byte;
-            if prose && text[..end].ends_with('\n') {
+            if prose && ends_with_newline(end) {
                 end -= 1;
-                if text[..end].ends_with('\r') {
+                if text.get(..end).is_some_and(|s| s.ends_with('\r')) {
                     end -= 1;
                 }
             }
+            // A newline-only gap (empty prose line) trims to zero width.
             if start < end {
                 exclusion_ranges.push((start, end));
             }

--- a/tests/e2e_semantic_blockquote.rs
+++ b/tests/e2e_semantic_blockquote.rs
@@ -817,6 +817,124 @@ fn test_blockquote_injection_tokens() {
     );
 }
 
+/// E2E test: blockquote prose lines with shortcut links highlight uniformly.
+///
+/// A blockquote paragraph whose lines contain shortcut links (`[foo]`) must
+/// render every identical line identically. The markdown_inline injection for
+/// the paragraph registers one exclusion gap per line, and interior gaps carry
+/// their trailing newline — which made `filter_by_injection_regions` classify
+/// them as multiline "container" regions (host `markup.quote` removed from the
+/// content), while the paragraph's LAST gap (no trailing newline) is
+/// single-line and keeps the host token as a gap filler. Result: `[` and
+/// `] aaa` lost their `string` coverage on interior lines only.
+///
+/// Expected (every `> [foo] aaa` line):
+/// ```text
+/// [string "> ["] [keyword "foo"] [string "] aaa"]
+/// ```
+#[test]
+fn test_blockquote_shortcut_link_uniform_highlight() {
+    let mut client = LspClient::new();
+
+    // Mirrors the user config that surfaced the bug: blockquote content is
+    // `string`, link labels are `keyword`, link brackets are suppressed.
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": {
+                "textDocument": {
+                    "semanticTokens": {
+                        "requests": { "full": true },
+                        "tokenTypes": ["keyword", "variable", "string", "number", "operator"],
+                        "tokenModifiers": [],
+                        "formats": ["relative"],
+                        "multilineTokenSupport": true
+                    }
+                }
+            },
+            "initializationOptions": {
+                "captureMappings": {
+                    "_": {
+                        "highlights": {
+                            "markup.quote": "string",
+                            "markup.link": "",
+                            "markup.link.label": "keyword",
+                            "markup.heading.1": "class"
+                        }
+                    }
+                }
+            }
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    // Lines:
+    //   0: "# fooo"
+    //   1: ""
+    //   2: "> foo"
+    //   3: "> [foo] aaa"   (interior)
+    //   4: "> [foo] aaa"   (interior)
+    //   5: "> foo"
+    //   6: "> [foo] aaa"   (last line of the paragraph)
+    let content = "# fooo\n\n> foo\n> [foo] aaa\n> [foo] aaa\n> foo\n> [foo] aaa\n";
+    let tokens = open_and_get_tokens(&mut client, content);
+    assert!(!tokens.is_empty(), "Should have semantic tokens");
+
+    let signature = |line: u32| -> Vec<(u32, u32, u32)> {
+        tokens
+            .iter()
+            .filter(|t| t.line == line)
+            .map(|t| (t.start, t.length, t.token_type))
+            .collect()
+    };
+
+    // Identical lines must produce identical token sequences, regardless of
+    // their position within the paragraph.
+    let interior = signature(3);
+    assert_eq!(
+        interior,
+        signature(4),
+        "Interior `> [foo] aaa` lines should match each other. All: {:?}",
+        tokens
+    );
+    assert_eq!(
+        interior,
+        signature(6),
+        "Interior `> [foo] aaa` lines should match the paragraph's last line. All: {:?}",
+        tokens
+    );
+
+    // The blockquote `string` coverage must include the text after the link
+    // (`] aaa`, cols 6..11) on interior lines — this is what regressed.
+    let string_type = 2u32;
+    for line in [3u32, 4, 6] {
+        assert!(
+            tokens.iter().any(|t| t.line == line
+                && t.token_type == string_type
+                && t.start <= 6
+                && t.start + t.length >= 11),
+            "Line {} should keep `string` (markup.quote) coverage over `] aaa`. Tokens: {:?}",
+            line,
+            signature(line)
+        );
+    }
+
+    // The plain `> foo` lines keep their full-line string coverage.
+    for line in [2u32, 5] {
+        assert!(
+            tokens.iter().any(|t| t.line == line
+                && t.token_type == string_type
+                && t.start == 0
+                && t.length == 5),
+            "Line {} should be fully covered by `string`. Tokens: {:?}",
+            line,
+            signature(line)
+        );
+    }
+}
+
 // ─── Snapshot tests for observing token output before/after fixes ────────────
 
 /// Helper: initialize client with full captureMappings config and multilineTokenSupport.

--- a/tests/e2e_semantic_blockquote.rs
+++ b/tests/e2e_semantic_blockquote.rs
@@ -921,6 +921,24 @@ fn test_blockquote_shortcut_link_uniform_highlight() {
         );
     }
 
+    // The markdown_inline injection must actually tokenize the shortcut
+    // link: its label `foo` (cols 3..6) maps to `keyword` via
+    // markup.link.label. Without this, the string-coverage assertions above
+    // could pass on a host-only markup.quote token while the injection is
+    // silently broken.
+    let keyword_type = 1u32; // server legend index (see token_type_name)
+    for line in [3u32, 4, 6] {
+        assert!(
+            tokens.iter().any(|t| t.line == line
+                && t.token_type == keyword_type
+                && t.start <= 3
+                && t.start + t.length >= 6),
+            "Line {} should carry a `keyword` (markup.link.label) token over the link label `foo`. Tokens: {:?}",
+            line,
+            signature(line)
+        );
+    }
+
     // The plain `> foo` lines keep their full-line string coverage.
     for line in [2u32, 5] {
         assert!(


### PR DESCRIPTION
## Problem

In a blockquote paragraph, identical lines rendered differently: interior `> [foo] aaa` lines lost the `markup.quote` host highlighting over `[` and `] aaa`, while the paragraph's **last** line kept it (screenshot bug report, reproduced from an LSP session log).

## Root cause

The markdown_inline injection registers one exclusion gap per paragraph line. Interior gaps carried their trailing newline, so each spanned `(L,c)..(L+1,0)` — which `filter_by_injection_regions` classifies as a **multiline container** region (host token stripped from content). The last gap ends flush with the text, classifies **single-line**, and keeps the host token as a gap filler.

## Fix

At the exclusion-range push in `rebuild_context`: when the injection's last included range is not newline-terminated (prose-style content, e.g. markdown_inline), trim the trailing newline (LF/CRLF) from every gap so each classifies as the single display line it covers and gap-fills uniformly. Container content (code-fence gaps are newline-terminated on every chunk) is untouched, preserving the "host must not leak into code" design and its tests.

Known accepted edge (documented at the decision site + pinned by a unit test): a fence left unterminated at EOF in a file without a trailing newline ends flush and classifies prose until it closes — at EOF the two shapes are indistinguishable from the ranges alone, and resolving toward container would reinstate the per-line asymmetry for a paragraph ending the file without a trailing newline, the worse artifact.

## Commits

- fix + wire-level e2e regression test reproducing the session log
- fail-soft slicing (`text.get`) matching the function's documented degradation posture
- doc alignment (`filter_by_injection_regions` docs, overlap-resolution ADR, combined-path exemption note)
- unit tests pinning the trim edges (LF/CRLF prose, closed-fence container untrimmed, EOF-flush fence flip)
- EOF-ambiguity rationale comment (codex round)

## Verification

- New e2e test fails on main with the exact reported signatures, passes here
- Full gate: fmt, clippy --all-targets -D warnings, 2776 lib tests, 42 blockquote e2e, full e2e suite 1675 tests green
- Review pipeline: 6-perspective local review (all findings fixed or deliberately kept with rationale), codex converged ("no comments to provide" from a fresh session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved semantic-token highlighting consistency for blockquote shortcut links across multiple lines.
  * Refined partial injection-region overlap handling with correct prose-gap newline trimming for both LF and CRLF.
  * Preserved newline behavior inside fenced code blocks and correctly trimmed prose gaps for unterminated fences at EOF.
* **Tests**
  * Added end-to-end assertions for uniform blockquote shortcut link highlighting.
  * Added coverage for prose-gap trimming and multiline partial-overlap edge cases.
* **Documentation**
  * Updated partial-overlap decision guidance, including the multiline partial-overlap scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->