### PR TITLE
fix(injection): support combined bridge documents

### DIFF
--- a/docs/architecture-decisions/language-server-bridge-virtual-document-model.md
+++ b/docs/architecture-decisions/language-server-bridge-virtual-document-model.md
@@ -1,10 +1,12 @@
 # Language Server Bridge Virtual Document Model
 
-## Decision–Implementation Gap
+## Implementation Status
 
-`isolation=true` (one virtual document per injection region) is implemented.
-`isolation=false` (combining same-language injections into a single virtual
-document) is deferred and not implemented.
+Isolated virtual documents remain the default. Query-authored
+`#set! injection.combined` patterns are implemented: captures from the same
+query pattern and language share one bridge virtual document, with host-only
+gaps masked by coordinate-preserving whitespace. The separately proposed
+user-facing `isolation=false` configuration remains deferred.
 
 ## Context
 
@@ -62,7 +64,10 @@ The appropriate isolation behavior depends on **both** the host document and the
 
 The same injection language (e.g., Python) may need different isolation behavior in different host contexts.
 
-**Note**: The current implementation only supports **isolated mode** (`isolation: true`). Non-isolated mode is deferred for future implementation. When non-isolated mode is added, configuration allows specifying isolation per `(host, injection)` pair:
+**Note**: Query-controlled `injection.combined` is supported independently of
+this proposed configuration. User-configurable `isolation=false` remains
+deferred; when added, configuration can specify isolation per `(host,
+injection)` pair:
 
 ```toml
 # Global default: isolate all injections
@@ -96,10 +101,18 @@ Note: The `isolation` field is configured per **host/injection pair** within the
 | `true` (default) | Documentation, tutorials | Each injection → independent virtual document |
 | `false` | Literate programming (`.lhs`, org-mode tangling) | All injections of same language → single virtual document |
 
-Non-isolated mode considerations for future implementation:
-- Insert placeholder lines (comments/whitespace) to preserve line numbers for diagnostics
+Remaining considerations for configurable non-isolated mode:
+- The query-controlled implementation already inserts coordinate-preserving
+  whitespace for host-only gaps. A configurable mode must define equivalent
+  grouping boundaries without query pattern identity.
 - Handle conflicting symbols gracefully (report as diagnostics from kakehashi, not language server)
 - Consider block ordering annotations for explicit concatenation order
+
+For non-contiguous combined documents, read-only bridge features remain
+available. Edit-producing methods are disabled until edit translation can
+validate the individual allowed host spans rather than only the combined
+document's outer range; this prevents masked gaps from becoming edits over
+real host text.
 
 #### Feature-Specific Isolation Overrides
 

--- a/docs/architecture-decisions/language-server-bridge-virtual-document-model.md
+++ b/docs/architecture-decisions/language-server-bridge-virtual-document-model.md
@@ -22,7 +22,7 @@ This decision affects:
 
 ## Decision
 
-**Isolate injections by default (`isolation: true`), with configurable non-isolated mode (`isolation: false`) for literate programming.**
+**Isolate injections by default (`isolation: true`), with a proposed (deferred) configurable non-isolated mode (`isolation: false`) for literate programming.**
 
 ### Isolated Mode (Default: `isolation: true`)
 
@@ -47,9 +47,9 @@ Host: file:///docs/tutorial.md
 
 Real-world documentation code blocks are typically **independent examples** that would conflict if combined.
 
-### Non-Isolated Mode (Configurable: `isolation: false`)
+### Non-Isolated Mode (Proposed configuration: `isolation: false` — deferred)
 
-For literate programming workflows, non-isolated mode concatenates all injections of the same language into a single virtual document.
+For literate programming workflows, non-isolated mode would concatenate all injections of the same language into a single virtual document. (Query-controlled `injection.combined` ships today; this user-facing configuration remains deferred — see the note below.)
 
 #### Fine-Grained Control: (Host, Injection) Pairs
 
@@ -94,7 +94,7 @@ The `_` wildcard matches any host or injection language, enabling layered defaul
 
 Precedence: **specific pair > host default > injection default > global default**
 
-Note: The `isolation` field is configured per **host/injection pair** within the `bridge` map, not per server. The same server handles both modes—only the virtual document structure differs.
+Note: In the deferred proposal, the `isolation` field would be configured per **host/injection pair** within the `bridge` map, not per server. The same server would handle both modes—only the virtual document structure differs.
 
 | Isolation | Use Case | Behavior |
 |-----------|----------|----------|

--- a/src/document/injections.rs
+++ b/src/document/injections.rs
@@ -113,8 +113,9 @@ pub(crate) struct DiscoveredBridgeRegion {
     /// Position-stable tracker ULID, byte-identical to the one minted for the
     /// `InjectionMap` (same `get_or_create` on the same node).
     pub region_id: String,
-    /// The region's clean content (gap ranges removed), the exact virtual-
-    /// document text the bridge opens downstream.
+    /// The exact virtual-document text the bridge opens downstream: excluded
+    /// prefixes are removed for a single region, while host-only gaps in an
+    /// `injection.combined` group are masked with coordinate-preserving spaces.
     pub content: String,
 }
 

--- a/src/document/injections.rs
+++ b/src/document/injections.rs
@@ -114,8 +114,8 @@ pub(crate) struct DiscoveredBridgeRegion {
     /// `InjectionMap` (same `get_or_create` on the same node).
     pub region_id: String,
     /// The exact virtual-document text the bridge opens downstream: excluded
-    /// prefixes are removed for a single region, while host-only gaps in an
-    /// `injection.combined` group are masked with coordinate-preserving spaces.
+    /// prefixes are removed, while an `injection.combined` group preserves host
+    /// line numbers with empty lines and uses spaces for later gaps on a line.
     pub content: String,
 }
 

--- a/src/document/injections.rs
+++ b/src/document/injections.rs
@@ -110,8 +110,9 @@ pub(crate) struct DiscoveredBridgeRegion {
     /// succeeds (e.g. `"py"` to `"python"`); otherwise this retains the raw
     /// identifier so both paths use the same fallback URI.
     pub language: String,
-    /// Position-stable tracker ULID, byte-identical to the one minted for the
-    /// `InjectionMap` (same `get_or_create` on the same node).
+    /// Tracker ULID shared with the `InjectionMap`, keyed by host geometry plus
+    /// the query-pattern/language discriminator so same-range alternatives
+    /// remain distinct within the document incarnation.
     pub region_id: String,
     /// The exact virtual-document text the bridge opens downstream: excluded
     /// prefixes are removed, while an `injection.combined` group preserves host

--- a/src/language/injection.rs
+++ b/src/language/injection.rs
@@ -23,8 +23,8 @@ pub(crate) use content::{
     parse_with_ranges,
 };
 pub(crate) use discovery::{
-    CacheableInjectionRegion, InjectionRegionInfo, InjectionResolver, ResolvedInjection,
-    collect_all_injections, detect_injection,
+    CacheableInjectionRegion, InjectionRegionInfo, InjectionResolver, REGION_IDENTITY_LAYER_BASE,
+    ResolvedInjection, collect_all_injections, detect_injection,
 };
 pub(crate) use offset::{InjectionOffset, effective_offset_for_pattern};
 pub(crate) use ranges::{

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -930,6 +930,13 @@ fn build_combined_virtual_content(
     span: Range<usize>,
     included: &[Range<usize>],
 ) -> (String, Vec<u32>) {
+    // Tree-sitter byte ranges are only valid for the exact parsed text. A
+    // stale tree must not turn a combined-document rebuild into an invalid
+    // UTF-8 slice or an oversized allocation.
+    let span = ceil_char_boundary(text, span.start)..floor_char_boundary(text, span.end);
+    if span.start >= span.end {
+        return (String::new(), Vec::new());
+    }
     let mut output = String::with_capacity(span.len());
     let mut offsets = Vec::new();
     let mut line_start = span.start;
@@ -1432,6 +1439,17 @@ mod tests {
             0..text.len(),
             std::slice::from_ref(&(1..usize::MAX)),
         );
+
+        assert_eq!(content, "x\n");
+        assert_eq!(offsets, vec![1, 0]);
+    }
+
+    #[test]
+    fn combined_content_snaps_stale_span_start_before_slicing() {
+        let text = "éx\n";
+
+        let (content, offsets) =
+            build_combined_virtual_content(text, 1..text.len(), &[1..text.len()]);
 
         assert_eq!(content, "x\n");
         assert_eq!(offsets, vec![1, 0]);

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -346,11 +346,10 @@ pub(crate) fn collect_all_injections<'a>(
             ))
     });
     for region in &mut injections {
-        // Derive identity from both stable query position and language. Dynamic
-        // `@injection.language` captures can produce several language layers
-        // from one pattern at the same range, so the pattern index alone aliases
-        // their virtual documents. A current-match ordinal is also unsuitable:
-        // removing one match would shift every later identity.
+        // Retain the stable query-position component for discovery tests. The
+        // collision-free language component is allocated later by
+        // `NodeTracker::named_layer_for_incarnation`, where URI lifecycle state
+        // can own and reclaim dynamic language names.
         region.identity_slot = region.pattern_index;
     }
     Some(injections)

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -297,7 +297,8 @@ pub(crate) fn collect_all_injections<'a>(
                 // `or_insert_with` so the per-pattern predicate scans
                 // (`has_include_children_for_pattern` / `effective_offset_for_pattern`)
                 // are skipped when this content-node range was already inserted by
-                // an earlier matching pattern. Same resulting map, fewer scans.
+                // an earlier matching pattern for the same language. Same
+                // resulting language layers, fewer scans.
                 injections_map.entry(key).or_insert_with(|| {
                     let offset = effective_offset_for_pattern(query, match_.pattern_index);
                     InjectionRegionInfo {
@@ -407,8 +408,8 @@ fn collect_injection_regions<'a>(
                 language.clone(),
             );
 
-            // Only keep the first injection for each unique range
-            // This handles cases where multiple patterns match the same node
+            // Keep the first match for each range/language pair; distinct
+            // languages on the same range remain separate layers.
             injections_map.entry(key).or_insert(RawInjectionRegion {
                 start_byte: content_node.start_byte(),
                 end_byte: content_node.end_byte(),
@@ -459,6 +460,10 @@ fn extract_content_and_language<'a>(
 }
 
 /// Find the injection region containing the given byte offset.
+///
+/// Regions are sorted by query pattern index, so same-range alternate
+/// languages use explicit query-order priority for single-result bridge APIs.
+/// Whole-document and hierarchy discovery still retain every language layer.
 ///
 /// Returns `(index, region)` for use with `calculate_region_id`, or `None` when the
 /// position is not within any injection region.
@@ -1311,6 +1316,43 @@ mod tests {
             vec!["rust", "doc", "comment"],
             "distinct language layers on the same node must survive discovery"
         );
+    }
+
+    #[test]
+    fn same_range_bridge_resolution_uses_query_pattern_priority() {
+        let mut parser = create_rust_parser();
+        let text = r#"fn main() { /* comment */ }"#;
+        let tree = parse_rust_code(&mut parser, text);
+        let language = tree_sitter_rust::LANGUAGE.into();
+        let query = Query::new(
+            &language,
+            r#"
+                ((block_comment) @injection.content
+                 (#set! injection.language "doc"))
+                ((block_comment) @injection.content
+                 (#set! injection.language "comment"))
+            "#,
+        )
+        .expect("valid query");
+
+        let all = collect_all_injections(&tree.root_node(), text, Some(&query)).unwrap();
+        assert_eq!(
+            all.len(),
+            2,
+            "both same-range languages remain discoverable"
+        );
+        let resolved = InjectionResolver::resolve_at_byte_offset(
+            &test_coordinator(),
+            &NodeTracker::new(),
+            &test_uri("same_range_priority"),
+            &tree,
+            text,
+            &query,
+            15,
+        )
+        .expect("comment position resolves");
+
+        assert_eq!(resolved.region.language, "doc");
     }
 
     #[test]

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -532,8 +532,6 @@ fn find_injection_at_position<'a>(
 pub(crate) struct ResolvedInjection {
     /// Cacheable injection region with line range information
     pub region: CacheableInjectionRegion,
-    /// Raw language identifier captured or assigned by the injection query.
-    pub raw_injection_language: String,
     /// Language of the injection content
     pub injection_language: String,
     /// Extracted virtual document content. Excluded line prefixes are stripped;
@@ -678,7 +676,6 @@ impl InjectionResolver {
             Self::resolve_language(coordinator, &region.language, &virtual_content);
         Some(ResolvedInjection {
             region: cacheable_region,
-            raw_injection_language: region.language.clone(),
             injection_language: resolved_language,
             virtual_content,
             line_column_offsets,
@@ -788,7 +785,6 @@ impl InjectionResolver {
             Self::resolve_language(coordinator, &first.language, &virtual_content);
         Some(ResolvedInjection {
             region: combined_region,
-            raw_injection_language: first.language.clone(),
             injection_language: resolved_language,
             virtual_content,
             line_column_offsets,
@@ -850,7 +846,7 @@ impl InjectionResolver {
                     == Some(identity_layer)
         })?;
 
-        let resolved = if region.combined {
+        if region.combined {
             let group: Vec<_> = regions
                 .iter()
                 .filter(|candidate| {
@@ -859,17 +855,28 @@ impl InjectionResolver {
                         && candidate.language == region.language
                 })
                 .collect();
+            // Every capture in a combined group has a tracker ID, while the
+            // virtual document uses the first capture's ID as its canonical
+            // identity. Resolving any member ID must still reach that shared
+            // document rather than rejecting non-first captures below.
             Self::build_combined_injection(
                 coordinator,
                 Some((tracker, uri, incarnation)),
                 &group,
                 None,
                 text,
-            )?
+            )
         } else {
-            Self::build_resolved_injection(coordinator, tracker, uri, region, text, incarnation)?
-        };
-        (resolved.region.region_id == region_id).then_some(resolved)
+            let resolved = Self::build_resolved_injection(
+                coordinator,
+                tracker,
+                uri,
+                region,
+                text,
+                incarnation,
+            )?;
+            (resolved.region.region_id == region_id).then_some(resolved)
+        }
     }
 
     /// [`resolve_all`](Self::resolve_all) minus the injection-query run, for a
@@ -972,7 +979,6 @@ impl InjectionResolver {
                     Self::resolve_language(coordinator, &region.language, &virtual_content);
                 resolved.push(ResolvedInjection {
                     region: cacheable[index].clone(),
-                    raw_injection_language: region.language.clone(),
                     injection_language: resolved_language,
                     virtual_content,
                     line_column_offsets,
@@ -1450,6 +1456,24 @@ mod tests {
         assert!(resolved[0].virtual_content.contains("</div>"));
         assert!(!resolved[0].virtual_content.contains("let close"));
         assert!(!resolved[0].contiguous);
+
+        let regions = collect_all_injections(&tree.root_node(), text, Some(&query)).unwrap();
+        let second_id = InjectionResolver::calculate_region_id(&tracker, &uri, &regions[1], 0)
+            .unwrap()
+            .to_string();
+        let via_second = InjectionResolver::resolve_by_region_id(
+            &coordinator,
+            &tracker,
+            &uri,
+            &tree,
+            text,
+            &query,
+            &second_id,
+            0,
+        )
+        .expect("a non-first combined capture resolves the shared document");
+        assert_eq!(via_second.region.region_id, resolved[0].region.region_id);
+        assert_eq!(via_second.virtual_content, resolved[0].virtual_content);
     }
 
     #[test]

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -505,15 +505,17 @@ pub(crate) struct ResolvedInjection {
     /// Language of the injection content
     pub injection_language: String,
     /// Extracted virtual document content. Excluded line prefixes are stripped;
-    /// combined regions additionally mask host-only gaps with whitespace.
+    /// combined regions additionally retain host line layout with empty or
+    /// whitespace-only gaps.
     pub virtual_content: String,
     /// Per-virtual-line column offsets for coordinate translation.
     /// Each entry is the UTF-16 column offset for that virtual line.
     pub line_column_offsets: Vec<u32>,
-    /// Whether `virtual_content` maps to one contiguous host byte range —
-    /// i.e. no host-only span between multiple captures was whitespace-masked.
-    /// A combined pattern that currently matches one capture uses the ordinary
-    /// single-region mapping and remains `true`.
+    /// Whether `virtual_content` maps through the ordinary single-region path.
+    /// For a multi-capture combined document this is `false` whenever the union
+    /// of included ranges leaves uncovered host bytes, including inter-capture
+    /// gaps and excluded prefix/child bytes. A combined pattern that currently
+    /// matches one capture uses the ordinary mapping and remains `true`.
     pub contiguous: bool,
 }
 

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -392,6 +392,21 @@ pub(crate) fn detect_injection<'a>(
             .then(a.language.as_str().cmp(b.language.as_str()))
     });
 
+    // Equal spans are alternative interpretations, not nested syntax. Keep
+    // the first query-pattern candidate for single-hierarchy consumers (the
+    // same priority used by bridge position resolution) while preserving real
+    // geometric nesting across different spans.
+    let mut previous_range = None;
+    sorted_injections.retain(|region| {
+        let range = (region.start_byte, region.end_byte);
+        if previous_range == Some(range) {
+            false
+        } else {
+            previous_range = Some(range);
+            true
+        }
+    });
+
     // Build the language hierarchy from outermost to innermost
     let mut hierarchy = vec![base_language.to_string()];
     for region in &sorted_injections {
@@ -1654,8 +1669,8 @@ mod tests {
         let (hierarchy, _, _) = result.unwrap();
         assert_eq!(
             hierarchy,
-            vec!["rust", "doc", "comment"],
-            "distinct language layers on the same node must survive discovery"
+            vec!["rust", "doc"],
+            "same-range alternatives use the first query pattern instead of fabricating nesting"
         );
     }
 

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -24,9 +24,22 @@ use crate::text::{ceil_char_boundary, clamped_slice, floor_char_boundary, fnv1a_
 // alternate language layers at identical host coordinates distinct ULIDs.
 const REGION_IDENTITY_LAYER_BASE: usize = usize::MAX / 2 + 1;
 
-fn region_identity_slot(pattern_index: usize, language: &str) -> usize {
-    ((fnv1a_hash(language) as usize) ^ pattern_index.wrapping_mul(0x9e37_79b9))
-        & (REGION_IDENTITY_LAYER_BASE - 1)
+fn region_identity_slot(pattern_index: usize, language: &str) -> Option<usize> {
+    type IdentitySlots = std::collections::HashMap<(usize, String), usize>;
+    static SLOTS: std::sync::OnceLock<std::sync::Mutex<IdentitySlots>> = std::sync::OnceLock::new();
+
+    let slots = SLOTS.get_or_init(Default::default);
+    let mut slots = slots.lock().ok()?;
+    let next = slots.len();
+    match slots.entry((pattern_index, language.to_owned())) {
+        std::collections::hash_map::Entry::Occupied(entry) => Some(*entry.get()),
+        std::collections::hash_map::Entry::Vacant(entry) => (next < REGION_IDENTITY_LAYER_BASE)
+            .then(|| {
+                let slot = next;
+                entry.insert(slot);
+                slot
+            }),
+    }
 }
 
 /// Iterates over the `@injection.content` captures in a query match.
@@ -67,8 +80,9 @@ pub(crate) struct InjectionRegionInfo<'a> {
     pub offset: Option<InjectionOffset>,
     /// Whether this pattern's captures form one virtual document.
     pub combined: bool,
-    /// Stable identity slot derived from the query pattern index. Unlike a
-    /// current-match ordinal, it does not shift when another pattern stops matching.
+    /// Stable, collision-free identity slot interned from query pattern and
+    /// language. Unlike a current-match ordinal, it does not shift when
+    /// another pattern stops matching.
     pub identity_slot: usize,
 }
 
@@ -357,7 +371,7 @@ pub(crate) fn collect_all_injections<'a>(
         // from one pattern at the same range, so the pattern index alone aliases
         // their virtual documents. A current-match ordinal is also unsuitable:
         // removing one match would shift every later identity.
-        region.identity_slot = region_identity_slot(region.pattern_index, &region.language);
+        region.identity_slot = region_identity_slot(region.pattern_index, &region.language)?;
     }
     Some(injections)
 }
@@ -1702,8 +1716,8 @@ mod tests {
     #[test]
     fn dynamic_languages_from_one_pattern_get_distinct_identity_slots() {
         assert_ne!(
-            region_identity_slot(7, "javascript"),
-            region_identity_slot(7, "typescript"),
+            region_identity_slot(7, "javascript").unwrap(),
+            region_identity_slot(7, "typescript").unwrap(),
             "one dynamic-language pattern must not alias distinct virtual documents"
         );
     }

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -276,7 +276,8 @@ pub(crate) fn collect_all_injections<'a>(
     let mut cursor = QueryCursor::new();
     let mut matches = cursor.matches(query, *root, text.as_bytes());
 
-    // Use a map to deduplicate by content node range.
+    // Deduplicate repeated matches of the same language layer while preserving
+    // distinct languages assigned to the same content range (#598).
     let mut injections_map = std::collections::HashMap::new();
 
     while let Some(match_) = matches.next() {
@@ -288,7 +289,11 @@ pub(crate) fn collect_all_injections<'a>(
                 continue;
             }
             if let Some(language) = extract_injection_language(query, match_, text) {
-                let key = (capture.node.start_byte(), capture.node.end_byte());
+                let key = (
+                    capture.node.start_byte(),
+                    capture.node.end_byte(),
+                    language.clone(),
+                );
                 // `or_insert_with` so the per-pattern predicate scans
                 // (`has_include_children_for_pattern` / `effective_offset_for_pattern`)
                 // are skipped when this content-node range was already inserted by
@@ -384,14 +389,19 @@ fn collect_injection_regions<'a>(
     let mut matches = cursor.matches(query, *root, text.as_bytes());
 
     // Collect all injection regions that contain our node
-    // Use a map to deduplicate by node range (start, end)
+    // Deduplicate by node range and language so alternate language layers on
+    // the same node remain discoverable.
     let mut injections_map = std::collections::HashMap::new();
 
     while let Some(match_) = matches.next() {
         if let Some((content_node, language, pattern_index)) =
             extract_content_and_language(node, match_, query, text)
         {
-            let key = (content_node.start_byte(), content_node.end_byte());
+            let key = (
+                content_node.start_byte(),
+                content_node.end_byte(),
+                language.clone(),
+            );
 
             // Only keep the first injection for each unique range
             // This handles cases where multiple patterns match the same node
@@ -405,8 +415,15 @@ fn collect_injection_regions<'a>(
         }
     }
 
-    // Convert to vector
-    let injections: Vec<_> = injections_map.into_values().collect();
+    let mut injections: Vec<_> = injections_map.into_values().collect();
+    injections.sort_by_key(|region| {
+        (
+            region.start_byte,
+            std::cmp::Reverse(region.end_byte),
+            region.pattern_index,
+            region.language.clone(),
+        )
+    });
 
     Some(injections)
 }
@@ -1163,9 +1180,7 @@ mod tests {
     }
 
     #[test]
-    fn test_duplicate_injections_same_node() {
-        // Test that multiple injection patterns matching the same node
-        // should only result in one injection (not nested)
+    fn same_range_injections_keep_distinct_languages() {
         let mut parser = create_rust_parser();
         let text = r#"fn main() { /* comment */ }"#;
         let tree = parse_rust_code(&mut parser, text);
@@ -1201,14 +1216,12 @@ mod tests {
         let node_in_comment = find_node_at_byte(&root, 14).expect("node in comment");
         let result = detect_injection(&node_in_comment, &root, text, Some(&query), "rust");
 
-        // Should detect only one injection (first pattern takes precedence)
         assert!(result.is_some(), "Should find injection");
         let (hierarchy, _, _) = result.unwrap();
-        // Should only use the first matching pattern, not both
         assert_eq!(
             hierarchy,
-            vec!["rust", "doc"],
-            "Should only show first injection"
+            vec!["rust", "doc", "comment"],
+            "distinct language layers on the same node must survive discovery"
         );
     }
 

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -558,14 +558,7 @@ impl InjectionResolver {
                 text,
             )
         } else {
-            Some(Self::build_resolved_injection(
-                coordinator,
-                tracker,
-                uri,
-                region,
-                text,
-                incarnation,
-            ))
+            Self::build_resolved_injection(coordinator, tracker, uri, region, text, incarnation)
         }
     }
 
@@ -687,13 +680,13 @@ impl InjectionResolver {
                 Self::resolve_language(coordinator, &first.language, &virtual_content);
             let mut region = first_cacheable.clone();
             region.content_hash = CacheableInjectionRegion::hash_content(&virtual_content);
-            return ResolvedInjection {
+            return Some(ResolvedInjection {
                 region,
                 injection_language,
                 virtual_content,
                 line_column_offsets,
                 contiguous: true,
-            };
+            });
         }
         let group_start = first_cacheable.byte_range.start;
         let group_end = cacheable
@@ -1341,7 +1334,7 @@ mod tests {
         let uri = test_uri("combined");
 
         let resolved =
-            InjectionResolver::resolve_all(&coordinator, &tracker, &uri, &tree, text, &query);
+            InjectionResolver::resolve_all(&coordinator, &tracker, &uri, &tree, text, &query, 0);
 
         assert_eq!(resolved.len(), 1, "combined captures form one document");
         assert!(resolved[0].virtual_content.contains("<div>"));
@@ -1374,6 +1367,7 @@ mod tests {
             &tree,
             text,
             &query,
+            0,
         );
 
         assert_eq!(resolved.len(), 1);
@@ -1415,6 +1409,7 @@ mod tests {
             &tree,
             text,
             &query,
+            0,
         );
 
         assert_eq!(resolved.len(), 1);
@@ -1477,6 +1472,7 @@ mod tests {
             &tree,
             text,
             &query,
+            0,
         );
 
         assert_eq!(resolved.len(), 1);
@@ -1510,6 +1506,7 @@ mod tests {
             &tree,
             text,
             &query,
+            0,
         );
 
         assert_eq!(resolved.len(), 2);
@@ -1595,6 +1592,7 @@ mod tests {
             text,
             &query,
             15,
+            0,
         )
         .expect("comment position resolves");
 

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -965,7 +965,9 @@ fn build_combined_virtual_content(
         let first_included = included.get(range_index).and_then(|range| {
             let start = ceil_char_boundary(text, range.start.max(line_start));
             let end = range.end.min(content_end);
-            (start < end).then_some(start)
+            let includes_line_break =
+                content_end < line_end && start == content_end && range.end > content_end;
+            (start < end || includes_line_break).then_some(start)
         });
 
         if let Some(first_included) = first_included {
@@ -1436,6 +1438,16 @@ mod tests {
 
         assert_eq!(content, "x\n");
         assert_eq!(offsets, vec![1, 0]);
+    }
+
+    #[test]
+    fn combined_blank_included_line_records_its_prefix_offset() {
+        let text = "> \n";
+        let (content, offsets) =
+            build_combined_virtual_content(text, 0..text.len(), &[2..text.len()]);
+
+        assert_eq!(content, "\n");
+        assert_eq!(offsets, vec![2, 0]);
     }
 
     #[test]

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -322,13 +322,19 @@ pub(crate) fn collect_all_injections<'a>(
 
     // Sort by start_byte (primary) and end_byte (secondary) to ensure deterministic ordering
     let mut injections: Vec<_> = injections_map.into_values().collect();
-    injections.sort_by_key(|r| {
+    injections.sort_by(|a, b| {
         (
-            r.content_node.start_byte(),
-            r.content_node.end_byte(),
-            r.pattern_index,
-            r.language.clone(),
+            a.content_node.start_byte(),
+            a.content_node.end_byte(),
+            a.pattern_index,
+            a.language.as_str(),
         )
+            .cmp(&(
+                b.content_node.start_byte(),
+                b.content_node.end_byte(),
+                b.pattern_index,
+                b.language.as_str(),
+            ))
     });
     Some(injections)
 }
@@ -421,13 +427,19 @@ fn collect_injection_regions<'a>(
     }
 
     let mut injections: Vec<_> = injections_map.into_values().collect();
-    injections.sort_by_key(|region| {
+    injections.sort_by(|a, b| {
         (
-            region.start_byte,
-            std::cmp::Reverse(region.end_byte),
-            region.pattern_index,
-            region.language.clone(),
+            a.start_byte,
+            std::cmp::Reverse(a.end_byte),
+            a.pattern_index,
+            a.language.as_str(),
         )
+            .cmp(&(
+                b.start_byte,
+                std::cmp::Reverse(b.end_byte),
+                b.pattern_index,
+                b.language.as_str(),
+            ))
     });
 
     Some(injections)

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -483,6 +483,9 @@ pub(crate) struct ResolvedInjection {
     /// Per-virtual-line column offsets for coordinate translation.
     /// Each entry is the UTF-16 column offset for that virtual line.
     pub line_column_offsets: Vec<u32>,
+    /// Whether `virtual_content` maps to one contiguous host byte range.
+    /// `false` for `injection.combined`, whose host-only gaps are masked.
+    pub contiguous: bool,
 }
 
 /// Central service for resolving injection regions at LSP positions
@@ -606,6 +609,7 @@ impl InjectionResolver {
             injection_language: resolved_language,
             virtual_content,
             line_column_offsets,
+            contiguous: true,
         })
     }
 
@@ -690,6 +694,7 @@ impl InjectionResolver {
             injection_language: resolved_language,
             virtual_content,
             line_column_offsets: vec![first_cacheable.start_column],
+            contiguous: false,
         })
     }
 
@@ -799,6 +804,7 @@ impl InjectionResolver {
                     injection_language: resolved_language,
                     virtual_content,
                     line_column_offsets,
+                    contiguous: true,
                 });
             } else {
                 let (tracker, uri, incarnation) =
@@ -1182,6 +1188,7 @@ mod tests {
         assert!(resolved[0].virtual_content.contains("<div>"));
         assert!(resolved[0].virtual_content.contains("</div>"));
         assert!(!resolved[0].virtual_content.contains("let close"));
+        assert!(!resolved[0].contiguous);
     }
 
     #[test]

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -24,6 +24,11 @@ use crate::text::{ceil_char_boundary, clamped_slice, floor_char_boundary, fnv1a_
 // alternate language layers at identical host coordinates distinct ULIDs.
 const REGION_IDENTITY_LAYER_BASE: usize = usize::MAX / 2 + 1;
 
+fn region_identity_slot(pattern_index: usize, language: &str) -> usize {
+    ((fnv1a_hash(language) as usize) ^ pattern_index.wrapping_mul(0x9e37_79b9))
+        & (REGION_IDENTITY_LAYER_BASE - 1)
+}
+
 /// Iterates over the `@injection.content` captures in a query match.
 fn iter_injection_content_captures<'a, 'b>(
     match_: &'b QueryMatch<'_, 'a>,
@@ -347,10 +352,12 @@ pub(crate) fn collect_all_injections<'a>(
             ))
     });
     for region in &mut injections {
-        // Pattern indexes remain stable when another same-range pattern stops
-        // matching. An ordinal among only the current matches would let the
-        // survivor inherit the removed pattern's tracked region identity.
-        region.identity_slot = region.pattern_index;
+        // Derive identity from both stable query position and language. Dynamic
+        // `@injection.language` captures can produce several language layers
+        // from one pattern at the same range, so the pattern index alone aliases
+        // their virtual documents. A current-match ordinal is also unsuitable:
+        // removing one match would shift every later identity.
+        region.identity_slot = region_identity_slot(region.pattern_index, &region.language);
     }
     Some(injections)
 }
@@ -1674,8 +1681,16 @@ mod tests {
 
         assert_eq!(regions.len(), 2);
         assert_ne!(regions[0].include_children, regions[1].include_children);
-        assert_eq!(regions[0].identity_slot, 0);
-        assert_eq!(regions[1].identity_slot, 1);
+        assert_ne!(regions[0].identity_slot, regions[1].identity_slot);
+    }
+
+    #[test]
+    fn dynamic_languages_from_one_pattern_get_distinct_identity_slots() {
+        assert_ne!(
+            region_identity_slot(7, "javascript"),
+            region_identity_slot(7, "typescript"),
+            "one dynamic-language pattern must not alias distinct virtual documents"
+        );
     }
 
     #[test]

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -602,7 +602,7 @@ impl InjectionResolver {
         injection: &InjectionRegionInfo,
         incarnation: u64,
     ) -> Option<Ulid> {
-        let identity_layer = REGION_IDENTITY_LAYER_BASE.checked_add(injection.identity_slot)?;
+        let identity_layer = Self::region_identity_layer(injection)?;
         tracker.get_or_create_in_layer_for_incarnation(
             uri,
             injection.content_node.start_byte(),
@@ -611,6 +611,11 @@ impl InjectionResolver {
             identity_layer,
             incarnation,
         )
+    }
+
+    /// Tracker-layer key used by both inline and batch region-ID minting.
+    pub(crate) fn region_identity_layer(injection: &InjectionRegionInfo) -> Option<usize> {
+        REGION_IDENTITY_LAYER_BASE.checked_add(injection.identity_slot)
     }
 
     /// Derive a parser-independent canonical injection language for bridge

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -716,8 +716,9 @@ impl InjectionResolver {
         })
     }
 
-    /// Resolve every injection region in the document (whole-doc operations
-    /// like `documentLink` use this rather than a position lookup). Holds no
+    /// Resolve every bridge virtual document in the host (whole-doc operations
+    /// like `documentLink` use this rather than a position lookup). Combined
+    /// capture groups produce one resolved document. Holds no
     /// Document lock — `tree`/`text` must already be cloned, typically via
     /// `DocumentSnapshot`. Empty vec when nothing matches.
     pub(crate) fn resolve_all(

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -19,6 +19,11 @@ use crate::language::node_tracker::NodeTracker;
 use crate::language::query_predicates::check_match_predicates;
 use crate::text::{ceil_char_boundary, clamped_slice, floor_char_boundary, fnv1a_hash};
 
+// Keep bridge-region identities in a namespace disjoint from real parse-tree
+// injection depths (0..=MAX_INJECTION_DEPTH). The per-range slot then gives
+// alternate language layers at identical host coordinates distinct ULIDs.
+const REGION_IDENTITY_LAYER_BASE: usize = usize::MAX / 2 + 1;
+
 /// Iterates over the `@injection.content` captures in a query match.
 fn iter_injection_content_captures<'a, 'b>(
     match_: &'b QueryMatch<'_, 'a>,
@@ -57,6 +62,9 @@ pub(crate) struct InjectionRegionInfo<'a> {
     pub offset: Option<InjectionOffset>,
     /// Whether this pattern's captures form one virtual document.
     pub combined: bool,
+    /// Deterministic identity slot among alternate layers with this exact host
+    /// byte range. Zero for the common single-layer case.
+    pub identity_slot: usize,
 }
 
 /// Owned injection region for caching (no lifetime dependency on parse tree)
@@ -313,6 +321,7 @@ pub(crate) fn collect_all_injections<'a>(
                         // multi-region grouping do not compose safely.
                         combined: has_combined_for_pattern(query, match_.pattern_index)
                             && offset.is_none(),
+                        identity_slot: 0,
                         offset,
                     }
                 });
@@ -336,6 +345,21 @@ pub(crate) fn collect_all_injections<'a>(
                 b.language.as_str(),
             ))
     });
+    let mut previous_range = None;
+    let mut identity_slot = 0usize;
+    for region in &mut injections {
+        let range = (
+            region.content_node.start_byte(),
+            region.content_node.end_byte(),
+        );
+        if previous_range == Some(range) {
+            identity_slot = identity_slot.saturating_add(1);
+        } else {
+            previous_range = Some(range);
+            identity_slot = 0;
+        }
+        region.identity_slot = identity_slot;
+    }
     Some(injections)
 }
 
@@ -566,26 +590,25 @@ impl InjectionResolver {
     ///
     /// Phase 2 (lazy-node-identity-tracking): keyed on position (start_byte,
     /// end_byte, kind, layer), so the ULID stays constant for the same position
-    /// key. Region IDs always use `layer = 0` (see below).
+    /// and same-range identity slot.
     ///
-    /// Minted via the host-layer `get_or_create` (`layer = 0`) **by design**:
-    /// `content_node` comes from the host document's injection query, so it is a
-    /// host-tree node. The `layer` discriminator (lazy-node-identity-tracking
-    /// §"Node Uniqueness Key") only needs to separate host from injected nodes,
-    /// and a region's content node is always the host side. If a navigation
-    /// `kakehashi/node` call resolves that same host node it dedups to this same
-    /// ULID, which is correct.
+    /// Region IDs use a reserved tracker-layer namespace plus the deterministic
+    /// same-range identity slot. This keeps alternate language/query layers at
+    /// identical host coordinates distinct without colliding with real parse
+    /// injection depths used by `kakehashi/node`.
     pub(crate) fn calculate_region_id(
         tracker: &NodeTracker,
         uri: &Url,
         injection: &InjectionRegionInfo,
         incarnation: u64,
     ) -> Option<Ulid> {
-        tracker.get_or_create_for_incarnation(
+        let identity_layer = REGION_IDENTITY_LAYER_BASE.checked_add(injection.identity_slot)?;
+        tracker.get_or_create_in_layer_for_incarnation(
             uri,
             injection.content_node.start_byte(),
             injection.content_node.end_byte(),
             injection.content_node.kind(),
+            identity_layer,
             incarnation,
         )
     }
@@ -768,6 +791,34 @@ impl InjectionResolver {
         };
 
         Self::resolve_from_regions(coordinator, tracker, uri, &injections, text, incarnation)
+    }
+
+    /// Resolve the exact bridge layer identified by an opaque region ID.
+    ///
+    /// A byte lookup alone is ambiguous when multiple query patterns assign
+    /// alternate languages or geometry to the same host node.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn resolve_by_region_id(
+        coordinator: &LanguageCoordinator,
+        tracker: &NodeTracker,
+        uri: &Url,
+        tree: &Tree,
+        text: &str,
+        injection_query: &Query,
+        region_id: &str,
+        incarnation: u64,
+    ) -> Option<ResolvedInjection> {
+        Self::resolve_all(
+            coordinator,
+            tracker,
+            uri,
+            tree,
+            text,
+            injection_query,
+            incarnation,
+        )
+        .into_iter()
+        .find(|resolved| resolved.region.region_id == region_id)
     }
 
     /// [`resolve_all`](Self::resolve_all) minus the injection-query run, for a
@@ -1602,10 +1653,38 @@ mod tests {
             2,
             "both same-range languages remain discoverable"
         );
+        let tracker = NodeTracker::new();
+        let uri = test_uri("same_range_priority");
+        let resolved_all = InjectionResolver::resolve_all(
+            &test_coordinator(),
+            &tracker,
+            &uri,
+            &tree,
+            text,
+            &query,
+            0,
+        );
+        assert_ne!(
+            resolved_all[0].region.region_id, resolved_all[1].region.region_id,
+            "alternate language layers at one host range need distinct identities"
+        );
+        let second_id = resolved_all[1].region.region_id.clone();
+        let second = InjectionResolver::resolve_by_region_id(
+            &test_coordinator(),
+            &tracker,
+            &uri,
+            &tree,
+            text,
+            &query,
+            &second_id,
+            0,
+        )
+        .expect("the exact alternate layer resolves from its region ID");
+        assert_eq!(second.injection_language, "comment");
         let resolved = InjectionResolver::resolve_at_byte_offset(
             &test_coordinator(),
-            &NodeTracker::new(),
-            &test_uri("same_range_priority"),
+            &tracker,
+            &uri,
             &tree,
             text,
             &query,
@@ -1973,6 +2052,7 @@ mod tests {
                 include_children: false,
                 offset: None,
                 combined: false,
+                identity_slot: 0,
             },
             InjectionRegionInfo {
                 language: "python".to_string(),
@@ -1981,6 +2061,7 @@ mod tests {
                 include_children: false,
                 offset: None,
                 combined: false,
+                identity_slot: 0,
             },
             InjectionRegionInfo {
                 language: "lua".to_string(),
@@ -1989,6 +2070,7 @@ mod tests {
                 include_children: false,
                 offset: None,
                 combined: false,
+                identity_slot: 0,
             },
         ];
 
@@ -2061,6 +2143,7 @@ mod tests {
                 include_children: false,
                 offset: None,
                 combined: false,
+                identity_slot: 0,
             },
             InjectionRegionInfo {
                 language: "python".to_string(),
@@ -2069,6 +2152,7 @@ mod tests {
                 include_children: false,
                 offset: None,
                 combined: false,
+                identity_slot: 0,
             },
             InjectionRegionInfo {
                 language: "lua".to_string(),
@@ -2077,6 +2161,7 @@ mod tests {
                 include_children: false,
                 offset: None,
                 combined: false,
+                identity_slot: 0,
             },
         ];
 

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -62,8 +62,8 @@ pub(crate) struct InjectionRegionInfo<'a> {
     pub offset: Option<InjectionOffset>,
     /// Whether this pattern's captures form one virtual document.
     pub combined: bool,
-    /// Deterministic identity slot among alternate layers with this exact host
-    /// byte range. Zero for the common single-layer case.
+    /// Stable identity slot derived from the query pattern index. Unlike a
+    /// current-match ordinal, it does not shift when another pattern stops matching.
     pub identity_slot: usize,
 }
 
@@ -346,20 +346,11 @@ pub(crate) fn collect_all_injections<'a>(
                 b.language.as_str(),
             ))
     });
-    let mut previous_range = None;
-    let mut identity_slot = 0usize;
     for region in &mut injections {
-        let range = (
-            region.content_node.start_byte(),
-            region.content_node.end_byte(),
-        );
-        if previous_range == Some(range) {
-            identity_slot = identity_slot.saturating_add(1);
-        } else {
-            previous_range = Some(range);
-            identity_slot = 0;
-        }
-        region.identity_slot = identity_slot;
+        // Pattern indexes remain stable when another same-range pattern stops
+        // matching. An ordinal among only the current matches would let the
+        // survivor inherit the removed pattern's tracked region identity.
+        region.identity_slot = region.pattern_index;
     }
     Some(injections)
 }
@@ -1683,6 +1674,8 @@ mod tests {
 
         assert_eq!(regions.len(), 2);
         assert_ne!(regions[0].include_children, regions[1].include_children);
+        assert_eq!(regions[0].identity_slot, 0);
+        assert_eq!(regions[1].identity_slot, 1);
     }
 
     #[test]

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -499,12 +499,10 @@ impl InjectionResolver {
                 .collect();
             Self::build_combined_injection(
                 coordinator,
-                tracker,
-                uri,
+                Some((tracker, uri, incarnation)),
                 &group,
                 None,
                 text,
-                Some(incarnation),
             )
         } else {
             Some(Self::build_resolved_injection(
@@ -598,19 +596,18 @@ impl InjectionResolver {
     /// line/column still maps directly back to the host document.
     fn build_combined_injection(
         coordinator: &LanguageCoordinator,
-        tracker: &NodeTracker,
-        uri: &Url,
+        identity: Option<(&NodeTracker, &Url, u64)>,
         regions: &[&InjectionRegionInfo<'_>],
         prebuilt: Option<&[&CacheableInjectionRegion]>,
         text: &str,
-        incarnation: Option<u64>,
     ) -> Option<ResolvedInjection> {
         debug_assert!(!regions.is_empty());
         let owned_cacheable;
         let cacheable: Vec<&CacheableInjectionRegion> = match prebuilt {
             Some(cacheable) => cacheable.to_vec(),
             None => {
-                let incarnation = incarnation?;
+                let (tracker, uri, incarnation) =
+                    identity.expect("non-prebuilt regions require identity");
                 owned_cacheable = regions
                     .iter()
                     .map(|region| {
@@ -710,12 +707,10 @@ impl InjectionResolver {
     ) -> Vec<ResolvedInjection> {
         Self::resolve_grouped(
             coordinator,
-            tracker,
-            uri,
+            Some((tracker, uri, incarnation)),
             regions,
             None,
             text,
-            Some(incarnation),
         )
     }
 
@@ -732,25 +727,15 @@ impl InjectionResolver {
         cacheable: &[CacheableInjectionRegion],
         text: &str,
     ) -> Vec<ResolvedInjection> {
-        Self::resolve_grouped(
-            coordinator,
-            &NodeTracker::new(),
-            &Url::parse("file:///prebuilt").unwrap(),
-            regions,
-            Some(cacheable),
-            text,
-            None,
-        )
+        Self::resolve_grouped(coordinator, None, regions, Some(cacheable), text)
     }
 
     fn resolve_grouped(
         coordinator: &LanguageCoordinator,
-        tracker: &NodeTracker,
-        uri: &Url,
+        identity: Option<(&NodeTracker, &Url, u64)>,
         regions: &[InjectionRegionInfo<'_>],
         prebuilt: Option<&[CacheableInjectionRegion]>,
         text: &str,
-        incarnation: Option<u64>,
     ) -> Vec<ResolvedInjection> {
         let mut resolved = Vec::new();
         let mut seen_combined = std::collections::HashSet::new();
@@ -775,12 +760,10 @@ impl InjectionResolver {
                     .map(|cacheable| indices.iter().map(|&i| &cacheable[i]).collect::<Vec<_>>());
                 if let Some(combined) = Self::build_combined_injection(
                     coordinator,
-                    tracker,
-                    uri,
+                    identity,
                     &group,
                     prebuilt_group.as_deref(),
                     text,
-                    incarnation,
                 ) {
                     resolved.push(combined);
                 }
@@ -796,16 +779,16 @@ impl InjectionResolver {
                     line_column_offsets,
                 });
             } else {
-                if let Some(incarnation) = incarnation
-                    && let Some(single) = Self::build_resolved_injection(
-                        coordinator,
-                        tracker,
-                        uri,
-                        region,
-                        text,
-                        incarnation,
-                    )
-                {
+                let (tracker, uri, incarnation) =
+                    identity.expect("non-prebuilt regions require identity");
+                if let Some(single) = Self::build_resolved_injection(
+                    coordinator,
+                    tracker,
+                    uri,
+                    region,
+                    text,
+                    incarnation,
+                ) {
                     resolved.push(single);
                 }
             }

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -935,7 +935,7 @@ fn build_combined_virtual_content(
     span: Range<usize>,
     included: &[Range<usize>],
 ) -> (String, Vec<u32>) {
-    let mut output = String::new();
+    let mut output = String::with_capacity(span.len());
     let mut offsets = Vec::new();
     let mut line_start = span.start;
     let mut range_index = 0;

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -510,8 +510,11 @@ pub(crate) struct ResolvedInjection {
     /// Per-virtual-line column offsets for coordinate translation.
     /// Each entry is the UTF-16 column offset for that virtual line.
     pub line_column_offsets: Vec<u32>,
-    /// Whether `virtual_content` maps to one contiguous host byte range.
-    /// `false` for `injection.combined`, whose host-only gaps are masked.
+    /// Whether `virtual_content` maps to one contiguous host byte range —
+    /// i.e. no excluded host bytes were whitespace-masked. A combined
+    /// pattern whose captures form one unbroken included range is still
+    /// `true`; any masked gap (between captures or within one) makes it
+    /// `false`.
     pub contiguous: bool,
 }
 
@@ -641,9 +644,11 @@ impl InjectionResolver {
     }
 
     /// Build one bridge virtual document for all captures of an
-    /// `injection.combined` pattern. Non-content bytes between captures are
-    /// replaced with coordinate-preserving whitespace: the downstream parser
-    /// sees one document and retains cross-block context, while every virtual
+    /// `injection.combined` pattern. Every host byte outside the included
+    /// ranges — the gaps between captures AND excluded bytes inside a
+    /// capture (e.g. non-content child/prefix bytes) — is replaced with
+    /// coordinate-preserving whitespace: the downstream parser sees one
+    /// document and retains cross-block context, while every virtual
     /// line/column still maps directly back to the host document.
     fn build_combined_injection(
         coordinator: &LanguageCoordinator,

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -298,9 +298,9 @@ pub(crate) fn collect_all_injections<'a>(
                 // (`has_include_children_for_pattern` / `effective_offset_for_pattern`)
                 // are skipped when this content-node range was already inserted by
                 // an earlier matching pattern. Same resulting map, fewer scans.
-                injections_map
-                    .entry(key)
-                    .or_insert_with(|| InjectionRegionInfo {
+                injections_map.entry(key).or_insert_with(|| {
+                    let offset = effective_offset_for_pattern(query, match_.pattern_index);
+                    InjectionRegionInfo {
                         language,
                         content_node: capture.node,
                         pattern_index: match_.pattern_index,
@@ -308,9 +308,13 @@ pub(crate) fn collect_all_injections<'a>(
                             query,
                             match_.pattern_index,
                         ),
-                        offset: effective_offset_for_pattern(query, match_.pattern_index),
-                        combined: has_combined_for_pattern(query, match_.pattern_index),
-                    });
+                        // Match the semantic path: effective offsets and
+                        // multi-region grouping do not compose safely.
+                        combined: has_combined_for_pattern(query, match_.pattern_index)
+                            && offset.is_none(),
+                        offset,
+                    }
+                });
             }
         }
     }
@@ -1228,6 +1232,39 @@ mod tests {
         assert_eq!(resolved.len(), 1);
         assert!(resolved[0].contiguous);
         assert_eq!(resolved[0].virtual_content, "<div></div>");
+    }
+
+    #[test]
+    fn combined_patterns_with_offsets_remain_separate() {
+        let mut parser = create_rust_parser();
+        let text = r#"fn main() { let a = "abc"; let b = "def"; }"#;
+        let tree = parse_rust_code(&mut parser, text);
+        let language = tree_sitter_rust::LANGUAGE.into();
+        let query = Query::new(
+            &language,
+            r#"
+                ((string_literal
+                   (string_content) @injection.content)
+                 (#set! injection.language "html")
+                 (#set! injection.combined)
+                 (#offset! @injection.content 0 1 0 -1))
+            "#,
+        )
+        .expect("valid query");
+
+        let resolved = InjectionResolver::resolve_all(
+            &test_coordinator(),
+            &NodeTracker::new(),
+            &test_uri("combined_offset"),
+            &tree,
+            text,
+            &query,
+        );
+
+        assert_eq!(resolved.len(), 2);
+        assert_eq!(resolved[0].virtual_content, "b");
+        assert_eq!(resolved[1].virtual_content, "e");
+        assert!(resolved.iter().all(|region| region.contiguous));
     }
 
     #[test]

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -960,7 +960,7 @@ fn build_combined_virtual_content(
             range_index += 1;
         }
         let first_included = included.get(range_index).and_then(|range| {
-            let start = range.start.max(line_start);
+            let start = ceil_char_boundary(text, range.start.max(line_start));
             let end = range.end.min(content_end);
             (start < end).then_some(start)
         });
@@ -1422,6 +1422,16 @@ mod tests {
             vec![2, 2, 0, 0, 0, 2, 0, 0]
         );
         assert!(!resolved[0].contiguous);
+    }
+
+    #[test]
+    fn combined_content_snaps_stale_included_start_to_char_boundary() {
+        let text = "éx\n";
+        let (content, offsets) =
+            build_combined_virtual_content(text, 0..text.len(), &[1..usize::MAX]);
+
+        assert_eq!(content, "x\n");
+        assert_eq!(offsets, vec![1, 0]);
     }
 
     #[test]

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -939,6 +939,9 @@ fn build_combined_virtual_content(
     let mut offsets = Vec::new();
     let mut line_start = span.start;
     let mut range_index = 0;
+    let mut host_line_start = text[..line_start]
+        .rfind('\n')
+        .map_or(0, |newline| newline + 1);
 
     while line_start < span.end {
         let remaining = clamped_slice(text, line_start..span.end);
@@ -966,9 +969,6 @@ fn build_combined_virtual_content(
         });
 
         if let Some(first_included) = first_included {
-            let host_line_start = text[..first_included]
-                .rfind('\n')
-                .map_or(0, |newline| newline + 1);
             offsets.push(
                 clamped_slice(text, host_line_start..first_included)
                     .encode_utf16()
@@ -985,6 +985,7 @@ fn build_combined_virtual_content(
         }
 
         line_start = line_end;
+        host_line_start = line_end;
     }
 
     if output.ends_with('\n') {

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -24,24 +24,6 @@ use crate::text::{ceil_char_boundary, clamped_slice, floor_char_boundary, fnv1a_
 // alternate language layers at identical host coordinates distinct ULIDs.
 const REGION_IDENTITY_LAYER_BASE: usize = usize::MAX / 2 + 1;
 
-fn region_identity_slot(pattern_index: usize, language: &str) -> Option<usize> {
-    type IdentitySlots = std::collections::HashMap<(usize, String), usize>;
-    static SLOTS: std::sync::OnceLock<std::sync::Mutex<IdentitySlots>> = std::sync::OnceLock::new();
-
-    let slots = SLOTS.get_or_init(Default::default);
-    let mut slots = slots.lock().ok()?;
-    let next = slots.len();
-    match slots.entry((pattern_index, language.to_owned())) {
-        std::collections::hash_map::Entry::Occupied(entry) => Some(*entry.get()),
-        std::collections::hash_map::Entry::Vacant(entry) => (next < REGION_IDENTITY_LAYER_BASE)
-            .then(|| {
-                let slot = next;
-                entry.insert(slot);
-                slot
-            }),
-    }
-}
-
 /// Iterates over the `@injection.content` captures in a query match.
 fn iter_injection_content_captures<'a, 'b>(
     match_: &'b QueryMatch<'_, 'a>,
@@ -80,9 +62,7 @@ pub(crate) struct InjectionRegionInfo<'a> {
     pub offset: Option<InjectionOffset>,
     /// Whether this pattern's captures form one virtual document.
     pub combined: bool,
-    /// Stable, collision-free identity slot interned from query pattern and
-    /// language. Unlike a current-match ordinal, it does not shift when
-    /// another pattern stops matching.
+    /// Stable query pattern index used as part of tracker identity.
     pub identity_slot: usize,
 }
 
@@ -371,7 +351,7 @@ pub(crate) fn collect_all_injections<'a>(
         // from one pattern at the same range, so the pattern index alone aliases
         // their virtual documents. A current-match ordinal is also unsuitable:
         // removing one match would shift every later identity.
-        region.identity_slot = region_identity_slot(region.pattern_index, &region.language)?;
+        region.identity_slot = region.pattern_index;
     }
     Some(injections)
 }
@@ -631,7 +611,7 @@ impl InjectionResolver {
         injection: &InjectionRegionInfo,
         incarnation: u64,
     ) -> Option<Ulid> {
-        let identity_layer = Self::region_identity_layer(injection)?;
+        let identity_layer = Self::region_identity_layer(tracker, uri, injection, incarnation)?;
         tracker.get_or_create_in_layer_for_incarnation(
             uri,
             injection.content_node.start_byte(),
@@ -643,8 +623,19 @@ impl InjectionResolver {
     }
 
     /// Tracker-layer key used by both inline and batch region-ID minting.
-    pub(crate) fn region_identity_layer(injection: &InjectionRegionInfo) -> Option<usize> {
-        REGION_IDENTITY_LAYER_BASE.checked_add(injection.identity_slot)
+    pub(crate) fn region_identity_layer(
+        tracker: &NodeTracker,
+        uri: &Url,
+        injection: &InjectionRegionInfo,
+        incarnation: u64,
+    ) -> Option<usize> {
+        let slot = tracker.named_layer_for_incarnation(
+            uri,
+            injection.pattern_index,
+            &injection.language,
+            incarnation,
+        )?;
+        REGION_IDENTITY_LAYER_BASE.checked_add(slot)
     }
 
     /// Derive a parser-independent canonical injection language for bridge
@@ -854,7 +845,8 @@ impl InjectionResolver {
             candidate.content_node.start_byte() == start
                 && candidate.content_node.end_byte() == end
                 && candidate.content_node.kind() == kind
-                && Self::region_identity_layer(candidate) == Some(identity_layer)
+                && Self::region_identity_layer(tracker, uri, candidate, incarnation)
+                    == Some(identity_layer)
         })?;
 
         let resolved = if region.combined {
@@ -1715,9 +1707,15 @@ mod tests {
 
     #[test]
     fn dynamic_languages_from_one_pattern_get_distinct_identity_slots() {
+        let tracker = NodeTracker::new();
+        let uri = test_uri("dynamic_identity");
         assert_ne!(
-            region_identity_slot(7, "javascript").unwrap(),
-            region_identity_slot(7, "typescript").unwrap(),
+            tracker
+                .named_layer_for_incarnation(&uri, 7, "javascript", 0)
+                .unwrap(),
+            tracker
+                .named_layer_for_incarnation(&uri, 7, "typescript", 0)
+                .unwrap(),
             "one dynamic-language pattern must not alias distinct virtual documents"
         );
     }

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -358,10 +358,15 @@ pub(crate) fn detect_injection<'a>(
     let mut sorted_injections = injections;
     sorted_injections.sort_by(|a, b| {
         // Sort by start byte (ascending), then by end byte (descending)
-        // This ensures outer injections come before inner ones
+        // This ensures outer injections come before inner ones. Same-range
+        // alternate-language layers tie-break by (pattern_index, language) —
+        // the discovery sorts' exact order — so the hierarchy and the
+        // innermost pick stay deterministic regardless of input order.
         a.start_byte
             .cmp(&b.start_byte)
             .then(b.end_byte.cmp(&a.end_byte))
+            .then(a.pattern_index.cmp(&b.pattern_index))
+            .then(a.language.as_str().cmp(b.language.as_str()))
     });
 
     // Build the language hierarchy from outermost to innermost

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -11,7 +11,8 @@ use super::content::{compute_line_column_offsets, extract_clean_content};
 use super::language::extract_injection_language;
 use super::offset::{InjectionOffset, effective_offset_for_pattern};
 use super::ranges::{
-    compute_included_ranges, compute_included_ranges_clipped, has_include_children_for_pattern,
+    compute_included_ranges, compute_included_ranges_clipped, has_combined_for_pattern,
+    has_include_children_for_pattern,
 };
 use crate::language::LanguageCoordinator;
 use crate::language::node_tracker::NodeTracker;
@@ -54,6 +55,8 @@ pub(crate) struct InjectionRegionInfo<'a> {
     /// `CacheableInjectionRegion::from_region_info` run). `None` when the
     /// pattern has no directive.
     pub offset: Option<InjectionOffset>,
+    /// Whether this pattern's captures form one virtual document.
+    pub combined: bool,
 }
 
 /// Owned injection region for caching (no lifetime dependency on parse tree)
@@ -273,7 +276,7 @@ pub(crate) fn collect_all_injections<'a>(
     let mut cursor = QueryCursor::new();
     let mut matches = cursor.matches(query, *root, text.as_bytes());
 
-    // Use a map to deduplicate by content node range
+    // Use a map to deduplicate by content node range.
     let mut injections_map = std::collections::HashMap::new();
 
     while let Some(match_) = matches.next() {
@@ -301,6 +304,7 @@ pub(crate) fn collect_all_injections<'a>(
                             match_.pattern_index,
                         ),
                         offset: effective_offset_for_pattern(query, match_.pattern_index),
+                        combined: has_combined_for_pattern(query, match_.pattern_index),
                     });
             }
         }
@@ -308,7 +312,14 @@ pub(crate) fn collect_all_injections<'a>(
 
     // Sort by start_byte (primary) and end_byte (secondary) to ensure deterministic ordering
     let mut injections: Vec<_> = injections_map.into_values().collect();
-    injections.sort_by_key(|r| (r.content_node.start_byte(), r.content_node.end_byte()));
+    injections.sort_by_key(|r| {
+        (
+            r.content_node.start_byte(),
+            r.content_node.end_byte(),
+            r.pattern_index,
+            r.language.clone(),
+        )
+    });
     Some(injections)
 }
 
@@ -477,7 +488,34 @@ impl InjectionResolver {
     ) -> Option<ResolvedInjection> {
         let injections = collect_all_injections(&tree.root_node(), text, Some(injection_query))?;
         let (_region_index, region) = find_injection_at_position(&injections, byte_offset)?;
-        Self::build_resolved_injection(coordinator, tracker, uri, region, text, incarnation)
+        if region.combined {
+            let group: Vec<_> = injections
+                .iter()
+                .filter(|candidate| {
+                    candidate.combined
+                        && candidate.pattern_index == region.pattern_index
+                        && candidate.language == region.language
+                })
+                .collect();
+            Self::build_combined_injection(
+                coordinator,
+                tracker,
+                uri,
+                &group,
+                None,
+                text,
+                Some(incarnation),
+            )
+        } else {
+            Some(Self::build_resolved_injection(
+                coordinator,
+                tracker,
+                uri,
+                region,
+                text,
+                incarnation,
+            ))
+        }
     }
 
     /// Calculate a stable ULID-based region_id for an injection.
@@ -553,6 +591,90 @@ impl InjectionResolver {
         })
     }
 
+    /// Build one bridge virtual document for all captures of an
+    /// `injection.combined` pattern. Non-content bytes between captures are
+    /// replaced with coordinate-preserving whitespace: the downstream parser
+    /// sees one document and retains cross-block context, while every virtual
+    /// line/column still maps directly back to the host document.
+    fn build_combined_injection(
+        coordinator: &LanguageCoordinator,
+        tracker: &NodeTracker,
+        uri: &Url,
+        regions: &[&InjectionRegionInfo<'_>],
+        prebuilt: Option<&[&CacheableInjectionRegion]>,
+        text: &str,
+        incarnation: Option<u64>,
+    ) -> Option<ResolvedInjection> {
+        debug_assert!(!regions.is_empty());
+        let owned_cacheable;
+        let cacheable: Vec<&CacheableInjectionRegion> = match prebuilt {
+            Some(cacheable) => cacheable.to_vec(),
+            None => {
+                let incarnation = incarnation?;
+                owned_cacheable = regions
+                    .iter()
+                    .map(|region| {
+                        let id = Self::calculate_region_id(tracker, uri, region, incarnation)?;
+                        Some(CacheableInjectionRegion::from_region_info(
+                            region,
+                            &id.to_string(),
+                            text,
+                        ))
+                    })
+                    .collect::<Option<Vec<_>>>()?;
+                owned_cacheable.iter().collect()
+            }
+        };
+        let first = regions[0];
+        let first_cacheable = cacheable[0];
+        let group_start = first_cacheable.byte_range.start;
+        let group_end = cacheable
+            .iter()
+            .map(|region| region.byte_range.end)
+            .max()
+            .unwrap_or(group_start);
+
+        let mut included = Vec::new();
+        for (region, cacheable) in regions.iter().zip(&cacheable) {
+            let ranges = if region.offset.is_some() {
+                compute_included_ranges_clipped(
+                    &region.content_node,
+                    region.include_children,
+                    text,
+                    cacheable.byte_range.clone(),
+                )
+            } else {
+                compute_included_ranges(&region.content_node, region.include_children)
+            };
+            match ranges {
+                Some(ranges) => included.extend(ranges.into_iter().map(|range| {
+                    cacheable.byte_range.start + range.start_byte
+                        ..cacheable.byte_range.start + range.end_byte
+                })),
+                None => included.push(cacheable.byte_range.clone()),
+            }
+        }
+        included.sort_by_key(|range| (range.start, range.end));
+        let virtual_content = mask_outside_ranges(text, group_start..group_end, &included);
+
+        let mut combined_region = first_cacheable.clone();
+        combined_region.byte_range.end = group_end;
+        combined_region.line_range.end = cacheable
+            .iter()
+            .map(|region| region.line_range.end)
+            .max()
+            .unwrap_or(combined_region.line_range.end);
+        combined_region.content_hash = CacheableInjectionRegion::hash_content(&virtual_content);
+        let resolved_language =
+            Self::resolve_language(coordinator, &first.language, &virtual_content);
+        Some(ResolvedInjection {
+            region: combined_region,
+            injection_language: resolved_language,
+            virtual_content,
+            line_column_offsets: vec![first_cacheable.start_column],
+        })
+    }
+
     /// Resolve every injection region in the document (whole-doc operations
     /// like `documentLink` use this rather than a position lookup). Holds no
     /// Document lock — `tree`/`text` must already be cloned, typically via
@@ -586,12 +708,15 @@ impl InjectionResolver {
         text: &str,
         incarnation: u64,
     ) -> Vec<ResolvedInjection> {
-        regions
-            .iter()
-            .filter_map(|region| {
-                Self::build_resolved_injection(coordinator, tracker, uri, region, text, incarnation)
-            })
-            .collect()
+        Self::resolve_grouped(
+            coordinator,
+            tracker,
+            uri,
+            regions,
+            None,
+            text,
+            Some(incarnation),
+        )
     }
 
     /// [`resolve_from_regions`](Self::resolve_from_regions) fed with the
@@ -607,22 +732,109 @@ impl InjectionResolver {
         cacheable: &[CacheableInjectionRegion],
         text: &str,
     ) -> Vec<ResolvedInjection> {
-        regions
-            .iter()
-            .zip(cacheable.iter())
-            .map(|(region, cacheable_region)| {
+        Self::resolve_grouped(
+            coordinator,
+            &NodeTracker::new(),
+            &Url::parse("file:///prebuilt").unwrap(),
+            regions,
+            Some(cacheable),
+            text,
+            None,
+        )
+    }
+
+    fn resolve_grouped(
+        coordinator: &LanguageCoordinator,
+        tracker: &NodeTracker,
+        uri: &Url,
+        regions: &[InjectionRegionInfo<'_>],
+        prebuilt: Option<&[CacheableInjectionRegion]>,
+        text: &str,
+        incarnation: Option<u64>,
+    ) -> Vec<ResolvedInjection> {
+        let mut resolved = Vec::new();
+        let mut seen_combined = std::collections::HashSet::new();
+        for (index, region) in regions.iter().enumerate() {
+            if region.combined {
+                let key = (region.language.clone(), region.pattern_index);
+                if !seen_combined.insert(key) {
+                    continue;
+                }
+                let indices: Vec<_> = regions
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(candidate_index, candidate)| {
+                        (candidate.combined
+                            && candidate.pattern_index == region.pattern_index
+                            && candidate.language == region.language)
+                            .then_some(candidate_index)
+                    })
+                    .collect();
+                let group: Vec<_> = indices.iter().map(|&i| &regions[i]).collect();
+                let prebuilt_group = prebuilt
+                    .map(|cacheable| indices.iter().map(|&i| &cacheable[i]).collect::<Vec<_>>());
+                if let Some(combined) = Self::build_combined_injection(
+                    coordinator,
+                    tracker,
+                    uri,
+                    &group,
+                    prebuilt_group.as_deref(),
+                    text,
+                    incarnation,
+                ) {
+                    resolved.push(combined);
+                }
+            } else if let Some(cacheable) = prebuilt {
                 let (virtual_content, line_column_offsets) =
-                    extract_virtual_content_and_offsets(region, cacheable_region, text);
+                    extract_virtual_content_and_offsets(region, &cacheable[index], text);
                 let resolved_language =
                     Self::resolve_language(coordinator, &region.language, &virtual_content);
-                ResolvedInjection {
-                    region: cacheable_region.clone(),
+                resolved.push(ResolvedInjection {
+                    region: cacheable[index].clone(),
                     injection_language: resolved_language,
                     virtual_content,
                     line_column_offsets,
+                });
+            } else {
+                if let Some(incarnation) = incarnation
+                    && let Some(single) = Self::build_resolved_injection(
+                        coordinator,
+                        tracker,
+                        uri,
+                        region,
+                        text,
+                        incarnation,
+                    )
+                {
+                    resolved.push(single);
                 }
-            })
-            .collect()
+            }
+        }
+        resolved
+    }
+}
+
+fn mask_outside_ranges(text: &str, span: Range<usize>, included: &[Range<usize>]) -> String {
+    let mut output = String::new();
+    let mut cursor = span.start;
+    for range in included {
+        let start = range.start.clamp(cursor, span.end);
+        let end = range.end.clamp(start, span.end);
+        push_coordinate_whitespace(&mut output, clamped_slice(text, cursor..start));
+        output.push_str(clamped_slice(text, start..end));
+        cursor = end;
+    }
+    push_coordinate_whitespace(&mut output, clamped_slice(text, cursor..span.end));
+    output
+}
+
+fn push_coordinate_whitespace(output: &mut String, text: &str) {
+    for character in text.chars() {
+        if matches!(character, '\n' | '\r') {
+            output.push(character);
+        } else {
+            output.extend(std::iter::repeat_n(' ', character.len_utf16()));
+        }
     }
 }
 
@@ -936,6 +1148,35 @@ mod tests {
 
         // The actual deep recursion is tested through integration with refactor.rs
         // where handle_nested_injection recursively processes injections
+    }
+
+    #[test]
+    fn resolve_all_combines_regions_marked_combined() {
+        let mut parser = create_rust_parser();
+        let text = r#"fn main() { let open = "<div>"; let close = "</div>"; }"#;
+        let tree = parse_rust_code(&mut parser, text);
+        let language = tree_sitter_rust::LANGUAGE.into();
+        let query = Query::new(
+            &language,
+            r#"
+                ((string_literal
+                   (string_content) @injection.content)
+                 (#set! injection.language "html")
+                 (#set! injection.combined))
+            "#,
+        )
+        .expect("valid query");
+        let coordinator = test_coordinator();
+        let tracker = NodeTracker::new();
+        let uri = test_uri("combined");
+
+        let resolved =
+            InjectionResolver::resolve_all(&coordinator, &tracker, &uri, &tree, text, &query);
+
+        assert_eq!(resolved.len(), 1, "combined captures form one document");
+        assert!(resolved[0].virtual_content.contains("<div>"));
+        assert!(resolved[0].virtual_content.contains("</div>"));
+        assert!(!resolved[0].virtual_content.contains("let close"));
     }
 
     #[test]
@@ -1343,6 +1584,7 @@ mod tests {
                 pattern_index: 0,
                 include_children: false,
                 offset: None,
+                combined: false,
             },
             InjectionRegionInfo {
                 language: "python".to_string(),
@@ -1350,6 +1592,7 @@ mod tests {
                 pattern_index: 0,
                 include_children: false,
                 offset: None,
+                combined: false,
             },
             InjectionRegionInfo {
                 language: "lua".to_string(),
@@ -1357,6 +1600,7 @@ mod tests {
                 pattern_index: 0,
                 include_children: false,
                 offset: None,
+                combined: false,
             },
         ];
 
@@ -1428,6 +1672,7 @@ mod tests {
                 pattern_index: 0,
                 include_children: false,
                 offset: None,
+                combined: false,
             },
             InjectionRegionInfo {
                 language: "python".to_string(),
@@ -1435,6 +1680,7 @@ mod tests {
                 pattern_index: 0,
                 include_children: false,
                 offset: None,
+                combined: false,
             },
             InjectionRegionInfo {
                 language: "lua".to_string(),
@@ -1442,6 +1688,7 @@ mod tests {
                 pattern_index: 0,
                 include_children: false,
                 offset: None,
+                combined: false,
             },
         ];
 

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -291,41 +291,39 @@ pub(crate) fn collect_all_injections<'a>(
         if !check_match_predicates(query, match_, text) {
             continue;
         }
+        let Some(language) = extract_injection_language(query, match_, text) else {
+            continue;
+        };
         for capture in iter_injection_content_captures(match_, query) {
             if capture.node.start_byte() >= capture.node.end_byte() {
                 continue;
             }
-            if let Some(language) = extract_injection_language(query, match_, text) {
-                let key = (
-                    capture.node.start_byte(),
-                    capture.node.end_byte(),
-                    language.clone(),
-                    match_.pattern_index,
-                );
-                // `or_insert_with` so the per-pattern predicate scans
-                // (`has_include_children_for_pattern` / `effective_offset_for_pattern`)
-                // are skipped when this content-node range was already inserted by
-                // an earlier matching pattern for the same language. Same
-                // resulting language layers, fewer scans.
-                injections_map.entry(key).or_insert_with(|| {
-                    let offset = effective_offset_for_pattern(query, match_.pattern_index);
-                    InjectionRegionInfo {
-                        language,
-                        content_node: capture.node,
-                        pattern_index: match_.pattern_index,
-                        include_children: has_include_children_for_pattern(
-                            query,
-                            match_.pattern_index,
-                        ),
-                        // Match the semantic path: effective offsets and
-                        // multi-region grouping do not compose safely.
-                        combined: has_combined_for_pattern(query, match_.pattern_index)
-                            && offset.is_none(),
-                        identity_slot: 0,
-                        offset,
-                    }
-                });
-            }
+            let key = (
+                capture.node.start_byte(),
+                capture.node.end_byte(),
+                language.clone(),
+                match_.pattern_index,
+            );
+            // `or_insert_with` so the per-pattern predicate scans
+            // (`has_include_children_for_pattern` / `effective_offset_for_pattern`)
+            // are skipped when this content-node range was already inserted by
+            // an earlier matching pattern for the same language. Same
+            // resulting language layers, fewer scans.
+            injections_map.entry(key).or_insert_with(|| {
+                let offset = effective_offset_for_pattern(query, match_.pattern_index);
+                InjectionRegionInfo {
+                    language: language.clone(),
+                    content_node: capture.node,
+                    pattern_index: match_.pattern_index,
+                    include_children: has_include_children_for_pattern(query, match_.pattern_index),
+                    // Match the semantic path: effective offsets and
+                    // multi-region grouping do not compose safely.
+                    combined: has_combined_for_pattern(query, match_.pattern_index)
+                        && offset.is_none(),
+                    identity_slot: 0,
+                    offset,
+                }
+            });
         }
     }
 

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -487,7 +487,8 @@ pub(crate) struct ResolvedInjection {
     pub raw_injection_language: String,
     /// Language of the injection content
     pub injection_language: String,
-    /// Extracted virtual document content (clean, with blockquote prefixes stripped)
+    /// Extracted virtual document content. Single regions strip excluded
+    /// prefixes; combined regions mask excluded host gaps with whitespace.
     pub virtual_content: String,
     /// Per-virtual-line column offsets for coordinate translation.
     /// Each entry is the UTF-16 column offset for that virtual line.

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -877,7 +877,9 @@ impl InjectionResolver {
 }
 
 fn mask_outside_ranges(text: &str, span: Range<usize>, included: &[Range<usize>]) -> String {
-    let mut output = String::new();
+    // The output is the span verbatim with excluded bytes turned to spaces
+    // (multi-byte chars can shrink it, never grow it) — preallocate the span.
+    let mut output = String::with_capacity(span.len());
     let mut cursor = span.start;
     for range in included {
         let start = range.start.clamp(cursor, span.end);

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -813,17 +813,41 @@ impl InjectionResolver {
         region_id: &str,
         incarnation: u64,
     ) -> Option<ResolvedInjection> {
-        Self::resolve_all(
-            coordinator,
-            tracker,
-            uri,
-            tree,
-            text,
-            injection_query,
-            incarnation,
-        )
-        .into_iter()
-        .find(|resolved| resolved.region.region_id == region_id)
+        let ulid = Ulid::from_string(region_id).ok()?;
+        let (start, end, kind, identity_layer, tracked_incarnation) =
+            tracker.lookup_node(uri, &ulid)?;
+        if tracked_incarnation != incarnation {
+            return None;
+        }
+
+        let regions = collect_all_injections(&tree.root_node(), text, Some(injection_query))?;
+        let region = regions.iter().find(|candidate| {
+            candidate.content_node.start_byte() == start
+                && candidate.content_node.end_byte() == end
+                && candidate.content_node.kind() == kind
+                && Self::region_identity_layer(candidate) == Some(identity_layer)
+        })?;
+
+        let resolved = if region.combined {
+            let group: Vec<_> = regions
+                .iter()
+                .filter(|candidate| {
+                    candidate.combined
+                        && candidate.pattern_index == region.pattern_index
+                        && candidate.language == region.language
+                })
+                .collect();
+            Self::build_combined_injection(
+                coordinator,
+                Some((tracker, uri, incarnation)),
+                &group,
+                None,
+                text,
+            )?
+        } else {
+            Self::build_resolved_injection(coordinator, tracker, uri, region, text, incarnation)?
+        };
+        (resolved.region.region_id == region_id).then_some(resolved)
     }
 
     /// [`resolve_all`](Self::resolve_all) minus the injection-query run, for a

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -301,6 +301,7 @@ pub(crate) fn collect_all_injections<'a>(
                     capture.node.start_byte(),
                     capture.node.end_byte(),
                     language.clone(),
+                    match_.pattern_index,
                 );
                 // `or_insert_with` so the per-pattern predicate scans
                 // (`has_include_children_for_pattern` / `effective_offset_for_pattern`)
@@ -441,6 +442,7 @@ fn collect_injection_regions<'a>(
                 content_node.start_byte(),
                 content_node.end_byte(),
                 language.clone(),
+                pattern_index,
             );
 
             // Keep the first match for each range/language pair; distinct
@@ -1657,6 +1659,30 @@ mod tests {
             vec!["rust", "doc", "comment"],
             "distinct language layers on the same node must survive discovery"
         );
+    }
+
+    #[test]
+    fn same_range_same_language_keeps_distinct_pattern_semantics() {
+        let mut parser = create_rust_parser();
+        let text = r#"fn main() { /* comment */ }"#;
+        let tree = parse_rust_code(&mut parser, text);
+        let language = tree_sitter_rust::LANGUAGE.into();
+        let query = Query::new(
+            &language,
+            r#"
+            ((block_comment) @injection.content
+             (#set! injection.language "comment"))
+            ((block_comment) @injection.content
+             (#set! injection.language "comment")
+             (#set! injection.include-children))
+            "#,
+        )
+        .expect("valid query");
+
+        let regions = collect_all_injections(&tree.root_node(), text, Some(&query)).unwrap();
+
+        assert_eq!(regions.len(), 2);
+        assert_ne!(regions[0].include_children, regions[1].include_children);
     }
 
     #[test]

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -906,6 +906,12 @@ fn mask_outside_ranges(text: &str, span: Range<usize>, included: &[Range<usize>]
     let mut output = String::with_capacity(span.len());
     let mut cursor = span.start;
     for range in included {
+        if range.end <= cursor {
+            continue;
+        }
+        if range.start >= span.end {
+            break;
+        }
         let start = range.start.clamp(cursor, span.end);
         let end = range.end.clamp(start, span.end);
         push_coordinate_whitespace(&mut output, clamped_slice(text, cursor..start));
@@ -932,6 +938,7 @@ fn build_combined_virtual_content(
     let mut output = String::new();
     let mut offsets = Vec::new();
     let mut line_start = span.start;
+    let mut range_index = 0;
 
     while line_start < span.end {
         let remaining = clamped_slice(text, line_start..span.end);
@@ -946,14 +953,17 @@ fn build_combined_virtual_content(
             }
         }
 
-        let first_included = included
-            .iter()
-            .filter_map(|range| {
-                let start = range.start.max(line_start);
-                let end = range.end.min(content_end);
-                (start < end).then_some(start)
-            })
-            .min();
+        while included
+            .get(range_index)
+            .is_some_and(|range| range.end <= line_start)
+        {
+            range_index += 1;
+        }
+        let first_included = included.get(range_index).and_then(|range| {
+            let start = range.start.max(line_start);
+            let end = range.end.min(content_end);
+            (start < end).then_some(start)
+        });
 
         if let Some(first_included) = first_included {
             let host_line_start = text[..first_included]
@@ -967,7 +977,7 @@ fn build_combined_virtual_content(
             output.push_str(&mask_outside_ranges(
                 text,
                 first_included..line_end,
-                included,
+                &included[range_index..],
             ));
         } else {
             offsets.push(0);

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -504,17 +504,16 @@ pub(crate) struct ResolvedInjection {
     pub raw_injection_language: String,
     /// Language of the injection content
     pub injection_language: String,
-    /// Extracted virtual document content. Single regions strip excluded
-    /// prefixes; combined regions mask excluded host gaps with whitespace.
+    /// Extracted virtual document content. Excluded line prefixes are stripped;
+    /// combined regions additionally mask host-only gaps with whitespace.
     pub virtual_content: String,
     /// Per-virtual-line column offsets for coordinate translation.
     /// Each entry is the UTF-16 column offset for that virtual line.
     pub line_column_offsets: Vec<u32>,
     /// Whether `virtual_content` maps to one contiguous host byte range —
-    /// i.e. no excluded host bytes were whitespace-masked. A combined
-    /// pattern whose captures form one unbroken included range is still
-    /// `true`; any masked gap (between captures or within one) makes it
-    /// `false`.
+    /// i.e. no host-only span between multiple captures was whitespace-masked.
+    /// A combined pattern that currently matches one capture uses the ordinary
+    /// single-region mapping and remains `true`.
     pub contiguous: bool,
 }
 
@@ -644,12 +643,11 @@ impl InjectionResolver {
     }
 
     /// Build one bridge virtual document for all captures of an
-    /// `injection.combined` pattern. Every host byte outside the included
-    /// ranges — the gaps between captures AND excluded bytes inside a
-    /// capture (e.g. non-content child/prefix bytes) — is replaced with
-    /// coordinate-preserving whitespace: the downstream parser sees one
-    /// document and retains cross-block context, while every virtual
-    /// line/column still maps directly back to the host document.
+    /// `injection.combined` pattern. Excluded line prefixes are stripped and
+    /// recorded as per-line offsets, while host-only gaps between captures are
+    /// represented by empty or whitespace-only lines. The downstream parser
+    /// sees one document and retains cross-block context without inheriting
+    /// indentation from host prefixes.
     fn build_combined_injection(
         coordinator: &LanguageCoordinator,
         identity: Option<(&NodeTracker, &Url, u64)>,
@@ -680,6 +678,21 @@ impl InjectionResolver {
         };
         let first = regions[0];
         let first_cacheable = cacheable[0];
+        if regions.len() == 1 {
+            let (virtual_content, line_column_offsets) =
+                extract_virtual_content_and_offsets(first, first_cacheable, text);
+            let injection_language =
+                Self::resolve_language(coordinator, &first.language, &virtual_content);
+            let mut region = first_cacheable.clone();
+            region.content_hash = CacheableInjectionRegion::hash_content(&virtual_content);
+            return ResolvedInjection {
+                region,
+                injection_language,
+                virtual_content,
+                line_column_offsets,
+                contiguous: true,
+            };
+        }
         let group_start = first_cacheable.byte_range.start;
         let group_end = cacheable
             .iter()
@@ -716,7 +729,8 @@ impl InjectionResolver {
             covered_until = covered_until.max(range.end);
             true
         }) && covered_until >= group_end;
-        let virtual_content = mask_outside_ranges(text, group_start..group_end, &included);
+        let (virtual_content, line_column_offsets) =
+            build_combined_virtual_content(text, group_start..group_end, &included);
 
         let mut combined_region = first_cacheable.clone();
         combined_region.byte_range.end = group_end;
@@ -733,7 +747,7 @@ impl InjectionResolver {
             raw_injection_language: first.language.clone(),
             injection_language: resolved_language,
             virtual_content,
-            line_column_offsets: vec![first_cacheable.start_column],
+            line_column_offsets,
             contiguous,
         })
     }
@@ -900,6 +914,73 @@ fn mask_outside_ranges(text: &str, span: Range<usize>, included: &[Range<usize>]
     }
     push_coordinate_whitespace(&mut output, clamped_slice(text, cursor..span.end));
     output
+}
+
+/// Build a line-preserving combined document while stripping excluded prefixes.
+///
+/// Host-only gaps stay as empty or whitespace-only lines so virtual and host
+/// line numbers remain aligned. On lines containing injected content, bytes
+/// before the first included range are removed and recorded as a UTF-16 column
+/// offset, matching the isolated-region `extract_clean_content` contract. Any
+/// later gaps on the same line remain coordinate-preserving whitespace because
+/// the bridge offset model supports one translation offset per line.
+fn build_combined_virtual_content(
+    text: &str,
+    span: Range<usize>,
+    included: &[Range<usize>],
+) -> (String, Vec<u32>) {
+    let mut output = String::new();
+    let mut offsets = Vec::new();
+    let mut line_start = span.start;
+
+    while line_start < span.end {
+        let remaining = clamped_slice(text, line_start..span.end);
+        let line_end = remaining
+            .find('\n')
+            .map_or(span.end, |newline| line_start + newline + 1);
+        let mut content_end = line_end;
+        if text.as_bytes().get(content_end.saturating_sub(1)) == Some(&b'\n') {
+            content_end -= 1;
+            if text.as_bytes().get(content_end.saturating_sub(1)) == Some(&b'\r') {
+                content_end -= 1;
+            }
+        }
+
+        let first_included = included
+            .iter()
+            .filter_map(|range| {
+                let start = range.start.max(line_start);
+                let end = range.end.min(content_end);
+                (start < end).then_some(start)
+            })
+            .min();
+
+        if let Some(first_included) = first_included {
+            let host_line_start = text[..first_included]
+                .rfind('\n')
+                .map_or(0, |newline| newline + 1);
+            offsets.push(
+                clamped_slice(text, host_line_start..first_included)
+                    .encode_utf16()
+                    .count() as u32,
+            );
+            output.push_str(&mask_outside_ranges(
+                text,
+                first_included..line_end,
+                included,
+            ));
+        } else {
+            offsets.push(0);
+            output.push_str(clamped_slice(text, content_end..line_end));
+        }
+
+        line_start = line_end;
+    }
+
+    if output.ends_with('\n') {
+        offsets.push(0);
+    }
+    (output, offsets)
 }
 
 fn push_coordinate_whitespace(output: &mut String, text: &str) {
@@ -1283,6 +1364,87 @@ mod tests {
         assert_eq!(resolved.len(), 1);
         assert!(resolved[0].contiguous);
         assert_eq!(resolved[0].virtual_content, "<div></div>");
+    }
+
+    #[test]
+    fn combined_captures_strip_blockquote_prefixes_and_record_offsets() {
+        let md_language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        let mut parser = Parser::new();
+        parser.set_language(&md_language).expect("set md language");
+        let text = concat!(
+            "> ```python\n",
+            "> if True:\n",
+            ">   print(1)\n",
+            "> ```\n",
+            "> gap\n",
+            "> ```python\n",
+            ">   print(2)\n",
+            "> ```\n",
+        );
+        let tree = parser.parse(text, None).expect("parse markdown");
+        let query = Query::new(
+            &md_language,
+            r#"
+                ((fenced_code_block
+                   (info_string (language) @injection.language)
+                   (code_fence_content) @injection.content)
+                 (#set! injection.combined))
+            "#,
+        )
+        .expect("valid query");
+
+        let resolved = InjectionResolver::resolve_all(
+            &test_coordinator(),
+            &NodeTracker::new(),
+            &test_uri("combined_blockquote"),
+            &tree,
+            text,
+            &query,
+        );
+
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(
+            resolved[0].virtual_content,
+            "if True:\n  print(1)\n\n\n\n  print(2)\n"
+        );
+        assert_eq!(
+            resolved[0].line_column_offsets,
+            vec![2, 2, 0, 0, 0, 2, 0, 0]
+        );
+        assert!(!resolved[0].contiguous);
+    }
+
+    #[test]
+    fn single_combined_blockquote_uses_contiguous_single_region_mapping() {
+        let md_language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        let mut parser = Parser::new();
+        parser.set_language(&md_language).expect("set md language");
+        let text = "> ```python\n> if True:\n>   print(1)\n> ```\n";
+        let tree = parser.parse(text, None).expect("parse markdown");
+        let query = Query::new(
+            &md_language,
+            r#"
+                ((fenced_code_block
+                   (info_string (language) @injection.language)
+                   (code_fence_content) @injection.content)
+                 (#set! injection.combined))
+            "#,
+        )
+        .expect("valid query");
+
+        let resolved = InjectionResolver::resolve_all(
+            &test_coordinator(),
+            &NodeTracker::new(),
+            &test_uri("single_combined_blockquote"),
+            &tree,
+            text,
+            &query,
+        );
+
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].virtual_content, "if True:\n  print(1)\n");
+        assert_eq!(resolved[0].line_column_offsets, vec![2, 2, 0]);
+        assert!(resolved[0].contiguous);
     }
 
     #[test]

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -474,6 +474,8 @@ fn find_injection_at_position<'a>(
 pub(crate) struct ResolvedInjection {
     /// Cacheable injection region with line range information
     pub region: CacheableInjectionRegion,
+    /// Raw language identifier captured or assigned by the injection query.
+    pub raw_injection_language: String,
     /// Language of the injection content
     pub injection_language: String,
     /// Extracted virtual document content (clean, with blockquote prefixes stripped)
@@ -600,6 +602,7 @@ impl InjectionResolver {
             Self::resolve_language(coordinator, &region.language, &virtual_content);
         Some(ResolvedInjection {
             region: cacheable_region,
+            raw_injection_language: region.language.clone(),
             injection_language: resolved_language,
             virtual_content,
             line_column_offsets,
@@ -683,6 +686,7 @@ impl InjectionResolver {
             Self::resolve_language(coordinator, &first.language, &virtual_content);
         Some(ResolvedInjection {
             region: combined_region,
+            raw_injection_language: first.language.clone(),
             injection_language: resolved_language,
             virtual_content,
             line_column_offsets: vec![first_cacheable.start_column],
@@ -791,6 +795,7 @@ impl InjectionResolver {
                     Self::resolve_language(coordinator, &region.language, &virtual_content);
                 resolved.push(ResolvedInjection {
                     region: cacheable[index].clone(),
+                    raw_injection_language: region.language.clone(),
                     injection_language: resolved_language,
                     virtual_content,
                     line_column_offsets,

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -622,7 +622,9 @@ impl InjectionResolver {
         )
     }
 
-    /// Tracker-layer key used by both inline and batch region-ID minting.
+    /// Tracker-layer key used by both inline and batch region-ID minting. The
+    /// slot is collision-free and stable within one URI incarnation; its
+    /// numeric value depends on first-observation order.
     pub(crate) fn region_identity_layer(
         tracker: &NodeTracker,
         uri: &Url,

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -1428,8 +1428,11 @@ mod tests {
     #[test]
     fn combined_content_snaps_stale_included_start_to_char_boundary() {
         let text = "éx\n";
-        let (content, offsets) =
-            build_combined_virtual_content(text, 0..text.len(), &[1..usize::MAX]);
+        let (content, offsets) = build_combined_virtual_content(
+            text,
+            0..text.len(),
+            std::slice::from_ref(&(1..usize::MAX)),
+        );
 
         assert_eq!(content, "x\n");
         assert_eq!(offsets, vec![1, 0]);

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -676,6 +676,14 @@ impl InjectionResolver {
             }
         }
         included.sort_by_key(|range| (range.start, range.end));
+        let mut covered_until = group_start;
+        let contiguous = included.iter().all(|range| {
+            if range.start > covered_until {
+                return false;
+            }
+            covered_until = covered_until.max(range.end);
+            true
+        }) && covered_until >= group_end;
         let virtual_content = mask_outside_ranges(text, group_start..group_end, &included);
 
         let mut combined_region = first_cacheable.clone();
@@ -694,7 +702,7 @@ impl InjectionResolver {
             injection_language: resolved_language,
             virtual_content,
             line_column_offsets: vec![first_cacheable.start_column],
-            contiguous: false,
+            contiguous,
         })
     }
 
@@ -1189,6 +1197,37 @@ mod tests {
         assert!(resolved[0].virtual_content.contains("</div>"));
         assert!(!resolved[0].virtual_content.contains("let close"));
         assert!(!resolved[0].contiguous);
+    }
+
+    #[test]
+    fn single_combined_capture_remains_contiguous() {
+        let mut parser = create_rust_parser();
+        let text = r#"fn main() { let html = "<div></div>"; }"#;
+        let tree = parse_rust_code(&mut parser, text);
+        let language = tree_sitter_rust::LANGUAGE.into();
+        let query = Query::new(
+            &language,
+            r#"
+                ((string_literal
+                   (string_content) @injection.content)
+                 (#set! injection.language "html")
+                 (#set! injection.combined))
+            "#,
+        )
+        .expect("valid query");
+
+        let resolved = InjectionResolver::resolve_all(
+            &test_coordinator(),
+            &NodeTracker::new(),
+            &test_uri("single_combined"),
+            &tree,
+            text,
+            &query,
+        );
+
+        assert_eq!(resolved.len(), 1);
+        assert!(resolved[0].contiguous);
+        assert_eq!(resolved[0].virtual_content, "<div></div>");
     }
 
     #[test]

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -780,37 +780,57 @@ impl InjectionResolver {
         prebuilt: Option<&[CacheableInjectionRegion]>,
         text: &str,
     ) -> Vec<ResolvedInjection> {
-        let mut resolved = Vec::new();
-        let mut seen_combined = std::collections::HashSet::new();
+        enum Slot {
+            Single(usize),
+            Combined(Vec<usize>),
+        }
+
+        // Partition once in document order. A per-group scan makes dynamic
+        // language captures quadratic when nearly every region is its own
+        // (language, pattern) group.
+        let mut slots = Vec::new();
+        let mut combined_slots: std::collections::HashMap<(&str, usize), usize> =
+            std::collections::HashMap::new();
         for (index, region) in regions.iter().enumerate() {
             if region.combined {
-                let key = (region.language.clone(), region.pattern_index);
-                if !seen_combined.insert(key) {
+                let key = (region.language.as_str(), region.pattern_index);
+                if let Some(&slot_index) = combined_slots.get(&key) {
+                    let Slot::Combined(indices) = &mut slots[slot_index] else {
+                        unreachable!("combined slot index must identify a combined slot")
+                    };
+                    indices.push(index);
+                } else {
+                    combined_slots.insert(key, slots.len());
+                    slots.push(Slot::Combined(vec![index]));
+                }
+            } else {
+                slots.push(Slot::Single(index));
+            }
+        }
+
+        let mut resolved = Vec::with_capacity(slots.len());
+        for slot in slots {
+            let index = match slot {
+                Slot::Combined(indices) => {
+                    let group: Vec<_> = indices.iter().map(|&i| &regions[i]).collect();
+                    let prebuilt_group = prebuilt.map(|cacheable| {
+                        indices.iter().map(|&i| &cacheable[i]).collect::<Vec<_>>()
+                    });
+                    if let Some(combined) = Self::build_combined_injection(
+                        coordinator,
+                        identity,
+                        &group,
+                        prebuilt_group.as_deref(),
+                        text,
+                    ) {
+                        resolved.push(combined);
+                    }
                     continue;
                 }
-                let indices: Vec<_> = regions
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(candidate_index, candidate)| {
-                        (candidate.combined
-                            && candidate.pattern_index == region.pattern_index
-                            && candidate.language == region.language)
-                            .then_some(candidate_index)
-                    })
-                    .collect();
-                let group: Vec<_> = indices.iter().map(|&i| &regions[i]).collect();
-                let prebuilt_group = prebuilt
-                    .map(|cacheable| indices.iter().map(|&i| &cacheable[i]).collect::<Vec<_>>());
-                if let Some(combined) = Self::build_combined_injection(
-                    coordinator,
-                    identity,
-                    &group,
-                    prebuilt_group.as_deref(),
-                    text,
-                ) {
-                    resolved.push(combined);
-                }
-            } else if let Some(cacheable) = prebuilt {
+                Slot::Single(index) => index,
+            };
+            let region = &regions[index];
+            if let Some(cacheable) = prebuilt {
                 let (virtual_content, line_column_offsets) =
                     extract_virtual_content_and_offsets(region, &cacheable[index], text);
                 let resolved_language =

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -22,7 +22,7 @@ use crate::text::{ceil_char_boundary, clamped_slice, floor_char_boundary, fnv1a_
 // Keep bridge-region identities in a namespace disjoint from real parse-tree
 // injection depths (0..=MAX_INJECTION_DEPTH). The per-range slot then gives
 // alternate language layers at identical host coordinates distinct ULIDs.
-const REGION_IDENTITY_LAYER_BASE: usize = usize::MAX / 2 + 1;
+pub(crate) const REGION_IDENTITY_LAYER_BASE: usize = usize::MAX / 2 + 1;
 
 /// Iterates over the `@injection.content` captures in a query match.
 fn iter_injection_content_captures<'a, 'b>(

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -75,6 +75,7 @@ struct UriEntries {
     /// are reclaimed on close instead of accumulating process-wide.
     named_layers: HashMap<usize, HashMap<String, usize>>,
     next_named_layer: usize,
+    free_named_layers: Vec<usize>,
 }
 
 #[derive(Clone, Copy)]
@@ -102,19 +103,62 @@ impl UriEntries {
         if incarnation > self.latest_incarnation {
             self.named_layers.clear();
             self.next_named_layer = 0;
+            self.free_named_layers.clear();
         }
         self.latest_incarnation = incarnation;
         let languages = self.named_layers.entry(pattern_index).or_default();
         if let Some(slot) = languages.get(language) {
             return Some(*slot);
         }
-        let slot = self.next_named_layer;
-        if slot > usize::MAX / 2 {
-            return None;
-        }
+        let slot = if let Some(slot) = self.free_named_layers.pop() {
+            slot
+        } else {
+            let slot = self.next_named_layer;
+            if slot > usize::MAX / 2 {
+                return None;
+            }
+            self.next_named_layer += 1;
+            slot
+        };
         languages.insert(language.to_owned(), slot);
-        self.next_named_layer += 1;
         Some(slot)
+    }
+
+    fn reconcile_named_layers(
+        &mut self,
+        active: &std::collections::HashSet<(usize, &str)>,
+        layer_base: usize,
+    ) {
+        let mut retired = Vec::new();
+        self.named_layers.retain(|pattern, languages| {
+            languages.retain(|language, slot| {
+                let keep = active.contains(&(*pattern, language.as_str()));
+                if !keep {
+                    retired.push(*slot);
+                }
+                keep
+            });
+            !languages.is_empty()
+        });
+        if retired.is_empty() {
+            return;
+        }
+        let retired_layers: std::collections::HashSet<_> = retired
+            .iter()
+            .filter_map(|slot| layer_base.checked_add(*slot))
+            .collect();
+        let mut retired_ids = Vec::new();
+        self.forward.retain(|key, tracked| {
+            let keep = !retired_layers.contains(&key.layer);
+            if !keep {
+                retired_ids.push(tracked.ulid);
+            }
+            keep
+        });
+        for id in retired_ids {
+            self.reverse.remove(&id);
+        }
+        self.free_named_layers.extend(retired);
     }
 
     /// Get or insert a ULID for a position key, keeping both maps in sync.
@@ -182,6 +226,7 @@ impl UriEntries {
         if self.latest_incarnation <= closing_incarnation {
             self.named_layers.clear();
             self.next_named_layer = 0;
+            self.free_named_layers.clear();
         }
     }
 }
@@ -811,6 +856,7 @@ impl NodeTracker {
             shift_gen: entries.shift_gen + 1,
             named_layers: std::mem::take(&mut entries.named_layers),
             next_named_layer: entries.next_named_layer,
+            free_named_layers: std::mem::take(&mut entries.free_named_layers),
         };
 
         for (key, tracked) in entries.drain() {
@@ -1065,6 +1111,12 @@ impl NodeTracker {
         if (entry.shift_gen, epoch) != expected {
             return None;
         }
+        let keys: Vec<_> = keys.into_iter().collect();
+        let active = keys
+            .iter()
+            .map(|(_, _, _, pattern, language)| (*pattern, *language))
+            .collect();
+        entry.reconcile_named_layers(&active, layer_base);
         keys.into_iter()
             .map(|(start, end, kind, pattern_index, language)| {
                 let slot = entry.named_layer(pattern_index, language, incarnation)?;
@@ -1179,6 +1231,38 @@ mod tests {
                 .get(&uri)
                 .is_none_or(|entry| entry.named_layers.is_empty())
         );
+    }
+
+    #[test]
+    fn successful_named_batch_retires_obsolete_languages() {
+        let tracker = NodeTracker::new();
+        let uri = test_uri("named_layer_reconcile");
+        tracker.open_incarnation(&uri, 1);
+        let epoch = tracker.mint_epoch(&uri);
+        let old = tracker
+            .mint_named_batch_if_unshifted_for_incarnation(
+                &uri,
+                epoch,
+                1,
+                usize::MAX / 2 + 1,
+                [(0, 4, "word", 0, "old-language")],
+            )
+            .unwrap()[0];
+
+        tracker
+            .mint_named_batch_if_unshifted_for_incarnation(
+                &uri,
+                epoch,
+                1,
+                usize::MAX / 2 + 1,
+                [(0, 4, "word", 0, "new-language")],
+            )
+            .unwrap();
+
+        assert!(tracker.lookup_node(&uri, &old).is_none());
+        let entry = tracker.entries.get(&uri).unwrap();
+        assert!(!entry.named_layers[&0].contains_key("old-language"));
+        assert!(entry.named_layers[&0].contains_key("new-language"));
     }
 
     /// The batch reconciliation mint reuses an existing id by position and

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -73,7 +73,8 @@ struct UriEntries {
     /// Collision-free discriminators for bridge injection alternatives. Kept
     /// with the URI lifecycle so document-controlled dynamic language names
     /// are reclaimed on close instead of accumulating process-wide.
-    named_layers: HashMap<(usize, String), usize>,
+    named_layers: HashMap<usize, HashMap<String, usize>>,
+    next_named_layer: usize,
 }
 
 #[derive(Clone, Copy)]
@@ -100,19 +101,20 @@ impl UriEntries {
         }
         if incarnation > self.latest_incarnation {
             self.named_layers.clear();
+            self.next_named_layer = 0;
         }
         self.latest_incarnation = incarnation;
-        let next = self.named_layers.len();
-        match self
-            .named_layers
-            .entry((pattern_index, language.to_owned()))
-        {
-            Entry::Occupied(entry) => Some(*entry.get()),
-            Entry::Vacant(entry) => (next < usize::MAX / 2 + 1).then(|| {
-                entry.insert(next);
-                next
-            }),
+        let languages = self.named_layers.entry(pattern_index).or_default();
+        if let Some(slot) = languages.get(language) {
+            return Some(*slot);
         }
+        let slot = self.next_named_layer;
+        if slot > usize::MAX / 2 {
+            return None;
+        }
+        languages.insert(language.to_owned(), slot);
+        self.next_named_layer += 1;
+        Some(slot)
     }
 
     /// Get or insert a ULID for a position key, keeping both maps in sync.
@@ -179,6 +181,7 @@ impl UriEntries {
             .retain(|_, tracked| tracked.incarnation > closing_incarnation);
         if self.latest_incarnation <= closing_incarnation {
             self.named_layers.clear();
+            self.next_named_layer = 0;
         }
     }
 }
@@ -807,6 +810,7 @@ impl NodeTracker {
             latest_incarnation: entries.latest_incarnation,
             shift_gen: entries.shift_gen + 1,
             named_layers: std::mem::take(&mut entries.named_layers),
+            next_named_layer: entries.next_named_layer,
         };
 
         for (key, tracked) in entries.drain() {

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -177,6 +177,9 @@ impl UriEntries {
             .retain(|_, tracked| tracked.incarnation > closing_incarnation);
         self.reverse
             .retain(|_, tracked| tracked.incarnation > closing_incarnation);
+        if self.latest_incarnation <= closing_incarnation {
+            self.named_layers.clear();
+        }
     }
 }
 
@@ -396,8 +399,9 @@ impl NodeTracker {
     /// admission race. A concurrent reopen may already have edited or minted;
     /// retain either signal (`shift_gen > 0` or non-empty ids).
     fn remove_pristine_entry(&self, uri: &Url) {
-        self.entries
-            .remove_if(uri, |_, entry| entry.shift_gen == 0 && entry.len() == 0);
+        self.entries.remove_if(uri, |_, entry| {
+            entry.shift_gen == 0 && entry.len() == 0 && entry.named_layers.is_empty()
+        });
     }
 
     /// Get or create a stable ULID for a **host-layer** tree-sitter node.
@@ -890,7 +894,7 @@ impl NodeTracker {
             .or_insert(None);
         self.entries.remove_if_mut(uri, |_, entries| {
             entries.retain_newer_than(closing_incarnation);
-            entries.len() == 0
+            entries.len() == 0 && entries.named_layers.is_empty()
         });
     }
 
@@ -1064,6 +1068,27 @@ mod tests {
 
     fn test_uri(name: &str) -> Url {
         Url::parse(&format!("file:///test/{}.md", name)).unwrap()
+    }
+
+    #[test]
+    fn stale_cleanup_preserves_newer_named_layers() {
+        let tracker = NodeTracker::new();
+        let uri = test_uri("named_layer_cleanup");
+        tracker.open_incarnation(&uri, 2);
+        let javascript = tracker
+            .named_layer_for_incarnation(&uri, 0, "javascript", 2)
+            .unwrap();
+
+        tracker.cleanup(&uri, 1);
+
+        assert_eq!(
+            tracker.named_layer_for_incarnation(&uri, 0, "javascript", 2),
+            Some(javascript)
+        );
+        assert_ne!(
+            tracker.named_layer_for_incarnation(&uri, 0, "typescript", 2),
+            Some(javascript)
+        );
     }
 
     /// The batch reconciliation mint reuses an existing id by position and

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -1014,6 +1014,66 @@ impl NodeTracker {
         self.mint_batch_in_entry(&mut entry, expected, incarnation, keys)
     }
 
+    /// Atomically allocate named layer discriminators and mint their position
+    /// keys under the same parse-snapshot latch. A rejected stale batch leaves
+    /// neither ULIDs nor dynamic-language reservations behind.
+    pub(crate) fn mint_named_batch_if_unshifted_for_incarnation<'a>(
+        &self,
+        uri: &Url,
+        expected: (u64, u64),
+        incarnation: u64,
+        layer_base: usize,
+        keys: impl IntoIterator<Item = (usize, usize, &'static str, usize, &'a str)>,
+    ) -> Option<Vec<Ulid>> {
+        if !self.admits_incarnation(uri, incarnation) {
+            return None;
+        }
+        if let Some(mut entry) = self.entries.get_mut(uri) {
+            if !self.admits_incarnation(uri, incarnation) {
+                drop(entry);
+                self.remove_pristine_entry(uri);
+                return None;
+            }
+            return self.mint_named_batch_in_entry(
+                &mut entry,
+                expected,
+                incarnation,
+                layer_base,
+                keys,
+            );
+        }
+        let mut entry = self.entries.entry(uri.clone()).or_default();
+        if !self.admits_incarnation(uri, incarnation) {
+            drop(entry);
+            self.remove_pristine_entry(uri);
+            return None;
+        }
+        self.mint_named_batch_in_entry(&mut entry, expected, incarnation, layer_base, keys)
+    }
+
+    fn mint_named_batch_in_entry<'a>(
+        &self,
+        entry: &mut UriEntries,
+        expected: (u64, u64),
+        incarnation: u64,
+        layer_base: usize,
+        keys: impl IntoIterator<Item = (usize, usize, &'static str, usize, &'a str)>,
+    ) -> Option<Vec<Ulid>> {
+        let epoch = self
+            .cleanup_epoch
+            .load(std::sync::atomic::Ordering::Acquire);
+        if (entry.shift_gen, epoch) != expected {
+            return None;
+        }
+        keys.into_iter()
+            .map(|(start, end, kind, pattern_index, language)| {
+                let slot = entry.named_layer(pattern_index, language, incarnation)?;
+                let layer = layer_base.checked_add(slot)?;
+                entry.get_or_insert(PositionKey::new(start, end, kind, layer), incarnation)
+            })
+            .collect()
+    }
+
     /// The latch check + mint body of
     /// [`mint_batch_if_unshifted`](Self::mint_batch_if_unshifted), run while
     /// the caller holds `entry`'s exclusive lock.
@@ -1092,6 +1152,32 @@ mod tests {
         assert_ne!(
             tracker.named_layer_for_incarnation(&uri, 0, "typescript", 2),
             Some(javascript)
+        );
+    }
+
+    #[test]
+    fn rejected_named_batch_reserves_no_language_slots() {
+        let tracker = NodeTracker::new();
+        let uri = test_uri("stale_named_batch");
+        tracker.open_incarnation(&uri, 1);
+        let stale_epoch = (1, tracker.mint_epoch(&uri).1);
+
+        assert!(
+            tracker
+                .mint_named_batch_if_unshifted_for_incarnation(
+                    &uri,
+                    stale_epoch,
+                    1,
+                    usize::MAX / 2 + 1,
+                    [(0, 4, "word", 0, "javascript")],
+                )
+                .is_none()
+        );
+        assert!(
+            tracker
+                .entries
+                .get(&uri)
+                .is_none_or(|entry| entry.named_layers.is_empty())
         );
     }
 

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -70,6 +70,10 @@ struct UriEntries {
     /// comparison alone cannot: with two mid-pass edits, an entry minted
     /// between them is shifted by the second yet still missed the first).
     shift_gen: u64,
+    /// Collision-free discriminators for bridge injection alternatives. Kept
+    /// with the URI lifecycle so document-controlled dynamic language names
+    /// are reclaimed on close instead of accumulating process-wide.
+    named_layers: HashMap<(usize, String), usize>,
 }
 
 #[derive(Clone, Copy)]
@@ -85,6 +89,32 @@ struct TrackedPosition {
 }
 
 impl UriEntries {
+    fn named_layer(
+        &mut self,
+        pattern_index: usize,
+        language: &str,
+        incarnation: u64,
+    ) -> Option<usize> {
+        if incarnation < self.latest_incarnation {
+            return None;
+        }
+        if incarnation > self.latest_incarnation {
+            self.named_layers.clear();
+        }
+        self.latest_incarnation = incarnation;
+        let next = self.named_layers.len();
+        match self
+            .named_layers
+            .entry((pattern_index, language.to_owned()))
+        {
+            Entry::Occupied(entry) => Some(*entry.get()),
+            Entry::Vacant(entry) => (next < usize::MAX / 2 + 1).then(|| {
+                entry.insert(next);
+                next
+            }),
+        }
+    }
+
     /// Get or insert a ULID for a position key, keeping both maps in sync.
     fn get_or_insert(&mut self, key: PositionKey, incarnation: u64) -> Option<Ulid> {
         if incarnation < self.latest_incarnation {
@@ -333,6 +363,33 @@ impl NodeTracker {
         self.incarnations
             .get(uri)
             .is_none_or(|current| *current == Some(incarnation))
+    }
+
+    /// Allocate a collision-free, URI-lifecycle-owned layer discriminator for
+    /// an injection query pattern and its (possibly dynamic) language.
+    pub(crate) fn named_layer_for_incarnation(
+        &self,
+        uri: &Url,
+        pattern_index: usize,
+        language: &str,
+        incarnation: u64,
+    ) -> Option<usize> {
+        if !self.admits_incarnation(uri, incarnation) {
+            return None;
+        }
+        if let Some(mut entry) = self.entries.get_mut(uri) {
+            if !self.admits_incarnation(uri, incarnation) {
+                return None;
+            }
+            return entry.named_layer(pattern_index, language, incarnation);
+        }
+        let mut entry = self.entries.entry(uri.clone()).or_default();
+        if !self.admits_incarnation(uri, incarnation) {
+            drop(entry);
+            self.remove_pristine_entry(uri);
+            return None;
+        }
+        entry.named_layer(pattern_index, language, incarnation)
     }
 
     /// Reclaim an entry this call materialized only to lose the lifecycle
@@ -745,6 +802,7 @@ impl NodeTracker {
             reverse: HashMap::with_capacity(entries.len()),
             latest_incarnation: entries.latest_incarnation,
             shift_gen: entries.shift_gen + 1,
+            named_layers: std::mem::take(&mut entries.named_layers),
         };
 
         for (key, tracked) in entries.drain() {

--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -348,6 +348,7 @@ mod tests {
                 injection_language: "rust".to_string(),
                 virtual_content: String::new(),
                 line_column_offsets: vec![],
+                contiguous: true,
             },
             configs: vec![],
             upstream_request_id: None,

--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -344,7 +344,6 @@ mod tests {
                     region_id: "r0".to_string(),
                     content_hash: 0,
                 },
-                raw_injection_language: "rust".to_string(),
                 injection_language: "rust".to_string(),
                 virtual_content: String::new(),
                 line_column_offsets: vec![],

--- a/src/lsp/aggregation/server/dispatch.rs
+++ b/src/lsp/aggregation/server/dispatch.rs
@@ -344,6 +344,7 @@ mod tests {
                     region_id: "r0".to_string(),
                     content_hash: 0,
                 },
+                raw_injection_language: "rust".to_string(),
                 injection_language: "rust".to_string(),
                 virtual_content: String::new(),
                 line_column_offsets: vec![],

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -80,6 +80,7 @@ pub(crate) use text_document::{
     CodeActionEnvelope, CodeLensEnvelope, UpstreamCodeActionCaps, bridge_code_actions,
     extract_code_action_envelope, extract_code_lens_envelope, parse_code_actions_leniently,
 };
+pub(crate) use text_document::{KakehashiEnvelope, extract_envelope};
 pub(crate) use workspace::WorkspaceFolderSet;
 
 /// Integration tests for the bridge module.

--- a/src/lsp/bridge.rs
+++ b/src/lsp/bridge.rs
@@ -69,6 +69,7 @@ pub(crate) use protocol::RequestId;
 pub(crate) use protocol::VirtualDocumentUri;
 pub(crate) use protocol::decode_command;
 pub(crate) use protocol::location_link_to_location;
+pub(crate) use protocol::region_host_end;
 pub(crate) use protocol::strip_bridge_local_versions;
 pub(crate) use protocol::transform_workspace_edit_to_host;
 pub(crate) use protocol::translate_virtual_range_to_host;

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -19,17 +19,17 @@ use crate::lsp::request_id::CancelForwarder;
 
 use super::LanguageServerPool;
 
-/// An injection region resolved from a host document.
+/// A resolved bridge virtual-document payload from a host document.
 ///
-/// Represents a single code block embedded in a host document (e.g., a Lua
-/// code fence in a markdown file) along with its stable region ID (lazy-node-identity-tracking).
+/// Usually represents one injected region; an `injection.combined` payload can
+/// span multiple captures and uses the first capture's stable region ID.
 #[derive(Debug, Clone)]
 pub(crate) struct BridgeInjection {
     /// The injection language (e.g., "lua", "python", "rust")
     pub(crate) language: String,
     /// Stable ULID-based region ID (lazy-node-identity-tracking)
     pub(crate) region_id: String,
-    /// The text content of the injection region
+    /// The text content of the bridge virtual document
     pub(crate) content: String,
 }
 

--- a/src/lsp/bridge/text_document.rs
+++ b/src/lsp/bridge/text_document.rs
@@ -15,6 +15,7 @@ pub(crate) use code_action::{
 };
 pub(crate) use code_lens::{CodeLensEnvelope, extract_code_lens_envelope};
 mod completion;
+pub(crate) use completion::{KakehashiEnvelope, extract_envelope};
 mod completion_item;
 mod declaration;
 mod definition;

--- a/src/lsp/bridge/text_document/completion.rs
+++ b/src/lsp/bridge/text_document/completion.rs
@@ -77,6 +77,7 @@ impl LanguageServerPool {
                     Some(EnvelopeContext {
                         server_name,
                         host_uri: host_uri.as_str(),
+                        region_id,
                         offset: ctx.offset,
                         region_end: Some(region_end),
                     }),
@@ -392,6 +393,10 @@ pub(crate) struct KakehashiEnvelope {
     /// routing, matching the old behavior.
     #[serde(default)]
     pub host_uri: String,
+    /// Stable injection region identity for live resolve-time geometry checks.
+    /// Empty for envelopes minted before this field existed.
+    #[serde(default)]
+    pub region_id: String,
     /// The downstream server's original `data` value (preserved verbatim).
     pub inner: Option<Value>,
     /// Region offset snapshot for coordinate transformation of the resolved response.
@@ -446,6 +451,7 @@ pub(crate) struct EnvelopeContext<'a> {
     /// Host document URI the completion ran on, stored in the envelope so
     /// `completionItem/resolve` can route back to the originating connection.
     pub host_uri: &'a str,
+    pub region_id: &'a str,
     pub offset: &'a RegionOffset,
     /// Region end (host coords) snapshot for the resolve-path safety guard;
     /// `None` only when re-enveloping a legacy envelope that never carried it.
@@ -461,6 +467,7 @@ pub(crate) fn envelope_item_data(item: &mut CompletionItem, ctx: &EnvelopeContex
     let envelope = KakehashiEnvelope {
         origin: ctx.server_name.to_string(),
         host_uri: ctx.host_uri.to_string(),
+        region_id: ctx.region_id.to_string(),
         inner,
         offset: EnvelopeOffset::from(ctx.offset),
         region_end: ctx.region_end.map(|end| (end.line, end.character)),
@@ -1005,6 +1012,7 @@ mod tests {
         let ctx = EnvelopeContext {
             server_name: "lua-ls",
             host_uri: "file:///test/doc.md",
+            region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
             offset: &offset,
             region_end: Some(TEST_REGION_END),
         };
@@ -1063,6 +1071,7 @@ mod tests {
         let ctx = EnvelopeContext {
             server_name: "lua-ls",
             host_uri: "file:///test/doc.md",
+            region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
             offset: &offset,
             region_end: Some(TEST_REGION_END),
         };

--- a/src/lsp/bridge/text_document/completion_item.rs
+++ b/src/lsp/bridge/text_document/completion_item.rs
@@ -285,6 +285,7 @@ fn re_envelope_item(item: &mut CompletionItem, envelope: &KakehashiEnvelope) {
     let ctx = EnvelopeContext {
         server_name: &envelope.origin,
         host_uri: &envelope.host_uri,
+        region_id: &envelope.region_id,
         offset: &RegionOffset::from(&envelope.offset),
         region_end: envelope
             .region_end
@@ -333,6 +334,7 @@ mod tests {
         KakehashiEnvelope {
             origin: "lua-ls".to_string(),
             host_uri: "file:///test/doc.md".to_string(),
+            region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
             inner: Some(json!({"resolve_id": 99})),
             offset: EnvelopeOffset {
                 line: 5,
@@ -521,6 +523,7 @@ mod tests {
         let envelope = KakehashiEnvelope {
             origin: server.to_string(),
             host_uri: "file:///test/doc.md".to_string(),
+            region_id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
             inner: Some(json!({"resolve_id": 42})),
             offset: EnvelopeOffset {
                 line: 5,

--- a/src/lsp/bridge/text_document/did_open.rs
+++ b/src/lsp/bridge/text_document/did_open.rs
@@ -26,7 +26,7 @@ impl Drop for LifecycleCleanup<'_> {
 }
 
 impl LanguageServerPool {
-    /// Fire `didOpen` for every injection region's virtual URI so the downstream
+    /// Fire `didOpen` for every resolved bridge virtual URI so the downstream
     /// server starts analyzing immediately instead of waiting for the first
     /// user request. Fire-and-forget: per-document failures are logged at
     /// debug level and never propagated; one open failing leaves the others

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -279,18 +279,22 @@ impl CacheCoordinator {
             // pre-lever path) and defer identity to the next current pass —
             // the tracker is meanwhile kept live by the ordinary didChange
             // edit-shift.
+            let region_keys = regions
+                .iter()
+                .map(|info| {
+                    Some((
+                        info.content_node.start_byte(),
+                        info.content_node.end_byte(),
+                        info.content_node.kind(),
+                        crate::language::injection::InjectionResolver::region_identity_layer(info)?,
+                    ))
+                })
+                .collect::<Option<Vec<_>>>()?;
             let region_ids = tracker.mint_batch_if_unshifted_for_incarnation(
                 uri,
                 entry_mint_epoch,
                 incarnation,
-                regions.iter().map(|info| {
-                    (
-                        info.content_node.start_byte(),
-                        info.content_node.end_byte(),
-                        info.content_node.kind(),
-                        0,
-                    )
-                }),
+                region_keys,
             )?;
 
             // Convert to CacheableInjectionRegion pairing each region with

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -982,12 +982,15 @@ print("hello")
             true,
         );
 
-        // Verify the region still exists with the same region_id (position-based stability)
+        // The region still exists, but changing its dynamic language creates a
+        // different virtual-document layer at the same host position. Region
+        // identity includes that language discriminator so simultaneous
+        // same-range languages cannot alias; the old ID must not be reused.
         let regions_after = cache.get_injections(&uri).expect("should have injections");
         assert_eq!(regions_after.len(), 1);
-        assert_eq!(
+        assert_ne!(
             regions_after[0].region_id, initial_region_id,
-            "region_id should be stable (same position)"
+            "a language change must remint the virtual-document identity"
         );
         assert_eq!(
             regions_after[0].language, "python",

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -286,7 +286,12 @@ impl CacheCoordinator {
                         info.content_node.start_byte(),
                         info.content_node.end_byte(),
                         info.content_node.kind(),
-                        crate::language::injection::InjectionResolver::region_identity_layer(info)?,
+                        crate::language::injection::InjectionResolver::region_identity_layer(
+                            tracker,
+                            uri,
+                            info,
+                            incarnation,
+                        )?,
                     ))
                 })
                 .collect::<Option<Vec<_>>>()?;

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -282,23 +282,20 @@ impl CacheCoordinator {
             let region_keys = regions
                 .iter()
                 .map(|info| {
-                    Some((
+                    (
                         info.content_node.start_byte(),
                         info.content_node.end_byte(),
                         info.content_node.kind(),
-                        crate::language::injection::InjectionResolver::region_identity_layer(
-                            tracker,
-                            uri,
-                            info,
-                            incarnation,
-                        )?,
-                    ))
+                        info.pattern_index,
+                        info.language.as_str(),
+                    )
                 })
-                .collect::<Option<Vec<_>>>()?;
-            let region_ids = tracker.mint_batch_if_unshifted_for_incarnation(
+                .collect::<Vec<_>>();
+            let region_ids = tracker.mint_named_batch_if_unshifted_for_incarnation(
                 uri,
                 entry_mint_epoch,
                 incarnation,
+                crate::language::injection::REGION_IDENTITY_LAYER_BASE,
                 region_keys,
             )?;
 

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -377,7 +377,7 @@ fn ensure_editable_region(contiguous: bool) -> Result<(), String> {
     if contiguous {
         Ok(())
     } else {
-        Err("kakehashi: the edit targets a non-contiguous combined injection; it cannot be applied without overwriting host text between injected regions".to_string())
+        Err("kakehashi: the edit targets a non-contiguous virtual document (whitespace-masked host bytes — gaps between combined captures, stripped prefixes, or excluded child ranges); it cannot be applied without overwriting that host text".to_string())
     }
 }
 
@@ -496,7 +496,7 @@ mod tests {
     #[test]
     fn non_contiguous_combined_region_rejects_apply_edit() {
         let reason = ensure_editable_region(false).expect_err("masked gaps are not editable");
-        assert!(reason.contains("non-contiguous combined injection"));
+        assert!(reason.contains("non-contiguous virtual document"));
         assert!(ensure_editable_region(true).is_ok());
     }
 

--- a/src/lsp/lsp_impl/apply_edit_translation.rs
+++ b/src/lsp/lsp_impl/apply_edit_translation.rs
@@ -171,7 +171,7 @@ impl ApplyEditTranslator {
                 "kakehashi: the virtual document's host URI is unmappable: {host_url}"
             ));
         };
-        let Some((offset, region_end)) = resolve_region_offset(
+        let Some((offset, region_end, contiguous)) = resolve_region_offset(
             &self.documents,
             &self.language,
             &self.bridge,
@@ -186,6 +186,7 @@ impl ApplyEditTranslator {
                     .to_string(),
             );
         };
+        ensure_editable_region(contiguous)?;
 
         transform_params_to_host(&mut params, virtual_uri, &host_uri, &offset, region_end)?;
         Ok(params)
@@ -372,6 +373,14 @@ fn versioned_virtual_text_document_edits(edit: &WorkspaceEdit) -> Vec<(&str, i32
     versioned
 }
 
+fn ensure_editable_region(contiguous: bool) -> Result<(), String> {
+    if contiguous {
+        Ok(())
+    } else {
+        Err("kakehashi: the edit targets a non-contiguous combined injection; it cannot be applied without overwriting host text between injected regions".to_string())
+    }
+}
+
 /// Rewrite `params.edit` to host coordinates via the shared WorkspaceEdit
 /// transform. Pure mutation, split out so it can be unit-tested without a live
 /// parse. `Err` when the edit performs file operations on a virtual document
@@ -483,6 +492,13 @@ mod tests {
     use super::*;
     use serde_json::json;
     use std::str::FromStr;
+
+    #[test]
+    fn non_contiguous_combined_region_rejects_apply_edit() {
+        let reason = ensure_editable_region(false).expect_err("masked gaps are not editable");
+        assert!(reason.contains("non-contiguous combined injection"));
+        assert!(ensure_editable_region(true).is_ok());
+    }
 
     fn translator() -> ApplyEditTranslator {
         translator_with_bridge(Arc::new(BridgeCoordinator::new()))

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -48,6 +48,23 @@ fn capability_prefilter_applies(method: &str) -> bool {
     )
 }
 
+/// Whether a bridge response can directly mutate the editor document.
+///
+/// Non-contiguous `injection.combined` documents mask host-only gaps inside
+/// their outer range. Until edit translation carries those allowed spans,
+/// forwarding these methods could apply virtual whitespace over real host text.
+fn method_requires_contiguous_injection(method: &str) -> bool {
+    matches!(
+        method,
+        "textDocument/codeAction"
+            | "textDocument/colorPresentation"
+            | "textDocument/completion"
+            | "textDocument/inlayHint"
+            | "textDocument/onTypeFormatting"
+            | "textDocument/rename"
+    )
+}
+
 /// RAII sweep of the upstream-request registry for one request id: on drop,
 /// removes every entry a dropped/aborted layer future did not get to
 /// unregister itself. Idempotent with the arms' own refcounted unregisters.
@@ -732,6 +749,10 @@ impl Kakehashi {
             return None;
         };
 
+        if !resolved.contiguous && method_requires_contiguous_injection(method_name) {
+            return None;
+        }
+
         // Get upstream request ID from task-local storage (set by RequestIdCapture middleware)
         let upstream_request_id = current_upstream_id();
 
@@ -1359,6 +1380,9 @@ impl Kakehashi {
         let mapper = PositionMapper::new(snapshot.text());
         let mut contexts = Vec::new();
         for resolved in regions {
+            if !resolved.contiguous && method_requires_contiguous_injection(method_name) {
+                continue;
+            }
             // Clamp to the region so the translated range is in-region; skip a
             // region the range never touches.
             let Some(clamped) = clamp_range_to_region(&resolved, &range, &mapper) else {
@@ -2641,6 +2665,28 @@ mod tests {
                 capability_prefilter_applies(method),
                 "{method} must be prefiltered"
             );
+        }
+    }
+
+    #[test]
+    fn edit_producing_methods_require_contiguous_injections() {
+        for method in [
+            "textDocument/codeAction",
+            "textDocument/colorPresentation",
+            "textDocument/completion",
+            "textDocument/inlayHint",
+            "textDocument/onTypeFormatting",
+            "textDocument/rename",
+        ] {
+            assert!(method_requires_contiguous_injection(method), "{method}");
+        }
+        for method in [
+            "textDocument/definition",
+            "textDocument/hover",
+            "textDocument/references",
+            "textDocument/signatureHelp",
+        ] {
+            assert!(!method_requires_contiguous_injection(method), "{method}");
         }
     }
 

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -48,7 +48,10 @@ fn capability_prefilter_applies(method: &str) -> bool {
     )
 }
 
-/// Whether a bridge response can directly mutate the editor document.
+/// Whether a bridge response can carry edits, apply edits, or initiate an
+/// editor mutation. These methods require one contiguous host span even when
+/// the response itself (for example linked-editing ranges) is only a precursor
+/// to the client's edit.
 ///
 /// Non-contiguous `injection.combined` documents mask host-only gaps inside
 /// their outer range. Until edit translation carries those allowed spans,

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -53,8 +53,9 @@ fn capability_prefilter_applies(method: &str) -> bool {
 /// the response itself (for example linked-editing ranges) is only a precursor
 /// to the client's edit.
 ///
-/// Non-contiguous `injection.combined` documents mask host-only gaps inside
-/// their outer range. Until edit translation carries those allowed spans,
+/// Non-contiguous `injection.combined` documents mask bytes inside their outer
+/// range, including inter-capture gaps, stripped line prefixes, and excluded
+/// child ranges. Until edit translation carries the exact allowed spans,
 /// forwarding these methods could apply virtual whitespace over real host text.
 fn method_requires_contiguous_injection(method: &str) -> bool {
     matches!(

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -62,6 +62,7 @@ fn method_requires_contiguous_injection(method: &str) -> bool {
             | "textDocument/inlayHint"
             | "textDocument/linkedEditingRange"
             | "textDocument/onTypeFormatting"
+            | "textDocument/prepareRename"
             | "textDocument/rename"
     )
 }
@@ -2678,6 +2679,7 @@ mod tests {
             "textDocument/inlayHint",
             "textDocument/linkedEditingRange",
             "textDocument/onTypeFormatting",
+            "textDocument/prepareRename",
             "textDocument/rename",
         ] {
             assert!(method_requires_contiguous_injection(method), "{method}");

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -60,6 +60,7 @@ fn method_requires_contiguous_injection(method: &str) -> bool {
             | "textDocument/colorPresentation"
             | "textDocument/completion"
             | "textDocument/inlayHint"
+            | "textDocument/linkedEditingRange"
             | "textDocument/onTypeFormatting"
             | "textDocument/rename"
     )
@@ -2675,6 +2676,7 @@ mod tests {
             "textDocument/colorPresentation",
             "textDocument/completion",
             "textDocument/inlayHint",
+            "textDocument/linkedEditingRange",
             "textDocument/onTypeFormatting",
             "textDocument/rename",
         ] {

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -480,37 +480,30 @@ mod tests {
         let (service, _socket) = LspService::new(crate::lsp::lsp_impl::Kakehashi::new);
         let server = service.inner();
 
-        let registry = server.language.language_registry_for_parallel();
-        registry.register("markdown".to_string(), tree_sitter_md::LANGUAGE.into());
-        registry.register("python".to_string(), tree_sitter_python::LANGUAGE.into());
-        registry.register("lua".to_string(), tree_sitter_lua::LANGUAGE.into());
-        let markdown_language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
-        let injection_query = Query::new(
-            &markdown_language,
+        let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        let query = tree_sitter::Query::new(
+            &language,
             r#"
-            (fenced_code_block
-              (info_string (language) @_lang)
-              (code_fence_content) @injection.content
-              (#set-lang-from-info-string! @_lang)
-              (#offset! @injection.content 1 0 0 0))
+                ((string_literal
+                   (string_content) @injection.content)
+                 (#set! injection.language "html")
+                 (#set! injection.combined))
             "#,
         )
-        .expect("valid markdown injection query");
+        .expect("valid query");
         server
             .language
             .query_store()
-            .insert_injection_query("markdown".to_string(), std::sync::Arc::new(injection_query));
-
-        let text = "# T\n\n```py\nignored\nx = 1\n```\n\n```unknown\n#!/usr/bin/env lua\n#!/usr/bin/env python\ny = 2\n```\n";
-        let mut pool = server.language.create_document_parser_pool();
-        let mut parser = pool.acquire("markdown").expect("registered parser");
-        let tree = parser.parse(text, None).expect("parse markdown");
-        pool.release("markdown".to_string(), parser);
+            .insert_injection_query("rust".to_string(), std::sync::Arc::new(query));
+        let text = r#"fn main() { let open = "<div>"; let close = "</div>"; }"#;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&language).expect("load rust grammar");
+        let tree = parser.parse(text, None).expect("parse rust");
 
         let uri = Url::parse("file:///bridge_fast_path.md").unwrap();
         server
             .documents
-            .insert(uri.clone(), text.to_string(), Some("markdown".into()), None);
+            .insert(uri.clone(), text.to_string(), Some("rust".into()), None);
         server
             .documents
             .update_document(uri.clone(), text.to_string(), Some(tree.clone()));
@@ -535,7 +528,7 @@ mod tests {
                         crate::document::snapshot::ParseSnapshot {
                             text: std::sync::Arc::from(text),
                             tree: Some(tree.clone()),
-                            language: Some("markdown".to_string()),
+                            language: Some("rust".to_string()),
                             parsed_version,
                             incarnation,
                             injection_regions: None,
@@ -549,30 +542,8 @@ mod tests {
             assert!(landed, "test publish must land");
         };
         publish(None, content_version);
-        let inline = injection.resolve_injection_data(&uri, "markdown");
-        assert!(!inline.is_empty(), "the two fences must resolve");
-        assert!(
-            inline.iter().all(|region| region.language == "python"),
-            "inline eager discovery must use the request resolver's canonical language"
-        );
-        let interactive = InjectionResolver::resolve_all(
-            &server.language,
-            server.bridge.node_tracker(),
-            &uri,
-            &tree,
-            text,
-            &server
-                .language
-                .injection_query("markdown")
-                .expect("registered injection query"),
-            incarnation,
-        );
-        assert!(
-            interactive
-                .iter()
-                .all(|region| region.injection_language == "python"),
-            "interactive request discovery must use the canonical language"
-        );
+        let inline = injection.resolve_injection_data(&uri, "rust");
+        assert_eq!(inline.len(), 1, "combined captures form one eager document");
 
         // FAST PATH: populate derives the bridge regions from the same tree
         // (same tracker → same region ids); a newer current snapshot carries
@@ -581,7 +552,7 @@ mod tests {
             &uri,
             text,
             &tree,
-            "markdown",
+            "rust",
             &server.language,
             &server.bridge.node_tracker_arc(),
             server.bridge.node_tracker_arc().mint_epoch(&uri),
@@ -599,11 +570,7 @@ mod tests {
             Some((populated.generation, std::sync::Arc::new(bridge_regions))),
             content_version,
         );
-        let fast = injection.resolve_injection_data(&uri, "markdown");
-        assert!(
-            fast.iter().all(|region| region.language == "python"),
-            "cached eager discovery must use the request resolver's canonical language"
-        );
+        let fast = injection.resolve_injection_data(&uri, "rust");
 
         assert_eq!(
             inline.len(),

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -413,7 +413,7 @@ fn parser_enabled_injection_language(language: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{InjectionResolver, parser_enabled_injection_language};
+    use super::parser_enabled_injection_language;
 
     #[test]
     fn explicit_plaintext_does_not_request_a_parser() {
@@ -423,7 +423,6 @@ mod tests {
     use std::sync::Arc;
     use tokio::sync::Notify;
     use tower_lsp_server::LspService;
-    use tree_sitter::Query;
     use url::Url;
 
     #[tokio::test]

--- a/src/lsp/lsp_impl/region_offset.rs
+++ b/src/lsp/lsp_impl/region_offset.rs
@@ -6,8 +6,9 @@
 //! ([`ApplyEditTranslator`]). The offset is rebuilt exactly as the goto request
 //! path does (`region_id → node byte range → resolve injection → RegionOffset`),
 //! so inbound translation can't disagree with goto on the same region. The
-//! region's content-precise host end is returned alongside so an edit translator
-//! can reject a range that escapes the region.
+//! region's content-precise host end and contiguity are returned alongside so
+//! an edit translator can reject a range that escapes the region or targets a
+//! combined document with masked host gaps.
 //!
 //! [`ShowDocumentTranslator`]: super::show_document_translation::ShowDocumentTranslator
 //! [`ApplyEditTranslator`]: super::apply_edit_translation::ApplyEditTranslator
@@ -26,7 +27,8 @@ use crate::text::PositionMapper;
 /// `region_id` (a ULID in production). Returns `None` when the offset can't be
 /// rebuilt: region invalidated by edits (`lookup_node` misses), a `region_id`
 /// that no longer matches the live parse at that byte (edit race), or a missing
-/// document/snapshot/language/query.
+/// document/snapshot/language/query. The third tuple field reports whether the
+/// virtual content maps to one contiguous host span.
 pub(super) fn resolve_region_offset(
     documents: &DocumentStore,
     language: &Arc<LanguageCoordinator>,

--- a/src/lsp/lsp_impl/region_offset.rs
+++ b/src/lsp/lsp_impl/region_offset.rs
@@ -19,9 +19,9 @@ use tower_lsp_server::ls_types::Position;
 use url::Url;
 
 use crate::document::DocumentStore;
+use crate::language::injection::ResolvedInjection;
 use crate::language::{InjectionResolver, LanguageCoordinator};
-use crate::lsp::bridge::{BridgeCoordinator, RegionOffset};
-use crate::text::PositionMapper;
+use crate::lsp::bridge::{BridgeCoordinator, RegionOffset, region_host_end};
 
 /// Rebuild the region's current host offset from the live parse, keyed by its
 /// `region_id` (a ULID in production). Returns `None` when the offset can't be
@@ -68,18 +68,43 @@ pub(super) fn resolve_region_offset(
     if resolved.region.region_id != region_id {
         return None;
     }
-    // The region's exclusive host-document end, content-precise (the injection
-    // region's own byte range mapped through the live host text). Callers that
-    // translate an inbound edit use it to reject a range that runs past the
-    // region into unrelated host text.
-    let region_end =
-        PositionMapper::new(snapshot.text()).byte_to_position(resolved.region.byte_range.end)?;
-    // `start` is `Copy`; move `line_column_offsets` out (no clone — `resolved`
-    // is dropped after this).
+    Some(resolved_region_geometry(resolved))
+}
+
+/// Consume a resolved region into the geometry shared by freshness and edit
+/// validation. The end is derived from the exact virtual content rather than
+/// the raw content-node range, whose trailing named children may be excluded.
+fn resolved_region_geometry(resolved: ResolvedInjection) -> (RegionOffset, Position, bool) {
     let start_line = resolved.region.line_range.start;
-    Some((
-        RegionOffset::with_per_line_offsets(start_line, resolved.line_column_offsets),
-        region_end,
-        resolved.contiguous,
-    ))
+    let offset = RegionOffset::with_per_line_offsets(start_line, resolved.line_column_offsets);
+    let region_end = region_host_end(&resolved.virtual_content, &offset);
+    (offset, region_end, resolved.contiguous)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::language::injection::{CacheableInjectionRegion, ResolvedInjection};
+
+    #[test]
+    fn geometry_uses_virtual_content_end_not_raw_node_end() {
+        let resolved = ResolvedInjection {
+            region: CacheableInjectionRegion {
+                language: "rust".to_string(),
+                byte_range: 10..99,
+                line_range: 2..3,
+                start_column: 3,
+                region_id: "region".to_string(),
+                content_hash: 0,
+            },
+            injection_language: "rust".to_string(),
+            virtual_content: "x".to_string(),
+            line_column_offsets: vec![3],
+            contiguous: true,
+        };
+
+        let (_, region_end, _) = resolved_region_geometry(resolved);
+
+        assert_eq!(region_end, Position::new(2, 4));
+    }
 }

--- a/src/lsp/lsp_impl/region_offset.rs
+++ b/src/lsp/lsp_impl/region_offset.rs
@@ -33,7 +33,7 @@ pub(super) fn resolve_region_offset(
     bridge: &BridgeCoordinator,
     host_url: &Url,
     region_id: &str,
-) -> Option<(RegionOffset, Position)> {
+) -> Option<(RegionOffset, Position, bool)> {
     let ulid = ulid::Ulid::from_string(region_id).ok()?;
     let (start_byte, _end, _kind, _layer, tracked_incarnation) =
         bridge.node_tracker().lookup_node(host_url, &ulid)?;
@@ -78,5 +78,6 @@ pub(super) fn resolve_region_offset(
     Some((
         RegionOffset::with_per_line_offsets(start_line, resolved.line_column_offsets),
         region_end,
+        resolved.contiguous,
     ))
 }

--- a/src/lsp/lsp_impl/region_offset.rs
+++ b/src/lsp/lsp_impl/region_offset.rs
@@ -36,15 +36,9 @@ pub(super) fn resolve_region_offset(
     host_url: &Url,
     region_id: &str,
 ) -> Option<(RegionOffset, Position, bool)> {
-    let ulid = ulid::Ulid::from_string(region_id).ok()?;
-    let (_start_byte, _end, _kind, _layer, tracked_incarnation) =
-        bridge.node_tracker().lookup_node(host_url, &ulid)?;
     // Snapshot is owned, so the document handle (a store lock) is released
     // before `detect_document_language` reaches back into the store.
     let snapshot = documents.get(host_url)?.snapshot()?;
-    if snapshot.incarnation() != tracked_incarnation {
-        return None;
-    }
     let language_name = super::detect_document_language(language, documents, host_url)?;
     let injection_query = language.injection_query(&language_name)?;
     let resolved = InjectionResolver::resolve_by_region_id(
@@ -57,10 +51,9 @@ pub(super) fn resolve_region_offset(
         region_id,
         snapshot.incarnation(),
     )?;
-    // Exact-ID resolution also rejects an edit race: if the separately-fetched
-    // snapshot no longer contains the tracked layer, no resolved region has
-    // this ID and callers fall back safely instead of translating another
-    // same-range language layer.
+    // Exact-ID resolution also validates the tracker incarnation and rejects
+    // an edit race: if this snapshot no longer contains the tracked layer, no
+    // candidate has the ID and callers fall back safely.
     Some(resolved_region_geometry(resolved))
 }
 

--- a/src/lsp/lsp_impl/region_offset.rs
+++ b/src/lsp/lsp_impl/region_offset.rs
@@ -26,9 +26,9 @@ use crate::lsp::bridge::{BridgeCoordinator, RegionOffset, region_host_end};
 /// Rebuild the region's current host offset from the live parse, keyed by its
 /// `region_id` (a ULID in production). Returns `None` when the offset can't be
 /// rebuilt: region invalidated by edits (`lookup_node` misses), a `region_id`
-/// that no longer matches the live parse at that byte (edit race), or a missing
-/// document/snapshot/language/query. The third tuple field reports whether the
-/// virtual content maps to one contiguous host span.
+/// whose tracked geometry/layer no longer exists in the live parse, or a
+/// missing document/snapshot/language/query. The third tuple field reports
+/// whether the virtual content maps to one contiguous host span.
 pub(super) fn resolve_region_offset(
     documents: &DocumentStore,
     language: &Arc<LanguageCoordinator>,

--- a/src/lsp/lsp_impl/region_offset.rs
+++ b/src/lsp/lsp_impl/region_offset.rs
@@ -37,7 +37,7 @@ pub(super) fn resolve_region_offset(
     region_id: &str,
 ) -> Option<(RegionOffset, Position, bool)> {
     let ulid = ulid::Ulid::from_string(region_id).ok()?;
-    let (start_byte, _end, _kind, _layer, tracked_incarnation) =
+    let (_start_byte, _end, _kind, _layer, tracked_incarnation) =
         bridge.node_tracker().lookup_node(host_url, &ulid)?;
     // Snapshot is owned, so the document handle (a store lock) is released
     // before `detect_document_language` reaches back into the store.
@@ -47,27 +47,20 @@ pub(super) fn resolve_region_offset(
     }
     let language_name = super::detect_document_language(language, documents, host_url)?;
     let injection_query = language.injection_query(&language_name)?;
-    let resolved = InjectionResolver::resolve_at_byte_offset(
+    let resolved = InjectionResolver::resolve_by_region_id(
         language,
         bridge.node_tracker(),
         host_url,
         snapshot.tree(),
         snapshot.text(),
         injection_query.as_ref(),
-        start_byte,
+        region_id,
         snapshot.incarnation(),
     )?;
-    // `region_id`/`start_byte` came from the tracker + node map, but
-    // `resolved` came from a separately-fetched snapshot. If an edit landed
-    // in between, `start_byte` could fall inside a *different* live region —
-    // `resolve_at_byte_offset` returns whichever region contains the byte. A
-    // mismatched `region_id` means we'd translate coordinates against the
-    // wrong region, so return `None` (no offset); callers fall back to their
-    // safe default rather than risk a wrong translation. (The goto path can't
-    // hit this: there `resolved` and `region_id` come from one call.)
-    if resolved.region.region_id != region_id {
-        return None;
-    }
+    // Exact-ID resolution also rejects an edit race: if the separately-fetched
+    // snapshot no longer contains the tracked layer, no resolved region has
+    // this ID and callers fall back safely instead of translating another
+    // same-range language layer.
     Some(resolved_region_geometry(resolved))
 }
 

--- a/src/lsp/lsp_impl/show_document_translation.rs
+++ b/src/lsp/lsp_impl/show_document_translation.rs
@@ -128,7 +128,7 @@ impl ShowDocumentTranslator {
             host_url,
             region_id,
         )
-        .map(|(offset, _region_end)| offset)
+        .map(|(offset, _region_end, _contiguous)| offset)
     }
 }
 

--- a/src/lsp/lsp_impl/show_document_translation.rs
+++ b/src/lsp/lsp_impl/show_document_translation.rs
@@ -119,7 +119,7 @@ impl ShowDocumentTranslator {
     /// shared [`resolve_region_offset`]. On `None` the caller opens the host
     /// document without a selection rather than risk a wrong one. showDocument
     /// only needs the offset (it translates a single selection position, not an
-    /// edit), so the region-end bound is discarded.
+    /// edit), so the region-end bound and contiguity marker are discarded.
     fn region_offset(&self, host_url: &Url, region_id: &str) -> Option<RegionOffset> {
         resolve_region_offset(
             &self.documents,

--- a/src/lsp/lsp_impl/show_document_translation.rs
+++ b/src/lsp/lsp_impl/show_document_translation.rs
@@ -1,7 +1,7 @@
 //! Virtual→host translation for inbound `window/showDocument` requests.
 //!
 //! A bridged downstream server only knows the *virtual* document it was handed
-//! (one per injected region), so a `window/showDocument` it issues carries a
+//! (one per isolated region or combined group), so a `window/showDocument` carries a
 //! virtual URI and a `selection` in virtual coordinates. Before the bridge
 //! forwards the request to the editor, [`ShowDocumentTranslator`] rewrites the
 //! URI back to the host document and the selection back to host coordinates —

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -305,7 +305,7 @@ impl Kakehashi {
     ) -> Option<Position> {
         // Re-resolve the region from the LIVE parse (same construction as the
         // goto/showDocument offset path), yielding the current per-line offset
-        // AND the content-precise host byte range.
+        // and virtual content used to derive the exact mapped host end.
         let snapshot = self.documents.get(host_url)?.snapshot()?;
         let language_name = detect_document_language(&self.language, &self.documents, host_url)?;
         let injection_query = self.language.injection_query(&language_name)?;

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -325,6 +325,13 @@ impl Kakehashi {
             start_byte,
             snapshot.incarnation(),
         )?;
+        // The action may have been created while a single combined capture was
+        // contiguous, then resolved after another capture introduced a masked
+        // host gap. The stable first-region ID/offset alone cannot detect that
+        // geometry change, so re-check live edit safety here.
+        if !resolved.contiguous {
+            return None;
+        }
         // The tracker byte and the freshly-resolved region can disagree after an
         // edit (the byte now falls in a different live region); a mismatched
         // region_id means we'd bound/translate against the wrong region.

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -257,7 +257,8 @@ impl Kakehashi {
     /// the edit to wrong host columns — corruption. On any divergence fail soft
     /// (the client re-requests fresh actions), mirroring the stale-region case.
     /// The same live resolution yields the content-precise region end used to
-    /// bound the edit (`resolved.region.byte_range.end`, matching applyEdit).
+    /// bound the edit (the exact virtual-content end mapped through the live
+    /// per-line offset, matching applyEdit).
     ///
     /// Known limitation (shared with `code_lens_region_is_fresh`): for
     /// injections whose queries apply `#offset!` (today only YAML/TOML
@@ -282,7 +283,7 @@ impl Kakehashi {
             );
             return Err(RegionEndUnavailable::MalformedEnvelope);
         };
-        let Ok(ulid) = envelope.region_id.parse::<Ulid>() else {
+        let Ok(_ulid) = envelope.region_id.parse::<Ulid>() else {
             log::warn!(
                 target: "kakehashi::bridge",
                 "codeAction/resolve: envelope region_id {:?} is not a valid ULID",
@@ -290,7 +291,7 @@ impl Kakehashi {
             );
             return Err(RegionEndUnavailable::MalformedEnvelope);
         };
-        self.code_action_region_end_live(envelope, &host_url, ulid)
+        self.code_action_region_end_live(envelope, &host_url)
             .ok_or(RegionEndUnavailable::Stale)
     }
 
@@ -301,17 +302,11 @@ impl Kakehashi {
         &self,
         envelope: &CodeActionEnvelope,
         host_url: &Url,
-        ulid: Ulid,
     ) -> Option<Position> {
         // Re-resolve the region from the LIVE parse (same construction as the
         // goto/showDocument offset path), yielding the current per-line offset
         // AND the content-precise host byte range.
-        let (_start_byte, _end, _kind, _layer, tracked_incarnation) =
-            self.bridge.node_tracker().lookup_node(host_url, &ulid)?;
         let snapshot = self.documents.get(host_url)?.snapshot()?;
-        if snapshot.incarnation() != tracked_incarnation {
-            return None;
-        }
         let language_name = detect_document_language(&self.language, &self.documents, host_url)?;
         let injection_query = self.language.injection_query(&language_name)?;
         let resolved = InjectionResolver::resolve_by_region_id(

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -36,9 +36,8 @@ use crate::lsp::aggregation::server::{
 };
 use crate::lsp::bridge::{
     CodeActionEnvelope, HostDocument, RegionOffset, UpstreamCodeActionCaps, bridge_code_actions,
-    extract_code_action_envelope, parse_code_actions_leniently,
+    extract_code_action_envelope, parse_code_actions_leniently, region_host_end,
 };
-use crate::text::PositionMapper;
 
 const METHOD: &str = "textDocument/codeAction";
 
@@ -307,7 +306,7 @@ impl Kakehashi {
         // Re-resolve the region from the LIVE parse (same construction as the
         // goto/showDocument offset path), yielding the current per-line offset
         // AND the content-precise host byte range.
-        let (start_byte, _end, _kind, _layer, tracked_incarnation) =
+        let (_start_byte, _end, _kind, _layer, tracked_incarnation) =
             self.bridge.node_tracker().lookup_node(host_url, &ulid)?;
         let snapshot = self.documents.get(host_url)?.snapshot()?;
         if snapshot.incarnation() != tracked_incarnation {
@@ -315,14 +314,14 @@ impl Kakehashi {
         }
         let language_name = detect_document_language(&self.language, &self.documents, host_url)?;
         let injection_query = self.language.injection_query(&language_name)?;
-        let resolved = InjectionResolver::resolve_at_byte_offset(
+        let resolved = InjectionResolver::resolve_by_region_id(
             &self.language,
             self.bridge.node_tracker(),
             host_url,
             snapshot.tree(),
             snapshot.text(),
             injection_query.as_ref(),
-            start_byte,
+            &envelope.region_id,
             snapshot.incarnation(),
         )?;
         // The action may have been created while a single combined capture was
@@ -332,20 +331,11 @@ impl Kakehashi {
         if !resolved.contiguous {
             return None;
         }
-        // The tracker byte and the freshly-resolved region can disagree after an
-        // edit (the byte now falls in a different live region); a mismatched
-        // region_id means we'd bound/translate against the wrong region.
-        if resolved.region.region_id != envelope.region_id {
-            return None;
-        }
-        // Content-precise host end (matches applyEdit) — compute before moving
-        // `line_column_offsets` out of `resolved`.
-        let region_end = PositionMapper::new(snapshot.text())
-            .byte_to_position(resolved.region.byte_range.end)?;
         let live_offset = RegionOffset::with_per_line_offsets(
             resolved.region.line_range.start,
             resolved.line_column_offsets,
         );
+        let region_end = region_host_end(&resolved.virtual_content, &live_offset);
         // Compare the WHOLE offset, not just the start: a diverged interior
         // per-line column offset (e.g. a blockquote-prefix edit that left the
         // start line intact) would translate the resolved edit to wrong host

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -283,14 +283,14 @@ impl Kakehashi {
             );
             return Err(RegionEndUnavailable::MalformedEnvelope);
         };
-        let Ok(_ulid) = envelope.region_id.parse::<Ulid>() else {
+        if envelope.region_id.parse::<Ulid>().is_err() {
             log::warn!(
                 target: "kakehashi::bridge",
                 "codeAction/resolve: envelope region_id {:?} is not a valid ULID",
                 envelope.region_id
             );
             return Err(RegionEndUnavailable::MalformedEnvelope);
-        };
+        }
         self.code_action_region_end_live(envelope, &host_url)
             .ok_or(RegionEndUnavailable::Stale)
     }

--- a/src/lsp/lsp_impl/text_document/completion_item.rs
+++ b/src/lsp/lsp_impl/text_document/completion_item.rs
@@ -5,10 +5,14 @@
 //! `CompletionItem.data` during the original completion fan-out.
 
 use tower_lsp_server::jsonrpc::Result;
-use tower_lsp_server::ls_types::CompletionItem;
+use tower_lsp_server::ls_types::{CompletionItem, Position};
+use url::Url;
 
 use super::super::Kakehashi;
+use crate::lsp::bridge::RegionOffset;
+use crate::lsp::bridge::{KakehashiEnvelope, extract_envelope};
 use crate::lsp::current_upstream_id;
+use crate::lsp::lsp_impl::region_offset::resolve_region_offset;
 
 impl Kakehashi {
     /// Handle a `completionItem/resolve` request.
@@ -20,6 +24,14 @@ impl Kakehashi {
         &self,
         params: CompletionItem,
     ) -> Result<CompletionItem> {
+        // A lazy resolve can arrive after edits changed a formerly contiguous
+        // combined document into one with masked host gaps. Fail closed for
+        // legacy/stale envelopes before the downstream can add new edits.
+        if let Some(envelope) = extract_envelope(&params)
+            && !self.completion_envelope_is_fresh(&envelope)
+        {
+            return Ok(params);
+        }
         let settings = self.settings_manager.load_settings();
         let pool = self.bridge.pool_arc();
         let upstream_id = current_upstream_id();
@@ -27,5 +39,74 @@ impl Kakehashi {
             .dispatch_completion_resolve(params, &settings, upstream_id)
             .await;
         Ok(item)
+    }
+
+    fn completion_envelope_is_fresh(&self, envelope: &KakehashiEnvelope) -> bool {
+        let Ok(host_url) = Url::parse(&envelope.host_uri) else {
+            return false;
+        };
+        let Some((offset, region_end, contiguous)) = resolve_region_offset(
+            &self.documents,
+            &self.language,
+            &self.bridge,
+            &host_url,
+            &envelope.region_id,
+        ) else {
+            return false;
+        };
+        completion_geometry_matches(envelope, &offset, region_end, contiguous)
+    }
+}
+
+fn completion_geometry_matches(
+    envelope: &KakehashiEnvelope,
+    live_offset: &RegionOffset,
+    live_end: Position,
+    contiguous: bool,
+) -> bool {
+    !envelope.region_id.is_empty()
+        && contiguous
+        && RegionOffset::from(&envelope.offset) == *live_offset
+        && envelope.region_end == Some((live_end.line, live_end.character))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn envelope(region_id: &str) -> KakehashiEnvelope {
+        serde_json::from_value(serde_json::json!({
+            "origin": "lua-ls",
+            "host_uri": "file:///test.md",
+            "region_id": region_id,
+            "inner": null,
+            "offset": { "line": 3, "column": 2, "line_column_offsets": [2] },
+            "region_end": [3, 8]
+        }))
+        .expect("valid envelope")
+    }
+
+    #[test]
+    fn completion_resolve_requires_current_contiguous_geometry() {
+        let offset = RegionOffset::with_per_line_offsets(3, vec![2]);
+        let end = Position::new(3, 8);
+        assert!(completion_geometry_matches(
+            &envelope("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+            &offset,
+            end,
+            true
+        ));
+        assert!(!completion_geometry_matches(
+            &envelope(""),
+            &offset,
+            end,
+            true
+        ));
+        assert!(!completion_geometry_matches(
+            &envelope("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+            &offset,
+            end,
+            false
+        ));
     }
 }

--- a/src/lsp/lsp_impl/text_document/document_symbol.rs
+++ b/src/lsp/lsp_impl/text_document/document_symbol.rs
@@ -1,7 +1,7 @@
 //! Document symbol method for Kakehashi.
 //!
 //! Walks the resolved layer order (cross-layer-aggregation): the virt layer
-//! bridges every injection region and concatenates the per-region symbols,
+//! bridges every resolved virtual document and concatenates their symbols,
 //! the host layer (host-document-bridge) bridges the host document itself
 //! with the real URI and the response verbatim. The first layer producing a
 //! non-empty result wins (`preferred`).
@@ -52,7 +52,7 @@ impl Kakehashi {
         .await
     }
 
-    /// Virt layer: bridge every injection region and concatenate symbols.
+    /// Virt layer: bridge every resolved virtual document and concatenate symbols.
     async fn document_symbol_virt_layer(
         &self,
         lsp_uri: &Uri,

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -321,6 +321,39 @@ impl Kakehashi {
                 &resolved.injection_language,
                 "textDocument/formatting",
             );
+            let pipeline =
+                plan_region_format(agg.strategy, &agg.priorities, &configs, agg.max_fan_out);
+            match &pipeline {
+                RegionFormatPlan::Skip => {
+                    log::warn!(
+                        target: "kakehashi::formatting",
+                        "concatenated formatting for {}->{} lists only unconfigured \
+                         server(s) {:?}; none are configured for this region, so it \
+                         is left unformatted (priorities is an allowlist — \
+                         non-listed servers are not run)",
+                        language_name,
+                        resolved.injection_language,
+                        agg.priorities,
+                    );
+                    continue;
+                }
+                RegionFormatPlan::Disabled => {
+                    log::debug!(
+                        target: "kakehashi::formatting",
+                        "formatting disabled for {}->{} (priorities = [])",
+                        language_name,
+                        resolved.injection_language,
+                    );
+                    continue;
+                }
+                RegionFormatPlan::Concatenated(_) | RegionFormatPlan::Preferred => {}
+            }
+            if !seen_edit_ranges.insert((
+                resolved.region.byte_range.start,
+                resolved.region.byte_range.end,
+            )) {
+                continue;
+            }
             let region_ctx = DocumentRequestContext {
                 uri: uri.clone(),
                 resolved: resolved.clone(),
@@ -358,12 +391,7 @@ impl Kakehashi {
                     PRIORITIES_WILDCARD,
                 );
             }
-            let pipeline = match plan_region_format(
-                region_ctx.strategy,
-                &region_ctx.priorities,
-                &region_ctx.configs,
-                region_ctx.max_fan_out,
-            ) {
+            let pipeline = match pipeline {
                 RegionFormatPlan::Concatenated(servers) => {
                     // Capture the region's per-line host prefixes now, while
                     // the host snapshot is at hand: the pipeline's whole-region
@@ -383,45 +411,8 @@ impl Kakehashi {
                     Some((servers, host_line_prefixes))
                 }
                 RegionFormatPlan::Preferred => None,
-                RegionFormatPlan::Skip => {
-                    // `concatenated` with a non-empty `priorities` that names only
-                    // unconfigured servers: the allowlist resolved to nothing, so
-                    // running the region's other servers would violate it. Leave
-                    // the region unformatted and warn so the typo'd/missing name
-                    // surfaces instead of silently formatting with the wrong
-                    // server.
-                    log::warn!(
-                        target: "kakehashi::formatting",
-                        "concatenated formatting for {}->{} lists only unconfigured \
-                         server(s) {:?}; none are configured for this region, so it \
-                         is left unformatted (priorities is an allowlist — \
-                         non-listed servers are not run)",
-                        language_name,
-                        region_ctx.resolved.injection_language,
-                        region_ctx.priorities,
-                    );
-                    continue;
-                }
-                RegionFormatPlan::Disabled => {
-                    // priorities = []: the per-method fan-out kill switch
-                    // (aggregation-priorities-wildcard). Deliberate config, so
-                    // no warning — just skip the region.
-                    log::debug!(
-                        target: "kakehashi::formatting",
-                        "formatting disabled for {}->{} (priorities = [])",
-                        language_name,
-                        region_ctx.resolved.injection_language,
-                    );
-                    continue;
-                }
+                RegionFormatPlan::Skip | RegionFormatPlan::Disabled => unreachable!(),
             };
-            if !seen_edit_ranges.insert((
-                resolved.region.byte_range.start,
-                resolved.region.byte_range.end,
-            )) {
-                continue;
-            }
-
             // Mint this region's tracked-source token into the shared
             // aggregator ONLY for the preferred branch. Concatenated regions
             // (`pipeline.is_some()`) get no token — concatenated client progress

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -348,6 +348,11 @@ impl Kakehashi {
                 }
                 RegionFormatPlan::Concatenated(_) | RegionFormatPlan::Preferred => {}
             }
+            // Same-range query alternatives are tried in discovery priority
+            // order, but an unconfigured or explicitly disabled language is
+            // not a winner. Reserve the span only after planning so the first
+            // executable alternative formats it; later executable layers are
+            // suppressed to keep emitted edits non-overlapping.
             if !seen_edit_ranges.insert((
                 resolved.region.byte_range.start,
                 resolved.region.byte_range.end,
@@ -570,8 +575,10 @@ impl Kakehashi {
 /// Select one deterministic edit-producing layer for each host byte range.
 ///
 /// Discovery orders same-range alternate languages by query-pattern priority.
-/// Formatting must preserve that first winner because dispatching every layer
-/// would concatenate overlapping edits for the identical host span.
+/// This helper selects the first raw layer for tests of geometric deduplication;
+/// production formatting applies config/plan eligibility first and selects the
+/// first executable layer so an unconfigured alternative does not block a
+/// configured one for the same span.
 #[cfg(test)]
 pub(super) fn unique_edit_regions(
     regions: &[ResolvedInjection],

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -39,6 +39,7 @@ use crate::config::settings::AggregationStrategy;
 use crate::config::settings::{LayerSource, PRIORITIES_WILDCARD};
 use crate::error::LockResultExt;
 use crate::language::InjectionResolver;
+use crate::language::injection::ResolvedInjection;
 use crate::lsp::aggregation::region::collect_region_results_with_cancel;
 use crate::lsp::aggregation::server::FanInResult;
 use crate::lsp::aggregation::server::dispatch_preferred;
@@ -301,7 +302,7 @@ impl Kakehashi {
         });
         let mut cp_minted: Vec<NumberOrString> = Vec::new();
 
-        for resolved in all_regions.iter() {
+        for resolved in unique_edit_regions(&all_regions) {
             // Combined injections mask host-only gaps with whitespace. A formatter
             // returns a contiguous whole-document replacement, which would replace
             // those real host gaps as well and corrupt the document.
@@ -566,6 +567,23 @@ impl Kakehashi {
             FanInResult::Cancelled => Err(tower_lsp_server::jsonrpc::Error::request_cancelled()),
         }
     }
+}
+
+/// Select one deterministic edit-producing layer for each host byte range.
+///
+/// Discovery orders same-range alternate languages by query-pattern priority.
+/// Formatting must preserve that first winner because dispatching every layer
+/// would concatenate overlapping edits for the identical host span.
+pub(super) fn unique_edit_regions(
+    regions: &[ResolvedInjection],
+) -> impl Iterator<Item = &ResolvedInjection> {
+    let mut seen = std::collections::HashSet::new();
+    regions.iter().filter(move |resolved| {
+        seen.insert((
+            resolved.region.byte_range.start,
+            resolved.region.byte_range.end,
+        ))
+    })
 }
 
 /// Collapse a formatted text into a single whole-document replacement edit
@@ -1842,6 +1860,41 @@ pub(super) async fn finalize_formatting_edits(
 mod tests {
     use super::*;
     use tower_lsp_server::ls_types::{Position, Range};
+
+    fn resolved_region(
+        language: &str,
+        byte_range: std::ops::Range<usize>,
+    ) -> crate::language::injection::ResolvedInjection {
+        crate::language::injection::ResolvedInjection {
+            region: crate::language::injection::CacheableInjectionRegion {
+                language: language.to_string(),
+                byte_range,
+                line_range: 0..1,
+                start_column: 0,
+                region_id: language.to_string(),
+                content_hash: 0,
+            },
+            injection_language: language.to_string(),
+            virtual_content: String::new(),
+            line_column_offsets: vec![0],
+            contiguous: true,
+        }
+    }
+
+    #[test]
+    fn edit_regions_keep_first_language_for_identical_host_range() {
+        let regions = vec![
+            resolved_region("first", 10..20),
+            resolved_region("second", 10..20),
+            resolved_region("third", 30..40),
+        ];
+
+        let selected: Vec<_> = unique_edit_regions(&regions)
+            .map(|region| region.injection_language.as_str())
+            .collect();
+
+        assert_eq!(selected, ["first", "third"]);
+    }
 
     fn edit(start_line: u32, start_char: u32, new_text: &str) -> TextEdit {
         TextEdit {

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -1,10 +1,10 @@
 //! `textDocument/formatting` handler and helpers shared with
 //! `textDocument/rangeFormatting`.
 //!
-//! `textDocument/formatting` resolves every injection region in the document
-//! and asks the configured downstream language servers to format each one.
-//! Across regions the resulting [`TextEdit`] lists are concatenated, since each
-//! region edits a disjoint span of the host document.
+//! `textDocument/formatting` resolves bridge virtual documents in the host and
+//! asks the configured downstream language servers to format each safe,
+//! contiguous one. Their [`TextEdit`] lists are concatenated because the
+//! remaining documents edit disjoint host spans.
 //!
 //! Within a region, the aggregation strategy decides how multiple servers
 //! combine:
@@ -237,9 +237,9 @@ impl Kakehashi {
         Ok(result)
     }
 
-    /// Format every injection region (the **virt** layer): resolve regions
-    /// from the parsed snapshot, format each one per its aggregation config,
-    /// and concatenate the per-region edits (disjoint spans).
+    /// Format every safe bridge virtual document (the **virt** layer): resolve
+    /// from the parsed snapshot, skip non-contiguous groups, format each
+    /// remaining document, and concatenate its disjoint edits.
     #[allow(clippy::too_many_arguments)]
     async fn virt_format_edits(
         &self,

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -303,9 +303,9 @@ impl Kakehashi {
         let mut cp_minted: Vec<NumberOrString> = Vec::new();
 
         for resolved in unique_edit_regions(&all_regions) {
-            // Combined injections mask host-only gaps with whitespace. A formatter
-            // returns a contiguous whole-document replacement, which would replace
-            // those real host gaps as well and corrupt the document.
+            // Non-contiguous combined injections contain masked host-only gaps.
+            // A formatter returns a contiguous whole-document replacement, which
+            // would replace those real host gaps as well and corrupt the document.
             if !resolved.contiguous {
                 continue;
             }

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -39,6 +39,7 @@ use crate::config::settings::AggregationStrategy;
 use crate::config::settings::{LayerSource, PRIORITIES_WILDCARD};
 use crate::error::LockResultExt;
 use crate::language::InjectionResolver;
+#[cfg(test)]
 use crate::language::injection::ResolvedInjection;
 use crate::lsp::aggregation::region::collect_region_results_with_cancel;
 use crate::lsp::aggregation::server::FanInResult;
@@ -302,7 +303,8 @@ impl Kakehashi {
         });
         let mut cp_minted: Vec<NumberOrString> = Vec::new();
 
-        for resolved in unique_edit_regions(&all_regions) {
+        let mut seen_edit_ranges = std::collections::HashSet::new();
+        for resolved in all_regions.iter() {
             // Non-contiguous combined injections contain masked host-only gaps.
             // A formatter returns a contiguous whole-document replacement, which
             // would replace those real host gaps as well and corrupt the document.
@@ -314,7 +316,6 @@ impl Kakehashi {
             if configs.is_empty() {
                 continue;
             }
-
             let agg = self.resolve_aggregation_config(
                 language_name,
                 &resolved.injection_language,
@@ -414,6 +415,12 @@ impl Kakehashi {
                     continue;
                 }
             };
+            if !seen_edit_ranges.insert((
+                resolved.region.byte_range.start,
+                resolved.region.byte_range.end,
+            )) {
+                continue;
+            }
 
             // Mint this region's tracked-source token into the shared
             // aggregator ONLY for the preferred branch. Concatenated regions
@@ -574,6 +581,7 @@ impl Kakehashi {
 /// Discovery orders same-range alternate languages by query-pattern priority.
 /// Formatting must preserve that first winner because dispatching every layer
 /// would concatenate overlapping edits for the identical host span.
+#[cfg(test)]
 pub(super) fn unique_edit_regions(
     regions: &[ResolvedInjection],
 ) -> impl Iterator<Item = &ResolvedInjection> {
@@ -620,7 +628,7 @@ fn whole_document_replacement(original: &str, formatted: &str) -> Option<Vec<Tex
 /// How a single injection region should be formatted, derived from its resolved
 /// aggregation config. Extracted so the gating rule lives in one testable place.
 #[derive(Debug, PartialEq, Eq)]
-enum RegionFormatPlan {
+pub(super) enum RegionFormatPlan {
     /// Run the sequential concatenated pipeline over these effective servers
     /// (explicit `priorities` names filtered to configured servers, deduped,
     /// order preserved — the `"*"` wildcard is excluded, see
@@ -663,7 +671,7 @@ enum RegionFormatPlan {
 ///   allowlist forbids running the non-listed servers `preferred` would pick.
 ///   A `"*"` mixed into the list is ignored (no deterministic expansion order
 ///   for a sequential pipeline); the caller warns.
-fn plan_region_format(
+pub(super) fn plan_region_format(
     strategy: AggregationStrategy,
     priorities: &[String],
     configs: &[ResolvedServerConfig],

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -302,6 +302,12 @@ impl Kakehashi {
         let mut cp_minted: Vec<NumberOrString> = Vec::new();
 
         for resolved in all_regions.iter() {
+            // Combined injections mask host-only gaps with whitespace. A formatter
+            // returns a contiguous whole-document replacement, which would replace
+            // those real host gaps as well and corrupt the document.
+            if !resolved.contiguous {
+                continue;
+            }
             let configs = self
                 .bridge_configs_for_injection_language(language_name, &resolved.injection_language);
             if configs.is_empty() {

--- a/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
@@ -207,6 +207,7 @@ mod tests {
                     region_id: "r0".to_string(),
                     content_hash: 0,
                 },
+                raw_injection_language: "python".to_string(),
                 injection_language: "python".to_string(),
                 virtual_content: String::new(),
                 line_column_offsets: vec![],

--- a/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
@@ -211,6 +211,7 @@ mod tests {
                 injection_language: "python".to_string(),
                 virtual_content: String::new(),
                 line_column_offsets: vec![],
+                contiguous: true,
             },
             configs: vec![ResolvedServerConfig {
                 server_name: server.to_string(),

--- a/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/publish_diagnostic.rs
@@ -207,7 +207,6 @@ mod tests {
                     region_id: "r0".to_string(),
                     content_hash: 0,
                 },
-                raw_injection_language: "python".to_string(),
                 injection_language: "python".to_string(),
                 virtual_content: String::new(),
                 line_column_offsets: vec![],

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -235,23 +235,8 @@ impl Kakehashi {
                     &resolved.injection_language,
                     "textDocument/formatting",
                 );
-                let region_ctx = DocumentRequestContext {
-                    uri: uri.clone(),
-                    resolved: resolved.clone(),
-                    configs,
-                    upstream_request_id: upstream_request_id.clone(),
-                    priorities: agg.priorities,
-                    strategy: agg.strategy,
-                    max_fan_out: agg.max_fan_out,
-                    client_progress_token: None,
-                };
                 if matches!(
-                    plan_region_format(
-                        region_ctx.strategy,
-                        &region_ctx.priorities,
-                        &region_ctx.configs,
-                        region_ctx.max_fan_out,
-                    ),
+                    plan_region_format(agg.strategy, &agg.priorities, &configs, agg.max_fan_out,),
                     RegionFormatPlan::Skip | RegionFormatPlan::Disabled
                 ) {
                     continue;
@@ -262,7 +247,16 @@ impl Kakehashi {
                 )) {
                     continue;
                 }
-
+                let region_ctx = DocumentRequestContext {
+                    uri: uri.clone(),
+                    resolved: resolved.clone(),
+                    configs,
+                    upstream_request_id: upstream_request_id.clone(),
+                    priorities: agg.priorities,
+                    strategy: agg.strategy,
+                    max_fan_out: agg.max_fan_out,
+                    client_progress_token: None,
+                };
                 // Mint this region's tracked-source token into the shared
                 // aggregator (the per-region map dispatch hands to its winning
                 // downstream).

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -178,9 +178,9 @@ impl Kakehashi {
             let mut cp_minted: Vec<NumberOrString> = Vec::new();
 
             for resolved in unique_edit_regions(&all_regions) {
-                // Combined injections are non-contiguous in the host. Even a
-                // covering range may fall back to full formatting, whose single
-                // replacement would overwrite the masked host-only gaps.
+                // Non-contiguous combined injections contain masked host-only
+                // gaps. Even a covering range may fall back to full formatting,
+                // whose single replacement would overwrite those real gaps.
                 if !resolved.contiguous {
                     continue;
                 }

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -178,6 +178,12 @@ impl Kakehashi {
             let mut cp_minted: Vec<NumberOrString> = Vec::new();
 
             for resolved in all_regions.iter() {
+                // Combined injections are non-contiguous in the host. Even a
+                // covering range may fall back to full formatting, whose single
+                // replacement would overwrite the masked host-only gaps.
+                if !resolved.contiguous {
+                    continue;
+                }
                 // A covering request (its byte span encloses the whole region)
                 // prefers full formatting; a partial request range-formats the
                 // clipped span. Either way we compute the clipped+content-clamped

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -235,11 +235,30 @@ impl Kakehashi {
                     &resolved.injection_language,
                     "textDocument/formatting",
                 );
-                if matches!(
-                    plan_region_format(agg.strategy, &agg.priorities, &configs, agg.max_fan_out,),
-                    RegionFormatPlan::Skip | RegionFormatPlan::Disabled
-                ) {
-                    continue;
+                match plan_region_format(agg.strategy, &agg.priorities, &configs, agg.max_fan_out) {
+                    RegionFormatPlan::Skip => {
+                        log::warn!(
+                            target: "kakehashi::formatting",
+                            "concatenated formatting for {}->{} lists only unconfigured \
+                             server(s) {:?}; none are configured for this region, so it \
+                             is left unformatted (priorities is an allowlist — \
+                             non-listed servers are not run)",
+                            language_name,
+                            resolved.injection_language,
+                            agg.priorities,
+                        );
+                        continue;
+                    }
+                    RegionFormatPlan::Disabled => {
+                        log::debug!(
+                            target: "kakehashi::formatting",
+                            "formatting disabled for {}->{} (priorities = [])",
+                            language_name,
+                            resolved.injection_language,
+                        );
+                        continue;
+                    }
+                    RegionFormatPlan::Concatenated(_) | RegionFormatPlan::Preferred => {}
                 }
                 // Preserve discovery priority among executable same-range
                 // alternatives. Unconfigured/disabled layers deliberately do

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -36,7 +36,7 @@ use crate::lsp::lsp_impl::bridge_context::{DocumentRequestContext, parse_host_ve
 use crate::text::PositionMapper;
 
 use super::super::{Kakehashi, uri_to_url};
-use super::formatting::{finalize_formatting_edits, unique_edit_regions};
+use super::formatting::{RegionFormatPlan, finalize_formatting_edits, plan_region_format};
 
 impl Kakehashi {
     pub(crate) async fn range_formatting_impl(
@@ -177,7 +177,8 @@ impl Kakehashi {
             });
             let mut cp_minted: Vec<NumberOrString> = Vec::new();
 
-            for resolved in unique_edit_regions(&all_regions) {
+            let mut seen_edit_ranges = std::collections::HashSet::new();
+            for resolved in all_regions.iter() {
                 // Non-contiguous combined injections contain masked host-only
                 // gaps. Even a covering range may fall back to full formatting,
                 // whose single replacement would overwrite those real gaps.
@@ -220,7 +221,6 @@ impl Kakehashi {
                 if configs.is_empty() {
                     continue;
                 }
-
                 // Resolve aggregation under "textDocument/formatting", not
                 // "textDocument/rangeFormatting". Range formatting is the
                 // partial-document counterpart of full formatting and shares its
@@ -245,6 +245,23 @@ impl Kakehashi {
                     max_fan_out: agg.max_fan_out,
                     client_progress_token: None,
                 };
+                if matches!(
+                    plan_region_format(
+                        region_ctx.strategy,
+                        &region_ctx.priorities,
+                        &region_ctx.configs,
+                        region_ctx.max_fan_out,
+                    ),
+                    RegionFormatPlan::Skip | RegionFormatPlan::Disabled
+                ) {
+                    continue;
+                }
+                if !seen_edit_ranges.insert((
+                    resolved.region.byte_range.start,
+                    resolved.region.byte_range.end,
+                )) {
+                    continue;
+                }
 
                 // Mint this region's tracked-source token into the shared
                 // aggregator (the per-region map dispatch hands to its winning

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -36,7 +36,7 @@ use crate::lsp::lsp_impl::bridge_context::{DocumentRequestContext, parse_host_ve
 use crate::text::PositionMapper;
 
 use super::super::{Kakehashi, uri_to_url};
-use super::formatting::finalize_formatting_edits;
+use super::formatting::{finalize_formatting_edits, unique_edit_regions};
 
 impl Kakehashi {
     pub(crate) async fn range_formatting_impl(
@@ -177,7 +177,7 @@ impl Kakehashi {
             });
             let mut cp_minted: Vec<NumberOrString> = Vec::new();
 
-            for resolved in all_regions.iter() {
+            for resolved in unique_edit_regions(&all_regions) {
                 // Combined injections are non-contiguous in the host. Even a
                 // covering range may fall back to full formatting, whose single
                 // replacement would overwrite the masked host-only gaps.

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -241,6 +241,10 @@ impl Kakehashi {
                 ) {
                     continue;
                 }
+                // Preserve discovery priority among executable same-range
+                // alternatives. Unconfigured/disabled layers deliberately do
+                // not reserve the span, allowing the first configured layer to
+                // format it while preventing overlapping edits from later ones.
                 if !seen_edit_ranges.insert((
                     resolved.region.byte_range.start,
                     resolved.region.byte_range.end,

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -1,9 +1,9 @@
 //! Shared fan-out for whole-document bridged requests.
 //!
 //! documentLink, foldingRange, and codeLens all follow the same shape: no
-//! position parameter, so the request fans out to *every* injection region,
-//! uses the preferred strategy within each region, and concatenates the
-//! per-region results. This module hosts that shape once; the per-method
+//! position parameter, so the request fans out to every resolved bridge
+//! virtual document, uses the preferred strategy within each document, and
+//! concatenates those results. This module hosts that shape once; the per-method
 //! handlers supply only the LSP method name and the downstream send call.
 //!
 //! The fan-out is the virt layer of the resolved layer order


### PR DESCRIPTION
## Summary

- honor `injection.combined` in interactive, whole-document, eager-open, and cached bridge discovery
- preserve same-range alternate language layers with deterministic query-pattern priority for single-result position APIs
- mask host-only gaps with coordinate-preserving whitespace and gate unsafe edit-producing operations on non-contiguous documents
- keep effective-offset patterns isolated, share linear grouping/cache work, and update the virtual-document architecture record

## Safety

Non-contiguous combined documents remain available to read-only bridge features. Formatting, editor-mutating responses, inbound `workspace/applyEdit`, and lazy code-action/completion resolve fail closed until per-span edit validation is available.

## Validation

- `make check`
- `cargo test --lib language::injection::discovery::tests` (28 passed)
- `cargo test --lib completion_resolve_requires_current_contiguous_geometry`
- `cargo test --lib` with parser fixtures (2779 passed, 2 ignored)
- local multi-perspective review converged
- continued and fresh independent Codex reviews converged

Closes #598

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `injection.combined` to resolve into a single virtual document, including host-gap masking and multi-language layering.
  * `completionItem/resolve` now includes a stable `region_id` to improve routing and freshness checks.
* **Bug Fixes**
  * Prevented edit-producing LSP requests from operating on non-contiguous combined regions, reducing the risk of incorrect host mutations.
  * Tightened alignment between cached and live virtual-document resolution.
* **Documentation**
  * Updated architecture guidance and clarified combined/non-isolated behavior and safety constraints.
* **Tests**
  * Expanded coverage for combined resolution, contiguity, and `region_id` round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->