### PR TITLE
fix(bridge): open virtual documents with current content

### DIFF
--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -3617,6 +3617,21 @@ mod tests {
         assert!(Arc::ptr_eq(&before, &after));
     }
 
+    #[tokio::test]
+    async fn invalidation_reclaims_only_matching_latest_virtual_content() {
+        let pool = LanguageServerPool::new();
+        let host_uri = Url::parse("file:///test/cache-invalidation.md").unwrap();
+        pool.record_latest_virtual_content(&host_uri, "lua", TEST_ULID_LUA_0, "first");
+        pool.record_latest_virtual_content(&host_uri, "lua", TEST_ULID_LUA_1, "second");
+
+        pool.close_invalidated_docs(&host_uri, &[TEST_ULID_LUA_0.parse::<ulid::Ulid>().unwrap()])
+            .await;
+
+        let contents = pool.latest_virtual_contents.get(&host_uri).unwrap();
+        assert!(!contents.contains_key(&("lua".to_string(), TEST_ULID_LUA_0.to_string())));
+        assert!(contents.contains_key(&("lua".to_string(), TEST_ULID_LUA_1.to_string())));
+    }
+
     /// Test that ensure_document_opened skips didOpen when document is already opened.
     ///
     /// Already opened path: Document already claimed

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -196,6 +196,7 @@ struct OpenClaimGuard {
 }
 
 type OpenTransitionLocks = DashMap<(ConnectionKey, String), Arc<tokio::sync::Mutex<()>>>;
