### PR TITLE
fix(auto-install): dedupe metadata lookups

### DIFF
--- a/src/install/support_check.rs
+++ b/src/install/support_check.rs
@@ -52,10 +52,9 @@ const METADATA_CHECK_TIMEOUT: Duration = Duration::from_secs(65);
 
 /// Support-check result plus work that outlived the timeout.
 ///
-/// `completion` is present only when an already-started blocking metadata
-/// lookup could not be cancelled. Auto-install keeps its per-language claim
-/// until this handle finishes, preventing a timed-out lookup from overlapping
-/// a retry.
+/// `completion` is present when the check times out. It finishes after the
+/// blocking task is cancelled before starting or, if already running, after
+/// the lookup exits. Auto-install retains its per-language claim until then.
 pub(crate) struct TrackedSupportCheck {
     pub(crate) should_skip: bool,
     pub(crate) reason: Option<SkipReason>,

--- a/src/install/support_check.rs
+++ b/src/install/support_check.rs
@@ -309,26 +309,30 @@ return {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn timed_out_blocking_check_exposes_its_completion() {
-        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
         let (release_tx, release_rx) = std::sync::mpsc::channel();
 
-        let mut result = should_skip_unsupported_language_with_checker_tracked(
-            "lua",
-            None,
-            Duration::from_millis(20),
-            move |_lang, _options| {
-                let _ = started_tx.send(());
-                let _ = release_rx.recv();
-                Ok(true)
-            },
-        )
-        .await;
+        let check = tokio::spawn(async move {
+            should_skip_unsupported_language_with_checker_tracked(
+                "lua",
+                None,
+                Duration::from_millis(20),
+                move |_lang, _options| {
+                    let _ = started_tx.send(());
+                    let _ = release_rx.recv();
+                    Ok(true)
+                },
+            )
+            .await
+        });
 
         started_rx
-            .recv_timeout(Duration::from_secs(1))
+            .await
             .expect("blocking checker must start before timing out");
+        tokio::time::advance(Duration::from_millis(20)).await;
+        let mut result = check.await.expect("support check task must finish");
         let completion = result
             .completion
             .take()

--- a/src/install/support_check.rs
+++ b/src/install/support_check.rs
@@ -170,7 +170,20 @@ where
             // completion waiter to callers that must retain an in-flight claim.
             check.abort();
             let completion = tokio::spawn(async move {
-                let _ = check.await;
+                if let Err(join_error) = check.await {
+                    if join_error.is_panic() {
+                        log::error!(
+                            target: "kakehashi::auto_install",
+                            "Timed-out metadata support check panicked: {}",
+                            join_error
+                        );
+                    } else {
+                        log::debug!(
+                            target: "kakehashi::auto_install",
+                            "Timed-out metadata support check was cancelled before starting"
+                        );
+                    }
+                }
             });
             TrackedSupportCheck {
                 should_skip: true,

--- a/src/install/support_check.rs
+++ b/src/install/support_check.rs
@@ -180,7 +180,7 @@ where
                     } else {
                         log::debug!(
                             target: "kakehashi::auto_install",
-                            "Timed-out metadata support check was cancelled before starting"
+                            "Timed-out metadata support-check handle was cancelled"
                         );
                     }
                 }

--- a/src/install/support_check.rs
+++ b/src/install/support_check.rs
@@ -50,16 +50,34 @@ impl SkipReason {
 // Default timeout for metadata support checks; keeps the LSP path responsive
 const METADATA_CHECK_TIMEOUT: Duration = Duration::from_secs(65);
 
-/// Check if a language should be skipped during auto-install because it's not supported.
+/// Support-check result plus work that outlived the timeout.
 ///
-/// Skips (returns `should_skip = true`) when the language is unsupported by
-/// nvim-treesitter or when metadata can't be fetched within the timeout. Uses
-/// cached metadata to avoid repeated HTTP requests.
-pub async fn should_skip_unsupported_language(
+/// `completion` is present only when an already-started blocking metadata
+/// lookup could not be cancelled. Auto-install keeps its per-language claim
+/// until this handle finishes, preventing a timed-out lookup from overlapping
+/// a retry.
+pub(crate) struct TrackedSupportCheck {
+    pub(crate) should_skip: bool,
+    pub(crate) reason: Option<SkipReason>,
+    pub(crate) completion: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl TrackedSupportCheck {
+    pub(crate) fn completed(should_skip: bool, reason: Option<SkipReason>) -> Self {
+        Self {
+            should_skip,
+            reason,
+            completion: None,
+        }
+    }
+}
+
+/// Check support while retaining completion for blocking work that times out.
+pub(crate) async fn should_skip_unsupported_language_tracked(
     language: &str,
     options: Option<&FetchOptions<'_>>,
-) -> (bool, Option<SkipReason>) {
-    should_skip_unsupported_language_with_checker(
+) -> TrackedSupportCheck {
+    should_skip_unsupported_language_with_checker_tracked(
         language,
         options,
         METADATA_CHECK_TIMEOUT,
@@ -100,12 +118,12 @@ fn default_support_check(
     is_language_supported(&language, options.as_ref())
 }
 
-async fn should_skip_unsupported_language_with_checker<F>(
+async fn should_skip_unsupported_language_with_checker_tracked<F>(
     language: &str,
     options: Option<&FetchOptions<'_>>,
     timeout: Duration,
     check_fn: F,
-) -> (bool, Option<SkipReason>)
+) -> TrackedSupportCheck
 where
     F: FnOnce(String, Option<FetchOptionsOwned>) -> Result<bool, MetadataError> + Send + 'static,
 {
@@ -121,21 +139,21 @@ where
     tokio::select! {
         result = &mut check => {
             match result {
-                Ok(Ok(true)) => (false, None),
-                Ok(Ok(false)) => (
+                Ok(Ok(true)) => TrackedSupportCheck::completed(false, None),
+                Ok(Ok(false)) => TrackedSupportCheck::completed(
                     true,
                     Some(SkipReason::UnsupportedLanguage {
                         language: owned_language,
                     }),
                 ),
-                Ok(Err(error)) => (
+                Ok(Err(error)) => TrackedSupportCheck::completed(
                     true,
                     Some(SkipReason::MetadataUnavailable {
                         language: owned_language,
                         error,
                     }),
                 ),
-                Err(err) => (
+                Err(err) => TrackedSupportCheck::completed(
                     true,
                     Some(SkipReason::MetadataUnavailable {
                         language: owned_language,
@@ -148,16 +166,21 @@ where
             }
         }
         _ = &mut timeout_fut => {
-            // The task is still running; abort to avoid leaking blocking work
-            // and report the timeout to the caller.
+            // Abort prevents a queued blocking task from starting. Once a
+            // blocking closure has started Tokio cannot stop it, so expose a
+            // completion waiter to callers that must retain an in-flight claim.
             check.abort();
-            (
-                true,
-                Some(SkipReason::MetadataUnavailable {
+            let completion = tokio::spawn(async move {
+                let _ = check.await;
+            });
+            TrackedSupportCheck {
+                should_skip: true,
+                reason: Some(SkipReason::MetadataUnavailable {
                     language: owned_language,
                     error: MetadataError::Timeout,
                 }),
-            )
+                completion: Some(completion),
+            }
         }
     }
 }
@@ -191,13 +214,13 @@ return {
             use_cache: true,
         };
 
-        let (should_skip, reason) =
-            should_skip_unsupported_language("fake_lang_xyz", Some(&options)).await;
+        let result =
+            should_skip_unsupported_language_tracked("fake_lang_xyz", Some(&options)).await;
         assert!(
-            should_skip,
+            result.should_skip,
             "Expected to skip unsupported language 'fake_lang_xyz'"
         );
-        let reason = reason.expect("Expected a reason for skipping");
+        let reason = result.reason.expect("Expected a reason for skipping");
         assert!(
             matches!(reason, SkipReason::UnsupportedLanguage { language } if language == "fake_lang_xyz"),
             "Expected UnsupportedLanguage reason"
@@ -229,12 +252,15 @@ return {
             use_cache: true,
         };
 
-        let (should_skip, reason) = should_skip_unsupported_language("lua", Some(&options)).await;
+        let result = should_skip_unsupported_language_tracked("lua", Some(&options)).await;
         assert!(
-            !should_skip,
+            !result.should_skip,
             "Expected NOT to skip supported language 'lua'"
         );
-        assert!(reason.is_none(), "Expected no reason when not skipping");
+        assert!(
+            result.reason.is_none(),
+            "Expected no reason when not skipping"
+        );
     }
 
     #[tokio::test]
@@ -250,20 +276,20 @@ return {
             use_cache: true,
         };
 
-        let (should_skip, reason) = should_skip_unsupported_language("lua", Some(&options)).await;
+        let result = should_skip_unsupported_language_tracked("lua", Some(&options)).await;
         assert!(
-            should_skip,
+            result.should_skip,
             "Metadata errors should prevent auto-install attempts"
         );
         assert!(
-            matches!(reason, Some(SkipReason::MetadataUnavailable { .. })),
+            matches!(result.reason, Some(SkipReason::MetadataUnavailable { .. })),
             "Expected MetadataUnavailable reason"
         );
     }
 
     #[tokio::test]
     async fn test_should_skip_unsupported_language_times_out_and_skips() {
-        let (should_skip, reason) = should_skip_unsupported_language_with_checker(
+        let result = should_skip_unsupported_language_with_checker_tracked(
             "lua",
             None,
             Duration::from_millis(20),
@@ -274,11 +300,44 @@ return {
         )
         .await;
 
-        assert!(should_skip, "Timeouts should skip auto-install attempts");
         assert!(
-            matches!(reason, Some(SkipReason::MetadataUnavailable { language, .. }) if language == "lua"),
+            result.should_skip,
+            "Timeouts should skip auto-install attempts"
+        );
+        assert!(
+            matches!(result.reason, Some(SkipReason::MetadataUnavailable { language, .. }) if language == "lua"),
             "Timeouts should report metadata unavailable for the language"
         );
+    }
+
+    #[tokio::test]
+    async fn timed_out_blocking_check_exposes_its_completion() {
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+
+        let mut result = should_skip_unsupported_language_with_checker_tracked(
+            "lua",
+            None,
+            Duration::from_millis(20),
+            move |_lang, _options| {
+                let _ = started_tx.send(());
+                let _ = release_rx.recv();
+                Ok(true)
+            },
+        )
+        .await;
+
+        started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("blocking checker must start before timing out");
+        let completion = result
+            .completion
+            .take()
+            .expect("a timed-out blocking checker must expose completion");
+        assert!(!completion.is_finished());
+
+        let _ = release_tx.send(());
+        completion.await.expect("completion waiter must finish");
     }
 
     #[test]

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -124,9 +124,9 @@ impl std::fmt::Debug for AutoInstallManager {
 /// entry on drop. Manual `finish_install` calls would leak the marker if the
 /// calling future were dropped at an await, leaving the language stuck
 /// `AlreadyInstalling` (and, via `should_skip_parse`, never parsed) for the
-/// server's lifetime. For the install itself the guard moves into the
-/// spawned install task, so it tracks the blocking work's true lifetime
-/// rather than the caller's.
+/// server's lifetime. The guard first moves into the support-check task, then
+/// into the install task on success, so it tracks detached work's true
+/// lifetime rather than the caller's.
 struct InstallMarkerGuard {
     installing: InstallingLanguages,
     language: String,
@@ -295,8 +295,20 @@ impl AutoInstallManager {
         let lookup_language = language.to_string();
         let lookup_data_dir = default_data_dir.clone();
         let support_task = tokio::spawn(async move {
-            let result = support_check(lookup_language, lookup_data_dir).await;
-            (result, install_marker)
+            let mut result = support_check(lookup_language, lookup_data_dir).await;
+            if let Some(completion) = result.completion.take() {
+                // Start the keeper inside this detached task. If the caller
+                // dropped our JoinHandle while the check was running, task
+                // output would be discarded and could not safely carry the
+                // marker/completion pair back to it.
+                tokio::spawn(async move {
+                    let _marker = install_marker;
+                    let _ = completion.await;
+                });
+                (result, None)
+            } else {
+                (result, Some(install_marker))
+            }
         });
         let (support_result, install_marker) = match support_task.await {
             Ok(result) => result,
@@ -317,7 +329,7 @@ impl AutoInstallManager {
         let TrackedSupportCheck {
             should_skip,
             reason,
-            completion,
+            completion: _,
         } = support_result;
 
         if let Some(reason) = &reason {
@@ -328,17 +340,13 @@ impl AutoInstallManager {
         }
 
         if should_skip {
-            if let Some(completion) = completion {
-                tokio::spawn(async move {
-                    let _marker = install_marker;
-                    let _ = completion.await;
-                });
-            }
             return InstallResult {
                 outcome: InstallOutcome::Unsupported,
                 events,
             };
         }
+        let install_marker =
+            install_marker.expect("a completed supported lookup must return its install marker");
 
         // Progress begin
         events.push(InstallEvent::ProgressBegin);
@@ -683,6 +691,56 @@ mod tests {
         })
         .await
         .expect("the detached lookup task must release the claim after its support check finishes");
+    }
+
+    #[tokio::test]
+    async fn cancelled_caller_keeps_claim_after_lookup_timeout() {
+        let (manager, _temp) = create_test_manager();
+        let task_manager = manager.clone();
+        let (lookup_started_tx, lookup_started_rx) = tokio::sync::oneshot::channel();
+        let (timeout_tx, timeout_rx) = tokio::sync::oneshot::channel();
+        let (timed_out_tx, timed_out_rx) = tokio::sync::oneshot::channel();
+        let (work_release_tx, work_release_rx) = tokio::sync::oneshot::channel();
+
+        let caller = tokio::spawn(async move {
+            task_manager
+                .try_install_with_support_check("lua", |_, _| async move {
+                    let _ = lookup_started_tx.send(());
+                    let _ = timeout_rx.await;
+                    let completion = tokio::spawn(async move {
+                        let _ = work_release_rx.await;
+                    });
+                    let _ = timed_out_tx.send(());
+                    TrackedSupportCheck {
+                        should_skip: true,
+                        reason: None,
+                        completion: Some(completion),
+                    }
+                })
+                .await
+        });
+        lookup_started_rx.await.expect("support lookup must start");
+        caller.abort();
+        let _ = caller.await;
+
+        let _ = timeout_tx.send(());
+        timed_out_rx
+            .await
+            .expect("detached support lookup must report timeout");
+        tokio::task::yield_now().await;
+        assert!(
+            !manager.installing_languages.try_start_install("lua"),
+            "timeout completion must retain the claim after caller cancellation"
+        );
+
+        let _ = work_release_tx.send(());
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while !manager.installing_languages.try_start_install("lua") {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("claim keeper must release after timed-out blocking work finishes");
     }
 
     #[tokio::test]

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -275,7 +275,10 @@ impl AutoInstallManager {
         if !self.installing_languages.try_start_install(language) {
             events.push(InstallEvent::Log {
                 level: MessageType::INFO,
-                message: format!("Language '{}' is already being installed", language),
+                message: format!(
+                    "Language '{}' support is already being checked or installed",
+                    language
+                ),
             });
             return InstallResult {
                 outcome: InstallOutcome::AlreadyInstalling,
@@ -595,7 +598,8 @@ mod tests {
         assert_eq!(lookup_count.load(Ordering::SeqCst), 1);
         assert!(result.events.iter().any(|e| matches!(
             e,
-            InstallEvent::Log { level: MessageType::INFO, message } if message.contains("already being installed")
+            InstallEvent::Log { level: MessageType::INFO, message }
+                if message.contains("already being checked or installed")
         )));
 
         let _ = release_tx.send(());

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -266,6 +266,24 @@ impl AutoInstallManager {
             };
         }
 
+        // Claim before the network-backed support lookup so concurrent calls
+        // for the same language do not all fetch metadata. The RAII guard
+        // releases the claim on every lookup/error early return.
+        if !self.installing_languages.try_start_install(language) {
+            events.push(InstallEvent::Log {
+                level: MessageType::INFO,
+                message: format!("Language '{}' is already being installed", language),
+            });
+            return InstallResult {
+                outcome: InstallOutcome::AlreadyInstalling,
+                events,
+            };
+        }
+        let install_marker = InstallMarkerGuard {
+            installing: self.installing_languages.clone(),
+            language: language.to_string(),
+        };
+
         // Check if language is supported by nvim-treesitter
         let default_data_dir = crate::install::default_data_dir();
         let (should_skip, reason) =
@@ -284,22 +302,6 @@ impl AutoInstallManager {
                 events,
             };
         }
-
-        // Try to start installation (deduplication)
-        if !self.installing_languages.try_start_install(language) {
-            events.push(InstallEvent::Log {
-                level: MessageType::INFO,
-                message: format!("Language '{}' is already being installed", language),
-            });
-            return InstallResult {
-                outcome: InstallOutcome::AlreadyInstalling,
-                events,
-            };
-        }
-        let install_marker = InstallMarkerGuard {
-            installing: self.installing_languages.clone(),
-            language: language.to_string(),
-        };
 
         // Progress begin
         events.push(InstallEvent::ProgressBegin);
@@ -499,20 +501,92 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_try_install_returns_already_installing_on_duplicate() {
+    async fn concurrent_duplicate_install_skips_support_lookup() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        };
+
         let (manager, _temp) = create_test_manager();
+        let lookup_count = Arc::new(AtomicUsize::new(0));
+        let first_manager = manager.clone();
+        let first_lookup_count = Arc::clone(&lookup_count);
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
 
-        // Manually mark as installing
-        manager.installing_languages.try_start_install("lua");
+        let first = tokio::spawn(async move {
+            first_manager
+                .try_install_with_support_check("lua", |_, _| async move {
+                    first_lookup_count.fetch_add(1, Ordering::SeqCst);
+                    let _ = started_tx.send(());
+                    let _ = release_rx.await;
+                    (true, None)
+                })
+                .await
+        });
+        started_rx.await.expect("first support lookup must start");
 
-        // Try to install same language
-        let result = manager.try_install("lua").await;
+        let duplicate_lookup_count = Arc::clone(&lookup_count);
+        let result = manager
+            .try_install_with_support_check("lua", move |_, _| {
+                duplicate_lookup_count.fetch_add(1, Ordering::SeqCst);
+                async { (false, None) }
+            })
+            .await;
 
         assert_eq!(result.outcome, InstallOutcome::AlreadyInstalling);
+        assert_eq!(lookup_count.load(Ordering::SeqCst), 1);
         assert!(result.events.iter().any(|e| matches!(
             e,
             InstallEvent::Log { level: MessageType::INFO, message } if message.contains("already being installed")
         )));
+
+        let _ = release_tx.send(());
+        assert_eq!(
+            first.await.expect("first install task must finish").outcome,
+            InstallOutcome::Unsupported
+        );
+    }
+
+    #[tokio::test]
+    async fn skipped_support_lookup_releases_install_claim() {
+        let (manager, _temp) = create_test_manager();
+
+        let result = manager
+            .try_install_with_support_check("unsupported", |_, _| async { (true, None) })
+            .await;
+
+        assert_eq!(result.outcome, InstallOutcome::Unsupported);
+        assert!(
+            manager
+                .installing_languages
+                .try_start_install("unsupported"),
+            "unsupported and metadata-error exits share this skip path and must release the claim"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_support_lookup_releases_install_claim() {
+        let (manager, _temp) = create_test_manager();
+        let task_manager = manager.clone();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+
+        let task = tokio::spawn(async move {
+            task_manager
+                .try_install_with_support_check("lua", |_, _| async move {
+                    let _ = started_tx.send(());
+                    std::future::pending::<(bool, Option<SkipReason>)>().await
+                })
+                .await
+        });
+        started_rx.await.expect("support lookup must start");
+        task.abort();
+        let _ = task.await;
+
+        assert!(
+            manager.installing_languages.try_start_install("lua"),
+            "cancelling during metadata lookup must release the claim"
+        );
     }
 
     #[tokio::test]

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -8,10 +8,10 @@
 //! calls `try_install()`, dispatches the events, and then handles
 //! post-install coordination (settings update, language reload).
 
-use std::path::PathBuf;
+use std::{future::Future, path::PathBuf};
 use tower_lsp_server::ls_types::MessageType;
 
-use crate::install::support_check::should_skip_unsupported_language;
+use crate::install::support_check::{SkipReason, should_skip_unsupported_language};
 use crate::language::FailedParserRegistry;
 
 use super::{InstallingLanguages, InstallingLanguagesExt};
@@ -226,6 +226,28 @@ impl AutoInstallManager {
     /// `SettingsManager` (Kakehashi checks settings first), or reload the
     /// language (Kakehashi handles post-install).
     pub async fn try_install(&self, language: &str) -> InstallResult {
+        self.try_install_with_support_check(language, |language, default_data_dir| async move {
+            let fetch_options =
+                default_data_dir
+                    .as_ref()
+                    .map(|dir| crate::install::metadata::FetchOptions {
+                        data_dir: Some(dir.as_path()),
+                        use_cache: true,
+                    });
+            should_skip_unsupported_language(&language, fetch_options.as_ref()).await
+        })
+        .await
+    }
+
+    async fn try_install_with_support_check<F, Fut>(
+        &self,
+        language: &str,
+        support_check: F,
+    ) -> InstallResult
+    where
+        F: FnOnce(String, Option<PathBuf>) -> Fut,
+        Fut: Future<Output = (bool, Option<SkipReason>)>,
+    {
         let mut events = Vec::new();
 
         // Check if parser previously failed (crash protection)
@@ -246,16 +268,8 @@ impl AutoInstallManager {
 
         // Check if language is supported by nvim-treesitter
         let default_data_dir = crate::install::default_data_dir();
-        let fetch_options =
-            default_data_dir
-                .as_ref()
-                .map(|dir| crate::install::metadata::FetchOptions {
-                    data_dir: Some(dir.as_path()),
-                    use_cache: true,
-                });
-
         let (should_skip, reason) =
-            should_skip_unsupported_language(language, fetch_options.as_ref()).await;
+            support_check(language.to_string(), default_data_dir.clone()).await;
 
         if let Some(reason) = &reason {
             events.push(InstallEvent::Log {

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -245,8 +245,8 @@ impl AutoInstallManager {
         support_check: F,
     ) -> InstallResult
     where
-        F: FnOnce(String, Option<PathBuf>) -> Fut,
-        Fut: Future<Output = (bool, Option<SkipReason>)>,
+        F: FnOnce(String, Option<PathBuf>) -> Fut + Send + 'static,
+        Fut: Future<Output = (bool, Option<SkipReason>)> + Send + 'static,
     {
         let mut events = Vec::new();
 
@@ -286,8 +286,32 @@ impl AutoInstallManager {
 
         // Check if language is supported by nvim-treesitter
         let default_data_dir = crate::install::default_data_dir();
-        let (should_skip, reason) =
-            support_check(language.to_string(), default_data_dir.clone()).await;
+        // The task owns the claim so cancellation of this caller cannot release
+        // it while the lookup (which contains spawn_blocking work) continues.
+        // On normal completion the claim returns here and is either dropped by
+        // an early return or transferred to the parser-install task below.
+        let lookup_language = language.to_string();
+        let lookup_data_dir = default_data_dir.clone();
+        let support_task = tokio::spawn(async move {
+            let result = support_check(lookup_language, lookup_data_dir).await;
+            (result, install_marker)
+        });
+        let ((should_skip, reason), install_marker) = match support_task.await {
+            Ok(result) => result,
+            Err(join_error) => {
+                events.push(InstallEvent::Log {
+                    level: MessageType::ERROR,
+                    message: format!(
+                        "Support check task for '{}' failed: {}",
+                        language, join_error
+                    ),
+                });
+                return InstallResult {
+                    outcome: InstallOutcome::Failed,
+                    events,
+                };
+            }
+        };
 
         if let Some(reason) = &reason {
             events.push(InstallEvent::Log {
@@ -566,16 +590,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cancelled_support_lookup_releases_install_claim() {
+    async fn cancelled_caller_keeps_claim_until_support_lookup_finishes() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        };
+
         let (manager, _temp) = create_test_manager();
         let task_manager = manager.clone();
         let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
 
         let task = tokio::spawn(async move {
             task_manager
                 .try_install_with_support_check("lua", |_, _| async move {
                     let _ = started_tx.send(());
-                    std::future::pending::<(bool, Option<SkipReason>)>().await
+                    let _ = release_rx.await;
+                    (true, None)
                 })
                 .await
         });
@@ -583,10 +614,25 @@ mod tests {
         task.abort();
         let _ = task.await;
 
-        assert!(
-            manager.installing_languages.try_start_install("lua"),
-            "cancelling during metadata lookup must release the claim"
-        );
+        let duplicate_lookups = Arc::new(AtomicUsize::new(0));
+        let duplicate_count = Arc::clone(&duplicate_lookups);
+        let duplicate = manager
+            .try_install_with_support_check("lua", move |_, _| {
+                duplicate_count.fetch_add(1, Ordering::SeqCst);
+                async { (false, None) }
+            })
+            .await;
+        assert_eq!(duplicate.outcome, InstallOutcome::AlreadyInstalling);
+        assert_eq!(duplicate_lookups.load(Ordering::SeqCst), 0);
+
+        let _ = release_tx.send(());
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while !manager.installing_languages.try_start_install("lua") {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the detached lookup task must release the claim after its support check finishes");
     }
 
     #[tokio::test]

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -346,8 +346,19 @@ impl AutoInstallManager {
                 events,
             };
         }
-        let install_marker =
-            install_marker.expect("a completed supported lookup must return its install marker");
+        let Some(install_marker) = install_marker else {
+            events.push(InstallEvent::Log {
+                level: MessageType::ERROR,
+                message: format!(
+                    "Support check for '{}' completed without its install claim",
+                    language
+                ),
+            });
+            return InstallResult {
+                outcome: InstallOutcome::Failed,
+                events,
+            };
+        };
 
         // Progress begin
         events.push(InstallEvent::ProgressBegin);
@@ -646,6 +657,28 @@ mod tests {
         })
         .await
         .expect("claim keeper must release after timed-out work finishes");
+    }
+
+    #[tokio::test]
+    async fn supported_result_without_returned_claim_fails_closed() {
+        let (manager, _temp) = create_test_manager();
+
+        let result = manager
+            .try_install_with_support_check("lua", |_, _| async {
+                TrackedSupportCheck {
+                    should_skip: false,
+                    reason: None,
+                    completion: Some(tokio::spawn(async {})),
+                }
+            })
+            .await;
+
+        assert_eq!(result.outcome, InstallOutcome::Failed);
+        assert!(result.events.iter().any(|event| matches!(
+            event,
+            InstallEvent::Log { level: MessageType::ERROR, message }
+                if message.contains("completed without its install claim")
+        )));
     }
 
     #[tokio::test]

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -307,7 +307,13 @@ impl AutoInstallManager {
                 // marker/completion pair back to it.
                 tokio::spawn(async move {
                     let _marker = install_marker;
-                    let _ = completion.await;
+                    if let Err(join_error) = completion.await {
+                        log::error!(
+                            target: "kakehashi::auto_install",
+                            "Metadata support-check completion task failed: {}",
+                            join_error
+                        );
+                    }
                 });
                 (result, None)
             } else {

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -11,7 +11,9 @@
 use std::{future::Future, path::PathBuf};
 use tower_lsp_server::ls_types::MessageType;
 
-use crate::install::support_check::{SkipReason, should_skip_unsupported_language};
+use crate::install::support_check::{
+    TrackedSupportCheck, should_skip_unsupported_language_tracked,
+};
 use crate::language::FailedParserRegistry;
 
 use super::{InstallingLanguages, InstallingLanguagesExt};
@@ -234,7 +236,7 @@ impl AutoInstallManager {
                         data_dir: Some(dir.as_path()),
                         use_cache: true,
                     });
-            should_skip_unsupported_language(&language, fetch_options.as_ref()).await
+            should_skip_unsupported_language_tracked(&language, fetch_options.as_ref()).await
         })
         .await
     }
@@ -246,7 +248,7 @@ impl AutoInstallManager {
     ) -> InstallResult
     where
         F: FnOnce(String, Option<PathBuf>) -> Fut + Send + 'static,
-        Fut: Future<Output = (bool, Option<SkipReason>)> + Send + 'static,
+        Fut: Future<Output = TrackedSupportCheck> + Send + 'static,
     {
         let mut events = Vec::new();
 
@@ -296,7 +298,7 @@ impl AutoInstallManager {
             let result = support_check(lookup_language, lookup_data_dir).await;
             (result, install_marker)
         });
-        let ((should_skip, reason), install_marker) = match support_task.await {
+        let (support_result, install_marker) = match support_task.await {
             Ok(result) => result,
             Err(join_error) => {
                 events.push(InstallEvent::Log {
@@ -312,6 +314,11 @@ impl AutoInstallManager {
                 };
             }
         };
+        let TrackedSupportCheck {
+            should_skip,
+            reason,
+            completion,
+        } = support_result;
 
         if let Some(reason) = &reason {
             events.push(InstallEvent::Log {
@@ -321,6 +328,12 @@ impl AutoInstallManager {
         }
 
         if should_skip {
+            if let Some(completion) = completion {
+                tokio::spawn(async move {
+                    let _marker = install_marker;
+                    let _ = completion.await;
+                });
+            }
             return InstallResult {
                 outcome: InstallOutcome::Unsupported,
                 events,
@@ -544,7 +557,7 @@ mod tests {
                     first_lookup_count.fetch_add(1, Ordering::SeqCst);
                     let _ = started_tx.send(());
                     let _ = release_rx.await;
-                    (true, None)
+                    TrackedSupportCheck::completed(true, None)
                 })
                 .await
         });
@@ -554,7 +567,7 @@ mod tests {
         let result = manager
             .try_install_with_support_check("lua", move |_, _| {
                 duplicate_lookup_count.fetch_add(1, Ordering::SeqCst);
-                async { (false, None) }
+                async { TrackedSupportCheck::completed(false, None) }
             })
             .await;
 
@@ -577,7 +590,9 @@ mod tests {
         let (manager, _temp) = create_test_manager();
 
         let result = manager
-            .try_install_with_support_check("unsupported", |_, _| async { (true, None) })
+            .try_install_with_support_check("unsupported", |_, _| async {
+                TrackedSupportCheck::completed(true, None)
+            })
             .await;
 
         assert_eq!(result.outcome, InstallOutcome::Unsupported);
@@ -587,6 +602,41 @@ mod tests {
                 .try_start_install("unsupported"),
             "unsupported and metadata-error exits share this skip path and must release the claim"
         );
+    }
+
+    #[tokio::test]
+    async fn timed_out_support_work_keeps_claim_until_completion() {
+        let (manager, _temp) = create_test_manager();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+
+        let result = manager
+            .try_install_with_support_check("lua", |_, _| async move {
+                TrackedSupportCheck {
+                    should_skip: true,
+                    reason: None,
+                    completion: Some(tokio::spawn(async move {
+                        let _ = release_rx.await;
+                    })),
+                }
+            })
+            .await;
+        assert_eq!(result.outcome, InstallOutcome::Unsupported);
+
+        let duplicate = manager
+            .try_install_with_support_check("lua", |_, _| async {
+                TrackedSupportCheck::completed(false, None)
+            })
+            .await;
+        assert_eq!(duplicate.outcome, InstallOutcome::AlreadyInstalling);
+
+        let _ = release_tx.send(());
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while !manager.installing_languages.try_start_install("lua") {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("claim keeper must release after timed-out work finishes");
     }
 
     #[tokio::test]
@@ -606,7 +656,7 @@ mod tests {
                 .try_install_with_support_check("lua", |_, _| async move {
                     let _ = started_tx.send(());
                     let _ = release_rx.await;
-                    (true, None)
+                    TrackedSupportCheck::completed(true, None)
                 })
                 .await
         });
@@ -619,7 +669,7 @@ mod tests {
         let duplicate = manager
             .try_install_with_support_check("lua", move |_, _| {
                 duplicate_count.fetch_add(1, Ordering::SeqCst);
-                async { (false, None) }
+                async { TrackedSupportCheck::completed(false, None) }
             })
             .await;
         assert_eq!(duplicate.outcome, InstallOutcome::AlreadyInstalling);

--- a/src/lsp/auto_install/manager.rs
+++ b/src/lsp/auto_install/manager.rs
@@ -269,8 +269,9 @@ impl AutoInstallManager {
         }
 
         // Claim before the network-backed support lookup so concurrent calls
-        // for the same language do not all fetch metadata. The RAII guard
-        // releases the claim on every lookup/error early return.
+        // for the same language do not all fetch metadata. Ordinary early
+        // returns release the RAII claim; a timeout transfers it to a detached
+        // keeper until the still-running blocking lookup exits.
         if !self.installing_languages.try_start_install(language) {
             events.push(InstallEvent::Log {
                 level: MessageType::INFO,


### PR DESCRIPTION
## Summary

- claim a language before the network-backed support metadata lookup so concurrent auto-install requests do not duplicate that work
- retain the RAII claim across caller cancellation and metadata timeout until detached blocking work actually finishes
- add deterministic concurrency, cancellation, timeout, and claim-release coverage through a private support-check seam

PR #661 already solved #588's atomic query-install and interrupted/partial repair items. This PR addresses the remaining auto-install deduplication item.

## Validation

- `cargo test --lib lsp::auto_install::manager::tests --quiet` (11 passed)
- `cargo test --lib support_check::tests --quiet` (6 passed)
- timeout regression repeated 20 times
- `make check`
- local multi-perspective review converged
- Codex continued and fresh reviews converged

Closes #588

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-install language support checking with a tracked result that preserves correct async behavior when metadata checks time out.
  * Tightened dedup/locking so concurrent installs only perform a single support lookup, and install markers are retained until required completion (including timeout/cancellation).
  * Added validation to catch unexpected support-check completion/claim handling and fail safely.

* **Tests**
  * Updated and expanded Tokio tests for concurrent dedup, unsupported early returns, timeout “keeper” behavior, cancellation retention, and invalid completion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->