### PR TITLE
perf(diagnostics): stop the diagnostics wire flood (flap fix + quiet window + seal + unchanged pull reports)

### DIFF
--- a/docs/architecture-decisions/cross-layer-aggregation.md
+++ b/docs/architecture-decisions/cross-layer-aggregation.md
@@ -78,8 +78,9 @@ Phased roadmap:
    anyway, so one code path with a pure combine function replaces the
    `race_layers_preferred` machinery here. For
    `textDocument/publishDiagnostics`, `priorities = []` additionally seals
-   the editor-facing wire sends entirely (the pull-first opt-out; delivery
-   continues via `workspace/diagnostic/refresh` → re-pull) — see
+   the editor-facing wire sends (the pull-first opt-out; delivery continues
+   via `workspace/diagnostic/refresh` → re-pull, and `didClose`'s clearing
+   publish still fails open) — prerequisites and caveats in
    push-propagation-diagnostic-forwarding "Config wire seal".
 5. **Layer-level `concatenated` for `textDocument/codeAction`** — ✅
    implemented (and the DEFAULT for the method): the virt layer's actions

--- a/docs/architecture-decisions/cross-layer-aggregation.md
+++ b/docs/architecture-decisions/cross-layer-aggregation.md
@@ -76,7 +76,11 @@ Phased roadmap:
    push election is deferred. Diagnostics are joined rather than raced:
    they are not latency-interactive and `concatenated` needs every layer
    anyway, so one code path with a pure combine function replaces the
-   `race_layers_preferred` machinery here.
+   `race_layers_preferred` machinery here. For
+   `textDocument/publishDiagnostics`, `priorities = []` additionally seals
+   the editor-facing wire sends entirely (the pull-first opt-out; delivery
+   continues via `workspace/diagnostic/refresh` → re-pull) — see
+   push-propagation-diagnostic-forwarding "Config wire seal".
 5. **Layer-level `concatenated` for `textDocument/codeAction`** — ✅
    implemented (and the DEFAULT for the method): the virt layer's actions
    (merged across every injection region the request range overlaps) and the

--- a/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
+++ b/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
@@ -105,7 +105,8 @@ changed merge inside a 1 s quiet window after the last send is withheld
 completion, the post-parse geometry re-merge — measured ~2.2 × ~1 MB
 publishes/s during sustained typing) collapses into at most one full-set
 publish per second per host. The first publish after quiet passes through
-immediately, so the window adds no latency outside bursts. Only the wire
+immediately, so a change arriving after >= 1 s of wire quiet gains no latency
+(a second isolated change inside the window still waits for it). Only the wire
 waits: change detection, the coverage bump, and the refresh nudge fire at
 the same points as before, and `didClose`'s clearing publish bypasses the
 window (a deferred clear would be dropped by the trailing task's
@@ -115,18 +116,46 @@ closed-document guard).
 `textDocument/publishDiagnostics` doubles as a seal on the editor-facing wire
 sends: when `layers.aggregation."textDocument/publishDiagnostics".priorities`
 resolves to `[]` for the host's language, `republish` skips the
-`publishDiagnostics` send entirely. This is the opt-out for pull-first editor
-setups, where the proactive publish is a redundant second delivery of the same
-merged set — the editor either ignores it or (Neovim ≥ 0.11) renders it as a
-duplicate diagnostic namespace next to the pulled one; on a diagnostics-heavy
-host it dominated the editor pipe (measured: 51 publishes × ~1 MB in a 44 s
-typing burst, 68% of all server→client bytes), head-of-line blocking every
-other response. The seal skips only the wire send: the merge still runs and
-records the last-published set, so change detection keeps driving the
+`publishDiagnostics` send entirely (except `didClose`'s harmless clearing
+publish, which fails open by design when the document is gone). This is the
+opt-out for pull-first editor setups, where the proactive publish is a
+redundant second delivery of the same merged set — the editor either ignores
+it or (Neovim ≥ 0.11) renders it as a duplicate diagnostic namespace next to
+the pulled one; on a diagnostics-heavy host it dominated the editor pipe
+(measured: 51 publishes × ~1 MB in a 44 s typing burst, 68% of all
+server→client bytes), head-of-line blocking every other response. At the
+`republish` level the seal skips only the wire send: the merge still runs and
+records the last-merged set, so change detection keeps driving the
 push-origin coverage bump and `workspace/diagnostic/refresh` — the sealed
 setup's delivery signal (refresh → client re-pull). The seal is binary (all
 layers gated off); a partially gated priorities list still publishes the full
 merge — per-layer selection applies to the debounced pull feed, as before.
+
+Seal prerequisites and caveats:
+
+- The delivery signal presumes the client advertises **both**
+  `textDocument.diagnostic` (it pulls) and
+  `workspace.diagnostics.refreshSupport` (it honors the nudge — the refresh is
+  capability-gated). Sealing against a push-only client is a diagnostics
+  blackout; against a pull-without-refresh client, spontaneous pushes rot
+  until the client's next edit-triggered pull. Only seal for refresh-capable
+  pull clients (Neovim ≥ 0.11 and VS Code qualify).
+- Put the `[]` on the `"textDocument/publishDiagnostics"` key specifically,
+  never on the `"_"` method wildcard — an empty method-wildcard priorities
+  list disables every method's layer walk (hover, completion, formatting, …),
+  which has always been `[]`'s meaning there.
+- The same resolved value also gates the **debounced pull feed** for the
+  method (as before this decision), which carries the #431 host re-sync to
+  push-only `_self` host servers — under a seal such a server stops receiving
+  debounced text updates and its diagnostics go stale between other
+  host-bridge requests. Don't seal a language that relies on a push-only
+  `_self` server.
+- Apply the seal at startup. A mid-session seal (via
+  `didChangeConfiguration`) leaves the last pre-seal set frozen in the
+  editor's push namespace until `didClose` — config changes do not republish
+  open hosts (a pre-existing property of this pipeline).
+- Prior to this decision `priorities = []` on this method gated only the
+  pull feed; existing configs using it now also stop the wire sends.
 
 ### Path B — Client-initiated pull (retained)
 
@@ -231,8 +260,10 @@ Producing the host publish mirrors the existing staged pull aggregation:
 
 Re-merging on every push republishes the cumulative host set: when region A
 publishes, then the host layer, then region C, each event re-runs the merge and
-re-publishes `{A}`, `{A, host}`, `{A, host, C}` — a slot is *replaced* by its
-source's latest push, never accumulated.
+records `{A}`, `{A, host}`, `{A, host, C}` — a slot is *replaced* by its
+source's latest push, never accumulated. (The wire sends are subject to the
+quiet window below, so the editor may see `{A}` and then `{A, host, C}`
+directly, the intermediate state coalesced into the trailing flush.)
 
 ### Versioning and staleness (the crux)
 
@@ -269,7 +300,14 @@ policy clean:
   region-less set on each edit cycle (~2 × ~1 MB publishes per keystroke settle
   on a diagnostics-heavy host, plus visible flicker). The reparse loop's
   post-parse republish (gated on the same non-empty-region-slots predicate)
-  is the guaranteed retry that publishes with real offsets.
+  is the retry that publishes with real offsets, doubly backstopped by the
+  pass's debounced pull. A deferral still nudges pull-mode clients: the
+  push-origin callers treat it like a change for the coverage bump and
+  `workspace/diagnostic/refresh` (the retry is edit-origin and never nudges,
+  and the cache did change). Accepted caveat: a parse give-up (timeout,
+  parser gone) leaves the tree absent and both retries deferred until the
+  next edit — where the pre-deferral behavior published a region-LESS set,
+  which was worse.
 - **Version gate**: a slot whose epoch lags the source's current `content_epoch`
   is held (not published) until that server re-publishes at the current epoch,
   bounding the wrong-position window to the re-parse gap and self-healing. The virt
@@ -279,9 +317,10 @@ policy clean:
   (`host.rs`). This decision requires the virt sync to gain that content guard so
   the epoch advances only on a real content change.
 - **Re-merge on epoch bump**: when a source's `content_epoch` advances, kakehashi
-  re-merges and republishes that `host_uri` *immediately*, with the now-stale slots
-  held — otherwise nothing would clear the old diagnostics until a current-epoch
-  push happens to arrive. The bump itself is the trigger, not just incoming pushes.
+  re-merges that `host_uri` *immediately* (the wire send is subject to the quiet
+  window), with the now-stale slots held — otherwise nothing would clear the old
+  diagnostics until a current-epoch push happens to arrive. The bump itself is
+  the trigger, not just incoming pushes.
 - **Re-merge on geometry change**: a host edit that shifts a region's position
   without changing its content does *not* advance `content_epoch`, so lazy
   re-anchor alone would leave the previously-published (now mis-placed) host
@@ -511,9 +550,12 @@ because the #380 benefit now outweighs it:
   push.
 - The reader must transform and route pushes, interleaved with edits, relying on
   the per-URI ordering guarantee.
-- Re-publish is unthrottled by design (the `didChange` debounce is gone): a no-op
-  push is suppressed (winner content unchanged), but a chatty linter emitting
-  distinct results across separate loop wakes re-publishes each time. To bound the
+- Re-publish is unthrottled at the merge level (the `didChange` debounce is
+  gone): a no-op push is suppressed (winner content unchanged), and a chatty
+  linter emitting distinct results across separate loop wakes re-merges and
+  re-records each time — but the WIRE sends are coalesced by the per-host quiet
+  window (see "Wire quiet window"), so the editor sees at most one publish per
+  window. To bound the
   cost of a push-happy/misbehaving downstream, the forwarding loop first coalesces a
   drained burst of `publishDiagnostics` by `(connection, uri)` to the latest
   (`coalesce_upstream_batch`, #426), then records each surviving push in a

--- a/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
+++ b/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
@@ -137,6 +137,13 @@ kakehashi keeps answering `textDocument/diagnostic` from the client:
 - For push-driven downstream, serve their cached push slots from Path A via the
   `pushFallback` toggle.
 - Merge and respond. The advertised `diagnosticProvider` capability is unchanged.
+- The response is deterministically sorted (the same order as Path A's publish,
+  #423) and carries a **content-addressed `resultId`** (hash of the serialized
+  items — stateless, nothing to invalidate). A re-pull whose `previousResultId`
+  matches the recomputed id is answered with an `unchanged` report instead of
+  re-shipping the items: on a diagnostics-heavy host the full report is ~1 MB
+  (measured: ~2,235 items), and every `workspace/diagnostic/refresh`-induced
+  re-pull of a settled set previously re-shipped all of it.
 
 Path A writes the cache; Path B reads it for push-driven servers — one cache,
 two readers.

--- a/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
+++ b/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
@@ -224,6 +224,15 @@ policy clean:
   offset re-positions an unchanged region's diagnostics after an edit *above* it
   with no re-push and no flicker — provided the epoch keys on content, not geometry
   (above), so a position-only edit does not advance it.
+- **Geometry-unknown deferral**: between `did_change` clearing the visible tree
+  and the off-ingress reparse landing, the regions' current offsets cannot be
+  computed. A republish in that window **defers** (publishes nothing, records
+  nothing) rather than merging with empty offsets — that would silently drop
+  every region push slot and flap the editor between the full and the
+  region-less set on each edit cycle (~2 × ~1 MB publishes per keystroke settle
+  on a diagnostics-heavy host, plus visible flicker). The reparse loop's
+  post-parse republish (gated on the same non-empty-region-slots predicate)
+  is the guaranteed retry that publishes with real offsets.
 - **Version gate**: a slot whose epoch lags the source's current `content_epoch`
   is held (not published) until that server re-publishes at the current epoch,
   bounding the wrong-position window to the re-parse gap and self-healing. The virt

--- a/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
+++ b/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
@@ -151,9 +151,12 @@ Seal prerequisites and caveats:
   host-bridge requests. Don't seal a language that relies on a push-only
   `_self` server.
 - Apply the seal at startup. A mid-session seal (via
-  `didChangeConfiguration`) leaves the last pre-seal set frozen in the
-  editor's push namespace until `didClose` — config changes do not republish
-  open hosts (a pre-existing property of this pipeline).
+  `didChangeConfiguration`) leaves the last set that actually reached the
+  wire frozen in the editor's push namespace until `didClose` (a send
+  withheld by the quiet window at seal time is dropped with the gate state,
+  so the frozen view can be one window older than the last recorded set) —
+  config changes do not republish open hosts (a pre-existing property of
+  this pipeline).
 - Prior to this decision `priorities = []` on this method gated only the
   pull feed; existing configs using it now also stop the wire sends.
 

--- a/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
+++ b/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
@@ -98,6 +98,19 @@ source. Push-driven servers feed this path natively; pull-driven servers feed it
 via the `pullFallback` toggle and, opportunistically, via any push they emit (see
 Per-server source and fallback).
 
+**Wire quiet window.** The wire sends are additionally coalesced per host: a
+changed merge inside a 1 s quiet window after the last send is withheld
+(wire-dirty) and one trailing republish at the window's end re-merges the
+*latest* cache, so a burst of feeds (spontaneous pushes, the pull-layer
+completion, the post-parse geometry re-merge — measured ~2.2 × ~1 MB
+publishes/s during sustained typing) collapses into at most one full-set
+publish per second per host. The first publish after quiet passes through
+immediately, so the window adds no latency outside bursts. Only the wire
+waits: change detection, the coverage bump, and the refresh nudge fire at
+the same points as before, and `didClose`'s clearing publish bypasses the
+window (a deferred clear would be dropped by the trailing task's
+closed-document guard).
+
 **Config wire seal.** The cross-layer gate for
 `textDocument/publishDiagnostics` doubles as a seal on the editor-facing wire
 sends: when `layers.aggregation."textDocument/publishDiagnostics".priorities`

--- a/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
+++ b/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
@@ -308,8 +308,10 @@ policy clean:
   push-origin callers treat it like a change for the coverage bump and
   `workspace/diagnostic/refresh` (the cache did change; the retry itself
   nudges only as degraded-pull recovery — a per-host debt recorded by a pull
-  the parse wait failed, consumed by the post-parse pass, gated by coverage
-  and the single-flight like every refresh). Accepted caveat: a parse
+  the parse wait failed, consumed once by the post-parse pass or the
+  pull-side TOCTOU guard, forced past the coverage gate — the debt proves
+  the client holds a non-covering answer that version coverage cannot see —
+  but still single-flighted like every refresh). Accepted caveat: a parse
   give-up (timeout,
   parser gone) leaves the tree absent and both retries deferred until the
   next edit — where the pre-deferral behavior published a region-LESS set,

--- a/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
+++ b/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
@@ -98,6 +98,23 @@ source. Push-driven servers feed this path natively; pull-driven servers feed it
 via the `pullFallback` toggle and, opportunistically, via any push they emit (see
 Per-server source and fallback).
 
+**Config wire seal.** The cross-layer gate for
+`textDocument/publishDiagnostics` doubles as a seal on the editor-facing wire
+sends: when `layers.aggregation."textDocument/publishDiagnostics".priorities`
+resolves to `[]` for the host's language, `republish` skips the
+`publishDiagnostics` send entirely. This is the opt-out for pull-first editor
+setups, where the proactive publish is a redundant second delivery of the same
+merged set — the editor either ignores it or (Neovim ≥ 0.11) renders it as a
+duplicate diagnostic namespace next to the pulled one; on a diagnostics-heavy
+host it dominated the editor pipe (measured: 51 publishes × ~1 MB in a 44 s
+typing burst, 68% of all server→client bytes), head-of-line blocking every
+other response. The seal skips only the wire send: the merge still runs and
+records the last-published set, so change detection keeps driving the
+push-origin coverage bump and `workspace/diagnostic/refresh` — the sealed
+setup's delivery signal (refresh → client re-pull). The seal is binary (all
+layers gated off); a partially gated priorities list still publishes the full
+merge — per-layer selection applies to the debounced pull feed, as before.
+
 ### Path B — Client-initiated pull (retained)
 
 kakehashi keeps answering `textDocument/diagnostic` from the client:

--- a/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
+++ b/docs/architecture-decisions/push-propagation-diagnostic-forwarding.md
@@ -306,8 +306,11 @@ policy clean:
   is the retry that publishes with real offsets, doubly backstopped by the
   pass's debounced pull. A deferral still nudges pull-mode clients: the
   push-origin callers treat it like a change for the coverage bump and
