### PR TITLE
test(captures): pin didClose walk-memo liveness

### DIFF
--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -2287,6 +2287,111 @@ mod tests {
         );
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn closed_captures_loser_does_not_revive_walk_memo() {
+        let (service, _socket) = tower_lsp_server::LspService::new(Kakehashi::new);
+        let service = std::sync::Arc::new(service);
+        let uri = Url::parse("file:///captures_closed_loser.rs").unwrap();
+        let text = "fn main() {}";
+        service.inner().documents.insert(
+            uri.clone(),
+            text.to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        let incarnation = service
+            .inner()
+            .documents
+            .latest_snapshot(&uri)
+            .unwrap()
+            .slot
+            .current_incarnation;
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let tree = parser.parse(text, None).unwrap();
+        assert!(
+            service
+                .inner()
+                .documents
+                .get(&uri)
+                .unwrap()
+                .publish_snapshot(std::sync::Arc::new(
+                    crate::document::snapshot::ParseSnapshot {
+                        text: std::sync::Arc::from(text),
+                        tree: Some(tree),
+                        language: Some("rust".to_string()),
+                        parsed_version: 0,
+                        incarnation,
+                        injection_regions: None,
+                        bridge_regions: None,
+                        resolved_regions: None,
+                        layer_trees: std::sync::OnceLock::new(),
+                    },
+                ))
+        );
+
+        let generation = service.inner().cache.semantic_token_generation();
+        let key = (uri.clone(), "highlights".to_string(), false);
+        service.inner().captures_walk_inflight.insert(
+            key.clone(),
+            std::sync::Arc::new(CapturesWalkFlight::new(
+                CapturesWalkTag {
+                    incarnation,
+                    generation,
+                    parsed_version: 0,
+                },
+                crate::cancel::CancelToken::default(),
+            )),
+        );
+
+        let request = {
+            let service = std::sync::Arc::clone(&service);
+            let uri = uri.clone();
+            tokio::spawn(async move {
+                service
+                    .inner()
+                    .kakehashi_captures_full(CapturesFullParams {
+                        text_document: TextDocumentIdentifier {
+                            uri: crate::lsp::lsp_impl::url_to_uri(&uri).unwrap(),
+                        },
+                        kind: "highlights".to_string(),
+                        injection: false,
+                    })
+                    .await
+            })
+        };
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(!request.is_finished(), "the loser must park on the flight");
+
+        // Exercise didClose's lock-ordered captures teardown without its
+        // unrelated bridge/server shutdown work. Before c38af9a3f, the woken
+        // loser could reclaim the vacant flight and store its old snapshot
+        // after this retain/remove sequence.
+        {
+            let edit_lock = service.inner().documents.edit_lock(&uri);
+            let _edit_guard = edit_lock.lock().await;
+            service
+                .inner()
+                .captures_walk_cache
+                .retain(|cache_key, _| cache_key.0 != uri);
+            service.inner().cancel_captures_walks_for_document(&uri);
+            service.inner().documents.remove(&uri);
+        }
+
+        let result = request
+            .await
+            .unwrap()
+            .expect("a close-raced captures request returns protocol null");
+        assert!(result.is_none());
+        assert!(service.inner().documents.latest_snapshot(&uri).is_none());
+        assert!(
+            service.inner().captures_walk_cache.get(&key).is_none(),
+            "a loser woken by didClose must not resurrect the cleared walk memo"
+        );
+    }
+
     #[tokio::test]
     async fn captures_lineage_rejects_pre_reload_generation() {
         let (service, _socket) = tower_lsp_server::LspService::new(Kakehashi::new);

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -2365,20 +2365,10 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         assert!(!request.is_finished(), "the loser must park on the flight");
 
-        // Exercise didClose's lock-ordered captures teardown without its
-        // unrelated bridge/server shutdown work. Before c38af9a3f, the woken
-        // loser could reclaim the vacant flight and store its old snapshot
-        // after this retain/remove sequence.
-        {
-            let edit_lock = service.inner().documents.edit_lock(&uri);
-            let _edit_guard = edit_lock.lock().await;
-            service
-                .inner()
-                .captures_walk_cache
-                .retain(|cache_key, _| cache_key.0 != uri);
-            service.inner().cancel_captures_walks_for_document(&uri);
-            service.inner().documents.remove(&uri);
-        }
+        // Exercise didClose's lock-ordered teardown without its unrelated
+        // bridge/server shutdown work. Before c38af9a3f, the woken loser could
+        // reclaim the vacant flight and store its old snapshot after this.
+        service.inner().clear_document_state_on_close(&uri).await;
 
         let result = request
             .await

--- a/src/lsp/lsp_impl/text_document/did_close.rs
+++ b/src/lsp/lsp_impl/text_document/did_close.rs
@@ -5,6 +5,23 @@ use tower_lsp_server::ls_types::DidCloseTextDocumentParams;
 use super::super::{Kakehashi, uri_to_url};
 
 impl Kakehashi {
+    pub(in crate::lsp::lsp_impl) async fn clear_document_state_on_close(&self, uri: &url::Url) {
+        let edit_lock = self.documents.edit_lock(uri);
+        let _edit_guard = edit_lock.lock().await;
+        // Captures lineage and walk memos are installed under this same lock,
+        // so a store that won first is cleared while one arriving later sees
+        // the document gone and refuses to install obsolete state.
+        self.captures_cache.retain(|key, _| key.0 != *uri);
+        self.captures_walk_cache.retain(|key, _| key.0 != *uri);
+        self.cancel_captures_walks_for_document(uri);
+        self.documents.remove(uri);
+        self.cache.remove_document(uri);
+        // The match cache uses insert-then-verify. Clearing after document
+        // removal ensures a straggler either inserted before this clear or
+        // observes the closed document and self-removes.
+        self.captures_match_cache.clear_document(uri);
+    }
+
     pub(crate) async fn did_close_impl(&self, params: DidCloseTextDocumentParams) {
         let lsp_uri = params.text_document.uri;
 
@@ -23,35 +40,7 @@ impl Kakehashi {
         // still holds the old `Arc`, so a later edit would create a *fresh* lock
         // and stop serializing with the in-flight one. The guard is dropped right
         // after the removal — the remaining cleanups touch other subsystems.
-        {
-            let edit_lock = self.documents.edit_lock(&uri);
-            let _edit_guard = edit_lock.lock().await;
-            // Drop stored captures lineage BEFORE the removal and INSIDE the
-            // edit-lock section (captures-protocol): `store_lineage` inserts
-            // under this same lock, so clearing here cannot wipe a lineage a
-            // fast reopen's `full` stored after this close completed — that
-            // insert can only start once this section is over, against the
-            // reopened document's fresh open generation. (A didOpen landing
-            // *inside* this section is a wider lifecycle race; for captures it
-            // degrades to the self-healing "delta answers null → client calls
-            // full again", never to stale data.)
-            self.captures_cache.retain(|key, _| key.0 != uri);
-            self.captures_walk_cache.retain(|key, _| key.0 != uri);
-            self.cancel_captures_walks_for_document(&uri);
-            self.documents.remove(&uri);
-            // Semantic token handlers serialize their final currency check and
-            // cache insert with this lock. A store that won first is cleared;
-            // one that arrives later observes the document gone and refuses.
-            self.cache.remove_document(&uri);
-            // AFTER the document removal, deliberately: the match cache's
-            // store paths use an insert-then-verify handshake against this
-            // ordering — a straggler walk whose post-insert liveness probe
-            // saw the document open is guaranteed to have inserted before
-            // this clear runs, so the clear reclaims it; one that probes
-            // after the removal self-removes. Clearing BEFORE the removal
-            // would reopen the resurrection leak (codex review).
-            self.captures_match_cache.clear_document(&uri);
-        }
+        self.clear_document_state_on_close(&uri).await;
 
         // Clean up region ID mappings for this document
         // (lazy-node-identity-tracking). This runs AFTER the removal above

--- a/src/lsp/lsp_impl/text_document/did_close.rs
+++ b/src/lsp/lsp_impl/text_document/did_close.rs
@@ -38,8 +38,10 @@ impl Kakehashi {
         // document's edit lock first (the same lock `did_change` holds across its
         // reparse). Without it, `remove` could drop the lock entry while an edit
         // still holds the old `Arc`, so a later edit would create a *fresh* lock
-        // and stop serializing with the in-flight one. The guard is dropped right
-        // after the removal — the remaining cleanups touch other subsystems.
+        // and stop serializing with the in-flight one. The guard is held
+        // across the whole in-helper teardown (captures/walk cache clears,
+        // walk cancellation, document + cache removal); only the cleanups
+        // BELOW this call run outside the edit-lock section.
         self.clear_document_state_on_close(&uri).await;
 
         // Clean up region ID mappings for this document


### PR DESCRIPTION
## Summary

- add deterministic coverage for a captures loser woken by `didClose`
- route the handler and regression through one lock-ordered close-state helper so the test exercises production ordering
- verify the loser returns protocol null and cannot resurrect the cleared walk memo

## Context

The production bug reported in #565 is already fixed on `main` by c38af9a3f, which added the stronger edit-lock-serialized currency check and memo installation handshake. This PR does not add another production liveness mechanism; it closes the missing deterministic, close-specific regression coverage for that already-landed fix.

## Validation

- `cargo test --lib captures_loser_does_not_revive -- --nocapture`
- `make check`

Closes #565

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document close handling to more reliably clean up capture and related cache state while the document is locked for edits.
  * Prevented close/vs-in-flight capture activity from “reviving” stale single-flight or walk cache entries after a document is removed.

* **Tests**
  * Added a regression test covering a close vs captures race, verifying the close completes cleanly, the latest document snapshot is deleted, and no walk/capture cache entries are recreated afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->