### PR TITLE
fix(lsp): isolate node identities across reopen

### DIFF
--- a/docs/architecture-decisions/lazy-node-identity-tracking.md
+++ b/docs/architecture-decisions/lazy-node-identity-tracking.md
@@ -175,6 +175,10 @@ cleanup: pre-close ids still become indistinguishable from never-issued ids,
 while ids already published by the reopened snapshot remain resolvable.
 Incarnation is metadata, not part of the position uniqueness key, so a node at
 the same position in a new lifetime receives a fresh ULID.
+The tracker also records the URI's current open incarnation (or a lightweight
+closed marker). This closes the post-cleanup window where a direct reader that
+passed liveness before `didClose` could otherwise recreate an old-lifetime
+entry; the closed marker contains no node IDs and is replaced on `didOpen`.
 
 **Invalidate semantics**: When a node's START falls inside the edit range, both entries are removed. After removal, the ULID is **indistinguishable from "never issued"** — by design, no tombstone is kept, so memory stays bounded to live nodes only.
 

--- a/docs/architecture-decisions/lazy-node-identity-tracking.md
+++ b/docs/architecture-decisions/lazy-node-identity-tracking.md
@@ -167,6 +167,15 @@ reverse:  Ulid → PositionKey    (text/range resolution, parent/children naviga
 
 Both maps are kept in sync on `get_or_create`, `adjust_for_edits`, and `didClose`. The reverse direction is required because clients hold ULIDs as opaque references and have no way to reconstruct positions on their own.
 
+Each pair also carries the document **incarnation** that minted it. `didClose`
+passes the closing incarnation to `NodeTracker`; cleanup removes entries from
+that lifetime while retaining entries with a newer incarnation. This matters
+when a fast reopen parses and mints before the raced close reaches tracker
+cleanup: pre-close ids still become indistinguishable from never-issued ids,
+while ids already published by the reopened snapshot remain resolvable.
+Incarnation is metadata, not part of the position uniqueness key, so a node at
+the same position in a new lifetime receives a fresh ULID.
+
 **Invalidate semantics**: When a node's START falls inside the edit range, both entries are removed. After removal, the ULID is **indistinguishable from "never issued"** — by design, no tombstone is kept, so memory stays bounded to live nodes only.
 
 ## Example: Markdown Code Block

--- a/docs/architecture-decisions/lazy-node-identity-tracking.md
+++ b/docs/architecture-decisions/lazy-node-identity-tracking.md
@@ -179,6 +179,11 @@ The tracker also records the URI's current open incarnation (or a lightweight
 closed marker). This closes the post-cleanup window where a direct reader that
 passed liveness before `didClose` could otherwise recreate an old-lifetime
 entry; the closed marker contains no node IDs and is replaced on `didOpen`.
+Markers are deliberately retained for the process lifetime: one `Url` plus one
+optional `u64` per distinct URI ever closed (`O(U_closed)`), with no node IDs,
+text, trees, or per-edit growth. Removing a marker would reopen the exact stale
+direct-mint resurrection window it guards; a future bounded lifecycle-epoch
+store may replace this conservative trade-off if URI churn becomes measurable.
 
 **Invalidate semantics**: When a node's START falls inside the edit range, both entries are removed. After removal, the ULID is **indistinguishable from "never issued"** — by design, no tombstone is kept, so memory stays bounded to live nodes only.
 
@@ -214,7 +219,8 @@ More text
 - **Memory efficient**: Only requested nodes are tracked (O(k) where k = tracked nodes)
 - **Container stability**: Parent nodes retain ID when contents change
 - **Correct invalidation**: Nodes whose START lies inside the old edit range are explicitly removed
-- **Clean lifecycle**: `NodeTracker` dies with `Document` on `didClose`
+- **Clean node lifecycle**: node-ID entries die with `Document` on `didClose`;
+  only the bounded-per-URI lifecycle marker described above remains
 - **AST-aligned semantics**: START-based identity matches structural intuition
 
 ### Negative

