### PR TITLE
fix(lsp): enforce UTF-16 position encoding

### DIFF
--- a/docs/architecture-decisions/node-reference-protocol.md
+++ b/docs/architecture-decisions/node-reference-protocol.md
@@ -136,12 +136,12 @@ Controls whether the entry point resolves through tree-sitter's anonymous-inclus
 
 The boundary rules below are stated in terms of UTF-8 byte offsets (`b`, `[s, e)`, `L`), matching the representation used by tree-sitter internally. The API surface, however, accepts LSP `Position` values whose `character` field unit depends on the negotiated `positionEncoding`.
 
-**Kakehashi follows the LSP default**: the server does not advertise an explicit `positionEncoding` in `ServerCapabilities`, so per LSP 3.18 spec the client must treat `Position.character` as a **UTF-16 code unit** offset. The server converts each incoming `Position` to a UTF-8 byte offset (via `PositionMapper`) before applying any boundary rule. This conversion is transparent to clients, but two consequences matter:
+**Kakehashi uses UTF-16 exclusively**: when a client advertises `general.positionEncodings`, the server selects and announces `positionEncoding: "utf-16"`; when the capability is omitted, both sides use the LSP default of UTF-16. The server converts each incoming `Position` to a UTF-8 byte offset (via `PositionMapper`) before applying any boundary rule. This conversion is transparent to clients, but two consequences matter:
 
 - For documents containing only ASCII, UTF-16 code units, UTF-8 bytes, and characters coincide — most boundary discussions remain intuitive.
 - For documents with non-ASCII characters (multi-byte in UTF-8, multi-code-unit in UTF-16 for surrogate pairs), clients must compute `Position.character` in UTF-16 code units. Sending a byte-based character count will misalign with the byte ranges resolved server-side, especially around emoji or CJK glyphs at injection or node boundaries.
 
-If a client requires a different encoding (UTF-8 or UTF-32), it should negotiate via `general.positionEncodings` in the initialize request. Kakehashi may choose to support those in the future, but currently does not.
+Clients must support UTF-16 as required by LSP even when they also advertise UTF-8 or UTF-32. Kakehashi may support selecting those optional encodings in the future, but currently always selects UTF-16.
 
 #### Half-Open Intervals
 

--- a/docs/language-features.md
+++ b/docs/language-features.md
@@ -360,8 +360,9 @@ they came from; querying with an `id` from a different document returns `null`.
 | `kakehashi/node/namedChildren` | `{ textDocument, id }` | `NodeInfo[] \| null` | The node's immediate **named** children, in document order |
 | `kakehashi/node/text` | `{ textDocument, id }` | `{ text: string } \| null` | The node's current text |
 
-Positions use the LSP default encoding, UTF-16 code units. kakehashi does not
-currently advertise or negotiate an alternate position encoding.
+Positions always use UTF-16 code units. When the client advertises
+`general.positionEncodings`, kakehashi explicitly selects `utf-16`; otherwise
+both sides use the LSP default of UTF-16.
 
 ### The `injection` parameter
 

--- a/src/lsp/bridge/protocol/lifecycle.rs
+++ b/src/lsp/bridge/protocol/lifecycle.rs
@@ -152,12 +152,40 @@ pub(crate) fn validate_initialize_response(response: &serde_json::Value) -> std:
     }
 
     // 2. Reject if result is absent or null
-    if response.get("result").filter(|r| !r.is_null()).is_none() {
+    let Some(result) = response.get("result").filter(|r| !r.is_null()) else {
         return Err(std::io::Error::other(
             "bridge: initialize response missing valid result",
         ));
-    }
+    };
 
