### PR TITLE
fix(bridge): recycle servers after config reload

### DIFF
--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -282,11 +282,11 @@ impl BridgeCoordinator {
         Arc::clone(&self.pool)
     }
 
-    /// Propagate a merged-settings change to every live downstream connection
-    /// (downstream-settings-propagation, path c). Each server's settings are
-    /// re-resolved through the same wildcard merge used at spawn, so an
-    /// unchanged config yields identical values and pushes nothing. Returns the
-    /// number of connections pushed.
+    /// Apply merged server-config changes to live downstream connections.
+    /// Runtime `settings` changes are pushed in place; removed servers and
+    /// spawn-time config changes evict and shut down their connections so the
+    /// next use spawns from the new config. Returns the number of settings
+    /// notifications pushed (evictions are not counted).
     pub(crate) async fn propagate_settings(&self, settings: &WorkspaceSettings) -> usize {
         self.pool
             .propagate_settings(|server_name| resolve_reload_server_config(settings, server_name))

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -51,6 +51,23 @@ pub(crate) struct ResolvedServerConfig {
     pub(crate) config: Arc<BridgeServerConfig>,
 }
 
+fn resolve_reload_server_config(
+    settings: &WorkspaceSettings,
+    server_name: &str,
+) -> Option<BridgeServerConfig> {
+    // A wildcard supplies defaults to concrete entries; it must not keep a
+    // deleted concrete server alive merely because its old name is known by a
+    // live connection.
+    if !settings.language_servers.contains_key(server_name) {
+        return None;
+    }
+    resolve_with_wildcard(
+        &settings.language_servers,
+        server_name,
+        merge_bridge_server_configs,
+    )
+}
+
 /// A batch of eager-open task handles with a generation counter.
 ///
 /// The generation counter enables detection of stale pushes: when a concurrent
@@ -272,13 +289,7 @@ impl BridgeCoordinator {
     /// number of connections pushed.
     pub(crate) async fn propagate_settings(&self, settings: &WorkspaceSettings) -> usize {
         self.pool
-            .propagate_settings(|server_name| {
-                resolve_with_wildcard(
-                    &settings.language_servers,
-                    server_name,
-                    merge_bridge_server_configs,
-                )
-            })
+            .propagate_settings(|server_name| resolve_reload_server_config(settings, server_name))
             .await
     }
 
@@ -1315,6 +1326,20 @@ mod tests {
     use super::*;
     use crate::config::LanguageSettings;
     use crate::config::settings::BridgeLanguageConfig;
+
+    #[test]
+    fn reload_resolution_does_not_resurrect_deleted_server_from_wildcard() {
+        let mut settings = WorkspaceSettings::default();
+        settings.language_servers.insert(
+            crate::config::WILDCARD_KEY.to_string(),
+            BridgeServerConfig {
+                cmd: vec!["shared-server".into()],
+                ..Default::default()
+            },
+        );
+
+        assert!(resolve_reload_server_config(&settings, "deleted").is_none());
+    }
 
     /// Shutdown's `abort_all_eager_open` must drain the host-layer eager-open
     /// batch too (#429), not only the virt `eager_open_tasks`.

--- a/src/lsp/bridge/coordinator.rs
+++ b/src/lsp/bridge/coordinator.rs
@@ -278,7 +278,6 @@ impl BridgeCoordinator {
                     server_name,
                     merge_bridge_server_configs,
                 )
-                .and_then(|config| config.settings)
             })
             .await
     }

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -43,13 +43,34 @@ fn same_launch_config(
     old: &crate::config::settings::BridgeServerConfig,
     new: &crate::config::settings::BridgeServerConfig,
 ) -> bool {
-    old.cmd == new.cmd
-        && old.languages == new.languages
-        && old.initialization_options == new.initialization_options
-        && old.workspace_markers == new.workspace_markers
-        && old.on_type_formatting_triggers == new.on_type_formatting_triggers
-        && old.prefer_shared_instance == new.prefer_shared_instance
-        && old.enabled == new.enabled
+    use crate::config::settings::BridgeServerConfig;
+    let BridgeServerConfig {
+        cmd: old_cmd,
+        languages: old_languages,
+        initialization_options: old_initialization_options,
+        settings: _,
+        workspace_markers: old_workspace_markers,
+        on_type_formatting_triggers: old_on_type_formatting_triggers,
+        prefer_shared_instance: _,
+        enabled: _,
+    } = old;
+    let BridgeServerConfig {
+        cmd: new_cmd,
+        languages: new_languages,
+        initialization_options: new_initialization_options,
+        settings: _,
+        workspace_markers: new_workspace_markers,
+        on_type_formatting_triggers: new_on_type_formatting_triggers,
+        prefer_shared_instance: _,
+        enabled: _,
+    } = new;
+    old_cmd == new_cmd
+        && old_languages == new_languages
+        && old_initialization_options == new_initialization_options
+        && old_workspace_markers == new_workspace_markers
+        && old_on_type_formatting_triggers == new_on_type_formatting_triggers
+        && old.prefers_shared_instance() == new.prefers_shared_instance()
+        && old.is_enabled() == new.is_enabled()
 }
 
 fn shutdown_invalidated_connection(key: ConnectionKey, handle: Arc<ConnectionHandle>) {
@@ -6396,6 +6417,17 @@ mod tests {
             })
             .await;
         assert_eq!(pushed, 0, "no live connections → nothing pushed");