-  `workspace/diagnostic/refresh` (the retry is edit-origin and never nudges,
-  and the cache did change). Accepted caveat: a parse give-up (timeout,
+  `workspace/diagnostic/refresh` (the cache did change; the retry itself
+  nudges only as degraded-pull recovery — a per-host debt recorded by a pull
+  the parse wait failed, consumed by the post-parse pass, gated by coverage
+  and the single-flight like every refresh). Accepted caveat: a parse
+  give-up (timeout,
   parser gone) leaves the tree absent and both retries deferred until the
   next edit — where the pre-deferral behavior published a region-LESS set,
   which was worse.

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1225,6 +1225,17 @@ impl LanguageCoordinator {
         self.detect_language_logged(path, content, token, language_id, log::Level::Debug)
     }
 
+    /// Host-language detection for high-frequency paths that log at TRACE.
+    pub(crate) fn detect_language_trace(
+        &self,
+        path: &str,
+        content: &str,
+        token: Option<&str>,
+        language_id: Option<&str>,
+    ) -> Option<String> {
+        self.detect_language_logged(path, content, token, language_id, log::Level::Trace)
+    }
+
     /// Canonical injection language for bridge selection and virtual URIs.
     ///
     /// Candidate selection deliberately does not inspect parser state: eager

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -376,11 +376,15 @@ pub(crate) struct DiagnosticAggregator {
     /// removed — reclamation cannot race a republish into minting a second lock for
     /// the same host.
     republish_locks: Mutex<HashMap<Url, Arc<tokio::sync::Mutex<()>>>>,
-    /// The last diagnostic set published to the editor per host, so a republish
-    /// that would re-send an identical set is suppressed — the editor already has
-    /// it, and a redundant `publishDiagnostics` is a needless flicker/noise source
-    /// (#422). Updated under the host's republish lock (same-host republishes are
-    /// serialized), and forgotten on `didClose` ([`Self::forget_published`]).
+    /// The last **merged-and-recorded** diagnostic set per host, so a republish
+    /// producing an identical set is suppressed — a redundant re-emission is
+    /// needless flicker/noise (#422) — and the change signal driving the
+    /// refresh nudging stays exact. The wire send can lag this record (the
+    /// quiet window withholds it, tracked by [`WireGate::dirty`]) or be
+    /// skipped entirely (the publish seal: a pull-first client receives the
+    /// set via re-pull instead). Updated under the host's republish lock
+    /// (same-host republishes are serialized), and forgotten on `didClose`
+    /// ([`Self::forget_published`]).
     last_published: Mutex<HashMap<Url, Vec<Diagnostic>>>,
     /// Single-flight guard for the **workspace-wide** `workspace/diagnostic/refresh`
     /// nudge (#497). `workspace/diagnostic/refresh` is param-less and workspace-wide,
@@ -704,10 +708,11 @@ impl DiagnosticAggregator {
         cache.remove(host).is_some()
     }
 
-    /// Whether `diagnostics` differs from the set last published for `host`,
-    /// recording it as the new last when it does. Returns `false` when identical,
-    /// so the caller skips a redundant `publishDiagnostics` the editor already has
-    /// (#422). Called under the host's republish lock, so same-host calls serialize.
+    /// Whether `diagnostics` differs from the last merged-and-recorded set for
+    /// `host` (see the `last_published` field doc — the wire send can lag or be
+    /// sealed), recording it as the new last when it does. Returns `false` when
+    /// identical, so the caller skips a redundant re-emission (#422). Called
+    /// under the host's republish lock, so same-host calls serialize.
     ///
     /// The comparison is **order-independent**: `merge_cached_diagnostics` walks
     /// `HashMap`-keyed sources/servers, so the same logical set can serialize in a

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -406,9 +406,13 @@ pub(crate) struct DiagnosticAggregator {
     /// Per-host coalescing state for the editor-facing `publishDiagnostics`
     /// wire sends (the quiet window): see [`WireGate`] and
     /// [`Self::wire_gate_admit`]. Mutated under the host's republish lock
-    /// (same-host republishes are serialized) except the trailing task's
-    /// [`Self::wire_gate_take_pending`], which flips only `pending`; the inner
-    /// mutex is held briefly, never across an await. Forgotten on `didClose`.
+    /// (same-host republishes are serialized) with two off-lock exceptions:
+    /// the trailing task's [`Self::wire_gate_take_pending`] (flips only
+    /// `pending`) and `clear_host`'s [`Self::forget_wire_gate`] (idempotent
+    /// removal; a republish for a closed host never touches the gate, so the
+    /// off-lock forget cannot race state back in). The inner mutex is held
+    /// briefly, never across an await. Forgotten on `didClose` and under the
+    /// publish seal.
     wire_gate: Mutex<HashMap<Url, WireGate>>,
     /// Always-on counters for the diagnostic path (#533): push-origin republishes
     /// in, `workspace/diagnostic/refresh` requested vs actually sent (the gap is
@@ -440,11 +444,12 @@ struct RefreshFlight {
 /// every state change inside the window collapses into one send. An isolated
 /// change (window already elapsed, or first publish) passes through
 /// immediately — the gate adds no latency outside bursts.
-#[derive(Default)]
 struct WireGate {
-    /// When the last `publishDiagnostics` was actually written to the wire.
-    /// `None` until the first send (which therefore always passes).
-    last_sent_at: Option<tokio::time::Instant>,
+    /// When the last `publishDiagnostics` was actually written to the wire —
+    /// entries are minted by [`DiagnosticAggregator::wire_gate_commit_send`]
+    /// right after a completed send, so an entry always has one (a host with
+    /// no committed send yet simply has no entry, and its publish passes).
+    last_sent_at: tokio::time::Instant,
     /// A trailing republish task is scheduled; bounds the tasks to one per
     /// host per window.
     pending: bool,
@@ -462,8 +467,9 @@ pub(crate) enum WireAdmit {
     /// Window clear: write to the wire now.
     SendNow,
     /// Inside the quiet window: withhold. `schedule_trailing` is `true` for
-    /// exactly one caller per window (it must spawn the trailing republish
-    /// after `remaining`); later attempts in the same window get `false`.
+    /// at most one caller at a time — the first defer while no trailing task
+    /// is parked (it must spawn the trailing republish after `remaining`);
+    /// attempts while one is parked get `false`.
     Defer {
         schedule_trailing: bool,
         remaining: std::time::Duration,
@@ -740,8 +746,8 @@ impl DiagnosticAggregator {
         true
     }
 
-    /// Forget the last-published set for `host` (host `didClose`), so its entry
-    /// does not linger and a later re-open publishes afresh.
+    /// Forget the last-recorded set for `host` (host `didClose`), so its entry
+    /// does not linger and a later re-open starts change detection afresh.
     pub(crate) fn forget_published(&self, host: &Url) {
         self.last_published
             .lock()
@@ -902,47 +908,65 @@ impl DiagnosticAggregator {
     }
 
     /// Decide whether a wire `publishDiagnostics` for `host` may be written
-    /// now, given the per-host quiet `window` (see [`WireGate`]). `SendNow`
-    /// stamps the send time and clears `dirty`; `Defer` marks `dirty` (a
-    /// changed merge is being withheld) and hands exactly one caller per
-    /// window the duty to schedule the trailing republish. Called under the
-    /// host's republish lock, so same-host decisions are serialized.
+    /// now, given the per-host quiet `window` (see [`WireGate`]). `SendNow` is
+    /// a pure decision — the caller stamps it with
+    /// [`Self::wire_gate_commit_send`] only **after** the send actually
+    /// completed, so a republish aborted at the send await (the synthetic pull
+    /// task is abortable on supersession) leaves no gate state claiming a send
+    /// that never happened, and a withheld `dirty` debt is not consumed by it.
+    /// `Defer` marks `dirty` (a changed merge is being withheld) and hands the
+    /// trailing-republish duty to at most one caller at a time (the first
+    /// defer while no trailing task is parked). Called under the host's
+    /// republish lock, so same-host decisions are serialized — including the
+    /// decide→commit pair.
     pub(crate) fn wire_gate_admit(&self, host: &Url, window: std::time::Duration) -> WireAdmit {
         let now = tokio::time::Instant::now();
         let mut gates = self
             .wire_gate
             .lock()
             .recover_poison("DiagnosticAggregator::wire_gate");
-        // Look up by `&Url` first, cloning the host key only on first insert
-        // (matching `bump_current`'s convention): a fresh host has no prior
-        // send, so its first publish always passes.
-        if !gates.contains_key(host) {
+        // A host with no entry has no prior committed send, so its publish
+        // always passes; the entry is minted by the commit.
+        let Some(gate) = gates.get_mut(host) else {
+            return WireAdmit::SendNow;
+        };
+        let elapsed = now.duration_since(gate.last_sent_at);
+        if elapsed < window {
+            gate.dirty = true;
+            let schedule_trailing = !gate.pending;
+            gate.pending = true;
+            WireAdmit::Defer {
+                schedule_trailing,
+                remaining: window - elapsed,
+            }
+        } else {
+            WireAdmit::SendNow
+        }
+    }
+
+    /// Record that a wire `publishDiagnostics` for `host` was actually sent:
+    /// stamp the send time (opening a fresh quiet window) and clear the
+    /// withheld-send `dirty` marker. Called right after the send await, under
+    /// the same republish-lock hold as the [`Self::wire_gate_admit`] that
+    /// admitted it. Clones the key only on first insert.
+    pub(crate) fn wire_gate_commit_send(&self, host: &Url) {
+        let now = tokio::time::Instant::now();
+        let mut gates = self
+            .wire_gate
+            .lock()
+            .recover_poison("DiagnosticAggregator::wire_gate");
+        if let Some(gate) = gates.get_mut(host) {
+            gate.last_sent_at = now;
+            gate.dirty = false;
+        } else {
             gates.insert(
                 host.clone(),
                 WireGate {
-                    last_sent_at: Some(now),
-                    ..WireGate::default()
+                    last_sent_at: now,
+                    pending: false,
+                    dirty: false,
                 },
             );
-            return WireAdmit::SendNow;
-        }
-        let gate = gates.get_mut(host).expect("present: checked above");
-        let elapsed = gate.last_sent_at.map(|at| now.duration_since(at));
-        match elapsed {
-            Some(elapsed) if elapsed < window => {
-                gate.dirty = true;
-                let schedule_trailing = !gate.pending;
-                gate.pending = true;
-                WireAdmit::Defer {
-                    schedule_trailing,
-                    remaining: window - elapsed,
-                }
-            }
-            _ => {
-                gate.last_sent_at = Some(now);
-                gate.dirty = false;
-                WireAdmit::SendNow
-            }
         }
     }
 
@@ -957,11 +981,17 @@ impl DiagnosticAggregator {
             .is_some_and(|gate| gate.dirty)
     }
 
-    /// Clear the trailing-task marker for `host`: called by the trailing
-    /// republish task right before it re-runs `republish`, so a defer that
-    /// races the re-run schedules a fresh trailing task instead of being
-    /// silently absorbed by one that already woke.
-    pub(crate) fn wire_gate_take_pending(&self, host: &Url) {
+    /// Clear the trailing-task marker for `host`, returning whether gate state
+    /// still existed. Called by the trailing republish task right before it
+    /// re-runs `republish`, so a defer that races the re-run schedules a fresh
+    /// trailing task instead of being silently absorbed by one that already
+    /// woke. `false` means the entry was forgotten while the task was parked
+    /// (`didClose`, or the seal) — the withheld debt was cancelled, and the
+    /// task must bail rather than republish: a stale task from a previous
+    /// document incarnation would otherwise clobber the reopened incarnation's
+    /// `pending` marker and publish/stamp state the fresh incarnation never
+    /// owed.
+    pub(crate) fn wire_gate_take_pending(&self, host: &Url) -> bool {
         if let Some(gate) = self
             .wire_gate
             .lock()
@@ -969,12 +999,18 @@ impl DiagnosticAggregator {
             .get_mut(host)
         {
             gate.pending = false;
+            true
+        } else {
+            false
         }
     }
 
-    /// Forget the wire-gate state for `host` (`didClose`, next to
-    /// [`Self::forget_coverage`]) so the entry doesn't linger; a re-open's
-    /// first publish passes through immediately (`last_sent_at` reset).
+    /// Forget the wire-gate state for `host` so the entry doesn't linger and a
+    /// parked trailing task bails ([`Self::wire_gate_take_pending`] returns
+    /// `false`). Called on `didClose` (`clear_host`, next to
+    /// [`Self::forget_coverage`] — after the clearing republish, which
+    /// bypasses the gate for closed hosts) and when the publish seal renders
+    /// the gate state moot.
     pub(crate) fn forget_wire_gate(&self, host: &Url) {
         self.wire_gate
             .lock()
@@ -1091,6 +1127,7 @@ mod tests {
             WireAdmit::SendNow,
             "the first send always passes (no prior send to be quiet after)"
         );
+        agg.wire_gate_commit_send(&host());
 
         // Within the window: withheld, and exactly the FIRST defer is handed
         // the trailing-task duty.
@@ -1121,17 +1158,26 @@ mod tests {
             "later in-window attempts must not schedule a second task, got {second:?}"
         );
 
-        // Window elapsed: pass again, clearing the dirty marker.
+        // Window elapsed: pass again; the COMMIT (post-send) clears dirty.
         tokio::time::advance(window).await;
-        agg.wire_gate_take_pending(&host());
+        assert!(
+            agg.wire_gate_take_pending(&host()),
+            "the gate entry still exists while the host is open"
+        );
         assert_eq!(
             agg.wire_gate_admit(&host(), window),
             WireAdmit::SendNow,
             "the trailing attempt after the window sends"
         );
         assert!(
+            agg.wire_gate_is_dirty(&host()),
+            "the admit DECISION alone must not consume the withheld-send debt \
+             (an aborted send would otherwise lose it)"
+        );
+        agg.wire_gate_commit_send(&host());
+        assert!(
             !agg.wire_gate_is_dirty(&host()),
-            "a send clears the dirty marker"
+            "the post-send commit clears the dirty marker"
         );
     }
 
@@ -1143,6 +1189,7 @@ mod tests {
         let agg = DiagnosticAggregator::new();
         let window = std::time::Duration::from_secs(1);
         assert_eq!(agg.wire_gate_admit(&host(), window), WireAdmit::SendNow);
+        agg.wire_gate_commit_send(&host());
         assert!(matches!(
             agg.wire_gate_admit(&host(), window),
             WireAdmit::Defer {
@@ -1151,7 +1198,7 @@ mod tests {
             }
         ));
 
-        agg.wire_gate_take_pending(&host());
+        assert!(agg.wire_gate_take_pending(&host()));
         assert!(matches!(
             agg.wire_gate_admit(&host(), window),
             WireAdmit::Defer {
@@ -1159,6 +1206,28 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wire_gate_uncommitted_send_leaves_no_state_behind() {
+        // The admit decision is pure for SendNow: a republish aborted at the
+        // send await (synthetic pull tasks are abortable on supersession)
+        // commits nothing, so the next attempt passes again instead of being
+        // deferred behind a send that never reached the wire.
+        let agg = DiagnosticAggregator::new();
+        let window = std::time::Duration::from_secs(1);
+
+        assert_eq!(agg.wire_gate_admit(&host(), window), WireAdmit::SendNow);
+        // (no commit: the send was aborted)
+        assert_eq!(
+            agg.wire_gate_admit(&host(), window),
+            WireAdmit::SendNow,
+            "an uncommitted send must not open a quiet window"
+        );
+        assert!(
+            !agg.wire_gate_take_pending(&host()),
+            "no entry was minted; a parked trailing task for a forgotten gate bails"
+        );
     }
 
     #[tokio::test]

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -1004,7 +1004,7 @@ impl DiagnosticAggregator {
         // `published_set_changed` recorded the merge before the send, so
         // without the debt a later identical merge would skip past the
         // unchanged check while the editor never received the set.
-        if !gates.contains_key(host) {
+        let Some(gate) = gates.get_mut(host) else {
             gates.insert(
                 host.clone(),
                 WireGate {
@@ -1014,8 +1014,7 @@ impl DiagnosticAggregator {
                 },
             );
             return WireAdmit::SendNow;
-        }
-        let gate = gates.get_mut(host).expect("present: checked above");
+        };
         let elapsed = gate.last_sent_at.map(|at| now.duration_since(at));
         match elapsed {
             Some(elapsed) if elapsed < window => {

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -159,19 +159,31 @@ pub(crate) fn merge_cached_diagnostics(
     }
     // Deterministic published order (#423): the cache walks `HashMap`-keyed sources
     // and servers, so without this the array order varies between republishes for a
-    // multi-source/multi-server host. Order by host position (top-to-bottom — "order
-    // cross-region merge by region start position"), then by the cheap distinguishing
-    // fields (message, source, severity). This is the `concatenated` strategy (every
+    // multi-source/multi-server host. This is the `concatenated` strategy (every
     // server's diagnostics are kept); the `preferred` election is deferred (it needs a
     // per-source version baseline, which #422 left unbuilt).
-    //
-    // The final tiebreak is each diagnostic's full serialized form — a **total** order
-    // over every field (code, tags, data, relatedInformation, …), so two genuinely
-    // distinct diagnostics at the same span can never fall back to HashMap order. It is
-    // evaluated **lazily** (`then_with`), only when every cheap field above already
-    // ties, so the serialization is off the hot path. Fully-identical diagnostics
-    // serialize equally and keep their (immaterial) relative order.
-    merged.sort_by(|a, b| {
+    sort_diagnostics(&mut merged);
+    merged
+}
+
+/// Order diagnostics deterministically: by host position (top-to-bottom —
+/// "order cross-region merge by region start position"), then by the cheap
+/// distinguishing fields (message, source, severity).
+///
+/// The final tiebreak is each diagnostic's full serialized form — a **total**
+/// order over every field (code, tags, data, relatedInformation, …), so two
+/// genuinely distinct diagnostics at the same span can never fall back to
+/// input (e.g. `HashMap`-walk or fan-in completion) order. It is evaluated
+/// **lazily** (`then_with`), only when every cheap field above already ties,
+/// so the serialization is off the hot path. Fully-identical diagnostics
+/// serialize equally and keep their (immaterial) relative order.
+///
+/// Shared by the proactive publish merge ([`merge_cached_diagnostics`], #423)
+/// and the client-pull response (`diagnostic_impl`): the pull's `resultId` is
+/// a content hash of the serialized items, so the same logical set must
+/// serialize identically across pulls regardless of fan-in completion order.
+pub(crate) fn sort_diagnostics(diagnostics: &mut [Diagnostic]) {
+    diagnostics.sort_by(|a, b| {
         let key = |d: &Diagnostic| {
             (
                 d.range.start.line,
@@ -191,7 +203,6 @@ pub(crate) fn merge_cached_diagnostics(
                     .cmp(&serde_json::to_string(b).unwrap_or_default())
             })
     });
-    merged
 }
 
 /// Every distinct server name with a **push** slot (`Region`/`Host`, never

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -215,6 +215,19 @@ pub(crate) fn sort_diagnostics(diagnostics: &mut [Diagnostic]) {
     });
 }
 
+/// Whether `slots` holds any **non-empty** `Region` push slot — the shared
+/// predicate behind both [`DiagnosticAggregator::has_region_slots`] (the
+/// reparse loop's post-parse republish gate, on the raw cache) and
+/// `republish`'s `needs_geometry` (on the filtered publish snapshot). One
+/// implementation on purpose: the geometry-unknown deferral is retried only
+/// while this predicate holds, so the two call sites must never diverge.
+pub(crate) fn has_live_region_slots(slots: &SourceSlots) -> bool {
+    slots.iter().any(|(source, servers)| {
+        matches!(source, DiagnosticSource::Region(_))
+            && servers.values().any(|slot| !slot.diagnostics.is_empty())
+    })
+}
+
 /// Every distinct server name with a **push** slot (`Region`/`Host`, never
 /// `PullLayer`) in `snapshot`. Path B's `pushFallback` fold uses this to
 /// classify which cached pushers are push-driven (#425). Takes the snapshot the
@@ -726,12 +739,7 @@ impl DiagnosticAggregator {
     /// recompute on every edit.
     pub(crate) fn has_region_slots(&self, host: &Url) -> bool {
         let cache = self.lock();
-        cache.get(host).is_some_and(|sources| {
-            sources.iter().any(|(source, servers)| {
-                matches!(source, DiagnosticSource::Region(_))
-                    && servers.values().any(|slot| !slot.diagnostics.is_empty())
-            })
-        })
+        cache.get(host).is_some_and(has_live_region_slots)
     }
 
     /// Drop everything for a host (host `didClose`). Returns whether it existed.

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -445,17 +445,22 @@ struct RefreshFlight {
 /// change (window already elapsed, or first publish) passes through
 /// immediately — the gate adds no latency outside bursts.
 struct WireGate {
-    /// When the last `publishDiagnostics` was actually written to the wire —
-    /// entries are minted by [`DiagnosticAggregator::wire_gate_commit_send`]
-    /// right after a completed send, so an entry always has one (a host with
-    /// no committed send yet simply has no entry, and its publish passes).
-    last_sent_at: tokio::time::Instant,
+    /// When the last `publishDiagnostics` was actually **committed** (written
+    /// to the wire and stamped by [`DiagnosticAggregator::wire_gate_commit_send`]).
+    /// `None` means the entry was minted by an admit whose send has not
+    /// committed (yet, or ever — an aborted send): such a host's next publish
+    /// passes immediately, and the `dirty` debt below records that the
+    /// last-recorded set may never have reached the wire.
+    last_sent_at: Option<tokio::time::Instant>,
     /// A trailing republish task is scheduled; bounds the tasks to one per
     /// host per window.
     pending: bool,
-    /// A *changed* merge was withheld from the wire: the editor's
-    /// push-namespace view lags the recorded last-published set, so a later
-    /// republish must send even if its own merge compares unchanged.
+    /// The recorded last-published set may not have reached the editor's
+    /// push namespace: either a changed merge was withheld by the quiet
+    /// window, or a send was admitted but its commit never happened (aborted
+    /// at the send await). A later republish must send even if its own merge
+    /// compares unchanged. Set on every admit, cleared only by the post-send
+    /// commit.
     dirty: bool,
 }
 
@@ -821,9 +826,11 @@ impl DiagnosticAggregator {
 
     /// Bump a host's `current` coverage version (#497) — a **push-origin** change the
     /// editor doesn't know about just landed, so its last-pulled view is now stale.
-    /// Called only from the push/eviction paths (`publish_host_push`,
-    /// `publish_region_push`, `evict_connection_diagnostics`) when their `republish`
-    /// published a changed set — paired with the gated `request_pull_diagnostic_refresh`.
+    /// Called only from the push/eviction paths (`publish_recorded_hosts`,
+    /// `evict_connection_diagnostics`) when their `republish` reported Changed
+    /// (a changed merge was recorded; the wire send may be withheld or sealed)
+    /// or Deferred (the cache changed but region geometry was pending) —
+    /// paired with the gated `request_pull_diagnostic_refresh`.
     ///
     /// Deliberately **not** bumped on editor-originated republishes (`publish_pull_layer`
     /// /`clear_pull_layer`/edit-remerge/`clear_host`): those are answered by the
@@ -908,12 +915,13 @@ impl DiagnosticAggregator {
     }
 
     /// Decide whether a wire `publishDiagnostics` for `host` may be written
-    /// now, given the per-host quiet `window` (see [`WireGate`]). `SendNow` is
-    /// a pure decision — the caller stamps it with
-    /// [`Self::wire_gate_commit_send`] only **after** the send actually
-    /// completed, so a republish aborted at the send await (the synthetic pull
-    /// task is abortable on supersession) leaves no gate state claiming a send
-    /// that never happened, and a withheld `dirty` debt is not consumed by it.
+    /// now, given the per-host quiet `window` (see [`WireGate`]). A `SendNow`
+    /// decision marks the `dirty` debt and opens no quiet window — the caller
+    /// stamps the send with [`Self::wire_gate_commit_send`] only **after** it
+    /// actually completed, so a republish aborted at the send await (the
+    /// synthetic pull task is abortable on supersession) leaves the debt in
+    /// place: the recorded-but-unsent set forces the next republish past the
+    /// unchanged check and onto the wire.
     /// `Defer` marks `dirty` (a changed merge is being withheld) and hands the
     /// trailing-republish duty to at most one caller at a time (the first
     /// defer while no trailing task is parked). Called under the host's
@@ -925,30 +933,47 @@ impl DiagnosticAggregator {
             .wire_gate
             .lock()
             .recover_poison("DiagnosticAggregator::wire_gate");
-        // A host with no entry has no prior committed send, so its publish
-        // always passes; the entry is minted by the commit.
-        let Some(gate) = gates.get_mut(host) else {
+        // A host with no entry has no prior committed send: mint the entry
+        // with the debt already marked and pass. Marking `dirty` on EVERY
+        // admit (not just Defer) is what makes an aborted send recoverable —
+        // `published_set_changed` recorded the merge before the send, so
+        // without the debt a later identical merge would skip past the
+        // unchanged check while the editor never received the set.
+        if !gates.contains_key(host) {
+            gates.insert(
+                host.clone(),
+                WireGate {
+                    last_sent_at: None,
+                    pending: false,
+                    dirty: true,
+                },
+            );
             return WireAdmit::SendNow;
-        };
-        let elapsed = now.duration_since(gate.last_sent_at);
-        if elapsed < window {
-            gate.dirty = true;
-            let schedule_trailing = !gate.pending;
-            gate.pending = true;
-            WireAdmit::Defer {
-                schedule_trailing,
-                remaining: window - elapsed,
+        }
+        let gate = gates.get_mut(host).expect("present: checked above");
+        let elapsed = gate.last_sent_at.map(|at| now.duration_since(at));
+        match elapsed {
+            Some(elapsed) if elapsed < window => {
+                gate.dirty = true;
+                let schedule_trailing = !gate.pending;
+                gate.pending = true;
+                WireAdmit::Defer {
+                    schedule_trailing,
+                    remaining: window - elapsed,
+                }
             }
-        } else {
-            WireAdmit::SendNow
+            _ => {
+                gate.dirty = true;
+                WireAdmit::SendNow
+            }
         }
     }
 
     /// Record that a wire `publishDiagnostics` for `host` was actually sent:
-    /// stamp the send time (opening a fresh quiet window) and clear the
-    /// withheld-send `dirty` marker. Called right after the send await, under
-    /// the same republish-lock hold as the [`Self::wire_gate_admit`] that
-    /// admitted it. Clones the key only on first insert.
+    /// stamp the send time (opening a fresh quiet window) and settle the
+    /// `dirty` debt. Called right after the send await, under the same
+    /// republish-lock hold as the [`Self::wire_gate_admit`] that admitted it.
+    /// Clones the key only on first insert.
     pub(crate) fn wire_gate_commit_send(&self, host: &Url) {
         let now = tokio::time::Instant::now();
         let mut gates = self
@@ -956,13 +981,15 @@ impl DiagnosticAggregator {
             .lock()
             .recover_poison("DiagnosticAggregator::wire_gate");
         if let Some(gate) = gates.get_mut(host) {
-            gate.last_sent_at = now;
+            gate.last_sent_at = Some(now);
             gate.dirty = false;
         } else {
+            // The admit minted an entry, but a `forget_wire_gate` (seal) can
+            // race in off the happy path; re-minting settled is fine.
             gates.insert(
                 host.clone(),
                 WireGate {
-                    last_sent_at: now,
+                    last_sent_at: Some(now),
                     pending: false,
                     dirty: false,
                 },
@@ -986,11 +1013,12 @@ impl DiagnosticAggregator {
     /// re-runs `republish`, so a defer that races the re-run schedules a fresh
     /// trailing task instead of being silently absorbed by one that already
     /// woke. `false` means the entry was forgotten while the task was parked
-    /// (`didClose`, or the seal) — the withheld debt was cancelled, and the
-    /// task must bail rather than republish: a stale task from a previous
-    /// document incarnation would otherwise clobber the reopened incarnation's
-    /// `pending` marker and publish/stamp state the fresh incarnation never
-    /// owed.
+    /// (`didClose`, or the seal) — the withheld debt was cancelled and the
+    /// task must bail rather than republish. (The bail covers only the
+    /// entry-gone case: a stale task waking against a reopened incarnation's
+    /// fresh entry gets `true` and clears its `pending`, which at worst
+    /// schedules one extra trailing task — the defer-reschedule design, not
+    /// this bail, is what keeps that safe.)
     pub(crate) fn wire_gate_take_pending(&self, host: &Url) -> bool {
         if let Some(gate) = self
             .wire_gate
@@ -1209,24 +1237,31 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn wire_gate_uncommitted_send_leaves_no_state_behind() {
-        // The admit decision is pure for SendNow: a republish aborted at the
-        // send await (synthetic pull tasks are abortable on supersession)
-        // commits nothing, so the next attempt passes again instead of being
-        // deferred behind a send that never reached the wire.
+    async fn wire_gate_uncommitted_send_keeps_the_debt() {
+        // A republish aborted at the send await (synthetic pull tasks are
+        // abortable on supersession) commits nothing: the next attempt must
+        // pass again (no phantom quiet window) AND the dirty debt minted at
+        // admit must survive — `published_set_changed` recorded the merge
+        // before the send, so without the debt a later identical merge would
+        // skip the unchanged check while the editor never received the set.
         let agg = DiagnosticAggregator::new();
         let window = std::time::Duration::from_secs(1);
 
         assert_eq!(agg.wire_gate_admit(&host(), window), WireAdmit::SendNow);
         // (no commit: the send was aborted)
+        assert!(
+            agg.wire_gate_is_dirty(&host()),
+            "the admitted-but-uncommitted send leaves its debt marked"
+        );
         assert_eq!(
             agg.wire_gate_admit(&host(), window),
             WireAdmit::SendNow,
             "an uncommitted send must not open a quiet window"
         );
+        agg.wire_gate_commit_send(&host());
         assert!(
-            !agg.wire_gate_take_pending(&host()),
-            "no entry was minted; a parked trailing task for a forgotten gate bails"
+            !agg.wire_gate_is_dirty(&host()),
+            "the completed send settles the debt"
         );
     }
 

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -388,6 +388,13 @@ pub(crate) struct DiagnosticAggregator {
     /// `served`) sends no redundant nudge. Drives [`Self::bump_current`],
     /// [`Self::mark_served`], [`Self::is_dirty`]; forgotten on `didClose`.
     coverage: Mutex<HashMap<Url, HostCoverage>>,
+    /// Per-host coalescing state for the editor-facing `publishDiagnostics`
+    /// wire sends (the quiet window): see [`WireGate`] and
+    /// [`Self::wire_gate_admit`]. Mutated under the host's republish lock
+    /// (same-host republishes are serialized) except the trailing task's
+    /// [`Self::wire_gate_take_pending`], which flips only `pending`; the inner
+    /// mutex is held briefly, never across an await. Forgotten on `didClose`.
+    wire_gate: Mutex<HashMap<Url, WireGate>>,
     /// Always-on counters for the diagnostic path (#533): push-origin republishes
     /// in, `workspace/diagnostic/refresh` requested vs actually sent (the gap is
     /// what the #497 single-flight + coverage gate saves), and pulls answered with
@@ -409,6 +416,43 @@ struct RefreshFlight {
     /// refresh, #521), so the trailing must fire regardless of the coverage gate —
     /// there is no version representing what the downstream asked to refresh.
     pending_forced: bool,
+}
+
+/// Per-host coalescing state for the editor-facing `publishDiagnostics` wire
+/// sends. A changed merge inside the quiet window after the last send is
+/// **withheld** from the wire (`dirty`) and a single trailing republish is
+/// scheduled (`pending`); the trailing run re-merges the *latest* cache, so
+/// every state change inside the window collapses into one send. An isolated
+/// change (window already elapsed, or first publish) passes through
+/// immediately — the gate adds no latency outside bursts.
+#[derive(Default)]
+struct WireGate {
+    /// When the last `publishDiagnostics` was actually written to the wire.
+    /// `None` until the first send (which therefore always passes).
+    last_sent_at: Option<tokio::time::Instant>,
+    /// A trailing republish task is scheduled; bounds the tasks to one per
+    /// host per window.
+    pending: bool,
+    /// A *changed* merge was withheld from the wire: the editor's
+    /// push-namespace view lags the recorded last-published set, so a later
+    /// republish must send even if its own merge compares unchanged.
+    dirty: bool,
+}
+
+/// The wire-gate decision for one republish attempt: send now, or withhold
+/// until the quiet window elapses (scheduling the trailing republish iff no
+/// task is already parked).
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum WireAdmit {
+    /// Window clear: write to the wire now.
+    SendNow,
+    /// Inside the quiet window: withhold. `schedule_trailing` is `true` for
+    /// exactly one caller per window (it must spawn the trailing republish
+    /// after `remaining`); later attempts in the same window get `false`.
+    Defer {
+        schedule_trailing: bool,
+        remaining: std::time::Duration,
+    },
 }
 
 /// Per-host coverage versions for the refresh gate (#497, commit 2).
@@ -841,6 +885,87 @@ impl DiagnosticAggregator {
             .remove(host);
     }
 
+    /// Decide whether a wire `publishDiagnostics` for `host` may be written
+    /// now, given the per-host quiet `window` (see [`WireGate`]). `SendNow`
+    /// stamps the send time and clears `dirty`; `Defer` marks `dirty` (a
+    /// changed merge is being withheld) and hands exactly one caller per
+    /// window the duty to schedule the trailing republish. Called under the
+    /// host's republish lock, so same-host decisions are serialized.
+    pub(crate) fn wire_gate_admit(&self, host: &Url, window: std::time::Duration) -> WireAdmit {
+        let now = tokio::time::Instant::now();
+        let mut gates = self
+            .wire_gate
+            .lock()
+            .recover_poison("DiagnosticAggregator::wire_gate");
+        // Look up by `&Url` first, cloning the host key only on first insert
+        // (matching `bump_current`'s convention): a fresh host has no prior
+        // send, so its first publish always passes.
+        if !gates.contains_key(host) {
+            gates.insert(
+                host.clone(),
+                WireGate {
+                    last_sent_at: Some(now),
+                    ..WireGate::default()
+                },
+            );
+            return WireAdmit::SendNow;
+        }
+        let gate = gates.get_mut(host).expect("present: checked above");
+        let elapsed = gate.last_sent_at.map(|at| now.duration_since(at));
+        match elapsed {
+            Some(elapsed) if elapsed < window => {
+                gate.dirty = true;
+                let schedule_trailing = !gate.pending;
+                gate.pending = true;
+                WireAdmit::Defer {
+                    schedule_trailing,
+                    remaining: window - elapsed,
+                }
+            }
+            _ => {
+                gate.last_sent_at = Some(now);
+                gate.dirty = false;
+                WireAdmit::SendNow
+            }
+        }
+    }
+
+    /// Whether a changed merge for `host` was withheld from the wire and not
+    /// yet sent — the trailing republish must send even when its own merge
+    /// compares unchanged against the recorded last-published set.
+    pub(crate) fn wire_gate_is_dirty(&self, host: &Url) -> bool {
+        self.wire_gate
+            .lock()
+            .recover_poison("DiagnosticAggregator::wire_gate")
+            .get(host)
+            .is_some_and(|gate| gate.dirty)
+    }
+
+    /// Clear the trailing-task marker for `host`: called by the trailing
+    /// republish task right before it re-runs `republish`, so a defer that
+    /// races the re-run schedules a fresh trailing task instead of being
+    /// silently absorbed by one that already woke.
+    pub(crate) fn wire_gate_take_pending(&self, host: &Url) {
+        if let Some(gate) = self
+            .wire_gate
+            .lock()
+            .recover_poison("DiagnosticAggregator::wire_gate")
+            .get_mut(host)
+        {
+            gate.pending = false;
+        }
+    }
+
+    /// Forget the wire-gate state for `host` (`didClose`, next to
+    /// [`Self::forget_coverage`]) so the entry doesn't linger; a re-open's
+    /// first publish passes through immediately (`last_sent_at` reset).
+    pub(crate) fn forget_wire_gate(&self, host: &Url) {
+        self.wire_gate
+            .lock()
+            .recover_poison("DiagnosticAggregator::wire_gate")
+            .remove(host);
+    }
+
     /// Drop one `source`'s slots (every server) under `host` — e.g. a region
     /// invalidated by an edit, whose stale `Region` slots would otherwise linger
     /// until the whole host is closed (#424). Returns whether the source existed.
@@ -938,6 +1063,86 @@ mod tests {
 
     fn host() -> Url {
         Url::parse("file:///doc.md").unwrap()
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wire_gate_passes_leading_edge_and_defers_within_the_window() {
+        let agg = DiagnosticAggregator::new();
+        let window = std::time::Duration::from_secs(1);
+
+        assert_eq!(
+            agg.wire_gate_admit(&host(), window),
+            WireAdmit::SendNow,
+            "the first send always passes (no prior send to be quiet after)"
+        );
+
+        // Within the window: withheld, and exactly the FIRST defer is handed
+        // the trailing-task duty.
+        let first = agg.wire_gate_admit(&host(), window);
+        assert!(
+            matches!(
+                first,
+                WireAdmit::Defer {
+                    schedule_trailing: true,
+                    ..
+                }
+            ),
+            "the first in-window attempt schedules the trailing republish, got {first:?}"
+        );
+        assert!(
+            agg.wire_gate_is_dirty(&host()),
+            "a withheld change marks the wire dirty"
+        );
+        let second = agg.wire_gate_admit(&host(), window);
+        assert!(
+            matches!(
+                second,
+                WireAdmit::Defer {
+                    schedule_trailing: false,
+                    ..
+                }
+            ),
+            "later in-window attempts must not schedule a second task, got {second:?}"
+        );
+
+        // Window elapsed: pass again, clearing the dirty marker.
+        tokio::time::advance(window).await;
+        agg.wire_gate_take_pending(&host());
+        assert_eq!(
+            agg.wire_gate_admit(&host(), window),
+            WireAdmit::SendNow,
+            "the trailing attempt after the window sends"
+        );
+        assert!(
+            !agg.wire_gate_is_dirty(&host()),
+            "a send clears the dirty marker"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wire_gate_defer_after_take_pending_reschedules() {
+        // A defer that lands after the trailing task woke (take_pending) but
+        // before the window reopened must schedule a FRESH trailing task —
+        // otherwise its change would wait for a task that no longer exists.
+        let agg = DiagnosticAggregator::new();
+        let window = std::time::Duration::from_secs(1);
+        assert_eq!(agg.wire_gate_admit(&host(), window), WireAdmit::SendNow);
+        assert!(matches!(
+            agg.wire_gate_admit(&host(), window),
+            WireAdmit::Defer {
+                schedule_trailing: true,
+                ..
+            }
+        ));
+
+        agg.wire_gate_take_pending(&host());
+        assert!(matches!(
+            agg.wire_gate_admit(&host(), window),
+            WireAdmit::Defer {
+                schedule_trailing: true,
+                ..
+            }
+        ));
     }
 
     #[tokio::test]

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -770,7 +770,12 @@ impl DiagnosticAggregator {
         // Single lookup via `get_mut`: update in place when the host is already
         // present (the common path), cloning the `host` key only on first insert.
         if let Some(prev) = last.get_mut(host) {
-            if same_diagnostic_multiset(prev, diagnostics) {
+            // Fast path: `merge_cached_diagnostics` output is deterministically
+            // sorted (#423 / `sort_diagnostics`, a total order), so equal sets
+            // arrive slice-equal — the O(n²) multiset walk below is only the
+            // fallback for order variation a future unsorted caller could
+            // introduce.
+            if prev.as_slice() == diagnostics || same_diagnostic_multiset(prev, diagnostics) {
                 return false;
             }
             *prev = diagnostics.to_vec();

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -47,7 +47,7 @@
 //! version gate was evaluated and rejected (it converts a self-healing stale-overwrite
 //! into a reopen-resurrection hide); the stale-overwrite is left self-healing.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -403,6 +403,17 @@ pub(crate) struct DiagnosticAggregator {
     /// `served`) sends no redundant nudge. Drives [`Self::bump_current`],
     /// [`Self::mark_served`], [`Self::is_dirty`]; forgotten on `didClose`.
     coverage: Mutex<HashMap<Url, HostCoverage>>,
+    /// Hosts whose LAST pull was answered degraded — the bounded parse wait
+    /// lapsed while the aggregator held live region pushes, so the response
+    /// was missing the region fold and deliberately did not `mark_served`.
+    /// The reparse loop's post-parse backstop consumes an entry
+    /// ([`Self::take_degraded_pull`]) to request the recovery
+    /// `workspace/diagnostic/refresh` for exactly the hosts that owe one —
+    /// keying the recovery on this instead of the workspace-wide coverage
+    /// dirtiness keeps unrelated stale hosts from turning every edit's parse
+    /// pass into a refresh trigger. A later non-degraded pull clears the debt
+    /// (it marks served); `didClose` forgets it.
+    degraded_pulls: Mutex<HashSet<Url>>,
     /// Per-host coalescing state for the editor-facing `publishDiagnostics`
     /// wire sends (the quiet window): see [`WireGate`] and
     /// [`Self::wire_gate_admit`]. Mutated under the host's republish lock
@@ -911,6 +922,37 @@ impl DiagnosticAggregator {
         self.coverage
             .lock()
             .recover_poison("DiagnosticAggregator::coverage")
+            .remove(host);
+    }
+
+    /// Record that a pull for `host` was answered degraded (see the
+    /// `degraded_pulls` field doc). Clones the key only on first insert.
+    pub(crate) fn record_degraded_pull(&self, host: &Url) {
+        let mut degraded = self
+            .degraded_pulls
+            .lock()
+            .recover_poison("DiagnosticAggregator::degraded_pulls");
+        if !degraded.contains(host) {
+            degraded.insert(host.clone());
+        }
+    }
+
+    /// Consume `host`'s degraded-pull debt, returning whether one existed —
+    /// the post-parse backstop's trigger for the recovery refresh.
+    pub(crate) fn take_degraded_pull(&self, host: &Url) -> bool {
+        self.degraded_pulls
+            .lock()
+            .recover_poison("DiagnosticAggregator::degraded_pulls")
+            .remove(host)
+    }
+
+    /// Forget `host`'s degraded-pull debt without acting on it: a later
+    /// non-degraded pull covered the host (it marked served), or the host
+    /// closed.
+    pub(crate) fn forget_degraded_pull(&self, host: &Url) {
+        self.degraded_pulls
+            .lock()
+            .recover_poison("DiagnosticAggregator::degraded_pulls")
             .remove(host);
     }
 

--- a/src/lsp/diagnostic_cache.rs
+++ b/src/lsp/diagnostic_cache.rs
@@ -182,6 +182,16 @@ pub(crate) fn merge_cached_diagnostics(
 /// and the client-pull response (`diagnostic_impl`): the pull's `resultId` is
 /// a content hash of the serialized items, so the same logical set must
 /// serialize identically across pulls regardless of fan-in completion order.
+///
+/// The tiebreak's `unwrap_or_default` cannot fire in practice: `ls_types`
+/// values serialize infallibly (string-keyed maps only, no non-UTF-8, no
+/// custom `Serialize`), and the idiom predates this sort's extraction. Were
+/// serialization ever to fail, the cheap keys above still order by
+/// position/message/source/severity — only fully-tied distinct diagnostics
+/// could then keep input order, and the `resultId`'s length suffix plus the
+/// per-item hash of everything that DID serialize bound the unchanged-report
+/// consequence to the same accepted 2^-64 collision class documented at
+/// `diagnostic_result_id`.
 pub(crate) fn sort_diagnostics(diagnostics: &mut [Diagnostic]) {
     diagnostics.sort_by(|a, b| {
         let key = |d: &Diagnostic| {

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -680,11 +680,14 @@ impl Kakehashi {
                 // client until the next push. The per-host debt (recorded by
                 // that pull, consumed here exactly once) keys the recovery, so
                 // an ordinary edit cycle — or an unrelated host being dirty —
-                // never turns a parse pass into a refresh trigger; the
-                // request still goes through the coverage + single-flight
-                // gates like every other refresh origin.
+                // never turns a parse pass into a refresh trigger. FORCED past
+                // the coverage gate (still single-flighted): the debt proves
+                // the client holds a non-covering answer, which the
+                // version-based gate cannot see — an edit-race degradation
+                // leaves served == current, so a gated request would be
+                // suppressed while the client displays the region-less set.
                 if diagnostics.take_degraded_pull(&uri) {
-                    publisher.request_pull_diagnostic_refresh(false);
+                    publisher.request_pull_diagnostic_refresh(true);
                 }
 
                 // Schedule the debounced diagnostic HERE, after the reparse restored

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -673,16 +673,17 @@ impl Kakehashi {
                 // loses its retry (diagnostic_publisher.rs).
                 if diagnostics.has_region_slots(&uri) {
                     publisher.republish(&uri).await;
-                    // Degraded-pull recovery: a pull answered while THIS parse
-                    // was pending couldn't fold the region slots and skipped
-                    // `mark_served`, so coverage is still dirty — and no later
-                    // event re-nudges a pull-first client until the next push.
-                    // Ask through the existing coverage + single-flight gates:
-                    // this fires only when some host's change is genuinely
-                    // uncovered (a pull that raced the parse, or a push the
-                    // client never pulled for), so the ordinary edit cycle —
-                    // where the editor's own re-pull marks served — stays
-                    // refresh-free as documented.
+                }
+                // Degraded-pull recovery: a pull answered while THIS parse was
+                // pending couldn't fold the region slots and skipped
+                // `mark_served` — and no later event re-nudges a pull-first
+                // client until the next push. The per-host debt (recorded by
+                // that pull, consumed here exactly once) keys the recovery, so
+                // an ordinary edit cycle — or an unrelated host being dirty —
+                // never turns a parse pass into a refresh trigger; the
+                // request still goes through the coverage + single-flight
+                // gates like every other refresh origin.
+                if diagnostics.take_degraded_pull(&uri) {
                     publisher.request_pull_diagnostic_refresh(false);
                 }
 

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -673,6 +673,17 @@ impl Kakehashi {
                 // loses its retry (diagnostic_publisher.rs).
                 if diagnostics.has_region_slots(&uri) {
                     publisher.republish(&uri).await;
+                    // Degraded-pull recovery: a pull answered while THIS parse
+                    // was pending couldn't fold the region slots and skipped
+                    // `mark_served`, so coverage is still dirty — and no later
+                    // event re-nudges a pull-first client until the next push.
+                    // Ask through the existing coverage + single-flight gates:
+                    // this fires only when some host's change is genuinely
+                    // uncovered (a pull that raced the parse, or a push the
+                    // client never pulled for), so the ordinary edit cycle —
+                    // where the editor's own re-pull marks served — stays
+                    // refresh-free as documented.
+                    publisher.request_pull_diagnostic_refresh(false);
                 }
 
                 // Schedule the debounced diagnostic HERE, after the reparse restored

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -667,6 +667,10 @@ impl Kakehashi {
                 // (which re-anchors region push slots against the now-current
                 // injection geometry).
                 injection.process_injections(&uri, true).await;
+                // This gate is the geometry-deferral's retry backstop: keep it
+                // in lockstep with `republish`'s `needs_geometry` predicate
+                // (both mean "non-empty Region slots"), or a deferred publish
+                // loses its retry (diagnostic_publisher.rs).
                 if diagnostics.has_region_slots(&uri) {
                     publisher.republish(&uri).await;
                 }

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -667,10 +667,10 @@ impl Kakehashi {
                 // (which re-anchors region push slots against the now-current
                 // injection geometry).
                 injection.process_injections(&uri, true).await;
-                // This gate is the geometry-deferral's retry backstop: keep it
-                // in lockstep with `republish`'s `needs_geometry` predicate
-                // (both mean "non-empty Region slots"), or a deferred publish
-                // loses its retry (diagnostic_publisher.rs).
+                // This gate is the geometry-deferral's retry backstop —
+                // `republish`'s `needs_geometry` is the same shared predicate
+                // (`has_live_region_slots`), so a deferred publish always has
+                // this retry (diagnostic_publisher.rs).
                 if diagnostics.has_region_slots(&uri) {
                     publisher.republish(&uri).await;
                 }

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -851,10 +851,12 @@ impl DiagnosticPublisher {
     /// crash-driven eviction ([`Self::evict_connection_diagnostics`]), the
     /// upstream forwarding loop relaying a downstream server's own
     /// `workspace/diagnostic/refresh` (`deliver_upstream_notification`), and the
-    /// reparse loop's post-parse backstop as **degraded-pull recovery** (a pull
-    /// that raced the parse was answered without the region fold and did not
-    /// mark coverage served; the coverage gate below makes that call a no-op in
-    /// the ordinary covered cycle) — never from the pull-origin republish
+    /// reparse loop's post-parse backstop (and the pull-side TOCTOU guard) as
+    /// **degraded-pull recovery** — a pull that raced the parse was answered
+    /// without the region fold; the per-host debt keys the call, and it is
+    /// FORCED past the coverage gate because the debt proves the client holds
+    /// a non-covering answer the version-based gate cannot see (an edit-race
+    /// degradation leaves `served == current`) — never from the pull-origin republish
     /// ([`Self::publish_pull_layer`]) nor the editor-originated eviction paths
     /// ([`Self::clear_pull_layer`], [`Self::clear_host`]): those carry no *new*
     /// result the editor is unaware of — a pull-origin set is already the

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -165,17 +165,20 @@ impl DiagnosticPublisher {
     }
 
     async fn publish_recorded_hosts(&self, hosts: Vec<Url>) -> usize {
-        let mut published = 0;
+        // Counts hosts whose republish warrants the pull-client nudge (Changed
+        // or Deferred) — not wire sends, which the quiet window/seal may
+        // withhold.
+        let mut nudged = 0;
         for host in hosts {
             if self.republish(&host).await.nudges_pull_clients() {
                 self.bump_current_if_open(&host);
-                published += 1;
+                nudged += 1;
             }
         }
-        if published > 0 {
+        if nudged > 0 {
             self.request_pull_diagnostic_refresh(false);
         }
-        published
+        nudged
     }
 
     /// Record a `_self` host-layer push and republish the host (host-document-bridge).
@@ -691,7 +694,9 @@ impl DiagnosticPublisher {
         // `clear_host`'s forget, which does not hold the republish lock) would
         // be exactly what defers that clearing publish. Both republishes are
         // serialized on the per-host lock, so the clearing (empty) publish
-        // always lands last.
+        // always lands last. (This ungated send shares the pre-existing
+        // record-before-send hazard: an abort landing exactly at the send
+        // below loses it — same class as main, bounded to closed-host races.)
         if self.documents.get(host).is_none() {
             log::debug!(
                 target: LOG_TARGET,
@@ -762,9 +767,9 @@ impl DiagnosticPublisher {
     /// re-running, so a defer racing the re-run schedules a fresh task rather
     /// than being absorbed by one that already woke — and BAILS when the gate
     /// entry is gone (`didClose` or the seal forgot it while this task was
-    /// parked): the debt was cancelled, and a stale task from a previous
-    /// document incarnation must not republish/stamp state a reopened
-    /// incarnation never owed.
+    /// parked): the debt was cancelled. (A stale task waking against a
+    /// reopened incarnation's fresh entry is instead kept safe by the
+    /// defer-reschedule design — see `wire_gate_take_pending`.)
     ///
     /// Shutdown: a task parked at teardown fires up to one window later and
     /// sends a fire-and-forget notification into a closing client — tower-lsp
@@ -1308,8 +1313,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn republish_reports_whether_the_published_set_changed() {
-        // `republish` returns whether it published a *changed* set — the gate the
+    async fn republish_reports_whether_the_recorded_set_changed() {
+        // `republish` reports whether the merged-and-RECORDED set changed (the
+        // wire send may be withheld by the quiet window or sealed) — the gate the
         // push-origin paths use to decide whether to also emit
         // `workspace/diagnostic/refresh` (so a pull-mode editor re-pulls and sees an
         // async host push; push/pull-divergence, #422). A non-empty first publish is
@@ -1386,9 +1392,10 @@ mod tests {
     #[tokio::test]
     async fn republish_under_seal_keeps_the_change_contract() {
         // With the wire sealed, the merge and the last-published recording must
-        // behave exactly as in publish mode: a changed set reports true (drives
-        // the coverage bump + refresh — the sealed setup's delivery signal), an
-        // identical re-merge reports false. If the seal skipped the recording,
+        // behave exactly as in publish mode: a changed set reports Changed
+        // (drives the coverage bump + refresh — the sealed setup's delivery
+        // signal), an identical re-merge reports Unchanged. If the seal skipped
+        // the recording,
         // every push would re-report "changed" and spam refreshes forever.
         let (service, _socket) = LspService::new(Kakehashi::new);
         let server = service.inner();

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -6,8 +6,11 @@
 //! burst records all slots first and asks once per affected host): it snapshots the
 //! cache, transforms region push slots to host coordinates against the region's
 //! *current* offset (lazy re-anchor), merges with the host-event pull blob, and
-//! emits one `publishDiagnostics`. Routing every feed through one publisher is
-//! what keeps sibling regions intact against the client's URI-level clobber.
+//! emits at most one `publishDiagnostics` — the wire send is coalesced per host
+//! (the quiet window), can be sealed off by config, and is deferred while the
+//! region geometry is unknown (see [`DiagnosticPublisher::republish`]). Routing
+//! every feed through one publisher is what keeps sibling regions intact
+//! against the client's URI-level clobber.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -37,6 +40,37 @@ pub(crate) struct DiagnosticPush {
     pub(crate) diagnostics: Vec<Diagnostic>,
 }
 
+/// Outcome of one [`DiagnosticPublisher::republish`] pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RepublishOutcome {
+    /// The merged set changed and was recorded as the new last-published set
+    /// (and sent to the wire, unless the quiet window withheld it or the
+    /// config seal skipped it).
+    Changed,
+    /// The merge produced nothing new — identical to the recorded set (or the
+    /// host URI was unusable).
+    Unchanged,
+    /// Region geometry is unknown (tree pending): nothing was merged, recorded
+    /// or sent; the reparse loop's post-parse republish is the retry. The
+    /// CACHE did just change for a push-origin caller — that's why it asked to
+    /// republish — so push-origin callers treat this like `Changed` for the
+    /// coverage bump + `workspace/diagnostic/refresh` nudge: the retry is
+    /// edit-origin (it never nudges), and a pull-mode client whose own re-pull
+    /// raced ahead of the push would otherwise rot on a stale set until the
+    /// next edit (the #496 symptom). The nudged re-pull is safe mid-window —
+    /// the pull path waits for the tree and folds cached pushes with fresh
+    /// geometry.
+    Deferred,
+}
+
+impl RepublishOutcome {
+    /// Whether a push-origin caller should bump coverage and nudge
+    /// `workspace/diagnostic/refresh` for this outcome (see [`Self::Deferred`]).
+    fn nudges_pull_clients(self) -> bool {
+        matches!(self, Self::Changed | Self::Deferred)
+    }
+}
+
 /// Quiet window for the editor-facing `publishDiagnostics` wire sends, per
 /// host. A changed merge inside the window after the last send is withheld and
 /// re-merged by one trailing republish at the window's end, so a burst of
@@ -46,8 +80,12 @@ pub(crate) struct DiagnosticPush {
 /// ~2,235 merged diagnostics), so the gate bounds sustained-typing wire cost
 /// at ~1 MB/s/host where it was ~2.2. An isolated change (window already
 /// elapsed) passes through immediately: the gate adds no latency outside
-/// bursts. One second matches the cadence editors themselves update
-/// diagnostics UI at during active typing.
+/// bursts (more precisely: to a change arriving after >= 1 s of wire quiet).
+/// Deliberately a fixed constant, not a config knob: the window trades only
+/// push-namespace refresh cadence against pipe bytes, the failure mode of a
+/// wrong value is mild in both directions, and this branch's review explicitly
+/// chose existing config surfaces over new ones — revisit if a real setup
+/// needs a different cadence.
 const WIRE_PUBLISH_QUIET_WINDOW: std::time::Duration = std::time::Duration::from_secs(1);
 
 /// Bundles the state needed to merge the cache and publish for a host, so the
@@ -129,7 +167,7 @@ impl DiagnosticPublisher {
     async fn publish_recorded_hosts(&self, hosts: Vec<Url>) -> usize {
         let mut published = 0;
         for host in hosts {
-            if self.republish(&host).await {
+            if self.republish(&host).await.nudges_pull_clients() {
                 self.bump_current_if_open(&host);
                 published += 1;
             }
@@ -225,10 +263,17 @@ impl DiagnosticPublisher {
     /// Borrows the document text directly (no `snapshot()` clone) — detection
     /// never touches the tree, so this also avoids spuriously dropping a push for
     /// an open-but-not-yet-parsed document.
+    ///
+    /// Uses the trace-level detection variant: this runs per downstream push
+    /// (`record_host_push`) and up to twice more per changed republish
+    /// (`filter_stale_host_slots`, `publish_sealed`), so the debug-level
+    /// variant would re-grow the per-event `language_detection` log volume
+    /// that PR #677 moved off the hot paths. Detection itself is cheap here —
+    /// the `languageId` short-circuits at the first stage for open documents.
     fn open_document_language(&self, uri: &Url) -> Option<String> {
         let doc = self.documents.get(uri)?;
         self.language
-            .detect_language(uri.path(), doc.text(), None, doc.language_id())
+            .detect_language_hot(uri.path(), doc.text(), None, doc.language_id())
     }
 
     /// Remove `Host` push slots from `snapshot` whose server is no longer a
@@ -442,7 +487,7 @@ impl DiagnosticPublisher {
         let affected = self.aggregator.evict_connection(connection_id);
         let mut any_changed = false;
         for host in affected {
-            if self.republish(&host).await {
+            if self.republish(&host).await.nudges_pull_clients() {
                 // A crash eviction is a push-origin change the editor doesn't know
                 // about → bump coverage so the gated refresh below fires (#497).
                 self.bump_current_if_open(&host);
@@ -464,11 +509,16 @@ impl DiagnosticPublisher {
     /// event to learn about, so it does refresh).
     pub(crate) async fn clear_host(&self, host: &Url) {
         self.aggregator.evict_host(host);
-        // Drop the wire-gate state BEFORE the clearing republish so it passes
-        // the quiet window unconditionally: a deferred clear would be dropped
-        // by the trailing task's closed-document guard, leaving the editor's
-        // push namespace showing diagnostics for a closed buffer.
-        self.aggregator.forget_wire_gate(host);
+        // The clearing republish needs no gate preparation: `republish` bypasses
+        // the quiet window for a closed host (the document is already removed by
+        // `did_close` when this runs). Deliberately do NOT forget the wire-gate
+        // state before it — the `dirty` marker of a still-withheld send is what
+        // forces the clearing publish past the unchanged-skip when the withheld
+        // set was itself the empty set (all contributors cleared just before the
+        // close; the eviction then merges `[]` against a recorded `[]`, and
+        // without `dirty` the clearing publish would be skipped while the
+        // trailing task dies on its closed-document guard — pinning the closed
+        // buffer's stale diagnostics in the editor forever).
         self.republish(host).await;
         // The host is closed: forget its last-published set so the entry does not
         // linger and a later re-open publishes afresh (#422). Done after the
@@ -490,15 +540,20 @@ impl DiagnosticPublisher {
     /// Merge the host's cached slots and publish the cumulative result. Region
     /// slots are transformed against the host document's *current* injection
     /// offsets; an empty merge clears the editor's diagnostics for the host.
+    /// For a pull-capable client that has been observed pulling this host, the
+    /// wire send may lag: the quiet window can withhold it into the trailing
+    /// flush, and the config seal can skip it entirely — see the gates below.
     ///
-    /// Returns `true` when a *changed* set was published to the editor, `false`
-    /// when nothing was sent (bad URI, the merged set was identical to the last
-    /// publish, or the publish was **deferred** because the document's region
-    /// geometry is unknown mid-reparse — see the deferral below). Push-origin
-    /// callers ([`Self::publish_host_push`], [`Self::publish_region_push`]) use
-    /// this to decide whether to also nudge pull-mode clients with
-    /// [`Self::request_pull_diagnostic_refresh`].
-    pub(crate) async fn republish(&self, host: &Url) -> bool {
+    /// Returns [`RepublishOutcome::Changed`] when the merged set changed and
+    /// was recorded (the wire send may still be withheld or sealed),
+    /// [`RepublishOutcome::Unchanged`] when the merge produced nothing new,
+    /// and [`RepublishOutcome::Deferred`] when region geometry was unknown
+    /// mid-reparse (nothing merged or recorded; the reparse loop retries).
+    /// Push-origin callers (`publish_recorded_hosts`,
+    /// [`Self::evict_connection_diagnostics`]) nudge pull-mode clients with
+    /// [`Self::request_pull_diagnostic_refresh`] on `Changed` OR `Deferred` —
+    /// see [`RepublishOutcome::Deferred`] for why the deferral still nudges.
+    pub(crate) async fn republish(&self, host: &Url) -> RepublishOutcome {
         // Serialize the whole snapshot→merge→publish so concurrent republishes
         // (region push vs host-event pull) emit in order and a stale snapshot can
         // never publish after a fresh one (push-propagation-diagnostic-forwarding).
@@ -549,16 +604,23 @@ impl DiagnosticPublisher {
                 // between the full and the region-less set on every edit cycle
                 // (~2 × ~1 MB publishes per keystroke settle, plus visible
                 // flicker for push-mode clients). Defer instead: publish nothing,
-                // record nothing. The reparse loop always re-runs `republish`
-                // after the parse lands whenever non-empty region slots exist
-                // (`has_region_slots` — same predicate as `needs_geometry`), so
-                // the deferred publish is guaranteed to happen with real offsets.
+                // record nothing. The reparse loop re-runs `republish` after the
+                // parse lands whenever non-empty region slots remain
+                // (`has_region_slots` — the same predicate as `needs_geometry`),
+                // and the pass's debounced pull re-feeds and republishes too.
+                // Caveats, accepted: a parse give-up (timeout / parser gone)
+                // leaves the tree absent, so both retries stay deferred until
+                // the next edit (main published a region-LESS set there — worse);
+                // and an edit that evicts the very slots that forced this defer
+                // hands coverage to the debounced pull alone. Push-origin
+                // delivery does not depend on the retry: `Deferred` nudges
+                // pull-mode clients at defer time (see `RepublishOutcome`).
                 None => {
                     log::debug!(
                         target: LOG_TARGET,
                         "defer republish for {host}: tree pending, region geometry unknown"
                     );
-                    return false;
+                    return RepublishOutcome::Deferred;
                 }
             }
         } else {
@@ -570,7 +632,7 @@ impl DiagnosticPublisher {
             Ok(uri) => uri,
             Err(e) => {
                 log::warn!(target: LOG_TARGET, "skip publish, bad host URI {host}: {e}");
-                return false;
+                return RepublishOutcome::Unchanged;
             }
         };
 
@@ -581,14 +643,18 @@ impl DiagnosticPublisher {
         // send (`wire_gate_is_dirty`) still proceeds: the recorded set is ahead
         // of what actually reached the editor, so the trailing republish must
         // send even though its own merge compares unchanged.
-        let changed = self.aggregator.published_set_changed(host, &diagnostics);
-        if !changed && !self.aggregator.wire_gate_is_dirty(host) {
+        let changed = if self.aggregator.published_set_changed(host, &diagnostics) {
+            RepublishOutcome::Changed
+        } else {
+            RepublishOutcome::Unchanged
+        };
+        if changed == RepublishOutcome::Unchanged && !self.aggregator.wire_gate_is_dirty(host) {
             log::debug!(
                 target: LOG_TARGET,
                 "skip republish for {host}: merged set unchanged ({} diagnostics)",
                 diagnostics.len()
             );
-            return false;
+            return RepublishOutcome::Unchanged;
         }
 
         // The cross-layer gate for `textDocument/publishDiagnostics` doubles as a
@@ -616,6 +682,29 @@ impl DiagnosticPublisher {
             return changed;
         }
 
+        // A republish for a CLOSED host bypasses the quiet window and never
+        // touches gate state. This is (or races) `didClose`'s clearing publish,
+        // and both halves matter: a *deferred* clearing publish would be
+        // dropped by the trailing task's closed-document guard, pinning the
+        // closed buffer's last diagnostics in the editor forever; and a racing
+        // in-flight republish that *stamped* fresh gate state here (after
+        // `clear_host`'s forget, which does not hold the republish lock) would
+        // be exactly what defers that clearing publish. Both republishes are
+        // serialized on the per-host lock, so the clearing (empty) publish
+        // always lands last.
+        if self.documents.get(host).is_none() {
+            log::debug!(
+                target: LOG_TARGET,
+                "publishing {} merged diagnostics for closed host {} (quiet window bypassed)",
+                diagnostics.len(),
+                host
+            );
+            self.client
+                .publish_diagnostics(lsp_uri, diagnostics, None)
+                .await;
+            return changed;
+        }
+
         // Coalesce the wire sends per host (the quiet window): a burst of
         // set-changing feeds — spontaneous pushes, the pull-layer completion,
         // the post-parse geometry re-merge, each ~1 MB on a diagnostics-heavy
@@ -638,6 +727,14 @@ impl DiagnosticPublisher {
                 self.client
                     .publish_diagnostics(lsp_uri, diagnostics, None)
                     .await;
+                // Stamp the send only AFTER it completed: this republish can run
+                // inside an abortable task (the synthetic pull is aborted on
+                // supersession), and an abort landing at the send await must not
+                // leave gate state claiming a send that never happened — that
+                // would both defer the next change and consume a withheld
+                // `dirty` debt. Same lock hold as the admit, so the pair is
+                // atomic per host.
+                self.aggregator.wire_gate_commit_send(host);
             }
             crate::lsp::diagnostic_cache::WireAdmit::Defer {
                 schedule_trailing,
@@ -659,11 +756,21 @@ impl DiagnosticPublisher {
     }
 
     /// Re-run [`Self::republish`] for `host` once the quiet window elapses,
-    /// sending the (re-merged, latest) withheld set to the wire. Exactly one
-    /// task is parked per host per window ([`WireAdmit::Defer`]'s
+    /// sending the (re-merged, latest) withheld set to the wire. At most one
+    /// task is parked per host at a time ([`WireAdmit::Defer`]'s
     /// `schedule_trailing`). Clears the gate's `pending` marker *before*
     /// re-running, so a defer racing the re-run schedules a fresh task rather
-    /// than being absorbed by one that already woke.
+    /// than being absorbed by one that already woke — and BAILS when the gate
+    /// entry is gone (`didClose` or the seal forgot it while this task was
+    /// parked): the debt was cancelled, and a stale task from a previous
+    /// document incarnation must not republish/stamp state a reopened
+    /// incarnation never owed.
+    ///
+    /// Shutdown: a task parked at teardown fires up to one window later and
+    /// sends a fire-and-forget notification into a closing client — tower-lsp
+    /// suppresses or error-logs it; nothing panics and no fresh downstream
+    /// state is created (unlike the reparse loop, which checks the shutdown
+    /// token because its work spawns bridge connections).
     ///
     /// [`WireAdmit::Defer`]: crate::lsp::diagnostic_cache::WireAdmit::Defer
     fn spawn_trailing_wire_publish(&self, host: Url, remaining: std::time::Duration) {
@@ -674,11 +781,13 @@ impl DiagnosticPublisher {
         let deadline = tokio::time::Instant::now() + remaining;
         tokio::spawn(async move {
             tokio::time::sleep_until(deadline).await;
-            publisher.aggregator.wire_gate_take_pending(&host);
-            // A host closed while this task was parked: `clear_host` already
-            // published the clearing set and forgot the host's state —
-            // republishing would resurrect a `last_published` entry for a gone
-            // document.
+            if !publisher.aggregator.wire_gate_take_pending(&host) {
+                return; // gate forgotten while parked: debt cancelled
+            }
+            // Belt to the bail above: a host closed while this task was parked
+            // (but not yet forgotten) is `clear_host`'s to finish — its
+            // clearing republish bypasses the gate and lands last on the
+            // per-host lock.
             if publisher.documents.get(&host).is_none() {
                 return;
             }
@@ -975,9 +1084,11 @@ mod tests {
 
     /// [`rust_settings`]`(true)` plus the publish wire seal on the rust entry:
     /// `layers.aggregation."textDocument/publishDiagnostics".priorities = []`.
-    /// (On the exact language entry — `resolve_host_language_settings` is
-    /// exact-or-wildcard wholesale, so a `_` seal wouldn't reach a language
-    /// with its own entry.)
+    /// (On the exact language entry because `apply_settings` takes the raw
+    /// `WorkspaceSettings`, bypassing Phase 2 base resolution
+    /// (`resolve_base_configs`) — in production that phase field-merges the
+    /// `_` wildcard's `layers` into every configured language, so a
+    /// `languages._` seal DOES reach a language with its own entry there.)
     fn rust_settings_with_publish_seal() -> WorkspaceSettings {
         let mut settings = rust_settings(true);
         let lang = settings
@@ -1130,8 +1241,9 @@ mod tests {
             .await;
 
         assert_eq!(published_hosts, 1, "one host should be published once");
-        assert!(
-            !publisher.republish(&uri).await,
+        assert_eq!(
+            publisher.republish(&uri).await,
+            RepublishOutcome::Unchanged,
             "the batch must already have published its final aggregate"
         );
         let snapshot = server.diagnostics.snapshot(&uri);
@@ -1224,12 +1336,14 @@ mod tests {
             Some(ProgressConnectionId::for_test(1)),
             vec![diag("boom")],
         );
-        assert!(
+        assert_eq!(
             publisher.republish(&uri).await,
+            RepublishOutcome::Changed,
             "first publish of a non-empty host set must report a change (drives the refresh)"
         );
-        assert!(
-            !publisher.republish(&uri).await,
+        assert_eq!(
+            publisher.republish(&uri).await,
+            RepublishOutcome::Unchanged,
             "re-publishing the identical set must report unchanged (no redundant refresh)"
         );
     }
@@ -1298,12 +1412,14 @@ mod tests {
             vec![diag("boom")],
         );
 
-        assert!(
+        assert_eq!(
             publisher.republish(&uri).await,
-            "a changed set reports true under the seal (drives the refresh)"
+            RepublishOutcome::Changed,
+            "a changed set reports Changed under the seal (drives the refresh)"
         );
-        assert!(
-            !publisher.republish(&uri).await,
+        assert_eq!(
+            publisher.republish(&uri).await,
+            RepublishOutcome::Unchanged,
             "the sealed set was recorded as last-published, so a re-merge is unchanged"
         );
     }
@@ -1336,7 +1452,7 @@ mod tests {
             Some(ProgressConnectionId::for_test(1)),
             vec![diag("first")],
         );
-        assert!(publisher.republish(&uri).await);
+        assert_eq!(publisher.republish(&uri).await, RepublishOutcome::Changed);
         assert!(!server.diagnostics.wire_gate_is_dirty(&uri));
 
         // A second change inside the window: reported as changed, but the wire
@@ -1348,8 +1464,9 @@ mod tests {
             Some(ProgressConnectionId::for_test(1)),
             vec![diag("second")],
         );
-        assert!(
+        assert_eq!(
             publisher.republish(&uri).await,
+            RepublishOutcome::Changed,
             "a withheld change still reports changed (drives the refresh nudge)"
         );
         assert!(
@@ -1359,6 +1476,9 @@ mod tests {
 
         // The window elapses; the parked trailing task re-runs republish.
         tokio::time::advance(super::WIRE_PUBLISH_QUIET_WINDOW).await;
+        // Bounded yields to drain the woken trailing task under the paused
+        // clock (its republish takes the async per-host lock, so one poll is
+        // not enough; 20 is comfortably past what the task needs).
         for _ in 0..20 {
             tokio::task::yield_now().await;
         }
@@ -1366,8 +1486,9 @@ mod tests {
             !server.diagnostics.wire_gate_is_dirty(&uri),
             "the trailing republish flushed the withheld set"
         );
-        assert!(
-            !publisher.republish(&uri).await,
+        assert_eq!(
+            publisher.republish(&uri).await,
+            RepublishOutcome::Unchanged,
             "after the flush an identical re-merge is a plain unchanged skip"
         );
     }
@@ -1399,8 +1520,9 @@ mod tests {
         );
         let publisher = DiagnosticPublisher::new(server);
 
-        assert!(
-            !publisher.republish(&uri).await,
+        assert_eq!(
+            publisher.republish(&uri).await,
+            RepublishOutcome::Deferred,
             "a republish with live region slots but no parse snapshot must defer"
         );
         // Nothing was recorded as last-published: once the parse lands, the same
@@ -1437,8 +1559,9 @@ mod tests {
         );
         let publisher = DiagnosticPublisher::new(server);
 
-        assert!(
+        assert_eq!(
             publisher.republish(&uri).await,
+            RepublishOutcome::Changed,
             "an all-empty region snapshot needs no geometry; the (empty) merge publishes"
         );
     }
@@ -1470,6 +1593,98 @@ mod tests {
                 .current_region_offsets(&closed)
                 .is_some_and(|offsets| offsets.is_empty()),
             "a closed document has no regions to anchor, not unknown geometry"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn closed_host_republish_bypasses_the_quiet_window() {
+        // A republish for a closed host is (or races) didClose's clearing
+        // publish: it must never be deferred — a deferred clear dies on the
+        // trailing task's guards, pinning stale diagnostics on a closed buffer
+        // — and must never stamp gate state that would defer the clearing
+        // publish serialized behind it.
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        // Slots recorded for a URI that was never inserted as a document. The
+        // pull-layer slot is host-local and unfiltered, so it survives the
+        // closed-document merge (Host slots would be stale-filtered away).
+        let uri = Url::parse("file:///test/closed_host_bypass.rs").unwrap();
+        let publisher = DiagnosticPublisher::new(server);
+        server.diagnostics.set_pull_layer(&uri, vec![diag("stale")]);
+
+        assert_eq!(
+            publisher.republish(&uri).await,
+            RepublishOutcome::Changed,
+            "the first closed-host publish goes straight to the wire"
+        );
+        server.diagnostics.set_pull_layer(&uri, Vec::new());
+        assert_eq!(
+            publisher.republish(&uri).await,
+            RepublishOutcome::Changed,
+            "an immediate second closed-host publish must not be quiet-window deferred"
+        );
+        assert!(
+            !server.diagnostics.wire_gate_is_dirty(&uri),
+            "closed-host publishes leave no wire-gate state behind"
+        );
+        assert!(
+            !server.diagnostics.wire_gate_take_pending(&uri),
+            "no gate entry was minted for the closed host"
+        );
+    }
+
+    #[tokio::test]
+    async fn deferred_region_push_still_nudges_pull_clients() {
+        // A spontaneous region push landing in the tree-pending window defers
+        // the publish — but the CACHE changed, so the push-origin path must
+        // still bump coverage (making the workspace dirty) so the gated
+        // workspace/diagnostic/refresh nudges pull-mode clients. Losing the
+        // nudge here would revive the #496 rot: a client whose own re-pull
+        // raced ahead of the push keeps a stale set until the next edit.
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let host_uri = Url::parse("file:///test/deferred_nudge.md").unwrap();
+        server.documents.insert(
+            host_uri.clone(),
+            "```lua\nlocal x = 1\n```\n".to_string(),
+            Some("markdown".to_string()),
+            None, // tree pending: geometry unknown
+        );
+        let virtual_uri = VirtualDocumentUri::new(
+            &crate::lsp::lsp_impl::url_to_uri(&host_uri).unwrap(),
+            "lua",
+            "region-1",
+        );
+        server
+            .bridge
+            .register_opened_document_for_test(
+                &host_uri,
+                &virtual_uri,
+                &crate::lsp::bridge::ConnectionKey::for_server("lua_ls"),
+            )
+            .await;
+        let mut settings = WorkspaceSettings::default();
+        settings.language_servers.insert(
+            "lua_ls".to_string(),
+            BridgeServerConfig {
+                cmd: vec!["lua-language-server".to_string()],
+                ..Default::default()
+            },
+        );
+        server.settings_manager.apply_settings(settings);
+
+        assert!(!server.diagnostics.is_dirty(), "fresh host is clean");
+        DiagnosticPublisher::new(server)
+            .publish_region_push(
+                &virtual_uri.to_uri_string(),
+                "lua_ls".to_string(),
+                ProgressConnectionId::for_test(1),
+                vec![diag("unused variable")],
+            )
+            .await;
+        assert!(
+            server.diagnostics.is_dirty(),
+            "a geometry-deferred push must still bump coverage (drives the refresh nudge)"
         );
     }
 
@@ -1734,8 +1949,9 @@ mod tests {
         );
         let publisher = DiagnosticPublisher::new(server);
         // Establish the editor's baseline: the non-empty set is published.
-        assert!(
+        assert_eq!(
             publisher.republish(&uri).await,
+            RepublishOutcome::Changed,
             "the initial non-empty set is a change"
         );
 
@@ -1748,8 +1964,9 @@ mod tests {
         // `initialize` (server→client messages are suppressed until then), the
         // mock-client harness this file's tests deliberately avoid — true
         // end-to-end refresh coverage belongs in the e2e suite.
-        assert!(
-            !publisher.republish(&uri).await,
+        assert_eq!(
+            publisher.republish(&uri).await,
+            RepublishOutcome::Unchanged,
             "eviction published the empty changed set; re-publishing is unchanged"
         );
     }

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -37,9 +37,25 @@ pub(crate) struct DiagnosticPush {
     pub(crate) diagnostics: Vec<Diagnostic>,
 }
 
+/// Quiet window for the editor-facing `publishDiagnostics` wire sends, per
+/// host. A changed merge inside the window after the last send is withheld and
+/// re-merged by one trailing republish at the window's end, so a burst of
+/// feeds (spontaneous pushes, the pull-layer completion, the post-parse
+/// geometry re-merge) collapses into at most one full-set publish per window
+/// per host — on a diagnostics-heavy host each publish is ~1 MB (measured:
+/// ~2,235 merged diagnostics), so the gate bounds sustained-typing wire cost
+/// at ~1 MB/s/host where it was ~2.2. An isolated change (window already
+/// elapsed) passes through immediately: the gate adds no latency outside
+/// bursts. One second matches the cadence editors themselves update
+/// diagnostics UI at during active typing.
+const WIRE_PUBLISH_QUIET_WINDOW: std::time::Duration = std::time::Duration::from_secs(1);
+
 /// Bundles the state needed to merge the cache and publish for a host, so the
 /// notification feeds (reader push, host-event pull) can trigger a republish
-/// without each holding `Kakehashi`.
+/// without each holding `Kakehashi`. `Clone` is cheap (a `Client` handle plus
+/// `Arc`s) — the trailing wire-publish task clones it to re-run `republish`
+/// after the quiet window.
+#[derive(Clone)]
 pub(crate) struct DiagnosticPublisher {
     client: Client,
     language: Arc<LanguageCoordinator>,
@@ -448,6 +464,11 @@ impl DiagnosticPublisher {
     /// event to learn about, so it does refresh).
     pub(crate) async fn clear_host(&self, host: &Url) {
         self.aggregator.evict_host(host);
+        // Drop the wire-gate state BEFORE the clearing republish so it passes
+        // the quiet window unconditionally: a deferred clear would be dropped
+        // by the trailing task's closed-document guard, leaving the editor's
+        // push namespace showing diagnostics for a closed buffer.
+        self.aggregator.forget_wire_gate(host);
         self.republish(host).await;
         // The host is closed: forget its last-published set so the entry does not
         // linger and a later re-open publishes afresh (#422). Done after the
@@ -458,6 +479,8 @@ impl DiagnosticPublisher {
         // 0. (`clear_host` is editor-originated, so its republish doesn't bump
         // `current`; this just drops any prior push-origin coverage state.)
         self.aggregator.forget_coverage(host);
+        // And the wire-gate entry the clearing republish itself just stamped.
+        self.aggregator.forget_wire_gate(host);
         // didClose is off the hot path: reclaim republish-lock entries whose lock
         // now has no live holder — this host's, once the clear-republish above
         // released it, plus any earlier-closed hosts that have since drained (#466).
@@ -554,8 +577,12 @@ impl DiagnosticPublisher {
         // Suppress a republish that would re-send the exact set the editor already
         // has — a redundant publishDiagnostics is needless flicker/noise (#422).
         // Done under the per-host republish lock (held above), so the compare-and-set
-        // is serialized with other republishes for this host.
-        if !self.aggregator.published_set_changed(host, &diagnostics) {
+        // is serialized with other republishes for this host. A withheld wire
+        // send (`wire_gate_is_dirty`) still proceeds: the recorded set is ahead
+        // of what actually reached the editor, so the trailing republish must
+        // send even though its own merge compares unchanged.
+        let changed = self.aggregator.published_set_changed(host, &diagnostics);
+        if !changed && !self.aggregator.wire_gate_is_dirty(host) {
             log::debug!(
                 target: LOG_TARGET,
                 "skip republish for {host}: merged set unchanged ({} diagnostics)",
@@ -574,8 +601,11 @@ impl DiagnosticPublisher {
         // merge above still ran and recorded the set: change detection keeps
         // driving the push-origin coverage bump and
         // `workspace/diagnostic/refresh`, which IS the sealed setup's delivery
-        // signal (refresh → client re-pull).
+        // signal (refresh → client re-pull). The wire-gate state is dropped —
+        // there is no wire under the seal, so nothing can be owed to it (a
+        // stale `dirty` from before a mid-session seal would otherwise linger).
         if self.publish_sealed(host) {
+            self.aggregator.forget_wire_gate(host);
             log::debug!(
                 target: LOG_TARGET,
                 "seal: skipping publish of {} merged diagnostics for {} \
@@ -583,19 +613,77 @@ impl DiagnosticPublisher {
                 diagnostics.len(),
                 host
             );
-            return true;
+            return changed;
         }
 
-        log::debug!(
-            target: LOG_TARGET,
-            "publishing {} merged diagnostics for {}",
-            diagnostics.len(),
-            host
-        );
-        self.client
-            .publish_diagnostics(lsp_uri, diagnostics, None)
-            .await;
-        true
+        // Coalesce the wire sends per host (the quiet window): a burst of
+        // set-changing feeds — spontaneous pushes, the pull-layer completion,
+        // the post-parse geometry re-merge, each ~1 MB on a diagnostics-heavy
+        // host — collapses into at most one publish per window, re-merged from
+        // the LATEST cache by the trailing republish. An isolated change sends
+        // immediately. Deferral withholds only the wire: the set was already
+        // recorded above, so the return value (and with it the push-origin
+        // coverage bump + refresh nudge) is unaffected.
+        match self
+            .aggregator
+            .wire_gate_admit(host, WIRE_PUBLISH_QUIET_WINDOW)
+        {
+            crate::lsp::diagnostic_cache::WireAdmit::SendNow => {
+                log::debug!(
+                    target: LOG_TARGET,
+                    "publishing {} merged diagnostics for {}",
+                    diagnostics.len(),
+                    host
+                );
+                self.client
+                    .publish_diagnostics(lsp_uri, diagnostics, None)
+                    .await;
+            }
+            crate::lsp::diagnostic_cache::WireAdmit::Defer {
+                schedule_trailing,
+                remaining,
+            } => {
+                log::debug!(
+                    target: LOG_TARGET,
+                    "withholding publish of {} merged diagnostics for {} ({}ms of quiet window left)",
+                    diagnostics.len(),
+                    host,
+                    remaining.as_millis()
+                );
+                if schedule_trailing {
+                    self.spawn_trailing_wire_publish(host.clone(), remaining);
+                }
+            }
+        }
+        changed
+    }
+
+    /// Re-run [`Self::republish`] for `host` once the quiet window elapses,
+    /// sending the (re-merged, latest) withheld set to the wire. Exactly one
+    /// task is parked per host per window ([`WireAdmit::Defer`]'s
+    /// `schedule_trailing`). Clears the gate's `pending` marker *before*
+    /// re-running, so a defer racing the re-run schedules a fresh task rather
+    /// than being absorbed by one that already woke.
+    ///
+    /// [`WireAdmit::Defer`]: crate::lsp::diagnostic_cache::WireAdmit::Defer
+    fn spawn_trailing_wire_publish(&self, host: Url, remaining: std::time::Duration) {
+        let publisher = self.clone();
+        // Anchor the deadline NOW (at defer time), not at the task's first poll
+        // — under load the first poll can lag, which would silently stretch the
+        // quiet window.
+        let deadline = tokio::time::Instant::now() + remaining;
+        tokio::spawn(async move {
+            tokio::time::sleep_until(deadline).await;
+            publisher.aggregator.wire_gate_take_pending(&host);
+            // A host closed while this task was parked: `clear_host` already
+            // published the clearing set and forgot the host's state —
+            // republishing would resurrect a `last_published` entry for a gone
+            // document.
+            if publisher.documents.get(&host).is_none() {
+                return;
+            }
+            publisher.republish(&host).await;
+        });
     }
 
     /// Whether the editor-facing `publishDiagnostics` wire sends are sealed for
@@ -1217,6 +1305,70 @@ mod tests {
         assert!(
             !publisher.republish(&uri).await,
             "the sealed set was recorded as last-published, so a re-merge is unchanged"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn trailing_republish_flushes_the_withheld_wire_send() {
+        // Inside the quiet window a changed merge is withheld from the wire
+        // (dirty) and one trailing task is parked; once the window elapses the
+        // task re-runs republish, which sends despite its own merge comparing
+        // unchanged, and clears the dirty marker — after which an identical
+        // re-merge is a plain skip again.
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        register_rust(server);
+        server.settings_manager.apply_settings(rust_settings(true));
+        let uri = Url::parse("file:///test/host_trailing.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        let publisher = DiagnosticPublisher::new(server);
+
+        // Leading edge: first changed set passes through immediately.
+        server.diagnostics.record(
+            &uri,
+            DiagnosticSource::Host,
+            "rust_ls".to_string(),
+            Some(ProgressConnectionId::for_test(1)),
+            vec![diag("first")],
+        );
+        assert!(publisher.republish(&uri).await);
+        assert!(!server.diagnostics.wire_gate_is_dirty(&uri));
+
+        // A second change inside the window: reported as changed, but the wire
+        // send is withheld (dirty) with a trailing task parked.
+        server.diagnostics.record(
+            &uri,
+            DiagnosticSource::Host,
+            "rust_ls".to_string(),
+            Some(ProgressConnectionId::for_test(1)),
+            vec![diag("second")],
+        );
+        assert!(
+            publisher.republish(&uri).await,
+            "a withheld change still reports changed (drives the refresh nudge)"
+        );
+        assert!(
+            server.diagnostics.wire_gate_is_dirty(&uri),
+            "the change was withheld from the wire"
+        );
+
+        // The window elapses; the parked trailing task re-runs republish.
+        tokio::time::advance(super::WIRE_PUBLISH_QUIET_WINDOW).await;
+        for _ in 0..20 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !server.diagnostics.wire_gate_is_dirty(&uri),
+            "the trailing republish flushed the withheld set"
+        );
+        assert!(
+            !publisher.republish(&uri).await,
+            "after the flush an identical re-merge is a plain unchanged skip"
         );
     }
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -1499,12 +1499,9 @@ mod tests {
 
         // The window elapses; the parked trailing task re-runs republish.
         tokio::time::advance(super::WIRE_PUBLISH_QUIET_WINDOW).await;
-        // Bounded yields to drain the woken trailing task under the paused
-        // clock (its republish takes the async per-host lock, so one poll is
-        // not enough; 20 is comfortably past what the task needs).
-        for _ in 0..20 {
-            tokio::task::yield_now().await;
-        }
+        // Advance virtual time once more so Tokio drains the woken trailing
+        // task through its nested awaits without relying on a poll count.
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
         assert!(
             !server.diagnostics.wire_gate_is_dirty(&uri),
             "the trailing republish flushed the withheld set"

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -277,7 +277,7 @@ impl DiagnosticPublisher {
     fn open_document_language(&self, uri: &Url) -> Option<String> {
         let doc = self.documents.get(uri)?;
         self.language
-            .detect_language_hot(uri.path(), doc.text(), None, doc.language_id())
+            .detect_language_trace(uri.path(), doc.text(), None, doc.language_id())
     }
 
     /// Remove `Host` push slots from `snapshot` whose server is no longer a
@@ -980,7 +980,7 @@ impl DiagnosticPublisher {
         // region slots are present (every keystroke settle during a typing
         // burst) — the debug variant would re-grow the per-event
         // `language_detection` log volume PR #677 moved off hot paths.
-        let Some(language_name) = self.language.detect_language_hot(
+        let Some(language_name) = self.language.detect_language_trace(
             host.path(),
             snapshot.text(),
             None,

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -861,8 +861,10 @@ impl DiagnosticPublisher {
     /// answer to a pull the editor made, and an ordinary edit-origin re-merge
     /// is covered by the editor's own `didChange` re-pull — so a refresh there
     /// would be redundant. (No tight loop forms: a
-    /// refresh-induced pull is answered inline by `diagnostic_impl`, which never
-    /// republishes, so a refresh cannot directly beget another; the indirect
+    /// refresh-induced pull is answered inline by `diagnostic_impl`, which
+    /// never republishes; the one pull-side refresh — the degraded-pull TOCTOU
+    /// guard — consumes its debt on firing and the induced re-pull sees ready
+    /// geometry and answers covering, so it begets at most one round; the indirect
     /// push→refresh→re-pull→downstream-re-push→here path is bounded by
     /// `published_set_changed`, converging once the re-pushed set stabilizes.)
     ///

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -564,6 +564,28 @@ impl DiagnosticPublisher {
             return false;
         }
 
+        // The cross-layer gate for `textDocument/publishDiagnostics` doubles as a
+        // WIRE SEAL when it resolves to no layers at all: a pull-first editor
+        // setup can stop the proactive publishes entirely via existing config.
+        // On a diagnostics-heavy host they dominated the editor pipe (measured:
+        // 51 publishes × ~1 MB in a 44 s typing burst, 68% of all server→client
+        // bytes — head-of-line blocking every other response) while a pulling
+        // editor ignores them or renders them as a duplicate namespace. The
+        // merge above still ran and recorded the set: change detection keeps
+        // driving the push-origin coverage bump and
+        // `workspace/diagnostic/refresh`, which IS the sealed setup's delivery
+        // signal (refresh → client re-pull).
+        if self.publish_sealed(host) {
+            log::debug!(
+                target: LOG_TARGET,
+                "seal: skipping publish of {} merged diagnostics for {} \
+                 (layers.aggregation publishDiagnostics resolves to no layers)",
+                diagnostics.len(),
+                host
+            );
+            return true;
+        }
+
         log::debug!(
             target: LOG_TARGET,
             "publishing {} merged diagnostics for {}",
@@ -574,6 +596,33 @@ impl DiagnosticPublisher {
             .publish_diagnostics(lsp_uri, diagnostics, None)
             .await;
         true
+    }
+
+    /// Whether the editor-facing `publishDiagnostics` wire sends are sealed for
+    /// `host` by config: the cross-layer gate for
+    /// `textDocument/publishDiagnostics` resolves to an **empty** priorities
+    /// list (`layers.aggregation."textDocument/publishDiagnostics".priorities =
+    /// []` on the host's language or the `_` wildcard).
+    ///
+    /// The seal is deliberately **binary** (all layers gated off), not
+    /// per-layer: a partially gated list still publishes the full merge, and
+    /// per-layer selection keeps applying to the debounced pull feed
+    /// (`coordinator/diagnostic.rs`) as before — filtering the wire set by
+    /// layer would diverge it from the change-detection set that drives the
+    /// refresh nudging. Fails open (not sealed) when the document is gone or
+    /// its language is undetectable, so a `didClose` clearing publish still
+    /// goes out.
+    fn publish_sealed(&self, host: &Url) -> bool {
+        self.open_document_language(host)
+            .is_some_and(|language_name| {
+                crate::lsp::lsp_impl::bridge_context::resolve_layer_config_from_settings(
+                    &self.settings_manager.load_settings(),
+                    &language_name,
+                    "textDocument/publishDiagnostics",
+                )
+                .priorities
+                .is_empty()
+            })
     }
 
     /// Ask pull-mode clients to re-pull diagnostics (`workspace/diagnostic/refresh`)
@@ -778,7 +827,7 @@ mod tests {
     use super::*;
     use crate::config::settings::{
         BridgeLanguageConfig, BridgeServerConfig, HOST_BRIDGE_KEY, LanguageSettings,
-        WorkspaceSettings,
+        LayerAggregationConfig, LayersConfig, WorkspaceSettings,
     };
     use std::collections::HashMap;
     use tower_lsp_server::LspService;
@@ -834,6 +883,29 @@ mod tests {
             languages,
             ..Default::default()
         }
+    }
+
+    /// [`rust_settings`]`(true)` plus the publish wire seal on the rust entry:
+    /// `layers.aggregation."textDocument/publishDiagnostics".priorities = []`.
+    /// (On the exact language entry — `resolve_host_language_settings` is
+    /// exact-or-wildcard wholesale, so a `_` seal wouldn't reach a language
+    /// with its own entry.)
+    fn rust_settings_with_publish_seal() -> WorkspaceSettings {
+        let mut settings = rust_settings(true);
+        let lang = settings
+            .languages
+            .get_mut("rust")
+            .expect("rust_settings defines the rust language");
+        lang.layers = Some(LayersConfig {
+            aggregation: Some(HashMap::from([(
+                "textDocument/publishDiagnostics".to_string(),
+                LayerAggregationConfig {
+                    priorities: Some(Vec::new()),
+                    strategy: None,
+                },
+            )])),
+        });
+        settings
     }
 
     /// `service.inner()` borrows from `service`, so the harness is set up inline
@@ -1071,6 +1143,80 @@ mod tests {
         assert!(
             !publisher.republish(&uri).await,
             "re-publishing the identical set must report unchanged (no redundant refresh)"
+        );
+    }
+
+    #[tokio::test]
+    async fn publish_sealed_reflects_the_layer_gate() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        register_rust(server);
+        let uri = Url::parse("file:///test/host_seal.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        let publisher = DiagnosticPublisher::new(server);
+
+        server.settings_manager.apply_settings(rust_settings(true));
+        assert!(
+            !publisher.publish_sealed(&uri),
+            "default layer priorities publish as before"
+        );
+
+        server
+            .settings_manager
+            .apply_settings(rust_settings_with_publish_seal());
+        assert!(
+            publisher.publish_sealed(&uri),
+            "publishDiagnostics priorities = [] seals the wire sends"
+        );
+
+        let closed = Url::parse("file:///test/never_opened.rs").unwrap();
+        assert!(
+            !publisher.publish_sealed(&closed),
+            "an unresolvable document fails open (didClose's clearing publish goes out)"
+        );
+    }
+
+    #[tokio::test]
+    async fn republish_under_seal_keeps_the_change_contract() {
+        // With the wire sealed, the merge and the last-published recording must
+        // behave exactly as in publish mode: a changed set reports true (drives
+        // the coverage bump + refresh — the sealed setup's delivery signal), an
+        // identical re-merge reports false. If the seal skipped the recording,
+        // every push would re-report "changed" and spam refreshes forever.
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        register_rust(server);
+        server
+            .settings_manager
+            .apply_settings(rust_settings_with_publish_seal());
+        let uri = Url::parse("file:///test/host_sealed_contract.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        let publisher = DiagnosticPublisher::new(server);
+        server.diagnostics.record(
+            &uri,
+            DiagnosticSource::Host,
+            "rust_ls".to_string(),
+            Some(ProgressConnectionId::for_test(1)),
+            vec![diag("boom")],
+        );
+
+        assert!(
+            publisher.republish(&uri).await,
+            "a changed set reports true under the seal (drives the refresh)"
+        );
+        assert!(
+            !publisher.republish(&uri).await,
+            "the sealed set was recorded as last-published, so a re-merge is unchanged"
         );
     }
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -845,16 +845,19 @@ impl DiagnosticPublisher {
     /// Emitted **off** the per-host republish lock and **only** from the origins
     /// the editor can't learn about on its own — the push-origin paths
     /// ([`Self::publish_host_push`], [`Self::publish_region_push`]), the
-    /// crash-driven eviction ([`Self::evict_connection_diagnostics`]), and the
+    /// crash-driven eviction ([`Self::evict_connection_diagnostics`]), the
     /// upstream forwarding loop relaying a downstream server's own
-    /// `workspace/diagnostic/refresh` (`deliver_upstream_notification`) — never from
-    /// the pull-origin republish ([`Self::publish_pull_layer`]), the
-    /// editor-originated eviction paths ([`Self::clear_pull_layer`],
-    /// [`Self::clear_host`]), nor the edit-origin re-merge (`did_change`): those
-    /// carry no *new* result the editor is unaware of — a pull-origin set is already
-    /// the answer to a pull the editor made, and an edit-origin re-merge is covered
-    /// by the editor's own `didChange` re-pull — so a refresh there would be
-    /// redundant. (No tight loop forms: a
+    /// `workspace/diagnostic/refresh` (`deliver_upstream_notification`), and the
+    /// reparse loop's post-parse backstop as **degraded-pull recovery** (a pull
+    /// that raced the parse was answered without the region fold and did not
+    /// mark coverage served; the coverage gate below makes that call a no-op in
+    /// the ordinary covered cycle) — never from the pull-origin republish
+    /// ([`Self::publish_pull_layer`]) nor the editor-originated eviction paths
+    /// ([`Self::clear_pull_layer`], [`Self::clear_host`]): those carry no *new*
+    /// result the editor is unaware of — a pull-origin set is already the
+    /// answer to a pull the editor made, and an ordinary edit-origin re-merge
+    /// is covered by the editor's own `didChange` re-pull — so a refresh there
+    /// would be redundant. (No tight loop forms: a
     /// refresh-induced pull is answered inline by `diagnostic_impl`, which never
     /// republishes, so a refresh cannot directly beget another; the indirect
     /// push→refresh→re-pull→downstream-re-push→here path is bounded by

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -54,8 +54,9 @@ pub(crate) enum RepublishOutcome {
     /// or sent; the reparse loop's post-parse republish is the retry. The
     /// CACHE did just change for a push-origin caller — that's why it asked to
     /// republish — so push-origin callers treat this like `Changed` for the
-    /// coverage bump + `workspace/diagnostic/refresh` nudge: the retry is
-    /// edit-origin (it never nudges), and a pull-mode client whose own re-pull
+    /// coverage bump + `workspace/diagnostic/refresh` nudge: the retry nudges
+    /// only as degraded-pull recovery (per-host debt — see the reparse loop),
+    /// and a pull-mode client whose own re-pull
     /// raced ahead of the push would otherwise rot on a stale set until the
     /// next edit (the #496 symptom). The nudged re-pull is safe mid-window —
     /// the pull path waits for the tree and folds cached pushes with fresh
@@ -532,6 +533,8 @@ impl DiagnosticPublisher {
         // 0. (`clear_host` is editor-originated, so its republish doesn't bump
         // `current`; this just drops any prior push-origin coverage state.)
         self.aggregator.forget_coverage(host);
+        // And any degraded-pull debt — a closed doc owes no recovery refresh.
+        self.aggregator.forget_degraded_pull(host);
         // And the wire-gate entry the clearing republish itself just stamped.
         self.aggregator.forget_wire_gate(host);
         // didClose is off the hot path: reclaim republish-lock entries whose lock

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -906,7 +906,9 @@ impl DiagnosticPublisher {
         // `false` here means either one is already outstanding (recorded as `pending`,
         // so the outstanding task's loop fires the trailing) or — for a non-`forced`
         // request — nothing is dirty (the editor already has the current set). A
-        // `forced` downstream-forwarded refresh (#521) bypasses the coverage gate.
+        // `forced` request bypasses the coverage gate: the downstream-forwarded
+        // refresh (#521) and the degraded-pull recovery (whose per-host debt
+        // proves a non-covering answer no coverage version represents).
         if !self.aggregator.try_begin_refresh(forced) {
             return;
         }

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -590,14 +590,12 @@ impl DiagnosticPublisher {
         // Recompute injection offsets only when there are region push slots to
         // transform. A PullLayer-only snapshot (the common pull-driven case) needs
         // none, so skip the whole-document injection resolution — and shorten the
-        // time this host's republish lock is held. The predicate deliberately
-        // mirrors `DiagnosticAggregator::has_region_slots` (non-empty slots only):
-        // the geometry-unknown deferral below relies on the reparse loop's
-        // post-parse republish, which is gated on exactly that check.
-        let needs_geometry = snapshot.iter().any(|(source, servers)| {
-            matches!(source, DiagnosticSource::Region(_))
-                && servers.values().any(|slot| !slot.diagnostics.is_empty())
-        });
+        // time this host's republish lock is held. The predicate IS
+        // `DiagnosticAggregator::has_region_slots`'s (the shared
+        // `has_live_region_slots`): the geometry-unknown deferral below relies
+        // on the reparse loop's post-parse republish, which is gated on
+        // exactly that check.
+        let needs_geometry = crate::lsp::diagnostic_cache::has_live_region_slots(&snapshot);
         let region_offsets = if needs_geometry {
             match self.current_region_offsets(host) {
                 Some(offsets) => offsets,
@@ -977,10 +975,16 @@ impl DiagnosticPublisher {
         let Some(snapshot) = doc.snapshot() else {
             return None; // open but tree pending: geometry unknown, defer
         };
-        let Some(language_name) =
-            self.language
-                .detect_language(host.path(), snapshot.text(), None, doc.language_id())
-        else {
+        // Trace-level detection: this runs on the republish path whenever
+        // region slots are present (every keystroke settle during a typing
+        // burst) — the debug variant would re-grow the per-event
+        // `language_detection` log volume PR #677 moved off hot paths.
+        let Some(language_name) = self.language.detect_language_hot(
+            host.path(),
+            snapshot.text(),
+            None,
+            doc.language_id(),
+        ) else {
             return Some(offsets);
         };
         let Some(injection_query) = self.language.injection_query(&language_name) else {

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -469,10 +469,12 @@ impl DiagnosticPublisher {
     /// offsets; an empty merge clears the editor's diagnostics for the host.
     ///
     /// Returns `true` when a *changed* set was published to the editor, `false`
-    /// when nothing was sent (bad URI, or the merged set was identical to the
-    /// last publish). Push-origin callers ([`Self::publish_host_push`],
-    /// [`Self::publish_region_push`]) use this to decide whether to also nudge
-    /// pull-mode clients with [`Self::request_pull_diagnostic_refresh`].
+    /// when nothing was sent (bad URI, the merged set was identical to the last
+    /// publish, or the publish was **deferred** because the document's region
+    /// geometry is unknown mid-reparse — see the deferral below). Push-origin
+    /// callers ([`Self::publish_host_push`], [`Self::publish_region_push`]) use
+    /// this to decide whether to also nudge pull-mode clients with
+    /// [`Self::request_pull_diagnostic_refresh`].
     pub(crate) async fn republish(&self, host: &Url) -> bool {
         // Serialize the whole snapshot→merge→publish so concurrent republishes
         // (region push vs host-event pull) emit in order and a stale snapshot can
@@ -504,12 +506,38 @@ impl DiagnosticPublisher {
         // Recompute injection offsets only when there are region push slots to
         // transform. A PullLayer-only snapshot (the common pull-driven case) needs
         // none, so skip the whole-document injection resolution — and shorten the
-        // time this host's republish lock is held.
-        let region_offsets = if snapshot
-            .keys()
-            .any(|source| matches!(source, DiagnosticSource::Region(_)))
-        {
-            self.current_region_offsets(host)
+        // time this host's republish lock is held. The predicate deliberately
+        // mirrors `DiagnosticAggregator::has_region_slots` (non-empty slots only):
+        // the geometry-unknown deferral below relies on the reparse loop's
+        // post-parse republish, which is gated on exactly that check.
+        let needs_geometry = snapshot.iter().any(|(source, servers)| {
+            matches!(source, DiagnosticSource::Region(_))
+                && servers.values().any(|slot| !slot.diagnostics.is_empty())
+        });
+        let region_offsets = if needs_geometry {
+            match self.current_region_offsets(host) {
+                Some(offsets) => offsets,
+                // The document is open but has no parse snapshot: `did_change`
+                // cleared the tree and the off-ingress reparse hasn't landed yet,
+                // so the regions' current offsets are UNKNOWN — not gone. Merging
+                // now would silently drop every region push slot and publish a
+                // set missing whole servers, which the post-parse republish then
+                // reverts: on a diagnostics-heavy host that flapped the editor
+                // between the full and the region-less set on every edit cycle
+                // (~2 × ~1 MB publishes per keystroke settle, plus visible
+                // flicker for push-mode clients). Defer instead: publish nothing,
+                // record nothing. The reparse loop always re-runs `republish`
+                // after the parse lands whenever non-empty region slots exist
+                // (`has_region_slots` — same predicate as `needs_geometry`), so
+                // the deferred publish is guaranteed to happen with real offsets.
+                None => {
+                    log::debug!(
+                        target: LOG_TARGET,
+                        "defer republish for {host}: tree pending, region geometry unknown"
+                    );
+                    return false;
+                }
+            }
         } else {
             HashMap::new()
         };
@@ -669,25 +697,31 @@ impl DiagnosticPublisher {
 
     /// Map each currently-resolvable injection region of the host document to its
     /// offset, recomputed from the live document so region push slots re-anchor
-    /// after edits above them. Empty when the document is missing or has no
-    /// injections.
-    fn current_region_offsets(&self, host: &Url) -> HashMap<String, RegionOffset> {
+    /// after edits above them.
+    ///
+    /// `None` means the geometry is **unknown**: the document is open but has no
+    /// parse snapshot (`did_change` cleared the tree; the off-ingress reparse
+    /// hasn't landed) — the caller must defer publishing rather than treat the
+    /// regions as gone. `Some(empty)` means there legitimately are no regions to
+    /// anchor: the document is closed, or its language resolves to no injection
+    /// query — stale region slots drop from the merge.
+    fn current_region_offsets(&self, host: &Url) -> Option<HashMap<String, RegionOffset>> {
         let mut offsets = HashMap::new();
 
         let Some(doc) = self.documents.get(host) else {
-            return offsets;
+            return Some(offsets); // closed host: nothing to anchor against
         };
         let Some(snapshot) = doc.snapshot() else {
-            return offsets;
+            return None; // open but tree pending: geometry unknown, defer
         };
         let Some(language_name) =
             self.language
                 .detect_language(host.path(), snapshot.text(), None, doc.language_id())
         else {
-            return offsets;
+            return Some(offsets);
         };
         let Some(injection_query) = self.language.injection_query(&language_name) else {
-            return offsets;
+            return Some(offsets);
         };
 
         let resolved_regions = match self
@@ -714,7 +748,7 @@ impl DiagnosticPublisher {
                 ),
             );
         }
-        offsets
+        Some(offsets)
     }
 }
 
@@ -1037,6 +1071,107 @@ mod tests {
         assert!(
             !publisher.republish(&uri).await,
             "re-publishing the identical set must report unchanged (no redundant refresh)"
+        );
+    }
+
+    #[tokio::test]
+    async fn republish_defers_while_region_geometry_is_unknown() {
+        // `did_change` clears the visible tree; until the off-ingress reparse
+        // lands, `doc.snapshot()` is `None` and the regions' current offsets are
+        // unknown. A republish in that window must DEFER (publish nothing,
+        // record nothing) instead of merging with empty offsets — which silently
+        // dropped every region push slot and flapped the editor between the full
+        // and the region-less set on each edit cycle. The document here is
+        // inserted with no tree, modelling exactly that window.
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let uri = Url::parse("file:///test/host_geometry_unknown.md").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "```lua\nlocal x = 1\n```\n".to_string(),
+            Some("markdown".to_string()),
+            None, // no tree: snapshot() is None
+        );
+        server.diagnostics.record(
+            &uri,
+            DiagnosticSource::Region("region-1".to_string()),
+            "lua_ls".to_string(),
+            Some(ProgressConnectionId::for_test(1)),
+            vec![diag("unused variable")],
+        );
+        let publisher = DiagnosticPublisher::new(server);
+
+        assert!(
+            !publisher.republish(&uri).await,
+            "a republish with live region slots but no parse snapshot must defer"
+        );
+        // Nothing was recorded as last-published: once the parse lands, the same
+        // merged set must still count as a change (the deferred publish happens).
+        assert!(
+            server.diagnostics.published_set_changed(&uri, &[]),
+            "deferral must not record a last-published set"
+        );
+    }
+
+    #[tokio::test]
+    async fn republish_proceeds_without_a_tree_when_region_slots_are_empty() {
+        // The deferral is keyed on NON-EMPTY region slots (mirroring
+        // `has_region_slots`, the reparse loop's backstop gate). A host whose
+        // only region slot is an empty clearing push needs no geometry — its
+        // merge drops nothing real — so it publishes even while the tree is
+        // pending. If this deferred instead, the post-parse backstop would skip
+        // it (`has_region_slots` is false) and the publish would be lost.
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let uri = Url::parse("file:///test/host_empty_region_slot.md").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "```lua\nlocal x = 1\n```\n".to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        server.diagnostics.record(
+            &uri,
+            DiagnosticSource::Region("region-1".to_string()),
+            "lua_ls".to_string(),
+            Some(ProgressConnectionId::for_test(1)),
+            Vec::new(), // a clearing push: nothing to anchor
+        );
+        let publisher = DiagnosticPublisher::new(server);
+
+        assert!(
+            publisher.republish(&uri).await,
+            "an all-empty region snapshot needs no geometry; the (empty) merge publishes"
+        );
+    }
+
+    #[tokio::test]
+    async fn current_region_offsets_distinguishes_unknown_from_absent_geometry() {
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        let publisher = DiagnosticPublisher::new(server);
+
+        // Open document without a tree: geometry UNKNOWN → None (defer).
+        let pending = Url::parse("file:///test/pending.md").unwrap();
+        server.documents.insert(
+            pending.clone(),
+            "# doc".to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+        assert!(
+            publisher.current_region_offsets(&pending).is_none(),
+            "an open document with no parse snapshot has unknown geometry"
+        );
+
+        // Closed (never-opened) document: geometry ABSENT → Some(empty) (stale
+        // region slots legitimately drop; didClose's clearing publish proceeds).
+        let closed = Url::parse("file:///test/closed.md").unwrap();
+        assert!(
+            publisher
+                .current_region_offsets(&closed)
+                .is_some_and(|offsets| offsets.is_empty()),
+            "a closed document has no regions to anchor, not unknown geometry"
         );
     }
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -535,7 +535,8 @@ impl DiagnosticPublisher {
         self.aggregator.forget_coverage(host);
         // And any degraded-pull debt — a closed doc owes no recovery refresh.
         self.aggregator.forget_degraded_pull(host);
-        // And the wire-gate entry the clearing republish itself just stamped.
+        // And any wire-gate state left by earlier open-host publishes. The
+        // clearing republish above bypasses the gate because the host is closed.
         self.aggregator.forget_wire_gate(host);
         // didClose is off the hot path: reclaim republish-lock entries whose lock
         // now has no live holder — this host's, once the clear-republish above

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -822,11 +822,15 @@ fn diagnostic_result_id(items: &[Diagnostic]) -> String {
     const FNV_OFFSET: u64 = 0xcbf29ce484222325;
     let mut writer = FnvWriter(FNV_OFFSET);
     // Serialization of ls_types values cannot realistically fail (no non-string
-    // map keys) and `FnvWriter` never errors; were it ever to fail anyway, the
-    // partial-stream hash still differs per content and the `-len` suffix
-    // still discriminates by count, so a false "unchanged" additionally needs
-    // a hash collision — the accepted 2^-64 trade above.
-    let _ = serde_json::to_writer(&mut writer, items);
+    // map keys, and JSON numbers cannot be non-finite) and `FnvWriter` never
+    // errors; if it ever fails anyway, FAIL OPEN with an id that can never
+    // match a previous one — two differing sets could share a partial-stream
+    // prefix hash, and a false "unchanged" must stay impossible.
+    if serde_json::to_writer(&mut writer, items).is_err() {
+        static UNHASHABLE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let nonce = UNHASHABLE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        return format!("unhashable-{nonce}-{}", items.len());
+    }
     format!("{:016x}-{}", writer.0, items.len())
 }
 

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -352,26 +352,37 @@ impl Kakehashi {
         )
         .await;
 
+        // Degraded-answer guard (the pull-side sibling of `republish`'s
+        // geometry-unknown deferral): the bounded parse wait above can lapse
+        // under load, leaving `snapshot` `None` for an open document while the
+        // aggregator holds live region pushes — the fold above then silently
+        // skipped every cached `Region` slot, so this answer is missing whole
+        // servers' diagnostics. A pull must respond (there is no "defer" for a
+        // request), so serve the degraded set — but do NOT mark it served:
+        // coverage stays dirty, and the next push-origin change nudges the
+        // client back to a full view instead of the gap being masked until the
+        // next edit. The predicate mirrors `republish`'s `needs_geometry`
+        // (non-empty region slots only).
+        let degraded_virt =
+            virt_enabled && snapshot.is_none() && self.diagnostics.has_region_slots(&uri);
+
         // The editor is about to receive the current merged set: advance `served` to
         // the version captured at entry, so the refresh gate stops treating those
         // changes as dirty (#497). Pure bookkeeping — never republishes — so this
         // can't beget a refresh.
-        self.diagnostics.mark_served(&uri, served_version);
+        if !degraded_virt {
+            self.diagnostics.mark_served(&uri, served_version);
+        }
 
-        let mut items = combine_layer_diagnostics(&layer_cfg, virt_items, host_items);
-        // Deterministic order: the fan-outs above complete in arbitrary order,
-        // and the result id below is a hash of the serialized items, so the
-        // same logical set must serialize identically across pulls (it also
-        // gives the editor a stable list order, matching the publish path #423).
-        crate::lsp::diagnostic_cache::sort_diagnostics(&mut items);
-
-        // Content-addressed result id (stateless): the client echoes the id it
-        // last received as `previousResultId`; when the recomputed id matches,
-        // an UNCHANGED report replaces the full item list. On a
-        // diagnostics-heavy host a full report is ~1 MB (measured: ~2,235
-        // items), and every `workspace/diagnostic/refresh`-induced re-pull of
-        // a settled set previously re-shipped all of it.
-        let result_id = diagnostic_result_id(&items);
+        let items = combine_layer_diagnostics(&layer_cfg, virt_items, host_items);
+        // Content-addressed result id over the canonically sorted items
+        // (stateless): the client echoes the id it last received as
+        // `previousResultId`; when the recomputed id matches, an UNCHANGED
+        // report replaces the full item list. On a diagnostics-heavy host a
+        // full report is ~1 MB (measured: ~2,235 items), and every
+        // `workspace/diagnostic/refresh`-induced re-pull of a settled set
+        // previously re-shipped all of it.
+        let (items, result_id) = finalize_pull_items(items);
         if params.previous_result_id.as_deref() == Some(result_id.as_str()) {
             return Ok(unchanged_diagnostic_report(result_id));
         }
@@ -726,25 +737,57 @@ async fn dispatch_preferred_diagnostics(
     }
 }
 
+/// Canonicalize a pull result and mint its content-addressed id: sort the
+/// items deterministically (the fan-outs complete in arbitrary order, and the
+/// hash needs canonical serialization; it also gives the editor a stable list
+/// order, matching the publish path #423), then hash. One function so the
+/// handler cannot hash unsorted items — an order-unstable id would make
+/// `unchanged` reports silently never fire on multi-server hosts.
+fn finalize_pull_items(mut items: Vec<Diagnostic>) -> (Vec<Diagnostic>, String) {
+    crate::lsp::diagnostic_cache::sort_diagnostics(&mut items);
+    let id = diagnostic_result_id(&items);
+    (items, id)
+}
+
+/// FNV-1a 64-bit over a serde serialization stream: hashes without
+/// materializing the serialized form (a full pull set is ~1 MB — see
+/// [`diagnostic_result_id`]). Byte-identical to `fnv1a_hash(to_string(..))`
+/// because `to_writer` produces the same bytes as `to_string`.
+struct FnvWriter(u64);
+
+impl std::io::Write for FnvWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        const FNV_PRIME: u64 = 0x100000001b3;
+        for &byte in buf {
+            self.0 = (self.0 ^ u64::from(byte)).wrapping_mul(FNV_PRIME);
+        }
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
 /// Content-address a **sorted** pull result: the deterministic sort
-/// ([`sort_diagnostics`]) makes the serialization canonical, so the same
-/// logical set always hashes to the same id and any field change produces a
-/// different one. The length suffix is cheap insurance against a 64-bit
-/// collision making a changed set read as unchanged (the same accepted trade
-/// as the bridge's `document_tracker` content fingerprint). Stateless: the
-/// client echoes the id back as `previousResultId` and the handler just
-/// recomputes — nothing to invalidate.
+/// ([`sort_diagnostics`], applied by [`finalize_pull_items`]) makes the
+/// serialization canonical, so the same logical set always hashes to the same
+/// id and any field change produces a different one. The length suffix is
+/// cheap insurance against a 64-bit collision making a changed set read as
+/// unchanged (the same accepted trade as the bridge's `document_tracker`
+/// content fingerprint). Stateless: the client echoes the id back as
+/// `previousResultId` and the handler just recomputes — nothing to invalidate.
 ///
 /// [`sort_diagnostics`]: crate::lsp::diagnostic_cache::sort_diagnostics
 fn diagnostic_result_id(items: &[Diagnostic]) -> String {
-    // `to_string` on ls_types values cannot realistically fail (no non-string
-    // map keys); `unwrap_or_default` matches the sort tiebreak's idiom.
-    let serialized = serde_json::to_string(items).unwrap_or_default();
-    format!(
-        "{:016x}-{}",
-        crate::text::fnv1a_hash(&serialized),
-        items.len()
-    )
+    const FNV_OFFSET: u64 = 0xcbf29ce484222325;
+    let mut writer = FnvWriter(FNV_OFFSET);
+    // Serialization of ls_types values cannot realistically fail (no non-string
+    // map keys) and `FnvWriter` never errors; were it ever to fail anyway, the
+    // partial-stream hash still differs per content and the `-len` suffix
+    // still discriminates by count, so a false "unchanged" additionally needs
+    // a hash collision — the accepted 2^-64 trade above.
+    let _ = serde_json::to_writer(&mut writer, items);
+    format!("{:016x}-{}", writer.0, items.len())
 }
 
 /// Create a full diagnostic report from aggregated diagnostics. `result_id`
@@ -868,16 +911,35 @@ mod tests {
 
     #[test]
     fn result_id_is_stable_across_fan_in_order() {
-        // The pull's fan-outs complete in arbitrary order; after the shared
-        // deterministic sort, permutations of the same logical set must hash to
-        // the same result id — otherwise a client's previousResultId would
-        // never match and unchanged reports would never fire.
-        let mut a = vec![diag("x"), diag("y"), diag("z")];
-        let mut b = vec![diag("z"), diag("x"), diag("y")];
-        crate::lsp::diagnostic_cache::sort_diagnostics(&mut a);
-        crate::lsp::diagnostic_cache::sort_diagnostics(&mut b);
-        assert_eq!(a, b, "the sort canonicalizes permutations");
-        assert_eq!(diagnostic_result_id(&a), diagnostic_result_id(&b));
+        // The pull's fan-outs complete in arbitrary order; `finalize_pull_items`
+        // (the one function the handler goes through) must canonicalize
+        // permutations of the same logical set to the same result id —
+        // otherwise a client's previousResultId would never match on a
+        // multi-server host and unchanged reports would silently never fire.
+        // Deliberately feeds UNSORTED permutations so removing the sort inside
+        // `finalize_pull_items` fails this test.
+        let a = vec![diag("x"), diag("y"), diag("z")];
+        let b = vec![diag("z"), diag("x"), diag("y")];
+        let (sorted_a, id_a) = finalize_pull_items(a);
+        let (sorted_b, id_b) = finalize_pull_items(b);
+        assert_eq!(sorted_a, sorted_b, "the sort canonicalizes permutations");
+        assert_eq!(id_a, id_b);
+    }
+
+    #[test]
+    fn result_id_streaming_hash_matches_the_materialized_form() {
+        // `diagnostic_result_id` hashes through a serde writer to avoid a ~1 MB
+        // transient; the id must stay byte-identical to hashing the
+        // materialized serialization (the stateless contract: clients hold ids
+        // across server restarts, so the id algorithm is wire-format).
+        let items = vec![diag("x"), diag("y")];
+        let materialized = serde_json::to_string(&items).expect("serializes");
+        let expected = format!(
+            "{:016x}-{}",
+            crate::text::fnv1a_hash(&materialized),
+            items.len()
+        );
+        assert_eq!(diagnostic_result_id(&items), expected);
     }
 
     #[test]
@@ -893,6 +955,69 @@ mod tests {
         assert_ne!(id, diagnostic_result_id(&changed_message));
         assert_ne!(id, diagnostic_result_id(&changed_severity));
         assert_ne!(id, diagnostic_result_id(&shrunk));
+    }
+
+    #[tokio::test]
+    async fn degraded_pull_does_not_mark_the_change_served() {
+        // The pull-side sibling of republish's geometry deferral: when the
+        // bounded parse wait lapses (no snapshot) while the aggregator holds
+        // live region pushes, the answer is missing whole servers' diagnostics
+        // (the fold skips region slots without offsets). The answer must still
+        // be served — a pull cannot defer — but it must NOT advance `served`:
+        // coverage stays dirty so the next push-origin change nudges the
+        // client back to a full view instead of the gap being masked until the
+        // next edit.
+        let (service, _socket) = tower_lsp_server::LspService::new(Kakehashi::new);
+        let server = service.inner();
+        server
+            .language
+            .language_registry_for_parallel()
+            .register("rust".to_string(), tree_sitter_rust::LANGUAGE.into());
+        let uri = Url::parse("file:///test/degraded_pull.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            None, // tree pending: snapshot() is None
+        );
+        server.diagnostics.record(
+            &uri,
+            crate::lsp::diagnostic_cache::DiagnosticSource::Region("region-1".to_string()),
+            "lua_ls".to_string(),
+            Some(crate::lsp::bridge::ProgressConnectionId::for_test(1)),
+            vec![diag("boom")],
+        );
+        server.diagnostics.bump_current(&uri);
+        assert!(
+            server.diagnostics.is_dirty(),
+            "the push made the host dirty"
+        );
+
+        let params = DocumentDiagnosticParams {
+            text_document: tower_lsp_server::ls_types::TextDocumentIdentifier {
+                uri: "file:///test/degraded_pull.rs".parse().expect("uri"),
+            },
+            identifier: None,
+            previous_result_id: None,
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        };
+        let report = server
+            .diagnostic_impl(params)
+            .await
+            .expect("a degraded pull still answers");
+        let DocumentDiagnosticReportResult::Report(DocumentDiagnosticReport::Full(full)) = report
+        else {
+            panic!("degraded answer is a full report");
+        };
+        assert!(
+            full.full_document_diagnostic_report.items.is_empty(),
+            "the region push cannot be folded without geometry (that's the degradation)"
+        );
+        assert!(
+            server.diagnostics.is_dirty(),
+            "a degraded answer must not advance `served` — the gap would be masked"
+        );
     }
 
     #[test]

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -370,8 +370,14 @@ impl Kakehashi {
         // the version captured at entry, so the refresh gate stops treating those
         // changes as dirty (#497). Pure bookkeeping — never republishes — so this
         // can't beget a refresh.
-        if !degraded_virt {
+        if degraded_virt {
+            // The debt drives the post-parse recovery refresh (see
+            // `DiagnosticAggregator::degraded_pulls`).
+            self.diagnostics.record_degraded_pull(&uri);
+        } else {
             self.diagnostics.mark_served(&uri, served_version);
+            // A covering pull supersedes any earlier degraded answer.
+            self.diagnostics.forget_degraded_pull(&uri);
         }
 
         let items = combine_layer_diagnostics(&layer_cfg, virt_items, host_items);
@@ -1017,6 +1023,10 @@ mod tests {
         assert!(
             server.diagnostics.is_dirty(),
             "a degraded answer must not advance `served` — the gap would be masked"
+        );
+        assert!(
+            server.diagnostics.take_degraded_pull(&uri),
+            "the degraded answer records the per-host debt that keys the post-parse recovery refresh"
         );
     }
 

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -380,12 +380,17 @@ impl Kakehashi {
             // debt consumer already run — in between, leaving this
             // freshly-recorded debt with no consumer until the next edit. If
             // geometry is available NOW, consume the debt here and fire the
-            // recovery refresh ourselves (same coverage + single-flight
-            // gates). `take` on both consumers makes double-firing impossible;
-            // if the snapshot is still absent, the parse that produces it has
-            // not run its post-parse pass yet, so that pass will consume.
-            // Loop-bounded: the refresh-induced re-pull sees the ready
-            // geometry, answers covering, and clears everything.
+            // recovery refresh ourselves. FORCED past the coverage gate (still
+            // single-flighted): the debt itself proves the client just
+            // received a non-covering answer, which the version-based gate
+            // cannot see — an edit-race degradation leaves served == current
+            // (no push-origin change), so a gated request would be suppressed
+            // while the client displays the region-less set. `take` on both
+            // consumers makes double-firing impossible; if the snapshot is
+            // still absent, the parse that produces it has not run its
+            // post-parse pass yet, so that pass will consume. Loop-bounded:
+            // the refresh-induced re-pull sees the ready geometry, answers
+            // covering, and clears everything.
             let geometry_ready = self
                 .documents
                 .get(&uri)
@@ -393,7 +398,7 @@ impl Kakehashi {
                 .is_some();
             if geometry_ready && self.diagnostics.take_degraded_pull(&uri) {
                 crate::lsp::lsp_impl::DiagnosticPublisher::new(self)
-                    .request_pull_diagnostic_refresh(false);
+                    .request_pull_diagnostic_refresh(true);
             }
         } else {
             self.mark_pull_covered(&uri, served_version);

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -359,11 +359,12 @@ impl Kakehashi {
         // skipped every cached `Region` slot, so this answer is missing whole
         // servers' diagnostics. A pull must respond (there is no "defer" for a
         // request), so serve the degraded set — but do NOT mark it served, and
-        // record the per-host debt: the reparse loop's post-parse pass
-        // consumes it and requests the recovery refresh (coverage-gated) that
-        // brings the client back to a full view, instead of the gap being
-        // masked until the next edit. The predicate mirrors `republish`'s
-        // `needs_geometry` (non-empty region slots only).
+        // record the per-host debt: the reparse loop's post-parse pass (or the
+        // TOCTOU guard below) consumes it and requests the recovery refresh
+        // (single-flighted, forced past the coverage gate) that brings the
+        // client back to a full view, instead of the gap being masked until
+        // the next edit. The predicate mirrors `republish`'s `needs_geometry`
+        // (non-empty region slots only).
         let degraded_virt =
             virt_enabled && snapshot.is_none() && self.diagnostics.has_region_slots(&uri);
 

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -137,7 +137,7 @@ impl Kakehashi {
         // Get the language for this document
         let Some(language_name) = self.document_language(&uri) else {
             log::debug!(target: "kakehashi::diagnostic", "No language detected");
-            self.diagnostics.mark_served(&uri, served_version);
+            self.mark_pull_covered(&uri, served_version);
             return Ok(empty_diagnostic_report());
         };
 
@@ -158,7 +158,7 @@ impl Kakehashi {
                 "no diagnostic layer enabled for {} (layers.aggregation priorities / bridge._self)",
                 language_name
             );
-            self.diagnostics.mark_served(&uri, served_version);
+            self.mark_pull_covered(&uri, served_version);
             return Ok(empty_diagnostic_report());
         }
 
@@ -358,11 +358,12 @@ impl Kakehashi {
         // aggregator holds live region pushes — the fold above then silently
         // skipped every cached `Region` slot, so this answer is missing whole
         // servers' diagnostics. A pull must respond (there is no "defer" for a
-        // request), so serve the degraded set — but do NOT mark it served:
-        // coverage stays dirty, and the next push-origin change nudges the
-        // client back to a full view instead of the gap being masked until the
-        // next edit. The predicate mirrors `republish`'s `needs_geometry`
-        // (non-empty region slots only).
+        // request), so serve the degraded set — but do NOT mark it served, and
+        // record the per-host debt: the reparse loop's post-parse pass
+        // consumes it and requests the recovery refresh (coverage-gated) that
+        // brings the client back to a full view, instead of the gap being
+        // masked until the next edit. The predicate mirrors `republish`'s
+        // `needs_geometry` (non-empty region slots only).
         let degraded_virt =
             virt_enabled && snapshot.is_none() && self.diagnostics.has_region_slots(&uri);
 
@@ -375,9 +376,7 @@ impl Kakehashi {
             // `DiagnosticAggregator::degraded_pulls`).
             self.diagnostics.record_degraded_pull(&uri);
         } else {
-            self.diagnostics.mark_served(&uri, served_version);
-            // A covering pull supersedes any earlier degraded answer.
-            self.diagnostics.forget_degraded_pull(&uri);
+            self.mark_pull_covered(&uri, served_version);
         }
 
         let items = combine_layer_diagnostics(&layer_cfg, virt_items, host_items);
@@ -393,6 +392,15 @@ impl Kakehashi {
             return Ok(unchanged_diagnostic_report(result_id));
         }
         Ok(make_diagnostic_report(items, result_id))
+    }
+
+    /// A pull answered with a covering (non-degraded) report: advance the
+    /// coverage `served` marker and clear any earlier degraded-pull debt —
+    /// every covering exit must do both, or a stale debt would later fire an
+    /// unnecessary (though coverage-gated) recovery refresh.
+    fn mark_pull_covered(&self, uri: &Url, served_version: u64) {
+        self.diagnostics.mark_served(uri, served_version);
+        self.diagnostics.forget_degraded_pull(uri);
     }
 
     /// pushFallback fold (Path B, #425): append push-driven servers' cached
@@ -969,10 +977,10 @@ mod tests {
         // bounded parse wait lapses (no snapshot) while the aggregator holds
         // live region pushes, the answer is missing whole servers' diagnostics
         // (the fold skips region slots without offsets). The answer must still
-        // be served — a pull cannot defer — but it must NOT advance `served`:
-        // coverage stays dirty so the next push-origin change nudges the
-        // client back to a full view instead of the gap being masked until the
-        // next edit.
+        // be served — a pull cannot defer — but it must NOT advance `served`,
+        // and it records the per-host debt the post-parse pass consumes to
+        // fire the recovery refresh that brings the client back to a full
+        // view.
         let (service, _socket) = tower_lsp_server::LspService::new(Kakehashi::new);
         let server = service.inner();
         server

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -778,6 +778,12 @@ fn unchanged_diagnostic_report(result_id: String) -> DocumentDiagnosticReportRes
 }
 
 /// Create an empty diagnostic report (full report with no items).
+///
+/// Deliberately carries no `resultId`: these are the early-return paths
+/// (missing document, undetectable language, no participating layer) that
+/// answer before any merge exists. A tiny Full-empty response costs nothing to
+/// re-ship, and a client `previousResultId` can never match an absent id, so
+/// the unchanged-report machinery simply doesn't engage here.
 fn empty_diagnostic_report() -> DocumentDiagnosticReportResult {
     DocumentDiagnosticReportResult::Report(DocumentDiagnosticReport::Full(
         RelatedFullDocumentDiagnosticReport {

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -375,6 +375,26 @@ impl Kakehashi {
             // The debt drives the post-parse recovery refresh (see
             // `DiagnosticAggregator::degraded_pulls`).
             self.diagnostics.record_degraded_pull(&uri);
+            // TOCTOU guard: `snapshot` was captured before the fan-out/fold
+            // awaits above, so the parse may have landed — and the post-parse
+            // debt consumer already run — in between, leaving this
+            // freshly-recorded debt with no consumer until the next edit. If
+            // geometry is available NOW, consume the debt here and fire the
+            // recovery refresh ourselves (same coverage + single-flight
+            // gates). `take` on both consumers makes double-firing impossible;
+            // if the snapshot is still absent, the parse that produces it has
+            // not run its post-parse pass yet, so that pass will consume.
+            // Loop-bounded: the refresh-induced re-pull sees the ready
+            // geometry, answers covering, and clears everything.
+            let geometry_ready = self
+                .documents
+                .get(&uri)
+                .and_then(|doc| doc.snapshot())
+                .is_some();
+            if geometry_ready && self.diagnostics.take_degraded_pull(&uri) {
+                crate::lsp::lsp_impl::DiagnosticPublisher::new(self)
+                    .request_pull_diagnostic_refresh(false);
+            }
         } else {
             self.mark_pull_covered(&uri, served_version);
         }

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -16,6 +16,7 @@ use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::{
     Diagnostic, DocumentDiagnosticParams, DocumentDiagnosticReport, DocumentDiagnosticReportResult,
     FullDocumentDiagnosticReport, RelatedFullDocumentDiagnosticReport,
+    RelatedUnchangedDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport,
 };
 use url::Url;
 
@@ -357,9 +358,24 @@ impl Kakehashi {
         // can't beget a refresh.
         self.diagnostics.mark_served(&uri, served_version);
 
-        Ok(make_diagnostic_report(combine_layer_diagnostics(
-            &layer_cfg, virt_items, host_items,
-        )))
+        let mut items = combine_layer_diagnostics(&layer_cfg, virt_items, host_items);
+        // Deterministic order: the fan-outs above complete in arbitrary order,
+        // and the result id below is a hash of the serialized items, so the
+        // same logical set must serialize identically across pulls (it also
+        // gives the editor a stable list order, matching the publish path #423).
+        crate::lsp::diagnostic_cache::sort_diagnostics(&mut items);
+
+        // Content-addressed result id (stateless): the client echoes the id it
+        // last received as `previousResultId`; when the recomputed id matches,
+        // an UNCHANGED report replaces the full item list. On a
+        // diagnostics-heavy host a full report is ~1 MB (measured: ~2,235
+        // items), and every `workspace/diagnostic/refresh`-induced re-pull of
+        // a settled set previously re-shipped all of it.
+        let result_id = diagnostic_result_id(&items);
+        if params.previous_result_id.as_deref() == Some(result_id.as_str()) {
+            return Ok(unchanged_diagnostic_report(result_id));
+        }
+        Ok(make_diagnostic_report(items, result_id))
     }
 
     /// pushFallback fold (Path B, #425): append push-driven servers' cached
@@ -710,14 +726,52 @@ async fn dispatch_preferred_diagnostics(
     }
 }
 
-/// Create a full diagnostic report from aggregated diagnostics.
-fn make_diagnostic_report(diagnostics: Vec<Diagnostic>) -> DocumentDiagnosticReportResult {
+/// Content-address a **sorted** pull result: the deterministic sort
+/// ([`sort_diagnostics`]) makes the serialization canonical, so the same
+/// logical set always hashes to the same id and any field change produces a
+/// different one. The length suffix is cheap insurance against a 64-bit
+/// collision making a changed set read as unchanged (the same accepted trade
+/// as the bridge's `document_tracker` content fingerprint). Stateless: the
+/// client echoes the id back as `previousResultId` and the handler just
+/// recomputes — nothing to invalidate.
+///
+/// [`sort_diagnostics`]: crate::lsp::diagnostic_cache::sort_diagnostics
+fn diagnostic_result_id(items: &[Diagnostic]) -> String {
+    // `to_string` on ls_types values cannot realistically fail (no non-string
+    // map keys); `unwrap_or_default` matches the sort tiebreak's idiom.
+    let serialized = serde_json::to_string(items).unwrap_or_default();
+    format!(
+        "{:016x}-{}",
+        crate::text::fnv1a_hash(&serialized),
+        items.len()
+    )
+}
+
+/// Create a full diagnostic report from aggregated diagnostics. `result_id`
+/// lets the client echo `previousResultId` on its next pull so an unchanged
+/// set can be answered with [`unchanged_diagnostic_report`].
+fn make_diagnostic_report(
+    diagnostics: Vec<Diagnostic>,
+    result_id: String,
+) -> DocumentDiagnosticReportResult {
     DocumentDiagnosticReportResult::Report(DocumentDiagnosticReport::Full(
         RelatedFullDocumentDiagnosticReport {
             full_document_diagnostic_report: FullDocumentDiagnosticReport {
-                result_id: None, // No result_id for aggregated multi-region response
+                result_id: Some(result_id),
                 items: diagnostics,
             },
+            related_documents: None,
+        },
+    ))
+}
+
+/// Create an UNCHANGED diagnostic report: the client's `previousResultId`
+/// matches the current set, so no items are re-shipped (LSP 3.17 pull
+/// diagnostics).
+fn unchanged_diagnostic_report(result_id: String) -> DocumentDiagnosticReportResult {
+    DocumentDiagnosticReportResult::Report(DocumentDiagnosticReport::Unchanged(
+        RelatedUnchangedDocumentDiagnosticReport {
+            unchanged_document_diagnostic_report: UnchangedDocumentDiagnosticReport { result_id },
             related_documents: None,
         },
     ))
@@ -804,5 +858,55 @@ mod tests {
     fn combine_empty_priorities_yields_nothing() {
         let cfg = layer_cfg(vec![], AggregationStrategy::Concatenated);
         assert!(combine_layer_diagnostics(&cfg, vec![diag("virt")], vec![diag("host")]).is_empty());
+    }
+
+    #[test]
+    fn result_id_is_stable_across_fan_in_order() {
+        // The pull's fan-outs complete in arbitrary order; after the shared
+        // deterministic sort, permutations of the same logical set must hash to
+        // the same result id — otherwise a client's previousResultId would
+        // never match and unchanged reports would never fire.
+        let mut a = vec![diag("x"), diag("y"), diag("z")];
+        let mut b = vec![diag("z"), diag("x"), diag("y")];
+        crate::lsp::diagnostic_cache::sort_diagnostics(&mut a);
+        crate::lsp::diagnostic_cache::sort_diagnostics(&mut b);
+        assert_eq!(a, b, "the sort canonicalizes permutations");
+        assert_eq!(diagnostic_result_id(&a), diagnostic_result_id(&b));
+    }
+
+    #[test]
+    fn result_id_changes_with_any_content_change() {
+        let base = vec![diag("x"), diag("y")];
+        let mut changed_message = base.clone();
+        changed_message[1].message = "y'".to_string();
+        let mut changed_severity = base.clone();
+        changed_severity[0].severity = Some(tower_lsp_server::ls_types::DiagnosticSeverity::ERROR);
+        let shrunk = vec![diag("x")];
+
+        let id = diagnostic_result_id(&base);
+        assert_ne!(id, diagnostic_result_id(&changed_message));
+        assert_ne!(id, diagnostic_result_id(&changed_severity));
+        assert_ne!(id, diagnostic_result_id(&shrunk));
+    }
+
+    #[test]
+    fn unchanged_report_carries_the_id_and_no_items() {
+        let report = unchanged_diagnostic_report("abc-1".to_string());
+        let serialized = serde_json::to_value(&report).expect("serializes");
+        assert_eq!(serialized["kind"], "unchanged");
+        assert_eq!(serialized["resultId"], "abc-1");
+        assert!(
+            serialized.get("items").is_none(),
+            "an unchanged report re-ships no items"
+        );
+    }
+
+    #[test]
+    fn full_report_carries_the_result_id() {
+        let report = make_diagnostic_report(vec![diag("x")], "abc-1".to_string());
+        let serialized = serde_json::to_value(&report).expect("serializes");
+        assert_eq!(serialized["kind"], "full");
+        assert_eq!(serialized["resultId"], "abc-1");
+        assert_eq!(serialized["items"].as_array().map(Vec::len), Some(1));
     }
 }

--- a/tests/e2e_lsp_lua_diagnostic.rs
+++ b/tests/e2e_lsp_lua_diagnostic.rs
@@ -115,7 +115,10 @@ local x = 1
             // Redact items contents (vary by lua-ls timing) but preserve the array type
             let len = value.as_slice().map(|s| s.len()).unwrap_or(0);
             format!("[{len} items redacted]")
-        })
+        }),
+        // The resultId is a content hash of the items, so it varies with them;
+        // pin its presence, not its value.
+        ".resultId" => "[content hash redacted]",
     });
 
     shutdown_client(&mut client);

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -528,6 +528,97 @@ fn e2e_downstream_crash_refreshes_pull_clients() {
 }
 
 #[test]
+fn e2e_pull_result_id_roundtrip_reports_unchanged() {
+    // LSP 3.17 pull diagnostics: the full report carries a resultId; a re-pull
+    // echoing it as previousResultId while the set is unchanged is answered
+    // with an `unchanged` report (no items re-shipped — on a diagnostics-heavy
+    // host the full report is ~1 MB, and every refresh-induced re-pull of a
+    // settled set previously re-shipped all of it). A content change makes the
+    // next pull full again, with a different id.
+    let (mut client, _config_dir) = init_client();
+
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": { "uri": MD_URI, "languageId": "markdown", "version": 1, "text": MD_TEXT }
+        }),
+    );
+
+    // Wait for the spontaneous push so the folded set is stable across the two
+    // pulls below.
+    client
+        .wait_for_notification_where(
+            &["textDocument/publishDiagnostics"],
+            Duration::from_secs(15),
+            has_pushed_diag,
+        )
+        .expect("the push-driven mock should push on didOpen");
+
+    let first = client.send_request(
+        "textDocument/diagnostic",
+        json!({ "textDocument": { "uri": MD_URI } }),
+    );
+    assert_eq!(first["result"]["kind"], "full");
+    let result_id = first["result"]["resultId"]
+        .as_str()
+        .expect("a full pull report carries a resultId")
+        .to_string();
+
+    // Same set + matching previousResultId → unchanged, same id, no items.
+    let second = client.send_request(
+        "textDocument/diagnostic",
+        json!({
+            "textDocument": { "uri": MD_URI },
+            "previousResultId": result_id
+        }),
+    );
+    assert_eq!(
+        second["result"]["kind"], "unchanged",
+        "an unchanged set answered against a matching previousResultId re-ships nothing"
+    );
+    assert_eq!(second["result"]["resultId"], json!(result_id));
+    assert!(second["result"].get("items").is_none());
+
+    // A content change (the mock clears on didChange) invalidates the id: the
+    // next pull is full again with a different id. Wait for the cleared
+    // publish first so the cache settled.
+    client.send_notification(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": MD_URI, "version": 2 },
+            "contentChanges": [{ "text": MD_TEXT_EDITED }]
+        }),
+    );
+    client
+        .wait_for_notification_where(
+            &["textDocument/publishDiagnostics"],
+            Duration::from_secs(15),
+            cleared_host_diag,
+        )
+        .expect("the mock's empty push should clear the host set");
+
+    let third = client.send_request(
+        "textDocument/diagnostic",
+        json!({
+            "textDocument": { "uri": MD_URI },
+            "previousResultId": result_id
+        }),
+    );
+    assert_eq!(
+        third["result"]["kind"], "full",
+        "a changed set must be answered full even with a previousResultId"
+    );
+    assert_ne!(
+        third["result"]["resultId"],
+        json!(result_id),
+        "the id is content-addressed, so a changed set gets a new one"
+    );
+
+    client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
 fn e2e_publish_seal_delivers_via_refresh_and_pull_only() {
     // The cross-layer gate for `textDocument/publishDiagnostics` doubles as a
     // wire seal: `priorities = []` stops the proactive publishes entirely (a

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -528,6 +528,128 @@ fn e2e_downstream_crash_refreshes_pull_clients() {
 }
 
 #[test]
+fn e2e_publish_seal_via_language_wildcard_reaches_configured_languages() {
+    // The `languages._` wildcard's layers are field-merged into every
+    // configured language by Phase 2 base resolution (resolve_base_configs),
+    // so a wildcard seal reaches the markdown host even though this config
+    // also has explicit language entries via built-in defaults. Same shape as
+    // the exact-language seal e2e, minus the follow-up pull.
+    let config_dir = tempfile::TempDir::new().expect("temp dir");
+    let config_path = config_dir.path().join("publish_seal_wildcard.toml");
+    std::fs::write(&config_path, "").expect("write config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("utf8 path"))
+        .build();
+
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": { "workspace": { "diagnostics": { "refreshSupport": true } } },
+            "workspaceFolders": null,
+            "initializationOptions": {
+                "languageServers": {
+                    "mock-push": { "cmd": [mock_bin(), "diagnostics-push"], "languages": ["lua"] }
+                },
+                "languages": {
+                    "_": {
+                        "layers": {
+                            "aggregation": {
+                                "textDocument/publishDiagnostics": { "priorities": [] }
+                            }
+                        }
+                    }
+                }
+            }
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": { "uri": MD_URI, "languageId": "markdown", "version": 1, "text": MD_TEXT }
+        }),
+    );
+
+    let (refresh_id, _, publishes) = client
+        .wait_for_server_request_watching(
+            "workspace/diagnostic/refresh",
+            Duration::from_secs(15),
+            &["textDocument/publishDiagnostics"],
+        )
+        .expect("a wildcard-sealed setup must still drive workspace/diagnostic/refresh");
+    let host_publishes: Vec<_> = publishes
+        .iter()
+        .filter(|(_, params)| params["uri"] == json!(MD_URI))
+        .collect();
+    assert!(
+        host_publishes.is_empty(),
+        "a languages._ seal must reach the markdown host (got {host_publishes:?})"
+    );
+    client.send_response(refresh_id, json!(null));
+
+    client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
+fn e2e_didclose_clears_promptly_even_within_the_quiet_window() {
+    // The regression this pins: a clearing push withheld by the quiet window
+    // must not be dropped when the document closes — didClose's clearing
+    // publish bypasses the window and the withheld `dirty` debt forces it past
+    // the unchanged-skip, so a push-mode editor never keeps a closed buffer's
+    // diagnostics. Positive assertion: an empty publish for the host arrives
+    // regardless of whether the mock's clearing push raced the close.
+    let (mut client, _config_dir) = init_client();
+
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": { "uri": MD_URI, "languageId": "markdown", "version": 1, "text": MD_TEXT }
+        }),
+    );
+    client
+        .wait_for_notification_where(
+            &["textDocument/publishDiagnostics"],
+            Duration::from_secs(15),
+            has_pushed_diag,
+        )
+        .expect("editor should receive the pushed diagnostic");
+
+    // The edit drives the mock's clearing `[]` push; within 1 s of the last
+    // publish it is withheld by the quiet window. Closing right away must
+    // still clear the editor.
+    client.send_notification(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": MD_URI, "version": 2 },
+            "contentChanges": [{ "text": MD_TEXT_EDITED }]
+        }),
+    );
+    client.send_notification(
+        "textDocument/didClose",
+        json!({ "textDocument": { "uri": MD_URI } }),
+    );
+
+    let cleared = client.wait_for_notification_where(
+        &["textDocument/publishDiagnostics"],
+        Duration::from_secs(15),
+        cleared_host_diag,
+    );
+    assert!(
+        cleared.is_some(),
+        "closing within the quiet window must still deliver a clearing publish"
+    );
+
+    client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
+#[test]
 fn e2e_pull_result_id_roundtrip_reports_unchanged() {
     // LSP 3.17 pull diagnostics: the full report carries a resultId; a re-pull
     // echoing it as previousResultId while the set is unchanged is answered

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -460,23 +460,30 @@ fn e2e_downstream_crash_refreshes_pull_clients() {
         }),
     );
 
-    // The crash mock pushes one diagnostic on didOpen; the editor receives it.
-    client
-        .wait_for_notification_where(
-            &["textDocument/publishDiagnostics"],
+    // The spontaneous push changes the merged set, driving BOTH a refresh
+    // (push/pull-divergence, #422) and a publish. The publish can lag the
+    // refresh — the wire quiet-window may defer it to the trailing flush — so
+    // wait for the refresh while collecting publishes, then make sure the
+    // pushed publish arrived (from the collected ones or a fresh wait). Ack
+    // the refresh: the bridge single-flights it (#497), so the crash-eviction
+    // refresh below won't be sent until this one is answered.
+    let (push_refresh_id, _, publishes) = client
+        .wait_for_server_request_watching(
+            "workspace/diagnostic/refresh",
             Duration::from_secs(15),
-            has_pushed_diag,
+            &["textDocument/publishDiagnostics"],
         )
-        .expect("editor should receive the pushed diagnostic before the crash");
-
-    // That spontaneous push itself changed the merged set, so it also drives a
-    // refresh (push/pull-divergence, #422). Consume it, and **ack** it: the bridge
-    // single-flights the workspace refresh (#497), so the crash-eviction refresh
-    // below won't be sent until this one is answered.
-    let (push_refresh_id, _) = client
-        .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_secs(15))
         .expect("the spontaneous push must drive a workspace/diagnostic/refresh (#422)");
     client.send_response(push_refresh_id, json!(null));
+    if !publishes.iter().any(|(_, params)| has_pushed_diag(params)) {
+        client
+            .wait_for_notification_where(
+                &["textDocument/publishDiagnostics"],
+                Duration::from_secs(15),
+                has_pushed_diag,
+            )
+            .expect("editor should receive the pushed diagnostic before the crash");
+    }
 
     // The content-changing edit reaches the mock, driving it to exit (crash). The
     // bridge's reader sees EOF, evicts the dead connection's slots, and republishes
@@ -489,23 +496,32 @@ fn e2e_downstream_crash_refreshes_pull_clients() {
         }),
     );
 
-    client
-        .wait_for_notification_where(
-            &["textDocument/publishDiagnostics"],
+    // The eviction changed the merged set with no event the editor could see,
+    // so the bridge must emit a second `workspace/diagnostic/refresh` (#499),
+    // and the host must be republished cleared — again in either order (the
+    // cleared publish may ride the trailing quiet-window flush).
+    let (evict_refresh_id, _, publishes) = client
+        .wait_for_server_request_watching(
+            "workspace/diagnostic/refresh",
             Duration::from_secs(15),
-            cleared_host_diag,
+            &["textDocument/publishDiagnostics"],
         )
-        .expect("the crash must evict the dead server's diagnostic and republish cleared");
-
-    // The eviction changed the merged set with no event the editor could see, so
-    // the bridge must emit a second `workspace/diagnostic/refresh` (#499) after the
-    // cleared publish, telling the pull-mode editor to re-pull the now-current set.
-    assert!(
+        .expect(
+            "a crash eviction that clears the host must drive a workspace/diagnostic/refresh (#499)",
+        );
+    client.send_response(evict_refresh_id, json!(null));
+    if !publishes
+        .iter()
+        .any(|(_, params)| cleared_host_diag(params))
+    {
         client
-            .wait_for_server_request("workspace/diagnostic/refresh", Duration::from_secs(15))
-            .is_some(),
-        "a crash eviction that clears the host must drive a workspace/diagnostic/refresh (#499)"
-    );
+            .wait_for_notification_where(
+                &["textDocument/publishDiagnostics"],
+                Duration::from_secs(15),
+                cleared_host_diag,
+            )
+            .expect("the crash must evict the dead server's diagnostic and republish cleared");
+    }
 
     client.send_request("shutdown", json!(null));
     client.send_notification("exit", json!(null));
@@ -519,9 +535,11 @@ fn e2e_publish_seal_delivers_via_refresh_and_pull_only() {
     // namespace; measured at ~1 MB × dozens per typing burst on a
     // diagnostics-heavy host) while delivery continues via
     // `workspace/diagnostic/refresh` → client re-pull. Deterministic ordering:
-    // a publish (were it sent) is enqueued strictly before the refresh the
-    // same set-change drives, so collecting publishes while waiting for the
-    // refresh proves the seal without a negative timeout.
+    // a publish (were the seal broken) would be a host's FIRST — which the
+    // wire quiet-window never defers (leading edge) — so it would be enqueued
+    // strictly before the refresh the same set-change drives; collecting
+    // publishes while waiting for the refresh therefore proves the seal
+    // without a negative timeout.
     let config_dir = tempfile::TempDir::new().expect("temp dir");
     let config_path = config_dir.path().join("publish_seal.toml");
     std::fs::write(&config_path, "").expect("write config");

--- a/tests/e2e_push_diagnostics.rs
+++ b/tests/e2e_push_diagnostics.rs
@@ -511,6 +511,101 @@ fn e2e_downstream_crash_refreshes_pull_clients() {
     client.send_notification("exit", json!(null));
 }
 
+#[test]
+fn e2e_publish_seal_delivers_via_refresh_and_pull_only() {
+    // The cross-layer gate for `textDocument/publishDiagnostics` doubles as a
+    // wire seal: `priorities = []` stops the proactive publishes entirely (a
+    // pull-first editor setup ignores them or renders them as a duplicate
+    // namespace; measured at ~1 MB × dozens per typing burst on a
+    // diagnostics-heavy host) while delivery continues via
+    // `workspace/diagnostic/refresh` → client re-pull. Deterministic ordering:
+    // a publish (were it sent) is enqueued strictly before the refresh the
+    // same set-change drives, so collecting publishes while waiting for the
+    // refresh proves the seal without a negative timeout.
+    let config_dir = tempfile::TempDir::new().expect("temp dir");
+    let config_path = config_dir.path().join("publish_seal.toml");
+    std::fs::write(&config_path, "").expect("write config");
+
+    let mut client = LspClient::builder()
+        .arg("--config-file")
+        .arg(config_path.to_str().expect("utf8 path"))
+        .build();
+
+    client.send_request(
+        "initialize",
+        json!({
+            "processId": std::process::id(),
+            "rootUri": null,
+            "capabilities": { "workspace": { "diagnostics": { "refreshSupport": true } } },
+            "workspaceFolders": null,
+            "initializationOptions": {
+                "languageServers": {
+                    "mock-push": { "cmd": [mock_bin(), "diagnostics-push"], "languages": ["lua"] }
+                },
+                "languages": {
+                    "markdown": {
+                        "layers": {
+                            "aggregation": {
+                                "textDocument/publishDiagnostics": { "priorities": [] }
+                            }
+                        }
+                    }
+                }
+            }
+        }),
+    );
+    client.send_notification("initialized", json!({}));
+
+    client.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": { "uri": MD_URI, "languageId": "markdown", "version": 1, "text": MD_TEXT }
+        }),
+    );
+
+    // The mock's spontaneous push changes the merged set → the refresh nudge
+    // still fires (it is the sealed setup's delivery signal) — and no
+    // publishDiagnostics for the host may precede it.
+    let (refresh_id, _, publishes) = client
+        .wait_for_server_request_watching(
+            "workspace/diagnostic/refresh",
+            Duration::from_secs(15),
+            &["textDocument/publishDiagnostics"],
+        )
+        .expect("a sealed setup must still drive workspace/diagnostic/refresh on a push");
+    let host_publishes: Vec<_> = publishes
+        .iter()
+        .filter(|(_, params)| params["uri"] == json!(MD_URI))
+        .collect();
+    assert!(
+        host_publishes.is_empty(),
+        "the seal must stop publishDiagnostics for the host (got {host_publishes:?})"
+    );
+    client.send_response(refresh_id, json!(null));
+
+    // Delivery works through the pull: the push-only mock's cached push is
+    // folded into the client-pull response in host coordinates (pushFallback).
+    let response = client.send_request(
+        "textDocument/diagnostic",
+        json!({ "textDocument": { "uri": MD_URI } }),
+    );
+    let items = response["result"]["items"]
+        .as_array()
+        .expect("the pull answer is a full diagnostic report with an items array");
+    let pulled = items
+        .iter()
+        .find(|d| is_mock_push(d))
+        .expect("the pushed diagnostic must be deliverable through the client pull");
+    assert_eq!(
+        pulled["range"]["start"]["line"],
+        json!(HOST_LINE),
+        "the pulled diagnostic must be in host coordinates (host line {HOST_LINE})"
+    );
+
+    client.send_request("shutdown", json!(null));
+    client.send_notification("exit", json!(null));
+}
+
 /// Send a `didOpen` for the markdown host (with its lua region) so the bridge
 /// spawns the downstream mock for that region and forwards the region's events.
 fn open_host(client: &mut LspClient) {

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -723,17 +723,18 @@ impl LspClient {
             let Value::Object(mut map) = message else {
                 continue;
             };
-            let method = map
-                .get("method")
-                .and_then(|m| m.as_str())
-                .map(str::to_string);
-            match (method, map.remove("id")) {
-                (Some(method), Some(id)) if method == expected_method => {
+            let method = map.get("method").and_then(|m| m.as_str());
+            match method {
+                Some(method) if method == expected_method && map.contains_key("id") => {
+                    let id = map.remove("id").expect("present: checked above");
                     let params = map.remove("params").unwrap_or(Value::Null);
                     return Some((id, params, watched));
                 }
-                (Some(method), None) if watch.contains(&method.as_str()) => {
-                    watched.push((method, map.remove("params").unwrap_or(Value::Null)));
+                Some(method) if !map.contains_key("id") && watch.contains(&method) => {
+                    watched.push((
+                        method.to_string(),
+                        map.remove("params").unwrap_or(Value::Null),
+                    ));
                 }
                 _ => {} // other request/response/notification — skip
             }

--- a/tests/helpers/lsp_client.rs
+++ b/tests/helpers/lsp_client.rs
@@ -345,6 +345,11 @@ fn read_framed_message<R: BufRead>(reader: &mut R) -> ReadOutcome {
     }
 }
 
+/// A server→client request's `(id, params)` plus the watched notifications
+/// (method, params) collected while waiting for it — the result of
+/// [`LspClient::wait_for_server_request_watching`].
+pub(crate) type WatchedServerRequest = (Value, Value, Vec<(String, Value)>);
+
 impl LspClient {
     /// Spawn the kakehashi binary and create a new LSP client.
     pub fn new() -> Self {
@@ -690,6 +695,48 @@ impl LspClient {
             }
             // A response or notification, or a different request — skip and keep
             // waiting within the deadline.
+        }
+    }
+
+    /// Like [`Self::wait_for_server_request`], but also collects every
+    /// notification whose method is in `watch` seen while waiting (in arrival
+    /// order). Lets a test assert something did NOT precede the awaited request
+    /// — the pipe is FIFO, so anything the server enqueued earlier is in the
+    /// collected list — without resorting to a flaky negative timeout.
+    pub(crate) fn wait_for_server_request_watching(
+        &mut self,
+        expected_method: &str,
+        timeout: Duration,
+        watch: &[&str],
+    ) -> Option<WatchedServerRequest> {
+        let start_time = Instant::now();
+        let mut watched = Vec::new();
+
+        loop {
+            let remaining = timeout.saturating_sub(start_time.elapsed());
+            if remaining.is_zero() {
+                return None;
+            }
+
+            let message = self.try_receive_message(remaining)?;
+
+            let Value::Object(mut map) = message else {
+                continue;
+            };
+            let method = map
+                .get("method")
+                .and_then(|m| m.as_str())
+                .map(str::to_string);
+            match (method, map.remove("id")) {
+                (Some(method), Some(id)) if method == expected_method => {
+                    let params = map.remove("params").unwrap_or(Value::Null);
+                    return Some((id, params, watched));
+                }
+                (Some(method), None) if watch.contains(&method.as_str()) => {
+                    watched.push((method, map.remove("params").unwrap_or(Value::Null)));
+                }
+                _ => {} // other request/response/notification — skip
+            }
         }
     }
 

--- a/tests/snapshots/e2e_lsp_lua_diagnostic__diagnostic_response_structure.snap
+++ b/tests/snapshots/e2e_lsp_lua_diagnostic__diagnostic_response_structure.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/e2e_lsp_lua_diagnostic.rs
-assertion_line: 113
 expression: result
 ---
 {

--- a/tests/snapshots/e2e_lsp_lua_diagnostic__diagnostic_response_structure.snap
+++ b/tests/snapshots/e2e_lsp_lua_diagnostic__diagnostic_response_structure.snap
@@ -1,8 +1,10 @@
 ---
 source: tests/e2e_lsp_lua_diagnostic.rs
+assertion_line: 113
 expression: result
 ---
 {
   "kind": "full",
+  "resultId": "[content hash redacted]",
   "items": "[0 items redacted]"
 }


### PR DESCRIPTION
## Goal

Minimize semantic-tokens request→response latency — round 2, following #677. A fresh 44 s nvim capture (same 5,089-line host, 308 python + 231 lua + 77 ts fences) shows the progress storm and tsgo InvalidParams from round 1 are gone; the remaining flood is **diagnostics: 73.6 MB of the 75 MB server→client bytes**, head-of-line blocking every response on the shared stdout pipe:

- 51 × ~1 MB `textDocument/publishDiagnostics` (50.76 MB), the merged set flapping 2233↔1848 diagnostics per keystroke settle;
- 22.8 MB of pull responses — `resultId: None` meant every answered pull re-shipped the full ~2,235-item set, even refresh-induced re-pulls of a settled set.

## Changes

**1. Geometry-unknown deferral (the flap fix).** `did_change` clears the visible tree; a republish in that window got EMPTY region offsets and silently dropped every region push slot from the merge — publishing a set missing whole servers (lua's 385 diagnostics), which the post-parse republish then restored: ~2 × ~1 MB publishes per keystroke plus visible flicker. `current_region_offsets` now distinguishes *unknown* geometry (open doc, tree pending → defer: publish/record nothing) from *absent* geometry (closed doc / no injection query → slots legitimately drop). The reparse loop's post-parse republish — gated on the same non-empty-region-slots predicate — is the retry; a deferral still bumps coverage and nudges `workspace/diagnostic/refresh` at push-origin call sites (`RepublishOutcome::Deferred`).

**2. Config wire seal for pull-first setups.** `layers.aggregation."textDocument/publishDiagnostics".priorities = []` (previously honored only by the debounced pull feed) now also seals the editor-facing wire sends. For a pull-first editor (nvim ≥ 0.11) the proactive publish is a redundant second delivery — ignored or rendered as a duplicate namespace. The merge, change detection, coverage bump and refresh nudging keep running (refresh→re-pull is the sealed setup's delivery signal). Deliberately config-driven — no client-capability or observed-pull heuristics (capability alone doesn't prove the client's UI consumes pulls, and pull cadence is unknowable server-side). Prerequisites/caveats documented in the ADR (refreshSupport + pull capability, method-key-not-wildcard, the #431 push-only `_self` re-sync coupling, apply at startup).

**3. Per-host quiet window (1 s) on publish wire sends.** Leading pass-through (an isolated change gains no latency); a changed merge inside the window is withheld (`WireGate.dirty`) and one trailing task re-runs `republish` at the window's end, re-merging the *latest* cache — a burst of feeds collapses into ≤1 full-set publish per second per host. Only the wire waits: change detection and refresh nudging fire at the original points. Abort-safe by construction: every admit marks the dirty debt and only `wire_gate_commit_send` — after the send await — settles it, so a republish aborted at the send (superseded synthetic pull) can never lose an update. Closed-host republishes bypass the gate entirely, so `didClose`'s clearing publish can never be deferred-then-dropped.

**4. Pull path: content-addressed `resultId` + unchanged reports.** The response is deterministically sorted (the publish merge's #423 comparator, extracted and shared — required for canonical serialization, and gives the editor a stable order), and full reports carry `resultId = fnv1a(serialized items) + "-len"` (streamed through an `io::Write` adapter — no ~1 MB transient). A re-pull whose `previousResultId` matches is answered with an LSP 3.17 `unchanged` report (~90 B instead of ~388 KB). Stateless: recomputed per pull, nothing to invalidate, survives restarts. A *degraded* pull (bounded parse wait lapsed while live region pushes were unfoldable) skips `mark_served` and records a per-host debt; the post-parse pass (or the pull-side TOCTOU guard) consumes it once and fires the recovery refresh, forced past the coverage gate (the debt proves a non-covering answer no coverage version represents).

## Measured

### Production validation — real nvim session, before vs after (same document)

Two real editor captures of the 5089-line host (`01KX664Q` on `main`, 44.3 s / 84 edits; `01KXBAQJ` on this branch, 38.2 s / 20 edits). **Bytes on the wire are load-independent, so the byte comparison is valid across the two sessions** (per-edit normalized where the edit counts differ); the wall-clock latency comparison is *not* valid — see below.

| editor-pipe metric | main (`01KX664Q`) | branch (`01KXBAQJ`) | per-edit |
|---|---|---|---|
| total server→client bytes | 75.0 MB | 4.55 MB | 0.89 → 0.23 MB/edit (**3.9× less**) |
| **publishDiagnostics bytes** | **50.76 MB** (68% of all traffic) | **1.41 MB** (31%) | 0.60 → 0.07 MB/edit (**8.6× less**) |
| publishDiagnostics sends | 51 (flapping 2233↔1848 diags) | 5 (47 withheld/coalesced) | |
| pull-response bytes | 22.8 MB (25 full, no `resultId`) | 2.43 MB (6 `unchanged` @89 B + 3 full) | |
| pulls carrying `previousResultId` | 0 / 130 | 92 / 97 | resultId round-trip live |

The diagnosed root cause — the publishDiagnostics flood that was 68% of everything on the shared FIFO stdout pipe — is gone, and the pull `resultId`/`unchanged` path works against real Neovim (settled re-pulls collapse from ~380 KB to 89 B).

### Controlled A/B — harness, merge-base vs HEAD, interleaved 3× (deterministic metrics only)

`storm5.py`, real basedpyright + ruff + lua_ls + tsgo, 30 edits @60 ms, same machine, alternating runs:

| deterministic metric | before (merge-base) | after (HEAD) |
|---|---|---|
| publishDiagnostics during storm | 0, 0, **18 (1.59 MB)** across the 3 rounds | **0, 0, 0** |

The push coalescing + geometry-defer are deterministic (HEAD never re-publishes the flapping set); the "before" flood is intermittent in the harness because it only appears when basedpyright re-analyzes and changes the merged set inside the 30-edit window.

### Latency: now compute-bound, not wire-bound

Per-request wall-clock latency **cannot be cleanly A/B'd** here: both in the real logs and in the harness it is dominated by downstream (basedpyright) CPU variance (harness diagnostic p50 swung 76–1706 ms across rounds with no before/after signal; the two production sessions ran under 4–5× different machine load — token compute `host=54ms` unloaded vs `host=300ms` loaded). The wire benefit is therefore quantified as the byte reduction above (bytes-queued-ahead is the FIFO-pipe latency driver), not per-request timing.

Direct evidence the wire is no longer the bottleneck: in the branch capture, cached-delta `semanticTokens/full/delta` responses now return in **37–126 ms** with the pipe at 0.12 MB/s, where the `main` capture's pipe carried 1.7 MB/s. What remains on the slow tail is genuine token compute (host tokenization ~300 ms under load), tracked as a follow-up.

### Follow-ups filed from this measurement

- **#789** — downstream servers forward their own `workspace/diagnostic/refresh` un-coalesced (the branch capture shows 58 forwarded → 76 upstream, ~20/s in one burst); each drives a re-pull, adding CPU contention. Pre-existing (#521), more visible now that publishes are coalesced.
- **#790** — reduce semantic-tokens compute (host tokenization is the largest phase); the post-wire-flood latency lever.

## Review pipeline

- Stage 1: 10 parallel single-perspective reviewers + 2 delta verifiers over two rounds. Confirmed and fixed: two HIGH closed-host clearing-publish losses (racing gate re-stamp; withheld-empty dirty-debt erasure), gate-commit-before-send abort loss, the deferral silently dropping the push-origin refresh nudge (3 reviewers independently), the degraded-pull `served` masking, plus a full ADR/comment sweep. Refuted with evidence: fnv1a-64 collision trade (documented, matches the `document_tracker` precedent), report-ordering concerns (FIFO pipe + RTT argument).
- Stage 2: codex — 6 continued rounds (degraded-pull recovery chain: post-parse nudge → per-host debt → covering-exit clearing → TOCTOU guard → forced past the coverage gate), then a **fresh session answered "no comments to provide" on its first response**.
- Gate on the rebased head: `clippy --all-targets --features e2e -D warnings` clean; 2,789 lib tests; full e2e suite green.

## Out of scope (recorded for follow-ups)

- Downstream `window/logMessage` forwarding (4.4 k Info-level tsgo lines per 44 s forwarded to the editor) — transparency doctrine; would need a config knob.
- Threading `previousResultId` downstream (kakehashi as a client re-pulls full sets per region). **Latent trap noted:** the bridge currently maps a downstream `unchanged` report to an empty vec — must be fixed before threading ids.
- Per-pull live fan-out cost (~700 downstream requests per editor pull on this host) — serve-from-cache semantics need an ADR.
- Captures-protocol response bloat (round-1 leftover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Diagnostics now use deterministic ordering with content-addressed `resultId`, returning **UNCHANGED** when results match.
  - Improved behavior when diagnostic geometry isn’t ready: republish is deferred and degraded-pull recovery triggers `workspace/diagnostic/refresh` to reduce editor flicker.
  - Reduced notification “chattiness” via a wire quiet window and optional publish-seal suppression; `didClose` clears promptly (quiet-window bypass).
- **Documentation**
  - Updated architecture decisions for cross-layer diagnostics and push-propagation forwarding semantics.
- **Tests**
  - Expanded e2e/unit coverage for throttling, deferred delivery, `resultId` round-tripping, and refresh/publish ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