+    validate_utf16_encoding(
+        result
+            .get("capabilities")
+            .and_then(|capabilities| capabilities.get("positionEncoding")),
+        "capabilities.positionEncoding",
+    )?;
+    validate_utf16_encoding(result.get("offsetEncoding"), "offsetEncoding")?;
+
+    Ok(())
+}
+
+fn validate_utf16_encoding(
+    announced: Option<&serde_json::Value>,
+    field: &str,
+) -> std::io::Result<()> {
+    let Some(announced) = announced.filter(|value| !value.is_null()) else {
+        return Ok(());
+    };
+    let Some(encoding) = announced.as_str() else {
+        return Err(std::io::Error::other(format!(
+            "bridge: downstream initialize {field} is non-string; UTF-16 is required"
+        )));
+    };
+    if encoding != "utf-16" {
+        return Err(std::io::Error::other(format!(
+            "bridge: downstream initialize {field} announced {encoding:?}; UTF-16 is required"
+        )));
+    }
     Ok(())
 }
 
@@ -397,6 +425,16 @@ mod tests {
     #[case::valid_result_with_null_error(
         serde_json::json!({"result": {"capabilities": {}}, "error": null})
     )]
+    #[case::explicit_utf16_position_encoding(
+        serde_json::json!({
+            "result": {"capabilities": {"positionEncoding": "utf-16"}}
+        })
+    )]
+    #[case::legacy_utf16_offset_encoding(
+        serde_json::json!({
+            "result": {"capabilities": {}, "offsetEncoding": "utf-16"}
+        })
+    )]
     #[case::complex_result_object(
         serde_json::json!({
             "result": {
@@ -449,6 +487,41 @@ mod tests {
             expected_error,
             err_msg
         );
+    }
+
+    #[rstest]
+    #[case::standard_utf8(
+        serde_json::json!({
+            "result": {"capabilities": {"positionEncoding": "utf-8"}}
+        }),
+        "positionEncoding",
+        "utf-8",
+    )]
+    #[case::legacy_utf8(
+        serde_json::json!({
+            "result": {"capabilities": {}, "offsetEncoding": "utf-8"}
+        }),
+        "offsetEncoding",
+        "utf-8",
+    )]
+    #[case::malformed_standard_encoding(
+        serde_json::json!({
+            "result": {"capabilities": {"positionEncoding": 16}}
+        }),
+        "positionEncoding",
+        "non-string",
+    )]
+    #[trace]
+    fn validate_rejects_non_utf16_position_encoding(
+        #[case] response: serde_json::Value,
+        #[case] field: &str,
+        #[case] announced: &str,
+    ) {
+        let error = validate_initialize_response(&response)
+            .expect_err("non-UTF-16 downstream encoding must fail initialization");
+        let message = error.to_string();
+        assert!(message.contains(field), "unexpected error: {message}");
+        assert!(message.contains(announced), "unexpected error: {message}");
     }
 
     #[rstest]

