### PR TITLE
fix(lsp): reload grammar and parser state safely

### DIFF
--- a/src/analysis/semantic.rs
+++ b/src/analysis/semantic.rs
@@ -3,6 +3,7 @@ mod finalize;
 mod injection;
 mod legend;
 mod parallel;
+pub(crate) use parallel::invalidate_thread_local_parser_caches;
 mod range;
 mod token_collector;
 

--- a/src/analysis/semantic/parallel.rs
+++ b/src/analysis/semantic/parallel.rs
@@ -149,7 +149,6 @@ impl LruParserCache {
     }
 
     /// Clear the cache.
-    #[cfg(test)]
     fn clear(&mut self) {
         self.parsers.clear();
         self.order.clear();
@@ -167,8 +166,15 @@ impl LruParserCache {
 // Each Rayon worker thread maintains its own bounded LRU cache of parsers.
 // This avoids cross-thread synchronization during parallel injection processing
 // while preventing unbounded memory growth in long-running LSP servers.
+static PARSER_CACHE_GENERATION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 thread_local! {
-    static PARSER_CACHE: RefCell<LruParserCache> = RefCell::new(LruParserCache::new());
+    static PARSER_CACHE: RefCell<(u64, LruParserCache)> =
+        RefCell::new((0, LruParserCache::new()));
+}
+
+pub(crate) fn invalidate_thread_local_parser_caches() {
+    PARSER_CACHE_GENERATION.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
 }
 
 /// Factory for creating parsers with thread-local caching.
@@ -198,7 +204,13 @@ impl ThreadLocalParserFactory {
         included_ranges: Option<&[tree_sitter::Range]>,
     ) -> Option<Tree> {
         PARSER_CACHE.with(|cache| {
-            let mut cache = cache.borrow_mut();
+            let mut state = cache.borrow_mut();
+            let generation = PARSER_CACHE_GENERATION.load(std::sync::atomic::Ordering::Acquire);
+            if state.0 != generation {
+                state.1.clear();
+                state.0 = generation;
+            }
+            let cache = &mut state.1;
 
             // Get or create parser for this language
             if !cache.contains(language_id) {
@@ -233,7 +245,7 @@ impl ThreadLocalParserFactory {
     #[cfg(test)]
     pub fn clear_cache() {
         PARSER_CACHE.with(|cache| {
-            cache.borrow_mut().clear();
+            cache.borrow_mut().1.clear();
         });
     }
 }
@@ -1580,6 +1592,18 @@ mod tests {
             !tree.root_node().has_error(),
             "Parse tree should not have errors"
         );
+    }
+
+    #[test]
+    fn reload_generation_clears_thread_local_parsers() {
+        ThreadLocalParserFactory::clear_cache();
+        let factory = ThreadLocalParserFactory::new(create_test_registry());
+        assert!(factory.parse("rust", "fn main() {}", None).is_some());
+        PARSER_CACHE.with(|cache| assert_eq!(cache.borrow().1.len(), 1));
+
+        invalidate_thread_local_parser_caches();
+        assert!(factory.parse("unknown", "", None).is_none());
+        PARSER_CACHE.with(|cache| assert_eq!(cache.borrow().1.len(), 0));
     }
 
     #[test]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -537,7 +537,7 @@ pub type CaptureMappings = HashMap<String, QueryTypeMappings>;
 ///
 /// Used in the unified `queries` field to specify what kind of query a file contains.
 /// When not specified, the kind is inferred from the filename pattern.
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, JsonSchema)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Hash, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum QueryKind {
     /// Syntax highlighting queries

--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -259,8 +259,20 @@ impl Document {
         // Advancing the internal version makes every pre-reload parse result
         // stale and lets the scheduled current-generation snapshot supersede it.
         self.content_version = self.content_version.wrapping_add(1);
-        self.snapshot_tx
-            .send_replace(SnapshotSlot::bootstrap(self.incarnation));
+        self.snapshot_tx.send_replace(SnapshotSlot {
+            current_incarnation: self.incarnation,
+            snapshot: Some(Arc::new(ParseSnapshot {
+                text: Arc::clone(&self.text),
+                tree: None,
+                language: self.language_id.clone(),
+                parsed_version: self.content_version,
+                incarnation: self.incarnation,
+                injection_regions: None,
+                bridge_regions: None,
+                resolved_regions: None,
+                layer_trees: std::sync::OnceLock::new(),
+            })),
+        });
     }
 
     /// Store the open-time parse result — the detected `language` and the parsed

--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -252,6 +252,13 @@ impl Document {
         self.pending_seed = None;
     }
 
+    pub(crate) fn invalidate_parse(&mut self) {
+        self.tree = None;
+        self.pending_seed = None;
+        self.snapshot_tx
+            .send_replace(SnapshotSlot::bootstrap(self.incarnation));
+    }
+
     /// Store the open-time parse result — the detected `language` and the parsed
     /// `tree` (`None` for a parsed-to-nothing / no-language / crashed-parser open) —
     /// **preserving the existing text**.

--- a/src/document/model.rs
+++ b/src/document/model.rs
@@ -255,6 +255,10 @@ impl Document {
     pub(crate) fn invalidate_parse(&mut self) {
         self.tree = None;
         self.pending_seed = None;
+        // Grammar/query settings are parse inputs even when text is unchanged.
+        // Advancing the internal version makes every pre-reload parse result
+        // stale and lets the scheduled current-generation snapshot supersede it.
+        self.content_version = self.content_version.wrapping_add(1);
         self.snapshot_tx
             .send_replace(SnapshotSlot::bootstrap(self.incarnation));
     }

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -977,7 +977,9 @@ mod tests {
         let document = store.get(&uri).unwrap();
         assert!(document.tree().is_none());
         assert_eq!(document.content_version(), 1);
-        assert!(document.latest_snapshot_slot().snapshot.is_none());
+        let snapshot = document.latest_snapshot_slot().snapshot.unwrap();
+        assert_eq!(snapshot.parsed_version, 1);
+        assert!(snapshot.tree.is_none());
     }
 
     mod snapshot_cell {

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -874,6 +874,7 @@ mod tests {
 
         let document = store.get(&uri).unwrap();
         assert!(document.tree().is_none());
+        assert_eq!(document.content_version(), 1);
         assert!(document.latest_snapshot_slot().snapshot.is_none());
     }
 

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -114,6 +114,18 @@ impl DocumentStore {
         Self::default()
     }
 
+    pub(crate) fn invalidate_all_parses(&self) -> Vec<Url> {
+        let mut uris = Vec::with_capacity(self.documents.len());
+        for mut entry in self.documents.iter_mut() {
+            uris.push(entry.key().clone());
+            entry.value_mut().invalidate_parse();
+        }
+        for uri in &uris {
+            self.update_tree_availability(uri, false);
+        }
+        uris
+    }
+
     /// Update tree availability without affecting parse-in-progress tracking.
     /// The `in_progress` state is owned exclusively by mark_parse_started/mark_parse_finished.
     fn update_tree_availability(&self, uri: &Url, has_tree: bool) {
@@ -840,6 +852,30 @@ pub(crate) struct SnapshotView {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn reload_invalidation_clears_open_document_trees() {
+        let store = DocumentStore::new();
+        let uri = Url::parse("file:///reload.rs").unwrap();
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .unwrap();
+        let tree = parser.parse("fn main() {}", None).unwrap();
+        store.insert(
+            uri.clone(),
+            "fn main() {}".to_string(),
+            Some("rust".to_string()),
+            Some(tree),
+        );
+        assert!(store.get(&uri).unwrap().tree().is_some());
+
+        assert_eq!(store.invalidate_all_parses(), vec![uri.clone()]);
+
+        let document = store.get(&uri).unwrap();
+        assert!(document.tree().is_none());
+        assert!(document.latest_snapshot_slot().snapshot.is_none());
+    }
 
     mod snapshot_cell {
         use super::super::*;

--- a/src/document/store.rs
+++ b/src/document/store.rs
@@ -405,6 +405,7 @@ impl DocumentStore {
     ///   is the [`(incarnation, ticket)`](Document::incarnation) epoch's
     ///   incarnation half; the text and language checks remain because they guard
     ///   the orthogonal within-lifetime races above.
+    #[cfg(test)]
     pub(crate) fn update_tree_if_text_and_language_unchanged(
         &self,
         uri: &Url,
@@ -432,6 +433,33 @@ impl DocumentStore {
         stored
     }
 
+    pub(crate) fn update_tree_if_parse_inputs_unchanged(
+        &self,
+        uri: &Url,
+        expected_text: &str,
+        expected_language_id: Option<&str>,
+        expected_incarnation: u64,
+        expected_content_version: u64,
+        new_tree: Tree,
+    ) -> bool {
+        let stored = self.documents.get_mut(uri).is_some_and(|mut doc| {
+            if doc.incarnation() == expected_incarnation
+                && doc.content_version() == expected_content_version
+                && doc.text() == expected_text
+                && doc.language_id() == expected_language_id
+            {
+                doc.set_tree(new_tree);
+                true
+            } else {
+                false
+            }
+        });
+        if stored {
+            self.mark_tree_available_if_tracked(uri);
+        }
+        stored
+    }
+
     /// Like [`update_tree_if_text_and_language_unchanged`], but additionally stores
     /// the tree only if the document currently has **no** tree. For the off-ingress
     /// install reparse (`reparse_installed_document`), whose "don't clobber a
@@ -445,6 +473,7 @@ impl DocumentStore {
     /// install reparse is off-ingress, so a `didClose` + reopen (possibly relabelling
     /// the language) can race it. Without these checks the freshly-installed grammar's
     /// tree could attach to a reopened — even relabelled — document.
+    #[cfg(test)]
     pub(crate) fn attach_tree_if_absent(
         &self,
         uri: &Url,
@@ -467,6 +496,34 @@ impl DocumentStore {
         } else {
             false
         };
+        if stored {
+            self.mark_tree_available_if_tracked(uri);
+        }
+        stored
+    }
+
+    pub(crate) fn attach_tree_if_parse_inputs_unchanged(
+        &self,
+        uri: &Url,
+        expected_text: &str,
+        expected_language_id: Option<&str>,
+        expected_incarnation: u64,
+        expected_content_version: u64,
+        new_tree: Tree,
+    ) -> bool {
+        let stored = self.documents.get_mut(uri).is_some_and(|mut doc| {
+            if doc.tree().is_none()
+                && doc.incarnation() == expected_incarnation
+                && doc.content_version() == expected_content_version
+                && doc.text() == expected_text
+                && doc.language_id() == expected_language_id
+            {
+                doc.set_tree(new_tree);
+                true
+            } else {
+                false
+            }
+        });
         if stored {
             self.mark_tree_available_if_tracked(uri);
         }
@@ -501,6 +558,7 @@ impl DocumentStore {
     /// left gone, not resurrected — the resurrection-safety the open parse needs once
     /// it runs off the ingress ticket. Availability is marked only when a tree
     /// landed (the no-tree paths rely on the caller's `mark_parse_finished(false)`).
+    #[cfg(test)]
     pub(crate) fn set_parse_result_if_text_and_incarnation_unchanged(
         &self,
         uri: &Url,
@@ -525,6 +583,33 @@ impl DocumentStore {
         } else {
             false
         };
+        if stored && has_tree {
+            self.mark_tree_available_if_tracked(uri);
+        }
+        stored
+    }
+
+    pub(crate) fn set_parse_result_if_inputs_unchanged(
+        &self,
+        uri: &Url,
+        expected_text: &Arc<str>,
+        expected_incarnation: u64,
+        expected_content_version: u64,
+        language: Option<&str>,
+        tree: Option<Tree>,
+    ) -> bool {
+        let has_tree = tree.is_some();
+        let stored = self.documents.get_mut(uri).is_some_and(|mut doc| {
+            if doc.incarnation() == expected_incarnation
+                && doc.content_version() == expected_content_version
+                && Arc::ptr_eq(&doc.text_arc(), expected_text)
+            {
+                doc.set_parse_result(language.map(String::from), tree);
+                true
+            } else {
+                false
+            }
+        });
         if stored && has_tree {
             self.mark_tree_available_if_tracked(uri);
         }
@@ -868,9 +953,26 @@ mod tests {
             Some("rust".to_string()),
             Some(tree),
         );
-        assert!(store.get(&uri).unwrap().tree().is_some());
+        let document = store.get(&uri).unwrap();
+        assert!(document.tree().is_some());
+        let pre_reload_text = document.text_arc();
+        let incarnation = document.incarnation();
+        drop(document);
 
         assert_eq!(store.invalidate_all_parses(), vec![uri.clone()]);
+
+        let stale_tree = parser.parse("fn main() {}", None).unwrap();
+        assert!(
+            !store.set_parse_result_if_inputs_unchanged(
+                &uri,
+                &pre_reload_text,
+                incarnation,
+                0,
+                Some("rust"),
+                Some(stale_tree),
+            ),
+            "a pre-reload parse must not restore the legacy tree"
+        );
 
         let document = store.get(&uri).unwrap();
         assert!(document.tree().is_none());

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -883,6 +883,7 @@ impl LanguageCoordinator {
             .load_generation
             .load(std::sync::atomic::Ordering::Acquire)
             != expected_generation
+            || self.configured_load_failed(language_id, expected_generation)
         {
             return false;
         }
@@ -3325,14 +3326,15 @@ mod tests {
             .load_generation
             .load(std::sync::atomic::Ordering::Acquire);
         assert!(
-            coordinator.publish_dynamic_language(
+            !coordinator.publish_dynamic_language(
                 "markdown",
                 tree_sitter_rust::LANGUAGE.into(),
                 generation,
                 || {},
             ),
-            "simulate dynamic fallback winning the publication race"
+            "configured failure must reject same-generation dynamic publication"
         );
+        assert!(!coordinator.language_registry.contains("markdown"));
 
         assert!(
             !coordinator.ensure_language_loaded("markdown").success,

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1192,7 +1192,11 @@ impl LanguageCoordinator {
     /// Visibility: pub(crate) - called by LSP layer (lsp_impl) to check parser
     /// availability before attempting language operations.
     pub(crate) fn has_parser_available(&self, language_name: &str) -> bool {
-        self.language_registry.contains(language_name)
+        let generation = self
+            .load_generation
+            .load(std::sync::atomic::Ordering::Acquire);
+        !self.configured_load_failed(language_name, generation)
+            && self.has_current_parser_registration(language_name, generation)
     }
 
     /// language-detection-fallback-chain unified detection chain for host docs and injections; returns
@@ -3246,6 +3250,10 @@ mod tests {
         assert!(
             coordinator.language_registry.contains("dynamic"),
             "the regression requires a stale registry entry to remain present"
+        );
+        assert!(
+            !coordinator.has_parser_available("dynamic"),
+            "detection must not accept a stale registration"
         );
         assert!(
             !coordinator.ensure_language_loaded("dynamic").success,

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -73,9 +73,10 @@ pub(crate) struct LanguageCoordinator {
     /// re-poisoning — no clear-vs-store ordering to get right. The clear on
     /// `load_settings` is memory hygiene, not the correctness mechanism.
     failed_loads: dashmap::DashMap<String, u64>,
-    /// Registry entries discovered from search paths, tagged with the settings
-    /// generation that resolved their library path. A registered parser is not
-    /// a cache hit after reload unless this tag matches the current generation.
+    /// Reload-scoped registry entries, tagged with the settings generation that
+    /// resolved their library path. Manually pre-registered/built-in entries are
+    /// untagged; configured and dynamically discovered parsers must match the
+    /// current generation before they are cache hits.
     dynamically_loaded: dashmap::DashMap<String, u64>,
     /// Serializes settings-generation changes with registry publication so a
     /// load resolved under an old configuration cannot overwrite or retag a
@@ -814,22 +815,21 @@ impl LanguageCoordinator {
                 Ok(lang) => lang,
                 Err(result) => return result,
             };
-        if !self.register_dynamic_language(language_id, language.clone(), current_generation) {
+        let mut events = Vec::new();
+        if !self.publish_dynamic_language(language_id, language.clone(), current_generation, || {
+            // Publish queries under the same generation gate as the parser.
+            // A reload cannot advance the generation and then be overwritten
+            // by queries resolved from the previous search paths.
+            self.load_all_queries(
+                &language,
+                &search_paths,
+                language_id,
+                "Dynamically loaded",
+                &mut events,
+            );
+        }) {
             return LanguageLoadResult::default();
         }
-
-        let mut events = Vec::new();
-
-        // Use fault-tolerant loading for all query types
-        // This handles languages like TypeScript that inherit from ecma,
-        // and gracefully skips invalid patterns while preserving valid ones
-        self.load_all_queries(
-            &language,
-            &search_paths,
-            language_id,
-            "Dynamically loaded",
-            &mut events,
-        );
 
         events.push(LanguageEvent::log(
             LanguageLogLevel::Info,
@@ -844,12 +844,16 @@ impl LanguageCoordinator {
         LanguageLoadResult::success_with(events)
     }
 
-    fn register_dynamic_language(
+    fn publish_dynamic_language<F>(
         &self,
         language_id: &str,
         language: Language,
         expected_generation: u64,
-    ) -> bool {
+        publish_queries: F,
+    ) -> bool
+    where
+        F: FnOnce(),
+    {
         let _registration = self
             .registration_lock
             .lock()
@@ -865,6 +869,7 @@ impl LanguageCoordinator {
             .register(language_id.to_string(), language);
         self.dynamically_loaded
             .insert(language_id.to_string(), expected_generation);
+        publish_queries();
         true
     }
 
@@ -1496,7 +1501,11 @@ impl LanguageCoordinator {
             .recover_poison("LanguageCoordinator::register_configured_language");
         self.language_registry
             .register(language_id.to_string(), language);
-        self.dynamically_loaded.remove(language_id);
+        let generation = self
+            .load_generation
+            .load(std::sync::atomic::Ordering::Acquire);
+        self.dynamically_loaded
+            .insert(language_id.to_string(), generation);
     }
 
     fn load_queries_for_language(
@@ -3220,14 +3229,35 @@ mod tests {
         coordinator.register_configured_language("dynamic", tree_sitter_rust::LANGUAGE.into());
 
         assert!(
-            !coordinator
-                .register_dynamic_language("dynamic", tree_sitter_rust::LANGUAGE.into(), 0,),
+            !coordinator.publish_dynamic_language(
+                "dynamic",
+                tree_sitter_rust::LANGUAGE.into(),
+                0,
+                || {},
+            ),
             "a load resolved before the reload must lose publication"
         );
         assert!(coordinator.language_registry.contains("dynamic"));
         assert!(
-            coordinator.dynamically_loaded.get("dynamic").is_none(),
-            "the current configured parser must remain untagged"
+            coordinator
+                .dynamically_loaded
+                .get("dynamic")
+                .is_some_and(|generation| *generation == 1),
+            "the current configured parser must keep its newer generation"
+        );
+    }
+
+    #[test]
+    fn failed_config_reload_does_not_revalidate_old_parser() {
+        let coordinator = LanguageCoordinator::new();
+        coordinator.register_configured_language("configured", tree_sitter_rust::LANGUAGE.into());
+        assert!(coordinator.ensure_language_loaded("configured").success);
+
+        coordinator.load_settings(&WorkspaceSettings::default());
+
+        assert!(
+            !coordinator.ensure_language_loaded("configured").success,
+            "an old configured registration must not survive a generation where it was not loaded"
         );
     }
 

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -81,10 +81,11 @@ pub(crate) struct LanguageCoordinator {
     /// resolved their library path. Manually pre-registered/built-in entries are
     /// untagged; configured and dynamically discovered parsers must match the
     /// current generation before they are cache hits.
-    dynamically_loaded: dashmap::DashMap<String, u64>,
-    /// Languages whose current query set came from an explicit configured
-    /// override while their parser remained an untagged built-in registration.
-    configured_query_overrides: dashmap::DashSet<String>,
+    reload_scoped_registrations: dashmap::DashMap<String, u64>,
+    /// Original query kinds displaced by configured overrides on untagged
+    /// built-in registrations. Keeping each kind separately lets a partial
+    /// override preserve and later restore all other built-in query kinds.
+    builtin_queries: dashmap::DashMap<(String, QueryKind), Arc<tree_sitter::Query>>,
     /// Serializes settings-generation changes with registry publication so a
     /// load resolved under an old configuration cannot overwrite or retag a
     /// parser registered by a newer reload.
@@ -128,8 +129,8 @@ impl LanguageCoordinator {
             derived_languages: RwLock::new(HashSet::new()),
             failed_loads: dashmap::DashMap::new(),
             configured_load_failures: dashmap::DashMap::new(),
-            dynamically_loaded: dashmap::DashMap::new(),
-            configured_query_overrides: dashmap::DashSet::new(),
+            reload_scoped_registrations: dashmap::DashMap::new(),
+            builtin_queries: dashmap::DashMap::new(),
             registration_lock: Mutex::new(()),
             settings_reload_lock: Mutex::new(()),
             load_generation: std::sync::atomic::AtomicU64::new(0),
@@ -208,7 +209,7 @@ impl LanguageCoordinator {
     fn has_current_parser_registration(&self, language_id: &str, current_generation: u64) -> bool {
         self.language_registry.contains(language_id)
             && self
-                .dynamically_loaded
+                .reload_scoped_registrations
                 .get(language_id)
                 .is_none_or(|generation| *generation == current_generation)
     }
@@ -894,7 +895,7 @@ impl LanguageCoordinator {
         }
         self.language_registry
             .register(language_id.to_string(), language);
-        self.dynamically_loaded
+        self.reload_scoped_registrations
             .insert(language_id.to_string(), expected_generation);
         self.query_store.remove_queries(language_id);
         publish_queries();
@@ -1511,14 +1512,33 @@ impl LanguageCoordinator {
         let pre_registered =
             config.parser.is_none() && self.has_current_parser_registration(lang_name, generation);
         let pre_registered_is_builtin =
-            pre_registered && self.dynamically_loaded.get(lang_name).is_none();
-        let had_configured_query_override = self.configured_query_overrides.contains(lang_name);
-        let preserve_builtin_queries =
-            pre_registered_is_builtin && config.queries.is_none() && !had_configured_query_override;
-        if !preserve_builtin_queries {
+            pre_registered && self.reload_scoped_registrations.get(lang_name).is_none();
+        if pre_registered_is_builtin {
+            for kind in QueryKind::ALL {
+                let key = (lang_name.to_string(), kind);
+                if !self.builtin_queries.contains_key(&key)
+                    && let Some(query) = self.query_store.get_query(kind, lang_name)
+                {
+                    self.builtin_queries.insert(key, query);
+                }
+            }
+        }
+        if !pre_registered_is_builtin {
             // Query kinds absent from the new configuration must disappear; the
             // insertion helpers only replace kinds that successfully load.
             self.query_store.remove_queries(lang_name);
+        } else {
+            self.query_store.remove_queries(lang_name);
+            for kind in QueryKind::ALL {
+                if let Some(query) = self
+                    .builtin_queries
+                    .get(&(lang_name.to_string(), kind))
+                    .map(|entry| Arc::clone(entry.value()))
+                {
+                    self.query_store
+                        .insert_query(kind, lang_name.to_string(), query);
+                }
+            }
         }
         let language = if pre_registered {
             self.language_registry
@@ -1544,13 +1564,6 @@ impl LanguageCoordinator {
         }
 
         let mut events = self.load_queries_for_language(lang_name, config, search_paths, &language);
-        if pre_registered_is_builtin && config.queries.is_some() {
-            self.configured_query_overrides
-                .insert(lang_name.to_string());
-        } else {
-            self.configured_query_overrides.remove(lang_name);
-        }
-
         events.push(LanguageEvent::log(
             LanguageLogLevel::Info,
             format!("Language {lang_name} loaded."),
@@ -1569,7 +1582,7 @@ impl LanguageCoordinator {
         let generation = self
             .load_generation
             .load(std::sync::atomic::Ordering::Acquire);
-        self.dynamically_loaded
+        self.reload_scoped_registrations
             .insert(language_id.to_string(), generation);
     }
 
@@ -1581,7 +1594,7 @@ impl LanguageCoordinator {
         self.configured_load_failures
             .insert(language_id.to_string(), generation);
         self.language_registry.unregister(language_id);
-        self.dynamically_loaded.remove(language_id);
+        self.reload_scoped_registrations.remove(language_id);
         self.query_store.remove_queries(language_id);
     }
 
@@ -3284,7 +3297,7 @@ mod tests {
             .language_registry
             .register("dynamic".to_string(), tree_sitter_rust::LANGUAGE.into());
         coordinator
-            .dynamically_loaded
+            .reload_scoped_registrations
             .insert("dynamic".to_string(), 0);
         assert!(
             coordinator.ensure_language_loaded("dynamic").success,
@@ -3325,7 +3338,7 @@ mod tests {
         assert!(coordinator.language_registry.contains("dynamic"));
         assert!(
             coordinator
-                .dynamically_loaded
+                .reload_scoped_registrations
                 .get("dynamic")
                 .is_some_and(|generation| *generation == 1),
             "the current configured parser must keep its newer generation"
@@ -3424,12 +3437,17 @@ mod tests {
         coordinator.record_configured_load_failure("racing", generation);
 
         assert!(!coordinator.language_registry.contains("racing"));
-        assert!(coordinator.dynamically_loaded.get("racing").is_none());
+        assert!(
+            coordinator
+                .reload_scoped_registrations
+                .get("racing")
+                .is_none()
+        );
         assert!(coordinator.configured_load_failed("racing", generation));
     }
 
     #[test]
-    fn removing_builtin_query_override_clears_configured_queries() {
+    fn reload_without_override_preserves_builtin_queries() {
         let coordinator = LanguageCoordinator::new();
         let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
         coordinator
@@ -3441,9 +3459,6 @@ mod tests {
                 tree_sitter::Query::new(&language, "(identifier) @variable").unwrap(),
             ),
         );
-        coordinator
-            .configured_query_overrides
-            .insert("builtin".to_string());
         let mut languages = HashMap::new();
         languages.insert("builtin".to_string(), LanguageSettings::default());
 
@@ -3452,9 +3467,65 @@ mod tests {
             ..Default::default()
         });
 
-        assert!(coordinator.highlight_query("builtin").is_none());
-        assert!(!coordinator.configured_query_overrides.contains("builtin"));
+        assert!(coordinator.highlight_query("builtin").is_some());
         assert!(coordinator.has_parser_available("builtin"));
+    }
+
+    #[test]
+    fn partial_builtin_query_override_preserves_and_restores_other_kinds() {
+        let coordinator = LanguageCoordinator::new();
+        let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        coordinator
+            .language_registry
+            .register("builtin".to_string(), language.clone());
+        let builtin_highlight =
+            Arc::new(tree_sitter::Query::new(&language, "(identifier) @variable").unwrap());
+        let builtin_injection = Arc::new(
+            tree_sitter::Query::new(&language, "(string_literal) @injection.content").unwrap(),
+        );
+        coordinator
+            .query_store
+            .insert_highlight_query("builtin".to_string(), Arc::clone(&builtin_highlight));
+        coordinator
+            .query_store
+            .insert_injection_query("builtin".to_string(), Arc::clone(&builtin_injection));
+
+        let dir = tempdir().unwrap();
+        let configured_highlight_path = dir.path().join("highlights.scm");
+        fs::write(&configured_highlight_path, "(identifier) @function").unwrap();
+        let configured = LanguageSettings {
+            queries: Some(vec![crate::config::settings::QueryItem {
+                path: configured_highlight_path.to_string_lossy().into_owned(),
+                kind: Some(QueryKind::Highlights),
+            }]),
+            ..Default::default()
+        };
+        coordinator.load_settings(&WorkspaceSettings {
+            languages: HashMap::from([("builtin".to_string(), configured)]),
+            ..Default::default()
+        });
+
+        assert!(Arc::ptr_eq(
+            &coordinator.injection_query("builtin").unwrap(),
+            &builtin_injection
+        ));
+        assert!(!Arc::ptr_eq(
+            &coordinator.highlight_query("builtin").unwrap(),
+            &builtin_highlight
+        ));
+
+        coordinator.load_settings(&WorkspaceSettings {
+            languages: HashMap::from([("builtin".to_string(), LanguageSettings::default())]),
+            ..Default::default()
+        });
+        assert!(Arc::ptr_eq(
+            &coordinator.highlight_query("builtin").unwrap(),
+            &builtin_highlight
+        ));
+        assert!(Arc::ptr_eq(
+            &coordinator.injection_query("builtin").unwrap(),
+            &builtin_injection
+        ));
     }
 
     #[test]

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1506,9 +1506,9 @@ impl LanguageCoordinator {
             .load(std::sync::atomic::Ordering::Acquire);
         let pre_registered =
             config.parser.is_none() && self.has_current_parser_registration(lang_name, generation);
-        let preserve_builtin_queries = pre_registered
-            && self.dynamically_loaded.get(lang_name).is_none()
-            && config.queries.is_none();
+        let pre_registered_is_builtin =
+            pre_registered && self.dynamically_loaded.get(lang_name).is_none();
+        let preserve_builtin_queries = pre_registered_is_builtin && config.queries.is_none();
         if !preserve_builtin_queries {
             // Query kinds absent from the new configuration must disappear; the
             // insertion helpers only replace kinds that successfully load.
@@ -1533,7 +1533,9 @@ impl LanguageCoordinator {
                 }
             }
         };
-        self.register_configured_language(lang_name, language.clone());
+        if !pre_registered_is_builtin {
+            self.register_configured_language(lang_name, language.clone());
+        }
 
         let mut events = self.load_queries_for_language(lang_name, config, search_paths, &language);
 
@@ -3180,6 +3182,10 @@ mod tests {
             languages: reloaded_languages,
             ..Default::default()
         });
+        assert!(
+            coordinator.has_parser_available("markdown"),
+            "an untagged pre-registered base must survive repeated reloads"
+        );
 
         assert!(
             !coordinator.has_parser_available("rmd"),

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -891,6 +891,7 @@ impl LanguageCoordinator {
             .register(language_id.to_string(), language);
         self.dynamically_loaded
             .insert(language_id.to_string(), expected_generation);
+        self.query_store.remove_queries(language_id);
         publish_queries();
         true
     }
@@ -1499,6 +1500,9 @@ impl LanguageCoordinator {
         config: &LanguageSettings,
         search_paths: &[PathBuf],
     ) -> LanguageLoadResult {
+        // Query kinds absent from the new configuration must disappear; the
+        // insertion helpers only replace kinds that successfully load.
+        self.query_store.remove_queries(lang_name);
         // Error: parser was explicitly configured but can't be found
         let language = match self.load_parser(
             lang_name,
@@ -3303,6 +3307,13 @@ mod tests {
     #[test]
     fn configured_parser_failure_blocks_dynamic_fallback() {
         let coordinator = LanguageCoordinator::new();
+        let rust_language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        coordinator.query_store.insert_highlight_query(
+            "markdown".to_string(),
+            std::sync::Arc::new(
+                tree_sitter::Query::new(&rust_language, "(identifier) @variable").unwrap(),
+            ),
+        );
         let cwd = std::env::current_dir().expect("cwd");
         let grammar_dir = std::env::var("TREE_SITTER_GRAMMARS")
             .unwrap_or_else(|_| cwd.join("deps/tree-sitter").to_string_lossy().to_string());
@@ -3343,6 +3354,10 @@ mod tests {
             "configured failure must reject same-generation dynamic publication"
         );
         assert!(!coordinator.language_registry.contains("markdown"));
+        assert!(
+            coordinator.highlight_query("markdown").is_none(),
+            "queries from the previous configured grammar must be removed"
+        );
 
         assert!(
             !coordinator.ensure_language_loaded("markdown").success,

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1481,7 +1481,13 @@ impl LanguageCoordinator {
             LanguageLogLevel::Error,
         ) {
             Ok(lang) => lang,
-            Err(result) => return result,
+            Err(result) => {
+                let generation = self
+                    .load_generation
+                    .load(std::sync::atomic::Ordering::Acquire);
+                self.record_failed_load(lang_name, generation);
+                return result;
+            }
         };
         self.register_configured_language(lang_name, language.clone());
 
@@ -3258,6 +3264,43 @@ mod tests {
         assert!(
             !coordinator.ensure_language_loaded("configured").success,
             "an old configured registration must not survive a generation where it was not loaded"
+        );
+    }
+
+    #[test]
+    fn configured_parser_failure_blocks_dynamic_fallback() {
+        let coordinator = LanguageCoordinator::new();
+        let cwd = std::env::current_dir().expect("cwd");
+        let grammar_dir = std::env::var("TREE_SITTER_GRAMMARS")
+            .unwrap_or_else(|_| cwd.join("deps/tree-sitter").to_string_lossy().to_string());
+        let dynamic_parser = std::path::PathBuf::from(&grammar_dir)
+            .join("parser")
+            .join(format!("markdown.{}", std::env::consts::DLL_EXTENSION));
+        if !dynamic_parser.exists() {
+            eprintln!(
+                "skipping configured_parser_failure_blocks_dynamic_fallback: '{}' does not exist",
+                dynamic_parser.display()
+            );
+            return;
+        }
+        let mut languages = HashMap::new();
+        languages.insert(
+            "markdown".to_string(),
+            crate::config::settings::LanguageSettings {
+                parser: Some("/definitely/missing/parser.so".to_string()),
+                ..Default::default()
+            },
+        );
+
+        coordinator.load_settings(&WorkspaceSettings {
+            languages,
+            search_paths: vec![grammar_dir],
+            ..Default::default()
+        });
+
+        assert!(
+            !coordinator.ensure_language_loaded("markdown").success,
+            "an explicit configured parser failure must not fall back to dynamic discovery"
         );
     }
 

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -575,6 +575,7 @@ impl LanguageCoordinator {
         search_paths: &[PathBuf],
         language: &tree_sitter::Language,
     ) -> LanguageLoadResult {
+        self.query_store.remove_queries(derived_name);
         self.register_configured_language(derived_name, language.clone());
         self.derived_languages
             .write()
@@ -3412,6 +3413,36 @@ mod tests {
         assert!(
             summary.loaded.contains(&"rmd".to_string()),
             "leaf derived 'rmd' should load"
+        );
+    }
+
+    #[test]
+    fn derived_registration_replaces_standalone_queries() {
+        let coordinator = LanguageCoordinator::new();
+        let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        coordinator.query_store.insert_highlight_query(
+            "derived".to_string(),
+            std::sync::Arc::new(
+                tree_sitter::Query::new(&language, "(identifier) @variable").unwrap(),
+            ),
+        );
+
+        let result = coordinator.register_derived_from_base(
+            "derived",
+            "base",
+            &crate::config::settings::LanguageSettings {
+                base: Some("base".to_string()),
+                ..Default::default()
+            },
+            None,
+            &[],
+            &language,
+        );
+
+        assert!(result.success);
+        assert!(
+            coordinator.highlight_query("derived").is_none(),
+            "query kinds absent from the new base must not survive standalone-to-derived reload"
         );
     }
 

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -82,6 +82,9 @@ pub(crate) struct LanguageCoordinator {
     /// untagged; configured and dynamically discovered parsers must match the
     /// current generation before they are cache hits.
     dynamically_loaded: dashmap::DashMap<String, u64>,
+    /// Languages whose current query set came from an explicit configured
+    /// override while their parser remained an untagged built-in registration.
+    configured_query_overrides: dashmap::DashSet<String>,
     /// Serializes settings-generation changes with registry publication so a
     /// load resolved under an old configuration cannot overwrite or retag a
     /// parser registered by a newer reload.
@@ -126,6 +129,7 @@ impl LanguageCoordinator {
             failed_loads: dashmap::DashMap::new(),
             configured_load_failures: dashmap::DashMap::new(),
             dynamically_loaded: dashmap::DashMap::new(),
+            configured_query_overrides: dashmap::DashSet::new(),
             registration_lock: Mutex::new(()),
             settings_reload_lock: Mutex::new(()),
             load_generation: std::sync::atomic::AtomicU64::new(0),
@@ -1508,7 +1512,9 @@ impl LanguageCoordinator {
             config.parser.is_none() && self.has_current_parser_registration(lang_name, generation);
         let pre_registered_is_builtin =
             pre_registered && self.dynamically_loaded.get(lang_name).is_none();
-        let preserve_builtin_queries = pre_registered_is_builtin && config.queries.is_none();
+        let had_configured_query_override = self.configured_query_overrides.contains(lang_name);
+        let preserve_builtin_queries =
+            pre_registered_is_builtin && config.queries.is_none() && !had_configured_query_override;
         if !preserve_builtin_queries {
             // Query kinds absent from the new configuration must disappear; the
             // insertion helpers only replace kinds that successfully load.
@@ -1538,6 +1544,12 @@ impl LanguageCoordinator {
         }
 
         let mut events = self.load_queries_for_language(lang_name, config, search_paths, &language);
+        if pre_registered_is_builtin && config.queries.is_some() {
+            self.configured_query_overrides
+                .insert(lang_name.to_string());
+        } else {
+            self.configured_query_overrides.remove(lang_name);
+        }
 
         events.push(LanguageEvent::log(
             LanguageLogLevel::Info,
@@ -3414,6 +3426,35 @@ mod tests {
         assert!(!coordinator.language_registry.contains("racing"));
         assert!(coordinator.dynamically_loaded.get("racing").is_none());
         assert!(coordinator.configured_load_failed("racing", generation));
+    }
+
+    #[test]
+    fn removing_builtin_query_override_clears_configured_queries() {
+        let coordinator = LanguageCoordinator::new();
+        let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        coordinator
+            .language_registry
+            .register("builtin".to_string(), language.clone());
+        coordinator.query_store.insert_highlight_query(
+            "builtin".to_string(),
+            std::sync::Arc::new(
+                tree_sitter::Query::new(&language, "(identifier) @variable").unwrap(),
+            ),
+        );
+        coordinator
+            .configured_query_overrides
+            .insert("builtin".to_string());
+        let mut languages = HashMap::new();
+        languages.insert("builtin".to_string(), LanguageSettings::default());
+
+        coordinator.load_settings(&WorkspaceSettings {
+            languages,
+            ..Default::default()
+        });
+
+        assert!(coordinator.highlight_query("builtin").is_none());
+        assert!(!coordinator.configured_query_overrides.contains("builtin"));
+        assert!(coordinator.has_parser_available("builtin"));
     }
 
     #[test]

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -11,7 +11,7 @@ use crate::error::LockResultExt;
 use log::debug;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use tree_sitter::Language;
 
 /// Maximum length (in characters) for pattern previews in log messages.
@@ -77,6 +77,10 @@ pub(crate) struct LanguageCoordinator {
     /// generation that resolved their library path. A registered parser is not
     /// a cache hit after reload unless this tag matches the current generation.
     dynamically_loaded: dashmap::DashMap<String, u64>,
+    /// Serializes settings-generation changes with registry publication so a
+    /// load resolved under an old configuration cannot overwrite or retag a
+    /// parser registered by a newer reload.
+    registration_lock: Mutex<()>,
     /// Bumped by every `load_settings` (the only event that can make a
     /// failed load succeed) before the hygiene clear. Read-validated against
     /// `failed_loads` entries; see there.
@@ -112,6 +116,7 @@ impl LanguageCoordinator {
             derived_languages: RwLock::new(HashSet::new()),
             failed_loads: dashmap::DashMap::new(),
             dynamically_loaded: dashmap::DashMap::new(),
+            registration_lock: Mutex::new(()),
             load_generation: std::sync::atomic::AtomicU64::new(0),
             config_warnings: RwLock::new(Vec::new()),
             load_inflight: dashmap::DashMap::new(),
@@ -123,17 +128,26 @@ impl LanguageCoordinator {
     /// Visibility: pub(crate) - called by LSP layer (semantic_tokens, selection_range)
     /// and analysis modules to ensure parsers are available before use.
     pub(crate) fn ensure_language_loaded(&self, language_id: &str) -> LanguageLoadResult {
-        let current_generation = self
-            .load_generation
-            .load(std::sync::atomic::Ordering::Acquire);
-        if let Some(result) = self.cached_load_verdict(language_id, current_generation) {
+        loop {
+            let current_generation = self
+                .load_generation
+                .load(std::sync::atomic::Ordering::Acquire);
+            if let Some(result) = self.cached_load_verdict(language_id, current_generation) {
+                return result;
+            }
+            let result = self.try_load_language_by_id(language_id, current_generation);
+            if self
+                .load_generation
+                .load(std::sync::atomic::Ordering::Acquire)
+                != current_generation
+            {
+                continue;
+            }
+            if !result.success {
+                self.record_failed_load(language_id, current_generation);
+            }
             return result;
         }
-        let result = self.try_load_language_by_id(language_id, current_generation);
-        if !result.success {
-            self.record_failed_load(language_id, current_generation);
-        }
-        result
     }
 
     /// Already-decided verdict for a load, or `None` when a real attempt is
@@ -293,6 +307,13 @@ impl LanguageCoordinator {
                             ))
                         });
 
+                        if self
+                            .load_generation
+                            .load(std::sync::atomic::Ordering::Acquire)
+                            != current_generation
+                        {
+                            continue;
+                        }
                         return result;
                     }
                 }
@@ -349,8 +370,14 @@ impl LanguageCoordinator {
         // hygiene only: a stale store racing it lands with an old tag and is
         // inert, so no ordering between bump, clear, and in-flight scans can
         // produce a wrong suppression.
-        self.load_generation
-            .fetch_add(1, std::sync::atomic::Ordering::Release);
+        {
+            let _registration = self
+                .registration_lock
+                .lock()
+                .recover_poison("LanguageCoordinator::load_settings(generation)");
+            self.load_generation
+                .fetch_add(1, std::sync::atomic::Ordering::Release);
+        }
         self.failed_loads.clear();
 
         // Build base map from language configs
@@ -517,8 +544,7 @@ impl LanguageCoordinator {
         search_paths: &[PathBuf],
         language: &tree_sitter::Language,
     ) -> LanguageLoadResult {
-        self.language_registry
-            .register(derived_name.to_string(), language.clone());
+        self.register_configured_language(derived_name, language.clone());
         self.derived_languages
             .write()
             .recover_poison("LanguageCoordinator::register_derived_from_base(derived_languages)")
@@ -774,17 +800,14 @@ impl LanguageCoordinator {
         }
 
         // Warning: parser may not exist yet (dynamic discovery)
-        let language = match self.load_and_register_parser(
-            language_id,
-            None,
-            &search_paths,
-            LanguageLogLevel::Warning,
-        ) {
-            Ok(lang) => lang,
-            Err(result) => return result,
-        };
-        self.dynamically_loaded
-            .insert(language_id.to_string(), current_generation);
+        let language =
+            match self.load_parser(language_id, None, &search_paths, LanguageLogLevel::Warning) {
+                Ok(lang) => lang,
+                Err(result) => return result,
+            };
+        if !self.register_dynamic_language(language_id, language.clone(), current_generation) {
+            return LanguageLoadResult::default();
+        }
 
         let mut events = Vec::new();
 
@@ -812,16 +835,41 @@ impl LanguageCoordinator {
         LanguageLoadResult::success_with(events)
     }
 
-    /// Resolve, load, and register a parser for the given language.
+    fn register_dynamic_language(
+        &self,
+        language_id: &str,
+        language: Language,
+        expected_generation: u64,
+    ) -> bool {
+        let _registration = self
+            .registration_lock
+            .lock()
+            .recover_poison("LanguageCoordinator::register_dynamic_language");
+        if self
+            .load_generation
+            .load(std::sync::atomic::Ordering::Acquire)
+            != expected_generation
+        {
+            return false;
+        }
+        self.language_registry
+            .register(language_id.to_string(), language);
+        self.dynamically_loaded
+            .insert(language_id.to_string(), expected_generation);
+        true
+    }
+
+    /// Resolve and load a parser for the given language.
     ///
-    /// Returns `Ok(Language)` on success, or `Err(LanguageLoadResult)` with
-    /// an appropriate failure event on error.
+    /// Publication is deliberately separate so the caller can serialize it
+    /// with settings-generation changes. Returns `Ok(Language)` on success,
+    /// or `Err(LanguageLoadResult)` with an appropriate failure event.
     ///
     /// `missing_parser_level` controls how a missing parser is reported:
     /// - `Warning` for dynamic loading — the parser may not exist yet (normal)
     /// - `Error` for config-driven loading — the parser was explicitly configured
     ///   but cannot be found (configuration problem)
-    fn load_and_register_parser(
+    fn load_parser(
         &self,
         lang_name: &str,
         parser_config: Option<&str>,
@@ -844,7 +892,7 @@ impl LanguageCoordinator {
             let result = self
                 .parser_loader
                 .write()
-                .recover_poison("LanguageCoordinator::load_and_register_parser")
+                .recover_poison("LanguageCoordinator::load_parser")
                 .load_language(&lib_path, lang_name);
             match result {
                 Ok(lang) => lang,
@@ -859,9 +907,6 @@ impl LanguageCoordinator {
                 }
             }
         };
-
-        self.language_registry
-            .register(lang_name.to_string(), language.clone());
 
         Ok(language)
     }
@@ -1415,7 +1460,7 @@ impl LanguageCoordinator {
         search_paths: &[PathBuf],
     ) -> LanguageLoadResult {
         // Error: parser was explicitly configured but can't be found
-        let language = match self.load_and_register_parser(
+        let language = match self.load_parser(
             lang_name,
             config.parser.as_deref(),
             search_paths,
@@ -1424,11 +1469,7 @@ impl LanguageCoordinator {
             Ok(lang) => lang,
             Err(result) => return result,
         };
-        // Config-driven registration supersedes any older on-demand entry.
-        // Remove the generation tag only after the new parser is registered,
-        // so a concurrent cache read cannot mistake the old parser for an
-        // untagged, configuration-owned registration.
-        self.dynamically_loaded.remove(lang_name);
+        self.register_configured_language(lang_name, language.clone());
 
         let mut events = self.load_queries_for_language(lang_name, config, search_paths, &language);
 
@@ -1437,6 +1478,16 @@ impl LanguageCoordinator {
             format!("Language {lang_name} loaded."),
         ));
         LanguageLoadResult::success_with(events)
+    }
+
+    fn register_configured_language(&self, language_id: &str, language: Language) {
+        let _registration = self
+            .registration_lock
+            .lock()
+            .recover_poison("LanguageCoordinator::register_configured_language");
+        self.language_registry
+            .register(language_id.to_string(), language);
+        self.dynamically_loaded.remove(language_id);
     }
 
     fn load_queries_for_language(
@@ -3150,6 +3201,24 @@ mod tests {
         assert!(
             !coordinator.ensure_language_loaded("dynamic").success,
             "a prior-generation dynamic entry must not bypass current search-path resolution"
+        );
+    }
+
+    #[test]
+    fn stale_dynamic_load_cannot_retag_configured_registration() {
+        let coordinator = LanguageCoordinator::new();
+        coordinator.load_settings(&WorkspaceSettings::default());
+        coordinator.register_configured_language("dynamic", tree_sitter_rust::LANGUAGE.into());
+
+        assert!(
+            !coordinator
+                .register_dynamic_language("dynamic", tree_sitter_rust::LANGUAGE.into(), 0,),
+            "a load resolved before the reload must lose publication"
+        );
+        assert!(coordinator.language_registry.contains("dynamic"));
+        assert!(
+            coordinator.dynamically_loaded.get("dynamic").is_none(),
+            "the current configured parser must remain untagged"
         );
     }
 

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1513,6 +1513,12 @@ impl LanguageCoordinator {
             config.parser.is_none() && self.has_current_parser_registration(lang_name, generation);
         let pre_registered_is_builtin =
             pre_registered && self.reload_scoped_registrations.get(lang_name).is_none();
+        let configured_query_kinds = config.queries.as_ref().map(|queries| {
+            queries
+                .iter()
+                .filter_map(|query| query.kind.or_else(|| infer_query_kind(&query.path)))
+                .collect::<HashSet<_>>()
+        });
         if pre_registered_is_builtin {
             for kind in QueryKind::ALL {
                 let key = (lang_name.to_string(), kind);
@@ -1530,6 +1536,14 @@ impl LanguageCoordinator {
         } else {
             self.query_store.remove_queries(lang_name);
             for kind in QueryKind::ALL {
+                let restore_kind = match &configured_query_kinds {
+                    None => true,
+                    Some(kinds) if kinds.is_empty() => false,
+                    Some(kinds) => !kinds.contains(&kind),
+                };
+                if !restore_kind {
+                    continue;
+                }
                 if let Some(query) = self
                     .builtin_queries
                     .get(&(lang_name.to_string(), kind))
@@ -3526,6 +3540,19 @@ mod tests {
             &coordinator.injection_query("builtin").unwrap(),
             &builtin_injection
         ));
+
+        coordinator.load_settings(&WorkspaceSettings {
+            languages: HashMap::from([(
+                "builtin".to_string(),
+                LanguageSettings {
+                    queries: Some(Vec::new()),
+                    ..Default::default()
+                },
+            )]),
+            ..Default::default()
+        });
+        assert!(coordinator.highlight_query("builtin").is_none());
+        assert!(coordinator.injection_query("builtin").is_none());
     }
 
     #[test]

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -73,6 +73,10 @@ pub(crate) struct LanguageCoordinator {
     /// re-poisoning — no clear-vs-store ordering to get right. The clear on
     /// `load_settings` is memory hygiene, not the correctness mechanism.
     failed_loads: dashmap::DashMap<String, u64>,
+    /// Registry entries discovered from search paths, tagged with the settings
+    /// generation that resolved their library path. A registered parser is not
+    /// a cache hit after reload unless this tag matches the current generation.
+    dynamically_loaded: dashmap::DashMap<String, u64>,
     /// Bumped by every `load_settings` (the only event that can make a
     /// failed load succeed) before the hygiene clear. Read-validated against
     /// `failed_loads` entries; see there.
@@ -107,6 +111,7 @@ impl LanguageCoordinator {
             base_map: RwLock::new(HashMap::new()),
             derived_languages: RwLock::new(HashSet::new()),
             failed_loads: dashmap::DashMap::new(),
+            dynamically_loaded: dashmap::DashMap::new(),
             load_generation: std::sync::atomic::AtomicU64::new(0),
             config_warnings: RwLock::new(Vec::new()),
             load_inflight: dashmap::DashMap::new(),
@@ -124,7 +129,7 @@ impl LanguageCoordinator {
         if let Some(result) = self.cached_load_verdict(language_id, current_generation) {
             return result;
         }
-        let result = self.try_load_language_by_id(language_id);
+        let result = self.try_load_language_by_id(language_id, current_generation);
         if !result.success {
             self.record_failed_load(language_id, current_generation);
         }
@@ -146,7 +151,7 @@ impl LanguageCoordinator {
         language_id: &str,
         current_generation: u64,
     ) -> Option<LanguageLoadResult> {
-        if self.language_registry.contains(language_id) {
+        if self.has_current_parser_registration(language_id, current_generation) {
             return Some(LanguageLoadResult::success_with(Vec::new()));
         }
         if self
@@ -157,6 +162,14 @@ impl LanguageCoordinator {
             return Some(LanguageLoadResult::default());
         }
         None
+    }
+
+    fn has_current_parser_registration(&self, language_id: &str, current_generation: u64) -> bool {
+        self.language_registry.contains(language_id)
+            && self
+                .dynamically_loaded
+                .get(language_id)
+                .is_none_or(|generation| *generation == current_generation)
     }
 
     /// Record a failed load, tagged with the generation captured BEFORE the
@@ -250,7 +263,8 @@ impl LanguageCoordinator {
                         let coordinator = Arc::clone(self);
                         let owned_id = language_id.to_string();
                         let result = tokio::task::spawn_blocking(move || {
-                            let result = coordinator.try_load_language_by_id(&owned_id);
+                            let result = coordinator
+                                .try_load_language_by_id(&owned_id, current_generation);
                             // Record the failure INSIDE the blocking task so a
                             // winner cancelled mid-`.await` (its future dropped)
                             // still populates the negative cache: the detached
@@ -556,7 +570,10 @@ impl LanguageCoordinator {
         search_paths: &[PathBuf],
         visiting: &mut HashSet<String>,
     ) -> Result<(), LanguageLoadResult> {
-        if self.language_registry.contains(base_name) {
+        let current_generation = self
+            .load_generation
+            .load(std::sync::atomic::Ordering::Acquire);
+        if self.has_current_parser_registration(base_name, current_generation) {
             return Ok(());
         }
 
@@ -582,7 +599,7 @@ impl LanguageCoordinator {
                      base language '{base_name}' is part of a circular chain"
                 ),
             )),
-            None => self.try_load_language_by_id(base_name),
+            None => self.try_load_language_by_id(base_name, current_generation),
         };
 
         if base_result.success {
@@ -743,11 +760,11 @@ impl LanguageCoordinator {
     ///
     /// Visibility: Internal only - called by ensure_language_loaded.
     /// Not exposed as public API to keep interface minimal (YAGNI).
-    fn try_load_language_by_id(&self, language_id: &str) -> LanguageLoadResult {
-        if self.language_registry.contains(language_id) {
-            return LanguageLoadResult::success_with(Vec::new());
-        }
-
+    fn try_load_language_by_id(
+        &self,
+        language_id: &str,
+        current_generation: u64,
+    ) -> LanguageLoadResult {
         let search_paths = self.config_store.search_paths();
         if search_paths.is_empty() {
             return LanguageLoadResult::failure_with(LanguageEvent::log(
@@ -766,6 +783,8 @@ impl LanguageCoordinator {
             Ok(lang) => lang,
             Err(result) => return result,
         };
+        self.dynamically_loaded
+            .insert(language_id.to_string(), current_generation);
 
         let mut events = Vec::new();
 
@@ -1405,6 +1424,11 @@ impl LanguageCoordinator {
             Ok(lang) => lang,
             Err(result) => return result,
         };
+        // Config-driven registration supersedes any older on-demand entry.
+        // Remove the generation tag only after the new parser is registered,
+        // so a concurrent cache read cannot mistake the old parser for an
+        // untagged, configuration-owned registration.
+        self.dynamically_loaded.remove(lang_name);
 
         let mut events = self.load_queries_for_language(lang_name, config, search_paths, &language);
 
@@ -3100,6 +3124,32 @@ mod tests {
         assert!(
             !coordinator.has_queries("markdown"),
             "removed standalone-loaded derived language should have queries cleared on reload"
+        );
+    }
+
+    #[test]
+    fn settings_reload_invalidates_dynamic_registry_hits() {
+        let coordinator = LanguageCoordinator::new();
+        coordinator
+            .language_registry
+            .register("dynamic".to_string(), tree_sitter_rust::LANGUAGE.into());
+        coordinator
+            .dynamically_loaded
+            .insert("dynamic".to_string(), 0);
+        assert!(
+            coordinator.ensure_language_loaded("dynamic").success,
+            "the dynamic parser is current before reload"
+        );
+
+        coordinator.load_settings(&WorkspaceSettings::default());
+
+        assert!(
+            coordinator.language_registry.contains("dynamic"),
+            "the regression requires a stale registry entry to remain present"
+        );
+        assert!(
+            !coordinator.ensure_language_loaded("dynamic").success,
+            "a prior-generation dynamic entry must not bypass current search-path resolution"
         );
     }
 

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -73,6 +73,10 @@ pub(crate) struct LanguageCoordinator {
     /// re-poisoning — no clear-vs-store ordering to get right. The clear on
     /// `load_settings` is memory hygiene, not the correctness mechanism.
     failed_loads: dashmap::DashMap<String, u64>,
+    /// Explicit configured parser failures override same-generation dynamic
+    /// discovery. This closes the reload window where fallback publication can
+    /// race ahead of validating `languages.<id>.parser`.
+    configured_load_failures: dashmap::DashMap<String, u64>,
     /// Reload-scoped registry entries, tagged with the settings generation that
     /// resolved their library path. Manually pre-registered/built-in entries are
     /// untagged; configured and dynamically discovered parsers must match the
@@ -120,6 +124,7 @@ impl LanguageCoordinator {
             base_map: RwLock::new(HashMap::new()),
             derived_languages: RwLock::new(HashSet::new()),
             failed_loads: dashmap::DashMap::new(),
+            configured_load_failures: dashmap::DashMap::new(),
             dynamically_loaded: dashmap::DashMap::new(),
             registration_lock: Mutex::new(()),
             settings_reload_lock: Mutex::new(()),
@@ -171,6 +176,13 @@ impl LanguageCoordinator {
         language_id: &str,
         current_generation: u64,
     ) -> Option<LanguageLoadResult> {
+        if self
+            .configured_load_failures
+            .get(language_id)
+            .is_some_and(|generation| *generation == current_generation)
+        {
+            return Some(LanguageLoadResult::default());
+        }
         if self.has_current_parser_registration(language_id, current_generation) {
             return Some(LanguageLoadResult::success_with(Vec::new()));
         }
@@ -389,6 +401,7 @@ impl LanguageCoordinator {
                 .fetch_add(1, std::sync::atomic::Ordering::Release);
         }
         self.failed_loads.clear();
+        self.configured_load_failures.clear();
 
         // Build base map from language configs
         self.build_base_map(&settings.languages);
@@ -1485,6 +1498,8 @@ impl LanguageCoordinator {
                 let generation = self
                     .load_generation
                     .load(std::sync::atomic::Ordering::Acquire);
+                self.configured_load_failures
+                    .insert(lang_name.to_string(), generation);
                 self.record_failed_load(lang_name, generation);
                 return result;
             }
@@ -1507,6 +1522,7 @@ impl LanguageCoordinator {
             .recover_poison("LanguageCoordinator::register_configured_language");
         self.language_registry
             .register(language_id.to_string(), language);
+        self.configured_load_failures.remove(language_id);
         let generation = self
             .load_generation
             .load(std::sync::atomic::Ordering::Acquire);
@@ -3297,6 +3313,18 @@ mod tests {
             search_paths: vec![grammar_dir],
             ..Default::default()
         });
+        let generation = coordinator
+            .load_generation
+            .load(std::sync::atomic::Ordering::Acquire);
+        assert!(
+            coordinator.publish_dynamic_language(
+                "markdown",
+                tree_sitter_rust::LANGUAGE.into(),
+                generation,
+                || {},
+            ),
+            "simulate dynamic fallback winning the publication race"
+        );
 
         assert!(
             !coordinator.ensure_language_loaded("markdown").success,

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1501,24 +1501,36 @@ impl LanguageCoordinator {
         config: &LanguageSettings,
         search_paths: &[PathBuf],
     ) -> LanguageLoadResult {
-        // Query kinds absent from the new configuration must disappear; the
-        // insertion helpers only replace kinds that successfully load.
-        self.query_store.remove_queries(lang_name);
-        // Error: parser was explicitly configured but can't be found
-        let language = match self.load_parser(
-            lang_name,
-            config.parser.as_deref(),
-            search_paths,
-            LanguageLogLevel::Error,
-        ) {
-            Ok(lang) => lang,
-            Err(result) => {
-                let generation = self
-                    .load_generation
-                    .load(std::sync::atomic::Ordering::Acquire);
-                self.record_configured_load_failure(lang_name, generation);
-                self.record_failed_load(lang_name, generation);
-                return result;
+        let generation = self
+            .load_generation
+            .load(std::sync::atomic::Ordering::Acquire);
+        let pre_registered =
+            config.parser.is_none() && self.has_current_parser_registration(lang_name, generation);
+        let preserve_builtin_queries = pre_registered
+            && self.dynamically_loaded.get(lang_name).is_none()
+            && config.queries.is_none();
+        if !preserve_builtin_queries {
+            // Query kinds absent from the new configuration must disappear; the
+            // insertion helpers only replace kinds that successfully load.
+            self.query_store.remove_queries(lang_name);
+        }
+        let language = if pre_registered {
+            self.language_registry
+                .get(lang_name)
+                .expect("current parser registration disappeared")
+        } else {
+            match self.load_parser(
+                lang_name,
+                config.parser.as_deref(),
+                search_paths,
+                LanguageLogLevel::Error,
+            ) {
+                Ok(lang) => lang,
+                Err(result) => {
+                    self.record_configured_load_failure(lang_name, generation);
+                    self.record_failed_load(lang_name, generation);
+                    return result;
+                }
             }
         };
         self.register_configured_language(lang_name, language.clone());

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -154,6 +154,9 @@ impl LanguageCoordinator {
             {
                 continue;
             }
+            if self.configured_load_failed(language_id, current_generation) {
+                return LanguageLoadResult::default();
+            }
             if !result.success {
                 self.record_failed_load(language_id, current_generation);
             }
@@ -176,11 +179,7 @@ impl LanguageCoordinator {
         language_id: &str,
         current_generation: u64,
     ) -> Option<LanguageLoadResult> {
-        if self
-            .configured_load_failures
-            .get(language_id)
-            .is_some_and(|generation| *generation == current_generation)
-        {
+        if self.configured_load_failed(language_id, current_generation) {
             return Some(LanguageLoadResult::default());
         }
         if self.has_current_parser_registration(language_id, current_generation) {
@@ -194,6 +193,12 @@ impl LanguageCoordinator {
             return Some(LanguageLoadResult::default());
         }
         None
+    }
+
+    fn configured_load_failed(&self, language_id: &str, current_generation: u64) -> bool {
+        self.configured_load_failures
+            .get(language_id)
+            .is_some_and(|generation| *generation == current_generation)
     }
 
     fn has_current_parser_registration(&self, language_id: &str, current_generation: u64) -> bool {
@@ -331,6 +336,9 @@ impl LanguageCoordinator {
                             != current_generation
                         {
                             continue;
+                        }
+                        if self.configured_load_failed(language_id, current_generation) {
+                            return LanguageLoadResult::default();
                         }
                         return result;
                     }

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -1516,8 +1516,7 @@ impl LanguageCoordinator {
                 let generation = self
                     .load_generation
                     .load(std::sync::atomic::Ordering::Acquire);
-                self.configured_load_failures
-                    .insert(lang_name.to_string(), generation);
+                self.record_configured_load_failure(lang_name, generation);
                 self.record_failed_load(lang_name, generation);
                 return result;
             }
@@ -1546,6 +1545,18 @@ impl LanguageCoordinator {
             .load(std::sync::atomic::Ordering::Acquire);
         self.dynamically_loaded
             .insert(language_id.to_string(), generation);
+    }
+
+    fn record_configured_load_failure(&self, language_id: &str, generation: u64) {
+        let _registration = self
+            .registration_lock
+            .lock()
+            .recover_poison("LanguageCoordinator::record_configured_load_failure");
+        self.configured_load_failures
+            .insert(language_id.to_string(), generation);
+        self.language_registry.unregister(language_id);
+        self.dynamically_loaded.remove(language_id);
+        self.query_store.remove_queries(language_id);
     }
 
     fn load_queries_for_language(
@@ -3364,6 +3375,27 @@ mod tests {
             !coordinator.ensure_language_loaded("markdown").success,
             "an explicit configured parser failure must not fall back to dynamic discovery"
         );
+    }
+
+    #[test]
+    fn configured_failure_removes_racing_dynamic_publication() {
+        let coordinator = LanguageCoordinator::new();
+        coordinator.load_settings(&WorkspaceSettings::default());
+        let generation = coordinator
+            .load_generation
+            .load(std::sync::atomic::Ordering::Acquire);
+        assert!(coordinator.publish_dynamic_language(
+            "racing",
+            tree_sitter_rust::LANGUAGE.into(),
+            generation,
+            || {},
+        ));
+
+        coordinator.record_configured_load_failure("racing", generation);
+
+        assert!(!coordinator.language_registry.contains("racing"));
+        assert!(coordinator.dynamically_loaded.get("racing").is_none());
+        assert!(coordinator.configured_load_failed("racing", generation));
     }
 
     #[test]

--- a/src/language/coordinator.rs
+++ b/src/language/coordinator.rs
@@ -81,6 +81,10 @@ pub(crate) struct LanguageCoordinator {
     /// load resolved under an old configuration cannot overwrite or retag a
     /// parser registered by a newer reload.
     registration_lock: Mutex<()>,
+    /// Makes each config/query/registry reload one state transition. Without
+    /// this, concurrent didChangeConfiguration and post-install reloads can
+    /// combine one settings payload's languages with another's search paths.
+    settings_reload_lock: Mutex<()>,
     /// Bumped by every `load_settings` (the only event that can make a
     /// failed load succeed) before the hygiene clear. Read-validated against
     /// `failed_loads` entries; see there.
@@ -117,6 +121,7 @@ impl LanguageCoordinator {
             failed_loads: dashmap::DashMap::new(),
             dynamically_loaded: dashmap::DashMap::new(),
             registration_lock: Mutex::new(()),
+            settings_reload_lock: Mutex::new(()),
             load_generation: std::sync::atomic::AtomicU64::new(0),
             config_warnings: RwLock::new(Vec::new()),
             load_inflight: dashmap::DashMap::new(),
@@ -361,6 +366,10 @@ impl LanguageCoordinator {
     /// Visibility: pub(crate) - called by LSP layer during initialization and
     /// settings updates to configure language support.
     pub(crate) fn load_settings(&self, settings: &WorkspaceSettings) -> LanguageLoadSummary {
+        let _reload = self
+            .settings_reload_lock
+            .lock()
+            .recover_poison("LanguageCoordinator::load_settings(reload)");
         self.config_store.update_from_settings(settings);
         self.clear_derived_languages();
         // A reload (new search paths, or the post-install reload) is the only

--- a/src/language/loader.rs
+++ b/src/language/loader.rs
@@ -26,6 +26,13 @@ fn resolved_library_path(path: &Path) -> PathBuf {
     path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
 }
 
+fn loader_cache_key(lang_name: &str, normalized_path: &Path) -> (String, PathBuf) {
+    (
+        lang_name.to_string(),
+        resolved_library_path(normalized_path),
+    )
+}
+
 /// Load (or fetch the already-mapped) library at `normalized_path`, leaking it
 /// into the process-global cache so it can never be unmapped.
 fn immortal_library(normalized_path: &Path) -> Result<&'static Library, ParserLoadError> {
@@ -93,8 +100,7 @@ impl ParserLoader {
     ) -> Result<Language, ParserLoadError> {
         // Normalize the path before loading
         let normalized_path = path.clean();
-        let resolved_path = resolved_library_path(&normalized_path);
-        let cache_key = (lang_name.to_string(), resolved_path);
+        let cache_key = loader_cache_key(lang_name, &normalized_path);
 
         // Derive function name from language name using standard convention
         let func_name = format!("tree_sitter_{lang_name}");
@@ -128,30 +134,19 @@ impl ParserLoader {
 mod tests {
     use super::*;
 
-    #[cfg(target_os = "macos")]
-    const SYSTEM_LIBRARIES: [&str; 2] = ["/usr/lib/libSystem.B.dylib", "/usr/lib/libobjc.A.dylib"];
-    #[cfg(target_os = "linux")]
-    const SYSTEM_LIBRARIES: [&str; 2] = ["libc.so.6", "libm.so.6"];
-
     #[test]
     fn test_parser_loader_creation() {
         let loader = ParserLoader::new();
         assert!(loader.loaded_libraries.is_empty());
     }
 
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
     #[test]
-    fn same_language_name_tracks_each_resolved_library_path() {
-        let mut loader = ParserLoader::new();
+    fn same_language_name_keys_each_resolved_library_path() {
+        let first = loader_cache_key("example", Path::new("/missing/first-parser"));
+        let second = loader_cache_key("example", Path::new("/missing/second-parser"));
 
-        for path in SYSTEM_LIBRARIES {
-            assert!(matches!(
-                loader.load_language(Path::new(path), "definitely_missing"),
-                Err(ParserLoadError::SymbolNotFound(_))
-            ));
-        }
-
-        assert_eq!(loader.loaded_libraries.len(), 2);
+        assert_ne!(first, second);
+        assert_eq!(first.0, second.0);
     }
 
     #[test]

--- a/src/language/loader.rs
+++ b/src/language/loader.rs
@@ -22,6 +22,10 @@ use crate::error::LockResultExt;
 /// for the process lifetime, so immortality changes nothing there.
 static LOADED_LIBRARIES: OnceLock<Mutex<HashMap<PathBuf, &'static Library>>> = OnceLock::new();
 
+fn resolved_library_path(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
 /// Load (or fetch the already-mapped) library at `normalized_path`, leaking it
 /// into the process-global cache so it can never be unmapped.
 fn immortal_library(normalized_path: &Path) -> Result<&'static Library, ParserLoadError> {
@@ -29,9 +33,7 @@ fn immortal_library(normalized_path: &Path) -> Result<&'static Library, ParserLo
     // share one leaked entry (PathClean alone is lexical); fall back to the
     // cleaned path when the file cannot be resolved — `Library::new` will
     // then report the real error.
-    let key = normalized_path
-        .canonicalize()
-        .unwrap_or_else(|_| normalized_path.to_path_buf());
+    let key = resolved_library_path(normalized_path);
     let cache = LOADED_LIBRARIES.get_or_init(|| Mutex::new(HashMap::new()));
     let mut map = cache.lock().recover_poison("loader::immortal_library");
     if let Some(library) = map.get(&key) {
@@ -45,8 +47,8 @@ fn immortal_library(normalized_path: &Path) -> Result<&'static Library, ParserLo
 /// A wrapper around dynamic library loading for Tree-sitter language parsers
 #[derive(Default)]
 pub(crate) struct ParserLoader {
-    /// Per-loader name→library index into the process-global cache.
-    loaded_libraries: HashMap<String, &'static Library>,
+    /// Per-loader (name, resolved path) index into the process-global cache.
+    loaded_libraries: HashMap<(String, PathBuf), &'static Library>,
 }
 
 #[derive(Debug)]
@@ -91,18 +93,20 @@ impl ParserLoader {
     ) -> Result<Language, ParserLoadError> {
         // Normalize the path before loading
         let normalized_path = path.clean();
+        let resolved_path = resolved_library_path(&normalized_path);
+        let cache_key = (lang_name.to_string(), resolved_path);
 
         // Derive function name from language name using standard convention
         let func_name = format!("tree_sitter_{lang_name}");
 
         // Load the library if not already loaded
-        if !self.loaded_libraries.contains_key(lang_name) {
+        if !self.loaded_libraries.contains_key(&cache_key) {
             let library = immortal_library(&normalized_path)?;
-            self.loaded_libraries.insert(lang_name.to_string(), library);
+            self.loaded_libraries.insert(cache_key.clone(), library);
         }
 
         // Get the library from cache
-        let library = *self.loaded_libraries.get(lang_name).ok_or_else(|| {
+        let library = *self.loaded_libraries.get(&cache_key).ok_or_else(|| {
             ParserLoadError::CacheError(format!("Failed to get library for {lang_name}"))
         })?;
 
@@ -124,10 +128,30 @@ impl ParserLoader {
 mod tests {
     use super::*;
 
+    #[cfg(target_os = "macos")]
+    const SYSTEM_LIBRARIES: [&str; 2] = ["/usr/lib/libSystem.B.dylib", "/usr/lib/libobjc.A.dylib"];
+    #[cfg(target_os = "linux")]
+    const SYSTEM_LIBRARIES: [&str; 2] = ["libc.so.6", "libm.so.6"];
+
     #[test]
     fn test_parser_loader_creation() {
         let loader = ParserLoader::new();
         assert!(loader.loaded_libraries.is_empty());
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[test]
+    fn same_language_name_tracks_each_resolved_library_path() {
+        let mut loader = ParserLoader::new();
+
+        for path in SYSTEM_LIBRARIES {
+            assert!(matches!(
+                loader.load_language(Path::new(path), "definitely_missing"),
+                Err(ParserLoadError::SymbolNotFound(_))
+            ));
+        }
+
+        assert_eq!(loader.loaded_libraries.len(), 2);
     }
 
     #[test]

--- a/src/language/parser_pool.rs
+++ b/src/language/parser_pool.rs
@@ -32,7 +32,7 @@ pub struct DocumentParserPool {
     /// Factory for creating new parsers
     factory: ParserFactory,
     generation: u64,
-    reload_in_progress: bool,
+    reload_depth: usize,
 }
 
 impl DocumentParserPool {
@@ -42,24 +42,24 @@ impl DocumentParserPool {
             available: HashMap::new(),
             factory,
             generation: 0,
-            reload_in_progress: false,
+            reload_depth: 0,
         }
     }
 
     pub(crate) fn begin_reload(&mut self) {
         self.generation = self.generation.wrapping_add(1);
         self.available.clear();
-        self.reload_in_progress = true;
+        self.reload_depth = self.reload_depth.saturating_add(1);
     }
 
     pub(crate) fn finish_reload(&mut self) {
         self.generation = self.generation.wrapping_add(1);
         self.available.clear();
-        self.reload_in_progress = false;
+        self.reload_depth = self.reload_depth.saturating_sub(1);
     }
 
     pub(crate) fn acquire_versioned(&mut self, language_id: &str) -> Option<(Parser, u64)> {
-        if self.reload_in_progress {
+        if self.reload_depth != 0 {
             return None;
         }
         let generation = self.generation;

--- a/src/language/parser_pool.rs
+++ b/src/language/parser_pool.rs
@@ -35,6 +35,12 @@ pub struct DocumentParserPool {
     reload_depth: usize,
 }
 
+pub(crate) enum ParserCheckout {
+    Acquired(Parser, u64),
+    Reloading,
+    Unavailable,
+}
+
 impl DocumentParserPool {
     /// Create a new parser pool with the given factory
     pub fn new(factory: ParserFactory) -> Self {
@@ -58,12 +64,15 @@ impl DocumentParserPool {
         self.reload_depth = self.reload_depth.saturating_sub(1);
     }
 
-    pub(crate) fn acquire_versioned(&mut self, language_id: &str) -> Option<(Parser, u64)> {
+    pub(crate) fn acquire_versioned(&mut self, language_id: &str) -> ParserCheckout {
         if self.reload_depth != 0 {
-            return None;
+            return ParserCheckout::Reloading;
         }
         let generation = self.generation;
-        self.acquire(language_id).map(|parser| (parser, generation))
+        match self.acquire(language_id) {
+            Some(parser) => ParserCheckout::Acquired(parser, generation),
+            None => ParserCheckout::Unavailable,
+        }
     }
 
     pub(crate) fn release_versioned(

--- a/src/language/parser_pool.rs
+++ b/src/language/parser_pool.rs
@@ -59,12 +59,15 @@ impl DocumentParserPool {
         language_id: String,
         parser: Parser,
         generation: u64,
-    ) {
+    ) -> bool {
         if generation == self.generation {
             self.available
                 .entry(language_id)
                 .or_default()
                 .push((generation, parser));
+            true
+        } else {
+            false
         }
     }
 

--- a/src/language/parser_pool.rs
+++ b/src/language/parser_pool.rs
@@ -28,9 +28,10 @@ impl ParserFactory {
 /// Per-document parser pool for efficient parser reuse
 pub struct DocumentParserPool {
     /// Available parsers by language ID
-    available: HashMap<String, Vec<Parser>>,
+    available: HashMap<String, Vec<(u64, Parser)>>,
     /// Factory for creating new parsers
     factory: ParserFactory,
+    generation: u64,
 }
 
 impl DocumentParserPool {
@@ -39,6 +40,31 @@ impl DocumentParserPool {
         Self {
             available: HashMap::new(),
             factory,
+            generation: 0,
+        }
+    }
+
+    pub(crate) fn invalidate(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
+        self.available.clear();
+    }
+
+    pub(crate) fn acquire_versioned(&mut self, language_id: &str) -> Option<(Parser, u64)> {
+        let generation = self.generation;
+        self.acquire(language_id).map(|parser| (parser, generation))
+    }
+
+    pub(crate) fn release_versioned(
+        &mut self,
+        language_id: String,
+        parser: Parser,
+        generation: u64,
+    ) {
+        if generation == self.generation {
+            self.available
+                .entry(language_id)
+                .or_default()
+                .push((generation, parser));
         }
     }
 
@@ -47,7 +73,7 @@ impl DocumentParserPool {
     pub fn acquire(&mut self, language_id: &str) -> Option<Parser> {
         // Try to get from pool first
         if let Some(parsers) = self.available.get_mut(language_id)
-            && let Some(parser) = parsers.pop()
+            && let Some((_, parser)) = parsers.pop()
         {
             return Some(parser);
         }
@@ -58,7 +84,10 @@ impl DocumentParserPool {
 
     /// Release a parser back to the pool for reuse
     pub fn release(&mut self, language_id: String, parser: Parser) {
-        self.available.entry(language_id).or_default().push(parser);
+        self.available
+            .entry(language_id)
+            .or_default()
+            .push((self.generation, parser));
     }
 }
 

--- a/src/language/parser_pool.rs
+++ b/src/language/parser_pool.rs
@@ -59,15 +59,15 @@ impl DocumentParserPool {
         language_id: String,
         parser: Parser,
         generation: u64,
-    ) -> bool {
+    ) -> Result<(), String> {
         if generation == self.generation {
             self.available
                 .entry(language_id)
                 .or_default()
                 .push((generation, parser));
-            true
+            Ok(())
         } else {
-            false
+            Err(language_id)
         }
     }
 

--- a/src/language/parser_pool.rs
+++ b/src/language/parser_pool.rs
@@ -32,6 +32,7 @@ pub struct DocumentParserPool {
     /// Factory for creating new parsers
     factory: ParserFactory,
     generation: u64,
+    reload_in_progress: bool,
 }
 
 impl DocumentParserPool {
@@ -41,15 +42,26 @@ impl DocumentParserPool {
             available: HashMap::new(),
             factory,
             generation: 0,
+            reload_in_progress: false,
         }
     }
 
-    pub(crate) fn invalidate(&mut self) {
+    pub(crate) fn begin_reload(&mut self) {
         self.generation = self.generation.wrapping_add(1);
         self.available.clear();
+        self.reload_in_progress = true;
+    }
+
+    pub(crate) fn finish_reload(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
+        self.available.clear();
+        self.reload_in_progress = false;
     }
 
     pub(crate) fn acquire_versioned(&mut self, language_id: &str) -> Option<(Parser, u64)> {
+        if self.reload_in_progress {
+            return None;
+        }
         let generation = self.generation;
         self.acquire(language_id).map(|parser| (parser, generation))
     }

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -959,9 +959,15 @@ mod tests {
         pool.release("test".to_string(), tree_sitter::Parser::new());
 
         pool.begin_reload();
+        pool.begin_reload();
         assert!(
             pool.acquire_versioned("test").is_none(),
             "no parser checkout may start inside the reload window"
+        );
+        pool.finish_reload();
+        assert!(
+            pool.acquire_versioned("test").is_none(),
+            "one reload finishing must not close an overlapping reload window"
         );
         pool.finish_reload();
         pool.release("test".to_string(), tree_sitter::Parser::new());

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -97,6 +97,7 @@ pub(super) struct ReloadLanguageState<'a> {
     language: &'a LanguageCoordinator,
     parser_pool: &'a std::sync::Mutex<DocumentParserPool>,
     documents: &'a DocumentStore,
+    invalidate_documents: bool,
     request_semantic_refresh: bool,
 }
 
@@ -132,7 +133,11 @@ pub(super) async fn apply_shared_settings(
         .unwrap_or_else(|poisoned| poisoned.into_inner())
         .begin_reload();
     let mut summary = language_state.language.load_settings(&settings);
-    let reparse_uris = language_state.documents.invalidate_all_parses();
+    let reparse_uris = if language_state.invalidate_documents {
+        language_state.documents.invalidate_all_parses()
+    } else {
+        Vec::new()
+    };
     // Invalidate again after the synchronous swap: the first bump rejects
     // pre-reload checkouts, while this one rejects parsers acquired while the
     // registry and query stores were being replaced.
@@ -460,6 +465,7 @@ impl Kakehashi {
                 language: &self.language,
                 parser_pool: &self.parser_pool,
                 documents: &self.documents,
+                invalidate_documents: true,
                 request_semantic_refresh: true,
             },
             &self.settings_manager,
@@ -485,6 +491,7 @@ impl Kakehashi {
                 language: &self.language,
                 parser_pool: &self.parser_pool,
                 documents: &self.documents,
+                invalidate_documents: false,
                 request_semantic_refresh: false,
             },
             &self.settings_manager,

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -926,8 +926,9 @@ mod tests {
                 "test",
                 &url::Url::parse("file:///reload-race.test").unwrap(),
                 0,
-                move |parser, _deadline| {
+                move |parser, _deadline, generation_retry| {
                     let call = calls_for_parse.fetch_add(1, Ordering::SeqCst);
+                    assert_eq!(generation_retry, call != 0);
                     if call == 0 {
                         let mut pool = parser_pool.lock().unwrap();
                         pool.invalidate();

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -1091,33 +1091,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn parse_waits_for_reload_instead_of_giving_up() {
-        let (service, _socket) = tower_lsp_server::LspService::new(Kakehashi::new);
-        service.inner().parser_pool.lock().unwrap().begin_reload();
-        let parser_pool = std::sync::Arc::clone(&service.inner().parser_pool);
-        let finish_reload = std::thread::spawn(move || {
-            std::thread::sleep(std::time::Duration::from_millis(10));
-            let mut pool = parser_pool.lock().unwrap();
-            pool.finish_reload();
-            pool.release("test".to_string(), tree_sitter::Parser::new());
-        });
-
-        let parsed = service
-            .inner()
-            .parse_coordinator()
-            .parse_with_pool(
-                "test",
-                &url::Url::parse("file:///reload-wait.test").unwrap(),
-                0,
-                |parser, _deadline, _generation_retry| (parser, Some(1)),
-            )
-            .await;
-
-        finish_reload.join().unwrap();
-        assert_eq!(parsed, Some(1));
-    }
-
-    #[tokio::test]
     async fn parse_gives_up_when_reload_never_finishes() {
         let (service, _socket) = tower_lsp_server::LspService::new(Kakehashi::new);
         service.inner().parser_pool.lock().unwrap().begin_reload();

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -127,6 +127,7 @@ pub(super) async fn apply_shared_settings(
     // The second bump below then also invalidates anything a racing request
     // built MID-swap against a half-updated query set.
     cache.bump_semantic_token_generation();
+    crate::analysis::semantic::invalidate_thread_local_parser_caches();
     language_state
         .parser_pool
         .lock()

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -117,7 +117,15 @@ pub(super) async fn apply_shared_settings(
     // The second bump below then also invalidates anything a racing request
     // built MID-swap against a half-updated query set.
     cache.bump_semantic_token_generation();
+    language_state
+        .parser_pool
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .invalidate();
     let summary = language_state.language.load_settings(&settings);
+    // Invalidate again after the synchronous swap: the first bump rejects
+    // pre-reload checkouts, while this one rejects parsers acquired while the
+    // registry and query stores were being replaced.
     language_state
         .parser_pool
         .lock()

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -93,9 +93,14 @@ pub(super) fn bridge_configs_for_injection_language(
     bridge.cached_configs_for_injection_language(&settings, host_language, injection_language)
 }
 
+pub(super) struct ReloadLanguageState<'a> {
+    language: &'a LanguageCoordinator,
+    parser_pool: &'a std::sync::Mutex<DocumentParserPool>,
+}
+
 pub(super) async fn apply_shared_settings(
     client: &Client,
-    language: &LanguageCoordinator,
+    language_state: ReloadLanguageState<'_>,
     settings_manager: &SettingsManager,
     cache: &CacheCoordinator,
     bridge: &BridgeCoordinator,
@@ -112,7 +117,12 @@ pub(super) async fn apply_shared_settings(
     // The second bump below then also invalidates anything a racing request
     // built MID-swap against a half-updated query set.
     cache.bump_semantic_token_generation();
-    let summary = language.load_settings(&settings);
+    let summary = language_state.language.load_settings(&settings);
+    language_state
+        .parser_pool
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .invalidate();
     // Second bump IMMEDIATELY after the query swap, before any await: a
     // request that started after the transitional bump above but before the
     // swap computed against the OLD queries yet stamped the new generation —
@@ -406,7 +416,10 @@ impl Kakehashi {
     ) {
         apply_shared_settings(
             &self.client,
-            &self.language,
+            ReloadLanguageState {
+                language: &self.language,
+                parser_pool: &self.parser_pool,
+            },
             &self.settings_manager,
             &self.cache,
             &self.bridge,
@@ -819,6 +832,71 @@ mod tests {
 
     // Note: Wildcard config resolution tests are in src/config.rs
     // Note: apply_content_changes_with_edits tests are in src/lsp/text_sync.rs
+
+    #[tokio::test]
+    async fn settings_reload_discards_available_document_parsers() {
+        let (service, _socket) = tower_lsp_server::LspService::new(Kakehashi::new);
+        service
+            .inner()
+            .parser_pool
+            .lock()
+            .unwrap()
+            .release("stale".to_string(), tree_sitter::Parser::new());
+
+        service
+            .inner()
+            .apply_raw_settings(
+                RawWorkspaceSettings::default(),
+                WorkspaceSettings::default(),
+            )
+            .await;
+
+        assert!(
+            service
+                .inner()
+                .parser_pool
+                .lock()
+                .unwrap()
+                .acquire("stale")
+                .is_none(),
+            "settings reload must not reuse a parser configured before the reload"
+        );
+    }
+
+    #[tokio::test]
+    async fn parser_released_after_settings_reload_is_discarded() {
+        let (service, _socket) = tower_lsp_server::LspService::new(Kakehashi::new);
+        let (parser, generation) = {
+            let mut pool = service.inner().parser_pool.lock().unwrap();
+            pool.release("stale".to_string(), tree_sitter::Parser::new());
+            pool.acquire_versioned("stale").unwrap()
+        };
+
+        service
+            .inner()
+            .apply_raw_settings(
+                RawWorkspaceSettings::default(),
+                WorkspaceSettings::default(),
+            )
+            .await;
+        service
+            .inner()
+            .parser_pool
+            .lock()
+            .unwrap()
+            .release_versioned("stale".to_string(), parser, generation);
+
+        assert!(
+            service
+                .inner()
+                .parser_pool
+                .lock()
+                .unwrap()
+                .acquire("stale")
+                .is_none(),
+            "a parser checked out before reload must not re-enter the new pool generation"
+        );
+    }
 
     #[test]
     fn test_check_injected_languages_identifies_missing_parsers() {

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -122,7 +122,7 @@ pub(super) async fn apply_shared_settings(
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
         .begin_reload();
-    let summary = language_state.language.load_settings(&settings);
+    let mut summary = language_state.language.load_settings(&settings);
     // Invalidate again after the synchronous swap: the first bump rejects
     // pre-reload checkouts, while this one rejects parsers acquired while the
     // registry and query stores were being replaced.
@@ -174,6 +174,14 @@ pub(super) async fn apply_shared_settings(
     // `didChange` deliberately does NOT invalidate (delta needs the previous
     // tokens); only a query/config reload does.
     cache.bump_semantic_token_generation();
+    // Query removal/replacement affects unchanged documents too. Request one
+    // workspace refresh for every reload; ClientNotifier capability-gates and
+    // coalesces it with any language-specific refresh events in this batch.
+    summary
+        .events
+        .push(crate::language::LanguageEvent::semantic_tokens_refresh(
+            "workspace settings reload",
+        ));
     build_notifier(client, settings_manager)
         .log_language_events(&summary.events)
         .await;

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -877,7 +877,12 @@ mod tests {
         let (parser, generation) = {
             let mut pool = service.inner().parser_pool.lock().unwrap();
             pool.release("stale".to_string(), tree_sitter::Parser::new());
-            pool.acquire_versioned("stale").unwrap()
+            match pool.acquire_versioned("stale") {
+                crate::language::parser_pool::ParserCheckout::Acquired(parser, generation) => {
+                    (parser, generation)
+                }
+                _ => panic!("precondition: stale parser is available"),
+            }
         };
 
         service
@@ -961,17 +966,53 @@ mod tests {
         pool.begin_reload();
         pool.begin_reload();
         assert!(
-            pool.acquire_versioned("test").is_none(),
+            matches!(
+                pool.acquire_versioned("test"),
+                crate::language::parser_pool::ParserCheckout::Reloading
+            ),
             "no parser checkout may start inside the reload window"
         );
         pool.finish_reload();
         assert!(
-            pool.acquire_versioned("test").is_none(),
+            matches!(
+                pool.acquire_versioned("test"),
+                crate::language::parser_pool::ParserCheckout::Reloading
+            ),
             "one reload finishing must not close an overlapping reload window"
         );
         pool.finish_reload();
         pool.release("test".to_string(), tree_sitter::Parser::new());
-        assert!(pool.acquire_versioned("test").is_some());
+        assert!(matches!(
+            pool.acquire_versioned("test"),
+            crate::language::parser_pool::ParserCheckout::Acquired(_, _)
+        ));
+    }
+
+    #[tokio::test]
+    async fn parse_waits_for_reload_instead_of_giving_up() {
+        let (service, _socket) = tower_lsp_server::LspService::new(Kakehashi::new);
+        service.inner().parser_pool.lock().unwrap().begin_reload();
+        let parser_pool = std::sync::Arc::clone(&service.inner().parser_pool);
+        let finish_reload = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(10));
+            let mut pool = parser_pool.lock().unwrap();
+            pool.finish_reload();
+            pool.release("test".to_string(), tree_sitter::Parser::new());
+        });
+
+        let parsed = service
+            .inner()
+            .parse_coordinator()
+            .parse_with_pool(
+                "test",
+                &url::Url::parse("file:///reload-wait.test").unwrap(),
+                0,
+                |parser, _deadline, _generation_retry| (parser, Some(1)),
+            )
+            .await;
+
+        finish_reload.join().unwrap();
+        assert_eq!(parsed, Some(1));
     }
 
     #[test]

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -121,7 +121,7 @@ pub(super) async fn apply_shared_settings(
         .parser_pool
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .invalidate();
+        .begin_reload();
     let summary = language_state.language.load_settings(&settings);
     // Invalidate again after the synchronous swap: the first bump rejects
     // pre-reload checkouts, while this one rejects parsers acquired while the
@@ -130,7 +130,7 @@ pub(super) async fn apply_shared_settings(
         .parser_pool
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .invalidate();
+        .finish_reload();
     // Second bump IMMEDIATELY after the query swap, before any await: a
     // request that started after the transitional bump above but before the
     // swap computed against the OLD queries yet stamped the new generation —
@@ -939,7 +939,8 @@ mod tests {
                     assert_eq!(generation_retry, call != 0);
                     if call == 0 {
                         let mut pool = parser_pool.lock().unwrap();
-                        pool.invalidate();
+                        pool.begin_reload();
+                        pool.finish_reload();
                         pool.release("test".to_string(), tree_sitter::Parser::new());
                     }
                     (parser, Some(call + 1))
@@ -949,6 +950,22 @@ mod tests {
 
         assert_eq!(parsed, Some(2), "only the current-generation parse lands");
         assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn parser_checkout_is_rejected_throughout_reload() {
+        let (service, _socket) = tower_lsp_server::LspService::new(Kakehashi::new);
+        let mut pool = service.inner().parser_pool.lock().unwrap();
+        pool.release("test".to_string(), tree_sitter::Parser::new());
+
+        pool.begin_reload();
+        assert!(
+            pool.acquire_versioned("test").is_none(),
+            "no parser checkout may start inside the reload window"
+        );
+        pool.finish_reload();
+        pool.release("test".to_string(), tree_sitter::Parser::new());
+        assert!(pool.acquire_versioned("test").is_some());
     }
 
     #[test]

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -884,7 +884,8 @@ mod tests {
             .parser_pool
             .lock()
             .unwrap()
-            .release_versioned("stale".to_string(), parser, generation);
+            .release_versioned("stale".to_string(), parser, generation)
+            .is_ok();
 
         assert!(
             !parser_is_current,
@@ -901,6 +902,44 @@ mod tests {
                 .is_none(),
             "a parser checked out before reload must not re-enter the new pool generation"
         );
+    }
+
+    #[tokio::test]
+    async fn parse_retries_after_parser_generation_changes() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let (service, _socket) = tower_lsp_server::LspService::new(Kakehashi::new);
+        service
+            .inner()
+            .parser_pool
+            .lock()
+            .unwrap()
+            .release("test".to_string(), tree_sitter::Parser::new());
+        let parser_pool = std::sync::Arc::clone(&service.inner().parser_pool);
+        let calls = std::sync::Arc::new(AtomicUsize::new(0));
+        let calls_for_parse = std::sync::Arc::clone(&calls);
+
+        let parsed = service
+            .inner()
+            .parse_coordinator()
+            .parse_with_pool(
+                "test",
+                &url::Url::parse("file:///reload-race.test").unwrap(),
+                0,
+                move |parser, _deadline| {
+                    let call = calls_for_parse.fetch_add(1, Ordering::SeqCst);
+                    if call == 0 {
+                        let mut pool = parser_pool.lock().unwrap();
+                        pool.invalidate();
+                        pool.release("test".to_string(), tree_sitter::Parser::new());
+                    }
+                    (parser, Some(call + 1))
+                },
+            )
+            .await;
+
+        assert_eq!(parsed, Some(2), "only the current-generation parse lands");
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
     }
 
     #[test]

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -163,6 +163,7 @@ pub(super) async fn apply_shared_settings(
     // pre-reload checkouts, while this one rejects parsers acquired while the
     // registry and query stores were being replaced.
     drop(parser_reload);
+    crate::analysis::semantic::invalidate_thread_local_parser_caches();
     // Second bump IMMEDIATELY after the query swap, before any await: a
     // request that started after the transitional bump above but before the
     // swap computed against the OLD queries yet stamped the new generation —

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -99,6 +99,12 @@ pub(super) struct ReloadLanguageState<'a> {
     request_semantic_refresh: bool,
 }
 
+/// One server process owns one effective workspace settings snapshot. Keep the
+/// complete async reload transaction ordered across didChangeConfiguration and
+/// post-install reloads, including downstream propagation and SettingsManager
+/// publication after the synchronous language/query swap.
+static SETTINGS_RELOAD_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 pub(super) async fn apply_shared_settings(
     client: &Client,
     language_state: ReloadLanguageState<'_>,
@@ -108,6 +114,7 @@ pub(super) async fn apply_shared_settings(
     raw_settings: Option<RawWorkspaceSettings>,
     settings: WorkspaceSettings,
 ) {
+    let _reload = SETTINGS_RELOAD_LOCK.lock().await;
     // TRANSITIONAL generation bump BEFORE any query/config mutation: from
     // this instant, every generation-stamped product built from the OLD
     // queries (snapshot-riding discovery/bridge/resolved regions, layer

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -13,6 +13,7 @@ pub(crate) mod text_document;
 mod whole_document;
 mod workspace;
 
+use crate::error::LockResultExt;
 use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::ls_types::request::{
     GotoDeclarationParams, GotoDeclarationResponse, GotoImplementationParams,
@@ -107,6 +108,29 @@ pub(super) struct ReloadLanguageState<'a> {
 /// publication after the synchronous language/query swap.
 static SETTINGS_RELOAD_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
+struct ParserReloadGuard<'a> {
+    parser_pool: &'a std::sync::Mutex<DocumentParserPool>,
+}
+
+impl<'a> ParserReloadGuard<'a> {
+    fn begin(parser_pool: &'a std::sync::Mutex<DocumentParserPool>) -> Self {
+        parser_pool
+            .lock()
+            .recover_poison("ParserReloadGuard::begin")
+            .begin_reload();
+        Self { parser_pool }
+    }
+}
+
+impl Drop for ParserReloadGuard<'_> {
+    fn drop(&mut self) {
+        self.parser_pool
+            .lock()
+            .recover_poison("ParserReloadGuard::drop")
+            .finish_reload();
+    }
+}
+
 pub(super) async fn apply_shared_settings(
     client: &Client,
     language_state: ReloadLanguageState<'_>,
@@ -128,11 +152,7 @@ pub(super) async fn apply_shared_settings(
     // built MID-swap against a half-updated query set.
     cache.bump_semantic_token_generation();
     crate::analysis::semantic::invalidate_thread_local_parser_caches();
-    language_state
-        .parser_pool
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .begin_reload();
+    let parser_reload = ParserReloadGuard::begin(language_state.parser_pool);
     let mut summary = language_state.language.load_settings(&settings);
     let reparse_uris = if language_state.invalidate_documents {
         language_state.documents.invalidate_all_parses()
@@ -142,11 +162,7 @@ pub(super) async fn apply_shared_settings(
     // Invalidate again after the synchronous swap: the first bump rejects
     // pre-reload checkouts, while this one rejects parsers acquired while the
     // registry and query stores were being replaced.
-    language_state
-        .parser_pool
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .finish_reload();
+    drop(parser_reload);
     // Second bump IMMEDIATELY after the query swap, before any await: a
     // request that started after the transitional bump above but before the
     // swap computed against the OLD queries yet stamped the new generation —
@@ -1054,6 +1070,22 @@ mod tests {
         assert!(matches!(
             pool.acquire_versioned("test"),
             crate::language::parser_pool::ParserCheckout::Acquired(_, _)
+        ));
+    }
+
+    #[test]
+    fn parser_reload_guard_finishes_reload_during_unwind() {
+        let (service, _socket) = tower_lsp_server::LspService::new(Kakehashi::new);
+        let parser_pool = &service.inner().parser_pool;
+        let unwind = std::panic::catch_unwind(|| {
+            let _reload = ParserReloadGuard::begin(parser_pool);
+            panic!("simulate reload failure");
+        });
+
+        assert!(unwind.is_err());
+        assert!(!matches!(
+            parser_pool.lock().unwrap().acquire_versioned("test"),
+            crate::language::parser_pool::ParserCheckout::Reloading
         ));
     }
 

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -879,12 +879,17 @@ mod tests {
                 WorkspaceSettings::default(),
             )
             .await;
-        service
+        let parser_is_current = service
             .inner()
             .parser_pool
             .lock()
             .unwrap()
             .release_versioned("stale".to_string(), parser, generation);
+
+        assert!(
+            !parser_is_current,
+            "a parse from the previous pool generation must not publish its result"
+        );
 
         assert!(
             service

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -1084,6 +1084,26 @@ mod tests {
         assert_eq!(parsed, Some(1));
     }
 
+    #[tokio::test]
+    async fn parse_gives_up_when_reload_never_finishes() {
+        let (service, _socket) = tower_lsp_server::LspService::new(Kakehashi::new);
+        service.inner().parser_pool.lock().unwrap().begin_reload();
+
+        let parsed = service
+            .inner()
+            .parse_coordinator()
+            .parse_with_pool(
+                "test",
+                &url::Url::parse("file:///stuck-reload.test").unwrap(),
+                0,
+                |parser, _deadline, _generation_retry| (parser, Some(1)),
+            )
+            .await;
+
+        service.inner().parser_pool.lock().unwrap().finish_reload();
+        assert_eq!(parsed, None);
+    }
+
     #[test]
     fn test_check_injected_languages_identifies_missing_parsers() {
         // Test that check_injected_languages_auto_install correctly identifies

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -96,6 +96,7 @@ pub(super) fn bridge_configs_for_injection_language(
 pub(super) struct ReloadLanguageState<'a> {
     language: &'a LanguageCoordinator,
     parser_pool: &'a std::sync::Mutex<DocumentParserPool>,
+    request_semantic_refresh: bool,
 }
 
 pub(super) async fn apply_shared_settings(
@@ -177,11 +178,24 @@ pub(super) async fn apply_shared_settings(
     // Query removal/replacement affects unchanged documents too. Request one
     // workspace refresh for every reload; ClientNotifier capability-gates and
     // coalesces it with any language-specific refresh events in this batch.
-    summary
-        .events
-        .push(crate::language::LanguageEvent::semantic_tokens_refresh(
-            "workspace settings reload",
-        ));
+    if language_state.request_semantic_refresh {
+        summary
+            .events
+            .push(crate::language::LanguageEvent::semantic_tokens_refresh(
+                "workspace settings reload",
+            ));
+    } else {
+        // Initialization may produce language-specific refresh events (for
+        // example while registering a derived language). No refresh request is
+        // valid before InitializeResult/initialized, and no document has yet
+        // consumed tokens, so keep the logs while stripping every refresh.
+        summary.events.retain(|event| {
+            !matches!(
+                event,
+                crate::language::LanguageEvent::SemanticTokensRefresh { .. }
+            )
+        });
+    }
     build_notifier(client, settings_manager)
         .log_language_events(&summary.events)
         .await;
@@ -435,6 +449,29 @@ impl Kakehashi {
             ReloadLanguageState {
                 language: &self.language,
                 parser_pool: &self.parser_pool,
+                request_semantic_refresh: true,
+            },
+            &self.settings_manager,
+            &self.cache,
+            &self.bridge,
+            Some(raw_settings),
+            settings,
+        )
+        .await;
+        self.warn_on_misconfigured_settings().await;
+    }
+
+    async fn apply_initial_settings(
+        &self,
+        raw_settings: RawWorkspaceSettings,
+        settings: WorkspaceSettings,
+    ) {
+        apply_shared_settings(
+            &self.client,
+            ReloadLanguageState {
+                language: &self.language,
+                parser_pool: &self.parser_pool,
+                request_semantic_refresh: false,
             },
             &self.settings_manager,
             &self.cache,

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -96,6 +96,7 @@ pub(super) fn bridge_configs_for_injection_language(
 pub(super) struct ReloadLanguageState<'a> {
     language: &'a LanguageCoordinator,
     parser_pool: &'a std::sync::Mutex<DocumentParserPool>,
+    documents: &'a DocumentStore,
     request_semantic_refresh: bool,
 }
 
@@ -113,7 +114,7 @@ pub(super) async fn apply_shared_settings(
     bridge: &BridgeCoordinator,
     raw_settings: Option<RawWorkspaceSettings>,
     settings: WorkspaceSettings,
-) {
+) -> Vec<Url> {
     let _reload = SETTINGS_RELOAD_LOCK.lock().await;
     // TRANSITIONAL generation bump BEFORE any query/config mutation: from
     // this instant, every generation-stamped product built from the OLD
@@ -131,6 +132,7 @@ pub(super) async fn apply_shared_settings(
         .unwrap_or_else(|poisoned| poisoned.into_inner())
         .begin_reload();
     let mut summary = language_state.language.load_settings(&settings);
+    let reparse_uris = language_state.documents.invalidate_all_parses();
     // Invalidate again after the synchronous swap: the first bump rejects
     // pre-reload checkouts, while this one rejects parsers acquired while the
     // registry and query stores were being replaced.
@@ -206,6 +208,7 @@ pub(super) async fn apply_shared_settings(
     build_notifier(client, settings_manager)
         .log_language_events(&summary.events)
         .await;
+    reparse_uris
 }
 
 /// Convert url::Url to ls_types::Uri, the reverse conversion for bridge protocol
@@ -456,6 +459,7 @@ impl Kakehashi {
             ReloadLanguageState {
                 language: &self.language,
                 parser_pool: &self.parser_pool,
+                documents: &self.documents,
                 request_semantic_refresh: true,
             },
             &self.settings_manager,
@@ -464,7 +468,9 @@ impl Kakehashi {
             Some(raw_settings),
             settings,
         )
-        .await;
+        .await
+        .into_iter()
+        .for_each(|uri| self.schedule_reparse(uri, None));
         self.warn_on_misconfigured_settings().await;
     }
 
@@ -478,6 +484,7 @@ impl Kakehashi {
             ReloadLanguageState {
                 language: &self.language,
                 parser_pool: &self.parser_pool,
+                documents: &self.documents,
                 request_semantic_refresh: false,
             },
             &self.settings_manager,
@@ -486,7 +493,9 @@ impl Kakehashi {
             Some(raw_settings),
             settings,
         )
-        .await;
+        .await
+        .into_iter()
+        .for_each(|uri| self.schedule_reparse(uri, None));
         self.warn_on_misconfigured_settings().await;
     }
 

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -232,6 +232,7 @@ impl InstallCoordinator {
             ReloadLanguageState {
                 language: &self.language,
                 parser_pool: &self.parser_pool,
+                request_semantic_refresh: true,
             },
             &self.settings_manager,
             &self.cache,

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -227,11 +227,12 @@ impl InstallCoordinator {
         raw_settings: crate::config::RawWorkspaceSettings,
         settings: WorkspaceSettings,
     ) {
-        apply_shared_settings(
+        let reparse_uris = apply_shared_settings(
             &self.client,
             ReloadLanguageState {
                 language: &self.language,
                 parser_pool: &self.parser_pool,
+                documents: &self.documents,
                 request_semantic_refresh: true,
             },
             &self.settings_manager,
@@ -241,6 +242,10 @@ impl InstallCoordinator {
             settings,
         )
         .await;
+        let parse = self.parse_coordinator();
+        for uri in reparse_uris {
+            parse.reparse_latest(&uri, None).await;
+        }
     }
 
     fn notifier(&self) -> ClientNotifier<'_> {

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -9,7 +9,7 @@ use crate::lsp::bridge::BridgeCoordinator;
 use crate::lsp::cache::CacheCoordinator;
 use crate::lsp::client::ClientNotifier;
 use crate::lsp::lsp_impl::{
-    Kakehashi, apply_shared_settings, build_notifier, detect_document_language,
+    Kakehashi, ReloadLanguageState, apply_shared_settings, build_notifier, detect_document_language,
 };
 use crate::lsp::settings_manager::SettingsManager;
 use tower_lsp_server::Client;
@@ -229,7 +229,10 @@ impl InstallCoordinator {
     ) {
         apply_shared_settings(
             &self.client,
-            &self.language,
+            ReloadLanguageState {
+                language: &self.language,
+                parser_pool: &self.parser_pool,
+            },
             &self.settings_manager,
             &self.cache,
             &self.bridge,

--- a/src/lsp/lsp_impl/coordinator/install.rs
+++ b/src/lsp/lsp_impl/coordinator/install.rs
@@ -227,12 +227,13 @@ impl InstallCoordinator {
         raw_settings: crate::config::RawWorkspaceSettings,
         settings: WorkspaceSettings,
     ) {
-        let reparse_uris = apply_shared_settings(
+        let _reparse_uris = apply_shared_settings(
             &self.client,
             ReloadLanguageState {
                 language: &self.language,
                 parser_pool: &self.parser_pool,
                 documents: &self.documents,
+                invalidate_documents: false,
                 request_semantic_refresh: true,
             },
             &self.settings_manager,
@@ -242,10 +243,6 @@ impl InstallCoordinator {
             settings,
         )
         .await;
-        let parse = self.parse_coordinator();
-        for uri in reparse_uris {
-            parse.reparse_latest(&uri, None).await;
-        }
     }
 
     fn notifier(&self) -> ClientNotifier<'_> {

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -534,8 +534,8 @@ impl ParseCoordinator {
             let auto_install = self.auto_install.clone();
             let language_name_clone = language_name.clone();
 
-            let parsed_tree = self
-                .parse_with_pool(
+            let parsed_tree = if load_result.success {
+                self.parse_with_pool(
                     &language_name,
                     &uri,
                     text.len(),
@@ -547,7 +547,10 @@ impl ParseCoordinator {
                         (parser, parse_result)
                     },
                 )
-                .await;
+                .await
+            } else {
+                None
+            };
 
             if let Some(tree) = parsed_tree {
                 // Legacy tree CAS BEFORE the snapshot publish: a legacy-store
@@ -772,6 +775,11 @@ impl ParseCoordinator {
             .ensure_language_loaded_async(&language_name)
             .await;
         let mut events = load_result.events;
+        if !load_result.success {
+            self.documents.publish_giveup_snapshot(&uri);
+            self.notifier().log_language_events(&events).await;
+            return;
+        }
 
         for _ in 0..MAX_REPARSE_ATTEMPTS {
             // Re-read the latest text each attempt. Gone => closed (no resurrect);
@@ -984,6 +992,14 @@ impl ParseCoordinator {
             .language
             .ensure_language_loaded_async(&language_name)
             .await;
+        if !load_result.success {
+            self.documents.publish_giveup_snapshot(uri);
+            advance_watermark();
+            self.notifier()
+                .log_language_events(&load_result.events)
+                .await;
+            return;
+        }
 
         let text_len = text.len();
         let auto_install = self.auto_install.clone();

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -497,16 +497,14 @@ impl ParseCoordinator {
                 // entry (via `parse_sender`'s vacant insert) for the gone URI. The
                 // text + incarnation guard is what makes this resurrection-safe once
                 // the open parse runs off the ingress ticket (#6).
-                if self
-                    .documents
-                    .set_parse_result_if_text_and_incarnation_unchanged(
-                        &uri,
-                        &text,
-                        incarnation,
-                        Some(&language_name),
-                        None,
-                    )
-                {
+                if self.documents.set_parse_result_if_inputs_unchanged(
+                    &uri,
+                    &text,
+                    incarnation,
+                    content_version,
+                    Some(&language_name),
+                    None,
+                ) {
                     self.documents
                         .mark_parse_finished(&uri, parse_generation, false);
                 }
@@ -587,15 +585,14 @@ impl ParseCoordinator {
                 // `didClose` racing this off-ingress parse can't leave stale
                 // injection entries for a gone document. (`Tree` clone is a
                 // cheap refcount bump.)
-                let stored = self
-                    .documents
-                    .set_parse_result_if_text_and_incarnation_unchanged(
-                        &uri,
-                        &text,
-                        incarnation,
-                        Some(&language_name),
-                        Some(tree.clone()),
-                    );
+                let stored = self.documents.set_parse_result_if_inputs_unchanged(
+                    &uri,
+                    &text,
+                    incarnation,
+                    content_version,
+                    Some(&language_name),
+                    Some(tree.clone()),
+                );
                 // Populate BEFORE the publish so the derived discovery rides the
                 // snapshot (ADR §3 don't-discover-twice); readers keep serving
                 // the previous snapshot meanwhile. A rejected CAS (raced) skips
@@ -651,16 +648,14 @@ impl ParseCoordinator {
             // through to the no-language path below which would null it out. Host
             // bridging needs only text + language (never a tree), so preserving the
             // language keeps a host-bridged document working after a parse failure.
-            if self
-                .documents
-                .set_parse_result_if_text_and_incarnation_unchanged(
-                    &uri,
-                    &text,
-                    incarnation,
-                    Some(&language_name),
-                    None,
-                )
-            {
+            if self.documents.set_parse_result_if_inputs_unchanged(
+                &uri,
+                &text,
+                incarnation,
+                content_version,
+                Some(&language_name),
+                None,
+            ) {
                 self.documents
                     .mark_parse_finished(&uri, parse_generation, false);
             }
@@ -684,16 +679,14 @@ impl ParseCoordinator {
         }
 
         // No language detected at all → store no language, no tree.
-        if self
-            .documents
-            .set_parse_result_if_text_and_incarnation_unchanged(
-                &uri,
-                &text,
-                incarnation,
-                None,
-                None,
-            )
-        {
+        if self.documents.set_parse_result_if_inputs_unchanged(
+            &uri,
+            &text,
+            incarnation,
+            content_version,
+            None,
+            None,
+        ) {
             self.documents
                 .mark_parse_finished(&uri, parse_generation, false);
         }
@@ -856,11 +849,12 @@ impl ParseCoordinator {
             // when the tree actually landed, so a `didClose` racing this
             // reparse can't leave stale injection entries for a gone
             // document. (`Tree` clone is a cheap refcount bump.)
-            let stored = self.documents.attach_tree_if_absent(
+            let stored = self.documents.attach_tree_if_parse_inputs_unchanged(
                 &uri,
                 &text,
                 expected_language_id.as_deref(),
                 expected_incarnation,
+                content_version,
                 tree.clone(),
             );
             // Populate BEFORE the publish so the discovery rides the snapshot
@@ -1064,11 +1058,12 @@ impl ParseCoordinator {
             // identical-text reopen — the tree belongs to the prior lifetime
             // and must not attach to the reopened document (nor let the
             // watermark advance below run on the old lifetime's ticket).
-            let stored = self.documents.update_tree_if_text_and_language_unchanged(
+            let stored = self.documents.update_tree_if_parse_inputs_unchanged(
                 uri,
                 &text,
                 language_id.as_deref(),
                 incarnation,
+                content_version,
                 tree.clone(),
             );
             // Populate BEFORE the publish so the derived discovery rides the

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -69,13 +69,14 @@ fn should_emit_settle_refresh(
     cache: &CacheCoordinator,
     uri: &Url,
     content_version: u64,
+    tree_less_upgrade: bool,
 ) -> bool {
     let settled = documents
         .get(uri)
         .is_some_and(|doc| doc.content_version() == content_version);
-    let client_is_stale = cache
-        .served_semantic_version(uri)
-        .is_some_and(|served| served < content_version);
+    let client_is_stale = cache.served_semantic_version(uri).is_some_and(|served| {
+        served < content_version || (tree_less_upgrade && served == content_version)
+    });
     settled && client_is_stale
 }
 
@@ -1085,6 +1086,11 @@ impl ParseCoordinator {
             } else {
                 PopulatedSnapshotRegions::default()
             };
+            let tree_less_upgrade = self.documents.latest_snapshot(uri).is_some_and(|view| {
+                view.slot.snapshot.is_some_and(|snapshot| {
+                    snapshot.parsed_version == content_version && snapshot.tree.is_none()
+                })
+            });
             let published = self.publish_parse_snapshot(
                 uri,
                 crate::document::snapshot::ParseSnapshot {
@@ -1111,14 +1117,21 @@ impl ParseCoordinator {
             //   already reparsing newer text, whose own publish re-evaluates);
             // - some client actually consumes this document's semantic tokens
             //   (a served-version mark exists) AND its last served tokens
-            //   predate this snapshot (otherwise its own didChange-driven
-            //   request already caught up).
+            //   predate this snapshot, OR it served the reload's current
+            //   tree-less placeholder that this publish upgrades at the same
+            //   version (otherwise its own didChange-driven request caught up).
             // Net: at most one refresh per settle, none mid-burst, none for
             // documents nobody highlights. Emitted from the parse loop, never
             // didChange (synchronous clients can't answer a server request
             // mid-notification).
             if published
-                && should_emit_settle_refresh(&self.documents, &self.cache, uri, content_version)
+                && should_emit_settle_refresh(
+                    &self.documents,
+                    &self.cache,
+                    uri,
+                    content_version,
+                    tree_less_upgrade,
+                )
             {
                 events.push(crate::language::LanguageEvent::semantic_tokens_refresh(
                     language_name.clone(),
@@ -1153,28 +1166,42 @@ mod tests {
         // content_version == 0 now.
 
         // No served mark: nobody highlights this document -> no refresh.
-        assert!(!should_emit_settle_refresh(&documents, &cache, &uri, 0));
+        assert!(!should_emit_settle_refresh(
+            &documents, &cache, &uri, 0, false
+        ));
 
         // Client already served THIS version -> its didChange-driven request
         // caught up -> no refresh.
         cache.record_served_semantic_version(&uri, 0);
-        assert!(!should_emit_settle_refresh(&documents, &cache, &uri, 0));
+        assert!(!should_emit_settle_refresh(
+            &documents, &cache, &uri, 0, false
+        ));
 
         // An edit bumps the live version; the publish for v1 finds the client
         // stale (served 0 < 1) and the document settled (live == 1) -> emit.
         documents.update_document(uri.clone(), "ab".into(), None);
-        assert!(should_emit_settle_refresh(&documents, &cache, &uri, 1));
+        assert!(should_emit_settle_refresh(
+            &documents, &cache, &uri, 1, false
+        ));
 
         // Mid-burst: another edit already moved the live version past this
         // publish (live 2, publish v1) -> not settled -> no refresh (the v2
         // publish re-evaluates).
         documents.update_document(uri.clone(), "abc".into(), None);
-        assert!(!should_emit_settle_refresh(&documents, &cache, &uri, 1));
+        assert!(!should_emit_settle_refresh(
+            &documents, &cache, &uri, 1, false
+        ));
 
         // The mark is monotonic: a stale serve cannot regress it.
         cache.record_served_semantic_version(&uri, 2);
         cache.record_served_semantic_version(&uri, 1);
-        assert!(!should_emit_settle_refresh(&documents, &cache, &uri, 2));
+        assert!(!should_emit_settle_refresh(
+            &documents, &cache, &uri, 2, false
+        ));
+        assert!(
+            should_emit_settle_refresh(&documents, &cache, &uri, 2, true),
+            "a same-version tree-less to tree upgrade must heal an empty serve"
+        );
     }
 
     /// The deadline must actually abort the native parse (an expired one

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -156,6 +156,8 @@ impl ParseCoordinator {
     ///   a pinned thread would stall every document's tree-CPU)
     /// - The `PARSE_AWAIT_BACKSTOP` awaiter timeout fired (extreme queue
     ///   pressure; the work-unit still self-bounds)
+    /// - Settings changed while the parser was checked out, so the result was
+    ///   produced by the previous parser generation
     /// - The closure returned `None`
     pub(crate) async fn parse_with_pool<T, F>(
         &self,
@@ -190,11 +192,11 @@ impl ParseCoordinator {
                 // queue + parse with slack, so the result is not dropped.
                 let deadline = std::time::Instant::now() + PARSE_TIMEOUT;
                 let (parser, value) = parse_fn(parser, deadline);
-                parser_pool
+                let parser_is_current = parser_pool
                     .lock()
                     .recover_poison("ParseCoordinator::parse_with_pool(release)")
                     .release_versioned(language_name_owned, parser, parser_generation);
-                value
+                parser_is_current.then_some(value).flatten()
             }),
         )
         .await;

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -177,10 +177,10 @@ impl ParseCoordinator {
         let result = tokio::time::timeout(
             PARSE_AWAIT_BACKSTOP,
             self.compute_pool.run(None, move || {
-                let parser = parser_pool
+                let (parser, parser_generation) = parser_pool
                     .lock()
                     .recover_poison("ParseCoordinator::parse_with_pool(acquire)")
-                    .acquire(&language_name_owned)?;
+                    .acquire_versioned(&language_name_owned)?;
                 // The in-parse abort deadline is anchored at DEQUEUE, not
                 // submission: a parse that sat in the pool queue behind other
                 // documents' work still gets its full budget of actual parse
@@ -193,7 +193,7 @@ impl ParseCoordinator {
                 parser_pool
                     .lock()
                     .recover_poison("ParseCoordinator::parse_with_pool(release)")
-                    .release(language_name_owned, parser);
+                    .release_versioned(language_name_owned, parser, parser_generation);
                 value
             }),
         )

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -42,6 +42,11 @@ const PARSE_TIMEOUT: std::time::Duration = crate::language::injection::NATIVE_PA
 /// pool thread itself is protected by the in-parse abort, not by this.
 const PARSE_AWAIT_BACKSTOP: std::time::Duration = std::time::Duration::from_secs(60);
 
+#[cfg(not(test))]
+const RELOAD_WAIT_BACKSTOP: std::time::Duration = PARSE_TIMEOUT;
+#[cfg(test)]
+const RELOAD_WAIT_BACKSTOP: std::time::Duration = std::time::Duration::from_millis(100);
+
 /// Host-parse with a wall-clock abort — the shared
 /// [`parse_with_deadline`](crate::language::injection::parse_with_deadline)
 /// primitive under the name the parse-loop call sites use.
@@ -184,6 +189,7 @@ impl ParseCoordinator {
                 let mut parse_fn = parse_fn;
                 let mut language_name_owned = language_name_owned;
                 for attempt in 0..2 {
+                    let reload_wait_deadline = std::time::Instant::now() + RELOAD_WAIT_BACKSTOP;
                     let (parser, parser_generation) = loop {
                         match parser_pool
                             .lock()
@@ -198,6 +204,9 @@ impl ParseCoordinator {
                                 // A reload is synchronous and normally brief. Keep this
                                 // transient state inside the bounded work unit instead
                                 // of publishing a terminal tree-less result.
+                                if std::time::Instant::now() >= reload_wait_deadline {
+                                    return None;
+                                }
                                 std::thread::sleep(std::time::Duration::from_millis(1));
                             }
                             crate::language::parser_pool::ParserCheckout::Unavailable => {

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -42,10 +42,7 @@ const PARSE_TIMEOUT: std::time::Duration = crate::language::injection::NATIVE_PA
 /// pool thread itself is protected by the in-parse abort, not by this.
 const PARSE_AWAIT_BACKSTOP: std::time::Duration = std::time::Duration::from_secs(60);
 
-#[cfg(not(test))]
 const RELOAD_WAIT_BACKSTOP: std::time::Duration = PARSE_TIMEOUT;
-#[cfg(test)]
-const RELOAD_WAIT_BACKSTOP: std::time::Duration = std::time::Duration::from_millis(100);
 
 /// Host-parse with a wall-clock abort — the shared
 /// [`parse_with_deadline`](crate::language::injection::parse_with_deadline)
@@ -207,7 +204,9 @@ impl ParseCoordinator {
                                 if std::time::Instant::now() >= reload_wait_deadline {
                                     return None;
                                 }
-                                std::thread::sleep(std::time::Duration::from_millis(1));
+                                // Leave enough scheduling room for the reload owner
+                                // to reacquire the mutex and close the window.
+                                std::thread::sleep(std::time::Duration::from_millis(5));
                             }
                             crate::language::parser_pool::ParserCheckout::Unavailable => {
                                 return None;

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -156,8 +156,8 @@ impl ParseCoordinator {
     ///   a pinned thread would stall every document's tree-CPU)
     /// - The `PARSE_AWAIT_BACKSTOP` awaiter timeout fired (extreme queue
     ///   pressure; the work-unit still self-bounds)
-    /// - Settings changed while the parser was checked out, so the result was
-    ///   produced by the previous parser generation
+    /// - Settings changed during both the initial parse and its one retry, so
+    ///   neither result belongs to the current parser generation
     /// - The closure returned `None`
     pub(crate) async fn parse_with_pool<T, F>(
         &self,
@@ -167,7 +167,7 @@ impl ParseCoordinator {
         parse_fn: F,
     ) -> Option<T>
     where
-        F: FnOnce(tree_sitter::Parser, std::time::Instant) -> (tree_sitter::Parser, Option<T>)
+        F: FnMut(tree_sitter::Parser, std::time::Instant) -> (tree_sitter::Parser, Option<T>)
             + Send
             + 'static,
         T: Send + 'static,
@@ -179,24 +179,34 @@ impl ParseCoordinator {
         let result = tokio::time::timeout(
             PARSE_AWAIT_BACKSTOP,
             self.compute_pool.run(None, move || {
-                let (parser, parser_generation) = parser_pool
-                    .lock()
-                    .recover_poison("ParseCoordinator::parse_with_pool(acquire)")
-                    .acquire_versioned(&language_name_owned)?;
-                // The in-parse abort deadline is anchored at DEQUEUE, not
-                // submission: a parse that sat in the pool queue behind other
-                // documents' work still gets its full budget of actual parse
-                // CPU (a submission-anchored deadline let a burst of opens
-                // expire healthy parses in the queue, leaving those documents
-                // tree-less until the next edit). The awaiter above covers
-                // queue + parse with slack, so the result is not dropped.
-                let deadline = std::time::Instant::now() + PARSE_TIMEOUT;
-                let (parser, value) = parse_fn(parser, deadline);
-                let parser_is_current = parser_pool
-                    .lock()
-                    .recover_poison("ParseCoordinator::parse_with_pool(release)")
-                    .release_versioned(language_name_owned, parser, parser_generation);
-                parser_is_current.then_some(value).flatten()
+                let mut parse_fn = parse_fn;
+                let mut language_name_owned = language_name_owned;
+                for _attempt in 0..2 {
+                    let (parser, parser_generation) = parser_pool
+                        .lock()
+                        .recover_poison("ParseCoordinator::parse_with_pool(acquire)")
+                        .acquire_versioned(&language_name_owned)?;
+                    // The in-parse abort deadline is anchored at DEQUEUE, not
+                    // submission: a parse that sat in the pool queue behind other
+                    // documents' work still gets its full budget of actual parse
+                    // CPU (a submission-anchored deadline let a burst of opens
+                    // expire healthy parses in the queue, leaving those documents
+                    // tree-less until the next edit). The awaiter above covers
+                    // queue + parse with slack, so the result is not dropped.
+                    let deadline = std::time::Instant::now() + PARSE_TIMEOUT;
+                    let (parser, value) = parse_fn(parser, deadline);
+                    match parser_pool
+                        .lock()
+                        .recover_poison("ParseCoordinator::parse_with_pool(release)")
+                        .release_versioned(language_name_owned, parser, parser_generation)
+                    {
+                        Ok(()) => return value,
+                        Err(stale_language_name) => {
+                            language_name_owned = stale_language_name;
+                        }
+                    }
+                }
+                None
             }),
         )
         .await;

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -183,10 +183,27 @@ impl ParseCoordinator {
                 let mut parse_fn = parse_fn;
                 let mut language_name_owned = language_name_owned;
                 for attempt in 0..2 {
-                    let (parser, parser_generation) = parser_pool
-                        .lock()
-                        .recover_poison("ParseCoordinator::parse_with_pool(acquire)")
-                        .acquire_versioned(&language_name_owned)?;
+                    let (parser, parser_generation) = loop {
+                        match parser_pool
+                            .lock()
+                            .recover_poison("ParseCoordinator::parse_with_pool(acquire)")
+                            .acquire_versioned(&language_name_owned)
+                        {
+                            crate::language::parser_pool::ParserCheckout::Acquired(
+                                parser,
+                                generation,
+                            ) => break (parser, generation),
+                            crate::language::parser_pool::ParserCheckout::Reloading => {
+                                // A reload is synchronous and normally brief. Keep this
+                                // transient state inside the bounded work unit instead
+                                // of publishing a terminal tree-less result.
+                                std::thread::sleep(std::time::Duration::from_millis(1));
+                            }
+                            crate::language::parser_pool::ParserCheckout::Unavailable => {
+                                return None;
+                            }
+                        }
+                    };
                     // The in-parse abort deadline is anchored at DEQUEUE, not
                     // submission: a parse that sat in the pool queue behind other
                     // documents' work still gets its full budget of actual parse

--- a/src/lsp/lsp_impl/coordinator/parse.rs
+++ b/src/lsp/lsp_impl/coordinator/parse.rs
@@ -136,9 +136,10 @@ impl ParseCoordinator {
     /// work-unit on the bounded compute pool, with timeout.
     ///
     /// The caller provides the actual parse logic via `parse_fn`, which receives a
-    /// `tree_sitter::Parser` plus the work-unit's wall-clock deadline (feed it to
-    /// [`parse_text_with_deadline`]) and must return the parser along with an
-    /// optional result.
+    /// `tree_sitter::Parser`, the work-unit's wall-clock deadline (feed it to
+    /// [`parse_text_with_deadline`]), and whether this attempt follows a parser
+    /// generation change. Incremental callers must drop old-tree seeds on that
+    /// retry because the replacement parser may use a different grammar.
     /// The `parser_pool` sync mutex is acquired **only on the pool thread** (the
     /// parse-snapshot ADR's Stage-1 obligation: a tokio worker must never block on
     /// a mutex a compute thread holds), briefly around acquire and release; the
@@ -167,7 +168,7 @@ impl ParseCoordinator {
         parse_fn: F,
     ) -> Option<T>
     where
-        F: FnMut(tree_sitter::Parser, std::time::Instant) -> (tree_sitter::Parser, Option<T>)
+        F: FnMut(tree_sitter::Parser, std::time::Instant, bool) -> (tree_sitter::Parser, Option<T>)
             + Send
             + 'static,
         T: Send + 'static,
@@ -181,7 +182,7 @@ impl ParseCoordinator {
             self.compute_pool.run(None, move || {
                 let mut parse_fn = parse_fn;
                 let mut language_name_owned = language_name_owned;
-                for _attempt in 0..2 {
+                for attempt in 0..2 {
                     let (parser, parser_generation) = parser_pool
                         .lock()
                         .recover_poison("ParseCoordinator::parse_with_pool(acquire)")
@@ -194,7 +195,7 @@ impl ParseCoordinator {
                     // tree-less until the next edit). The awaiter above covers
                     // queue + parse with slack, so the result is not dropped.
                     let deadline = std::time::Instant::now() + PARSE_TIMEOUT;
-                    let (parser, value) = parse_fn(parser, deadline);
+                    let (parser, value) = parse_fn(parser, deadline, attempt != 0);
                     match parser_pool
                         .lock()
                         .recover_poison("ParseCoordinator::parse_with_pool(release)")
@@ -538,7 +539,7 @@ impl ParseCoordinator {
                     &language_name,
                     &uri,
                     text.len(),
-                    move |mut parser, deadline| {
+                    move |mut parser, deadline, _generation_retry| {
                         let _ = auto_install.begin_parsing(&language_name_clone);
                         let parse_result =
                             parse_text_with_deadline(&mut parser, &text_for_parse, None, deadline);
@@ -807,7 +808,7 @@ impl ParseCoordinator {
                     &language_name,
                     &uri,
                     text_len,
-                    move |mut parser, deadline| {
+                    move |mut parser, deadline, _generation_retry| {
                         let _ = auto_install.begin_parsing(&language_name_clone);
                         let result =
                             parse_text_with_deadline(&mut parser, &text_for_parse, None, deadline);
@@ -1000,12 +1001,16 @@ impl ParseCoordinator {
                 &language_name,
                 uri,
                 text_len,
-                move |mut parser, deadline| {
+                move |mut parser, deadline, generation_retry| {
                     let _ = auto_install.begin_parsing(&language_name_clone);
                     let result = parse_text_with_deadline(
                         &mut parser,
                         &text_for_parse,
-                        seed.as_ref(),
+                        if generation_retry {
+                            None
+                        } else {
+                            seed.as_ref()
+                        },
                         deadline,
                     );
                     let _ = auto_install.end_parsing(&language_name_clone);

--- a/src/lsp/lsp_impl/lifecycle.rs
+++ b/src/lsp/lsp_impl/lifecycle.rs
@@ -249,7 +249,7 @@ impl Kakehashi {
         //   every save on a round trip that can only return "no edits".
         let host_bridging_enabled = settings.any_host_bridging_enabled();
         let will_save_advertised = host_bridging_enabled || settings.any_bridge_server_runnable();
-        self.apply_raw_settings(raw_settings, settings).await;
+        self.apply_initial_settings(raw_settings, settings).await;
 
         self.notifier().log_info("server initialized!").await;
         Ok(InitializeResult {

--- a/src/lsp/lsp_impl/text_document/native_bindings.rs
+++ b/src/lsp/lsp_impl/text_document/native_bindings.rs
@@ -263,7 +263,7 @@ impl Kakehashi {
                 content_text.len(),
                 // The work-unit deadline is for main-document parses;
                 // parse_with_ranges self-bounds at NATIVE_PARSE_BUDGET.
-                move |mut parser, _deadline| {
+                move |mut parser, _deadline, _generation_retry| {
                     let tree = parse_with_ranges(
                         &mut parser,
                         &content_text_for_parse,

--- a/src/lsp/lsp_impl/text_document/native_bindings.rs
+++ b/src/lsp/lsp_impl/text_document/native_bindings.rs
@@ -97,11 +97,16 @@ impl Kakehashi {
         // doubles as the staleness witness for the publish-time check below
         // (every edit and reopen installs a fresh allocation).
         self.ensure_document_parsed(&uri).await;
-        let Some((text, tree)) = ({
+        let Some((text, tree, content_version, incarnation)) = ({
             let doc = self.documents.get(&uri);
             doc.and_then(|doc| {
                 let tree = doc.tree()?.clone();
-                Some((doc.text_arc(), tree))
+                Some((
+                    doc.text_arc(),
+                    tree,
+                    doc.content_version(),
+                    doc.incarnation(),
+                ))
             })
         }) else {
             return Ok(None);
@@ -184,10 +189,11 @@ impl Kakehashi {
         // A didChange between the snapshot and here makes every computed
         // range stale — worst case a rename WorkspaceEdit applied to newer
         // text. Publish only while the snapshot's text is still current.
-        let unchanged = self
-            .documents
-            .get(&uri)
-            .is_some_and(|doc| std::sync::Arc::ptr_eq(&doc.text_arc(), &text));
+        let unchanged = self.documents.get(&uri).is_some_and(|doc| {
+            doc.content_version() == content_version
+                && doc.incarnation() == incarnation
+                && std::sync::Arc::ptr_eq(&doc.text_arc(), &text)
+        });
         if !unchanged {
             return Ok(None);
         }

--- a/src/lsp/lsp_impl/text_document/native_bindings.rs
+++ b/src/lsp/lsp_impl/text_document/native_bindings.rs
@@ -245,10 +245,6 @@ impl Kakehashi {
         if !load.success {
             return Some(None);
         }
-        let Some(query) = self.language.bindings_query(&layer_language) else {
-            return Some(None);
-        };
-
         let included_ranges =
             compute_included_ranges(&region.content_node, region.include_children);
         // The pooled spawn_blocking + timeout protocol every parse site
@@ -277,7 +273,15 @@ impl Kakehashi {
             .await;
 
         match parsed {
-            Some(layer_tree) => Some(Some((query, content_text, layer_tree, content_range.start))),
+            Some(layer_tree) => {
+                // Resolve after parse_with_pool: a reload can invalidate the
+                // first parser generation and make it retry with the new
+                // grammar, whose bindings query must accompany that tree.
+                let Some(query) = self.language.bindings_query(&layer_language) else {
+                    return Some(None);
+                };
+                Some(Some((query, content_text, layer_tree, content_range.start)))
+            }
             None => Some(None),
         }
     }

--- a/src/lsp/lsp_impl/text_document/native_bindings.rs
+++ b/src/lsp/lsp_impl/text_document/native_bindings.rs
@@ -97,6 +97,7 @@ impl Kakehashi {
         // doubles as the staleness witness for the publish-time check below
         // (every edit and reopen installs a fresh allocation).
         self.ensure_document_parsed(&uri).await;
+        let settings_generation = self.cache.semantic_token_generation();
         let Some((text, tree, content_version, incarnation)) = ({
             let doc = self.documents.get(&uri);
             doc.and_then(|doc| {
@@ -194,7 +195,7 @@ impl Kakehashi {
                 && doc.incarnation() == incarnation
                 && std::sync::Arc::ptr_eq(&doc.text_arc(), &text)
         });
-        if !unchanged {
+        if !unchanged || self.cache.semantic_token_generation() != settings_generation {
             return Ok(None);
         }
         Ok(answer)

--- a/src/lsp/lsp_impl/text_document/native_bindings.rs
+++ b/src/lsp/lsp_impl/text_document/native_bindings.rs
@@ -230,7 +230,10 @@ impl Kakehashi {
             return Some(None);
         }
         let content_range = region.content_node.byte_range();
-        let Some(content_text) = text.get(content_range.clone()).map(str::to_string) else {
+        let Some(content_text) = text
+            .get(content_range.clone())
+            .map(std::sync::Arc::<str>::from)
+        else {
             return Some(None);
         };
         let Some((layer_language, load)) = self
@@ -251,6 +254,7 @@ impl Kakehashi {
         // The pooled spawn_blocking + timeout protocol every parse site
         // uses: a pathological region cannot pin an async worker.
         let lang_for_parse = layer_language.clone();
+        let content_text_for_parse = std::sync::Arc::clone(&content_text);
         let parsed = self
             .parse_coordinator()
             .parse_with_pool(
@@ -262,23 +266,18 @@ impl Kakehashi {
                 move |mut parser, _deadline| {
                     let tree = parse_with_ranges(
                         &mut parser,
-                        &content_text,
+                        &content_text_for_parse,
                         included_ranges.as_deref(),
                         "kakehashi::bindings",
                         &lang_for_parse,
                     );
-                    (parser, tree.map(|tree| (tree, content_text)))
+                    (parser, tree)
                 },
             )
             .await;
 
         match parsed {
-            Some((layer_tree, content_text)) => Some(Some((
-                query,
-                std::sync::Arc::from(content_text),
-                layer_tree,
-                content_range.start,
-            ))),
+            Some(layer_tree) => Some(Some((query, content_text, layer_tree, content_range.start))),
             None => Some(None),
         }
     }

--- a/src/lsp/lsp_impl/text_document/selection_range.rs
+++ b/src/lsp/lsp_impl/text_document/selection_range.rs
@@ -94,6 +94,8 @@ impl Kakehashi {
         if snapshot.tree.is_none() {
             return Ok(None);
         }
+        let expected_version = snapshot.parsed_version;
+        let expected_incarnation = snapshot.incarnation;
 
         // Run the synchronous injection-aware walk as one work-unit on the
         // compute pool against the snapshot's consistent (text, tree). The
@@ -119,6 +121,18 @@ impl Kakehashi {
                 )
             })
             .await;
+
+        let still_current = self.documents.latest_snapshot(&uri).is_some_and(|view| {
+            view.content_version == expected_version
+                && view.slot.current_incarnation == expected_incarnation
+                && view.slot.snapshot.is_some_and(|snapshot| {
+                    snapshot.parsed_version == expected_version
+                        && snapshot.incarnation == expected_incarnation
+                })
+        });
+        if !still_current {
+            return Err(crate::error::content_modified_error());
+        }
 
         // None = the work-unit panicked (logged by the pool); serve the
         // no-result fallback rather than an error.

--- a/src/lsp/lsp_impl/text_document/selection_range.rs
+++ b/src/lsp/lsp_impl/text_document/selection_range.rs
@@ -96,6 +96,7 @@ impl Kakehashi {
         }
         let expected_version = snapshot.parsed_version;
         let expected_incarnation = snapshot.incarnation;
+        let expected_settings_generation = self.cache.semantic_token_generation();
 
         // Run the synchronous injection-aware walk as one work-unit on the
         // compute pool against the snapshot's consistent (text, tree). The
@@ -130,7 +131,8 @@ impl Kakehashi {
                         && snapshot.incarnation == expected_incarnation
                 })
         });
-        if !still_current {
+        if !still_current || self.cache.semantic_token_generation() != expected_settings_generation
+        {
             return Err(crate::error::content_modified_error());
         }
 

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -1116,12 +1116,23 @@ impl Kakehashi {
         };
         let text = std::sync::Arc::clone(&snapshot.text);
 
-        if !self
+        let language_loaded = self
             .language
             .ensure_language_loaded_async(&language_name)
             .await
-            .success
-        {
+            .success;
+        let edit_lock = self.documents.edit_lock(&uri);
+        let _edit_guard = edit_lock.lock().await;
+        if !self.semantic_snapshot_is_current(
+            &uri,
+            snapshot.incarnation,
+            snapshot.parsed_version,
+            generation,
+            &edit_lock,
+        ) {
+            return Err(crate::error::content_modified_error());
+        }
+        if !language_loaded {
             self.cache
                 .record_served_semantic_version(&uri, snapshot.parsed_version);
             return Ok(Some(SemanticTokensRangeResult::Tokens(SemanticTokens {
@@ -1130,11 +1141,14 @@ impl Kakehashi {
             })));
         }
         let Some(query) = self.language.highlight_query(&language_name) else {
+            self.cache
+                .record_served_semantic_version(&uri, snapshot.parsed_version);
             return Ok(Some(SemanticTokensRangeResult::Tokens(SemanticTokens {
                 result_id: None,
                 data: vec![],
             })));
         };
+        drop(_edit_guard);
 
         // Short-circuit an identical-viewport re-request of an unchanged document
         // (#535). `cache_key` folds the document text with the settings generation,

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -1114,6 +1114,17 @@ impl Kakehashi {
         };
         let text = std::sync::Arc::clone(&snapshot.text);
 
+        if !self
+            .language
+            .ensure_language_loaded_async(&language_name)
+            .await
+            .success
+        {
+            return Ok(Some(SemanticTokensRangeResult::Tokens(SemanticTokens {
+                result_id: None,
+                data: vec![],
+            })));
+        }
         let Some(query) = self.language.highlight_query(&language_name) else {
             return Ok(Some(SemanticTokensRangeResult::Tokens(SemanticTokens {
                 result_id: None,

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -1122,6 +1122,8 @@ impl Kakehashi {
             .await
             .success
         {
+            self.cache
+                .record_served_semantic_version(&uri, snapshot.parsed_version);
             return Ok(Some(SemanticTokensRangeResult::Tokens(SemanticTokens {
                 result_id: None,
                 data: vec![],

--- a/src/lsp/lsp_impl/text_document/semantic_tokens.rs
+++ b/src/lsp/lsp_impl/text_document/semantic_tokens.rs
@@ -1107,6 +1107,8 @@ impl Kakehashi {
         };
         let (Some(language_name), Some(tree)) = (snapshot.language.clone(), snapshot.tree.clone())
         else {
+            self.cache
+                .record_served_semantic_version(&uri, snapshot.parsed_version);
             return Ok(Some(SemanticTokensRangeResult::Tokens(SemanticTokens {
                 result_id: None,
                 data: vec![],


### PR DESCRIPTION
## Summary

- key loaded grammar libraries by resolved path and generation-scope runtime parser/query registrations
- serialize settings reload publication and reject/retry parser work across reload generations
- invalidate and reparse open document snapshots safely, including semantic-token refresh/healing and long-running reader revalidation
- preserve configured parser failure precedence over dynamic fallback and replace stale query kinds

## User-visible impact

Changing parser paths, search paths, base grammars, or queries through configuration now takes effect without restarting kakehashi. Open documents no longer mix pre-reload parsers/trees with post-reload queries, and auto-install reloads preserve their targeted downstream lifecycle.

Closes #586.

## Validation

- focused loader, parser-pool, reload, semantic range, native bindings, selection range, configured-fallback, query replacement, and document invalidation regressions
- `make check`
- local multi-perspective review: clean
- continued Codex review: converged clean
- final fresh Codex review: no comments to provide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings reloads with generation-aware invalidation to prevent stale thread-local parsers and cached language data from being reused.
  * Open documents now properly invalidate parse state/clearing tree visibility, with tests covering cache reload behavior.
  * Added safer parser pool reload/retry handling, and strengthened publish-time validity checks for semantic tokens, selection ranges, native bindings, and language dynamic loading failure cases (including corrected library caching by resolved path).
* **User Experience**
  * Semantic token refreshes are requested and emitted more consistently after applicable settings changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->