--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -136,6 +136,7 @@ pub(crate) async fn handle_semantic_tokens_full(
             tracker: p.tracker.as_ref(),
             cache: p.cache.as_ref(),
             generation: p.generation,
+            incarnation: p.incarnation,
             // Currency latch for region-id minting, taken here inside the
             // work-unit so the race window is the compute itself, not the
             // pool-queue wait. A stale serve goes read-only on the tracker

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -772,12 +772,13 @@ fn discover_single_region(
                         incarnation,
                     )?
                 } else {
-                    tracker.lookup_in_layer(
+                    tracker.lookup_in_layer_for_incarnation(
                         uri,
                         injection.content_node.start_byte(),
                         injection.content_node.end_byte(),
                         injection.content_node.kind(),
                         0,
+                        incarnation,
                     )?
                 }
                 .to_string();

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -770,7 +770,7 @@ fn discover_single_region(
                         injection.content_node.end_byte(),
                         injection.content_node.kind(),
                         incarnation,
-                    )
+                    )?
                 } else {
                     tracker.lookup_in_layer(
                         uri,

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -66,6 +66,7 @@ pub(crate) struct InjectionCacheCtx<'a> {
     pub tracker: &'a NodeTracker,
     pub cache: &'a InjectionTokenCache,
     pub generation: u64,
+    pub incarnation: u64,
     /// Whether the snapshot this compute serves was current when the
     /// work-unit started: only then may region ids be MINTED into the
     /// live-coordinate tracker. A stale serve reuses existing ids read-only
@@ -467,7 +468,7 @@ fn collect_injection_contexts_sync<'a>(
     coordinator: &LanguageCoordinator,
     content_start_byte: usize,
     parent_included_ranges: Option<&[tree_sitter::Range]>,
-    cache_ctx: Option<(&Url, &NodeTracker, bool)>,
+    cache_ctx: Option<(&Url, &NodeTracker, u64, bool)>,
     cancel: Option<&crate::cancel::CancelToken>,
 ) -> (Vec<InjectionContext<'a>>, Vec<(usize, usize)>, bool) {
     use crate::language::injection::collect_all_injections;
@@ -632,7 +633,7 @@ fn discover_single_region(
     text: &str,
     coordinator: &LanguageCoordinator,
     parent_included_ranges: Option<&[tree_sitter::Range]>,
-    cache_for_singles: Option<(&Url, &NodeTracker, bool)>,
+    cache_for_singles: Option<(&Url, &NodeTracker, u64, bool)>,
     // The producer path's already-built cache identity for THIS region
     // (populate minted the id and hashed the content moments earlier):
     // reused instead of a second tracker op + content hash on the
@@ -752,7 +753,7 @@ fn discover_single_region(
     // eviction itself is content-addressed and needs no id). Eligibility
     // is this request's translation predicate: column-0 start AND no per-row
     // prefixes (singles are never injection.combined).
-    let token_cache = cache_for_singles.and_then(|(uri, tracker, mint_regions)| {
+    let token_cache = cache_for_singles.and_then(|(uri, tracker, incarnation, mint_regions)| {
         let cacheable_owned;
         let cacheable = match prebuilt_cacheable {
             Some(prebuilt) => prebuilt,
@@ -763,11 +764,12 @@ fn discover_single_region(
                 // cache warm for regions the edits did not shift; an unknown
                 // region simply goes uncached for this stale serve.
                 let region_id = if mint_regions {
-                    tracker.get_or_create(
+                    tracker.get_or_create_for_incarnation(
                         uri,
                         injection.content_node.start_byte(),
                         injection.content_node.end_byte(),
                         injection.content_node.kind(),
+                        incarnation,
                     )
                 } else {
                     tracker.lookup_in_layer(
@@ -974,6 +976,7 @@ pub(crate) fn build_document_discovery(
     uri: &Url,
     tracker: &NodeTracker,
     generation: u64,
+    incarnation: u64,
 ) -> Option<DiscoveredInjections> {
     // Partition exactly as collect_injection_contexts_sync does: an
     // injection.combined pattern (with no effective #offset!) → drop the
@@ -1026,7 +1029,7 @@ pub(crate) fn build_document_discovery(
             text,
             coordinator,
             None,
-            Some((uri, tracker, true)),
+            Some((uri, tracker, incarnation, true)),
             Some(prebuilt),
             false,
         ) {
@@ -1295,7 +1298,7 @@ pub(crate) fn collect_injection_tokens_parallel(
                 coordinator,
                 0,
                 None,
-                cache_ctx.map(|c| (c.uri, c.tracker, c.mint_regions)),
+                cache_ctx.map(|c| (c.uri, c.tracker, c.incarnation, c.mint_regions)),
                 // `cancel` is polled inside the per-region discovery loop — that
                 // resolve loop is the dominant cost on a large document, so a
                 // supersede must be able to abort it mid-loop.
@@ -2937,6 +2940,7 @@ local b = 2
             tracker: &tracker,
             cache: &cache,
             generation: 0,
+            incarnation: 0,
             mint_regions: false,
             discovery: None,
         };
@@ -2967,6 +2971,7 @@ local b = 2
             tracker: &tracker,
             cache: &cache,
             generation: 0,
+            incarnation: 0,
             mint_regions: true,
             discovery: None,
         };
@@ -3041,6 +3046,7 @@ local b = 2
             tracker: &tracker,
             cache: &cache,
             generation: 0,
+            incarnation: 0,
             mint_regions: true,
             discovery: None,
         };
@@ -3143,6 +3149,7 @@ local b = 2
             &uri,
             &tracker,
             0,
+            0,
         )
         .expect("eight single lua blocks clear the gate and discovery completes");
         assert_eq!(discovery.regions.len(), 8);
@@ -3153,6 +3160,7 @@ local b = 2
             tracker: &tracker,
             cache: &cache,
             generation: 0,
+            incarnation: 0,
             mint_regions: true,
             discovery: Some(&discovery),
         };
@@ -3211,6 +3219,7 @@ local b = 2
             tracker: &tracker,
             cache: &cache,
             generation: 1,
+            incarnation: 0,
             mint_regions: true,
             discovery: Some(&discovery),
         };
@@ -3304,6 +3313,7 @@ local b = 2
             &uri,
             &tracker,
             0,
+            0,
         )
         .expect("gate-clearing singles must store a (partial) discovery");
         assert!(
@@ -3377,6 +3387,7 @@ local b = 2
             tracker: &tracker,
             cache: &cache,
             generation: 0,
+            incarnation: 0,
             mint_regions: true,
             discovery: Some(&discovery),
         };
@@ -3444,6 +3455,7 @@ local b = 2
             &coordinator,
             &uri,
             &tracker,
+            0,
             0,
         )
         .expect("discovery is stored with the unresolvable regions dropped");
@@ -3540,6 +3552,7 @@ local b = 2
             tracker: &tracker,
             cache: &cache,
             generation: 0,
+            incarnation: 0,
             mint_regions: true,
             discovery: None,
         };
@@ -3589,6 +3602,7 @@ local b = 2
             tracker: &tracker,
             cache: &cache,
             generation: 0,
+            incarnation: 0,
             mint_regions: true,
             discovery: None,
         };
@@ -3667,6 +3681,7 @@ local b = 2
             tracker: &tracker,
             cache: &cache,
             generation: 0,
+            incarnation: 0,
             mint_regions: true,
             discovery: None,
         };

--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -9,6 +9,7 @@ use super::snapshot::{ParseSnapshot, SnapshotSlot};
 pub(crate) struct DocumentSnapshot {
     text: Arc<str>,
     tree: Tree,
+    incarnation: u64,
 }
 
 impl DocumentSnapshot {
@@ -27,6 +28,10 @@ impl DocumentSnapshot {
     /// Get the parse tree
     pub(crate) fn tree(&self) -> &Tree {
         &self.tree
+    }
+
+    pub(crate) fn incarnation(&self) -> u64 {
+        self.incarnation
     }
 }
 
@@ -216,6 +221,7 @@ impl Document {
         Some(DocumentSnapshot {
             text: self.text.clone(),
             tree: self.tree.as_ref()?.clone(),
+            incarnation: self.incarnation,
         })
     }
 

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -194,7 +194,13 @@ impl DocumentStore {
     }
 
     // Lock safety: Single insert() call - no read lock held before or during write
-    pub fn insert(&self, uri: Url, text: String, language_id: Option<String>, tree: Option<Tree>) {
+    pub fn insert(
+        &self,
+        uri: Url,
+        text: String,
+        language_id: Option<String>,
+        tree: Option<Tree>,
+    ) -> u64 {
         let has_tree = tree.is_some();
         // didOpen registers a fresh lifetime → a fresh incarnation, so an
         // in-flight parse from a prior open of this URI can't publish against it.
@@ -214,6 +220,7 @@ impl DocumentStore {
         // entry being present. A reopen replaces any leftover prior-lifetime channel.
         self.ensure_watermark_entry(&uri, incarnation);
         self.documents.insert(uri, document);
+        incarnation
     }
 
     // Lock safety: Returns DocumentHandle wrapping Ref - caller holds read lock until drop

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -466,6 +466,7 @@ impl InjectionResolver {
     ///
     /// Does not hold any Document lock: inputs (`tree`, `text`) must be pre-cloned,
     /// typically via `DocumentSnapshot`.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn resolve_at_byte_offset(
         coordinator: &LanguageCoordinator,
         tracker: &NodeTracker,
@@ -474,6 +475,7 @@ impl InjectionResolver {
         text: &str,
         injection_query: &Query,
         byte_offset: usize,
+        incarnation: u64,
     ) -> Option<ResolvedInjection> {
         let injections = collect_all_injections(&tree.root_node(), text, Some(injection_query))?;
         let (_region_index, region) = find_injection_at_position(&injections, byte_offset)?;
@@ -483,6 +485,7 @@ impl InjectionResolver {
             uri,
             region,
             text,
+            incarnation,
         ))
     }
 
@@ -503,12 +506,14 @@ impl InjectionResolver {
         tracker: &NodeTracker,
         uri: &Url,
         injection: &InjectionRegionInfo,
+        incarnation: u64,
     ) -> Ulid {
-        tracker.get_or_create(
+        tracker.get_or_create_for_incarnation(
             uri,
             injection.content_node.start_byte(),
             injection.content_node.end_byte(),
             injection.content_node.kind(),
+            incarnation,
         )
     }
 
@@ -545,8 +550,9 @@ impl InjectionResolver {
         uri: &Url,
         region: &InjectionRegionInfo,
         text: &str,
+        incarnation: u64,
     ) -> ResolvedInjection {
-        let region_id = Self::calculate_region_id(tracker, uri, region);
+        let region_id = Self::calculate_region_id(tracker, uri, region, incarnation);
         let region_id_str = region_id.to_string();
         let cacheable_region =
             CacheableInjectionRegion::from_region_info(region, &region_id_str, text);
@@ -573,6 +579,7 @@ impl InjectionResolver {
         tree: &Tree,
         text: &str,
         injection_query: &Query,
+        incarnation: u64,
     ) -> Vec<ResolvedInjection> {
         let Some(injections) =
             collect_all_injections(&tree.root_node(), text, Some(injection_query))
@@ -580,7 +587,7 @@ impl InjectionResolver {
             return Vec::new();
         };
 
-        Self::resolve_from_regions(coordinator, tracker, uri, &injections, text)
+        Self::resolve_from_regions(coordinator, tracker, uri, &injections, text, incarnation)
     }
 
     /// [`resolve_all`](Self::resolve_all) minus the injection-query run, for a
@@ -592,10 +599,13 @@ impl InjectionResolver {
         uri: &Url,
         regions: &[InjectionRegionInfo<'_>],
         text: &str,
+        incarnation: u64,
     ) -> Vec<ResolvedInjection> {
         regions
             .iter()
-            .map(|region| Self::build_resolved_injection(coordinator, tracker, uri, region, text))
+            .map(|region| {
+                Self::build_resolved_injection(coordinator, tracker, uri, region, text, incarnation)
+            })
             .collect()
     }
 
@@ -1020,7 +1030,7 @@ mod tests {
         let uri = test_uri("offset_frontmatter");
 
         let resolved =
-            InjectionResolver::resolve_all(&coordinator, &tracker, &uri, &tree, text, &query);
+            InjectionResolver::resolve_all(&coordinator, &tracker, &uri, &tree, text, &query, 0);
         assert_eq!(resolved.len(), 1);
         assert_eq!(resolved[0].virtual_content, "title: x\n");
         assert_eq!(resolved[0].region.line_range.start, 1);
@@ -1053,7 +1063,7 @@ mod tests {
         let uri = test_uri("offset_blockquote");
 
         let resolved =
-            InjectionResolver::resolve_all(&coordinator, &tracker, &uri, &tree, text, &query);
+            InjectionResolver::resolve_all(&coordinator, &tracker, &uri, &tree, text, &query, 0);
         assert_eq!(resolved.len(), 1);
         // The row offset trims the first content line; child exclusion strips
         // the remaining `> ` prefixes.
@@ -1087,6 +1097,7 @@ mod tests {
             text,
             &query,
             22,
+            0,
         );
         assert!(resolved.is_some(), "Should resolve injection");
         let region_id = resolved.unwrap().region.region_id;
@@ -1135,6 +1146,7 @@ mod tests {
             text,
             &query,
             byte_offsets[0],
+            0,
         );
         let r2 = InjectionResolver::resolve_at_byte_offset(
             &coordinator,
@@ -1144,6 +1156,7 @@ mod tests {
             text,
             &query,
             byte_offsets[1],
+            0,
         );
         let r3 = InjectionResolver::resolve_at_byte_offset(
             &coordinator,
@@ -1153,6 +1166,7 @@ mod tests {
             text,
             &query,
             byte_offsets[2],
+            0,
         );
 
         // Each should have different ULIDs (different ordinals)
@@ -1192,6 +1206,7 @@ mod tests {
             text,
             &query,
             byte_offset,
+            0,
         );
         let r2 = InjectionResolver::resolve_at_byte_offset(
             &coordinator,
@@ -1201,6 +1216,7 @@ mod tests {
             text,
             &query,
             byte_offset,
+            0,
         );
 
         assert_eq!(
@@ -1261,9 +1277,9 @@ mod tests {
 
         // Phase 2: calculate_region_id uses position-based keys (not ordinals)
         // Different positions → different ULIDs regardless of language
-        let ulid_0 = InjectionResolver::calculate_region_id(&tracker, &uri, &injections[0]);
-        let ulid_1 = InjectionResolver::calculate_region_id(&tracker, &uri, &injections[1]);
-        let ulid_2 = InjectionResolver::calculate_region_id(&tracker, &uri, &injections[2]);
+        let ulid_0 = InjectionResolver::calculate_region_id(&tracker, &uri, &injections[0], 0);
+        let ulid_1 = InjectionResolver::calculate_region_id(&tracker, &uri, &injections[1], 0);
+        let ulid_2 = InjectionResolver::calculate_region_id(&tracker, &uri, &injections[2], 0);
 
         // All different because they have different byte positions
         assert_ne!(
@@ -1280,7 +1296,8 @@ mod tests {
         );
 
         // Same position returns same ULID (stability)
-        let ulid_0_again = InjectionResolver::calculate_region_id(&tracker, &uri, &injections[0]);
+        let ulid_0_again =
+            InjectionResolver::calculate_region_id(&tracker, &uri, &injections[0], 0);
         assert_eq!(
             ulid_0, ulid_0_again,
             "Same position key should return same ULID"

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -1270,9 +1270,12 @@ mod tests {
 
         // Phase 2: calculate_region_id uses position-based keys (not ordinals)
         // Different positions → different ULIDs regardless of language
-        let ulid_0 = InjectionResolver::calculate_region_id(&tracker, &uri, &injections[0], 0);
-        let ulid_1 = InjectionResolver::calculate_region_id(&tracker, &uri, &injections[1], 0);
-        let ulid_2 = InjectionResolver::calculate_region_id(&tracker, &uri, &injections[2], 0);
+        let ulid_0 = InjectionResolver::calculate_region_id(&tracker, &uri, &injections[0], 0)
+            .expect("unmanaged test tracker admits the mint");
+        let ulid_1 = InjectionResolver::calculate_region_id(&tracker, &uri, &injections[1], 0)
+            .expect("unmanaged test tracker admits the mint");
+        let ulid_2 = InjectionResolver::calculate_region_id(&tracker, &uri, &injections[2], 0)
+            .expect("unmanaged test tracker admits the mint");
 
         // All different because they have different byte positions
         assert_ne!(
@@ -1290,7 +1293,8 @@ mod tests {
 
         // Same position returns same ULID (stability)
         let ulid_0_again =
-            InjectionResolver::calculate_region_id(&tracker, &uri, &injections[0], 0);
+            InjectionResolver::calculate_region_id(&tracker, &uri, &injections[0], 0)
+                .expect("same-lifetime remint is admitted");
         assert_eq!(
             ulid_0, ulid_0_again,
             "Same position key should return same ULID"

--- a/src/language/injection/discovery.rs
+++ b/src/language/injection/discovery.rs
@@ -479,14 +479,7 @@ impl InjectionResolver {
     ) -> Option<ResolvedInjection> {
         let injections = collect_all_injections(&tree.root_node(), text, Some(injection_query))?;
         let (_region_index, region) = find_injection_at_position(&injections, byte_offset)?;
-        Some(Self::build_resolved_injection(
-            coordinator,
-            tracker,
-            uri,
-            region,
-            text,
-            incarnation,
-        ))
+        Self::build_resolved_injection(coordinator, tracker, uri, region, text, incarnation)
     }
 
     /// Calculate a stable ULID-based region_id for an injection.
@@ -507,7 +500,7 @@ impl InjectionResolver {
         uri: &Url,
         injection: &InjectionRegionInfo,
         incarnation: u64,
-    ) -> Ulid {
+    ) -> Option<Ulid> {
         tracker.get_or_create_for_incarnation(
             uri,
             injection.content_node.start_byte(),
@@ -551,8 +544,8 @@ impl InjectionResolver {
         region: &InjectionRegionInfo,
         text: &str,
         incarnation: u64,
-    ) -> ResolvedInjection {
-        let region_id = Self::calculate_region_id(tracker, uri, region, incarnation);
+    ) -> Option<ResolvedInjection> {
+        let region_id = Self::calculate_region_id(tracker, uri, region, incarnation)?;
         let region_id_str = region_id.to_string();
         let cacheable_region =
             CacheableInjectionRegion::from_region_info(region, &region_id_str, text);
@@ -560,12 +553,12 @@ impl InjectionResolver {
             extract_virtual_content_and_offsets(region, &cacheable_region, text);
         let resolved_language =
             Self::resolve_language(coordinator, &region.language, &virtual_content);
-        ResolvedInjection {
+        Some(ResolvedInjection {
             region: cacheable_region,
             injection_language: resolved_language,
             virtual_content,
             line_column_offsets,
-        }
+        })
     }
 
     /// Resolve every injection region in the document (whole-doc operations
@@ -603,7 +596,7 @@ impl InjectionResolver {
     ) -> Vec<ResolvedInjection> {
         regions
             .iter()
-            .map(|region| {
+            .filter_map(|region| {
                 Self::build_resolved_injection(coordinator, tracker, uri, region, text, incarnation)
             })
             .collect()

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -821,9 +821,16 @@ impl NodeTracker {
         &self,
         uri: &Url,
         expected: (u64, u64),
+        incarnation: u64,
         commit: impl FnOnce() -> R,
     ) -> Option<R> {
+        if !self.admits_incarnation(uri, incarnation) {
+            return None;
+        }
         let entry = self.entries.entry(uri.clone()).or_default();
+        if !self.admits_incarnation(uri, incarnation) {
+            return None;
+        }
         let epoch = self
             .cleanup_epoch
             .load(std::sync::atomic::Ordering::Acquire);
@@ -1070,8 +1077,13 @@ mod tests {
         let tracker = NodeTracker::new();
         let uri = test_uri("stale_after_cleanup");
         tracker.open_incarnation(&uri, 1);
+        let stale_latch = tracker.mint_epoch(&uri);
         tracker.cleanup(&uri, 1);
 
+        assert_eq!(
+            tracker.commit_if_unshifted(&uri, stale_latch, 1, || "committed"),
+            None
+        );
         let stale_id = tracker.get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 1);
         assert_eq!(tracker.lookup_node(&uri, &stale_id), None);
         assert!(

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -104,11 +104,6 @@ impl UriEntries {
         ulid
     }
 
-    /// Lookup a position key by ULID.
-    fn lookup(&self, ulid: &Ulid) -> Option<&PositionKey> {
-        self.reverse.get(ulid).map(|tracked| &tracked.key)
-    }
-
     /// Returns the number of (key, ulid) pairs currently tracked.
     fn len(&self) -> usize {
         debug_assert_eq!(
@@ -459,9 +454,9 @@ impl NodeTracker {
         &self,
         uri: &Url,
         ulid: &Ulid,
-    ) -> Option<(usize, usize, &'static str)> {
-        let (start, end, kind, _layer) = self.lookup_node(uri, ulid)?;
-        Some((start, end, kind))
+    ) -> Option<(usize, usize, &'static str, u64)> {
+        let (start, end, kind, _layer, incarnation) = self.lookup_node(uri, ulid)?;
+        Some((start, end, kind, incarnation))
     }
 
     /// Resolve a ULID back to its tracked `(start_byte, end_byte, kind, layer)`.
@@ -474,10 +469,17 @@ impl NodeTracker {
         &self,
         uri: &Url,
         ulid: &Ulid,
-    ) -> Option<(usize, usize, &'static str, usize)> {
+    ) -> Option<(usize, usize, &'static str, usize, u64)> {
         let entries = self.entries.get(uri)?;
-        let key = entries.lookup(ulid)?;
-        Some((key.start_byte, key.end_byte, key.kind, key.layer))
+        let tracked = entries.reverse.get(ulid)?;
+        let key = tracked.key;
+        Some((
+            key.start_byte,
+            key.end_byte,
+            key.kind,
+            key.layer,
+            tracked.incarnation,
+        ))
     }
 
     /// Get the ULID for a position in a layer if it exists, without creating
@@ -1050,7 +1052,7 @@ mod tests {
         );
         assert_eq!(
             tracker.lookup_node(&uri, &reopened_id),
-            Some((10, 14, "word", 0)),
+            Some((10, 14, "word", 0, 2)),
             "the reopened lifetime's id survives the raced close"
         );
         assert_eq!(
@@ -1071,7 +1073,7 @@ mod tests {
         assert_eq!(tracker.lookup_node(&uri, &old_id), None);
         assert_eq!(
             tracker.lookup_node(&uri, &reopened_id),
-            Some((0, 4, "word", 0))
+            Some((0, 4, "word", 0, 2))
         );
     }
 
@@ -1086,7 +1088,7 @@ mod tests {
         assert_eq!(tracker.lookup_node(&uri, &stale_id), None);
         assert_eq!(
             tracker.lookup_node(&uri, &reopened_id),
-            Some((0, 4, "word", 0))
+            Some((0, 4, "word", 0, 2))
         );
     }
 
@@ -1113,7 +1115,7 @@ mod tests {
         let reopened_id = tracker.get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 2);
         assert_eq!(
             tracker.lookup_node(&uri, &reopened_id),
-            Some((0, 4, "word", 0))
+            Some((0, 4, "word", 0, 2))
         );
     }
 
@@ -1290,13 +1292,13 @@ mod tests {
 
         assert_eq!(
             tracker.lookup_node(&uri, &ulid),
-            Some((5, 15, "block", 3)),
+            Some((5, 15, "block", 3, 0)),
             "lookup_node should round-trip the layer discriminator"
         );
         assert_eq!(
             tracker.lookup_position(&uri, &ulid),
-            Some((5, 15, "block")),
-            "lookup_position should drop the layer"
+            Some((5, 15, "block", 0)),
+            "lookup_position should drop the layer but retain incarnation"
         );
     }
 
@@ -1363,7 +1365,7 @@ mod tests {
 
         assert_eq!(
             tracker.lookup_position(&uri, &ulid),
-            Some((30, 50, "block")),
+            Some((30, 50, "block", 0)),
             "Newly issued ULID must be resolvable via reverse index"
         );
     }
@@ -1418,7 +1420,7 @@ mod tests {
 
         assert_eq!(
             tracker.lookup_position(&uri, &ulid),
-            Some((55, 75, "block")),
+            Some((55, 75, "block", 0)),
             "lookup_position should follow adjusted node range"
         );
     }

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -340,6 +340,14 @@ impl NodeTracker {
             .is_none_or(|current| *current == Some(incarnation))
     }
 
+    /// Reclaim an entry this call materialized only to lose the lifecycle
+    /// admission race. A concurrent reopen may already have edited or minted;
+    /// retain either signal (`shift_gen > 0` or non-empty ids).
+    fn remove_pristine_entry(&self, uri: &Url) {
+        self.entries
+            .remove_if(uri, |_, entry| entry.shift_gen == 0 && entry.len() == 0);
+    }
+
     /// Get or create a stable ULID for a **host-layer** tree-sitter node.
     ///
     /// Convenience for the common case (host tree, region content nodes): it
@@ -413,12 +421,16 @@ impl NodeTracker {
         // pattern to avoid DashMap lifetime ambiguity.)
         if let Some(mut entry) = self.entries.get_mut(uri) {
             if !self.admits_incarnation(uri, incarnation) {
+                drop(entry);
+                self.remove_pristine_entry(uri);
                 return Ulid::new();
             }
             return entry.get_or_insert(key, incarnation);
         }
         let mut entry = self.entries.entry(uri.clone()).or_default();
         if !self.admits_incarnation(uri, incarnation) {
+            drop(entry);
+            self.remove_pristine_entry(uri);
             return Ulid::new();
         }
         entry.get_or_insert(key, incarnation)
@@ -829,6 +841,8 @@ impl NodeTracker {
         }
         let entry = self.entries.entry(uri.clone()).or_default();
         if !self.admits_incarnation(uri, incarnation) {
+            drop(entry);
+            self.remove_pristine_entry(uri);
             return None;
         }
         let epoch = self
@@ -896,12 +910,16 @@ impl NodeTracker {
         // concurrent FIRST edit on a never-minted URI.
         if let Some(mut entry) = self.entries.get_mut(uri) {
             if !self.admits_incarnation(uri, incarnation) {
+                drop(entry);
+                self.remove_pristine_entry(uri);
                 return None;
             }
             return self.mint_batch_in_entry(&mut entry, expected, incarnation, keys);
         }
         let mut entry = self.entries.entry(uri.clone()).or_default();
         if !self.admits_incarnation(uri, incarnation) {
+            drop(entry);
+            self.remove_pristine_entry(uri);
             return None;
         }
         self.mint_batch_in_entry(&mut entry, expected, incarnation, keys)

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -491,6 +491,7 @@ impl NodeTracker {
     /// of positions the intervening edits did not shift (keeping the delta
     /// lineage minimal) without ever writing its stale coordinates into this
     /// live-coordinate index.
+    #[cfg(test)]
     pub(crate) fn lookup_in_layer(
         &self,
         uri: &Url,
@@ -505,6 +506,24 @@ impl NodeTracker {
             .forward
             .get(&key)
             .map(|entry| entry.ulid)
+    }
+
+    /// Incarnation-filtered read-only lookup for stale-serving paths. A pass
+    /// from an older lifetime must never reuse a reopened lifetime's ID even
+    /// when its position key is byte-identical.
+    pub(crate) fn lookup_in_layer_for_incarnation(
+        &self,
+        uri: &Url,
+        start: usize,
+        end: usize,
+        kind: &'static str,
+        layer: usize,
+        incarnation: u64,
+    ) -> Option<Ulid> {
+        let key = PositionKey::new(start, end, kind, layer);
+        let entries = self.entries.get(uri)?;
+        let tracked = entries.forward.get(&key)?;
+        (tracked.incarnation == incarnation).then_some(tracked.ulid)
     }
 
     /// Get the ULID for a host-layer position if it exists, without creating it.
@@ -1096,6 +1115,11 @@ mod tests {
         let stale_id = tracker.get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 1);
 
         assert_eq!(stale_id, None);
+        assert_eq!(
+            tracker.lookup_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 1),
+            None,
+            "an older lifetime cannot reuse the reopened lifetime's position ID"
+        );
         assert_eq!(
             tracker.lookup_node(&uri, &reopened_id),
             Some((0, 4, "word", 0, 2))

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -86,14 +86,14 @@ struct TrackedPosition {
 
 impl UriEntries {
     /// Get or insert a ULID for a position key, keeping both maps in sync.
-    fn get_or_insert(&mut self, key: PositionKey, incarnation: u64) -> Ulid {
+    fn get_or_insert(&mut self, key: PositionKey, incarnation: u64) -> Option<Ulid> {
         if incarnation < self.latest_incarnation {
-            return Ulid::new();
+            return None;
         }
         self.latest_incarnation = incarnation;
         if let Some(existing) = self.forward.get(&key) {
             if existing.incarnation == incarnation {
-                return existing.ulid;
+                return Some(existing.ulid);
             }
             self.reverse.remove(&existing.ulid);
         }
@@ -101,7 +101,7 @@ impl UriEntries {
         self.forward.insert(key, TrackedUlid { ulid, incarnation });
         self.reverse
             .insert(ulid, TrackedPosition { key, incarnation });
-        ulid
+        Some(ulid)
     }
 
     /// Returns the number of (key, ulid) pairs currently tracked.
@@ -422,7 +422,7 @@ impl NodeTracker {
                 self.remove_pristine_entry(uri);
                 return None;
             }
-            return Some(entry.get_or_insert(key, incarnation));
+            return entry.get_or_insert(key, incarnation);
         }
         let mut entry = self.entries.entry(uri.clone()).or_default();
         if !self.admits_incarnation(uri, incarnation) {
@@ -430,7 +430,7 @@ impl NodeTracker {
             self.remove_pristine_entry(uri);
             return None;
         }
-        Some(entry.get_or_insert(key, incarnation))
+        entry.get_or_insert(key, incarnation)
     }
 
     /// The count of coordinate shifts (edit applications) `uri`'s index has
@@ -945,13 +945,11 @@ impl NodeTracker {
         if (entry.shift_gen, epoch) != expected {
             return None;
         }
-        Some(
-            keys.into_iter()
-                .map(|(start, end, kind, layer)| {
-                    entry.get_or_insert(PositionKey::new(start, end, kind, layer), incarnation)
-                })
-                .collect(),
-        )
+        keys.into_iter()
+            .map(|(start, end, kind, layer)| {
+                entry.get_or_insert(PositionKey::new(start, end, kind, layer), incarnation)
+            })
+            .collect()
     }
 
     /// The (per-URI shift generation, global cleanup epoch) pair a pass

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -32,14 +32,17 @@ pub(crate) struct NodeTracker {
     /// Current document lifetime for URIs managed by the LSP lifecycle.
     /// `None` is a close tombstone: it prevents a direct mint that passed its
     /// last reader-side liveness check before didClose from recreating an old
-    /// entry after cleanup. An absent key keeps standalone/test trackers usable.
+    /// entry after cleanup. Markers are retained at one `(Url, Option<u64>)`
+    /// per distinct URI for process lifetime; they contain no node IDs or
+    /// document data. An absent key keeps standalone/test trackers usable.
     incarnations: DashMap<Url, Option<u64>>,
     /// Bumped by every [`cleanup`](Self::cleanup) (didClose). Folded into the
     /// mint latch ([`mint_epoch`](Self::mint_epoch)) so a close/reopen —
     /// which removes the per-URI index and would reset its `shift_gen` to 0
     /// (ABA) — can never make an old-lifetime latch compare equal. Global
-    /// (not per-URI) so closed documents leave NO retained state; the cost
-    /// is that a close of any document mid-pass refuses that pass's
+    /// (not per-URI) so closed documents leave no retained node-id state
+    /// (only the small lifecycle marker documented on `incarnations`); the
+    /// cost is that a close of any document mid-pass refuses that pass's
     /// remaining mint batches — a rare event with a one-null-re-sync
     /// consequence.
     cleanup_epoch: std::sync::atomic::AtomicU64,
@@ -397,6 +400,13 @@ impl NodeTracker {
         incarnation: u64,
     ) -> Ulid {
         let key = PositionKey::new(start, end, kind, layer);
+
+        // Reject a known-closed/wrong lifetime before materializing an empty
+        // tracker entry. Re-check under the entry lock below: didClose can
+        // change lifecycle admission between this fast rejection and locking.
+        if !self.admits_incarnation(uri, incarnation) {
+            return Ulid::new();
+        }
 
         // `get_mut` first: the hot path (index already exists) avoids the
         // `Url` clone `entry()` needs for its owned key. (Explicit two-step
@@ -867,6 +877,11 @@ impl NodeTracker {
         incarnation: u64,
         keys: impl IntoIterator<Item = (usize, usize, &'static str, usize)>,
     ) -> Option<Vec<Ulid>> {
+        // Avoid leaving an empty `entries` slot for a known-stale batch. The
+        // under-lock checks below remain load-bearing against a raced close.
+        if !self.admits_incarnation(uri, incarnation) {
+            return None;
+        }
         // `get_mut` first: the hot path (index already exists — every batch
         // after a document's first) avoids the `Url` clone `entry()` needs
         // for its owned key. The absent-entry `entry().or_default()`
@@ -1059,6 +1074,10 @@ mod tests {
 
         let stale_id = tracker.get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 1);
         assert_eq!(tracker.lookup_node(&uri, &stale_id), None);
+        assert!(
+            tracker.entries.get(&uri).is_none(),
+            "a denied stale mint must not materialize an empty node index"
+        );
 
         tracker.open_incarnation(&uri, 2);
         let reopened_id = tracker.get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 2);

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -359,6 +359,7 @@ impl NodeTracker {
         kind: &'static str,
     ) -> Ulid {
         self.get_or_create_for_incarnation(uri, start, end, kind, 0)
+            .expect("unmanaged test incarnation is admitted")
     }
 
     pub(crate) fn get_or_create_for_incarnation(
@@ -368,7 +369,7 @@ impl NodeTracker {
         end: usize,
         kind: &'static str,
         incarnation: u64,
-    ) -> Ulid {
+    ) -> Option<Ulid> {
         self.get_or_create_in_layer_for_incarnation(uri, start, end, kind, 0, incarnation)
     }
 
@@ -391,6 +392,7 @@ impl NodeTracker {
         layer: usize,
     ) -> Ulid {
         self.get_or_create_in_layer_for_incarnation(uri, start, end, kind, layer, 0)
+            .expect("unmanaged test incarnation is admitted")
     }
 
     pub(crate) fn get_or_create_in_layer_for_incarnation(
@@ -401,14 +403,14 @@ impl NodeTracker {
         kind: &'static str,
         layer: usize,
         incarnation: u64,
-    ) -> Ulid {
+    ) -> Option<Ulid> {
         let key = PositionKey::new(start, end, kind, layer);
 
         // Reject a known-closed/wrong lifetime before materializing an empty
         // tracker entry. Re-check under the entry lock below: didClose can
         // change lifecycle admission between this fast rejection and locking.
         if !self.admits_incarnation(uri, incarnation) {
-            return Ulid::new();
+            return None;
         }
 
         // `get_mut` first: the hot path (index already exists) avoids the
@@ -418,17 +420,17 @@ impl NodeTracker {
             if !self.admits_incarnation(uri, incarnation) {
                 drop(entry);
                 self.remove_pristine_entry(uri);
-                return Ulid::new();
+                return None;
             }
-            return entry.get_or_insert(key, incarnation);
+            return Some(entry.get_or_insert(key, incarnation));
         }
         let mut entry = self.entries.entry(uri.clone()).or_default();
         if !self.admits_incarnation(uri, incarnation) {
             drop(entry);
             self.remove_pristine_entry(uri);
-            return Ulid::new();
+            return None;
         }
-        entry.get_or_insert(key, incarnation)
+        Some(entry.get_or_insert(key, incarnation))
     }
 
     /// The count of coordinate shifts (edit applications) `uri`'s index has
@@ -1038,10 +1040,13 @@ mod tests {
     fn cleanup_invalidates_closed_incarnation_but_keeps_reopened_entries() {
         let tracker = NodeTracker::new();
         let uri = test_uri("cleanup_reopen");
-        let old_id = tracker.get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 1);
+        let old_id = tracker
+            .get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 1)
+            .unwrap();
         let pre_close_latch = tracker.mint_epoch(&uri);
-        let reopened_id =
-            tracker.get_or_create_in_layer_for_incarnation(&uri, 10, 14, "word", 0, 2);
+        let reopened_id = tracker
+            .get_or_create_in_layer_for_incarnation(&uri, 10, 14, "word", 0, 2)
+            .unwrap();
 
         tracker.cleanup(&uri, 1);
 
@@ -1066,8 +1071,12 @@ mod tests {
     fn reopened_incarnation_remints_same_position_with_a_fresh_id() {
         let tracker = NodeTracker::new();
         let uri = test_uri("same_position_reopen");
-        let old_id = tracker.get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 1);
-        let reopened_id = tracker.get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 2);
+        let old_id = tracker
+            .get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 1)
+            .unwrap();
+        let reopened_id = tracker
+            .get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 2)
+            .unwrap();
 
         assert_ne!(old_id, reopened_id);
         assert_eq!(tracker.lookup_node(&uri, &old_id), None);
@@ -1081,11 +1090,14 @@ mod tests {
     fn stale_incarnation_cannot_evict_reopened_entry() {
         let tracker = NodeTracker::new();
         let uri = test_uri("stale_after_reopen");
-        let reopened_id = tracker.get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 2);
+        tracker.open_incarnation(&uri, 2);
+        let reopened_id = tracker
+            .get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 2)
+            .unwrap();
 
         let stale_id = tracker.get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 1);
 
-        assert_eq!(tracker.lookup_node(&uri, &stale_id), None);
+        assert_eq!(stale_id, None);
         assert_eq!(
             tracker.lookup_node(&uri, &reopened_id),
             Some((0, 4, "word", 0, 2))
@@ -1105,14 +1117,16 @@ mod tests {
             None
         );
         let stale_id = tracker.get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 1);
-        assert_eq!(tracker.lookup_node(&uri, &stale_id), None);
+        assert_eq!(stale_id, None);
         assert!(
             tracker.entries.get(&uri).is_none(),
             "a denied stale mint must not materialize an empty node index"
         );
 
         tracker.open_incarnation(&uri, 2);
-        let reopened_id = tracker.get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 2);
+        let reopened_id = tracker
+            .get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 2)
+            .unwrap();
         assert_eq!(
             tracker.lookup_node(&uri, &reopened_id),
             Some((0, 4, "word", 0, 2))
@@ -1326,6 +1340,7 @@ mod tests {
         tracker.cleanup(&uri, 0);
 
         // After cleanup, same key should create NEW ULID
+        tracker.open_incarnation(&uri, 0);
         let ulid_after = tracker.get_or_create(&uri, 0, 10, "code_block");
 
         assert_ne!(

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -20,8 +20,8 @@ use url::Url;
 /// Protocol ([node-reference-protocol](../../docs/architecture-decisions/node-reference-protocol.md)).
 ///
 /// Maintains a bidirectional index per URI:
-/// - forward (`PositionKey -> Ulid`) for assignment / dedup on `get_or_create`
-/// - reverse (`Ulid -> PositionKey`) for resolving a held ULID back to a node
+/// - forward (`PositionKey -> (Ulid, incarnation)`) for assignment / dedup
+/// - reverse (`Ulid -> (PositionKey, incarnation)`) for resolving a held ULID back to a node
 ///   range (used by `kakehashi/node/text` and future navigation methods).
 ///
 /// Both directions are kept in sync across `get_or_create`, `adjust_for_edits`,
@@ -48,8 +48,12 @@ pub(crate) struct NodeTracker {
 /// directly.
 #[derive(Default)]
 struct UriEntries {
-    forward: HashMap<PositionKey, Ulid>,
-    reverse: HashMap<Ulid, PositionKey>,
+    forward: HashMap<PositionKey, TrackedUlid>,
+    reverse: HashMap<Ulid, TrackedPosition>,
+    /// Highest document incarnation that has minted into this URI index.
+    /// Once a reopen mints, a straggling older-lifetime reader must not evict
+    /// or append entries behind it.
+    latest_incarnation: u64,
     /// Count of coordinate shifts (edit applications) this index has
     /// received. Read/written under the same DashMap entry lock as the maps,
     /// so [`mint_batch_if_unshifted`](NodeTracker::mint_batch_if_unshifted)
@@ -60,21 +64,41 @@ struct UriEntries {
     shift_gen: u64,
 }
 
+#[derive(Clone, Copy)]
+struct TrackedUlid {
+    ulid: Ulid,
+    incarnation: u64,
+}
+
+#[derive(Clone, Copy)]
+struct TrackedPosition {
+    key: PositionKey,
+    incarnation: u64,
+}
+
 impl UriEntries {
     /// Get or insert a ULID for a position key, keeping both maps in sync.
-    fn get_or_insert(&mut self, key: PositionKey) -> Ulid {
+    fn get_or_insert(&mut self, key: PositionKey, incarnation: u64) -> Ulid {
+        if incarnation < self.latest_incarnation {
+            return Ulid::new();
+        }
+        self.latest_incarnation = incarnation;
         if let Some(existing) = self.forward.get(&key) {
-            return *existing;
+            if existing.incarnation == incarnation {
+                return existing.ulid;
+            }
+            self.reverse.remove(&existing.ulid);
         }
         let ulid = Ulid::new();
-        self.forward.insert(key, ulid);
-        self.reverse.insert(ulid, key);
+        self.forward.insert(key, TrackedUlid { ulid, incarnation });
+        self.reverse
+            .insert(ulid, TrackedPosition { key, incarnation });
         ulid
     }
 
     /// Lookup a position key by ULID.
     fn lookup(&self, ulid: &Ulid) -> Option<&PositionKey> {
-        self.reverse.get(ulid)
+        self.reverse.get(ulid).map(|tracked| &tracked.key)
     }
 
     /// Returns the number of (key, ulid) pairs currently tracked.
@@ -88,7 +112,7 @@ impl UriEntries {
     }
 
     /// Drain all (key, ulid) entries, clearing both maps.
-    fn drain(&mut self) -> impl Iterator<Item = (PositionKey, Ulid)> + '_ {
+    fn drain(&mut self) -> impl Iterator<Item = (PositionKey, TrackedUlid)> + '_ {
         self.reverse.clear();
         self.forward.drain()
     }
@@ -98,15 +122,28 @@ impl UriEntries {
     /// Returns `Err(existing_ulid)` if a different ULID already occupies the
     /// position. Caller decides what to do with the collision (the current
     /// adjust_for_edits policy is "first wins").
-    fn insert(&mut self, key: PositionKey, ulid: Ulid) -> std::result::Result<(), Ulid> {
+    fn insert(&mut self, key: PositionKey, tracked: TrackedUlid) -> std::result::Result<(), Ulid> {
         match self.forward.entry(key) {
             Entry::Vacant(e) => {
-                e.insert(ulid);
-                self.reverse.insert(ulid, key);
+                e.insert(tracked);
+                self.reverse.insert(
+                    tracked.ulid,
+                    TrackedPosition {
+                        key,
+                        incarnation: tracked.incarnation,
+                    },
+                );
                 Ok(())
             }
-            Entry::Occupied(e) => Err(*e.get()),
+            Entry::Occupied(e) => Err(e.get().ulid),
         }
+    }
+
+    fn retain_newer_than(&mut self, closing_incarnation: u64) {
+        self.forward
+            .retain(|_, tracked| tracked.incarnation > closing_incarnation);
+        self.reverse
+            .retain(|_, tracked| tracked.incarnation > closing_incarnation);
     }
 }
 
@@ -290,6 +327,7 @@ impl NodeTracker {
     /// with `layer = 0`. Injection-aware call sites that mint nodes from a
     /// deeper layer MUST use `get_or_create_in_layer` so host and injected
     /// nodes sharing `(start, end, kind)` receive distinct ULIDs.
+    #[cfg(test)]
     pub(crate) fn get_or_create(
         &self,
         uri: &Url,
@@ -297,7 +335,18 @@ impl NodeTracker {
         end: usize,
         kind: &'static str,
     ) -> Ulid {
-        self.get_or_create_in_layer(uri, start, end, kind, 0)
+        self.get_or_create_for_incarnation(uri, start, end, kind, 0)
+    }
+
+    pub(crate) fn get_or_create_for_incarnation(
+        &self,
+        uri: &Url,
+        start: usize,
+        end: usize,
+        kind: &'static str,
+        incarnation: u64,
+    ) -> Ulid {
+        self.get_or_create_in_layer_for_incarnation(uri, start, end, kind, 0, incarnation)
     }
 
     /// Get or create a stable ULID for a tree-sitter node at injection `layer`.
@@ -309,6 +358,7 @@ impl NodeTracker {
     ///
     /// Updates both the forward and reverse index so the returned ULID can be
     /// resolved back to its position via [`lookup_node`](Self::lookup_node).
+    #[cfg(test)]
     pub(crate) fn get_or_create_in_layer(
         &self,
         uri: &Url,
@@ -317,16 +367,28 @@ impl NodeTracker {
         kind: &'static str,
         layer: usize,
     ) -> Ulid {
+        self.get_or_create_in_layer_for_incarnation(uri, start, end, kind, layer, 0)
+    }
+
+    pub(crate) fn get_or_create_in_layer_for_incarnation(
+        &self,
+        uri: &Url,
+        start: usize,
+        end: usize,
+        kind: &'static str,
+        layer: usize,
+        incarnation: u64,
+    ) -> Ulid {
         let key = PositionKey::new(start, end, kind, layer);
 
         // `get_mut` first: the hot path (index already exists) avoids the
         // `Url` clone `entry()` needs for its owned key. (Explicit two-step
         // pattern to avoid DashMap lifetime ambiguity.)
         if let Some(mut entry) = self.entries.get_mut(uri) {
-            return entry.get_or_insert(key);
+            return entry.get_or_insert(key, incarnation);
         }
         let mut entry = self.entries.entry(uri.clone()).or_default();
-        entry.get_or_insert(key)
+        entry.get_or_insert(key, incarnation)
     }
 
     /// The count of coordinate shifts (edit applications) `uri`'s index has
@@ -389,7 +451,11 @@ impl NodeTracker {
         layer: usize,
     ) -> Option<Ulid> {
         let key = PositionKey::new(start, end, kind, layer);
-        self.entries.get(uri)?.forward.get(&key).copied()
+        self.entries
+            .get(uri)?
+            .forward
+            .get(&key)
+            .map(|entry| entry.ulid)
     }
 
     /// Get the ULID for a host-layer position if it exists, without creating it.
@@ -609,18 +675,19 @@ impl NodeTracker {
         let mut new_entries = UriEntries {
             forward: HashMap::with_capacity(entries.len()),
             reverse: HashMap::with_capacity(entries.len()),
+            latest_incarnation: entries.latest_incarnation,
             shift_gen: entries.shift_gen + 1,
         };
 
-        for (key, ulid) in entries.drain() {
+        for (key, tracked) in entries.drain() {
             if Self::should_invalidate_node(&key, edit) {
-                invalidated.push(ulid);
+                invalidated.push(tracked.ulid);
                 continue; // INVALIDATE
             }
 
             // Position adjustment (returns None if range collapsed)
             let Some(new_key) = adjust_position_for_edit(key, edit, delta) else {
-                invalidated.push(ulid);
+                invalidated.push(tracked.ulid);
                 continue; // INVALIDATE: range collapsed
             };
 
@@ -637,14 +704,14 @@ impl NodeTracker {
             // 3. Collisions may indicate a bug in invalidation logic anyway
             //
             // Log at warn level for observability and debugging.
-            if let Err(_existing) = new_entries.insert(new_key, ulid) {
+            if let Err(_existing) = new_entries.insert(new_key, tracked) {
                 warn!(
                     target: "kakehashi::node_tracker",
                     "Position collision after edit - ULID mapping dropped: ulid={}, start={}, end={}, kind={}, layer={}",
-                    ulid, new_key.start_byte, new_key.end_byte, new_key.kind, new_key.layer
+                    tracked.ulid, new_key.start_byte, new_key.end_byte, new_key.kind, new_key.layer
                 );
                 // Note: Collided ULID is also invalidated (both nodes can't coexist)
-                invalidated.push(ulid);
+                invalidated.push(tracked.ulid);
             }
         }
 
@@ -652,70 +719,41 @@ impl NodeTracker {
         invalidated
     }
 
-    /// Remove all tracked regions for a document.
+    /// Remove tracked nodes minted by the closing document lifetime.
     ///
-    /// Called on didClose to prevent memory leaks. The removal resets the
-    /// URI's `shift_gen`, so the global [`cleanup_epoch`](Self::cleanup_epoch)
-    /// is bumped instead: the latch-gated passes fold it into their latch
-    /// ([`mint_epoch`](Self::mint_epoch)), making an old-lifetime latch
-    /// unequal to any post-close/reopen observation without retaining any
-    /// per-closed-URI state.
+    /// Each bidirectional entry carries the document incarnation that minted
+    /// it. A raced reopen may have already minted newer entries before this
+    /// didClose reaches cleanup, so cleanup retains only entries whose
+    /// incarnation is newer than `closing_incarnation`. This simultaneously
+    /// invalidates every pre-close id and preserves every published reopened id.
+    /// When no newer entries remain, the whole URI index is removed.
     ///
-    /// The bump runs BEFORE the removal, and the order is load-bearing: a
+    /// The global epoch bump runs BEFORE retention, and the order is
+    /// load-bearing: a
     /// latch check that passes reads the pre-bump epoch, so it strictly
     /// precedes this close in epoch order, and whatever it minted is wiped
-    /// by the removal that follows — a closed document still leaves no
-    /// state. Removing FIRST would open a gap where a pre-close latch
+    /// by the retention that follows. Retaining FIRST would open a gap where a pre-close latch
     /// `(0, E)` re-materializes the just-removed entry (`or_default`,
     /// `shift_gen` back at 0) and passes against the not-yet-bumped epoch,
-    /// leaving stale-lifetime coordinates alive in a reopened document's
-    /// index with nothing left to reclaim them.
-    ///
-    /// `reopened` guards the removal against the inverse race: didClose
-    /// runs this AFTER removing the document and OUTSIDE `edit_lock`, so a
-    /// fast reopen's parse may already have minted the NEW lifetime's ids
-    /// into this entry — an unconditional wipe would publish a snapshot
-    /// whose ids immediately resolve `null`. The probe is evaluated under
-    /// the entry's exclusive lock: probe-sees-open ⇒ the entry is the
-    /// reopened document's live index, keep it (the epoch bump above still
-    /// refuses any old-lifetime latch; old-lifetime entries it may carry
-    /// are position-keyed and bounded, invalidated by the new lifetime's
-    /// edits like any other). ACCEPTED residual of that keep: a pre-close
-    /// id can stay resolvable against the reopened document instead of
-    /// degrading to `null` — this is the didOpen-racing-didClose lifecycle
-    /// class the close path deliberately defers to a per-document
-    /// lifecycle-epoch gate (see the residual notes in `did_close.rs`);
-    /// separating the lifetimes here would need incarnation-tagged
-    /// entries, while the alternative (unconditional wipe) nulls the
-    /// reopened snapshot's ENTIRE id set — strictly worse.
-    /// Probe-sees-closed ⇒ no new-lifetime mint can
-    /// have happened — mints are liveness-gated on the reopened snapshot,
-    /// whose insert happens-before any mint that passed the gate, which
-    /// happens-before this probe under the same entry lock — so the removal
-    /// reclaims only old-lifetime state.
-    ///
-    /// Lock-order contract: `reopened` runs while this method holds `uri`'s
-    /// entry (shard) lock, so it MUST NOT touch this tracker (self-deadlock)
-    /// and may only take locks that never call back into the tracker while
-    /// held — the document-store read the didClose probe performs is fine
-    /// (the store never re-enters the tracker under its own locks); a future
-    /// probe must preserve that one-way ordering.
+    /// leaving stale-lifetime coordinates alive after cleanup.
     ///
     /// Memory-ordering note (why `Release` on the bump suffices, no
     /// `SeqCst` needed): the only way another thread can OBSERVE the
-    /// removal is through the entry's shard lock (`get_mut` /
+    /// retention is through the entry's shard lock (`get_mut` /
     /// `entry().or_default()`), and that lock's release/acquire pair makes
-    /// every write sequenced before the removal — including this bump —
+    /// every write sequenced before retention — including this bump —
     /// visible to the observer, so a check that finds the entry gone always
     /// reads the bumped epoch and refuses. A check that instead wins the
-    /// shard lock BEFORE the removal may still read the pre-bump epoch and
+    /// shard lock BEFORE retention may still read the pre-bump epoch and
     /// pass, but it then minted into the still-present entry, which the
-    /// removal (queued behind that same lock) wipes — a closed document
-    /// leaves no state on either interleaving.
-    pub(crate) fn cleanup(&self, uri: &Url, reopened: impl FnOnce() -> bool) {
+    /// retention (queued behind that same lock) removes it.
+    pub(crate) fn cleanup(&self, uri: &Url, closing_incarnation: u64) {
         self.cleanup_epoch
             .fetch_add(1, std::sync::atomic::Ordering::Release);
-        self.entries.remove_if(uri, |_, _| !reopened());
+        self.entries.remove_if_mut(uri, |_, entries| {
+            entries.retain_newer_than(closing_incarnation);
+            entries.len() == 0
+        });
     }
 
     /// Run `commit` only if `uri`'s (shift generation, cleanup epoch) still
@@ -777,10 +815,21 @@ impl NodeTracker {
     /// [`commit_if_unshifted`](Self::commit_if_unshifted) documents.
     ///
     /// Returns the ids aligned with `keys`' iteration order.
+    #[cfg(test)]
     pub(crate) fn mint_batch_if_unshifted(
         &self,
         uri: &Url,
         expected: (u64, u64),
+        keys: impl IntoIterator<Item = (usize, usize, &'static str, usize)>,
+    ) -> Option<Vec<Ulid>> {
+        self.mint_batch_if_unshifted_for_incarnation(uri, expected, 0, keys)
+    }
+
+    pub(crate) fn mint_batch_if_unshifted_for_incarnation(
+        &self,
+        uri: &Url,
+        expected: (u64, u64),
+        incarnation: u64,
         keys: impl IntoIterator<Item = (usize, usize, &'static str, usize)>,
     ) -> Option<Vec<Ulid>> {
         // `get_mut` first: the hot path (index already exists — every batch
@@ -789,10 +838,10 @@ impl NodeTracker {
         // fallback stays load-bearing: it serializes the latch check with a
         // concurrent FIRST edit on a never-minted URI.
         if let Some(mut entry) = self.entries.get_mut(uri) {
-            return self.mint_batch_in_entry(&mut entry, expected, keys);
+            return self.mint_batch_in_entry(&mut entry, expected, incarnation, keys);
         }
         let mut entry = self.entries.entry(uri.clone()).or_default();
-        self.mint_batch_in_entry(&mut entry, expected, keys)
+        self.mint_batch_in_entry(&mut entry, expected, incarnation, keys)
     }
 
     /// The latch check + mint body of
@@ -802,6 +851,7 @@ impl NodeTracker {
         &self,
         entry: &mut UriEntries,
         expected: (u64, u64),
+        incarnation: u64,
         keys: impl IntoIterator<Item = (usize, usize, &'static str, usize)>,
     ) -> Option<Vec<Ulid>> {
         let epoch = self
@@ -813,7 +863,7 @@ impl NodeTracker {
         Some(
             keys.into_iter()
                 .map(|(start, end, kind, layer)| {
-                    entry.get_or_insert(PositionKey::new(start, end, kind, layer))
+                    entry.get_or_insert(PositionKey::new(start, end, kind, layer), incarnation)
                 })
                 .collect(),
         )
@@ -902,23 +952,60 @@ mod tests {
     /// ids must survive — while the epoch bump still refuses any
     /// old-lifetime latch.
     #[test]
-    fn cleanup_keeps_reopened_index_but_still_bumps_epoch() {
+    fn cleanup_invalidates_closed_incarnation_but_keeps_reopened_entries() {
         let tracker = NodeTracker::new();
         let uri = test_uri("cleanup_reopen");
-        // Stands in for the reopened lifetime's first mint, which the raced
-        // didClose's cleanup must not wipe.
-        let id = tracker.get_or_create_in_layer(&uri, 0, 4, "word", 0);
+        let old_id = tracker.get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 1);
         let pre_close_latch = tracker.mint_epoch(&uri);
-        tracker.cleanup(&uri, || true);
+        let reopened_id =
+            tracker.get_or_create_in_layer_for_incarnation(&uri, 10, 14, "word", 0, 2);
+
+        tracker.cleanup(&uri, 1);
+
         assert_eq!(
-            tracker.lookup_in_layer(&uri, 0, 4, "word", 0),
-            Some(id),
-            "a reopened document's index survives the raced close"
+            tracker.lookup_node(&uri, &old_id),
+            None,
+            "the closed lifetime's id is invalidated"
+        );
+        assert_eq!(
+            tracker.lookup_node(&uri, &reopened_id),
+            Some((10, 14, "word", 0)),
+            "the reopened lifetime's id survives the raced close"
         );
         assert_eq!(
             tracker.mint_batch_if_unshifted(&uri, pre_close_latch, [(10, 14, "word", 0)]),
             None,
             "the epoch bump still refuses latches taken before the close"
+        );
+    }
+
+    #[test]
+    fn reopened_incarnation_remints_same_position_with_a_fresh_id() {
+        let tracker = NodeTracker::new();
+        let uri = test_uri("same_position_reopen");
+        let old_id = tracker.get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 1);
+        let reopened_id = tracker.get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 2);
+
+        assert_ne!(old_id, reopened_id);
+        assert_eq!(tracker.lookup_node(&uri, &old_id), None);
+        assert_eq!(
+            tracker.lookup_node(&uri, &reopened_id),
+            Some((0, 4, "word", 0))
+        );
+    }
+
+    #[test]
+    fn stale_incarnation_cannot_evict_reopened_entry() {
+        let tracker = NodeTracker::new();
+        let uri = test_uri("stale_after_reopen");
+        let reopened_id = tracker.get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 2);
+
+        let stale_id = tracker.get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 1);
+
+        assert_eq!(tracker.lookup_node(&uri, &stale_id), None);
+        assert_eq!(
+            tracker.lookup_node(&uri, &reopened_id),
+            Some((0, 4, "word", 0))
         );
     }
 
@@ -931,7 +1018,7 @@ mod tests {
         let uri = test_uri("batch_mint_cleanup");
         let other = test_uri("batch_mint_other");
         let latch = tracker.mint_epoch(&uri);
-        tracker.cleanup(&other, || false);
+        tracker.cleanup(&other, 0);
         assert_eq!(
             tracker.mint_batch_if_unshifted(&uri, latch, [(0, 4, "word", 0)]),
             None
@@ -976,7 +1063,7 @@ mod tests {
         // to a post-reopen observation — including for a URI that never
         // tracked a node.
         let (_, epoch_before) = tracker.mint_epoch(&uri);
-        tracker.cleanup(&uri, || false);
+        tracker.cleanup(&uri, 0);
         let (gen_after, epoch_after) = tracker.mint_epoch(&uri);
         assert_eq!(gen_after, 0, "the fresh index restarts at generation 0");
         assert!(
@@ -1126,7 +1213,7 @@ mod tests {
         let ulid_before = tracker.get_or_create(&uri, 0, 10, "code_block");
 
         // Cleanup
-        tracker.cleanup(&uri, || false);
+        tracker.cleanup(&uri, 0);
 
         // After cleanup, same key should create NEW ULID
         let ulid_after = tracker.get_or_create(&uri, 0, 10, "code_block");
@@ -1148,7 +1235,7 @@ mod tests {
         let _ulid2 = tracker.get_or_create(&uri2, 0, 10, "code_block");
 
         // Cleanup only uri2
-        tracker.cleanup(&uri2, || false);
+        tracker.cleanup(&uri2, 0);
 
         // uri1 should still have its ULID
         let ulid1_after = tracker.get_or_create(&uri1, 0, 10, "code_block");
@@ -1196,7 +1283,7 @@ mod tests {
         let ulid = tracker.get_or_create(&uri, 10, 20, "block");
         assert!(tracker.lookup_position(&uri, &ulid).is_some());
 
-        tracker.cleanup(&uri, || false);
+        tracker.cleanup(&uri, 0);
 
         assert_eq!(
             tracker.lookup_position(&uri, &ulid),

--- a/src/language/node_tracker.rs
+++ b/src/language/node_tracker.rs
@@ -29,6 +29,11 @@ use url::Url;
 /// one (per lazy-node-identity-tracking "no tombstone" rule).
 pub(crate) struct NodeTracker {
     entries: DashMap<Url, UriEntries>,
+    /// Current document lifetime for URIs managed by the LSP lifecycle.
+    /// `None` is a close tombstone: it prevents a direct mint that passed its
+    /// last reader-side liveness check before didClose from recreating an old
+    /// entry after cleanup. An absent key keeps standalone/test trackers usable.
+    incarnations: DashMap<Url, Option<u64>>,
     /// Bumped by every [`cleanup`](Self::cleanup) (didClose). Folded into the
     /// mint latch ([`mint_epoch`](Self::mint_epoch)) so a close/reopen —
     /// which removes the per-URI index and would reset its `shift_gen` to 0
@@ -316,8 +321,20 @@ impl NodeTracker {
     pub(crate) fn new() -> Self {
         Self {
             entries: DashMap::new(),
+            incarnations: DashMap::new(),
             cleanup_epoch: std::sync::atomic::AtomicU64::new(0),
         }
+    }
+
+    /// Register the current open lifetime before any request can mint for it.
+    pub(crate) fn open_incarnation(&self, uri: &Url, incarnation: u64) {
+        self.incarnations.insert(uri.clone(), Some(incarnation));
+    }
+
+    fn admits_incarnation(&self, uri: &Url, incarnation: u64) -> bool {
+        self.incarnations
+            .get(uri)
+            .is_none_or(|current| *current == Some(incarnation))
     }
 
     /// Get or create a stable ULID for a **host-layer** tree-sitter node.
@@ -352,8 +369,8 @@ impl NodeTracker {
     /// Get or create a stable ULID for a tree-sitter node at injection `layer`.
     ///
     /// Uses lazy-node-identity-tracking composite key `(start_byte, end_byte,
-    /// kind, layer)`: the same key always returns the same ULID, while
-    /// different nodes — including a host vs injected node that share an
+    /// kind, layer)`: the same key returns the same ULID within one document
+    /// incarnation, while a reopen remints it. Different nodes — including a host vs injected node that share an
     /// identical span and kind (`layer` differs) — receive distinct ULIDs.
     ///
     /// Updates both the forward and reverse index so the returned ULID can be
@@ -385,9 +402,15 @@ impl NodeTracker {
         // `Url` clone `entry()` needs for its owned key. (Explicit two-step
         // pattern to avoid DashMap lifetime ambiguity.)
         if let Some(mut entry) = self.entries.get_mut(uri) {
+            if !self.admits_incarnation(uri, incarnation) {
+                return Ulid::new();
+            }
             return entry.get_or_insert(key, incarnation);
         }
         let mut entry = self.entries.entry(uri.clone()).or_default();
+        if !self.admits_incarnation(uri, incarnation) {
+            return Ulid::new();
+        }
         entry.get_or_insert(key, incarnation)
     }
 
@@ -727,6 +750,10 @@ impl NodeTracker {
     /// incarnation is newer than `closing_incarnation`. This simultaneously
     /// invalidates every pre-close id and preserves every published reopened id.
     /// When no newer entries remain, the whole URI index is removed.
+    /// The lifecycle map keeps a lightweight close tombstone so a direct mint
+    /// that passed its reader-side check before didClose cannot recreate the
+    /// just-removed lifetime afterward; didOpen replaces it with the new
+    /// incarnation before that lifetime starts minting.
     ///
     /// The global epoch bump runs BEFORE retention, and the order is
     /// load-bearing: a
@@ -750,6 +777,14 @@ impl NodeTracker {
     pub(crate) fn cleanup(&self, uri: &Url, closing_incarnation: u64) {
         self.cleanup_epoch
             .fetch_add(1, std::sync::atomic::Ordering::Release);
+        self.incarnations
+            .entry(uri.clone())
+            .and_modify(|current| {
+                if *current == Some(closing_incarnation) {
+                    *current = None;
+                }
+            })
+            .or_insert(None);
         self.entries.remove_if_mut(uri, |_, entries| {
             entries.retain_newer_than(closing_incarnation);
             entries.len() == 0
@@ -838,9 +873,15 @@ impl NodeTracker {
         // fallback stays load-bearing: it serializes the latch check with a
         // concurrent FIRST edit on a never-minted URI.
         if let Some(mut entry) = self.entries.get_mut(uri) {
+            if !self.admits_incarnation(uri, incarnation) {
+                return None;
+            }
             return self.mint_batch_in_entry(&mut entry, expected, incarnation, keys);
         }
         let mut entry = self.entries.entry(uri.clone()).or_default();
+        if !self.admits_incarnation(uri, incarnation) {
+            return None;
+        }
         self.mint_batch_in_entry(&mut entry, expected, incarnation, keys)
     }
 
@@ -1003,6 +1044,24 @@ mod tests {
         let stale_id = tracker.get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 1);
 
         assert_eq!(tracker.lookup_node(&uri, &stale_id), None);
+        assert_eq!(
+            tracker.lookup_node(&uri, &reopened_id),
+            Some((0, 4, "word", 0))
+        );
+    }
+
+    #[test]
+    fn direct_mint_cannot_resurrect_closed_incarnation_after_cleanup() {
+        let tracker = NodeTracker::new();
+        let uri = test_uri("stale_after_cleanup");
+        tracker.open_incarnation(&uri, 1);
+        tracker.cleanup(&uri, 1);
+
+        let stale_id = tracker.get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 1);
+        assert_eq!(tracker.lookup_node(&uri, &stale_id), None);
+
+        tracker.open_incarnation(&uri, 2);
+        let reopened_id = tracker.get_or_create_in_layer_for_incarnation(&uri, 0, 4, "word", 0, 2);
         assert_eq!(
             tracker.lookup_node(&uri, &reopened_id),
             Some((0, 4, "word", 0))

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -722,6 +722,10 @@ impl BridgeCoordinator {
         self.node_tracker.cleanup(uri, closing_incarnation)
     }
 
+    pub(crate) fn open_tracker_incarnation(&self, uri: &Url, incarnation: u64) {
+        self.node_tracker.open_incarnation(uri, incarnation);
+    }
+
     // ========================================
     // Lifecycle (delegate to pool)
     // ========================================

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -716,11 +716,10 @@ impl BridgeCoordinator {
 
     /// Remove all tracked regions for a document.
     ///
-    /// Called on didClose to prevent memory leaks. `reopened` is the
-    /// raced-reopen probe forwarded to [`NodeTracker::cleanup`] — see the
-    /// removal guard there.
-    pub(crate) fn cleanup(&self, uri: &Url, reopened: impl FnOnce() -> bool) {
-        self.node_tracker.cleanup(uri, reopened)
+    /// Called on didClose to remove the closing incarnation while preserving
+    /// entries a raced reopen already minted.
+    pub(crate) fn cleanup(&self, uri: &Url, closing_incarnation: u64) {
+        self.node_tracker.cleanup(uri, closing_incarnation)
     }
 
     // ========================================

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -207,6 +207,7 @@ impl CacheCoordinator {
         language: &LanguageCoordinator,
         tracker: &NodeTracker,
         entry_mint_epoch: (u64, u64),
+        incarnation: u64,
         build_bridge_regions: bool,
         build_resolved_regions: bool,
     ) -> Option<PopulatedInjections> {
@@ -278,9 +279,10 @@ impl CacheCoordinator {
             // pre-lever path) and defer identity to the next current pass —
             // the tracker is meanwhile kept live by the ordinary didChange
             // edit-shift.
-            let region_ids = tracker.mint_batch_if_unshifted(
+            let region_ids = tracker.mint_batch_if_unshifted_for_incarnation(
                 uri,
                 entry_mint_epoch,
+                incarnation,
                 regions.iter().map(|info| {
                     (
                         info.content_node.start_byte(),
@@ -365,6 +367,7 @@ impl CacheCoordinator {
                 uri,
                 tracker,
                 generation,
+                incarnation,
             );
 
             // Live-hash set for the content-addressed injection-token cache's
@@ -906,6 +909,7 @@ print("hello")
             &coordinator,
             &tracker,
             tracker.mint_epoch(&uri),
+            0,
             true,
             true,
         );
@@ -968,6 +972,7 @@ print("hello")
             &coordinator,
             &tracker,
             tracker.mint_epoch(&uri),
+            0,
             true,
             true,
         );
@@ -1044,6 +1049,7 @@ print("hello")
             &coordinator,
             &tracker,
             tracker.mint_epoch(&uri),
+            0,
             true,
             true,
         );
@@ -1090,6 +1096,7 @@ print("goodbye")
             &coordinator,
             &tracker,
             tracker.mint_epoch(&uri),
+            0,
             true,
             true,
         );

--- a/src/lsp/cache.rs
+++ b/src/lsp/cache.rs
@@ -242,7 +242,7 @@ impl CacheCoordinator {
                 // aborts the pass (`None`): reporting ran-and-empty while
                 // the old entries survive would leave them unreclaimed
                 // until another parse.
-                tracker.commit_if_unshifted(uri, entry_mint_epoch, || {
+                tracker.commit_if_unshifted(uri, entry_mint_epoch, incarnation, || {
                     self.injection_map.clear(uri);
                     self.injection_token_cache.clear_document(uri);
                 })?;
@@ -259,7 +259,7 @@ impl CacheCoordinator {
                 // epoch-gated like the commit below, and aborting (`None`)
                 // on refusal like it too: ran-and-empty must only be
                 // reported after the clear actually landed.
-                tracker.commit_if_unshifted(uri, entry_mint_epoch, || {
+                tracker.commit_if_unshifted(uri, entry_mint_epoch, incarnation, || {
                     self.injection_map.clear(uri);
                     self.injection_token_cache.clear_document(uri);
                 })?;
@@ -407,7 +407,7 @@ impl CacheCoordinator {
             // correct-at-birth — the intervening edit shifts it like any
             // live entry. The token-cache sweep runs inside the commit
             // closure, so a stale pass performs no eviction at all.
-            let committed = tracker.commit_if_unshifted(uri, entry_mint_epoch, || {
+            let committed = tracker.commit_if_unshifted(uri, entry_mint_epoch, incarnation, || {
                 // Commit point: record the committed pass's region set (test
                 // observability today; no production reader since token
                 // eviction went content-addressed — a plain move), and run

--- a/src/lsp/lsp_impl/bridge_context.rs
+++ b/src/lsp/lsp_impl/bridge_context.rs
@@ -726,6 +726,7 @@ impl Kakehashi {
             snapshot.text(),
             injection_query.as_ref(),
             byte_offset,
+            snapshot.incarnation(),
         ) else {
             // Not in an injection region - return None
             return None;
@@ -1344,6 +1345,7 @@ impl Kakehashi {
             snapshot.tree(),
             snapshot.text(),
             injection_query.as_ref(),
+            snapshot.incarnation(),
         );
 
         // One upstream request ID for the whole scan: every overlapping

--- a/src/lsp/lsp_impl/cli/session.rs
+++ b/src/lsp/lsp_impl/cli/session.rs
@@ -135,6 +135,7 @@ impl Kakehashi {
                 snapshot.tree(),
                 snapshot.text(),
                 injection_query.as_ref(),
+                snapshot.incarnation(),
             );
             for resolved in regions {
                 configs.extend(self.bridge_configs_for_injection_language(

--- a/src/lsp/lsp_impl/coordinator/diagnostic.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic.rs
@@ -202,6 +202,7 @@ impl DiagnosticScheduler {
                                 snapshot.tree(),
                                 snapshot.text(),
                                 injection_query.as_ref(),
+                                snapshot.incarnation(),
                             )),
                         };
 

--- a/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
+++ b/src/lsp/lsp_impl/coordinator/diagnostic_publisher.rs
@@ -702,6 +702,7 @@ impl DiagnosticPublisher {
                 snapshot.tree(),
                 snapshot.text(),
                 injection_query.as_ref(),
+                snapshot.incarnation(),
             )),
         };
         for resolved in resolved_regions.iter() {

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -136,6 +136,7 @@ impl InjectionCoordinator {
             return Vec::new();
         };
         let text = doc.text_arc();
+        let incarnation = doc.incarnation();
         drop(doc);
 
         let Some(regions) =
@@ -151,8 +152,12 @@ impl InjectionCoordinator {
         regions
             .iter()
             .map(|region| {
-                let region_id =
-                    InjectionResolver::calculate_region_id(self.bridge.node_tracker(), uri, region);
+                let region_id = InjectionResolver::calculate_region_id(
+                    self.bridge.node_tracker(),
+                    uri,
+                    region,
+                    incarnation,
+                );
                 let included_ranges = crate::language::injection::compute_included_ranges(
                     &region.content_node,
                     region.include_children,
@@ -455,6 +460,7 @@ mod tests {
             &server.language,
             &server.bridge.node_tracker_arc(),
             server.bridge.node_tracker_arc().mint_epoch(&uri),
+            incarnation,
             true,
             true,
         );

--- a/src/lsp/lsp_impl/coordinator/injection.rs
+++ b/src/lsp/lsp_impl/coordinator/injection.rs
@@ -151,13 +151,13 @@ impl InjectionCoordinator {
 
         regions
             .iter()
-            .map(|region| {
+            .filter_map(|region| {
                 let region_id = InjectionResolver::calculate_region_id(
                     self.bridge.node_tracker(),
                     uri,
                     region,
                     incarnation,
-                );
+                )?;
                 let included_ranges = crate::language::injection::compute_included_ranges(
                     &region.content_node,
                     region.include_children,
@@ -167,11 +167,11 @@ impl InjectionCoordinator {
                     region.content_node.byte_range(),
                     included_ranges.as_deref(),
                 );
-                BridgeInjection {
+                Some(BridgeInjection {
                     language: region.language.clone(),
                     region_id: region_id.to_string(),
                     content,
-                }
+                })
             })
             .collect()
     }

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -395,6 +395,7 @@ impl ParseCoordinator {
                     &language,
                     &tracker,
                     entry_mint_epoch,
+                    incarnation,
                     build_bridge_regions,
                     build_bridge_regions,
                 ) else {

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -1554,7 +1554,14 @@ fn execute_captures_walk(
             // unregistered ids must still be unique per capture.
             capture_keys()
                 .map(|(start, end, kind, layer)| {
-                    match tracker.lookup_in_layer(uri, start, end, kind, layer) {
+                    match tracker.lookup_in_layer_for_incarnation(
+                        uri,
+                        start,
+                        end,
+                        kind,
+                        layer,
+                        incarnation,
+                    ) {
                         Some(live) => live,
                         None => ulid::Ulid::new(),
                     }

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -3037,7 +3037,7 @@ mod tests {
         for m in &matches {
             for c in m["captures"].as_array().unwrap() {
                 let id: ulid::Ulid = c["node"]["id"].as_str().unwrap().parse().unwrap();
-                let (s, e, kind, _layer) = rig
+                let (s, e, kind, _layer, _incarnation) = rig
                     .tracker
                     .lookup_node(&rig.uri, &id)
                     .expect("a current serve mints resolvable ids");
@@ -3145,7 +3145,7 @@ mod tests {
         let id: ulid::Ulid = captures[0]["node"]["id"].as_str().unwrap().parse().unwrap();
         assert_eq!(
             rig.tracker.lookup_node(&rig.uri, &id),
-            Some((3, 4, "identifier", 0)),
+            Some((3, 4, "identifier", 0, 0)),
             "the survivor must keep ITS OWN id, not inherit the dropped capture's"
         );
     }

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -1240,6 +1240,7 @@ impl Kakehashi {
                     &tracker,
                     &documents,
                     entry_mint_epoch,
+                    incarnation,
                     mint_into_tracker,
                     generation,
                     &match_cache,
@@ -1359,6 +1360,7 @@ fn execute_captures_walk(
     tracker: &crate::language::NodeTracker,
     documents: &crate::document::DocumentStore,
     entry_mint_epoch: (u64, u64),
+    incarnation: u64,
     mint_into_tracker: bool,
     generation: u64,
     match_cache: &super::captures_match_cache::CapturesMatchCache,
@@ -1535,7 +1537,12 @@ fn execute_captures_walk(
             })
         };
         let layer_ulids: Vec<ulid::Ulid> = if mint_into_tracker {
-            tracker.mint_batch_if_unshifted(uri, entry_mint_epoch, capture_keys())
+            tracker.mint_batch_if_unshifted_for_incarnation(
+                uri,
+                entry_mint_epoch,
+                incarnation,
+                capture_keys(),
+            )
         } else {
             None
         }
@@ -2775,6 +2782,7 @@ mod tests {
             &tracker,
             &store,
             tracker.mint_epoch(&uri),
+            0,
             true,
             0,
             &match_cache,
@@ -2805,6 +2813,7 @@ mod tests {
             &tracker,
             &store,
             tracker.mint_epoch(&uri),
+            0,
             false,
             0,
             &match_cache,
@@ -2837,6 +2846,7 @@ mod tests {
             &stale_tracker,
             &store,
             stale_tracker.mint_epoch(&uri),
+            0,
             false,
             0,
             &match_cache,
@@ -2991,6 +3001,7 @@ mod tests {
                 &self.tracker,
                 &self.store,
                 entry_mint_epoch,
+                incarnation,
                 mint_into_tracker,
                 generation,
                 &self.match_cache,

--- a/src/lsp/lsp_impl/kakehashi/captures.rs
+++ b/src/lsp/lsp_impl/kakehashi/captures.rs
@@ -3143,9 +3143,10 @@ mod tests {
         assert_eq!(captures.len(), 1, "the unmappable capture is dropped");
         assert_eq!(captures[0]["name"], "survivor");
         let id: ulid::Ulid = captures[0]["node"]["id"].as_str().unwrap().parse().unwrap();
+        let incarnation = rig.store.get(&rig.uri).unwrap().incarnation();
         assert_eq!(
             rig.tracker.lookup_node(&rig.uri, &id),
-            Some((3, 4, "identifier", 0, 0)),
+            Some((3, 4, "identifier", 0, incarnation)),
             "the survivor must keep ITS OWN id, not inherit the dropped capture's"
         );
     }

--- a/src/lsp/lsp_impl/kakehashi/node/children.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/children.rs
@@ -131,7 +131,7 @@ impl Kakehashi {
         };
 
         let tracker = self.bridge.node_tracker();
-        let infos: Vec<Value> = child_infos
+        let infos: Option<Vec<Value>> = child_infos
             .into_iter()
             .map(|(c_start, c_end, c_kind)| {
                 // Children live in the same tree as their parent, so they are
@@ -143,13 +143,16 @@ impl Kakehashi {
                     c_kind,
                     layer,
                     incarnation,
-                );
-                json!({
+                )?;
+                Some(json!({
                     "id": child_ulid.to_string(),
                     "kind": c_kind,
-                })
+                }))
             })
             .collect();
+        let Some(infos) = infos else {
+            return Ok(Value::Null);
+        };
 
         Ok(Value::Array(infos))
     }

--- a/src/lsp/lsp_impl/kakehashi/node/children.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/children.rs
@@ -81,6 +81,7 @@ impl Kakehashi {
             log::debug!(target: "kakehashi::node::children", "no current parse snapshot for {}", uri);
             return Ok(Value::Null);
         };
+        let incarnation = snapshot.incarnation;
         let host_text: &str = &snapshot.text;
         let Some(host_tree) = snapshot.tree.as_ref() else {
             return Ok(Value::Null);
@@ -131,8 +132,14 @@ impl Kakehashi {
             .map(|(c_start, c_end, c_kind)| {
                 // Children live in the same tree as their parent, so they are
                 // minted in the same `layer`.
-                let child_ulid =
-                    tracker.get_or_create_in_layer(&uri, c_start, c_end, c_kind, layer);
+                let child_ulid = tracker.get_or_create_in_layer_for_incarnation(
+                    &uri,
+                    c_start,
+                    c_end,
+                    c_kind,
+                    layer,
+                    incarnation,
+                );
                 json!({
                     "id": child_ulid.to_string(),
                     "kind": c_kind,

--- a/src/lsp/lsp_impl/kakehashi/node/children.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/children.rs
@@ -61,7 +61,8 @@ impl Kakehashi {
         // None means: never issued, invalidated by a prior edit, or this URI
         // has no entries. `layer` pins resolution and child minting to the
         // language tree that minted the node (node-reference-protocol Scope rule).
-        let Some((start, end, kind, layer)) = self.bridge.node_tracker().lookup_node(&uri, &ulid)
+        let Some((start, end, kind, layer, tracked_incarnation)) =
+            self.bridge.node_tracker().lookup_node(&uri, &ulid)
         else {
             return Ok(Value::Null);
         };
@@ -82,6 +83,9 @@ impl Kakehashi {
             return Ok(Value::Null);
         };
         let incarnation = snapshot.incarnation;
+        if incarnation != tracked_incarnation {
+            return Ok(Value::Null);
+        }
         let host_text: &str = &snapshot.text;
         let Some(host_tree) = snapshot.tree.as_ref() else {
             return Ok(Value::Null);

--- a/src/lsp/lsp_impl/kakehashi/node/common.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/common.rs
@@ -450,10 +450,13 @@ impl Kakehashi {
         else {
             return Value::Null;
         };
-        let infos: Vec<Value> = items
+        let infos: Option<Vec<Value>> = items
             .into_iter()
-            .map(|triple| self.mint_node_info(&uri, layer, incarnation, triple))
+            .map(|triple| {
+                let info = self.mint_node_info(&uri, layer, incarnation, triple);
+                (!info.is_null()).then_some(info)
+            })
             .collect();
-        Value::Array(infos)
+        infos.map_or(Value::Null, Value::Array)
     }
 }

--- a/src/lsp/lsp_impl/kakehashi/node/common.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/common.rs
@@ -196,7 +196,8 @@ impl Kakehashi {
 
         // Tracked `(start, end, kind, layer)`. `layer` pins resolution to the
         // language tree that minted the node so navigation stays in-layer.
-        let (start, end, kind, layer) = self.bridge.node_tracker().lookup_node(&uri, &ulid)?;
+        let (start, end, kind, layer, tracked_incarnation) =
+            self.bridge.node_tracker().lookup_node(&uri, &ulid)?;
 
         // Resolve a CURRENT snapshot (parse-snapshot ADR §3): the tracked
         // `(start, end)` lives at the current `content_version` (the tracker
@@ -204,6 +205,9 @@ impl Kakehashi {
         // tree would be wrong, not merely late — reject immediately with the
         // universal null; only the bounded first-parse wait applies.
         let snapshot = self.current_snapshot(&uri).await?;
+        if snapshot.incarnation != tracked_incarnation {
+            return None;
+        }
         let host_text = std::sync::Arc::clone(&snapshot.text);
         let host_tree = snapshot.tree.clone()?;
 
@@ -356,17 +360,18 @@ impl Kakehashi {
         };
 
         let tracker = self.bridge.node_tracker();
-        let Some((start, end, kind, layer)) = tracker.lookup_node(&uri, &ulid) else {
+        let Some((start, end, kind, layer, tracked_incarnation)) = tracker.lookup_node(&uri, &ulid)
+        else {
             return Value::Null;
         };
-        let Some((desc_start, desc_end, desc_kind, desc_layer)) =
+        let Some((desc_start, desc_end, desc_kind, desc_layer, desc_incarnation)) =
             tracker.lookup_node(&uri, &descendant_ulid)
         else {
             return Value::Null;
         };
         // Two-id same-layer contract: ids minted in different layers never
         // share a tree, so the relation is undefined — null, not an error.
-        if layer != desc_layer {
+        if layer != desc_layer || tracked_incarnation != desc_incarnation {
             return Value::Null;
         }
 
@@ -374,6 +379,9 @@ impl Kakehashi {
         let Some(snapshot) = self.current_snapshot(&uri).await else {
             return Value::Null;
         };
+        if snapshot.incarnation != tracked_incarnation {
+            return Value::Null;
+        }
         let host_text: &str = &snapshot.text;
         let Some(host_tree) = snapshot.tree.as_ref() else {
             return Value::Null;

--- a/src/lsp/lsp_impl/kakehashi/node/common.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/common.rs
@@ -275,6 +275,9 @@ impl Kakehashi {
             .bridge
             .node_tracker()
             .get_or_create_in_layer_for_incarnation(uri, start, end, kind, layer, incarnation);
+        let Some(ulid) = ulid else {
+            return Value::Null;
+        };
         json!({ "id": ulid.to_string(), "kind": kind })
     }
 

--- a/src/lsp/lsp_impl/kakehashi/node/common.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/common.rs
@@ -144,7 +144,7 @@ impl Kakehashi {
         lsp_uri: &Uri,
         id: &str,
         mut f: impl FnMut(tree_sitter::Node<'_>) -> R + Send + 'static,
-    ) -> Option<(Url, usize, R)> {
+    ) -> Option<(Url, usize, u64, R)> {
         // Most accessors don't need the document text; ignore it.
         self.with_node_text(lsp_uri, id, move |node, _text| f(node))
             .await
@@ -165,7 +165,7 @@ impl Kakehashi {
         lsp_uri: &Uri,
         id: &str,
         mut f: impl FnMut(tree_sitter::Node<'_>, &str) -> R + Send + 'static,
-    ) -> Option<(Url, usize, R)> {
+    ) -> Option<(Url, usize, u64, R)> {
         // Most accessors don't need the minting layer's included ranges.
         self.with_node_text_ranges(lsp_uri, id, move |node, text, _ranges| f(node, text))
             .await
@@ -182,7 +182,7 @@ impl Kakehashi {
         lsp_uri: &Uri,
         id: &str,
         mut f: impl FnMut(tree_sitter::Node<'_>, &str, &[tree_sitter::Range]) -> R + Send + 'static,
-    ) -> Option<(Url, usize, R)> {
+    ) -> Option<(Url, usize, u64, R)> {
         // An unparseable URI signals a misbehaving client; warn for parity with
         // `node` / `node/text` / `node/parent` / `node/children` while still
         // collapsing to `null`.
@@ -253,7 +253,7 @@ impl Kakehashi {
             );
             return None;
         };
-        Some((uri, layer, result))
+        Some((uri, layer, snapshot.incarnation, result))
     }
 
     /// Mint (or reuse) a stable ULID for a related node in `layer` and shape it
@@ -263,13 +263,14 @@ impl Kakehashi {
         &self,
         uri: &Url,
         layer: usize,
+        incarnation: u64,
         triple: NodeTriple,
     ) -> Value {
         let (start, end, kind) = triple;
         let ulid = self
             .bridge
             .node_tracker()
-            .get_or_create_in_layer(uri, start, end, kind, layer);
+            .get_or_create_in_layer_for_incarnation(uri, start, end, kind, layer, incarnation);
         json!({ "id": ulid.to_string(), "kind": kind })
     }
 
@@ -288,11 +289,12 @@ impl Kakehashi {
         id: &str,
         f: impl FnMut(tree_sitter::Node<'_>) -> Option<NodeTriple> + Send + 'static,
     ) -> Value {
-        let Some((uri, layer, picked)) = self.with_node_by_id(lsp_uri, id, f).await else {
+        let Some((uri, layer, incarnation, picked)) = self.with_node_by_id(lsp_uri, id, f).await
+        else {
             return Value::Null;
         };
         match picked {
-            Some(triple) => self.mint_node_info(&uri, layer, triple),
+            Some(triple) => self.mint_node_info(&uri, layer, incarnation, triple),
             None => Value::Null,
         }
     }
@@ -309,11 +311,13 @@ impl Kakehashi {
         + Send
         + 'static,
     ) -> Value {
-        let Some((uri, layer, picked)) = self.with_node_text_ranges(lsp_uri, id, f).await else {
+        let Some((uri, layer, incarnation, picked)) =
+            self.with_node_text_ranges(lsp_uri, id, f).await
+        else {
             return Value::Null;
         };
         match picked {
-            Some(triple) => self.mint_node_info(&uri, layer, triple),
+            Some(triple) => self.mint_node_info(&uri, layer, incarnation, triple),
             None => Value::Null,
         }
     }
@@ -414,7 +418,7 @@ impl Kakehashi {
             return Value::Null;
         };
         match picked {
-            Some(triple) => self.mint_node_info(&uri, layer, triple),
+            Some(triple) => self.mint_node_info(&uri, layer, snapshot.incarnation, triple),
             None => Value::Null,
         }
     }
@@ -431,12 +435,13 @@ impl Kakehashi {
         id: &str,
         f: impl FnMut(tree_sitter::Node<'_>) -> Vec<NodeTriple> + Send + 'static,
     ) -> Value {
-        let Some((uri, layer, items)) = self.with_node_by_id(lsp_uri, id, f).await else {
+        let Some((uri, layer, incarnation, items)) = self.with_node_by_id(lsp_uri, id, f).await
+        else {
             return Value::Null;
         };
         let infos: Vec<Value> = items
             .into_iter()
-            .map(|triple| self.mint_node_info(&uri, layer, triple))
+            .map(|triple| self.mint_node_info(&uri, layer, incarnation, triple))
             .collect();
         Value::Array(infos)
     }

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -301,6 +301,9 @@ impl Kakehashi {
                     layer_index,
                     incarnation,
                 );
+                let Some(ulid) = ulid else {
+                    return Value::Null;
+                };
 
                 json!({
                     "id": ulid.to_string(),
@@ -334,6 +337,9 @@ impl Kakehashi {
             node.kind(),
             incarnation,
         );
+        let Some(ulid) = ulid else {
+            return Value::Null;
+        };
 
         json!({
             "id": ulid.to_string(),

--- a/src/lsp/lsp_impl/kakehashi/node/entry.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/entry.rs
@@ -172,6 +172,7 @@ impl Kakehashi {
             log::debug!(target: "kakehashi::node", "no current parse snapshot for {}", uri);
             return Ok(Value::Null);
         };
+        let incarnation = snapshot.incarnation;
 
         let text: &str = &snapshot.text;
         let Some(tree) = snapshot.tree.as_ref() else {
@@ -199,7 +200,7 @@ impl Kakehashi {
         // keeps the no-injection request shape (the dominant case for plain
         // documents) at PR-1 cost.
         if matches!(selector, InjectionSelector::Host) {
-            return Ok(self.resolve_host_layer_node(&uri, tree, byte, doc_len));
+            return Ok(self.resolve_host_layer_node(&uri, tree, byte, doc_len, incarnation));
         }
 
         // We need the host language to seed `injection_stack_at` with the
@@ -235,6 +236,7 @@ impl Kakehashi {
             log::debug!(target: "kakehashi::node", "no current parse snapshot for {} after load", uri);
             return Ok(Value::Null);
         };
+        let incarnation = snapshot.incarnation;
         let text = std::sync::Arc::clone(&snapshot.text);
         let Some(tree) = snapshot.tree.clone() else {
             return Ok(Value::Null);
@@ -291,12 +293,13 @@ impl Kakehashi {
                 // sharing (start, end, kind) get distinct ULIDs and stay navigable
                 // in their own tree (lazy-node-identity-tracking §"Node Uniqueness
                 // Key", issue #313).
-                let ulid = tracker.get_or_create_in_layer(
+                let ulid = tracker.get_or_create_in_layer_for_incarnation(
                     &uri,
                     node.start_byte(),
                     node.end_byte(),
                     node.kind(),
                     layer_index,
+                    incarnation,
                 );
 
                 json!({
@@ -318,16 +321,18 @@ impl Kakehashi {
         tree: &tree_sitter::Tree,
         byte: usize,
         doc_len: usize,
+        incarnation: u64,
     ) -> Value {
         let Some(node) = smallest_containing_node(tree, byte, doc_len) else {
             return Value::Null;
         };
 
-        let ulid = self.bridge.node_tracker().get_or_create(
+        let ulid = self.bridge.node_tracker().get_or_create_for_incarnation(
             uri,
             node.start_byte(),
             node.end_byte(),
             node.kind(),
+            incarnation,
         );
 
         json!({

--- a/src/lsp/lsp_impl/kakehashi/node/field.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/field.rs
@@ -68,7 +68,7 @@ impl Kakehashi {
                 index.and_then(|i| n.field_name_for_child(i))
             })
             .await
-            .map(|(_uri, _layer, field)| json!({ "fieldName": field }))
+            .map(|(_uri, _layer, _incarnation, field)| json!({ "fieldName": field }))
             .unwrap_or(Value::Null);
         Ok(value)
     }
@@ -86,7 +86,7 @@ impl Kakehashi {
                 index.and_then(|i| n.field_name_for_named_child(i))
             })
             .await
-            .map(|(_uri, _layer, field)| json!({ "fieldName": field }))
+            .map(|(_uri, _layer, _incarnation, field)| json!({ "fieldName": field }))
             .unwrap_or(Value::Null);
         Ok(value)
     }

--- a/src/lsp/lsp_impl/kakehashi/node/metadata.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/metadata.rs
@@ -32,7 +32,7 @@ macro_rules! scalar_accessor {
         let value = $self
             .with_node_by_id(&$params.text_document.uri, &$params.id, $f)
             .await
-            .map(|(_uri, _layer, v)| json!({ $field: v }))
+            .map(|(_uri, _layer, _incarnation, v)| json!({ $field: v }))
             .unwrap_or(Value::Null);
         Ok(value)
     }};
@@ -102,7 +102,7 @@ impl Kakehashi {
                 |n| json!({ "startByte": n.start_byte(), "endByte": n.end_byte() }),
             )
             .await
-            .map(|(_uri, _layer, v)| v)
+            .map(|(_uri, _layer, _incarnation, v)| v)
             .unwrap_or(Value::Null);
         Ok(value)
     }

--- a/src/lsp/lsp_impl/kakehashi/node/parent.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/parent.rs
@@ -79,6 +79,7 @@ impl Kakehashi {
             log::debug!(target: "kakehashi::node::parent", "no current parse snapshot for {}", uri);
             return Ok(Value::Null);
         };
+        let incarnation = snapshot.incarnation;
         let host_text: &str = &snapshot.text;
         let Some(host_tree) = snapshot.tree.as_ref() else {
             return Ok(Value::Null);
@@ -125,7 +126,14 @@ impl Kakehashi {
         let parent_ulid = self
             .bridge
             .node_tracker()
-            .get_or_create_in_layer(&uri, p_start, p_end, p_kind, layer);
+            .get_or_create_in_layer_for_incarnation(
+                &uri,
+                p_start,
+                p_end,
+                p_kind,
+                layer,
+                incarnation,
+            );
 
         Ok(json!({
             "id": parent_ulid.to_string(),

--- a/src/lsp/lsp_impl/kakehashi/node/parent.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/parent.rs
@@ -62,7 +62,8 @@ impl Kakehashi {
         // has no entries. `layer` pins resolution to the language tree that
         // minted the node so navigation stays in-layer (node-reference-protocol
         // Scope rule).
-        let Some((start, end, kind, layer)) = self.bridge.node_tracker().lookup_node(&uri, &ulid)
+        let Some((start, end, kind, layer, tracked_incarnation)) =
+            self.bridge.node_tracker().lookup_node(&uri, &ulid)
         else {
             return Ok(Value::Null);
         };
@@ -80,6 +81,9 @@ impl Kakehashi {
             return Ok(Value::Null);
         };
         let incarnation = snapshot.incarnation;
+        if incarnation != tracked_incarnation {
+            return Ok(Value::Null);
+        }
         let host_text: &str = &snapshot.text;
         let Some(host_tree) = snapshot.tree.as_ref() else {
             return Ok(Value::Null);

--- a/src/lsp/lsp_impl/kakehashi/node/parent.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/parent.rs
@@ -138,6 +138,9 @@ impl Kakehashi {
                 layer,
                 incarnation,
             );
+        let Some(parent_ulid) = parent_ulid else {
+            return Ok(Value::Null);
+        };
 
         Ok(json!({
             "id": parent_ulid.to_string(),

--- a/src/lsp/lsp_impl/kakehashi/node/position.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/position.rs
@@ -45,7 +45,7 @@ impl Kakehashi {
                 ))
             })
             .await
-            .and_then(|(_uri, _layer, span)| span)
+            .and_then(|(_uri, _layer, _incarnation, span)| span)
             .map(|(start, end)| json!({ "start": start, "end": end }))
             .unwrap_or(Value::Null);
         Ok(value)
@@ -60,7 +60,7 @@ impl Kakehashi {
                 PositionMapper::new(text).byte_to_position(n.start_byte())
             })
             .await
-            .and_then(|(_uri, _layer, pos)| pos)
+            .and_then(|(_uri, _layer, _incarnation, pos)| pos)
             .map(|pos| json!({ "startPosition": pos }))
             .unwrap_or(Value::Null);
         Ok(value)
@@ -74,7 +74,7 @@ impl Kakehashi {
                 PositionMapper::new(text).byte_to_position(n.end_byte())
             })
             .await
-            .and_then(|(_uri, _layer, pos)| pos)
+            .and_then(|(_uri, _layer, _incarnation, pos)| pos)
             .map(|pos| json!({ "endPosition": pos }))
             .unwrap_or(Value::Null);
         Ok(value)
@@ -151,7 +151,9 @@ impl Kakehashi {
             .await;
 
         let value = match resolved {
-            Some((uri, layer, Some(triple))) => self.mint_node_info(&uri, layer, triple),
+            Some((uri, layer, incarnation, Some(triple))) => {
+                self.mint_node_info(&uri, layer, incarnation, triple)
+            }
             _ => Value::Null,
         };
         Ok(value)

--- a/src/lsp/lsp_impl/kakehashi/node/text.rs
+++ b/src/lsp/lsp_impl/kakehashi/node/text.rs
@@ -48,7 +48,8 @@ impl Kakehashi {
 
         // Look up the tracked range. None means: never issued, invalidated by a
         // prior edit, or this URI's tracker entries have been cleared.
-        let Some((start, end, _kind)) = self.bridge.node_tracker().lookup_position(&uri, &ulid)
+        let Some((start, end, _kind, tracked_incarnation)) =
+            self.bridge.node_tracker().lookup_position(&uri, &ulid)
         else {
             return Ok(Value::Null);
         };
@@ -63,6 +64,9 @@ impl Kakehashi {
             let Some(doc) = self.documents.get(&uri) else {
                 return Ok(Value::Null);
             };
+            if doc.incarnation() != tracked_incarnation {
+                return Ok(Value::Null);
+            }
             let text = doc.text();
             if end > text.len() || start > end {
                 log::warn!(

--- a/src/lsp/lsp_impl/region_offset.rs
+++ b/src/lsp/lsp_impl/region_offset.rs
@@ -49,6 +49,7 @@ pub(super) fn resolve_region_offset(
         snapshot.text(),
         injection_query.as_ref(),
         start_byte,
+        snapshot.incarnation(),
     )?;
     // `region_id`/`start_byte` came from the tracker + node map, but
     // `resolved` came from a separately-fetched snapshot. If an edit landed

--- a/src/lsp/lsp_impl/region_offset.rs
+++ b/src/lsp/lsp_impl/region_offset.rs
@@ -35,10 +35,14 @@ pub(super) fn resolve_region_offset(
     region_id: &str,
 ) -> Option<(RegionOffset, Position)> {
     let ulid = ulid::Ulid::from_string(region_id).ok()?;
-    let (start_byte, _end, _kind, _layer) = bridge.node_tracker().lookup_node(host_url, &ulid)?;
+    let (start_byte, _end, _kind, _layer, tracked_incarnation) =
+        bridge.node_tracker().lookup_node(host_url, &ulid)?;
     // Snapshot is owned, so the document handle (a store lock) is released
     // before `detect_document_language` reaches back into the store.
     let snapshot = documents.get(host_url)?.snapshot()?;
+    if snapshot.incarnation() != tracked_incarnation {
+        return None;
+    }
     let language_name = super::detect_document_language(language, documents, host_url)?;
     let injection_query = language.injection_query(&language_name)?;
     let resolved = InjectionResolver::resolve_at_byte_offset(

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -307,9 +307,12 @@ impl Kakehashi {
         // Re-resolve the region from the LIVE parse (same construction as the
         // goto/showDocument offset path), yielding the current per-line offset
         // AND the content-precise host byte range.
-        let (start_byte, _end, _kind, _layer) =
+        let (start_byte, _end, _kind, _layer, tracked_incarnation) =
             self.bridge.node_tracker().lookup_node(host_url, &ulid)?;
         let snapshot = self.documents.get(host_url)?.snapshot()?;
+        if snapshot.incarnation() != tracked_incarnation {
+            return None;
+        }
         let language_name = detect_document_language(&self.language, &self.documents, host_url)?;
         let injection_query = self.language.injection_query(&language_name)?;
         let resolved = InjectionResolver::resolve_at_byte_offset(

--- a/src/lsp/lsp_impl/text_document/code_action.rs
+++ b/src/lsp/lsp_impl/text_document/code_action.rs
@@ -320,6 +320,7 @@ impl Kakehashi {
             snapshot.text(),
             injection_query.as_ref(),
             start_byte,
+            snapshot.incarnation(),
         )?;
         // The tracker byte and the freshly-resolved region can disagree after an
         // edit (the byte now falls in a different live region); a mismatched

--- a/src/lsp/lsp_impl/text_document/code_lens.rs
+++ b/src/lsp/lsp_impl/text_document/code_lens.rs
@@ -98,7 +98,7 @@ impl Kakehashi {
         let Ok(ulid) = envelope.region_id.parse::<Ulid>() else {
             return false;
         };
-        let Some((start_byte, _end, _kind)) =
+        let Some((start_byte, _end, _kind, tracked_incarnation)) =
             self.bridge.node_tracker().lookup_position(&uri, &ulid)
         else {
             return false;
@@ -106,6 +106,9 @@ impl Kakehashi {
         let Some(doc) = self.documents.get(&uri) else {
             return false;
         };
+        if doc.incarnation() != tracked_incarnation {
+            return false;
+        }
         let mapper = PositionMapper::new(doc.text());
         let Some(position) = mapper.byte_to_position(start_byte) else {
             return false;

--- a/src/lsp/lsp_impl/text_document/diagnostic.rs
+++ b/src/lsp/lsp_impl/text_document/diagnostic.rs
@@ -202,6 +202,7 @@ impl Kakehashi {
                             snapshot.tree(),
                             snapshot.text(),
                             injection_query.as_ref(),
+                            snapshot.incarnation(),
                         )),
                     }
                 })

--- a/src/lsp/lsp_impl/text_document/did_close.rs
+++ b/src/lsp/lsp_impl/text_document/did_close.rs
@@ -6,27 +6,33 @@ use super::super::{Kakehashi, uri_to_url};
 
 impl Kakehashi {
     #[cfg(test)]
-    pub(in crate::lsp::lsp_impl) async fn clear_document_state_on_close(&self, uri: &url::Url) {
+    pub(in crate::lsp::lsp_impl) async fn clear_document_state_on_close(
+        &self,
+        uri: &url::Url,
+    ) -> Option<u64> {
         let edit_lock = self.documents.edit_lock(uri);
         let edit_guard = edit_lock.lock().await;
-        self.clear_document_state_on_close_locked(uri);
+        let closing_incarnation = self.clear_document_state_on_close_locked(uri);
         drop(edit_guard);
         self.documents.remove_edit_lock_if_unshared(uri, &edit_lock);
+        closing_incarnation
     }
 
-    fn clear_document_state_on_close_locked(&self, uri: &url::Url) {
+    fn clear_document_state_on_close_locked(&self, uri: &url::Url) -> Option<u64> {
         // Captures lineage and walk memos are installed under this same lock,
         // so a store that won first is cleared while one arriving later sees
         // the document gone and refuses to install obsolete state.
         self.captures_cache.retain(|key, _| key.0 != *uri);
         self.captures_walk_cache.retain(|key, _| key.0 != *uri);
         self.cancel_captures_walks_for_document(uri);
+        let closing_incarnation = self.documents.get(uri).map(|doc| doc.incarnation());
         self.documents.remove_preserving_edit_lock(uri);
         self.cache.remove_document(uri);
         // The match cache uses insert-then-verify. Clearing after document
         // removal ensures a straggler either inserted before this clear or
         // observes the closed document and self-removes.
         self.captures_match_cache.clear_document(uri);
+        closing_incarnation
     }
 
     async fn close_document_lifecycle(
@@ -36,11 +42,12 @@ impl Kakehashi {
     ) {
         let edit_lock = self.documents.edit_lock(uri);
         let edit_guard = edit_lock.lock().await;
-        self.clear_document_state_on_close_locked(uri);
+        let closing_incarnation = self.clear_document_state_on_close_locked(uri);
         after_remove.await;
 
-        self.bridge
-            .cleanup(uri, || self.documents.latest_snapshot(uri).is_some());
+        if let Some(closing_incarnation) = closing_incarnation {
+            self.bridge.cleanup(uri, closing_incarnation);
+        }
         self.synthetic_diagnostics.remove_document(uri);
         self.debounced_diagnostics.cancel(uri);
         self.bridge.cancel_eager_open(uri);

--- a/src/lsp/lsp_impl/text_document/did_close.rs
+++ b/src/lsp/lsp_impl/text_document/did_close.rs
@@ -48,6 +48,11 @@ impl Kakehashi {
         if let Some(closing_incarnation) = closing_incarnation {
             self.bridge.cleanup(uri, closing_incarnation);
         }
+        // `None` means another teardown already removed the document. Do not
+        // invent a maximal incarnation and wipe the tracker: a reopen can land
+        // between that absent observation and here, and its newer published IDs
+        // must survive. The first teardown already installed the close marker,
+        // which rejects any later stale mint, so skipping is leak-safe.
         self.synthetic_diagnostics.remove_document(uri);
         self.debounced_diagnostics.cancel(uri);
         self.bridge.cancel_eager_open(uri);

--- a/src/lsp/lsp_impl/text_document/did_open.rs
+++ b/src/lsp/lsp_impl/text_document/did_open.rs
@@ -45,8 +45,10 @@ impl Kakehashi {
         // Insert document immediately (without tree) so concurrent requests can find it.
         // This handles race conditions where semanticTokens/full arrives before
         // parse_document completes. The tree will be updated by parse_document.
-        self.documents
-            .insert(uri.clone(), text.clone(), language_name.clone(), None);
+        let incarnation =
+            self.documents
+                .insert(uri.clone(), text.clone(), language_name.clone(), None);
+        self.bridge.open_tracker_incarnation(&uri, incarnation);
         drop(edit_guard);
 
         // Host-tier hoist (parse-decoupled-document-lifecycle ADR): attach the real

--- a/src/lsp/lsp_impl/text_document/document_color.rs
+++ b/src/lsp/lsp_impl/text_document/document_color.rs
@@ -88,6 +88,7 @@ impl Kakehashi {
                 snapshot.tree(),
                 snapshot.text(),
                 injection_query.as_ref(),
+                snapshot.incarnation(),
             )),
         };
 

--- a/src/lsp/lsp_impl/text_document/document_symbol.rs
+++ b/src/lsp/lsp_impl/text_document/document_symbol.rs
@@ -111,6 +111,7 @@ impl Kakehashi {
                 snapshot.tree(),
                 snapshot.text(),
                 injection_query.as_ref(),
+                snapshot.incarnation(),
             )),
         };
 

--- a/src/lsp/lsp_impl/text_document/formatting.rs
+++ b/src/lsp/lsp_impl/text_document/formatting.rs
@@ -267,6 +267,7 @@ impl Kakehashi {
                 snapshot.tree(),
                 snapshot.text(),
                 injection_query.as_ref(),
+                snapshot.incarnation(),
             )),
         };
 

--- a/src/lsp/lsp_impl/text_document/range_formatting.rs
+++ b/src/lsp/lsp_impl/text_document/range_formatting.rs
@@ -128,6 +128,7 @@ impl Kakehashi {
                     snapshot.tree(),
                     snapshot.text(),
                     injection_query.as_ref(),
+                    snapshot.incarnation(),
                 )),
             };
 

--- a/src/lsp/lsp_impl/whole_document.rs
+++ b/src/lsp/lsp_impl/whole_document.rs
@@ -119,6 +119,7 @@ impl Kakehashi {
                     snapshot_tree,
                     &snapshot.text,
                     injection_query.as_ref(),
+                    snapshot.incarnation,
                 )),
             };
 


### PR DESCRIPTION
## Summary

- tag both NodeTracker index directions with the document incarnation that minted each ID
- have didClose retain only entries from a newer raced reopen and reject post-close stale direct/batch/commit mutations
- carry incarnation through all production mint and lookup paths so old IDs degrade to `null` across lifetimes
- document the lifecycle marker and retained-state bound in the lazy-node-identity ADR

## Why

A fast reopen could mint and publish new-lifetime IDs before the raced old `didClose` reached tracker cleanup. The old probe-based cleanup had to keep the entire URI index, preserving pre-close IDs too. Incarnation-tagged entries let cleanup invalidate the closing lifetime without wiping the reopened one.

## Validation

- `cargo test --lib node_tracker::tests -q` (124 passed)
- `cargo check --tests -q`
- `make check`
- independent Codex review converged; final fresh review returned no comments

Full `cargo test --lib -q` was attempted; one unrelated environment-dependent test (`process_injection_sync_returns_incomplete_on_mid_region_cancel`) fails because the Rust parser fixture is not installed.

Closes #569.

Out-of-scope bugs found during review: #696, #698.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node and region identity tracking across document open/close, rapid edits, and fast reopens using document-lifetime-aware identifiers.
  * Prevented stale nodes/regions from being reused after reopen by tightening freshness checks and returning `null` when the resolved lifetime doesn’t match.
  * Made injection-region resolution incarnation-aware so navigation, text, diagnostics, formatting, code actions, code lenses, and related outputs stay consistent with the current document state.
  * Updated close cleanup to remove only entries for the closing lifetime while keeping newer reopen states resolvable.
* **Documentation**
  * Updated the architecture decision record to describe the lifetime/incarnation behavior and cleanup semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->