+type LatestVirtualContents = DashMap<Url, DashMap<(String, String), Arc<str>>>;
 
 impl OpenClaimGuard {
     fn disarm(&mut self) {
@@ -264,7 +265,7 @@ pub struct LanguageServerPool {
     /// Latest extracted content observed from host didChange for each injection.
     /// Interactive requests may carry an older snapshot while awaiting server
     /// startup; the didOpen path reads this after claiming the transition.
-    latest_virtual_contents: DashMap<(Url, String, String), Arc<str>>,
+    latest_virtual_contents: LatestVirtualContents,
     /// Host-document sync state per `(uri, connection key)`
     /// (host-document-bridge): the real-URI documents opened on downstream
     /// servers via `bridge._self`, with their version and content
@@ -1076,12 +1077,15 @@ impl LanguageServerPool {
         };
         let current_content = self
             .latest_virtual_contents
-            .get(&(
-                host_uri.clone(),
-                virtual_uri.language().to_string(),
-                virtual_uri.region_id().to_string(),
-            ))
-            .map(|entry| Arc::clone(entry.value()));
+            .get(host_uri)
+            .and_then(|contents| {
+                contents
+                    .get(&(
+                        virtual_uri.language().to_string(),
+                        virtual_uri.region_id().to_string(),
+                    ))
+                    .map(|entry| Arc::clone(entry.value()))
+            });
         let virtual_content = current_content.as_deref().unwrap_or(virtual_content);
         // Register host_to_virtual BEFORE send so that close_host_document
         // can find this document even if the task is aborted after send.
@@ -1134,19 +1138,22 @@ impl LanguageServerPool {
         region_id: &str,
         content: &str,
     ) {
-        self.latest_virtual_contents.insert(
-            (
-                host_uri.clone(),
-                language.to_string(),
-                region_id.to_string(),
-            ),
-            Arc::<str>::from(content),
-        );
+        let contents = self
+            .latest_virtual_contents
+            .entry(host_uri.clone())
+            .or_default();
+        let key = (language.to_string(), region_id.to_string());
+        if contents
+            .get(&key)
+            .is_some_and(|cached| cached.as_ref() == content)
+        {
+            return;
+        }
+        contents.insert(key, Arc::<str>::from(content));
     }
 
     pub(crate) fn clear_latest_virtual_contents(&self, host_uri: &Url) {
-        self.latest_virtual_contents
-            .retain(|(uri, _, _), _| uri != host_uri);
+        self.latest_virtual_contents.remove(host_uri);
     }
 
     pub(crate) fn clear_invalidated_virtual_contents(
@@ -1156,8 +1163,9 @@ impl LanguageServerPool {
     ) {
         let invalidated: std::collections::HashSet<String> =
             invalidated_ulids.iter().map(ToString::to_string).collect();
-        self.latest_virtual_contents
-            .retain(|(uri, _, region_id), _| uri != host_uri || !invalidated.contains(region_id));
+        if let Some(contents) = self.latest_virtual_contents.get(host_uri) {
+            contents.retain(|(_, region_id), _| !invalidated.contains(region_id));
+        }
     }
 
     /// Increment the version of a virtual document and return the new version,
@@ -3577,6 +3585,33 @@ mod tests {
         assert!(pool.close_host_document(&host_uri).await.is_empty());
 
         assert!(pool.latest_virtual_contents.is_empty());
+    }
+
+    #[test]
+    fn unchanged_latest_virtual_content_reuses_allocation() {
+        let pool = LanguageServerPool::new();
+        let host_uri = Url::parse("file:///test/cache-dedup.md").unwrap();
+        pool.record_latest_virtual_content(&host_uri, "lua", TEST_ULID_LUA_0, "print('same')");
+        let before = Arc::clone(
+            pool.latest_virtual_contents
+                .get(&host_uri)
+                .unwrap()
+                .get(&("lua".to_string(), TEST_ULID_LUA_0.to_string()))
+                .unwrap()
+                .value(),
+        );
+
+        pool.record_latest_virtual_content(&host_uri, "lua", TEST_ULID_LUA_0, "print('same')");
+
+        let after = Arc::clone(
+            pool.latest_virtual_contents
+                .get(&host_uri)
+                .unwrap()
+                .get(&("lua".to_string(), TEST_ULID_LUA_0.to_string()))
+                .unwrap()
+                .value(),
+        );
+        assert!(Arc::ptr_eq(&before, &after));
     }
 
     /// Test that ensure_document_opened skips didOpen when document is already opened.

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -261,6 +261,10 @@ pub struct LanguageServerPool {
     /// Serializes didOpen enqueue/promotion, rollback, and didClose per exact
     /// downstream document so wire order matches tracker state transitions.
     open_transition_locks: Arc<OpenTransitionLocks>,
+    /// Latest extracted content observed from host didChange for each injection.
+    /// Interactive requests may carry an older snapshot while awaiting server
+    /// startup; the didOpen path reads this after claiming the transition.
+    latest_virtual_contents: DashMap<(Url, String, String), Arc<str>>,
     /// Host-document sync state per `(uri, connection key)`
     /// (host-document-bridge): the real-URI documents opened on downstream
     /// servers via `bridge._self`, with their version and content
@@ -372,6 +376,7 @@ impl LanguageServerPool {
             shutting_down: AtomicBool::new(false),
             document_tracker: Arc::new(DocumentTracker::new()),
             open_transition_locks: Arc::new(DashMap::new()),
+            latest_virtual_contents: DashMap::new(),
             host_documents: Mutex::new(HashMap::new()),
             upstream_request_registry: std::sync::Mutex::new(HashMap::new()),
             cancel_metrics: CancelForwardingMetrics::default(),
@@ -1069,6 +1074,15 @@ impl LanguageServerPool {
             connection_key: connection_key.clone(),
             armed: true,
         };
+        let current_content = self
+            .latest_virtual_contents
+            .get(&(
+                host_uri.clone(),
+                virtual_uri.language().to_string(),
+                virtual_uri.region_id().to_string(),
+            ))
+            .map(|entry| Arc::clone(entry.value()));
+        let virtual_content = current_content.as_deref().unwrap_or(virtual_content);
         // Register host_to_virtual BEFORE send so that close_host_document
         // can find this document even if the task is aborted after send.
         // The single-writer loop (ls-bridge-message-ordering) guarantees FIFO ordering, so
@@ -1111,6 +1125,39 @@ impl LanguageServerPool {
             .record_sent_content_fingerprint(virtual_uri, connection_key, virtual_content)
             .await;
         Ok(())
+    }
+
+    pub(crate) fn record_latest_virtual_content(
+        &self,
+        host_uri: &Url,
+        language: &str,
+        region_id: &str,
+        content: &str,
+    ) {
+        self.latest_virtual_contents.insert(
+            (
+                host_uri.clone(),
+                language.to_string(),
+                region_id.to_string(),
+            ),
+            Arc::<str>::from(content),
+        );
+    }
+
+    pub(crate) fn clear_latest_virtual_contents(&self, host_uri: &Url) {
+        self.latest_virtual_contents
+            .retain(|(uri, _, _), _| uri != host_uri);
+    }
+
+    pub(crate) fn clear_invalidated_virtual_contents(
+        &self,
+        host_uri: &Url,
+        invalidated_ulids: &[ulid::Ulid],
+    ) {
+        let invalidated: std::collections::HashSet<String> =
+            invalidated_ulids.iter().map(ToString::to_string).collect();
+        self.latest_virtual_contents
+            .retain(|(uri, _, region_id), _| uri != host_uri || !invalidated.contains(region_id));
     }
 
     /// Increment the version of a virtual document and return the new version,
@@ -3472,6 +3519,64 @@ mod tests {
             }
             _ => panic!("Expected Notification, got Request"),
         }
+    }
+
+    #[tokio::test]
+    async fn ensure_document_opened_uses_edit_that_arrived_while_server_was_starting() {
+        let pool = LanguageServerPool::new();
+        let host_uri = Url::parse("file:///test/stale-open.md").unwrap();
+        let host_uri_lsp = url_to_uri(&host_uri);
+        let virtual_uri = VirtualDocumentUri::new(&host_uri_lsp, "lua", TEST_ULID_LUA_0);
+        let connection_key = ConnectionKey::for_server("lua");
+
+        pool.forward_didchange_to_opened_docs(
+            &host_uri,
+            &[super::super::coordinator::BridgeInjection {
+                language: "lua".to_string(),
+                region_id: TEST_ULID_LUA_0.to_string(),
+                content: "print('current')".to_string(),
+            }],
+        )
+        .await;
+
+        let (mut sender, mut rx) = tokio::sync::mpsc::channel::<OutboundMessage>(1);
+        pool.ensure_document_opened(
+            &mut sender,
+            &host_uri,
+            &virtual_uri,
+            "print('stale')",
+            &connection_key,
+        )
+        .await
+        .unwrap();
+
+        let OutboundMessage::Untracked(message) = rx.try_recv().unwrap() else {
+            panic!("didOpen must be an untracked notification");
+        };
+        assert_eq!(
+            message["params"]["textDocument"]["text"],
+            "print('current')"
+        );
+    }
+
+    #[tokio::test]
+    async fn host_close_reclaims_unopened_latest_virtual_content() {
+        let pool = LanguageServerPool::new();
+        let host_uri = Url::parse("file:///test/cache-close.md").unwrap();
+        pool.forward_didchange_to_opened_docs(
+            &host_uri,
+            &[super::super::coordinator::BridgeInjection {
+                language: "lua".to_string(),
+                region_id: TEST_ULID_LUA_0.to_string(),
+                content: "print('cached')".to_string(),
+            }],
+        )
+        .await;
+        assert_eq!(pool.latest_virtual_contents.len(), 1);
+
+        assert!(pool.close_host_document(&host_uri).await.is_empty());
+
+        assert!(pool.latest_virtual_contents.is_empty());
     }
 
     /// Test that ensure_document_opened skips didOpen when document is already opened.

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1169,6 +1169,8 @@ impl LanguageServerPool {
         if let Some(contents) = self.latest_virtual_contents.get(host_uri) {
             contents.retain(|(_, region_id), _| !invalidated.contains(region_id));
         }
+        self.latest_virtual_contents
+            .remove_if(host_uri, |_, contents| contents.is_empty());
     }
 
     /// Increment the version of a virtual document and return the new version,
@@ -3630,6 +3632,11 @@ mod tests {
         let contents = pool.latest_virtual_contents.get(&host_uri).unwrap();
         assert!(!contents.contains_key(&("lua".to_string(), TEST_ULID_LUA_0.to_string())));
         assert!(contents.contains_key(&("lua".to_string(), TEST_ULID_LUA_1.to_string())));
+        drop(contents);
+
+        pool.close_invalidated_docs(&host_uri, &[TEST_ULID_LUA_1.parse::<ulid::Ulid>().unwrap()])
+            .await;
+        assert!(!pool.latest_virtual_contents.contains_key(&host_uri));
     }
 
     /// Test that ensure_document_opened skips didOpen when document is already opened.

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -1075,6 +1075,17 @@ impl LanguageServerPool {
             connection_key: connection_key.clone(),
             armed: true,
         };
+        // Register host_to_virtual BEFORE send so that close_host_document
+        // can find this document even if the task is aborted after send.
+        // The single-writer loop (ls-bridge-message-ordering) guarantees FIFO ordering, so
+        // any subsequent didClose queued by close_host_document will arrive
+        // after didOpen on the wire.
+        self.document_tracker
+            .register_pending_document(host_uri, virtual_uri, connection_key)
+            .await;
+        // Read as close to enqueue as possible, after pending registration's
+        // awaits. If an edit publishes after this read, it observes the open
+        // claim and serializes a didChange behind this didOpen transition.
         let current_content = self
             .latest_virtual_contents
             .get(host_uri)
@@ -1087,14 +1098,6 @@ impl LanguageServerPool {
                     .map(|entry| Arc::clone(entry.value()))
             });
         let virtual_content = current_content.as_deref().unwrap_or(virtual_content);
-        // Register host_to_virtual BEFORE send so that close_host_document
-        // can find this document even if the task is aborted after send.
-        // The single-writer loop (ls-bridge-message-ordering) guarantees FIFO ordering, so
-        // any subsequent didClose queued by close_host_document will arrive
-        // after didOpen on the wire.
-        self.document_tracker
-            .register_pending_document(host_uri, virtual_uri, connection_key)
-            .await;
         let did_open = build_didopen_notification(virtual_uri, virtual_content);
         if let Err(e) = sender.send_notification(did_open).await {
             self.document_tracker

--- a/src/lsp/bridge/text_document/did_change.rs
+++ b/src/lsp/bridge/text_document/did_change.rs
@@ -51,6 +51,16 @@ impl LanguageServerPool {
 
         // For each injection, check if it's actually opened and send didChange
         for injection in injections {
+            // Publish the latest content even when no downstream document is
+            // open yet. A first interactive request may still be awaiting the
+            // server handshake with an older snapshot; its didOpen consumes
+            // this value after taking the per-document transition.
+            self.record_latest_virtual_content(
+                host_uri,
+                &injection.language,
+                &injection.region_id,
+                &injection.content,
+            );
             let virtual_uri =
                 VirtualDocumentUri::new(&host_uri_lsp, &injection.language, &injection.region_id);
 

--- a/src/lsp/bridge/text_document/did_change.rs
+++ b/src/lsp/bridge/text_document/did_change.rs
@@ -54,7 +54,9 @@ impl LanguageServerPool {
             // Publish the latest content even when no downstream document is
             // open yet. A first interactive request may still be awaiting the
             // server handshake with an older snapshot; its didOpen consumes
-            // this value after taking the per-document transition.
+            // this value after taking the per-document transition. Keep the
+            // value after didOpen so a respawned server also reopens from the
+            // latest host content; unchanged edits avoid replacing it.
             self.record_latest_virtual_content(
                 host_uri,
                 &injection.language,

--- a/src/lsp/bridge/text_document/did_close.rs
+++ b/src/lsp/bridge/text_document/did_close.rs
@@ -189,6 +189,7 @@ impl LanguageServerPool {
     /// The connection to downstream language servers remains open — only the
     /// virtual documents are closed.
     pub(crate) async fn close_host_document(&self, host_uri: &Url) -> Vec<OpenedVirtualDoc> {
+        self.clear_latest_virtual_contents(host_uri);
         // 1. Remove and get all virtual docs for this host
         let virtual_docs = self.remove_host_virtual_docs(host_uri).await;
 
@@ -210,6 +211,7 @@ impl LanguageServerPool {
     /// orphaned in downstream LSs. Matching docs are atomically removed from
     /// tracking and sent didClose (best effort); docs never opened are skipped.
     pub(crate) async fn close_invalidated_docs(&self, host_uri: &Url, invalidated_ulids: &[Ulid]) {
+        self.clear_invalidated_virtual_contents(host_uri, invalidated_ulids);
         // Atomically remove matching docs from host_to_virtual
         let to_close = self
             .remove_matching_virtual_docs(host_uri, invalidated_ulids)


### PR DESCRIPTION
## Summary

- remember the latest extracted injection content even before a downstream virtual document is opened
- consume that content after the first request owns the didOpen transition, avoiding stale request-entry snapshots after server startup waits
- reclaim cached unopened content on host close and region invalidation
- add regressions for the stale didOpen interleaving and cache cleanup

## Validation

- `make check`
- `TREE_SITTER_GRAMMARS=/Users/atusy/ghq/github.com/atusy/kakehashi___main/deps/tree-sitter make test` (2802 passed, 2 ignored)
- Codex initial and fresh reviews: no actionable findings

Closes #573

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language-server synchronization by using the most recent host edits when opening virtual documents after a server has started.
  * Updates the stored “latest host content” immediately on edits, even before downstream documents are opened.
  * Clears cached latest/invalidated virtual contents when host documents are closed or invalidated to avoid stale updates.

* **Tests**
  * Added/extended coverage to verify “arrived while starting” content usage and correct caching/invalidation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->