### PR TITLE
fix(injection): honor helper capture predicates

### DIFF
--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -15,10 +15,10 @@ use super::ranges::{
 };
 use crate::language::LanguageCoordinator;
 use crate::language::node_tracker::NodeTracker;
-use crate::language::query_predicates::check_predicate;
+use crate::language::query_predicates::check_match_predicates;
 use crate::text::{ceil_char_boundary, clamped_slice, floor_char_boundary, fnv1a_hash};
 
-/// Iterates over `@injection.content` captures that pass general predicate filtering.
+/// Iterates over `@injection.content` captures from predicate-valid matches.
 ///
 /// Combines predicate evaluation (e.g., `#lua-match?`) and capture name checking
 /// into a single iterator, eliminating duplication between `collect_all_injections`
@@ -28,8 +28,9 @@ fn iter_valid_injection_content_captures<'a, 'b>(
     query: &'b Query,
     text: &'b str,
 ) -> impl Iterator<Item = QueryCapture<'a>> + 'b {
+    let predicates_match = check_match_predicates(query, match_, text);
     match_.captures.iter().copied().filter(move |capture| {
-        if !check_predicate(query, match_, capture, text) {
+        if !predicates_match {
             return false;
         }
         query
@@ -1428,6 +1429,32 @@ mod tests {
             content.starts_with(';'),
             "Injected content should start with ';', got: {:?}",
             content
+        );
+    }
+
+    #[test]
+    fn test_collect_all_injections_respects_predicate_on_helper_capture() {
+        let mut parser = create_rust_parser();
+        let text = "foo!(x)";
+        let tree = parse_rust_code(&mut parser, text);
+        let root = tree.root_node();
+
+        let query_str = r#"
+            ((macro_invocation
+                macro: (identifier) @_macro
+                (token_tree) @injection.content)
+              (#lua-match? @_macro "^html$")
+              (#set! injection.language "html"))
+        "#;
+        let language = tree_sitter_rust::LANGUAGE.into();
+        let query = Query::new(&language, query_str).expect("valid query");
+
+        let injections =
+            collect_all_injections(&root, text, Some(&query)).expect("injection collection");
+
+        assert!(
+            injections.is_empty(),
+            "a failed helper-capture predicate must reject the whole match"
         );
     }
 

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -18,21 +18,12 @@ use crate::language::node_tracker::NodeTracker;
 use crate::language::query_predicates::check_match_predicates;
 use crate::text::{ceil_char_boundary, clamped_slice, floor_char_boundary, fnv1a_hash};
 
-/// Iterates over `@injection.content` captures from predicate-valid matches.
-///
-/// Combines predicate evaluation (e.g., `#lua-match?`) and capture name checking
-/// into a single iterator, eliminating duplication between `collect_all_injections`
-/// and `extract_content_and_language`.
-fn iter_valid_injection_content_captures<'a, 'b>(
+/// Iterates over the `@injection.content` captures in a query match.
+fn iter_injection_content_captures<'a, 'b>(
     match_: &'b QueryMatch<'_, 'a>,
     query: &'b Query,
-    text: &'b str,
 ) -> impl Iterator<Item = QueryCapture<'a>> + 'b {
-    let predicates_match = check_match_predicates(query, match_, text);
-    match_.captures.iter().copied().filter(move |capture| {
-        if !predicates_match {
-            return false;
-        }
+    match_.captures.iter().copied().filter(|capture| {
         query
             .capture_names()
             .get(capture.index as usize)
@@ -286,7 +277,10 @@ pub(crate) fn collect_all_injections<'a>(
     let mut injections_map = std::collections::HashMap::new();
 
     while let Some(match_) = matches.next() {
-        for capture in iter_valid_injection_content_captures(match_, query, text) {
+        if !check_match_predicates(query, match_, text) {
+            continue;
+        }
+        for capture in iter_injection_content_captures(match_, query) {
             if capture.node.start_byte() >= capture.node.end_byte() {
                 continue;
             }
@@ -414,11 +408,14 @@ fn extract_content_and_language<'a>(
     query: &Query,
     text: &str,
 ) -> Option<(Node<'a>, String, usize)> {
-    for capture in iter_valid_injection_content_captures(match_, query, text) {
+    for capture in iter_injection_content_captures(match_, query) {
         let content_node = capture.node;
 
         // Check if our node is within this injection region
         if is_node_within(node, &content_node) {
+            if !check_match_predicates(query, match_, text) {
+                return None;
+            }
             // Extract the injection language
             if let Some(language) = extract_injection_language(query, match_, text) {
                 return Some((content_node, language, match_.pattern_index));
@@ -1455,6 +1452,32 @@ mod tests {
         assert!(
             injections.is_empty(),
             "a failed helper-capture predicate must reject the whole match"
+        );
+    }
+
+    #[test]
+    fn test_detect_injection_respects_predicate_on_helper_capture() {
+        let mut parser = create_rust_parser();
+        let text = "foo!(x)";
+        let tree = parse_rust_code(&mut parser, text);
+        let root = tree.root_node();
+        let node = find_node_at_byte(&root, 5).expect("node inside macro token tree");
+
+        let query_str = r#"
+            ((macro_invocation
+                macro: (identifier) @_macro
+                (token_tree) @injection.content)
+              (#lua-match? @_macro "^html$")
+              (#set! injection.language "html"))
+        "#;
+        let language = tree_sitter_rust::LANGUAGE.into();
+        let query = Query::new(&language, query_str).expect("valid query");
+
+        let injection = detect_injection(&node, &root, text, Some(&query), "rust");
+
+        assert!(
+            injection.is_none(),
+            "a failed helper-capture predicate must reject point detection"
         );
     }
 


### PR DESCRIPTION
## Summary
- gate injection discovery with Neovim-compatible whole-match predicate evaluation so guards on helper captures are enforced
- preserve point-detection performance by evaluating predicates only after finding a containing injection content capture
- cover both whole-document collection and point detection with the `foo!(x)` helper-capture regression

## Verification
- `cargo test --lib test_collect_all_injections_respects`
- `cargo test --lib test_detect_injection_respects_predicate_on_helper_capture`
- `cargo test --lib language::injection::discovery::tests`
- `make check`

Closes #597.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected evaluation of injection match predicates, ensuring conditions that depend on helper/capture identifiers are handled correctly.
  * When predicates fail, invalid matches are consistently rejected for both whole-document injection collection and per-position injection detection.
* **Tests**
  * Added regression coverage for helper-capture–based predicate failures, confirming rejection behavior across both collection and point detection paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->