+    }
+
+    #[test]
+    fn launch_config_compares_boolean_defaults_by_effective_value() {
+        let inherited = crate::config::settings::BridgeServerConfig::default();
+        let explicit = crate::config::settings::BridgeServerConfig {
+            prefer_shared_instance: Some(false),
+            enabled: Some(true),
+            ..Default::default()
+        };
+        assert!(same_launch_config(&inherited, &explicit));
     }
 
     #[tokio::test]

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -39,6 +39,17 @@ pub(crate) use dynamic_capability_registry::DynamicCapabilityRegistry;
 pub(crate) use message_sender::{ConnectionHandleSender, MessageSender};
 pub(crate) use shutdown_timeout::GlobalShutdownTimeout;
 
+fn same_launch_config(
+    old: &crate::config::settings::BridgeServerConfig,
+    new: &crate::config::settings::BridgeServerConfig,
+) -> bool {
+    let mut old = old.clone();
+    let mut new = new.clone();
+    old.settings = None;
+    new.settings = None;
+    old == new
+}
+
 use std::collections::HashMap;
 use std::io;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -551,12 +562,13 @@ impl LanguageServerPool {
         self.connections.lock().await
     }
 
-    /// Propagate a workspace-settings change to every live connection whose
-    /// settings changed (downstream-settings-propagation, path c).
+    /// Apply a resolved server-config reload to every live connection.
     ///
-    /// `resolve` maps a server name to its newly merged settings. For each
-    /// connection the resolved value is diffed against the connection's current
-    /// settings cell; on a change the cell is re-stored — so a later
+    /// `resolve` maps a server name to its newly merged config. A server that
+    /// vanished, or whose spawn-time config changed, is removed and shut down;
+    /// its next use therefore spawns from the new config. `settings` is the one
+    /// runtime-mutable field: it is diffed against the connection's current
+    /// settings cell and, on a change, the cell is re-stored — so a later
     /// `workspace/configuration` re-pull reflects it — and a best-effort
     /// `workspace/didChangeConfiguration` is pushed (carrying the new value, or
     /// `null` when settings were cleared). Unchanged servers get nothing, so a
