### PR TITLE
fix(diagnostics): prevent debounce resurrection after close

### DIFF
--- a/src/lsp/debounced_diagnostics.rs
+++ b/src/lsp/debounced_diagnostics.rs
@@ -290,10 +290,10 @@ async fn execute_debounced_diagnostic(data: DebouncedDiagnosticData) {
     let edit_guard = edit_lock.lock().await;
     let current_incarnation = documents.get(&uri).map(|doc| doc.incarnation());
     if current_incarnation != Some(incarnation) {
-        drop(edit_guard);
         if current_incarnation.is_none() {
             documents.remove_edit_lock_if_unshared(&uri, &edit_lock);
         }
+        drop(edit_guard);
         return;
     }
 
@@ -347,15 +347,21 @@ async fn execute_debounced_diagnostic(data: DebouncedDiagnosticData) {
         let diagnostics =
             collect_push_diagnostics(snapshot_data, &bridge_pool, &uri_clone, LOG_TARGET).await;
 
-        // Collection can outlive the timer body's entry gate. Reject a closed
-        // document or a new lifetime at the last boundary before mutating the
-        // diagnostic cache/editor; didClose also aborts this registered task and
-        // clears the host, but the incarnation check makes stale publication
-        // independently impossible.
-        if publish_documents
+        // Collection can outlive the timer body's entry gate. Serialize the
+        // final liveness check + publication with didClose's
+        // `clear_document_state_on_close` edit-lock section: publish-first is
+        // cleared by the following close, while close-first observes no matching
+        // lifetime and returns. didClose also aborts this registered task.
+        let publish_edit_lock = publish_documents.edit_lock(&uri_clone);
+        let publish_edit_guard = publish_edit_lock.lock().await;
+        let current_incarnation = publish_documents
             .get(&uri_clone)
-            .is_none_or(|doc| doc.incarnation() != incarnation)
-        {
+            .map(|doc| doc.incarnation());
+        if current_incarnation != Some(incarnation) {
+            if current_incarnation.is_none() {
+                publish_documents.remove_edit_lock_if_unshared(&uri_clone, &publish_edit_lock);
+            }
+            drop(publish_edit_guard);
             return;
         }
 
@@ -380,6 +386,7 @@ async fn execute_debounced_diagnostic(data: DebouncedDiagnosticData) {
                 publisher.publish_pull_layer(&uri_clone, diagnostics).await;
             }
         }
+        drop(publish_edit_guard);
     });
 
     // Register with SyntheticDiagnosticsManager for superseding