--- a/src/lsp/bridge/protocol/lifecycle.rs
+++ b/src/lsp/bridge/protocol/lifecycle.rs
@@ -177,9 +177,9 @@ fn validate_utf16_encoding(
         return Ok(());
     };
     if announced.is_null() {
-        return Err(std::io::Error::other(format!(
-            "bridge: downstream initialize {field} is null; UTF-16 is required"
-        )));
+        // Optional JSON-RPC fields are commonly serialized as explicit null;
+        // like absence, that announces no alternative to the UTF-16 default.
+        return Ok(());
     }
     let Some(encoding) = announced.as_str() else {
         return Err(std::io::Error::other(format!(
@@ -440,6 +440,16 @@ mod tests {
             "result": {"capabilities": {}, "offsetEncoding": "utf-16"}
         })
     )]
+    #[case::null_standard_encoding(
+        serde_json::json!({
+            "result": {"capabilities": {"positionEncoding": null}}
+        })
+    )]
+    #[case::null_legacy_encoding(
+        serde_json::json!({
+            "result": {"capabilities": {}, "offsetEncoding": null}
+        })
+    )]
     #[case::complex_result_object(
         serde_json::json!({
             "result": {
@@ -515,20 +525,6 @@ mod tests {
         }),
         "positionEncoding",
         "non-string",
-    )]
-    #[case::null_standard_encoding(
-        serde_json::json!({
-            "result": {"capabilities": {"positionEncoding": null}}
-        }),
-        "positionEncoding",
-        "null",
-    )]
-    #[case::null_legacy_encoding(
-        serde_json::json!({
-            "result": {"capabilities": {}, "offsetEncoding": null}
-        }),
-        "offsetEncoding",
-        "null",
     )]
     #[trace]
     fn validate_rejects_non_utf16_position_encoding(

--- a/src/lsp/bridge/protocol/lifecycle.rs
+++ b/src/lsp/bridge/protocol/lifecycle.rs
@@ -173,9 +173,14 @@ fn validate_utf16_encoding(
     announced: Option<&serde_json::Value>,
     field: &str,
 ) -> std::io::Result<()> {
-    let Some(announced) = announced.filter(|value| !value.is_null()) else {
+    let Some(announced) = announced else {
         return Ok(());
     };
+    if announced.is_null() {
+        return Err(std::io::Error::other(format!(
+            "bridge: downstream initialize {field} is null; UTF-16 is required"
+        )));
+    }
     let Some(encoding) = announced.as_str() else {
         return Err(std::io::Error::other(format!(
             "bridge: downstream initialize {field} is non-string; UTF-16 is required"
@@ -510,6 +515,20 @@ mod tests {
         }),
         "positionEncoding",
         "non-string",
+    )]
+    #[case::null_standard_encoding(
+        serde_json::json!({
+            "result": {"capabilities": {"positionEncoding": null}}
+        }),
+        "positionEncoding",
+        "null",
+    )]
+    #[case::null_legacy_encoding(
+        serde_json::json!({
+            "result": {"capabilities": {}, "offsetEncoding": null}
+        }),
+        "offsetEncoding",
+        "null",
     )]
     #[trace]
     fn validate_rejects_non_utf16_position_encoding(

--- a/src/lsp/lsp_impl/kakehashi/node/position.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/position.rs
@@ -10,8 +10,9 @@
 //! ## Why LSP `Position`, not tree-sitter `Point`
 //!
 //! The whole protocol accepts and returns LSP `Position` at its boundary
-//! (node-reference-protocol §"Position Encoding"); kakehashi advertises no
-//! `positionEncoding`, so `character` is a UTF-16 code unit per LSP 3.18. A
+//! (node-reference-protocol §"Position Encoding"); kakehashi selects UTF-16
+//! explicitly when the client advertises position encodings and otherwise uses
+//! the LSP default, so `character` is always a UTF-16 code unit. A
 //! tree-sitter `Point.column` is a UTF-8 byte offset, which diverges from LSP
 //! around any non-ASCII character (emoji, CJK). Returning native points would
 //! make these the only accessors a client must special-case. Instead the server

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -6,19 +6,19 @@ use tower_lsp_server::Client;
 use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::ColorProviderCapability;
 use tower_lsp_server::ls_types::{
-    CodeActionOptions, CodeActionProviderCapability, CodeLensOptions, CompletionOptions,
-    DeclarationCapability, DeclarationOptions, DefinitionOptions, DiagnosticOptions,
-    DiagnosticServerCapabilities, DocumentFormattingOptions, DocumentLinkOptions,
-    DocumentOnTypeFormattingOptions, DocumentRangeFormattingOptions, DocumentSymbolOptions,
-    ExecuteCommandOptions, FoldingRangeProviderCapability, HoverProviderCapability,
-    ImplementationProviderCapability, InitializeParams, InitializeResult, InitializedParams,
-    InlayHintOptions, InlayHintServerCapabilities, LinkedEditingRangeServerCapabilities, OneOf,
-    ReferenceOptions, RenameOptions, SaveOptions, SelectionRangeProviderCapability,
-    SemanticTokenModifier, SemanticTokenType, SemanticTokensFullOptions, SemanticTokensLegend,
-    SemanticTokensOptions, SemanticTokensServerCapabilities, ServerCapabilities, ServerInfo,
-    SignatureHelpOptions, TextDocumentSyncCapability, TextDocumentSyncKind,
-    TextDocumentSyncOptions, TextDocumentSyncSaveOptions, TypeDefinitionProviderCapability, Uri,
-    WorkDoneProgressOptions,
+    ClientCapabilities, CodeActionOptions, CodeActionProviderCapability, CodeLensOptions,
+    CompletionOptions, DeclarationCapability, DeclarationOptions, DefinitionOptions,
+    DiagnosticOptions, DiagnosticServerCapabilities, DocumentFormattingOptions,
+    DocumentLinkOptions, DocumentOnTypeFormattingOptions, DocumentRangeFormattingOptions,
+    DocumentSymbolOptions, ExecuteCommandOptions, FoldingRangeProviderCapability,
+    HoverProviderCapability, ImplementationProviderCapability, InitializeParams, InitializeResult,
+    InitializedParams, InlayHintOptions, InlayHintServerCapabilities,
+    LinkedEditingRangeServerCapabilities, OneOf, PositionEncodingKind, ReferenceOptions,
+    RenameOptions, SaveOptions, SelectionRangeProviderCapability, SemanticTokenModifier,
+    SemanticTokenType, SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
+    SemanticTokensServerCapabilities, ServerCapabilities, ServerInfo, SignatureHelpOptions,
+    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
+    TextDocumentSyncSaveOptions, TypeDefinitionProviderCapability, Uri, WorkDoneProgressOptions,
 };
 use url::Url;
 
@@ -54,11 +54,20 @@ fn lsp_legend_modifiers() -> Vec<SemanticTokenModifier> {
         .collect()
 }
 
+fn host_position_encoding(capabilities: &ClientCapabilities) -> Option<PositionEncodingKind> {
+    capabilities
+        .general
+        .as_ref()
+        .and_then(|general| general.position_encodings.as_ref())
+        .map(|_| PositionEncodingKind::UTF16)
+}
+
 impl Kakehashi {
     pub(crate) async fn initialize_impl(
         &self,
         params: InitializeParams,
     ) -> Result<InitializeResult> {
+        let position_encoding = host_position_encoding(&params.capabilities);
         // Store client capabilities for LSP compliance checks (e.g., refresh support).
         // Uses SettingsManager which wraps OnceLock for "set once, read many" semantics.
         self.settings_manager
@@ -259,6 +268,7 @@ impl Kakehashi {
             }),
             offset_encoding: None,
             capabilities: ServerCapabilities {
+                position_encoding,
                 text_document_sync: Some(TextDocumentSyncCapability::Options(
                     TextDocumentSyncOptions {
                         open_close: Some(true),
@@ -1596,6 +1606,31 @@ async fn upstream_forwarding_loop_with_cancel(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn host_announces_utf16_when_position_encodings_are_advertised() {
+        use tower_lsp_server::ls_types::{
+            ClientCapabilities, GeneralClientCapabilities, PositionEncodingKind,
+        };
+
+        let capabilities = ClientCapabilities {
+            general: Some(GeneralClientCapabilities {
+                position_encodings: Some(vec![PositionEncodingKind::UTF8]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            host_position_encoding(&capabilities),
+            Some(PositionEncodingKind::UTF16),
+        );
+        assert_eq!(
+            host_position_encoding(&ClientCapabilities::default()),
+            None,
+            "omitted capability uses the protocol's UTF-16 default",
+        );
+    }
 
     /// A throwaway cancel context for tests that don't exercise cancellation.
     fn test_forwarded_cancel() -> crate::lsp::bridge::ForwardedRequestCancel {

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -54,22 +54,12 @@ fn lsp_legend_modifiers() -> Vec<SemanticTokenModifier> {
         .collect()
 }
 
-fn host_position_encoding(
-    capabilities: &ClientCapabilities,
-) -> Result<Option<PositionEncodingKind>> {
-    let advertised = capabilities
+fn host_position_encoding(capabilities: &ClientCapabilities) -> Option<PositionEncodingKind> {
+    capabilities
         .general
         .as_ref()
-        .and_then(|general| general.position_encodings.as_ref());
-    match advertised {
-        None => Ok(None),
-        Some(encodings) if encodings.contains(&PositionEncodingKind::UTF16) => {
-            Ok(Some(PositionEncodingKind::UTF16))
-        }
-        Some(_) => Err(tower_lsp_server::jsonrpc::Error::invalid_params(
-            "kakehashi requires UTF-16 position encoding",
-        )),
-    }
+        .and_then(|general| general.position_encodings.as_ref())
+        .map(|_| PositionEncodingKind::UTF16)
 }
 
 impl Kakehashi {
@@ -77,7 +67,7 @@ impl Kakehashi {
         &self,
         params: InitializeParams,
     ) -> Result<InitializeResult> {
-        let position_encoding = host_position_encoding(&params.capabilities)?;
+        let position_encoding = host_position_encoding(&params.capabilities);
         // Store client capabilities for LSP compliance checks (e.g., refresh support).
         // Uses SettingsManager which wraps OnceLock for "set once, read many" semantics.
         self.settings_manager
@@ -1618,40 +1608,28 @@ mod tests {
     use super::*;
 
     #[test]
-    fn host_negotiates_only_advertised_utf16() {
+    fn host_announces_utf16_when_position_encodings_are_advertised() {
         use tower_lsp_server::ls_types::{
             ClientCapabilities, GeneralClientCapabilities, PositionEncodingKind,
         };
 
         let capabilities = ClientCapabilities {
             general: Some(GeneralClientCapabilities {
-                position_encodings: Some(vec![
-                    PositionEncodingKind::UTF8,
-                    PositionEncodingKind::UTF16,
-                ]),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-
-        assert_eq!(
-            host_position_encoding(&capabilities).unwrap(),
-            Some(PositionEncodingKind::UTF16),
-        );
-        assert_eq!(
-            host_position_encoding(&ClientCapabilities::default()).unwrap(),
-            None,
-            "omitted capability uses the protocol's UTF-16 default",
-        );
-
-        let utf8_only = ClientCapabilities {
-            general: Some(GeneralClientCapabilities {
                 position_encodings: Some(vec![PositionEncodingKind::UTF8]),
                 ..Default::default()
             }),
             ..Default::default()
         };
-        assert!(host_position_encoding(&utf8_only).is_err());
+
+        assert_eq!(
+            host_position_encoding(&capabilities),
+            Some(PositionEncodingKind::UTF16),
+        );
+        assert_eq!(
+            host_position_encoding(&ClientCapabilities::default()),
+            None,
+            "omitted capability uses the protocol's UTF-16 default",
+        );
     }
 
     /// A throwaway cancel context for tests that don't exercise cancellation.

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -54,12 +54,22 @@ fn lsp_legend_modifiers() -> Vec<SemanticTokenModifier> {
         .collect()
 }
 
-fn host_position_encoding(capabilities: &ClientCapabilities) -> Option<PositionEncodingKind> {
-    capabilities
+fn host_position_encoding(
+    capabilities: &ClientCapabilities,
+) -> Result<Option<PositionEncodingKind>> {
+    let advertised = capabilities
         .general
         .as_ref()
-        .and_then(|general| general.position_encodings.as_ref())
-        .map(|_| PositionEncodingKind::UTF16)
+        .and_then(|general| general.position_encodings.as_ref());
+    match advertised {
+        None => Ok(None),
+        Some(encodings) if encodings.contains(&PositionEncodingKind::UTF16) => {
+            Ok(Some(PositionEncodingKind::UTF16))
+        }
+        Some(_) => Err(tower_lsp_server::jsonrpc::Error::invalid_params(
+            "kakehashi requires UTF-16 position encoding",
+        )),
+    }
 }
 
 impl Kakehashi {
@@ -67,7 +77,7 @@ impl Kakehashi {
         &self,
         params: InitializeParams,
     ) -> Result<InitializeResult> {
-        let position_encoding = host_position_encoding(&params.capabilities);
+        let position_encoding = host_position_encoding(&params.capabilities)?;
         // Store client capabilities for LSP compliance checks (e.g., refresh support).
         // Uses SettingsManager which wraps OnceLock for "set once, read many" semantics.
         self.settings_manager
@@ -1608,28 +1618,40 @@ mod tests {
     use super::*;
 
     #[test]
-    fn host_announces_utf16_when_position_encodings_are_advertised() {
+    fn host_negotiates_only_advertised_utf16() {
         use tower_lsp_server::ls_types::{
             ClientCapabilities, GeneralClientCapabilities, PositionEncodingKind,
         };
 
         let capabilities = ClientCapabilities {
             general: Some(GeneralClientCapabilities {
-                position_encodings: Some(vec![PositionEncodingKind::UTF8]),
+                position_encodings: Some(vec![
+                    PositionEncodingKind::UTF8,
+                    PositionEncodingKind::UTF16,
+                ]),
                 ..Default::default()
             }),
             ..Default::default()
         };
 
         assert_eq!(
-            host_position_encoding(&capabilities),
+            host_position_encoding(&capabilities).unwrap(),
             Some(PositionEncodingKind::UTF16),
         );
         assert_eq!(
-            host_position_encoding(&ClientCapabilities::default()),
+            host_position_encoding(&ClientCapabilities::default()).unwrap(),
             None,
             "omitted capability uses the protocol's UTF-16 default",
         );
+
+        let utf8_only = ClientCapabilities {
+            general: Some(GeneralClientCapabilities {
+                position_encodings: Some(vec![PositionEncodingKind::UTF8]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(host_position_encoding(&utf8_only).is_err());
     }
 
     /// A throwaway cancel context for tests that don't exercise cancellation.


### PR DESCRIPTION
## Summary

- explicitly announce `positionEncoding: "utf-16"` when an upstream client advertises `general.positionEncodings`
- preserve the protocol's implicit UTF-16 default for clients that omit the capability
- reject downstream servers that announce a non-UTF-16 standard `capabilities.positionEncoding` or clangd legacy `offsetEncoding`
- update the active node-protocol decision, module docs, and user-facing language guide to match negotiation behavior

UTF-16 remains mandatory in LSP 3.18: if a client omits it from `general.positionEncodings`, servers may safely assume the client supports it.

## Validation

- `cargo test --lib -q host_announces_utf16_when_position_encodings_are_advertised`
- `cargo test --lib -q lsp::bridge::protocol::lifecycle::tests` — 32 passed
- `TREE_SITTER_GRAMMARS=/Users/atusy/ghq/github.com/atusy/kakehashi___main/deps/tree-sitter make test` — 2806 passed, 2 ignored
- `make check`

Closes #596


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * When a client advertises `general.positionEncodings`, the server now announces UTF-16 and treats `Position.character` semantics as UTF-16 code units for position/offset handling; if omitted, it follows the LSP default (UTF-16).
* **Bug Fixes**
  * Stricter initialization validation now rejects malformed or non-UTF-16 announced encoding values (including non-string values) with clearer error details.
* **Documentation**
  * Updated protocol and language-feature docs to explicitly describe the UTF-16-only behavior and position-to-byte-offset mapping.
* **Tests**
  * Expanded initialization/validation coverage for accepted UTF-16 and rejected non-UTF-16 inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->