### PR TITLE
fix(bridge): prevent virtual document resurrection after host close

### DIFF
--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -3040,6 +3040,7 @@ mod tests {
         }
 
         let host_uri = Url::parse("file:///test/doc.md").unwrap();
+        pool.open_host_incarnation(&host_uri, 1).await;
         let host_position = Position {
             line: 3,
             character: 5,
@@ -3114,6 +3115,7 @@ mod tests {
         }
 
         let host_uri = Url::parse("file:///test/doc.md").unwrap();
+        pool.open_host_incarnation(&host_uri, 1).await;
         let host_position = Position {
             line: 3,
             character: 5,
@@ -3187,6 +3189,7 @@ mod tests {
         let config = lua_ls_config();
 
         let host_uri = Url::parse("file:///test/doc.md").unwrap();
+        pool.open_host_incarnation(&host_uri, 1).await;
         let host_position = Position {
             line: 3,
             character: 5,
@@ -3515,6 +3518,7 @@ mod tests {
         let config = lua_ls_config();
 
         let host_uri = Url::parse("file:///project/doc.md").unwrap();
+        pool.open_host_incarnation(&host_uri, 1).await;
         let host_position = tower_lsp_server::ls_types::Position {
             line: 3,
             character: 5,
@@ -3577,6 +3581,7 @@ mod tests {
         let config = lua_ls_config();
 
         let host_uri = Url::parse("file:///project/doc.md").unwrap();
+        pool.open_host_incarnation(&host_uri, 1).await;
 
         // First, send hover requests to establish connection and open virtual docs
         // Use positions that are within the code block (position.line >= region_start_line)

--- a/src/lsp/bridge/pool/execute.rs
+++ b/src/lsp/bridge/pool/execute.rs
@@ -34,7 +34,48 @@ pub(crate) struct BridgeResponseContext<'a> {
     pub offset: &'a RegionOffset,
 }
 
+struct RequestHostLifecycle<'a> {
+    pool: &'a LanguageServerPool,
+    host_uri: &'a Url,
+    lifecycle: Arc<tokio::sync::Mutex<()>>,
+    guard: Option<tokio::sync::OwnedMutexGuard<()>>,
+}
+
+impl Drop for RequestHostLifecycle<'_> {
+    fn drop(&mut self) {
+        self.guard.take();
+        self.pool
+            .remove_host_lifecycle_lock_if_unshared(self.host_uri, &self.lifecycle);
+    }
+}
+
 impl LanguageServerPool {
+    async fn request_host_lifecycle<'a>(
+        &'a self,
+        host_uri: &'a Url,
+    ) -> io::Result<RequestHostLifecycle<'a>> {
+        let lifecycle = self.existing_host_lifecycle_lock(host_uri).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotConnected,
+                format!("bridge: host document is closed: {host_uri}"),
+            )
+        })?;
+        let guard = Arc::clone(&lifecycle).lock_owned().await;
+        let lifecycle = RequestHostLifecycle {
+            pool: self,
+            host_uri,
+            lifecycle,
+            guard: Some(guard),
+        };
+        if self.current_host_incarnation(host_uri).is_none() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotConnected,
+                format!("bridge: host document is closed: {host_uri}"),
+            ));
+        }
+        Ok(lifecycle)
+    }
+
     /// Drive a bridge request end-to-end on a pre-fetched `ConnectionHandle`
     /// (callers obtain it via `get_or_create_connection`, usually because they
     /// need capability checks first). `build_request` shapes the JSON-RPC body
@@ -101,8 +142,11 @@ impl LanguageServerPool {
         // Build virtual document URI
         let virtual_uri = VirtualDocumentUri::new(&host_uri_lsp, injection_language, region_id);
 
-        // Register in the upstream request registry FIRST for cancel lookup.
-        // This order matters: if a cancel arrives between pool and router registration,
+        let host_lifecycle = self.request_host_lifecycle(host_uri).await?;
+
+        // Register in the upstream request registry before downstream router
+        // registration for cancel lookup. This relative order matters: if a
+        // cancel arrives between pool and router registration,
         // the cancel will fail at the router lookup (which is acceptable for best-effort
         // cancel semantics) rather than finding the server but no downstream ID.
         if let Some(ref id) = upstream_request_id {
@@ -193,6 +237,7 @@ impl LanguageServerPool {
                 return Err(e.into());
             }
         }
+        drop(host_lifecycle);
 
         // Wait for response via oneshot channel (no Mutex held) with timeout.
         // After this returns (success, channel-closed, or timeout),
@@ -311,6 +356,29 @@ mod tests {
     use crate::lsp::bridge::pool::ConnectionState;
     use crate::lsp::bridge::pool::test_helpers::*;
     use std::sync::Arc;
+
+    #[tokio::test]
+    async fn host_close_waits_for_request_enqueue_guard() {
+        let pool = Arc::new(LanguageServerPool::new());
+        let host_uri = Url::parse("file:///test/guarded-close.md").unwrap();
+        pool.open_host_incarnation(&host_uri, 1).await;
+        let guard = pool.request_host_lifecycle(&host_uri).await.unwrap();
+
+        let close = {
+            let pool = Arc::clone(&pool);
+            let host_uri = host_uri.clone();
+            tokio::spawn(async move { pool.close_host_incarnation(&host_uri, 1).await })
+        };
+        tokio::task::yield_now().await;
+        assert!(!close.is_finished());
+
+        drop(guard);
+        close.await.unwrap();
+        let Err(error) = pool.request_host_lifecycle(&host_uri).await else {
+            panic!("closed host must reject a late request");
+        };
+        assert_eq!(error.kind(), io::ErrorKind::NotConnected);
+    }
 
     /// Test that send_hover_request returns Ok(None) when server lacks hover capability.
     ///


### PR DESCRIPTION
## Summary

- gate virtual-document didOpen and request enqueue on the host document lifecycle
- serialize host close against in-flight request/eager-open enqueue without retaining per-URI tombstones
- preserve a consistent host lifecycle -> connections -> document transition lock order
- add race, reopen, lock-order, and lifecycle-churn regressions

## Validation

- `make check`
- `TREE_SITTER_GRAMMARS=/Users/atusy/ghq/github.com/atusy/kakehashi___main/deps/tree-sitter make test` (2804 passed, 2 ignored)
- Codex fresh review: no actionable findings

Closes #574

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Reopened host documents before hover, completion, and document-link requests to avoid stale lifecycle state.
  - Prevented virtual-document didOpen from enqueuing when a host is closed; late opens now fail instead of continuing.

- **Reliability**
  - Added per-host lifecycle coordination to correctly synchronize concurrent open/close flows.
  - Ensured close establishes host lifecycle state before removing virtual contents, and that in-flight opens are properly accounted for.

- **Tests**
  - Updated/expanded integration coverage for late-open failure, reopen recovery, and lifecycle cleanup across host URI churn.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->