--- a/src/lsp/debounced_diagnostics.rs
+++ b/src/lsp/debounced_diagnostics.rs
@@ -342,9 +342,22 @@ async fn execute_debounced_diagnostic(data: DebouncedDiagnosticData) {
     // Spawn the actual diagnostic task (similar to DiagnosticScheduler::spawn_synthetic_diagnostic_task)
     // This task is registered with SyntheticDiagnosticsManager for superseding
     let uri_clone = uri.clone();
+    let publish_documents = Arc::clone(&documents);
     let task = tokio::spawn(async move {
         let diagnostics =
             collect_push_diagnostics(snapshot_data, &bridge_pool, &uri_clone, LOG_TARGET).await;
+
+        // Collection can outlive the timer body's entry gate. Reject a closed
+        // document or a new lifetime at the last boundary before mutating the
+        // diagnostic cache/editor; didClose also aborts this registered task and
+        // clears the host, but the incarnation check makes stale publication
+        // independently impossible.
+        if publish_documents
+            .get(&uri_clone)
+            .is_none_or(|doc| doc.incarnation() != incarnation)
+        {
+            return;
+        }
 
         // Feed the host-event pull outcome into the cache and republish the merged
         // set (push-propagation-diagnostic-forwarding) — push slots survive.

--- a/src/lsp/debounced_diagnostics.rs
+++ b/src/lsp/debounced_diagnostics.rs
@@ -54,11 +54,22 @@ struct DebouncedDiagnosticData {
     /// text at sync time (under the bridge's `host_documents` lock) so a late
     /// re-sync sends the latest text rather than this fire's snapshot (#422).
     documents: Arc<crate::document::DocumentStore>,
+    /// Open lifetime captured when the timer was scheduled. A close/reopen at
+    /// the same URI must not let this prior lifetime register new work.
+    incarnation: u64,
     /// Reference to synthetic diagnostics manager for task registration
     synthetic_diagnostics: Arc<SyntheticDiagnosticsManager>,
     /// The single proactive publisher: feeds the pull result into the cache and
     /// republishes the merged set (push-propagation-diagnostic-forwarding).
     publisher: Arc<DiagnosticPublisher>,
+    #[cfg(test)]
+    execution_gate: Option<Arc<DebounceExecutionGate>>,
+}
+
+#[cfg(test)]
+pub(crate) struct DebounceExecutionGate {
+    pub(crate) entered: tokio::sync::Notify,
+    pub(crate) release: tokio::sync::Notify,
 }
 
 /// Manager for debounced diagnostic triggers.
@@ -76,6 +87,8 @@ pub(crate) struct DebouncedDiagnosticsManager {
     /// schedules without rebuilding the manager (it lives behind an `Arc`). Read at
     /// schedule time; in-flight timers keep the value they were spawned with.
     debounce_millis: AtomicU64,
+    #[cfg(test)]
+    execution_gate: std::sync::Mutex<Option<Arc<DebounceExecutionGate>>>,
 }
 
 impl Default for DebouncedDiagnosticsManager {
@@ -95,6 +108,8 @@ impl DebouncedDiagnosticsManager {
         Self {
             active_timers: DashMap::new(),
             debounce_millis: AtomicU64::new(debounce_duration.as_millis() as u64),
+            #[cfg(test)]
+            execution_gate: std::sync::Mutex::new(None),
         }
     }
 
@@ -108,6 +123,16 @@ impl DebouncedDiagnosticsManager {
     #[cfg(test)]
     pub(crate) fn debounce_millis(&self) -> u64 {
         self.debounce_millis.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn install_execution_gate(&self) -> Arc<DebounceExecutionGate> {
+        let gate = Arc::new(DebounceExecutionGate {
+            entered: tokio::sync::Notify::new(),
+            release: tokio::sync::Notify::new(),
+        });
+        *self.execution_gate.lock().unwrap() = Some(Arc::clone(&gate));
+        gate
     }
 
     /// Schedule a debounced diagnostic for a document.
@@ -142,6 +167,9 @@ impl DebouncedDiagnosticsManager {
                 uri
             );
         }
+        let Some(incarnation) = documents.get(&uri).map(|doc| doc.incarnation()) else {
+            return;
+        };
 
         let data = DebouncedDiagnosticData {
             uri: uri.clone(),
@@ -151,6 +179,9 @@ impl DebouncedDiagnosticsManager {
             synthetic_diagnostics,
             publisher,
             documents,
+            incarnation,
+            #[cfg(test)]
+            execution_gate: self.execution_gate.lock().unwrap().clone(),
         };
 
         let duration = Duration::from_millis(self.debounce_millis.load(Ordering::Relaxed));
@@ -233,7 +264,31 @@ async fn execute_debounced_diagnostic(data: DebouncedDiagnosticData) {
         synthetic_diagnostics,
         publisher,
         documents,
+        incarnation,
+        #[cfg(test)]
+        execution_gate,
     } = data;
+
+    #[cfg(test)]
+    if let Some(gate) = execution_gate {
+        gate.entered.notify_one();
+        gate.release.notified().await;
+    }
+
+    // Serialize timer side effects with didClose's document removal. If this
+    // body wins, it registers eager/synthetic work before close performs its
+    // cancellation cleanup; if close wins, liveness/incarnation rejects this
+    // prior timer. The new await is also a cancellation checkpoint after sleep.
+    let edit_lock = documents.edit_lock(&uri);
+    let edit_guard = edit_lock.lock().await;
+    let current_incarnation = documents.get(&uri).map(|doc| doc.incarnation());
+    if current_incarnation != Some(incarnation) {
+        drop(edit_guard);
+        if current_incarnation.is_none() {
+            documents.remove_edit_lock_if_unshared(&uri, &edit_lock);
+        }
+        return;
+    }
 
     // #431: re-sync the host document to its `_self` host servers at this debounced
     // cadence (after the user stops typing), so a push-only host server — which the
@@ -311,6 +366,7 @@ async fn execute_debounced_diagnostic(data: DebouncedDiagnosticData) {
     // If a didSave or another debounced didChange triggers while this is running,
     // the new task will supersede this one
     synthetic_diagnostics.register_task(uri, task.abort_handle());
+    drop(edit_guard);
 }
 
 #[cfg(test)]

--- a/src/lsp/debounced_diagnostics.rs
+++ b/src/lsp/debounced_diagnostics.rs
@@ -248,6 +248,13 @@ impl DebouncedDiagnosticsManager {
     pub(crate) fn active_timer_count(&self) -> usize {
         self.active_timers.len()
     }
+
+    #[cfg(test)]
+    pub(crate) fn timer_abort_handle(&self, uri: &Url) -> Option<AbortHandle> {
+        self.active_timers
+            .get(uri)
+            .map(|entry| entry.value().clone())
+    }
 }
 
 /// Execute diagnostic collection and publishing after debounce timer expires.

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -838,6 +838,77 @@ print("hello")
         );
     }
 
+    #[tokio::test]
+    async fn fired_debounce_cannot_resync_document_closed_before_body_runs() {
+        use std::sync::Arc;
+
+        use crate::config::settings::{AggregationStrategy, LayerSource, ResolvedLayerConfig};
+        use crate::lsp::debounced_diagnostics::DebouncedDiagnosticsManager;
+        use crate::lsp::lsp_impl::DiagnosticPublisher;
+        use crate::lsp::lsp_impl::bridge_context::HostRequestContext;
+        use crate::lsp::lsp_impl::text_document::publish_diagnostic::DiagnosticSnapshot;
+        use crate::lsp::synthetic_diagnostics::SyntheticDiagnosticsManager;
+
+        let (service, _socket) = LspService::new(Kakehashi::new);
+        let server = service.inner();
+        configure_rust_self_host(server);
+        server.bridge.insert_ready_test_connection("rust_ls").await;
+        let uri = Url::parse("file:///test/closed_debounce.rs").unwrap();
+        server.documents.insert(
+            uri.clone(),
+            "fn stale() {}".to_string(),
+            Some("rust".to_string()),
+            None,
+        );
+        let configs = server
+            .bridge
+            .get_host_configs_for_language(&server.settings_manager.load_settings(), "rust");
+        let snapshot = DiagnosticSnapshot {
+            virt_contexts: vec![],
+            host_pull_enabled: true,
+            host: Some(HostRequestContext {
+                uri: uri.clone(),
+                language_id: "rust".to_string(),
+                text: Arc::from("fn stale() {}"),
+                configs,
+                priorities: vec![],
+                strategy: AggregationStrategy::Concatenated,
+                max_fan_out: None,
+                upstream_request_id: None,
+            }),
+            layer_cfg: ResolvedLayerConfig {
+                priorities: vec![LayerSource::Host],
+                strategy: AggregationStrategy::Concatenated,
+            },
+        };
+        let manager = DebouncedDiagnosticsManager::with_duration(Duration::ZERO);
+        let gate = manager.install_execution_gate();
+        manager.schedule(
+            uri.clone(),
+            Some(snapshot),
+            server.bridge.pool_arc(),
+            Arc::clone(&server.bridge),
+            Arc::new(SyntheticDiagnosticsManager::new()),
+            Arc::new(DiagnosticPublisher::new(server)),
+            Arc::clone(&server.documents),
+        );
+        gate.entered.notified().await;
+
+        server.documents.remove(&uri);
+        gate.release.notify_one();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        assert_eq!(
+            server
+                .bridge
+                .pool()
+                .host_document_version(&uri, "rust_ls")
+                .await,
+            None,
+            "a timer cancelled after firing must not reopen a closed host"
+        );
+    }
+
     /// Locks the load-bearing property behind #431: `prepare_diagnostic_snapshot`
     /// builds the host context for a `_self`-bridged doc WITHOUT gating on the
     /// server advertising `diagnosticProvider`. A push-only `rust_ls` (no

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -893,10 +893,17 @@ print("hello")
             Arc::clone(&server.documents),
         );
         gate.entered.notified().await;
+        let timer = manager.timer_abort_handle(&uri).unwrap();
 
         server.documents.remove(&uri);
         gate.release.notify_one();
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        timeout(Duration::from_secs(1), async {
+            while !timer.is_finished() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("released debounce body should finish");
 
         assert_eq!(
             server

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -905,15 +905,19 @@ print("hello")
         .await
         .expect("released debounce body should finish");
 
-        assert_eq!(
-            server
-                .bridge
-                .pool()
-                .host_document_version(&uri, "rust_ls")
-                .await,
-            None,
-            "a timer cancelled after firing must not reopen a closed host"
-        );
+        let observation_deadline = tokio::time::Instant::now() + Duration::from_millis(100);
+        while tokio::time::Instant::now() < observation_deadline {
+            assert_eq!(
+                server
+                    .bridge
+                    .pool()
+                    .host_document_version(&uri, "rust_ls")
+                    .await,
+                None,
+                "a timer cancelled after firing must not reopen a closed host"
+            );
+            tokio::task::yield_now().await;
+        }
     }
 
     /// Locks the load-bearing property behind #431: `prepare_diagnostic_snapshot`


### PR DESCRIPTION
## Summary

- capture the document incarnation when scheduling a debounced diagnostic
- serialize fired-timer side effects with didClose document removal using the per-document edit lock
- reject closed or reopened document lifetimes before eager host sync or synthetic-task registration
- add a deterministic regression for a timer body that resumes after document removal

## Validation

- `make check`
- `TREE_SITTER_GRAMMARS=/Users/atusy/ghq/github.com/atusy/kakehashi___main/deps/tree-sitter make test` (2801 passed, 2 ignored)
- Codex initial and fresh reviews: no actionable findings

Closes #584

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented debounced diagnostics from acting on documents that changed since the debounce was scheduled (e.g., closed, reopened, replaced, or removed mid-execution).
  * Added stronger incarnation/version checks before publishing diagnostics to avoid stale updates and unnecessary state changes.
* **Tests**
  * Added a regression test ensuring a debounced diagnostics “fire” that runs while the document is removed does not recreate/resync the host document afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->