### PR TITLE
fix(bridge): canonicalize eager injection languages

### DIFF
--- a/src/document/injections.rs
+++ b/src/document/injections.rs
@@ -105,10 +105,9 @@ pub(crate) struct DiscoveredInjections {
 /// the downstream path), and carried on the `ParseSnapshot`.
 #[derive(Clone)]
 pub(crate) struct DiscoveredBridgeRegion {
-    /// The RAW injection language identifier (e.g. `"py"`), exactly as the
-    /// query captured it — bridge config lookup and auto-install resolve it
-    /// themselves, so no canonicalization here (identical to the inline path).
-    pub raw_language: String,
+    /// Canonical injection language (e.g. `"python"` after resolving `"py"`),
+    /// shared by eager lifecycle messages and interactive request dispatch.
+    pub language: String,
     /// Position-stable tracker ULID, byte-identical to the one minted for the
     /// `InjectionMap` (same `get_or_create` on the same node).
     pub region_id: String,

--- a/src/document/injections.rs
+++ b/src/document/injections.rs
@@ -105,8 +105,10 @@ pub(crate) struct DiscoveredInjections {
 /// the downstream path), and carried on the `ParseSnapshot`.
 #[derive(Clone)]
 pub(crate) struct DiscoveredBridgeRegion {
-    /// Canonical injection language (e.g. `"python"` after resolving `"py"`),
-    /// shared by eager lifecycle messages and interactive request dispatch.
+    /// Resolved injection language, shared by eager lifecycle messages and
+    /// interactive request dispatch. Aliases are canonicalized when detection
+    /// succeeds (e.g. `"py"` to `"python"`); otherwise this retains the raw
+    /// identifier so both paths use the same fallback URI.
     pub language: String,
     /// Position-stable tracker ULID, byte-identical to the one minted for the
     /// `InjectionMap` (same `get_or_create` on the same node).

--- a/src/language/injection.rs
+++ b/src/language/injection.rs
@@ -19,8 +19,8 @@ mod ranges;
 pub(crate) const MAX_INJECTION_DEPTH: usize = 10;
 
 pub(crate) use content::{
-    NATIVE_PARSE_BUDGET, byte_to_point, byte_to_point_anchored, extract_clean_content,
-    parse_with_deadline, parse_with_ranges,
+    NATIVE_PARSE_BUDGET, byte_to_point, byte_to_point_anchored, parse_with_deadline,
+    parse_with_ranges,
 };
 pub(crate) use discovery::{
     CacheableInjectionRegion, InjectionRegionInfo, InjectionResolver, ResolvedInjection,

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -515,7 +515,7 @@ impl InjectionResolver {
     ///
     /// Falls back to the raw identifier if no resolution is found, allowing the
     /// bridge lookup to fail gracefully with a clear error message.
-    fn resolve_language(
+    pub(crate) fn resolve_language(
         coordinator: &LanguageCoordinator,
         raw_identifier: &str,
         content: &str,

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -515,7 +515,7 @@ impl InjectionResolver {
     ///
     /// Falls back to the raw identifier if no resolution is found, allowing the
     /// bridge lookup to fail gracefully with a clear error message.
-    pub(crate) fn resolve_language(
+    fn resolve_language(
         coordinator: &LanguageCoordinator,
         raw_identifier: &str,
         content: &str,

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -759,6 +759,14 @@ impl BridgeCoordinator {
         self.pool.close_invalidated_docs(uri, ulids).await;
     }
 
+    pub(crate) async fn close_replaced_docs(
+        &self,
+        uri: &Url,
+        injections: &[BridgeInjection],
+    ) -> std::collections::HashSet<String> {
+        self.pool.close_replaced_docs(uri, injections).await
+    }
+
     /// Take the upstream notification receiver for forwarding to the editor.
     ///
     /// Returns `Some(receiver)` on first call, `None` on subsequent calls.

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -913,6 +913,16 @@ impl LanguageServerPool {
             .await
     }
 
+    pub(crate) async fn remove_replaced_virtual_docs(
+        &self,
+        host_uri: &Url,
+        expected_uris: &std::collections::HashMap<String, String>,
+    ) -> Vec<OpenedVirtualDoc> {
+        self.document_tracker
+            .remove_replaced_virtual_docs(host_uri, expected_uris)
+            .await
+    }
+
     /// Remove a document from all tracking state (version tracking and opened state).
     pub(crate) async fn untrack_document(
         &self,

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1364,6 +1364,24 @@ impl LanguageServerPool {
         }
     }
 
+    pub(crate) fn clear_replaced_virtual_contents(
+        &self,
+        host_uri: &Url,
+        replaced: &[OpenedVirtualDoc],
+    ) {
+        if let Some(host) = self.latest_virtual_contents.get(host_uri) {
+            for doc in replaced {
+                let language = doc.virtual_uri.language();
+                let region_id = doc.virtual_uri.region_id();
+                if let Some(regions) = host.contents.get(language) {
+                    regions.remove(region_id);
+                }
+                host.contents
+                    .remove_if(language, |_, regions| regions.is_empty());
+            }
+        }
+    }
+
     /// Increment the version of a virtual document and return the new version,
     /// or `None` if the document has not been opened.
     ///
@@ -3969,6 +3987,30 @@ mod tests {
                 .unwrap()
                 .contents
                 .get("lua")
+                .is_some_and(|regions| regions.contains_key(TEST_ULID_LUA_0))
+        );
+    }
+
+    #[tokio::test]
+    async fn replacement_reclaims_only_old_language_virtual_content() {
+        let pool = LanguageServerPool::new();
+        let host_uri = Url::parse("file:///test/cache-replacement.md").unwrap();
+        pool.open_host_incarnation(&host_uri, 1).await;
+        pool.record_latest_virtual_content(&host_uri, 1, "lua", TEST_ULID_LUA_0, "old");
+        pool.record_latest_virtual_content(&host_uri, 1, "python", TEST_ULID_LUA_0, "new");
+        let replaced = OpenedVirtualDoc {
+            virtual_uri: VirtualDocumentUri::new(&url_to_uri(&host_uri), "lua", TEST_ULID_LUA_0),
+            connection_key: ConnectionKey::for_server("lua"),
+            connection_generation: 0,
+        };
+
+        pool.clear_replaced_virtual_contents(&host_uri, &[replaced]);
+
+        let host = pool.latest_virtual_contents.get(&host_uri).unwrap();
+        assert!(!host.contents.contains_key("lua"));
+        assert!(
+            host.contents
+                .get("python")
                 .is_some_and(|regions| regions.contains_key(TEST_ULID_LUA_0))
         );
     }

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -916,10 +916,10 @@ impl LanguageServerPool {
     pub(crate) async fn remove_replaced_virtual_docs(
         &self,
         host_uri: &Url,
-        expected_uris: &std::collections::HashMap<String, String>,
+        expected_languages: &std::collections::HashMap<&str, &str>,
     ) -> Vec<OpenedVirtualDoc> {
         self.document_tracker
-            .remove_replaced_virtual_docs(host_uri, expected_uris)
+            .remove_replaced_virtual_docs(host_uri, expected_languages)
             .await
     }
 
@@ -1373,11 +1373,15 @@ impl LanguageServerPool {
             for doc in replaced {
                 let language = doc.virtual_uri.language();
                 let region_id = doc.virtual_uri.region_id();
-                if let Some(regions) = host.contents.get(language) {
+                let empty = if let Some(regions) = host.contents.get(language) {
                     regions.remove(region_id);
+                    regions.is_empty()
+                } else {
+                    false
+                };
+                if empty {
+                    host.contents.remove(language);
                 }
-                host.contents
-                    .remove_if(language, |_, regions| regions.is_empty());
             }
         }
     }

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -746,7 +746,7 @@ impl DocumentTracker {
     pub(crate) async fn remove_replaced_virtual_docs(
         &self,
         host_uri: &Url,
-        expected_uris: &std::collections::HashMap<String, String>,
+        expected_languages: &std::collections::HashMap<&str, &str>,
     ) -> Vec<OpenedVirtualDoc> {
         let mut host_map = self.host_to_virtual.lock().await;
         let Some(docs) = host_map.get_mut(host_uri) else {
@@ -755,10 +755,10 @@ impl DocumentTracker {
 
         let mut to_close = Vec::new();
         docs.retain(|doc| {
-            let Some(expected) = expected_uris.get(doc.virtual_uri.region_id()) else {
+            let Some(expected) = expected_languages.get(doc.virtual_uri.region_id()) else {
                 return true;
             };
-            let replaced = doc.virtual_uri.to_uri_string() != *expected;
+            let replaced = doc.virtual_uri.language() != *expected;
             if replaced {
                 to_close.push(doc.clone());
             }
@@ -1520,8 +1520,6 @@ mod tests {
         let tracker = DocumentTracker::new();
         let host_uri = test_host_uri("canonical_language_change");
         let old_uri = VirtualDocumentUri::new(&url_to_uri(&host_uri), "lua", TEST_ULID_LUA_0);
-        let expected_uri =
-            VirtualDocumentUri::new(&url_to_uri(&host_uri), "python", TEST_ULID_LUA_0);
         let sibling_uri =
             VirtualDocumentUri::new(&url_to_uri(&host_uri), "lua", TEST_ULID_PYTHON_0);
         let connection = ConnectionKey::for_server("server");
@@ -1532,10 +1530,7 @@ mod tests {
             .register_opened_document(&host_uri, &sibling_uri, &connection)
             .await;
 
-        let expected = std::collections::HashMap::from([(
-            TEST_ULID_LUA_0.to_string(),
-            expected_uri.to_uri_string(),
-        )]);
+        let expected = std::collections::HashMap::from([(TEST_ULID_LUA_0, "python")]);
         let removed = tracker
             .remove_replaced_virtual_docs(&host_uri, &expected)
             .await;

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -740,7 +740,7 @@ impl DocumentTracker {
         to_close
     }
 
-    /// Take opened documents whose URI no longer matches the canonical URI for
+    /// Take opened documents whose URI no longer matches the expected URI for
     /// their still-live region. A content-based language change can preserve
     /// the region ULID while changing the language-derived URI extension.
     pub(crate) async fn remove_replaced_virtual_docs(

--- a/src/lsp/bridge/pool/document_tracker.rs
+++ b/src/lsp/bridge/pool/document_tracker.rs
@@ -740,6 +740,38 @@ impl DocumentTracker {
         to_close
     }
 
+    /// Take opened documents whose URI no longer matches the canonical URI for
+    /// their still-live region. A content-based language change can preserve
+    /// the region ULID while changing the language-derived URI extension.
+    pub(crate) async fn remove_replaced_virtual_docs(
+        &self,
+        host_uri: &Url,
+        expected_uris: &std::collections::HashMap<String, String>,
+    ) -> Vec<OpenedVirtualDoc> {
+        let mut host_map = self.host_to_virtual.lock().await;
+        let Some(docs) = host_map.get_mut(host_uri) else {
+            return Vec::new();
+        };
+
+        let mut to_close = Vec::new();
+        docs.retain(|doc| {
+            let Some(expected) = expected_uris.get(doc.virtual_uri.region_id()) else {
+                return true;
+            };
+            let replaced = doc.virtual_uri.to_uri_string() != *expected;
+            if replaced {
+                to_close.push(doc.clone());
+            }
+            !replaced
+        });
+        drop(host_map);
+
+        for doc in &to_close {
+            self.remove_from_reverse_index(&doc.virtual_uri.to_uri_string(), &doc.connection_key);
+        }
+        to_close
+    }
+
     /// Decrement the reference count for an opened document URI.
     ///
     /// Removes the entry entirely when the count reaches zero.
@@ -1482,6 +1514,44 @@ mod tests {
     // ========================================
     // remove_matching_virtual_docs tests
     // ========================================
+
+    #[tokio::test]
+    async fn remove_replaced_virtual_docs_removes_old_language_uri_for_stable_region() {
+        let tracker = DocumentTracker::new();
+        let host_uri = test_host_uri("canonical_language_change");
+        let old_uri = VirtualDocumentUri::new(&url_to_uri(&host_uri), "lua", TEST_ULID_LUA_0);
+        let expected_uri =
+            VirtualDocumentUri::new(&url_to_uri(&host_uri), "python", TEST_ULID_LUA_0);
+        let sibling_uri =
+            VirtualDocumentUri::new(&url_to_uri(&host_uri), "lua", TEST_ULID_PYTHON_0);
+        let connection = ConnectionKey::for_server("server");
+        tracker
+            .register_opened_document(&host_uri, &old_uri, &connection)
+            .await;
+        tracker
+            .register_opened_document(&host_uri, &sibling_uri, &connection)
+            .await;
+
+        let expected = std::collections::HashMap::from([(
+            TEST_ULID_LUA_0.to_string(),
+            expected_uri.to_uri_string(),
+        )]);
+        let removed = tracker
+            .remove_replaced_virtual_docs(&host_uri, &expected)
+            .await;
+
+        assert_eq!(removed.len(), 1);
+        assert_eq!(
+            removed[0].virtual_uri.to_uri_string(),
+            old_uri.to_uri_string()
+        );
+        let remaining = tracker.host_virtual_docs(&host_uri).await;
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(
+            remaining[0].virtual_uri.to_uri_string(),
+            sibling_uri.to_uri_string()
+        );
+    }
 
     #[tokio::test]
     async fn remove_matching_virtual_docs_removes_matching_docs() {

--- a/src/lsp/bridge/text_document/did_close.rs
+++ b/src/lsp/bridge/text_document/did_close.rs
@@ -226,6 +226,43 @@ impl LanguageServerPool {
             self.close_single_virtual_doc(doc).await;
         }
     }
+
+    /// Close the old language-bearing URI when a live region keeps its ULID but
+    /// resolves to a different canonical language after an edit.
+    pub(crate) async fn close_replaced_docs(
+        &self,
+        host_uri: &Url,
+        injections: &[crate::lsp::bridge::coordinator::BridgeInjection],
+    ) -> std::collections::HashSet<String> {
+        let Ok(host_uri_lsp) = crate::lsp::lsp_impl::url_to_uri(host_uri) else {
+            return std::collections::HashSet::new();
+        };
+        let expected_uris = injections
+            .iter()
+            .map(|injection| {
+                (
+                    injection.region_id.clone(),
+                    VirtualDocumentUri::new(
+                        &host_uri_lsp,
+                        &injection.language,
+                        &injection.region_id,
+                    )
+                    .to_uri_string(),
+                )
+            })
+            .collect();
+        let to_close = self
+            .remove_replaced_virtual_docs(host_uri, &expected_uris)
+            .await;
+        let replaced_regions = to_close
+            .iter()
+            .map(|doc| doc.virtual_uri.region_id().to_string())
+            .collect();
+        for doc in &to_close {
+            self.close_single_virtual_doc(doc).await;
+        }
+        replaced_regions
+    }
 }
 
 #[cfg(test)]

--- a/src/lsp/bridge/text_document/did_close.rs
+++ b/src/lsp/bridge/text_document/did_close.rs
@@ -234,32 +234,12 @@ impl LanguageServerPool {
         host_uri: &Url,
         injections: &[crate::lsp::bridge::coordinator::BridgeInjection],
     ) -> std::collections::HashSet<String> {
-        let host_uri_lsp = match crate::lsp::lsp_impl::url_to_uri(host_uri) {
-            Ok(uri) => uri,
-            Err(error) => {
-                log::error!(
-                    target: "kakehashi::bridge",
-                    "Failed to convert host URI; replaced virtual documents remain open: {error}"
-                );
-                return std::collections::HashSet::new();
-            }
-        };
-        let expected_uris = injections
+        let expected_languages = injections
             .iter()
-            .map(|injection| {
-                (
-                    injection.region_id.clone(),
-                    VirtualDocumentUri::new(
-                        &host_uri_lsp,
-                        &injection.language,
-                        &injection.region_id,
-                    )
-                    .to_uri_string(),
-                )
-            })
+            .map(|injection| (injection.region_id.as_str(), injection.language.as_str()))
             .collect();
         let to_close = self
-            .remove_replaced_virtual_docs(host_uri, &expected_uris)
+            .remove_replaced_virtual_docs(host_uri, &expected_languages)
             .await;
         self.clear_replaced_virtual_contents(host_uri, &to_close);
         let replaced_regions = to_close

--- a/src/lsp/bridge/text_document/did_close.rs
+++ b/src/lsp/bridge/text_document/did_close.rs
@@ -222,8 +222,8 @@ impl LanguageServerPool {
         }
 
         // Send didClose and clean up tracking for each closed doc
-        for doc in &to_close {
-            self.close_single_virtual_doc(doc).await;
+        for doc in to_close {
+            self.close_single_virtual_doc(&doc).await;
         }
     }
 
@@ -265,8 +265,8 @@ impl LanguageServerPool {
             .iter()
             .map(|doc| doc.virtual_uri.region_id().to_string())
             .collect();
-        for doc in &to_close {
-            self.close_single_virtual_doc(doc).await;
+        for doc in to_close {
+            self.close_single_virtual_doc(&doc).await;
         }
         replaced_regions
     }

--- a/src/lsp/bridge/text_document/did_close.rs
+++ b/src/lsp/bridge/text_document/did_close.rs
@@ -234,8 +234,15 @@ impl LanguageServerPool {
         host_uri: &Url,
         injections: &[crate::lsp::bridge::coordinator::BridgeInjection],
     ) -> std::collections::HashSet<String> {
-        let Ok(host_uri_lsp) = crate::lsp::lsp_impl::url_to_uri(host_uri) else {
-            return std::collections::HashSet::new();
+        let host_uri_lsp = match crate::lsp::lsp_impl::url_to_uri(host_uri) {
+            Ok(uri) => uri,
+            Err(error) => {
+                log::error!(
+                    target: "kakehashi::bridge",
+                    "Failed to convert host URI; replaced virtual documents remain open: {error}"
+                );
+                return std::collections::HashSet::new();
+            }
         };
         let expected_uris = injections
             .iter()

--- a/src/lsp/bridge/text_document/did_close.rs
+++ b/src/lsp/bridge/text_document/did_close.rs
@@ -261,6 +261,7 @@ impl LanguageServerPool {
         let to_close = self
             .remove_replaced_virtual_docs(host_uri, &expected_uris)
             .await;
+        self.clear_replaced_virtual_contents(host_uri, &to_close);
         let replaced_regions = to_close
             .iter()
             .map(|doc| doc.virtual_uri.region_id().to_string())

--- a/src/lsp/bridge/text_document/did_close.rs
+++ b/src/lsp/bridge/text_document/did_close.rs
@@ -228,7 +228,7 @@ impl LanguageServerPool {
     }
 
     /// Close the old language-bearing URI when a live region keeps its ULID but
-    /// resolves to a different canonical language after an edit.
+    /// resolves to a different language after an edit.
     pub(crate) async fn close_replaced_docs(
         &self,
         host_uri: &Url,

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -305,6 +305,19 @@ impl CacheCoordinator {
                 })
                 .collect();
 
+            // Resolve once for every consumer that needs canonical language /
+            // virtual content. In production the bridge and whole-document
+            // gates rise together, so resolving independently would duplicate
+            // the language-detection chain on the parse critical path.
+            let resolved = (build_bridge_regions || build_resolved_regions).then(|| {
+                crate::language::injection::InjectionResolver::resolve_from_prebuilt(
+                    language,
+                    &regions,
+                    &cacheable_regions,
+                    text,
+                )
+            });
+
             // Bridge-downstream regions from the SAME collected `regions`
             // (parse-snapshot ADR §3, never discover twice): the exact
             // (canonical language, region_id, clean content) triple
@@ -316,30 +329,14 @@ impl CacheCoordinator {
             // any late-configured bridge fall back to inline resolution.
             let bridge_regions: Option<Vec<crate::document::DiscoveredBridgeRegion>> =
                 build_bridge_regions.then(|| {
-                    regions
+                    resolved
+                        .as_ref()
+                        .expect("bridge regions requested resolution")
                         .iter()
-                        .zip(cacheable_regions.iter())
-                        .map(|(info, cacheable)| {
-                            let included_ranges =
-                                crate::language::injection::compute_included_ranges(
-                                    &info.content_node,
-                                    info.include_children,
-                                );
-                            let content = crate::language::injection::extract_clean_content(
-                                text,
-                                info.content_node.byte_range(),
-                                included_ranges.as_deref(),
-                            );
-                            crate::document::DiscoveredBridgeRegion {
-                                language:
-                                    crate::language::injection::InjectionResolver::resolve_language(
-                                        language,
-                                        &info.language,
-                                        &content,
-                                    ),
-                                region_id: cacheable.region_id.clone(),
-                                content,
-                            }
+                        .map(|region| crate::document::DiscoveredBridgeRegion {
+                            language: region.injection_language.clone(),
+                            region_id: region.region.region_id.clone(),
+                            content: region.virtual_content.clone(),
                         })
                         .collect()
                 });
@@ -348,14 +345,8 @@ impl CacheCoordinator {
             // same single query run — and from the SAME per-region ids and
             // content hashes already in `cacheable_regions` (no duplicate
             // mint/hash on this critical path).
-            let resolved_regions = build_resolved_regions.then(|| {
-                crate::language::injection::InjectionResolver::resolve_from_prebuilt(
-                    language,
-                    &regions,
-                    &cacheable_regions,
-                    text,
-                )
-            });
+            let resolved_regions = build_resolved_regions
+                .then(|| resolved.expect("whole-document regions requested resolution"));
 
             // Producer half of the discovery lever: build the owned discovery
             // from the SAME `regions` just collected — the injection query (`Q`)

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -331,7 +331,12 @@ impl CacheCoordinator {
                                 included_ranges.as_deref(),
                             );
                             crate::document::DiscoveredBridgeRegion {
-                                raw_language: info.language.clone(),
+                                raw_language:
+                                    crate::language::injection::InjectionResolver::resolve_language(
+                                        language,
+                                        &info.language,
+                                        &content,
+                                    ),
                                 region_id: cacheable.region_id.clone(),
                                 content,
                             }

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -305,7 +305,7 @@ impl CacheCoordinator {
                 })
                 .collect();
 
-            // Resolve once for every consumer that needs canonical language /
+            // Resolve once for every consumer that needs resolved language /
             // virtual content. In production the bridge and whole-document
             // gates rise together, so resolving independently would duplicate
             // the language-detection chain on the parse critical path.
@@ -320,7 +320,7 @@ impl CacheCoordinator {
 
             // Bridge-downstream regions from the SAME collected `regions`
             // (parse-snapshot ADR §3, never discover twice): the exact
-            // (canonical language, region_id, clean content) triple
+            // (resolved language, region_id, clean content) triple
             // `resolve_injection_data` used to re-derive by re-running the
             // injection query per downstream pass. Gated on a bridge server
             // actually being configured: populate runs on the pre-publish

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -307,7 +307,7 @@ impl CacheCoordinator {
 
             // Bridge-downstream regions from the SAME collected `regions`
             // (parse-snapshot ADR §3, never discover twice): the exact
-            // (raw language, region_id, clean content) triple
+            // (canonical language, region_id, clean content) triple
             // `resolve_injection_data` used to re-derive by re-running the
             // injection query per downstream pass. Gated on a bridge server
             // actually being configured: populate runs on the pre-publish
@@ -331,7 +331,7 @@ impl CacheCoordinator {
                                 included_ranges.as_deref(),
                             );
                             crate::document::DiscoveredBridgeRegion {
-                                raw_language:
+                                language:
                                     crate::language::injection::InjectionResolver::resolve_language(
                                         language,
                                         &info.language,

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -172,6 +172,36 @@ impl InjectionCoordinator {
     /// Resolves injection data once and reuses it across all three steps. Must be
     /// called AFTER parse_document so the AST is available.
     pub(crate) async fn process_injections(&self, uri: &Url, forward_did_change: bool) {
+        self.process_injections_after_lifecycle_lock(
+            uri,
+            forward_did_change,
+            std::future::ready(()),
+        )
+        .await;
+    }
+
+    async fn process_injections_after_lifecycle_lock<F>(
+        &self,
+        uri: &Url,
+        forward_did_change: bool,
+        after_lifecycle_lock: F,
+    ) where
+        F: std::future::Future<Output = ()>,
+    {
+        // Serialize the complete tree-derived downstream pass with didClose and
+        // didOpen. A parse task belongs to the document incarnation that exists
+        // when it acquires this guard; holding the same lifecycle lock through
+        // cancellation, close/update, and eager-open prevents an old task from
+        // mutating a fast-reopened lifetime between check and side effect.
+        let edit_lock = self.documents.edit_lock(uri);
+        let _lifecycle_guard = edit_lock.lock().await;
+        after_lifecycle_lock.await;
+        if self.documents.get(uri).is_none() {
+            self.bridge.cancel_eager_open(uri);
+            self.documents.remove_edit_lock_if_unshared(uri, &edit_lock);
+            return;
+        }
+
         let Some(host_language) = self.get_language_for_document(uri) else {
             self.bridge.cancel_eager_open(uri);
             return;
@@ -375,9 +405,74 @@ impl InjectionCoordinator {
 #[cfg(test)]
 mod tests {
     use super::InjectionResolver;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use tokio::sync::Notify;
     use tower_lsp_server::LspService;
     use tree_sitter::Query;
     use url::Url;
+
+    #[tokio::test]
+    async fn process_injections_finishes_before_fast_reopen() {
+        let (service, _socket) = LspService::new(crate::lsp::lsp_impl::Kakehashi::new);
+        let server = service.inner();
+        let uri = Url::parse("file:///injection-lifecycle.md").unwrap();
+        let old_incarnation = server.documents.insert(
+            uri.clone(),
+            "# old".to_string(),
+            Some("markdown".to_string()),
+            None,
+        );
+
+        let entered = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let injection = server.injection_coordinator();
+        let process_uri = uri.clone();
+        let process_entered = Arc::clone(&entered);
+        let process_release = Arc::clone(&release);
+        let process = tokio::spawn(async move {
+            injection
+                .process_injections_after_lifecycle_lock(&process_uri, false, async move {
+                    process_entered.notify_one();
+                    process_release.notified().await;
+                })
+                .await;
+        });
+        entered.notified().await;
+
+        let reopen_waiting = Arc::new(Notify::new());
+        let reopened = Arc::new(AtomicBool::new(false));
+        let documents = Arc::clone(&server.documents);
+        let reopen_uri = uri.clone();
+        let reopen_waiting_task = Arc::clone(&reopen_waiting);
+        let reopened_task = Arc::clone(&reopened);
+        let reopen = tokio::spawn(async move {
+            let edit_lock = documents.edit_lock(&reopen_uri);
+            reopen_waiting_task.notify_one();
+            let _guard = edit_lock.lock().await;
+            documents.remove_preserving_edit_lock(&reopen_uri);
+            let incarnation = documents.insert(
+                reopen_uri,
+                "# new".to_string(),
+                Some("markdown".to_string()),
+                None,
+            );
+            reopened_task.store(true, Ordering::Release);
+            incarnation
+        });
+        reopen_waiting.notified().await;
+
+        assert!(
+            !reopened.load(Ordering::Acquire),
+            "reopen must remain behind the old injection pass's lifecycle guard"
+        );
+        release.notify_one();
+        process.await.unwrap();
+        let new_incarnation = reopen.await.unwrap();
+
+        assert!(reopened.load(Ordering::Acquire));
+        assert_ne!(new_incarnation, old_incarnation);
+    }
 
     /// The snapshot fast path of `resolve_injection_data` must produce
     /// exactly what the inline (live-tree) resolution produces — the fast

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -189,8 +189,8 @@ impl InjectionCoordinator {
         F: std::future::Future<Output = ()>,
     {
         // Serialize the complete tree-derived downstream pass with didClose and
-        // didOpen. A parse task belongs to the document incarnation that exists
-        // when it acquires this guard; holding the same lifecycle lock through
+        // didOpen. The pass uses the document state observed after it acquires
+        // this guard; holding the same lifecycle lock through
         // cancellation, close/update, and eager-open prevents an old task from
         // mutating a fast-reopened lifetime between check and side effect.
         let edit_lock = self.documents.edit_lock(uri);

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -472,6 +472,7 @@ mod tests {
                 .language
                 .injection_query("markdown")
                 .expect("registered injection query"),
+            incarnation,
         );
         assert!(
             interactive

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -186,6 +186,10 @@ impl InjectionCoordinator {
             return;
         }
 
+        // Stop the previous pass before closing a replaced language-bearing URI;
+        // otherwise an old eager task can enqueue didOpen after the close and
+        // resurrect the stale URI. The new batch is created below after cleanup.
+        self.bridge.cancel_eager_open(uri);
         let replaced_regions = self.bridge.close_replaced_docs(uri, &injections).await;
         for region_id in replaced_regions {
             self.diagnostics

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -406,7 +406,6 @@ impl InjectionCoordinator {
 mod tests {
     use super::InjectionResolver;
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicBool, Ordering};
     use tokio::sync::Notify;
     use tower_lsp_server::LspService;
     use tree_sitter::Query;
@@ -440,37 +439,22 @@ mod tests {
         });
         entered.notified().await;
 
-        let reopen_waiting = Arc::new(Notify::new());
-        let reopened = Arc::new(AtomicBool::new(false));
-        let documents = Arc::clone(&server.documents);
-        let reopen_uri = uri.clone();
-        let reopen_waiting_task = Arc::clone(&reopen_waiting);
-        let reopened_task = Arc::clone(&reopened);
-        let reopen = tokio::spawn(async move {
-            let edit_lock = documents.edit_lock(&reopen_uri);
-            reopen_waiting_task.notify_one();
-            let _guard = edit_lock.lock().await;
-            documents.remove_preserving_edit_lock(&reopen_uri);
-            let incarnation = documents.insert(
-                reopen_uri,
-                "# new".to_string(),
-                Some("markdown".to_string()),
-                None,
-            );
-            reopened_task.store(true, Ordering::Release);
-            incarnation
-        });
-        reopen_waiting.notified().await;
-
+        let edit_lock = server.documents.edit_lock(&uri);
         assert!(
-            !reopened.load(Ordering::Acquire),
-            "reopen must remain behind the old injection pass's lifecycle guard"
+            tokio::time::timeout(std::time::Duration::from_millis(50), edit_lock.lock())
+                .await
+                .is_err(),
+            "the old injection pass must still own the lifecycle guard"
         );
         release.notify_one();
         process.await.unwrap();
-        let new_incarnation = reopen.await.unwrap();
+        let _guard = edit_lock.lock().await;
+        server.documents.remove_preserving_edit_lock(&uri);
+        let new_incarnation =
+            server
+                .documents
+                .insert(uri, "# new".to_string(), Some("markdown".to_string()), None);
 
-        assert!(reopened.load(Ordering::Acquire));
         assert_ne!(new_incarnation, old_incarnation);
     }
 

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -168,7 +168,11 @@ impl InjectionCoordinator {
                     included_ranges.as_deref(),
                 );
                 Some(BridgeInjection {
-                    language: region.language.clone(),
+                    language: InjectionResolver::resolve_language(
+                        &self.language,
+                        &region.language,
+                        &content,
+                    ),
                     region_id: region_id.to_string(),
                     content,
                 })
@@ -374,7 +378,9 @@ impl InjectionCoordinator {
 
 #[cfg(test)]
 mod tests {
+    use super::InjectionResolver;
     use tower_lsp_server::LspService;
+    use tree_sitter::Query;
     use url::Url;
 
     /// The snapshot fast path of `resolve_injection_data` must produce
@@ -386,26 +392,28 @@ mod tests {
         let (service, _socket) = LspService::new(crate::lsp::lsp_impl::Kakehashi::new);
         let server = service.inner();
 
-        let settings = crate::config::WorkspaceSettings {
-            search_paths: vec![
-                std::env::var("TREE_SITTER_GRAMMARS")
-                    .unwrap_or_else(|_| "deps/tree-sitter".to_string()),
-            ],
-            ..Default::default()
-        };
-        let _ = server.language.load_settings(&settings);
-        for lang in ["markdown", "markdown_inline", "lua"] {
-            if !server.language.ensure_language_loaded(lang).success {
-                eprintln!("Skipping: {lang} parser not available");
-                return;
-            }
-        }
+        let registry = server.language.language_registry_for_parallel();
+        registry.register("markdown".to_string(), tree_sitter_md::LANGUAGE.into());
+        registry.register("python".to_string(), tree_sitter_python::LANGUAGE.into());
+        let markdown_language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
+        let injection_query = Query::new(
+            &markdown_language,
+            r#"
+            (fenced_code_block
+              (info_string (language) @_lang)
+              (code_fence_content) @injection.content
+              (#set-lang-from-info-string! @_lang))
+            "#,
+        )
+        .expect("valid markdown injection query");
+        server
+            .language
+            .query_store()
+            .insert_injection_query("markdown".to_string(), std::sync::Arc::new(injection_query));
 
-        let text = "# T\n\n```lua\nlocal x = 1\n```\n\n```lua\nlocal y = 2\n```\n";
+        let text = "# T\n\n```py\nx = 1\n```\n\n```py\ny = 2\n```\n";
         let mut pool = server.language.create_document_parser_pool();
-        let Some(mut parser) = pool.acquire("markdown") else {
-            return;
-        };
+        let mut parser = pool.acquire("markdown").expect("registered parser");
         let tree = parser.parse(text, None).expect("parse markdown");
         pool.release("markdown".to_string(), parser);
 
@@ -453,6 +461,27 @@ mod tests {
         publish(None, content_version);
         let inline = injection.resolve_injection_data(&uri, "markdown");
         assert!(!inline.is_empty(), "the two fences must resolve");
+        assert!(
+            inline.iter().all(|region| region.language == "python"),
+            "inline eager discovery must use the request resolver's canonical language"
+        );
+        let interactive = InjectionResolver::resolve_all(
+            &server.language,
+            server.bridge.node_tracker(),
+            &uri,
+            &tree,
+            text,
+            &server
+                .language
+                .injection_query("markdown")
+                .expect("registered injection query"),
+        );
+        assert!(
+            interactive
+                .iter()
+                .all(|region| region.injection_language == "python"),
+            "interactive request discovery must use the canonical language"
+        );
 
         // FAST PATH: populate derives the bridge regions from the same tree
         // (same tracker → same region ids); a newer current snapshot carries
@@ -480,6 +509,10 @@ mod tests {
             content_version,
         );
         let fast = injection.resolve_injection_data(&uri, "markdown");
+        assert!(
+            fast.iter().all(|region| region.language == "python"),
+            "cached eager discovery must use the request resolver's canonical language"
+        );
 
         assert_eq!(
             inline.len(),
@@ -487,7 +520,7 @@ mod tests {
             "fast path must resolve the same regions"
         );
         for (a, b) in inline.iter().zip(fast.iter()) {
-            assert_eq!(a.language, b.language, "raw language must match");
+            assert_eq!(a.language, b.language, "canonical language must match");
             assert_eq!(a.region_id, b.region_id, "region id must match");
             assert_eq!(a.content, b.content, "clean content must match");
         }

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -186,6 +186,12 @@ impl InjectionCoordinator {
             return;
         }
 
+        let replaced_regions = self.bridge.close_replaced_docs(uri, &injections).await;
+        for region_id in replaced_regions {
+            self.diagnostics
+                .evict_source(uri, &DiagnosticSource::Region(region_id));
+        }
+
         if forward_did_change {
             self.bridge
                 .forward_didchange_to_opened_docs(uri, incarnation, &injections)

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -149,35 +149,21 @@ impl InjectionCoordinator {
             return Vec::new();
         }
 
-        regions
-            .iter()
-            .filter_map(|region| {
-                let region_id = InjectionResolver::calculate_region_id(
-                    self.bridge.node_tracker(),
-                    uri,
-                    region,
-                    incarnation,
-                )?;
-                let included_ranges = crate::language::injection::compute_included_ranges(
-                    &region.content_node,
-                    region.include_children,
-                );
-                let content = crate::language::injection::extract_clean_content(
-                    &text,
-                    region.content_node.byte_range(),
-                    included_ranges.as_deref(),
-                );
-                Some(BridgeInjection {
-                    language: InjectionResolver::resolve_language(
-                        &self.language,
-                        &region.language,
-                        &content,
-                    ),
-                    region_id: region_id.to_string(),
-                    content,
-                })
-            })
-            .collect()
+        InjectionResolver::resolve_from_regions(
+            &self.language,
+            self.bridge.node_tracker(),
+            uri,
+            &regions,
+            &text,
+            incarnation,
+        )
+        .into_iter()
+        .map(|region| BridgeInjection {
+            language: region.injection_language,
+            region_id: region.region.region_id,
+            content: region.virtual_content,
+        })
+        .collect()
     }
 
     /// Process injected languages: resolve injection data, optionally forward didChange,
@@ -402,7 +388,8 @@ mod tests {
             (fenced_code_block
               (info_string (language) @_lang)
               (code_fence_content) @injection.content
-              (#set-lang-from-info-string! @_lang))
+              (#set-lang-from-info-string! @_lang)
+              (#offset! @injection.content 1 0 0 0))
             "#,
         )
         .expect("valid markdown injection query");
@@ -411,7 +398,7 @@ mod tests {
             .query_store()
             .insert_injection_query("markdown".to_string(), std::sync::Arc::new(injection_query));
 
-        let text = "# T\n\n```py\nx = 1\n```\n\n```py\ny = 2\n```\n";
+        let text = "# T\n\n```py\nignored\nx = 1\n```\n\n```unknown\n#!/usr/bin/env lua\n#!/usr/bin/env python\ny = 2\n```\n";
         let mut pool = server.language.create_document_parser_pool();
         let mut parser = pool.acquire("markdown").expect("registered parser");
         let tree = parser.parse(text, None).expect("parse markdown");

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -118,7 +118,7 @@ impl InjectionCoordinator {
             return bridge_regions
                 .iter()
                 .map(|region| BridgeInjection {
-                    language: region.raw_language.clone(),
+                    language: region.language.clone(),
                     region_id: region.region_id.clone(),
                     content: region.content.clone(),
                 })

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -441,9 +441,7 @@ mod tests {
 
         let edit_lock = server.documents.edit_lock(&uri);
         assert!(
-            tokio::time::timeout(std::time::Duration::from_millis(50), edit_lock.lock())
-                .await
-                .is_err(),
+            edit_lock.try_lock().is_err(),
             "the old injection pass must still own the lifecycle guard"
         );
         release.notify_one();

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -486,6 +486,7 @@ mod tests {
         let registry = server.language.language_registry_for_parallel();
         registry.register("markdown".to_string(), tree_sitter_md::LANGUAGE.into());
         registry.register("python".to_string(), tree_sitter_python::LANGUAGE.into());
+        registry.register("lua".to_string(), tree_sitter_lua::LANGUAGE.into());
         let markdown_language: tree_sitter::Language = tree_sitter_md::LANGUAGE.into();
         let injection_query = Query::new(
             &markdown_language,


### PR DESCRIPTION
## Summary

- canonicalize eager bridge injection languages through the same `ResolvedInjection` pipeline used by interactive request dispatch
- reuse offset-aware virtual content for cached and inline eager discovery, including `#offset!` and first-line fallback
- resolve cached regions once on the parse critical path instead of repeating language detection
- close and untrack an old language-bearing virtual URI when a stable region ID resolves to a new canonical language

## Regression coverage

- pins `py` to `python` across inline eager, cached eager, and interactive resolution paths
- covers offset-aware first-line fallback so excluded content cannot select a different eager URI
- covers stable-region language changes by removing the old URI while preserving sibling documents

## Validation

- focused bridge injection and virtual-document replacement tests
- `TREE_SITTER_GRAMMARS=/Users/atusy/ghq/github.com/atusy/kakehashi___main/deps/tree-sitter make test` — 2796 passed, 2 ignored
  - the explicit fixture path is required because this new worktree does not contain `deps/tree-sitter`; an initial unqualified run failed only the existing Rust fixture assertion
- `make check`

## Follow-up

Parser-availability-dependent canonicalization is shared pre-existing behavior across eager and interactive paths, not the #687 divergence. It is tracked separately in #691.

Closes #687


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedded-language handling by consistently using canonical language names for resolved injections.
  * Prevented stale “replaced” embedded virtual documents from remaining open when language-derived URIs change, and ensured related diagnostics are cleared.
* **Performance**
  * Reduced repeated injection-resolution work by reusing pre-resolved injection data within a populate pass.
* **Tests**
  * Updated and expanded tests to verify canonical language behavior across fast-path and interactive resolution, and to confirm replaced-doc cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->