@@ -567,12 +579,44 @@ impl LanguageServerPool {
     /// anti-storm behavior is observable to callers and tests.
     pub(crate) async fn propagate_settings(
         &self,
-        resolve: impl Fn(&str) -> Option<serde_json::Value>,
+        resolve: impl Fn(&str) -> Option<crate::config::settings::BridgeServerConfig>,
     ) -> usize {
-        let connections = self.connections.lock().await;
+        let mut connections = self.connections.lock().await;
+        let mut invalidated = Vec::new();
+        let mut resolved = HashMap::new();
+        for (key, handle) in connections.iter() {
+            let config = resolve(key.server());
+            let launch_changed = match (handle.launch_config(), config.as_ref()) {
+                (Some(old), Some(new)) => !same_launch_config(old, new),
+                (Some(_), None) => true,
+                // Test-only handles created without a spawn snapshot retain the
+                // legacy settings-propagation behavior.
+                (None, _) => false,
+            };
+            if launch_changed {
+                invalidated.push(key.clone());
+            } else {
+                resolved.insert(key.clone(), config.and_then(|config| config.settings));
+            }
+        }
+
+        let mut stale_handles = Vec::new();
+        for key in invalidated {
+            self.host_documents
+                .lock()
+                .await
+                .retain(|(_, connection_key), _| connection_key != &key);
+            self.document_tracker.purge_connection(&key).await;
+            self.purge_open_transition_locks(&key).await;
+            if let Some(handle) = connections.remove(&key) {
+                handle.begin_shutdown();
+                stale_handles.push((key, handle));
+            }
+        }
+
         let mut pushed = 0;
-        for handle in connections.values() {
-            let resolved = resolve(handle.key().server());
+        for (key, handle) in connections.iter() {
+            let resolved = resolved.remove(key).flatten();
             // Diff by value (Arc identity is irrelevant); skip unchanged servers
             // so an unchanged config reload pushes nothing.
             if resolved.as_ref() == handle.current_settings().as_deref() {
@@ -606,6 +650,23 @@ impl LanguageServerPool {
                     pushed += 1;
                 }
             }
+        }
+        drop(connections);
+        for (key, handle) in stale_handles {
+            tokio::spawn(async move {
+                const RELOAD_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
+                if tokio::time::timeout(RELOAD_SHUTDOWN_TIMEOUT, handle.graceful_shutdown())
+                    .await
+                    .is_err()
+                {
+                    log::warn!(
+                        target: "kakehashi::bridge",
+                        "Timed out shutting down invalidated {} connection",
+                        key
+                    );
+                    handle.complete_shutdown();
+                }
+            });
         }
         pushed
     }
@@ -1883,6 +1944,7 @@ impl LanguageServerPool {
             workspace_folders,
             settings_cell,
         ));
+        handle.record_launch_config(server_config.clone());
 
         // Insert into pool immediately so concurrent requests see Initializing state
         connections.insert(connection_key.clone(), Arc::clone(&handle));
@@ -6161,6 +6223,8 @@ mod tests {
         let lua_value = Arc::new(json!({ "Lua": { "telemetry": { "enable": false } } }));
         let lua =
             create_handle_with_key(ConnectionState::Ready, ConnectionKey::for_server("lua")).await;
+        ra.record_launch_config(crate::config::settings::BridgeServerConfig::default());
+        lua.record_launch_config(crate::config::settings::BridgeServerConfig::default());
         lua.store_settings(Some(Arc::clone(&lua_value)));
         {
             let mut conns = pool.connections().await;
@@ -6173,8 +6237,14 @@ mod tests {
         let lua_value_for_resolve = (*lua_value).clone();
         let pushed = pool
             .propagate_settings(move |name| match name {
-                "rust-analyzer" => Some(ra_value_for_resolve.clone()),
-                "lua" => Some(lua_value_for_resolve.clone()),
+                "rust-analyzer" => Some(crate::config::settings::BridgeServerConfig {
+                    settings: Some(ra_value_for_resolve.clone()),
+                    ..Default::default()
+                }),
+                "lua" => Some(crate::config::settings::BridgeServerConfig {
+                    settings: Some(lua_value_for_resolve.clone()),
+                    ..Default::default()
+                }),
                 _ => None,
             })
             .await;
@@ -6199,8 +6269,14 @@ mod tests {
         let ra_again = ra_value.clone();
         let pushed_again = pool
             .propagate_settings(move |name| match name {
-                "rust-analyzer" => Some(ra_again.clone()),
-                "lua" => Some(lua_again.clone()),
+                "rust-analyzer" => Some(crate::config::settings::BridgeServerConfig {
+                    settings: Some(ra_again.clone()),
+                    ..Default::default()
+                }),
+                "lua" => Some(crate::config::settings::BridgeServerConfig {
+                    settings: Some(lua_again.clone()),
+                    ..Default::default()
+                }),
                 _ => None,
             })
             .await;
@@ -6228,7 +6304,12 @@ mod tests {
         let value = json!({ "rust-analyzer": { "cargo": { "features": "all" } } });
         let value_for_resolve = value.clone();
         let pushed = pool
-            .propagate_settings(move |_| Some(value_for_resolve.clone()))
+            .propagate_settings(move |_| {
+                Some(crate::config::settings::BridgeServerConfig {
+                    settings: Some(value_for_resolve.clone()),
+                    ..Default::default()
+                })
+            })
             .await;
 
         assert_eq!(pushed, 0, "an initializing connection is not notified");
@@ -6245,8 +6326,74 @@ mod tests {
     async fn propagate_settings_no_connections_is_noop() {
         let pool = LanguageServerPool::new();
         let pushed = pool
-            .propagate_settings(|_| Some(serde_json::json!({ "x": 1 })))
+            .propagate_settings(|_| {
+                Some(crate::config::settings::BridgeServerConfig {
+                    settings: Some(serde_json::json!({ "x": 1 })),
+                    ..Default::default()
+                })
+            })
             .await;
         assert_eq!(pushed, 0, "no live connections → nothing pushed");
+    }
+
+    #[tokio::test]
+    async fn propagate_settings_invalidates_changed_and_removed_launch_configs() {
+        use crate::config::settings::BridgeServerConfig;
+
+        let pool = LanguageServerPool::new();
+        let changed_key = ConnectionKey::for_server("changed");
+        let removed_key = ConnectionKey::for_server("removed");
+        let unchanged_key = ConnectionKey::for_server("unchanged");
+        let changed = create_handle_with_key(ConnectionState::Ready, changed_key.clone()).await;
+        let removed = create_handle_with_key(ConnectionState::Ready, removed_key.clone()).await;
+        let unchanged = create_handle_with_key(ConnectionState::Ready, unchanged_key.clone()).await;
+
+        let old_changed = BridgeServerConfig {
+            cmd: vec!["old-server".into()],
+            ..Default::default()
+        };
+        let old_removed = BridgeServerConfig {
+            cmd: vec!["removed-server".into()],
+            ..Default::default()
+        };
+        let stable = BridgeServerConfig {
+            cmd: vec!["stable-server".into()],
+            ..Default::default()
+        };
+        changed.record_launch_config(old_changed);
+        removed.record_launch_config(old_removed);
+        unchanged.record_launch_config(stable.clone());
+        {
+            let mut connections = pool.connections().await;
+            connections.insert(changed_key.clone(), Arc::clone(&changed));
+            connections.insert(removed_key.clone(), Arc::clone(&removed));
+            connections.insert(unchanged_key.clone(), Arc::clone(&unchanged));
+        }
+
+        let stable_for_resolve = stable.clone();
+        pool.propagate_settings(move |name| match name {
+            "changed" => Some(BridgeServerConfig {
+                cmd: vec!["new-server".into()],
+                ..Default::default()
+            }),
+            "removed" => None,
+            "unchanged" => Some(stable_for_resolve.clone()),
+            _ => unreachable!(),
+        })
+        .await;
+
+        let connections = pool.connections().await;
+        assert!(!connections.contains_key(&changed_key));
+        assert!(!connections.contains_key(&removed_key));
+        assert!(connections.contains_key(&unchanged_key));
+        assert!(matches!(
+            changed.state(),
+            ConnectionState::Closing | ConnectionState::Closed
+        ));
+        assert!(matches!(
+            removed.state(),
+            ConnectionState::Closing | ConnectionState::Closed
+        ));
+        assert_eq!(unchanged.state(), ConnectionState::Ready);
     }
 }

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -50,6 +50,24 @@ fn same_launch_config(
     old == new
 }
 
+fn shutdown_invalidated_connection(key: ConnectionKey, handle: Arc<ConnectionHandle>) {
+    handle.begin_shutdown();
+    tokio::spawn(async move {
+        const RELOAD_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
+        if tokio::time::timeout(RELOAD_SHUTDOWN_TIMEOUT, handle.graceful_shutdown())
+            .await
+            .is_err()
+        {
+            log::warn!(
+                target: "kakehashi::bridge",
+                "Timed out shutting down invalidated {} connection",
+                key
+            );
+            handle.complete_shutdown();
+        }
+    });
+}
+
 use std::collections::HashMap;
 use std::io;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -609,7 +627,6 @@ impl LanguageServerPool {
             self.document_tracker.purge_connection(&key).await;
             self.purge_open_transition_locks(&key).await;
             if let Some(handle) = connections.remove(&key) {
-                handle.begin_shutdown();
                 stale_handles.push((key, handle));
             }
         }
@@ -653,20 +670,7 @@ impl LanguageServerPool {
         }
         drop(connections);
         for (key, handle) in stale_handles {
-            tokio::spawn(async move {
-                const RELOAD_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
-                if tokio::time::timeout(RELOAD_SHUTDOWN_TIMEOUT, handle.graceful_shutdown())
-                    .await
-                    .is_err()
-                {
-                    log::warn!(
-                        target: "kakehashi::bridge",
-                        "Timed out shutting down invalidated {} connection",
-                        key
-                    );
-                    handle.complete_shutdown();
-                }
-            });
+            shutdown_invalidated_connection(key, handle);
         }
         pushed
     }
@@ -1786,7 +1790,18 @@ impl LanguageServerPool {
         // reused by the ReturnExisting arm below.
         // Use pure decision function for testability (ls-bridge-message-ordering Operation Gating)
         let existing = connections.get(&connection_key);
-        let existing_state = existing.map(|h| h.state());
+        let launch_config_changed = existing.is_some_and(|handle| {
+            handle
+                .launch_config()
+                .is_some_and(|old| !same_launch_config(old, server_config))
+        });
+        let existing_state = if launch_config_changed {
+            // Reuse the stale/closed cleanup path below. `Failed` maps to
+            // SpawnNew, while the explicit flag also schedules process shutdown.
+            Some(ConnectionState::Failed)
+        } else {
+            existing.map(|h| h.state())
+        };
         match decide_connection_action(existing_state, panic_count) {
             ConnectionAction::ReturnExisting => {
                 // `decide_connection_action` only returns ReturnExisting when a
@@ -1820,6 +1835,8 @@ impl LanguageServerPool {
             ConnectionAction::SpawnNew => {
                 // Remove stale connection if present (Failed or Closed state)
                 if existing_state.is_some() {
+                    let invalidated_handle =
+                        launch_config_changed.then(|| existing.cloned()).flatten();
                     // Drop the dead connection's document state with it: the
                     // replacement process has nothing open, so the lazy host
                     // sync must re-send didOpen and the virt tracker must let
@@ -1842,6 +1859,9 @@ impl LanguageServerPool {
                     // entry remains and the next acquire retries the idempotent
                     // purge instead of spawning over partial document state.
                     connections.remove(&connection_key);
+                    if let Some(handle) = invalidated_handle {
+                        shutdown_invalidated_connection(connection_key.clone(), handle);
+                    }
                 }
             }
         }

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -635,6 +635,9 @@ impl LanguageServerPool {
 
         let mut stale_handles = Vec::new();
         for key in invalidated {
+            if let Some(handle) = connections.get(&key) {
+                handle.begin_shutdown();
+            }
             self.host_documents
                 .lock()
                 .await
@@ -1852,6 +1855,9 @@ impl LanguageServerPool {
                 if existing_state.is_some() {
                     let invalidated_handle =
                         launch_config_changed.then(|| existing.cloned()).flatten();
+                    if let Some(handle) = &invalidated_handle {
+                        handle.begin_shutdown();
+                    }
                     // Drop the dead connection's document state with it: the
                     // replacement process has nothing open, so the lazy host
                     // sync must re-send didOpen and the virt tracker must let

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -43,11 +43,13 @@ fn same_launch_config(
     old: &crate::config::settings::BridgeServerConfig,
     new: &crate::config::settings::BridgeServerConfig,
 ) -> bool {
-    let mut old = old.clone();
-    let mut new = new.clone();
-    old.settings = None;
-    new.settings = None;
-    old == new
+    old.cmd == new.cmd
+        && old.languages == new.languages
+        && old.initialization_options == new.initialization_options
+        && old.workspace_markers == new.workspace_markers
+        && old.on_type_formatting_triggers == new.on_type_formatting_triggers
+        && old.prefer_shared_instance == new.prefer_shared_instance
+        && old.enabled == new.enabled
 }
 
 fn shutdown_invalidated_connection(key: ConnectionKey, handle: Arc<ConnectionHandle>) {
@@ -2091,6 +2093,18 @@ impl LanguageServerPool {
                     Ok(())
                 }
                 Ok(Err(e)) => {
+                    if matches!(
+                        handle_for_handshake.state(),
+                        ConnectionState::Closing | ConnectionState::Closed
+                    ) {
+                        log::debug!(
+                            target: "kakehashi::bridge::init",
+                            "[{}] LSP handshake interrupted by connection invalidation: {}",
+                            server_name_for_log,
+                            e
+                        );
+                        return Err(e);
+                    }
                     // Init failed with io::Error - transition to Failed
                     // Preserve the original ErrorKind for proper error categorization
                     log::error!(
@@ -6248,8 +6262,12 @@ mod tests {
         let lua_value = Arc::new(json!({ "Lua": { "telemetry": { "enable": false } } }));
         let lua =
             create_handle_with_key(ConnectionState::Ready, ConnectionKey::for_server("lua")).await;
-        ra.record_launch_config(crate::config::settings::BridgeServerConfig::default());
+        ra.record_launch_config(crate::config::settings::BridgeServerConfig {
+            settings: Some(json!({ "not-retained": true })),
+            ..Default::default()
+        });
         lua.record_launch_config(crate::config::settings::BridgeServerConfig::default());
+        assert!(ra.launch_config().unwrap().settings.is_none());
         lua.store_settings(Some(Arc::clone(&lua_value)));
         {
             let mut conns = pool.connections().await;

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -56,16 +56,29 @@ fn shutdown_invalidated_connection(key: ConnectionKey, handle: Arc<ConnectionHan
     handle.begin_shutdown();
     tokio::spawn(async move {
         const RELOAD_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
-        if tokio::time::timeout(RELOAD_SHUTDOWN_TIMEOUT, handle.graceful_shutdown())
-            .await
-            .is_err()
-        {
-            log::warn!(
-                target: "kakehashi::bridge",
-                "Timed out shutting down invalidated {} connection",
-                key
-            );
-            handle.complete_shutdown();
+        let shutdown_handle = Arc::clone(&handle);
+        let shutdown_task = tokio::spawn(async move { shutdown_handle.graceful_shutdown().await });
+        let abort = shutdown_task.abort_handle();
+        match tokio::time::timeout(RELOAD_SHUTDOWN_TIMEOUT, shutdown_task).await {
+            Ok(Ok(_)) => {}
+            Ok(Err(error)) => {
+                log::error!(
+                    target: "kakehashi::bridge",
+                    "Shutdown task for invalidated {} connection failed: {}",
+                    key,
+                    error
+                );
+                handle.complete_shutdown();
+            }
+            Err(_) => {
+                abort.abort();
+                log::warn!(
+                    target: "kakehashi::bridge",
+                    "Timed out shutting down invalidated {} connection",
+                    key
+                );
+                handle.complete_shutdown();
+            }
         }
     });
 }
@@ -1966,7 +1979,7 @@ impl LanguageServerPool {
             workspace_folders,
             settings_cell,
         ));
-        handle.record_launch_config(server_config.clone());
+        handle.record_launch_config(server_config);
 
         // Insert into pool immediately so concurrent requests see Initializing state
         connections.insert(connection_key.clone(), Arc::clone(&handle));
@@ -6262,11 +6275,11 @@ mod tests {
         let lua_value = Arc::new(json!({ "Lua": { "telemetry": { "enable": false } } }));
         let lua =
             create_handle_with_key(ConnectionState::Ready, ConnectionKey::for_server("lua")).await;
-        ra.record_launch_config(crate::config::settings::BridgeServerConfig {
+        ra.record_launch_config(&crate::config::settings::BridgeServerConfig {
             settings: Some(json!({ "not-retained": true })),
             ..Default::default()
         });
-        lua.record_launch_config(crate::config::settings::BridgeServerConfig::default());
+        lua.record_launch_config(&crate::config::settings::BridgeServerConfig::default());
         assert!(ra.launch_config().unwrap().settings.is_none());
         lua.store_settings(Some(Arc::clone(&lua_value)));
         {
@@ -6404,9 +6417,9 @@ mod tests {
             cmd: vec!["stable-server".into()],
             ..Default::default()
         };
-        changed.record_launch_config(old_changed);
-        removed.record_launch_config(old_removed);
-        unchanged.record_launch_config(stable.clone());
+        changed.record_launch_config(&old_changed);
+        removed.record_launch_config(&old_removed);
+        unchanged.record_launch_config(&stable);
         {
             let mut connections = pool.connections().await;
             connections.insert(changed_key.clone(), Arc::clone(&changed));

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -74,7 +74,6 @@ fn same_launch_config(
 }
 
 fn shutdown_invalidated_connection(key: ConnectionKey, handle: Arc<ConnectionHandle>) {
-    handle.begin_shutdown();
     tokio::spawn(async move {
         const RELOAD_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
         let shutdown_handle = Arc::clone(&handle);

--- a/src/lsp/bridge/pool.rs
+++ b/src/lsp/bridge/pool.rs
@@ -2040,7 +2040,12 @@ impl LanguageServerPool {
                             build_did_change_configuration_notification(payload),
                         );
                     }
-                    handle_for_handshake.set_state(ConnectionState::Ready);
+                    if !handle_for_handshake.transition_initializing_to_ready() {
+                        return Err(io::Error::new(
+                            io::ErrorKind::Interrupted,
+                            "bridge: connection was invalidated during initialization",
+                        ));
+                    }
                     // Record advertised palette command names AFTER Ready, so a
                     // command fired without an action context (raw name) routes
                     // back to a Ready connection (#628). Dedup is by name across
@@ -6344,7 +6349,8 @@ mod tests {
         let changed_key = ConnectionKey::for_server("changed");
         let removed_key = ConnectionKey::for_server("removed");
         let unchanged_key = ConnectionKey::for_server("unchanged");
-        let changed = create_handle_with_key(ConnectionState::Ready, changed_key.clone()).await;
+        let changed =
+            create_handle_with_key(ConnectionState::Initializing, changed_key.clone()).await;
         let removed = create_handle_with_key(ConnectionState::Ready, removed_key.clone()).await;
         let unchanged = create_handle_with_key(ConnectionState::Ready, unchanged_key.clone()).await;
 
@@ -6390,6 +6396,10 @@ mod tests {
             changed.state(),
             ConnectionState::Closing | ConnectionState::Closed
         ));
+        assert!(
+            !changed.transition_initializing_to_ready(),
+            "a completing handshake must not resurrect an invalidated connection"
+        );
         assert!(matches!(
             removed.state(),
             ConnectionState::Closing | ConnectionState::Closed

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -139,6 +139,11 @@ pub(crate) struct ConnectionHandle {
     /// re-stores it here on a merge change (path c) so a re-pull reflects the
     /// current config. `None` slot = no settings configured for this server.
     settings: Arc<arc_swap::ArcSwapOption<serde_json::Value>>,
+    /// Resolved server configuration that created this process.
+    ///
+    /// `settings` is ignored when comparing this snapshot on reload because it
+    /// can be propagated at runtime; every other field is spawn-time state.
+    launch_config: OnceLock<crate::config::settings::BridgeServerConfig>,
 }
 
 impl ConnectionHandle {
@@ -206,7 +211,16 @@ impl ConnectionHandle {
             workspace_folders,
             incapable_fallback_logged: AtomicBool::new(false),
             settings,
+            launch_config: OnceLock::new(),
         }
+    }
+
+    pub(super) fn record_launch_config(&self, config: crate::config::settings::BridgeServerConfig) {
+        let _ = self.launch_config.set(config);
+    }
+
+    pub(super) fn launch_config(&self) -> Option<&crate::config::settings::BridgeServerConfig> {
+        self.launch_config.get()
     }
 
     /// This connection's current workspace settings, if any

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -435,6 +435,23 @@ impl ConnectionHandle {
         self.state_watch.send_replace(new_state);
     }
 
+    /// Complete initialization only while this handle still belongs to its
+    /// original lifecycle. A reload or global shutdown may move an
+    /// initializing handle to `Closing`; the handshake task must not resurrect
+    /// it as `Ready` afterwards.
+    pub(super) fn transition_initializing_to_ready(&self) -> bool {
+        let mut state = self
+            .state
+            .write()
+            .recover_poison("ConnectionHandle::transition_initializing_to_ready");
+        if *state != ConnectionState::Initializing {
+            return false;
+        }
+        *state = ConnectionState::Ready;
+        self.state_watch.send_replace(ConnectionState::Ready);
+        true
+    }
+
     /// Store server capabilities from the initialize response.
     ///
     /// Called once after successful LSP handshake, before transitioning to Ready.

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -215,7 +215,11 @@ impl ConnectionHandle {
         }
     }
 
-    pub(super) fn record_launch_config(&self, config: crate::config::settings::BridgeServerConfig) {
+    pub(super) fn record_launch_config(
+        &self,
+        mut config: crate::config::settings::BridgeServerConfig,
+    ) {
+        config.settings = None;
         let _ = self.launch_config.set(config);
     }
 

--- a/src/lsp/bridge/pool/connection_handle.rs
+++ b/src/lsp/bridge/pool/connection_handle.rs
@@ -217,10 +217,19 @@ impl ConnectionHandle {
 
     pub(super) fn record_launch_config(
         &self,
-        mut config: crate::config::settings::BridgeServerConfig,
+        config: &crate::config::settings::BridgeServerConfig,
     ) {
-        config.settings = None;
-        let _ = self.launch_config.set(config);
+        let snapshot = crate::config::settings::BridgeServerConfig {
+            cmd: config.cmd.clone(),
+            languages: config.languages.clone(),
+            initialization_options: config.initialization_options.clone(),
+            settings: None,
+            workspace_markers: config.workspace_markers.clone(),
+            on_type_formatting_triggers: config.on_type_formatting_triggers.clone(),
+            prefer_shared_instance: config.prefer_shared_instance,
+            enabled: config.enabled,
+        };
+        let _ = self.launch_config.set(snapshot);
     }
 
     pub(super) fn launch_config(&self) -> Option<&crate::config::settings::BridgeServerConfig> {

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -128,9 +128,9 @@ pub(super) async fn apply_shared_settings(
         None => settings_manager.apply_settings(settings),
     }
     let settings = settings_manager.load_settings();
-    // Path c: push the new per-server settings to live downstream connections
-    // at this single reload choke point (initialize, didChangeConfiguration,
-    // auto-install reload).
+    // Path c: apply downstream config at this single reload choke point
+    // (initialize, didChangeConfiguration, auto-install reload): push runtime
+    // settings in place and recycle connections whose launch config changed.
     // At initialize time there are no connections yet, so it is a clean no-op
     // (downstream-settings-propagation).
     let pushed = bridge.propagate_settings(&settings).await;

--- a/src/lsp/lsp_impl.rs
+++ b/src/lsp/lsp_impl.rs
@@ -120,9 +120,17 @@ pub(super) async fn apply_shared_settings(
     // whole awaited propagate below. (The final bump after apply_settings
     // covers the settings-side inputs the apply swaps.)
     cache.bump_semantic_token_generation();
+    // Publish the settings snapshot before invalidating downstream connections:
+    // once propagation exposes a pool miss, a concurrent request must resolve
+    // the NEW launch config rather than respawn from the old snapshot (#587).
+    match raw_settings {
+        Some(raw_settings) => settings_manager.apply_settings_with_raw(raw_settings, settings),
+        None => settings_manager.apply_settings(settings),
+    }
+    let settings = settings_manager.load_settings();
     // Path c: push the new per-server settings to live downstream connections
     // at this single reload choke point (initialize, didChangeConfiguration,
-    // auto-install reload), before `settings` is consumed by the apply below.
+    // auto-install reload).
     // At initialize time there are no connections yet, so it is a clean no-op
     // (downstream-settings-propagation).
     let pushed = bridge.propagate_settings(&settings).await;
@@ -131,10 +139,6 @@ pub(super) async fn apply_shared_settings(
             target: "kakehashi::bridge",
             "Propagated settings change to {} downstream connection(s)", pushed
         );
-    }
-    match raw_settings {
-        Some(raw_settings) => settings_manager.apply_settings_with_raw(raw_settings, settings),
-        None => settings_manager.apply_settings(settings),
     }
     // A settings/query reload can change tokenization for unchanged text, so
     // bump the semantic-token cache generation once more: the ladder is one


### PR DESCRIPTION
## Summary
- remember the resolved spawn configuration for each downstream connection
- evict and asynchronously shut down connections when their server disappears or non-runtime configuration changes
- preserve in-place `workspace/didChangeConfiguration` propagation for settings-only reloads

## Tests
- `cargo test --lib propagate_settings`
- `make test`
- `make check`
- `codex review --base origin/main`

Closes #587

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bridge server settings propagation to be launch-aware, invalidating/removing connections when a server’s launch configuration changes or the server is deleted.
  * Only sends `didChangeConfiguration` to connections in **Ready** when the effective settings value actually changes.
  * Reload now applies and publishes the updated settings snapshot earlier in the reload sequence, before invalidation and downstream propagation.
* **Tests**
  * Added a unit test to ensure wildcard entries don’t “resurrect” deleted concrete servers.
  * Added/updated coverage for launch-config change/removal invalidation behavior and `same_launch_config` correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->